### PR TITLE
[opt] Set `has_global_side_effect` to `false` for some statements

### DIFF
--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -377,4 +377,3 @@ class StackAccAdjointStmt : public Stmt {
 };
 
 TLANG_NAMESPACE_END
-        

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -225,6 +225,10 @@ class LoopIndexStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
+  virtual bool has_global_side_effect() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, index, is_struct_for);
   DEFINE_ACCEPT
 };
@@ -237,6 +241,10 @@ class GlobalTemporaryStmt : public Stmt {
       : offset(offset) {
     this->ret_type = ret_type;
     TI_STMT_REG_FIELDS;
+  }
+
+  virtual bool has_global_side_effect() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, offset);
@@ -278,6 +286,10 @@ class StackAllocaStmt : public Stmt {
     return sizeof(int32) + entry_size_in_bytes() * max_size;
   }
 
+  virtual bool has_global_side_effect() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, dt, max_size);
   DEFINE_ACCEPT
 };
@@ -290,6 +302,10 @@ class StackLoadTopStmt : public Stmt {
     TI_ASSERT(stack->is<StackAllocaStmt>());
     this->stack = stack;
     TI_STMT_REG_FIELDS;
+  }
+
+  virtual bool has_global_side_effect() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, stack);
@@ -306,6 +322,10 @@ class StackLoadTopAdjStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
+  virtual bool has_global_side_effect() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, stack);
   DEFINE_ACCEPT
 };
@@ -318,6 +338,10 @@ class StackPopStmt : public Stmt {
     TI_ASSERT(stack->is<StackAllocaStmt>());
     this->stack = stack;
     TI_STMT_REG_FIELDS;
+  }
+
+  virtual bool has_global_side_effect() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, stack);
@@ -336,6 +360,10 @@ class StackPushStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
+  virtual bool has_global_side_effect() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, stack, v);
   DEFINE_ACCEPT
 };
@@ -350,6 +378,10 @@ class StackAccAdjointStmt : public Stmt {
     this->stack = stack;
     this->v = v;
     TI_STMT_REG_FIELDS;
+  }
+
+  virtual bool has_global_side_effect() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, stack, v);

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -29,7 +29,7 @@ class ElementShuffleStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -46,7 +46,7 @@ class IntegerOffsetStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -66,7 +66,7 @@ class LinearizeStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -86,7 +86,7 @@ class OffsetAndExtractBitsStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -100,7 +100,7 @@ class GetRootStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -129,7 +129,7 @@ class SNodeLookupStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return activate;
   }
 
@@ -150,7 +150,7 @@ class GetChStmt : public Stmt {
 
   GetChStmt(Stmt *input_ptr, int chid);
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -225,7 +225,7 @@ class LoopIndexStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -243,7 +243,7 @@ class GlobalTemporaryStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -286,7 +286,7 @@ class StackAllocaStmt : public Stmt {
     return sizeof(int32) + entry_size_in_bytes() * max_size;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -304,7 +304,7 @@ class StackLoadTopStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -322,7 +322,7 @@ class StackLoadTopAdjStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -338,10 +338,6 @@ class StackPopStmt : public Stmt {
     TI_ASSERT(stack->is<StackAllocaStmt>());
     this->stack = stack;
     TI_STMT_REG_FIELDS;
-  }
-
-  virtual bool has_global_side_effect() const override {
-    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, stack);
@@ -360,10 +356,6 @@ class StackPushStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
-    return false;
-  }
-
   TI_STMT_DEF_FIELDS(ret_type, stack, v);
   DEFINE_ACCEPT
 };
@@ -380,12 +372,9 @@ class StackAccAdjointStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
-    return false;
-  }
-
   TI_STMT_DEF_FIELDS(ret_type, stack, v);
   DEFINE_ACCEPT
 };
 
 TLANG_NAMESPACE_END
+        

--- a/tests/cpp/test_alg_simp.cpp
+++ b/tests/cpp/test_alg_simp.cpp
@@ -91,7 +91,6 @@ TI_TEST("alg_simp") {
                      config_without_fast_math);  // should eliminate mul, add
     irpass::die(block.get());                    // should eliminate zero, load
 
-    irpass::print(block.get());
     TI_CHECK(block->size() == 3);  // one address, one one, one store
 
     block = std::make_unique<Block>();

--- a/tests/cpp/test_alg_simp.cpp
+++ b/tests/cpp/test_alg_simp.cpp
@@ -91,8 +91,8 @@ TI_TEST("alg_simp") {
                      config_without_fast_math);  // should eliminate mul, add
     irpass::die(block.get());                    // should eliminate zero, load
 
-    TI_CHECK(block->size() == 4);  // two addresses, one one, one store
-    TI_CHECK((*block)[0]->is<GlobalTemporaryStmt>());
+    irpass::print(block.get());
+    TI_CHECK(block->size() == 3);  // one address, one one, one store
 
     block = std::make_unique<Block>();
 
@@ -122,8 +122,7 @@ TI_TEST("alg_simp") {
                      config_with_fast_math);  // should eliminate mul, add
     irpass::die(block.get());                 // should eliminate zero, load
 
-    TI_CHECK(block->size() == 4);  // two addresses, one one, one store
-    TI_CHECK((*block)[0]->is<GlobalTemporaryStmt>());
+    TI_CHECK(block->size() == 3);  // one address, one one, one store
   }
 
   SECTION("simplify_and_minus_one") {


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #656 (maybe not directly related)

This PR sets `has_global_side_effect` to `false` for `LoopIndexStmt, GlobalTemporaryStmt, StackAllocaStmt, StackLoadTopStmt, StackLoadTopAdjStmt`.

Benchmark:
**Before**:
![benchmark20200428](https://user-images.githubusercontent.com/22582118/80552026-5f486800-8993-11ea-8e77-8c69cc5c5df0.png)

**After** (Notice that this also affect the numbers when `advanced_optimization = false`!):
![benchmark20200428_3](https://user-images.githubusercontent.com/22582118/80553604-789fe300-8998-11ea-84f9-9cbacfe5baba.png)


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
