### PR TITLE
[Opt] Add strength reduction optimizations

### DIFF
--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -437,6 +437,23 @@ float64 TypedConstant::val_float() const {
   }
 }
 
+TypedConstant TypedConstant::operator-() const {
+  TI_ASSERT(is_signed(dt));
+  TypedConstant result(dt);
+  if (dt == DataType::i32) {
+    result.val_i32 = -val_i32;
+  } else if (dt == DataType::i64) {
+    result.val_i64 = -val_i64;
+  } else if (dt == DataType::i8) {
+    result.val_i8 = -val_i8;
+  } else if (dt == DataType::i16) {
+    result.val_i16 = -val_i16;
+  } else {
+    TI_NOT_IMPLEMENTED
+  }
+  return result;
+}
+
 }  // namespace lang
 
 void initialize_benchmark() {

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -207,6 +207,8 @@ class TypedConstant {
     return equal_type_and_value(o);
   }
 
+  TypedConstant operator-() const;
+
   int32 &val_int32();
   float32 &val_float32();
   int64 &val_int64();

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -122,8 +122,8 @@ class AlgSimp : public BasicStmtVisitor {
         auto one_raw = one.get();
         to_insert_before.emplace_back(std::move(one), stmt);
         if (stmt->ret_type.data_type != one_raw->ret_type.data_type) {
-          auto cast = Stmt::make_typed<UnaryOpStmt>(UnaryOpType::cast_value,
-                                                    one_raw);
+          auto cast =
+              Stmt::make_typed<UnaryOpStmt>(UnaryOpType::cast_value, one_raw);
           cast->cast_type = stmt->ret_type.data_type;
           cast->ret_type.data_type = stmt->ret_type.data_type;
           one_raw = cast.get();

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -140,16 +140,17 @@ class AlgSimp : public BasicStmtVisitor {
         to_insert_before.emplace_back(std::move(product), stmt);
         to_erase.push_back(stmt);
       } else if (rhs && is_integral(rhs->ret_type.data_type) &&
-          ((is_signed(rhs->ret_type.data_type) &&
-              rhs->val[0].val_int() >= 0 &&
-              rhs->val[0].val_int() <= max_weaken_exponent) ||
-              (is_unsigned(rhs->ret_type.data_type) &&
-                  rhs->val[0].val_uint() <= max_weaken_exponent))) {
+                 ((is_signed(rhs->ret_type.data_type) &&
+                   rhs->val[0].val_int() >= 0 &&
+                   rhs->val[0].val_int() <= max_weaken_exponent) ||
+                  (is_unsigned(rhs->ret_type.data_type) &&
+                   rhs->val[0].val_uint() <= max_weaken_exponent))) {
         // a ** n -> Exponentiation by squaring
         auto a = stmt->lhs;
         cast_to_result_type(a, stmt);
-        int exponent = is_signed(rhs->ret_type.data_type) ?
-                       (int)rhs->val[0].val_int() : (int)rhs->val[0].val_uint();
+        int exponent = is_signed(rhs->ret_type.data_type)
+                           ? (int)rhs->val[0].val_int()
+                           : (int)rhs->val[0].val_uint();
         Stmt *result = nullptr;
         auto a_power_of_2 = a;
         int current_exponent = 1;

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -159,8 +159,8 @@ class AlgSimp : public BasicStmtVisitor {
             if (!result)
               result = a_power_of_2;
             else {
-              auto new_result = Stmt::make<BinaryOpStmt>(
-                  BinaryOpType::mul, result, a_power_of_2);
+              auto new_result = Stmt::make<BinaryOpStmt>(BinaryOpType::mul,
+                                                         result, a_power_of_2);
               new_result->ret_type.data_type = a->ret_type.data_type;
               result = new_result.get();
               to_insert_before.emplace_back(std::move(new_result), stmt);
@@ -186,13 +186,13 @@ class AlgSimp : public BasicStmtVisitor {
         auto one_raw = one.get();
         to_insert_before.emplace_back(std::move(one), stmt);
         cast_to_result_type(one_raw, stmt);
-        auto exponent = Stmt::make<ConstStmt>(
-            LaneAttribute<TypedConstant>(-rhs->val[0]));
-        auto a_to_n = Stmt::make<BinaryOpStmt>(
-            BinaryOpType::pow, stmt->lhs, exponent.get());
+        auto exponent =
+            Stmt::make<ConstStmt>(LaneAttribute<TypedConstant>(-rhs->val[0]));
+        auto a_to_n = Stmt::make<BinaryOpStmt>(BinaryOpType::pow, stmt->lhs,
+                                               exponent.get());
         a_to_n->ret_type.data_type = stmt->ret_type.data_type;
-        auto result = Stmt::make<BinaryOpStmt>(
-            BinaryOpType::div, one_raw, a_to_n.get());
+        auto result =
+            Stmt::make<BinaryOpStmt>(BinaryOpType::div, one_raw, a_to_n.get());
         stmt->replace_with(result.get());
         to_insert_before.emplace_back(std::move(exponent), stmt);
         to_insert_before.emplace_back(std::move(a_to_n), stmt);

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -102,8 +102,8 @@ class AlgSimp : public BasicStmtVisitor {
           } else {
             TI_NOT_IMPLEMENTED
           }
-          auto product = Stmt::make<BinaryOpStmt>(
-              BinaryOpType::mul, stmt->lhs, reciprocal.get());
+          auto product = Stmt::make<BinaryOpStmt>(BinaryOpType::mul, stmt->lhs,
+                                                  reciprocal.get());
           product->ret_type.data_type = stmt->ret_type.data_type;
           stmt->replace_with(product.get());
           to_insert_before.emplace_back(std::move(reciprocal), stmt);

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -139,11 +139,12 @@ class AlgSimp : public BasicStmtVisitor {
         stmt->replace_with(product.get());
         to_insert_before.emplace_back(std::move(product), stmt);
         to_erase.push_back(stmt);
-      } else if (rhs && ((is_signed(rhs->ret_type.data_type) &&
-          rhs->val[0].val_int() >= 0 &&
-          rhs->val[0].val_int() <= max_weaken_exponent) ||
-          (is_unsigned(rhs->ret_type.data_type) &&
-              rhs->val[0].val_uint() <= max_weaken_exponent))) {
+      } else if (rhs && is_integral(rhs->ret_type.data_type) &&
+          ((is_signed(rhs->ret_type.data_type) &&
+              rhs->val[0].val_int() >= 0 &&
+              rhs->val[0].val_int() <= max_weaken_exponent) ||
+              (is_unsigned(rhs->ret_type.data_type) &&
+                  rhs->val[0].val_uint() <= max_weaken_exponent))) {
         // a ** n -> Exponentiation by squaring
         auto a = stmt->lhs;
         cast_to_result_type(a, stmt);
@@ -175,7 +176,8 @@ class AlgSimp : public BasicStmtVisitor {
         }
         stmt->replace_with(result);
         to_erase.push_back(stmt);
-      } else if (rhs && is_signed(rhs->ret_type.data_type) &&
+      } else if (rhs && is_integral(rhs->ret_type.data_type) &&
+                 is_signed(rhs->ret_type.data_type) &&
                  rhs->val[0].val_int() < 0 &&
                  rhs->val[0].val_int() >= -max_weaken_exponent) {
         // a ** -n -> 1 / a ** n


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #944

This PR contains: 
- `a * 2 -> a + a, 2 * a -> a + a` (for all types, cast to the original result type)
- `a / const -> a * (1 / const)` (floating point only & fast_math only -- is this necessary?)
- `a ** 1 -> a` (for all types)
- `a ** 0 -> 1` (for all types & fast_math only, cast to the original result type)
- `a ** 2 -> a * a` (for all types, cast to the original result type)

Benchmark:
![benchmark20200526](https://user-images.githubusercontent.com/22582118/82952150-73718c00-9f76-11ea-9361-dbd32eeae6df.png)


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
