### PR TITLE
[ir][refactor] First step to move Frontend IR to its own file

### DIFF
--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -4,6 +4,7 @@
 #include "taichi/common/util.h"
 #include "taichi/common/dict.h"
 #include "taichi/util/io.h"
+#include "taichi/ir/frontend_ir.h"
 
 namespace taichi {
 static_assert(

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "taichi/lang_util.h"
+#include "taichi/ir/ir.h"
+#include "taichi/ir/expr.h"
+
+TLANG_NAMESPACE_BEGIN
+
+class FrontendAllocaStmt : public Stmt {
+ public:
+  Identifier ident;
+
+  FrontendAllocaStmt(const Identifier &lhs, DataType type) : ident(lhs) {
+    ret_type = VectorType(1, type);
+  }
+
+  DEFINE_ACCEPT
+};
+
+TLANG_NAMESPACE_END

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 
 #include "taichi/ir/frontend.h"
+#include "taichi/ir/frontend_ir.h"
 #include "taichi/ir/statements.h"
 
 TLANG_NAMESPACE_BEGIN

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -828,17 +828,6 @@ inline ExprGroup operator,(const ExprGroup &a, const Expr &b) {
   return ExprGroup(a, b);
 }
 
-class FrontendAllocaStmt : public Stmt {
- public:
-  Identifier ident;
-
-  FrontendAllocaStmt(const Identifier &lhs, DataType type) : ident(lhs) {
-    ret_type = VectorType(1, type);
-  }
-
-  DEFINE_ACCEPT
-};
-
 class AllocaStmt : public Stmt {
  public:
   AllocaStmt(DataType type) {

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "taichi/lang_util.h"
 #include "arch.h"
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -327,7 +327,8 @@ void export_lang(py::module &m) {
   m.def("layout", layout);
 
   m.def("value_cast", static_cast<Expr (*)(const Expr &expr, DataType)>(cast));
-  m.def("bits_cast", static_cast<Expr (*)(const Expr &expr, DataType)>(bit_cast));
+  m.def("bits_cast",
+        static_cast<Expr (*)(const Expr &expr, DataType)>(bit_cast));
 
   m.def("expr_atomic_add", [&](const Expr &a, const Expr &b) {
     return Expr::make<AtomicOpExpression>(AtomicOpType::add, ptr_if_global(a),

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -4,6 +4,7 @@
 #include "pybind11/pybind11.h"
 
 #include "taichi/ir/frontend.h"
+#include "taichi/ir/frontend_ir.h"
 #include "taichi/program/extension.h"
 #include "taichi/common/interface.h"
 #include "taichi/python/export.h"

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -1,7 +1,9 @@
 // The IRPrinter prints the IR in a human-readable format
 
 #include <typeinfo>
+
 #include "taichi/ir/ir.h"
+#include "taichi/ir/frontend_ir.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -127,8 +129,8 @@ class IRPrinter : public IRVisitor {
 
   void visit(UnaryOpStmt *stmt) override {
     if (stmt->is_cast()) {
-      std::string reint = stmt->op_type == UnaryOpType::cast_value ?
-        "" : "reinterpret_";
+      std::string reint =
+          stmt->op_type == UnaryOpType::cast_value ? "" : "reinterpret_";
       print("{}{} = {}{}<{}> {}", stmt->type_hint(), stmt->name(), reint,
             unary_op_type_name(stmt->op_type),
             data_type_short_name(stmt->cast_type), stmt->operand->name());

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -1,6 +1,7 @@
-#include "taichi/ir/ir.h"
-
 #include <unordered_set>
+
+#include "taichi/ir/ir.h"
+#include "taichi/ir/frontend_ir.h"
 
 TLANG_NAMESPACE_BEGIN
 


### PR DESCRIPTION
In this PR, I just moved `FrontendAllocaStmt` to a new file `frontend_ir.h`. If this looks OK, I will move all the other `Frontend*Stmt` (maybe `*Expression` as well ?)

Related issue = #689 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
