### PR TITLE
cmake on NVIDIA Jetson 

### DIFF
--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -39,7 +39,7 @@ if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}"
         message("Setting -march=nehalem for x86_64 processors")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=nehalem -DTI_ARCH_x86_64")
     endif()
-elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm") # TODO: not sure about letter cases, pre/subfixes
+elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64") 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_ARCH_ARM")
 else()
     message(FATAL_ERROR "Unknown processor type ${CMAKE_SYSTEM_PROCESSOR}")


### PR DESCRIPTION
$ cmake ..  -DCMAKE_C_COMPILER=/usr/local/clang-8.0.1/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/clang-8.0.1/bin/clang++   -DPYTHON_EXECUTABLE=python3.6
Taichi Version 0.3.21
       Commit efcb7657ed6796da2f6cd16abe03dbcc4d33bc48
Using C++ compiler: /usr/local/clang-8.0.1/bin/clang++
Clang compiler detected. Using std=c++17.
Building for processor aarch64
Using float32 (single) precision as real
Using python3.6 as python executable.
Python 3.6.9
    version: 3.6
    include: /usr/include/python3.6m
    library: PYTHON_LIBRARY-NOTFOUND
    numpy include: /usr/local/lib/python3.6/dist-packages/numpy/core/include
    pybind11 include: /usr/local/include/python3.6;/home/jetson/.local/include/python3.6m
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found CUDA: /usr/local/cuda (found suitable version "10.0", minimum required is "10.0") 
Building with CUDA 10.0
Found CUDA. Arch = 61
-- Found LLVM 8.0.1
-- Using LLVMConfig.cmake in: /usr/local/lib/cmake/llvm
llvm include dirs /usr/local/include
-- Found OpenMP_C: -fopenmp=libomp (found version "3.1") 
-- Found OpenMP_CXX: -fopenmp=libomp (found version "3.1") 
-- Found OpenMP: TRUE (found version "3.1")  
Found OpenMP.
PYTHON_LIBRARIESPYTHON_LIBRARY-NOTFOUND
**C++ Flags:  -DTC_ISE_NONE -std=c++17 -fsized-deallocation -Wall  -DTI_ARCH_ARM -DTC_PASS_EXCEPTION_TO_PYTHON -DTC_INCLUDED -g -DCUDA_FOUND -DTLANG_WITH_CUDA -D TLANG_CUDA_VERSION='"10.0"' -DOPENMP_FOUND -DTLANG_WITH_OPENMP**
Build type: RelWithDebInfo
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jetson/taichi/build