### PR TITLE
Add Metal SNode compiler

### DIFF
--- a/taichi/backends/struct_metal.cpp
+++ b/taichi/backends/struct_metal.cpp
@@ -1,0 +1,112 @@
+#include "struct_metal.h"
+
+#ifdef TC_SUPPORTS_METAL
+
+TLANG_NAMESPACE_BEGIN
+namespace metal {
+
+MetalStructCompiler::CompiledResult MetalStructCompiler::run(SNode &node) {
+  TC_ASSERT(node.type == SNodeType::root);
+  collect_snodes(node);
+  // The host side has run this!
+  // infer_snode_properties(node);
+
+  auto snodes_rev = snodes_;
+  std::reverse(snodes_rev.begin(), snodes_rev.end());
+
+  emit("using byte = uchar;");
+  for (auto &n : snodes_rev) {
+    generate_types(*n);
+  }
+  CompiledResult result;
+  result.source_code = std::move(src_code_);
+  result.root_size = compute_snode_size(node);
+  return result;
+}
+
+void MetalStructCompiler::collect_snodes(SNode &snode) {
+  snodes_.push_back(&snode);
+  for (int ch_id = 0; ch_id < (int)snode.ch.size(); ch_id++) {
+    auto &ch = snode.ch[ch_id];
+    collect_snodes(*ch);
+  }
+}
+
+void MetalStructCompiler::generate_types(const SNode &snode) {
+  const bool is_place = snode.is_place();
+  if (!is_place) {
+    const std::string class_name = snode.node_type_name + "_ch";
+    emit("class {} {{", class_name);
+    emit(" private:");
+    emit("  device byte* addr_;");
+    emit(" public:");
+    emit("  {}(device byte* a) : addr_(a) {{}}", class_name);
+
+    std::string stride_str;
+    for (int i = 0; i < (int)snode.ch.size(); i++) {
+      const auto &ch_node_name = snode.ch[i]->node_type_name;
+      emit("  {} get{}() {{", ch_node_name, i);
+      if (stride_str.empty()) {
+        emit("    return {{addr_}};");
+        stride_str = ch_node_name + "::stride";
+      } else {
+        emit("    return {{addr_ + ({})}};", stride_str);
+        stride_str += " + " + ch_node_name + "::stride";
+      }
+      emit("  }}");
+    }
+    if (stride_str.empty()) {
+      // Is it possible for this to have no children?
+      stride_str = "0";
+    }
+    emit("  constant static constexpr int stride = {};", stride_str);
+    emit("}};");
+  }
+  emit("");
+  const auto &node_name = snode.node_type_name;
+  if (is_place) {
+    const auto dt_name = metal_data_type_name(snode.dt);
+    emit("struct {} {{", node_name);
+    emit("  // place");
+    emit("  constant static constexpr int stride = sizeof({});", dt_name);
+    emit("  {}(device byte* v) : val((device {}*)v) {{}}", node_name, dt_name);
+    emit("  device {}* val;", dt_name);
+    emit("}};");
+  } else if (snode.type == SNodeType::dense || snode.type == SNodeType::root) {
+    emit("struct {} {{", node_name);
+    emit("  // {}", snode_type_name(snode.type));
+    const int n = (snode.type == SNodeType::dense) ? snode.n : 1;
+    emit("  constant static constexpr int n = {};", n);
+    emit("  constant static constexpr int stride = {}_ch::stride * n;",
+         node_name);
+    emit("  {}(device byte* a) : addr_(a) {{}}", node_name);
+    emit("  {}_ch children(int i) {{", node_name);
+    emit("    return {{addr_ + i * {}_ch::stride}};", node_name);
+    emit("  }}");
+    emit(" private:");
+    emit("  device byte* addr_;");
+    emit("}};");
+  } else {
+    TC_ERROR("SNodeType={} not supported on Metal",
+             snode_type_name(snode.type));
+    TC_NOT_IMPLEMENTED;
+  }
+  emit("");
+}
+
+size_t MetalStructCompiler::compute_snode_size(const SNode &sn) {
+  if (sn.is_place()) {
+    return metal_data_type_bytes(to_metal_type(sn.dt));
+  }
+  size_t ch_size = 0;
+  for (const auto &ch : sn.ch) {
+    ch_size += compute_snode_size(*ch);
+  }
+  const int n = (sn.type == SNodeType::dense) ? sn.n : 1;
+  return n * ch_size;
+}
+
+}  // namespace metal
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL

--- a/taichi/backends/struct_metal.h
+++ b/taichi/backends/struct_metal.h
@@ -1,0 +1,42 @@
+// Codegen for the hierarchical data structure
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <taichi/snode.h>
+#include <taichi/platform/metal/metal_data_types.h>
+#include <taichi/platform/metal/metal_kernel_util.h>
+#include "base.h"
+
+#ifdef TC_SUPPORTS_METAL
+
+TLANG_NAMESPACE_BEGIN
+namespace metal {
+
+class MetalStructCompiler {
+ public:
+  using CompiledResult = metal::StructCompiledResult;
+
+  CompiledResult run(SNode &node);
+
+ private:
+  void collect_snodes(SNode &snode);
+  void generate_types(const SNode &snode);
+  size_t compute_snode_size(const SNode &sn);
+
+  template <typename... Args>
+  void emit(std::string f, Args &&... args) {
+    src_code_ += fmt::format(f, std::forward<Args>(args)...) + '\n';
+  }
+
+  std::vector<SNode *> snodes_;
+  std::string src_code_;
+};
+
+}  // namespace metal
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL


### PR DESCRIPTION
Issue #396 

This one produces the Metal source code for the corresponding SNodes. I mostly followed [how `struct.cc` generated these types](https://github.com/taichi-dev/taichi/blob/master/taichi/backends/struct.cpp#L135-L199). I.e. an interleaved chain of `S0 -> S0_ch -> S1 -> S1_ch ...`.

Example:

* Taichi

```py
x = ti.var(ti.i32)
y = ti.Vector(2, dt=ti.f32)
n = 128

@ti.layout
def place():
  sn = ti.root.dense(ti.i, n)
  sn.place(x)
  sn.dense(ti.j, n).place(y)
```

* Metal

```cpp
namespace {
using byte = uchar;

struct S5 {
  // place
  constant static constexpr int stride = sizeof(float);
  S5(device byte* v) : val((device float*)v) {}
  device float* val;
};


struct S4 {
  // place
  constant static constexpr int stride = sizeof(float);
  S4(device byte* v) : val((device float*)v) {}
  device float* val;
};

class S3_ch {
 private:
  device byte* addr_;
 public:
  S3_ch(device byte* a) : addr_(a) {}
  S4 get0() {
    return {addr_};
  }
  S5 get1() {
    return {addr_ + (S4::stride)};
  }
  constant static constexpr int stride = S4::stride + S5::stride;
};

struct S3 {
  // dense
  constant static constexpr int n = 128;
  constant static constexpr int stride = S3_ch::stride * n;
  S3(device byte* a) : addr_(a) {}
  S3_ch children(int i) {
    return {addr_ + i * S3_ch::stride};
  }
 private:
  device byte* addr_;
};


struct S2 {
  // place
  constant static constexpr int stride = sizeof(int32_t);
  S2(device byte* v) : val((device int32_t*)v) {}
  device int32_t* val;
};

class S1_ch {
 private:
  device byte* addr_;
 public:
  S1_ch(device byte* a) : addr_(a) {}
  S2 get0() {
    return {addr_};
  }
  S3 get1() {
    return {addr_ + (S2::stride)};
  }
  constant static constexpr int stride = S2::stride + S3::stride;
};

struct S1 {
  // dense
  constant static constexpr int n = 128;
  constant static constexpr int stride = S1_ch::stride * n;
  S1(device byte* a) : addr_(a) {}
  S1_ch children(int i) {
    return {addr_ + i * S1_ch::stride};
  }
 private:
  device byte* addr_;
};

class S0_ch {
 private:
  device byte* addr_;
 public:
  S0_ch(device byte* a) : addr_(a) {}
  S1 get0() {
    return {addr_};
  }
  constant static constexpr int stride = S1::stride;
};

struct S0 {
  // root
  constant static constexpr int n = 1;
  constant static constexpr int stride = S0_ch::stride * n;
  S0(device byte* a) : addr_(a) {}
  S0_ch children(int i) {
    return {addr_ + i * S0_ch::stride};
  }
 private:
  device byte* addr_;
};

}  // namespace
```