### PR TITLE
Fix how num_elements is computed in Dense node

### DIFF
--- a/taichi/runtime/node_dense.h
+++ b/taichi/runtime/node_dense.h
@@ -9,12 +9,16 @@ struct DenseMeta : public StructMeta {
 STRUCT_FIELD(DenseMeta, bitmasked)
 STRUCT_FIELD(DenseMeta, morton_dim)
 
+i32 Dense_get_num_elements(Ptr meta, Ptr node) {
+  return ((StructMeta *)meta)->max_num_elements;
+}
+
 void Dense_activate(Ptr meta, Ptr node, int i) {
   auto smeta = (StructMeta *)meta;
   auto dmeta = (DenseMeta *)meta;
   if (DenseMeta_get_bitmasked(dmeta)) {
     auto element_size = StructMeta_get_element_size(smeta);
-    auto num_elements = StructMeta_get_element_size(smeta);
+    auto num_elements = Dense_get_num_elements(meta, node);
     auto data_section_size = element_size * num_elements;
     auto mask_begin = (uint64 *)(node + data_section_size);
     atomic_or_u64(&mask_begin[i / 64], 1UL << (i % 64));
@@ -26,7 +30,7 @@ i32 Dense_is_active(Ptr meta, Ptr node, int i) {
   auto dmeta = (DenseMeta *)meta;
   if (DenseMeta_get_bitmasked(dmeta)) {
     auto element_size = StructMeta_get_element_size(smeta);
-    auto num_elements = StructMeta_get_element_size(smeta);
+    auto num_elements = Dense_get_num_elements(meta, node);
     auto data_section_size = element_size * num_elements;
     auto mask_begin = node + data_section_size;
     return i32(bool((mask_begin[i / 8] >> (i % 8)) & 1));
@@ -37,8 +41,4 @@ i32 Dense_is_active(Ptr meta, Ptr node, int i) {
 
 Ptr Dense_lookup_element(Ptr meta, Ptr node, int i) {
   return node + ((StructMeta *)meta)->element_size * i;
-}
-
-i32 Dense_get_num_elements(Ptr meta, Ptr node) {
-  return ((StructMeta *)meta)->max_num_elements;
 }


### PR DESCRIPTION
It seems like `num_elements` was miscomputed as `element_size` to me, so I'd like you to help verify if this fix is correct. BTW, I guess the canonical way to write this should be

```cpp
auto num_elements = meta->get_num_elements(meta, node);
```

But then it seems that `StructMeta::get_num_elements` just points to `Dense_get_num_elements` for `dense` SNodes?

(Sorry for the reduced works these days, I'm busy following the news on COVID-19 here in Tokyo 😂 )