### PR TITLE
[metal] Skip allocating Runtime::ListManager if no sparse SNode is used

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -413,8 +413,11 @@ class KernelManager::Impl {
           compiled_structs_.runtime_size, mem_pool_);
       runtime_buffer_ = new_mtl_buffer_no_copy(
           device_.get(), runtime_mem_->ptr(), runtime_mem_->size());
-      TI_ASSERT(runtime_buffer_ != nullptr);
       TI_DEBUG("Metal runtime buffer size: {} bytes", runtime_mem_->size());
+      TI_ASSERT_INFO(
+          runtime_buffer_ != nullptr,
+          "Failed to allocate Metal runtime buffer, requested {} bytes",
+          runtime_mem_->size());
       init_runtime(params.root_id);
     }
   }


### PR DESCRIPTION


Related issue = #975

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
