### PR TITLE
[metal] Initialize root ListManager's data only if there is sparse SNode

### DIFF
--- a/taichi/backends/metal/struct_metal.cpp
+++ b/taichi/backends/metal/struct_metal.cpp
@@ -75,6 +75,7 @@ class StructCompiler {
     emit_runtime_structs(&root);
     line_appender_.dump(&result.runtime_utils_source_code);
     result.runtime_size = compute_runtime_size();
+    result.need_snode_lists_data = has_sparse_snode_;
     result.max_snodes = max_snodes_;
     result.snode_descriptors = std::move(snode_descriptors_);
     TI_DEBUG("Metal: root_size={} runtime_size={}", result.root_size,
@@ -221,7 +222,7 @@ class StructCompiler {
     size_t result = (max_snodes_) *
                     (kSNodeMetaSize + kSNodeExtractorsSize + kListManagerSize);
     result += sizeof(uint32_t) * kNumRandSeeds;
-    TI_DEBUG("Metal runtime fields size: {} bytes", result);
+    TI_DEBUG("Metal sizeof(Runtime): {} bytes", result);
     if (has_sparse_snode_) {
       // We only need additional memory to hold sparsity information. Don't
       // allocate it if there is no sparse SNode at all.
@@ -232,6 +233,8 @@ class StructCompiler {
       const size_t list_data_size = total_items * kListgenElementSize;
       TI_DEBUG("Metal runtime sparse list data size: {} bytes", list_data_size);
       result += list_data_size;
+    } else {
+      TI_TRACE("Metal runtime doesn't need additional memory for snode_lists");
     }
     return result;
   }

--- a/taichi/backends/metal/struct_metal.h
+++ b/taichi/backends/metal/struct_metal.h
@@ -44,19 +44,28 @@ struct CompiledStructs {
   //     SNodeExtractors snode_extractors[max_snodes];
   //     ListManager snode_lists[max_snodes];
   //     uint32_t rand_seeds[kNumRandSeeds];
-  // }
-  // However, |runtime_size| is usually greater than sizeof(Runtime). That is
-  // because the memory is divided into two parts. The first part of
-  // sizeof(Runtime), as expected, is used to hold the Runtime struct. The
-  // second part is used to hold the data of |snode_lists|.
+  // };
   //
-  // |---- Runtime ----|--------------- snode_lists data ---------------|
-  // |<------------------------ runtime_size -------------------------->|
+  // If |need_snode_lists_data| is `true`, |runtime_size| will be greater than
+  // sizeof(Runtime). This is because the memory is divided into two parts. The
+  // first part, with size being sizeof(Runtime), is used to hold the Runtime
+  // struct as expected. The second part is used to hold the data of
+  // |snode_lists|.
   //
-  // The actual data address for the i-th ListManager is:
+  // |---- Runtime ----|--------------- |snode_lists| data ---------------|
+  // |<------------------------- runtime_size --------------------------->|
+  //
+  // The actual data address for the i-th ListManager is then:
   // runtime memory address + list[i].mem_begin
+  //
+  // Otherwise if |need_snode_lists_data| is `false`, |runtime_size| will be
+  // equal to sizeof(Runtime).
+  //
   // TODO(k-ye): See if Metal ArgumentBuffer can directly store the pointers.
   size_t runtime_size;
+  // In case there is no sparse SNode (e.g. bitmasked), we don't need to
+  // allocate the additional memory for |snode_lists|.
+  bool need_snode_lists_data;
   // max(ID of Root or Dense Snode) + 1
   int max_snodes;
   // Map from SNode ID to its descriptor.


### PR DESCRIPTION
This is to fix https://github.com/taichi-dev/taichi/issues/975#issuecomment-628665115, where we didn't allocate the additional memory, but still wrote to it...

Related issue = #975 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
