### PR TITLE
[Bug] [opengl] [llvm] [metal] Fix floordiv overflow when `lhs * rhs` is large

### DIFF
--- a/taichi/backends/metal/shaders/helpers.metal.h
+++ b/taichi/backends/metal/shaders/helpers.metal.h
@@ -33,7 +33,8 @@ STR(
 
     inline int ifloordiv(int lhs, int rhs) {
       const int intm = (lhs / rhs);
-      return (((lhs * rhs < 0) && (rhs * intm != lhs)) ? (intm - 1) : intm);
+      return (((lhs < 0) != (rhs < 0) && lhs &&
+            (rhs * intm != lhs)) ? (intm - 1) : intm);
     }
 
     int32_t pow_i32(int32_t x, int32_t n) {

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -386,7 +386,7 @@ class KernelGen : public IRVisitor {
       if (is_integral(bin->lhs->element_type()) &&
           is_integral(bin->rhs->element_type())) {
         emit(
-            "{} {} = {}({} * {} >= 0 ? abs({}) / abs({}) : sign({}) * "
+            "{} {} = {}(sign({}) * {} >= 0 ? abs({}) / abs({}) : sign({}) * "
             "(abs({}) + abs({}) - 1) / {});",
             dt_name, bin_name, dt_name, lhs_name, rhs_name, lhs_name, rhs_name,
             lhs_name, lhs_name, rhs_name, rhs_name);

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -96,12 +96,12 @@ T ifloordiv(T a, T b) {
   // new = (a < 0) != (b < 0) && a
   //
   //  a  b old new
-  //  -  -  f = f (f&f)
-  //  -  +  t = t (t&f)
+  //  -  -  f = f (f&t)
+  //  -  +  t = t (t&t)
   //  0  -  f = f (t&f)
   //  0  +  f = f (f&f)
-  //  +  -  t = t (t&f)
-  //  +  +  f = f (f&f)
+  //  +  -  t = t (t&t)
+  //  +  +  f = f (f&t)
   //
   // the situation of `b = 0` is ignored since we get FPE anyway.
   //


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = closes #969

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
