### PR TITLE
Add LineAppender to dedupe code emitting methods

### DIFF
--- a/taichi/util/line_appender.h
+++ b/taichi/util/line_appender.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <string>
+
+#include "spdlog/spdlog.h"
+#include "taichi/common/util.h"
+
+TI_NAMESPACE_BEGIN
+
+class LineAppender {
+ public:
+  explicit LineAppender(int indent_size = 2)
+      : single_indent_(indent_size, ' ') {
+  }
+
+  LineAppender(const LineAppender &) = default;
+  LineAppender &operator=(const LineAppender &) = default;
+  LineAppender(LineAppender &&) = default;
+  LineAppender &operator=(LineAppender &&) = default;
+
+  inline const std::string &lines() const {
+    return lines_;
+  }
+
+  template <typename... Args>
+  void append(std::string f, Args &&... args) {
+    lines_ += indent_ + fmt::format(f, std::forward<Args>(args)...) + '\n';
+  }
+
+  inline void append_raw(const std::string &s) {
+    lines_ += s + '\n';
+  }
+
+  inline void dump(std::string *output) {
+    *output = std::move(lines_);
+  }
+
+  void clear_lines() {
+    // Free up the memory as well
+    std::string s;
+    dump(&s);
+  }
+
+  void clear_all() {
+    clear_lines();
+    indent_.clear();
+  }
+
+  inline void push_indent() {
+    indent_ += single_indent_;
+  }
+
+  inline void pop_indent() {
+    indent_.erase(indent_.size() - single_indent_.size());
+  }
+
+ private:
+  std::string single_indent_;
+  std::string indent_;
+  std::string lines_;
+};
+
+class ScopedIndent {
+ public:
+  explicit ScopedIndent(LineAppender &la) : la_(la) {
+    la_.push_indent();
+  }
+
+  ~ScopedIndent() {
+    la_.pop_indent();
+  }
+
+ private:
+  LineAppender &la_;
+};
+
+TI_NAMESPACE_END


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have checked out [Contributor Guideline](https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: Feb 18, 2019). A few simple rules are mentioned there to make us work together more efficiently :-) -->

Related issue id = N/A

This is mostly code cleanup. I've refactored out a `LineAppender` class, so that we don't have to duplicate the code emitting methods in the codegens.

 @archibate  pls let me know if you want me to update this for the OpenGL backend (could accidentally break the tests..), or you prefer doing this yourself.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
