### PR TITLE
[test] Fix test when `advanced_optimization == false`

### DIFF
--- a/tests/cpp/test_simplify.cpp
+++ b/tests/cpp/test_simplify.cpp
@@ -36,8 +36,10 @@ TI_TEST("simplify") {
     irpass::alg_simp(block.get(), CompileConfig());
     irpass::die(block.get());  // should eliminate consts
     // irpass::print(block.get());
-    TI_CHECK(block->size() ==
-             5);  // get root, const 0, lookup, get child, lookup
+    if (advanced_optimization) {
+      // get root, const 0, lookup, get child, lookup
+      TI_CHECK(block->size() == 5);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

This is because `irpass::simplify(block.get());` won't lower `linearized` when `advanced_optimization` is `false`.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
