### PR TITLE
[opt] Eliminate useless local stores and atomics

### DIFF
--- a/taichi/analysis/gather_used_atomics.cpp
+++ b/taichi/analysis/gather_used_atomics.cpp
@@ -3,7 +3,6 @@
 
 TLANG_NAMESPACE_BEGIN
 
-
 class UsedAtomicsSearcher : public BasicStmtVisitor {
  private:
   std::unordered_set<AtomicOpStmt *> used_atomics;
@@ -36,7 +35,6 @@ class UsedAtomicsSearcher : public BasicStmtVisitor {
     return searcher.used_atomics;
   }
 };
-
 
 namespace irpass::analysis {
 std::unordered_set<AtomicOpStmt *> gather_used_atomics(IRNode *root) {

--- a/taichi/analysis/gather_used_atomics.cpp
+++ b/taichi/analysis/gather_used_atomics.cpp
@@ -1,0 +1,47 @@
+#include "taichi/ir/ir.h"
+#include <unordered_set>
+
+TLANG_NAMESPACE_BEGIN
+
+
+class UsedAtomicsSearcher : public BasicStmtVisitor {
+ private:
+  std::unordered_set<AtomicOpStmt *> used_atomics;
+
+ public:
+  UsedAtomicsSearcher() {
+    allow_undefined_visitor = true;
+    invoke_default_visitor = true;
+  }
+
+  void search_operands(Stmt *stmt) {
+    for (auto &op : stmt->get_operands()) {
+      if (op != nullptr && op->is<AtomicOpStmt>()) {
+        used_atomics.insert(op->as<AtomicOpStmt>());
+      }
+    }
+  }
+
+  void preprocess_container_stmt(Stmt *stmt) override {
+    search_operands(stmt);
+  }
+
+  void visit(Stmt *stmt) override {
+    search_operands(stmt);
+  }
+
+  static std::unordered_set<AtomicOpStmt *> run(IRNode *root) {
+    UsedAtomicsSearcher searcher;
+    root->accept(&searcher);
+    return searcher.used_atomics;
+  }
+};
+
+
+namespace irpass::analysis {
+std::unordered_set<AtomicOpStmt *> gather_used_atomics(IRNode *root) {
+  return UsedAtomicsSearcher::run(root);
+}
+}  // namespace irpass::analysis
+
+TLANG_NAMESPACE_END

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -128,6 +128,7 @@ std::unordered_set<Stmt *> detect_loops_with_continue(IRNode *root);
 std::unordered_set<SNode *> gather_deactivations(IRNode *root);
 std::vector<Stmt *> gather_statements(IRNode *root,
                                       const std::function<bool(Stmt *)> &test);
+std::unordered_set<AtomicOpStmt *> gather_used_atomics(IRNode *root);
 bool has_load_or_atomic(IRNode *root, Stmt *var);
 bool has_store_or_atomic(IRNode *root, const std::vector<Stmt *> &vars);
 std::pair<bool, Stmt *> last_store_or_atomic(IRNode *root, Stmt *var);

--- a/taichi/transforms/optimize_local_variable.cpp
+++ b/taichi/transforms/optimize_local_variable.cpp
@@ -80,6 +80,11 @@ class AllocaOptimize : public IRVisitor {
   void visit(LocalStoreStmt *stmt) override {
     if (stmt->ptr != alloca_stmt)
       return;
+    if (last_store && !last_store_loaded) {
+      // The last store is never loaded.
+      last_store->parent->erase(last_store);
+      throw IRModified();
+    }
     stored = true;
     last_store = stmt;
     last_store_valid = true;

--- a/taichi/transforms/optimize_local_variable.cpp
+++ b/taichi/transforms/optimize_local_variable.cpp
@@ -148,7 +148,7 @@ class AllocaOptimize : public IRVisitor {
     }
   }
 
-  AllocaOptimize new_instance_for_if_stmt() const {
+  AllocaOptimize new_instance_if_stmt() const {
     AllocaOptimize new_instance = *this;
     // Avoid eliminating the last store and the last AtomicOpStmt.
     if (last_store)
@@ -166,8 +166,8 @@ class AllocaOptimize : public IRVisitor {
     TI_ASSERT(if_stmt->false_mask == nullptr);
 
     // Create two new instances for IfStmt
-    AllocaOptimize true_branch = new_instance_for_if_stmt();
-    AllocaOptimize false_branch = new_instance_for_if_stmt();
+    AllocaOptimize true_branch = new_instance_if_stmt();
+    AllocaOptimize false_branch = new_instance_if_stmt();
     if (if_stmt->true_statements) {
       if_stmt->true_statements->accept(&true_branch);
     }

--- a/taichi/transforms/optimize_local_variable.cpp
+++ b/taichi/transforms/optimize_local_variable.cpp
@@ -75,11 +75,7 @@ class AllocaOptimize : public IRVisitor {
   void visit(AtomicOpStmt *stmt) override {
     if (stmt->dest != alloca_stmt)
       return;
-    if (last_store && !last_store_loaded) {
-      // The last store is never loaded.
-      last_store->parent->erase(last_store);
-      throw IRModified();
-    }
+    // This statement is loading the last store, so we can't eliminate it.
     stored = true;
     loaded = true;
     last_store = nullptr;

--- a/taichi/transforms/optimize_local_variable.cpp
+++ b/taichi/transforms/optimize_local_variable.cpp
@@ -52,7 +52,7 @@ class AllocaOptimize : public IRVisitor {
   bool loaded_before_first_store_in_current_block;
 
   explicit AllocaOptimize(AllocaStmt *alloca_stmt,
-      std::unordered_set<AtomicOpStmt *> *used_atomics)
+                          std::unordered_set<AtomicOpStmt *> *used_atomics)
       : alloca_stmt(alloca_stmt),
         used_atomics(used_atomics),
         stored(false),
@@ -206,7 +206,8 @@ class AllocaOptimize : public IRVisitor {
       if (last_store == true_branch.last_store) {
         TI_ASSERT(!true_branch.stored_in_current_block);
         TI_ASSERT(!false_branch.stored_in_current_block);
-        last_store_loaded = last_store_loaded ||
+        last_store_loaded =
+            last_store_loaded ||
             true_branch.loaded_before_first_store_in_current_block ||
             false_branch.loaded_before_first_store_in_current_block;
       } else {
@@ -222,12 +223,14 @@ class AllocaOptimize : public IRVisitor {
         // The last store didn't change.
         TI_ASSERT(!true_branch.stored_in_current_block);
         TI_ASSERT(!false_branch.stored_in_current_block);
-        last_store_loaded = last_store_loaded ||
+        last_store_loaded =
+            last_store_loaded ||
             true_branch.loaded_before_first_store_in_current_block ||
             false_branch.loaded_before_first_store_in_current_block;
       } else {
         // The last store changed.
-        bool current_eliminable = last_store && !last_store_loaded &&
+        bool current_eliminable =
+            last_store && !last_store_loaded &&
             !true_branch.loaded_before_first_store_in_current_block &&
             !false_branch.loaded_before_first_store_in_current_block;
         bool true_eliminable = true_branch.last_store != last_store &&
@@ -257,12 +260,14 @@ class AllocaOptimize : public IRVisitor {
     if (true_branch.last_atomic == last_atomic &&
         false_branch.last_atomic == last_atomic) {
       // The last AtomicOpStmt didn't change.
-      last_atomic_eliminable = last_atomic_eliminable &&
+      last_atomic_eliminable =
+          last_atomic_eliminable &&
           !true_branch.loaded_before_first_store_in_current_block &&
           !false_branch.loaded_before_first_store_in_current_block;
     } else {
       // The last AtomicOpStmt changed.
-      bool current_eliminable = last_atomic && last_atomic_eliminable &&
+      bool current_eliminable =
+          last_atomic && last_atomic_eliminable &&
           !true_branch.loaded_before_first_store_in_current_block &&
           !false_branch.loaded_before_first_store_in_current_block;
       bool true_eliminable = true_branch.last_atomic != last_atomic &&
@@ -279,7 +284,7 @@ class AllocaOptimize : public IRVisitor {
         last_atomic_eliminable = true;
       } else if (current_eliminable) {
         TI_ASSERT(!true_branch.stored_in_current_block ||
-            !false_branch.stored_in_current_block);
+                  !false_branch.stored_in_current_block);
         last_atomic_eliminable = true;
       } else {
         // Neither branch provides a eliminable AtomicOpStmt.

--- a/tests/python/test_optimization.py
+++ b/tests/python/test_optimization.py
@@ -21,3 +21,29 @@ def test_advanced_store_forwarding_nested_loops():
     val[None] = 10
     func()
     assert val[None] == 10
+
+
+@ti.all_archs
+def test_advanced_unused_store_elimination_if():
+    val = ti.var(ti.i32)
+    ti.root.place(val)
+
+    @ti.kernel
+    def func():
+        a = 1
+        if val[None]:
+            a = 2
+            if val[None]:
+                a = 3
+            else:
+                a = 4
+            val[None] = a
+        else:
+            val[None] = a
+
+
+    val[None] = 0
+    func()
+    assert val[None] == 1
+    func()
+    assert val[None] == 3


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #656 

`gather_used_atomics` can be utilized in #857.

Benchmark:
**before**:
![benchmark20200423](https://user-images.githubusercontent.com/22582118/80154301-4ef84d80-858d-11ea-80d9-17a427c564d0.png)

**after: nothing changed.**

**after adding a test**...:
![benchmark20200423_3](https://user-images.githubusercontent.com/22582118/80165274-254d1f80-85a9-11ea-85d3-09b23f3a047f.png)


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
