### PR TITLE
Plugin in Metal backend to Taichi!

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -24,6 +24,7 @@ cfg = default_cfg()
 current_cfg = current_cfg()
 x86_64 = core.x86_64
 cuda = core.cuda
+metal = core.metal
 profiler_print = lambda: core.get_current_program().profiler_print()
 profiler_clear = lambda: core.get_current_program().profiler_clear()
 

--- a/taichi/kernel.cpp
+++ b/taichi/kernel.cpp
@@ -43,9 +43,9 @@ void Kernel::compile() {
 void Kernel::operator()() {
   if (!compiled)
     compile();
-  std::vector<void *> host_buffers(args.size());
-  std::vector<void *> device_buffers(args.size());
   if (arch == Arch::cuda) {
+    std::vector<void *> host_buffers(args.size());
+    std::vector<void *> device_buffers(args.size());
 #if defined(CUDA_FOUND)
     // copy data to GRAM
     bool has_buffer = false;

--- a/taichi/program.h
+++ b/taichi/program.h
@@ -14,8 +14,15 @@
 #include <taichi/system/threading.h>
 #include <taichi/unified_allocator.h>
 #include "memory_pool.h"
+
 #if defined(TC_PLATFORM_UNIX)
 #include <dlfcn.h>
+#endif
+
+#if defined(TC_SUPPORTS_METAL)
+#include <optional>
+#include <taichi/platform/metal/metal_kernel_util.h>
+#include <taichi/platform/metal/metal_runtime.h>
 #endif
 
 TLANG_NAMESPACE_BEGIN
@@ -166,6 +173,12 @@ class Program {
   void finalize();
 
   ~Program();
+
+ private:
+#if defined(TC_SUPPORTS_METAL)
+  std::optional<metal::StructCompiledResult> metal_struct_compiled_;
+  std::unique_ptr<metal::MetalRuntime> metal_runtime_;
+#endif
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/snode.h
+++ b/taichi/snode.h
@@ -50,6 +50,7 @@ class Index {
 // "Structural" nodes
 class SNode {
  public:
+  // Children
   std::vector<Handle<SNode>> ch;
 
   IndexExtractor extractors[max_num_indices];
@@ -100,11 +101,11 @@ class SNode {
   bool _bitmasked{};
   bool has_aux_structure{};
 
-  std::string get_node_type_name() {
+  std::string get_node_type_name() const {
     return fmt::format("S{}", id);
   }
 
-  std::string get_node_type_name_hinted() {
+  std::string get_node_type_name_hinted() const {
     return fmt::format("S{}{}", id, snode_type_name(type));
   }
 

--- a/taichi/tlang_util.cpp
+++ b/taichi/tlang_util.cpp
@@ -186,6 +186,7 @@ std::string binary_op_type_symbol(BinaryOpType type) {
     REGISTER_TYPE(mod, %);
     REGISTER_TYPE(max, max);
     REGISTER_TYPE(min, min);
+    REGISTER_TYPE(atan2, atan2);
     REGISTER_TYPE(cmp_lt, <);
     REGISTER_TYPE(cmp_le, <=);
     REGISTER_TYPE(cmp_gt, >);


### PR DESCRIPTION
Issue #396 

A few cleanups:

* As you've suggested in #448 , let me move `fatomic_add` (probably `ifloordiv()` as well) to a separate function.
* I think the codegen part doesn't have to be guarded by `TC_SUPPORTS_METAL`, only the runtime parts does. This isn't that important, though.

One question: I started to use `std::optional`, which is only available in C++17. Is Metal always compiled with C++17?

Also, I'd like to port all those tests that only use `dense` to Metal before we announce `ti.metal` is available. WDYT?