### PR TITLE
[bug] [ir] Fix Block::replace_with segment faults when stmts.size() == 0

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -757,7 +757,7 @@ void Block::replace_with(Stmt *old_statement,
     }
   }
   TI_ASSERT(location != -1);
-  if (replace_usages && !new_statements.empty())
+  if (replace_usages && !new_statements.stmts.empty())
     old_statement->replace_with(new_statements.back().get());
   trash_bin.push_back(std::move(statements[location]));
   if (new_statements.size() == 1) {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -757,7 +757,7 @@ void Block::replace_with(Stmt *old_statement,
     }
   }
   TI_ASSERT(location != -1);
-  if (replace_usages)
+  if (replace_usages && !new_statements.empty())
     old_statement->replace_with(new_statements.back().get());
   trash_bin.push_back(std::move(statements[location]));
   if (new_statements.size() == 1) {

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -331,7 +331,10 @@ class LowerAST : public IRVisitor {
     auto fctx = make_flatten_ctx();
     expr->flatten(&fctx);
     stmt->eval_expr.cast<EvalExpression>()->stmt_ptr = stmt->expr->stmt;
-    stmt->parent->replace_with(stmt, std::move(fctx.stmts));
+    if (fctx.stmts.stmts.size())
+      stmt->parent->replace_with(stmt, std::move(fctx.stmts));
+    else
+      stmt->parent->erase(stmt);
     throw IRModified();
   }
 

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -331,7 +331,7 @@ class LowerAST : public IRVisitor {
     auto fctx = make_flatten_ctx();
     expr->flatten(&fctx);
     stmt->eval_expr.cast<EvalExpression>()->stmt_ptr = stmt->expr->stmt;
-    stmt->parent->replace_with(stmt, std::move(fctx.stmts), false);
+    stmt->parent->replace_with(stmt, std::move(fctx.stmts));
     throw IRModified();
   }
 

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -331,10 +331,7 @@ class LowerAST : public IRVisitor {
     auto fctx = make_flatten_ctx();
     expr->flatten(&fctx);
     stmt->eval_expr.cast<EvalExpression>()->stmt_ptr = stmt->expr->stmt;
-    if (fctx.stmts.stmts.size())
-      stmt->parent->replace_with(stmt, std::move(fctx.stmts));
-    else
-      stmt->parent->erase(stmt);
+    stmt->parent->replace_with(stmt, std::move(fctx.stmts), false);
     throw IRModified();
   }
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = close #1071

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

Seems `replace_usage = true` not working when `new_statements.size() == 0`:
https://github.com/taichi-dev/taichi/blob/c193e4b431d52ffa4e875940ece589d5be9599f0/taichi/ir/ir.cpp#L760-L761
... where `new_statements.back() == nullptr`.