### PR TITLE
[misc] Generate changelog before trying to run build.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
 - export TAICHI_REPO_DIR=$TRAVIS_BUILD_DIR
 - export PYTHONPATH=$TAICHI_REPO_DIR/python
 - export PATH=$TAICHI_REPO_DIR/bin:$PATH
-- ti test -vr2 -t2 && cd python && $PYTHON build.py try_upload
+- ti test -vr2 -t2 && ti changelog --save && cd python && $PYTHON build.py try_upload
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
 - export TAICHI_REPO_DIR=$TRAVIS_BUILD_DIR
 - export PYTHONPATH=$TAICHI_REPO_DIR/python
 - export PATH=$TAICHI_REPO_DIR/bin:$PATH
-- ti test -vr2 -t2 && ti changelog --save && cd python && $PYTHON build.py try_upload
+- ti test -vr2 -t2 && cd python && $PYTHON build.py try_upload
 
 env:
   global:

--- a/python/build.py
+++ b/python/build.py
@@ -85,6 +85,8 @@ else:
     shutil.copy('../runtimes/RelWithDebInfo/taichi_core.dll',
                 'taichi/lib/taichi_core.pyd')
 
+os.system('{} -m taichi changelog --save && cat ../CHANGELOG.md'.format(get_python_executable()))
+
 shutil.copy('../CHANGELOG.md', './taichi/CHANGELOG.md')
 shutil.copytree('../tests/python', './taichi/tests')
 shutil.copytree('../examples', './taichi/examples')

--- a/python/build.py
+++ b/python/build.py
@@ -85,7 +85,8 @@ else:
     shutil.copy('../runtimes/RelWithDebInfo/taichi_core.dll',
                 'taichi/lib/taichi_core.pyd')
 
-os.system('{} -m taichi changelog --save && cat ../CHANGELOG.md'.format(get_python_executable()))
+os.system('{} -m taichi changelog --save && cat ../CHANGELOG.md'.format(
+    get_python_executable()))
 
 shutil.copy('../CHANGELOG.md', './taichi/CHANGELOG.md')
 shutil.copytree('../tests/python', './taichi/tests')

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -191,7 +191,7 @@ class TaichiMain:
             args = parser.parse_args(arguments)
 
             from . import make_changelog
-            res = make_changelog.main(args.version)
+            res = make_changelog.main(args.version, ti.core.get_repo_dir())
             if args.save:
                 changelog_md = os.path.join(ti.core.get_repo_dir(),
                                             'CHANGELOG.md')

--- a/python/taichi/make_changelog.py
+++ b/python/taichi/make_changelog.py
@@ -4,8 +4,8 @@ import sys
 from git import Repo
 
 
-def main(ver='master'):
-    g = Repo('.')
+def main(ver='master', repo_dir='.'):
+    g = Repo(repo_dir)
     commits = list(g.iter_commits(ver, max_count=200))
     begin, end = -1, 0
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #1153

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

---
CI is red since `build.py` cannot find `../CHANGELOG.md`, this PR tries to fix it.