### PR TITLE
[ir][refactor] Avoid throwing exception in `replace_statements_with`

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -719,6 +719,12 @@ void Block::replace_with(Stmt *old_statement,
   if (replace_usages)
     old_statement->replace_with(new_statements.back().get());
   trash_bin.push_back(std::move(statements[location]));
+  if (new_statements.size() == 1) {
+    // Keep all std::vector::iterator valid in this case.
+    statements[location] = std::move(new_statements[0]);
+    statements[location]->parent = this;
+    return;
+  }
   statements.erase(statements.begin() + location);
   for (int i = (int)new_statements.size() - 1; i >= 0; i--) {
     insert(std::move(new_statements[i]), location);

--- a/taichi/transforms/statement_replace.cpp
+++ b/taichi/transforms/statement_replace.cpp
@@ -24,8 +24,7 @@ class StatementReplace : public IRVisitor {
       auto block = stmt->parent;
       auto new_stmt = generator();
       irpass::replace_all_usages_with(node, stmt, new_stmt.get());
-      block->replace_with(stmt, std::move(new_stmt));
-      throw IRModified();
+      block->replace_with(stmt, std::move(new_stmt), false);
     }
   }
 
@@ -64,14 +63,7 @@ class StatementReplace : public IRVisitor {
   }
 
   void run() {
-    while (true) {
-      try {
-        node->accept(this);
-      } catch (IRModified) {
-        continue;
-      }
-      break;
-    }
+    node->accept(this);
   }
 };
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

I realized that what caused #953 to fail is
https://github.com/taichi-dev/taichi/blob/e0ef399b2c2f053918e1013fea9850022c96bced/taichi/transforms/statement_replace.cpp#L27
calling `get_ir_root()`, not the exceptions...

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
