### PR TITLE
[metal] Implement range_for using grid stride loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 python3 -m pip install taichi
 ```
 **Supported OS**: Windows, Linux, Mac OS X; **Python**: 3.6, 3.7, 3.8; **Backends**: x64 CPUs, CUDA, Apple Metal.
- 
+
 Please build from source for other configurations (e.g., you need the experimental OpenGL backend or your CPU is ARM).
 
 **Note:**

--- a/taichi/codegen/codegen_metal.cpp
+++ b/taichi/codegen/codegen_metal.cpp
@@ -30,6 +30,7 @@ constexpr char kArgsBufferName[] = "args_addr";
 constexpr char kRuntimeBufferName[] = "runtime_addr";
 constexpr char kArgsContextName[] = "args_ctx_";
 constexpr char kRuntimeVarName[] = "runtime_";
+constexpr char kLinearLoopIndexName[] = "linear_loop_idx_";
 constexpr char kListgenElemVarName[] = "listgen_elem_";
 constexpr char kRandStateVarName[] = "rand_state_";
 
@@ -314,16 +315,7 @@ class KernelCodegen : public IRVisitor {
     const auto stmt_name = stmt->raw_name();
     if (type == TaskType::range_for) {
       TI_ASSERT(stmt->index == 0);
-      if (current_kernel_attribs_->range_for_attribs.const_begin) {
-        emit("const int {} = (static_cast<int>({}) + {});", stmt_name,
-             kKernelThreadIdName,
-             current_kernel_attribs_->range_for_attribs.begin);
-      } else {
-        auto begin_stmt = inject_load_global_tmp(
-            current_kernel_attribs_->range_for_attribs.begin);
-        emit("const int {} = (static_cast<int>({}) + {});", stmt_name,
-             kKernelThreadIdName, begin_stmt);
-      }
+      emit("const int {} = {};", stmt_name, kLinearLoopIndexName);
     } else if (type == TaskType::struct_for) {
       emit("const int {} = {}.coords[{}];", stmt_name, kListgenElemVarName,
            stmt->index);
@@ -635,7 +627,8 @@ class KernelCodegen : public IRVisitor {
       current_kernel_attribs_ = &ka;
       const auto mtl_func_name = mtl_kernel_func_name(mtl_kernel_name);
       emit_mtl_kernel_func_def(mtl_func_name, ka.buffers, stmt->body.get());
-      emit_call_mtl_kernel_func(mtl_func_name, ka.buffers);
+      emit_call_mtl_kernel_func(mtl_func_name, ka.buffers,
+                                /*loop_index_expr=*/"0");
     }
     // Close kernel
     emit("}}\n");
@@ -663,28 +656,52 @@ class KernelCodegen : public IRVisitor {
         (stmt->const_end ? stmt->end_value : stmt->end_offset);
 
     current_appender().push_indent();
+    const std::string total_elems_name("total_elems");
+    // Begin expression of the for range, this can be either a constant
+    // (const_begin == true), or a variable loaded from the global temporaries.
+    std::string begin_expr;
     if (range_for_attribs.const_range()) {
-      ka.num_threads = range_for_attribs.end - range_for_attribs.begin;
+      const int num_elems = range_for_attribs.end - range_for_attribs.begin;
+      begin_expr = std::to_string(stmt->begin_value);
       emit("// range_for, range known at compile time");
-      emit("if ({} >= {}) return;", kKernelThreadIdName, ka.num_threads);
+      emit("const int {} = {};", total_elems_name, num_elems);
+      // We don't clamp this to kMaxNumThreadsGridStrideLoop, because we know
+      // for sure that we need |num_elems| of threads.
+      // sdf_renderer.py benchmark for setting |num_threads|
+      // - num_elemnts: ~20 samples/s
+      // - kMaxNumThreadsGridStrideLoop: ~12 samples/s
+      ka.num_threads = num_elems;
     } else {
-      ka.num_threads = -1;
       emit("// range_for, range known at runtime");
-      const auto begin_stmt = stmt->const_begin
-                                  ? std::to_string(stmt->begin_value)
-                                  : inject_load_global_tmp(stmt->begin_offset);
-      const auto end_stmt = stmt->const_end
+      begin_expr = stmt->const_begin
+                       ? std::to_string(stmt->begin_value)
+                       : inject_load_global_tmp(stmt->begin_offset);
+      const auto end_expr = stmt->const_end
                                 ? std::to_string(stmt->end_value)
                                 : inject_load_global_tmp(stmt->end_offset);
-      emit("if ({} >= ({} - {})) return;", kKernelThreadIdName, end_stmt,
-           begin_stmt);
+      emit("const int {} = {} - {};", total_elems_name, end_expr, begin_expr);
+      ka.num_threads = kMaxNumThreadsGridStrideLoop;
     }
+    // (total_elems + thread_grid_size - 1) / thread_grid_size
+    emit("const int range_ = max((int)(({0} + {1} - 1) / {1}), 1);",
+         total_elems_name, kKernelGridSizeName);
+    // range_ * thread_id + begin_expr
+    emit("const int begin_ = (range_ * (int){}) + {};", kKernelThreadIdName,
+         begin_expr);
+    // min(range_ * (thread_id + 1), total_elems) + begin_expr
+    emit("const int end_ = min(range_ * (int)({} + 1), {}) + {};",
+         kKernelThreadIdName, total_elems_name, begin_expr);
+    emit("for (int ii = begin_; ii < end_; ++ii) {{");
+    {
+      ScopedIndent s2(current_appender());
 
-    current_kernel_attribs_ = &ka;
-    const auto mtl_func_name = mtl_kernel_func_name(mtl_kernel_name);
-    emit_mtl_kernel_func_def(mtl_func_name, ka.buffers, stmt->body.get());
-    emit_call_mtl_kernel_func(mtl_func_name, ka.buffers);
-
+      current_kernel_attribs_ = &ka;
+      const auto mtl_func_name = mtl_kernel_func_name(mtl_kernel_name);
+      emit_mtl_kernel_func_def(mtl_func_name, ka.buffers, stmt->body.get());
+      emit_call_mtl_kernel_func(mtl_func_name, ka.buffers,
+                                /*loop_index_expr=*/"ii");
+    }
+    emit("}}");  // closes for loop
     current_appender().pop_indent();
     // Close kernel
     emit("}}\n");
@@ -780,7 +797,8 @@ class KernelCodegen : public IRVisitor {
           stmt->body.get());
       emit_call_mtl_kernel_func(mtl_func_name, ka.buffers,
                                 /*extra_args=*/
-                                {kListgenElemVarName});
+                                {kListgenElemVarName},
+                                /*loop_index_expr=*/"ii");
       current_kernel_attribs_ = nullptr;
     }
     emit("}}");  // closes for loop
@@ -847,8 +865,7 @@ class KernelCodegen : public IRVisitor {
     for (const auto &p : extra_params) {
       emit("    {} {},", p.type, p.name);
     }
-    emit("    const uint {},", kKernelGridSizeName);
-    emit("    const uint {}) {{", kKernelThreadIdName);
+    emit("    const int {}) {{", kLinearLoopIndexName);
 
     {
       ScopedIndent s(current_appender());
@@ -861,10 +878,10 @@ class KernelCodegen : public IRVisitor {
       // Init RandState
       emit(
           "device {rty}* {rand} = reinterpret_cast<device "
-          "{rty}*>({rtm}->rand_seeds + ({tid} % {nums}));",
+          "{rty}*>({rtm}->rand_seeds + ({lidx} % {nums}));",
           fmt::arg("rty", "RandState"), fmt::arg("rand", kRandStateVarName),
           fmt::arg("rtm", kRuntimeVarName),
-          fmt::arg("tid", kKernelThreadIdName),
+          fmt::arg("lidx", kLinearLoopIndexName),
           fmt::arg("nums", kNumRandSeeds));
     }
     // We do not need additional indentation, because |func_ir| itself is a
@@ -885,7 +902,8 @@ class KernelCodegen : public IRVisitor {
   void emit_call_mtl_kernel_func(
       const std::string &kernel_func_name,
       const std::vector<KernelAttributes::Buffers> &buffers,
-      const std::vector<std::string> &extra_args) {
+      const std::vector<std::string> &extra_args,
+      const std::string &loop_index_expr) {
     TI_ASSERT(code_section_ == Section::Kernels);
     std::string call = kernel_func_name + "(";
     for (auto b : buffers) {
@@ -894,14 +912,16 @@ class KernelCodegen : public IRVisitor {
     for (const auto &a : extra_args) {
       call += a + ", ";
     }
-    call += fmt::format("{}, {});", kKernelGridSizeName, kKernelThreadIdName);
+    call += fmt::format("{});", loop_index_expr);
     emit(std::move(call));
   }
 
   inline void emit_call_mtl_kernel_func(
       const std::string &kernel_func_name,
-      const std::vector<KernelAttributes::Buffers> &buffers) {
-    emit_call_mtl_kernel_func(kernel_func_name, buffers, /*extra_args=*/{});
+      const std::vector<KernelAttributes::Buffers> &buffers,
+      const std::string &loop_index_expr) {
+    emit_call_mtl_kernel_func(kernel_func_name, buffers, /*extra_args=*/{},
+                              loop_index_expr);
   }
 
   void emit_mtl_kernel_sig(

--- a/tests/python/test_loops.py
+++ b/tests/python/test_loops.py
@@ -114,8 +114,8 @@ def test_zero_inner_loop():
     assert x[None] == 0
 
 
-@ti.archs_excluding(ti.opengl
-                    )  # OpenGL backend doesn't support dynamic loop ranges yet
+# OpenGL backend doesn't support dynamic loop ranges yet
+@ti.archs_excluding(ti.opengl)
 def test_dynamic_loop_range():
     x = ti.var(ti.i32)
     c = ti.var(ti.i32)
@@ -138,8 +138,8 @@ def test_dynamic_loop_range():
     assert sum(x.to_numpy()) == (n * (n - 1) // 2) + n * n
 
 
-@ti.archs_excluding(ti.opengl
-                    )  # OpenGL backend doesn't support dynamic loop ranges yet
+# OpenGL backend doesn't support dynamic loop ranges yet
+@ti.archs_excluding(ti.opengl)
 def test_loop_arg_as_range():
     # Dynamic range loops are intended to make sure global tmps work
     x = ti.var(ti.i32)


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

With this change, we no longer need  a sync to figure out the number of threads to launch.

Related issue = #722 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

Might be easier to see what's going on with an example... The following snippet is part of the output from https://github.com/taichi-dev/taichi/blob/f0d6bd70f90f51cf2aa39cb2ed716e8a7acf0f11/tests/python/test_loops.py#L143-L155

```cpp
void mtl_k0000_test_c4_0_1_func(
    device byte* root_addr,
    device byte* global_tmps_addr,
    device byte* args_addr,
    device byte* runtime_addr,
    const int linear_loop_idx_) {
  device Runtime *runtime_ = reinterpret_cast<device Runtime *>(runtime_addr);
  mtl_k0000_test_c4_0_args args_ctx_(args_addr);
  device RandState* rand_state_ = reinterpret_cast<device RandState*>(runtime_->rand_seeds + (linear_loop_idx_ % 65536));
  const int tmp9 = linear_loop_idx_;
  const int32_t tmp10 = *args_ctx_.arg0();
  const int32_t tmp11 = (tmp9 - tmp10);
  S0 tmp13(root_addr);
  S0_ch tmp15 = tmp13.children(tmp14);
  S1 tmp16 = tmp15.get0();
  auto tmp17 = (((0 + tmp11) >> 0) & ((1 << 10) - 1));
  S1_ch tmp21 = tmp16.children(tmp17);
  device int32_t* tmp22 = tmp21.get0().val;
  *tmp22 = tmp9;
}

kernel void mtl_k0000_test_c4_0_1(
    device byte* root_addr [[buffer(0)]],
    device byte* global_tmps_addr [[buffer(1)]],
    device byte* args_addr [[buffer(2)]],
    device byte* runtime_addr [[buffer(3)]],
    const uint ugrid_size_ [[threads_per_grid]],
    const uint utid_ [[thread_position_in_grid]]) {
  // range_for, range known at runtime
  device int32_t* tmp37 = reinterpret_cast<device int32_t*>(global_tmps_addr + 0);
  int32_t tmp38 = *tmp37;  // begin_expr
  device int32_t* tmp39 = reinterpret_cast<device int32_t*>(global_tmps_addr + 4);
  int32_t tmp40 = *tmp39;  // end_expr
  const int total_elems = tmp40 - tmp38;
  const int range_ = max((int)((total_elems + ugrid_size_ - 1) / ugrid_size_), 1);
  const int begin_ = (range_ * (int)utid_) + tmp38;
  const int end_ = min(range_ * (int)(utid_ + 1), total_elems) + tmp38;
  for (int ii = begin_; ii < end_; ++ii) {
    mtl_k0000_test_c4_0_1_func(root_addr, global_tmps_addr, args_addr, runtime_addr, ii);
  }
}
```

---

I have a question for the grid stride loop. In the [tutorial](https://devblogs.nvidia.com/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/), each thread advances by the size of the entire grid. Do you know why?

In Metal, I first figure out the number of elements in the kernel, then compute `range_ = (total_elems + grid_size - 1) / grid_size`, and each thread only covers `[thread_id * range_, (thread_id + 1) * range)`. I thought this could somewhat improve the spatial locality..?