### PR TITLE
[opt] Improve optimization for OffsetAndExtractBitsStmt

### DIFF
--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -682,14 +682,16 @@ class BasicBlockSimplify : public IRVisitor {
     }
 
     // step 2: eliminate useless extraction of another OffsetAndExtractBitsStmt
-    if (stmt->offset == 0 &&
-        stmt->bit_begin == 0 &&
-        stmt->input->is<OffsetAndExtractBitsStmt>()) {
-      auto bstmt = stmt->input->as<OffsetAndExtractBitsStmt>();
-      if (stmt->bit_end == bstmt->bit_end - bstmt->bit_begin) {
-        stmt->replace_with(bstmt);
-        stmt->parent->erase(current_stmt_id);
-        throw IRModified();
+    if (advanced_optimization) {
+      if (stmt->offset == 0 &&
+          stmt->bit_begin == 0 &&
+          stmt->input->is<OffsetAndExtractBitsStmt>()) {
+        auto bstmt = stmt->input->as<OffsetAndExtractBitsStmt>();
+        if (stmt->bit_end == bstmt->bit_end - bstmt->bit_begin) {
+          stmt->replace_with(bstmt);
+          stmt->parent->erase(current_stmt_id);
+          throw IRModified();
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #656

The geometric mean of optimization factor: 1.0683373262848908 -> 1.0746597390735222
![benchmark20200422](https://user-images.githubusercontent.com/22582118/80048642-c327e800-84de-11ea-9e97-f54c6af9a317.png)

Tests with significant optimization (> 1.5):
```
test_ad_if__test_ad_if : 1.5348837209302326
test_ad_if__test_ad_if_mutable : 2.0485436893203883
test_ad_if__test_ad_if_parallel : 1.9245283018867925
test_ad_if__test_ad_if_parallel_complex : 1.625
test_basics__test_if_global_load : 1.5441176470588236
test_continue__test_kernel_continue : 1.605263157894737
test_continue__test_unconditional_continue : 1.5106382978723405
```

Tests that become worse in the sense of the number of statements (< 0.85):
```
test_ndrange__test_static_grouped_static : 0.8333333333333334
test_struct_for__test_singleton : 0.8333333333333334
test_tensor_dimensionality__test_dimensionality : 0.7862595419847328
test_tensor_reflection__test_POT1 : 0.7671232876712328
```

The above tests may be mismatched due to a weird behavior on Windows, as discussed in #656.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
