### PR TITLE
[ir] Add checks for `loop_var`s and print names for loops

### DIFF
--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -20,10 +20,9 @@ class IRVerifier : public BasicStmtVisitor {
   }
 
   void basic_verify(Stmt *stmt) {
-    TI_ASSERT_INFO(
-        stmt->parent == current_block,
-        "stmt({})->parent({}) != current_block({})", stmt->id,
-        fmt::ptr(stmt->parent), fmt::ptr(current_block));
+    TI_ASSERT_INFO(stmt->parent == current_block,
+                   "stmt({})->parent({}) != current_block({})", stmt->id,
+                   fmt::ptr(stmt->parent), fmt::ptr(current_block));
     for (auto &op : stmt->get_operands()) {
       if (op == nullptr)
         continue;
@@ -34,8 +33,8 @@ class IRVerifier : public BasicStmtVisitor {
           break;
         }
       }
-      TI_ASSERT_INFO(
-          found, "stmt {} cannot have operand {}.", stmt->id, op->id);
+      TI_ASSERT_INFO(found, "stmt {} cannot have operand {}.", stmt->id,
+                     op->id);
     }
     visible_stmts.back().insert(stmt);
   }
@@ -75,16 +74,19 @@ class IRVerifier : public BasicStmtVisitor {
   void visit(RangeForStmt *for_stmt) override {
     basic_verify(for_stmt);
     TI_ASSERT(for_stmt->loop_var->is<AllocaStmt>());
-    TI_ASSERT_INFO(irpass::analysis::gather_statements(for_stmt->loop_var->parent,
-        [&] (Stmt *s) {
-          if (auto store = s->cast<LocalStoreStmt>())
-            return store->ptr == for_stmt->loop_var;
-          else if (auto atomic = s->cast<AtomicOpStmt>()) {
-            return atomic->dest == for_stmt->loop_var;
-          } else {
-            return false;
-          }
-    }).empty(), "loop_var of {} modified", for_stmt->id);
+    TI_ASSERT_INFO(irpass::analysis::gather_statements(
+                       for_stmt->loop_var->parent,
+                       [&](Stmt *s) {
+                         if (auto store = s->cast<LocalStoreStmt>())
+                           return store->ptr == for_stmt->loop_var;
+                         else if (auto atomic = s->cast<AtomicOpStmt>()) {
+                           return atomic->dest == for_stmt->loop_var;
+                         } else {
+                           return false;
+                         }
+                       })
+                       .empty(),
+                   "loop_var of {} modified", for_stmt->id);
     for_stmt->body->accept(this);
   }
 
@@ -92,16 +94,19 @@ class IRVerifier : public BasicStmtVisitor {
     basic_verify(for_stmt);
     for (auto &loop_var : for_stmt->loop_vars) {
       TI_ASSERT(loop_var->is<AllocaStmt>());
-      TI_ASSERT_INFO(irpass::analysis::gather_statements(loop_var->parent,
-                                                         [&] (Stmt *s) {
-                                                           if (auto store = s->cast<LocalStoreStmt>())
-                                                             return store->ptr == loop_var;
-                                                           else if (auto atomic = s->cast<AtomicOpStmt>()) {
-                                                             return atomic->dest == loop_var;
-                                                           } else {
-                                                             return false;
-                                                           }
-                                                         }).empty(), "loop_var of {} modified", for_stmt->id);
+      TI_ASSERT_INFO(irpass::analysis::gather_statements(
+                         loop_var->parent,
+                         [&](Stmt *s) {
+                           if (auto store = s->cast<LocalStoreStmt>())
+                             return store->ptr == loop_var;
+                           else if (auto atomic = s->cast<AtomicOpStmt>()) {
+                             return atomic->dest == loop_var;
+                           } else {
+                             return false;
+                           }
+                         })
+                         .empty(),
+                     "loop_var of {} modified", for_stmt->id);
     }
     for_stmt->body->accept(this);
   }

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -22,8 +22,8 @@ class IRVerifier : public BasicStmtVisitor {
   void basic_verify(Stmt *stmt) {
     TI_ASSERT_INFO(
         stmt->parent == current_block,
-        fmt::format("stmt({})->parent({}) != current_block({})", stmt->id,
-                    fmt::ptr(stmt->parent), fmt::ptr(current_block)));
+        "stmt({})->parent({}) != current_block({})", stmt->id,
+        fmt::ptr(stmt->parent), fmt::ptr(current_block));
     for (auto &op : stmt->get_operands()) {
       if (op == nullptr)
         continue;
@@ -34,8 +34,8 @@ class IRVerifier : public BasicStmtVisitor {
           break;
         }
       }
-      TI_ASSERT_INFO(found, fmt::format("stmt {} cannot have operand {}.",
-                                        stmt->id, op->id));
+      TI_ASSERT_INFO(
+          found, "stmt {} cannot have operand {}.", stmt->id, op->id);
     }
     visible_stmts.back().insert(stmt);
   }
@@ -70,6 +70,40 @@ class IRVerifier : public BasicStmtVisitor {
   void visit(LocalStoreStmt *stmt) override {
     basic_verify(stmt);
     TI_ASSERT(stmt->ptr->is<AllocaStmt>());
+  }
+
+  void visit(RangeForStmt *for_stmt) override {
+    basic_verify(for_stmt);
+    TI_ASSERT(for_stmt->loop_var->is<AllocaStmt>());
+    TI_ASSERT_INFO(irpass::analysis::gather_statements(for_stmt->loop_var->parent,
+        [&] (Stmt *s) {
+          if (auto store = s->cast<LocalStoreStmt>())
+            return store->ptr == for_stmt->loop_var;
+          else if (auto atomic = s->cast<AtomicOpStmt>()) {
+            return atomic->dest == for_stmt->loop_var;
+          } else {
+            return false;
+          }
+    }).empty(), "loop_var of {} modified", for_stmt->id);
+    for_stmt->body->accept(this);
+  }
+
+  void visit(StructForStmt *for_stmt) override {
+    basic_verify(for_stmt);
+    for (auto &loop_var : for_stmt->loop_vars) {
+      TI_ASSERT(loop_var->is<AllocaStmt>());
+      TI_ASSERT_INFO(irpass::analysis::gather_statements(loop_var->parent,
+                                                         [&] (Stmt *s) {
+                                                           if (auto store = s->cast<LocalStoreStmt>())
+                                                             return store->ptr == loop_var;
+                                                           else if (auto atomic = s->cast<AtomicOpStmt>()) {
+                                                             return atomic->dest == loop_var;
+                                                           } else {
+                                                             return false;
+                                                           }
+                                                         }).empty(), "loop_var of {} modified", for_stmt->id);
+    }
+    for_stmt->body->accept(this);
   }
 
   static void run(IRNode *root) {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -231,13 +231,13 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(WhileStmt *stmt) override {
-    print("while true {{");
+    print("{} : while true {{", stmt->name());
     stmt->body->accept(this);
     print("}}");
   }
 
   void visit(FrontendWhileStmt *stmt) override {
-    print("while {} {{", stmt->cond->serialize());
+    print("{} : while {} {{", stmt->name(), stmt->cond->serialize());
     stmt->body->accept(this);
     print("}}");
   }
@@ -247,10 +247,10 @@ class IRPrinter : public IRVisitor {
         for_stmt->loop_var_id,
         [](const Ident &id) -> std::string { return id.name(); });
     if (for_stmt->is_ranged()) {
-      print("for {} in range({}, {}) {{", vars, for_stmt->begin->serialize(),
+      print("{} : for {} in range({}, {}) {{", for_stmt->name(), vars, for_stmt->begin->serialize(),
             for_stmt->end->serialize());
     } else {
-      print("for {} where {} active {{", vars,
+      print("{} : for {} where {} active {{", for_stmt->name(), vars,
             for_stmt->global_var.cast<GlobalVariableExpression>()
                 ->snode->get_node_type_name_hinted());
     }
@@ -259,8 +259,8 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(RangeForStmt *for_stmt) override {
-    print("{}for {} in range({}, {}, step {}) {{",
-          for_stmt->reversed ? "reversed " : "", for_stmt->loop_var->name(),
+    print("{} : {}for {} in range({}, {}, step {}) {{",
+          for_stmt->name(), for_stmt->reversed ? "reversed " : "", for_stmt->loop_var->name(),
           for_stmt->begin->name(), for_stmt->end->name(), for_stmt->vectorize);
     for_stmt->body->accept(this);
     print("}}");
@@ -270,7 +270,7 @@ class IRPrinter : public IRVisitor {
     auto loop_vars = make_list<Stmt *>(
         for_stmt->loop_vars,
         [](Stmt *const &stmt) -> std::string { return stmt->name(); });
-    print("for {} where {} active, step {} {{", loop_vars,
+    print("{} : for {} where {} active, step {} {{", for_stmt->name(), loop_vars,
           for_stmt->snode->get_node_type_name_hinted(), for_stmt->vectorize);
     for_stmt->body->accept(this);
     print("}}");

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -247,8 +247,8 @@ class IRPrinter : public IRVisitor {
         for_stmt->loop_var_id,
         [](const Ident &id) -> std::string { return id.name(); });
     if (for_stmt->is_ranged()) {
-      print("{} : for {} in range({}, {}) {{", for_stmt->name(), vars, for_stmt->begin->serialize(),
-            for_stmt->end->serialize());
+      print("{} : for {} in range({}, {}) {{", for_stmt->name(), vars,
+            for_stmt->begin->serialize(), for_stmt->end->serialize());
     } else {
       print("{} : for {} where {} active {{", for_stmt->name(), vars,
             for_stmt->global_var.cast<GlobalVariableExpression>()
@@ -259,8 +259,8 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(RangeForStmt *for_stmt) override {
-    print("{} : {}for {} in range({}, {}, step {}) {{",
-          for_stmt->name(), for_stmt->reversed ? "reversed " : "", for_stmt->loop_var->name(),
+    print("{} : {}for {} in range({}, {}, step {}) {{", for_stmt->name(),
+          for_stmt->reversed ? "reversed " : "", for_stmt->loop_var->name(),
           for_stmt->begin->name(), for_stmt->end->name(), for_stmt->vectorize);
     for_stmt->body->accept(this);
     print("}}");
@@ -270,8 +270,9 @@ class IRPrinter : public IRVisitor {
     auto loop_vars = make_list<Stmt *>(
         for_stmt->loop_vars,
         [](Stmt *const &stmt) -> std::string { return stmt->name(); });
-    print("{} : for {} where {} active, step {} {{", for_stmt->name(), loop_vars,
-          for_stmt->snode->get_node_type_name_hinted(), for_stmt->vectorize);
+    print("{} : for {} where {} active, step {} {{", for_stmt->name(),
+          loop_vars, for_stmt->snode->get_node_type_name_hinted(),
+          for_stmt->vectorize);
     for_stmt->body->accept(this);
     print("}}");
   }

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -203,7 +203,9 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(WhileControlStmt *stmt) override {
-    print("while control {}, {}", stmt->mask ? stmt->mask->name() : "nullptr", stmt->cond->name());
+    print("{} : while control {}, {}",
+        stmt->name(), stmt->mask ? stmt->mask->name() : "nullptr",
+        stmt->cond->name());
   }
 
   void visit(ContinueStmt *stmt) override {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -203,7 +203,7 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(WhileControlStmt *stmt) override {
-    print("while control {}, {}", stmt->mask->name(), stmt->cond->name());
+    print("while control {}, {}", stmt->mask ? stmt->mask->name() : "nullptr", stmt->cond->name());
   }
 
   void visit(ContinueStmt *stmt) override {


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = https://github.com/taichi-dev/taichi/pull/788#issuecomment-614320136 https://github.com/taichi-dev/taichi/pull/788#issuecomment-613739361

Also fixes a bug introduced in #788 when calling `irpass::print`: we can't print `WhileControlStmt::mask->name()` if `WhileControlStmt::mask == nullptr`.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
