### PR TITLE
Allow `ti test_python` to take in individual test files

### DIFF
--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -6,16 +6,24 @@ import random
 from taichi.tools.video import make_video, interpolate_frames, mp4_to_gif, scale_video, crop_video, accelerate_video
 
 
-def test_python(verbose=False):
+def test_python(test_files=None, verbose=False):
   print("\nRunning python tests...\n")
   import taichi as ti
   import pytest
+  test_dir = None
   if ti.is_release():
-    test_dir = os.path.join(ti.package_root(), 'tests')
+    test_dir = ti.package_root()
   else:
-    test_dir = os.path.join(ti.get_repo_directory(), 'tests')
-
-  args = [test_dir]
+    test_dir = ti.get_repo_directory()
+  test_dir = os.path.join(test_dir, 'tests', 'python')
+  args = []
+  if test_files:
+    # run individual tests
+    for f in test_files:
+      args.append(os.path.join(test_dir, f))
+  else:
+    # run all the tests
+    args = [test_dir]
   if verbose:
     args += ['-s']
 
@@ -92,7 +100,7 @@ def main(debug=False):
       script = script.read()
     exec(script, {'__name__': '__main__'})
   elif mode == "test_python":
-    return test_python()
+    return test_python(test_files=sys.argv[2:])
   elif mode == "test_cpp":
     return test_cpp()
   elif mode == "test":
@@ -100,7 +108,7 @@ def main(debug=False):
       return -1
     return test_cpp()
   elif mode == "test_verbose":
-    if test_python(True) != 0:
+    if test_python(verbose=True) != 0:
       return -1
     return test_cpp()
   elif mode == "build":


### PR DESCRIPTION
Example usage:

```
ti test_python test_abs.py test_basics.py
```

I think this simplifies the devs's work if they want to run a specific test file locally. I'd like to support these for `ti test` `ti test_verbose` as well, but then the CPP tests are already using `sys.args[2:]`... IMO it's better to rewrite this using [`argparse`](https://docs.python.org/3/library/argparse.html) 

No issue..