### PR TITLE
[LLVM] Upgrade to LLVM 10.0, and keep backwards compatibility with LLVM 8.0.

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -76,8 +76,11 @@ if (TI_WITH_OPENGL)
 endif()
 
 # http://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
-find_package(LLVM REQUIRED CONFIG 8.0)
+find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+if(${LLVM_PACKAGE_VERSION} VERSION_LESS "8.0")
+    message(FATAL_ERROR "LLVM less than 8.0 is not supported")
+endif()
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(${LLVM_INCLUDE_DIRS})
     message("llvm include dirs ${LLVM_INCLUDE_DIRS}")

--- a/taichi/codegen/codegen_llvm_cuda.cpp
+++ b/taichi/codegen/codegen_llvm_cuda.cpp
@@ -225,17 +225,31 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
               llvm_val[stmt->val],
               llvm::AtomicOrdering::SequentiallyConsistent);
         } else if (stmt->val->ret_type.data_type == DataType::f32) {
+#if LLVM_VERSION_MAJOR >= 10
+          old_value = builder->CreateAtomicRMW(
+              llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
+              llvm_val[stmt->val],
+              AtomicOrdering::SequentiallyConsistent);
+#else
           auto dt = tlctx->get_data_type(DataType::f32);
           old_value = builder->CreateIntrinsic(
               Intrinsic::nvvm_atomic_load_add_f32,
               {llvm::PointerType::get(dt, 0)},
               {llvm_val[stmt->dest], llvm_val[stmt->val]});
+#endif
         } else if (stmt->val->ret_type.data_type == DataType::f64) {
+#if LLVM_VERSION_MAJOR >= 10
+          old_value = builder->CreateAtomicRMW(
+              llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
+              llvm_val[stmt->val],
+              AtomicOrdering::SequentiallyConsistent);
+#else
           auto dt = tlctx->get_data_type(DataType::f64);
           old_value = builder->CreateIntrinsic(
               Intrinsic::nvvm_atomic_load_add_f64,
               {llvm::PointerType::get(dt, 0)},
               {llvm_val[stmt->dest], llvm_val[stmt->val]});
+#endif
         } else {
           TI_NOT_IMPLEMENTED
         }

--- a/taichi/codegen/codegen_llvm_cuda.cpp
+++ b/taichi/codegen/codegen_llvm_cuda.cpp
@@ -228,8 +228,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
 #if LLVM_VERSION_MAJOR >= 10
           old_value = builder->CreateAtomicRMW(
               llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              AtomicOrdering::SequentiallyConsistent);
+              llvm_val[stmt->val], AtomicOrdering::SequentiallyConsistent);
 #else
           auto dt = tlctx->get_data_type(DataType::f32);
           old_value = builder->CreateIntrinsic(
@@ -241,8 +240,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
 #if LLVM_VERSION_MAJOR >= 10
           old_value = builder->CreateAtomicRMW(
               llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              AtomicOrdering::SequentiallyConsistent);
+              llvm_val[stmt->val], AtomicOrdering::SequentiallyConsistent);
 #else
           auto dt = tlctx->get_data_type(DataType::f64);
           old_value = builder->CreateIntrinsic(

--- a/taichi/jit/jit_arch_cpu.cpp
+++ b/taichi/jit/jit_arch_cpu.cpp
@@ -183,7 +183,7 @@ class JITSessionCPU : public JITSession {
   std::unique_ptr<llvm::Module> optimize_module(
       std::unique_ptr<llvm::Module> M) {
     // Create a function pass manager.
-    auto FPM = llvm::make_unique<legacy::FunctionPassManager>(M.get());
+    auto FPM = std::make_unique<legacy::FunctionPassManager>(M.get());
 
     // Add some optimizations.
     FPM->add(createInstructionCombiningPass());
@@ -311,7 +311,7 @@ std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch) {
     TI_ERROR("LLVM TargetMachineBuilder has failed when getting data layout.");
   }
 
-  return llvm::make_unique<JITSessionCPU>(std::move(*jtmb), std::move(*DL));
+  return std::make_unique<JITSessionCPU>(std::move(*jtmb), std::move(*DL));
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/llvm/llvm_codegen_utils.h
+++ b/taichi/llvm/llvm_codegen_utils.h
@@ -8,6 +8,10 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#if LLVM_VERSION_MAJOR >= 10
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsNVPTX.h"
+#endif
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
@@ -63,8 +67,13 @@ class ModuleBuilder {
     llvm::IRBuilderBase::InsertPointGuard guard(*builder);
     builder->SetInsertPoint(entry_block);
     auto alloca = builder->CreateAlloca(type, (unsigned)0);
-    if (alignment != 0)
+    if (alignment != 0) {
+#if LLVM_VERSION_MAJOR >= 10
+      alloca->setAlignment(llvm::MaybeAlign(alignment));
+#else
       alloca->setAlignment(alignment);
+#endif
+    }
     return alloca;
   }
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -314,7 +314,6 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
 
       patch_atomic_add("atomic_add_i64", llvm::AtomicRMWInst::Add);
 
-
 #if LLVM_VERSION_MAJOR >= 10
       patch_atomic_add("atomic_add_f32", llvm::AtomicRMWInst::FAdd);
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -11,6 +11,10 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#if LLVM_VERSION_MAJOR >= 10
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsNVPTX.h"
+#endif
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
@@ -281,7 +285,8 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
         TaichiLLVMContext::force_inline(func);
       };
 
-      auto patch_atomic_add_int = [&](std::string name) {
+      auto patch_atomic_add = [&](std::string name,
+                                  llvm::AtomicRMWInst::BinOp op) {
         auto func = runtime_module->getFunction(name);
         func->deleteBody();
         auto bb = llvm::BasicBlock::Create(*ctx, "entry", func);
@@ -291,7 +296,7 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
         for (auto &arg : func->args())
           args.push_back(&arg);
         builder.CreateRet(builder.CreateAtomicRMW(
-            llvm::AtomicRMWInst::Add, args[0], args[1],
+            op, args[0], args[1],
             llvm::AtomicOrdering::SequentiallyConsistent));
         TaichiLLVMContext::force_inline(func);
       };
@@ -305,10 +310,16 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
       patch_intrinsic("grid_memfence", Intrinsic::nvvm_membar_gl, false);
       patch_intrinsic("system_memfence", Intrinsic::nvvm_membar_sys, false);
 
-      patch_atomic_add_int("atomic_add_i32");
+      patch_atomic_add("atomic_add_i32", llvm::AtomicRMWInst::Add);
 
-      patch_atomic_add_int("atomic_add_i64");
+      patch_atomic_add("atomic_add_i64", llvm::AtomicRMWInst::Add);
 
+
+#if LLVM_VERSION_MAJOR >= 10
+      patch_atomic_add("atomic_add_f32", llvm::AtomicRMWInst::FAdd);
+
+      patch_atomic_add("atomic_add_f64", llvm::AtomicRMWInst::FAdd);
+#else
       patch_intrinsic(
           "atomic_add_f32", Intrinsic::nvvm_atomic_load_add_f32, true,
           {llvm::PointerType::get(get_data_type(DataType::f32), 0)});
@@ -316,6 +327,7 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
       patch_intrinsic(
           "atomic_add_f64", Intrinsic::nvvm_atomic_load_add_f64, true,
           {llvm::PointerType::get(get_data_type(DataType::f64), 0)});
+#endif
 
       // patch_intrinsic("sync_warp", Intrinsic::nvvm_bar_warp_sync, false);
       // patch_intrinsic("warp_ballot", Intrinsic::nvvm_vote_ballot, false);


### PR DESCRIPTION
This PR is the first stage for LLVM 10.0. This PR makes taichi buildable with LLVM 10.0, but still keep all things about LLVM 8.0. The macro `LLVM_VERSION_MAJOR`, rather than `TI_LLVM_VERSION` since the former is more standard.

Everything should works with LLVM 10.0, and the next step is upgrade the `OrcJIT` part to the newer version in LLVM, and deprecate LLVM 8.0 support, but those part will be another PR.

Related issue = #655

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
