### PR TITLE
[ir] [refactor] Add constructor TypedConstant(DataType, T)

### DIFF
--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -199,6 +199,38 @@ class TypedConstant {
   TypedConstant(float64 x) : dt(DataType::f64), val_f64(x) {
   }
 
+  template <typename T>
+  TypedConstant(DataType dt, const T &value) : dt(dt) {
+    if (dt == DataType::f32) {
+      val_f32 = value;
+    } else if (dt == DataType::i32) {
+      val_i32 = value;
+    } else if (dt == DataType::i64) {
+      val_i64 = value;
+    } else if (dt == DataType::f64) {
+      val_f64 = value;
+    } else if (dt == DataType::i8) {
+      val_i8 = value;
+    } else if (dt == DataType::i16) {
+      val_i16 = value;
+    } else if (dt == DataType::u8) {
+      val_u8 = value;
+    } else if (dt == DataType::u16) {
+      val_u16 = value;
+    } else if (dt == DataType::u32) {
+      val_u32 = value;
+    } else if (dt == DataType::u64) {
+      val_u64 = value;
+    } else {
+      TI_NOT_IMPLEMENTED
+    }
+  }
+
+  template <typename T>
+  bool equal_value(const T &value) const {
+    return equal_type_and_value(TypedConstant(dt, value));
+  }
+
   std::string stringify() const;
 
   bool equal_type_and_value(const TypedConstant &o) const;

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -232,75 +232,27 @@ class AlgSimp : public BasicStmtVisitor {
   }
 
   static bool alg_is_zero(ConstStmt *stmt) {
-    if (!stmt)
+    if (!stmt || stmt->width() != 1)
       return false;
-    if (stmt->width() != 1)
-      return false;
-    auto val = stmt->val[0];
-    auto data_type = stmt->ret_type.data_type;
-    if (is_real(data_type))
-      return val.val_float() == 0;
-    else if (is_signed(data_type))
-      return val.val_int() == 0;
-    else if (is_unsigned(data_type))
-      return val.val_uint() == 0;
-    else {
-      TI_NOT_IMPLEMENTED
-    }
+    return stmt->val[0].equal_value(0);
   }
 
   static bool alg_is_one(ConstStmt *stmt) {
-    if (!stmt)
+    if (!stmt || stmt->width() != 1)
       return false;
-    if (stmt->width() != 1)
-      return false;
-    auto val = stmt->val[0];
-    auto data_type = stmt->ret_type.data_type;
-    if (is_real(data_type))
-      return val.val_float() == 1;
-    else if (is_signed(data_type))
-      return val.val_int() == 1;
-    else if (is_unsigned(data_type))
-      return val.val_uint() == 1;
-    else {
-      TI_NOT_IMPLEMENTED
-    }
+    return stmt->val[0].equal_value(1);
   }
 
   static bool alg_is_two(ConstStmt *stmt) {
-    if (!stmt)
+    if (!stmt || stmt->width() != 1)
       return false;
-    if (stmt->width() != 1)
-      return false;
-    auto val = stmt->val[0];
-    auto data_type = stmt->ret_type.data_type;
-    if (is_real(data_type))
-      return val.val_float() == 2;
-    else if (is_signed(data_type))
-      return val.val_int() == 2;
-    else if (is_unsigned(data_type))
-      return val.val_uint() == 2;
-    else {
-      TI_NOT_IMPLEMENTED
-    }
+    return stmt->val[0].equal_value(2);
   }
 
   static bool alg_is_minus_one(ConstStmt *stmt) {
-    if (!stmt)
+    if (!stmt || stmt->width() != 1)
       return false;
-    if (stmt->width() != 1)
-      return false;
-    auto val = stmt->val[0];
-    auto data_type = stmt->ret_type.data_type;
-    if (is_real(data_type))
-      return val.val_float() == -1;
-    else if (is_signed(data_type))
-      return val.val_int() == -1;
-    else if (is_unsigned(data_type))
-      return val.val_uint() == (uint64)-1;
-    else {
-      TI_NOT_IMPLEMENTED
-    }
+    return stmt->val[0].equal_value(-1);
   }
 
   static bool run(IRNode *node, bool fast_math) {


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = N/A

Also simplifies `alg_simp.cpp`.

Benchmark (number of statements of unit tests): nothing changed.

Benchmark (running time):
```
C:\Users\xmk\Desktop\taichi>ti regression
[Taichi] mode=development
[Taichi] <dev mode>, supported archs: [cpu only], commit f3559aab, python 3.7.
4

 *******************************************
 **     Taichi Programming Language       **
 *******************************************

x64::sscal________________________________________________
time_avg                      ?[35m1.3e+02?[39m -> ?[36m1.3e+02 ?[31m    +0.4%
?[39m

x64::saxpy________________________________________________
time_avg                      ?[35m1.9e+02?[39m -> ?[36m1.9e+02 ?[31m    +0.0%
?[39m

x64::root_listgen_________________________________________
time_avg                      ?[35m    7.7?[39m -> ?[36m    6.6 ?[32m   -14.0%
?[39m

x64::nested_struct_listgen_8x8____________________________
time_avg                      ?[35m    8.7?[39m -> ?[36m    6.6 ?[32m   -24.4%
?[39m

x64::nested_struct_listgen_16x16__________________________
time_avg                      ?[35m    7.7?[39m -> ?[36m    7.6 ?[32m    -1.2%
?[39m

x64::nested_struct_fill_and_clear_________________________
time_avg                      ?[35m6.2e+01?[39m -> ?[36m6.2e+01 ?[32m    -0.3%
?[39m

x64::nested_struct________________________________________
time_avg                      ?[35m2.3e+01?[39m -> ?[36m2.3e+01 ?[31m    +1.0%
?[39m

x64::nested_range_blocked_________________________________
time_avg                      ?[35m    6.1?[39m -> ?[36m    6.1 ?[32m    -0.6%
?[39m

x64::nested_range_________________________________________
time_avg                      ?[35m1.2e+01?[39m -> ?[36m1.2e+01 ?[31m    +0.3%
?[39m

x64::memset_______________________________________________
time_avg                      ?[35m  1e+02?[39m -> ?[36m  1e+02 ?[31m    +1.6%
?[39m

x64::memcpy_______________________________________________
time_avg                      ?[35m1.4e+02?[39m -> ?[36m1.4e+02 ?[31m    +1.0%
?[39m

x64::flat_struct__________________________________________
time_avg                      ?[35m    6.9?[39m -> ?[36m    6.4 ?[32m    -6.8%
?[39m

x64::flat_range___________________________________________
time_avg                      ?[35m1.3e+01?[39m -> ?[36m  1e+01 ?[32m   -21.4%
?[39m

x64::fill_scalar__________________________________________
time_avg                      ?[35m  0.003?[39m -> ?[36m  0.004 ?[31m   +33.3%
?[39m


>>> Running time: 0.01s

```

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
