### PR TITLE
[Lang] support v.x, v.y, v.z for easy Vector subscript

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -227,6 +227,62 @@ class Matrix(TaichiOperations):
                 j = 0
             return self(i, j)
 
+    @property
+    def x(self):
+        if impl.inside_kernel():
+            return self.subscript(0)
+        else:
+            return self[0]
+
+    @property
+    def y(self):
+        if impl.inside_kernel():
+            return self.subscript(1)
+        else:
+            return self[1]
+
+    @property
+    def z(self):
+        if impl.inside_kernel():
+            return self.subscript(2)
+        else:
+            return self[2]
+
+    @property
+    def w(self):
+        if impl.inside_kernel():
+            return self.subscript(3)
+        else:
+            return self[3]
+
+    @x.setter
+    def x(self, value):
+        if impl.inside_kernel():
+            self.subscript(0).assign(value)
+        else:
+            self[0] = value
+
+    @y.setter
+    def y(self, value):
+        if impl.inside_kernel():
+            self.subscript(1).assign(value)
+        else:
+            self[1] = value
+
+    @z.setter
+    def z(self, value):
+        if impl.inside_kernel():
+            self.subscript(2).assign(value)
+        else:
+            self[2] = value
+
+    @w.setter
+    def w(self, value):
+        if impl.inside_kernel():
+            self.subscript(3).assign(value)
+        else:
+            self[3] = value
+
     class Proxy:
         def __init__(self, mat, index):
             self.mat = mat


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = as a GAMES 201 Student said in our WeChat Group.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
