### PR TITLE
[misc] Split accessor and other kernels in statistics

### DIFF
--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -17,9 +17,12 @@ KernelCodeGen::KernelCodeGen(Kernel *kernel, IRNode *ir)
   if (ir == nullptr)
     this->ir = kernel->ir;
 
+  auto num_stmts = irpass::analysis::count_statements(this->ir);
   if (!kernel->is_accessor)
-    stat.add("codegen_statements",
-             irpass::analysis::count_statements(this->ir));
+    stat.add("codegen_kernel_statements", num_stmts);
+  else
+    stat.add("codegen_accessor_statements", num_stmts);
+  stat.add("codegen_statements", num_stmts);
 }
 
 FunctionType KernelCodeGen::compile() {

--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -18,7 +18,8 @@ KernelCodeGen::KernelCodeGen(Kernel *kernel, IRNode *ir)
     this->ir = kernel->ir;
 
   if (!kernel->is_accessor)
-    stat.add("codegen_statements", irpass::analysis::count_statements(this->ir));
+    stat.add("codegen_statements",
+             irpass::analysis::count_statements(this->ir));
 }
 
 FunctionType KernelCodeGen::compile() {

--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -17,7 +17,8 @@ KernelCodeGen::KernelCodeGen(Kernel *kernel, IRNode *ir)
   if (ir == nullptr)
     this->ir = kernel->ir;
 
-  stat.add("codegen_statements", irpass::analysis::count_statements(this->ir));
+  if (!kernel->is_accessor)
+    stat.add("codegen_statements", irpass::analysis::count_statements(this->ir));
 }
 
 FunctionType KernelCodeGen::compile() {

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -2,7 +2,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
-const bool advanced_optimization = true;
+const bool advanced_optimization = false;
 
 CompileConfig::CompileConfig() {
   arch = host_arch();

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -2,7 +2,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
-const bool advanced_optimization = false;
+const bool advanced_optimization = true;
 
 CompileConfig::CompileConfig() {
   arch = host_arch();

--- a/taichi/util/statistics.cpp
+++ b/taichi/util/statistics.cpp
@@ -28,8 +28,6 @@ void Statistics::print(std::string *output) {
 
 void Statistics::clear() {
   counters.clear();
-  counters["codegen_statements"] = 0;
-  counters["codegen_offloaded_tasks"] = 0;
 }
 
 TI_NAMESPACE_END


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related PR = #851

The geometric mean of optimization factor on kernels: 1.1146766978072276

![benchmark20200422_2](https://user-images.githubusercontent.com/22582118/80052881-b0ff7700-84e9-11ea-874b-3bf21c195520.png)

Tests with significant optimization (> 1.5):
```
test_ad_basics__test_frac : 1.558139534883721
test_ad_basics__test_minmax : 1.5142857142857142
test_ad_basics__test_poly : 1.5714285714285714
test_ad_basics__test_unary : 1.5454545454545454
test_ad_if__test_ad_if : 1.8214285714285714
test_ad_if__test_ad_if_mutable : 2.5671641791044775
test_ad_if__test_ad_if_parallel : 2.357142857142857
test_ad_if__test_ad_if_parallel_complex : 1.82
test_ad_offload__test_offload_order : 1.532258064516129
test_atomic__test_atomic_sub_expr_evaled : 1.6470588235294117
test_basics__test_if_global_load : 1.6428571428571428
test_basics__test_while_global_load : 1.8666666666666667
test_continue__test_kernel_continue : 1.605263157894737
test_continue__test_unconditional_continue : 1.5106382978723405
test_fill__test_fill_matrix_scalar : 1.6
test_numpy_io__test_f64 : 1.5454545454545454
test_numpy_io__test_matrix : 1.5454545454545454
test_numpy_io__test_to_numpy_2d : 1.5454545454545454
test_struct_for__test_nested_2d : 1.5454545454545454
```

Tests that become worse in the sense of the number of statements (< 0.9):
```
test_ndrange__test_static_grouped_static : 0.8478260869565217
test_static__test_static_if_error : 0.8983050847457628
test_types__test_overflow[dt0-8] : 0.8888888888888888
test_types__test_type_tensor64[dt0] : 0.8823529411764706
test_types__test_type_tensor64[dt1] : 0.8888888888888888
test_types__test_type_tensor64[dt2] : 0.8888888888888888
test_types__test_type_tensor[dt1] : 0.8888888888888888
test_types__test_type_tensor[dt2] : 0.8888888888888888
test_types__test_type_tensor[dt3] : 0.8823529411764706
test_types__test_type_tensor[dt4] : 0.8888888888888888
test_types__test_type_tensor[dt5] : 0.8888888888888888
test_types__test_type_tensor[dt6] : 0.8888888888888888
```


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)