### PR TITLE
[metal] Use grid-stride loop to implement `listgen` kernels

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -237,6 +237,8 @@ class CompiledTaichiKernel {
 
       TI_ASSERT(kernel != nullptr);
       compiled_mtl_kernels.push_back(std::move(kernel));
+      TI_DEBUG("Added {} for Taichi kernel {}", ka.debug_string(),
+               params.taichi_kernel_name);
     }
     if (args_attribs.has_args()) {
       args_mem = std::make_unique<BufferMemoryView>(args_attribs.total_bytes(),

--- a/taichi/backends/metal/kernel_util.h
+++ b/taichi/backends/metal/kernel_util.h
@@ -58,6 +58,9 @@ struct KernelAttributes {
   RangeForAttributes range_for_attribs;
   // clear_list + listgen
   RuntimeListOpAttributes runtime_list_op_attribs;
+
+  static std::string buffers_name(Buffers b);
+  std::string debug_string() const;
 };
 
 // Note that all Metal kernels belonging to the same Taichi kernel will share

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -43,9 +43,9 @@ struct Runtime {
 METAL_BEGIN_RUNTIME_KERNELS_DEF
 STR(
     // clang-format on
-    kernel void clear_list(device byte *runtime_addr [[buffer(0)]],
-                           device int *args [[buffer(1)]],
-                           const uint utid_ [[thread_position_in_grid]]) {
+    kernel void clear_list(device byte *runtime_addr[[buffer(0)]],
+                           device int *args[[buffer(1)]],
+                           const uint utid_[[thread_position_in_grid]]) {
       if (utid_ > 0)
         return;
       int child_snode_id = args[1];
@@ -55,11 +55,11 @@ STR(
       clear(child_list);
     }
 
-    kernel void element_listgen(device byte *runtime_addr [[buffer(0)]],
-                                device byte *root_addr [[buffer(1)]],
-                                device int *args [[buffer(2)]],
-                                const uint utid_ [[thread_position_in_grid]],
-                                const uint grid_size [[threads_per_grid]]) {
+    kernel void element_listgen(device byte *runtime_addr[[buffer(0)]],
+                                device byte *root_addr[[buffer(1)]],
+                                device int *args[[buffer(2)]],
+                                const uint utid_[[thread_position_in_grid]],
+                                const uint grid_size[[threads_per_grid]]) {
       device Runtime *runtime =
           reinterpret_cast<device Runtime *>(runtime_addr);
       device byte *list_data_addr =

--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -680,11 +680,12 @@ class KernelCodegen : public IRVisitor {
       ka.num_threads = 1;
       ka.buffers = {BuffersEnum::Runtime, BuffersEnum::Args};
     } else if (type == Type::listgen) {
-      // This launches |total_num_elems_from_root| number of threads, which
-      // could be a huge waste of GPU resources.
-      // TODO(k-ye): use grid-stride loop to reduce #threads.
-      ka.num_threads = compiled_structs_->snode_descriptors.find(sn->id)
-                           ->second.total_num_elems_from_root;
+      // listgen kernels use grid-stride loops, so that we can cap its maximum
+      // number of threads at 1M.
+      ka.num_threads =
+          std::min(compiled_structs_->snode_descriptors.find(sn->id)
+                       ->second.total_num_elems_from_root,
+                   1024 * 1024);
       ka.buffers = {BuffersEnum::Runtime, BuffersEnum::Root, BuffersEnum::Args};
     } else {
       TI_ERROR("Unsupported offload task type {}", stmt->task_name());

--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -685,7 +685,7 @@ class KernelCodegen : public IRVisitor {
       ka.num_threads =
           std::min(compiled_structs_->snode_descriptors.find(sn->id)
                        ->second.total_num_elems_from_root,
-                   1024 * 1024);
+                   64 * 1024);
       ka.buffers = {BuffersEnum::Runtime, BuffersEnum::Root, BuffersEnum::Args};
     } else {
       TI_ERROR("Unsupported offload task type {}", stmt->task_name());

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -1,9 +1,12 @@
 // Intermediate representations
 
-#include "ir.h"
-#include <thread>
+#include "taichi/ir/ir.h"
+
 #include <numeric>
-#include "frontend.h"
+#include <thread>
+#include <unordered_map>
+
+#include "taichi/ir/frontend.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -529,6 +532,19 @@ std::string OffloadedStmt::task_name() const {
   } else {
     TI_NOT_IMPLEMENTED
   }
+}
+
+// static
+std::string OffloadedStmt::task_type_name(TaskType tt) {
+#define REGISTER_NAME(x) \
+  { TaskType::x, #x }
+  const static std::unordered_map<TaskType, std::string> m = {
+      REGISTER_NAME(serial),     REGISTER_NAME(range_for),
+      REGISTER_NAME(struct_for), REGISTER_NAME(clear_list),
+      REGISTER_NAME(listgen),    REGISTER_NAME(gc),
+  };
+#undef REGISTER_NAME
+  return m.find(tt)->second;
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1,5 +1,6 @@
 #pragma once
-#include "ir.h"
+
+#include "taichi/ir/ir.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -189,6 +190,8 @@ class OffloadedStmt : public Stmt {
   OffloadedStmt(TaskType task_type, SNode *snode);
 
   std::string task_name() const;
+
+  static std::string task_type_name(TaskType tt);
 
   bool has_body() const {
     return task_type != clear_list && task_type != listgen && task_type != gc;

--- a/tests/python/test_bitmasked.py
+++ b/tests/python/test_bitmasked.py
@@ -109,6 +109,3 @@ def test_huge_bitmasked():
     func()
     count()
     assert s[None] == (n * n * 2) // 32
-
-
-test_huge_bitmasked()

--- a/tests/python/test_bitmasked.py
+++ b/tests/python/test_bitmasked.py
@@ -82,3 +82,33 @@ def test_bitmasked_bitmasked():
 
     func()
     assert s[None] == 4
+
+
+@archs_support_bitmasked
+def test_huge_bitmasked():
+    # Mainly for testing Metal listgen's grid-stride loop implementation.
+    x = ti.var(ti.f32)
+    s = ti.var(ti.i32)
+
+    n = 1024
+
+    ti.root.bitmasked(ti.i, n).bitmasked(ti.i, 2 * n).place(x)
+    ti.root.place(s)
+
+    @ti.kernel
+    def func():
+        for i in range(n * n * 2):
+            if i % 32 == 0:
+                x[i] = 1.0
+
+    @ti.kernel
+    def count():
+        for i in x:
+            s[None] += 1
+
+    func()
+    count()
+    assert s[None] == (n * n * 2) // 32
+
+
+test_huge_bitmasked()


### PR DESCRIPTION
Also added `KernelAttributes::debug_string()` method, making the PR a bit noisy. These are the files that deserve attention..

* `taichi/backends/metal/shaders/runtime_kernels.metal.h`
* `taichi/codegen/codegen_metal.cpp`

Note that I just put a limit of #threads to be `1024 x 1024`. Does this makes sense (i.e. is there a fancier way to decide this limit)?

---

I used `taichi_sparse.py` as a rough benchmark. The FPS went from `35` to `40`. I guess that's because each thread now only handles a few child slots. (Previously each thread had to handle all the slots.)

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #678 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
