### PR TITLE
[opengl] [Bug] Fix crash with old GLX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	shallow = true
 [submodule "external/glfw"]
 	path = external/glfw
-	url = https://github.com/taichi-dev/glfw
+	url = https://github.com/archibate/glfw
 	shallow = true
 [submodule "external/glad"]
 	path = external/glad

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -297,7 +297,8 @@ bool initialize_opengl(bool error_tolerance) {
   }
 
   const char *glver = (const char *)glGetString(GL_VERSION);
-  if (glver) TI_TRACE("[glsl] OpenGL {}", glver);
+  if (glver)
+    TI_TRACE("[glsl] OpenGL {}", glver);
 
   GLint major = 0, minor = 0;
   glGetIntegerv(GL_MAJOR_VERSION, &major);

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -337,7 +337,6 @@ bool initialize_opengl(bool error_tolerance) {
     return false;
   }
 
-
 #define PER_OPENGL_EXTENSION(x)    \
   if ((opengl_has_##x = GLAD_##x)) \
     TI_TRACE("[glsl] Found " #x);

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -296,6 +296,9 @@ bool initialize_opengl(bool error_tolerance) {
     TI_ERROR("[glsl] cannot initialize GLAD");
   }
 
+  const char *glver = (const char *)glGetString(GL_VERSION);
+  if (glver) TI_TRACE("[glsl] OpenGL {}", glver);
+
   GLint major = 0, minor = 0;
   glGetIntegerv(GL_MAJOR_VERSION, &major);
   check_opengl_error("glGetIntegerv(GL_MAJOR_VERSION)");
@@ -332,9 +335,6 @@ bool initialize_opengl(bool error_tolerance) {
   }
   glfwHideWindow(window);
   glfwMakeContextCurrent(window);
-
-  const char *glver = (const char *)glGetString(GL_VERSION);
-  TI_TRACE("[glsl] OpenGL {}", glver);
 
 #define PER_OPENGL_EXTENSION(x)    \
   if ((opengl_has_##x = GLAD_##x)) \


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #958 #1106

<del>@TroyZhai do you have a taichi dev setup to help me test if the problem is gone? Many thanks!
Hope this could resolve your issue systematically :)</del> more tests required.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

A similar issue: http://www.mujoco.org/forum/index.php?threads/segmentation-fault-when-running-bin-simulate-on-ubuntu-16-04.3512/ or https://github.com/glfw/glfw/issues/1096
Related pieces in GLFW: https://github.com/glfw/glfw/blob/e0c77f71f90e3bb8495c5c88fb0fb054d71cf7fc/src/glx_context.c#L62-L66