### PR TITLE
[IR] Avoid promoting both operands of "pow" to the same type

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -450,9 +450,9 @@ void CodeGenLLVM::visit(BinaryOpStmt *stmt) {
     if (arch_is_cpu(current_arch())) {
       if (ret_type == DataType::f32) {
         if (stmt->rhs->ret_type.data_type == DataType::f32) {
-          llvm_val[stmt] =
-              create_call("pow_f32", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
-        } else if (stmt->rhs->ret_type.data_type == DataType::i64){
+          llvm_val[stmt] = create_call(
+              "pow_f32", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        } else if (stmt->rhs->ret_type.data_type == DataType::i64) {
           llvm_val[stmt] = create_call(
               "pow_f32_i64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
         } else {
@@ -461,9 +461,9 @@ void CodeGenLLVM::visit(BinaryOpStmt *stmt) {
         }
       } else if (ret_type == DataType::f64) {
         if (stmt->rhs->ret_type.data_type == DataType::f64) {
-          llvm_val[stmt] =
-              create_call("pow_f64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
-        } else if (stmt->rhs->ret_type.data_type == DataType::i64){
+          llvm_val[stmt] = create_call(
+              "pow_f64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        } else if (stmt->rhs->ret_type.data_type == DataType::i64) {
           llvm_val[stmt] = create_call(
               "pow_f64_i64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
         } else {

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -449,11 +449,27 @@ void CodeGenLLVM::visit(BinaryOpStmt *stmt) {
   } else if (op == BinaryOpType::pow) {
     if (arch_is_cpu(current_arch())) {
       if (ret_type == DataType::f32) {
-        llvm_val[stmt] =
-            create_call("pow_f32", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        if (stmt->rhs->ret_type.data_type == DataType::f32) {
+          llvm_val[stmt] =
+              create_call("pow_f32", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        } else if (stmt->rhs->ret_type.data_type == DataType::i64){
+          llvm_val[stmt] = create_call(
+              "pow_f32_i64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        } else {
+          TI_P(data_type_name(stmt->rhs->ret_type.data_type));
+          TI_NOT_IMPLEMENTED
+        }
       } else if (ret_type == DataType::f64) {
-        llvm_val[stmt] =
-            create_call("pow_f64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        if (stmt->rhs->ret_type.data_type == DataType::f64) {
+          llvm_val[stmt] =
+              create_call("pow_f64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        } else if (stmt->rhs->ret_type.data_type == DataType::i64){
+          llvm_val[stmt] = create_call(
+              "pow_f64_i64", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});
+        } else {
+          TI_P(data_type_name(stmt->rhs->ret_type.data_type));
+          TI_NOT_IMPLEMENTED
+        }
       } else if (ret_type == DataType::i32) {
         llvm_val[stmt] =
             create_call("pow_i32", {llvm_val[stmt->lhs], llvm_val[stmt->rhs]});

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -268,6 +268,38 @@ f64 pow_f64(f64 a, f64 b) {
   return std::pow(a, b);
 }
 
+f32 pow_f32_i64(f32 x, i64 n) {
+  if (n > 512)
+    return std::pow(x, n);
+  bool neg = n < 0;
+  n = abs(n);
+  f32 tmp = x;
+  f32 ans = 1;
+  while (n) {
+    if (n & 1)
+      ans *= tmp;
+    tmp *= tmp;
+    n >>= 1;
+  }
+  return neg ? 1.0 / ans : ans;
+}
+
+f64 pow_f64_i64(f64 x, i64 n) {
+  if (n > 512)
+    return std::pow(x, n);
+  bool neg = n < 0;
+  n = abs(n);
+  f64 tmp = x;
+  f64 ans = 1;
+  while (n) {
+    if (n & 1)
+      ans *= tmp;
+    tmp *= tmp;
+    n >>= 1;
+  }
+  return neg ? 1.0 / ans : ans;
+}
+
 f32 __nv_sgnf(f32 x) {
   return sgn_f32(x);
 }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -277,9 +277,9 @@ class TypeCheck : public IRVisitor {
     matching = matching && (stmt->lhs->ret_type.data_type != DataType::unknown);
     matching = matching && (stmt->rhs->ret_type.data_type != DataType::unknown);
     matching = matching && (stmt->lhs->ret_type == stmt->rhs->ret_type ||
-        (stmt->op_type == BinaryOpType::pow &&
-            is_real(stmt->lhs->ret_type.data_type) &&
-            stmt->rhs->ret_type.data_type == DataType::i64));
+                            (stmt->op_type == BinaryOpType::pow &&
+                             is_real(stmt->lhs->ret_type.data_type) &&
+                             stmt->rhs->ret_type.data_type == DataType::i64));
     if (!matching) {
       error();
     }


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = fix #1141

I think this solution looks a bit ad-hoc, and it may break other backends...

Do you have better solutions?

**Test case:**
```python
@ti.kernel
def calc_pi() -> ti.f32:
  sum = 0.0
  for i in range(66666666):
    n = 2 * i + 1
    sum += pow(-1.0, i) / n
  return sum * 4
```
Before:
```
[I 06/04/20 17:17:42.365] [compile_to_offloads.cpp:taichi::lang::irpass::co
mpile_to_offloads::<lambda_44aeda62b30289419801af51381ceafc>::operator ()@2
1] Simplified III:
kernel {
  $0 = offloaded  {
    <f32*x1> $1 = global tmp var (offset = 0 B)
    <f32 x1> $2 = const [0.0]
    <f32*x1> $3 : global store [$1 <- $2]
  }
  $4 = offloaded range_for(0, 66666666) block_dim=adaptive {
    <i32 x1> $5 = loop $4 index 0
    <i32 x1> $6 = add $5 $5
    <i32 x1> $7 = const [1]
    <i32 x1> $8 = add $6 $7
    <f32 x1> $9 = cast_value<f32> $5
    <f32 x1> $10 = const [-1.0]
    <f32 x1> $11 = pow $10 $9
    <f32 x1> $12 = cast_value<f32> $8
    <f32 x1> $13 = div $11 $12
    <f32*x1> $14 = global tmp var (offset = 0 B)
    <f32 x1> $15 = atomic add($14, $13)
  }
  $16 = offloaded  {
    <f32*x1> $17 = global tmp var (offset = 0 B)
    <f32 x1> $18 = global load $17
    <f32 x1> $19 = const [4.0]
    <f32 x1> $20 = mul $18 $19
    <f32 x1> $21 : kernel return $20
  }
}
3.141597032546997
```
After:
```
[I 06/04/20 17:54:50.889] [compile_to_offloads.cpp:taichi::lang::irpass::co
mpile_to_offloads::<lambda_44aeda62b30289419801af51381ceafc>::operator ()@2
1] Simplified III:
kernel {
  $0 = offloaded  {
    <f32*x1> $1 = global tmp var (offset = 0 B)
    <f32 x1> $2 = const [0.0]
    <f32*x1> $3 : global store [$1 <- $2]
  }
  $4 = offloaded range_for(0, 66666666) block_dim=adaptive {
    <i32 x1> $5 = loop $4 index 0
    <i32 x1> $6 = add $5 $5
    <i32 x1> $7 = const [1]
    <i32 x1> $8 = add $6 $7
    <i64 x1> $9 = cast_value<i64> $5
    <f32 x1> $10 = const [-1.0]
    <f32 x1> $11 = pow $10 $9
    <f32 x1> $12 = cast_value<f32> $8
    <f32 x1> $13 = div $11 $12
    <f32*x1> $14 = global tmp var (offset = 0 B)
    <f32 x1> $15 = atomic add($14, $13)
  }
  $16 = offloaded  {
    <f32*x1> $17 = global tmp var (offset = 0 B)
    <f32 x1> $18 = global load $17
    <f32 x1> $19 = const [4.0]
    <f32 x1> $20 = mul $18 $19
    <f32 x1> $21 : kernel return $20
  }
}
3.141596555709839
```

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
