### PR TITLE
[refactor] Construct `MetalKernelArgsAttribute` directly from `Kernel::Arg`s

### DIFF
--- a/taichi/platform/metal/metal_kernel_util.cpp
+++ b/taichi/platform/metal/metal_kernel_util.cpp
@@ -8,28 +8,26 @@ TLANG_NAMESPACE_BEGIN
 
 namespace metal {
 
-int MetalKernelArgsAttributes::insert_arg(DataType dt,
-                                         bool is_array,
-                                         size_t size,
-                                         bool is_return_val) {
-  ArgAttributes a;
-  a.dt = to_metal_type(dt);
-  const size_t dt_bytes = metal_data_type_bytes(a.dt);
-  if (dt_bytes > 4) {
-    // Metal doesn't support 64bit data buffers.
-    // TODO(k-ye): See if Metal supports less-than-32bit data buffers.
-    TI_ERROR("Metal kernel only supports <= 32-bit data, got {}",
-            metal_data_type_name(a.dt));
+MetalKernelArgsAttributes::MetalKernelArgsAttributes(
+    const std::vector<Kernel::Arg>& args)
+    : args_bytes_(0), extra_args_bytes_(Context::extra_args_size) {
+  arg_attribs_vec_.reserve(args.size());
+  for (const auto& ka : args) {
+    ArgAttributes ma;
+    ma.dt = to_metal_type(ka.dt);
+    const size_t dt_bytes = metal_data_type_bytes(ma.dt);
+    if (dt_bytes > 4) {
+      // Metal doesn't support 64bit data buffers.
+      TI_ERROR("Metal kernel only supports <= 32-bit data, got {}",
+               metal_data_type_name(ma.dt));
+    }
+    ma.is_array = ka.is_nparray;
+    ma.stride = ma.is_array ? ka.size : dt_bytes;
+    ma.index = arg_attribs_vec_.size();
+    ma.is_return_val = ka.is_return_value;
+    arg_attribs_vec_.push_back(ma);
   }
-  a.is_array = is_array;
-  a.stride = is_array ? size : dt_bytes;
-  a.index = arg_attribs_vec_.size();
-  a.is_return_val = is_return_val;
-  arg_attribs_vec_.push_back(a);
-  return a.index;
-}
 
-void MetalKernelArgsAttributes::finalize() {
   std::vector<int> scalar_indices;
   std::vector<int> array_indices;
   for (int i = 0; i < arg_attribs_vec_.size(); ++i) {
@@ -39,7 +37,6 @@ void MetalKernelArgsAttributes::finalize() {
       scalar_indices.push_back(i);
     }
   }
-  args_bytes_ = 0;
   // Put scalar args in the memory first
   for (int i : scalar_indices) {
     auto& arg = arg_attribs_vec_[i];
@@ -52,7 +49,6 @@ void MetalKernelArgsAttributes::finalize() {
     arg.offset_in_mem = args_bytes_;
     args_bytes_ += arg.stride;
   }
-  extra_args_bytes_ = Context::extra_args_size;
 }
 
 }  // namespace metal


### PR DESCRIPTION

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = #396 
