### PR TITLE
[metal] Skip `listgen` for leaf Snode

### DIFF
--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -643,6 +643,9 @@ class KernelCodegen : public IRVisitor {
     if (!mtl_kernels_attribs_.empty() &&
         mtl_kernels_attribs_.back().task_type ==
             OffloadedStmt::TaskType::listgen) {
+      // TODO(#689): this is somewhat hacky. Once the IR is more polished, we
+      // can easily iterate through all the offloaded tasks beforehand to remove
+      // the (clear, listgen) for leaf node, instead of doing it here.
       TI_ASSERT(mtl_kernels_attribs_.size() >= 2);
       for (int i = 0; i < 2; ++i) {
         TI_ASSERT(


### PR DESCRIPTION
`struct_for` also uses grid-loop stride now.

`taichi_sparse.py` went up by about another `4-5` FPS.

---

You can probably tell how similar this change is to https://github.com/taichi-dev/taichi/blob/40bf0c0a84b5ea77f483e11250d399c4fd72f50e/taichi/backends/metal/shaders/runtime_kernels.metal.h#L68-L98

I cannot think of a very good way to unify these for now. Since most of the duplicate code are procedures, it's difficult to wrap them into functions. We could use macros to solve this, although I'm not a very big fan of macros..

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #678 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
