### PR TITLE
[GUI] Fix blinking particles and random segmentation faults during ti.GUI.circles

### DIFF
--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -85,7 +85,10 @@ class GUI:
 
         assert pos.shape == (n, 2)
         pos = np.ascontiguousarray(pos.astype(np.float32))
-        pos = int(pos.ctypes.data)
+        # Note: do not use "pos = int(pos.ctypes.data)" here
+        # Otherwise pos will get garbage collected by Python
+        # and the pointer to its data becomes invalid
+        pos_ptr = int(pos.ctypes.data)
 
         if isinstance(color, np.ndarray):
             assert color.shape == (n, )
@@ -110,7 +113,7 @@ class GUI:
         else:
             raise ValueError('Radius must be an ndarray or float (e.g., 0.4)')
 
-        self.canvas.circles_batched(n, pos, color_single, color_array,
+        self.canvas.circles_batched(n, pos_ptr, color_single, color_array,
                                     radius_single, radius_array)
 
     def triangle(self, a, b, c, color=0xFFFFFF):


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = https://github.com/taichi-dev/taichi_elements/pull/23

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
