### PR TITLE
use locale_encode() for lib_dir #428

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -36,7 +36,17 @@ def import_tc_core():
   tc_core = core
   if get_os_name() != 'win':
     sys.setdlopenflags(old_flags)
-  core.set_lib_dir(os.path.join(package_root(), 'lib'))
+  lib_dir = os.path.join(package_root(), 'lib')
+  core.set_lib_dir(locale_encode(lib_dir))
+
+
+def locale_encode(s):
+  try:
+    import locale
+    encoding = locale.getdefaultlocale()[1]
+  except:
+    encoding = 'utf8'
+  return s.encode(encoding)
 
 
 def is_ci():


### PR DESCRIPTION
when a string is passed from python to C++, convert it into locale encoding, or it will fail if you try to pass it to OS API as file path.