### PR TITLE
Use Runtime::temporaries to back Metal runtime's global tmps buffer

### DIFF
--- a/taichi/constants.h
+++ b/taichi/constants.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstddef>
+
 constexpr int taichi_max_num_indices = 8;
 constexpr int taichi_max_num_args = 8;
 constexpr int taichi_max_num_snodes = 1024;
-constexpr int taichi_global_tmp_buffer_size = 1024 * 1024;
+constexpr std::size_t taichi_global_tmp_buffer_size = 1024 * 1024;
 constexpr int taichi_max_num_mem_requests = 1024 * 64;
-
+constexpr std::size_t taichi_page_size = 4096;
 
 using assert_failed_type = void (*)(const char *);

--- a/taichi/runtime/runtime.cpp
+++ b/taichi/runtime/runtime.cpp
@@ -647,23 +647,24 @@ Ptr Runtime_initialize(Runtime **runtime_ptr,
     printf("[runtime.cpp: Initializing runtime with %d snode(s)...]\n",
            num_snodes);
 
-  constexpr uint64_t kPageSize = 4096;
   // runtime->allocate ready to use
   runtime->mem_req_queue = (MemRequestQueue *)runtime->allocate_aligned(
-      sizeof(MemRequestQueue), kPageSize);
+      sizeof(MemRequestQueue), taichi_page_size);
 
   // For Metal runtime, we have to make sure that both the beginning adddress
   // and the size of the root buffer memory are aligned to page size. I think
   // it is fine to allocate the memory that is larger than what the LLVM struct
   // requires?
-  runtime->root_mem_size = taichi::iroundup(root_size, kPageSize);
-  auto root_ptr = runtime->allocate_aligned(runtime->root_mem_size, kPageSize);
+  runtime->root_mem_size =
+      taichi::iroundup((size_t)root_size, taichi_page_size);
+  auto root_ptr =
+      runtime->allocate_aligned(runtime->root_mem_size, taichi_page_size);
 
-  runtime->temporaries =
-      (Ptr)runtime->allocate_aligned(taichi_global_tmp_buffer_size, kPageSize);
+  runtime->temporaries = (Ptr)runtime->allocate_aligned(
+      taichi_global_tmp_buffer_size, taichi_page_size);
 
   runtime->rand_states = (RandState *)runtime->allocate_aligned(
-      sizeof(RandState) * num_rand_states, kPageSize);
+      sizeof(RandState) * num_rand_states, taichi_page_size);
   for (int i = 0; i < num_rand_states; i++)
     initialize_rand_state(&runtime->rand_states[i], i);
 


### PR DESCRIPTION
Issue #396 

This is a follow up of #488. I think all this PR does is just to save a few pages...