### PR TITLE
[Lang] Support template arguments for ti.func

### DIFF
--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -34,7 +34,6 @@ class ASTTransformer(ast.NodeTransformer):
         self.local_scopes = []
         self.excluded_parameters = excluded_paremeters
         self.is_kernel = is_kernel
-        self.is_classfunc = is_classfunc
         self.func = func
         self.arg_features = arg_features
         self.returns = None
@@ -211,7 +210,7 @@ class ASTTransformer(ast.NodeTransformer):
             raise TaichiSyntaxError(
                 "'else' clause for 'while' not supported in Taichi kernels")
 
-        template = ''' 
+        template = '''
 if 1:
   ti.core.begin_frontend_while(ti.Expr(1).ptr)
   __while_cond = 0
@@ -249,7 +248,7 @@ if 1:
             # Do nothing
             return node
 
-        template = ''' 
+        template = '''
 if 1:
   __cond = 0
   ti.core.begin_frontend_if(ti.Expr(__cond).ptr)
@@ -297,7 +296,7 @@ if 1:
         self.generic_visit(node, ['body'])
         if is_grouped:
             assert len(node.iter.args[0].args) == 1
-            template = ''' 
+            template = '''
 if 1:
     __ndrange_arg = 0
     from taichi.lang.exception import TaichiSyntaxError
@@ -326,10 +325,10 @@ if 1:
         self.generic_visit(node, ['body'])
         loop_var = node.target.id
         self.check_loop_var(loop_var)
-        template = ''' 
+        template = '''
 if 1:
     {} = ti.Expr(ti.core.make_id_expr(''))
-    ___begin = ti.Expr(0) 
+    ___begin = ti.Expr(0)
     ___end = ti.Expr(0)
     ___begin = ti.cast(___begin, ti.i32)
     ___end = ti.cast(___end, ti.i32)
@@ -445,7 +444,7 @@ if 1:
             t.body[0].value = node.iter
             t.body = t.body[:cut] + node.body + t.body[cut:]
         else:
-            template = ''' 
+            template = '''
 if 1:
 {}
     ___loop_var = 0
@@ -642,7 +641,7 @@ if 1:
             # Transform as func (all parameters passed by value)
             arg_decls = []
             for i, arg in enumerate(args.args):
-                if i == 0 and self.is_classfunc:
+                if isinstance(self.func.arguments[i], ti.template):
                     continue
                 arg_init = self.parse_stmt('x = ti.expr_init_func(0)')
                 arg_init.targets[0].id = arg.arg

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -751,8 +751,10 @@ if 1:
             # TODO: check if it's at the end of a kernel, throw TaichiSyntaxError if not
             if node.value is not None:
                 if self.returns is None:
-                    raise TaichiSyntaxError('kernel with return value must be '
-                        'annotated with a return type, e.g. def func() -> ti.f32')
+                    raise TaichiSyntaxError(
+                        'kernel with return value must be '
+                        'annotated with a return type, e.g. def func() -> ti.f32'
+                    )
                 ret_expr = self.parse_expr('ti.cast(ti.Expr(0), 0)')
                 ret_expr.args[0].args[0] = node.value
                 ret_expr.args[1] = self.returns

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -604,6 +604,8 @@ if 1:
                 node.returns = None
 
             for i, arg in enumerate(args.args):
+                # Directly pass in template arguments,
+                # such as class instances ("self"), tensors, SNodes, etc.
                 if isinstance(self.func.arguments[i], ti.template):
                     continue
                 import taichi as ti
@@ -641,8 +643,12 @@ if 1:
             # Transform as func (all parameters passed by value)
             arg_decls = []
             for i, arg in enumerate(args.args):
+                # Directly pass in template arguments,
+                # such as class instances ("self"), tensors, SNodes, etc.
                 if isinstance(self.func.arguments[i], ti.template):
                     continue
+                # Create a copy for non-template arguments,
+                # so that they are passed by value.
                 arg_init = self.parse_stmt('x = ti.expr_init_func(0)')
                 arg_init.targets[0].id = arg.arg
                 self.create_variable(arg.arg)

--- a/tests/python/test_kernel_templates.py
+++ b/tests/python/test_kernel_templates.py
@@ -80,7 +80,8 @@ def test_func_template():
 
     @ti.func
     def sample(x: ti.template(), l: ti.template(), I):
-        return x[l][I] # `x` is a list of ti.vars, so a compile time constant `l` is need to access it. 
+        return x[l][
+            I]  # `x` is a list of ti.vars, so a compile time constant `l` is need to access it.
 
     @ti.kernel
     def fill(l: ti.template()):

--- a/tests/python/test_kernel_templates.py
+++ b/tests/python/test_kernel_templates.py
@@ -71,7 +71,7 @@ def test_kernel_template_gradient():
 
 
 @ti.all_archs
-def _test_func_template():
+def test_func_template():
     a = [ti.var(dt=ti.f32) for _ in range(2)]
     b = [ti.var(dt=ti.f32) for _ in range(2)]
 
@@ -79,8 +79,8 @@ def _test_func_template():
         ti.root.dense(ti.ij, 16).place(a[l], b[l])
 
     @ti.func
-    def sample_a(l: ti.template(), I):
-        return a[l][I]
+    def sample(x: ti.template(), l: ti.template(), I):
+        return x[l][I] # `x` is a list of ti.vars, so a compile time constant `l` is need to access it. 
 
     @ti.kernel
     def fill(l: ti.template()):
@@ -90,7 +90,7 @@ def _test_func_template():
     @ti.kernel
     def aTob(l: ti.template()):  # doesnt compile
         for I in ti.grouped(b[l]):
-            b[l][I] = sample_a(l, I)
+            b[l][I] = sample(a, l, I)
 
     for l in range(2):
         fill(l)

--- a/tests/python/test_kernel_templates.py
+++ b/tests/python/test_kernel_templates.py
@@ -69,13 +69,14 @@ def test_kernel_template_gradient():
         assert z[i] == i * 4 + 3
         assert x.grad[i] == 4
 
+
 @ti.all_archs
 def _test_func_template():
     a = [ti.var(dt=ti.f32) for _ in range(2)]
     b = [ti.var(dt=ti.f32) for _ in range(2)]
 
     for l in range(2):
-        ti.root.dense(ti.ij, 16).place(a[l],b[l])
+        ti.root.dense(ti.ij, 16).place(a[l], b[l])
 
     @ti.func
     def sample_a(l: ti.template(), I):
@@ -87,7 +88,7 @@ def _test_func_template():
             a[l][I] = l
 
     @ti.kernel
-    def aTob(l: ti.template()): # doesnt compile
+    def aTob(l: ti.template()):  # doesnt compile
         for I in ti.grouped(b[l]):
             b[l][I] = sample_a(l, I)
 
@@ -98,4 +99,4 @@ def _test_func_template():
     for l in range(2):
         for i in range(16):
             for j in range(16):
-                assert b[l][i,j] == l
+                assert b[l][i, j] == l


### PR DESCRIPTION
This PR implements support for template arguments in ```ti.func```s. This just required skipping python AST transform for arguments type-hinted with ```ti.template()```. I also slightly refactored ASTTransformer by removing the ```is_classfunc``` argument.

The test I added doesn't work atm. For some reason it runs into a python sytnax error. This syntax error does not occur when the test is run as stand alone script. So I think its related some weird nested function syntax. If you have another idea for the test to get around that please let me know!

Related issue = #1042 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
