### PR TITLE
[refactor] SNode now uses unique_ptr instead of shared_ptr for clearer children ownership

### DIFF
--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -205,10 +205,7 @@ void SNode::set_kernel_args(Kernel *kernel, const std::vector<int> &I) {
   }
 }
 
-SNode::SNode() {
-  id = counter++;
-  node_type_name = get_node_type_name();
-  type = SNodeType::undefined;
+SNode::SNode() : SNode(0, SNodeType::undefined) {
 }
 
 SNode::SNode(int depth, SNodeType t) : depth(depth), type(t) {
@@ -227,7 +224,9 @@ SNode::SNode(int depth, SNodeType t) : depth(depth), type(t) {
   writer_kernel = nullptr;
 }
 
-SNode::~SNode() {
+SNode::SNode(const SNode &) {
+  TI_NOT_IMPLEMENTED;  // Copying an SNode is forbidden. However we need the
+                       // definition here to make pybind11 happy.
 }
 
 std::string SNode::get_node_type_name() const {

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -52,7 +52,7 @@ class Index {
 class SNode {
  public:
   // Children
-  std::vector<std::shared_ptr<SNode>> ch;
+  std::vector<std::unique_ptr<SNode>> ch;
 
   IndexExtractor extractors[taichi_max_num_indices];
   int num_active_indices{};
@@ -80,9 +80,13 @@ class SNode {
   Kernel *writer_kernel{};
   Expr expr;
 
-  std::string data_type_name() {
-    return lang::data_type_name(dt);
-  }
+  SNode();
+
+  SNode(int depth, SNodeType t);
+
+  SNode(const SNode &);
+
+  ~SNode() = default;
 
   std::string node_type_name;
   SNodeType type;
@@ -92,14 +96,8 @@ class SNode {
 
   std::string get_node_type_name_hinted() const;
 
-  SNode();
-
-  SNode(int depth, SNodeType t);
-
-  ~SNode();
-
   SNode &insert_children(SNodeType t) {
-    ch.push_back(create(depth + 1, t));
+    ch.emplace_back(create(depth + 1, t));
     // Note: parent will not be set until structural nodes are compiled!
     return *ch.back();
   }
@@ -167,8 +165,8 @@ class SNode {
   }
 
   template <typename... Args>
-  static std::shared_ptr<SNode> create(Args &&... args) {
-    return std::make_shared<SNode>(std::forward<Args>(args)...);
+  static std::unique_ptr<SNode> create(Args &&... args) {
+    return std::make_unique<SNode>(std::forward<Args>(args)...);
   }
 
   std::string type_name() {
@@ -277,15 +275,15 @@ class SNodeAttributes {
   std::map<SNode *, SNodeAttribute> snode_llvm_attr;
 
  public:
-  SNodeAttribute &operator[](SNode *snode) {
-    return snode_llvm_attr[snode];
-  }
-
   SNodeAttribute &operator[](SNode &snode) {
     return snode_llvm_attr[&snode];
   }
 
-  SNodeAttribute &operator[](const std::shared_ptr<SNode> &snode) {
+  SNodeAttribute &operator[](SNode *snode) {
+    return snode_llvm_attr[snode];
+  }
+
+  SNodeAttribute &operator[](const std::unique_ptr<SNode> &snode) {
     return snode_llvm_attr[snode.get()];
   }
 };

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -97,7 +97,7 @@ class SNode {
   std::string get_node_type_name_hinted() const;
 
   SNode &insert_children(SNodeType t) {
-    ch.emplace_back(create(depth + 1, t));
+    ch.push_back(create(depth + 1, t));
     // Note: parent will not be set until structural nodes are compiled!
     return *ch.back();
   }

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -167,7 +167,7 @@ void StructCompilerLLVM::generate_child_accessors(SNode &snode) {
         builder.CreateBitCast(ret, llvm::Type::getInt8PtrTy(*llvm_ctx)));
   }
 
-  for (auto ch : snode.ch) {
+  for (auto &ch : snode.ch) {
     generate_child_accessors(*ch);
   }
 

--- a/tests/cpp/test_same_statements.cpp
+++ b/tests/cpp/test_same_statements.cpp
@@ -83,7 +83,7 @@ TI_TEST("test_same_snode_lookup") {
   auto get_root = block->push_back<GetRootStmt>();
   auto zero = block->push_back<ConstStmt>(LaneAttribute<TypedConstant>(0));
   SNode root(0, SNodeType::root);
-  auto child = root.insert_children(SNodeType::dense);
+  auto &child = root.insert_children(SNodeType::dense);
   auto lookup1 = block->push_back<SNodeLookupStmt>(&root, get_root, zero, false,
                                                    std::vector<Stmt *>());
   auto lookup2 = block->push_back<SNodeLookupStmt>(&root, get_root, zero, false,


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #518 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
