### PR TITLE
[Bug] [Opt] Fix a bug in local variable optimization

### DIFF
--- a/taichi/transforms/optimize_local_variable.cpp
+++ b/taichi/transforms/optimize_local_variable.cpp
@@ -225,12 +225,13 @@ class AllocaOptimize : public IRVisitor {
       // no nested loops with the same alloca
       TI_ASSERT(is_inside_loop == outside_loop);
     }
-    AllocaOptimize loop(alloca_stmt);
-    loop.is_inside_loop = inside_loop_may_have_stores;
     if (is_inside_loop == inside_loop_no_stores) {
       // Already checked that there are no stores inside.
-      loop.is_inside_loop = inside_loop_no_stores;
+      body->accept(this);
+      return;
     }
+    AllocaOptimize loop(alloca_stmt);
+    loop.is_inside_loop = inside_loop_may_have_stores;
     body->accept(&loop);
 
     stored = stored || loop.stored;

--- a/tests/python/test_optimization.py
+++ b/tests/python/test_optimization.py
@@ -1,0 +1,23 @@
+import taichi as ti
+
+
+@ti.all_archs
+def test_advanced_store_forwarding_nested_loops():
+    val = ti.var(ti.i32)
+    ti.root.place(val)
+
+    @ti.kernel
+    def func():
+        # If we want to do store-forwarding to local loads inside loops,
+        # we should pass the last local store into the loop, rather than use
+        # an empty AllocaOptimize loop.
+        # See https://github.com/taichi-dev/taichi/pull/849.
+        a = val[None]
+        for i in range(1):
+            for j in range(1):
+                val[None] = a
+
+
+    val[None] = 10
+    func()
+    assert val[None] == 10


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Fix #847.

If we want to do store-forwarding to local loads inside loops, we should pass the last local store into the loop, rather than use an empty `AllocaOptimize loop`.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
