### PR TITLE
[opt] [refactor] [bug] Avoid throwing exceptions in whole_kernel_cse and fix a bug

### DIFF
--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -840,6 +840,7 @@ class Block : public IRNode {
                     std::unique_ptr<Stmt> &&new_statement,
                     bool replace_usages = true);
   void insert_before(Stmt *old_statement, VecStatement &&new_statements);
+  void insert_after(Stmt *old_statement, VecStatement &&new_statements);
   void replace_with(Stmt *old_statement,
                     VecStatement &&new_statements,
                     bool replace_usages = true);
@@ -875,6 +876,7 @@ class Block : public IRNode {
 class DelayedIRModifier {
  private:
   std::vector<std::pair<Stmt *, VecStatement>> to_insert_before;
+  std::vector<std::pair<Stmt *, VecStatement>> to_insert_after;
   std::vector<Stmt *> to_erase;
 
  public:
@@ -882,6 +884,8 @@ class DelayedIRModifier {
   void erase(Stmt *stmt);
   void insert_before(Stmt *old_statement, std::unique_ptr<Stmt> new_statement);
   void insert_before(Stmt *old_statement, VecStatement &&new_statements);
+  void insert_after(Stmt *old_statement, std::unique_ptr<Stmt> new_statement);
+  void insert_after(Stmt *old_statement, VecStatement &&new_statements);
   bool modify_ir();
 };
 

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -16,7 +16,7 @@ void die(IRNode *root);
 void simplify(IRNode *root, Kernel *kernel = nullptr);
 void cfg_optimization(IRNode *root);
 bool alg_simp(IRNode *root);
-void whole_kernel_cse(IRNode *root);
+bool whole_kernel_cse(IRNode *root);
 void variable_optimization(IRNode *root, bool after_lower_access);
 void extract_constant(IRNode *root);
 void full_simplify(IRNode *root, Kernel *kernel = nullptr);

--- a/taichi/transforms/whole_kernel_cse.cpp
+++ b/taichi/transforms/whole_kernel_cse.cpp
@@ -41,7 +41,6 @@ class WholeKernelCSE : public BasicStmtVisitor {
         if (irpass::analysis::same_statements(stmt, prev_stmt)) {
           stmt->replace_with(prev_stmt);
           modifier.erase(stmt);
-          std::cout << "to_erase " << stmt->id << std::endl;
           return;
         }
       }

--- a/taichi/transforms/whole_kernel_cse.cpp
+++ b/taichi/transforms/whole_kernel_cse.cpp
@@ -11,6 +11,7 @@ class WholeKernelCSE : public BasicStmtVisitor {
   std::unordered_set<int> visited;
   // each scope corresponds to an unordered_set
   std::vector<std::unordered_set<Stmt *>> visible_stmts;
+  DelayedIRModifier modifier;
 
  public:
   using BasicStmtVisitor::visit;
@@ -39,8 +40,9 @@ class WholeKernelCSE : public BasicStmtVisitor {
       for (auto &prev_stmt : scope) {
         if (irpass::analysis::same_statements(stmt, prev_stmt)) {
           stmt->replace_with(prev_stmt);
-          stmt->parent->erase(stmt);
-          throw IRModified();
+          modifier.erase(stmt);
+          std::cout << "to_erase " << stmt->id << std::endl;
+          return;
         }
       }
     }
@@ -60,14 +62,12 @@ class WholeKernelCSE : public BasicStmtVisitor {
     if (if_stmt->true_statements) {
       if (if_stmt->true_statements->statements.empty()) {
         if_stmt->true_statements = nullptr;
-        throw IRModified();
       }
     }
 
     if (if_stmt->false_statements) {
       if (if_stmt->false_statements->statements.empty()) {
         if_stmt->false_statements = nullptr;
-        throw IRModified();
       }
     }
 
@@ -79,24 +79,26 @@ class WholeKernelCSE : public BasicStmtVisitor {
       if (irpass::analysis::same_statements(
               true_clause->statements[0].get(),
               false_clause->statements[0].get())) {
+        // Directly modify this because it won't invalidate any iterators.
         auto common_stmt = true_clause->extract(0);
         irpass::replace_all_usages_with(false_clause.get(),
                                         false_clause->statements[0].get(),
                                         common_stmt.get());
-        if_stmt->insert_before_me(std::move(common_stmt));
+        modifier.insert_before(if_stmt, std::move(common_stmt));
         false_clause->erase(0);
-        throw IRModified();
       }
-      if (irpass::analysis::same_statements(
+      if (!true_clause->statements.empty() &&
+          !false_clause->statements.empty() &&
+          irpass::analysis::same_statements(
               true_clause->statements.back().get(),
               false_clause->statements.back().get())) {
+        // Directly modify this because it won't invalidate any iterators.
         auto common_stmt = true_clause->extract((int)true_clause->size() - 1);
         irpass::replace_all_usages_with(false_clause.get(),
                                         false_clause->statements.back().get(),
                                         common_stmt.get());
-        if_stmt->insert_before_me(std::move(common_stmt));
+        modifier.insert_after(if_stmt, std::move(common_stmt));
         false_clause->erase((int)false_clause->size() - 1);
-        throw IRModified();
       }
     }
 
@@ -106,27 +108,24 @@ class WholeKernelCSE : public BasicStmtVisitor {
       if_stmt->false_statements->accept(this);
   }
 
-  static void run(IRNode *node) {
+  static bool run(IRNode *node) {
     WholeKernelCSE eliminator;
+    bool modified = false;
     while (true) {
-      bool modified = false;
-      try {
-        node->accept(&eliminator);
-      } catch (IRModified) {
+      node->accept(&eliminator);
+      if (eliminator.modifier.modify_ir())
         modified = true;
-      }
-      if (!modified)
+      else
         break;
     }
+    return modified;
   }
 };
 
 namespace irpass {
-
-void whole_kernel_cse(IRNode *root) {
-  WholeKernelCSE::run(root);
+bool whole_kernel_cse(IRNode *root) {
+  return WholeKernelCSE::run(root);
 }
-
 }  // namespace irpass
 
 TLANG_NAMESPACE_END


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #1059 

Fix a bug:
```
$1 = ...
$2 : if $1 {
  $3 = const [0]
} else {
  $4 = const [0]
}
```
This pass would move the first statements of both branches outside the clause and crash when checking if the last statements of both branches are the same.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
