### PR TITLE
Convert `@classkernel` to `@kernel`

### DIFF
--- a/docs/odop.rst
+++ b/docs/odop.rst
@@ -31,17 +31,17 @@ A brief example:
       root.dense(ti.ij, (self.n, self.m)).place(self.val)
       root.place(self.total)
 
-    @ti.classkernel
+    @ti.kernel
     def inc(self):
       for i, j in self.val:
         ti.atomic_add(self.val[i, j], self.increment)
 
-    @ti.classkernel
+    @ti.kernel
     def inc2(self, increment: ti.i32):
       for i, j in self.val:
         ti.atomic_add(self.val[i, j], increment)
 
-    @ti.classkernel
+    @ti.kernel
     def reduce(self):
       for i, j in self.val:
         ti.atomic_add(self.total, self.val[i, j] * 4)

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -385,7 +385,7 @@ class Kernel:
     return self.compiled_functions[key](*args)
 
 import re
-_DECORATED_CLASS_STACKFRAME_STMT_RE = re.compile(r'@\w+\.data_oriented')
+_DECORATED_CLASS_STACKFRAME_STMT_RE = re.compile(r'@(\w+\.)?data_oriented')
 
 def _kernel_impl(func, level_of_class_stackframe, verbose=False):
   # Can decorators determine if a function is being defined inside a class?

--- a/python/taichi/lang/tape.py
+++ b/python/taichi/lang/tape.py
@@ -25,8 +25,5 @@ class Tape:
     assert self.entered == True, "Before evaluating gradiends tape must be entered."
     assert self.gradient_evaluated == False, "Gradients of grad can be evaluated only once."
     for func, args in reversed(self.calls):
-      if hasattr(func, 'grad'):
-        func.grad(*args)
-      # else:
-      #   func(*args, _gradient=True)
+      func.grad(*args)
     self.gradient_evaluated = True

--- a/python/taichi/lang/tape.py
+++ b/python/taichi/lang/tape.py
@@ -27,6 +27,6 @@ class Tape:
     for func, args in reversed(self.calls):
       if hasattr(func, 'grad'):
         func.grad(*args)
-      else:
-        func(*args, _gradient=True)
+      # else:
+      #   func(*args, _gradient=True)
     self.gradient_evaluated = True

--- a/tests/python/test_complex_kernels.py
+++ b/tests/python/test_complex_kernels.py
@@ -72,7 +72,7 @@ def test_complex_kernels_indirect():
 
 @ti.all_archs
 def test_complex_kernels_oop():
-
+  @ti.data_oriented
   class A:
 
     def __init__(self):
@@ -84,7 +84,7 @@ def test_complex_kernels_oop():
       ti.root.dense(ti.i, self.n).place(self.x)
       ti.root.place(self.total)
 
-    @ti.classkernel
+    @ti.kernel
     def func(self, mul: ti.f32):
       for i in range(self.n):
         ti.atomic_add(self.total[None], self.x[i] * mul)
@@ -96,7 +96,7 @@ def test_complex_kernels_oop():
 
     @ti.complex_kernel_grad(forward)
     def backward(self, mul):
-      self.func(mul, _gradient=True)
+      self.func.grad(mul)
 
   a = A()
 
@@ -113,7 +113,7 @@ def test_complex_kernels_oop():
 
 @ti.all_archs
 def test_complex_kernels_oop2():
-
+  @ti.data_oriented
   class A:
 
     def __init__(self):
@@ -125,7 +125,7 @@ def test_complex_kernels_oop2():
       ti.root.dense(ti.i, self.n).place(self.x)
       ti.root.place(self.total)
 
-    @ti.classkernel
+    @ti.kernel
     def func(self, mul: ti.f32):
       for i in range(self.n):
         ti.atomic_add(self.total[None], self.x[i] * mul)
@@ -140,7 +140,7 @@ def test_complex_kernels_oop2():
 
     @ti.complex_kernel_grad(forward)
     def backward(self, mul):
-      self.func(mul, _gradient=True)
+      self.func.grad(mul)
 
   a = A()
 

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -138,6 +138,13 @@ def test_oop_two_items():
     ti.root.place(arr2)
     ti.root.lazy_grad()
 
+  arr1.inc()
+  arr1.inc.grad()
+  arr2.inc()
+  arr2.inc.grad()
+  assert arr1.val[3, 4] == arr1_inc
+  assert arr2.val[8, 6] == arr2_inc
+
   with ti.Tape(loss=arr1.total):
     arr1.reduce()
   with ti.Tape(loss=arr2.total, clear_gradients=False):

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -15,7 +15,7 @@ def test_classfunc():
     def inc(self, i, j):
       self.val[i, j] += i * j
     
-    @ti.classkernel
+    @ti.kernel
     def fill(self):
       for i, j in self.val:
         self.inc(i, j)
@@ -45,17 +45,17 @@ def test_oop():
       root.dense(ti.ij, (self.n, self.m)).place(self.val)
       root.place(self.total)
 
-    @ti.classkernel
+    @ti.kernel
     def inc(self):
       for i, j in self.val:
         ti.atomic_add(self.val[i, j], self.increment)
 
-    @ti.classkernel
+    @ti.kernel
     def inc2(self, increment: ti.i32):
       for i, j in self.val:
         ti.atomic_add(self.val[i, j], increment)
 
-    @ti.classkernel
+    @ti.kernel
     def reduce(self):
       for i, j in self.val:
         ti.atomic_add(self.total, self.val[i, j] * 4)


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = #548 

Basically, we used the trick in https://stackoverflow.com/a/8793684/12003165 to detect if a function being decorated belongs to a class or not. Note that we cannot apply that trick as-is -- To support OOP, Taichi classes *must* be decorated by `@ti.data_oriented`. So instead of looking for `class `, we look for `@(\w+\.)?data_oriented`

Another thing being unified is `grad` on the wrapped kernel. There is no need for the special kwarg `_gradient: bool` on class kernels now. I made a small change to `DifferentiableMethod` (renamed to  `BoundedDifferentiableMethods`) so that it can get `adjoint` from the passed in wrapped function.

Also, both types of kernels' primal `Kernel` instance have a `grad` referencing the adjoint instance. In this way we are also able to unify the way to insert `(primal, args)` to a `Tape`.

**Limits**

* Users must decorate their classes with `@ti.data_oriented`. They still have the freedom to name `taichi` however they want (not limited to `ti`), but they must not alias the name `data_oriented`.

