### PR TITLE
[opengl] Fix unwanted "used.int64_t = true" in KernelReturnStmt

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -86,16 +86,18 @@ class KernelGen : public IRVisitor {
   void generate_header() {
   }
 
-  std::string opengl_data_type_name(DataType dt) {  // catch & forward
-    if (dt == DataType::i64)
-      used.int64 = true;
-    return opengl::opengl_data_type_name(dt);
-  }
-
-  std::string opengl_data_type_short_name(DataType dt) {  // catch & forward
+  // Note that the following two functions not only returns the corresponding
+  // data type, but also **records** the usage of `i64`.
+  std::string opengl_data_type_short_name(DataType dt) {
     if (dt == DataType::i64)
       used.int64 = true;
     return data_type_short_name(dt);
+  }
+
+  std::string opengl_data_type_name(DataType dt) {
+    if (dt == DataType::i64)
+      used.int64 = true;
+    return opengl::opengl_data_type_name(dt);
   }
 
   void generate_bottom() {


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = close #1001

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
