### PR TITLE
[test][refactor] Deprecate @ti.layout in test cases

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from .core import taichi_lang_core
 from .expr import Expr
 from .snode import SNode
@@ -268,6 +269,7 @@ AOS = Layout(soa=False)
 
 def layout(func):
     assert not pytaichi.materialized, "All layout must be specified before the first kernel launch / data access."
+    warnings.warn(f"@ti.layout will be deprecated in the future, use ti.root directly to specify data layout anytime before the data structure materializes.", PendingDeprecationWarning, stacklevel=3)
     pytaichi.layout_functions.append(func)
 
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -269,7 +269,10 @@ AOS = Layout(soa=False)
 
 def layout(func):
     assert not pytaichi.materialized, "All layout must be specified before the first kernel launch / data access."
-    warnings.warn(f"@ti.layout will be deprecated in the future, use ti.root directly to specify data layout anytime before the data structure materializes.", PendingDeprecationWarning, stacklevel=3)
+    warnings.warn(
+        f"@ti.layout will be deprecated in the future, use ti.root directly to specify data layout anytime before the data structure materializes.",
+        PendingDeprecationWarning,
+        stacklevel=3)
     pytaichi.layout_functions.append(func)
 
 

--- a/tests/python/grad_test.py
+++ b/tests/python/grad_test.py
@@ -10,9 +10,7 @@ def grad_test(tifunc, npfunc=None):
     x = ti.var(ti.f32)
     y = ti.var(ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, 1).place(x, x.grad, y, y.grad)
+    ti.root.dense(ti.i, 1).place(x, x.grad, y, y.grad)
 
     @ti.kernel
     def func():

--- a/tests/python/test_abs.py
+++ b/tests/python/test_abs.py
@@ -8,11 +8,9 @@ def test_abs():
 
     N = 16
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x)
-        ti.root.dense(ti.i, N).place(y)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, N).place(x)
+    ti.root.dense(ti.i, N).place(y)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():

--- a/tests/python/test_ad_atomic.py
+++ b/tests/python/test_ad_atomic.py
@@ -9,9 +9,7 @@ def test_ad_reduce():
 
     N = 16
 
-    @ti.layout
-    def place():
-        ti.root.place(loss, loss.grad).dense(ti.i, N).place(x, x.grad)
+    ti.root.place(loss, loss.grad).dense(ti.i, N).place(x, x.grad)
 
     @ti.kernel
     def func():

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -30,9 +30,7 @@ def grad_test(tifunc, npfunc=None, default_fp=ti.f32):
         x = ti.var(default_fp)
         y = ti.var(default_fp)
 
-        @ti.layout
-        def place():
-            ti.root.dense(ti.i, 1).place(x, x.grad, y, y.grad)
+        ti.root.dense(ti.i, 1).place(x, x.grad, y, y.grad)
 
         @ti.kernel
         def func():
@@ -57,9 +55,7 @@ def grad_test(tifunc, npfunc=None, default_fp=ti.f32):
 def test_size1():
     x = ti.var(ti.i32)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)    
 
     x[0] = 1
     assert x[0] == 1
@@ -120,10 +116,8 @@ def test_mod():
     x = ti.var(ti.i32)
     y = ti.var(ti.i32)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, 1).place(x, y)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, 1).place(x, y)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():
@@ -173,10 +167,8 @@ def test_obey_kernel_simplicity():
     x = ti.var(ti.f32)
     y = ti.var(ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, 1).place(x, y)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, 1).place(x, y)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -55,7 +55,7 @@ def grad_test(tifunc, npfunc=None, default_fp=ti.f32):
 def test_size1():
     x = ti.var(ti.i32)
 
-    ti.root.dense(ti.i, 1).place(x)    
+    ti.root.dense(ti.i, 1).place(x)
 
     x[0] = 1
     assert x[0] == 1

--- a/tests/python/test_arg_check.py
+++ b/tests/python/test_arg_check.py
@@ -5,9 +5,7 @@ import taichi as ti
 def test_argument_error():
     x = ti.var(ti.i32)
 
-    @ti.layout
-    def layout():
-        ti.root.place(x)
+    ti.root.place(x)
 
     try:
 

--- a/tests/python/test_arg_load.py
+++ b/tests/python/test_arg_load.py
@@ -6,9 +6,7 @@ def test_arg_load():
     x = ti.var(ti.i32)
     y = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.place(x, y)
+    ti.root.place(x, y)
 
     @ti.kernel
     def set_i32(v: ti.i32):
@@ -37,9 +35,7 @@ def test_arg_load_f64():
     x = ti.var(ti.i32)
     y = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.place(x, y)
+    ti.root.place(x, y)
 
     @ti.kernel
     def set_f64(v: ti.f64):
@@ -61,9 +57,7 @@ def test_ext_arr():
     N = 128
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, N).place(x)
+    ti.root.dense(ti.i, N).place(x)
 
     @ti.kernel
     def set_f32(v: ti.ext_arr()):

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -9,10 +9,8 @@ def run_atomic_add_global_case(vartype, step, valproc=lambda x: x):
     y = ti.var(vartype)
     c = ti.var(vartype)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x, y)
-        ti.root.place(c)
+    ti.root.dense(ti.i, n).place(x, y)
+    ti.root.place(c)
 
     # Make Taichi correctly infer the type
     # TODO: Taichi seems to treat numpy.int32 as a float type, fix that.
@@ -53,9 +51,7 @@ def test_atomic_add_expr_evaled():
     c = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.place(c)
+    ti.root.place(c)
 
     @ti.kernel
     def func():
@@ -75,9 +71,7 @@ def test_atomic_add_demoted():
     y = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x, y)
+    ti.root.dense(ti.i, n).place(x, y)
 
     @ti.kernel
     def func():
@@ -108,9 +102,7 @@ def test_atomic_add_with_local_store_simplify1():
     y = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x, y)
+    ti.root.dense(ti.i, n).place(x, y)
 
     @ti.kernel
     def func():
@@ -141,9 +133,7 @@ def test_atomic_add_with_local_store_simplify2():
     x = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
+    ti.root.dense(ti.i, n).place(x)
 
     @ti.kernel
     def func():
@@ -164,9 +154,7 @@ def test_atomic_add_with_if_simplify():
     x = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
+    ti.root.dense(ti.i, n).place(x)
 
     boundary = n / 2
 
@@ -213,9 +201,7 @@ def test_atomic_sub_expr_evaled():
     c = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.place(c)
+    ti.root.place(c)
 
     @ti.kernel
     def func():
@@ -233,9 +219,7 @@ def test_atomic_max_expr_evaled():
     c = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.place(c)
+    ti.root.place(c)
 
     @ti.kernel
     def func():
@@ -253,9 +237,7 @@ def test_atomic_min_expr_evaled():
     c = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.place(c)
+    ti.root.place(c)
 
     @ti.kernel
     def func():
@@ -274,9 +256,7 @@ def test_atomic_and_expr_evaled():
     c = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.place(c)
+    ti.root.place(c)
 
     max_int = 2147483647
 
@@ -297,9 +277,7 @@ def test_atomic_or_expr_evaled():
     c = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.place(c)
+    ti.root.place(c)
 
     @ti.kernel
     def func():
@@ -318,9 +296,7 @@ def test_atomic_xor_expr_evaled():
     c = ti.var(ti.i32)
     step = 42
 
-    @ti.layout
-    def place():
-        ti.root.place(c)
+    ti.root.place(c)
 
     @ti.kernel
     def func():

--- a/tests/python/test_bitmasked.py
+++ b/tests/python/test_bitmasked.py
@@ -41,10 +41,8 @@ def test_bitmasked_then_dense():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.bitmasked(ti.i, n).dense(ti.i, n).place(x)
-        ti.root.place(s)
+    ti.root.bitmasked(ti.i, n).dense(ti.i, n).place(x)
+    ti.root.place(s)
 
     @ti.kernel
     def func():

--- a/tests/python/test_clear_all_gradients.py
+++ b/tests/python/test_clear_all_gradients.py
@@ -10,12 +10,10 @@ def test_clear_all_gradients():
 
     n = 128
 
-    @ti.layout
-    def layout():
-        ti.root.place(x)
-        ti.root.dense(ti.i, n).place(y)
-        ti.root.dense(ti.i, n).dense(ti.j, n).place(z, w)
-        ti.root.lazy_grad()
+    ti.root.place(x)
+    ti.root.dense(ti.i, n).place(y)
+    ti.root.dense(ti.i, n).dense(ti.j, n).place(z, w)
+    ti.root.lazy_grad()
 
     x.grad[None] = 3
     for i in range(n):

--- a/tests/python/test_complex_kernels.py
+++ b/tests/python/test_complex_kernels.py
@@ -8,11 +8,9 @@ def test_complex_kernels():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.place(total)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.place(total)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func(mul: ti.f32):
@@ -41,11 +39,9 @@ def test_complex_kernels_indirect():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.place(total)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.place(total)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func(mul: ti.f32):

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -10,9 +10,7 @@ def test_dynamic():
     x = ti.var(ti.f32)
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dynamic(ti.i, n, 32).place(x)
+    ti.root.dynamic(ti.i, n, 32).place(x)
 
     @ti.kernel
     def func():
@@ -30,9 +28,7 @@ def test_dynamic2():
     x = ti.var(ti.f32)
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dynamic(ti.i, n, 32).place(x)
+    ti.root.dynamic(ti.i, n, 32).place(x)
 
     @ti.kernel
     def func():
@@ -50,9 +46,7 @@ def test_dynamic_matrix():
     x = ti.Matrix(2, 1, dt=ti.i32)
     n = 8192
 
-    @ti.layout
-    def place():
-        ti.root.dynamic(ti.i, n, chunk_size=128).place(x)
+    ti.root.dynamic(ti.i, n, chunk_size=128).place(x)
 
     @ti.kernel
     def func():
@@ -75,9 +69,7 @@ def test_append():
     x = ti.var(ti.i32)
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dynamic(ti.i, n, 32).place(x)
+    ti.root.dynamic(ti.i, n, 32).place(x)
 
     @ti.kernel
     def func():
@@ -100,9 +92,7 @@ def test_length():
     y = ti.var(ti.f32, shape=())
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dynamic(ti.i, n, 32).place(x)
+    ti.root.dynamic(ti.i, n, 32).place(x)
 
     @ti.kernel
     def func():
@@ -127,11 +117,9 @@ def test_append_ret_value():
     z = ti.var(ti.i32)
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dynamic(ti.i, n, 32).place(x)
-        ti.root.dynamic(ti.i, n, 32).place(y)
-        ti.root.dynamic(ti.i, n, 32).place(z)
+    ti.root.dynamic(ti.i, n, 32).place(x)
+    ti.root.dynamic(ti.i, n, 32).place(y)
+    ti.root.dynamic(ti.i, n, 32).place(z)
 
     @ti.kernel
     def func():
@@ -153,9 +141,7 @@ def test_dense_dynamic():
     x = ti.var(ti.i32)
     l = ti.var(ti.i32, shape=n)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).dynamic(ti.j, n, 8).place(x)
+    ti.root.dense(ti.i, n).dynamic(ti.j, n, 8).place(x)
 
     @ti.kernel
     def func():
@@ -179,9 +165,7 @@ def test_dense_dynamic_len():
     x = ti.var(ti.i32)
     l = ti.var(ti.i32, shape=n)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).dynamic(ti.j, n, 32).place(x)
+    ti.root.dense(ti.i, n).dynamic(ti.j, n, 32).place(x)
 
     @ti.kernel
     def func():

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -8,9 +8,7 @@ def test_fill_scalar():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     for i in range(n):
         for j in range(m):
@@ -30,9 +28,7 @@ def test_fill_matrix_scalar():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     for i in range(n):
         for j in range(m):
@@ -56,9 +52,7 @@ def test_fill_matrix_matrix():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     for i in range(n):
         for j in range(m):

--- a/tests/python/test_global_store_grad.py
+++ b/tests/python/test_global_store_grad.py
@@ -2,6 +2,7 @@ import taichi as ti
 
 ti.cfg.print_ir = True
 
+
 def test_global_store_branching():
     # ti.reset()
 

--- a/tests/python/test_global_store_grad.py
+++ b/tests/python/test_global_store_grad.py
@@ -1,36 +1,30 @@
-'''
 import taichi as ti
 
 ti.cfg.print_ir = True
 
 def test_global_store_branching():
-  # ti.reset()
+    # ti.reset()
 
-  N = 16
-  ti.runtime.print_preprocessed = True
-  x = ti.var(ti.f32)
-  y = ti.var(ti.f32)
+    N = 16
+    ti.runtime.print_preprocessed = True
+    x = ti.var(ti.f32)
+    y = ti.var(ti.f32)
 
-  @ti.layout
-  def place():
     ti.root.dense(ti.i, N).place(x)
     ti.root.dense(ti.i, N).place(y)
     ti.root.lazy_grad()
 
-  @ti.kernel
-  def oldeven():
+    @ti.kernel
+    def oldeven():
+        for i in range(N):
+            if i % 2 == 0:
+                x[i] = y[i]
+
     for i in range(N):
-      if i % 2 == 0:
-        x[i] = y[i]
+        x.grad[i] = 1
 
-  for i in range(N):
-    x.grad[i] = 1
+    oldeven()
+    oldeven.grad()
 
-  oldeven()
-  oldeven.grad()
-
-  for i in range(N):
-    assert y.grad[i] == (i % 2 == 0)
-
-test_global_store_branching()
-'''
+    for i in range(N):
+        assert y.grad[i] == (i % 2 == 0)

--- a/tests/python/test_global_store_grad.py
+++ b/tests/python/test_global_store_grad.py
@@ -1,3 +1,4 @@
+"""
 import taichi as ti
 
 ti.cfg.print_ir = True
@@ -29,3 +30,4 @@ def test_global_store_branching():
 
     for i in range(N):
         assert y.grad[i] == (i % 2 == 0)
+"""

--- a/tests/python/test_grouped.py
+++ b/tests/python/test_grouped.py
@@ -9,9 +9,7 @@ def test_vector_index():
     m = 7
     p = 11
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
+    ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     @ti.kernel
     def test():
@@ -37,9 +35,7 @@ def test_grouped():
     m = 8
     p = 16
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
+    ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     @ti.kernel
     def test():

--- a/tests/python/test_kernel_template_mapper.py
+++ b/tests/python/test_kernel_template_mapper.py
@@ -6,9 +6,7 @@ def test_kernel_template_mapper():
     x = ti.var(ti.i32)
     y = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.place(x, y)
+    ti.root.place(x, y)
 
     mapper = ti.KernelTemplateMapper(
         (ti.template(), ti.template(), ti.template()),
@@ -37,9 +35,7 @@ def test_kernel_template_mapper_numpy():
     x = ti.var(ti.i32)
     y = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.place(x, y)
+    ti.root.place(x, y)
 
     annotations = (ti.template(), ti.template(), ti.ext_arr())
 

--- a/tests/python/test_kernel_templates.py
+++ b/tests/python/test_kernel_templates.py
@@ -8,9 +8,7 @@ def test_kernel_template_basic():
 
     n = 16
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, n).place(x, y)
+    ti.root.dense(ti.i, n).place(x, y)
 
     @ti.kernel
     def inc(a: ti.template(), b: ti.template()):
@@ -41,11 +39,9 @@ def test_kernel_template_gradient():
     z = ti.var(ti.f32)
     loss = ti.var(ti.f32)
 
-    @ti.layout
-    def tensors():
-        ti.root.dense(ti.i, 16).place(x, y, z)
-        ti.root.place(loss)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, 16).place(x, y, z)
+    ti.root.place(loss)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def double(a: ti.template(), b: ti.template()):

--- a/tests/python/test_lang.py
+++ b/tests/python/test_lang.py
@@ -6,10 +6,8 @@ def test_nested_subscript():
     x = ti.var(ti.i32)
     y = ti.var(ti.i32)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, 1).place(x)
-        ti.root.dense(ti.i, 1).place(y)
+    ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(y)
 
     x[0] = 0
 
@@ -30,9 +28,7 @@ def test_norm():
 
     n = 1024
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.i, 2).place(val, f)
+    ti.root.dense(ti.i, n).dense(ti.i, 2).place(val, f)
 
     @ti.kernel
     def test():
@@ -63,9 +59,7 @@ def test_simple2():
 
     n = 16
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).place(val, f)
+    ti.root.dense(ti.i, n).place(val, f)
 
     @ti.kernel
     def test():

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -13,9 +13,7 @@ def test_basic_utils():
     normA = ti.var(ti.f32)
     normSqrA = ti.var(ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.place(a, b, abT, aNormalized, normA, normSqrA)
+    ti.root.place(a, b, abT, aNormalized, normA, normSqrA)
 
     @ti.kernel
     def init():
@@ -53,9 +51,7 @@ def test_cross():
     b2 = ti.Vector(2, dt=ti.f32)
     c2 = ti.var(dt=ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.place(a, b, c, a2, b2, c2)
+    ti.root.place(a, b, c, a2, b2, c2)
 
     @ti.kernel
     def init():
@@ -84,9 +80,7 @@ def test_dot():
     b2 = ti.Vector(2, dt=ti.f32)
     c2 = ti.var(dt=ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.place(a, b, c, a2, b2, c2)
+    ti.root.place(a, b, c, a2, b2, c2)
 
     @ti.kernel
     def init():
@@ -108,9 +102,7 @@ def test_transpose():
     dim = 3
     m = ti.Matrix(dim, dim, ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.place(m)
+    ti.root.place(m)
 
     @ti.kernel
     def transpose():
@@ -135,9 +127,7 @@ def _test_polar_decomp(dim, dt):
     I = ti.Matrix(dim, dim, dt)
     D = ti.Matrix(dim, dim, dt)
 
-    @ti.layout
-    def place():
-        ti.root.place(m, r, s, I, D)
+    ti.root.place(m, r, s, I, D)
 
     @ti.kernel
     def polar():
@@ -181,9 +171,7 @@ def test_polar_decomp():
 def test_matrix():
     x = ti.Matrix(2, 2, dt=ti.i32)
 
-    @ti.layout
-    def xy():
-        ti.root.dense(ti.i, 16).place(x)
+    ti.root.dense(ti.i, 16).place(x)
 
     @ti.kernel
     def inc():

--- a/tests/python/test_listgen.py
+++ b/tests/python/test_listgen.py
@@ -7,11 +7,10 @@ def test_listgen():
     x = ti.var(ti.i32)
     n = 1024
 
-    ti.root.dense(ti.ij, 4).dense(ti.ij,
-                                      4).dense(ti.ij,
-                                               4).dense(ti.ij,
-                                                        4).dense(ti.ij,
-                                                                 4).place(x)
+    ti.root.dense(ti.ij, 4).dense(ti.ij, 4).dense(ti.ij,
+                                                  4).dense(ti.ij,
+                                                           4).dense(ti.ij,
+                                                                    4).place(x)
 
     @ti.kernel
     def fill(c: ti.i32):
@@ -39,8 +38,8 @@ def test_nested_3d():
     n = 128
 
     ti.root.dense(ti.ijk, 4).dense(ti.ijk, 4).dense(ti.ijk,
-                                                        4).dense(ti.ijk,
-                                                                 2).place(x)
+                                                    4).dense(ti.ijk,
+                                                             2).place(x)
 
     @ti.kernel
     def fill():

--- a/tests/python/test_listgen.py
+++ b/tests/python/test_listgen.py
@@ -7,9 +7,7 @@ def test_listgen():
     x = ti.var(ti.i32)
     n = 1024
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.ij, 4).dense(ti.ij,
+    ti.root.dense(ti.ij, 4).dense(ti.ij,
                                       4).dense(ti.ij,
                                                4).dense(ti.ij,
                                                         4).dense(ti.ij,
@@ -40,9 +38,7 @@ def test_nested_3d():
     x = ti.var(ti.i32)
     n = 128
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.ijk, 4).dense(ti.ijk, 4).dense(ti.ijk,
+    ti.root.dense(ti.ijk, 4).dense(ti.ijk, 4).dense(ti.ijk,
                                                         4).dense(ti.ijk,
                                                                  2).place(x)
 

--- a/tests/python/test_loop_grad.py
+++ b/tests/python/test_loop_grad.py
@@ -8,10 +8,8 @@ def test_loop_grad():
     n = 16
     m = 8
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, (n, m)).place(x)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.ij, (n, m)).place(x)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():
@@ -41,10 +39,8 @@ def test_loop_grad_complex():
     n = 16
     m = 8
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, (n, m)).place(x)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.ij, (n, m)).place(x)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():

--- a/tests/python/test_loops.py
+++ b/tests/python/test_loops.py
@@ -8,11 +8,9 @@ def test_loops():
 
     N = 512
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x)
-        ti.root.dense(ti.i, N).place(y)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, N).place(x)
+    ti.root.dense(ti.i, N).place(y)
+    ti.root.lazy_grad()
 
     for i in range(N // 2, N):
         y[i] = i - 300
@@ -38,11 +36,9 @@ def test_numpy_loops():
 
     N = 512
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x)
-        ti.root.dense(ti.i, N).place(y)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, N).place(x)
+    ti.root.dense(ti.i, N).place(y)
+    ti.root.lazy_grad()
 
     for i in range(N // 2, N):
         y[i] = i - 300
@@ -72,9 +68,7 @@ def test_nested_loops():
 
     n = 2048
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.ij, n).place(x)
+    ti.root.dense(ti.ij, n).place(x)
 
     @ti.kernel
     def paint():
@@ -120,10 +114,8 @@ def test_dynamic_loop_range():
     c = ti.var(ti.i32)
     n = 2000
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.place(c)
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.place(c)
 
     @ti.kernel
     def test():
@@ -143,9 +135,7 @@ def test_loop_arg_as_range():
     x = ti.var(ti.i32)
     n = 1000
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, n).place(x)
+    ti.root.dense(ti.i, n).place(x)
 
     @ti.kernel
     def test(b: ti.i32, e: ti.i32):

--- a/tests/python/test_native_functions.py
+++ b/tests/python/test_native_functions.py
@@ -7,9 +7,7 @@ def test_abs():
 
     N = 16
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x)
+    ti.root.dense(ti.i, N).place(x)
 
     @ti.kernel
     def func():
@@ -30,9 +28,7 @@ def test_int():
 
     N = 16
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x)
+    ti.root.dense(ti.i, N).place(x)
 
     @ti.kernel
     def func():
@@ -58,9 +54,7 @@ def test_minmax():
 
     N = 16
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x, y, minimum, maximum)
+    ti.root.dense(ti.i, N).place(x, y, minimum, maximum)
 
     @ti.kernel
     def func():

--- a/tests/python/test_no_grad.py
+++ b/tests/python/test_no_grad.py
@@ -9,10 +9,8 @@ def test_no_grad():
     N = 1
 
     # no gradients allocated for x
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x)
-        ti.root.place(loss, loss.grad)
+    ti.root.dense(ti.i, N).place(x)
+    ti.root.place(loss, loss.grad)
 
     @ti.kernel
     def func():

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -7,9 +7,7 @@ def with_data_type(dt):
 
     n = 4
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).place(val)
+    ti.root.dense(ti.i, n).place(val)
 
     @ti.kernel
     def test_numpy(arr: ti.ext_arr()):
@@ -56,9 +54,7 @@ def test_numpy_2d():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.j, m).place(val)
+    ti.root.dense(ti.i, n).dense(ti.j, m).place(val)
 
     @ti.kernel
     def test_numpy(arr: ti.ext_arr()):
@@ -86,9 +82,7 @@ def test_numpy_2d_transpose():
     n = 8
     m = 8
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     @ti.kernel
     def test_numpy(arr: ti.ext_arr()):
@@ -116,9 +110,7 @@ def test_numpy_3d():
     m = 7
     p = 11
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
+    ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     @ti.kernel
     def test_numpy(arr: ti.ext_arr()):
@@ -150,9 +142,7 @@ def test_numpy_3d():
     m = 7
     p = 11
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
+    ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     @ti.kernel
     def test_numpy(arr: ti.ext_arr()):

--- a/tests/python/test_numpy_io.py
+++ b/tests/python/test_numpy_io.py
@@ -9,9 +9,7 @@ def test_from_numpy_2d():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     for i in range(n):
         for j in range(m):
@@ -32,9 +30,7 @@ def test_to_numpy_2d():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     arr = np.empty(shape=(n, m), dtype=np.int32)
 
@@ -56,9 +52,7 @@ def test_to_numpy_2d():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     arr = np.empty(shape=(n, m), dtype=np.int32)
 
@@ -81,9 +75,7 @@ def test_f64():
     n = 4
     m = 7
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.ij, (n, m)).place(val)
+    ti.root.dense(ti.ij, (n, m)).place(val)
 
     for i in range(n):
         for j in range(m):

--- a/tests/python/test_offload.py
+++ b/tests/python/test_offload.py
@@ -10,12 +10,10 @@ def test_running_loss():
     running_loss = ti.var(ti.f32)
     additional_loss = ti.var(ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.place(total_loss)
-        ti.root.dense(ti.i, steps).place(running_loss)
-        ti.root.place(additional_loss)
-        ti.root.lazy_grad()
+    ti.root.place(total_loss)
+    ti.root.dense(ti.i, steps).place(running_loss)
+    ti.root.place(additional_loss)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def compute_loss():
@@ -38,9 +36,7 @@ def test_reduce_separate():
     b = ti.var(ti.f32, shape=(4))
     c = ti.var(ti.f32, shape=())
 
-    @ti.layout
-    def l():
-        ti.root.lazy_grad()
+    ti.root.lazy_grad()
 
     @ti.kernel
     def reduce1():
@@ -68,9 +64,7 @@ def test_reduce_merged():
     b = ti.var(ti.f32, shape=(4))
     c = ti.var(ti.f32, shape=())
 
-    @ti.layout
-    def l():
-        ti.root.lazy_grad()
+    ti.root.lazy_grad()
 
     @ti.kernel
     def reduce():

--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -5,9 +5,7 @@ import taichi as ti
 def test_offload_with_cross_block_locals():
     ret = ti.var(ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.place(ret)
+    ti.root.place(ret)
 
     @ti.kernel
     def ker():
@@ -25,9 +23,7 @@ def test_offload_with_cross_block_locals():
 def test_offload_with_cross_block_locals2():
     ret = ti.var(ti.f32)
 
-    @ti.layout
-    def place():
-        ti.root.place(ret)
+    ti.root.place(ret)
 
     @ti.kernel
     def ker():

--- a/tests/python/test_scope_errors.py
+++ b/tests/python/test_scope_errors.py
@@ -5,9 +5,7 @@ import taichi as ti
 def test_if():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -24,9 +22,7 @@ def test_if():
 def test_for():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -41,9 +37,7 @@ def test_for():
 def test_while():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():

--- a/tests/python/test_sparse_basics.py
+++ b/tests/python/test_sparse_basics.py
@@ -8,10 +8,8 @@ def test_pointer():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.pointer(ti.i, n).dense(ti.i, n).place(x)
-        ti.root.place(s)
+    ti.root.pointer(ti.i, n).dense(ti.i, n).place(x)
+    ti.root.place(s)
 
     @ti.kernel
     def func():
@@ -56,10 +54,8 @@ def test_pointer2():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.pointer(ti.i, n).pointer(ti.i, n).dense(ti.i, n).place(x)
-        ti.root.place(s)
+    ti.root.pointer(ti.i, n).pointer(ti.i, n).dense(ti.i, n).place(x)
+    ti.root.place(s)
 
     @ti.kernel
     def func():

--- a/tests/python/test_sparse_parallel.py
+++ b/tests/python/test_sparse_parallel.py
@@ -8,10 +8,8 @@ def test_pointer():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.pointer(ti.i, n).dense(ti.i, n).place(x)
-        ti.root.place(s)
+    ti.root.pointer(ti.i, n).dense(ti.i, n).place(x)
+    ti.root.place(s)
 
     @ti.kernel
     def activate():
@@ -35,10 +33,8 @@ def test_pointer2():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.pointer(ti.i, n).dense(ti.i, n).place(x)
-        ti.root.place(s)
+    ti.root.pointer(ti.i, n).dense(ti.i, n).place(x)
+    ti.root.place(s)
 
     @ti.kernel
     def activate():
@@ -61,9 +57,7 @@ def test_nested_struct_fill_and_clear():
     a = ti.var(dt=ti.f32)
     N = 512
 
-    @ti.layout
-    def place():
-        ti.root.pointer(ti.ij, [N, N]).dense(ti.ij, [8, 8]).place(a)
+    ti.root.pointer(ti.ij, [N, N]).dense(ti.ij, [8, 8]).place(a)
 
     @ti.kernel
     def fill():

--- a/tests/python/test_static.py
+++ b/tests/python/test_static.py
@@ -7,9 +7,7 @@ def test_static_if():
         ti.init()
         x = ti.var(ti.i32)
 
-        @ti.layout
-        def place():
-            ti.root.dense(ti.i, 1).place(x)
+        ti.root.dense(ti.i, 1).place(x)
 
         @ti.kernel
         def static():
@@ -26,9 +24,7 @@ def test_static_if():
 def test_static_if_error():
     x = ti.var(ti.i32)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def static():

--- a/tests/python/test_stencils.py
+++ b/tests/python/test_stencils.py
@@ -9,9 +9,7 @@ def test_simple():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x, y)
+    ti.root.dense(ti.i, n).place(x, y)
 
     @ti.kernel
     def run():

--- a/tests/python/test_stop_grad.py
+++ b/tests/python/test_stop_grad.py
@@ -8,11 +8,9 @@ def test_normal_grad():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.place(loss)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.place(loss)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():
@@ -36,11 +34,9 @@ def test_stop_grad():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.place(loss)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.place(loss)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():
@@ -65,11 +61,9 @@ def test_stop_grad2():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.place(loss)
-        ti.root.lazy_grad()
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.place(loss)
+    ti.root.lazy_grad()
 
     @ti.kernel
     def func():

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -8,10 +8,8 @@ def test_linear():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.dense(ti.i, n).place(y)
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.dense(ti.i, n).place(y)
 
     for i in range(n):
         x[i] = i
@@ -34,10 +32,8 @@ def test_linear_nested():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n // 16).dense(ti.i, 16).place(x)
-        ti.root.dense(ti.i, n // 16).dense(ti.i, 16).place(y)
+    ti.root.dense(ti.i, n // 16).dense(ti.i, 16).place(x)
+    ti.root.dense(ti.i, n // 16).dense(ti.i, 16).place(y)
 
     for i in range(n):
         x[i] = i
@@ -55,9 +51,7 @@ def test_linear_nested_aos():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n // 16).dense(ti.i, 16).place(x, y)
+    ti.root.dense(ti.i, n // 16).dense(ti.i, 16).place(x, y)
 
     for i in range(n):
         x[i] = i
@@ -74,9 +68,7 @@ def test_2d_nested():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, n // 16).dense(ti.ij, (32, 16)).place(x)
+    ti.root.dense(ti.ij, n // 16).dense(ti.ij, (32, 16)).place(x)
 
     for i in range(n * 2):
         for j in range(n):

--- a/tests/python/test_struct_for.py
+++ b/tests/python/test_struct_for.py
@@ -19,9 +19,7 @@ def test_singleton():
 def test_singleton2():
     x = ti.var(ti.i32)
 
-    @ti.layout
-    def l():
-        ti.root.place(x)
+    ti.root.place(x)
 
     @ti.kernel
     def fill():
@@ -40,10 +38,8 @@ def test_linear():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).place(x)
-        ti.root.dense(ti.i, n).place(y)
+    ti.root.dense(ti.i, n).place(x)
+    ti.root.dense(ti.i, n).place(y)
 
     @ti.kernel
     def fill():
@@ -65,10 +61,8 @@ def test_nested():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n // 4).dense(ti.i, 4).place(x)
-        ti.root.dense(ti.i, n).place(y)
+    ti.root.dense(ti.i, n // 4).dense(ti.i, 4).place(x)
+    ti.root.dense(ti.i, n).place(y)
 
     @ti.kernel
     def fill():
@@ -90,13 +84,11 @@ def test_nested2():
 
     n = 2048
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n // 512).dense(ti.i,
-                                            16).dense(ti.i,
-                                                      8).dense(ti.i,
-                                                               4).place(x)
-        ti.root.dense(ti.i, n).place(y)
+    ti.root.dense(ti.i, n // 512).dense(ti.i,
+                                        16).dense(ti.i,
+                                                    8).dense(ti.i,
+                                                            4).place(x)
+    ti.root.dense(ti.i, n).place(y)
 
     @ti.kernel
     def fill():
@@ -118,9 +110,7 @@ def test_2d():
 
     n, m = 32, 16
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, n).place(x, y)
+    ti.root.dense(ti.ij, n).place(x, y)
 
     @ti.kernel
     def fill():
@@ -141,9 +131,7 @@ def test_2d_non_POT():
 
     n, m = 13, 17
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, (n, m)).place(x)
+    ti.root.dense(ti.ij, (n, m)).place(x)
 
     @ti.kernel
     def fill():
@@ -166,9 +154,7 @@ def test_nested_2d():
 
     n = 32
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, n // 4).dense(ti.ij, 4).place(x, y)
+    ti.root.dense(ti.ij, n // 4).dense(ti.ij, 4).place(x, y)
 
     @ti.kernel
     def fill():
@@ -189,12 +175,10 @@ def test_nested_2d_more_nests():
 
     n = 64
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, n // 16).dense(ti.ij,
-                                            2).dense(ti.ij,
-                                                     4).dense(ti.ij,
-                                                              2).place(x, y)
+    ti.root.dense(ti.ij, n // 16).dense(ti.ij,
+                                        2).dense(ti.ij,
+                                                    4).dense(ti.ij,
+                                                            2).place(x, y)
 
     @ti.kernel
     def fill():
@@ -214,9 +198,7 @@ def test_linear_k():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.k, n).place(x)
+    ti.root.dense(ti.k, n).place(x)
 
     @ti.kernel
     def fill():

--- a/tests/python/test_struct_for.py
+++ b/tests/python/test_struct_for.py
@@ -84,10 +84,9 @@ def test_nested2():
 
     n = 2048
 
-    ti.root.dense(ti.i, n // 512).dense(ti.i,
-                                        16).dense(ti.i,
-                                                    8).dense(ti.i,
-                                                            4).place(x)
+    ti.root.dense(ti.i, n // 512).dense(ti.i, 16).dense(ti.i,
+                                                        8).dense(ti.i,
+                                                                 4).place(x)
     ti.root.dense(ti.i, n).place(y)
 
     @ti.kernel
@@ -177,8 +176,8 @@ def test_nested_2d_more_nests():
 
     ti.root.dense(ti.ij, n // 16).dense(ti.ij,
                                         2).dense(ti.ij,
-                                                    4).dense(ti.ij,
-                                                            2).place(x, y)
+                                                 4).dense(ti.ij,
+                                                          2).place(x, y)
 
     @ti.kernel
     def fill():

--- a/tests/python/test_struct_for_dynamic.py
+++ b/tests/python/test_struct_for_dynamic.py
@@ -12,9 +12,7 @@ def test_dynamic():
 
     n = 128
 
-    @ti.layout
-    def place():
-        ti.root.dynamic(ti.i, n).place(x)
+    ti.root.dynamic(ti.i, n).place(x)
 
     @ti.kernel
     def count():
@@ -34,9 +32,7 @@ def test_dense_dynamic():
 
     x = ti.var(ti.i32)
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, n).dynamic(ti.j, n, 128).place(x)
+    ti.root.dense(ti.i, n).dynamic(ti.j, n, 128).place(x)
 
     @ti.kernel
     def append():

--- a/tests/python/test_struct_for_intermediate.py
+++ b/tests/python/test_struct_for_intermediate.py
@@ -9,9 +9,7 @@ def test_nested():
     p, q = 3, 7
     n, m = 2, 4
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, (p, q)).dense(ti.ij, (n, m)).place(x)
+    ti.root.dense(ti.ij, (p, q)).dense(ti.ij, (n, m)).place(x)
 
     @ti.kernel
     def iterate():
@@ -34,9 +32,7 @@ def test_nested_demote():
     p, q = 3, 7
     n, m = 2, 4
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.ij, (p, q)).dense(ti.ij, (n, m)).place(x)
+    ti.root.dense(ti.ij, (p, q)).dense(ti.ij, (n, m)).place(x)
 
     @ti.kernel
     def iterate():

--- a/tests/python/test_struct_for_non_pot.py
+++ b/tests/python/test_struct_for_non_pot.py
@@ -8,10 +8,8 @@ def test_1d():
 
     n = 100
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.k, n).place(x)
-        ti.root.place(sum)
+    ti.root.dense(ti.k, n).place(x)
+    ti.root.place(sum)
 
     @ti.kernel
     def accumulate():
@@ -32,10 +30,8 @@ def test_2d():
     n = 100
     m = 19
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.k, n).dense(ti.i, m).place(x)
-        ti.root.place(sum)
+    ti.root.dense(ti.k, n).dense(ti.i, m).place(x)
+    ti.root.place(sum)
 
     @ti.kernel
     def accumulate():

--- a/tests/python/test_syntax_errors.py
+++ b/tests/python/test_syntax_errors.py
@@ -5,9 +5,7 @@ import taichi as ti
 def test_try():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -23,9 +21,7 @@ def test_try():
 def test_import():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -38,9 +34,7 @@ def test_import():
 def test_for_else():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -56,9 +50,7 @@ def test_for_else():
 def test_while_else():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -74,9 +66,7 @@ def test_while_else():
 def test_loop_var_range():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -91,9 +81,7 @@ def test_loop_var_range():
 def test_loop_var_struct():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -108,9 +96,7 @@ def test_loop_var_struct():
 def test_loop_var_struct():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():
@@ -125,9 +111,7 @@ def test_loop_var_struct():
 def test_ternary():
     x = ti.var(ti.f32)
 
-    @ti.layout
-    def layout():
-        ti.root.dense(ti.i, 1).place(x)
+    ti.root.dense(ti.i, 1).place(x)
 
     @ti.kernel
     def func():

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -9,9 +9,7 @@ def test_POT1():
     m = 8
     p = 16
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
+    ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     assert val.dim() == 3
     assert val.shape() == (n, m, p)
@@ -25,9 +23,7 @@ def test_POT2():
     m = 7
     p = 11
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
+    ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     assert val.dim() == 3
     assert val.shape() == (n, m, p)
@@ -41,9 +37,7 @@ def test_unordered():
     m = 7
     p = 11
 
-    @ti.layout
-    def values():
-        ti.root.dense(ti.k, n).dense(ti.i, m).dense(ti.j, p).place(val)
+    ti.root.dense(ti.k, n).dense(ti.i, m).dense(ti.j, p).place(val)
 
     assert val.dim() == 3
     assert val.shape() == (n, m, p)

--- a/tests/python/test_while.py
+++ b/tests/python/test_while.py
@@ -7,9 +7,7 @@ def test_while():
 
     N = 1
 
-    @ti.layout
-    def place():
-        ti.root.dense(ti.i, N).place(x)
+    ti.root.dense(ti.i, N).place(x)
 
     @ti.kernel
     def func():


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = Resolves #1077 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

---
- [x] Remove @ti.layout usages from test cases
- [x] Add a `PendingDeprecationWarning` to the decorator

