### PR TITLE
[Lang] ti.sqr(x) is now deprecated: please use x ** 2 instead

### DIFF
--- a/benchmarks/mpm2d.py
+++ b/benchmarks/mpm2d.py
@@ -34,10 +34,7 @@ def benchmark_range():
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)
             # Quadratic kernels  [http://mpm.graphics   Eqn. 123, with x=fx, fx-1,fx-2]
-            w = [
-                0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1),
-                0.5 * ti.sqr(fx - 0.5)
-            ]
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
             F[p] = (ti.Matrix.identity(ti.f32, 2) +
                     dt * C[p]) @ F[p]  # deformation gradient update
             h = ti.exp(
@@ -90,8 +87,7 @@ def benchmark_range():
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)
             w = [
-                0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0),
-                0.5 * ti.sqr(fx - 0.5)
+                0.5 * (1.5 - fx)**2, 0.75 - (fx - 1.0)**2, 0.5 * (fx - 0.5)**2
             ]
             new_v = ti.Vector.zero(ti.f32, 2)
             new_C = ti.Matrix.zero(ti.f32, 2, 2)
@@ -163,10 +159,7 @@ def benchmark_struct():
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)
             # Quadratic kernels  [http://mpm.graphics   Eqn. 123, with x=fx, fx-1,fx-2]
-            w = [
-                0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1),
-                0.5 * ti.sqr(fx - 0.5)
-            ]
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
             F[p] = (ti.Matrix.identity(ti.f32, 2) +
                     dt * C[p]) @ F[p]  # deformation gradient update
             h = ti.exp(
@@ -221,8 +214,7 @@ def benchmark_struct():
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)
             w = [
-                0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0),
-                0.5 * ti.sqr(fx - 0.5)
+                0.5 * (1.5 - fx)**2, 0.75 - (fx - 1.0)**2, 0.5 * (fx - 0.5)**2
             ]
             new_v = ti.Vector.zero(ti.f32, 2)
             new_C = ti.Matrix.zero(ti.f32, 2, 2)

--- a/docs/syntax.rst
+++ b/docs/syntax.rst
@@ -124,7 +124,6 @@ Supported scalar functions:
 * ``ti.acos(x)``
 * ``ti.atan2(x, y)``
 * ``ti.cast(x, type)``
-* ``ti.sqr(x)``
 * ``ti.sqrt(x)``
 * ``ti.floor(x)``
 * ``ti.inv(x)``

--- a/examples/mpm128.py
+++ b/examples/mpm128.py
@@ -31,7 +31,7 @@ def substep():
     base = (x[p] * inv_dx - 0.5).cast(int)
     fx = x[p] * inv_dx - base.cast(float)
     # Quadratic kernels  [http://mpm.graphics   Eqn. 123, with x=fx, fx-1,fx-2]
-    w = [0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1), 0.5 * ti.sqr(fx - 0.5)]
+    w = [0.5 * (1.5 - fx) ** 2, 0.75 - (fx - 1) ** 2, 0.5 * (fx - 0.5) ** 2]
     F[p] = (ti.Matrix.identity(ti.f32, 2) + dt * C[p]) @ F[p] # deformation gradient update
     h = max(0.1, min(5, ti.exp(10 * (1.0 - Jp[p])))) # Hardening coefficient: snow gets harder when compressed
     if material[p] == 1: # jelly, make it softer
@@ -74,7 +74,7 @@ def substep():
   for p in x: # grid to particle (G2P)
     base = (x[p] * inv_dx - 0.5).cast(int)
     fx = x[p] * inv_dx - base.cast(float)
-    w = [0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0), 0.5 * ti.sqr(fx - 0.5)]
+    w = [0.5 * (1.5 - fx) ** 2, 0.75 - (fx - 1.0) ** 2, 0.5 * (fx - 0.5) ** 2]
     new_v = ti.Vector.zero(ti.f32, 2)
     new_C = ti.Matrix.zero(ti.f32, 2, 2)
     for i, j in ti.static(ti.ndrange(3, 3)): # loop over 3x3 grid node neighborhood

--- a/examples/mpm88.py
+++ b/examples/mpm88.py
@@ -26,7 +26,7 @@ def substep():
   for p in x:
     base = (x[p] * inv_dx - 0.5).cast(int)
     fx = x[p] * inv_dx - base.cast(float)
-    w = [0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1), 0.5 * ti.sqr(fx - 0.5)]
+    w = [0.5 * (1.5 - fx) ** 2, 0.75 - (fx - 1) ** 2, 0.5 * (fx - 0.5) ** 2]
     stress = -dt * p_vol * (J[p] - 1) * 4 * inv_dx * inv_dx * E
     affine = ti.Matrix([[stress, 0], [0, stress]]) + p_mass * C[p]
     for i in ti.static(range(3)):
@@ -57,7 +57,7 @@ def substep():
     base = (x[p] * inv_dx - 0.5).cast(int)
     fx = x[p] * inv_dx - base.cast(float)
     w = [
-        0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0), 0.5 * ti.sqr(fx - 0.5)
+        0.5 * (1.5 - fx) ** 2, 0.75 - (fx - 1.0) ** 2, 0.5 * (fx - 0.5) ** 2
     ]
     new_v = ti.Vector.zero(ti.f32, 2)
     new_C = ti.Matrix.zero(ti.f32, 2, 2)

--- a/examples/mpm99.py
+++ b/examples/mpm99.py
@@ -27,7 +27,7 @@ def substep():
     base = (x[p] * inv_dx - 0.5).cast(int)
     fx = x[p] * inv_dx - base.cast(float)
     # Quadratic kernels  [http://mpm.graphics   Eqn. 123, with x=fx, fx-1,fx-2]
-    w = [0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1), 0.5 * ti.sqr(fx - 0.5)]
+    w = [0.5 * (1.5 - fx) ** 2, 0.75 - (fx - 1) ** 2, 0.5 * (fx - 0.5) ** 2]
     F[p] = (ti.Matrix.identity(ti.f32, 2) + dt * C[p]) @ F[p] # deformation gradient update
     h = ti.exp(10 * (1.0 - Jp[p])) # Hardening coefficient: snow gets harder when compressed
     if material[p] == 1: # jelly, make it softer
@@ -68,7 +68,7 @@ def substep():
   for p in x: # grid to particle (G2P)
     base = (x[p] * inv_dx - 0.5).cast(int)
     fx = x[p] * inv_dx - base.cast(float)
-    w = [0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0), 0.5 * ti.sqr(fx - 0.5)]
+    w = [0.5 * (1.5 - fx) ** 2, 0.75 - (fx - 1.0) ** 2, 0.5 * (fx - 0.5) ** 2]
     new_v = ti.Vector.zero(ti.f32, 2)
     new_C = ti.Matrix.zero(ti.f32, 2, 2)
     for i, j in ti.static(ti.ndrange(3, 3)): # loop over 3x3 grid node neighborhood

--- a/examples/mpm_lagrangian_forces.py
+++ b/examples/mpm_lagrangian_forces.py
@@ -69,10 +69,7 @@ def p2g():
     for p in x:
         base = ti.cast(x[p] * inv_dx - 0.5, ti.i32)
         fx = x[p] * inv_dx - ti.cast(base, ti.f32)
-        w = [
-            0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1),
-            0.5 * ti.sqr(fx - 0.5)
-        ]
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
         affine = p_mass * C[p]
         for i in ti.static(range(3)):
             for j in ti.static(range(3)):
@@ -117,10 +114,7 @@ def g2p():
     for p in x:
         base = ti.cast(x[p] * inv_dx - 0.5, ti.i32)
         fx = x[p] * inv_dx - ti.cast(base, ti.f32)
-        w = [
-            0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0),
-            0.5 * ti.sqr(fx - 0.5)
-        ]
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1.0)**2, 0.5 * (fx - 0.5)**2]
         new_v = ti.Vector([0.0, 0.0])
         new_C = ti.Matrix([[0.0, 0.0], [0.0, 0.0]])
 

--- a/examples/particle_renderer.py
+++ b/examples/particle_renderer.py
@@ -439,9 +439,9 @@ def copy(img: ti.ext_arr(), samples: ti.i32):
         u = 1.0 * i / res[0]
         v = 1.0 * j / res[1]
 
-        darken = 1.0 - vignette_strength * max((ti.sqrt(
-            ti.sqr(u - vignette_center[0]) + ti.sqr(v - vignette_center[1])) -
-                                                vignette_radius), 0)
+        darken = 1.0 - vignette_strength * max(
+            (ti.sqrt((u - vignette_center[0])**2 +
+                     (v - vignette_center[1])**2) - vignette_radius), 0)
 
         for c in ti.static(range(3)):
             img[i, j, c] = ti.sqrt(color_buffer[i, j][c] * darken * exposure /

--- a/examples/regression.py
+++ b/examples/regression.py
@@ -30,15 +30,12 @@ def regress():
         est = 0.0
         for j in ti.static(range(number_coeffs)):
             est += coeffs[j] * (v**j)
-        loss.atomic_add(0.5 * ti.sqr(y[i] - est))
+        loss[None] += 0.5 * (y[i] - est)**2
 
 
 @ti.kernel
 def update():
     for i in ti.static(range(number_coeffs)):
-        # ti.print(i)
-        # ti.print(coeffs[i][None])
-        # ti.print(coeffs[i].grad[None])
         coeffs[i][None] -= learning_rate * coeffs[i].grad[None]
         coeffs[i].grad[None] = 0
 

--- a/examples/waterwave.py
+++ b/examples/waterwave.py
@@ -30,9 +30,8 @@ def reset():
 
 @ti.func
 def laplacian(i, j):
-    return (-4 * height[i, j] + height[i, j - 1] +
-            height[i, j + 1] + height[i + 1, j] +
-            height[i - 1, j]) / (4 * dx ** 2)
+    return (-4 * height[i, j] + height[i, j - 1] + height[i, j + 1] +
+            height[i + 1, j] + height[i - 1, j]) / (4 * dx**2)
 
 
 @ti.func
@@ -50,16 +49,16 @@ def take_linear(i, j):
     ret = 0.0
     if 0 <= i < shape[0] and 0 <= i < shape[1]:
         ret = (i * j * background[m + 1, n + 1] +
-              (1 - i) * j * background[m, n + 1] + i *
-              (1 - j) * background[m + 1, n] + (1 - i) *
-              (1 - j) * background[m, n])
+               (1 - i) * j * background[m, n + 1] + i *
+               (1 - j) * background[m + 1, n] + (1 - i) *
+               (1 - j) * background[m, n])
     return ret
 
 
 @ti.kernel
 def touch_at(hurt: ti.f32, x: ti.f32, y: ti.f32):
     for i, j in ti.ndrange((1, shape[0] - 1), (1, shape[1] - 1)):
-        r2 = ti.sqr(i - x) + ti.sqr(j - y)
+        r2 = (i - x)**2 + (j - y)**2
         height[i, j] = height[i, j] + hurt * ti.exp(-0.02 * r2)
 
 
@@ -79,7 +78,7 @@ def paint():
         g = gradient(i, j)
         # https://www.jianshu.com/p/66a40b06b436
         cos_i = 1 / ti.sqrt(1 + g.norm_sqr())
-        cos_o = ti.sqrt(1 - (1 - ti.sqr(cos_i)) * (1 / eta ** 2))
+        cos_o = ti.sqrt(1 - (1 - (cos_i)**2) * (1 / eta**2))
         fr = pow(1 - cos_i, 2)
         coh = cos_o * depth
         g = g * coh

--- a/misc/benchmark_parallel_compilation.py
+++ b/misc/benchmark_parallel_compilation.py
@@ -28,10 +28,7 @@ def substep():
         for p in x:
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)
-            w = [
-                0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1),
-                0.5 * ti.sqr(fx - 0.5)
-            ]
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
             F[p] = (ti.Matrix.identity(ti.f32, 2) + dt * C[p]) @ F[p]
             h = ti.exp(10 * (1.0 - Jp[p]))
             if material[p] == 1:

--- a/misc/test_poly_timed.py
+++ b/misc/test_poly_timed.py
@@ -43,7 +43,7 @@ def test_poly():
     grad_test(lambda x: x)
     grad_test(lambda x: -x)
     grad_test(lambda x: x * x)
-    grad_test(lambda x: ti.sqr(x))
+    grad_test(lambda x: x**2)
     grad_test(lambda x: x * x * x)
     grad_test(lambda x: x * x * x * x)
     grad_test(lambda x: 0.4 * x * x - 3)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -553,8 +553,9 @@ class Matrix:
         assert l == 2
         return impl.sqrt(self.norm_sqr() + eps)
 
+    # TODO: avoid using sqr here since people might consider "sqr" as "square root". New name TBD.
     def norm_sqr(self):
-        return impl.sqr(self).sum()
+        return (self**2).sum()
 
     def max(self):
         ret = self.entries[0]

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -78,6 +78,9 @@ def bit_cast(obj, type):
 
 
 def sqr(obj):
+    import warnings
+    warnings.warn('ti.sqr(x) is deprecated. Please use x ** 2 directly.',
+                  DeprecationWarning)
     return obj * obj
 
 

--- a/tests/python/test_ad_atomic.py
+++ b/tests/python/test_ad_atomic.py
@@ -16,7 +16,7 @@ def test_ad_reduce():
     @ti.kernel
     def func():
         for i in x:
-            loss.atomic_add(ti.sqr(x[i]))
+            loss.atomic_add(x[i]**2)
 
     total_loss = 0
     for i in range(N):

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -70,7 +70,7 @@ def test_poly():
     grad_test(lambda x: x)
     grad_test(lambda x: -x)
     grad_test(lambda x: x * x)
-    grad_test(lambda x: ti.sqr(x))
+    grad_test(lambda x: x**2)
     grad_test(lambda x: x * x * x)
     grad_test(lambda x: x * x * x * x)
     grad_test(lambda x: 0.4 * x * x - 3)

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -28,10 +28,7 @@ def test_mpm88():
         for p in x:
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)
-            w = [
-                0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1),
-                0.5 * ti.sqr(fx - 0.5)
-            ]
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
             stress = -dt * p_vol * (J[p] - 1) * 4 * inv_dx * inv_dx * E
             affine = ti.Matrix([[stress, 0], [0, stress]]) + p_mass * C[p]
             for i in ti.static(range(3)):
@@ -62,8 +59,7 @@ def test_mpm88():
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)
             w = [
-                0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0),
-                0.5 * ti.sqr(fx - 0.5)
+                0.5 * (1.5 - fx)**2, 0.75 - (fx - 1.0)**2, 0.5 * (fx - 0.5)**2
             ]
             new_v = ti.Vector.zero(ti.f32, 2)
             new_C = ti.Matrix.zero(ti.f32, 2, 2)


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #833 

People tend to think `sqr` means **square root** instead of **square** (https://forum.taichi.graphics/t/what-the-result-of-ti-sqr-x-x-is-a-vector-if-any-element-of-x-is-negative/125/3).

Fortunately, we have `** 2` now thanks to @archibate...

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
