### PR TITLE
python bin/taichi instead of python -m taichi, for exit code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,5 +56,5 @@ build_script:
   - cd ..
   - '%PYTHON% -c "import taichi"'
   - "%PYTHON% examples/laplace.py"
-  - "%PYTHON% -m taichi test"
+  - "%PYTHON% bin/taichi test"
   - "cd python && %PYTHON% build.py try_upload"


### PR DESCRIPTION
This makes taichi.main can return exit code instead of always 0.
Btw, simply `ti test` fails because `cmd` doesn't support sh-bang, i.e. `#!/usr/bin/python`.
