### PR TITLE
Fix Travis CI by detecting Metal API at runtime

### DIFF
--- a/taichi/common/util.h
+++ b/taichi/common/util.h
@@ -49,9 +49,8 @@ static_assert(false, "32-bit Windows systems are not supported")
 // OSX
 #if defined(__APPLE__)
 #define TC_PLATFORM_OSX
-// According to https://developer.apple.com/documentation/metal?language=objc,
-// Metal is supported since macOS 10.11+, so we can just assume that it is
-// available for all Mac users?
+// This is wrong, we cannot detect the Metal availability just at compilation
+// time. Deprecate it.
 #define TC_SUPPORTS_METAL
 #endif
 

--- a/taichi/platform/mac/objc_api.h
+++ b/taichi/platform/mac/objc_api.h
@@ -1,5 +1,9 @@
 #include <string>
 
+#include <taichi/common/util.h>
+
+#ifdef TC_PLATFORM_OSX
+
 #include <objc/message.h>
 #include <objc/objc.h>
 #include <objc/runtime.h>
@@ -50,3 +54,5 @@ nsobj_unique_ptr<TC_NSString> wrap_string_as_ns_string(const std::string &str);
 
 }  // namespace mac
 }  // namespace taichi
+
+#endif  // TC_PLATFORM_OSX

--- a/taichi/platform/metal/metal_api.cpp
+++ b/taichi/platform/metal/metal_api.cpp
@@ -1,10 +1,10 @@
 #include "metal_api.h"
 
-#ifdef TC_SUPPORTS_METAL
-
 TLANG_NAMESPACE_BEGIN
 
 namespace metal {
+
+#ifdef TC_SUPPORTS_METAL
 
 extern "C" {
 id MTLCreateSystemDefaultDevice();
@@ -118,8 +118,19 @@ void dispatch_threadgroups(MTLComputeCommandEncoder *encoder, int32_t blocks_x,
        threads_per_threadgroup);
 }
 
+#endif  // TC_SUPPORTS_METAL
+
+bool is_metal_api_available() {
+#ifdef TC_PLATFORM_OSX
+  // If the macOS is provided by a VM (e.g. Travis CI), it's possible that there
+  // is no GPU device, so we still have to do a runtime check.
+  auto device = mtl_create_system_default_device();
+  return device != nullptr;
+#else
+  return false;
+#endif
+}
+
 } // namespace metal
 
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_api.h
+++ b/taichi/platform/metal/metal_api.h
@@ -7,8 +7,6 @@
 #include <taichi/common.h>
 #include <taichi/common/util.h>
 
-#ifdef TC_SUPPORTS_METAL
-
 #include <taichi/platform/mac/objc_api.h>
 
 TLANG_NAMESPACE_BEGIN
@@ -24,6 +22,8 @@ struct MTLComputeCommandEncoder;
 struct MTLFunction;
 struct MTLComputePipelineState;
 struct MTLBuffer;
+
+#ifdef TC_SUPPORTS_METAL
 
 using mac::nsobj_unique_ptr;
 
@@ -89,8 +89,10 @@ inline void *mtl_buffer_contents(MTLBuffer *buffer) {
   return mac::cast_call<void *>(buffer, "contents");
 }
 
+#endif  // TC_SUPPORTS_METAL
+
+bool is_metal_api_available();
+
 } // namespace metal
 
 TLANG_NAMESPACE_END
-
-#endif  // TC_SUPPORTS_METAL

--- a/taichi/platform/metal/metal_runtime.cpp
+++ b/taichi/platform/metal/metal_runtime.cpp
@@ -206,6 +206,7 @@ MetalRuntime::MetalRuntime(size_t root_size,
       mem_pool_(mem_pool),
       profiler_(profiler),
       root_buffer_mem_(std::max(root_size, 1UL), mem_pool) {
+  TC_ASSERT(is_metal_api_available());
   device_ = mtl_create_system_default_device();
   TC_ASSERT(device_ != nullptr);
   command_queue_ = new_command_queue(device_.get());

--- a/taichi/program.cpp
+++ b/taichi/program.cpp
@@ -1,6 +1,8 @@
 // Program, which is a context for a taichi program execution
 
 #include <taichi/common/task.h>
+#include <taichi/platform/metal/metal_api.h>
+
 #include "program.h"
 #include "snode.h"
 #include "backends/struct.h"
@@ -38,6 +40,12 @@ Program::Program(Arch arch) {
     }
   }
 #endif
+  if (arch == Arch::metal) {
+    if (!metal::is_metal_api_available()) {
+      TC_WARN("No Metal API detected, falling back to x86_64");
+      arch = Arch::x86_64;
+    }
+  }
   memory_pool = std::make_unique<MemoryPool>(this);
   TC_ASSERT_INFO(num_instances == 0, "Only one instance at a time");
   total_compilation_time = 0;

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -13,6 +13,7 @@
 #include <taichi/system/memory.h>
 #include <taichi/system/unit_dll.h>
 #include <taichi/geometry/factory.h>
+#include <taichi/platform/metal/metal_api.h>
 #if defined(TI_WITH_CUDA)
 #include <cuda_runtime_api.h>
 #endif
@@ -78,14 +79,6 @@ void stop_duplicating_stdout_to_file(const std::string &fn) {
 
 bool with_cuda() {
 #if defined(TI_WITH_CUDA)
-  return true;
-#else
-  return false;
-#endif
-}
-
-bool with_metal() {
-#if defined(TC_SUPPORTS_METAL)
   return true;
 #else
   return false;
@@ -170,7 +163,7 @@ void export_misc(py::module &m) {
     printf("test was successful.\n");
   });
   m.def("with_cuda", with_cuda);
-  m.def("with_metal", with_metal);
+  m.def("with_metal", taichi::Tlang::metal::is_metal_api_available);
 }
 
 TC_NAMESPACE_END


### PR DESCRIPTION
Since we are likely need more time review #457 , I've separated out the Metal API detection to allow Travis CI to run successfully.

Note that this PR doesn't contain the Metal runtime fix around the number of threads, so it may still crash if you run locally..