### PR TITLE
[metal] Fix bug in `listgen` where it goes beyond `ListManager`'s capacity

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -510,6 +510,8 @@ class KernelManager::Impl {
       rtm_meta->element_stride = sn_meta.element_stride;
       rtm_meta->num_slots = sn_meta.num_slots;
       rtm_meta->mem_offset_in_parent = sn_meta.mem_offset_in_parent;
+      TI_DEBUG("SnodeMeta\n  id={}\n  element_stride={}\n  num_slots={}\n\n", i,
+               rtm_meta->element_stride, rtm_meta->num_slots);
       switch (sn_meta.snode->type) {
         case SNodeType::dense:
           rtm_meta->type = SNodeMeta::Dense;
@@ -563,6 +565,8 @@ class KernelManager::Impl {
       rtm_list->next = 0;
       rtm_list->mem_begin = list_data_mem_begin;
       list_data_mem_begin += rtm_list->max_num_elems * rtm_list->element_stride;
+      TI_DEBUG("ListManager\n  id={}\n  num_slots={}\n  mem_begin={}\n\n", i,
+               rtm_list->max_num_elems, rtm_list->mem_begin);
     }
     addr += sizeof(ListManager) * max_snodes;
     // root list data are static

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -76,8 +76,9 @@ STR(
       const int range = max(
           (int)((child_list->max_num_elems + grid_size - 1) / grid_size), 1);
       const int begin = range * (int)utid_;
+      const int end = min(begin + range, child_list->max_num_elems);
 
-      for (int ii = begin; ii < (begin + range); ++ii) {
+      for (int ii = begin; ii < end; ++ii) {
         const int parent_idx = (ii / num_slots);
         if (parent_idx >= num_active(parent_list)) {
           // Since |parent_idx| increases monotonically, we can return directly


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

FYI, without this change, the added test could actually fail on Metal...

Related issue = #593 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
