### PR TITLE
[bug] [test] Fix CUDA segmentation fault when printing more than 32 entries

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -106,6 +106,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
 
   void visit(PrintStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
+    TI_ASSERT_INFO(stmt->contents.size() < 32,
+        "CUDA `print()` doesn't support more than 32 entries");
 
     std::vector<llvm::Type *> types;
     std::vector<llvm::Value *> values;

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -107,7 +107,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
   void visit(PrintStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
     TI_ASSERT_INFO(stmt->contents.size() < 32,
-        "CUDA `print()` doesn't support more than 32 entries");
+                   "CUDA `print()` doesn't support more than 32 entries");
 
     std::vector<llvm::Type *> types;
     std::vector<llvm::Value *> values;

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -14,6 +14,9 @@ def test_print(dt):
         print(ti.cast(1234.5, dt))
 
     func()
+    # Discussion: https://github.com/taichi-dev/taichi/issues/1063#issuecomment-636421904
+    # Synchronize to prevent cross-test failure of print:
+    ti.sync()
 
 
 # TODO: As described by @k-ye above, what we want to ensure
@@ -25,6 +28,7 @@ def test_multi_print():
         print(x, 1234.5, y)
 
     func(666, 233.3)
+    ti.sync()
 
 
 @ti.archs_excluding(ti.metal, ti.opengl)
@@ -36,15 +40,19 @@ def test_print_string():
         print('cool', x, 'well', y)
 
     func(666, 233.3)
+    ti.sync()
 
 
 @ti.archs_excluding(ti.metal, ti.opengl)
 def test_print_matrix():
     x = ti.Matrix(2, 3, dt=ti.f32, shape=())
-    y = ti.Vector(4, dt=ti.f32, shape=3)
+    y = ti.Vector(3, dt=ti.f32, shape=3)
 
     @ti.kernel
     def func(k: ti.f32):
-        print('hello', x[None], 'and', y[2] * k, x[None] / k)
+        print('hello', x[None], 'world!')
+        print(y[2] * k, x[None] / k, y[2])
 
     func(233.3)
+    ti.sync()
+

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -55,4 +55,3 @@ def test_print_matrix():
 
     func(233.3)
     ti.sync()
-


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = fix #1063

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
