### PR TITLE
[GUI] Support ti.GUI.EXIT on Mac

### DIFF
--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -292,10 +292,6 @@ void GUI::process_event() {
        "runMode:beforeDate:", NSDefaultRunLoopMode,
        clscall("NSDate", "distantPast"));
   while (1) {
-    if (window_received_close.load()) {
-      send_window_close_message();
-      window_received_close.store(false);
-    }
     auto event = call(
         NSApp, "nextEventMatchingMask:untilDate:inMode:dequeue:", NSUIntegerMax,
         clscall("NSDate", "distantPast"), NSDefaultRunLoopMode, YES);
@@ -347,6 +343,10 @@ void GUI::process_event() {
     } else {
       break;
     }
+  }
+  if (window_received_close.load()) {
+    send_window_close_message();
+    window_received_close.store(false);
   }
 }
 

--- a/taichi/gui/gui.h
+++ b/taichi/gui/gui.h
@@ -3,6 +3,8 @@
 #include "taichi/math/math.h"
 #include "taichi/system/timer.h"
 #include "taichi/program/profiler.h"
+
+#include <atomic>
 #include <ctime>
 #include <numeric>
 
@@ -454,6 +456,7 @@ class GUIBaseCocoa {
   id window, view;
   std::size_t img_data_length;
   std::vector<uint8_t> img_data;
+  std::atomic_bool window_received_close = false;
 };
 
 using GUIBase = GUIBaseCocoa;


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

This is a follow up of #1152. Unlike the other platforms, Mac doesn't seem to provide a direct windows closed event that can be polled from the event loop. Instead, we need to register a `NSWindowsDelegate` object, and receive this event asynchronously. This is why I used an atomic bool, `window_received_closed`, to record this event.

Related issue = #1118

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
