### PR TITLE
[OpenGL] Remove GLFW dependency on glibc 2.27 and improve portability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	shallow = true
 [submodule "external/glfw"]
 	path = external/glfw
-	url = https://github.com/glfw/glfw
+	url = https://github.com/taichi-dev/glfw
 	shallow = true
 [submodule "external/glad"]
 	path = external/glad


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

It's reported that taichi no longer works on their system since they don't have glibc 2.27. I took a look and realized the dependency was introduced by GLFW. So I have to patch GLFW to remove the dependency: https://github.com/taichi-dev/glfw/commit/8bc966bbae4967a008252f1ac9b625e4dc77ad64

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
