### PR TITLE
[refactor] Remove `FrontendContext` and the global `context`

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -15,7 +15,7 @@ TLANG_NAMESPACE_BEGIN
 #include "expression.h"
 
 IRBuilder &current_ast_builder() {
-  return context->builder();
+  return *get_current_program().get_current_kernel().ir_builder;
 }
 
 bool maybe_same_address(Stmt *var1, Stmt *var2) {
@@ -487,11 +487,6 @@ GetChStmt::GetChStmt(Stmt *input_ptr, int chid)
 
 DecoratorRecorder dec;
 
-FrontendContext::FrontendContext() {
-  root_node = std::make_unique<Block>();
-  current_builder = std::make_unique<IRBuilder>(root_node.get());
-}
-
 FrontendForStmt::FrontendForStmt(const Expr &loop_var,
                                  const Expr &begin,
                                  const Expr &end)
@@ -552,12 +547,6 @@ FrontendAssignStmt::FrontendAssignStmt(const Expr &lhs, const Expr &rhs)
     : lhs(lhs), rhs(rhs) {
   TI_ASSERT(lhs->is_lvalue());
 }
-
-IRNode *FrontendContext::root() {
-  return static_cast<IRNode *>(root_node.get());
-}
-
-std::unique_ptr<FrontendContext> context;
 
 Expr Var(const Expr &x) {
   auto var = Expr(std::make_shared<IdExpression>());

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -199,27 +199,6 @@ class DecoratorRecorder {
   void reset();
 };
 
-class FrontendContext {
- private:
-  std::unique_ptr<IRBuilder> current_builder;
-  std::unique_ptr<Block> root_node;
-
- public:
-  FrontendContext();
-
-  IRBuilder &builder() {
-    return *current_builder;
-  }
-
-  IRNode *root();
-
-  std::unique_ptr<Block> get_root() {
-    return std::move(root_node);
-  }
-};
-
-extern std::unique_ptr<FrontendContext> context;
-
 class IRBuilder {
  private:
   std::vector<Block *> stack;

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -15,9 +15,10 @@ Kernel::Kernel(Program &program,
   program.initialize_device_llvm_context();
   is_accessor = false;
   compiled = nullptr;
-  taichi::lang::context = std::make_unique<FrontendContext>();
-  ir_holder = taichi::lang::context->get_root();
-  ir = ir_holder.get();
+  auto root_block = std::make_unique<Block>();
+  ir = root_block.get();
+  ir_builder = std::make_unique<IRBuilder>(root_block.get());
+  ir_holder = std::move(root_block);
 
   program.current_kernel = this;
   program.start_function_definition(this);

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -10,8 +10,9 @@ class Program;
 
 class Kernel {
  public:
-  std::unique_ptr<IRNode> ir_holder;
   IRNode *ir;
+  std::unique_ptr<IRBuilder> ir_builder;
+  std::unique_ptr<IRNode> ir_holder;
   Program &program;
   FunctionType compiled;
   std::string name;


### PR DESCRIPTION
Since `Program` is global, and it also provides `current_kernel`, I think `current_ast_builder()` can be implemented via `current_program -> current_kernel -> ir_builder`. This PR inlines `FrontendContext`' members directly into `Kernel`, and removes the global `FrontendContext context`.

@yuanming-hu i saw that `FrontendContext` was introduced for quite some time now (Feb 2019). Could you take a look and confirm if this change makes sense? I think `current_ast_builder()` is used when constructing the AST, during which time `program.current_kernel` is set:

https://github.com/taichi-dev/taichi/blob/d19ccd93be22d788b01f5aef3e0b4bdbf0ddb045/taichi/program/kernel.cpp#L22-L26

Related issue = #689 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
