### PR TITLE
[Doc] Improve a bit for developer build guidance

### DIFF
--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -75,7 +75,7 @@ Setting up Taichi for development
     mkdir build
     cd build
     cmake ..
-    # if you donot set clang as the default compiler in Linux
+    # if you do not set clang as the default compiler
     # use the line below:
     #   cmake .. -DCMAKE_CXX_COMPILER=clang-8
     # if you are building with CUDA 10.0, use the line below:

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -78,6 +78,10 @@ Setting up Taichi for development
     # if you do not set clang as the default compiler
     # use the line below:
     #   cmake .. -DCMAKE_CXX_COMPILER=clang-8
+    #
+    # Alternatively, if you would like to set clang as the default compiler
+    # CMAKE honors variables ``CC`` and ``CXX`` upon detecting the C and C++ compiler to use
+    #
     # if you are building with CUDA 10.0, use the line below:
     #   cmake .. -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL=True
     make -j$(nproc)

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -34,7 +34,7 @@ Installing Depedencies
     mkdir build
     cd build
     cmake ..
-    make -j$(nproc)
+    make -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 8)
     sudo make install
 
 
@@ -49,7 +49,7 @@ Installing Depedencies
     cd build
     cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
     # If you are building on NVIDIA Jetson TX2, use -DLLVM_TARGETS_TO_BUILD="ARM;NVPTX"
-    make -j$(nproc)
+    make -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 8)
     sudo make install
 
 Setting up CUDA (optional)
@@ -84,7 +84,7 @@ Setting up Taichi for development
     #
     # if you are building with CUDA 10.0, use the line below:
     #   cmake .. -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL=True
-    make -j$(nproc)
+    make -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 8)
 
 - Add the following script to your ``~/.bashrc``:
 

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -80,7 +80,7 @@ Setting up Taichi for development
     #   cmake .. -DCMAKE_CXX_COMPILER=clang-8
     #
     # Alternatively, if you would like to set clang as the default compiler
-    # CMAKE honors variables ``CC`` and ``CXX`` upon detecting the C and C++ compiler to use
+    # On Unix CMake honors environment variables $CC and $CXX upon deciding which C and C++ compilers to use
     #
     # if you are building with CUDA 10.0, use the line below:
     #   cmake .. -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL=True

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -34,7 +34,7 @@ Installing Depedencies
     mkdir build
     cd build
     cmake ..
-    make -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 8)
+    make -j 8
     sudo make install
 
 
@@ -49,7 +49,7 @@ Installing Depedencies
     cd build
     cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
     # If you are building on NVIDIA Jetson TX2, use -DLLVM_TARGETS_TO_BUILD="ARM;NVPTX"
-    make -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 8)
+    make -j 8
     sudo make install
 
 Setting up CUDA (optional)
@@ -70,8 +70,8 @@ Setting up Taichi for development
   .. code-block:: bash
 
     git clone https://github.com/taichi-dev/taichi --depth=1 --branch=master
-    git submodule update --init --recursive --depth=1
     cd taichi
+    git submodule update --init --recursive --depth=1
     mkdir build
     cd build
     cmake ..
@@ -84,7 +84,7 @@ Setting up Taichi for development
     #
     # if you are building with CUDA 10.0, use the line below:
     #   cmake .. -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL=True
-    make -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 8)
+    make -j 8
 
 - Add the following script to your ``~/.bashrc``:
 

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -34,7 +34,7 @@ Installing Depedencies
     mkdir build
     cd build
     cmake ..
-    make -j 8
+    make -j$(nproc)
     sudo make install
 
 
@@ -49,7 +49,7 @@ Installing Depedencies
     cd build
     cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
     # If you are building on NVIDIA Jetson TX2, use -DLLVM_TARGETS_TO_BUILD="ARM;NVPTX"
-    make -j 8
+    make -j$(nproc)
     sudo make install
 
 Setting up CUDA (optional)
@@ -75,9 +75,12 @@ Setting up Taichi for development
     mkdir build
     cd build
     cmake ..
+    # if you donot set clang as the default compiler in Linux
+    # use the line below:
+    #   cmake .. -DCMAKE_CXX_COMPILER=clang-8
     # if you are building with CUDA 10.0, use the line below:
     #   cmake .. -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL=True
-    make -j 8
+    make -j$(nproc)
 
 - Add the following script to your ``~/.bashrc``:
 


### PR DESCRIPTION
Tell (dev) user to explicitly assign clang as compiler, since in Linux the default is usually gcc.
use $(nproc) instead of 8 when make, safer for machines with fewer processors.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
