### PR TITLE
[doc] Use build from source than scratch

### DIFF
--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -4,7 +4,7 @@ Developer installation
 ======================
 
 Note this is for the compiler developers of the Taichi programming language.
-End users should use the pip packages instead of building from scratch.
+End users should use the pip packages instead of building from source.
 To build with NVIDIA GPU support, CUDA 10.0+ is needed.
 This installation guide works for Ubuntu 16.04+ and OS X 10.14+.
 For precise build instructions on Windows, please check out `appveyor.yml <https://github.com/taichi-dev/taichi/blob/master/appveyor.yml>`_, which does basically the same thing as the following instructions.
@@ -24,7 +24,7 @@ Installing Depedencies
 
 * (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8``. (``clang-7`` should work as well).
 
-* (If on other Linux distributions) Please build clang 8.0.1 from scratch:
+* (If on other Linux distributions) Please build clang 8.0.1 from source:
 
   .. code-block:: bash
 
@@ -38,7 +38,7 @@ Installing Depedencies
     sudo make install
 
 
-- Make sure you have LLVM 8.0.1 built from scratch. To do so:
+- Make sure you have LLVM 8.0.1 built from source. To do so:
 
   .. code-block:: bash
 

--- a/docs/legacy_installation.rst
+++ b/docs/legacy_installation.rst
@@ -8,7 +8,7 @@ Installing the legacy Taichi Library
  `spgrid_topo_opt <https://github.com/yuanming-hu/spgrid_topo_opt>`_)
  you should always install Taichi using ``pip``.
 
- If you are working on the Taichi compiler and need to build from scratch, see :ref:`dev_install`.
+ If you are working on the Taichi compiler and need to build from source, see :ref:`dev_install`.
 
 Supported platforms:
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#pr-title-tags -->

Related issue = #... (if any)

- As discussed in https://github.com/taichi-dev/taichi-docs-zh-cn/pull/58, it's probably better and more formal to use `build from source` across the documentation. (see [example](https://www.tensorflow.org/install/source) )

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
