### PR TITLE
Make test_types.py work for the Metal backend

### DIFF
--- a/taichi/platform/metal/metal_runtime.cpp
+++ b/taichi/platform/metal/metal_runtime.cpp
@@ -278,6 +278,7 @@ class MetalRuntime::Impl {
 
     auto *llvm_ctx = params.llvm_ctx;
     auto *llvm_rtm = params.llvm_runtime;
+    TI_ASSERT(llvm_ctx != nullptr && llvm_rtm != nullptr);
     const size_t rtm_root_mem_size = llvm_ctx->lookup_function<size_t(void *)>(
         "Runtime_get_root_mem_size")(llvm_rtm);
     if (rtm_root_mem_size > 0) {
@@ -286,6 +287,7 @@ class MetalRuntime::Impl {
                 rtm_root_mem_size);
       auto *rtm_root_mem = params.llvm_ctx->lookup_function<uint8 *(void *)>(
           "Runtime_get_root")(llvm_rtm);
+      TI_ASSERT(rtm_root_mem != nullptr);
       root_buffer_ = new_mtl_buffer_no_copy(device_.get(), rtm_root_mem,
                                             rtm_root_mem_size);
     } else {

--- a/taichi/program.cpp
+++ b/taichi/program.cpp
@@ -190,7 +190,8 @@ void Program::materialize_layout() {
   std::unique_ptr<StructCompiler> scomp = StructCompiler::make(this, Arch::x64);
   scomp->run(*snode_root, true);
 
-  if (arch_is_cpu(config.arch) || config.arch == Arch::cuda) {
+  if (arch_is_cpu(config.arch) || config.arch == Arch::cuda ||
+      config.arch == Arch::metal) {
     initialize_runtime_system(scomp.get());
   }
 

--- a/tests/python/test_types.py
+++ b/tests/python/test_types.py
@@ -14,14 +14,14 @@ def _test_type_assign_argument(dt):
   func(3)
   assert x[None] == 3
 
-@ti.parametrize('dt', _TI_TYPES)
+@pytest.mark.parametrize('dt', _TI_TYPES)
 # Metal backend doesn't support arg type other than 32-bit yet.
 @ti.archs_excluding(ti.metal)
 def test_type_assign_argument(dt):
   _test_type_assign_argument(dt)
 
 
-@ti.parametrize('dt', _TI_64_TYPES)
+@pytest.mark.parametrize('dt', _TI_64_TYPES)
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_type_assign_argument64(dt):
@@ -46,12 +46,12 @@ def _test_type_operator(dt):
       assert add[None] == x[None] + y[None]
       assert mul[None] == x[None] * y[None]
 
-@ti.parametrize('dt', _TI_TYPES)
+@pytest.mark.parametrize('dt', _TI_TYPES)
 @ti.all_archs
 def test_type_operator(dt):
   _test_type_operator(dt)
 
-@ti.parametrize('dt', _TI_64_TYPES)
+@pytest.mark.parametrize('dt', _TI_64_TYPES)
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_type_operator64(dt):
@@ -70,12 +70,12 @@ def _test_type_tensor(dt):
       assert x[i, j] == 3
 
 
-@ti.parametrize('dt', _TI_TYPES)
+@pytest.mark.parametrize('dt', _TI_TYPES)
 @ti.all_archs
 def test_type_tensor(dt):
   _test_type_tensor(dt)
 
-@ti.parametrize('dt', _TI_64_TYPES)
+@pytest.mark.parametrize('dt', _TI_64_TYPES)
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_type_tensor64(dt):
@@ -103,7 +103,7 @@ def _test_overflow(dt, n):
   else:
     assert c[None] == 2 ** n // 3 * 2 # does not overflow
 
-@ti.parametrize('dt,n', [
+@pytest.mark.parametrize('dt,n', [
   (ti.i8, 8),
   (ti.u8, 8),
   (ti.i16, 16),
@@ -115,7 +115,7 @@ def _test_overflow(dt, n):
 def test_overflow(dt, n):
   _test_overflow(dt, n)
 
-@ti.parametrize('dt,n', [
+@pytest.mark.parametrize('dt,n', [
   (ti.i64, 64),
   (ti.u64, 64),
 ])

--- a/tests/python/test_types.py
+++ b/tests/python/test_types.py
@@ -1,73 +1,98 @@
 import taichi as ti
+import pytest
 
-def all_data_types_and_test(foo):
-  def wrapped():
-    tests = []
-    for dt in [ti.i32, ti.i64, ti.i8, ti.i16, ti.u8, ti.u16, ti.u32, ti.u64, ti.f32, ti.f64]:
-      tests.append(foo(dt))
-    for test in tests:
-      # variables are expected to be declared before kernel invocation, discuss at:
-      # https://github.com/taichi-dev/taichi/pull/505#issuecomment-588644274
-      test()
-  return wrapped
+_TI_TYPES = [ti.i8, ti.i16, ti.i32, ti.u8, ti.u16, ti.u32, ti.f32]
+_TI_64_TYPES = [ti.i64, ti.u64, ti.f64]
 
-@ti.all_archs
-@all_data_types_and_test
-def test_type_assign_argument(dt):
+def _test_type_assign_argument(dt):
   x = ti.var(dt, shape=())
 
-  def tester():
-    @ti.kernel
-    def func(value: dt):
-      x[None] = value
+  @ti.kernel
+  def func(value: dt):
+    x[None] = value
 
-    func(3)
-    assert x[None] == 3
+  func(3)
+  assert x[None] == 3
 
-  return tester
+@pytest.mark.parametrize('dt', _TI_TYPES)
+def test_type_assign_argument(dt):
+  # Metal backend doesn't support arg type other than 32-bit yet.
+  @ti.archs_excluding(ti.metal)
+  def run():
+    _test_type_assign_argument(dt)
+  run()
 
-@ti.all_archs
-@all_data_types_and_test
-def test_type_operator(dt):
+
+@pytest.mark.parametrize('dt', _TI_64_TYPES)
+def test_type_assign_argument64(dt):
+  @ti.require(ti.extension.data64)
+  @ti.all_archs
+  def run():
+    _test_type_assign_argument(dt)
+  run()
+
+def _test_type_operator(dt):
   x = ti.var(dt, shape=())
   y = ti.var(dt, shape=())
   add = ti.var(dt, shape=())
   mul = ti.var(dt, shape=())
 
-  def tester():
-    @ti.kernel
-    def func():
-      add[None] = x[None] + y[None]
-      mul[None] = x[None] * y[None]
+  @ti.kernel
+  def func():
+    add[None] = x[None] + y[None]
+    mul[None] = x[None] * y[None]
 
-    for i in range(0, 3):
-      for j in range(0, 3):
-        x[None] = i
-        y[None] = j
-        func()
-        assert add[None] == x[None] + y[None]
-        assert mul[None] == x[None] * y[None]
+  for i in range(0, 3):
+    for j in range(0, 3):
+      x[None] = i
+      y[None] = j
+      func()
+      assert add[None] == x[None] + y[None]
+      assert mul[None] == x[None] * y[None]
 
-  return tester
+@pytest.mark.parametrize('dt', _TI_TYPES)
+def test_type_operator(dt):
+  @ti.all_archs
+  def run():
+    _test_type_operator(dt)
+  run()
 
-@ti.all_archs
-@all_data_types_and_test
-def test_type_tensor(dt):
+@pytest.mark.parametrize('dt', _TI_64_TYPES)
+def test_type_operator64(dt):
+  @ti.require(ti.extension.data64)
+  @ti.all_archs
+  def run():
+    _test_type_operator(dt)
+  run()
+
+def _test_type_tensor(dt):
   x = ti.var(dt, shape=(3, 2))
 
-  def tester():
-    @ti.kernel
-    def func(i: ti.i32, j: ti.i32):
-      x[i, j] = 3
+  @ti.kernel
+  def func(i: ti.i32, j: ti.i32):
+    x[i, j] = 3
 
-    for i in range(0, 3):
-      for j in range(0, 2):
-        func(i, j)
-        assert x[i, j] == 3
+  for i in range(0, 3):
+    for j in range(0, 2):
+      func(i, j)
+      assert x[i, j] == 3
 
-  return tester
 
-@ti.all_archs
+@pytest.mark.parametrize('dt', _TI_TYPES)
+def test_type_tensor(dt):
+  @ti.all_archs
+  def run():
+    _test_type_tensor(dt)
+  run()
+
+@pytest.mark.parametrize('dt', _TI_64_TYPES)
+def test_type_tensor64(dt):
+  @ti.require(ti.extension.data64)
+  @ti.all_archs
+  def run():
+    _test_type_tensor(dt)
+  run()
+
 def _test_overflow(dt, n):
   a = ti.var(dt, shape=())
   b = ti.var(dt, shape=())
@@ -90,12 +115,27 @@ def _test_overflow(dt, n):
   else:
     assert c[None] == 2 ** n // 3 * 2 # does not overflow
 
-def test_overflow():
-  _test_overflow(ti.i8, 8)
-  _test_overflow(ti.u8, 8)
-  _test_overflow(ti.i16, 16)
-  _test_overflow(ti.u16, 16)
-  _test_overflow(ti.i32, 32)
-  _test_overflow(ti.u32, 32)
-  _test_overflow(ti.i64, 64)
-  _test_overflow(ti.u64, 64)
+@pytest.mark.parametrize('dt,n', [
+  (ti.i8, 8),
+  (ti.u8, 8),
+  (ti.i16, 16),
+  (ti.u16, 16),
+  (ti.i32, 32),
+  (ti.u32, 32),
+])
+def test_overflow(dt, n):
+  @ti.all_archs
+  def run():
+    _test_overflow(dt, n)
+  run()
+
+@pytest.mark.parametrize('dt,n', [
+  (ti.i64, 64),
+  (ti.u64, 64),
+])
+def test_overflow64(dt, n):
+  @ti.require(ti.extension.data64)
+  @ti.all_archs
+  def run():
+    _test_overflow(dt, n)
+  run()

--- a/tests/python/test_types.py
+++ b/tests/python/test_types.py
@@ -14,22 +14,18 @@ def _test_type_assign_argument(dt):
   func(3)
   assert x[None] == 3
 
-@pytest.mark.parametrize('dt', _TI_TYPES)
+@ti.parametrize('dt', _TI_TYPES)
+# Metal backend doesn't support arg type other than 32-bit yet.
+@ti.archs_excluding(ti.metal)
 def test_type_assign_argument(dt):
-  # Metal backend doesn't support arg type other than 32-bit yet.
-  @ti.archs_excluding(ti.metal)
-  def run():
-    _test_type_assign_argument(dt)
-  run()
+  _test_type_assign_argument(dt)
 
 
-@pytest.mark.parametrize('dt', _TI_64_TYPES)
+@ti.parametrize('dt', _TI_64_TYPES)
+@ti.require(ti.extension.data64)
+@ti.all_archs
 def test_type_assign_argument64(dt):
-  @ti.require(ti.extension.data64)
-  @ti.all_archs
-  def run():
-    _test_type_assign_argument(dt)
-  run()
+  _test_type_assign_argument(dt)
 
 def _test_type_operator(dt):
   x = ti.var(dt, shape=())
@@ -50,20 +46,16 @@ def _test_type_operator(dt):
       assert add[None] == x[None] + y[None]
       assert mul[None] == x[None] * y[None]
 
-@pytest.mark.parametrize('dt', _TI_TYPES)
+@ti.parametrize('dt', _TI_TYPES)
+@ti.all_archs
 def test_type_operator(dt):
-  @ti.all_archs
-  def run():
-    _test_type_operator(dt)
-  run()
+  _test_type_operator(dt)
 
-@pytest.mark.parametrize('dt', _TI_64_TYPES)
+@ti.parametrize('dt', _TI_64_TYPES)
+@ti.require(ti.extension.data64)
+@ti.all_archs
 def test_type_operator64(dt):
-  @ti.require(ti.extension.data64)
-  @ti.all_archs
-  def run():
-    _test_type_operator(dt)
-  run()
+  _test_type_operator(dt)
 
 def _test_type_tensor(dt):
   x = ti.var(dt, shape=(3, 2))
@@ -78,20 +70,16 @@ def _test_type_tensor(dt):
       assert x[i, j] == 3
 
 
-@pytest.mark.parametrize('dt', _TI_TYPES)
+@ti.parametrize('dt', _TI_TYPES)
+@ti.all_archs
 def test_type_tensor(dt):
-  @ti.all_archs
-  def run():
-    _test_type_tensor(dt)
-  run()
+  _test_type_tensor(dt)
 
-@pytest.mark.parametrize('dt', _TI_64_TYPES)
+@ti.parametrize('dt', _TI_64_TYPES)
+@ti.require(ti.extension.data64)
+@ti.all_archs
 def test_type_tensor64(dt):
-  @ti.require(ti.extension.data64)
-  @ti.all_archs
-  def run():
-    _test_type_tensor(dt)
-  run()
+  _test_type_tensor(dt)
 
 def _test_overflow(dt, n):
   a = ti.var(dt, shape=())
@@ -115,7 +103,7 @@ def _test_overflow(dt, n):
   else:
     assert c[None] == 2 ** n // 3 * 2 # does not overflow
 
-@pytest.mark.parametrize('dt,n', [
+@ti.parametrize('dt,n', [
   (ti.i8, 8),
   (ti.u8, 8),
   (ti.i16, 16),
@@ -123,19 +111,15 @@ def _test_overflow(dt, n):
   (ti.i32, 32),
   (ti.u32, 32),
 ])
+@ti.all_archs
 def test_overflow(dt, n):
-  @ti.all_archs
-  def run():
-    _test_overflow(dt, n)
-  run()
+  _test_overflow(dt, n)
 
-@pytest.mark.parametrize('dt,n', [
+@ti.parametrize('dt,n', [
   (ti.i64, 64),
   (ti.u64, 64),
 ])
+@ti.require(ti.extension.data64)
+@ti.all_archs
 def test_overflow64(dt, n):
-  @ti.require(ti.extension.data64)
-  @ti.all_archs
-  def run():
-    _test_overflow(dt, n)
-  run()
+  _test_overflow(dt, n)


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = #504 #396 

Hi @archibate 

Sorry i changed your tests quite a bit, in order to make it work for the Metal backend as well. The problem with Metal is that it doesn't support 64bit buffers, so we had to separate the tests into 64-bit vs the rest. 

I found a nice decorator `@pytest.mark.parametrize()` ([doc](http://doc.pytest.org/en/latest/parametrize.html#pytest-mark-parametrize)) that can somewhat simplify the code. 

Also I saw that you got this "variables are expected to be declared before kernel invocation" problem,  therefore had to create another wrapper inside each test? IIUC, `ti.all_archs(_with)` resets the test case here:
https://github.com/taichi-dev/taichi/blob/57287cf0493f5719e0e8b021fe18cdfe0c20c718/python/taichi/lang/__init__.py#L224

So by putting `@ti.all_archs` at the bottom of the decorator chain, we no longer need to wrap it, because it resets Taichi every time the test case is called. (Unfortunately, this doesn't apply to this PR, as explained below)

At last, I tried something like this:

```py
def _test_foo(x):
  ...

@pytest.mark.parametrize('x', [1, 2, 3])
@ti.all_archs
def test_foo(x):
  _test_foo(x)
```

But `@pytest.mark.parametrize` didn't work well with `@ti.all_archs`  this way. So I had to once again, wrap the `_test_foo()` inside `test_foo()`, so that `@ti.all_archs` can correctly apply the decoration:

```py
@pytest.mark.parametrize('x', [1, 2, 3])
def test_foo(x):
  @ti.all_archs
  def run():
    _test_foo(x)
  run()
```