### PR TITLE
Expose a few profiler methods so that it can be used in Python.

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -29,6 +29,8 @@ cuda = core.cuda
 metal = core.metal
 profiler_print = lambda: core.get_current_program().profiler_print()
 profiler_clear = lambda: core.get_current_program().profiler_clear()
+profiler_start = lambda n: core.get_current_program().profiler_start(n)
+profiler_stop = lambda: core.get_current_program().profiler_stop()
 
 class _Extension(object):
   def __init__(self):

--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -37,6 +37,7 @@ class GUI:
     self.background_color = background_color
     self.key_pressed = set()
     self.clear()
+    self.core.set_profiler(ti.core.get_current_program().get_profiler())
     
   def clear(self, color=None):
     if color is None:

--- a/taichi/program.h
+++ b/taichi/program.h
@@ -88,6 +88,21 @@ class Program {
     }
   }
 
+  void profiler_start(const std::string &name) {
+    TI_ASSERT(config.use_llvm);
+    profiler_llvm->start(name);
+  }
+
+  void profiler_stop() {
+    TI_ASSERT(config.use_llvm);
+    profiler_llvm->stop();
+  }
+
+  ProfilerBase *get_profiler() {
+    TI_ASSERT(config.use_llvm);
+    return profiler_llvm.get();
+  }
+
   Context &get_context() {
     context.runtime = (Runtime *)llvm_runtime;
     return context;

--- a/taichi/python/export_visual.cpp
+++ b/taichi/python/export_visual.cpp
@@ -32,6 +32,10 @@ void export_visual(py::module &m) {
       .def("get_key_event_head_pos", &GUI::get_key_event_head_pos)
       .def("pop_key_event_head", &GUI::pop_key_event_head)
       .def("get_cursor_pos", &GUI::get_cursor_pos)
+      .def("set_profiler",
+           [](GUI *gui, void *profiler) -> void {
+             gui->set_profiler((Tlang::ProfilerBase *)profiler);
+           })
       .def("update", &GUI::update);
   py::class_<Canvas>(m, "Canvas")
       .def("clear", static_cast<void (Canvas::*)(uint32)>(&Canvas::clear))

--- a/taichi/python_bindings.cpp
+++ b/taichi/python_bindings.cpp
@@ -6,6 +6,7 @@
 #include <taichi/extension.h>
 #include <taichi/common/interface.h>
 #include <taichi/python/export.h>
+#include <taichi/visual/gui.h>
 #include "svd.h"
 
 TI_NAMESPACE_BEGIN
@@ -103,12 +104,22 @@ void export_lang(py::module &m) {
       .def_readonly("config", &Program::config)
       .def("profiler_print", &Program::profiler_print)
       .def("profiler_clear", &Program::profiler_clear)
+      .def("profiler_start", &Program::profiler_start)
+      .def("profiler_stop", &Program::profiler_stop)
+      .def("get_profiler",
+           [](Program *program) -> void * {
+             // We didn't expose the ProfilerBase interface, so the only purpose
+             // of this method is to expose the address of the profiler, so that
+             // other modules (e.g. GUI) can receive the profiler.
+             return (void *)(program->get_profiler());
+           })
       .def("finalize", &Program::finalize)
-      .def("get_root",
-           [&](Program *program) -> SNode * {
-             return program->snode_root.get();
-           },
-           py::return_value_policy::reference)
+      .def(
+          "get_root",
+          [&](Program *program) -> SNode * {
+            return program->snode_root.get();
+          },
+          py::return_value_policy::reference)
       .def("get_snode_writer", &Program::get_snode_writer)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("synchronize", &Program::synchronize);

--- a/taichi/visual/gui.h
+++ b/taichi/visual/gui.h
@@ -443,6 +443,10 @@ class GUIBaseCocoa {
 using GUIBase = GUIBaseCocoa;
 #endif
 
+namespace Tlang {
+class ProfilerBase;
+}  // namespace Tlang
+
 class GUI : public GUIBase {
  public:
   std::string window_name;
@@ -459,6 +463,7 @@ class GUI : public GUIBase {
   Vector2i cursor_pos;
   bool button_status[3];
   int widget_height;
+  Tlang::ProfilerBase *profiler;
 
   void set_mouse_pos(int x, int y) {
     cursor_pos = Vector2i(x, y);
@@ -838,6 +843,10 @@ class GUI : public GUIBase {
   }
 
   ~GUI();
+
+  void set_profiler(Tlang::ProfilerBase *profiler) {
+    this->profiler = profiler;
+  }
 };
 
 TI_NAMESPACE_END


### PR DESCRIPTION
Issue #489 

This PR exposes the profiler methods to Taichi, so that users can profile their scripts:

```python
  ti.profiler_start('heavy_work')
  heavy_work(foo)
  ti.profiler_stop()
```

It also passes the profiler to GUI