### PR TITLE
[opt] Eliminate assertions with non-zero const conditions

### DIFF
--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -74,6 +74,17 @@ class AlgSimp : public BasicStmtVisitor {
     }
   }
 
+  void visit(AssertStmt *stmt) override {
+    auto cond = stmt->cond->cast<ConstStmt>();
+    if (!cond)
+      return;
+    if (!alg_is_zero(cond)) {
+      // this statement has no effect
+      stmt->parent->erase(stmt);
+      throw IRModified();
+    }
+  }
+
   void visit(WhileControlStmt *stmt) override {
     auto cond = stmt->cond->cast<ConstStmt>();
     if (!cond)


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Thanks for @archibate 's idea!
Related PR = https://github.com/taichi-dev/taichi/pull/839#issuecomment-619482117
**Before**:
![benchmark20200426_41fcc24](https://user-images.githubusercontent.com/22582118/80299578-84569400-8763-11ea-912f-820ee3a93ce1.png)
**After**:
![benchmark20200426_2](https://user-images.githubusercontent.com/22582118/80299576-80c30d00-8763-11ea-94aa-b507b36ef9ce.png)

WDYT if we optimize a kernel to 0 statements... I set it to 1 statement to avoid division by 0 here. But it's causing too much "improvement" to the geometric mean: nearly 1.02x.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
