### PR TITLE
[opengl] Use `compile_to_offloads` for IR lowering

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -718,6 +718,7 @@ void OpenglCodeGen::lower() {
                               /*ad_use_stack=*/false, config.print_ir,
                               /*lower_global_access*/true);
   global_tmps_buffer_size_ = res.total_size;
+  TI_TRACE("[glsl] Global temporary buffer size {} B", global_tmp_buffer_size_);
 #ifdef _GLSL_DEBUG
   irpass::print(ir);
 #endif

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -1,4 +1,4 @@
-//#define _GLSL_DEBUG 1
+#define _GLSL_DEBUG 1
 #include "codegen_opengl.h"
 
 #include <string>
@@ -693,125 +693,6 @@ class KernelGen : public IRVisitor {
 
 }  // namespace
 
-void OpenglCodeGen::lower() {  // {{{
-  auto ir = kernel_->ir;
-  const bool print_ir = prog_->config.print_ir;
-  if (print_ir) {
-    TI_TRACE("Initial IR:");
-    irpass::print(ir);
-  }
-
-  if (kernel_->grad) {
-    irpass::reverse_segments(ir);
-    irpass::re_id(ir);
-    if (print_ir) {
-      TI_TRACE("Segment reversed (for autodiff):");
-      irpass::print(ir);
-    }
-  }
-
-  irpass::lower(ir);
-  irpass::re_id(ir);
-  if (print_ir) {
-    TI_TRACE("Lowered:");
-    irpass::print(ir);
-  }
-
-  irpass::typecheck(ir);
-  irpass::re_id(ir);
-  if (print_ir) {
-    TI_TRACE("Typechecked:");
-    irpass::print(ir);
-  }
-
-  irpass::demote_dense_struct_fors(ir);
-  irpass::typecheck(ir);
-  if (print_ir) {
-    TI_TRACE("Dense Struct-for demoted:");
-    irpass::print(ir);
-  }
-
-  irpass::constant_fold(ir);
-  if (prog_->config.simplify_before_lower_access) {
-    irpass::simplify(ir);
-    irpass::re_id(ir);
-    if (print_ir) {
-      TI_TRACE("Simplified I:");
-      irpass::print(ir);
-    }
-  }
-
-  if (kernel_->grad) {
-    irpass::demote_atomics(ir);
-    irpass::full_simplify(ir, prog_->config);
-    irpass::typecheck(ir);
-    if (print_ir) {
-      TI_TRACE("Before make_adjoint:");
-      irpass::print(ir);
-    }
-    irpass::make_adjoint(ir);
-    if (print_ir) {
-      TI_TRACE("After make_adjoint:");
-      irpass::print(ir);
-    }
-    irpass::typecheck(ir);
-  }
-
-  irpass::lower_access(ir, prog_->config.use_llvm);
-  irpass::re_id(ir);
-  if (print_ir) {
-    TI_TRACE("Access Lowered:");
-    irpass::print(ir);
-  }
-
-  irpass::die(ir);
-  irpass::re_id(ir);
-  if (print_ir) {
-    TI_TRACE("DIEd:");
-    irpass::print(ir);
-  }
-
-  irpass::flag_access(ir);
-  irpass::re_id(ir);
-  if (print_ir) {
-    TI_TRACE("Access Flagged:");
-    irpass::print(ir);
-  }
-
-  irpass::constant_fold(ir);
-  if (print_ir) {
-    TI_TRACE("Constant folded:");
-    irpass::re_id(ir);
-    irpass::print(ir);
-  }
-
-  global_tmps_buffer_size_ =
-      std::max(irpass::offload(ir).total_size, (size_t)(1));
-  if (print_ir) {
-    TI_TRACE("Offloaded:");
-    irpass::re_id(ir);
-    irpass::print(ir);
-  }
-
-  irpass::full_simplify(ir, prog_->config);
-  if (print_ir) {
-    TI_TRACE("Simplified II:");
-    irpass::re_id(ir);
-    irpass::print(ir);
-  }
-
-  irpass::demote_atomics(ir);
-  if (print_ir) {
-    TI_TRACE("Atomics demoted:");
-    irpass::re_id(ir);
-    irpass::print(ir);
-  }
-
-#ifdef _GLSL_DEBUG
-  irpass::print(ir);
-#endif
-}  // }}}
-
 FunctionType OpenglCodeGen::gen(void) {
 #if defined(TI_WITH_OPENGL)
   KernelGen codegen(kernel_, kernel_name_, struct_compiled_,
@@ -825,6 +706,19 @@ FunctionType OpenglCodeGen::gen(void) {
   };
 #else
   TI_NOT_IMPLEMENTED
+#endif
+}
+
+void OpenglCodeGen::lower() {
+  auto ir = kernel_->ir;
+  auto &config = kernel_->program.config;
+  config.demote_dense_struct_fors = true;
+  irpass::compile_to_offloads(ir, config,
+                              /*vectorize=*/false, kernel_->grad,
+                              /*ad_use_stack=*/false, config.print_ir,
+                              /*lower_global_access*/true);
+#ifdef _GLSL_DEBUG
+  irpass::print(ir);
 #endif
 }
 

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -1,4 +1,4 @@
-#define _GLSL_DEBUG 1
+//#define _GLSL_DEBUG 1
 #include "codegen_opengl.h"
 
 #include <string>

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -718,7 +718,7 @@ void OpenglCodeGen::lower() {
                               /*ad_use_stack=*/false, config.print_ir,
                               /*lower_global_access*/true);
   global_tmps_buffer_size_ = res.total_size;
-  TI_TRACE("[glsl] Global temporary buffer size {} B", global_tmp_buffer_size_);
+  TI_TRACE("[glsl] Global temporary buffer size {} B", global_tmps_buffer_size_);
 #ifdef _GLSL_DEBUG
   irpass::print(ir);
 #endif

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -713,10 +713,11 @@ void OpenglCodeGen::lower() {
   auto ir = kernel_->ir;
   auto &config = kernel_->program.config;
   config.demote_dense_struct_fors = true;
-  irpass::compile_to_offloads(ir, config,
+  auto res = irpass::compile_to_offloads(ir, config,
                               /*vectorize=*/false, kernel_->grad,
                               /*ad_use_stack=*/false, config.print_ir,
                               /*lower_global_access*/true);
+  global_tmps_buffer_size_ = res.total_size;
 #ifdef _GLSL_DEBUG
   irpass::print(ir);
 #endif

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -506,6 +506,7 @@ void GLSLLaunchGuard::unmap_buffer(size_t idx) {
 
 GLSLLaunchGuard::~GLSLLaunchGuard() {
   for (int i = 0; i < impl->ssbo.size(); i++) {
+    TI_INFO("UMBUF {}", i);
     if (!iov[i].size)
       continue;
     void *p = impl->ssbo[i].map();  // 0, iov[i].size);  // output

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -506,7 +506,6 @@ void GLSLLaunchGuard::unmap_buffer(size_t idx) {
 
 GLSLLaunchGuard::~GLSLLaunchGuard() {
   for (int i = 0; i < impl->ssbo.size(); i++) {
-    TI_INFO("UMBUF {}", i);
     if (!iov[i].size)
       continue;
     void *p = impl->ssbo[i].map();  // 0, iov[i].size);  // output

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -115,7 +115,8 @@ void demote_dense_struct_fors(IRNode *root);
 void demote_atomics(IRNode *root);
 void reverse_segments(IRNode *root);  // for autograd
 std::unique_ptr<ScratchPads> initialize_scratch_pad(StructForStmt *root);
-void compile_to_offloads(IRNode *ir,
+OffloadedResult compile_to_offloads(
+                         IRNode *ir,
                          const CompileConfig &config,
                          bool vectorize,
                          bool grad,

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -129,6 +129,8 @@ OffloadedResult compile_to_offloads(
   // Final field registration correctness & type checking
   irpass::typecheck(ir);
   irpass::analysis::verify(ir);
+
+  return res;
 }
 
 }  // namespace irpass

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -4,7 +4,8 @@ TLANG_NAMESPACE_BEGIN
 
 namespace irpass {
 
-void compile_to_offloads(IRNode *ir,
+OffloadedResult compile_to_offloads(
+                         IRNode *ir,
                          const CompileConfig &config,
                          bool vectorize,
                          bool grad,
@@ -102,7 +103,7 @@ void compile_to_offloads(IRNode *ir,
   irpass::constant_fold(ir);
   print("Constant folded");
 
-  irpass::offload(ir);
+  auto res = irpass::offload(ir);
   print("Offloaded");
   irpass::analysis::verify(ir);
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related PR id = #700

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
