### PR TITLE
[misc] Simplify the usage of <filesystem>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ language: cpp
 matrix:
   include:
   - os: osx
-    osx_image: xcode10.3
+    osx_image: xcode11.5
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.6.1 && PYTHON=python"
   - os: osx
-    osx_image: xcode10.3
+    osx_image: xcode11.5
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.7.1 && PYTHON=python"
   - os: osx
-    osx_image: xcode10.3
+    osx_image: xcode11.5
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.8.1 && PYTHON=python"
 


### PR DESCRIPTION
I think we can just choose to use `<experimental/filesystem>` when the system version is too old.

Related issue = #1161

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
