### PR TITLE
raise error when TAICHI_REPO_DIR invalid

### DIFF
--- a/python/taichi/misc/settings.py
+++ b/python/taichi/misc/settings.py
@@ -20,8 +20,7 @@ def get_repo_directory():
   else:
     repo_dir = os.environ.get('TAICHI_REPO_DIR')
     if not os.path.exists(repo_dir):
-      print('Error: TAICHI_REPO_DIR "' + repo_dir + '" invalid. Try remove TAICHI_REPO_DIR from your environment variables (.bashrc)')
-      assert False
+      raise ValueError(f"TAICHI_REPO_DIR [{repo_dir}] does not exist.")
   return repo_dir
 
 

--- a/python/taichi/misc/settings.py
+++ b/python/taichi/misc/settings.py
@@ -16,8 +16,13 @@ def get_directory(dir):
 
 def get_repo_directory():
   if 'TAICHI_REPO_DIR' not in os.environ:
-    return os.path.join(os.environ.get('HOME'), ".taichi")
-  return os.environ.get('TAICHI_REPO_DIR')
+    repo_dir = os.path.join(os.environ.get('HOME'), ".taichi")
+  else:
+    repo_dir = os.environ.get('TAICHI_REPO_DIR')
+    if not os.path.exists(repo_dir):
+      print('Error: TAICHI_REPO_DIR "' + repo_dir + '" invalid. Try remove TAICHI_REPO_DIR from your environment variables (.bashrc)')
+      assert False
+  return repo_dir
 
 
 def get_project_directory(project=None):


### PR DESCRIPTION
Provide better message if non-developer user set TAICHI_REPO_DIR wrongly.
Might be the solution of @dodydharma's problem:
after linux restart, when running the python script with taichi, it is always failed like this:
```
Traceback (most recent call last):
File "fractal.py", line 1, in <module>
import taichi as ti
File "/usr/local/lib/python3.6/dist-packages/taichi/init.py", line 1, in <module>
from taichi.main import main
File "/usr/local/lib/python3.6/dist-packages/taichi/main.py", line 6, in <module>
from taichi.tools.video import make_video, interpolate_frames, mp4_to_gif, scale_video, crop_video, accelerate_video
File "/usr/local/lib/python3.6/dist-packages/taichi/tools/video.py", line 3, in <module>
import taichi.core as core
File "/usr/local/lib/python3.6/dist-packages/taichi/core/init.py", line 1, in <module>
from .util import tc_core, build, format, load_module, start_memory_monitoring, \
File "/usr/local/lib/python3.6/dist-packages/taichi/core/util.py", line 181, in <module>
assert os.path.exists(os.path.join(bin_dir, 'libtaichi_core.so'))
```