### PR TITLE
[misc] tell users to check troubleshooting page when error occurred

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,6 +20,11 @@ Taichi can be easily installed via ``pip``:
 Troubleshooting
 ---------------
 
+Windows issues
+**************
+
+- If Taichi crashes and reports ``ImportError`` on Windows: Please consider installing `Microsoft Visual C++ Redistributable <https://aka.ms/vs/16/release/vc_redist.x64.exe>`_.
+
 Python issues
 *************
 
@@ -49,7 +54,7 @@ CUDA issues
 
 - If Taichi crashes with the following messages:
 
-    .. code-block::
+    .. code-block:: none
 
         [Taichi] mode=release
         [Taichi] version 0.6.0, supported archs: [cpu, cuda, opengl], commit 14094f25, python 3.8.2
@@ -71,7 +76,7 @@ OpenGL issues
 
 - If Taichi crashes with a stack backtrace containing a line of ``glfwCreateWindow`` (see `#958 <https://github.com/taichi-dev/taichi/issues/958>`_):
 
-  .. code-block::
+  .. code-block:: none
 
         [Taichi] mode=release
         [E 05/12/20 18.25:00.129] Received signal 11 (Segmentation Fault)
@@ -95,4 +100,10 @@ OpenGL issues
 Linux issues
 ************
 
-- If Taichi crashes and reports ``libtinfo.so.5 not found``: Please install ``libtinfo5`` on Ubuntu or ``ncurses5-compat-libs`` (AUR) on Arch Linux.
+- If Taichi crashes and reports ``libtinfo.so.5 not found``: Please install ``libtinfo5`` for Ubuntu or ``ncurses5-compat-libs`` (AUR) for Arch Linux.
+
+
+Other issues
+************
+
+- If none of those above address your problem, please report this by `opening an issue <https://github.com/taichi-dev/taichi/issues/new?labels=potential+bug&template=bug_report.md>`_ on GitHub. This would help us improve user experiences and compatibility, many thanks!

--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -35,8 +35,8 @@ def import_ti_core(tmp_dir=None):
         import taichi_core as core
     except Exception as e:
         if isinstance(e, ImportError):
-            print(Fore.YELLOW +
-                "Share object taichi_core import failed, "
+            print(
+                Fore.YELLOW + "Share object taichi_core import failed, "
                 "check this page for possible solutions:\n"
                 "https://taichi.readthedocs.io/en/stable/install.html#troubleshooting"
                 + Fore.RESET)

--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -35,9 +35,11 @@ def import_ti_core(tmp_dir=None):
         import taichi_core as core
     except Exception as e:
         if isinstance(e, ImportError):
-            print(
-                "Share object taichi_core import failed. If you are on Windows, please consider installing \"Microsoft Visual C++ Redistributable\" (https://aka.ms/vs/16/release/vc_redist.x64.exe)"
-            )
+            print(Fore.YELLOW +
+                "Share object taichi_core import failed, "
+                "check this page for possible solutions:\n"
+                "https://taichi.readthedocs.io/en/stable/install.html#troubleshooting"
+                + Fore.RESET)
         raise e
     ti_core = core
     if get_os_name() != 'win':

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -403,11 +403,8 @@ class TaichiMain:
         """Reformat modified source files"""
         parser = argparse.ArgumentParser(description=f"{self.format.__doc__}")
         parser.add_argument(
-            '-d',
-            '--diff',
-            required=False,
-            default=None,
-            dest='diff',
+            'diff',
+            nargs='?',
             type=str,
             help="A commit hash that git can use to compare diff with")
         args = parser.parse_args(arguments)

--- a/taichi/system/traceback.cpp
+++ b/taichi/system/traceback.cpp
@@ -354,7 +354,8 @@ TI_EXPORT void print_traceback() {
   std::free(strings);
 #endif
 
-  fmt::print(fg(fmt::color::orange),
+  fmt::print(
+      fg(fmt::color::orange),
       "\nInternal Error occurred, check this page for possible solutions:\n"
       "https://taichi.readthedocs.io/en/stable/install.html#troubleshooting\n");
 }

--- a/taichi/system/traceback.cpp
+++ b/taichi/system/traceback.cpp
@@ -353,6 +353,10 @@ TI_EXPORT void print_traceback() {
   }
   std::free(strings);
 #endif
+
+  fmt::print(fg(fmt::color::orange),
+      "\nInternal Error occurred, check this page for possible solutions:\n"
+      "https://taichi.readthedocs.io/en/stable/install.html#troubleshooting\n");
 }
 
 TI_NAMESPACE_END


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #... (if any)

Many GAMES 201 students complain about these issues on GitHub, so I put a link in the error message to make a quick response for them.
Link: https://taichi.readthedocs.io/en/stable/install.html#troubleshooting

WANT_LGTM = any

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
