### PR TITLE
[metal] Simplify Metal backend's namings

### DIFF
--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -1,6 +1,7 @@
 #include "taichi/backends/metal/data_types.h"
 
 TLANG_NAMESPACE_BEGIN
+namespace metal {
 
 MetalDataType to_metal_type(DataType dt) {
   switch (dt) {
@@ -133,4 +134,5 @@ std::string metal_unary_op_type_symbol(UnaryOpType type) {
   return "";
 }
 
+}  // namespace metal
 TLANG_NAMESPACE_END

--- a/taichi/backends/metal/data_types.h
+++ b/taichi/backends/metal/data_types.h
@@ -5,6 +5,7 @@
 #include "taichi/lang_util.h"
 
 TLANG_NAMESPACE_BEGIN
+namespace metal {
 
 enum class MetalDataType : int {
   f32,
@@ -42,5 +43,7 @@ inline bool is_metal_binary_op_infix(BinaryOpType type) {
   return !((type == BinaryOpType::min) || (type == BinaryOpType::max) ||
            (type == BinaryOpType::atan2) || (type == BinaryOpType::pow));
 }
+
+}  // namespace metal
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -1,4 +1,4 @@
-#include "taichi/backends/metal/runtime.h"
+#include "taichi/backends/metal/kernel_manager.h"
 
 #include <algorithm>
 #include <cstring>
@@ -26,7 +26,7 @@ namespace shaders {
 }
 
 using KernelTaskType = OffloadedStmt::TaskType;
-using BufferEnum = MetalKernelAttributes::Buffers;
+using BufferEnum = KernelAttributes::Buffers;
 
 // This class requests the Metal buffer memory of |size| bytes from |mem_pool|.
 // Once allocated, it does not own the memory (hence the name "view"). Instead,
@@ -67,7 +67,7 @@ using InputBuffersMap = std::unordered_map<BufferEnum, MTLBuffer *>;
 class CompiledMtlKernelBase {
  public:
   struct Params {
-    const MetalKernelAttributes *kerenl_attribs;
+    const KernelAttributes *kerenl_attribs;
     MTLDevice *device;
     MTLFunction *mtl_func;
   };
@@ -82,7 +82,7 @@ class CompiledMtlKernelBase {
 
   virtual ~CompiledMtlKernelBase() = default;
 
-  inline MetalKernelAttributes *kernel_attribs() {
+  inline KernelAttributes *kernel_attribs() {
     return &kernel_attribs_;
   }
 
@@ -118,7 +118,7 @@ class CompiledMtlKernelBase {
     end_encoding(encoder.get());
   }
 
-  MetalKernelAttributes kernel_attribs_;
+  KernelAttributes kernel_attribs_;
   nsobj_unique_ptr<MTLComputePipelineState> pipeline_state_;
 };
 
@@ -201,8 +201,8 @@ class CompiledTaichiKernel {
   struct Params {
     std::string_view taichi_kernel_name;
     std::string mtl_source_code;
-    const std::vector<MetalKernelAttributes> *mtl_kernels_attribs;
-    const MetalKernelArgsAttributes *args_attribs;
+    const std::vector<KernelAttributes> *mtl_kernels_attribs;
+    const KernelArgsAttributes *args_attribs;
     MTLDevice *device;
     MemoryPool *mem_pool;
     ProfilerBase *profiler;
@@ -249,7 +249,7 @@ class CompiledTaichiKernel {
   // Have to be exposed as public for Impl to use. We cannot friend the Impl
   // class because it is private.
   std::vector<std::unique_ptr<CompiledMtlKernelBase>> compiled_mtl_kernels;
-  MetalKernelArgsAttributes args_attribs;
+  KernelArgsAttributes args_attribs;
   std::unique_ptr<BufferMemoryView> args_mem;
   nsobj_unique_ptr<MTLBuffer> args_buffer;
 
@@ -258,7 +258,7 @@ class CompiledTaichiKernel {
 
 class HostMetalArgsBlitter {
  public:
-  HostMetalArgsBlitter(const MetalKernelArgsAttributes *args_attribs,
+  HostMetalArgsBlitter(const KernelArgsAttributes *args_attribs,
                        Context *ctx,
                        BufferMemoryView *args_mem)
       : args_attribs_(args_attribs), ctx_(ctx), args_mem_(args_mem) {
@@ -356,18 +356,18 @@ class HostMetalArgsBlitter {
   }
 
  private:
-  const MetalKernelArgsAttributes *const args_attribs_;
+  const KernelArgsAttributes *const args_attribs_;
   Context *const ctx_;
   BufferMemoryView *const args_mem_;
 };
 
 }  // namespace
 
-class MetalRuntime::Impl {
+class KernelManager::Impl {
  public:
   explicit Impl(Params params)
       : config_(params.config),
-        compiled_snodes_(params.compiled_snodes),
+        compiled_structs_(params.compiled_structs),
         mem_pool_(params.mem_pool),
         profiler_(params.profiler) {
     if (config_->debug) {
@@ -379,9 +379,9 @@ class MetalRuntime::Impl {
     TI_ASSERT(command_queue_ != nullptr);
     create_new_command_buffer();
 
-    if (compiled_snodes_.root_size > 0) {
-      root_mem_ = std::make_unique<BufferMemoryView>(compiled_snodes_.root_size,
-                                                     mem_pool_);
+    if (compiled_structs_.root_size > 0) {
+      root_mem_ = std::make_unique<BufferMemoryView>(
+          compiled_structs_.root_size, mem_pool_);
       root_buffer_ = new_mtl_buffer_no_copy(device_.get(), root_mem_->ptr(),
                                             root_mem_->size());
       TI_ASSERT(root_buffer_ != nullptr);
@@ -394,9 +394,9 @@ class MetalRuntime::Impl {
         device_.get(), global_tmps_mem_->ptr(), global_tmps_mem_->size());
     TI_ASSERT(global_tmps_buffer_ != nullptr);
 
-    if (compiled_snodes_.runtime_size > 0) {
+    if (compiled_structs_.runtime_size > 0) {
       runtime_mem_ = std::make_unique<BufferMemoryView>(
-          compiled_snodes_.runtime_size, mem_pool_);
+          compiled_structs_.runtime_size, mem_pool_);
       runtime_buffer_ = new_mtl_buffer_no_copy(
           device_.get(), runtime_mem_->ptr(), runtime_mem_->size());
       TI_ASSERT(runtime_buffer_ != nullptr);
@@ -408,9 +408,9 @@ class MetalRuntime::Impl {
   void register_taichi_kernel(
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
-      const std::vector<MetalKernelAttributes> &kernels_attribs,
+      const std::vector<KernelAttributes> &kernels_attribs,
       size_t global_tmps_size,
-      const MetalKernelArgsAttributes &args_attribs) {
+      const KernelArgsAttributes &args_attribs) {
     TI_ASSERT(compiled_taichi_kernels_.find(taichi_kernel_name) ==
               compiled_taichi_kernels_.end());
     // Make sure |taichi_global_tmp_buffer_size| is large enough
@@ -495,8 +495,8 @@ class MetalRuntime::Impl {
   void init_runtime(int root_id) {
     using namespace shaders;
     char *addr = reinterpret_cast<char *>(runtime_mem_->ptr());
-    const int max_snodes = compiled_snodes_.max_snodes;
-    const auto &snode_descriptors = compiled_snodes_.snode_descriptors;
+    const int max_snodes = compiled_structs_.max_snodes;
+    const auto &snode_descriptors = compiled_structs_.snode_descriptors;
     // init snode_metas
     for (int i = 0; i < max_snodes; ++i) {
       auto iter = snode_descriptors.find(i);
@@ -584,7 +584,7 @@ class MetalRuntime::Impl {
   }
 
   CompileConfig *const config_;
-  const StructCompiledResult compiled_snodes_;
+  const CompiledStructs compiled_structs_;
   MemoryPool *const mem_pool_;
   ProfilerBase *const profiler_;
   nsobj_unique_ptr<MTLDevice> device_;
@@ -602,7 +602,7 @@ class MetalRuntime::Impl {
 
 #else
 
-class MetalRuntime::Impl {
+class KernelManager::Impl {
  public:
   explicit Impl(Params) {
     TI_ERROR("Metal not supported on the current OS");
@@ -629,30 +629,30 @@ class MetalRuntime::Impl {
 
 #endif  // TI_PLATFORM_OSX
 
-MetalRuntime::MetalRuntime(Params params)
+KernelManager::KernelManager(Params params)
     : impl_(std::make_unique<Impl>(std::move(params))) {
 }
 
-MetalRuntime::~MetalRuntime() {
+KernelManager::~KernelManager() {
 }
 
-void MetalRuntime::register_taichi_kernel(
+void KernelManager::register_taichi_kernel(
     const std::string &taichi_kernel_name,
     const std::string &mtl_kernel_source_code,
-    const std::vector<MetalKernelAttributes> &kernels_attribs,
+    const std::vector<KernelAttributes> &kernels_attribs,
     size_t global_tmps_size,
-    const MetalKernelArgsAttributes &args_attribs) {
+    const KernelArgsAttributes &args_attribs) {
   impl_->register_taichi_kernel(taichi_kernel_name, mtl_kernel_source_code,
                                 kernels_attribs, global_tmps_size,
                                 args_attribs);
 }
 
-void MetalRuntime::launch_taichi_kernel(const std::string &taichi_kernel_name,
-                                        Context *ctx) {
+void KernelManager::launch_taichi_kernel(const std::string &taichi_kernel_name,
+                                         Context *ctx) {
   impl_->launch_taichi_kernel(taichi_kernel_name, ctx);
 }
 
-void MetalRuntime::synchronize() {
+void KernelManager::synchronize() {
   impl_->synchronize();
 }
 

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -611,9 +611,9 @@ class KernelManager::Impl {
   void register_taichi_kernel(
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
-      const std::vector<MetalKernelAttributes> &kernels_attribs,
+      const std::vector<KernelAttributes> &kernels_attribs,
       size_t global_tmps_size,
-      const MetalKernelArgsAttributes &args_attribs) {
+      const KernelArgsAttributes &args_attribs) {
     TI_ERROR("Metal not supported on the current OS");
   }
 

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -3,9 +3,10 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
-#include "taichi/lang_util.h"
 #include "taichi/backends/metal/kernel_util.h"
+#include "taichi/lang_util.h"
 #include "taichi/program/profiler.h"
 #include "taichi/struct/struct_metal.h"
 #include "taichi/system/memory_pool.h"

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -20,19 +20,19 @@ namespace metal {
 // the compiled Metal kernels pipelines and Metal buffers memory. It is the
 // runtime interface between Taichi and Metal, and knows how to locate the
 // series of Metal kernels generated from a Taichi kernel.
-class MetalRuntime {
+class KernelManager {
  public:
   struct Params {
-    StructCompiledResult compiled_snodes;
+    CompiledStructs compiled_structs;
     CompileConfig *config;
     MemoryPool *mem_pool;
     ProfilerBase *profiler;
     int root_id;
   };
 
-  explicit MetalRuntime(Params params);
+  explicit KernelManager(Params params);
   // To make Pimpl + std::unique_ptr work
-  ~MetalRuntime();
+  ~KernelManager();
 
   // Register a Taichi kernel to the Metal runtime.
   // * |mtl_kernel_source_code| is the complete source code compiled from a
@@ -43,9 +43,9 @@ class MetalRuntime {
   void register_taichi_kernel(
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
-      const std::vector<MetalKernelAttributes> &kernels_attribs,
+      const std::vector<KernelAttributes> &kernels_attribs,
       size_t global_tmps_size,
-      const MetalKernelArgsAttributes &args_attribs);
+      const KernelArgsAttributes &args_attribs);
 
   // Launch the given |taichi_kernel_name|.
   // Kernel launching is asynchronous, therefore the Metal memory is not valid

--- a/taichi/backends/metal/kernel_util.cpp
+++ b/taichi/backends/metal/kernel_util.cpp
@@ -8,8 +8,7 @@ TLANG_NAMESPACE_BEGIN
 
 namespace metal {
 
-MetalKernelArgsAttributes::MetalKernelArgsAttributes(
-    const std::vector<Kernel::Arg> &args)
+KernelArgsAttributes::KernelArgsAttributes(const std::vector<Kernel::Arg> &args)
     : args_bytes_(0), extra_args_bytes_(Context::extra_args_size) {
   arg_attribs_vec_.reserve(args.size());
   for (const auto &ka : args) {

--- a/taichi/backends/metal/kernel_util.h
+++ b/taichi/backends/metal/kernel_util.h
@@ -21,8 +21,8 @@ class SNode;
 
 namespace metal {
 
-// This struct holds the necesary information to launch a Metal kernel.
-struct MetalKernelAttributes {
+// This struct holds the necessary information to launch a Metal kernel.
+struct KernelAttributes {
   enum class Buffers {
     Root,
     GlobalTmps,
@@ -63,7 +63,7 @@ struct MetalKernelAttributes {
 // Note that all Metal kernels belonging to the same Taichi kernel will share
 // the same kernel args (attributes + Metal buffer). This is because kernel
 // arguments is a Taichi-level concept.
-class MetalKernelArgsAttributes {
+class KernelArgsAttributes {
  public:
   // Attribute for a single argument.
   // This is mostly the same as Kernel::Arg. It's extended to contain a few
@@ -80,7 +80,7 @@ class MetalKernelArgsAttributes {
     bool is_return_val = false;
   };
 
-  explicit MetalKernelArgsAttributes(const std::vector<Kernel::Arg> &args);
+  explicit KernelArgsAttributes(const std::vector<Kernel::Arg> &args);
 
   inline bool has_args() const {
     return !arg_attribs_vec_.empty();

--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -14,7 +14,7 @@ namespace shaders {
 #include "taichi/backends/metal/shaders/runtime_structs.metal.h"
 }  // namespace shaders
 
-using BuffersEnum = MetalKernelAttributes::Buffers;
+using BuffersEnum = KernelAttributes::Buffers;
 
 constexpr char kKernelThreadIdName[] = "utid_";  // 'u' for unsigned
 constexpr char kRootBufferName[] = "root_addr";
@@ -25,22 +25,22 @@ constexpr char kArgsContextName[] = "args_ctx_";
 constexpr char kRuntimeVarName[] = "runtime_";
 constexpr char kListgenElemVarName[] = "listgen_elem_";
 
-class MetalKernelCodegen : public IRVisitor {
+class KernelCodegen : public IRVisitor {
  public:
-  MetalKernelCodegen(const std::string &mtl_kernel_prefix,
-                     const std::string &root_snode_type_name,
-                     Kernel *kernel,
-                     const StructCompiledResult *compiled_snode_structs)
+  KernelCodegen(const std::string &mtl_kernel_prefix,
+                const std::string &root_snode_type_name,
+                Kernel *kernel,
+                const CompiledStructs *compiled_structs)
       : mtl_kernel_prefix_(mtl_kernel_prefix),
         root_snode_type_name_(root_snode_type_name),
         kernel_(kernel),
-        compiled_snodes_(compiled_snode_structs),
-        needs_root_buffer_(compiled_snodes_->root_size > 0),
+        compiled_structs_(compiled_structs),
+        needs_root_buffer_(compiled_structs_->root_size > 0),
         args_attribs_(kernel_->args) {
     // allow_undefined_visitor = true;
   }
 
-  const MetalKernelArgsAttributes &kernel_args_attribs() const {
+  const KernelArgsAttributes &kernel_args_attribs() const {
     return args_attribs_;
   }
 
@@ -48,7 +48,7 @@ class MetalKernelCodegen : public IRVisitor {
     return line_appender_.lines();
   }
 
-  const std::vector<MetalKernelAttributes> &kernels_attribs() const {
+  const std::vector<KernelAttributes> &kernels_attribs() const {
     return mtl_kernels_attribs_;
   }
 
@@ -492,13 +492,13 @@ class MetalKernelCodegen : public IRVisitor {
     line_appender_.append_raw(kMetalHelpersSourceCode);
 #undef TI_INSIDE_METAL_CODEGEN
     emit("");
-    line_appender_.append_raw(compiled_snodes_->snode_structs_source_code);
+    line_appender_.append_raw(compiled_structs_->snode_structs_source_code);
     emit("");
-    line_appender_.append_raw(compiled_snodes_->runtime_utils_source_code);
+    line_appender_.append_raw(compiled_structs_->runtime_utils_source_code);
     emit("");
     emit("}}  // namespace");
     emit("");
-    line_appender_.append_raw(compiled_snodes_->runtime_kernels_source_code);
+    line_appender_.append_raw(compiled_structs_->runtime_kernels_source_code);
     emit("");
   }
 
@@ -551,7 +551,7 @@ class MetalKernelCodegen : public IRVisitor {
   void generate_serial_kernel(OffloadedStmt *stmt) {
     TI_ASSERT(stmt->task_type == OffloadedStmt::TaskType::serial);
     const std::string mtl_kernel_name = make_kernel_name();
-    MetalKernelAttributes ka;
+    KernelAttributes ka;
     ka.name = mtl_kernel_name;
     ka.task_type = stmt->task_type;
     ka.buffers = get_root_tmps_args_buffers();
@@ -573,7 +573,7 @@ class MetalKernelCodegen : public IRVisitor {
   void generate_range_for_kernel(OffloadedStmt *stmt) {
     TI_ASSERT(stmt->task_type == OffloadedStmt::TaskType::range_for);
     const std::string mtl_kernel_name = make_kernel_name();
-    MetalKernelAttributes ka;
+    KernelAttributes ka;
     ka.name = mtl_kernel_name;
     ka.task_type = stmt->task_type;
     ka.buffers = get_root_tmps_args_buffers();
@@ -625,7 +625,7 @@ class MetalKernelCodegen : public IRVisitor {
     TI_ASSERT(stmt->task_type == OffloadedStmt::TaskType::struct_for);
     const std::string mtl_kernel_name = make_kernel_name();
 
-    MetalKernelAttributes ka;
+    KernelAttributes ka;
     ka.name = mtl_kernel_name;
     ka.task_type = stmt->task_type;
     ka.buffers = get_root_tmps_args_buffers();
@@ -634,7 +634,7 @@ class MetalKernelCodegen : public IRVisitor {
     emit_mtl_kernel_func_sig(mtl_kernel_name, ka.buffers);
 
     const int sn_id = stmt->snode->id;
-    ka.num_threads = compiled_snodes_->snode_descriptors.find(sn_id)
+    ka.num_threads = compiled_structs_->snode_descriptors.find(sn_id)
                          ->second.total_num_elems_from_root;
 
     line_appender_.push_indent();
@@ -673,7 +673,7 @@ class MetalKernelCodegen : public IRVisitor {
     using Type = OffloadedStmt::TaskType;
     const auto type = stmt->task_type;
     auto *const sn = stmt->snode;
-    MetalKernelAttributes ka;
+    KernelAttributes ka;
     ka.name = kernel_name;
     ka.task_type = stmt->task_type;
     if (type == Type::clear_list) {
@@ -683,7 +683,7 @@ class MetalKernelCodegen : public IRVisitor {
       // This launches |total_num_elems_from_root| number of threads, which
       // could be a huge waste of GPU resources.
       // TODO(k-ye): use grid-stride loop to reduce #threads.
-      ka.num_threads = compiled_snodes_->snode_descriptors.find(sn->id)
+      ka.num_threads = compiled_structs_->snode_descriptors.find(sn->id)
                            ->second.total_num_elems_from_root;
       ka.buffers = {BuffersEnum::Runtime, BuffersEnum::Root, BuffersEnum::Args};
     } else {
@@ -708,7 +708,8 @@ class MetalKernelCodegen : public IRVisitor {
   std::string make_snode_meta_bm(const SNode *sn,
                                  const std::string &var_name) const {
     TI_ASSERT(sn->type == SNodeType::bitmasked);
-    const auto &meta = compiled_snodes_->snode_descriptors.find(sn->id)->second;
+    const auto &meta =
+        compiled_structs_->snode_descriptors.find(sn->id)->second;
     LineAppender la = line_appender_;
     // Keep the indentation settings only
     la.clear_lines();
@@ -730,7 +731,7 @@ class MetalKernelCodegen : public IRVisitor {
 
   void emit_mtl_kernel_func_sig(
       const std::string &kernel_name,
-      const std::vector<MetalKernelAttributes::Buffers> &buffers) {
+      const std::vector<KernelAttributes::Buffers> &buffers) {
     auto buffer_to_name = [](BuffersEnum b) -> std::string {
       switch (b) {
         case BuffersEnum::Root:
@@ -768,37 +769,37 @@ class MetalKernelCodegen : public IRVisitor {
   const std::string mtl_kernel_prefix_;
   const std::string root_snode_type_name_;
   Kernel *const kernel_;
-  const StructCompiledResult *const compiled_snodes_;
+  const CompiledStructs *const compiled_structs_;
   const bool needs_root_buffer_;
-  const MetalKernelArgsAttributes args_attribs_;
+  const KernelArgsAttributes args_attribs_;
 
   bool is_top_level_{true};
   int mtl_kernel_count_{0};
-  std::vector<MetalKernelAttributes> mtl_kernels_attribs_;
+  std::vector<KernelAttributes> mtl_kernels_attribs_;
   GetRootStmt *root_stmt_{nullptr};
-  MetalKernelAttributes *current_kernel_attribs_{nullptr};
+  KernelAttributes *current_kernel_attribs_{nullptr};
   LineAppender line_appender_;
 };
 
 }  // namespace
 
-MetalCodeGen::MetalCodeGen(const std::string &kernel_name,
-                           const StructCompiledResult *struct_compiled)
+CodeGen::CodeGen(const std::string &kernel_name,
+                 const CompiledStructs *compiled_structs)
     : id_(Program::get_kernel_id()),
       taichi_kernel_name_(fmt::format("mtl_k{:04d}_{}", id_, kernel_name)),
-      struct_compiled_(struct_compiled) {
+      compiled_structs_(compiled_structs) {
 }
 
-FunctionType MetalCodeGen::compile(Program &,
-                                   Kernel &kernel,
-                                   MetalRuntime *runtime) {
+FunctionType CodeGen::compile(Program &,
+                              Kernel &kernel,
+                              KernelManager *kernel_mgr) {
   this->prog_ = &kernel.program;
   this->kernel_ = &kernel;
   lower();
-  return gen(*prog_->snode_root, runtime);
+  return gen(*prog_->snode_root, kernel_mgr);
 }
 
-void MetalCodeGen::lower() {
+void CodeGen::lower() {
   auto ir = kernel_->ir;
   const bool print_ir = prog_->config.print_ir;
   if (print_ir) {
@@ -913,18 +914,18 @@ void MetalCodeGen::lower() {
   }
 }
 
-FunctionType MetalCodeGen::gen(const SNode &root_snode, MetalRuntime *runtime) {
+FunctionType CodeGen::gen(const SNode &root_snode, KernelManager *kernel_mgr) {
   // Make a copy of the name!
   const std::string taichi_kernel_name = taichi_kernel_name_;
-  MetalKernelCodegen codegen(taichi_kernel_name, root_snode.node_type_name,
-                             kernel_, struct_compiled_);
+  KernelCodegen codegen(taichi_kernel_name, root_snode.node_type_name, kernel_,
+                        compiled_structs_);
   codegen.run();
-  runtime->register_taichi_kernel(
+  kernel_mgr->register_taichi_kernel(
       taichi_kernel_name, codegen.kernel_source_code(),
       codegen.kernels_attribs(), global_tmps_buffer_size_,
       codegen.kernel_args_attribs());
-  return [runtime, taichi_kernel_name](Context &ctx) {
-    runtime->launch_taichi_kernel(taichi_kernel_name, &ctx);
+  return [kernel_mgr, taichi_kernel_name](Context &ctx) {
+    kernel_mgr->launch_taichi_kernel(taichi_kernel_name, &ctx);
   };
 }
 

--- a/taichi/codegen/codegen_metal.h
+++ b/taichi/codegen/codegen_metal.h
@@ -9,27 +9,27 @@
 #include "taichi/lang_util.h"
 #include "taichi/backends/metal/data_types.h"
 #include "taichi/backends/metal/kernel_util.h"
-#include "taichi/backends/metal/runtime.h"
+#include "taichi/backends/metal/kernel_manager.h"
 #include "taichi/program/program.h"
 #include "taichi/struct/struct_metal.h"
 
 TLANG_NAMESPACE_BEGIN
 namespace metal {
 
-class MetalCodeGen {
+class CodeGen {
  public:
-  MetalCodeGen(const std::string &kernel_name,
-               const StructCompiledResult *struct_compiled);
+  CodeGen(const std::string &kernel_name,
+          const CompiledStructs *compiled_structs);
 
-  FunctionType compile(Program &, Kernel &kernel, MetalRuntime *runtime);
+  FunctionType compile(Program &, Kernel &kernel, KernelManager *kernel_mgr);
 
  private:
   void lower();
-  FunctionType gen(const SNode &root_snode, MetalRuntime *runtime);
+  FunctionType gen(const SNode &root_snode, KernelManager *runtime);
 
   const int id_;
   const std::string taichi_kernel_name_;
-  const StructCompiledResult *const struct_compiled_;
+  const CompiledStructs *const compiled_structs_;
 
   Program *prog_;
   Kernel *kernel_;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -101,8 +101,8 @@ FunctionType Program::compile(Kernel &kernel) {
     auto codegen = KernelCodeGen::create(kernel.arch, &kernel);
     ret = codegen->compile();
   } else if (kernel.arch == Arch::metal) {
-    metal::MetalCodeGen codegen(kernel.name, &metal_struct_compiled_.value());
-    ret = codegen.compile(*this, kernel, metal_runtime_.get());
+    metal::CodeGen codegen(kernel.name, &metal_compiled_structs_.value());
+    ret = codegen.compile(*this, kernel, metal_kernel_mgr_.get());
   } else if (kernel.arch == Arch::opengl) {
     opengl::OpenglCodeGen codegen(kernel.name,
                                   &opengl_struct_compiled_.value());
@@ -237,15 +237,16 @@ void Program::materialize_layout() {
   } else if (config.arch == Arch::metal) {
     TI_ASSERT_INFO(config.use_llvm,
                    "Metal arch requires that LLVM being enabled");
-    metal_struct_compiled_ = metal::compile_structs(*snode_root);
-    if (metal_runtime_ == nullptr) {
-      metal::MetalRuntime::Params params;
-      params.compiled_snodes = metal_struct_compiled_.value();
+    metal_compiled_structs_ = metal::compile_structs(*snode_root);
+    if (metal_kernel_mgr_ == nullptr) {
+      metal::KernelManager::Params params;
+      params.compiled_structs = metal_compiled_structs_.value();
       params.config = &config;
       params.mem_pool = memory_pool.get();
       params.profiler = profiler.get();
       params.root_id = snode_root->id;
-      metal_runtime_ = std::make_unique<metal::MetalRuntime>(std::move(params));
+      metal_kernel_mgr_ =
+          std::make_unique<metal::KernelManager>(std::move(params));
     }
   } else if (config.arch == Arch::opengl) {
     opengl::OpenglStructCompiler scomp;
@@ -283,7 +284,7 @@ void Program::synchronize() {
       TI_ERROR("No CUDA support");
 #endif
     } else if (config.arch == Arch::metal) {
-      metal_runtime_->synchronize();
+      metal_kernel_mgr_->synchronize();
     }
     sync = true;
   }

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -10,7 +10,7 @@
 #include "taichi/ir/snode.h"
 #include "taichi/lang_util.h"
 #include "taichi/llvm/llvm_context.h"
-#include "taichi/backends/metal/runtime.h"
+#include "taichi/backends/metal/kernel_manager.h"
 #include "taichi/platform/opengl/opengl_kernel_util.h"
 #include "taichi/program/kernel.h"
 #include "taichi/program/profiler.h"
@@ -177,8 +177,8 @@ class Program {
 
  private:
   // Metal related data structures
-  std::optional<metal::StructCompiledResult> metal_struct_compiled_;
-  std::unique_ptr<metal::MetalRuntime> metal_runtime_;
+  std::optional<metal::CompiledStructs> metal_compiled_structs_;
+  std::unique_ptr<metal::KernelManager> metal_kernel_mgr_;
   // OpenGL related data structures
   std::optional<opengl::StructCompiledResult> opengl_struct_compiled_;
 };

--- a/taichi/struct/struct_metal.cpp
+++ b/taichi/struct/struct_metal.cpp
@@ -44,7 +44,7 @@ inline int get_n(const SNode &sn) {
 
 class StructCompiler {
  public:
-  StructCompiledResult run(SNode &root) {
+  CompiledStructs run(SNode &root) {
     TI_ASSERT(root.type == SNodeType::root);
     collect_snodes(root);
     // The host side has run this!
@@ -66,7 +66,7 @@ class StructCompiler {
     for (auto &n : snodes_rev) {
       generate_types(*n);
     }
-    StructCompiledResult result;
+    CompiledStructs result;
     result.root_size = compute_snode_size(&root);
     line_appender_.dump(&result.snode_structs_source_code);
     emit_runtime_structs(&root);
@@ -247,7 +247,7 @@ class StructCompiler {
 
 }  // namespace
 
-StructCompiledResult compile_structs(SNode &root) {
+CompiledStructs compile_structs(SNode &root) {
   return StructCompiler().run(root);
 }
 }  // namespace metal

--- a/taichi/struct/struct_metal.h
+++ b/taichi/struct/struct_metal.h
@@ -29,7 +29,7 @@ struct SNodeDescriptor {
   int mem_offset_in_parent = 0;
 };
 
-struct StructCompiledResult {
+struct CompiledStructs {
   // Source code of the SNode data structures compiled to Metal
   std::string snode_structs_source_code;
   // Runtime related source code
@@ -64,7 +64,7 @@ struct StructCompiledResult {
 };
 
 // Compile all snodes to Metal source code
-StructCompiledResult compile_structs(SNode &root);
+CompiledStructs compile_structs(SNode &root);
 
 }  // namespace metal
 TLANG_NAMESPACE_END


### PR DESCRIPTION
* Because these classes are already inside the `metal` namespace,
they do not need to start with `Metal`.
* Also renamed `metal::Runtime` to `metal::KernelManager`.

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #593 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
