### PR TITLE
[metal] Increment by thread grid size for the grid-strip loops

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -682,16 +682,11 @@ class KernelCodegen : public IRVisitor {
       emit("const int {} = {} - {};", total_elems_name, end_expr, begin_expr);
       ka.num_threads = kMaxNumThreadsGridStrideLoop;
     }
-    // (total_elems + thread_grid_size - 1) / thread_grid_size
-    emit("const int range_ = max((int)(({0} + {1} - 1) / {1}), 1);",
-         total_elems_name, kKernelGridSizeName);
-    // range_ * thread_id + begin_expr
-    emit("const int begin_ = (range_ * (int){}) + {};", kKernelThreadIdName,
-         begin_expr);
-    // min(range_ * (thread_id + 1), total_elems) + begin_expr
-    emit("const int end_ = min(range_ * (int)({} + 1), {}) + {};",
-         kKernelThreadIdName, total_elems_name, begin_expr);
-    emit("for (int ii = begin_; ii < end_; ++ii) {{");
+    // begin_ = thread_id   + begin_expr
+    emit("const int begin_ = {} + {};", kKernelThreadIdName, begin_expr);
+    // end_   = total_elems + begin_expr
+    emit("const int end_ = {} + {};", total_elems_name, begin_expr);
+    emit("for (int ii = begin_; ii < end_; ii += {}) {{", kKernelGridSizeName);
     {
       ScopedIndent s2(current_appender());
 
@@ -757,14 +752,10 @@ class KernelCodegen : public IRVisitor {
          sn_id);
     emit("const int child_stride = child_meta.element_stride;");
     emit("const int child_num_slots = child_meta.num_slots;");
-    emit(
-        "const int range_ = max((int)((child_list->max_num_elems + {0} - "
-        "1) / {0}), 1);",
-        kKernelGridSizeName);
-    emit("const int begin_ = range_ * (int){};", kKernelThreadIdName);
-    emit("const int end_ = min(begin_ + range_, child_list->max_num_elems);");
-
-    emit("for (int ii = begin_; ii < end_; ++ii) {{");
+    // grid-stride loops
+    // Each thread begins at thread_index, and increases by grid_size
+    emit("for (int ii = {}; ii < child_list->max_num_elems; ii += {}) {{",
+         kKernelThreadIdName, kKernelGridSizeName);
     {
       ScopedIndent s2(current_appender());
       emit("const int parent_idx_ = (ii / child_num_slots);");

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -752,8 +752,8 @@ class KernelCodegen : public IRVisitor {
          sn_id);
     emit("const int child_stride = child_meta.element_stride;");
     emit("const int child_num_slots = child_meta.num_slots;");
-    // grid-stride loops
-    // Each thread begins at thread_index, and increases by grid_size
+    // Grid-stride loops:
+    // Each thread begins at thread_index, and incremets by grid_size
     emit("for (int ii = {}; ii < child_list->max_num_elems; ii += {}) {{",
          kKernelThreadIdName, kKernelGridSizeName);
     {

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -43,9 +43,9 @@ struct Runtime {
 METAL_BEGIN_RUNTIME_KERNELS_DEF
 STR(
     // clang-format on
-    kernel void clear_list(device byte *runtime_addr [[buffer(0)]],
-                           device int *args [[buffer(1)]],
-                           const uint utid_ [[thread_position_in_grid]]) {
+    kernel void clear_list(device byte *runtime_addr[[buffer(0)]],
+                           device int *args[[buffer(1)]],
+                           const uint utid_[[thread_position_in_grid]]) {
       if (utid_ > 0)
         return;
       int child_snode_id = args[1];
@@ -55,11 +55,11 @@ STR(
       clear(child_list);
     }
 
-    kernel void element_listgen(device byte *runtime_addr [[buffer(0)]],
-                                device byte *root_addr [[buffer(1)]],
-                                device int *args [[buffer(2)]],
-                                const uint utid_ [[thread_position_in_grid]],
-                                const uint grid_size [[threads_per_grid]]) {
+    kernel void element_listgen(device byte *runtime_addr[[buffer(0)]],
+                                device byte *root_addr[[buffer(1)]],
+                                device int *args[[buffer(2)]],
+                                const uint utid_[[thread_position_in_grid]],
+                                const uint grid_size[[threads_per_grid]]) {
       device Runtime *runtime =
           reinterpret_cast<device Runtime *>(runtime_addr);
       device byte *list_data_addr =

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -43,9 +43,9 @@ struct Runtime {
 METAL_BEGIN_RUNTIME_KERNELS_DEF
 STR(
     // clang-format on
-    kernel void clear_list(device byte *runtime_addr[[buffer(0)]],
-                           device int *args[[buffer(1)]],
-                           const uint utid_[[thread_position_in_grid]]) {
+    kernel void clear_list(device byte *runtime_addr [[buffer(0)]],
+                           device int *args [[buffer(1)]],
+                           const uint utid_ [[thread_position_in_grid]]) {
       if (utid_ > 0)
         return;
       int child_snode_id = args[1];
@@ -55,11 +55,11 @@ STR(
       clear(child_list);
     }
 
-    kernel void element_listgen(device byte *runtime_addr[[buffer(0)]],
-                                device byte *root_addr[[buffer(1)]],
-                                device int *args[[buffer(2)]],
-                                const uint utid_[[thread_position_in_grid]],
-                                const uint grid_size[[threads_per_grid]]) {
+    kernel void element_listgen(device byte *runtime_addr [[buffer(0)]],
+                                device byte *root_addr [[buffer(1)]],
+                                device int *args [[buffer(2)]],
+                                const uint utid_ [[thread_position_in_grid]],
+                                const uint grid_size [[threads_per_grid]]) {
       device Runtime *runtime =
           reinterpret_cast<device Runtime *>(runtime_addr);
       device byte *list_data_addr =
@@ -73,12 +73,8 @@ STR(
       const SNodeMeta child_meta = runtime->snode_metas[child_snode_id];
       const int child_stride = child_meta.element_stride;
       const int num_slots = child_meta.num_slots;
-      const int range = max(
-          (int)((child_list->max_num_elems + grid_size - 1) / grid_size), 1);
-      const int begin = range * (int)utid_;
-      const int end = min(begin + range, child_list->max_num_elems);
 
-      for (int ii = begin; ii < end; ++ii) {
+      for (int ii = utid_; ii < child_list->max_num_elems; ii += grid_size) {
         const int parent_idx = (ii / num_slots);
         if (parent_idx >= num_active(parent_list)) {
           // Since |parent_idx| increases monotonically, we can return directly


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

I manually tested `taichi_sparse` and `sdf_render`, and found no performance difference..

Related issue = #722 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
