### PR TITLE
[misc] Fix imread not reading properly when image is not equal in height and width

### DIFF
--- a/python/taichi/misc/image.py
+++ b/python/taichi/misc/image.py
@@ -19,8 +19,9 @@ def imwrite(img, filename):
         comp = img.shape[2]
     else:
         comp = 1
-    img = np.ascontiguousarray(img).ctypes.data
-    ti.core.imwrite(filename, img, resx, resy, comp)
+    img = np.ascontiguousarray(img.swapaxes(0, 1)[::-1, :, :])
+    ptr = img.ctypes.data
+    ti.core.imwrite(filename, ptr, resx, resy, comp)
 
 
 def imread(filename, channels=0):

--- a/python/taichi/misc/image.py
+++ b/python/taichi/misc/image.py
@@ -25,11 +25,12 @@ def imwrite(img, filename):
 
 def imread(filename, channels=0):
     ptr, resx, resy, comp = ti.core.imread(filename, channels)
-    img = np.ndarray(shape=(resx, resy, comp), dtype=np.uint8)
+    img = np.ndarray(shape=(resy, resx, comp), dtype=np.uint8)
     img = np.ascontiguousarray(img)
     # TODO(archibate): Figure out how np.ndarray constructor works and replace:
     ti.core.C_memcpy(img.ctypes.data, ptr, resx * resy * comp)
-    return img
+    # Discussion: https://github.com/taichi-dev/taichi/issues/802
+    return img.swapaxes(0, 1)[:, ::-1, :]
 
 
 def imshow(img, winname='Taichi'):

--- a/taichi/util/image_io.cpp
+++ b/taichi/util/image_io.cpp
@@ -19,10 +19,8 @@ void imwrite(const std::string &filename,
     result =
         stbi_write_png(filename.c_str(), resx, resy, comp, data, comp * resx);
   } else if (suffix == ".bmp") {
-    // TODO: test
     result = stbi_write_bmp(filename.c_str(), resx, resy, comp, data);
   } else if (suffix == ".jpg") {
-    // TODO: test
     result = stbi_write_jpg(filename.c_str(), resx, resy, comp, data, 95);
   } else {
     TI_ERROR("Unknown image file suffix {}", suffix);
@@ -37,7 +35,6 @@ std::vector<size_t> imread(const std::string &filename, int comp) {
   int resx = 0, resy = 0;
   void *data = stbi_load(filename.c_str(), &resx, &resy, &comp, comp);
   if (!data) {
-    // TODO(archibate): throw python exceptions instead of abort...
     TI_ERROR("Cannot read image file [{}]", filename);
   }
 

--- a/tests/python/test_image_io.py
+++ b/tests/python/test_image_io.py
@@ -3,8 +3,9 @@ import numpy as np
 import os
 
 
+@ti.host_arch_only
 def test_image_io():
-    pixel = (np.random.rand(128, 128, 3) * 255).astype(np.uint8)
+    pixel = (np.random.rand(201, 173, 3) * 255).astype(np.uint8)
     for ext in [
             'bmp', 'png'
     ]:  # jpg is also supported but hard to test here since it's lossy


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #802

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
