### PR TITLE
Simplify lookup_function's template args by not passing std::function

### DIFF
--- a/taichi/backends/struct_llvm.cpp
+++ b/taichi/backends/struct_llvm.cpp
@@ -249,33 +249,29 @@ void StructCompilerLLVM::run(SNode &root, bool host) {
     }
 
     // TODO(yuanming-hu): move runtime initialization to somewhere else
-    auto initialize_runtime = tlctx->lookup_function<std::function<void *(
-        void *, void *, int, std::size_t, void *, bool)>>(
-        "Runtime_initialize");
+    auto initialize_runtime = tlctx->lookup_function<void *(
+        void *, void *, int, std::size_t, void *, bool)>("Runtime_initialize");
 
     auto initialize_runtime2 =
-        tlctx->lookup_function<std::function<void(void *, void *, int, int)>>(
+        tlctx->lookup_function<void(void *, void *, int, int)>(
             "Runtime_initialize2");
 
-    auto set_assert_failed =
-        tlctx->lookup_function<std::function<void(void *, void *)>>(
-            "Runtime_set_assert_failed");
+    auto set_assert_failed = tlctx->lookup_function<void(void *, void *)>(
+        "Runtime_set_assert_failed");
 
     auto allocate_ambient =
-        tlctx->lookup_function<std::function<void(void *, int)>>(
-            "Runtime_allocate_ambient");
+        tlctx->lookup_function<void(void *, int)>("Runtime_allocate_ambient");
 
     auto initialize_allocator =
-        tlctx->lookup_function<std::function<void *(void *, int, std::size_t)>>(
+        tlctx->lookup_function<void *(void *, int, std::size_t)>(
             "NodeAllocator_initialize");
 
     auto runtime_initialize_thread_pool =
-        tlctx->lookup_function<std::function<void(void *, void *, void *)>>(
+        tlctx->lookup_function<void(void *, void *, void *)>(
             "Runtime_initialize_thread_pool");
 
     auto runtime_set_root =
-        tlctx->lookup_function<std::function<void(void *, void *)>>(
-            "Runtime_set_root");
+        tlctx->lookup_function<void(void *, void *)>("Runtime_set_root");
 
     // By the time when creator is called, "this" is already destoried. Therefor
     // it is necessary to capture members by values.
@@ -289,9 +285,8 @@ void StructCompilerLLVM::run(SNode &root, bool host) {
           &prog->llvm_runtime, prog, (int)snodes.size(), root_size,
           (void *)&taichi_allocate_aligned, logger.get_level() <= 1);
 
-      auto mem_req_queue =
-          tlctx->lookup_function<std::function<void *(void *)>>(
-              "Runtime_get_mem_req_queue")(prog->llvm_runtime);
+      auto mem_req_queue = tlctx->lookup_function<void *(void *)>(
+          "Runtime_get_mem_req_queue")(prog->llvm_runtime);
       prog->memory_pool->set_queue((MemRequestQueue *)mem_req_queue);
 
       initialize_runtime2(prog->llvm_runtime, root, root_id,
@@ -326,16 +321,14 @@ void StructCompilerLLVM::run(SNode &root, bool host) {
 
       runtime_set_root(prog->llvm_runtime, root);
 
-      tlctx->lookup_function<std::function<void(void *, void *)>>(
-          "Runtime_set_profiler")(prog->llvm_runtime,
-                                  prog->profiler_llvm.get());
+      tlctx->lookup_function<void(void *, void *)>("Runtime_set_profiler")(
+          prog->llvm_runtime, prog->profiler_llvm.get());
 
-      tlctx->lookup_function<std::function<void(void *, void *)>>(
+      tlctx->lookup_function<void(void *, void *)>(
           "Runtime_set_profiler_start")(prog->llvm_runtime,
                                         (void *)&ProfilerBase::profiler_start);
-      tlctx->lookup_function<std::function<void(void *, void *)>>(
-          "Runtime_set_profiler_stop")(prog->llvm_runtime,
-                                       (void *)&ProfilerBase::profiler_stop);
+      tlctx->lookup_function<void(void *, void *)>("Runtime_set_profiler_stop")(
+          prog->llvm_runtime, (void *)&ProfilerBase::profiler_stop);
     };
   }
   tlctx->snode_attr = snode_attr;

--- a/taichi/taichi_llvm_context.h
+++ b/taichi/taichi_llvm_context.h
@@ -1,6 +1,8 @@
 #pragma once
 // A helper for the llvm backend
 
+#include <functional>
+
 #include "tlang_util.h"
 #include "llvm_fwd.h"
 #include "snode.h"
@@ -30,8 +32,10 @@ class TaichiLLVMContext {
   void set_struct_module(const std::unique_ptr<llvm::Module> &module);
 
   template <typename T>
-  T lookup_function(const std::string &name) {
-    auto ret = T((function_pointer_type<T>)jit_lookup_name(jit.get(), name));
+  auto lookup_function(const std::string &name) {
+    using FuncT = typename std::function<T>;
+    auto ret =
+        FuncT((function_pointer_type<FuncT>)jit_lookup_name(jit.get(), name));
     TC_ASSERT(ret != nullptr);
     return ret;
   }


### PR DESCRIPTION
I'm planning to use LLVM context and saw this method. I feel like it's a bit cleaner to just pass in the function type signature?