### PR TITLE
[refactor] Remove `vprintf` in `runtime/llvm/runtime.cpp` to avoid name conflicts

### DIFF
--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -324,6 +324,15 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
 
       link_module_with_cuda_libdevice(runtime_module);
 
+      // To prevent potential symbol name conflicts, we use "cuda_vprintf"
+      // instead of "vprintf" in llvm/runtime.cpp. Now we change it back for
+      // linking
+      for (auto &f : *runtime_module) {
+        if (f.getName() == "cuda_vprintf") {
+          f.setName("vprintf");
+        }
+      }
+
       // runtime_module->print(llvm::errs(), nullptr);
     }
   }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -3,12 +3,6 @@
 
 #if !defined(TI_INCLUDED) || !defined(_WIN32)
 
-#if defined(_WIN32)
-#define vprintf vprintf_windows
-#include <cstdio>
-#undef vprintf
-#endif
-
 #include <atomic>
 #include <cstdint>
 #include <cmath>
@@ -105,7 +99,7 @@ void taichi_printf(LLVMRuntime *runtime, const char *format, Args &&... args);
 extern "C" {
 
 #if ARCH_cuda
-void vprintf(Ptr format, Ptr arg);
+void cuda_vprintf(Ptr format, Ptr arg);
 #endif
 
 #define DEFINE_UNARY_REAL_FUNC(F) \
@@ -329,7 +323,7 @@ void taichi_assert_runtime(LLVMRuntime *runtime, i32 test, const char *msg);
 
 void ___stubs___() {
 #if ARCH_cuda
-  vprintf(nullptr, nullptr);
+  cuda_vprintf(nullptr, nullptr);
 #endif
 }
 }
@@ -1279,7 +1273,7 @@ void taichi_printf(LLVMRuntime *runtime, const char *format, Args &&... args) {
 #if ARCH_cuda
   printf_helper helper;
   helper.push_back(std::forward<Args>(args)...);
-  vprintf((Ptr)format, helper.ptr());
+  cuda_vprintf((Ptr)format, helper.ptr());
 #else
   runtime->host_printf(format, args...);
 #endif


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #745 

@matyklug18 I'm not sure if this solves your issue since I can't reproduce that on my end. Could you have a try and let us know if everything is fixed? Thanks!

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
