### PR TITLE
[refactor] [opt] Move LocalLoadSearcher and 2 other classes to irpass::analysis

### DIFF
--- a/python/build.py
+++ b/python/build.py
@@ -117,8 +117,7 @@ elif mode == 'test':
     print('Uninstalling old taichi packages...')
     os.system('{} -m pip uninstall taichi-nightly'.format(
         get_python_executable()))
-    os.system('{} -m pip uninstall taichi'.format(
-        get_python_executable()))
+    os.system('{} -m pip uninstall taichi'.format(get_python_executable()))
     dists = os.listdir('dist')
     assert len(dists) == 1
     dist = dists[0]

--- a/taichi/analysis/has_load_or_atomic.cpp
+++ b/taichi/analysis/has_load_or_atomic.cpp
@@ -1,0 +1,45 @@
+#include "taichi/ir/ir.h"
+
+TLANG_NAMESPACE_BEGIN
+
+// Find if there is a load (or AtomicOpStmt).
+class LocalLoadSearcher : public BasicStmtVisitor {
+ private:
+  Stmt *var;
+  bool result;
+
+ public:
+  using BasicStmtVisitor::visit;
+
+  explicit LocalLoadSearcher(Stmt *var) : var(var), result(false) {
+    TI_ASSERT(var->is<AllocaStmt>());
+    allow_undefined_visitor = true;
+    invoke_default_visitor = true;
+  }
+
+  void visit(LocalLoadStmt *stmt) override {
+    if (stmt->has_source(var)) {
+      result = true;
+    }
+  }
+
+  void visit(AtomicOpStmt *stmt) override {
+    if (stmt->dest == var) {
+      result = true;
+    }
+  }
+
+  static bool run(IRNode *root, Stmt *var) {
+    LocalLoadSearcher searcher(var);
+    root->accept(&searcher);
+    return searcher.result;
+  }
+};
+
+namespace irpass::analysis {
+bool has_load_or_atomic(IRNode *root, Stmt *var) {
+  return LocalLoadSearcher::run(root, var);
+}
+}  // namespace irpass::analysis
+
+TLANG_NAMESPACE_END

--- a/taichi/analysis/has_store_or_atomic.cpp
+++ b/taichi/analysis/has_store_or_atomic.cpp
@@ -1,0 +1,54 @@
+#include "taichi/ir/ir.h"
+
+TLANG_NAMESPACE_BEGIN
+
+// Find if there is a store (or AtomicOpStmt).
+class LocalStoreSearcher : public BasicStmtVisitor {
+ private:
+  const std::vector<Stmt *> &vars;
+  bool result;
+
+ public:
+  using BasicStmtVisitor::visit;
+
+  explicit LocalStoreSearcher(const std::vector<Stmt *> &vars)
+      : vars(vars), result(false) {
+    for (auto var : vars) {
+      TI_ASSERT(var->is<AllocaStmt>());
+    }
+    allow_undefined_visitor = true;
+    invoke_default_visitor = true;
+  }
+
+  void visit(LocalStoreStmt *stmt) override {
+    for (auto var : vars) {
+      if (stmt->ptr == var) {
+        result = true;
+        break;
+      }
+    }
+  }
+
+  void visit(AtomicOpStmt *stmt) override {
+    for (auto var : vars) {
+      if (stmt->dest == var) {
+        result = true;
+        break;
+      }
+    }
+  }
+
+  static bool run(IRNode *root, const std::vector<Stmt *> &vars) {
+    LocalStoreSearcher searcher(vars);
+    root->accept(&searcher);
+    return searcher.result;
+  }
+};
+
+namespace irpass::analysis {
+bool has_store_or_atomic(IRNode *root, const std::vector<Stmt *> &vars) {
+  return LocalStoreSearcher::run(root, vars);
+}
+}  // namespace irpass::analysis
+
+TLANG_NAMESPACE_END

--- a/taichi/analysis/last_store_or_atomic.cpp
+++ b/taichi/analysis/last_store_or_atomic.cpp
@@ -1,0 +1,121 @@
+#include "taichi/ir/ir.h"
+
+TLANG_NAMESPACE_BEGIN
+
+// Find the **last** store, or return invalid if there is an AtomicOpStmt
+// after the last store.
+class LocalStoreForwarder : public BasicStmtVisitor {
+ private:
+  Stmt *var;
+  bool is_valid;
+  Stmt *result;
+
+ public:
+  using BasicStmtVisitor::visit;
+
+  explicit LocalStoreForwarder(Stmt *var)
+      : var(var), is_valid(true), result(nullptr) {
+    TI_ASSERT(var->is<AllocaStmt>());
+    allow_undefined_visitor = true;
+    invoke_default_visitor = true;
+  }
+
+  void visit(LocalStoreStmt *stmt) override {
+    if (stmt->ptr == var) {
+      is_valid = true;
+      result = stmt;
+    }
+  }
+
+  void visit(AllocaStmt *stmt) override {
+    if (stmt == var) {
+      is_valid = true;
+      result = stmt;
+    }
+  }
+
+  void visit(AtomicOpStmt *stmt) override {
+    if (stmt->dest == var) {
+      is_valid = false;
+    }
+  }
+
+  // Only if **both** branches finally store the variable with exactly the same
+  // data, can we forward it to the local load statement.
+  void visit(IfStmt *if_stmt) override {
+    // the default return value: valid, no stores
+    std::pair<bool, Stmt *> true_branch(true, nullptr);
+    if (if_stmt->true_statements) {
+      // create a new LocalStoreForwarder instance
+      true_branch = run(if_stmt->true_statements.get(), var);
+    }
+    std::pair<bool, Stmt *> false_branch(true, nullptr);
+    if (if_stmt->false_statements) {
+      false_branch = run(if_stmt->false_statements.get(), var);
+    }
+    auto true_stmt = true_branch.second;
+    auto false_stmt = false_branch.second;
+    if (!true_branch.first || !false_branch.first) {
+      // at least one branch finally modifies the variable without storing
+      is_valid = false;
+    } else if (true_stmt == nullptr && false_stmt == nullptr) {
+      // both branches don't modify the variable
+      return;
+    } else if (true_stmt == nullptr || false_stmt == nullptr) {
+      // only one branch modifies the variable
+      is_valid = false;
+    } else {
+      TI_ASSERT(true_stmt->is<LocalStoreStmt>());
+      TI_ASSERT(false_stmt->is<LocalStoreStmt>());
+      if (true_stmt->as<LocalStoreStmt>()->data !=
+          false_stmt->as<LocalStoreStmt>()->data) {
+        // two branches finally store the variable differently
+        is_valid = false;
+      } else {
+        is_valid = true;
+        result = true_stmt;  // same as false_stmt
+      }
+    }
+  }
+
+  // We don't know if a loop's body will be executed, so we cannot forward
+  // the "last" store inside a loop to the local load statement.
+  // What we can do is just check if the loop doesn't modify the variable.
+  void visit(WhileStmt *stmt) override {
+    if (irpass::analysis::has_store_or_atomic(stmt, {var})) {
+      is_valid = false;
+    }
+  }
+
+  void visit(RangeForStmt *stmt) override {
+    if (irpass::analysis::has_store_or_atomic(stmt, {var})) {
+      is_valid = false;
+    }
+  }
+
+  void visit(StructForStmt *stmt) override {
+    if (irpass::analysis::has_store_or_atomic(stmt, {var})) {
+      is_valid = false;
+    }
+  }
+
+  void visit(OffloadedStmt *stmt) override {
+    if (irpass::analysis::has_store_or_atomic(stmt, {var})) {
+      is_valid = false;
+    }
+  }
+
+  static std::pair<bool, Stmt *> run(IRNode *root, Stmt *var) {
+    LocalStoreForwarder searcher(var);
+    root->accept(&searcher);
+    return std::make_pair(searcher.is_valid, searcher.result);
+  }
+};
+
+namespace irpass::analysis {
+std::pair<bool, Stmt *> last_store_or_atomic(IRNode *root, Stmt *var) {
+  return LocalStoreForwarder::run(root, var);
+}
+}  // namespace irpass::analysis
+
+TLANG_NAMESPACE_END

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -127,6 +127,9 @@ std::unordered_set<Stmt *> detect_loops_with_continue(IRNode *root);
 std::unordered_set<SNode *> gather_deactivations(IRNode *root);
 std::vector<Stmt *> gather_statements(IRNode *root,
                                       const std::function<bool(Stmt *)> &test);
+bool has_load_or_atomic(IRNode *root, Stmt *var);
+bool has_store_or_atomic(IRNode *root, const std::vector<Stmt *> &vars);
+std::pair<bool, Stmt *> last_store_or_atomic(IRNode *root, Stmt *var);
 bool same_statements(IRNode *root1, IRNode *root2);
 DiffRange value_diff(Stmt *stmt, int lane, Stmt *alloca);
 void verify(IRNode *root);

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -5,193 +5,6 @@
 
 TLANG_NAMESPACE_BEGIN
 
-// Find if there is a load (or AtomicOpStmt).
-class LocalLoadSearcher : public BasicStmtVisitor {
- private:
-  Stmt *var;
-  bool result;
-
- public:
-  using BasicStmtVisitor::visit;
-
-  explicit LocalLoadSearcher(Stmt *var) : var(var), result(false) {
-    TI_ASSERT(var->is<AllocaStmt>());
-    allow_undefined_visitor = true;
-    invoke_default_visitor = true;
-  }
-
-  void visit(LocalLoadStmt *stmt) override {
-    if (stmt->has_source(var)) {
-      result = true;
-    }
-  }
-
-  void visit(AtomicOpStmt *stmt) override {
-    if (stmt->dest == var) {
-      result = true;
-    }
-  }
-
-  static bool run(IRNode *root, Stmt *var) {
-    LocalLoadSearcher searcher(var);
-    root->accept(&searcher);
-    return searcher.result;
-  }
-};
-
-// Find if there is a store (or AtomicOpStmt).
-class LocalStoreSearcher : public BasicStmtVisitor {
- private:
-  const std::vector<Stmt *> &vars;
-  bool result;
-
- public:
-  using BasicStmtVisitor::visit;
-
-  explicit LocalStoreSearcher(const std::vector<Stmt *> &vars)
-      : vars(vars), result(false) {
-    for (auto var : vars) {
-      TI_ASSERT(var->is<AllocaStmt>());
-    }
-    allow_undefined_visitor = true;
-    invoke_default_visitor = true;
-  }
-
-  void visit(LocalStoreStmt *stmt) override {
-    for (auto var : vars) {
-      if (stmt->ptr == var) {
-        result = true;
-        break;
-      }
-    }
-  }
-
-  void visit(AtomicOpStmt *stmt) override {
-    for (auto var : vars) {
-      if (stmt->dest == var) {
-        result = true;
-        break;
-      }
-    }
-  }
-
-  static bool run(IRNode *root, const std::vector<Stmt *> &vars) {
-    LocalStoreSearcher searcher(vars);
-    root->accept(&searcher);
-    return searcher.result;
-  }
-};
-
-// Find the **last** store, or return invalid if there is an AtomicOpStmt
-// after the last store.
-class LocalStoreForwarder : public BasicStmtVisitor {
- private:
-  Stmt *var;
-  bool is_valid;
-  Stmt *result;
-
- public:
-  using BasicStmtVisitor::visit;
-
-  explicit LocalStoreForwarder(Stmt *var)
-      : var(var), is_valid(true), result(nullptr) {
-    TI_ASSERT(var->is<AllocaStmt>());
-    allow_undefined_visitor = true;
-    invoke_default_visitor = true;
-  }
-
-  void visit(LocalStoreStmt *stmt) override {
-    if (stmt->ptr == var) {
-      is_valid = true;
-      result = stmt;
-    }
-  }
-
-  void visit(AllocaStmt *stmt) override {
-    if (stmt == var) {
-      is_valid = true;
-      result = stmt;
-    }
-  }
-
-  void visit(AtomicOpStmt *stmt) override {
-    if (stmt->dest == var) {
-      is_valid = false;
-    }
-  }
-
-  // Only if **both** branches finally store the variable with exactly the same
-  // data, can we forward it to the local load statement.
-  void visit(IfStmt *if_stmt) override {
-    // the default return value: valid, no stores
-    std::pair<bool, Stmt *> true_branch(true, nullptr);
-    if (if_stmt->true_statements) {
-      // create a new LocalStoreForwarder instance
-      true_branch = run(if_stmt->true_statements.get(), var);
-    }
-    std::pair<bool, Stmt *> false_branch(true, nullptr);
-    if (if_stmt->false_statements) {
-      false_branch = run(if_stmt->false_statements.get(), var);
-    }
-    auto true_stmt = true_branch.second;
-    auto false_stmt = false_branch.second;
-    if (!true_branch.first || !false_branch.first) {
-      // at least one branch finally modifies the variable without storing
-      is_valid = false;
-    } else if (true_stmt == nullptr && false_stmt == nullptr) {
-      // both branches don't modify the variable
-      return;
-    } else if (true_stmt == nullptr || false_stmt == nullptr) {
-      // only one branch modifies the variable
-      is_valid = false;
-    } else {
-      TI_ASSERT(true_stmt->is<LocalStoreStmt>());
-      TI_ASSERT(false_stmt->is<LocalStoreStmt>());
-      if (true_stmt->as<LocalStoreStmt>()->data !=
-          false_stmt->as<LocalStoreStmt>()->data) {
-        // two branches finally store the variable differently
-        is_valid = false;
-      } else {
-        is_valid = true;
-        result = true_stmt;  // same as false_stmt
-      }
-    }
-  }
-
-  // We don't know if a loop's body will be executed, so we cannot forward
-  // the "last" store inside a loop to the local load statement.
-  // What we can do is just check if the loop doesn't modify the variable.
-  void visit(WhileStmt *stmt) override {
-    if (LocalStoreSearcher::run(stmt, {var})) {
-      is_valid = false;
-    }
-  }
-
-  void visit(RangeForStmt *stmt) override {
-    if (LocalStoreSearcher::run(stmt, {var})) {
-      is_valid = false;
-    }
-  }
-
-  void visit(StructForStmt *stmt) override {
-    if (LocalStoreSearcher::run(stmt, {var})) {
-      is_valid = false;
-    }
-  }
-
-  void visit(OffloadedStmt *stmt) override {
-    if (LocalStoreSearcher::run(stmt, {var})) {
-      is_valid = false;
-    }
-  }
-
-  static std::pair<bool, Stmt *> run(IRNode *root, Stmt *var) {
-    LocalStoreForwarder searcher(var);
-    root->accept(&searcher);
-    return std::make_pair(searcher.is_valid, searcher.result);
-  }
-};
-
 // Common subexpression elimination, store forwarding, useless local store
 // elimination; Simplify if statements into conditional stores.
 class BasicBlockSimplify : public IRVisitor {
@@ -459,7 +272,7 @@ class BasicBlockSimplify : public IRVisitor {
                 }
                 continue;
               }
-              if (LocalStoreSearcher::run(block->statements[j].get(), vars)) {
+              if (irpass::analysis::has_store_or_atomic(block->statements[j].get(), vars)) {
                 has_related_store = true;
                 break;
               }
@@ -512,8 +325,8 @@ class BasicBlockSimplify : public IRVisitor {
           }
           continue;
         }
-        auto last_store =
-            LocalStoreForwarder::run(block->statements[i].get(), alloca);
+        auto last_store = irpass::analysis::last_store_or_atomic(
+            block->statements[i].get(), alloca);
         if (!last_store.first) {
           // invalid
           break;
@@ -581,8 +394,8 @@ class BasicBlockSimplify : public IRVisitor {
                 }
                 continue;
               }
-              if (LocalLoadSearcher::run(block->statements[j].get(),
-                                         stmt->ptr)) {
+              if (irpass::analysis::has_load_or_atomic(
+                  block->statements[j].get(), stmt->ptr)) {
                 has_load = true;
                 break;
               }
@@ -627,7 +440,8 @@ class BasicBlockSimplify : public IRVisitor {
           }
           continue;
         }
-        if (LocalLoadSearcher::run(block->statements[i].get(), stmt->ptr)) {
+        if (irpass::analysis::has_load_or_atomic(
+            block->statements[i].get(), stmt->ptr)) {
           has_related = true;
           break;
         }

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -272,7 +272,8 @@ class BasicBlockSimplify : public IRVisitor {
                 }
                 continue;
               }
-              if (irpass::analysis::has_store_or_atomic(block->statements[j].get(), vars)) {
+              if (irpass::analysis::has_store_or_atomic(
+                      block->statements[j].get(), vars)) {
                 has_related_store = true;
                 break;
               }
@@ -395,7 +396,7 @@ class BasicBlockSimplify : public IRVisitor {
                 continue;
               }
               if (irpass::analysis::has_load_or_atomic(
-                  block->statements[j].get(), stmt->ptr)) {
+                      block->statements[j].get(), stmt->ptr)) {
                 has_load = true;
                 break;
               }
@@ -440,8 +441,8 @@ class BasicBlockSimplify : public IRVisitor {
           }
           continue;
         }
-        if (irpass::analysis::has_load_or_atomic(
-            block->statements[i].get(), stmt->ptr)) {
+        if (irpass::analysis::has_load_or_atomic(block->statements[i].get(),
+                                                 stmt->ptr)) {
           has_related = true;
           break;
         }


### PR DESCRIPTION

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = https://github.com/taichi-dev/taichi/issues/656#issuecomment-612299909

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
