### PR TITLE
[opt] Avoid storing constants across offloaded tasks

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -815,6 +815,10 @@ void SNodeOpExpression::flatten(VecStatement &ret) {
   stmt = ret.back().get();
 }
 
+std::unique_ptr<ConstStmt> ConstStmt::copy() {
+  return std::make_unique<ConstStmt>(val);
+}
+
 For::For(const Expr &s, const Expr &e, const std::function<void(Expr)> &func) {
   auto i = Expr(std::make_shared<IdExpression>());
   auto stmt_unique = std::make_unique<FrontendForStmt>(i, s, e);

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -1622,6 +1622,8 @@ class ConstStmt : public Stmt {
     return false;
   }
 
+  std::unique_ptr<ConstStmt> copy();
+
   TI_STMT_DEF_FIELDS(ret_type, val);
   DEFINE_ACCEPT
 };

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -234,9 +234,11 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
       return;
     if (stmt_to_offloaded[stmt] == current_offloaded)
       return;
-    if (stmt->is<ConstStmt>()) {
-      // Directly insert copies of ConstStmts later
-      return;
+    if (advanced_optimization) {
+      if (stmt->is<ConstStmt>()) {
+        // Directly insert copies of ConstStmts later
+        return;
+      }
     }
     if (local_to_global.find(stmt) == local_to_global.end()) {
       // Not yet allocated
@@ -442,13 +444,15 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
       if (stmt_to_offloaded[stmt] ==
           stmt_to_offloaded[op])  // same OffloadedStmt
         continue;
-      if (op->is<ConstStmt>()) {
-        auto copy = op->as<ConstStmt>()->copy();
-        stmt_to_offloaded[copy.get()] = stmt_to_offloaded[stmt];
-        stmt->set_operand(i, copy.get());
-        stmt->insert_before_me(std::move(copy));
-        modified = true;
-        continue;
+      if (advanced_optimization) {
+        if (op->is<ConstStmt>()) {
+          auto copy = op->as<ConstStmt>()->copy();
+          stmt_to_offloaded[copy.get()] = stmt_to_offloaded[stmt];
+          stmt->set_operand(i, copy.get());
+          stmt->insert_before_me(std::move(copy));
+          modified = true;
+          continue;
+        }
       }
       if (local_to_global_offset.find(op) == local_to_global_offset.end())
         continue;

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -234,6 +234,10 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
       return;
     if (stmt_to_offloaded[stmt] == current_offloaded)
       return;
+    if (stmt->is<ConstStmt>()) {
+      // Directly insert copies of ConstStmts later
+      return;
+    }
     if (local_to_global.find(stmt) == local_to_global.end()) {
       // Not yet allocated
       local_to_global[stmt] = allocate_global(stmt->ret_type);
@@ -435,10 +439,18 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
       auto op = stmt->operand(i);
       if (op == nullptr)
         continue;
-      if (local_to_global_offset.find(op) == local_to_global_offset.end())
-        continue;
       if (stmt_to_offloaded[stmt] ==
           stmt_to_offloaded[op])  // same OffloadedStmt
+        continue;
+      if (op->is<ConstStmt>()) {
+        auto copy = op->as<ConstStmt>()->copy();
+        stmt_to_offloaded[copy.get()] = stmt_to_offloaded[stmt];
+        stmt->set_operand(i, copy.get());
+        stmt->insert_before_me(std::move(copy));
+        modified = true;
+        continue;
+      }
+      if (local_to_global_offset.find(op) == local_to_global_offset.end())
         continue;
 
       auto global = Stmt::make<GlobalTemporaryStmt>(local_to_global_offset[op],


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #656 #729 

**Test case**: `test_local_atomics.py::test_implicit_local_atomic_or`

**before**:
```
kernel {
  $0 = offloaded  {
    <i32*x1> $1 = global tmp var (offset = 0 B)
    <i32 x1> $2 = const [0]
    <i32*x1> $3 : global store [$1 <- $2]
    <i32*x1> $4 = global tmp var (offset = 4 B)
    <i32*x1> $5 : global store [$4 <- $2]
    <i32*x1> $6 = global tmp var (offset = 0 B)
    <i32*x1> $7 = global tmp var (offset = 4 B)
    <i32 x1> $8 = global load $7
    <i32*x1> $9 : global store [$6 <- $8]
  }
  $10 = offloaded range_for(0, 10) block_dim=adaptive {
    <i32 x1> $11 = const [2]
    <i32 x1> $12 = loop index 0
    <i32 x1> $13 = pow $11 $12
    <i32*x1> $14 = global tmp var (offset = 0 B)
    <i32 x1> $15 = atomic bit_or($14, $13)
  }
  $16 = offloaded  {
    <i32*x1> $17 = global tmp var (offset = 0 B)
    <i32 x1> $18 = global load $17
    <gen*x1> $19 = get root
    <i32*x1> $20 = global tmp var (offset = 4 B)
    <i32 x1> $21 = global load $20
    <gen*x1> $22 = [S0root][root]::lookup($19, $21) activate = false
    <gen*x1> $23 = get child [S0root->S1dense] $22
    <i32*x1> $24 = global tmp var (offset = 4 B)
    <i32 x1> $25 = global load $24
    <gen*x1> $26 = [S1dense][dense]::lookup($23, $25) activate = false
    <i32*x1> $27 = get child [S1dense->S2place_i32] $26
    <i32*x1> $28 : global store [$27 <- $18]
  }
}
```

**after**:
```
kernel {
  $0 = offloaded  {
    <i32*x1> $1 = global tmp var (offset = 0 B)
    <i32 x1> $2 = const [0]
    <i32*x1> $3 : global store [$1 <- $2]
    <i32*x1> $4 = global tmp var (offset = 0 B)
    <i32*x1> $5 : global store [$4 <- $2]
  }
  $6 = offloaded range_for(0, 10) block_dim=adaptive {
    <i32 x1> $7 = const [2]
    <i32 x1> $8 = loop index 0
    <i32 x1> $9 = pow $7 $8
    <i32*x1> $10 = global tmp var (offset = 0 B)
    <i32 x1> $11 = atomic bit_or($10, $9)
  }
  $12 = offloaded  {
    <i32*x1> $13 = global tmp var (offset = 0 B)
    <i32 x1> $14 = global load $13
    <gen*x1> $15 = get root
    <i32 x1> $16 = const [0]
    <gen*x1> $17 = [S0root][root]::lookup($15, $16) activate = false
    <gen*x1> $18 = get child [S0root->S1dense] $17
    <gen*x1> $19 = [S1dense][dense]::lookup($18, $16) activate = false
    <i32*x1> $20 = get child [S1dense->S2place_i32] $19
    <i32*x1> $21 : global store [$20 <- $14]
  }
}
```

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
