### PR TITLE
Add assertions to prevent infinite loop in `least_pot_bound` in case of negative snode size

### DIFF
--- a/taichi/common/bit.h
+++ b/taichi/common/bit.h
@@ -96,6 +96,9 @@ TI_FORCE_INLINE constexpr T product(const std::array<T, N> arr) {
 }
 
 constexpr std::size_t least_pot_bound(std::size_t v) {
+  if (v > std::numeric_limits<std::size_t>::max() / 2 + 1) {
+    TI_ERROR("v({}) too large", v)
+  }
   std::size_t ret = 1;
   while (ret < v) {
     ret *= 2;

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -43,6 +43,7 @@ SNode &SNode::create_node(std::vector<Index> indices,
   new_node.n = 1;
   for (int i = 0; i < sizes.size(); i++) {
     auto s = sizes[i];
+    TI_ASSERT(sizes[i] > 0);
     if (!bit::is_power_of_two(s)) {
       auto promoted_s = bit::least_pot_bound(s);
       TI_DEBUG("Non-power-of-two node size {} promoted to {}.", s, promoted_s);


### PR DESCRIPTION
Test case:
```python
import taichi as ti
ti.root.dense(ti.i, -1)
```
