### PR TITLE
[metal] Support `KernelReturnStmt`

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -87,7 +87,7 @@ class KernelCodegen : public IRVisitor {
     }
   }
 
-  const KernelContextAttributes &kernel_args_attribs() const {
+  const KernelContextAttributes &kernel_ctx_attribs() const {
     return ctx_attribs_;
   }
 
@@ -1042,7 +1042,7 @@ FunctionType CodeGen::compile() {
   const auto source_code = codegen.run();
   kernel_mgr_->register_taichi_kernel(taichi_kernel_name_, source_code,
                                       codegen.kernels_attribs(),
-                                      codegen.kernel_args_attribs());
+                                      codegen.kernel_ctx_attribs());
   return [kernel_mgr = kernel_mgr_,
           kernel_name = taichi_kernel_name_](Context &ctx) {
     kernel_mgr->launch_taichi_kernel(kernel_name, &ctx);

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -262,8 +262,8 @@ class CompiledTaichiKernel {
 class HostMetalCtxBlitter {
  public:
   HostMetalCtxBlitter(const KernelContextAttributes *args_attribs,
-                       Context *ctx,
-                       BufferMemoryView *args_mem)
+                      Context *ctx,
+                      BufferMemoryView *args_mem)
       : ctx_attribs_(args_attribs), ctx_(ctx), args_mem_(args_mem) {
   }
 
@@ -303,8 +303,7 @@ class HostMetalCtxBlitter {
       }
     }
     char *device_ptr = base + ctx_attribs_->ctx_bytes();
-    std::memcpy(device_ptr, ctx_->extra_args,
-                ctx_attribs_->extra_args_bytes());
+    std::memcpy(device_ptr, ctx_->extra_args, ctx_attribs_->extra_args_bytes());
 #undef TO_METAL
   }
 
@@ -365,7 +364,7 @@ class HostMetalCtxBlitter {
       return nullptr;
     }
     return std::make_unique<HostMetalCtxBlitter>(&kernel.args_attribs, ctx,
-                                                  kernel.args_mem.get());
+                                                 kernel.args_mem.get());
   }
 
  private:
@@ -422,7 +421,7 @@ class KernelManager::Impl {
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<KernelAttributes> &kernels_attribs,
-      const KernelContextAttributes &args_attribs) {
+      const KernelContextAttributes &ctx_attribs) {
     TI_ASSERT(compiled_taichi_kernels_.find(taichi_kernel_name) ==
               compiled_taichi_kernels_.end());
 
@@ -437,7 +436,7 @@ class KernelManager::Impl {
     params.taichi_kernel_name = taichi_kernel_name;
     params.mtl_source_code = mtl_kernel_source_code;
     params.mtl_kernels_attribs = &kernels_attribs;
-    params.args_attribs = &args_attribs;
+    params.args_attribs = &ctx_attribs;
     params.device = device_.get();
     params.mem_pool = mem_pool_;
     params.profiler = profiler_;
@@ -621,7 +620,7 @@ class KernelManager::Impl {
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<KernelAttributes> &kernels_attribs,
-      const KernelArgsAttributes &args_attribs) {
+      const KernelContextAttributes &ctx_attribs) {
     TI_ERROR("Metal not supported on the current OS");
   }
 
@@ -648,9 +647,9 @@ void KernelManager::register_taichi_kernel(
     const std::string &taichi_kernel_name,
     const std::string &mtl_kernel_source_code,
     const std::vector<KernelAttributes> &kernels_attribs,
-    const KernelContextAttributes &args_attribs) {
+    const KernelContextAttributes &ctx_attribs) {
   impl_->register_taichi_kernel(taichi_kernel_name, mtl_kernel_source_code,
-                                kernels_attribs, args_attribs);
+                                kernels_attribs, ctx_attribs);
 }
 
 void KernelManager::launch_taichi_kernel(const std::string &taichi_kernel_name,

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -43,7 +43,7 @@ class KernelManager {
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<KernelAttributes> &kernels_attribs,
-      const KernelContextAttributes &args_attribs);
+      const KernelContextAttributes &ctx_attribs);
 
   // Launch the given |taichi_kernel_name|.
   // Kernel launching is asynchronous, therefore the Metal memory is not valid

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -43,7 +43,7 @@ class KernelManager {
       const std::string &taichi_kernel_name,
       const std::string &mtl_kernel_source_code,
       const std::vector<KernelAttributes> &kernels_attribs,
-      const KernelArgsAttributes &args_attribs);
+      const KernelContextAttributes &args_attribs);
 
   // Launch the given |taichi_kernel_name|.
   // Kernel launching is asynchronous, therefore the Metal memory is not valid

--- a/taichi/backends/metal/kernel_util.cpp
+++ b/taichi/backends/metal/kernel_util.cpp
@@ -43,8 +43,8 @@ std::string KernelAttributes::debug_string() const {
   return result;
 }
 
-KernelArgsAttributes::KernelArgsAttributes(const Kernel &kernel)
-    : args_rets_bytes_(0), extra_args_bytes_(Context::extra_args_size) {
+KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
+    : ctx_bytes_(0), extra_args_bytes_(Context::extra_args_size) {
   arg_attribs_vec_.reserve(kernel.args.size());
   for (const auto &ka : kernel.args) {
     ArgAttributes ma;
@@ -76,7 +76,7 @@ KernelArgsAttributes::KernelArgsAttributes(const Kernel &kernel)
   }
 
   auto arrange_scalar_before_array = [&bytes =
-                                          this->args_rets_bytes_](auto *vec) {
+                                          this->ctx_bytes_](auto *vec) {
     std::vector<int> scalar_indices;
     std::vector<int> array_indices;
     for (int i = 0; i < vec->size(); ++i) {

--- a/taichi/backends/metal/kernel_util.cpp
+++ b/taichi/backends/metal/kernel_util.cpp
@@ -75,8 +75,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
     ret_attribs_vec_.push_back(mr);
   }
 
-  auto arrange_scalar_before_array = [&bytes =
-                                          this->ctx_bytes_](auto *vec) {
+  auto arrange_scalar_before_array = [&bytes = this->ctx_bytes_](auto *vec) {
     std::vector<int> scalar_indices;
     std::vector<int> array_indices;
     for (int i = 0; i < vec->size(); ++i) {

--- a/taichi/backends/metal/kernel_util.cpp
+++ b/taichi/backends/metal/kernel_util.cpp
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 
+#include "taichi/program/kernel.h"
 #define TI_RUNTIME_HOST
 #include "taichi/runtime/llvm/context.h"
 #undef TI_RUNTIME_HOST
@@ -42,10 +43,10 @@ std::string KernelAttributes::debug_string() const {
   return result;
 }
 
-KernelArgsAttributes::KernelArgsAttributes(const std::vector<Kernel::Arg> &args)
-    : args_bytes_(0), extra_args_bytes_(Context::extra_args_size) {
-  arg_attribs_vec_.reserve(args.size());
-  for (const auto &ka : args) {
+KernelArgsAttributes::KernelArgsAttributes(const Kernel &kernel)
+    : args_rets_bytes_(0), extra_args_bytes_(Context::extra_args_size) {
+  arg_attribs_vec_.reserve(kernel.args.size());
+  for (const auto &ka : kernel.args) {
     ArgAttributes ma;
     ma.dt = to_metal_type(ka.dt);
     const size_t dt_bytes = metal_data_type_bytes(ma.dt);
@@ -57,31 +58,50 @@ KernelArgsAttributes::KernelArgsAttributes(const std::vector<Kernel::Arg> &args)
     ma.is_array = ka.is_nparray;
     ma.stride = ma.is_array ? ka.size : dt_bytes;
     ma.index = arg_attribs_vec_.size();
-    ma.is_return_val = ka.is_return_value;
     arg_attribs_vec_.push_back(ma);
   }
-
-  std::vector<int> scalar_indices;
-  std::vector<int> array_indices;
-  for (int i = 0; i < arg_attribs_vec_.size(); ++i) {
-    if (arg_attribs_vec_[i].is_array) {
-      array_indices.push_back(i);
-    } else {
-      scalar_indices.push_back(i);
+  for (const auto &kr : kernel.rets) {
+    RetAttributes mr;
+    mr.dt = to_metal_type(kr.dt);
+    const size_t dt_bytes = metal_data_type_bytes(mr.dt);
+    if (dt_bytes > 4) {
+      // Metal doesn't support 64bit data buffers.
+      TI_ERROR("Metal kernel only supports <= 32-bit data, got {}",
+               metal_data_type_name(mr.dt));
     }
+    mr.is_array = false;  // TODO(#909): this is a temporary limitation
+    mr.stride = dt_bytes;
+    mr.index = ret_attribs_vec_.size();
+    ret_attribs_vec_.push_back(mr);
   }
-  // Put scalar args in the memory first
-  for (int i : scalar_indices) {
-    auto &arg = arg_attribs_vec_[i];
-    arg.offset_in_mem = args_bytes_;
-    args_bytes_ += arg.stride;
-  }
-  // Then the array args
-  for (int i : array_indices) {
-    auto &arg = arg_attribs_vec_[i];
-    arg.offset_in_mem = args_bytes_;
-    args_bytes_ += arg.stride;
-  }
+
+  auto arrange_scalar_before_array = [&bytes =
+                                          this->args_rets_bytes_](auto *vec) {
+    std::vector<int> scalar_indices;
+    std::vector<int> array_indices;
+    for (int i = 0; i < vec->size(); ++i) {
+      if ((*vec)[i].is_array) {
+        array_indices.push_back(i);
+      } else {
+        scalar_indices.push_back(i);
+      }
+    }
+    // Put scalar args in the memory first
+    for (int i : scalar_indices) {
+      auto &attribs = (*vec)[i];
+      attribs.offset_in_mem = bytes;
+      bytes += attribs.stride;
+    }
+    // Then the array args
+    for (int i : array_indices) {
+      auto &attribs = (*vec)[i];
+      attribs.offset_in_mem = bytes;
+      bytes += attribs.stride;
+    }
+  };
+
+  arrange_scalar_before_array(&arg_attribs_vec_);
+  arrange_scalar_before_array(&ret_attribs_vec_);
 }
 
 }  // namespace metal

--- a/taichi/backends/metal/kernel_util.h
+++ b/taichi/backends/metal/kernel_util.h
@@ -69,9 +69,7 @@ struct KernelAttributes {
 // Note that all Metal kernels belonging to the same Taichi kernel will share
 // the same kernel args (i.e. they use the same Metal buffer for input args and
 // return values). This is because kernel arguments is a Taichi-level concept.
-//
-// TODO(#909): Rename to KernelArgsRetsAttributes
-class KernelArgsAttributes {
+class KernelContextAttributes {
  private:
   // Attributes that are shared by the input arg and the return value.
   struct AttribsBase {
@@ -92,7 +90,7 @@ class KernelArgsAttributes {
   // This is mostly the same as Kernel::Ret, with Metal specific attributes.
   struct RetAttributes : public AttribsBase {};
 
-  explicit KernelArgsAttributes(const Kernel &kernel);
+  explicit KernelContextAttributes(const Kernel &kernel);
 
   inline bool has_args() const {
     return !arg_attribs_vec_.empty();
@@ -116,15 +114,15 @@ class KernelArgsAttributes {
   }
 
   // Total size in bytes of the input args and return values
-  inline size_t args_rets_bytes() const {
-    return args_rets_bytes_;
+  inline size_t ctx_bytes() const {
+    return ctx_bytes_;
   }
   inline size_t extra_args_bytes() const {
     return extra_args_bytes_;
   }
   // Total bytes needed for allocating the Metal buffer
   inline size_t total_bytes() const {
-    return args_rets_bytes_ + extra_args_bytes_;
+    return ctx_bytes_ + extra_args_bytes_;
   }
 
  private:
@@ -138,7 +136,7 @@ class KernelArgsAttributes {
   std::vector<ArgAttributes> arg_attribs_vec_;
   std::vector<RetAttributes> ret_attribs_vec_;
   // Total size in bytes of the input args and return values
-  size_t args_rets_bytes_;
+  size_t ctx_bytes_;
   size_t extra_args_bytes_;
 };
 


### PR DESCRIPTION
This is probably mentioned somewhere, but I think we should add a new `rets` in `Context` as well?

https://github.com/taichi-dev/taichi/blob/bbddaa10def6e2e9e566ec8f665daf480aab652e/taichi/runtime/llvm/context.h#L15-L18

Once we do that, OpenGL/Metal can copy the return values back to `Context::rets`, so that we don't have to overuse `Context::args` for holding return values:

https://github.com/taichi-dev/taichi/blob/bbddaa10def6e2e9e566ec8f665daf480aab652e/taichi/program/program.cpp#L500

Related issue = #909 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
