### PR TITLE
Add Metal data types

### DIFF
--- a/taichi/platform/metal/metal_data_types.cpp
+++ b/taichi/platform/metal/metal_data_types.cpp
@@ -1,0 +1,142 @@
+#include "metal_data_types.h"
+
+#ifdef TC_SUPPORTS_METAL
+
+TLANG_NAMESPACE_BEGIN
+
+MetalDataType to_metal_type(DataType dt) {
+  switch (dt) {
+#define METAL_CASE(x) \
+  case DataType::x:   \
+    return MetalDataType::x
+
+    METAL_CASE(f32);
+    METAL_CASE(f64);
+    METAL_CASE(i8);
+    METAL_CASE(i16);
+    METAL_CASE(i32);
+    METAL_CASE(i64);
+    METAL_CASE(u8);
+    METAL_CASE(u16);
+    METAL_CASE(u32);
+    METAL_CASE(u64);
+    METAL_CASE(unknown);
+#undef METAL_CASE
+
+    default:
+      TC_NOT_IMPLEMENTED;
+      break;
+  }
+  return MetalDataType::unknown;
+}
+
+std::string metal_data_type_name(MetalDataType dt) {
+  switch (dt) {
+    case MetalDataType::f32:
+      return "float";
+    case MetalDataType::f64:
+      return "double";
+    case MetalDataType::i8:
+      return "int8_t";
+    case MetalDataType::i16:
+      return "int16_t";
+    case MetalDataType::i32:
+      return "int32_t";
+    case MetalDataType::i64:
+      return "int64_t";
+    case MetalDataType::u8:
+      return "uint8_t";
+    case MetalDataType::u16:
+      return "uint16_t";
+    case MetalDataType::u32:
+      return "uint32_t";
+    case MetalDataType::u64:
+      return "uint64_t";
+    case MetalDataType::unknown:
+      return "unknown";
+    default:
+      TC_NOT_IMPLEMENTED;
+      break;
+  }
+  return "";
+}
+
+size_t metal_data_type_bytes(MetalDataType dt) {
+  switch (dt) {
+    case MetalDataType::f32:
+      return 4;
+    case MetalDataType::f64:
+      return 8;
+    case MetalDataType::i8:
+      return 1;
+    case MetalDataType::i16:
+      return 2;
+    case MetalDataType::i32:
+      return 4;
+    case MetalDataType::i64:
+      return 8;
+    case MetalDataType::u8:
+      return 1;
+    case MetalDataType::u16:
+      return 2;
+    case MetalDataType::u32:
+      return 4;
+    case MetalDataType::u64:
+      return 8;
+    default:
+      TC_NOT_IMPLEMENTED;
+      break;
+  }
+  return 0;
+}
+
+std::string metal_unary_op_type_symbol(UnaryOpType type) {
+  switch (type)
+  {
+  
+  case UnaryOpType::neg:
+    return "-";
+  case UnaryOpType::sqrt:
+    return "sqrt";
+  case UnaryOpType::floor:
+    return "floor";
+  case UnaryOpType::ceil:
+    return "ceil";
+  case UnaryOpType::abs:
+    return "abs";
+  case UnaryOpType::sgn:
+    return "sign";
+  case UnaryOpType::sin:
+    return "sin";
+  case UnaryOpType::asin:
+    return "asin";
+  case UnaryOpType::cos:
+    return "cos";
+  case UnaryOpType::acos:
+    return "acos";
+  case UnaryOpType::tan:
+    return "tan";
+  case UnaryOpType::tanh:
+    return "tanh";
+  case UnaryOpType::exp:
+    return "exp";
+  case UnaryOpType::log:
+    return "log";
+  case UnaryOpType::rsqrt:
+    return "rsqrt";
+  case UnaryOpType::bit_not:
+    return "~";
+  case UnaryOpType::logic_not:
+    return "!";
+  // case UnaryOpType::inv:
+  // case UnaryOpType::rcp:
+  // case UnaryOpType::undefined:
+  default:
+    TC_NOT_IMPLEMENTED;
+  }
+  return "";
+}
+
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_data_types.h
+++ b/taichi/platform/metal/metal_data_types.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <taichi/common/util.h>
+#include <taichi/tlang_util.h>
+#include <string>
+
+#ifdef TC_SUPPORTS_METAL
+
+TLANG_NAMESPACE_BEGIN
+
+enum class MetalDataType : int {
+  f32,
+  f64,
+  i8,
+  i16,
+  i32,
+  i64,
+  u8,
+  u16,
+  u32,
+  u64,
+  // ptr,
+  // none,  // "void"
+  unknown
+};
+
+MetalDataType to_metal_type(DataType dt);
+
+std::string metal_data_type_name(MetalDataType dt);
+
+inline std::string metal_data_type_name(DataType dt) {
+  return metal_data_type_name(to_metal_type(dt));
+}
+
+size_t metal_data_type_bytes(MetalDataType dt);
+
+std::string metal_unary_op_type_symbol(UnaryOpType type);
+
+inline std::string metal_binary_op_type_symbol(BinaryOpType type) {
+  return binary_op_type_symbol(type);
+}
+
+inline bool is_metal_binary_op_infix(BinaryOpType type) {
+  return !((type == BinaryOpType::min) || (type == BinaryOpType::max) ||
+           (type == BinaryOpType::atan2));
+}
+
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL


### PR DESCRIPTION
Issue #396 

For binary operations, I just relied on the builtin Metal operators, instead of implementing our own as `runtime.cc` did. Because of this, a lot of the binary ops need to be emitted in infix order.

TEST

* `ti test` passed
* Rebased `metal` branch onto this and verified it's working 