### PR TITLE
[Lang] Fix `ti.static(ti.grouped(ti.ndrange(...)))` syntax checker false positive

### DIFF
--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -462,12 +462,6 @@ if 1:
         if decorator == 'static':
             if double_decorator == 'static':
                 raise TaichiSyntaxError("'ti.static' cannot be nested")
-            if double_decorator == 'grouped' and (
-                    len(node.iter.args[0].args) != 1
-                    or self.get_decorator(node.iter.args[0].args[0]) == ''):
-                raise TaichiSyntaxError(
-                    "Static grouped struct for loop is not allowed. Please use 'ti.static(ti.grouped(ti.ndrange(...)))' instead."
-                )
             return self.visit_static_for(node)
         elif decorator == 'ndrange':
             if double_decorator != '':

--- a/tests/python/test_grouped.py
+++ b/tests/python/test_grouped.py
@@ -159,3 +159,27 @@ def test_static_grouped_ndrange_0d():
     test()
 
     assert val[None] == 42
+
+
+@ti.all_archs
+def test_static_grouped_func():
+
+    K = 3
+    dim = 2
+
+    v = ti.Vector(K, dt=ti.i32, shape=((K, ) * dim))
+
+    def stencil_range():
+        return ti.ndrange(*((K, ) * (dim + 1)))
+
+    @ti.kernel
+    def p2g():
+        for I in ti.static(ti.grouped(stencil_range())):
+            v[I[0], I[1]][I[2]] = I[0] + I[1] * 3 + I[2] * 10
+
+    p2g()
+
+    for i in range(K):
+        for j in range(K):
+            for k in range(K):
+                assert v[i, j][k] == i + j * 3 + k * 10

--- a/tests/python/test_syntax_errors.py
+++ b/tests/python/test_syntax_errors.py
@@ -212,6 +212,8 @@ def test_nested_ndrange():
     func()
 
 
+# Skipping this test case until we figure out a systematic solution to syntax checking here.
+'''
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_static_grouped_struct_for():
     val = ti.var(ti.i32)
@@ -224,3 +226,4 @@ def test_static_grouped_struct_for():
             pass
 
     test()
+'''


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

This is a special case that we should let pass. A more systematic solution is to defer the checking to the stage when the AST generating script is executed.

Related issue = #https://github.com/taichi-dev/taichi_elements/issues/13

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
