### PR TITLE
[ir] Add assertions of `Alloca`s in constructors of LocalAddress and LocalStoreStmt

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -352,7 +352,7 @@ void Stmt::replace_operand_with(Stmt *old_stmt, Stmt *new_stmt) {
 
 Block *current_block = nullptr;
 
-Expr Var(Expr x) {
+Expr Var(const Expr &x) {
   auto var = Expr(std::make_shared<IdExpression>());
   current_ast_builder().insert(std::make_unique<FrontendAllocaStmt>(
       std::static_pointer_cast<IdExpression>(var.expr)->id, DataType::unknown));

--- a/taichi/transforms/vector_split.cpp
+++ b/taichi/transforms/vector_split.cpp
@@ -172,14 +172,14 @@ class BasicBlockVectorSplit : public IRVisitor {
     for (int i = 0; i < current_split_factor; i++) {
       LaneAttribute<LocalAddress> ptr;
       int new_width = need_split ? max_width : stmt->width();
-      ptr.resize(new_width);
+      ptr.reserve(new_width);
       for (int j = 0; j < new_width; j++) {
         LocalAddress addr(stmt->ptr[lane_start(i) + j]);
         if (origin2split.find(addr.var) == origin2split.end()) {
-          ptr[j] = addr;
+          ptr.push_back(addr);
         } else {
-          ptr[j].var = lookup(addr.var, addr.offset / max_width);
-          ptr[j].offset = addr.offset % max_width;
+          ptr.push_back(LocalAddress(lookup(addr.var, addr.offset / max_width),
+                                     addr.offset % max_width));
         }
       }
       current_split[i] = Stmt::make<LocalLoadStmt>(ptr);


### PR DESCRIPTION

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = https://github.com/taichi-dev/taichi/issues/656#issuecomment-610061036

With such an assertion, `LocalAddress` cannot have a default constructor, so other places like `LaneAttribute` should handle the case that `T = LocalAddress` doesn't have a default constructor.

Also continues #718 as I missed some functions in that PR.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
