### PR TITLE
[misc] Add an option TI_GENERATE_COMMIT_HASH to toggle whether generate commit hash per-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ SET(TI_VERSION_MAJOR 0)
 SET(TI_VERSION_MINOR 5)
 SET(TI_VERSION_PATCH 14)
 
+option(TI_GENERATE_COMMIT_HASH "Generate commit hash for each build" ON)
+
 execute_process(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMAND git rev-parse --short HEAD
@@ -65,11 +67,16 @@ endif()
 
 message("python=${PYTHON_EXECUTABLE}")
 
-add_custom_target(
+if (TI_GENERATE_COMMIT_HASH)
+  add_custom_target(
     generate_commit_hash
     COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_LIST_DIR}/misc/generate_commit_hash.py"
-)
-add_dependencies(${CORE_LIBRARY_NAME} generate_commit_hash)
+    )
+  add_dependencies(${CORE_LIBRARY_NAME} generate_commit_hash)
+else()
+  FILE(WRITE ${CMAKE_CURRENT_LIST_DIR}/taichi/common/commit_hash.h
+    "#define TI_COMMIT_HASH \"${TI_COMMIT_HASH}\"\n")
+endif()
 
 FILE(WRITE ${CMAKE_CURRENT_LIST_DIR}/taichi/common/version.h
         "#pragma once\n"

--- a/misc/generate_commit_hash.py
+++ b/misc/generate_commit_hash.py
@@ -6,12 +6,5 @@ commit_hash = str(repo.head.commit)
 print(f"Building commit {commit_hash}")
 
 output_fn = os.path.join(repo_dir, 'taichi/common/commit_hash.h')
-try:
-    with open(output_fn, 'r') as f:
-        old_hash = f.read().split('"')[1]  # parse last commit hash
-        if commit_hash == old_hash:
-            exit()  # not changed
-except:
-    pass
 with open(output_fn, 'w') as f:
     f.write(f"#define TI_COMMIT_HASH \"{commit_hash}\"\n")

--- a/misc/generate_commit_hash.py
+++ b/misc/generate_commit_hash.py
@@ -4,7 +4,6 @@ repo_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../')
 repo = Repo(repo_dir)
 commit_hash = str(repo.head.commit)
 print(f"Building commit {commit_hash}")
-exit()
 
 output_fn = os.path.join(repo_dir, 'taichi/common/commit_hash.h')
 try:

--- a/misc/generate_commit_hash.py
+++ b/misc/generate_commit_hash.py
@@ -4,7 +4,15 @@ repo_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../')
 repo = Repo(repo_dir)
 commit_hash = str(repo.head.commit)
 print(f"Building commit {commit_hash}")
+exit()
 
 output_fn = os.path.join(repo_dir, 'taichi/common/commit_hash.h')
+try:
+    with open(output_fn, 'r') as f:
+        old_hash = f.read().split('"')[1]  # parse last commit hash
+        if commit_hash == old_hash:
+            exit()  # not changed
+except:
+    pass
 with open(output_fn, 'w') as f:
     f.write(f"#define TI_COMMIT_HASH \"{commit_hash}\"\n")


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #856

`TI_GENERATE_COMMIT_HASH=OFF`: generate per-`make`.
`TI_GENERATE_COMMIT_HASH=ON`: generate per-`cmake`.

It's hard to let `make` not re-link, so I have to use this way..

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
