### PR TITLE
[opengl] [refactor] Remove the global `no_gc` in `opengl_codegen.cpp`

### DIFF
--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -9,6 +9,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
+class Kernel;
+
 namespace opengl {
 
 void initialize_opengl();
@@ -16,12 +18,23 @@ bool is_opengl_api_available();
 int opengl_get_threads_per_group();
 extern bool opengl_has_GL_NV_shader_atomic_float;
 
-struct GLProgram;
-struct CompiledGLSL {
-  std::unique_ptr<GLProgram> glsl;
-  CompiledGLSL(const std::string &source);
-  ~CompiledGLSL();
-  void launch_glsl(int num_groups) const;
+struct CompiledProgram {
+  struct Impl;
+  std::unique_ptr<Impl> impl;
+
+  // disscussion:
+  // https://github.com/taichi-dev/taichi/pull/696#issuecomment-609332527
+  CompiledProgram(CompiledProgram &&) = default;
+  CompiledProgram &operator=(CompiledProgram &&) = default;
+
+  CompiledProgram(Kernel *kernel, size_t gtmp_size);
+  ~CompiledProgram();
+
+  void add(const std::string &kernel_name,
+           const std::string &kernel_source_code,
+           int num_groups,
+           const UsedFeature &used);
+  void launch(Context &ctx, GLSLLauncher *launcher) const;
 };
 
 }  // namespace opengl

--- a/taichi/backends/opengl/opengl_kernel_launcher.h
+++ b/taichi/backends/opengl/opengl_kernel_launcher.h
@@ -7,6 +7,7 @@ TLANG_NAMESPACE_BEGIN
 
 namespace opengl {
 
+struct CompiledProgram;
 struct GLSLLauncherImpl;
 
 struct GLSLLaunchGuard {
@@ -23,6 +24,8 @@ struct GLSLLauncher {
   GLSLLaunchGuard create_launch_guard(const std::vector<IOV> &iov) {
     return GLSLLaunchGuard(impl.get(), iov);
   }
+
+  void keep(std::unique_ptr<CompiledProgram> program);
 };
 
 }  // namespace opengl

--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -12,6 +12,15 @@ class SNode;
 
 namespace opengl {
 
+struct UsedFeature {
+  bool random{false};
+  bool argument{false};
+  bool extra_arg{false};
+  bool external_ptr{false};
+  bool atomic_float{false};
+  bool global_temp{false};
+};
+
 struct StructCompiledResult {
   // Source code of the SNode data structures compiled to GLSL
   std::string source_code;

--- a/taichi/codegen/codegen_opengl.cpp
+++ b/taichi/codegen/codegen_opengl.cpp
@@ -760,7 +760,7 @@ FunctionType OpenglCodeGen::gen(void) {
                     global_tmps_buffer_size_);
   codegen.run(*prog_->snode_root);
   auto compiled = codegen.get_compiled_program();
-  auto* ptr = compiled.get();
+  auto *ptr = compiled.get();
   kernel_launcher_->keep(std::move(compiled));
   return [ptr, launcher = kernel_launcher_](Context &ctx) {
     ptr->launch(ctx, launcher);


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

I moved bunch of code around to get rid of `no_gc` in `codegen_opengl.cpp`. Now `GLSLLauncher` will keep all the `std::unique_ptr<CompiledProgram>`.

* `CompiledKernel` is now completely hidden inside `opengl_api.cpp`. We can also get rid of `CompiledGLSL` now.
* We have to expose the `CompileddProgram` so that `GSLSLauncher` knows about it.
* By using PIMPL on `CompiledProgram`, we don't have to expose `CompiledKernel` to the public.

I don't really have access to OpenGL, but I managed to make this compile with `TI_WITH_OPENGL` **enabled** (Had to mock out some portion of the code to do so). Could you fetch this to your local environment and run the tests (most likely they are broken)? Could you either tell me where the problem is, or even better, just fix them :)? Really appreciated!

Related issue = #695 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
