### PR TITLE
Support GUI key/mouse events on Mac OS X

### DIFF
--- a/examples/mpm128.py
+++ b/examples/mpm128.py
@@ -98,7 +98,7 @@ def reset():
   Jp.fill(1)
   C.fill(0)
   
-print("[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse bottons to attract/repel. (OS X not yet supported)")
+print("[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse bottons to attract/repel.")
 gui = ti.GUI("Taichi MLS-MPM-128", res=512, background_color=0x112F41)
 reset()
 


### PR DESCRIPTION
Follow up of PR #459  by @archibate 

I think there are some opportunities for refactoring more:

1. All the key string constants (e.g. `"Shift"`) can be defined in a single place and shared by all platforms.
2. `MouseEvent` should probably include a button field to distinguish left, middle or right.
https://github.com/taichi-dev/taichi/blob/2097096488de7641c242b5274cd020ca1a1e5013/taichi/visual/gui.h#L495
3. For mouse events, we can do the `push_back` here:
https://github.com/taichi-dev/taichi/blob/2097096488de7641c242b5274cd020ca1a1e5013/taichi/visual/gui.h#L718
4. Actually,  I think `key_events` is a little bit abused for holding mouse events.  Maybe have `ti.has_input_event()` and `ti.get_input_event()`?  The item returned by `ti.get_input_event()` has a type to tell if it's a mouse or a keyboard event (or any other input device). But i guess this can be deferred because it's not that trivial and the current GUI works OK enough. @yuanming-hu @archibate  Thoughts?
