### PR TITLE
Fix bugs found when porting tests to Metal

### DIFF
--- a/taichi/platform/metal/metal_runtime.h
+++ b/taichi/platform/metal/metal_runtime.h
@@ -6,6 +6,7 @@
 
 #include "metal_api.h"
 #include "metal_kernel_util.h"
+#include <taichi/tlang_util.h>
 #include <taichi/memory_pool.h>
 #include <taichi/profiler.h>
 
@@ -42,7 +43,7 @@ class BufferMemoryView {
 // series of Metal kernels generated from a Taichi kernel.
 class MetalRuntime {
  public:
-  MetalRuntime(size_t root_size, MemoryPool *mem_pool, ProfilerBase *profiler);
+  MetalRuntime(size_t root_size, CompileConfig* config, MemoryPool *mem_pool, ProfilerBase *profiler);
 
   // Register a Taichi kernel to the Metal runtime.
   // * |mtl_kernel_source_code| is the complete source code compiled from a
@@ -124,6 +125,7 @@ class MetalRuntime {
     ProfilerBase *const profiler_;
   };
 
+  CompileConfig* const config_;
   MemoryPool *const mem_pool_;
   ProfilerBase *const profiler_;
   BufferMemoryView root_buffer_mem_;

--- a/taichi/program.cpp
+++ b/taichi/program.cpp
@@ -106,10 +106,10 @@ void Program::materialize_layout() {
     metal_struct_compiled_ = scomp.run(*snode_root);
     if (metal_runtime_ == nullptr) {
       metal_runtime_ = std::make_unique<metal::MetalRuntime>(
-          metal_struct_compiled_->root_size, memory_pool.get(),
+          metal_struct_compiled_->root_size, &config, memory_pool.get(),
           profiler_llvm.get());
     }
-    TC_DEBUG("Metal root buffer size={}", metal_struct_compiled_->root_size);
+    TC_INFO("Metal root buffer size: {} B", metal_struct_compiled_->root_size);
 #else
     TC_ERROR("Metal not supported on the current OS");
 #endif  // TC_SUPPORTS_METAL


### PR DESCRIPTION
Issue #396 

* `union_cast` was not handled previously (found by `test_svd.py`)
* Flip the order of threadsPerGroup and threadgroups (found by `test_listgen.py`). Can't believe it actually worked before!
* Make sure all the buffers have a non-empty size, or some buffers may not get initialized (found by `test_empty.py`)