### PR TITLE
[Bug] Fix CPU SNode reader in debug mode

### DIFF
--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -69,7 +69,7 @@ void Kernel::operator()() {
     }
     compiled(program.get_context());
     program.sync = (program.sync && arch_is_cpu(arch));
-    if (program.config.debug && arch_is_cpu(arch)) {
+    if (program.config.debug && arch_is_cpu(arch) && !is_accessor) {
       program.check_runtime_error();
     }
   } else {

--- a/tests/python/test_debug.py
+++ b/tests/python/test_debug.py
@@ -1,9 +1,10 @@
 import taichi as ti
 
+
 def test_cpu_debug_snode_reader():
     ti.init(arch=ti.x64, debug=True)
-    
+
     x = ti.var(ti.f32, shape=())
     x[None] = 10.0
-    
-    assert x[None]==10.0
+
+    assert x[None] == 10.0

--- a/tests/python/test_debug.py
+++ b/tests/python/test_debug.py
@@ -1,0 +1,9 @@
+import taichi as ti
+
+def test_cpu_debug_snode_reader():
+    ti.init(arch=ti.x64, debug=True)
+    
+    x = ti.var(ti.f32, shape=())
+    x[None] = 10.0
+    
+    assert x[None]==10.0


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

The reason is the 8-byte result buffer for the reader is overwritten by the error code of the runtime error checker. This is a temporary fix, at the cost that the access out-of-bounds will not be detected for SNode reader/writers... We should revisit this later for a more systematic solution. Maybe we need multiple buffers...

(Feel free to merge if you approve and CI passes)

Related issue = #886 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
