### PR TITLE
[refactor] Use unordered_map for Block::local_var_alloca

### DIFF
--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -806,7 +806,7 @@ class Block : public IRNode {
  public:
   Block *parent;
   std::vector<std::unique_ptr<Stmt>> statements, trash_bin;
-  std::map<Identifier, Stmt *> local_var_alloca;  // Only used in frontend
+  std::unordered_map<Identifier, Stmt *> local_var_alloca;  // Only used in frontend
   Stmt *mask_var;
   std::vector<SNode *> stop_gradients;
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = https://github.com/taichi-dev/taichi/pull/1029#discussion_r428620940

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
