### PR TITLE
Port all the existing tests to Metal

### DIFF
--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -302,7 +302,7 @@ class Kernel:
                 callbacks.append(get_call_back(v, host_v))
             else:
               # External tensor on cpu
-              if taichi_arch != taichi_lang_core.Arch.x86_64:
+              if taichi_arch == taichi_lang_core.Arch.cuda:
                 gpu_v = v.cuda()
                 tmp = gpu_v
                 callbacks.append(get_call_back(v, gpu_v))

--- a/tests/python/test_arg_load.py
+++ b/tests/python/test_arg_load.py
@@ -18,6 +18,29 @@ def test_arg_load():
   def set_f32(v: ti.f32):
     y[None] = v
 
+  set_i32(123)
+  assert x[None] == 123
+
+  set_i32(456)
+  assert x[None] == 456
+
+  set_f32(0.125)
+  assert y[None] == 0.125
+
+  set_f32(1.5)
+  assert y[None] == 1.5
+
+
+@ti.require(ti.extension.data64)
+@ti.all_archs
+def test_arg_load_f64():
+  x = ti.var(ti.i32)
+  y = ti.var(ti.f32)
+
+  @ti.layout
+  def layout():
+    ti.root.place(x, y)
+
   @ti.kernel
   def set_f64(v: ti.f64):
     y[None] = ti.cast(v, ti.f32)
@@ -26,20 +49,8 @@ def test_arg_load():
   def set_i64(v: ti.i64):
     y[None] = v
 
-  set_i32(123)
-  assert x[None] == 123
-
-  set_i32(456)
-  assert x[None] == 456
-
   set_i64(789)
   assert y[None] == 789
-
-  set_f32(0.125)
-  assert y[None] == 0.125
-
-  set_f32(1.5)
-  assert y[None] == 1.5
 
   set_f64(2.5)
   assert y[None] == 2.5

--- a/tests/python/test_cast.py
+++ b/tests/python/test_cast.py
@@ -1,7 +1,20 @@
 import taichi as ti
 
 @ti.all_archs
-def test_cast():
+def test_cast_f32():
+  z = ti.var(ti.i32, shape=())
+  
+  @ti.kernel
+  def func():
+    z[None] = ti.cast(1e9, ti.f32) / ti.cast(1e6, ti.f32) + 1e-3
+  
+  func()
+  assert z[None] == 1000
+
+
+@ti.require(ti.extension.data64)
+@ti.all_archs
+def test_cast_f64():
   z = ti.var(ti.i32, shape=())
   
   @ti.kernel

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -1,6 +1,7 @@
 import taichi as ti
 
-@ti.all_archs
+
+@ti.archs_support_sparse
 def test_dynamic():
   x = ti.var(ti.f32)
   n = 128
@@ -20,7 +21,7 @@ def test_dynamic():
     assert x[i] == i
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_dynamic2():
   x = ti.var(ti.f32)
   n = 128
@@ -40,7 +41,7 @@ def test_dynamic2():
     assert x[i] == i
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_dynamic_matrix():
   x = ti.Matrix(2, 1, dt=ti.i32)
   n = 8192
@@ -65,7 +66,7 @@ def test_dynamic_matrix():
       assert b == 0
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_append():
   x = ti.var(ti.i32)
   n = 128
@@ -87,8 +88,9 @@ def test_append():
   elements.sort()
   for i in range(n):
     assert elements[i] == i
-    
-@ti.all_archs
+
+
+@ti.archs_support_sparse
 def test_length():
   x = ti.var(ti.i32)
   y = ti.var(ti.f32, shape=())
@@ -112,8 +114,9 @@ def test_length():
   get_len()
   
   assert y[None] == n
-  
-@ti.all_archs
+
+
+@ti.archs_support_sparse
 def test_append_ret_value():
   x = ti.var(ti.i32)
   y = ti.var(ti.i32)
@@ -139,7 +142,8 @@ def test_append_ret_value():
     assert x[i] + 1 == y[i]
     assert x[i] + 3 == z[i]
 
-@ti.all_archs
+
+@ti.archs_support_sparse
 def test_dense_dynamic():
   n = 128
   x = ti.var(ti.i32)
@@ -163,8 +167,9 @@ def test_dense_dynamic():
   
   for i in range(n):
     assert l[i] == n
-  
-@ti.all_archs
+
+
+@ti.archs_support_sparse
 def test_dense_dynamic_len():
   n = 128
   x = ti.var(ti.i32)

--- a/tests/python/test_internal_func.py
+++ b/tests/python/test_internal_func.py
@@ -2,7 +2,12 @@ import taichi as ti
 import time
 
 # TODO: these are not really tests...
-@ti.all_archs
+def all_archs_for_this(test):
+  # ti.call_internal() is not supported on Metal yet
+  return ti.archs_excluding(ti.metal)(test)
+
+
+@all_archs_for_this
 def test_basic():
   @ti.kernel
   def test():
@@ -12,7 +17,7 @@ def test_basic():
   test()
 
 
-@ti.all_archs
+@all_archs_for_this
 def test_host_polling():
   return
   @ti.kernel
@@ -24,7 +29,7 @@ def test_host_polling():
     test()
     time.sleep(0.1)
     
-@ti.all_archs
+@all_archs_for_this
 def test_list_manager():
   @ti.kernel
   def test():
@@ -34,7 +39,7 @@ def test_list_manager():
   test()
 
 
-@ti.all_archs
+@all_archs_for_this
 def test_node_manager():
   @ti.kernel
   def test():

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -27,7 +27,6 @@ def test_transpose():
       assert m(j, i)[None] == approx(i * 2 + j * 7)
 
 
-@ti.all_archs
 def _test_polar_decomp(dim, dt):
   m = ti.Matrix(dim, dim, dt)
   r = ti.Matrix(dim, dim, dt)
@@ -68,10 +67,13 @@ def _test_polar_decomp(dim, dt):
       
  
 def test_polar_decomp():
-  _test_polar_decomp(2, ti.f32)
-  _test_polar_decomp(2, ti.f64)
-  _test_polar_decomp(3, ti.f32)
-  _test_polar_decomp(3, ti.f64)
+  for dim in [2, 3]:
+    for dt in [ti.f32, ti.f64]:
+      @ti.all_archs_with(default_fp=dt)
+      def wrapped():
+        _test_polar_decomp(dim, dt)
+
+      wrapped()
 
 
 @ti.all_archs

--- a/tests/python/test_listgen.py
+++ b/tests/python/test_listgen.py
@@ -1,4 +1,5 @@
 import taichi as ti
+from random import randrange
 
 
 @ti.all_archs
@@ -16,9 +17,43 @@ def test_listgen():
       x[i, j] = i * 10 + j + c
       
   for c in range(2):
+    print('Testing c=%d' % c)
     fill(c)
-    
+    # read it out once to avoid launching too many operator[] kernels
+    xnp = x.to_numpy()
     for i in range(n):
       for j in range(n):
-        assert x[i, j] == i * 10 + j + c
+        assert xnp[i, j] == i * 10 + j + c
+
+    # Randomly check 1000 items to ensure [] work as well
+    for _ in range(1000):
+      i, j = randrange(n), randrange(n)
+      assert x[i, j] == i * 10 + j + c
+
+
+@ti.all_archs
+def test_nested_3d():
+  x = ti.var(ti.i32)
+  n = 128
+  
+  @ti.layout
+  def layout():
+    ti.root.dense(ti.ijk, 4).dense(ti.ijk, 4).dense(ti.ijk, 4).dense(ti.ijk, 2).place(x)
+    
+  @ti.kernel
+  def fill():
+    for i, j, k in x:
+      x[i, j, k] = (i * n + j) * n + k
       
+  fill()
+  # read it out once to avoid launching too many operator[] kernels
+  xnp = x.to_numpy()
+  for i in range(n):
+    for j in range(n):
+      for k in range(n):
+        assert xnp[i, j, k] == (i * n + j) * n + k
+
+  # Randomly check 1000 items to ensure [] work as well
+  for _ in range(1000):
+    i, j, k = randrange(n), randrange(n), randrange(n)
+    assert x[i, j, k] == (i * n + j) * n + k

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -32,6 +32,7 @@ def test_numpy_f32():
   with_data_type(np.float32)
 
 
+@ti.require(ti.extension.data64)
 @ti.all_archs
 def test_numpy_f64():
   with_data_type(np.float64)
@@ -42,6 +43,7 @@ def test_numpy_i32():
   with_data_type(np.int32)
 
 
+@ti.require(ti.extension.data64)
 @ti.all_archs
 def test_numpy_i64():
   with_data_type(np.int64)

--- a/tests/python/test_numpy_io.py
+++ b/tests/python/test_numpy_io.py
@@ -73,6 +73,7 @@ def test_to_numpy_2d():
       assert val[i, j] == i + j * 3
 
 
+@ti.require(ti.extension.data64)
 @ti.all_archs
 def test_f64():
   val = ti.var(ti.f64)
@@ -101,7 +102,7 @@ def test_matrix():
   m = 7
   val = ti.Matrix(2, 3, ti.f32, shape=(n, m))
 
-  nparr = np.empty(shape=(n, m, 2, 3))
+  nparr = np.empty(shape=(n, m, 2, 3), dtype=np.float32)
   for i in range(n):
     for j in range(m):
       for k in range(2):

--- a/tests/python/test_parallel_range_for.py
+++ b/tests/python/test_parallel_range_for.py
@@ -14,6 +14,7 @@ def test_parallel_range_for():
       val[i] = i
 
   fill()
-
+  # To speed up
+  val_np = val.to_numpy()
   for i in range(n):
-    assert val[i] == i
+    assert val_np[i] == i

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -2,7 +2,8 @@ import taichi as ti
 
 # Not really testable..
 # Just making sure it does not crash
-@ti.all_archs
+# Metal doesn't support ti.print() or 64-bit data
+@ti.archs_excluding(ti.metal)
 def print_dt(dt):
   @ti.kernel
   def func():

--- a/tests/python/test_random.py
+++ b/tests/python/test_random.py
@@ -2,7 +2,11 @@ import taichi as ti
 from pytest import approx
 
 
-@ti.all_archs
+def archs_support_random(func):
+  return ti.archs_excluding(ti.metal)(func)
+
+
+@archs_support_random
 def test_random_float():
   for precision in [ti.f32, ti.f64]:
     ti.init()
@@ -20,7 +24,7 @@ def test_random_float():
     for i in range(4):
       assert (X**i).mean() == approx(1 / (i + 1), rel=1e-2)
 
-@ti.all_archs
+@archs_support_random
 def test_random_int():
   for precision in [ti.i32, ti.i64]:
     ti.init()

--- a/tests/python/test_sparse_basics.py
+++ b/tests/python/test_sparse_basics.py
@@ -1,7 +1,7 @@
 import taichi as ti
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_bitmasked():
   x = ti.var(ti.f32)
   s = ti.var(ti.i32)
@@ -27,7 +27,7 @@ def test_bitmasked():
   assert s[None] == 256
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_pointer():
   x = ti.var(ti.f32)
   s = ti.var(ti.i32)
@@ -51,7 +51,7 @@ def test_pointer():
   func()
   assert s[None] == 256
   
-@ti.all_archs
+@ti.archs_support_sparse
 def test_pointer_is_active():
   x = ti.var(ti.f32)
   s = ti.var(ti.i32)
@@ -74,7 +74,7 @@ def test_pointer_is_active():
   assert s[None] == 256
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_pointer2():
   x = ti.var(ti.f32)
   s = ti.var(ti.i32)

--- a/tests/python/test_sparse_deactivate.py
+++ b/tests/python/test_sparse_deactivate.py
@@ -1,6 +1,7 @@
 import taichi as ti
 
-@ti.all_archs
+
+@ti.archs_support_sparse
 def test_pointer():
   x = ti.var(ti.f32)
   s = ti.var(ti.i32)
@@ -34,7 +35,7 @@ def test_pointer():
   func()
   assert s[None] == 16
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_pointer2():
   x = ti.var(ti.f32)
 
@@ -72,7 +73,7 @@ def test_pointer2():
     else:
       assert x[i] == 10.0
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_pointer3():
   x = ti.var(ti.f32)
   x_temp = ti.var(ti.f32)
@@ -137,7 +138,7 @@ def test_pointer3():
 
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_dynamic():
   x = ti.var(ti.i32)
   s = ti.var(ti.i32)

--- a/tests/python/test_sparse_parallel.py
+++ b/tests/python/test_sparse_parallel.py
@@ -1,7 +1,7 @@
 import taichi as ti
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_pointer():
   x = ti.var(ti.f32)
   s = ti.var(ti.i32)
@@ -28,7 +28,7 @@ def test_pointer():
   assert s[None] == n * n
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_pointer2():
   x = ti.var(ti.f32)
   s = ti.var(ti.i32)
@@ -55,7 +55,7 @@ def test_pointer2():
   N = n * n
   assert s[None] == N * (N - 1) / 2
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_nested_struct_fill_and_clear():
   a = ti.var(dt=ti.f32)
   N = 512

--- a/tests/python/test_struct_for_dynamic.py
+++ b/tests/python/test_struct_for_dynamic.py
@@ -1,6 +1,6 @@
 import taichi as ti
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_dynamic():
   x = ti.var(ti.i32)
   y = ti.var(ti.i32, shape=())
@@ -23,7 +23,7 @@ def test_dynamic():
   assert y[None] == n // 3 + 1
 
 
-@ti.all_archs
+@ti.archs_support_sparse
 def test_dense_dynamic():
   n = 128
   

--- a/tests/python/test_unary_ops.py
+++ b/tests/python/test_unary_ops.py
@@ -1,11 +1,11 @@
 import taichi as ti
 import numpy as np
 
-@ti.all_archs
+
 def _test_op(dt, taichi_op, np_op):
+  print('arch={} default_fp={}'.format(ti.cfg.arch, ti.cfg.default_fp))
   n = 4
   val = ti.var(dt, shape=n)
-  ti.get_runtime().default_fp = dt
 
   def f(i):
     return i * 0.1 + 0.4
@@ -26,12 +26,20 @@ def _test_op(dt, taichi_op, np_op):
 
 
 def test_f64_trig():
+  op_pairs = [
+    (ti.sin, np.sin),
+    (ti.cos, np.cos),
+    (ti.asin, np.arcsin),
+    (ti.acos, np.arccos),
+    (ti.tan, np.tan),
+    (ti.tanh, np.tanh),
+    (ti.exp, np.exp),
+    (ti.log, np.log),
+  ]
   for dt in [ti.f32, ti.f64]:
-    _test_op(dt, ti.sin, np.sin)
-    _test_op(dt, ti.cos, np.cos)
-    _test_op(dt, ti.asin, np.arcsin)
-    _test_op(dt, ti.acos, np.arccos)
-    _test_op(dt, ti.tan, np.tan)
-    _test_op(dt, ti.tanh, np.tanh)
-    _test_op(dt, ti.exp, np.exp)
-    _test_op(dt, ti.log, np.log)
+    for taichi_op, np_op in op_pairs:
+      @ti.all_archs_with(default_fp=dt)
+      def wrapped():
+        _test_op(dt, taichi_op, np_op)
+      wrapped()
+


### PR DESCRIPTION
A few fixes

* Fixed kernel.py to set PyTorch tensor device to cuda only if arch == ti.cuda
* Fixed ti.all_archs_with to get fp/ip from |kwargs|
* Rename some variables in the decorators so that it is obvious which function should be the test

IMO, the `ti.all_archs_with()` is getting a bit complicated to set up now, especially if I passed in something that's a reference  (e.g. `arch=ti.cfg.arch`. It seems that `ti.cfg.arch` is a reference value, so `arch` could actually change after `ti.reset()`). I think it's better for taichi's `default_config()` to be an immutable config, and use `current_config()` as the one to be the mutable config. Also, to eliminate the by-reference problem,  the C++ side can provide `cfg`'s members' getter/setters, where getters return a copy of the value, as least for simple types?