### PR TITLE
remove unused __getitem__ in Expr

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -133,10 +133,6 @@ class Expr:
     other = Expr(other)
     return Expr(taichi_lang_core.expr_cmp_ne(self.ptr, other.ptr))
 
-  def __getitem__(self, item):
-    item = Expr(item)
-    return Expr(expr_index(self, item.ptr))
-
   def __and__(self, item):
     item = Expr(item)
     return Expr(taichi_lang_core.expr_bit_and(self.ptr, item.ptr))


### PR DESCRIPTION
There are two `__getitem__` defined for `Expr`. I believe only [the later one](https://github.com/taichi-dev/taichi/blob/master/python/taichi/lang/expr.py#L200) is used, so removing the first one...