### PR TITLE
[metal] Remove global constant def section

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -59,14 +59,15 @@ class KernelCodegen : public IRVisitor {
   enum class Section {
     Headers,
     Structs,
-    ConstantsDefs,
     KernelFuncs,
     Kernels,
   };
 
   static constexpr Section kAllSections[] = {
-      Section::Headers,     Section::Structs, Section::ConstantsDefs,
-      Section::KernelFuncs, Section::Kernels,
+      Section::Headers,
+      Section::Structs,
+      Section::KernelFuncs,
+      Section::Kernels,
   };
 
   struct UsedFeatures {
@@ -129,12 +130,8 @@ class KernelCodegen : public IRVisitor {
   }
 
   void visit(ConstStmt *const_stmt) override {
-    // We define all the constants at the global scope. Thanks to the global
-    // unique namings, all offloaded task (Metal kernels) can reference these
-    // constants correctly.
-    SectionGuard sg(this, Section::ConstantsDefs);
     TI_ASSERT(const_stmt->width() == 1);
-    emit("constant constexpr {} {} = {};",
+    emit("constexpr {} {} = {};",
          metal_data_type_name(const_stmt->element_type()),
          const_stmt->raw_name(), const_stmt->val[0].stringify());
   }


### PR DESCRIPTION
This was added back in #729 , because constants were optimized away across kernels. As a workaround, I defined all the constants at the namespace scope, which worked thanks to SSA.

However, this approach blocked me from merging multiple Metal kernels into one source code file, which was useful for profiling. So I'd like to revert this workaround now..

Related issue =  #729

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
