### PR TITLE
Fix how SNodeOpStmt's type is set

### DIFF
--- a/taichi/ir.h
+++ b/taichi/ir.h
@@ -1397,7 +1397,7 @@ class SNodeOpStmt : public Stmt {
     if (val)
       add_operand(this->val);
     width() = 1;
-    element_type() = snode->dt;
+    element_type() = DataType::i32;
   }
 
   DEFINE_ACCEPT


### PR DESCRIPTION
`SNodeOpStmt` can be either `append` or `length`, so its return type is `i32`. However, it seems that the current code is not causing a problem, because [its type is later set to `i32` in `type_check.cpp`](https://github.com/taichi-dev/taichi/blob/master/taichi/transforms/type_check.cpp#L93). So this PR just reduces confusion..?