### PR TITLE
[ir] Remove BasicStmtVisitor::current_struct_for

### DIFF
--- a/taichi/ir/basic_stmt_visitor.cpp
+++ b/taichi/ir/basic_stmt_visitor.cpp
@@ -4,7 +4,6 @@
 TLANG_NAMESPACE_BEGIN
 
 BasicStmtVisitor::BasicStmtVisitor() {
-  current_struct_for = nullptr;
   allow_undefined_visitor = true;
 }
 
@@ -35,9 +34,7 @@ void BasicStmtVisitor::visit(RangeForStmt *for_stmt) {
 
 void BasicStmtVisitor::visit(StructForStmt *for_stmt) {
   preprocess_container_stmt(for_stmt);
-  current_struct_for = for_stmt;
   for_stmt->body->accept(this);
-  current_struct_for = nullptr;
 }
 
 void BasicStmtVisitor::visit(OffloadedStmt *stmt) {

--- a/taichi/ir/visitors.h
+++ b/taichi/ir/visitors.h
@@ -5,9 +5,6 @@ TLANG_NAMESPACE_BEGIN
 
 // Visits all non-containing statements
 class BasicStmtVisitor : public IRVisitor {
- private:
-  StructForStmt *current_struct_for;
-
  public:
   BasicStmtVisitor();
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Looks like `BasicStmtVisitor::current_struct_for` is never used.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
