### PR TITLE
[ir] Fix out-of-scope operands during offloading

### DIFF
--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -187,6 +187,8 @@ class IdentifyLocalVars : public BasicStmtVisitor {
   }
 
   void test_and_allocate(Stmt *stmt) {
+    if (stmt == nullptr)
+      return;
     if (inst_to_offloaded[stmt] == current_offloaded)
       return;
     if (local_to_global.find(stmt) == local_to_global.end()) {
@@ -220,7 +222,6 @@ class IdentifyLocalVars : public BasicStmtVisitor {
   }
 
   void visit(Stmt *stmt) override {
-    // irpass::print(stmt);
     if (current_offloaded != nullptr) {
       // inside a offloaded stmt, record its belong offloaded_stmt
       inst_to_offloaded[stmt] = current_offloaded;
@@ -420,9 +421,11 @@ class PromoteLocals : public BasicStmtVisitor {
     bool modified = false;
     for (int i = 0; i < n_op; i++) {
       auto op = stmt->operand(i);
+      if (op == nullptr)
+        continue;
       if (local_to_global_offset.find(op) == local_to_global_offset.end())
         continue;
-      if (inst_to_offload[stmt] == inst_to_offload[op]) // same OffloadedStmt
+      if (inst_to_offload[stmt] == inst_to_offload[op])  // same OffloadedStmt
         continue;
 
       auto global = Stmt::make<GlobalTemporaryStmt>(local_to_global_offset[op],

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -135,7 +135,7 @@ After offloading, some local variables/instructions are accessed across
 offloaded blocks. This pass promote these local values into global variables.
 
 Steps:
-  1. Traverse offloaded blocks to identify out-of-block local LD/ST, instruction
+  1. (IdentifyLocalVars) Traverse offloaded blocks to identify out-of-block local LD/ST, instruction
 references
   2. Replace alloca with global var initialization (set to 0)
      Replace local LD/ST with global LD/ST
@@ -217,10 +217,6 @@ class IdentifyLocalVars : public BasicStmtVisitor {
     }
   }
 
-  void visit(ContinueStmt *stmt) override {
-    // do nothing
-  }
-
   void visit(Stmt *stmt) override {
     if (current_offloaded != nullptr) {
       // inside a offloaded stmt, record its belong offloaded_stmt
@@ -243,6 +239,7 @@ class IdentifyLocalVars : public BasicStmtVisitor {
   }
 };
 
+// Store intermediate values to globals so that statements in later offloaded statement can load
 class PromoteIntermediate : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
@@ -286,7 +283,7 @@ class InstToOffload : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
 
-  // Local variables alloc to its containing offloaded statement
+  // Local variables to its containing offloaded statement
   std::map<Stmt *, Stmt *> inst_to_offloaded;
 
   Stmt *current_offloaded;

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -254,9 +254,6 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   }
 
   void visit(Stmt *stmt) override {
-    if (current_offloaded != nullptr) {
-      // inside a offloaded stmt, record its belong offloaded_stmt
-    }
     int n_op = stmt->num_operands();
     for (int i = 0; i < n_op; i++) {
       auto op = stmt->operand(i);
@@ -278,9 +275,7 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
  private:
   // Local variables to global temporary offsets (in bytes)
   StmtToOffsetMap local_to_global;
-
   std::unordered_map<Stmt *, Stmt *> stmt_to_offloaded;
-
   Stmt *current_offloaded;
   std::size_t global_offset;
 };

--- a/tests/python/test_continue.py
+++ b/tests/python/test_continue.py
@@ -21,7 +21,7 @@ def test_for_continue():
     for i in range(n):
         expect = 0 if i % 2 == 0 else i
         assert xs[i] == expect
-'''
+
 
 @ti.all_archs
 def test_while_continue():
@@ -82,4 +82,3 @@ def test_unconditional_continue():
     xs = x.to_numpy()
     for i in range(n):
         assert xs[i] == 0
-'''

--- a/tests/python/test_continue.py
+++ b/tests/python/test_continue.py
@@ -21,7 +21,7 @@ def test_for_continue():
     for i in range(n):
         expect = 0 if i % 2 == 0 else i
         assert xs[i] == expect
-
+'''
 
 @ti.all_archs
 def test_while_continue():
@@ -82,3 +82,4 @@ def test_unconditional_continue():
     xs = x.to_numpy()
     for i in range(n):
         assert xs[i] == 0
+'''


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #729 

The logic is still a bit messy here...

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
