### PR TITLE
Mention ffi-navigator support in Python README

### DIFF
--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -45,3 +45,4 @@ Set ``ti.cfg.print_accessor_ir = True`` to inspect the IR transformation process
 
 Set ``ti.cfg.print_kernel_llvm_ir = True`` to inspect the emitted LLVM IR for each invoked kernel.
 
+To navigate around the code base, [ffi-navigator](https://github.com/tqchen/ffi-navigator) allows you to jump from C++ extension symbols exported via taichi_core in Python code to their defintion in C++. Follow their README to set up your editor.


### PR DESCRIPTION
Hi @yuanming-hu , to easily navigate between python and cpp, I've just added support for taichi in [ffi-navigator](https://github.com/tqchen/ffi-navigator) tool in [this commit](https://github.com/tqchen/ffi-navigator/pull/32) (the large diff there comes from testing code for dummy repo, the actual implementation is only [30 lines](https://github.com/tqchen/ffi-navigator/blob/master/python/ffi_navigator/dialect/taichi.py#L7-L38)).

Their gif demos on their README (emacs one recorded by me!) should give you a good sense of what ffi-navigator can do. I happen to have a detailed knowledge of the project so I was able to add taichi support with minimum effort. 

Right now it can jump from python symbols such as
* `ti.core.global_var_expr_from_snode`
* `taichi_lang_core.expr_add`, `taichi_lang_core.create_kernel`
* `tc_core.Array2DVector4`

to their definition in cpp files where they are exported via pybind. Once you are in cpp, you can use any cpp LSP client such as ccls, clangd to navigate within cpp.
