### PR TITLE
[async] Each JIT thread now has its own LLVM context

### DIFF
--- a/examples/mpm99.py
+++ b/examples/mpm99.py
@@ -1,6 +1,6 @@
 import taichi as ti
 import numpy as np
-ti.init(arch=ti.x64) # Try to run on GPU. Use arch=ti.opengl on old GPUs
+ti.init(arch=ti.cuda) # Try to run on GPU. Use arch=ti.opengl on old GPUs
 quality = 1 # Use a larger value for higher-res simulations
 n_particles, n_grid = 9000 * quality ** 2, 128 * quality
 dx, inv_dx = 1 / n_grid, float(n_grid)

--- a/examples/mpm99.py
+++ b/examples/mpm99.py
@@ -1,6 +1,6 @@
 import taichi as ti
 import numpy as np
-ti.init(arch=ti.cuda) # Try to run on GPU. Use arch=ti.opengl on old GPUs
+ti.init(arch=ti.x64) # Try to run on GPU. Use arch=ti.opengl on old GPUs
 quality = 1 # Use a larger value for higher-res simulations
 n_particles, n_grid = 9000 * quality ** 2, 128 * quality
 dx, inv_dx = 1 / n_grid, float(n_grid)

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1564,7 +1564,7 @@ void CodeGenLLVM::initialize_context() {
   } else {
     tlctx = prog->llvm_context_host.get();
   }
-  llvm_context = tlctx->ctx.get();
+  llvm_context = tlctx->ctx;
   builder = std::make_unique<llvm::IRBuilder<>>(*llvm_context);
 }
 

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1564,7 +1564,7 @@ void CodeGenLLVM::initialize_context() {
   } else {
     tlctx = prog->llvm_context_host.get();
   }
-  llvm_context = tlctx->ctx;
+  llvm_context = tlctx->get_this_thread_context();
   builder = std::make_unique<llvm::IRBuilder<>>(*llvm_context);
 }
 

--- a/taichi/jit/jit_session.cpp
+++ b/taichi/jit/jit_session.cpp
@@ -9,15 +9,13 @@ std::unique_ptr<JITSession> create_llvm_jit_session_cuda(Arch arch);
 std::unique_ptr<JITSession> JITSession::create(Arch arch) {
   if (arch_is_cpu(arch)) {
     return create_llvm_jit_session_cpu(arch);
-  }
-  else if (arch == Arch::cuda) {
+  } else if (arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
     return create_llvm_jit_session_cuda(arch);
 #else
     TI_NOT_IMPLEMENTED
 #endif
-  }
-  else
+  } else
     TI_NOT_IMPLEMENTED
 }
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -174,14 +174,17 @@ std::string libdevice_path() {
   return fmt::format("{}/slim_libdevice.{}.bc", folder, cuda_version_major);
 }
 
-std::unique_ptr<llvm::Module> clone_module_to_context(
+std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_module_to_context(
     llvm::Module *module,
     llvm::LLVMContext *target_context) {
+  // Dump a module from one context to bitcode and then parse the bitcode in a
+  // different context
   std::string bitcode;
 
   {
-    // Use a scope to make sure sos flushes on destruction
+    std::lock_guard<std::mutex> _(mut);
     llvm::raw_string_ostream sos(bitcode);
+    // Use a scope to make sure sos flushes on destruction
     llvm::WriteBitcodeToFile(*module, sos);
   }
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -41,11 +41,10 @@ TLANG_NAMESPACE_BEGIN
 
 using namespace llvm;
 
-TaichiLLVMContext::TaichiLLVMContext(Arch arch)
-    : arch(arch),
-      main_thread_id(std::this_thread::get_id()),
-      main_thread_data(get_this_thread_data()) {
+TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
   TI_TRACE("Creating Taichi llvm context for arch: {}", arch_name(arch));
+  main_thread_id = std::this_thread::get_id();
+  main_thread_data = get_this_thread_data();
   llvm::remove_fatal_error_handler();
   llvm::install_fatal_error_handler(
       [](void *user_data, const std::string &reason, bool gen_crash_diag) {

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -43,6 +43,8 @@ using namespace llvm;
 
 TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
   TI_TRACE("Creating Taichi llvm context for arch: {}", arch_name(arch));
+  main_thread_id = std::this_thread::get_id();
+  main_thread_data = get_this_thread_data();
   llvm::remove_fatal_error_handler();
   llvm::install_fatal_error_handler(
       [](void *user_data, const std::string &reason, bool gen_crash_diag) {
@@ -64,12 +66,12 @@ TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
     TI_NOT_IMPLEMENTED
 #endif
   }
-  ctx = get_this_thread_context();
   jit = JITSession::create(arch);
   TI_TRACE("Taichi llvm context created.");
 }
 
 llvm::Type *TaichiLLVMContext::get_data_type(DataType dt) {
+  auto ctx = get_this_thread_context();
   if (dt == DataType::i32) {
     return llvm::Type::getInt32Ty(*ctx);
   } else if (dt == DataType::i8) {
@@ -171,8 +173,31 @@ std::string libdevice_path() {
   return fmt::format("{}/slim_libdevice.{}.bc", folder, cuda_version_major);
 }
 
-std::unique_ptr<llvm::Module> TaichiLLVMContext::get_init_module() {
-  return clone_runtime_module();
+std::unique_ptr<llvm::Module> clone_module_to_context(
+    llvm::Module *module,
+    llvm::LLVMContext *target_context) {
+  std::string bitcode;
+
+  {
+    // Use a scope to make sure sos flushes on destruction
+    llvm::raw_string_ostream sos(bitcode);
+    llvm::WriteBitcodeToFile(*module, sos);
+  }
+
+  auto cloned = parseBitcodeFile(
+      llvm::MemoryBufferRef(bitcode, "runtime_bitcode"), *target_context);
+  if (!cloned) {
+    auto error = cloned.takeError();
+    TI_ERROR("Bitcode cloned failed.");
+  }
+  return std::move(cloned.get());
+}
+
+std::unique_ptr<llvm::Module>
+TaichiLLVMContext::clone_module_to_this_thread_context(llvm::Module *module) {
+  TI_ASSERT(module);
+  auto this_context = get_this_thread_context();
+  return clone_module_to_context(module, this_context);
 }
 
 std::unique_ptr<llvm::Module> module_from_bitcode_file(std::string bitcode_path,
@@ -251,16 +276,20 @@ static void remove_useless_cuda_libdevice_functions(llvm::Module *module) {
 
 std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
   TI_AUTO_PROF
-  if (!runtime_module) {
+  TI_ASSERT(std::this_thread::get_id() == main_thread_id);
+  auto data = get_this_thread_data();
+  auto ctx = get_this_thread_context();
+  if (!data->runtime_module) {
     if (is_release()) {
-      runtime_module = module_from_bitcode_file(
+      data->runtime_module = module_from_bitcode_file(
           fmt::format("{}/{}", compiled_lib_dir, get_runtime_fn(arch)), ctx);
     } else {
       compile_runtime_bitcode(arch);
-      runtime_module = module_from_bitcode_file(
+      data->runtime_module = module_from_bitcode_file(
           fmt::format("{}/{}", get_runtime_dir(), get_runtime_fn(arch)), ctx);
     }
     if (arch == Arch::cuda) {
+      auto &runtime_module = data->runtime_module;
       runtime_module->setTargetTriple("nvptx64-nvidia-cuda");
 
       auto patch_intrinsic = [&](std::string name, Intrinsic::ID intrin,
@@ -331,7 +360,7 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
       // patch_intrinsic("warp_active_mask", Intrinsic::nvvm_membar_cta, false);
       patch_intrinsic("block_memfence", Intrinsic::nvvm_membar_cta, false);
 
-      link_module_with_cuda_libdevice(runtime_module);
+      link_module_with_cuda_libdevice(data->runtime_module);
 
       // To prevent potential symbol name conflicts, we use "cuda_vprintf"
       // instead of "vprintf" in llvm/runtime.cpp. Now we change it back for
@@ -349,7 +378,7 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
   std::unique_ptr<llvm::Module> cloned;
   {
     TI_PROFILER("clone module");
-    cloned = llvm::CloneModule(*runtime_module);
+    cloned = llvm::CloneModule(*data->runtime_module);
   }
 
   return cloned;
@@ -360,7 +389,8 @@ void TaichiLLVMContext::link_module_with_cuda_libdevice(
   TI_AUTO_PROF
   TI_ASSERT(arch == Arch::cuda);
 
-  auto libdevice_module = module_from_bitcode_file(libdevice_path(), ctx);
+  auto libdevice_module =
+      module_from_bitcode_file(libdevice_path(), get_this_thread_context());
 
   std::vector<std::string> libdevice_function_names;
   for (auto &f : *libdevice_module) {
@@ -390,20 +420,22 @@ void TaichiLLVMContext::link_module_with_cuda_libdevice(
 
 std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_struct_module() {
   TI_AUTO_PROF
+  auto struct_module = get_this_thread_struct_module();
   TI_ASSERT(struct_module);
   return llvm::CloneModule(*struct_module);
 }
 
 void TaichiLLVMContext::set_struct_module(
     const std::unique_ptr<llvm::Module> &module) {
+  auto data = get_this_thread_data();
   TI_ASSERT(module);
   if (llvm::verifyModule(*module, &llvm::errs())) {
     module->print(llvm::errs(), nullptr);
     TI_ERROR("module broken");
   }
-  struct_module = llvm::CloneModule(*module);
+  data->struct_module = llvm::CloneModule(*module);
   if (!arch_is_cpu(arch)) {
-    for (auto &f : *struct_module) {
+    for (auto &f : *data->struct_module) {
       bool is_kernel = false;
       if (arch == Arch::cuda) {
         std::string func_name = f.getName();
@@ -431,6 +463,7 @@ void TaichiLLVMContext::set_struct_module(
 
 template <typename T>
 llvm::Value *TaichiLLVMContext::get_constant(DataType dt, T t) {
+  auto ctx = get_this_thread_context();
   if (dt == DataType::f32) {
     return llvm::ConstantFP::get(*ctx, llvm::APFloat((float32)t));
   } else if (dt == DataType::f64) {
@@ -455,6 +488,7 @@ template llvm::Value *TaichiLLVMContext::get_constant(DataType dt, float64 t);
 
 template <typename T>
 llvm::Value *TaichiLLVMContext::get_constant(T t) {
+  auto ctx = get_this_thread_context();
   using TargetType = T;
   if constexpr (std::is_same_v<TargetType, float32> ||
                 std::is_same_v<TargetType, float64>) {
@@ -527,6 +561,7 @@ JITModule *TaichiLLVMContext::add_module(std::unique_ptr<llvm::Module> module) {
 }
 
 void TaichiLLVMContext::mark_function_as_cuda_kernel(llvm::Function *func) {
+  auto ctx = get_this_thread_context();
   /*******************************************************************
   Example annotation from llvm PTX doc:
 
@@ -568,16 +603,33 @@ void TaichiLLVMContext::eliminate_unused_functions(
   manager.run(*module);
 }
 
-llvm::LLVMContext *TaichiLLVMContext::get_this_thread_context() {
+TaichiLLVMContext::ThreadLocalData *TaichiLLVMContext::get_this_thread_data() {
   std::lock_guard<std::mutex> _(mut);
   auto tid = std::this_thread::get_id();
-  if (per_thread_context.find(tid) == per_thread_context.end()) {
+  if (per_thread_data.find(tid) == per_thread_data.end()) {
     std::stringstream ss;
     ss << tid;
-    TI_TRACE("Creating LLVM context for thread {}", ss.str());
-    per_thread_context[tid] = std::make_unique<llvm::LLVMContext>();
+    TI_TRACE("Creating thread local data for thread {}", ss.str());
+    per_thread_data[tid] = std::make_unique<ThreadLocalData>();
   }
-  return per_thread_context[tid].get();
+  return per_thread_data[tid].get();
+}
+
+llvm::LLVMContext *TaichiLLVMContext::get_this_thread_context() {
+  ThreadLocalData *data = get_this_thread_data();
+  if (!data->llvm_context) {
+    data->llvm_context = std::make_unique<llvm::LLVMContext>();
+  }
+  return data->llvm_context.get();
+}
+
+llvm::Module *TaichiLLVMContext::get_this_thread_struct_module() {
+  ThreadLocalData *data = get_this_thread_data();
+  if (!data->struct_module) {
+    data->struct_module = clone_module_to_this_thread_context(
+        main_thread_data->struct_module.get());
+  }
+  return data->struct_module.get();
 }
 
 template llvm::Value *TaichiLLVMContext::get_constant(float32 t);

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -41,10 +41,11 @@ TLANG_NAMESPACE_BEGIN
 
 using namespace llvm;
 
-TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
+TaichiLLVMContext::TaichiLLVMContext(Arch arch)
+    : arch(arch),
+      main_thread_id(std::this_thread::get_id()),
+      main_thread_data(get_this_thread_data()) {
   TI_TRACE("Creating Taichi llvm context for arch: {}", arch_name(arch));
-  main_thread_id = std::this_thread::get_id();
-  main_thread_data = get_this_thread_data();
   llvm::remove_fatal_error_handler();
   llvm::install_fatal_error_handler(
       [](void *user_data, const std::string &reason, bool gen_crash_diag) {

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -10,6 +10,7 @@
 #include "taichi/lang_util.h"
 #include "taichi/llvm/llvm_fwd.h"
 #include "taichi/ir/snode.h"
+#include "taichi/system/threading.h"
 #include "taichi/jit/jit_session.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -17,12 +18,17 @@ class JITSessionCPU;
 
 class TaichiLLVMContext {
  public:
-  std::unique_ptr<llvm::LLVMContext> ctx;
-  std::unique_ptr<JITSession> jit;
+  std::unordered_map<std::thread::id, std::unique_ptr<llvm::LLVMContext>>
+      per_thread_context;
+
   std::unique_ptr<llvm::Module> runtime_module, struct_module;
+  llvm::LLVMContext *ctx; // TODO: rename to main_llvm_context
+  std::unique_ptr<JITSession> jit;
   JITModule *runtime_jit_module;
   std::mutex mut;
   Arch arch;
+
+  llvm::LLVMContext *get_this_thread_context();
 
   TaichiLLVMContext(Arch arch);
 

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -7,11 +7,11 @@
 
 #include <mutex>
 #include <functional>
+#include <thread>
 
 #include "taichi/lang_util.h"
 #include "taichi/llvm/llvm_fwd.h"
 #include "taichi/ir/snode.h"
-#include "taichi/system/threading.h"
 #include "taichi/jit/jit_session.h"
 
 TLANG_NAMESPACE_BEGIN

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -27,6 +27,8 @@ class TaichiLLVMContext {
   std::unordered_map<std::thread::id, std::unique_ptr<ThreadLocalData>>
       per_thread_data;
 
+  Arch arch;
+
   std::thread::id main_thread_id;
   ThreadLocalData *main_thread_data;
   std::mutex mut;
@@ -35,13 +37,6 @@ class TaichiLLVMContext {
   std::unique_ptr<JITSession> jit;
   // main_thread is defined to be the thread that runs the initializer
   JITModule *runtime_jit_module;
-  Arch arch;
-
-  ThreadLocalData *get_main_thread_data() {
-    return main_thread_data;
-  }
-
-  ThreadLocalData *get_this_thread_data();
 
   llvm::LLVMContext *get_this_thread_context();
 
@@ -108,6 +103,8 @@ class TaichiLLVMContext {
 
   std::unique_ptr<llvm::Module> clone_module_to_this_thread_context(
       llvm::Module *module);
+
+  ThreadLocalData *get_this_thread_data();
 
   virtual ~TaichiLLVMContext();
 };

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -38,6 +38,10 @@ class TaichiLLVMContext {
   // main_thread is defined to be the thread that runs the initializer
   JITModule *runtime_jit_module;
 
+  std::unique_ptr<llvm::Module> clone_module_to_context(
+      llvm::Module *module,
+      llvm::LLVMContext *target_context);
+
   llvm::LLVMContext *get_this_thread_context();
 
   TaichiLLVMContext(Arch arch);

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -220,7 +220,7 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
       std::size_t node_size;
       auto element_size =
           tlctx->get_type_size(StructCompilerLLVM::get_llvm_element_type(
-              tlctx->struct_module.get(), snodes[i]));
+              tlctx->get_this_thread_struct_module(), snodes[i]));
       if (snodes[i]->type == SNodeType::pointer) {
         // pointer. Allocators are for single elements
         node_size = element_size;

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -87,6 +87,9 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
        ch_type},
       type_stub_name(&snode));
 
+
+  // Create a dummy function in the module with the type stub as return type
+  // so that the type is referenced in the module
   auto ft = llvm::FunctionType::get(llvm::PointerType::get(stub, 0), false);
   llvm::Function::Create(ft, llvm::Function::ExternalLinkage,
                          type_stub_name(&snode) + "_func", module.get());

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -16,7 +16,7 @@ StructCompilerLLVM::StructCompilerLLVM(Program *prog, Arch arch)
       LLVMModuleBuilder(prog->get_llvm_context(arch)->get_init_module()),
       arch(arch) {
   tlctx = prog->get_llvm_context(arch);
-  llvm_ctx = tlctx->ctx.get();
+  llvm_ctx = tlctx->ctx;
 }
 
 void StructCompilerLLVM::generate_types(SNode &snode) {

--- a/taichi/transforms/whole_kernel_cse.cpp
+++ b/taichi/transforms/whole_kernel_cse.cpp
@@ -28,8 +28,6 @@ class WholeKernelCSE : public BasicStmtVisitor {
     // Move common statements at the beginning or the end of both branches
     // outside.
     if (if_stmt->true_statements && if_stmt->false_statements) {
-      auto block = if_stmt->parent;
-      int current_stmt_id = block->locate(if_stmt);
       auto &true_clause = if_stmt->true_statements;
       auto &false_clause = if_stmt->false_statements;
       if (irpass::analysis::same_statements(


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #742 

LLVM context is not thread-safe. We are doing this for parallel compilation.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
