### PR TITLE
Add basic Metal APIs

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -88,7 +88,7 @@ endif()
 # Optional dependencies
 
 if (APPLE)
-    target_link_libraries(${CORE_LIBRARY_NAME} "-framework Cocoa")
+    target_link_libraries(${CORE_LIBRARY_NAME} "-framework Cocoa -framework Metal")
 endif ()
 
 if (NOT WIN32)

--- a/taichi/common/util.h
+++ b/taichi/common/util.h
@@ -49,6 +49,10 @@ static_assert(false, "32-bit Windows systems are not supported")
 // OSX
 #if defined(__APPLE__)
 #define TC_PLATFORM_OSX
+// According to https://developer.apple.com/documentation/metal?language=objc,
+// Metal is supported since macOS 10.11+, so we can just assume that it is
+// available for all Mac users?
+#define TC_SUPPORTS_METAL
 #endif
 
 #if (defined(TC_PLATFORM_LINUX) || defined(TC_PLATFORM_OSX))

--- a/taichi/platform/mac/objc_api.cpp
+++ b/taichi/platform/mac/objc_api.cpp
@@ -1,8 +1,7 @@
+#include "objc_api.h"
 #include <taichi/common/util.h>
 
-#if defined(TC_GUI_COCOA)
-
-#include "objc_api.h"
+#ifdef TC_PLATFORM_OSX
 
 namespace taichi {
 namespace mac {
@@ -20,4 +19,4 @@ nsobj_unique_ptr<TC_NSString> wrap_string_as_ns_string(const std::string &str) {
 }  // namespace mac
 }  // namespace taichi
 
-#endif
+#endif  // TC_PLATFORM_OSX

--- a/taichi/platform/mac/objc_api.h
+++ b/taichi/platform/mac/objc_api.h
@@ -43,6 +43,9 @@ nsobj_unique_ptr<O> wrap_as_nsobj_unique_ptr(O *nsobj) {
 // Prepend "TC_" to native ObjC type names, otherwise clang-format thinks this
 // is an ObjC file and is not happy formatting it.
 struct TC_NSString;
+
+// |str| must exist during the entire lifetime of the returned object, as it
+// does not own the underlying memory. Think of it as std::string_view.
 nsobj_unique_ptr<TC_NSString> wrap_string_as_ns_string(const std::string &str);
 
 }  // namespace mac

--- a/taichi/platform/metal/metal_api.cpp
+++ b/taichi/platform/metal/metal_api.cpp
@@ -1,0 +1,125 @@
+#include "metal_api.h"
+
+#ifdef TC_SUPPORTS_METAL
+
+TLANG_NAMESPACE_BEGIN
+
+namespace metal {
+
+extern "C" {
+id MTLCreateSystemDefaultDevice();
+}
+
+namespace {
+
+using mac::call;
+using mac::cast_call;
+using mac::clscall;
+using mac::nsobj_unique_ptr;
+using mac::wrap_as_nsobj_unique_ptr;
+
+} // namespace
+
+nsobj_unique_ptr<MTLDevice> mtl_create_system_default_device() {
+  id dev = MTLCreateSystemDefaultDevice();
+  return wrap_as_nsobj_unique_ptr(reinterpret_cast<MTLDevice *>(dev));
+}
+
+nsobj_unique_ptr<MTLCommandQueue> new_command_queue(MTLDevice *dev) {
+  auto *queue = cast_call<MTLCommandQueue *>(dev, "newCommandQueue");
+  return wrap_as_nsobj_unique_ptr(queue);
+}
+
+nsobj_unique_ptr<MTLCommandBuffer> new_command_buffer(MTLCommandQueue *queue) {
+  auto *buffer = cast_call<MTLCommandBuffer *>(queue, "commandBuffer");
+  return wrap_as_nsobj_unique_ptr(buffer);
+}
+
+nsobj_unique_ptr<MTLComputeCommandEncoder>
+new_compute_command_encoder(MTLCommandBuffer *buffer) {
+  auto *encoder =
+      cast_call<MTLComputeCommandEncoder *>(buffer, "computeCommandEncoder");
+  return wrap_as_nsobj_unique_ptr(encoder);
+}
+
+nsobj_unique_ptr<MTLLibrary>
+new_library_with_source(MTLDevice *device, const std::string &source) {
+  auto source_str = mac::wrap_string_as_ns_string(source);
+
+  id options = clscall("MTLCompileOptions", "alloc");
+  options = call(options, "init");
+  auto options_cleanup = wrap_as_nsobj_unique_ptr(options);
+  call(options, "setFastMathEnabled:", false);
+
+  auto *lib = cast_call<MTLLibrary *>(
+      device, "newLibraryWithSource:options:error:", source_str.get(), options,
+      nullptr);
+
+  return wrap_as_nsobj_unique_ptr(lib);
+}
+
+nsobj_unique_ptr<MTLFunction> new_function_with_name(MTLLibrary *library,
+                                                     const std::string &name) {
+  auto name_str = mac::wrap_string_as_ns_string(name);
+  auto *func =
+      cast_call<MTLFunction *>(library, "newFunctionWithName:", name_str.get());
+  return wrap_as_nsobj_unique_ptr(func);
+}
+
+nsobj_unique_ptr<MTLComputePipelineState>
+new_compute_pipeline_state_with_function(MTLDevice *device,
+                                         MTLFunction *function) {
+  auto *pipeline_state = cast_call<MTLComputePipelineState *>(
+      device, "newComputePipelineStateWithFunction:error:", function, nullptr);
+  return wrap_as_nsobj_unique_ptr(pipeline_state);
+}
+
+nsobj_unique_ptr<MTLBuffer> new_mtl_buffer(MTLDevice *device, size_t length) {
+  constexpr int kMtlBufferResourceOptions = 0;
+  auto *buffer =
+      cast_call<MTLBuffer *>(device, "newBufferWithLength:options:", length,
+                             kMtlBufferResourceOptions);
+  return wrap_as_nsobj_unique_ptr(buffer);
+}
+
+nsobj_unique_ptr<MTLBuffer> new_mtl_buffer_no_copy(MTLDevice *device, void *ptr,
+                                                   size_t length) {
+  // MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared
+  constexpr int kMtlBufferResourceOptions = 0;
+
+  auto *buffer = cast_call<MTLBuffer *>(
+      device, "newBufferWithBytesNoCopy:length:options:deallocator:", ptr,
+      length, kMtlBufferResourceOptions, nullptr);
+  return wrap_as_nsobj_unique_ptr(buffer);
+}
+
+void dispatch_threadgroups(MTLComputeCommandEncoder *encoder, int32_t blocks_x,
+                           int32_t blocks_y, int32_t blocks_z,
+                           int32_t threads_x, int32_t threads_y,
+                           int32_t threads_z) {
+  struct MTLSize {
+    uint64_t width;
+    uint64_t height;
+    uint64_t depth;
+  };
+
+  MTLSize threadgroups_per_grid;
+  threadgroups_per_grid.width = blocks_x;
+  threadgroups_per_grid.height = blocks_y;
+  threadgroups_per_grid.depth = blocks_z;
+
+  MTLSize threads_per_threadgroup;
+  threads_per_threadgroup.width = threads_x;
+  threads_per_threadgroup.height = threads_y;
+  threads_per_threadgroup.depth = threads_z;
+
+  call(encoder,
+       "dispatchThreadgroups:threadsPerThreadgroup:", threadgroups_per_grid,
+       threads_per_threadgroup);
+}
+
+} // namespace metal
+
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_api.h
+++ b/taichi/platform/metal/metal_api.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// Reference implementation:
+// https://github.com/halide/Halide/blob/master/src/runtime/metal.cpp
+
+#include <string>
+#include <taichi/common.h>
+#include <taichi/common/util.h>
+
+#ifdef TC_SUPPORTS_METAL
+
+#include <taichi/platform/mac/objc_api.h>
+
+TLANG_NAMESPACE_BEGIN
+
+namespace metal {
+
+struct MTLDevice;
+struct MTLLibrary;
+struct MTLComputePipelineState;
+struct MTLCommandQueue;
+struct MTLCommandBuffer;
+struct MTLComputeCommandEncoder;
+struct MTLFunction;
+struct MTLComputePipelineState;
+struct MTLBuffer;
+
+using mac::nsobj_unique_ptr;
+
+nsobj_unique_ptr<MTLDevice> mtl_create_system_default_device();
+
+nsobj_unique_ptr<MTLCommandQueue> new_command_queue(MTLDevice *dev);
+
+nsobj_unique_ptr<MTLCommandBuffer> new_command_buffer(MTLCommandQueue *queue);
+
+nsobj_unique_ptr<MTLComputeCommandEncoder>
+new_compute_command_encoder(MTLCommandBuffer *buffer);
+
+nsobj_unique_ptr<MTLLibrary> new_library_with_source(MTLDevice *device,
+                                                     const std::string &source);
+
+nsobj_unique_ptr<MTLFunction> new_function_with_name(MTLLibrary *library,
+                                                     const std::string &name);
+
+nsobj_unique_ptr<MTLComputePipelineState>
+new_compute_pipeline_state_with_function(MTLDevice *device,
+                                         MTLFunction *function);
+
+inline void
+set_compute_pipeline_state(MTLComputeCommandEncoder *encoder,
+                           MTLComputePipelineState *pipeline_state) {
+  mac::call(encoder, "setComputePipelineState:", pipeline_state);
+}
+
+inline void end_encoding(MTLComputeCommandEncoder *encoder) {
+  mac::call(encoder, "endEncoding");
+}
+
+nsobj_unique_ptr<MTLBuffer> new_mtl_buffer(MTLDevice *device, size_t length);
+
+nsobj_unique_ptr<MTLBuffer> new_mtl_buffer_no_copy(MTLDevice *device, void *ptr,
+                                                   size_t length);
+
+inline void set_mtl_buffer(MTLComputeCommandEncoder *encoder, MTLBuffer *buffer,
+                           size_t offset, size_t index) {
+  mac::call(encoder, "setBuffer:offset:atIndex:", buffer, offset, index);
+}
+
+void dispatch_threadgroups(MTLComputeCommandEncoder *encoder, int32_t blocks_x,
+                           int32_t blocks_y, int32_t blocks_z,
+                           int32_t threads_x, int32_t threads_y,
+                           int32_t threads_z);
+
+// 1D
+inline void dispatch_threadgroups(MTLComputeCommandEncoder *encoder,
+                                  int32_t blocks_x, int32_t threads_x) {
+  dispatch_threadgroups(encoder, blocks_x, 1, 1, threads_x, 1, 1);
+}
+
+inline void commit_command_buffer(MTLCommandBuffer *cmd_buffer) {
+  mac::call(cmd_buffer, "commit");
+}
+
+inline void wait_until_completed(MTLCommandBuffer *cmd_buffer) {
+  mac::call(cmd_buffer, "waitUntilCompleted");
+}
+
+inline void *mtl_buffer_contents(MTLBuffer *buffer) {
+  return mac::cast_call<void *>(buffer, "contents");
+}
+
+} // namespace metal
+
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL


### PR DESCRIPTION
Issue #396 

1. I put the Metal related code under `platform/metal`, but not sure if this is the best option. We can also put it under `platform/mac/metal`, but then it seems too deeply nested..?
1. I can confirm this works because I've rebase my Metal branch onto this. You can also find a minimal example here: https://github.com/k-ye/cpp-host-metal/blob/master/main.cpp. And of course, a lot of the code are borrowed from Halide's design: https://github.com/halide/Halide/blob/master/src/runtime/metal.cpp
1. Let me know if this breaks other platforms again...