### PR TITLE
[Example] Add Multiple Importance Sampling to the cornell box scene

### DIFF
--- a/examples/cornell_box.py
+++ b/examples/cornell_box.py
@@ -1,5 +1,6 @@
 import taichi as ti
 import time
+import sys
 import math
 import numpy as np
 from renderer_utils import ray_aabb_intersection, intersect_sphere, ray_plane_intersect, reflect, refract
@@ -7,35 +8,256 @@ from renderer_utils import ray_aabb_intersection, intersect_sphere, ray_plane_in
 ti.init(arch=ti.gpu)
 res = (800, 800)
 color_buffer = ti.Vector(3, dt=ti.f32, shape=res)
+count_var = ti.var(ti.i32, shape=(1, ))
+
 max_ray_depth = 10
 eps = 1e-4
 inf = 1e10
-fov = 1.0
+fov = 0.8
 
-camera_pos = ti.Vector([0.0, 0.6, 2.0])
-lihgt_min_pos = ti.Vector([-0.2, 1.99, 0.3])
-light_max_pos = ti.Vector([0.2, 1.99, 0.4])
-light_color = ti.Vector([0.9, 0.85, 0.7])
-mat_lambertian = 0
-mat_metal = 1
-mat_glass = 2
-refr_idx = 2.4  # diamond!
+camera_pos = ti.Vector([0.0, 0.6, 3.0])
+
+mat_none = 0
+mat_lambertian = 1
+mat_specular = 2
+mat_glass = 3
+mat_light = 4
+
+light_y_pos = 2.0 - eps
+light_x_min_pos = -0.25
+light_x_range = 0.5
+light_z_min_pos = 1.0
+light_z_range = 0.12
+light_area = light_x_range * light_z_range
+light_min_pos = ti.Vector([light_x_min_pos, light_y_pos, light_z_min_pos])
+light_max_pos = ti.Vector([
+    light_x_min_pos + light_x_range, light_y_pos,
+    light_z_min_pos + light_z_range
+])
+light_color = ti.Vector(list(np.array([0.9, 0.85, 0.7])))
+light_normal = ti.Vector([0.0, -1.0, 0.0])
+
+# No absorbtion, integrates over a unit hemisphere
+lambertian_brdf = 1.0 / math.pi
+# diamond!
+refr_idx = 2.4
 
 # right near sphere
-sp1_center = ti.Vector([0.35, 0.22, 1.14])
-sp1_radius = 0.21
+sp1_center = ti.Vector([0.4, 0.225, 1.75])
+sp1_radius = 0.22
 # left far sphere
-sp2_center = ti.Vector([-0.28, 0.6, 0.6])
-sp2_radius = 0.42
+sp2_center = ti.Vector([-0.28, 0.55, 0.8])
+sp2_radius = 0.32
 
 
 @ti.func
-def intersect_light(pos, d):
-    intersect, tmin, _ = ray_aabb_intersection(lihgt_min_pos, light_max_pos,
-                                               pos, d)
-    if tmin < 0 or intersect == 0:
-        tmin = inf
-    return tmin
+def intersect_light(pos, d, tmax):
+    hit, t, _ = ray_aabb_intersection(light_min_pos, light_max_pos, pos, d)
+    if hit and 0 < t < tmax:
+        hit = 1
+    else:
+        hit = 0
+        t = inf
+    return hit, t
+
+
+@ti.func
+def intersect_scene(pos, ray_dir):
+    closest, normal = inf, ti.Vector.zero(ti.f32, 3)
+    c, mat = ti.Vector.zero(ti.f32, 3), mat_none
+
+    # right near sphere
+    cur_dist, hit_pos = intersect_sphere(pos, ray_dir, sp1_center, sp1_radius)
+    if 0 < cur_dist < closest:
+        closest = cur_dist
+        normal = ti.normalized(hit_pos - sp1_center)
+        c, mat = ti.Vector([1.0, 1.0, 1.0]), mat_glass
+    # left far sphere
+    cur_dist, hit_pos = intersect_sphere(pos, ray_dir, sp2_center, sp2_radius)
+    if 0 < cur_dist < closest:
+        closest = cur_dist
+        normal = ti.normalized(hit_pos - sp2_center)
+        c, mat = ti.Vector([0.8, 0.5, 0.4]), mat_specular
+    # left
+    pnorm = ti.Vector([1.0, 0.0, 0.0])
+    cur_dist, _ = ray_plane_intersect(pos, ray_dir, ti.Vector([-1.1, 0.0,
+                                                               0.0]), pnorm)
+    if 0 < cur_dist < closest:
+        closest = cur_dist
+        normal = pnorm
+        c, mat = ti.Vector([0.65, 0.05, 0.05]), mat_lambertian
+    # right
+    pnorm = ti.Vector([-1.0, 0.0, 0.0])
+    cur_dist, _ = ray_plane_intersect(pos, ray_dir, ti.Vector([1.1, 0.0, 0.0]),
+                                      pnorm)
+    if 0 < cur_dist < closest:
+        closest = cur_dist
+        normal = pnorm
+        c, mat = ti.Vector([0.12, 0.45, 0.15]), mat_lambertian
+    # bottom
+    gray = ti.Vector([0.93, 0.93, 0.93])
+    pnorm = ti.Vector([0.0, 1.0, 0.0])
+    cur_dist, _ = ray_plane_intersect(pos, ray_dir, ti.Vector([0.0, 0.0, 0.0]),
+                                      pnorm)
+    if 0 < cur_dist < closest:
+        closest = cur_dist
+        normal = pnorm
+        c, mat = gray, mat_lambertian
+    # top
+    pnorm = ti.Vector([0.0, -1.0, 0.0])
+    cur_dist, _ = ray_plane_intersect(pos, ray_dir, ti.Vector([0.0, 2.0, 0.0]),
+                                      pnorm)
+    if 0 < cur_dist < closest:
+        closest = cur_dist
+        normal = pnorm
+        c, mat = gray, mat_lambertian
+    # far
+    pnorm = ti.Vector([0.0, 0.0, 1.0])
+    cur_dist, _ = ray_plane_intersect(pos, ray_dir, ti.Vector([0.0, 0.0, 0.0]),
+                                      pnorm)
+    if 0 < cur_dist < closest:
+        closest = cur_dist
+        normal = pnorm
+        c, mat = gray, mat_lambertian
+    # light
+    hit_l, cur_dist = intersect_light(pos, ray_dir, closest)
+    if hit_l and 0 < cur_dist < closest:
+        # technically speaking, no need to check the second term
+        closest = cur_dist
+        normal = light_normal
+        c, mat = light_color, mat_light
+
+    return closest, normal, c, mat
+
+
+@ti.func
+def visible_to_light(pos, ray_dir):
+    a, b, c, mat = intersect_scene(pos, ray_dir)
+    return mat == mat_light
+
+
+@ti.func
+def dot_or_zero(n, l):
+    return max(0.0, n.dot(l))
+
+
+@ti.func
+def mis_power_heuristic(pf, pg):
+    # Assume 1 sample for each distribution
+    f = pf**2
+    g = pg**2
+    return f / (f + g)
+
+
+@ti.func
+def compute_area_light_pdf(pos, ray_dir):
+    hit_l, t = intersect_light(pos, ray_dir, inf)
+    pdf = 0.0
+    if hit_l:
+        l_cos = light_normal.dot(-ray_dir)
+        if l_cos > eps:
+            tmp = ray_dir * t
+            dist_sqr = tmp.dot(tmp)
+            pdf = dist_sqr / (light_area * l_cos)
+    return pdf
+
+
+@ti.func
+def compute_brdf_pdf(normal, sample_dir):
+    return dot_or_zero(normal, sample_dir) / math.pi
+
+
+@ti.func
+def sample_area_light(hit_pos, pos_normal):
+    # sampling inside the light area
+    x = ti.random() * light_x_range + light_x_min_pos
+    z = ti.random() * light_z_range + light_z_min_pos
+    on_light_pos = ti.Vector([x, light_y_pos, z])
+    return ti.normalized(on_light_pos - hit_pos)
+
+
+@ti.func
+def sample_brdf(normal):
+    # cosine hemisphere sampling
+    # first, uniformly sample on a disk (r, theta)
+    r, theta = 0.0, 0.0
+    sx = ti.random() * 2.0 - 1.0
+    sy = ti.random() * 2.0 - 1.0
+    if sx >= -sy:
+        if sx > sy:
+            # first region
+            r = sx
+            div = abs(sy / r)
+            if sy > 0.0:
+                theta = div
+            else:
+                theta = 7.0 + div
+        else:
+            # second region
+            r = sy
+            div = abs(sx / r)
+            if sx > 0.0:
+                theta = 1.0 + sx / r
+            else:
+                theta = 2.0 + sx / r
+    else:
+        if sx <= sy:
+            # third region
+            r = -sx
+            div = abs(sy / r)
+            if sy > 0.0:
+                theta = 3.0 + div
+            else:
+                theta = 4.0 + div
+        else:
+            # fourth region
+            r = -sy
+            div = abs(sx / r)
+            if sx < 0.0:
+                theta = 5.0 + div
+            else:
+                theta = 6.0 + div
+    # Malley's method
+    u = ti.Vector([1.0, 0.0, 0.0])
+    if abs(normal[1]) < 1 - eps:
+        u = ti.cross(normal, ti.Vector([0.0, 1.0, 0.0]))
+    v = ti.cross(normal, u)
+
+    theta = theta * math.pi * 0.25
+    costt, sintt = ti.cos(theta), ti.sin(theta)
+    xy = (u * costt + v * sintt) * r
+    zlen = ti.sqrt(max(0.0, 1.0 - xy.dot(xy)))
+    return xy + zlen * normal
+
+
+@ti.func
+def sample_direct_light(hit_pos, hit_normal, hit_color):
+    direct_li = ti.Vector([0.0, 0.0, 0.0])
+    fl = lambertian_brdf * hit_color * light_color
+    light_pdf, brdf_pdf = 0.0, 0.0
+    # sample area light
+    to_light_dir = sample_area_light(hit_pos, hit_normal)
+    if to_light_dir.dot(hit_normal) > 0:
+        light_pdf = compute_area_light_pdf(hit_pos, to_light_dir)
+        brdf_pdf = compute_brdf_pdf(hit_normal, to_light_dir)
+        if light_pdf > 0 and brdf_pdf > 0:
+            l_visible = visible_to_light(hit_pos, to_light_dir)
+            if l_visible:
+                w = mis_power_heuristic(light_pdf, brdf_pdf)
+                nl = dot_or_zero(to_light_dir, hit_normal)
+                direct_li += fl * w * nl / light_pdf
+    # sample brdf
+    brdf_dir = sample_brdf(hit_normal)
+    brdf_pdf = compute_brdf_pdf(hit_normal, brdf_dir)
+    if brdf_pdf > 0:
+        light_pdf = compute_area_light_pdf(hit_pos, brdf_dir)
+        if light_pdf > 0:
+            l_visible = visible_to_light(hit_pos, brdf_dir)
+            if l_visible:
+                w = mis_power_heuristic(brdf_pdf, light_pdf)
+                nl = dot_or_zero(brdf_dir, hit_normal)
+                direct_li += fl * w * nl / brdf_pdf
+    return direct_li
 
 
 @ti.func
@@ -46,25 +268,20 @@ def schlick(cos, eta):
 
 
 @ti.func
-def out_dir(indir, n, mat):
-    u = ti.Vector([1.0, 0.0, 0.0])
+def sample_ray_dir(indir, normal, hit_pos, mat):
+    u = ti.Vector([0.0, 0.0, 0.0])
+    pdf = 1.0
     if mat == mat_lambertian:
-        if abs(n[1]) < 1 - eps:
-            u = ti.normalized(ti.cross(n, ti.Vector([0.0, 1.0, 0.0])))
-        v = ti.cross(n, u)
-        phi = 2 * math.pi * ti.random()
-        ay = ti.sqrt(ti.random())
-        ax = ti.sqrt(1 - ay**2)
-        u = ax * (ti.cos(phi) * u + ti.sin(phi) * v) + ay * n
-    elif mat == mat_metal:
-        u = reflect(indir, n)
-    else:
-        # glass
-        cos = ti.dot(indir, n)
+        u = sample_brdf(normal)
+        pdf = max(eps, compute_brdf_pdf(normal, u))
+    elif mat == mat_specular:
+        u = reflect(indir, normal)
+    elif mat == mat_glass:
+        cos = indir.dot(normal)
         ni_over_nt = refr_idx
-        outn = n
+        outn = normal
         if cos > 0.0:
-            outn = -n
+            outn = -normal
             cos = refr_idx * cos
         else:
             ni_over_nt = 1.0 / refr_idx
@@ -74,71 +291,14 @@ def out_dir(indir, n, mat):
         if has_refr:
             refl_prob = schlick(cos, refr_idx)
         if ti.random() < refl_prob:
-            u = reflect(indir, n)
+            u = reflect(indir, normal)
         else:
             u = refr_dir
-    return ti.normalized(u)
+    return ti.normalized(u), pdf
 
 
-@ti.func
-def next_hit(pos, d):
-    closest, normal = inf, ti.Vector.zero(ti.f32, 3)
-    c, mat = ti.Vector.zero(ti.f32, 3), mat_lambertian
-
-    # right near sphere
-    cur_dist, hit_pos = intersect_sphere(pos, d, sp1_center, sp1_radius)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = ti.normalized(hit_pos - sp1_center)
-        c, mat = ti.Vector([1.0, 1.0, 1.0]), mat_glass
-    # left far sphere
-    cur_dist, hit_pos = intersect_sphere(pos, d, sp2_center, sp2_radius)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = ti.normalized(hit_pos - sp2_center)
-        c, mat = ti.Vector([0.8, 0.5, 0.4]), mat_metal
-    # left
-    pnorm = ti.Vector([1.0, 0.0, 0.0])
-    cur_dist, _ = ray_plane_intersect(pos, d, ti.Vector([-1.0, 0.0, 0.0]),
-                                      pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([1.0, 0.0, 0.0]), mat_lambertian
-    # right
-    pnorm = ti.Vector([-1.0, 0.0, 0.0])
-    cur_dist, _ = ray_plane_intersect(pos, d, ti.Vector([1.0, 0.0, 0.0]),
-                                      pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([0.0, 1.0, 0.0]), mat_lambertian
-    # bottom
-    pnorm = ti.Vector([0.0, 1.0, 0.0])
-    cur_dist, _ = ray_plane_intersect(pos, d, ti.Vector([0.0, 0.0, 0.0]),
-                                      pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([1.0, 1.0, 1.0]), mat_lambertian
-    # top
-    pnorm = ti.Vector([0.0, -1.0, 0.0])
-    cur_dist, _ = ray_plane_intersect(pos, d, ti.Vector([0.0, 2.0, 0.0]),
-                                      pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([1.0, 1.0, 1.0]), mat_lambertian
-    # far
-    pnorm = ti.Vector([0.0, 0.0, 1.0])
-    cur_dist, _ = ray_plane_intersect(pos, d, ti.Vector([0.0, 0.0, 0.0]),
-                                      pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([1.0, 1.0, 1.0]), mat_lambertian
-
-    return closest, normal, c, mat
+stratify_res = 5
+inv_stratify = 1.0 / 5.0
 
 
 @ti.kernel
@@ -146,46 +306,59 @@ def render():
     for u, v in color_buffer:
         aspect_ratio = res[0] / res[1]
         pos = camera_pos
-        d = ti.Vector([
-            (2 * fov * (u + ti.random()) / res[1] - fov * aspect_ratio - 1e-5),
-            (2 * fov * (v + ti.random()) / res[1] - fov - 1e-5),
+        cur_iter = count_var[0]
+        str_x, str_y = (cur_iter / stratify_res), (cur_iter % stratify_res)
+        ray_dir = ti.Vector([
+            (2 * fov * (u + (str_x + ti.random()) * inv_stratify) / res[1] -
+             fov * aspect_ratio - 1e-5),
+            (2 * fov * (v + (str_y + ti.random()) * inv_stratify) / res[1] -
+             fov - 1e-5),
             -1.0,
         ])
-        d = ti.normalized(d)
+        ray_dir = ti.normalized(ray_dir)
 
+        acc_color = ti.Vector([0.0, 0.0, 0.0])
         throughput = ti.Vector([1.0, 1.0, 1.0])
 
         depth = 0
-        hit_light = 0.0
-
         while depth < max_ray_depth:
-            closest, normal, c, mat = next_hit(pos, d)
+            closest, hit_normal, hit_color, mat = intersect_scene(pos, ray_dir)
+            if abs(closest - inf) < eps:
+                break
+
+            hit_pos = pos + closest * ray_dir
+            hit_light = (mat == mat_light)
+            if hit_light:
+                acc_color += throughput * light_color
+                break
+            elif mat == mat_lambertian:
+                acc_color += throughput * sample_direct_light(
+                    hit_pos, hit_normal, hit_color)
+
             depth += 1
-            dist_to_light = intersect_light(pos, d)
-            if dist_to_light < closest:
-                hit_light = 1.0
-                depth = max_ray_depth
-                throughput *= light_color
+            ray_dir, pdf = sample_ray_dir(ray_dir, hit_normal, hit_pos, mat)
+            pos = hit_pos + 1e-4 * ray_dir
+            if mat == mat_lambertian:
+                throughput *= lambertian_brdf * hit_color * dot_or_zero(
+                    hit_normal, ray_dir) / pdf
             else:
-                if normal.norm_sqr() != 0:
-                    hit_pos = pos + closest * d
-                    d = out_dir(d, normal, mat)
-                    pos = hit_pos + 1e-4 * d
-                    throughput *= c
-                else:
-                    depth = max_ray_depth
-        color_buffer[u, v] += throughput * hit_light
+                throughput *= hit_color
+        color_buffer[u, v] += acc_color
+    count_var[0] = (count_var[0] + 1) % (stratify_res * stratify_res)
 
 
 gui = ti.GUI('Cornell Box', res)
 last_t = 0
-for i in range(50000):
+for i in range(1000001):
     render()
     interval = 10
     if i % interval == 0 and i > 0:
-        print("{:.2f} samples/s".format(interval / (time.time() - last_t)))
         last_t = time.time()
         img = color_buffer.to_numpy(as_vector=True) * (1 / (i + 1))
-        img = img / img.mean() * 0.24
-        gui.set_image(np.sqrt(img))
+        img = np.sqrt(img / img.mean() * 0.24)
+        print("{:.2f} samples/s ({} iters, var={})".format(
+            interval / (time.time() - last_t), i, np.var(img)))
+        gui.set_image(img)
         gui.show()
+
+input("Press any key to quit")

--- a/examples/cornell_box.py
+++ b/examples/cornell_box.py
@@ -1,6 +1,5 @@
 import taichi as ti
 import time
-import sys
 import math
 import numpy as np
 from renderer_utils import ray_aabb_intersection, intersect_sphere, ray_plane_intersect, reflect, refract
@@ -323,7 +322,7 @@ def render():
         depth = 0
         while depth < max_ray_depth:
             closest, hit_normal, hit_color, mat = intersect_scene(pos, ray_dir)
-            if abs(closest - inf) < eps:
+            if mat == mat_none:
                 break
 
             hit_pos = pos + closest * ray_dir
@@ -349,7 +348,7 @@ def render():
 
 gui = ti.GUI('Cornell Box', res)
 last_t = 0
-for i in range(1000001):
+for i in range(50000):
     render()
     interval = 10
     if i % interval == 0 and i > 0:

--- a/examples/cornell_box.py
+++ b/examples/cornell_box.py
@@ -347,16 +347,16 @@ def render():
 
 
 gui = ti.GUI('Cornell Box', res)
-last_t = 0
+last_t = time.time()
 for i in range(50000):
     render()
     interval = 10
     if i % interval == 0 and i > 0:
-        last_t = time.time()
         img = color_buffer.to_numpy(as_vector=True) * (1 / (i + 1))
         img = np.sqrt(img / img.mean() * 0.24)
         print("{:.2f} samples/s ({} iters, var={})".format(
             interval / (time.time() - last_t), i, np.var(img)))
+        last_t = time.time()
         gui.set_image(img)
         gui.show()
 


### PR DESCRIPTION
I added MIS to the cornell box example so as to denoise the scene. Below are the comparisons, with each running for 1000 iterations.

* Reference (img variance=0.1455)
<img width="500" alt="ref_var=0 14548" src="https://user-images.githubusercontent.com/7481356/80364135-576bc380-88c0-11ea-9820-501493790ab0.png">

* New code with MIS (img variance=0.1094)
<img width="500" alt="new_var=0 10938" src="https://user-images.githubusercontent.com/7481356/80364434-df51cd80-88c0-11ea-9c17-3e7c2f51677f.png">

Here's a result after running 15K iterations:

<img width="500" alt="new_iters=15k" src="https://user-images.githubusercontent.com/7481356/80364474-f98bab80-88c0-11ea-9254-87a99a45e424.png">

---

The MIS is done by doing two samples per intersection. Note that this is carried out only when the ray hits a lambertian material (i.e. the boudaries)

* One ray that shoots toward a random point on the light source (`sample_area_light`)
* One ray that samples from a cosine hemisphere distribution (`sample_brdf`).

This is basically what the PBR book Chapter 15 has described. I didn't look much into the special handling of sampler on specular materials (delta functions), but the result looks fine..

A few useful references I've found:

* the PBR book (Chapter 8, 14, 15)
* [Progressive Path Tracing with Explicit Light Sampling](https://computergraphics.stackexchange.com/questions/5152/progressive-path-tracing-with-explicit-light-sampling/5153#5153)
* [Cornell CS 6630 - Path Tracing](https://www.cs.cornell.edu/courses/cs6630/2015fa/index.shtml)

Also Kajiya-1986, Veach-[1995, 1997] may also be worth a read, but I've had enough fun with ray tracers for now...

---

I don't want to waste much of your time reviewing the details here, and absolutely no rush on this :)

Related issue = N/A

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
