### PR TITLE
[Mac] [GUI] Fix bug due to View class name conflict

### DIFF
--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -1,15 +1,15 @@
-#include "taichi/util/bit.h"
 #include "taichi/common/task.h"
 #include "taichi/gui/gui.h"
+#include "taichi/util/bit.h"
 
 #if defined(TI_GUI_COCOA)
-
-#include "taichi/platform/mac/objc_api.h"
 
 #include <algorithm>
 #include <optional>
 #include <string>
 #include <unordered_map>
+
+#include "taichi/platform/mac/objc_api.h"
 
 // https://stackoverflow.com/questions/4356441/mac-os-cocoa-draw-a-simple-pixel-on-a-canvas
 // http://cocoadevcentral.com/d/intro_to_quartz/
@@ -134,6 +134,10 @@ constexpr int NSApplicationActivationPolicyRegular = 0;
 constexpr int NSEventTypeKeyDown = 10;
 constexpr int NSEventTypeKeyUp = 11;
 
+// We need to give the View class a somewhat unique name, so that it won't
+// conflict with other modules (e.g. matplotlib). See issue#998.
+constexpr char kTaichiViewClassName[] = "TaichiGuiClass";
+
 }  // namespace
 
 extern id NSApp;
@@ -204,7 +208,8 @@ Class ViewClass;
 Class AppDelClass;
 
 __attribute__((constructor)) static void initView() {
-  ViewClass = objc_allocateClassPair((Class)objc_getClass("NSView"), "View", 0);
+  ViewClass = objc_allocateClassPair((Class)objc_getClass("NSView"),
+                                     kTaichiViewClassName, 0);
   // There are two ways to update NSView's content, either via "drawRect:" or
   // "updateLayer". Updating via layer can be a lot faster, so we use this
   // method. See also:
@@ -258,7 +263,7 @@ void GUI::create_window() {
        (NSTitledWindowMask | NSClosableWindowMask | NSResizableWindowMask |
         NSMiniaturizableWindowMask),
        0, false);
-  view = call(clscall("View", "alloc"), "initWithFrame:", rect);
+  view = call(clscall(kTaichiViewClassName, "alloc"), "initWithFrame:", rect);
   gui_from_id[view] = this;
   // Use layer to speed up the draw
   // https://developer.apple.com/documentation/appkit/nsview/1483695-wantslayer?language=objc

--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -136,7 +136,7 @@ constexpr int NSEventTypeKeyUp = 11;
 
 // We need to give the View class a somewhat unique name, so that it won't
 // conflict with other modules (e.g. matplotlib). See issue#998.
-constexpr char kTaichiViewClassName[] = "TaichiGuiClass";
+constexpr char kTaichiViewClassName[] = "TaichiGuiView";
 
 }  // namespace
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

There was a conflict in class naming in Cocoa, let's rename our view class to `TaichiGuiView`.

Related issue = #998

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
