### PR TITLE
[CUDA] [test] Improve portability and remove GC tests on CUDA for now 

### DIFF
--- a/taichi/runtime/llvm/internal_functions.h
+++ b/taichi/runtime/llvm/internal_functions.h
@@ -115,7 +115,7 @@ i32 test_node_allocator_gc_cpu(Context *context) {
   }
   nodes->gc_serial();
   // After GC, all items should be returned to |free_list|.
-  printf("free_list_size=%d\n", nodes->free_list->size());
+  taichi_printf(runtime, "free_list_size=%d\n", nodes->free_list->size());
   TI_TEST_CHECK(nodes->free_list->size() == kN, runtime);
 
   return 0;

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1337,7 +1337,7 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
   std::memset(stack_top_primal(stack, element_size), 0, element_size * 2);
 }
 
-#include "internal_function.h"
+#include "internal_functions.h"
 }
 
 #endif

--- a/tests/python/test_internal_func.py
+++ b/tests/python/test_internal_func.py
@@ -4,8 +4,8 @@ import time
 
 # TODO: these are not really tests...
 def all_archs_for_this(test):
-    # ti.call_internal() is not supported on Metal and OpenGL yet
-    return ti.archs_excluding(ti.metal, ti.opengl)(test)
+    # ti.call_internal() is not supported on CUDA, Metal, OpenGL yet
+    return ti.archs_excluding(ti.metal, ti.opengl, ti.cuda)(test)
 
 
 @all_archs_for_this
@@ -52,6 +52,7 @@ def test_node_manager():
     test()
 
 
+@all_archs_for_this
 def test_node_manager_gc():
     @ti.kernel
     def test_cpu():


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

`call_internal` doesn't work on CUDA at this moment.

Related issue = #1076

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
