### PR TITLE
[metal] Set labels on the command buffer/encoder

### DIFF
--- a/taichi/backends/metal/api.h
+++ b/taichi/backends/metal/api.h
@@ -70,6 +70,8 @@ inline void set_mtl_buffer(MTLComputeCommandEncoder *encoder,
   mac::call(encoder, "setBuffer:offset:atIndex:", buffer, offset, index);
 }
 
+// void set_label(MTLComputeCommandEncoder *encoder, const std::string &label);
+
 void dispatch_threadgroups(MTLComputeCommandEncoder *encoder,
                            int32_t blocks_x,
                            int32_t blocks_y,
@@ -83,6 +85,21 @@ inline void dispatch_threadgroups(MTLComputeCommandEncoder *encoder,
                                   int32_t blocks_x,
                                   int32_t threads_x) {
   dispatch_threadgroups(encoder, blocks_x, 1, 1, threads_x, 1, 1);
+}
+
+template <
+    typename T,
+    typename = std::enable_if_t<std::is_same_v<T, MTLComputeCommandEncoder> ||
+                                std::is_same_v<T, MTLCommandBuffer>>>
+void set_label(T *mtl_obj, const std::string &label) {
+  // Set labels on Metal command buffer and encoders, so that they can be
+  // tracked in Instrument - Metal System Trace
+  auto label_str = mac::wrap_string_as_ns_string(label);
+  mac::call(mtl_obj, "setLabel:", label_str.get());
+}
+
+inline void enqueue_command_buffer(MTLCommandBuffer *cmd_buffer) {
+  mac::call(cmd_buffer, "enqueue");
 }
 
 inline void commit_command_buffer(MTLCommandBuffer *cmd_buffer) {

--- a/taichi/backends/metal/api.h
+++ b/taichi/backends/metal/api.h
@@ -70,8 +70,6 @@ inline void set_mtl_buffer(MTLComputeCommandEncoder *encoder,
   mac::call(encoder, "setBuffer:offset:atIndex:", buffer, offset, index);
 }
 
-// void set_label(MTLComputeCommandEncoder *encoder, const std::string &label);
-
 void dispatch_threadgroups(MTLComputeCommandEncoder *encoder,
                            int32_t blocks_x,
                            int32_t blocks_y,

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -106,6 +106,7 @@ class CompiledMtlKernelBase {
     auto encoder = new_compute_command_encoder(command_buffer);
     TI_ASSERT(encoder != nullptr);
 
+    set_label(encoder.get(), kernel_attribs_.name);
     set_compute_pipeline_state(encoder.get(), pipeline_state_.get());
 
     for (int bi = 0; bi < buffers.size(); ++bi) {
@@ -381,7 +382,8 @@ class KernelManager::Impl {
       : config_(params.config),
         compiled_structs_(params.compiled_structs),
         mem_pool_(params.mem_pool),
-        profiler_(params.profiler) {
+        profiler_(params.profiler),
+        command_buffer_id_(0) {
     if (config_->debug) {
       TI_ASSERT(is_metal_api_available());
     }
@@ -583,6 +585,8 @@ class KernelManager::Impl {
   void create_new_command_buffer() {
     cur_command_buffer_ = new_command_buffer(command_queue_.get());
     TI_ASSERT(cur_command_buffer_ != nullptr);
+    set_label(cur_command_buffer_.get(),
+              fmt::format("command_buffer_{}", command_buffer_id_++));
   }
 
   template <typename T>
@@ -598,6 +602,7 @@ class KernelManager::Impl {
   nsobj_unique_ptr<MTLDevice> device_;
   nsobj_unique_ptr<MTLCommandQueue> command_queue_;
   nsobj_unique_ptr<MTLCommandBuffer> cur_command_buffer_;
+  std::size_t command_buffer_id_;
   std::unique_ptr<BufferMemoryView> root_mem_;
   nsobj_unique_ptr<MTLBuffer> root_buffer_;
   std::unique_ptr<BufferMemoryView> global_tmps_mem_;


### PR DESCRIPTION
This allows us to trace the system behavior more clearly. E.g.

<img width="1498" alt="Screen Shot 2020-05-11 at 23 35 27" src="https://user-images.githubusercontent.com/7481356/81574093-5074a300-93e0-11ea-819a-1c71e00a71e1.png">

Related issue = #935 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
