### PR TITLE
[ir][refactor] Deprecate `ArgStoreStmt` (both frontend and CHI)

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -263,13 +263,6 @@ class KernelCodegen : public IRVisitor {
     }
   }
 
-  void visit(ArgStoreStmt *stmt) override {
-    const auto dt = metal_data_type_name(stmt->element_type());
-    TI_ASSERT(!stmt->is_ptr);
-    emit("*{}.arg{}() = {};", kArgsContextName, stmt->arg_id,
-         stmt->val->raw_name());
-  }
-
   void visit(KernelReturnStmt *stmt) override {
     // TODO: use stmt->ret_id instead of 0 as index
     emit("*{}.ret0() = {};", kArgsContextName, stmt->value->raw_name());

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -520,15 +520,6 @@ class KernelGen : public IRVisitor {
     }
   }
 
-  void visit(ArgStoreStmt *stmt) override {
-    TI_ASSERT(!stmt->is_ptr);
-    used.argument = true;
-    emit("_args_{}_[{} << {}] = {};",
-         data_type_short_name(stmt->element_type()), stmt->arg_id,
-         opengl_argument_address_shifter(stmt->element_type()),
-         stmt->val->short_name());
-  }
-
   std::string make_kernel_name() {
     return fmt::format("{}{}", glsl_kernel_prefix_, glsl_kernel_count_++);
   }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -864,23 +864,6 @@ void CodeGenLLVM::visit(ArgLoadStmt *stmt) {
   }
 }
 
-void CodeGenLLVM::visit(ArgStoreStmt *stmt) {
-  if (stmt->is_ptr) {
-    TI_NOT_IMPLEMENTED
-  } else {
-    auto intermediate_bits = tlctx->get_data_type(stmt->val->ret_type.data_type)
-                                 ->getPrimitiveSizeInBits();
-    llvm::Type *intermediate_type =
-        llvm::Type::getIntNTy(*llvm_context, intermediate_bits);
-    llvm::Type *dest_ty = tlctx->get_data_type<int64>();
-    auto extended = builder->CreateZExt(
-        builder->CreateBitCast(llvm_val[stmt->val], intermediate_type),
-        dest_ty);
-    builder->CreateCall(get_runtime_function("LLVMRuntime_store_result"),
-                        {get_runtime(), extended});
-  }
-}
-
 void CodeGenLLVM::visit(KernelReturnStmt *stmt) {
   if (stmt->is_ptr) {
     TI_NOT_IMPLEMENTED

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -169,8 +169,6 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(ArgLoadStmt *stmt) override;
 
-  void visit(ArgStoreStmt *stmt) override;
-
   void visit(KernelReturnStmt *stmt) override;
 
   void visit(LocalLoadStmt *stmt) override;

--- a/taichi/inc/statements.inc.h
+++ b/taichi/inc/statements.inc.h
@@ -10,7 +10,6 @@ PER_STATEMENT(FrontendAssignStmt)
 PER_STATEMENT(FrontendEvalStmt)
 PER_STATEMENT(FrontendSNodeOpStmt)  // activate, deactivate, append, clear
 PER_STATEMENT(FrontendAssertStmt)
-PER_STATEMENT(FrontendArgStoreStmt)
 PER_STATEMENT(FrontendFuncDefStmt)
 PER_STATEMENT(FrontendKernelReturnStmt)
 
@@ -43,7 +42,6 @@ PER_STATEMENT(LocalStoreStmt)
 PER_STATEMENT(SNodeOpStmt)
 PER_STATEMENT(RangeAssumptionStmt)
 PER_STATEMENT(AssertStmt)
-PER_STATEMENT(ArgStoreStmt)
 
 // Locals with reverse-mode autodiff
 PER_STATEMENT(StackAllocaStmt)

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -22,24 +22,6 @@ class FrontendAllocaStmt : public Stmt {
   DEFINE_ACCEPT
 };
 
-// For return values
-class FrontendArgStoreStmt : public Stmt {
- public:
-  int arg_id;
-  Expr expr;
-
-  FrontendArgStoreStmt(int arg_id, const Expr &expr)
-      : arg_id(arg_id), expr(expr) {
-  }
-
-  // Arguments are considered global (nonlocal)
-  virtual bool has_global_side_effect() const override {
-    return true;
-  }
-
-  DEFINE_ACCEPT
-};
-
 class FrontendSNodeOpStmt : public Stmt {
  public:
   SNodeOpType op_type;

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -934,25 +934,6 @@ class ArgLoadStmt : public Stmt {
   DEFINE_ACCEPT
 };
 
-// For return values
-class ArgStoreStmt : public Stmt {
- public:
-  int arg_id;
-  Stmt *val;
-
-  ArgStoreStmt(int arg_id, Stmt *val) : arg_id(arg_id), val(val) {
-    TI_STMT_REG_FIELDS;
-  }
-
-  // Arguments are considered global (nonlocal)
-  virtual bool has_global_side_effect() const override {
-    return true;
-  }
-
-  TI_STMT_DEF_FIELDS(ret_type, arg_id, val);
-  DEFINE_ACCEPT
-};
-
 class RandStmt : public Stmt {
  public:
   RandStmt(DataType dt) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -213,7 +213,7 @@ void Kernel::set_arch(Arch arch) {
 }
 
 int Kernel::insert_arg(DataType dt, bool is_nparray) {
-  args.push_back(Arg{dt, is_nparray, 0, false});
+  args.push_back(Arg{dt, is_nparray, /*size=*/0});
   return args.size() - 1;
 }
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -196,10 +196,6 @@ int64 Kernel::get_ret_int(int i) {
   }
 }
 
-void Kernel::mark_arg_return_value(int i, bool is_return) {
-  args[i].is_return_value = is_return;
-}
-
 void Kernel::set_extra_arg_int(int i, int j, int32 d) {
   program.context.extra_args[i][j] = d;
 }

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -23,16 +23,11 @@ class Kernel {
     DataType dt;
     bool is_nparray;
     std::size_t size;
-    bool is_return_value;
 
     Arg(DataType dt = DataType::unknown,
         bool is_nparray = false,
-        std::size_t size = 0,
-        bool is_return_value = 0)
-        : dt(dt),
-          is_nparray(is_nparray),
-          size(size),
-          is_return_value(is_return_value) {
+        std::size_t size = 0)
+        : dt(dt), is_nparray(is_nparray), size(size) {
     }
   };
 

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -77,8 +77,6 @@ class Kernel {
 
   void set_extra_arg_int(int i, int j, int32 d);
 
-  void mark_arg_return_value(int i, bool is_return = true);
-
   void set_arg_nparray(int i, uint64 ptr, uint64 size);
 
   void set_arch(Arch arch);

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -309,16 +309,6 @@ class IRPrinter : public IRVisitor {
     print("{}{} = arg[{}]", stmt->type_hint(), stmt->name(), stmt->arg_id);
   }
 
-  void visit(FrontendArgStoreStmt *stmt) override {
-    print("{}{} : store arg {} <- {}", stmt->type_hint(), stmt->name(),
-          stmt->arg_id, stmt->expr->serialize());
-  }
-
-  void visit(ArgStoreStmt *stmt) override {
-    print("{}{} : store arg {} <- {}", stmt->type_hint(), stmt->name(),
-          stmt->arg_id, stmt->val->name());
-  }
-
   void visit(FrontendKernelReturnStmt *stmt) override {
     print("{}{} : kernel return {}", stmt->type_hint(), stmt->name(),
           stmt->value->serialize());

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -371,15 +371,6 @@ class LowerAST : public IRVisitor {
     throw IRModified();
   }
 
-  void visit(FrontendArgStoreStmt *stmt) override {
-    // expand value
-    auto fctx = make_flatten_ctx();
-    stmt->expr->flatten(&fctx);
-    fctx.push_back<ArgStoreStmt>(stmt->arg_id, fctx.back_stmt());
-    stmt->parent->replace_with(stmt, std::move(fctx.stmts));
-    throw IRModified();
-  }
-
   static void run(IRNode *node) {
     LowerAST inst(irpass::analysis::detect_fors_with_break(node));
     while (true) {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -317,7 +317,6 @@ class TypeCheck : public IRVisitor {
     }
     auto &args = current_kernel->args;
     TI_ASSERT(0 <= stmt->arg_id && stmt->arg_id < args.size());
-    TI_ASSERT(!args[stmt->arg_id].is_return_value);
     stmt->ret_type = VectorType(1, args[stmt->arg_id].dt);
   }
 
@@ -330,7 +329,6 @@ class TypeCheck : public IRVisitor {
     TI_ASSERT(0 <= stmt->arg_id && stmt->arg_id < args.size());
     auto arg = args[stmt->arg_id];
     auto arg_type = arg.dt;
-    TI_ASSERT(arg.is_return_value);
     TI_ASSERT(stmt->val->ret_type.data_type == arg_type);
     stmt->ret_type = VectorType(1, arg_type);
   }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -320,19 +320,6 @@ class TypeCheck : public IRVisitor {
     stmt->ret_type = VectorType(1, args[stmt->arg_id].dt);
   }
 
-  void visit(ArgStoreStmt *stmt) {
-    Kernel *current_kernel = kernel;
-    if (current_kernel == nullptr) {
-      current_kernel = &get_current_program().get_current_kernel();
-    }
-    auto &args = current_kernel->args;
-    TI_ASSERT(0 <= stmt->arg_id && stmt->arg_id < args.size());
-    auto arg = args[stmt->arg_id];
-    auto arg_type = arg.dt;
-    TI_ASSERT(stmt->val->ret_type.data_type == arg_type);
-    stmt->ret_type = VectorType(1, arg_type);
-  }
-
   void visit(KernelReturnStmt *stmt) {
     Kernel *current_kernel = kernel;
     if (current_kernel == nullptr) {


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Also removed some helpers that are unused now:

* `mark_arg_return_value()`
* `Kernel::Arg::is_return_value`

Related issue = #909 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
