### PR TITLE
[doc] Tell Arch users to build clang-8 from scratch

### DIFF
--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -22,9 +22,9 @@ Installing Depedencies
     python3 -m pip install --user setuptools astpretty astor pytest opencv-python pybind11
     python3 -m pip install --user Pillow numpy scipy GitPython yapf colorama psutil autograd
 
-* (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8``.
+* (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8``. (or ``clang-8`` should work as well).
 
-* (If on Arch Linux) Please build clang 8.0.1 from scratch:
+* (If on other Linux distributions) Please build clang 8.0.1 from scratch:
 
   .. code-block:: bash
 

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -22,7 +22,7 @@ Installing Depedencies
     python3 -m pip install --user setuptools astpretty astor pytest opencv-python pybind11
     python3 -m pip install --user Pillow numpy scipy GitPython yapf colorama psutil autograd
 
-* (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8``. (or ``clang-8`` should work as well).
+* (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8``. (``clang-7`` should work as well).
 
 * (If on other Linux distributions) Please build clang 8.0.1 from scratch:
 

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -22,18 +22,20 @@ Installing Depedencies
     python3 -m pip install --user setuptools astpretty astor pytest opencv-python pybind11
     python3 -m pip install --user Pillow numpy scipy GitPython yapf colorama psutil autograd
 
-* (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8`` (or ``clang-7`` should work as well).
+* (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8``.
 
-* (If on Arch Linux) Execute
+* (If on Arch Linux) Please build clang 8.0.1 from scratch:
 
   .. code-block:: bash
 
-    wget https://archive.archlinux.org/packages/c/clang/clang-8.0.1-1-x86_64.pkg.tar.xz
-    sudo pacman -Qp clang-8.0.1-1-x86_64.pkg.tar.xz
-
-  .. warning::
-    If you have installed ``clang`` (9.0.1) before, this command will overrides the existing ``clang``.
-    If you don't want to break up depedencies, please build from scratch and install it in ``/opt``. Then add ``/opt/clang/bin`` to your ``$PATH``.
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/cfe-8.0.1.src.tar.xz
+    tar xvJf cfe-8.0.1.src.tar.xz
+    cd cfe-8.0.1.src
+    mkdir build
+    cd build
+    cmake ..
+    make -j 8
+    sudo make install
 
 
 - Make sure you have LLVM 8.0.1 built from scratch. To do so:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ The Taichi Programming Language
 
 
 .. toctree::
-   :caption: Contribution
+   :caption: Contributing
    :maxdepth: 1
 
    dev_install


### PR DESCRIPTION
So that they install `clang-8` in `/usr/local/bin` instead of overwriting `/usr/bin` which breaks deps like `kdesktop`.

<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #866

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
