### PR TITLE
Refactor UnifiedAllocator to take in the kernel arch

### DIFF
--- a/taichi/arch.h
+++ b/taichi/arch.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <taichi/common/util.h>
+#include <taichi/common.h>
+
+TLANG_NAMESPACE_BEGIN
+
+enum class Arch {
+#define PER_ARCH(x) x,
+#include "inc/archs.inc.h"
+#undef PER_ARCH
+};
+
+inline std::string arch_name(Arch arch) {
+  switch (arch) {
+#define PER_ARCH(x) \
+  case Arch::x:     \
+    return #x;      \
+    break;
+#include "inc/archs.inc.h"
+#undef PER_ARCH
+    default:
+      TC_NOT_IMPLEMENTED
+  }
+}
+
+TLANG_NAMESPACE_END

--- a/taichi/memory_pool.cpp
+++ b/taichi/memory_pool.cpp
@@ -34,7 +34,6 @@ void MemoryPool::set_queue(MemRequestQueue *queue) {
 
 void *MemoryPool::allocate(std::size_t size, std::size_t alignment) {
   std::lock_guard<std::mutex> _(mut_allocators);
-  bool use_cuda = prog->config.arch == Arch::cuda;
   void *ret = nullptr;
   if (!allocators.empty()) {
     ret = allocators.back()->allocate(size, alignment);
@@ -43,7 +42,7 @@ void *MemoryPool::allocate(std::size_t size, std::size_t alignment) {
     // allocation have failed
     auto new_buffer_size = std::max(size, default_allocator_size);
     allocators.emplace_back(
-        std::make_unique<UnifiedAllocator>(new_buffer_size, use_cuda));
+        std::make_unique<UnifiedAllocator>(new_buffer_size, prog->config.arch));
     ret = allocators.back()->allocate(size, alignment);
   }
   TC_ASSERT(ret);

--- a/taichi/tlang_util.h
+++ b/taichi/tlang_util.h
@@ -1,6 +1,7 @@
 // Definitions of utility functions and enums
 
 #pragma once
+#include <taichi/arch.h>
 #include <taichi/common/util.h>
 #include <taichi/io/io.h>
 #include <taichi/common.h>
@@ -12,25 +13,6 @@ template <typename T>
 using Handle = std::shared_ptr<T>;
 
 constexpr int default_simd_width_x86_64 = 8;
-
-enum class Arch {
-#define PER_ARCH(x) x,
-#include "inc/archs.inc.h"
-#undef PER_ARCH
-};
-
-inline std::string arch_name(Arch arch) {
-  switch (arch) {
-#define PER_ARCH(x) \
-  case Arch::x:     \
-    return #x;      \
-    break;
-#include "inc/archs.inc.h"
-#undef PER_ARCH
-    default:
-      TC_NOT_IMPLEMENTED
-  }
-}
 
 int default_simd_width(Arch arch);
 

--- a/taichi/unified_allocator.cpp
+++ b/taichi/unified_allocator.cpp
@@ -10,9 +10,9 @@
 
 TLANG_NAMESPACE_BEGIN
 
-UnifiedAllocator::UnifiedAllocator(std::size_t size, bool cuda)
-    : size(size), cuda(cuda) {
-  if (cuda) {
+UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch)
+    : size(size), arch_(arch) {
+  if (arch_ == Arch::cuda) {
     TC_INFO("Allocating unified (CPU+GPU) address space of size {} MB",
             size / 1024 / 1024);
 #if defined(CUDA_FOUND)
@@ -54,7 +54,7 @@ taichi::Tlang::UnifiedAllocator::~UnifiedAllocator() {
   if (!initialized()) {
     return;
   }
-  if (cuda) {
+  if (arch_ == Arch::cuda) {
 #if defined(CUDA_FOUND)
     check_cuda_errors(cudaFree(_cuda_data));
 #else

--- a/taichi/unified_allocator.h
+++ b/taichi/unified_allocator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "arch.h"
 #include "common.h"
 #include <mutex>
 #include <vector>
@@ -17,7 +18,7 @@ class UnifiedAllocator {
   void *_cuda_data;
 #endif
   std::size_t size;
-  bool cuda;
+  Arch arch_;
 
   // put these two on the unified memory so that GPU can have access
  public:
@@ -27,7 +28,7 @@ class UnifiedAllocator {
   std::mutex lock;
 
  public:
-  UnifiedAllocator(std::size_t size, bool cuda);
+  UnifiedAllocator(std::size_t size, Arch arch);
 
   ~UnifiedAllocator();
 


### PR DESCRIPTION
This change is to decouple the allocator from just `x86` or `cuda` archs. 

As part of the refactor, I also moved the Arch enum into its own file. Alternatively, we can just let `unified_allocator.h` depend on `tlang_util.h`, but I feel like it's better to decompose this into smaller modules?

