### PR TITLE
[Metal] Support `ti.random()` on Metal

### DIFF
--- a/taichi/backends/metal/constants.h
+++ b/taichi/backends/metal/constants.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+#include "taichi/lang_util.h"
+
+TLANG_NAMESPACE_BEGIN
+namespace metal {
+
+inline constexpr int kMaxNumThreadsGridStrideLoop = 64 * 1024;
+inline constexpr int kNumRandSeeds = 64 * 1024;  // 256 KB is nothing
+
+}  // namespace metal
+TLANG_NAMESPACE_END

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -215,7 +215,10 @@ class CompiledTaichiKernel {
   CompiledTaichiKernel(Params params) : args_attribs(*params.args_attribs) {
     auto *const device = params.device;
     auto kernel_lib = new_library_with_source(device, params.mtl_source_code);
-    TI_ASSERT(kernel_lib != nullptr);
+    if (kernel_lib == nullptr) {
+      TI_ERROR("Failed to compile Metal kernel! Generated code:\n\n{}",
+               params.mtl_source_code);
+    }
     for (const auto &ka : *(params.mtl_kernels_attribs)) {
       auto mtl_func = new_function_with_name(kernel_lib.get(), ka.name);
       TI_ASSERT(mtl_func != nullptr);

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -577,6 +577,7 @@ class KernelManager::Impl {
     }
     addr += sizeof(ListManager) * max_snodes;
     // init rand_seeds
+    // TODO(k-ye): Provide a way to use a fixed seed in dev mode.
     std::mt19937 generator(
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch())

--- a/taichi/backends/metal/shaders/helpers.metal.h
+++ b/taichi/backends/metal/shaders/helpers.metal.h
@@ -23,8 +23,7 @@ static_assert(false, "Do not include");
 METAL_BEGIN_HELPERS_DEF
 STR(
     // clang-format on
-    template <typename T, typename G>
-    T union_cast(G g) {
+    template <typename T, typename G> T union_cast(G g) {
       // For some reason, if I emit taichi/common.h's union_cast(), Metal failed
       // to compile. More strangely, if I copy the generated code to XCode as a
       // Metal kernel, it compiled successfully...
@@ -91,6 +90,39 @@ STR(
             metal::memory_order_relaxed);
       }
       return old_val;
+    }
+
+    struct RandState {
+      uint32_t seed;
+    };
+
+    uint32_t metal_rand_u32(device RandState * state) {
+      device uint *sp = (device uint *)&(state->seed);
+      bool done = false;
+      uint32_t nxt = 0;
+      while (!done) {
+        uint32_t o = *sp;
+        // https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
+        nxt = o * 1103515245 + 12345;
+        done = atomic_compare_exchange_weak_explicit(
+            (device atomic_uint *)sp, &o, nxt, metal::memory_order_relaxed,
+            metal::memory_order_relaxed);
+      }
+      return nxt * 1000000007;
+    }
+
+    int32_t metal_rand_i32(device RandState * state) {
+      return metal_rand_u32(state);
+    }
+
+    float metal_rand_f32(device RandState *state) {
+      // The multiplication is suprisingly prohibitively slow.
+      // Benchmark
+      // * GPU:       AMD Radeon Pro 5500M 8 GB
+      // * Test case: sdf_renderer.py
+      // * With mult: 22 samples/s
+      // * Without:   70 samples/s (output is garbage)
+      return metal_rand_u32(state) * (1.0f / 4294967296.0f);
     }
     // clang-format off
 )

--- a/taichi/backends/metal/shaders/helpers.metal.h
+++ b/taichi/backends/metal/shaders/helpers.metal.h
@@ -114,12 +114,6 @@ STR(
     }
 
     float metal_rand_f32(device RandState *state) {
-      // The multiplication is suprisingly prohibitively slow.
-      // Benchmark
-      // * GPU:       AMD Radeon Pro 5500M 8 GB
-      // * Test case: sdf_renderer.py
-      // * With mult: 22 samples/s
-      // * Without:   70 samples/s (output is garbage)
       return metal_rand_u32(state) * (1.0f / 4294967296.0f);
     }
     // clang-format off

--- a/taichi/backends/metal/shaders/helpers.metal.h
+++ b/taichi/backends/metal/shaders/helpers.metal.h
@@ -92,9 +92,7 @@ STR(
       return old_val;
     }
 
-    struct RandState {
-      uint32_t seed;
-    };
+    struct RandState { uint32_t seed; };
 
     uint32_t metal_rand_u32(device RandState * state) {
       device uint *sp = (device uint *)&(state->seed);

--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -659,8 +659,6 @@ class KernelCodegen : public IRVisitor {
 
     line_appender_.push_indent();
     emit("// struct_for");
-    emit("device Runtime *{} = reinterpret_cast<device Runtime *>({});",
-         kRuntimeVarName, kRuntimeBufferName);
     emit(
         "device byte *list_data_addr = reinterpret_cast<device byte *>({} + "
         "1);",
@@ -822,7 +820,7 @@ class KernelCodegen : public IRVisitor {
 
   template <typename... Args>
   void emit(std::string f, Args &&... args) {
-    line_appender_.append(std::move(f), std::move(args)...);
+    line_appender_.append(std::move(f), std::forward<Args>(args)...);
   }
 
   const std::string mtl_kernel_prefix_;

--- a/taichi/struct/struct_metal.cpp
+++ b/taichi/struct/struct_metal.cpp
@@ -6,9 +6,10 @@
 #include <string>
 #include <vector>
 
-#include "taichi/math/arithmetic.h"
+#include "taichi/backends/metal/constants.h"
 #include "taichi/backends/metal/data_types.h"
 #include "taichi/backends/metal/kernel_util.h"
+#include "taichi/math/arithmetic.h"
 #include "taichi/util/line_appender.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -211,6 +212,7 @@ class StructCompiler {
     emit("  SNodeMeta snode_metas[{}];", max_snodes_);
     emit("  SNodeExtractors snode_extractors[{}];", max_snodes_);
     emit("  ListManager snode_lists[{}];", max_snodes_);
+    emit("  uint32_t rand_seeds[{}];", kNumRandSeeds);
     emit("}};");
   }
 
@@ -223,6 +225,7 @@ class StructCompiler {
   size_t compute_runtime_size() {
     size_t result = (max_snodes_) *
                     (kSNodeMetaSize + kSNodeExtractorsSize + kListManagerSize);
+    result += sizeof(uint32_t) * kNumRandSeeds;
     TI_DEBUG("Metal runtime fields size: {} bytes", result);
     int total_items = 0;
     for (const auto &kv : snode_descriptors_) {

--- a/taichi/struct/struct_metal.h
+++ b/taichi/struct/struct_metal.h
@@ -44,6 +44,7 @@ struct CompiledStructs {
   //     SNodeMeta snode_metas[max_snodes];
   //     SNodeExtractors snode_extractors[max_snodes];
   //     ListManager snode_lists[max_snodes];
+  //     uint32_t rand_seeds[kNumRandSeeds];
   // }
   // However, |runtime_size| is usually greater than sizeof(Runtime). That is
   // because the memory is divided into two parts. The first part of


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #396 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

This has caused quite some headaches, so I'll document what I've found with Metal.

---

First of all, Metal's memory order seems, if not fundamentally broken, very restricted across threads, making it impossible to implement a SpinLock with atomics.

In the beginning, I tried to follow LLVM's rand state design, with 4 seeds guarded by 1 lock:

https://github.com/taichi-dev/taichi/blob/811f468a8bde4911815f540cbd9ba84e9e0578e8/taichi/runtime/llvm/locked_task.h#L19

However, it turned out that after a thread releases a lock (setting atomic to `0` again), it didn't get broadcasted to the rest of the threads. 

```cpp
// a Metal thread

// 1
while (compare_exchange_swap(&lock, /*desired=*/1, metal::memory_order_relaxed) == 1);
// acquired
// 2
// do work
// 3
store(&lock, 0, metal::memory_order_relaxed);
// released

```

Even after the winning thread passes `3`, the rest of the threads are just stuck in `1`. I tried adding memory fences, yet it didn't help.

The reason I claimed this to be broken is that, even without memory fences, `memory_order_relaxed` should guarantee the atomicity on `lock` itself. That is, once a thread `A` passes `3`, another thread `B` should be able to move beyond `1`, although `B` may not observe the works done in `2` by `A`. However, on Metal the rest of the threads are just stuck at `1` (and froze my MBP a few times 🙄)

As a workaround, I had to use just one seed, and make the seed itself atomic. While this reduces the seed space from 128-bit to 32-bit, it at least guarantees that each invocation to `metal_rand_*()` mutates the seed. Fortunately, 32-bit seems still able to produce reasonably good results:

https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use

<img width="1279" alt="Screen Shot 2020-04-05 at 14 48 05" src="https://user-images.githubusercontent.com/7481356/78467882-8fae3500-774c-11ea-95c2-ce79ff1efec4.png">

The quality of `sdf_renderer.py` on Metal seems acceptable?

---

Secondly, I got `22 samples/s` on Metal, which is subpar compared to CUDA or OpenGL. However, if I remove ` * (1.0f / 4294967296.0f)` and run, I got `70 samples/s` (of course the output is completely garbage)! If I multiply that by a larger number, e.g. `0.001` or something, it was around `50 samples/s`. It seems like Metal's floating point arithmetic is poor at handling floatings around `0.0`...?

https://github.com/k-ye/taichi/blob/1a1fbba033268e6aa2555671ba95cd1a2d837b2c/taichi/backends/metal/shaders/helpers.metal.h#L125

---

Finally, I have a question regarding memory fences on CUDA. To my understanding, memory fences means that all threads must reach that point before any thread can go beyond. i.e. it is a countdown latch, a barrier, etc...

Does this mean we cannot use memory barriers in places where there could be a conditional branch? E.g. is the following code broken?

```cpp
// within a CUDA thread

if (foo) {
  doSomething();
  mem_fence();
}
```