### PR TITLE
[CUDA] Limit memory allocation chunk size to 128 MB

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -97,6 +97,10 @@ Program::Program(Arch desired_arch) {
     async_engine = std::make_unique<AsyncEngine>();
   }
 
+  // TODO: allow users to run in debug mode without out-of-bound checks
+  if (config.debug)
+    config.check_out_of_bound = true;
+
   if (!arch_is_cpu(config.arch)) {
     if (config.check_out_of_bound) {
       TI_WARN(
@@ -105,9 +109,6 @@ Program::Program(Arch desired_arch) {
       config.check_out_of_bound = false;
     }
   }
-
-  // TODO: allow users to run in debug mode without out-of-bound checks
-  config.check_out_of_bound = config.debug;
 
   TI_TRACE("Program arch={}", arch_name(arch));
 }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -547,12 +547,17 @@ struct NodeManager {
   NodeManager(LLVMRuntime *runtime,
               i32 element_size,
               i32 chunk_num_elements = -1)
-      : runtime(runtime),
-        element_size(element_size),
-        chunk_num_elements(chunk_num_elements) {
+      : runtime(runtime), element_size(element_size) {
     // 16K elements per chunk, by default
-    if (chunk_num_elements == -1)
+    if (chunk_num_elements == -1) {
       chunk_num_elements = 16 * 1024;
+    }
+    // Maximum chunk size = 128 MB
+    while (chunk_num_elements > 1 &&
+           (uint64)chunk_num_elements * element_size > 128UL * 1024 * 1024) {
+      chunk_num_elements /= 2;
+    }
+    this->chunk_num_elements = chunk_num_elements;
     free_list_used = 0;
     free_list = runtime->create<ListManager>(runtime, sizeof(list_data_type),
                                              chunk_num_elements);


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #https://github.com/taichi-dev/taichi_elements/pull/23

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
