### PR TITLE
[GUI][Metal] Support SPACE key

### DIFF
--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -113,6 +113,8 @@ std::string lookup_keysym(ushort keycode) {
       return "Alt_R";
     case kVK_CapsLock:
       return "Caps_Lock";
+    case kVK_Space:
+      return " ";
     default:
       break;
   }

--- a/taichi/ir/visitors.h
+++ b/taichi/ir/visitors.h
@@ -11,7 +11,8 @@ class BasicStmtVisitor : public IRVisitor {
  public:
   BasicStmtVisitor();
 
-  virtual void preprocess_container_stmt(Stmt *stmt) {}
+  virtual void preprocess_container_stmt(Stmt *stmt) {
+  }
 
   void visit(Block *stmt_list) override;
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = N/A

Thanks to @archibate 's #741 , I discovered that `ti.GUI.SPACE` wasn't supported before..

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
