### PR TITLE
[Doc] Add export_result section on how to export images and videos

### DIFF
--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -13,12 +13,12 @@ Export images using ``ti.GUI.show``
 +++++++++++++++++++++++++++++++++++
 
 - ``ti.GUI.show(filename)`` can not only display the GUI canvas on your screen, but also save the image to your specified ``filename``.
-- Note that the format of the image is fully determined by the suffix of ``filename``. 
+- Note that the format of the image is fully determined by the suffix of ``filename``.
 - Taichi now supports saving to ``png``, ``jpg``, and ``bmp`` formats.
 - We recommend using ``png`` format. For example:
 
 .. code-block:: python
-    
+
     import taichi as ti
     import os
 
@@ -49,7 +49,7 @@ Export images using ``ti.imwrite``
 ++++++++++++++++++++++++++++++++++
 
 To save images without creating a ``ti.GUI``, use ``ti.imwrite``. For example:
-    
+
     .. code-block:: python
 
         import taichi as ti
@@ -74,7 +74,7 @@ Export Videos
 -------------
 
 .. note::
-    
+
     The video export utilities of Taichi depend on ``ffmpeg``. If ``ffmpeg`` is not installed on your machine, please follow the installation instructions of ``ffmpeg`` at the end of this page.
 
 - ``ti.VideoManger`` can help you export results in ``mp4`` or ``gif`` format. For example,
@@ -107,7 +107,7 @@ Export Videos
     video_manger.make_video(gif=True, mp4=True)
     print(f"MP4 video is saved to {video_manger.get_output_filename(".mp4")}")
     print(f"GIF video is saved to {video_manger.get_output_filename(".gif")}")
-    
+
 After running the code above, you will find the output videos in the ``./results/`` folder.
 
 Install ffmpeg
@@ -122,7 +122,7 @@ Install ffmpeg on Windows
 
 - **Important:** add ``D:/YOUR_FFMPEG_FOLDER/bin`` to the ``PATH`` environment variable;
 
-- Open the Windows ``cmd`` or ``PowerShell`` and type the line of code below to test your installation. If ``ffmpeg`` is set up properly, the version information will be printed. 
+- Open the Windows ``cmd`` or ``PowerShell`` and type the line of code below to test your installation. If ``ffmpeg`` is set up properly, the version information will be printed.
 
 .. code-block:: shell
 
@@ -150,7 +150,7 @@ Install ``ffmpeg`` on Linux
 
     sudo pacman -S ffmpeg
 
-- Test your installation using 
+- Test your installation using
 
 .. code-block:: shell
 

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -1,0 +1,180 @@
+Export Your Results
+===================
+Taichi has some functions that can help you to **export results to images or videos**. This tutorial will tell you how to do that step by step.
+Please make sure that your program runs well before reading this tutorial.
+
+Export Images
+-------------
+
+- There are 2 common ways to export the result of your program(presumably a Taichi tensor) to images. The first one working with ti.GUI that it is more friendly to begginers. 
+- The second approach is to call some built-in functions in Taichi to make things done, which is more flexible and harder.
+
+Export Images by ti.GUI
++++++++++++++++++++++++
+
+.. note::
+    
+    For beginners and debug purposes, we recommend this first method by ti.GUI!
+
+- The first method of exporting images is to use **ti.GUI.show()**. It can not only display the result to the screen but also export the result to your specified place.
+- About the format of saved images: **the type of image is fully determined by your suffix**. 
+- Though Taichi now supports exporting to .png, .jpg and .bmp these 3 mainstream formats, we strongly **recommend using .png** which has been tested well at this moment. For example:
+
+.. code-block:: python
+    
+    import taichi as ti
+    import os
+    pixel = ti.var(ti.u8, shape=(512, 512, 3))
+
+    @ti.kernel
+    def paint():
+        for I in ti.grouped(pixel):
+            pixel[I] = ti.random() * 255
+
+    iterations = 1000
+    gui = ti.GUI("Export Result", res = 512)
+
+    # set up the images output
+    output_dir = "./results/"
+    if os.path.exists(output_dir) == False:
+        os.makedirs(output_dir)
+
+    # mainloop
+    for i in range(iterations):
+        paint()
+        gui.set_image(pixel)
+
+        # img_name = os.path.join(output_dir, f"frame_{i}.jpg")   # create filename with suffix jpg
+        # img_name = os.path.join(output_dir, f"frame_{i}.bmp")   # create filename with suffix bmp
+        img_name = os.path.join(output_dir, f"frame_{i}.png")   # create filename with suffix png
+        print("%s recorded in frame %d" % (img_name, i))
+        gui.show(img_name)  # export and show in GUI
+
+- After running these codes above, you should get a batch of images in your "./results" folder.
+
+Export Images by Taichi built-ins
++++++++++++++++++++++++++++++++++
+
+- Why we have to instantiate GUI just for the sake of export images? The former method under the help of "ti.GUI" looks weird.
+- If you are familiared with Taichi, we recommend using these following methods for manipulating images.
+- This second approach is to use **ti.imwrite**. It is much more flexible compared with its former.
+
+.. function:: ti.imwrite(img, filename)
+
+    :parameter img: (Matrix or Expr) the images you want to export
+    :parameter filename: (string) filename you want to save
+
+    Please make sure that the input image is a Taichi Matrix or Expr and **it has shape [height, width, compoents] correctly**. For example:
+    
+    .. code-block:: python
+
+        import taichi as ti
+        pixel = ti.var(ti.u8, shape=(512, 512, 3))
+
+        @ti.kernel
+        def set_pixel():
+            for I in ti.grouped(pixel):
+                pixel[I] = ti.random() * 255
+        
+        set_pixel()
+        ti.imwrite(pixel.to_numpy(), f"imwrite_export.png")
+
+.. function:: ti.imread(filename, channels = 0)
+
+    :parameter filename: (string) filename of the image you want to load
+    :parameter channels: (int) the number of channels in your specified image, the default value is zero.
+    
+    This function can load an image from the target filename, return it as a np.ndarray
+
+.. function:: ti.imshow(img, windname)
+
+    :parameter img: (Matrix or Expr) the image you want to show in the GUI
+    :parameter windname: (string) the name of GUI window
+
+    This function will open an instance of ti.GUI and show the input image on the screen.
+
+
+Export Videos
+-------------
+
+.. note::
+    
+    Taichi utils for exporting videos are dependent on ffmpeg. If ffmpeg hasn't been installed properly on your device, please follow the installation instructions of ffmpeg at the end of this document.
+
+- **ti.VideoManger** can help you to export results in .mp4 or .git format. For example
+
+.. code-block:: python
+
+    import taichi as ti
+
+    pixel = ti.var(ti.u8, shape=(512, 512, 3))
+
+    @ti.kernel
+    def paint():
+        for I in ti.grouped(pixel):
+            pixel[I] = ti.random() * 255
+
+    result_dir = "./results"
+    video_manger = ti.VideoManager(output_dir=result_dir, framerate=24, automatic_build=False)
+
+    for i in range(50):
+        paint()
+
+        pixel_img = pixel.to_numpy()
+        video_manger.write_frame(pixel_img)
+        print("\rframe %d/%d" % (i, 50), end='')
+
+    video_manger.make_video(gif = True, mp4 = True)
+    print("mp4 video saved to %s" % video_manger.get_output_filename(".mp4"))
+    print("gif video saved to %s" % video_manger.get_output_filename(".gif"))
+    
+Running these codes above, you can find the resulting video in "./results/" folder :)
+
+Install ffmpeg
+--------------
+
+Install ffmpeg on Windows
++++++++++++++++++++++++++
+
+- Download the ffmpeg archive(named ffmpeg-2020xxx.zip) from `ffmpeg <https://ffmpeg.org/download.html>`_
+
+- unzip this archive to where you would like, such as "D:/YOUR_FFMPEG_FOLDER"
+
+- IMPORTANT: **add "D:/YOUR_FFMPEG_FOLDER/bin" to the environment variables**
+
+- open the Windows CLI and type this line of code below to test the installation. The version info should be output if ffmpeg is set up properly.
+
+.. code-block:: shell
+
+    FFmpeg -version
+
+Install FFmpeg on Linux
++++++++++++++++++++++++
+- Most Linux distribution came with Linux natively.
+- Install ffmpeg on Ubuntu
+
+.. code-block:: shell
+
+    sudo apt-get update
+    sudo apt-get install ffmpeg
+
+- Install ffmpeg on CenteOS and RHEL
+
+.. code-block:: shell
+
+    sudo yum install ffmpeg ffmpeg-devel
+
+- test your installation by 
+
+.. code-block:: shell
+
+    ffmpeg -h
+
+Install ffmpeg on OSX
++++++++++++++++++++++
+
+- ffmpeg can be installed on OSX by brew
+
+.. code-block:: shell
+
+    brew install ffmpeg

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -20,9 +20,11 @@ Export Images by ti.GUI
     
     import taichi as ti
     import os
+
+    ti.init()
+
     pixel = ti.var(ti.u8, shape=(512, 512, 3))
 
-ti.init()
     @ti.kernel
     def paint():
         for i, j, k in pixel:
@@ -47,42 +49,27 @@ Export Images by Taichi built-ins
 
 - Why we have to instantiate GUI just for the sake of export images? The former method under the help of "ti.GUI" looks weird.
 - If you are familiared with Taichi, we recommend using these following methods for manipulating images.
-- This second approach is to use **ti.imwrite**. It is much more flexible compared with its former.
-
-.. function:: ti.imwrite(img, filename)
-
-    :parameter img: (Matrix or Expr) the images you want to export
-    :parameter filename: (string) filename you want to save
-
-    Please make sure that the input image is a Taichi Matrix or Expr and **it has shape [height, width, compoents] correctly**. For example:
+- This second approach is to use **ti.imwrite**, which is much more flexible compared with its former. For example:
     
     .. code-block:: python
 
         import taichi as ti
+
+        ti.init()
+
         pixel = ti.var(ti.u8, shape=(512, 512, 3))
 
         @ti.kernel
         def set_pixel():
-            for I in ti.grouped(pixel):
-                pixel[I] = ti.random() * 255
-        
+            for i, j, k in pixel:
+                pixel[i, j, k] = ti.random() * 255
+
         set_pixel()
-        ti.imwrite(pixel.to_numpy(), f"imwrite_export.png")
+        img_name = f"imwrite_export.png"
+        ti.imwrite(pixel.to_numpy(), img_name)
+        print(f"The image has been saved to {img_name}")
 
-.. function:: ti.imread(filename, channels = 0)
-
-    :parameter filename: (string) filename of the image you want to load
-    :parameter channels: (int) the number of channels in your specified image, the default value is zero.
-    
-    This function can load an image from the target filename, return it as a np.ndarray
-
-.. function:: ti.imshow(img, windname)
-
-    :parameter img: (Matrix or Expr) the image you want to show in the GUI
-    :parameter windname: (string) the name of GUI window
-
-    This function will open an instance of ti.GUI and show the input image on the screen.
-
+- Taichi offers some helper functions that can read/write/show images easily. Please check :ref:`gui` for more details.
 
 Export Videos
 -------------
@@ -97,12 +84,14 @@ Export Videos
 
     import taichi as ti
 
+    ti.init()
+
     pixel = ti.var(ti.u8, shape=(512, 512, 3))
 
     @ti.kernel
     def paint():
-        for I in ti.grouped(pixel):
-            pixel[I] = ti.random() * 255
+        for i, j, k in pixel:
+            pixel[i, j, k] = ti.random() * 255
 
     result_dir = "./results"
     video_manger = ti.VideoManager(output_dir=result_dir, framerate=24, automatic_build=False)
@@ -112,11 +101,12 @@ Export Videos
 
         pixel_img = pixel.to_numpy()
         video_manger.write_frame(pixel_img)
-        print("\rframe %d/%d" % (i, 50), end='')
+        print(f"\rFrame {i+1}/50 is recorded", end='')
 
+    print("\nBegin to export .mp4 and .gif videos ...")
     video_manger.make_video(gif = True, mp4 = True)
-    print("mp4 video saved to %s" % video_manger.get_output_filename(".mp4"))
-    print("gif video saved to %s" % video_manger.get_output_filename(".gif"))
+    print("Mp4 video is saved to %s" % video_manger.get_output_filename(".mp4"))
+    print("Gif video is saved to %s" % video_manger.get_output_filename(".gif"))
     
 Running these codes above, you can find the resulting video in "./results/" folder :)
 

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -1,20 +1,21 @@
-Export Your Results
+Export your results
 ===================
-Taichi has some functions that can help you to **export results to images or videos**. This tutorial will tell you how to do that step by step.
-Please make sure that your program runs well before reading this tutorial.
+Taichi has functions that help you **export visual results to images or videos**. This tutorial demonstrates how to use them step by step.
 
-Export Images
+Export images
 -------------
 
-- There are 2 common ways to export the result of your program (presumably a Taichi tensor) to images. The first one working with ti.GUI that it is more friendly to begginers. 
-- The second approach is to call some built-in functions in Taichi to make things done, which is more flexible and harder.
+- There are two ways to export visual results of your program to images.
+- The first and easier way is to make use of ``ti.GUI``.
+- The second way is to call some Taichi functions such as ``ti.imwrite``.
 
-Export Images by ti.GUI
-+++++++++++++++++++++++
+Export images using ``ti.GUI.show``
++++++++++++++++++++++++++++++++++++
 
-- For beginners and debug purposes, we recommend this first method by ti.GUI! That is to use **ti.GUI.show(filename)**. It can not only display the result to the screen but also export the result to your specified `filename`.
-- Note that **the format of image is fully determined by your suffix**. 
-- Though Taichi now supports exporting to .png, .jpg and .bmp these 3 mainstream formats, we strongly **recommend using .png** which has been tested well at this moment. For example:
+- ``ti.GUI.show(filename)`` can not only display the GUI canvas on your screen, but also save the image to your specified ``filename``.
+- Note that the format of the image is fully determined by the suffix of ``filename``. 
+- Taichi now supports saving to ``png``, ``jpg``, and ``bmp`` formats.
+- We recommend using ``png`` format. For example:
 
 .. code-block:: python
     
@@ -23,33 +24,31 @@ Export Images by ti.GUI
 
     ti.init()
 
-    pixel = ti.var(ti.u8, shape=(512, 512, 3))
+    pixels = ti.var(ti.u8, shape=(512, 512, 3))
 
     @ti.kernel
     def paint():
-        for i, j, k in pixel:
-            pixel[i, j, k] = ti.random() * 255
+        for i, j, k in pixels:
+            pixels[i, j, k] = ti.random() * 255
 
     iterations = 1000
-    gui = ti.GUI("Export Result", res = 512)
+    gui = ti.GUI("Random pixels", res=512)
 
     # mainloop
     for i in range(iterations):
         paint()
         gui.set_image(pixel)
 
-        img_name = f"frame_{i}.png"   # create filename with suffix png
-        print("Frame %d is recorded in %s" % (i, img_name))
+        img_name = f"frame_{i:05d}.png"   # create filename with suffix png
+        print(f"Frame {i} is recorded in {img_name}")
         gui.show(img_name)  # export and show in GUI
 
-- After running these codes above, you should get a batch of images in your "./results" folder.
+- After running the code above, you will get a series of images in the current folder.
 
-Export Images by Taichi built-ins
-+++++++++++++++++++++++++++++++++
+Export images using ``ti.imwrite``
+++++++++++++++++++++++++++++++++++
 
-- Why we have to instantiate GUI just for the sake of export images? The former method under the help of "ti.GUI" looks weird.
-- If you are familiared with Taichi, we recommend using these following methods for manipulating images.
-- This second approach is to use **ti.imwrite**, which is much more flexible compared with its former. For example:
+To save images without creating a ``ti.GUI``, use ``ti.imwrite``. For example:
     
     .. code-block:: python
 
@@ -69,16 +68,16 @@ Export Images by Taichi built-ins
         ti.imwrite(pixel.to_numpy(), img_name)
         print(f"The image has been saved to {img_name}")
 
-- Taichi offers some helper functions that can read/write/show images easily. Please check :ref:`gui` for more details.
+Taichi offers helper functions that read, write, and show images. Please check out :ref:`gui` for more details.
 
 Export Videos
 -------------
 
 .. note::
     
-    Taichi utils for exporting videos are dependent on ffmpeg. If ffmpeg hasn't been installed properly on your device, please follow the installation instructions of ffmpeg at the end of this document.
+    The video export utilities of Taichi depend on ``ffmpeg``. If ``ffmpeg`` is not installed on your machine, please follow the installation instructions of ``ffmpeg`` at the end of this page.
 
-- **ti.VideoManger** can help you to export results in .mp4 or .git format. For example
+- ``ti.VideoManger`` can help you export results in ``mp4`` or ``gif`` format. For example,
 
 .. code-block:: python
 
@@ -103,12 +102,13 @@ Export Videos
         video_manger.write_frame(pixel_img)
         print(f"\rFrame {i+1}/50 is recorded", end='')
 
-    print("\nBegin to export .mp4 and .gif videos ...")
-    video_manger.make_video(gif = True, mp4 = True)
-    print("Mp4 video is saved to %s" % video_manger.get_output_filename(".mp4"))
-    print("Gif video is saved to %s" % video_manger.get_output_filename(".gif"))
+    print()
+    print("Exporting .mp4 and .gif videos...")
+    video_manger.make_video(gif=True, mp4=True)
+    print(f"MP4 video is saved to {video_manger.get_output_filename(".mp4")}")
+    print(f"GIF video is saved to {video_manger.get_output_filename(".gif")}")
     
-Running these codes above, you can find the resulting video in "./results/" folder :)
+After running the code above, you will find the output videos in the ``./results/`` folder.
 
 Install ffmpeg
 --------------
@@ -116,50 +116,50 @@ Install ffmpeg
 Install ffmpeg on Windows
 +++++++++++++++++++++++++
 
-- Download the ffmpeg archive(named ffmpeg-2020xxx.zip) from `ffmpeg <https://ffmpeg.org/download.html>`_
+- Download the ``ffmpeg`` archive(named ``ffmpeg-2020xxx.zip``) from `ffmpeg <https://ffmpeg.org/download.html>`_;
 
-- unzip this archive to where you would like, such as "D:/YOUR_FFMPEG_FOLDER"
+- Unzip this archive to a folder, such as "D:/YOUR_FFMPEG_FOLDER";
 
-- IMPORTANT: **add "D:/YOUR_FFMPEG_FOLDER/bin" to the environment variables**
+- **Important:** add ``D:/YOUR_FFMPEG_FOLDER/bin`` to the ``PATH`` environment variable;
 
-- open the Windows CLI and type this line of code below to test the installation. The version info should be output if ffmpeg is set up properly.
+- Open the Windows ``cmd`` or ``PowerShell`` and type the line of code below to test your installation. If ``ffmpeg`` is set up properly, the version information will be printed. 
 
 .. code-block:: shell
 
-    FFmpeg -version
+    ffmpeg -version
 
-Install FFmpeg on Linux
-+++++++++++++++++++++++
-- Most Linux distribution came with ``ffmpeg`` natively.
-- Install ffmpeg on Ubuntu
+Install ``ffmpeg`` on Linux
++++++++++++++++++++++++++++
+- Most Linux distribution came with ``ffmpeg`` natively, so you do not need to read this part if the ``ffmpeg`` command is already there on your machine.
+- Install ``ffmpeg`` on Ubuntu
 
 .. code-block:: shell
 
     sudo apt-get update
     sudo apt-get install ffmpeg
 
-- Install ffmpeg on CenteOS and RHEL
+- Install ``ffmpeg`` on CentOS and RHEL
 
 .. code-block:: shell
 
     sudo yum install ffmpeg ffmpeg-devel
 
-- Install ffmpeg on Arch Linux:
+- Install ``ffmpeg`` on Arch Linux:
 
 .. code-block: shell
 
     sudo pacman -S ffmpeg
 
-- test your installation by 
+- Test your installation using 
 
 .. code-block:: shell
 
     ffmpeg -h
 
-Install ffmpeg on OSX
-+++++++++++++++++++++
+Install ``ffmpeg`` on OS X
+++++++++++++++++++++++++++
 
-- ffmpeg can be installed on OSX by brew
+- ``ffmpeg`` can be installed on OS X using ``homebrew``:
 
 .. code-block:: shell
 

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -6,18 +6,14 @@ Please make sure that your program runs well before reading this tutorial.
 Export Images
 -------------
 
-- There are 2 common ways to export the result of your program(presumably a Taichi tensor) to images. The first one working with ti.GUI that it is more friendly to begginers. 
+- There are 2 common ways to export the result of your program (presumably a Taichi tensor) to images. The first one working with ti.GUI that it is more friendly to begginers. 
 - The second approach is to call some built-in functions in Taichi to make things done, which is more flexible and harder.
 
 Export Images by ti.GUI
 +++++++++++++++++++++++
 
-.. note::
-    
-    For beginners and debug purposes, we recommend this first method by ti.GUI!
-
-- The first method of exporting images is to use **ti.GUI.show()**. It can not only display the result to the screen but also export the result to your specified place.
-- About the format of saved images: **the type of image is fully determined by your suffix**. 
+- For beginners and debug purposes, we recommend this first method by ti.GUI! That is to use **ti.GUI.show(filename)**. It can not only display the result to the screen but also export the result to your specified `filename`.
+- Note that **the format of image is fully determined by your suffix**. 
 - Though Taichi now supports exporting to .png, .jpg and .bmp these 3 mainstream formats, we strongly **recommend using .png** which has been tested well at this moment. For example:
 
 .. code-block:: python
@@ -26,28 +22,22 @@ Export Images by ti.GUI
     import os
     pixel = ti.var(ti.u8, shape=(512, 512, 3))
 
+ti.init()
     @ti.kernel
     def paint():
-        for I in ti.grouped(pixel):
-            pixel[I] = ti.random() * 255
+        for i, j, k in pixel:
+            pixel[i, j, k] = ti.random() * 255
 
     iterations = 1000
     gui = ti.GUI("Export Result", res = 512)
-
-    # set up the images output
-    output_dir = "./results/"
-    if os.path.exists(output_dir) == False:
-        os.makedirs(output_dir)
 
     # mainloop
     for i in range(iterations):
         paint()
         gui.set_image(pixel)
 
-        # img_name = os.path.join(output_dir, f"frame_{i}.jpg")   # create filename with suffix jpg
-        # img_name = os.path.join(output_dir, f"frame_{i}.bmp")   # create filename with suffix bmp
-        img_name = os.path.join(output_dir, f"frame_{i}.png")   # create filename with suffix png
-        print("%s recorded in frame %d" % (img_name, i))
+        img_name = f"frame_{i}.png"   # create filename with suffix png
+        print("Frame %d is recorded in %s" % (i, img_name))
         gui.show(img_name)  # export and show in GUI
 
 - After running these codes above, you should get a batch of images in your "./results" folder.
@@ -150,7 +140,7 @@ Install ffmpeg on Windows
 
 Install FFmpeg on Linux
 +++++++++++++++++++++++
-- Most Linux distribution came with Linux natively.
+- Most Linux distribution came with ``ffmpeg`` natively.
 - Install ffmpeg on Ubuntu
 
 .. code-block:: shell
@@ -163,6 +153,12 @@ Install FFmpeg on Linux
 .. code-block:: shell
 
     sudo yum install ffmpeg ffmpeg-devel
+
+- Install ffmpeg on Arch Linux:
+
+.. code-block: shell
+
+    sudo pacman -S ffmpeg
 
 - test your installation by 
 

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -37,11 +37,11 @@ Export images using ``ti.GUI.show``
     # mainloop
     for i in range(iterations):
         paint()
-        gui.set_image(pixel)
+        gui.set_image(pixels)
 
-        img_name = f"frame_{i:05d}.png"   # create filename with suffix png
-        print(f"Frame {i} is recorded in {img_name}")
-        gui.show(img_name)  # export and show in GUI
+        filename = f'frame_{i:05d}.png'   # create filename with suffix png
+        print(f'Frame {i} is recorded in {filename}')
+        gui.show(filename)  # export and show in GUI
 
 - After running the code above, you will get a series of images in the current folder.
 
@@ -56,21 +56,21 @@ To save images without creating a ``ti.GUI``, use ``ti.imwrite``. For example:
 
         ti.init()
 
-        pixel = ti.var(ti.u8, shape=(512, 512, 3))
+        pixels = ti.var(ti.u8, shape=(512, 512, 3))
 
         @ti.kernel
-        def set_pixel():
-            for i, j, k in pixel:
-                pixel[i, j, k] = ti.random() * 255
+        def set_pixels():
+            for i, j, k in pixels:
+                pixels[i, j, k] = ti.random() * 255
 
-        set_pixel()
-        img_name = f"imwrite_export.png"
-        ti.imwrite(pixel.to_numpy(), img_name)
-        print(f"The image has been saved to {img_name}")
+        set_pixels()
+        filename = f'imwrite_export.png'
+        ti.imwrite(pixels.to_numpy(), filename)
+        print(f'The image has been saved to {filename}')
 
 Taichi offers helper functions that read, write, and show images. Please check out :ref:`gui` for more details.
 
-Export Videos
+Export videos
 -------------
 
 .. note::
@@ -85,12 +85,12 @@ Export Videos
 
     ti.init()
 
-    pixel = ti.var(ti.u8, shape=(512, 512, 3))
+    pixels = ti.var(ti.u8, shape=(512, 512, 3))
 
     @ti.kernel
     def paint():
-        for i, j, k in pixel:
-            pixel[i, j, k] = ti.random() * 255
+        for i, j, k in pixels:
+            pixels[i, j, k] = ti.random() * 255
 
     result_dir = "./results"
     video_manger = ti.VideoManager(output_dir=result_dir, framerate=24, automatic_build=False)
@@ -98,15 +98,15 @@ Export Videos
     for i in range(50):
         paint()
 
-        pixel_img = pixel.to_numpy()
-        video_manger.write_frame(pixel_img)
-        print(f"\rFrame {i+1}/50 is recorded", end='')
+        pixels_img = pixels.to_numpy()
+        video_manger.write_frame(pixels_img)
+        print(f'\rFrame {i+1}/50 is recorded', end='')
 
     print()
-    print("Exporting .mp4 and .gif videos...")
+    print('Exporting .mp4 and .gif videos...')
     video_manger.make_video(gif=True, mp4=True)
-    print(f"MP4 video is saved to {video_manger.get_output_filename(".mp4")}")
-    print(f"GIF video is saved to {video_manger.get_output_filename(".gif")}")
+    print(f'MP4 video is saved to {video_manger.get_output_filename(".mp4")}')
+    print(f'GIF video is saved to {video_manger.get_output_filename(".gif")}')
 
 After running the code above, you will find the output videos in the ``./results/`` folder.
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -279,10 +279,32 @@ A *event filter* is a list combined of *key*, *type* and *(type, key)* tuple, e.
 Image I/O
 ---------
 
+.. function:: ti.imread(filename, channels = 0)
+
+    :parameter filename: (string) filename of the image you want to load
+    :parameter channels: (int) the number of channels in your specified image, the default value is zero.
+    
+    This function can load an image from the target filename, return it as a np.ndarray
+
+.. function:: ti.imshow(img, windname)
+
+    :parameter img: (Matrix or Expr) the image you want to show in the GUI
+    :parameter windname: (string) the name of GUI window
+
+    This function will open an instance of ti.GUI and show the input image on the screen.
+
+.. function:: ti.imwrite(img, filename)
+
+    :parameter img: (Matrix or Expr) the images you want to export
+    :parameter filename: (string) filename you want to save
+
+    Please make sure that the input image is a Taichi Matrix or Expr and **it has shape [height, width, compoents] correctly**. For example:
+    
+    
+- And here is a simple example:
+
 .. code-block:: python
 
     img = ti.imread('hello.png')
     ti.imshow(img, 'Window Title')
     ti.imwrite(img, 'hello2.png')
-
-TODO: complete here

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -279,29 +279,29 @@ A *event filter* is a list combined of *key*, *type* and *(type, key)* tuple, e.
 Image I/O
 ---------
 
-.. function:: ti.imread(filename, channels = 0)
+.. function:: ti.imread(filename, channels=0)
 
-    :parameter filename: (string) filename of the image you want to load
-    :parameter channels: (int) the number of channels in your specified image, the default value is zero.
+    :parameter filename: (string) the filename of the image to load
+    :parameter channels: (int) the number of channels in your specified image. The default value ``0`` means the channels of the returned image is adaptive to the image file.
     
-    This function can load an image from the target filename, return it as a np.ndarray
+    This function loads an image from the target filename and returns it as a ``np.ndarray``.
 
 .. function:: ti.imshow(img, windname)
 
-    :parameter img: (Matrix or Expr) the image you want to show in the GUI
-    :parameter windname: (string) the name of GUI window
+    :parameter img: (Matrix or Expr) the image to show in the GUI
+    :parameter windname: (string) the name of the GUI window
 
-    This function will open an instance of ti.GUI and show the input image on the screen.
+    This function will create an instance of ``ti.GUI`` and show the input image on the screen.
 
 .. function:: ti.imwrite(img, filename)
 
     :parameter img: (Matrix or Expr) the images you want to export
     :parameter filename: (string) filename you want to save
 
-    Please make sure that the input image is a Taichi Matrix or Expr and **it has shape [height, width, compoents] correctly**. For example:
+    Please make sure that the input image is a Taichi tensor of scalar or Vector, and **the tensor has correct shape (height, width, components)**. For example:
     
     
-- And here is a simple example:
+Here is a simple example:
 
 .. code-block:: python
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -283,7 +283,7 @@ Image I/O
 
     :parameter filename: (string) the filename of the image to load
     :parameter channels: (int) the number of channels in your specified image. The default value ``0`` means the channels of the returned image is adaptive to the image file.
-    
+
     This function loads an image from the target filename and returns it as a ``np.ndarray``.
 
 .. function:: ti.imshow(img, windname)
@@ -299,8 +299,8 @@ Image I/O
     :parameter filename: (string) filename you want to save
 
     Please make sure that the input image is a Taichi tensor of scalar or Vector, and **the tensor has correct shape (height, width, components)**. For example:
-    
-    
+
+
 Here is a simple example:
 
 .. code-block:: python

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -298,11 +298,7 @@ Image I/O
     :parameter img: (Matrix or Expr) the images you want to export
     :parameter filename: (string) filename you want to save
 
-    Please make sure that the input image is a Taichi tensor of scalar or Vector, and **the tensor has correct shape (height, width, components)**. For example:
-
-
-Here is a simple example:
-
+    Please make sure that the input image is a Taichi tensor of scalar or Vector, and **the tensor has correct shape (height, width, components)**, see ``ti.GUI.set_image``. For example:
 .. code-block:: python
 
     img = ti.imread('hello.png')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ The Taichi Programming Language
    :maxdepth: 3
 
    gui
+   export_results
    global_settings
    faq
    acknowledgments

--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -1,7 +1,7 @@
 .. _offset:
 
 Coordinate offsets
-========
+==================
 
 - A Taichi tensor can be defined with **coordinate offsets**. The offsets will move tensor bounds so that tensor origins are no longer zero vectors. A typical use case is to support voxels with negative coordinates in physical simulations.
 - For example, a matrix of ``32x64`` elements with coordinate offset ``(-16, 8)`` can be defined as the following:


### PR DESCRIPTION
Related issue = Close #1116 

Hi all,

I finished this new tutorial that can help our beginners exporting results as images and videos.Feel free to point out **ANYTHING you would not like(or hate)** so that I can make it better then.

On Ubuntu 18.04 and macOS Mojave this tutorial works well. But currently I have no Windows available at hand, Would anyone be happy to test the install instructions of ffmpeg on windows?

Thank a lot!

Bests,
Xudong
