### PR TITLE
check_cuda_errors: err evaluated three times

### DIFF
--- a/taichi/cuda_utils.h
+++ b/taichi/cuda_utils.h
@@ -6,10 +6,12 @@
 #include <cuda_runtime_api.h>
 #include <driver_types.h>
 
-#define check_cuda_errors(err)                              \
-  if (int(err))                                             \
-    TC_ERROR("Cuda Error {}: {}", get_cuda_error_name(err), \
-             get_cuda_error_string(err));
+#define check_cuda_errors(err) do {                           \
+  CUresult __err = (err);                                     \
+  if (int(__err))                                             \
+    TC_ERROR("Cuda Error {}: {}", get_cuda_error_name(__err), \
+             get_cuda_error_string(__err));                   \
+  } while (0)
 
 TLANG_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Due to the rule of C macros, when you write:
`check_cuda_errors(cudaAPI(233));`
You actually did `cudaAPI(233)` three times if it result in error.
Expanded:
```
if (int(cudaAPI(233))) {
 TC_ERROR("Cuda Error {} {}", cudaAPI(233), cudaAPI(233));
}
```
You'll lose the infomation of first call to `cudaAPI(233)`.
Please use a temperate variable to save it.
Might be the cause of issue #356.