### PR TITLE
[Refactor] Hide MetalStructCompiler to the cpp file

### DIFF
--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -1,7 +1,8 @@
-#include "codegen_metal.h"
+#include "taichi/codegen/codegen_metal.h"
 
 #include <string>
-#include <taichi/ir/ir.h>
+
+#include "taichi/ir/ir.h"
 
 TLANG_NAMESPACE_BEGIN
 namespace metal {

--- a/taichi/codegen/codegen_metal.h
+++ b/taichi/codegen/codegen_metal.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <taichi/inc/constants.h>
-#include <taichi/platform/metal/metal_data_types.h>
-#include <taichi/platform/metal/metal_kernel_util.h>
-#include <taichi/platform/metal/metal_runtime.h>
-#include <taichi/lang_util.h>
-
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-#include "codegen.h"
+#include "taichi/inc/constants.h"
+#include "taichi/lang_util.h"
+#include "taichi/platform/metal/metal_data_types.h"
+#include "taichi/platform/metal/metal_kernel_util.h"
+#include "taichi/platform/metal/metal_runtime.h"
+#include "taichi/program/program.h"
+#include "taichi/struct/struct_metal.h"
 
 TLANG_NAMESPACE_BEGIN
 namespace metal {

--- a/taichi/platform/metal/metal_kernel_util.h
+++ b/taichi/platform/metal/metal_kernel_util.h
@@ -21,13 +21,6 @@ class SNode;
 
 namespace metal {
 
-struct StructCompiledResult {
-  // Source code of the SNode data structures compiled to Metal
-  std::string source_code;
-  // Root buffer size in bytes.
-  size_t root_size;
-};
-
 // This struct holds the necesary information to launch a Metal kernel.
 struct MetalKernelAttributes {
   std::string name;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -224,7 +224,7 @@ void Program::materialize_layout() {
       StructCompiler::make(this, host_arch());
   scomp->run(*snode_root, true);
 
-  if (arch_is_cpu(config.arch) || config.arch == Arch::metal) {
+  if (arch_is_cpu(config.arch)) {
     initialize_runtime_system(scomp.get());
   }
 
@@ -238,8 +238,7 @@ void Program::materialize_layout() {
   } else if (config.arch == Arch::metal) {
     TI_ASSERT_INFO(config.use_llvm,
                    "Metal arch requires that LLVM being enabled");
-    metal::MetalStructCompiler scomp;
-    metal_struct_compiled_ = scomp.run(*snode_root);
+    metal_struct_compiled_ = metal::compile_structs(*snode_root);
     if (metal_runtime_ == nullptr) {
       metal::MetalRuntime::Params params;
       params.root_size = metal_struct_compiled_->root_size;

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -7,19 +7,19 @@
 
 #define TI_RUNTIME_HOST
 #include "taichi/ir/ir.h"
-#include "taichi/program/kernel.h"
 #include "taichi/ir/snode.h"
-#include "taichi/llvm/llvm_context.h"
 #include "taichi/lang_util.h"
-#include "taichi/runtime/llvm/context.h"
-#include "taichi/program/profiler.h"
-#include "taichi/system/threading.h"
-#include "taichi/system/unified_allocator.h"
-#include "taichi/system/memory_pool.h"
-#include "taichi/platform/metal/metal_kernel_util.h"
+#include "taichi/llvm/llvm_context.h"
 #include "taichi/platform/metal/metal_runtime.h"
 #include "taichi/platform/opengl/opengl_kernel_util.h"
+#include "taichi/program/kernel.h"
+#include "taichi/program/profiler.h"
+#include "taichi/runtime/llvm/context.h"
 #include "taichi/runtime/runtime.h"
+#include "taichi/struct/struct_metal.h"
+#include "taichi/system/memory_pool.h"
+#include "taichi/system/threading.h"
+#include "taichi/system/unified_allocator.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -174,9 +174,11 @@ class Program {
   ~Program();
 
  private:
+  // Metal related data structures
   std::optional<metal::StructCompiledResult> metal_struct_compiled_;
-  std::optional<opengl::StructCompiledResult> opengl_struct_compiled_;
   std::unique_ptr<metal::MetalRuntime> metal_runtime_;
+  // OpenGL related data structures
+  std::optional<opengl::StructCompiledResult> opengl_struct_compiled_;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/struct/struct_metal.cpp
+++ b/taichi/struct/struct_metal.cpp
@@ -1,108 +1,127 @@
-#include "struct_metal.h"
+#include "taichi/struct/struct_metal.h"
 
 TLANG_NAMESPACE_BEGIN
 namespace metal {
+namespace {
 
-MetalStructCompiler::CompiledResult MetalStructCompiler::run(SNode &node) {
-  TI_ASSERT(node.type == SNodeType::root);
-  collect_snodes(node);
-  // The host side has run this!
-  // infer_snode_properties(node);
+class StructCompiler {
+ public:
+  StructCompiledResult run(SNode &root) {
+    TI_ASSERT(root.type == SNodeType::root);
+    collect_snodes(root);
+    // The host side has run this!
+    // infer_snode_properties(node);
 
-  auto snodes_rev = snodes_;
-  std::reverse(snodes_rev.begin(), snodes_rev.end());
+    auto snodes_rev = snodes_;
+    std::reverse(snodes_rev.begin(), snodes_rev.end());
 
-  emit("using byte = uchar;");
-  for (auto &n : snodes_rev) {
-    generate_types(*n);
+    emit("using byte = uchar;");
+    for (auto &n : snodes_rev) {
+      generate_types(*n);
+    }
+    StructCompiledResult result;
+    result.source_code = std::move(src_code_);
+    result.root_size = compute_snode_size(root);
+    return result;
   }
-  CompiledResult result;
-  result.source_code = std::move(src_code_);
-  result.root_size = compute_snode_size(node);
-  return result;
-}
 
-void MetalStructCompiler::collect_snodes(SNode &snode) {
-  snodes_.push_back(&snode);
-  for (int ch_id = 0; ch_id < (int)snode.ch.size(); ch_id++) {
-    auto &ch = snode.ch[ch_id];
-    collect_snodes(*ch);
+ private:
+  void collect_snodes(SNode &snode) {
+    snodes_.push_back(&snode);
+    for (int ch_id = 0; ch_id < (int)snode.ch.size(); ch_id++) {
+      auto &ch = snode.ch[ch_id];
+      collect_snodes(*ch);
+    }
   }
-}
 
-void MetalStructCompiler::generate_types(const SNode &snode) {
-  const bool is_place = snode.is_place();
-  if (!is_place) {
-    const std::string class_name = snode.node_type_name + "_ch";
-    emit("class {} {{", class_name);
-    emit(" private:");
-    emit("  device byte* addr_;");
-    emit(" public:");
-    emit("  {}(device byte* a) : addr_(a) {{}}", class_name);
+  void generate_types(const SNode &snode) {
+    const bool is_place = snode.is_place();
+    if (!is_place) {
+      const std::string class_name = snode.node_type_name + "_ch";
+      emit("class {} {{", class_name);
+      emit(" private:");
+      emit("  device byte* addr_;");
+      emit(" public:");
+      emit("  {}(device byte* a) : addr_(a) {{}}", class_name);
 
-    std::string stride_str;
-    for (int i = 0; i < (int)snode.ch.size(); i++) {
-      const auto &ch_node_name = snode.ch[i]->node_type_name;
-      emit("  {} get{}() {{", ch_node_name, i);
-      if (stride_str.empty()) {
-        emit("    return {{addr_}};");
-        stride_str = ch_node_name + "::stride";
-      } else {
-        emit("    return {{addr_ + ({})}};", stride_str);
-        stride_str += " + " + ch_node_name + "::stride";
+      std::string stride_str;
+      for (int i = 0; i < (int)snode.ch.size(); i++) {
+        const auto &ch_node_name = snode.ch[i]->node_type_name;
+        emit("  {} get{}() {{", ch_node_name, i);
+        if (stride_str.empty()) {
+          emit("    return {{addr_}};");
+          stride_str = ch_node_name + "::stride";
+        } else {
+          emit("    return {{addr_ + ({})}};", stride_str);
+          stride_str += " + " + ch_node_name + "::stride";
+        }
+        emit("  }}");
       }
+      if (stride_str.empty()) {
+        // Is it possible for this to have no children?
+        stride_str = "0";
+      }
+      emit("  constant static constexpr int stride = {};", stride_str);
+      emit("}};");
+    }
+    emit("");
+    const auto &node_name = snode.node_type_name;
+    if (is_place) {
+      const auto dt_name = metal_data_type_name(snode.dt);
+      emit("struct {} {{", node_name);
+      emit("  // place");
+      emit("  constant static constexpr int stride = sizeof({});", dt_name);
+      emit("  {}(device byte* v) : val((device {}*)v) {{}}", node_name,
+           dt_name);
+      emit("  device {}* val;", dt_name);
+      emit("}};");
+    } else if (snode.type == SNodeType::dense ||
+               snode.type == SNodeType::root) {
+      emit("struct {} {{", node_name);
+      emit("  // {}", snode_type_name(snode.type));
+      const int n = (snode.type == SNodeType::dense) ? snode.n : 1;
+      emit("  constant static constexpr int n = {};", n);
+      emit("  constant static constexpr int stride = {}_ch::stride * n;",
+           node_name);
+      emit("  {}(device byte* a) : addr_(a) {{}}", node_name);
+      emit("  {}_ch children(int i) {{", node_name);
+      emit("    return {{addr_ + i * {}_ch::stride}};", node_name);
       emit("  }}");
+      emit(" private:");
+      emit("  device byte* addr_;");
+      emit("}};");
+    } else {
+      TI_ERROR("SNodeType={} not supported on Metal",
+               snode_type_name(snode.type));
+      TI_NOT_IMPLEMENTED;
     }
-    if (stride_str.empty()) {
-      // Is it possible for this to have no children?
-      stride_str = "0";
+    emit("");
+  }
+  size_t compute_snode_size(const SNode &sn) {
+    if (sn.is_place()) {
+      return metal_data_type_bytes(to_metal_type(sn.dt));
     }
-    emit("  constant static constexpr int stride = {};", stride_str);
-    emit("}};");
+    size_t ch_size = 0;
+    for (const auto &ch : sn.ch) {
+      ch_size += compute_snode_size(*ch);
+    }
+    const int n = (sn.type == SNodeType::dense) ? sn.n : 1;
+    return n * ch_size;
   }
-  emit("");
-  const auto &node_name = snode.node_type_name;
-  if (is_place) {
-    const auto dt_name = metal_data_type_name(snode.dt);
-    emit("struct {} {{", node_name);
-    emit("  // place");
-    emit("  constant static constexpr int stride = sizeof({});", dt_name);
-    emit("  {}(device byte* v) : val((device {}*)v) {{}}", node_name, dt_name);
-    emit("  device {}* val;", dt_name);
-    emit("}};");
-  } else if (snode.type == SNodeType::dense || snode.type == SNodeType::root) {
-    emit("struct {} {{", node_name);
-    emit("  // {}", snode_type_name(snode.type));
-    const int n = (snode.type == SNodeType::dense) ? snode.n : 1;
-    emit("  constant static constexpr int n = {};", n);
-    emit("  constant static constexpr int stride = {}_ch::stride * n;",
-         node_name);
-    emit("  {}(device byte* a) : addr_(a) {{}}", node_name);
-    emit("  {}_ch children(int i) {{", node_name);
-    emit("    return {{addr_ + i * {}_ch::stride}};", node_name);
-    emit("  }}");
-    emit(" private:");
-    emit("  device byte* addr_;");
-    emit("}};");
-  } else {
-    TI_ERROR("SNodeType={} not supported on Metal",
-             snode_type_name(snode.type));
-    TI_NOT_IMPLEMENTED;
-  }
-  emit("");
-}
 
-size_t MetalStructCompiler::compute_snode_size(const SNode &sn) {
-  if (sn.is_place()) {
-    return metal_data_type_bytes(to_metal_type(sn.dt));
+  template <typename... Args>
+  void emit(std::string f, Args &&... args) {
+    src_code_ += fmt::format(f, std::forward<Args>(args)...) + '\n';
   }
-  size_t ch_size = 0;
-  for (const auto &ch : sn.ch) {
-    ch_size += compute_snode_size(*ch);
-  }
-  const int n = (sn.type == SNodeType::dense) ? sn.n : 1;
-  return n * ch_size;
-}
 
+  std::vector<SNode *> snodes_;
+  std::string src_code_;
+};
+
+}  // namespace
+
+StructCompiledResult compile_structs(SNode &root) {
+  return StructCompiler().run(root);
+}
 }  // namespace metal
 TLANG_NAMESPACE_END

--- a/taichi/struct/struct_metal.h
+++ b/taichi/struct/struct_metal.h
@@ -1,37 +1,27 @@
 // Codegen for the hierarchical data structure
 #pragma once
 
-#include <taichi/platform/metal/metal_data_types.h>
-#include <taichi/platform/metal/metal_kernel_util.h>
-#include <taichi/ir/snode.h>
-
 #include <algorithm>
 #include <functional>
 #include <string>
 #include <vector>
 
+#include "taichi/ir/snode.h"
+#include "taichi/platform/metal/metal_data_types.h"
+#include "taichi/platform/metal/metal_kernel_util.h"
+
 TLANG_NAMESPACE_BEGIN
 namespace metal {
 
-class MetalStructCompiler {
- public:
-  using CompiledResult = metal::StructCompiledResult;
-
-  CompiledResult run(SNode &node);
-
- private:
-  void collect_snodes(SNode &snode);
-  void generate_types(const SNode &snode);
-  size_t compute_snode_size(const SNode &sn);
-
-  template <typename... Args>
-  void emit(std::string f, Args &&... args) {
-    src_code_ += fmt::format(f, std::forward<Args>(args)...) + '\n';
-  }
-
-  std::vector<SNode *> snodes_;
-  std::string src_code_;
+struct StructCompiledResult {
+  // Source code of the SNode data structures compiled to Metal
+  std::string source_code;
+  // Root buffer size in bytes.
+  size_t root_size;
 };
+
+// Compile all snodes to Metal source code
+StructCompiledResult compile_structs(SNode& root);
 
 }  // namespace metal
 TLANG_NAMESPACE_END


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = #396 


* `MetalStructCompiler` is no longer exposed. This is a prep step to support `bitmasked`
* `StructCompiledResult` is moved from `taichi/platform/metal/metal_kernel_util.h` to `taichi/struct/struct_metal.h`
*  Following #568 , we no longer need to `initialize_runtime_system()` inside `Program:: materialize_layout()`.