### PR TITLE
[metal][refactor] Use `compile_to_offloads()` in codegen

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -418,13 +418,9 @@ class KernelManager::Impl {
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<KernelAttributes> &kernels_attribs,
-      size_t global_tmps_size,
       const KernelArgsAttributes &args_attribs) {
     TI_ASSERT(compiled_taichi_kernels_.find(taichi_kernel_name) ==
               compiled_taichi_kernels_.end());
-    // Make sure |taichi_global_tmp_buffer_size| is large enough
-    TI_ASSERT(iroundup(global_tmps_size, taichi_page_size) <=
-              global_tmps_mem_->size());
 
     if (config_->print_kernel_llvm_ir) {
       // If users have enabled |print_kernel_llvm_ir|, it probably means that
@@ -638,7 +634,6 @@ class KernelManager::Impl {
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<KernelAttributes> &kernels_attribs,
-      size_t global_tmps_size,
       const KernelArgsAttributes &args_attribs) {
     TI_ERROR("Metal not supported on the current OS");
   }
@@ -666,11 +661,9 @@ void KernelManager::register_taichi_kernel(
     const std::string &taichi_kernel_name,
     const std::string &mtl_kernel_source_code,
     const std::vector<KernelAttributes> &kernels_attribs,
-    size_t global_tmps_size,
     const KernelArgsAttributes &args_attribs) {
   impl_->register_taichi_kernel(taichi_kernel_name, mtl_kernel_source_code,
-                                kernels_attribs, global_tmps_size,
-                                args_attribs);
+                                kernels_attribs, args_attribs);
 }
 
 void KernelManager::launch_taichi_kernel(const std::string &taichi_kernel_name,

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -39,13 +39,10 @@ class KernelManager {
   // * |mtl_kernel_source_code| is the complete source code compiled from a
   // Taichi kernel. It may include one or more Metal compute kernels. Each
   // Metal kernel is identified by one item in |kernels_attribs|.
-  // * |global_tmps_size| is the total size of global temporary variables,
-  // computed during the offloading pass.
   void register_taichi_kernel(
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<KernelAttributes> &kernels_attribs,
-      size_t global_tmps_size,
       const KernelArgsAttributes &args_attribs);
 
   // Launch the given |taichi_kernel_name|.

--- a/taichi/codegen/codegen_metal.h
+++ b/taichi/codegen/codegen_metal.h
@@ -18,22 +18,21 @@ namespace metal {
 
 class CodeGen {
  public:
-  CodeGen(const std::string &kernel_name,
+  CodeGen(Kernel *kernel,
+          KernelManager *kernel_mgr,
           const CompiledStructs *compiled_structs);
 
-  FunctionType compile(Program &, Kernel &kernel, KernelManager *kernel_mgr);
+  FunctionType compile();
 
  private:
   void lower();
   FunctionType gen(const SNode &root_snode, KernelManager *runtime);
 
+  Kernel *const kernel_;
+  KernelManager *const kernel_mgr_;
+  const CompiledStructs *const compiled_structs_;
   const int id_;
   const std::string taichi_kernel_name_;
-  const CompiledStructs *const compiled_structs_;
-
-  Program *prog_;
-  Kernel *kernel_;
-  size_t global_tmps_buffer_size_{0};
 };
 
 }  // namespace metal

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -120,8 +120,9 @@ FunctionType Program::compile(Kernel &kernel) {
     auto codegen = KernelCodeGen::create(kernel.arch, &kernel);
     ret = codegen->compile();
   } else if (kernel.arch == Arch::metal) {
-    metal::CodeGen codegen(kernel.name, &metal_compiled_structs_.value());
-    ret = codegen.compile(*this, kernel, metal_kernel_mgr_.get());
+    metal::CodeGen codegen(&kernel, metal_kernel_mgr_.get(),
+                           &metal_compiled_structs_.value());
+    ret = codegen.compile();
   } else if (kernel.arch == Arch::opengl) {
     opengl::OpenglCodeGen codegen(kernel.name, &opengl_struct_compiled_.value(),
                                   opengl_kernel_launcher_.get());


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

As promised.. :) Again, i don't think there's any new feature..

Related issue = #722 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
