### PR TITLE
[doc] Add Google code review article PDFs

### DIFF
--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -62,7 +62,7 @@ Making good pull requests
 - All PRs should pass **continuous integration tests** before they get merged;
 - PR authors **should not squash commits on their own**;
 - PR titles should follow :ref:`prtag`;
-- A great article from Google on `how to have your PR merged quickly <https://testing.googleblog.com/2017/06/code-health-too-many-comments-on-your.html>`_.
+- A great article from Google on `how to have your PR merged quickly <https://testing.googleblog.com/2017/06/code-health-too-many-comments-on-your.html>`_. `[PDF] <https://github.com/yuanming-hu/public_files/blob/master/graphics/taichi/google_review_comments.pdf>`_
 
 
 Reviewing & PR merging
@@ -70,8 +70,8 @@ Reviewing & PR merging
 
 - Please try to follow these tips from Google
 
-  - `Code Health: Understanding Code In Review <https://testing.googleblog.com/2018/05/code-health-understanding-code-in-review.html>`_;
-  - `Code Health: Respectful Reviews == Useful Reviews <https://testing.googleblog.com/2019/11/code-health-respectful-reviews-useful.html>`_.
+  - `Code Health: Understanding Code In Review <https://testing.googleblog.com/2018/05/code-health-understanding-code-in-review.html>`_; `[PDF] <https://github.com/yuanming-hu/public_files/blob/master/graphics/taichi/google_understanding_code.pdf>`_
+  - `Code Health: Respectful Reviews == Useful Reviews <https://testing.googleblog.com/2019/11/code-health-respectful-reviews-useful.html>`_. `[PDF] <https://github.com/yuanming-hu/public_files/blob/master/graphics/taichi/google_respectful_reviews.pdf>`_
 
 - The merger should always **squash and merge** PRs into the master branch;
 - The master branch is required to have a **linear history**;

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -39,4 +39,4 @@ To print out all statistics in Python:
 
 .. code-block:: Python
 
-    ti.core.print_statistics()
+    ti.core.print_stat()


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

@archibate I uploaded the PDFs of the code review articles, in case you don't have access to Google. I highly recommend spending some time reading these carefully: https://github.com/taichi-dev/taichi/blob/9366443224495ced352a5bddcf3d17b042eec105/docs/contributor_guide.rst#making-good-pull-requests

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
