### PR TITLE
[example] mpm128 gravity now init as [0, -1], become [0, 0] once key up

### DIFF
--- a/examples/mpm128.py
+++ b/examples/mpm128.py
@@ -100,15 +100,13 @@ def reset():
 print("[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse bottons to attract/repel. Press R to reset.")
 gui = ti.GUI("Taichi MLS-MPM-128", res=512, background_color=0x112F41)
 reset()
-
 gravity[None] = [0, -1]
 
 for frame in range(20000):
-  while gui.has_key_event():
-    e = gui.get_key_event()
-    if e.type == ti.GUI.RELEASE: gravity[None] = [0, 0]
-    elif e.key == 'r': reset()
-    elif e.key == ti.GUI.ESCAPE: exit(0)
+  while gui.get_event(ti.GUI.PRESS):
+    if gui.event.key == 'r': reset()
+    elif gui.event.key == ti.GUI.ESCAPE: exit(0)
+  if gui.event is not None: gravity[None] = [0, 0] # if had any event
   if gui.is_pressed(ti.GUI.LEFT,  'a'): gravity[None][0] = -1
   if gui.is_pressed(ti.GUI.RIGHT, 'd'): gravity[None][0] = 1
   if gui.is_pressed(ti.GUI.UP,    'w'): gravity[None][1] = 1

--- a/examples/mpm128.py
+++ b/examples/mpm128.py
@@ -92,7 +92,7 @@ def reset():
   for i in range(n_particles):
     x[i] = [ti.random() * 0.2 + 0.3 + 0.10 * (i // group_size), ti.random() * 0.2 + 0.05 + 0.32 * (i // group_size)]
     material[i] = i // group_size # 0: fluid 1: jelly 2: snow
-    v[i] = [0, -1]
+    v[i] = [0, 0]
     F[i] = ti.Matrix([[1, 0], [0, 1]])
     Jp[i] = 1
     C[i] = ti.Matrix.zero(ti.f32, 2, 2)
@@ -101,11 +101,12 @@ print("[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse botto
 gui = ti.GUI("Taichi MLS-MPM-128", res=512, background_color=0x112F41)
 reset()
 
+gravity[None] = [0, -1]
+
 for frame in range(20000):
-  gravity[None] = [0, 0]
   while gui.has_key_event():
     e = gui.get_key_event()
-    if e.type == ti.GUI.RELEASE: continue
+    if e.type == ti.GUI.RELEASE: gravity[None] = [0, 0]
     elif e.key == 'r': reset()
     elif e.key == ti.GUI.ESCAPE: exit(0)
   if gui.is_pressed(ti.GUI.LEFT,  'a'): gravity[None][0] = -1


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = N/A

Now it acts same as mpm99 if we don't press any key...

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
