### PR TITLE
[metal] Add APIs to list all the available Metal devices

### DIFF
--- a/taichi/backends/metal/api.cpp
+++ b/taichi/backends/metal/api.cpp
@@ -9,6 +9,7 @@ namespace metal {
 
 extern "C" {
 id MTLCreateSystemDefaultDevice();
+id MTLCopyAllDevices();
 }
 
 namespace {
@@ -24,6 +25,15 @@ using mac::wrap_as_nsobj_unique_ptr;
 nsobj_unique_ptr<MTLDevice> mtl_create_system_default_device() {
   id dev = MTLCreateSystemDefaultDevice();
   return wrap_as_nsobj_unique_ptr(reinterpret_cast<MTLDevice *>(dev));
+}
+
+nsobj_unique_ptr<mac::TI_NSArray> mtl_copy_all_devices() {
+  id na = MTLCopyAllDevices();
+  return wrap_as_nsobj_unique_ptr(reinterpret_cast<mac::TI_NSArray *>(na));
+}
+
+std::string mtl_device_name(MTLDevice *dev) {
+  return mac::to_string(cast_call<mac::TI_NSString *>(dev, "name"));
 }
 
 nsobj_unique_ptr<MTLCommandQueue> new_command_queue(MTLDevice *dev) {

--- a/taichi/backends/metal/api.h
+++ b/taichi/backends/metal/api.h
@@ -31,6 +31,10 @@ using mac::nsobj_unique_ptr;
 
 nsobj_unique_ptr<MTLDevice> mtl_create_system_default_device();
 
+nsobj_unique_ptr<mac::TI_NSArray> mtl_copy_all_devices();
+
+std::string mtl_device_name(MTLDevice *dev);
+
 nsobj_unique_ptr<MTLCommandQueue> new_command_queue(MTLDevice *dev);
 
 nsobj_unique_ptr<MTLCommandBuffer> new_command_buffer(MTLCommandQueue *queue);

--- a/taichi/platform/mac/objc_api.cpp
+++ b/taichi/platform/mac/objc_api.cpp
@@ -15,6 +15,14 @@ nsobj_unique_ptr<TI_NSString> wrap_string_as_ns_string(const std::string &str) {
   return wrap_as_nsobj_unique_ptr(ptr);
 }
 
+std::string to_string(TI_NSString *ns) {
+  return cast_call<const char *>(ns, "UTF8String");
+}
+
+int ns_array_count(TI_NSArray *na) {
+  return cast_call<int>(na, "count");
+}
+
 }  // namespace mac
 }  // namespace taichi
 

--- a/taichi/platform/mac/objc_api.h
+++ b/taichi/platform/mac/objc_api.h
@@ -49,10 +49,20 @@ nsobj_unique_ptr<O> wrap_as_nsobj_unique_ptr(O *nsobj) {
 // Prepend "TI_" to native ObjC type names, otherwise clang-format thinks this
 // is an ObjC file and is not happy formatting it.
 struct TI_NSString;
+struct TI_NSArray;
 
 // |str| must exist during the entire lifetime of the returned object, as it
 // does not own the underlying memory. Think of it as std::string_view.
 nsobj_unique_ptr<TI_NSString> wrap_string_as_ns_string(const std::string &str);
+
+std::string to_string(TI_NSString *ns);
+
+int ns_array_count(TI_NSArray *na);
+
+template <typename R>
+R ns_array_object_at_index(TI_NSArray *na, int i) {
+  return cast_call<R>(na, "objectAtIndex:", i);
+}
 
 }  // namespace mac
 }  // namespace taichi


### PR DESCRIPTION
When debugging #1128 , I find it useful to be able to select which GPU to run. This PR adds the necessary APIs for us to choose GPUs.

Related issue = #1128 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
