### PR TITLE
[doc] tell arch users to install ncurses5-compat-libs for libtinfo5

### DIFF
--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -28,7 +28,8 @@ Installing Depedencies
 
   .. code-block:: bash
 
-    sudo pacman -S ncurses5-compat-libs  # /usr/lib/libtinfo.so.5
+    sudo pacman -S yaourt
+    yaourt -S ncurses5-compat-libs  # /usr/lib/libtinfo.so.5
     wget https://archive.archlinux.org/packages/c/clang/clang-8.0.1-1-x86_64.pkg.tar.xz
     sudo pacman -Qp clang-8.0.1-1-x86_64.pkg.tar.xz
 

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -28,6 +28,7 @@ Installing Depedencies
 
   .. code-block:: bash
 
+    sudo pacman -S ncurses5-compat-libs  # /usr/lib/libtinfo.so.5
     wget https://archive.archlinux.org/packages/c/clang/clang-8.0.1-1-x86_64.pkg.tar.xz
     sudo pacman -Qp clang-8.0.1-1-x86_64.pkg.tar.xz
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #791

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
