### PR TITLE
[Lang][ir] "print" now support multiple scalar arguments

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -299,8 +299,8 @@ def layout(func):
     pytaichi.layout_functions.append(func)
 
 
-def ti_print(var):
-    taichi_lang_core.create_print(Expr(var).ptr)
+def ti_print(*vars):
+    taichi_lang_core.create_print([Expr(var).ptr for var in vars])
 
 
 def ti_int(var):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -300,9 +300,7 @@ def layout(func):
 
 
 def ti_print(var):
-    code = inspect.getframeinfo(inspect.currentframe().f_back).code_context[0]
-    arg_name = code[code.index('(') + 1:code.rindex(')')]
-    taichi_lang_core.print_(Expr(var).ptr, arg_name)
+    taichi_lang_core.create_print(Expr(var).ptr)
 
 
 def ti_int(var):

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -113,7 +113,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     std::vector<llvm::Value *> values;
 
     std::string formats;
-    for (auto &&content : stmt->contents) {
+    for (auto content : stmt->contents) {
       if (formats.size() != 0)  // not the first expr?
         formats += " ";         // add seperator
       formats += data_type_format(content->ret_type.data_type);

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -105,6 +105,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
   }
 
   void visit(PrintStmt *stmt) override {
+    // TODO(@archibate): ask @yuanming-hu about how to deal with CUDA print
+
     TI_ASSERT(stmt->width() == 1);
 
     auto content = stmt->contents[0];

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -105,8 +105,6 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
   }
 
   void visit(PrintStmt *stmt) override {
-    // TODO(@archibate): ask @yuanming-hu about how to deal with CUDA print
-
     TI_ASSERT(stmt->width() == 1);
 
     std::vector<llvm::Type *> types;

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -107,21 +107,23 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
   void visit(PrintStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
 
-    auto value_type = tlctx->get_data_type(stmt->stmt->ret_type.data_type);
+    auto content = stmt->contents[0];
+
+    auto value_type = tlctx->get_data_type(content->ret_type.data_type);
 
     std::string format;
 
-    auto value = llvm_val[stmt->stmt];
+    auto value = llvm_val[content];
 
-    if (stmt->stmt->ret_type.data_type == DataType::i32) {
+    if (content->ret_type.data_type == DataType::i32) {
       format = "%d";
-    } else if (stmt->stmt->ret_type.data_type == DataType::i64) {
+    } else if (content->ret_type.data_type == DataType::i64) {
       format = "%lld";
-    } else if (stmt->stmt->ret_type.data_type == DataType::f32) {
+    } else if (content->ret_type.data_type == DataType::f32) {
       value_type = llvm::Type::getDoubleTy(*llvm_context);
       value = builder->CreateFPExt(value, value_type);
       format = "%f";
-    } else if (stmt->stmt->ret_type.data_type == DataType::f64) {
+    } else if (content->ret_type.data_type == DataType::f64) {
       format = "%.12f";
     } else {
       TI_NOT_IMPLEMENTED
@@ -134,7 +136,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
         values, {tlctx->get_constant(0), tlctx->get_constant(0)});
     builder->CreateStore(value, value_ptr);
 
-    auto format_str = "[debug] " + stmt->str + " = " + format + "\n";
+    auto format_str = "[debug] " + format + "\n";
 
     llvm_val[stmt] = LLVMModuleBuilder::call(
         builder.get(), "vprintf",

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -648,8 +648,9 @@ void CodeGenLLVM::visit(PrintStmt *stmt) {
   TI_ASSERT(stmt->width() == 1);
   std::vector<Value *> args;
   std::string format;
-  auto value = llvm_val[stmt->stmt];
-  auto dt = stmt->stmt->ret_type.data_type;
+  auto content = stmt->contents[0];
+  auto value = llvm_val[content];
+  auto dt = content->ret_type.data_type;
   if (dt == DataType::i32) {
     format = "%d";
   } else if (dt == DataType::i64) {
@@ -668,8 +669,7 @@ void CodeGenLLVM::visit(PrintStmt *stmt) {
   }
   auto runtime_printf = call("LLVMRuntime_get_host_printf", get_runtime());
   args.push_back(builder->CreateGlobalStringPtr(
-      ("[debug] " + stmt->str + " = " + format + "\n").c_str(),
-      "format_string"));
+      ("[debug] " + format + "\n").c_str(), "format_string"));
   args.push_back(value);
 
   llvm_val[stmt] = builder->CreateCall(runtime_printf, args);

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -634,7 +634,7 @@ void CodeGenLLVM::visit(PrintStmt *stmt) {
   TI_ASSERT(stmt->width() == 1);
   std::vector<Value *> args;
   std::string formats;
-  for (auto &&content : stmt->contents) {
+  for (auto content : stmt->contents) {
     auto value = llvm_val[content];
     if (content->ret_type.data_type == DataType::f32)
       value = builder->CreateFPExt(value, tlctx->get_data_type(DataType::f64));

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -199,8 +199,4 @@ Expr Var(const Expr &x) {
   return var;
 }
 
-void Print_(const Expr &a, const std::string &str) {
-  current_ast_builder().insert(std::make_unique<FrontendPrintStmt>(a, str));
-}
-
 TLANG_NAMESPACE_END

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -132,7 +132,6 @@ inline Expr smart_load(const Expr &var) {
 }
 
 // Begin: legacy frontend functions
-void Print_(const Expr &a, const std::string &str);
 void Cache(int v, const Expr &var);
 void CacheL1(const Expr &var);
 Expr Var(const Expr &x);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -75,11 +75,12 @@ class FrontendIfStmt : public Stmt {
 
 class FrontendPrintStmt : public Stmt {
  public:
-  Expr expr;
-  std::string str;
+  std::vector<Expr> contents;
 
-  FrontendPrintStmt(const Expr &expr, const std::string &str)
-      : expr(load_if_ptr(expr)), str(str) {
+  FrontendPrintStmt(const std::vector<Expr> &contents_) {
+    for (const auto &c : contents_) {
+      contents.push_back(load_if_ptr(c));
+    }
   }
 
   TI_DEFINE_ACCEPT

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -270,12 +270,13 @@ class IRNode {
     visitor->visit(this);                    \
   }
 
-#define TI_DEFINE_CLONE                                                        \
-  std::unique_ptr<Stmt> clone() const override {                               \
-    auto new_stmt = std::make_unique<std::decay<decltype(*this)>::type>(*this);\
-    new_stmt->mark_fields_registered();                                        \
-    new_stmt->io(new_stmt->field_manager);                                     \
-    return new_stmt;                                                           \
+#define TI_DEFINE_CLONE                                             \
+  std::unique_ptr<Stmt> clone() const override {                    \
+    auto new_stmt =                                                 \
+        std::make_unique<std::decay<decltype(*this)>::type>(*this); \
+    new_stmt->mark_fields_registered();                             \
+    new_stmt->io(new_stmt->field_manager);                          \
+    return new_stmt;                                                \
   }
 
 #define TI_DEFINE_ACCEPT_AND_CLONE \
@@ -582,7 +583,7 @@ class Stmt : public IRNode {
   }
 
   std::string type();
-  
+
   virtual std::unique_ptr<Stmt> clone() const {
     TI_NOT_IMPLEMENTED
   }
@@ -805,7 +806,7 @@ class Block : public IRNode {
  public:
   Block *parent;
   std::vector<std::unique_ptr<Stmt>> statements, trash_bin;
-  std::map<Identifier, Stmt *> local_var_alloca; // Only used in frontend
+  std::map<Identifier, Stmt *> local_var_alloca;  // Only used in frontend
   Stmt *mask_var;
   std::vector<SNode *> stop_gradients;
 
@@ -1020,14 +1021,13 @@ class IfStmt : public Stmt {
 
 class PrintStmt : public Stmt {
  public:
-  Stmt *stmt;
-  std::string str;
+  std::vector<Stmt *> contents;
 
-  PrintStmt(Stmt *stmt, const std::string &str) : stmt(stmt), str(str) {
+  PrintStmt(const std::vector<Stmt *> &content_) : contents(content_) {
     TI_STMT_REG_FIELDS;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, stmt, str);
+  TI_STMT_DEF_FIELDS(ret_type, contents);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 
@@ -1127,8 +1127,12 @@ class StructForStmt : public Stmt {
 
   std::unique_ptr<Stmt> clone() const override;
 
-  TI_STMT_DEF_FIELDS(loop_vars, snode, vectorize, parallelize, block_dim,
-      scratch_opt);
+  TI_STMT_DEF_FIELDS(loop_vars,
+                     snode,
+                     vectorize,
+                     parallelize,
+                     block_dim,
+                     scratch_opt);
   TI_DEFINE_ACCEPT
 };
 

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -87,6 +87,24 @@ std::string data_type_name(DataType t) {
   return type_names[t];
 }
 
+std::string data_type_format(DataType dt) {
+  if (dt == DataType::i32) {
+    return "%d";
+  } else if (dt == DataType::i64) {
+#if defined(TI_PLATFORM_UNIX)
+    return "%lld";
+#else
+    return "%I64d";
+#endif
+  } else if (dt == DataType::f32) {
+    return "%f";
+  } else if (dt == DataType::f64) {
+    return "%.12f";
+  } else {
+    TI_NOT_IMPLEMENTED
+  }
+}
+
 int data_type_size(DataType t) {
   static std::map<DataType, int> type_sizes;
   if (type_sizes.empty()) {

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -56,6 +56,8 @@ inline DataType get_data_type() {
 
 std::string data_type_name(DataType t);
 
+std::string data_type_format(DataType dt);
+
 std::string data_type_short_name(DataType t);
 
 enum class SNodeType {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -490,7 +490,12 @@ void export_lang(py::module &m) {
           return get_current_program().kernel(name, grad);
         });
 
-  m.def("print_", Print_);
+  m.def("create_print", [&](const Expr &a) {
+    std::vector<Expr> contents;
+    contents.push_back(a);
+    current_ast_builder().insert(
+        std::make_unique<FrontendPrintStmt>(std::move(contents)));
+  });
 
   m.def("decl_arg", [&](DataType dt, bool is_nparray) {
     return get_current_program().get_current_kernel().insert_arg(dt,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -111,9 +111,10 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def("default_compile_config",
-        [&]() -> CompileConfig & { return default_compile_config; },
-        py::return_value_policy::reference);
+  m.def(
+      "default_compile_config",
+      [&]() -> CompileConfig & { return default_compile_config; },
+      py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -130,11 +131,12 @@ void export_lang(py::module &m) {
              return (void *)(program->get_profiler());
            })
       .def("finalize", &Program::finalize)
-      .def("get_root",
-           [&](Program *program) -> SNode * {
-             return program->snode_root.get();
-           },
-           py::return_value_policy::reference)
+      .def(
+          "get_root",
+          [&](Program *program) -> SNode * {
+            return program->snode_root.get();
+          },
+          py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("synchronize", &Program::synchronize);
@@ -142,9 +144,10 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def("current_compile_config",
-        [&]() -> CompileConfig & { return get_current_program().config; },
-        py::return_value_policy::reference);
+  m.def(
+      "current_compile_config",
+      [&]() -> CompileConfig & { return get_current_program().config; },
+      py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -174,9 +177,10 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def("get_ch",
-           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-           py::return_value_policy::reference)
+      .def(
+          "get_ch",
+          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+          py::return_value_policy::reference)
       .def("lazy_grad", &SNode::lazy_grad)
       .def("read_int", &SNode::read_int)
       .def("read_uint", &SNode::read_uint)
@@ -226,13 +230,14 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def("define",
-           [](Program::KernelProxy *ker,
-              const std::function<void()> &func) -> Kernel & {
-             py::gil_scoped_release release;
-             return ker->def(func);
-           },
-           py::return_value_policy::reference);
+      .def(
+          "define",
+          [](Program::KernelProxy *ker,
+             const std::function<void()> &func) -> Kernel & {
+            py::gil_scoped_release release;
+            return ker->def(func);
+          },
+          py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -111,9 +111,10 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def("default_compile_config",
-        [&]() -> CompileConfig & { return default_compile_config; },
-        py::return_value_policy::reference);
+  m.def(
+      "default_compile_config",
+      [&]() -> CompileConfig & { return default_compile_config; },
+      py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -130,11 +131,12 @@ void export_lang(py::module &m) {
              return (void *)(program->get_profiler());
            })
       .def("finalize", &Program::finalize)
-      .def("get_root",
-           [&](Program *program) -> SNode * {
-             return program->snode_root.get();
-           },
-           py::return_value_policy::reference)
+      .def(
+          "get_root",
+          [&](Program *program) -> SNode * {
+            return program->snode_root.get();
+          },
+          py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("synchronize", &Program::synchronize);
@@ -142,9 +144,10 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def("current_compile_config",
-        [&]() -> CompileConfig & { return get_current_program().config; },
-        py::return_value_policy::reference);
+  m.def(
+      "current_compile_config",
+      [&]() -> CompileConfig & { return get_current_program().config; },
+      py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -174,9 +177,10 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def("get_ch",
-           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-           py::return_value_policy::reference)
+      .def(
+          "get_ch",
+          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+          py::return_value_policy::reference)
       .def("lazy_grad", &SNode::lazy_grad)
       .def("read_int", &SNode::read_int)
       .def("read_uint", &SNode::read_uint)
@@ -226,13 +230,14 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def("define",
-           [](Program::KernelProxy *ker,
-              const std::function<void()> &func) -> Kernel & {
-             py::gil_scoped_release release;
-             return ker->def(func);
-           },
-           py::return_value_policy::reference);
+      .def(
+          "define",
+          [](Program::KernelProxy *ker,
+             const std::function<void()> &func) -> Kernel & {
+            py::gil_scoped_release release;
+            return ker->def(func);
+          },
+          py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);
@@ -490,11 +495,8 @@ void export_lang(py::module &m) {
           return get_current_program().kernel(name, grad);
         });
 
-  m.def("create_print", [&](const Expr &a) {
-    std::vector<Expr> contents;
-    contents.push_back(a);
-    current_ast_builder().insert(
-        std::make_unique<FrontendPrintStmt>(std::move(contents)));
+  m.def("create_print", [&](const std::vector<Expr> &contents) {
+    current_ast_builder().insert(std::make_unique<FrontendPrintStmt>(contents));
   });
 
   m.def("decl_arg", [&](DataType dt, bool is_nparray) {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -111,10 +111,9 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def(
-      "default_compile_config",
-      [&]() -> CompileConfig & { return default_compile_config; },
-      py::return_value_policy::reference);
+  m.def("default_compile_config",
+        [&]() -> CompileConfig & { return default_compile_config; },
+        py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -131,12 +130,11 @@ void export_lang(py::module &m) {
              return (void *)(program->get_profiler());
            })
       .def("finalize", &Program::finalize)
-      .def(
-          "get_root",
-          [&](Program *program) -> SNode * {
-            return program->snode_root.get();
-          },
-          py::return_value_policy::reference)
+      .def("get_root",
+           [&](Program *program) -> SNode * {
+             return program->snode_root.get();
+           },
+           py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("synchronize", &Program::synchronize);
@@ -144,10 +142,9 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def(
-      "current_compile_config",
-      [&]() -> CompileConfig & { return get_current_program().config; },
-      py::return_value_policy::reference);
+  m.def("current_compile_config",
+        [&]() -> CompileConfig & { return get_current_program().config; },
+        py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -177,10 +174,9 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def(
-          "get_ch",
-          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-          py::return_value_policy::reference)
+      .def("get_ch",
+           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+           py::return_value_policy::reference)
       .def("lazy_grad", &SNode::lazy_grad)
       .def("read_int", &SNode::read_int)
       .def("read_uint", &SNode::read_uint)
@@ -230,14 +226,13 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def(
-          "define",
-          [](Program::KernelProxy *ker,
-             const std::function<void()> &func) -> Kernel & {
-            py::gil_scoped_release release;
-            return ker->def(func);
-          },
-          py::return_value_policy::reference);
+      .def("define",
+           [](Program::KernelProxy *ker,
+              const std::function<void()> &func) -> Kernel & {
+             py::gil_scoped_release release;
+             return ker->def(func);
+           },
+           py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -181,16 +181,24 @@ class IRPrinter : public IRVisitor {
     print("}}");
   }
 
-  void visit(FrontendPrintStmt *print_stmt) override {
-    print("print {}", print_stmt->contents[0].serialize());
-  }
-
   void visit(FrontendEvalStmt *stmt) override {
     print("{} = eval {}", stmt->name(), stmt->expr.serialize());
   }
 
+  void visit(FrontendPrintStmt *print_stmt) override {
+    std::vector<std::string> contents;
+    for (auto c : print_stmt->contents) {
+      contents.push_back(c.serialize());
+    }
+    print("print {}", fmt::join(contents, ", "));
+  }
+
   void visit(PrintStmt *print_stmt) override {
-    print("print {}", print_stmt->contents[0]->name());
+    std::vector<std::string> names;
+    for (auto c : print_stmt->contents) {
+      names.push_back(c->name());
+    }
+    print("print {}", fmt::join(names, ", "));
   }
 
   void visit(ConstStmt *const_stmt) override {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -182,7 +182,7 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(FrontendPrintStmt *print_stmt) override {
-    print("print \"{}\", {}", print_stmt->str, print_stmt->expr.serialize());
+    print("print {}", print_stmt->contents[0].serialize());
   }
 
   void visit(FrontendEvalStmt *stmt) override {
@@ -190,8 +190,7 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(PrintStmt *print_stmt) override {
-    print("{}print {}, {}", print_stmt->type_hint(), print_stmt->str,
-          print_stmt->stmt->name());
+    print("print {}", print_stmt->contents[0]->name());
   }
 
   void visit(ConstStmt *const_stmt) override {

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -115,10 +115,13 @@ class LowerAST : public IRVisitor {
 
   void visit(FrontendPrintStmt *stmt) override {
     // expand rhs
-    auto expr = load_if_ptr(stmt->expr);
+    std::vector<Stmt *> stmts;
     auto fctx = make_flatten_ctx();
-    expr->flatten(&fctx);
-    fctx.push_back<PrintStmt>(expr->stmt, stmt->str);
+    for (auto &&x : stmt->contents) {
+      x->flatten(&fctx);
+      stmts.push_back(x->stmt);
+    }
+    fctx.push_back<PrintStmt>(stmts);
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
     throw IRModified();
   }

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -117,7 +117,7 @@ class LowerAST : public IRVisitor {
     // expand rhs
     std::vector<Stmt *> stmts;
     auto fctx = make_flatten_ctx();
-    for (auto &&x : stmt->contents) {
+    for (auto x : stmt->contents) {
       x->flatten(&fctx);
       stmts.push_back(x->stmt);
     }

--- a/taichi/transforms/vector_split.cpp
+++ b/taichi/transforms/vector_split.cpp
@@ -244,7 +244,7 @@ class BasicBlockVectorSplit : public IRVisitor {
     for (int i = 0; i < current_split_factor; i++) {
       std::vector<Stmt *> new_contents;
       std::transform(stmt->contents.begin(), stmt->contents.end(),
-                     new_contents.begin(),
+                     std::back_inserter(new_contents),
                      [=](auto x) { return lookup(x, i); });
       current_split[i] = Stmt::make<PrintStmt>(new_contents);
     }

--- a/taichi/transforms/vector_split.cpp
+++ b/taichi/transforms/vector_split.cpp
@@ -245,7 +245,7 @@ class BasicBlockVectorSplit : public IRVisitor {
       std::vector<Stmt *> new_contents;
       std::transform(stmt->contents.begin(), stmt->contents.end(),
                      new_contents.begin(),
-                     [&](auto &&x) { return lookup(x, i); });
+                     [=](auto x) { return lookup(x, i); });
       current_split[i] = Stmt::make<PrintStmt>(new_contents);
     }
   }

--- a/taichi/transforms/vector_split.cpp
+++ b/taichi/transforms/vector_split.cpp
@@ -3,6 +3,7 @@
 #include "taichi/ir/ir.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/visitors.h"
+#include <algorithm>
 
 TLANG_NAMESPACE_BEGIN
 
@@ -241,8 +242,11 @@ class BasicBlockVectorSplit : public IRVisitor {
 
   void visit(PrintStmt *stmt) override {
     for (int i = 0; i < current_split_factor; i++) {
-      current_split[i] =
-          Stmt::make<PrintStmt>(lookup(stmt->stmt, i), stmt->str);
+      std::vector<Stmt *> new_contents;
+      std::transform(stmt->contents.begin(), stmt->contents.end(),
+                     new_contents.begin(),
+                     [&](auto &&x) { return lookup(x, i); });
+      current_split[i] = Stmt::make<PrintStmt>(new_contents);
     }
   }
 

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -17,3 +17,14 @@ def print_dt(dt):
 def test_print():
     for dt in [ti.i32, ti.f32, ti.i64, ti.f64]:
         print_dt(dt)
+
+
+# TODO: As described by @k-ye above, what we want to ensure
+#       is that, the content shows on console is *correct*.
+@ti.archs_excluding(ti.metal, ti.opengl)
+def test_multi_print():
+    @ti.kernel
+    def func(x: ti.i32, y: ti.f32):
+        print(x, 1234.5, y)
+
+    func(666, 233.3)


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #923

- [x] print for only one expr
- [x] print multiple expr
<del>- [ ] print string + expr (iapr)</del>
<del>- [ ] print vector&matrix (iapr)</del>

note: iapr = in another pull request, no more note for this on core devs.

[[Click to format]](http://kun.csail.mit.edu:31415/1029)
