### PR TITLE
Mark sync bit only after running a kernel on GPU

### DIFF
--- a/taichi/kernel.cpp
+++ b/taichi/kernel.cpp
@@ -80,7 +80,7 @@ void Kernel::operator()() {
     auto &c = program.get_context();
     compiled(c);
   }
-  program.sync = false;
+  program.sync = (program.sync && arch_is_cpu(arch));
 }
 
 void Kernel::set_arg_float(int i, float64 d) {

--- a/tests/python/test_sync.py
+++ b/tests/python/test_sync.py
@@ -1,0 +1,25 @@
+import taichi as ti
+
+
+@ti.all_archs
+def test_kernel_sync():
+  n = 128
+  x = ti.var(ti.i32, shape=(3,))
+  y = ti.var(ti.i32, shape=(n,))
+  # These [] calls are all on CPU, so no synchronization needed
+  x[0] = 42
+  assert x[0] == 42
+  x[1] = 233
+  x[2] = -1
+
+  @ti.kernel
+  def func():
+    for i in y:
+      y[i] = x[i % 3]
+  # Kernel *may* run on GPU
+  # Note that the previous kernel is a write, which didn't do a sync. But that
+  # should be fine -- we only need to sync the memory after GPU -> CPU.
+  func()
+  # These [] calls are on CPU. They should be smart enough to sync only once.
+  for i in range(n):
+    assert y[i] == x[i % 3]


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = -1

I think kernel synchronization can be a bit smarter, i.e. a sync is needed only when a CPU kernel is run after a GPU one. With this change, I saw that `mpm99.py`'s initialization time was reduced from `15s` to `5s` with `quality = 2`. Basically, all those `[]` at startup won't result in a `synchronize()` any more.

However, this might be that Metal's sync has a relatively large overhead. What i'm not sure is that

* Does `cudaDeviceSynchronize()` also have a non-negligible overhead if a large number of `[]` is used?
* Is this still useful, or even correct, once the unified memory is removed? 