### PR TITLE
[bug] [gui] Use lower case for Win32 key events to unify with X11

### DIFF
--- a/docs/global_settings.rst
+++ b/docs/global_settings.rst
@@ -1,6 +1,7 @@
 Global settings
 ---------------
 
+- Disable advanced optimization to save compile time: ``ti.core.toggle_advanced_optimization(False)``
 - Restart the Taichi runtime system (clear memory, destroy all variables and kernels): ``ti.reset()``
 - Eliminate verbose outputs: ``ti.get_runtime().set_verbose(False)``
 - To not trigger GDB when crashes: ``export TI_GDB_TRIGGER=0``

--- a/taichi/gui/win32.cpp
+++ b/taichi/gui/win32.cpp
@@ -53,7 +53,7 @@ static std::string lookup_keysym(WPARAM wParam, LPARAM lParam) {
     default:
       if (VK_F1 <= key && key <= VK_F12)
         return fmt::format("F{}", key - VK_F1);
-      else if (std::isascii(key))
+      else if (isascii(key))
         return std::string(1, std::tolower(key));
       else
         return fmt::format("Vk{}", key);

--- a/taichi/gui/win32.cpp
+++ b/taichi/gui/win32.cpp
@@ -53,7 +53,7 @@ static std::string lookup_keysym(WPARAM wParam, LPARAM lParam) {
       if (VK_F1 <= key && key <= VK_F12)
         return fmt::format("F{}", key - VK_F1);
       else if (isascii(key))
-        return std::string(1, key);
+        return std::string(1, ::tolower(key));
       else
         return fmt::format("Vk{}", key);
   }

--- a/taichi/gui/win32.cpp
+++ b/taichi/gui/win32.cpp
@@ -4,6 +4,7 @@
 #include <windowsx.h>
 #include "taichi/common/task.h"
 #include "taichi/gui/gui.h"
+#include <cctype>
 #include <map>
 
 // Note: some code is copied from MSDN:
@@ -52,8 +53,8 @@ static std::string lookup_keysym(WPARAM wParam, LPARAM lParam) {
     default:
       if (VK_F1 <= key && key <= VK_F12)
         return fmt::format("F{}", key - VK_F1);
-      else if (isascii(key))
-        return std::string(1, ::tolower(key));
+      else if (std::isascii(key))
+        return std::string(1, std::tolower(key));
       else
         return fmt::format("Vk{}", key);
   }


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = close #1138

Win32 seems to return upper case for keys, while OS X and X11 uses lower case, let's unify them. Btw, @k-ye do you find ASWD keys working well on OS X? (just run `examples/keyboard.py`)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
