### PR TITLE
Use Runtime::root as Metal root buffer's memory

### DIFF
--- a/taichi/arithmetic.h
+++ b/taichi/arithmetic.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <type_traits>
+
+namespace taichi {
+
+namespace detail {
+template <class T>
+struct always_false : std::false_type {};
+
+template <class T>
+inline constexpr bool always_false_v = always_false<T>::value;
+}  // namespace detail
+
+// Round up |a| to the closest multiple of |b|, works only for integers.
+template <typename T>
+T iroundup(T a, T b) {
+  if constexpr (std::is_integral_v<T>) {
+    return ((a + b - 1) / b) * b;
+  } else {
+    // Have to be type dependent: https://stackoverflow.com/a/53945549/12003165
+    static_assert(detail::always_false_v<T>, "Must be integral type");
+  }
+}
+
+}  // namespace taichi

--- a/taichi/platform/metal/metal_runtime.h
+++ b/taichi/platform/metal/metal_runtime.h
@@ -3,6 +3,7 @@
 #include <taichi/memory_pool.h>
 #include <taichi/profiler.h>
 #include <taichi/tlang_util.h>
+#include <taichi/taichi_llvm_context.h>
 
 #include <memory>
 #include <string>
@@ -22,8 +23,16 @@ namespace metal {
 // series of Metal kernels generated from a Taichi kernel.
 class MetalRuntime {
  public:
-  MetalRuntime(size_t root_size, CompileConfig *config, MemoryPool *mem_pool,
-               ProfilerBase *profiler);
+  struct Options {
+    size_t root_size;
+    void* llvm_runtime;
+    TaichiLLVMContext* llvm_ctx;
+    CompileConfig* config;
+    MemoryPool *mem_pool;
+    ProfilerBase *profiler;
+  };
+
+  explicit MetalRuntime(Options options);
   // To make Pimpl + std::unique_ptr work
   ~MetalRuntime();
 


### PR DESCRIPTION
Issue #396 

Pros:

1. we can launch SNode reader/write kernels on the host side.
1. Save some memory -- MetalRuntime now doesn't maintain the root buffer's memory (unless the LLVM runtime's memory is zero, in which we still had to allocate to make sure things don't break. This can be cleaned up later..)

Cons:

1. I think the host-side reader/writer kernels work because for dense nodes, the data layout produced by LLVM happen to be the same as how we interpret the memory in Metal. This can be fragile. But given that the dense nodes are really just a bunch of arrays of primitives, i feel that this can work just fine.
2. Because Metal requires both the **address** and the **size**  of its buffer memory to be page aligned ([doc](https://developer.apple.com/documentation/metal/mtldevice/1433382-newbufferwithbytesnocopy?language=objc)), I had to change the Runtime's `root` allocation to round up the size to `kPagesize`. This can waste at most 4KB memory, but I don't expect it introducing a correctness issue?

For `bitmasked` snodes, i think the bit masks are stored after the real data?