### PR TITLE
[opt] Eliminate WhileControlStmt with non-zero const conditions

### DIFF
--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -74,6 +74,17 @@ class AlgSimp : public BasicStmtVisitor {
     }
   }
 
+  void visit(WhileControlStmt *stmt) override {
+    auto cond = stmt->cond->cast<ConstStmt>();
+    if (!cond)
+      return;
+    if (!alg_is_zero(cond)) {
+      // this statement has no effect
+      stmt->parent->erase(stmt);
+      throw IRModified();
+    }
+  }
+
   static bool alg_is_zero(ConstStmt *stmt) {
     if (!stmt)
       return false;


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #656

I put it in `alg_simp.cpp` since there seem to be no better places.

I thought I found
```
<i32 x1> $5 = const [1]
$6 : while control nullptr, $5
```
in some files like `test_for_break.py`, but I can't find such IRs now... This PR doesn't reduce the number of statements for any tests in `test_for_break.py`.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
