### PR TITLE
[gui] Fix memory leak as circles were not cleared

### DIFF
--- a/taichi/gui/gui.h
+++ b/taichi/gui/gui.h
@@ -407,7 +407,7 @@ class Canvas {
   }
 
   void clear(uint32 c) {
-    img.reset(color_from_hex(c));
+    clear(color_from_hex(c));
   }
 
   ~Canvas() {


### PR DESCRIPTION
Before this fix:

```
[20:54:21] vms=5940.1MB, rss=263.8MB
[20:54:21] vms=6102.1MB, rss=414.4MB
[20:54:22] vms=6422.1MB, rss=647.7MB
[20:54:23] vms=6422.1MB, rss=717.3MB
[20:54:24] vms=7062.1MB, rss=1106.3MB
[20:54:24] vms=7062.1MB, rss=1173.1MB
[20:54:25] vms=7060.1MB, rss=1239.8MB
```

With this fix:

```
[20:53:00] vms=5703.1MB, rss=148.7MB
[20:53:00] vms=5703.1MB, rss=149.8MB
[20:53:01] vms=5703.1MB, rss=153.1MB
[20:53:02] vms=5703.1MB, rss=153.1MB
[20:53:02] vms=5704.2MB, rss=154.1MB
[20:53:03] vms=5705.2MB, rss=154.8MB
[20:53:03] vms=5705.2MB, rss=154.8MB
[20:53:04] vms=5830.1MB, rss=158.5MB
[20:53:05] vms=5828.0MB, rss=158.4MB
[20:53:05] vms=5828.0MB, rss=158.4MB
[20:53:06] vms=5828.0MB, rss=158.4MB
```

Related issue = Fixes #1108 (if any)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
