### PR TITLE
Add ti.require() and ti.archs_excluding() decorators

### DIFF
--- a/taichi/extension.cpp
+++ b/taichi/extension.cpp
@@ -1,0 +1,19 @@
+#include "extension.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+TLANG_NAMESPACE_BEGIN
+
+bool is_supported(Arch arch, Extension ext) {
+  static std::unordered_map<Arch, std::unordered_set<Extension>> arch2ext = {
+      {Arch::x86_64, {Extension::sparse, Extension::data64}},
+      {Arch::arm, {Extension::sparse, Extension::data64}},
+      {Arch::cuda, {Extension::sparse, Extension::data64}},
+      {Arch::metal, {/*What a shame...*/}},
+  };
+  const auto &exts = arch2ext[arch];
+  return exts.find(ext) != exts.end();
+}
+
+TLANG_NAMESPACE_END

--- a/taichi/extension.h
+++ b/taichi/extension.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <taichi/common.h>
+#include <taichi/arch.h>
+
+TLANG_NAMESPACE_BEGIN
+
+// The Taichi core feature set (dense SNode) should probably be supported by all
+// the backends. In addition, each backend can optionally support features in
+// the extension set.
+//
+// The notion of core vs. extension feature set is defined mainly because the
+// Metal backend can only support the dense SNodes. We may need to define this
+// notion more precisely in the future.
+
+enum class Extension {
+#define PER_EXTENSION(x) x,
+#include "inc/extensions.inc.h"
+#undef PER_EXTENSION
+};
+
+bool is_supported(Arch arch, Extension ext);
+
+TLANG_NAMESPACE_END

--- a/taichi/inc/extensions.inc.h
+++ b/taichi/inc/extensions.inc.h
@@ -1,0 +1,3 @@
+// Lists of extension features
+PER_EXTENSION(sparse)
+PER_EXTENSION(data64)  // Metal doesn't support 64-bit data buffers yet...

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -3,6 +3,7 @@
     The use of this software is governed by the LICENSE file.
 *******************************************************************************/
 
+#include <taichi/common/util.h>
 #include <taichi/common/task.h>
 #include <taichi/math/math.h>
 #include <taichi/python/exception.h>
@@ -77,6 +78,14 @@ void stop_duplicating_stdout_to_file(const std::string &fn) {
 
 bool with_cuda() {
 #if defined(TLANG_WITH_CUDA)
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool with_metal() {
+#if defined(TC_SUPPORTS_METAL)
   return true;
 #else
   return false;
@@ -158,6 +167,7 @@ void export_misc(py::module &m) {
     printf("test was successful.\n");
   });
   m.def("with_cuda", with_cuda);
+  m.def("with_metal", with_metal);
 }
 
 TC_NAMESPACE_END

--- a/taichi/python_bindings.cpp
+++ b/taichi/python_bindings.cpp
@@ -3,6 +3,7 @@
 #include "tlang.h"
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
+#include <taichi/extension.h>
 #include <taichi/common/interface.h>
 #include <taichi/python/export.h>
 #include "svd.h"
@@ -50,6 +51,12 @@ void export_lang(py::module &m) {
 #define PER_SNODE(x) .value(#x, SNodeType::x)
 #include "inc/snodes.inc.h"
 #undef PER_SNODE
+      .export_values();
+
+  py::enum_<Extension>(m, "Extension", py::arithmetic())
+#define PER_EXTENSION(x) .value(#x, Extension::x)
+#include "inc/extensions.inc.h"
+#undef PER_EXTENSION
       .export_values();
 
   py::class_<CompileConfig>(m, "CompileConfig")
@@ -436,6 +443,7 @@ void export_lang(py::module &m) {
   m.def("global_var_expr_from_snode", [](SNode *snode) {
     return Expr::make<GlobalVariableExpression>(snode);
   });
+  m.def("is_supported", is_supported);
 }
 
 TC_NAMESPACE_END


### PR DESCRIPTION
Also added the (informal) concept of Extension to define which set of features
an Arch can support.

For now, `extension` has two enums: `sparse` and `data64`. The later one is because Metal kernel doesn't support 64-bit buffers...