### PR TITLE
[misc] Avoid mutable defaults in `PyTaichi`

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -132,7 +132,7 @@ def chain_compare(comparators, ops):
 
 
 class PyTaichi:
-    def __init__(self, kernels=[]):
+    def __init__(self, kernels=None):
         self.materialized = False
         self.prog = None
         self.layout_functions = []
@@ -146,7 +146,7 @@ class PyTaichi:
         self.default_ip = i32
         self.target_tape = None
         self.inside_complex_kernel = False
-        self.kernels = kernels
+        self.kernels = kernels or []
         Expr.materialize_layout_callback = self.materialize
 
     def get_num_compiled_functions(self):


### PR DESCRIPTION
By looking at `reset()`, it seems that using a mutable default is not intended.
But I might be wrong since I'm not yet a taichi user.

See: https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html about the antipattern.