### PR TITLE
Make atomic_add() return value (should be ready to review...)

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -54,7 +54,7 @@ class Expr:
   __radd__ = __add__
 
   def __iadd__(self, other):
-    taichi_lang_core.expr_atomic_add(self.ptr, other.ptr)
+    self.atomic_add(other)
 
   def __neg__(self):
     return Expr(taichi_lang_core.expr_neg(self.ptr), tb=self.stack_info())
@@ -65,7 +65,9 @@ class Expr:
         taichi_lang_core.expr_sub(self.ptr, other.ptr), tb=self.stack_info())
 
   def __isub__(self, other):
-    taichi_lang_core.expr_atomic_sub(self.ptr, other.ptr)
+    # TODO: add atomic_sub()
+    import taichi as ti
+    ti.expr_init(taichi_lang_core.expr_atomic_sub(self.ptr, other.ptr))
 
   def __imul__(self, other):
     self.assign(Expr(taichi_lang_core.expr_mul(self.ptr, other.ptr)))
@@ -97,7 +99,7 @@ class Expr:
 
   def __rtruediv__(self, other):
     return Expr(taichi_lang_core.expr_truediv(Expr(other).ptr, self.ptr))
-  
+
   def __floordiv__(self, other):
     return Expr(taichi_lang_core.expr_floordiv(self.ptr, Expr(other).ptr))
 
@@ -237,7 +239,9 @@ class Expr:
     fill_tensor(self, val)
 
   def atomic_add(self, other):
-    taichi_lang_core.expr_atomic_add(self.ptr, other.ptr)
+    import taichi as ti
+    other_ptr = ti.wrap_scalar(other).ptr
+    return ti.expr_init(taichi_lang_core.expr_atomic_add(self.ptr, other_ptr))
 
   def __pow__(self, power, modulo=None):
     assert isinstance(power, int) and power >= 0

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -35,8 +35,7 @@ def wrap_scalar(x):
 
 
 def atomic_add(a, b):
-  a.atomic_add(wrap_scalar(b))
-
+  return a.atomic_add(b)
 
 def subscript(value, *indices):
   import numpy as np

--- a/taichi/python_bindings.cpp
+++ b/taichi/python_bindings.cpp
@@ -238,13 +238,13 @@ void export_lang(py::module &m) {
   m.def("value_cast", static_cast<Expr (*)(const Expr &expr, DataType)>(cast));
 
   m.def("expr_atomic_add", [&](const Expr &a, const Expr &b) {
-    current_ast_builder().insert(Stmt::make<FrontendAtomicStmt>(
-        AtomicOpType::add, ptr_if_global(a), load_if_ptr(b)));
+    return Expr::make<AtomicOpExpression>(AtomicOpType::add, ptr_if_global(a),
+                                          load_if_ptr(b));
   });
 
   m.def("expr_atomic_sub", [&](const Expr &a, const Expr &b) {
-    current_ast_builder().insert(Stmt::make<FrontendAtomicStmt>(
-        AtomicOpType::sub, ptr_if_global(a), load_if_ptr(b)));
+    return Expr::make<AtomicOpExpression>(AtomicOpType::sub, ptr_if_global(a),
+                                          load_if_ptr(b));
   });
 
   m.def("expr_add", expr_add);

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -52,6 +52,9 @@ class TypeCheck : public IRVisitor {
       stmt->val = insert_type_cast_before(stmt, stmt->val,
                                           stmt->dest->ret_type.data_type);
     }
+    if (stmt->element_type() == DataType::unknown) {
+      stmt->ret_type = stmt->dest->ret_type;
+    }
   }
 
   void visit(LocalLoadStmt *stmt) {

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -1,0 +1,188 @@
+import taichi as ti
+from pytest import approx
+
+ti.cfg.print_ir = True
+n = 128
+
+
+def run_atomic_add_global_case(vartype, step, valproc=lambda x: x):
+  x = ti.var(vartype)
+  y = ti.var(vartype)
+  c = ti.var(vartype)
+
+  @ti.layout
+  def place():
+    ti.root.dense(ti.i, n).place(x, y)
+    ti.root.place(c)
+
+  @ti.kernel
+  def func():
+    ck = ti.to_numpy_type(vartype)(0)
+    for i in range(n):
+      x[i] = ti.atomic_add(c[None], step)
+      y[i] = ti.atomic_add(ck, step)
+
+  func()
+
+  assert valproc(c[None]) == n * step
+  x_actual = sorted(x.to_numpy())
+  y_actual = sorted(y.to_numpy())
+  expect = [i * step for i in range(n)]
+  for (xa, ya, e) in zip(x_actual, y_actual, expect):
+    assert valproc(xa) == e
+    assert valproc(ya) == e
+
+
+@ti.all_archs
+def test_atomic_add_global_i32():
+  run_atomic_add_global_case(ti.i32, 42)
+
+
+@ti.all_archs
+def test_atomic_add_global_f32():
+  run_atomic_add_global_case(
+      ti.f32, 4.2, valproc=lambda x: approx(x, rel=1e-5))
+
+
+@ti.all_archs
+def test_atomic_add_expr_evaled():
+  c = ti.var(ti.i32)
+  step = 42
+
+  @ti.layout
+  def place():
+    ti.root.place(c)
+
+  @ti.kernel
+  def func():
+    for i in range(n):
+      # this is an expr with side effect, make sure it's not optimized out.
+      ti.atomic_add(c[None], step)
+
+  func()
+
+  assert c[None] == n * step
+
+
+@ti.all_archs
+def test_atomic_add_demoted():
+  # Ensure demoted atomics do not crash the program.
+  x = ti.var(ti.i32)
+  y = ti.var(ti.i32)
+  step = 42
+
+  @ti.layout
+  def place():
+    ti.root.dense(ti.i, n).place(x, y)
+
+  @ti.kernel
+  def func():
+    for i in range(n):
+      s = i
+      # Both adds should get demoted.
+      x[i] = ti.atomic_add(s, step)
+      y[i] = s.atomic_add(step)
+
+  func()
+
+  for i in range(n):
+    assert x[i] == i
+    assert y[i] == i + step
+
+
+@ti.all_archs
+def test_atomic_add_with_local_store_simplify1():
+  # Test for the following LocalStoreStmt simplification case:
+  #
+  # local store [$a <- ...]
+  # atomic add ($a, ...)
+  # local store [$a <- ...]
+  #
+  # Specifically, the second store should not suppress the first one, because
+  # atomic_add can return value.
+  x = ti.var(ti.i32)
+  y = ti.var(ti.i32)
+  step = 42
+
+  @ti.layout
+  def place():
+    ti.root.dense(ti.i, n).place(x, y)
+
+  @ti.kernel
+  def func():
+    for i in range(n):
+      # do a local store
+      j = i
+      x[i] = ti.atomic_add(j, step)
+      # do another local store, make sure the previous one is not optimized out
+      j = x[i]
+      y[i] = j
+
+  func()
+
+  for i in range(n):
+    assert x[i] == i
+    assert y[i] == i
+
+
+@ti.all_archs
+def test_atomic_add_with_local_store_simplify2():
+  # Test for the following LocalStoreStmt simplification case:
+  #
+  # local store [$a <- ...]
+  # atomic add ($a, ...)
+  #
+  # Specifically, the local store should not be removed, because
+  # atomic_add can return its value.
+  x = ti.var(ti.i32)
+  step = 42
+
+  @ti.layout
+  def place():
+    ti.root.dense(ti.i, n).place(x)
+
+  @ti.kernel
+  def func():
+    for i in range(n):
+      j = i
+      x[i] = ti.atomic_add(j, step)
+
+  func()
+
+  for i in range(n):
+    assert x[i] == i
+
+
+@ti.all_archs
+def test_atomic_add_with_if_simplify():
+  # Make sure IfStmt simplification doesn't move stmts depending on the result
+  # of atomic_add()
+  x = ti.var(ti.i32)
+  step = 42
+
+  @ti.layout
+  def place():
+    ti.root.dense(ti.i, n).place(x)
+
+  boundary = n / 2
+  @ti.kernel
+  def func():
+    for i in range(n):
+      if i > boundary:
+        # A sequence of commands designed such that atomic_add() is the only
+        # thing to decide whether the if branch can be simplified.
+        s = i
+        j = s.atomic_add(s)
+        k = j + s
+        x[i] = k
+      else:
+        # If we look at the IR, this branch should be simplified, since nobody
+        # is using atomic_add's result.
+        x[i].atomic_add(i)
+        x[i] += step
+
+  func()
+
+  for i in range(n):
+    expect = i * 3 if i > boundary else (i + step)
+    assert x[i] == expect


### PR DESCRIPTION
Issue #332 

I've finally got things working (only tested on CPU, sadly...). I had to make a few changes to IR passes to adapt to this change. Specifically:

1. Demote atomics should replace the demoted stmt with the **old value** loaded before add, as you've pointed out in https://github.com/taichi-dev/taichi/issues/332#issuecomment-573485416
1. `LocalStoreStmt` cannot be simplified in a few cases where atomic ops appeared
1. `IfStmt` cannot move certain `LocalStore` out of the branch clauses if the store depends on atomic operations. This one is somewhat nontrivial in this change, as it does two things
    1. it no longer moves `LocalStore` that depend on atomics, for correctness reasons
    1. it no longer moves `AllocaStmt` that is 1) in the clause, and 2) the dest of `LocalStore`. This is for performance reason, as otherwise some dead code cannot be eliminated. 

I wonder if this PR is getting too big, especially the `IfStmt -> AllocaStmt` part, as that is logically a separate thing, and lacks proper unit tests... If you think so, I can separate this into two PRs.

If you think the code looks fine, can you help test the GPU version? Or is Travis CI able to test that? 