### PR TITLE
[Metal] [sparse] Experimental support for dynamic SNode

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "taichi/backends/metal/constants.h"
+#include "taichi/backends/metal/features.h"
 #include "taichi/ir/ir.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/util/line_appender.h"
@@ -207,8 +208,7 @@ class KernelCodegen : public IRVisitor {
     emit(R"({}_ch {} = {}.children({});)", sn->node_type_name, stmt->raw_name(),
          parent, index_name);
     if (stmt->activate) {
-      TI_ASSERT(sn->type == SNodeType::bitmasked ||
-                sn->type == SNodeType::dynamic);
+      TI_ASSERT(is_supported_sparse_type(sn->type));
       emit("{{");
       {
         ScopedIndent s(current_appender());

--- a/taichi/backends/metal/features.h
+++ b/taichi/backends/metal/features.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "taichi/lang_util.h"
+
+TLANG_NAMESPACE_BEGIN
+namespace metal {
+
+inline bool is_supported_sparse_type(SNodeType t) {
+  return t == SNodeType::bitmasked || t == SNodeType::dynamic;
+}
+
+}  // namespace metal
+
+TLANG_NAMESPACE_END

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -519,6 +519,9 @@ class KernelManager::Impl {
         case SNodeType::bitmasked:
           rtm_meta->type = SNodeMeta::Bitmasked;
           break;
+        case SNodeType::dynamic:
+          rtm_meta->type = SNodeMeta::Dynamic;
+          break;
         default:
           TI_ERROR("Unsupported SNode type={}",
                    snode_type_name(sn_meta.snode->type));

--- a/taichi/backends/metal/shaders/runtime_structs.metal.h
+++ b/taichi/backends/metal/shaders/runtime_structs.metal.h
@@ -51,7 +51,7 @@ STR(
 
     // This class is very similar to metal::SNodeDescriptor
     struct SNodeMeta {
-      enum Type { Root = 0, Dense = 1, Bitmasked = 2 };
+      enum Type { Root = 0, Dense = 1, Bitmasked = 2, Dynamic = 3 };
       int32_t element_stride = 0;
       int32_t num_slots = 0;
       int32_t mem_offset_in_parent = 0;

--- a/taichi/backends/metal/struct_metal.cpp
+++ b/taichi/backends/metal/struct_metal.cpp
@@ -8,6 +8,7 @@
 
 #include "taichi/backends/metal/constants.h"
 #include "taichi/backends/metal/data_types.h"
+#include "taichi/backends/metal/features.h"
 #include "taichi/backends/metal/kernel_util.h"
 #include "taichi/math/arithmetic.h"
 #include "taichi/util/line_appender.h"
@@ -63,8 +64,7 @@ class StructCompiler {
             ty == SNodeType::bitmasked || ty == SNodeType::dynamic) {
           max_snodes_ = std::max(max_snodes_, sn->id);
         }
-        has_sparse_snode_ = has_sparse_snode_ || (ty == SNodeType::bitmasked) ||
-                            (ty == SNodeType::dynamic);
+        has_sparse_snode_ = has_sparse_snode_ || is_supported_sparse_type(ty);
       }
       ++max_snodes_;
     }

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -1,7 +1,11 @@
 import taichi as ti
 
 
-@ti.archs_support_sparse
+def ti_support_dynamic(test):
+    return ti.archs_excluding(ti.opengl)(test)
+
+
+@ti_support_dynamic
 def test_dynamic():
     x = ti.var(ti.f32)
     n = 128
@@ -21,7 +25,7 @@ def test_dynamic():
         assert x[i] == i
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_dynamic2():
     x = ti.var(ti.f32)
     n = 128
@@ -41,7 +45,7 @@ def test_dynamic2():
         assert x[i] == i
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_dynamic_matrix():
     x = ti.Matrix(2, 1, dt=ti.i32)
     n = 8192
@@ -66,7 +70,7 @@ def test_dynamic_matrix():
             assert b == 0
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_append():
     x = ti.var(ti.i32)
     n = 128
@@ -90,7 +94,7 @@ def test_append():
         assert elements[i] == i
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_length():
     x = ti.var(ti.i32)
     y = ti.var(ti.f32, shape=())
@@ -116,7 +120,7 @@ def test_length():
     assert y[None] == n
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_append_ret_value():
     x = ti.var(ti.i32)
     y = ti.var(ti.i32)
@@ -143,7 +147,7 @@ def test_append_ret_value():
         assert x[i] + 3 == z[i]
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_dense_dynamic():
     n = 128
     x = ti.var(ti.i32)
@@ -169,7 +173,7 @@ def test_dense_dynamic():
         assert l[i] == n
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_dense_dynamic_len():
     n = 128
     x = ti.var(ti.i32)

--- a/tests/python/test_struct_for_dynamic.py
+++ b/tests/python/test_struct_for_dynamic.py
@@ -1,7 +1,11 @@
 import taichi as ti
 
 
-@ti.archs_support_sparse
+def ti_support_dynamic(test):
+    return ti.archs_excluding(ti.opengl)(test)
+
+
+@ti_support_dynamic
 def test_dynamic():
     x = ti.var(ti.i32)
     y = ti.var(ti.i32, shape=())
@@ -24,7 +28,7 @@ def test_dynamic():
     assert y[None] == n // 3 + 1
 
 
-@ti.archs_support_sparse
+@ti_support_dynamic
 def test_dense_dynamic():
     n = 128
 


### PR DESCRIPTION
This is an experimental support for `dynamic` SNode on Metal.

The PR is surprisingly small. Here, `dynamic` is simply `dense` + `8 bytes` to hold the the number of elements currently in it. I managed to port some of the tests I've found.

Other things I can think of:

* Add more tests
* Finer-grained `ti.extensions`. I think instead of `ti.extensions.sparse`, we need one tag for each sparse data types now.
* Use `dynamic` in `pbf2d.py`. (I expect this could hurt the performance because the sparsity runtime overhead could easily become dominant for this small example. Still, it at least tests the functionality.)
* I tried to port `particles_renderer.py`, but there were two problems.
  1. Its predefined size is way too big for Metal, due to the lack of memory allocation.
  1. It also uses `pointer`.

So far I tried to shrink of size and the particles of this example, and replaced `pointer` with `bitmasked`, but then I got to a state where:
  1. running this on **CPU** slowed down by O(10), even at a much lower resolution!
  1. Cannot run on Metal. Interestingly it appears to be stuck at the `copy` kernel, which seems much simpler than `render`: https://github.com/taichi-dev/taichi/blob/8b1db49ca8aa4fff710441a1523e881f4e471331/examples/particle_renderer.py#L436-L437

---

Related issue = #860 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
