### PR TITLE
[refactor] Remove `SNodeAttr` and decouple `SNode` from LLVM

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1,5 +1,7 @@
 #include "codegen_llvm.h"
 
+#include "taichi/struct/struct_llvm.h"
+
 TLANG_NAMESPACE_BEGIN
 
 // TODO: sort function definitions to match declaration order in header
@@ -223,7 +225,9 @@ void CodeGenLLVM::emit_struct_meta_base(const std::string &name,
   RuntimeObject common("StructMeta", this, builder.get(), node_meta);
   std::size_t element_size;
   if (snode->type == SNodeType::dense) {
-    auto element_ty = snode_attr[snode].llvm_body_type->getArrayElementType();
+    auto body_type =
+        StructCompilerLLVM::get_llvm_body_type(module.get(), snode);
+    auto element_ty = body_type->getArrayElementType();
     element_size = tlctx->get_type_size(element_ty);
   } else if (snode->type == SNodeType::pointer) {
     auto element_ty = tlctx->snode_attr[snode->ch[0]].llvm_type;
@@ -266,9 +270,9 @@ void CodeGenLLVM::emit_struct_meta_base(const std::string &name,
 }
 
 CodeGenLLVM::CodeGenLLVM(Kernel *kernel, IRNode *ir)
-    // TODO: simplify ModuleBuilder ctor input
-    : ModuleBuilder(kernel->program.get_llvm_context(kernel->arch)
-                        ->clone_struct_module()),
+    // TODO: simplify LLVMModuleBuilder ctor input
+    : LLVMModuleBuilder(kernel->program.get_llvm_context(kernel->arch)
+                            ->clone_struct_module()),
       kernel(kernel),
       ir(ir),
       prog(&kernel->program),

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -208,14 +208,6 @@ std::unique_ptr<RuntimeObject> CodeGenLLVM::emit_struct_meta_object(
     TI_P(snode_type_name(snode->type));
     TI_NOT_IMPLEMENTED;
   }
-  if (false) {
-    // auto ptr_type = llvm::Type::getInt8PtrTy(*llvm_context, 0);
-    auto ptr_type = llvm::PointerType::get(meta->type, 0);
-    auto ptr = meta->ptr;  // builder->CreatePointerCast(meta->ptr, ptr_type);
-    auto struct_meta_size = tlctx->get_type_size(meta->type);
-    builder->CreateIntrinsic(llvm::Intrinsic::invariant_start, {ptr_type},
-                             {tlctx->get_constant(struct_meta_size), ptr});
-  }
   return meta;
 }
 
@@ -230,10 +222,12 @@ void CodeGenLLVM::emit_struct_meta_base(const std::string &name,
     auto element_ty = body_type->getArrayElementType();
     element_size = tlctx->get_type_size(element_ty);
   } else if (snode->type == SNodeType::pointer) {
-    auto element_ty = tlctx->snode_attr[snode->ch[0]].llvm_type;
+    auto element_ty = StructCompilerLLVM::get_llvm_node_type(
+        module.get(), snode->ch[0].get());
     element_size = tlctx->get_type_size(element_ty);
   } else {
-    auto element_ty = tlctx->snode_attr[snode].llvm_element_type;
+    auto element_ty =
+        StructCompilerLLVM::get_llvm_element_type(module.get(), snode);
     element_size = tlctx->get_type_size(element_ty);
   }
   common.set("snode_id", tlctx->get_constant(snode->id));
@@ -275,8 +269,7 @@ CodeGenLLVM::CodeGenLLVM(Kernel *kernel, IRNode *ir)
                             ->clone_struct_module()),
       kernel(kernel),
       ir(ir),
-      prog(&kernel->program),
-      snode_attr(prog->get_llvm_context(kernel->arch)->snode_attr) {
+      prog(&kernel->program) {
   if (ir == nullptr)
     this->ir = kernel->ir;
   initialize_context();
@@ -1121,8 +1114,9 @@ llvm::Value *CodeGenLLVM::call(SNode *snode,
 
 void CodeGenLLVM::visit(GetRootStmt *stmt) {
   llvm_val[stmt] = builder->CreateBitCast(
-      get_root(),
-      PointerType::get(snode_attr[prog->snode_root.get()].llvm_type, 0));
+      get_root(), PointerType::get(StructCompilerLLVM::get_llvm_node_type(
+                                       module.get(), prog->snode_root.get()),
+                                   0));
 }
 
 void CodeGenLLVM::visit(OffsetAndExtractBitsStmt *stmt) {
@@ -1188,7 +1182,9 @@ void CodeGenLLVM::visit(GetChStmt *stmt) {
       {builder->CreateBitCast(llvm_val[stmt->input_ptr],
                               PointerType::getInt8PtrTy(*llvm_context))});
   llvm_val[stmt] = builder->CreateBitCast(
-      ch, PointerType::get(snode_attr[stmt->output_snode].llvm_type, 0));
+      ch, PointerType::get(StructCompilerLLVM::get_llvm_node_type(
+                               module.get(), stmt->output_snode),
+                           0));
 }
 
 void CodeGenLLVM::visit(ExternalPtrStmt *stmt) {

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -66,7 +66,6 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::BasicBlock *current_while_after_loop;
   llvm::FunctionType *task_function_type;
   OffloadedStmt *current_offloaded_stmt;
-  SNodeAttributes &snode_attr;
   std::unordered_map<Stmt *, llvm::Value *> llvm_val;
   llvm::Function *func;
   std::unique_ptr<OffloadedTask> current_task;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -48,7 +48,7 @@ class FunctionCreationGuard {
   ~FunctionCreationGuard();
 };
 
-class CodeGenLLVM : public IRVisitor, public ModuleBuilder {
+class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
  public:
   static uint64 task_counter;
 
@@ -74,7 +74,7 @@ class CodeGenLLVM : public IRVisitor, public ModuleBuilder {
   BasicBlock *func_body_bb;
 
   using IRVisitor::visit;
-  using ModuleBuilder::call;
+  using LLVMModuleBuilder::call;
 
   CodeGenLLVM(Kernel *kernel, IRNode *ir = nullptr);
 

--- a/taichi/codegen/codegen_llvm_cuda.cpp
+++ b/taichi/codegen/codegen_llvm_cuda.cpp
@@ -135,7 +135,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
 
     auto format_str = "[debug] " + stmt->str + " = " + format + "\n";
 
-    llvm_val[stmt] = ModuleBuilder::call(
+    llvm_val[stmt] = LLVMModuleBuilder::call(
         builder.get(), "vprintf",
         builder->CreateGlobalStringPtr(format_str, "format_string"),
         builder->CreateBitCast(values,

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -256,28 +256,4 @@ class SNode {
   uint64 fetch_reader_result();  // TODO: refactor
 };
 
-class SNodeAttribute {
- public:
-  llvm::Type *llvm_type, *llvm_body_type, *llvm_aux_type;
-  llvm::Type *llvm_element_type;
-};
-
-class SNodeAttributes {
- private:
-  std::map<SNode *, SNodeAttribute> snode_llvm_attr;
-
- public:
-  SNodeAttribute &operator[](SNode &snode) {
-    return snode_llvm_attr[&snode];
-  }
-
-  SNodeAttribute &operator[](SNode *snode) {
-    return snode_llvm_attr[snode];
-  }
-
-  SNodeAttribute &operator[](const std::unique_ptr<SNode> &snode) {
-    return snode_llvm_attr[snode.get()];
-  }
-};
-
 TLANG_NAMESPACE_END

--- a/taichi/llvm/llvm_codegen_utils.h
+++ b/taichi/llvm/llvm_codegen_utils.h
@@ -50,7 +50,7 @@ inline bool check_func_call_signature(llvm::Value *func, Args &&... args) {
   return check_func_call_signature(func, {args...});
 }
 
-class ModuleBuilder {
+class LLVMModuleBuilder {
  public:
   std::unique_ptr<llvm::Module> module;
   llvm::BasicBlock *entry_block;
@@ -58,7 +58,7 @@ class ModuleBuilder {
   TaichiLLVMContext *tlctx;
   llvm::LLVMContext *llvm_context;
 
-  ModuleBuilder(std::unique_ptr<llvm::Module> &&module)
+  LLVMModuleBuilder(std::unique_ptr<llvm::Module> &&module)
       : module(std::move(module)) {
   }
 
@@ -131,12 +131,12 @@ class RuntimeObject {
  public:
   std::string cls_name;
   llvm::Value *ptr;
-  ModuleBuilder *mb;
+  LLVMModuleBuilder *mb;
   llvm::Type *type;
   llvm::IRBuilder<> *builder;
 
   RuntimeObject(const std::string &cls_name,
-                ModuleBuilder *mb,
+                LLVMModuleBuilder *mb,
                 llvm::IRBuilder<> *builder,
                 llvm::Value *init = nullptr)
       : cls_name(cls_name), mb(mb), builder(builder) {

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -22,8 +22,6 @@ class TaichiLLVMContext {
   JITModule *runtime_jit_module;
   Arch arch;
 
-  SNodeAttributes snode_attr;
-
   TaichiLLVMContext(Arch arch);
 
   std::unique_ptr<llvm::Module> get_init_module();

--- a/taichi/struct/struct.h
+++ b/taichi/struct/struct.h
@@ -14,8 +14,6 @@ class StructCompiler {
   std::size_t root_size;
   Program *prog;
 
-  SNodeAttributes snode_attr;
-
   explicit StructCompiler(Program *prog);
 
   virtual ~StructCompiler() = default;

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -210,6 +210,40 @@ void StructCompilerLLVM::run(SNode &root, bool host) {
   tlctx->set_struct_module(module);
 }
 
+llvm::Type *StructCompilerLLVM::get_stub(llvm::Module *module,
+                                         SNode *snode,
+                                         uint32 index) {
+  TI_ASSERT(module);
+  TI_ASSERT(snode);
+  auto stub = module->getTypeByName(type_stub_name(snode));
+  TI_ASSERT(stub);
+  TI_ASSERT(stub->getStructNumElements() == 4);
+  TI_ASSERT(0 <= index && index < 4);
+  auto type = stub->getContainedType(index);
+  TI_ASSERT(type);
+  return type;
+}
+
+llvm::Type *StructCompilerLLVM::get_llvm_node_type(llvm::Module *module,
+                                                   SNode *snode) {
+  return get_stub(module, snode, 0);
+}
+
+llvm::Type *StructCompilerLLVM::get_llvm_body_type(llvm::Module *module,
+                                                   SNode *snode) {
+  return get_stub(module, snode, 1);
+}
+
+llvm::Type *StructCompilerLLVM::get_llvm_aux_type(llvm::Module *module,
+                                                  SNode *snode) {
+  return get_stub(module, snode, 2);
+}
+
+llvm::Type *StructCompilerLLVM::get_llvm_element_type(llvm::Module *module,
+                                                      SNode *snode) {
+  return get_stub(module, snode, 3);
+}
+
 std::unique_ptr<StructCompiler> StructCompiler::make(Program *prog, Arch arch) {
   return std::make_unique<StructCompilerLLVM>(prog, arch);
 }

--- a/taichi/struct/struct_llvm.h
+++ b/taichi/struct/struct_llvm.h
@@ -1,11 +1,11 @@
 // Codegen for the hierarchical data structure (LLVM)
 
-#include "struct.h"
+#include "taichi/struct/struct.h"
 #include "taichi/llvm/llvm_codegen_utils.h"
 
 TLANG_NAMESPACE_BEGIN
 
-class StructCompilerLLVM : public StructCompiler, public ModuleBuilder {
+class StructCompilerLLVM : public StructCompiler, public LLVMModuleBuilder {
  public:
   StructCompilerLLVM(Program *prog, Arch arch);
 
@@ -20,6 +20,14 @@ class StructCompilerLLVM : public StructCompiler, public ModuleBuilder {
   void run(SNode &node, bool host) override;
 
   void generate_refine_coordinates(SNode *snode);
+
+  static std::string type_stub_name(SNode *snode);
+
+  static llvm::Type *get_llvm_body_type(llvm::Module *module,
+                                        SNode *snode) {
+    auto stub = module->getTypeByName(type_stub_name(snode));
+    return stub->getContainedType(2);
+  }
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/struct/struct_llvm.h
+++ b/taichi/struct/struct_llvm.h
@@ -23,35 +23,15 @@ class StructCompilerLLVM : public StructCompiler, public LLVMModuleBuilder {
 
   static std::string type_stub_name(SNode *snode);
 
-  static llvm::Type *get_stub(llvm::Module *module,
-                              SNode *snode,
-                              uint32 index) {
-    TI_ASSERT(module);
-    TI_ASSERT(snode);
-    auto stub = module->getTypeByName(type_stub_name(snode));
-    TI_ASSERT(stub);
-    TI_ASSERT(stub->getStructNumElements() == 4);
-    TI_ASSERT(0 <= index && index < 4);
-    auto type = stub->getContainedType(index);
-    TI_ASSERT(type);
-    return type;
-  }
+  static llvm::Type *get_stub(llvm::Module *module, SNode *snode, uint32 index);
 
-  static llvm::Type *get_llvm_node_type(llvm::Module *module, SNode *snode) {
-    return get_stub(module, snode, 0);
-  }
+  static llvm::Type *get_llvm_node_type(llvm::Module *module, SNode *snode);
 
-  static llvm::Type *get_llvm_body_type(llvm::Module *module, SNode *snode) {
-    return get_stub(module, snode, 1);
-  }
+  static llvm::Type *get_llvm_body_type(llvm::Module *module, SNode *snode);
 
-  static llvm::Type *get_llvm_aux_type(llvm::Module *module, SNode *snode) {
-    return get_stub(module, snode, 2);
-  }
+  static llvm::Type *get_llvm_aux_type(llvm::Module *module, SNode *snode);
 
-  static llvm::Type *get_llvm_element_type(llvm::Module *module, SNode *snode) {
-    return get_stub(module, snode, 3);
-  }
+  static llvm::Type *get_llvm_element_type(llvm::Module *module, SNode *snode);
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/struct/struct_llvm.h
+++ b/taichi/struct/struct_llvm.h
@@ -23,10 +23,34 @@ class StructCompilerLLVM : public StructCompiler, public LLVMModuleBuilder {
 
   static std::string type_stub_name(SNode *snode);
 
-  static llvm::Type *get_llvm_body_type(llvm::Module *module,
-                                        SNode *snode) {
+  static llvm::Type *get_stub(llvm::Module *module,
+                              SNode *snode,
+                              uint32 index) {
+    TI_ASSERT(module);
+    TI_ASSERT(snode);
     auto stub = module->getTypeByName(type_stub_name(snode));
-    return stub->getContainedType(2);
+    TI_ASSERT(stub);
+    TI_ASSERT(stub->getStructNumElements() == 4);
+    TI_ASSERT(0 <= index && index < 4);
+    auto type = stub->getContainedType(index);
+    TI_ASSERT(type);
+    return type;
+  }
+
+  static llvm::Type *get_llvm_node_type(llvm::Module *module, SNode *snode) {
+    return get_stub(module, snode, 0);
+  }
+
+  static llvm::Type *get_llvm_body_type(llvm::Module *module, SNode *snode) {
+    return get_stub(module, snode, 1);
+  }
+
+  static llvm::Type *get_llvm_aux_type(llvm::Module *module, SNode *snode) {
+    return get_stub(module, snode, 2);
+  }
+
+  static llvm::Type *get_llvm_element_type(llvm::Module *module, SNode *snode) {
+    return get_stub(module, snode, 3);
   }
 };
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #562 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
