### PR TITLE
Make sure KernelTemplateMapper extractors's size is the same as the number of args

### DIFF
--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -60,7 +60,10 @@ class KernelTemplateMapper:
 
   def __init__(self, annotations, template_slot_locations):
     self.annotations = annotations
-    self.extractors = tuple((i, anno.extract) for (i, anno) in enumerate(self.annotations) if hasattr(anno, 'extract'))
+    # Make sure extractors's size is the same as the number of args
+    dummy_extract = lambda arg: (type(arg).__name__, )
+    self.extractors = tuple((i, getattr(anno, 'extract', dummy_extract))
+                            for (i, anno) in enumerate(self.annotations))
     self.num_args = len(annotations)
     self.template_slot_locations = template_slot_locations
     self.mapping = {}

--- a/tests/python/test_empty.py
+++ b/tests/python/test_empty.py
@@ -8,3 +8,12 @@ def test_empty():
     pass
 
   func()
+
+@ti.all_archs
+def test_empty_args():
+
+  @ti.kernel
+  def func(x: ti.i32, arr: ti.ext_arr()):
+    pass
+
+  foo(42, np.arange(10, dtype=np.float32))

--- a/tests/python/test_empty.py
+++ b/tests/python/test_empty.py
@@ -16,4 +16,5 @@ def test_empty_args():
   def func(x: ti.i32, arr: ti.ext_arr()):
     pass
 
-  foo(42, np.arange(10, dtype=np.float32))
+  import numpy as np
+  func(42, np.arange(10, dtype=np.float32))


### PR DESCRIPTION
Fixes #531

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->
