### PR TITLE
Minor fix of alg_simp.cpp and add cast from i32 to f32 in constant_fold

### DIFF
--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -25,6 +25,12 @@ class ConstantFold : public BasicStmtVisitor {
           new_constant.val_i32 = int32(v);
           success = true;
         }
+      } else if (src_type == DataType::i32) {
+        auto v = input.val_int32();
+        if (dst_type == DataType::f32) {
+          new_constant.val_f32 = float32(v);
+          success = true;
+        }
       }
 
       if (success) {


### PR DESCRIPTION
See https://github.com/taichi-dev/taichi/commit/ab1bfed008518c2dbe206e883d2dda81bfb8b587#r37342924.

Also add cast from i32 to f32 in constant_fold.cpp to write more comprehensive tests more conveniently (obviating the need of writing `TypedConstant(0.0f)` and just write `TypedConstant(0)`).