### PR TITLE
Major Metal compiler/runtime refactors

### DIFF
--- a/taichi/backends/codegen_metal.cpp
+++ b/taichi/backends/codegen_metal.cpp
@@ -2,8 +2,6 @@
 
 #include <taichi/ir.h>
 
-#ifdef TC_SUPPORTS_METAL
-
 TLANG_NAMESPACE_BEGIN
 namespace metal {
 namespace {
@@ -21,9 +19,7 @@ class MetalKernelCodegen : public IRVisitor {
     // allow_undefined_visitor = true;
   }
 
-  const std::string &kernel_source_code() const {
-    return kernel_src_code_;
-  }
+  const std::string &kernel_source_code() const { return kernel_src_code_; }
 
   const std::vector<MetalKernelAttributes> &kernels_attribs() const {
     return mtl_kernels_attribs_;
@@ -557,9 +553,7 @@ class MetalKernelCodegen : public IRVisitor {
     }
   }
 
-  void push_indent() {
-    indent_ += "  ";
-  }
+  void push_indent() { indent_ += "  "; }
 
   void pop_indent() {
     indent_.pop_back();
@@ -591,11 +585,9 @@ MetalCodeGen::MetalCodeGen(const std::string &kernel_name,
                            const StructCompiledResult *struct_compiled)
     : id_(CodeGenBase::get_kernel_id()),
       taichi_kernel_name_(fmt::format("mtl_k{:04d}_{}", id_, kernel_name)),
-      struct_compiled_(struct_compiled) {
-}
+      struct_compiled_(struct_compiled) {}
 
-FunctionType MetalCodeGen::compile(Program &,
-                                   Kernel &kernel,
+FunctionType MetalCodeGen::compile(Program &, Kernel &kernel,
                                    MetalRuntime *runtime) {
   this->prog_ = &kernel.program;
   this->kernel_ = &kernel;
@@ -739,5 +731,3 @@ FunctionType MetalCodeGen::gen(const SNode &root_snode, MetalRuntime *runtime) {
 
 }  // namespace metal
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/backends/codegen_metal.h
+++ b/taichi/backends/codegen_metal.h
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
 #include <taichi/common.h>
 #include <taichi/constants.h>
 #include <taichi/platform/metal/metal_data_types.h>
 #include <taichi/platform/metal/metal_kernel_util.h>
 #include <taichi/platform/metal/metal_runtime.h>
 #include <taichi/tlang_util.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 #include "base.h"
 #include "kernel.h"
-
-#ifdef TC_SUPPORTS_METAL
 
 TLANG_NAMESPACE_BEGIN
 namespace metal {
@@ -42,5 +41,3 @@ class MetalCodeGen {
 }  // namespace metal
 
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/backends/struct_metal.cpp
+++ b/taichi/backends/struct_metal.cpp
@@ -1,7 +1,5 @@
 #include "struct_metal.h"
 
-#ifdef TC_SUPPORTS_METAL
-
 TLANG_NAMESPACE_BEGIN
 namespace metal {
 
@@ -108,5 +106,3 @@ size_t MetalStructCompiler::compute_snode_size(const SNode &sn) {
 
 }  // namespace metal
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/backends/struct_metal.h
+++ b/taichi/backends/struct_metal.h
@@ -1,17 +1,16 @@
 // Codegen for the hierarchical data structure
 #pragma once
 
+#include <taichi/platform/metal/metal_data_types.h>
+#include <taichi/platform/metal/metal_kernel_util.h>
+#include <taichi/snode.h>
+
 #include <algorithm>
 #include <functional>
 #include <string>
 #include <vector>
 
-#include <taichi/snode.h>
-#include <taichi/platform/metal/metal_data_types.h>
-#include <taichi/platform/metal/metal_kernel_util.h>
 #include "base.h"
-
-#ifdef TC_SUPPORTS_METAL
 
 TLANG_NAMESPACE_BEGIN
 namespace metal {
@@ -38,5 +37,3 @@ class MetalStructCompiler {
 
 }  // namespace metal
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/common/util.h
+++ b/taichi/common/util.h
@@ -49,9 +49,6 @@ static_assert(false, "32-bit Windows systems are not supported")
 // OSX
 #if defined(__APPLE__)
 #define TC_PLATFORM_OSX
-// This is wrong, we cannot detect the Metal availability just at compilation
-// time. Deprecate it.
-#define TC_SUPPORTS_METAL
 #endif
 
 #if (defined(TC_PLATFORM_LINUX) || defined(TC_PLATFORM_OSX))

--- a/taichi/platform/mac/objc_api.cpp
+++ b/taichi/platform/mac/objc_api.cpp
@@ -1,8 +1,6 @@
-#include <taichi/common/util.h>
+#include "objc_api.h"
 
 #ifdef TC_PLATFORM_OSX
-
-#include "objc_api.h"
 
 namespace taichi {
 namespace mac {

--- a/taichi/platform/metal/metal_api.cpp
+++ b/taichi/platform/metal/metal_api.cpp
@@ -4,7 +4,7 @@ TLANG_NAMESPACE_BEGIN
 
 namespace metal {
 
-#ifdef TC_SUPPORTS_METAL
+#ifdef TC_PLATFORM_OSX
 
 extern "C" {
 id MTLCreateSystemDefaultDevice();
@@ -18,7 +18,7 @@ using mac::clscall;
 using mac::nsobj_unique_ptr;
 using mac::wrap_as_nsobj_unique_ptr;
 
-} // namespace
+}  // namespace
 
 nsobj_unique_ptr<MTLDevice> mtl_create_system_default_device() {
   id dev = MTLCreateSystemDefaultDevice();
@@ -35,15 +35,15 @@ nsobj_unique_ptr<MTLCommandBuffer> new_command_buffer(MTLCommandQueue *queue) {
   return wrap_as_nsobj_unique_ptr(buffer);
 }
 
-nsobj_unique_ptr<MTLComputeCommandEncoder>
-new_compute_command_encoder(MTLCommandBuffer *buffer) {
+nsobj_unique_ptr<MTLComputeCommandEncoder> new_compute_command_encoder(
+    MTLCommandBuffer *buffer) {
   auto *encoder =
       cast_call<MTLComputeCommandEncoder *>(buffer, "computeCommandEncoder");
   return wrap_as_nsobj_unique_ptr(encoder);
 }
 
-nsobj_unique_ptr<MTLLibrary>
-new_library_with_source(MTLDevice *device, const std::string &source) {
+nsobj_unique_ptr<MTLLibrary> new_library_with_source(
+    MTLDevice *device, const std::string &source) {
   auto source_str = mac::wrap_string_as_ns_string(source);
 
   id options = clscall("MTLCompileOptions", "alloc");
@@ -118,7 +118,7 @@ void dispatch_threadgroups(MTLComputeCommandEncoder *encoder, int32_t blocks_x,
        threads_per_threadgroup);
 }
 
-#endif  // TC_SUPPORTS_METAL
+#endif  // TC_PLATFORM_OSX
 
 bool is_metal_api_available() {
 #ifdef TC_PLATFORM_OSX
@@ -131,6 +131,6 @@ bool is_metal_api_available() {
 #endif
 }
 
-} // namespace metal
+}  // namespace metal
 
 TLANG_NAMESPACE_END

--- a/taichi/platform/metal/metal_api.cpp
+++ b/taichi/platform/metal/metal_api.cpp
@@ -118,6 +118,12 @@ void dispatch_threadgroups(MTLComputeCommandEncoder *encoder, int32_t blocks_x,
        threads_per_threadgroup);
 }
 
+size_t get_max_total_threads_per_threadgroup(
+    MTLComputePipelineState *pipeline_state) {
+  // The value of the pointer returned by call is the actual result
+  return (size_t)call(pipeline_state, "maxTotalThreadsPerThreadgroup");
+}
+
 #endif  // TC_PLATFORM_OSX
 
 bool is_metal_api_available() {

--- a/taichi/platform/metal/metal_api.h
+++ b/taichi/platform/metal/metal_api.h
@@ -3,16 +3,18 @@
 // Reference implementation:
 // https://github.com/halide/Halide/blob/master/src/runtime/metal.cpp
 
-#include <string>
 #include <taichi/common.h>
 #include <taichi/common/util.h>
-
 #include <taichi/platform/mac/objc_api.h>
+
+#include <string>
 
 TLANG_NAMESPACE_BEGIN
 
 namespace metal {
 
+// Expose these incomplete structs so that other modules (e.g. MetalRuntime)
+// don't have to be compiled conditionally.
 struct MTLDevice;
 struct MTLLibrary;
 struct MTLComputePipelineState;
@@ -23,7 +25,7 @@ struct MTLFunction;
 struct MTLComputePipelineState;
 struct MTLBuffer;
 
-#ifdef TC_SUPPORTS_METAL
+#ifdef TC_PLATFORM_OSX
 
 using mac::nsobj_unique_ptr;
 
@@ -33,8 +35,8 @@ nsobj_unique_ptr<MTLCommandQueue> new_command_queue(MTLDevice *dev);
 
 nsobj_unique_ptr<MTLCommandBuffer> new_command_buffer(MTLCommandQueue *queue);
 
-nsobj_unique_ptr<MTLComputeCommandEncoder>
-new_compute_command_encoder(MTLCommandBuffer *buffer);
+nsobj_unique_ptr<MTLComputeCommandEncoder> new_compute_command_encoder(
+    MTLCommandBuffer *buffer);
 
 nsobj_unique_ptr<MTLLibrary> new_library_with_source(MTLDevice *device,
                                                      const std::string &source);
@@ -46,9 +48,9 @@ nsobj_unique_ptr<MTLComputePipelineState>
 new_compute_pipeline_state_with_function(MTLDevice *device,
                                          MTLFunction *function);
 
-inline void
-set_compute_pipeline_state(MTLComputeCommandEncoder *encoder,
-                           MTLComputePipelineState *pipeline_state) {
+inline void set_compute_pipeline_state(
+    MTLComputeCommandEncoder *encoder,
+    MTLComputePipelineState *pipeline_state) {
   mac::call(encoder, "setComputePipelineState:", pipeline_state);
 }
 
@@ -89,10 +91,10 @@ inline void *mtl_buffer_contents(MTLBuffer *buffer) {
   return mac::cast_call<void *>(buffer, "contents");
 }
 
-#endif  // TC_SUPPORTS_METAL
+#endif  // TC_PLATFORM_OSX
 
 bool is_metal_api_available();
 
-} // namespace metal
+}  // namespace metal
 
 TLANG_NAMESPACE_END

--- a/taichi/platform/metal/metal_api.h
+++ b/taichi/platform/metal/metal_api.h
@@ -91,6 +91,8 @@ inline void *mtl_buffer_contents(MTLBuffer *buffer) {
   return mac::cast_call<void *>(buffer, "contents");
 }
 
+size_t get_max_total_threads_per_threadgroup(
+    MTLComputePipelineState *pipeline_state);
 #endif  // TC_PLATFORM_OSX
 
 bool is_metal_api_available();

--- a/taichi/platform/metal/metal_data_types.cpp
+++ b/taichi/platform/metal/metal_data_types.cpp
@@ -1,7 +1,5 @@
 #include "metal_data_types.h"
 
-#ifdef TC_SUPPORTS_METAL
-
 TLANG_NAMESPACE_BEGIN
 
 MetalDataType to_metal_type(DataType dt) {
@@ -138,5 +136,3 @@ std::string metal_unary_op_type_symbol(UnaryOpType type) {
 }
 
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_data_types.h
+++ b/taichi/platform/metal/metal_data_types.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include <taichi/common/util.h>
 #include <taichi/tlang_util.h>
 #include <string>
-
-#ifdef TC_SUPPORTS_METAL
 
 TLANG_NAMESPACE_BEGIN
 
@@ -46,5 +43,3 @@ inline bool is_metal_binary_op_infix(BinaryOpType type) {
 }
 
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_kernel_util.cpp
+++ b/taichi/platform/metal/metal_kernel_util.cpp
@@ -4,8 +4,6 @@
 #include <taichi/context.h>
 #undef TI_RUNTIME_HOST
 
-#ifdef TC_SUPPORTS_METAL
-
 TLANG_NAMESPACE_BEGIN
 
 namespace metal {
@@ -61,5 +59,3 @@ void MetalKernelArgsAttributes::finalize() {
 }  // namespace metal
 
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_kernel_util.h
+++ b/taichi/platform/metal/metal_kernel_util.h
@@ -14,8 +14,6 @@
 // compiled to more than one Metal compute kernels. Concretely, each offloaded
 // task in the Taichi kernel maps to a Metal kernel.
 
-#ifdef TC_SUPPORTS_METAL
-
 TLANG_NAMESPACE_BEGIN
 
 class SNode;
@@ -109,5 +107,3 @@ class MetalKernelArgsAttributes {
 }  // namespace metal
 
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_runtime.cpp
+++ b/taichi/platform/metal/metal_runtime.cpp
@@ -7,39 +7,146 @@
 #include <taichi/context.h>
 #undef TI_RUNTIME_HOST
 
-#ifdef TC_SUPPORTS_METAL
-
-// If TC_SUPPORTS_METAL is defined, we are definitely on macOS. Therefore we
-// don't need macro-guarding here.
+#ifdef TC_PLATFORM_OSX
 #include <sys/mman.h>
 #include <unistd.h>
 
-TLANG_NAMESPACE_BEGIN
+#include "metal_api.h"
+#endif  // TC_PLATFORM_OSX
 
+TLANG_NAMESPACE_BEGIN
 namespace metal {
+
+#ifdef TC_PLATFORM_OSX
 
 namespace {
 // TODO(k-ye): Figure this out at runtime, or make it configurable?
 constexpr int kThreadsPerGroup = 512;
 using KernelTaskType = OffloadedStmt::TaskType;
 
-}  // namespace
+// This class requests the Metal buffer memory of |size| bytes from |mem_pool|.
+// Once allocated, it does not own the memory (hence the name "view"). Instead,
+// GC is deferred to the memory pool.
+class BufferMemoryView {
+ public:
+  BufferMemoryView(size_t size, MemoryPool *mem_pool) {
+    const size_t pagesize = getpagesize();
+    // Both |ptr_| and |size_| must be aligned to page size.
+    size_ = ((size + pagesize - 1) / pagesize) * pagesize;
+    ptr_ = mem_pool->allocate(size_, pagesize);
+    TC_ASSERT(ptr_ != nullptr);
+  }
 
-BufferMemoryView::BufferMemoryView(size_t size, MemoryPool *mem_pool) {
-  const size_t pagesize = getpagesize();
-  // Both |ptr_| and |size_| must be aligned to page size.
-  size_ = ((size + pagesize - 1) / pagesize) * pagesize;
-  ptr_ = mem_pool->allocate(size_, pagesize);
-  TC_ASSERT(ptr_ != nullptr);
-}
+  inline size_t size() const { return size_; }
+  inline void *ptr() const { return ptr_; }
 
-class MetalRuntime::HostMetalArgsBlitter {
+ private:
+  size_t size_;
+  void *ptr_;
+};
+
+// Info for launching a compiled Metal kernel
+class CompiledMtlKernel {
+ public:
+  CompiledMtlKernel(const MetalKernelAttributes &md, MTLDevice *device,
+                    MTLFunction *func, ProfilerBase *profiler)
+      : kernel_attribs_(md),
+        pipeline_state_(new_compute_pipeline_state_with_function(device, func)),
+        profiler_(profiler),
+        profiler_id_(fmt::format("{}_dispatch", kernel_attribs_.name)) {
+    TC_ASSERT(pipeline_state_ != nullptr);
+  }
+
+  void launch(MTLBuffer *root_buffer, MTLBuffer *global_tmps_buffer,
+              MTLBuffer *args_buffer, MTLCommandBuffer *command_buffer) {
+    // 0 is valid for |num_threads|!
+    TC_ASSERT(kernel_attribs_.num_threads >= 0);
+    profiler_->start(profiler_id_);
+    auto encoder = new_compute_command_encoder(command_buffer);
+    TC_ASSERT(encoder != nullptr);
+
+    set_compute_pipeline_state(encoder.get(), pipeline_state_.get());
+    int buffer_index = 0;
+    set_mtl_buffer(encoder.get(), root_buffer, /*offset=*/0, buffer_index++);
+    set_mtl_buffer(encoder.get(), global_tmps_buffer, /*offset=*/0,
+                   buffer_index++);
+    if (args_buffer) {
+      set_mtl_buffer(encoder.get(), args_buffer, /*offset=*/0, buffer_index++);
+    }
+    const int num_threads = kernel_attribs_.num_threads;
+    const int num_groups =
+        ((num_threads + kThreadsPerGroup - 1) / kThreadsPerGroup);
+    dispatch_threadgroups(encoder.get(), num_groups,
+                          std::min(num_threads, kThreadsPerGroup));
+    end_encoding(encoder.get());
+    profiler_->stop();
+    if ((kernel_attribs_.task_type == KernelTaskType::range_for) &&
+        !kernel_attribs_.range_for_attribs.const_range()) {
+      // Set |num_thread| to an invalid number to make sure the next launch
+      // re-computes it correctly.
+      kernel_attribs_.num_threads = -1;
+    }
+  }
+
+  inline MetalKernelAttributes *kernel_attribs() { return &kernel_attribs_; }
+
+ private:
+  MetalKernelAttributes kernel_attribs_;
+  nsobj_unique_ptr<MTLComputePipelineState> pipeline_state_{nullptr};
+  ProfilerBase *const profiler_;
+  const std::string profiler_id_;
+};
+
+// Info for launching a compiled Taichi kernel, which consists of a series of
+// compiled Metal kernels.
+class CompiledTaichiKernel {
+ public:
+  CompiledTaichiKernel(
+      const std::string &taichi_kernel_name, const std::string &source_code,
+      const std::vector<MetalKernelAttributes> &mtl_kernels_attribs,
+      size_t global_tmps_size, const MetalKernelArgsAttributes &args_attribs,
+      MTLDevice *device, MemoryPool *mem_pool, ProfilerBase *profiler)
+      : global_tmps_mem(global_tmps_size, mem_pool),
+        args_attribs(args_attribs),
+        mtl_source_code_(source_code),
+        profiler_(profiler) {
+    auto kernel_lib = new_library_with_source(device, mtl_source_code_);
+    TC_ASSERT(kernel_lib != nullptr);
+    for (const auto &ka : mtl_kernels_attribs) {
+      auto kernel_func = new_function_with_name(kernel_lib.get(), ka.name);
+      TC_ASSERT(kernel_func != nullptr);
+      // Note that CompiledMtlKernel doesn't own |kernel_func|.
+      compiled_mtl_kernels.push_back(std::make_unique<CompiledMtlKernel>(
+          ka, device, kernel_func.get(), profiler_));
+    }
+    global_tmps_buffer = new_mtl_buffer_no_copy(device, global_tmps_mem.ptr(),
+                                                global_tmps_mem.size());
+    if (args_attribs.has_args()) {
+      args_mem = std::make_unique<BufferMemoryView>(args_attribs.total_bytes(),
+                                                    mem_pool);
+      args_buffer =
+          new_mtl_buffer_no_copy(device, args_mem->ptr(), args_mem->size());
+    }
+  }
+  // Have to be exposed as public for Impl to use. We cannot friend the Impl
+  // class because it is private.
+  std::vector<std::unique_ptr<CompiledMtlKernel>> compiled_mtl_kernels;
+  BufferMemoryView global_tmps_mem;
+  nsobj_unique_ptr<MTLBuffer> global_tmps_buffer;
+  MetalKernelArgsAttributes args_attribs;
+  std::unique_ptr<BufferMemoryView> args_mem{nullptr};
+  nsobj_unique_ptr<MTLBuffer> args_buffer{nullptr};
+
+ private:
+  std::string mtl_source_code_;
+  ProfilerBase *const profiler_;
+};
+
+class HostMetalArgsBlitter {
  public:
   HostMetalArgsBlitter(const MetalKernelArgsAttributes *args_attribs,
-                       Context *ctx,
-                       BufferMemoryView *args_mem)
-      : args_attribs_(args_attribs), ctx_(ctx), args_mem_(args_mem) {
-  }
+                       Context *ctx, BufferMemoryView *args_mem)
+      : args_attribs_(args_attribs), ctx_(ctx), args_mem_(args_mem) {}
 
   void host_to_metal() {
 #define TO_METAL(type)             \
@@ -105,13 +212,12 @@ class MetalRuntime::HostMetalArgsBlitter {
   }
 
   static std::unique_ptr<HostMetalArgsBlitter> make_if_has_args(
-      const MetalRuntime::CompiledTaichiKernel &kernel,
-      Context *ctx) {
-    if (!kernel.args_attribs_.has_args()) {
+      const CompiledTaichiKernel &kernel, Context *ctx) {
+    if (!kernel.args_attribs.has_args()) {
       return nullptr;
     }
-    return std::make_unique<HostMetalArgsBlitter>(&kernel.args_attribs_, ctx,
-                                                  kernel.args_mem_.get());
+    return std::make_unique<HostMetalArgsBlitter>(&kernel.args_attribs, ctx,
+                                                  kernel.args_mem.get());
   }
 
  private:
@@ -120,183 +226,169 @@ class MetalRuntime::HostMetalArgsBlitter {
   BufferMemoryView *const args_mem_{nullptr};
 };
 
-MetalRuntime::CompiledMtlKernel::CompiledMtlKernel(
-    const MetalKernelAttributes &md,
-    MTLDevice *device,
-    MTLFunction *func,
-    ProfilerBase *profiler)
-    : kernel_attribs_(md),
-      pipeline_state_(new_compute_pipeline_state_with_function(device, func)),
-      profiler_(profiler),
-      profiler_id_(fmt::format("{}_dispatch", kernel_attribs_.name)) {
-  TC_ASSERT(pipeline_state_ != nullptr);
-}
+}  // namespace
 
-void MetalRuntime::CompiledMtlKernel::launch(
-    MTLBuffer *root_buffer,
-    MTLBuffer *global_tmps_buffer,
-    MTLBuffer *args_buffer,
-    MTLCommandBuffer *command_buffer) {
-  // 0 is valid for |num_threads|!
-  TC_ASSERT(kernel_attribs_.num_threads >= 0);
-  profiler_->start(profiler_id_);
-  auto encoder = new_compute_command_encoder(command_buffer);
-  TC_ASSERT(encoder != nullptr);
+class MetalRuntime::Impl {
+ public:
+  Impl(size_t root_size, CompileConfig *config, MemoryPool *mem_pool,
+       ProfilerBase *profiler)
+      : config_(config),
+        mem_pool_(mem_pool),
+        profiler_(profiler),
+        root_buffer_mem_(std::max(root_size, 1UL), mem_pool) {
+    if (config_->debug) {
+      TC_ASSERT(is_metal_api_available());
+    }
+    device_ = mtl_create_system_default_device();
+    TC_ASSERT(device_ != nullptr);
+    command_queue_ = new_command_queue(device_.get());
+    TC_ASSERT(command_queue_ != nullptr);
+    create_new_command_buffer();
+    root_buffer_ = new_mtl_buffer_no_copy(device_.get(), root_buffer_mem_.ptr(),
+                                          root_buffer_mem_.size());
+    TC_ASSERT(root_buffer_ != nullptr);
+  }
 
-  set_compute_pipeline_state(encoder.get(), pipeline_state_.get());
-  int buffer_index = 0;
-  set_mtl_buffer(encoder.get(), root_buffer, /*offset=*/0, buffer_index++);
-  set_mtl_buffer(encoder.get(), global_tmps_buffer, /*offset=*/0,
-                 buffer_index++);
-  if (args_buffer) {
-    set_mtl_buffer(encoder.get(), args_buffer, /*offset=*/0, buffer_index++);
-  }
-  const int num_threads = kernel_attribs_.num_threads;
-  const int num_groups =
-      ((num_threads + kThreadsPerGroup - 1) / kThreadsPerGroup);
-  dispatch_threadgroups(encoder.get(), num_groups,
-                        std::min(num_threads, kThreadsPerGroup));
-  end_encoding(encoder.get());
-  profiler_->stop();
-  if ((kernel_attribs_.task_type == KernelTaskType::range_for) &&
-      !kernel_attribs_.range_for_attribs.const_range()) {
-    // Set |num_thread| to an invalid number to make sure the next launch
-    // re-computes it correctly.
-    kernel_attribs_.num_threads = -1;
-  }
-}
+  void register_taichi_kernel(
+      const std::string &taichi_kernel_name,
+      const std::string &mtl_kernel_source_code,
+      const std::vector<MetalKernelAttributes> &kernels_attribs,
+      size_t global_tmps_size, const MetalKernelArgsAttributes &args_attribs) {
+    TC_ASSERT(compiled_taichi_kernels_.find(taichi_kernel_name) ==
+              compiled_taichi_kernels_.end());
 
-MetalRuntime::CompiledTaichiKernel::CompiledTaichiKernel(
-    const std::string &taichi_kernel_name,
-    const std::string &source_code,
-    const std::vector<MetalKernelAttributes> &mtl_kernels_attribs,
-    size_t global_tmps_size,
-    const MetalKernelArgsAttributes &args_attribs,
-    MTLDevice *device,
-    MemoryPool *mem_pool,
-    ProfilerBase *profiler)
-    : mtl_source_code_(source_code),
-      global_tmps_mem_(global_tmps_size, mem_pool),
-      args_attribs_(args_attribs),
-      profiler_(profiler) {
-  auto kernel_lib = new_library_with_source(device, mtl_source_code_);
-  TC_ASSERT(kernel_lib != nullptr);
-  for (const auto &ka : mtl_kernels_attribs) {
-    auto kernel_func = new_function_with_name(kernel_lib.get(), ka.name);
-    TC_ASSERT(kernel_func != nullptr);
-    // Note that CompiledMtlKernel doesn't own |kernel_func|.
-    compiled_mtl_kernels_.push_back(std::make_unique<CompiledMtlKernel>(
-        ka, device, kernel_func.get(), profiler_));
+    if (config_->print_kernel_llvm_ir) {
+      // If users have enabled |print_kernel_llvm_ir|, it probably means that
+      // they want to see the compiled code on the given arch. Maybe rename this
+      // flag, or add another flag (e.g. |print_kernel_source_code|)?
+      TC_INFO("Metal source code for kernel <{}>\n{}", taichi_kernel_name,
+              mtl_kernel_source_code);
+    }
+    compiled_taichi_kernels_[taichi_kernel_name] =
+        std::make_unique<CompiledTaichiKernel>(
+            taichi_kernel_name, mtl_kernel_source_code, kernels_attribs,
+            global_tmps_size, args_attribs, device_.get(), mem_pool_,
+            profiler_);
+    TC_INFO("Registered Taichi kernel <{}>", taichi_kernel_name);
   }
-  global_tmps_buffer_ = new_mtl_buffer_no_copy(device, global_tmps_mem_.ptr(),
-                                               global_tmps_mem_.size());
-  if (args_attribs_.has_args()) {
-    args_mem_ = std::make_unique<BufferMemoryView>(args_attribs_.total_bytes(),
-                                                   mem_pool);
-    args_buffer_ =
-        new_mtl_buffer_no_copy(device, args_mem_->ptr(), args_mem_->size());
-  }
-}
 
-MetalRuntime::MetalRuntime(size_t root_size,
-                           CompileConfig *config,
-                           MemoryPool *mem_pool,
-                           ProfilerBase *profiler)
-    : config_(config),
-      mem_pool_(mem_pool),
-      profiler_(profiler),
-      root_buffer_mem_(std::max(root_size, 1UL), mem_pool) {
-  TC_ASSERT(is_metal_api_available());
-  device_ = mtl_create_system_default_device();
-  TC_ASSERT(device_ != nullptr);
-  command_queue_ = new_command_queue(device_.get());
-  TC_ASSERT(command_queue_ != nullptr);
-  create_new_command_buffer();
-  root_buffer_ = new_mtl_buffer_no_copy(device_.get(), root_buffer_mem_.ptr(),
-                                        root_buffer_mem_.size());
-  TC_ASSERT(root_buffer_ != nullptr);
-}
+  void launch_taichi_kernel(const std::string &taichi_kernel_name,
+                            Context *ctx) {
+    auto &ctk = *compiled_taichi_kernels_.find(taichi_kernel_name)->second;
+    auto args_blitter = HostMetalArgsBlitter::make_if_has_args(ctk, ctx);
+    if (config_->verbose_kernel_launches) {
+      TC_INFO("Lauching Taichi kernel <{}>", taichi_kernel_name);
+    }
+    if (args_blitter) {
+      args_blitter->host_to_metal();
+    }
+    for (const auto &mk : ctk.compiled_mtl_kernels) {
+      auto *ka = mk->kernel_attribs();
+      if ((ka->task_type == KernelTaskType::range_for) &&
+          !ka->range_for_attribs.const_range()) {
+        // If the for loop range is determined at runtime, it will be computed
+        // in the previous serial kernel. We need to read it back to the host
+        // side to decide how many kernel threads to launch.
+        synchronize();
+        const char *global_tmps_membegin = (char *)ctk.global_tmps_mem.ptr();
+        auto load_global_tmp = [=](int offset) -> int {
+          return *reinterpret_cast<const int *>(global_tmps_membegin + offset);
+        };
+        const int begin = ka->range_for_attribs.const_begin
+                              ? ka->range_for_attribs.begin
+                              : load_global_tmp(ka->range_for_attribs.begin);
+        const int end = ka->range_for_attribs.const_end
+                            ? ka->range_for_attribs.end
+                            : load_global_tmp(ka->range_for_attribs.end);
+        TC_ASSERT(ka->num_threads == -1);
+        ka->num_threads = end - begin;
+      }
+      mk->launch(root_buffer_.get(), ctk.global_tmps_buffer.get(),
+                 ctk.args_buffer.get(), cur_command_buffer_.get());
+    }
+    if (args_blitter) {
+      // TODO(k-ye): One optimization is to synchronize only when we absolutely
+      // need to transfer the data back to host. This includes the cases where
+      // an arg is 1) an array, or 2) used as return value.
+      synchronize();
+      args_blitter->metal_to_host();
+    }
+  }
+
+  void synchronize() {
+    profiler_->start("metal_synchronize");
+    commit_command_buffer(cur_command_buffer_.get());
+    wait_until_completed(cur_command_buffer_.get());
+    create_new_command_buffer();
+    profiler_->stop();
+  }
+
+ private:
+  void create_new_command_buffer() {
+    cur_command_buffer_ = new_command_buffer(command_queue_.get());
+    TC_ASSERT(cur_command_buffer_ != nullptr);
+  }
+  CompileConfig *const config_;
+  MemoryPool *const mem_pool_;
+  ProfilerBase *const profiler_;
+  BufferMemoryView root_buffer_mem_;
+  nsobj_unique_ptr<MTLDevice> device_{nullptr};
+  nsobj_unique_ptr<MTLCommandQueue> command_queue_{nullptr};
+  nsobj_unique_ptr<MTLCommandBuffer> cur_command_buffer_{nullptr};
+  nsobj_unique_ptr<MTLBuffer> root_buffer_{nullptr};
+  std::unordered_map<std::string, std::unique_ptr<CompiledTaichiKernel>>
+      compiled_taichi_kernels_;
+};
+
+#else
+
+class MetalRuntime::Impl {
+ public:
+  Impl(size_t root_size, CompileConfig *config, MemoryPool *mem_pool,
+       ProfilerBase *profiler) {
+    TC_ERROR("Metal not supported on the current OS");
+  }
+
+  void register_taichi_kernel(
+      const std::string &taichi_kernel_name,
+      const std::string &mtl_kernel_source_code,
+      const std::vector<MetalKernelAttributes> &kernels_attribs,
+      size_t global_tmps_size, const MetalKernelArgsAttributes &args_attribs) {
+    TC_ERROR("Metal not supported on the current OS");
+  }
+
+  void launch_taichi_kernel(const std::string &taichi_kernel_name,
+                            Context *ctx) {
+    TC_ERROR("Metal not supported on the current OS");
+  }
+
+  void synchronize() { TC_ERROR("Metal not supported on the current OS"); }
+};
+
+#endif  // TC_PLATFORM_OSX
+
+MetalRuntime::MetalRuntime(size_t root_size, CompileConfig *config,
+                           MemoryPool *mem_pool, ProfilerBase *profiler)
+    : impl_(std::make_unique<Impl>(root_size, config, mem_pool, profiler)) {}
+
+MetalRuntime::~MetalRuntime() {}
 
 void MetalRuntime::register_taichi_kernel(
     const std::string &taichi_kernel_name,
     const std::string &mtl_kernel_source_code,
     const std::vector<MetalKernelAttributes> &kernels_attribs,
-    size_t global_tmps_size,
-    const MetalKernelArgsAttributes &args_attribs) {
-  TC_ASSERT(compiled_taichi_kernels_.find(taichi_kernel_name) ==
-            compiled_taichi_kernels_.end());
-
-  if (config_->print_kernel_llvm_ir) {
-    // If users have enabled |print_kernel_llvm_ir|, it probably means that they
-    // want to see the compiled code on the given arch. Maybe rename this flag,
-    // or add another flag (e.g. |print_kernel_source_code|)?
-    TC_INFO("Metal source code for kernel <{}>\n{}", taichi_kernel_name,
-            mtl_kernel_source_code);
-  }
-  compiled_taichi_kernels_[taichi_kernel_name] =
-      std::make_unique<CompiledTaichiKernel>(
-          taichi_kernel_name, mtl_kernel_source_code, kernels_attribs,
-          global_tmps_size, args_attribs, device_.get(), mem_pool_, profiler_);
-  TC_INFO("Registered Taichi kernel <{}>", taichi_kernel_name);
+    size_t global_tmps_size, const MetalKernelArgsAttributes &args_attribs) {
+  impl_->register_taichi_kernel(taichi_kernel_name, mtl_kernel_source_code,
+                                kernels_attribs, global_tmps_size,
+                                args_attribs);
 }
 
 void MetalRuntime::launch_taichi_kernel(const std::string &taichi_kernel_name,
                                         Context *ctx) {
-  auto &ctk = *compiled_taichi_kernels_.find(taichi_kernel_name)->second;
-  auto args_blitter = HostMetalArgsBlitter::make_if_has_args(ctk, ctx);
-  if (config_->verbose_kernel_launches) {
-    TC_INFO("Lauching Taichi kernel <{}>", taichi_kernel_name);
-  }
-  if (args_blitter) {
-    args_blitter->host_to_metal();
-  }
-  for (const auto &mk : ctk.compiled_mtl_kernels_) {
-    auto *ka = mk->kernel_attribs();
-    if ((ka->task_type == KernelTaskType::range_for) &&
-        !ka->range_for_attribs.const_range()) {
-      // If the for loop range is determined at runtime, it will be computed in
-      // the previous serial kernel. We need to read it back to the host side to
-      // decide how many kernel threads to launch.
-      synchronize();
-      const char *global_tmps_mem_begin = (char *)ctk.global_tmps_mem_.ptr();
-      auto load_global_tmp = [=](int offset) -> int {
-        return *reinterpret_cast<const int *>(global_tmps_mem_begin + offset);
-      };
-      const int begin = ka->range_for_attribs.const_begin
-                            ? ka->range_for_attribs.begin
-                            : load_global_tmp(ka->range_for_attribs.begin);
-      const int end = ka->range_for_attribs.const_end
-                          ? ka->range_for_attribs.end
-                          : load_global_tmp(ka->range_for_attribs.end);
-      TC_ASSERT(ka->num_threads == -1);
-      ka->num_threads = end - begin;
-    }
-    mk->launch(root_buffer_.get(), ctk.global_tmps_buffer_.get(),
-               ctk.args_buffer_.get(), cur_command_buffer_.get());
-  }
-  if (args_blitter) {
-    // TODO(k-ye): One optimization is to synchronize only when we absolutely
-    // need to transfer the data back to host. This includes the cases where an
-    // arg is 1) an array, or 2) used as return value.
-    synchronize();
-    args_blitter->metal_to_host();
-  }
+  impl_->launch_taichi_kernel(taichi_kernel_name, ctx);
 }
 
-void MetalRuntime::synchronize() {
-  profiler_->start("metal_synchronize");
-  commit_command_buffer(cur_command_buffer_.get());
-  wait_until_completed(cur_command_buffer_.get());
-  create_new_command_buffer();
-  profiler_->stop();
-}
-
-void MetalRuntime::create_new_command_buffer() {
-  cur_command_buffer_ = new_command_buffer(command_queue_.get());
-  TC_ASSERT(cur_command_buffer_ != nullptr);
-}
+void MetalRuntime::synchronize() { impl_->synchronize(); }
 
 }  // namespace metal
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_runtime.h
+++ b/taichi/platform/metal/metal_runtime.h
@@ -1,16 +1,14 @@
 #pragma once
 
+#include <taichi/memory_pool.h>
+#include <taichi/profiler.h>
+#include <taichi/tlang_util.h>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 
-#include "metal_api.h"
 #include "metal_kernel_util.h"
-#include <taichi/tlang_util.h>
-#include <taichi/memory_pool.h>
-#include <taichi/profiler.h>
-
-#ifdef TC_SUPPORTS_METAL
 
 TLANG_NAMESPACE_BEGIN
 
@@ -18,32 +16,16 @@ struct Context;
 
 namespace metal {
 
-// This class requests the Metal buffer memory of |size| bytes from |mem_pool|.
-// Once allocated, it does not own the memory (hence the name "view"). Instead,
-// GC is deferred to the memory pool.
-class BufferMemoryView {
- public:
-  BufferMemoryView(size_t size, MemoryPool *mem_pool);
-
-  inline size_t size() const {
-    return size_;
-  }
-  inline void *ptr() const {
-    return ptr_;
-  }
-
- private:
-  size_t size_;
-  void *ptr_;
-};
-
 // MetalRuntime manages everything the Metal kernels need at runtime, including
 // the compiled Metal kernels pipelines and Metal buffers memory. It is the
 // runtime interface between Taichi and Metal, and knows how to locate the
 // series of Metal kernels generated from a Taichi kernel.
 class MetalRuntime {
  public:
-  MetalRuntime(size_t root_size, CompileConfig* config, MemoryPool *mem_pool, ProfilerBase *profiler);
+  MetalRuntime(size_t root_size, CompileConfig *config, MemoryPool *mem_pool,
+               ProfilerBase *profiler);
+  // To make Pimpl + std::unique_ptr work
+  ~MetalRuntime();
 
   // Register a Taichi kernel to the Metal runtime.
   // * |mtl_kernel_source_code| is the complete source code compiled from a
@@ -55,8 +37,7 @@ class MetalRuntime {
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<MetalKernelAttributes> &kernels_attribs,
-      size_t global_tmps_size,
-      const MetalKernelArgsAttributes &args_attribs);
+      size_t global_tmps_size, const MetalKernelArgsAttributes &args_attribs);
 
   // Launch the given |taichi_kernel_name|.
   // Kernel launching is asynchronous, therefore the Metal memory is not valid
@@ -68,76 +49,11 @@ class MetalRuntime {
   void synchronize();
 
  private:
-  void create_new_command_buffer();
-
-  class HostMetalArgsBlitter;
-  // Info for launching a compiled Metal kernel
-  class CompiledMtlKernel {
-   public:
-    CompiledMtlKernel(const MetalKernelAttributes &md,
-                      MTLDevice *device,
-                      MTLFunction *func,
-                      ProfilerBase *profiler);
-
-    void launch(MTLBuffer *root_buffer,
-                MTLBuffer *global_tmp_buffer,
-                MTLBuffer *args_buffer,
-                MTLCommandBuffer *command_buffer);
-
-    inline MetalKernelAttributes *kernel_attribs() {
-      return &kernel_attribs_;
-    }
-
-   private:
-    MetalKernelAttributes kernel_attribs_;
-    nsobj_unique_ptr<MTLComputePipelineState> pipeline_state_{nullptr};
-    ProfilerBase *const profiler_;
-    const std::string profiler_id_;
-  };
-
-  // Info for launching a compiled Taichi kernel, which consists of a series of
-  // compiled Metal kernels.
-  class CompiledTaichiKernel {
-   public:
-    CompiledTaichiKernel(
-        const std::string &taichi_kernel_name,
-        const std::string &source_code,
-        const std::vector<MetalKernelAttributes> &mtl_kernels_attribs,
-        size_t global_tmps_size,
-        const MetalKernelArgsAttributes &args_attribs,
-        MTLDevice *device,
-        MemoryPool *mem_pool,
-        ProfilerBase *profiler);
-
-   private:
-    friend void MetalRuntime::launch_taichi_kernel(
-        const std::string &taichi_kernel_name,
-        Context *ctx);
-    friend class HostMetalArgsBlitter;
-
-    std::string mtl_source_code_;
-    std::vector<std::unique_ptr<CompiledMtlKernel>> compiled_mtl_kernels_;
-    BufferMemoryView global_tmps_mem_;
-    nsobj_unique_ptr<MTLBuffer> global_tmps_buffer_;
-    MetalKernelArgsAttributes args_attribs_;
-    std::unique_ptr<BufferMemoryView> args_mem_{nullptr};
-    nsobj_unique_ptr<MTLBuffer> args_buffer_{nullptr};
-    ProfilerBase *const profiler_;
-  };
-
-  CompileConfig* const config_;
-  MemoryPool *const mem_pool_;
-  ProfilerBase *const profiler_;
-  BufferMemoryView root_buffer_mem_;
-  nsobj_unique_ptr<MTLDevice> device_{nullptr};
-  nsobj_unique_ptr<MTLCommandQueue> command_queue_{nullptr};
-  nsobj_unique_ptr<MTLCommandBuffer> cur_command_buffer_{nullptr};
-  nsobj_unique_ptr<MTLBuffer> root_buffer_{nullptr};
-  std::unordered_map<std::string, std::unique_ptr<CompiledTaichiKernel>>
-      compiled_taichi_kernels_;
+  // Use Pimpl so that we can expose this interface without conditionally
+  // compiling on TC_PLATFORM_OSX
+  class Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace metal
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/program.h
+++ b/taichi/program.h
@@ -14,15 +14,12 @@
 #include <taichi/system/threading.h>
 #include <taichi/unified_allocator.h>
 #include "memory_pool.h"
-
-#if defined(TC_PLATFORM_UNIX)
-#include <dlfcn.h>
-#endif
-
-#if defined(TC_SUPPORTS_METAL)
 #include <optional>
 #include <taichi/platform/metal/metal_kernel_util.h>
 #include <taichi/platform/metal/metal_runtime.h>
+
+#if defined(TC_PLATFORM_UNIX)
+#include <dlfcn.h>
 #endif
 
 TLANG_NAMESPACE_BEGIN
@@ -175,10 +172,8 @@ class Program {
   ~Program();
 
  private:
-#if defined(TC_SUPPORTS_METAL)
   std::optional<metal::StructCompiledResult> metal_struct_compiled_;
   std::unique_ptr<metal::MetalRuntime> metal_runtime_;
-#endif
 };
 
 TLANG_NAMESPACE_END


### PR DESCRIPTION
Issue #396 

Sorry about the large size, I'm mostly moving `MetalRuntime`'s code to `cpp` file.

* Use Pimpl for MetalRuntime so that we don't have to check TC_PLATFORM_OSX
  whereever it's been used.
* Correctly detects the Metal API availability at runtime
* If Metal API is not available, Program will automatically falls back to x86_64