### PR TITLE
Support atomic min/max/bit_and/bit_or/bit_xor on Metal

### DIFF
--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -252,8 +252,9 @@ class MetalKernelCodegen : public IRVisitor {
     const auto lhs_name = bin->lhs->raw_name();
     const auto rhs_name = bin->rhs->raw_name();
     const auto bin_name = bin->raw_name();
-    if (bin->op_type == BinaryOpType::floordiv) {
-      if (is_integral(bin->element_type())) {
+    const auto op_type = bin->op_type;
+    if (op_type == BinaryOpType::floordiv) {
+      if (is_integral(bin->ret_type.data_type)) {
         emit("const {} {} = ifloordiv({}, {});", dt_name, bin_name, lhs_name,
              rhs_name);
       } else {
@@ -262,7 +263,13 @@ class MetalKernelCodegen : public IRVisitor {
       }
       return;
     }
-    const auto binop = metal_binary_op_type_symbol(bin->op_type);
+    if (op_type == BinaryOpType::pow && is_integral(bin->ret_type.data_type)) {
+      // TODO(k-ye): Make sure the type is not i64?
+      emit("const {} {} = pow_i32({}, {});", dt_name, bin_name, lhs_name,
+           rhs_name);
+      return;
+    }
+    const auto binop = metal_binary_op_type_symbol(op_type);
     if (is_metal_binary_op_infix(bin->op_type)) {
       emit("const {} {} = ({} {} {});", dt_name, bin_name, lhs_name, binop,
            rhs_name);
@@ -282,19 +289,48 @@ class MetalKernelCodegen : public IRVisitor {
 
   void visit(AtomicOpStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    TI_ASSERT(stmt->op_type == AtomicOpType::add);
     const auto dt = stmt->val->element_type();
-    if (dt == DataType::i32) {
-      emit(
-          "const auto {} = atomic_fetch_add_explicit((device atomic_int*){}, "
-          "{}, "
-          "metal::memory_order_relaxed);",
-          stmt->raw_name(), stmt->dest->raw_name(), stmt->val->raw_name());
-    } else if (dt == DataType::f32) {
-      emit("const float {} = fatomic_fetch_add({}, {});", stmt->raw_name(),
-           stmt->dest->raw_name(), stmt->val->raw_name());
+    const auto op_type = stmt->op_type;
+    std::string op_name;
+    bool handle_float = false;
+    if (op_type == AtomicOpType::add || op_type == AtomicOpType::min ||
+        op_type == AtomicOpType::max) {
+      op_name = atomic_op_type_name(op_type);
+      handle_float = true;
+    } else if (op_type == AtomicOpType::bit_and ||
+               op_type == AtomicOpType::bit_or ||
+               op_type == AtomicOpType::bit_xor) {
+      // Skip "bit_"
+      op_name = atomic_op_type_name(op_type).substr(/*pos=*/4);
+      handle_float = false;
     } else {
       TI_NOT_IMPLEMENTED;
+    }
+
+    if (dt == DataType::i32) {
+      emit(
+          "const auto {} = atomic_fetch_{}_explicit((device atomic_int*){}, "
+          "{}, "
+          "metal::memory_order_relaxed);",
+          stmt->raw_name(), op_name, stmt->dest->raw_name(),
+          stmt->val->raw_name());
+    } else if (dt == DataType::u32) {
+      emit(
+          "const auto {} = atomic_fetch_{}_explicit((device atomic_uint*){}, "
+          "{}, "
+          "metal::memory_order_relaxed);",
+          stmt->raw_name(), op_name, stmt->dest->raw_name(),
+          stmt->val->raw_name());
+    } else if (dt == DataType::f32) {
+      if (handle_float) {
+        emit("const float {} = fatomic_fetch_{}({}, {});", stmt->raw_name(),
+             op_name, stmt->dest->raw_name(), stmt->val->raw_name());
+      } else {
+        TI_ERROR("Metal does not support atomic {} for floating points",
+                 op_name);
+      }
+    } else {
+      TI_ERROR("Metal only supports 32-bit atomic data types");
     }
   }
 

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -1,10 +1,11 @@
 // Definitions of utility functions and enums
 
 #include "lang_util.h"
-#include "taichi/system/timer.h"
+
 #include "taichi/math/linalg.h"
 #include "taichi/program/arch.h"
 #include "taichi/program/compile_config.h"
+#include "taichi/system/timer.h"
 
 TI_NAMESPACE_BEGIN
 
@@ -194,6 +195,9 @@ std::string atomic_op_type_name(AtomicOpType type) {
     REGISTER_TYPE(add);
     REGISTER_TYPE(max);
     REGISTER_TYPE(min);
+    REGISTER_TYPE(bit_and);
+    REGISTER_TYPE(bit_or);
+    REGISTER_TYPE(bit_xor);
 #undef REGISTER_TYPE
   }
   return type_names[type];

--- a/taichi/platform/metal/shaders/helpers.metal.h
+++ b/taichi/platform/metal/shaders/helpers.metal.h
@@ -20,15 +20,13 @@ static_assert(false, "Do not include");
 #endif  // TI_INSIDE_METAL_CODEGEN
 
 METAL_BEGIN_HELPERS_DEF
-STR(
-    template <typename T, typename G>
-    T union_cast(G g) {
-      // For some reason, if I emit taichi/common.h's union_cast(), Metal failed
-      // to compile. More strangely, if I copy the generated code to XCode as a
-      // Metal kernel, it compiled successfully...
-      static_assert(sizeof(T) == sizeof(G), "Size mismatch");
-      return *reinterpret_cast<thread const T *>(&g);
-    }
+STR(template <typename T, typename G> T union_cast(G g) {
+  // For some reason, if I emit taichi/common.h's union_cast(), Metal failed
+  // to compile. More strangely, if I copy the generated code to XCode as a
+  // Metal kernel, it compiled successfully...
+  static_assert(sizeof(T) == sizeof(G), "Size mismatch");
+  return *reinterpret_cast<thread const T *>(&g);
+}
 
     inline int ifloordiv(int lhs, int rhs) {
       const int intm = (lhs / rhs);

--- a/taichi/platform/metal/shaders/helpers.metal.h
+++ b/taichi/platform/metal/shaders/helpers.metal.h
@@ -20,17 +20,31 @@ static_assert(false, "Do not include");
 #endif  // TI_INSIDE_METAL_CODEGEN
 
 METAL_BEGIN_HELPERS_DEF
-STR(template <typename T, typename G> T union_cast(G g) {
-  // For some reason, if I emit taichi/common.h's union_cast(), Metal failed
-  // to compile. More strangely, if I copy the generated code to XCode as a
-  // Metal kernel, it compiled successfully...
-  static_assert(sizeof(T) == sizeof(G), "Size mismatch");
-  return *reinterpret_cast<thread const T *>(&g);
-}
+STR(
+    template <typename T, typename G>
+    T union_cast(G g) {
+      // For some reason, if I emit taichi/common.h's union_cast(), Metal failed
+      // to compile. More strangely, if I copy the generated code to XCode as a
+      // Metal kernel, it compiled successfully...
+      static_assert(sizeof(T) == sizeof(G), "Size mismatch");
+      return *reinterpret_cast<thread const T *>(&g);
+    }
 
     inline int ifloordiv(int lhs, int rhs) {
       const int intm = (lhs / rhs);
       return (((lhs * rhs < 0) && (rhs * intm != lhs)) ? (intm - 1) : intm);
+    }
+
+    int32_t pow_i32(int32_t x, int32_t n) {
+      int32_t tmp = x;
+      int32_t ans = 1;
+      while (n) {
+        if (n & 1)
+          ans *= tmp;
+        tmp *= tmp;
+        n >>= 1;
+      }
+      return ans;
     }
 
     float fatomic_fetch_add(device float *dest, const float operand) {
@@ -41,6 +55,34 @@ STR(template <typename T, typename G> T union_cast(G g) {
       while (!ok) {
         old_val = *dest;
         float new_val = (old_val + operand);
+        ok = atomic_compare_exchange_weak_explicit(
+            (device atomic_int *)dest, (thread int *)(&old_val),
+            *((thread int *)(&new_val)), metal::memory_order_relaxed,
+            metal::memory_order_relaxed);
+      }
+      return old_val;
+    }
+
+    float fatomic_fetch_min(device float *dest, const float operand) {
+      bool ok = false;
+      float old_val = 0.0f;
+      while (!ok) {
+        old_val = *dest;
+        float new_val = (old_val < operand) ? old_val : operand;
+        ok = atomic_compare_exchange_weak_explicit(
+            (device atomic_int *)dest, (thread int *)(&old_val),
+            *((thread int *)(&new_val)), metal::memory_order_relaxed,
+            metal::memory_order_relaxed);
+      }
+      return old_val;
+    }
+
+    float fatomic_fetch_max(device float *dest, const float operand) {
+      bool ok = false;
+      float old_val = 0.0f;
+      while (!ok) {
+        old_val = *dest;
+        float new_val = (old_val > operand) ? old_val : operand;
         ok = atomic_compare_exchange_weak_explicit(
             (device atomic_int *)dest, (thread int *)(&old_val),
             *((thread int *)(&new_val)), metal::memory_order_relaxed,


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = #606

This is a follow up of #627 

I also found out that Metal's `pow` doesn't support integral types, which are used by the tests. Adding that support here as well.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
