### PR TITLE
[misc] Fix `ti.cfg.gdb_trigger` not found

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -142,7 +142,13 @@ def init(arch=None,
     environ_config("print_benchmark_stat")
     environ_config("device_memory_fraction", float)
     environ_config("device_memory_GB", float)
-    environ_config("gdb_trigger")
+
+    # Q: Why not environ_config("gdb_trigger")?
+    # A: We don't have ti.cfg.gdb_trigger yet.
+    # Discussion: https://github.com/taichi-dev/taichi/pull/879
+    gdb_trigger = os.environ.get('TI_GDB_TRIGGER', '')
+    if len(gdb_trigger):
+        ti.set_gdb_trigger(bool(int(gdb_trigger)))
     
     # Q: Why not environ_config("arch", ti.core.arch_from_name)?
     # A: We need adaptive_arch_select for all.


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related PR id = #769

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

I made an error in #769: there is no `ti.cfg.gdb_trigger` at all!
Now the problem is where should `gdb_trigger` be, `CompileConfig` or `CoreState`?
The first seems only accessible only by compiler parts. So `get_current_program().config` stand for only compiler configuations so it's not found anywhere in `logger.cpp`?