### PR TITLE
[doc] Include a few links to Google Code Health articles in contributor guidelines

### DIFF
--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -62,10 +62,16 @@ Making good pull requests
 - All PRs should pass **continuous integration tests** before they get merged;
 - PR authors **should not squash commits on their own**;
 - PR titles should follow :ref:`prtag`;
+- A great article from Google on `how to have your PR merged quickly <https://testing.googleblog.com/2017/06/code-health-too-many-comments-on-your.html>`_.
 
 
 Reviewing & PR merging
 ----------------------
+
+- Please try to follow these tips from Google
+
+  - `Code Health: Understanding Code In Review <https://testing.googleblog.com/2018/05/code-health-understanding-code-in-review.html>`_;
+  - `Code Health: Respectful Reviews == Useful Reviews <https://testing.googleblog.com/2019/11/code-health-respectful-reviews-useful.html>`_.
 
 - The merger should always **squash and merge** PRs into the master branch;
 - The master branch is required to have a **linear history**;


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

@k-ye I'm stealing a few great articles from Google so that we don't have to re-discover on our own these battle-tested code health practices. You are probably already very familiar with these - do you think of adopting these tips in the Taichi community?
 
[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
