### PR TITLE
[ir][refactor] Remove the global `current_block`

### DIFF
--- a/taichi/ir/basic_stmt_visitor.cpp
+++ b/taichi/ir/basic_stmt_visitor.cpp
@@ -8,12 +8,9 @@ BasicStmtVisitor::BasicStmtVisitor() {
 }
 
 void BasicStmtVisitor::visit(Block *stmt_list) {
-  auto backup_block = current_block;
-  current_block = stmt_list;
   for (auto &stmt : stmt_list->statements) {
     stmt->accept(this);
   }
-  current_block = backup_block;
 }
 
 void BasicStmtVisitor::visit(IfStmt *if_stmt) {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -565,8 +565,6 @@ IRNode *FrontendContext::root() {
 
 std::unique_ptr<FrontendContext> context;
 
-Block *current_block = nullptr;
-
 Expr Var(const Expr &x) {
   auto var = Expr(std::make_shared<IdExpression>());
   current_ast_builder().insert(std::make_unique<FrontendAllocaStmt>(

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -1921,10 +1921,6 @@ class RangeAssumptionExpression : public Expression {
   }
 };
 
-// TODO: fix this hack...
-// for current ast
-extern Block *current_block;
-
 class IdExpression : public Expression {
  public:
   Identifier id;

--- a/taichi/transforms/lower_access.cpp
+++ b/taichi/transforms/lower_access.cpp
@@ -17,12 +17,9 @@ class LowerAccess : public IRVisitor {
   }
 
   void visit(Block *stmt_list) override {
-    auto backup_block = current_block;
-    current_block = stmt_list;
     for (auto &stmt : stmt_list->statements) {
       stmt->accept(this);
     }
-    current_block = backup_block;
   }
 
   void visit(IfStmt *if_stmt) override {

--- a/taichi/transforms/statement_replace.cpp
+++ b/taichi/transforms/statement_replace.cpp
@@ -28,12 +28,9 @@ class StatementReplace : public IRVisitor {
   }
 
   void visit(Block *stmt_list) override {
-    auto backup_block = current_block;
-    current_block = stmt_list;
     for (auto &stmt : stmt_list->statements) {
       stmt->accept(this);
     }
-    current_block = backup_block;
   }
 
   void visit(IfStmt *if_stmt) override {


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #689 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
