### PR TITLE
Add Metal runtime manager skeleton code

### DIFF
--- a/taichi/platform/metal/metal_runtime.cpp
+++ b/taichi/platform/metal/metal_runtime.cpp
@@ -1,0 +1,118 @@
+#include "metal_runtime.h"
+
+#include <algorithm>
+#include <cstring>
+
+#define TI_RUNTIME_HOST
+#include <taichi/context.h>
+#undef TI_RUNTIME_HOST
+
+#ifdef TC_SUPPORTS_METAL
+
+// If TC_SUPPORTS_METAL is defined, we are definitely on macOS. Therefore we
+// don't need macro-guarding here.
+#include <sys/mman.h>
+#include <unistd.h>
+
+TLANG_NAMESPACE_BEGIN
+
+namespace metal {
+
+namespace {
+using KernelTaskType = OffloadedStmt::TaskType;
+
+}  // namespace
+
+BufferMemoryView::BufferMemoryView(size_t size, MemoryPool *mem_pool) {
+  const size_t pagesize = getpagesize();
+  // Both |ptr_| and |size_| must be aligned to page size.
+  size_ = ((size + pagesize - 1) / pagesize) * pagesize;
+  ptr_ = mem_pool->allocate(size_, pagesize);
+  TC_ASSERT(ptr_ != nullptr);
+}
+
+MetalRuntime::CompiledMtlKernel::CompiledMtlKernel(
+    const MetalKernelAttributes &md,
+    MTLDevice *device,
+    MTLFunction *func,
+    CPUProfiler *profiler)
+    : kernel_attribs_(md),
+      pipeline_state_(new_compute_pipeline_state_with_function(device, func)),
+      profiler_(profiler),
+      profiler_id_(fmt::format("{}_dispatch", kernel_attribs_.name)) {
+  TC_ASSERT(pipeline_state_ != nullptr);
+}
+
+MetalRuntime::CompiledTaichiKernel::CompiledTaichiKernel(
+    const std::string &taichi_kernel_name,
+    const std::string &source_code,
+    const std::vector<MetalKernelAttributes> &mtl_kernels_attribs,
+    size_t global_tmps_size,
+    const MetalKernelArgsAttributes &args_attribs,
+    MTLDevice *device,
+    MemoryPool *mem_pool,
+    CPUProfiler *profiler)
+    : mtl_source_code_(source_code),
+      global_tmps_mem_(global_tmps_size, mem_pool),
+      args_attribs_(args_attribs),
+      profiler_(profiler) {
+  auto kernel_lib = new_library_with_source(device, mtl_source_code_);
+  TC_ASSERT(kernel_lib != nullptr);
+  for (const auto &ka : mtl_kernels_attribs) {
+    auto kernel_func = new_function_with_name(kernel_lib.get(), ka.name);
+    TC_ASSERT(kernel_func != nullptr);
+    // Note that CompiledMtlKernel doesn't own |kernel_func|.
+    compiled_mtl_kernels_.push_back(std::make_unique<CompiledMtlKernel>(
+        ka, device, kernel_func.get(), profiler_));
+  }
+  global_tmps_buffer_ = new_mtl_buffer_no_copy(device, global_tmps_mem_.ptr(),
+                                               global_tmps_mem_.size());
+  if (args_attribs_.has_args()) {
+    args_mem_ = std::make_unique<BufferMemoryView>(args_attribs_.total_bytes(),
+                                                   mem_pool);
+    args_buffer_ =
+        new_mtl_buffer_no_copy(device, args_mem_->ptr(), args_mem_->size());
+  }
+}
+
+MetalRuntime::MetalRuntime(size_t root_size,
+                           MemoryPool *mem_pool,
+                           CPUProfiler *profiler)
+    : mem_pool_(mem_pool),
+      profiler_(profiler),
+      root_buffer_mem_(root_size, mem_pool) {
+  device_ = mtl_create_system_default_device();
+  TC_ASSERT(device_ != nullptr);
+  command_queue_ = new_command_queue(device_.get());
+  TC_ASSERT(command_queue_ != nullptr);
+  create_new_command_buffer();
+  root_buffer_ = new_mtl_buffer_no_copy(device_.get(), root_buffer_mem_.ptr(),
+                                        root_buffer_mem_.size());
+  TC_ASSERT(root_buffer_ != nullptr);
+}
+
+void MetalRuntime::register_taichi_kernel(
+    const std::string &taichi_kernel_name,
+    const std::string &mtl_kernel_source_code,
+    const std::vector<MetalKernelAttributes> &kernels_attribs,
+    size_t global_tmps_size,
+    const MetalKernelArgsAttributes &args_attribs) {
+  TC_ASSERT(compiled_taichi_kernels_.find(taichi_kernel_name) ==
+            compiled_taichi_kernels_.end());
+  TC_INFO("Registering taichi kernel \"{}\", Metal source code:\n{}",
+          taichi_kernel_name, mtl_kernel_source_code);
+  compiled_taichi_kernels_[taichi_kernel_name] =
+      std::make_unique<CompiledTaichiKernel>(
+          taichi_kernel_name, mtl_kernel_source_code, kernels_attribs,
+          global_tmps_size, args_attribs, device_.get(), mem_pool_, profiler_);
+}
+
+void MetalRuntime::create_new_command_buffer() {
+  cur_command_buffer_ = new_command_buffer(command_queue_.get());
+  TC_ASSERT(cur_command_buffer_ != nullptr);
+}
+
+}  // namespace metal
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_runtime.h
+++ b/taichi/platform/metal/metal_runtime.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "metal_api.h"
+#include "metal_kernel_util.h"
+#include <taichi/memory_pool.h>
+#include <taichi/profiler.h>
+
+#ifdef TC_SUPPORTS_METAL
+
+TLANG_NAMESPACE_BEGIN
+
+struct Context;
+
+namespace metal {
+
+// This class requests the Metal buffer memory of |size| bytes from |mem_pool|.
+// Once allocated, it does not own the memory (hence the name "view"). Instead,
+// GC is deferred to the memory pool.
+class BufferMemoryView {
+ public:
+  BufferMemoryView(size_t size, MemoryPool *mem_pool);
+
+  inline size_t size() const {
+    return size_;
+  }
+  inline void *ptr() const {
+    return ptr_;
+  }
+
+ private:
+  size_t size_;
+  void *ptr_;
+};
+
+// MetalRuntime manages everything the Metal kernels need at runtime, including
+// the compiled Metal kernels pipelines and Metal buffers memory. It is the
+// runtime interface between Taichi and Metal, and knows how to locate the
+// series of Metal kernels generated from a Taichi kernel.
+class MetalRuntime {
+ public:
+  MetalRuntime(size_t root_size, MemoryPool *mem_pool, CPUProfiler *profiler);
+
+  // Register a Taichi kernel to the Metal runtime.
+  // * |mtl_kernel_source_code| is the complete source code compiled from a
+  // Taichi kernel. It may include one or more Metal compute kernels. Each
+  // Metal kernel is identified by one item in |kernels_attribs|.
+  // * |global_tmps_size| is the total size of global temporary variables,
+  // computed during the offloading pass.
+  void register_taichi_kernel(
+      const std::string &taichi_kernel_name,
+      const std::string &mtl_kernel_source_code,
+      const std::vector<MetalKernelAttributes> &kernels_attribs,
+      size_t global_tmps_size,
+      const MetalKernelArgsAttributes &args_attribs);
+
+ private:
+  void create_new_command_buffer();
+
+  // Info for launching a compiled Metal kernel
+  class CompiledMtlKernel {
+   public:
+    CompiledMtlKernel(const MetalKernelAttributes &md,
+                      MTLDevice *device,
+                      MTLFunction *func,
+                      CPUProfiler *profiler);
+
+   private:
+    MetalKernelAttributes kernel_attribs_;
+    nsobj_unique_ptr<MTLComputePipelineState> pipeline_state_{nullptr};
+    CPUProfiler *const profiler_;
+    const std::string profiler_id_;
+  };
+
+  // Info for launching a compiled Taichi kernel, which consists of a series of
+  // compiled Metal kernels.
+  class CompiledTaichiKernel {
+   public:
+    CompiledTaichiKernel(
+        const std::string &taichi_kernel_name,
+        const std::string &source_code,
+        const std::vector<MetalKernelAttributes> &mtl_kernels_attribs,
+        size_t global_tmps_size,
+        const MetalKernelArgsAttributes &args_attribs,
+        MTLDevice *device,
+        MemoryPool *mem_pool,
+        CPUProfiler *profiler);
+
+   private:
+    std::string mtl_source_code_;
+    std::vector<std::unique_ptr<CompiledMtlKernel>> compiled_mtl_kernels_;
+    BufferMemoryView global_tmps_mem_;
+    nsobj_unique_ptr<MTLBuffer> global_tmps_buffer_;
+    MetalKernelArgsAttributes args_attribs_;
+    std::unique_ptr<BufferMemoryView> args_mem_{nullptr};
+    nsobj_unique_ptr<MTLBuffer> args_buffer_{nullptr};
+    CPUProfiler *const profiler_;
+  };
+
+  MemoryPool *const mem_pool_;
+  CPUProfiler *const profiler_;
+  BufferMemoryView root_buffer_mem_;
+  nsobj_unique_ptr<MTLDevice> device_{nullptr};
+  nsobj_unique_ptr<MTLCommandQueue> command_queue_{nullptr};
+  nsobj_unique_ptr<MTLCommandBuffer> cur_command_buffer_{nullptr};
+  nsobj_unique_ptr<MTLBuffer> root_buffer_{nullptr};
+  std::unordered_map<std::string, std::unique_ptr<CompiledTaichiKernel>>
+      compiled_taichi_kernels_;
+};
+
+}  // namespace metal
+TLANG_NAMESPACE_END
+
+#endif  // TC_SUPPORTS_METAL


### PR DESCRIPTION
Issue #396 

I left out the kernel launching part to the next PR in order to reduce the size of this one...

Metal runtime is integrated with the memory pool :)