### PR TITLE
Add IR visiting methods for Metal codegen

### DIFF
--- a/taichi/backends/codegen_metal.h
+++ b/taichi/backends/codegen_metal.h
@@ -28,7 +28,7 @@ class MetalCodeGen {
 
  private:
   void lower();
-  FunctionType gen(MetalRuntime *runtime);
+  FunctionType gen(const SNode &root_snode, MetalRuntime *runtime);
 
   const int id_;
   const std::string taichi_kernel_name_;


### PR DESCRIPTION
Issue #396 

Most of the implementation are copied from the legacy codegen.

* Each `OffloadedStmt` causes a metal kernel to be generated.
* `LoopIndexStmt`: We launch `n = end - begin` number of threads, so the thread ID `utid_`, given by Metal, is `0 <= utid_ < n`. The loop index is therefore `utid_ + begin`.
* `BinaryOpStmt`: special handling of `floordiv`. The impl is identical to [`ifloordiv()`](https://github.com/taichi-dev/taichi/blob/afc63bd1e714cddae55b9ddb61a1ba4993d91c4c/taichi/runtime/runtime.cpp#L77)
* `AtomicOpStmt`: Metal doesn't support atomic floating point number. As a workaround, we compute the result using plain `+`, then cast that value as an integer pointer and do CAS in a loop. This appears to work OK.
* `RandStmt` is not supported yet