### PR TITLE
Access out-of-bound checking on CPU backends (Stage 1)

### DIFF
--- a/taichi/codegen/codegen_cpu.cpp
+++ b/taichi/codegen/codegen_cpu.cpp
@@ -90,6 +90,9 @@ void CodeGenCPU::lower() {
       irpass::print(ir);
     }
   }
+  if (prog->config.debug) {
+    irpass::check_out_of_bound(ir);
+  }
   irpass::lower_access(ir, true);
   if (print_ir) {
     TI_TRACE("Access Lowered:");

--- a/taichi/codegen/codegen_cpu.cpp
+++ b/taichi/codegen/codegen_cpu.cpp
@@ -92,6 +92,11 @@ void CodeGenCPU::lower() {
   }
   if (prog->config.debug) {
     irpass::check_out_of_bound(ir);
+    if (print_ir) {
+      TI_TRACE("Bound checked:");
+      irpass::re_id(ir);
+      irpass::print(ir);
+    }
   }
   irpass::lower_access(ir, true);
   if (print_ir) {

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -901,6 +901,7 @@ class CodeGenLLVM : public IRVisitor, public ModuleBuilder {
       text = builder->CreateGlobalStringPtr(stmt->text);
     } else {
       std::vector<Value *> args;
+      args.emplace_back(builder->CreateGlobalStringPtr(stmt->text));
       for (auto arg : stmt->args) {
         args.emplace_back(arg->value);
       }

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -896,8 +896,18 @@ class CodeGenLLVM : public IRVisitor, public ModuleBuilder {
   }
 
   void visit(AssertStmt *stmt) override {
-    stmt->value = call("taichi_assert", get_context(), stmt->val->value,
-                       builder->CreateGlobalStringPtr(stmt->text));
+    Value *text;
+    if (stmt->args.empty()) {
+      text = builder->CreateGlobalStringPtr(stmt->text);
+    } else {
+      std::vector<Value *> args;
+      for (auto arg : stmt->args) {
+        args.emplace_back(arg->value);
+      }
+      text = create_call("get_assert_msg", args);
+    }
+    stmt->value = call("taichi_assert", get_context(), stmt->cond->value,
+                       text);
   }
 
   void visit(SNodeOpStmt *stmt) override {

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -901,6 +901,7 @@ class CodeGenLLVM : public IRVisitor, public ModuleBuilder {
       text = builder->CreateGlobalStringPtr(stmt->text);
     } else {
       std::vector<Value *> args;
+      args.emplace_back(get_runtime());
       args.emplace_back(builder->CreateGlobalStringPtr(stmt->text));
       for (auto arg : stmt->args) {
         TI_ASSERT(arg->value);

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -903,6 +903,7 @@ class CodeGenLLVM : public IRVisitor, public ModuleBuilder {
       std::vector<Value *> args;
       args.emplace_back(builder->CreateGlobalStringPtr(stmt->text));
       for (auto arg : stmt->args) {
+        TI_ASSERT(arg->value);
         args.emplace_back(arg->value);
       }
       text = create_call("get_assert_msg", args);

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -96,6 +96,7 @@ void loop_vectorize(IRNode *root);
 void slp_vectorize(IRNode *root);
 void vector_split(IRNode *root, int max_width, bool serial_schedule);
 void replace_all_usages_with(IRNode *root, Stmt *old_stmt, Stmt *new_stmt);
+void check_out_of_bound(IRNode *root);
 void lower_access(IRNode *root, bool lower_atomic);
 void make_adjoint(IRNode *root);
 void constant_fold(IRNode *root);

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -1465,12 +1465,19 @@ class FrontendAssertStmt : public Stmt {
 
 class AssertStmt : public Stmt {
  public:
+  Stmt *cond;
   std::string text;
-  Stmt *val;
+  std::vector<Stmt *> args;
 
-  AssertStmt(const std::string &text, Stmt *val) : text(text), val(val) {
-    add_operand(this->val);
-    TI_ASSERT(val);
+  AssertStmt(const std::string &text, Stmt *cond) : cond(cond), text(text) {
+    add_operand(this->cond);
+    TI_ASSERT(cond);
+  }
+
+  AssertStmt(Stmt *cond, const std::string &text, const std::vector<Stmt *> &args)
+      : cond(cond), text(text), args(args) {
+    add_operand(this->cond);
+    TI_ASSERT(cond);
   }
 
   DEFINE_ACCEPT

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -1477,6 +1477,9 @@ class AssertStmt : public Stmt {
   AssertStmt(Stmt *cond, const std::string &text, const std::vector<Stmt *> &args)
       : cond(cond), text(text), args(args) {
     add_operand(this->cond);
+    for (auto &arg : this->args) {
+      add_operand(arg);
+    }
     TI_ASSERT(cond);
   }
 

--- a/taichi/llvm/llvm_codegen_utils.cpp
+++ b/taichi/llvm/llvm_codegen_utils.cpp
@@ -13,10 +13,6 @@ void check_func_call_signature(llvm::Value *func,
                                std::vector<llvm::Value *> arglist) {
   auto func_type = func->getType()->getPointerElementType();
   int num_params = func_type->getFunctionNumParams();
-  if (num_params != arglist.size()) {
-    std::cout << num_params << " " << arglist.size() << std::endl;
-    std::cout << type_name(func->getType()) << std::endl;
-  }
   if (func_type->isFunctionVarArg()) {
     TI_ASSERT(num_params <= arglist.size());
   } else {

--- a/taichi/llvm/llvm_codegen_utils.cpp
+++ b/taichi/llvm/llvm_codegen_utils.cpp
@@ -13,6 +13,9 @@ void check_func_call_signature(llvm::Value *func,
                                std::vector<llvm::Value *> arglist) {
   auto func_type = func->getType()->getPointerElementType();
   int num_params = func_type->getFunctionNumParams();
+  if (num_params != arglist.size()) {
+    std::cout << type_name(func->getType()) << std::endl;
+  }
   TI_ASSERT(num_params == arglist.size());
 
   for (int i = 0; i < (int)arglist.size(); i++) {

--- a/taichi/llvm/llvm_codegen_utils.cpp
+++ b/taichi/llvm/llvm_codegen_utils.cpp
@@ -14,11 +14,16 @@ void check_func_call_signature(llvm::Value *func,
   auto func_type = func->getType()->getPointerElementType();
   int num_params = func_type->getFunctionNumParams();
   if (num_params != arglist.size()) {
+    std::cout << num_params << " " << arglist.size() << std::endl;
     std::cout << type_name(func->getType()) << std::endl;
   }
-  TI_ASSERT(num_params == arglist.size());
+  if (func_type->isFunctionVarArg()) {
+    TI_ASSERT(num_params <= arglist.size());
+  } else {
+    TI_ASSERT(num_params == arglist.size());
+  }
 
-  for (int i = 0; i < (int)arglist.size(); i++) {
+  for (int i = 0; i < num_params; i++) {
     auto required = func_type->getFunctionParamType(i);
     auto provided = arglist[i]->getType();
     // TI_INFO("    required from context {}", (void *)&required->getContext());

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -156,11 +156,11 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
   TI_TRACE("Allocating data structure of size {} B", scomp->root_size);
 
   runtime
-      ->call<void *, void *, std::size_t, std::size_t, void *, void *, void *>(
+      ->call<void *, void *, std::size_t, std::size_t, void *, void *, void *, void *>(
           "runtime_initialize", result_buffer, this,
           (std::size_t)scomp->root_size, prealloc_size,
           preallocated_device_buffer, (void *)&taichi_allocate_aligned,
-          (void *)std::printf);
+          (void *)std::printf, (void *)std::vsnprintf);
 
   TI_TRACE("LLVMRuntime initialized");
   llvm_runtime = runtime->fetch_result<void *>();

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cmath>
+#include <cstdarg>
 #include <cstdlib>
 #include <algorithm>
 #include <type_traits>
@@ -635,6 +636,16 @@ void taichi_assert_runtime(LLVMRuntime *runtime, i32 test, const char *msg) {
 
 void taichi_assert(Context *context, i32 test, const char *msg) {
   taichi_assert_runtime(context->runtime, test, msg);
+}
+
+const std::size_t ASSERT_MSG_BUFFER_SIZE = 2048;
+char assert_msg_buffer[ASSERT_MSG_BUFFER_SIZE];
+char *get_assert_msg(const char *format, ...) {
+  std::va_list args;
+  va_start(args, format);
+  std::vsnprintf(assert_msg_buffer, ASSERT_MSG_BUFFER_SIZE, format, args);
+  va_end(args);
+  return assert_msg_buffer;
 }
 
 Ptr LLVMRuntime::allocate_aligned(std::size_t size, std::size_t alignment) {

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -39,7 +39,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
       result = new_stmts.push_back<BinaryOpStmt>(
           BinaryOpType::bit_and, result, check_i);
     }
-    new_stmts.push_back<AssertStmt>("Accessing Tensor of Size [...] with indices (...)", result);
+    new_stmts.push_back<AssertStmt>(result, "Accessing Tensor of Size [...] with indices (...)", std::vector<Stmt *>());
     stmt->parent->insert_before(stmt, std::move(new_stmts));
     set_done(stmt);
     throw IRModified();

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -19,6 +19,12 @@ class CheckOutOfBound : public BasicStmtVisitor {
     visited.insert(stmt->instance_id);
   }
 
+  static std::string to_string(int value) {
+    static char buffer[64];
+    snprintf(buffer, 64, "%d", value);
+    return std::string(buffer);
+  }
+
   void visit(GlobalPtrStmt *stmt) override {
     if (is_done(stmt))
       return;
@@ -27,19 +33,34 @@ class CheckOutOfBound : public BasicStmtVisitor {
     auto new_stmts = VecStatement();
     auto zero = new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(0));
     Stmt *result = new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(true));
+
+    std::string msg = "Accessing Tensor of Size [";
+    std::vector<Stmt *> args;
     for (int i = 0; i < stmt->indices.size(); i++) {
       auto check_zero = new_stmts.push_back<BinaryOpStmt>(
           BinaryOpType::cmp_ge, stmt->indices[i], zero);
-      auto bound = new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(
-          snode->extractors[snode->physical_index_position[i]].num_elements));
+      int size_i = snode->extractors[snode->physical_index_position[i]].num_elements;
+      auto bound = new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(size_i));
       auto check_bound = new_stmts.push_back<BinaryOpStmt>(
           BinaryOpType::cmp_lt, stmt->indices[i], bound);
       auto check_i = new_stmts.push_back<BinaryOpStmt>(
           BinaryOpType::bit_and, check_zero, check_bound);
       result = new_stmts.push_back<BinaryOpStmt>(
           BinaryOpType::bit_and, result, check_i);
+      if (i > 0)
+        msg += ", ";
+      msg += to_string(size_i);
+      args.emplace_back(stmt->indices[i]);
     }
-    new_stmts.push_back<AssertStmt>(result, "Accessing Tensor of Size [...] with indices (...)", std::vector<Stmt *>());
+    msg += "] with indices (";
+    for (int i = 0; i < stmt->indices.size(); i++) {
+      if (i > 0)
+        msg += ", ";
+      msg += "%d";
+    }
+    msg += ")";
+
+    new_stmts.push_back<AssertStmt>(result, msg, args);
     stmt->parent->insert_before(stmt, std::move(new_stmts));
     set_done(stmt);
     throw IRModified();

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -1,0 +1,25 @@
+#include "taichi/ir/ir.h"
+
+TLANG_NAMESPACE_BEGIN
+
+class CheckOutOfBound : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
+
+  CheckOutOfBound() : BasicStmtVisitor() {
+  }
+
+  static void run(IRNode *node) {
+    ;
+  }
+};
+
+namespace irpass {
+
+void check_out_of_bound(IRNode *root) {
+  return CheckOutOfBound::run(root);
+}
+
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -1,3 +1,4 @@
+#include <set>
 #include "taichi/ir/ir.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -5,12 +6,57 @@ TLANG_NAMESPACE_BEGIN
 class CheckOutOfBound : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
+  std::set<int> visited;
 
-  CheckOutOfBound() : BasicStmtVisitor() {
+  CheckOutOfBound() : BasicStmtVisitor(), visited() {
+  }
+
+  bool is_done(Stmt *stmt) {
+    return visited.find(stmt->instance_id) != visited.end();
+  }
+
+  void set_done(Stmt *stmt) {
+    visited.insert(stmt->instance_id);
+  }
+
+  void visit(GlobalPtrStmt *stmt) override {
+    if (is_done(stmt))
+      return;
+    TI_ASSERT(stmt->snodes.size() == 1);
+    auto snode = stmt->snodes[0];
+    auto new_stmts = VecStatement();
+    auto zero = new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(0));
+    Stmt *result = new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(true));
+    for (int i = 0; i < stmt->indices.size(); i++) {
+      auto check_zero = new_stmts.push_back<BinaryOpStmt>(
+          BinaryOpType::cmp_ge, stmt->indices[i], zero);
+      auto bound = new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(
+          snode->extractors[snode->physical_index_position[i]].num_elements));
+      auto check_bound = new_stmts.push_back<BinaryOpStmt>(
+          BinaryOpType::cmp_lt, stmt->indices[i], bound);
+      auto check_i = new_stmts.push_back<BinaryOpStmt>(
+          BinaryOpType::bit_and, check_zero, check_bound);
+      result = new_stmts.push_back<BinaryOpStmt>(
+          BinaryOpType::bit_and, result, check_i);
+    }
+    new_stmts.push_back<AssertStmt>("Accessing Tensor of Size [...] with indices (...)", result);
+    stmt->parent->insert_before(stmt, std::move(new_stmts));
+    set_done(stmt);
+    throw IRModified();
   }
 
   static void run(IRNode *node) {
-    ;
+    CheckOutOfBound checker;
+    while (true) {
+      bool modified = false;
+      try {
+        node->accept(&checker);
+      } catch (IRModified) {
+        modified = true;
+      }
+      if (!modified)
+        break;
+    }
   }
 };
 

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -19,12 +19,6 @@ class CheckOutOfBound : public BasicStmtVisitor {
     visited.insert(stmt->instance_id);
   }
 
-  static std::string to_string(int value) {
-    static char buffer[64];
-    snprintf(buffer, 64, "%d", value);
-    return std::string(buffer);
-  }
-
   void visit(GlobalPtrStmt *stmt) override {
     if (is_done(stmt))
       return;
@@ -49,7 +43,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
           BinaryOpType::bit_and, result, check_i);
       if (i > 0)
         msg += ", ";
-      msg += to_string(size_i);
+      msg += std::to_string(size_i);
       args.emplace_back(stmt->indices[i]);
     }
     msg += "] with indices (";

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -60,7 +60,7 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(AssertStmt *assert) override {
-    print("{} : assert {}, \"{}\"", assert->id, assert->val->name(),
+    print("{} : assert {}, \"{}\"", assert->id, assert->cond->name(),
           assert->text);
   }
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -60,8 +60,13 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(AssertStmt *assert) override {
-    print("{} : assert {}, \"{}\"", assert->id, assert->cond->name(),
-          assert->text);
+    std::string extras = "";
+    for (auto &arg : assert->args) {
+      extras += ", ";
+      extras += arg->name();
+    }
+    print("{} : assert {}, \"{}\"{}", assert->id, assert->cond->name(),
+          assert->text, extras);
   }
 
   void visit(FrontendSNodeOpStmt *stmt) override {


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = #561

Also extends `AssertStmt` from `(message, condition)` to also `(condition, format_str, values)`.