### PR TITLE
Make `ti format` cover all files from upstream/master to the working tree

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -158,8 +158,10 @@ def format(all=False, diff=None):
     else:
         if diff is None:
             # Finds all modified files from upstream/master to working tree
-            # 1. diffs between the index and upstream/master
+            # 1. diffs between the index and upstream/master. Also inclulde
+            # origin/master for repo owners.
             files = repo.index.diff('upstream/master')
+            files += repo.index.diff('origin/master')
             # 2. diffs between the index and the working tree
             # https://gitpython.readthedocs.io/en/stable/tutorial.html#obtaining-diff-information
             files += repo.index.diff(None)
@@ -169,9 +171,10 @@ def format(all=False, diff=None):
             map(lambda x: os.path.join(tc.get_repo_directory(), x.a_path),
                 files))
 
+    files = set(map(str, files))
     clang_format_bin = _find_clang_format_bin()
     print('Code formatting ...')
-    for fn in map(str, files):
+    for fn in files:
         if os.path.isdir(fn):
             continue
         if fn.find('.pytest_cache') != -1:

--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -171,7 +171,7 @@ def format(all=False, diff=None):
             map(lambda x: os.path.join(tc.get_repo_directory(), x.a_path),
                 files))
 
-    files = set(map(str, files))
+    files = sorted(set(map(str, files)))
     clang_format_bin = _find_clang_format_bin()
     print('Code formatting ...')
     for fn in files:

--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import ctypes
 from pathlib import Path
+from colorama import Fore, Back, Style
 
 if sys.version_info[0] < 3 or sys.version_info[1] <= 5:
     print("\nPlease restart with Python 3.6+\n")
@@ -66,9 +67,6 @@ def is_release():
     return os.environ.get('TAICHI_REPO_DIR', '') == ''
 
 
-from colorama import Fore, Back, Style
-
-
 def get_core_shared_object():
     if is_release():
         directory = os.path.join(package_root(), 'lib')
@@ -126,11 +124,15 @@ def _find_clang_format_bin():
                 break
         except:
             pass
+    import colorama
+    colorama.init()
     if result is None:
-        print('Did not find any clang-format executable, skipping C++ files',
+        print(Fore.YELLOW +
+              'Did not find any clang-format executable, skipping C++ files',
               file=sys.stderr)
     else:
-        print('C++ formatter: {}'.format(result))
+        print('C++ formatter: {}{}'.format(Fore.GREEN, result))
+    print(Style.RESET_ALL)
     return result
 
 

--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -158,6 +158,9 @@ def format(all=False, diff=None):
                 except:
                     return []
 
+            # TODO(#628): Have a way to customize the repo names, in order to
+            # support noncanonical namings.
+            #
             # Finds all modified files from upstream/master to working tree
             # 1. diffs between the index and upstream/master. Also inclulde
             # origin/master for repo owners.


### PR DESCRIPTION

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = #628 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
