### PR TITLE
[refactor] CUDA-related infrastructure

### DIFF
--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -52,7 +52,7 @@ void CUDAContext::launch(void *func,
                          std::vector<void *> arg_pointers,
                          unsigned gridDim,
                          unsigned blockDim) {
-  // auto _ = cuda_context->get_guard();
+  // auto _ = CUDAContext::get_instance().get_guard();
   make_current();
 
   // Kernel launch
@@ -85,7 +85,14 @@ CUDAContext::~CUDAContext() {
   */
 }
 
-std::unique_ptr<CUDAContext> cuda_context;
+CUDAContext &CUDAContext::get_instance() {
+  if (!instance) {
+    instance = std::make_unique<CUDAContext>();
+  }
+  return *instance;
+}
+
+std::unique_ptr<CUDAContext> CUDAContext::instance;
 
 TLANG_NAMESPACE_END
 #endif

--- a/taichi/backends/cuda/runtime.cpp
+++ b/taichi/backends/cuda/runtime.cpp
@@ -8,21 +8,18 @@ TLANG_NAMESPACE_BEGIN
 class RuntimeCUDA : public Runtime {
  public:
   RuntimeCUDA() {
-    if (!cuda_context) {
-      cuda_context = std::make_unique<CUDAContext>();
-    }
   }
 
   std::size_t get_total_memory() override {
-    return cuda_context->get_total_memory();
+    return CUDAContext::get_instance().get_total_memory();
   }
 
   std::size_t get_available_memory() override {
-    return cuda_context->get_free_memory();
+    return CUDAContext::get_instance().get_free_memory();
   }
 
   bool detected() override {
-    return cuda_context->detected();
+    return CUDAContext::get_instance().detected();
   }
 
   ~RuntimeCUDA() {

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -69,7 +69,7 @@ class TaichiLLVMContext {
 
   std::string type_name(llvm::Type *type);
 
-  void link_module_with_libdevice(std::unique_ptr<llvm::Module> &module);
+  void link_module_with_cuda_libdevice(std::unique_ptr<llvm::Module> &module);
 
   static void force_inline(llvm::Function *func);
 

--- a/taichi/system/unified_allocator.cpp
+++ b/taichi/system/unified_allocator.cpp
@@ -25,7 +25,7 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch)
     TI_TRACE("Allocating unified (CPU+GPU) address space of size {} MB",
              size / 1024 / 1024);
 #if defined(TI_WITH_CUDA)
-    // std::lock_guard<std::mutex> _(cuda_context->lock);
+    // std::lock_guard<std::mutex> _(CUDAContext::get_instance().lock);
     check_cuda_error(cudaMallocManaged(&_cuda_data, size));
     if (_cuda_data == nullptr) {
       TI_ERROR("CUDA memory allocation failed.");


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #518 

- Removed `cuda_context` global var 
- Added comments on why `remove_useless_libdevice_functions` is needed

(`CUDAContext::get_instance().get_guard()` sometimes leads to deadlocks on CUDA - that's why they are commented for now until we figure out why.)

This PR should close #518 once merged.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
