### PR TITLE
[Doc] Fix in docs/syntax_sugars.po

### DIFF
--- a/docs/syntax_sugars.rst
+++ b/docs/syntax_sugars.rst
@@ -4,7 +4,7 @@ Syntax sugars
 Aliases
 -------------------------------------------------------
 
-Creating aliases for global variables and functions with cumbersome names can sometimes improve readability. In Taichi, this can be done by assigning kernel and function local variables with ``ti.static()``, which forces Taichi to use standard python pointer assignement.
+Creating aliases for global variables and functions with cumbersome names can sometimes improve readability. In Taichi, this can be done by assigning kernel and function local variables with ``ti.static()``, which forces Taichi to use standard python pointer assignment.
 
 For example, consider the simple kernel:
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

### Change made

Change `assignement` to `assignment` in [docs/syntax_sugars.rst](https://github.com/taichi-dev/taichi/blob/master/docs/syntax_sugars.rst)

No related issue;

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
