### PR TITLE
[Doc] Fix typo in snode.rst

### DIFF
--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -46,7 +46,7 @@ See :ref:`layout` for more details about data layout. ``ti.root`` is the root no
 
     :parameter snode: (SNode)
     :parameter index: axis (0 for ``i`` and 1 for ``j``)
-    :return: (scalar) the size of tensor alone that axis
+    :return: (scalar) the size of tensor along that axis
 
     Equivalent to ``tensor.shape()[i]``.
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

No related issue;

### Changes made

**alone** to **along** in `docs/snode.rst`:

```markdown
the size of tensor alone that axis
=>
the size of tensor along that axis
```
[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
