### PR TITLE
Replace ti.pow() by ** in examples/regression.py

### DIFF
--- a/examples/regression.py
+++ b/examples/regression.py
@@ -29,7 +29,7 @@ def regress():
         v = x[i]
         est = 0.0
         for j in ti.static(range(number_coeffs)):
-            est += coeffs[j] * ti.pow(v, j)
+            est += coeffs[j] * (v ** j)
         loss.atomic_add(0.5 * ti.sqr(y[i] - est))
 
 


### PR DESCRIPTION
Otherwise it will raise AttributeError: module 'taichi' has no attribute 'pow'

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #... (if any)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
