### PR TITLE
[ir][refactor] Move all frontend stmts to `frontend_ir.h`

### DIFF
--- a/taichi/analysis/detect_fors_with_break.cpp
+++ b/taichi/analysis/detect_fors_with_break.cpp
@@ -1,4 +1,5 @@
 #include "taichi/ir/ir.h"
+#include "taichi/ir/frontend_ir.h"
 
 #include <unordered_set>
 

--- a/taichi/ir/basic_stmt_visitor.cpp
+++ b/taichi/ir/basic_stmt_visitor.cpp
@@ -1,4 +1,5 @@
-#include "visitors.h"
+#include "taichi/ir/visitors.h"
+#include "taichi/ir/frontend_ir.h"
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -1,5 +1,7 @@
-#include "expr.h"
-#include "ir.h"
+#include "taichi/ir/expr.h"
+
+#include "taichi/ir/frontend_ir.h"
+#include "taichi/ir/ir.h"
 #include "taichi/program/program.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -35,7 +37,8 @@ Expr operator~(const Expr &expr) {
 }
 
 Expr cast(const Expr &input, DataType dt) {
-  auto ret = std::make_shared<UnaryOpExpression>(UnaryOpType::cast_value, input);
+  auto ret =
+      std::make_shared<UnaryOpExpression>(UnaryOpType::cast_value, input);
   ret->cast_type = dt;
   return Expr(ret);
 }

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -71,7 +71,6 @@ class FrontendAssignStmt : public Stmt {
   DEFINE_ACCEPT
 };
 
-
 class FrontendIfStmt : public Stmt {
  public:
   Expr condition;
@@ -156,7 +155,6 @@ class FrontendFuncDefStmt : public Stmt {
   DEFINE_ACCEPT
 };
 
-
 class FrontendBreakStmt : public Stmt {
  public:
   FrontendBreakStmt() {
@@ -194,7 +192,5 @@ class FrontendWhileStmt : public Stmt {
 
   DEFINE_ACCEPT
 };
-
-
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -17,4 +17,184 @@ class FrontendAllocaStmt : public Stmt {
   DEFINE_ACCEPT
 };
 
+// For return values
+class FrontendArgStoreStmt : public Stmt {
+ public:
+  int arg_id;
+  Expr expr;
+
+  FrontendArgStoreStmt(int arg_id, const Expr &expr)
+      : arg_id(arg_id), expr(expr) {
+  }
+
+  // Arguments are considered global (nonlocal)
+  virtual bool has_global_side_effect() const override {
+    return true;
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendSNodeOpStmt : public Stmt {
+ public:
+  SNodeOpType op_type;
+  SNode *snode;
+  ExprGroup indices;
+  Expr val;
+
+  FrontendSNodeOpStmt(SNodeOpType op_type,
+                      SNode *snode,
+                      const ExprGroup &indices,
+                      const Expr &val = Expr(nullptr));
+
+  DEFINE_ACCEPT
+};
+
+class FrontendAssertStmt : public Stmt {
+ public:
+  std::string text;
+  Expr val;
+
+  FrontendAssertStmt(const std::string &text, const Expr &val)
+      : text(text), val(val) {
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendAssignStmt : public Stmt {
+ public:
+  Expr lhs, rhs;
+
+  FrontendAssignStmt(const Expr &lhs, const Expr &rhs);
+
+  DEFINE_ACCEPT
+};
+
+
+class FrontendIfStmt : public Stmt {
+ public:
+  Expr condition;
+  std::unique_ptr<Block> true_statements, false_statements;
+
+  FrontendIfStmt(const Expr &condition) : condition(load_if_ptr(condition)) {
+  }
+
+  bool is_container_statement() const override {
+    return true;
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendPrintStmt : public Stmt {
+ public:
+  Expr expr;
+  std::string str;
+
+  FrontendPrintStmt(const Expr &expr, const std::string &str)
+      : expr(load_if_ptr(expr)), str(str) {
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendEvalStmt : public Stmt {
+ public:
+  Expr expr;
+  Expr eval_expr;
+
+  FrontendEvalStmt(const Expr &expr) : expr(load_if_ptr(expr)) {
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendForStmt : public Stmt {
+ public:
+  Expr begin, end;
+  Expr global_var;
+  std::unique_ptr<Block> body;
+  std::vector<Identifier> loop_var_id;
+  int vectorize;
+  int parallelize;
+  bool strictly_serialized;
+  ScratchPadOptions scratch_opt;
+  int block_dim;
+
+  bool is_ranged() const {
+    if (global_var.expr == nullptr) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  FrontendForStmt(const ExprGroup &loop_var, const Expr &global_var);
+
+  FrontendForStmt(const Expr &loop_var, const Expr &begin, const Expr &end);
+
+  bool is_container_statement() const override {
+    return true;
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendFuncDefStmt : public Stmt {
+ public:
+  std::string funcid;
+  std::unique_ptr<Block> body;
+
+  FrontendFuncDefStmt(const std::string &funcid) : funcid(funcid) {
+  }
+
+  bool is_container_statement() const override {
+    return true;
+  }
+
+  DEFINE_ACCEPT
+};
+
+
+class FrontendBreakStmt : public Stmt {
+ public:
+  FrontendBreakStmt() {
+  }
+
+  bool is_container_statement() const override {
+    return false;
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendContinueStmt : public Stmt {
+ public:
+  FrontendContinueStmt() = default;
+
+  bool is_container_statement() const override {
+    return false;
+  }
+
+  DEFINE_ACCEPT
+};
+
+class FrontendWhileStmt : public Stmt {
+ public:
+  Expr cond;
+  std::unique_ptr<Block> body;
+
+  FrontendWhileStmt(const Expr &cond) : cond(load_if_ptr(cond)) {
+  }
+
+  bool is_container_statement() const override {
+    return true;
+  }
+
+  DEFINE_ACCEPT
+};
+
+
+
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -1005,4 +1005,34 @@ bool ContinueStmt::as_return() const {
   return false;
 }
 
+If::If(const Expr &cond) {
+  auto stmt_tmp = std::make_unique<FrontendIfStmt>(cond);
+  stmt = stmt_tmp.get();
+  current_ast_builder().insert(std::move(stmt_tmp));
+}
+
+If::If(const Expr &cond, const std::function<void()> &func) : If(cond) {
+  Then(func);
+}
+
+If &If::Then(const std::function<void()> &func) {
+  auto _ = current_ast_builder().create_scope(stmt->true_statements);
+  func();
+  return *this;
+}
+
+If &If::Else(const std::function<void()> &func) {
+  auto _ = current_ast_builder().create_scope(stmt->false_statements);
+  func();
+  return *this;
+}
+
+While::While(const Expr &cond, const std::function<void()> &func) {
+  auto while_stmt = std::make_unique<FrontendWhileStmt>(cond);
+  FrontendWhileStmt *ptr = while_stmt.get();
+  current_ast_builder().insert(std::move(while_stmt));
+  auto _ = current_ast_builder().create_scope(ptr->body);
+  func();
+}
+
 TLANG_NAMESPACE_END

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -19,6 +19,7 @@
 #include "taichi/backends/opengl/struct_opengl.h"
 #include "taichi/system/unified_allocator.h"
 #include "taichi/ir/snode.h"
+#include "taichi/ir/frontend_ir.h"
 #include "taichi/program/async_engine.h"
 #include "taichi/util/statistics.h"
 

--- a/taichi/transforms/re_id.cpp
+++ b/taichi/transforms/re_id.cpp
@@ -1,4 +1,5 @@
 #include "taichi/ir/ir.h"
+#include "taichi/ir/frontend_ir.h"
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/transforms/reverse_segments.cpp
+++ b/taichi/transforms/reverse_segments.cpp
@@ -1,4 +1,6 @@
 #include "taichi/ir/ir.h"
+#include "taichi/ir/frontend_ir.h"
+
 #include <set>
 
 TLANG_NAMESPACE_BEGIN


### PR DESCRIPTION
This is a follow up of #914 . We move all `Frontend*Stmt` to `frontend_ir.h`. (Expressions will be handled separately)

Related issue = #689 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
