### PR TITLE
[refactor] [ir] Deprecate the unused OffloadedResult

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -10,13 +10,6 @@ TLANG_NAMESPACE_BEGIN
 // IR passes
 namespace irpass {
 
-struct OffloadedResult {
-  // Total size in bytes of the global temporary variables
-  std::size_t total_size;
-  // Offloaded local variables to its offset in the global tmps memory.
-  std::unordered_map<const Stmt *, std::size_t> local_to_global_offset;
-};
-
 void re_id(IRNode *root);
 void flag_access(IRNode *root);
 void die(IRNode *root);
@@ -40,7 +33,7 @@ void check_out_of_bound(IRNode *root);
 void lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
 void make_adjoint(IRNode *root, bool use_stack = false);
 void constant_fold(IRNode *root);
-OffloadedResult offload(IRNode *root);
+void offload(IRNode *root);
 void fix_block_parents(IRNode *root);
 void replace_statements_with(IRNode *root,
                              std::function<bool(Stmt *)> filter,
@@ -49,13 +42,13 @@ void demote_dense_struct_fors(IRNode *root);
 void demote_atomics(IRNode *root);
 void reverse_segments(IRNode *root);  // for autograd
 std::unique_ptr<ScratchPads> initialize_scratch_pad(StructForStmt *root);
-OffloadedResult compile_to_offloads(IRNode *ir,
-                                    const CompileConfig &config,
-                                    bool vectorize,
-                                    bool grad,
-                                    bool ad_use_stack,
-                                    bool verbose,
-                                    bool lower_global_access = true);
+void compile_to_offloads(IRNode *ir,
+                         const CompileConfig &config,
+                         bool vectorize,
+                         bool grad,
+                         bool ad_use_stack,
+                         bool verbose,
+                         bool lower_global_access = true);
 
 }  // namespace irpass
 

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -7,8 +7,7 @@ TLANG_NAMESPACE_BEGIN
 
 namespace irpass {
 
-OffloadedResult compile_to_offloads(
-                         IRNode *ir,
+void compile_to_offloads(IRNode *ir,
                          const CompileConfig &config,
                          bool vectorize,
                          bool grad,
@@ -106,7 +105,7 @@ OffloadedResult compile_to_offloads(
   irpass::constant_fold(ir);
   print("Constant folded");
 
-  auto res = irpass::offload(ir);
+  irpass::offload(ir);
   print("Offloaded");
   irpass::analysis::verify(ir);
 
@@ -132,8 +131,6 @@ OffloadedResult compile_to_offloads(
   // Final field registration correctness & type checking
   irpass::typecheck(ir);
   irpass::analysis::verify(ir);
-
-  return res;
 }
 
 }  // namespace irpass


### PR DESCRIPTION
Now that all backends are using the static global tmp buffer size

https://github.com/taichi-dev/taichi/blob/8efba16602bc8fe1e2700307dca3130899d1629d/taichi/inc/constants.h#L9

We can remove the unused `OffloadedResult` now.

Related issue = N/A
WANT_LGTM=any

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
