### PR TITLE
[metal] Add kernel side memory allocator

### DIFF
--- a/taichi/backends/metal/shaders/atomic_stubs.h
+++ b/taichi/backends/metal/shaders/atomic_stubs.h
@@ -14,6 +14,7 @@ template <typename T>
 bool atomic_compare_exchange_weak_explicit(T *object,
                                            T *expected,
                                            T desired,
+                                           metal::memory_order,
                                            metal::memory_order) {
   const T val = *object;
   if (val == *expected) {

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -43,49 +43,53 @@ struct Runtime {
 METAL_BEGIN_RUNTIME_KERNELS_DEF
 STR(
     // clang-format on
-    kernel void clear_list(device byte *runtime_addr[[buffer(0)]],
-                           device int *args[[buffer(1)]],
-                           const uint utid_[[thread_position_in_grid]]) {
+    kernel void clear_list(device byte *runtime_addr [[buffer(0)]],
+                           device int *args [[buffer(1)]],
+                           const uint utid_ [[thread_position_in_grid]]) {
       if (utid_ > 0)
         return;
       int child_snode_id = args[1];
-      device ListManager *child_list =
-          &(reinterpret_cast<device Runtime *>(runtime_addr)
-                ->snode_lists[child_snode_id]);
-      clear(child_list);
+      ListManager child_list;
+      child_list.lm_data =
+          (reinterpret_cast<device Runtime *>(runtime_addr)->snode_lists +
+           child_snode_id);
+      clear(&child_list);
     }
 
-    kernel void element_listgen(device byte *runtime_addr[[buffer(0)]],
-                                device byte *root_addr[[buffer(1)]],
-                                device int *args[[buffer(2)]],
-                                const uint utid_[[thread_position_in_grid]],
-                                const uint grid_size[[threads_per_grid]]) {
+    kernel void element_listgen(device byte *runtime_addr [[buffer(0)]],
+                                device byte *root_addr [[buffer(1)]],
+                                device int *args [[buffer(2)]],
+                                const uint utid_ [[thread_position_in_grid]],
+                                const uint grid_size [[threads_per_grid]]) {
       device Runtime *runtime =
           reinterpret_cast<device Runtime *>(runtime_addr);
-      device byte *list_data_addr =
-          reinterpret_cast<device byte *>(runtime + 1);
+      device MemoryAllocator *mem_alloc =
+          reinterpret_cast<device MemoryAllocator *>(runtime + 1);
 
-      int parent_snode_id = args[0];
-      int child_snode_id = args[1];
-      device ListManager *parent_list =
-          &(runtime->snode_lists[parent_snode_id]);
-      device ListManager *child_list = &(runtime->snode_lists[child_snode_id]);
+      const int parent_snode_id = args[0];
+      const int child_snode_id = args[1];
+      ListManager parent_list;
+      parent_list.lm_data = (runtime->snode_lists + parent_snode_id);
+      parent_list.mem_alloc = mem_alloc;
+      ListManager child_list;
+      child_list.lm_data = (runtime->snode_lists + child_snode_id);
+      child_list.mem_alloc = mem_alloc;
       const SNodeMeta parent_meta = runtime->snode_metas[parent_snode_id];
       const int child_stride = parent_meta.element_stride;
       const int num_slots = parent_meta.num_slots;
       const SNodeMeta child_meta = runtime->snode_metas[child_snode_id];
       // |max_num_elems| is NOT padded to power-of-two, while |num_slots| is.
       // So we need to cap the loop precisely at child's |max_num_elems|.
-      for (int ii = utid_; ii < child_list->max_num_elems; ii += grid_size) {
+      const int max_num_elems = args[2];
+      for (int ii = utid_; ii < max_num_elems; ii += grid_size) {
         const int parent_idx = (ii / num_slots);
-        if (parent_idx >= num_active(parent_list)) {
+        if (parent_idx >= num_active(&parent_list)) {
           // Since |parent_idx| increases monotonically, we can return directly
           // once it goes beyond the number of active parent elements.
           return;
         }
         const int child_idx = (ii % num_slots);
-        const auto parent_elem =
-            get<ListgenElement>(parent_list, parent_idx, list_data_addr);
+        const auto parent_elem = get<ListgenElement>(&parent_list, parent_idx);
         ListgenElement child_elem;
         child_elem.root_mem_offset = parent_elem.root_mem_offset +
                                      child_idx * child_stride +
@@ -95,7 +99,7 @@ STR(
           refine_coordinates(parent_elem,
                              runtime->snode_extractors[parent_snode_id],
                              child_idx, &child_elem);
-          append(child_list, child_elem, list_data_addr);
+          append(&child_list, child_elem);
         }
       }
     }

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -43,9 +43,9 @@ struct Runtime {
 METAL_BEGIN_RUNTIME_KERNELS_DEF
 STR(
     // clang-format on
-    kernel void clear_list(device byte *runtime_addr [[buffer(0)]],
-                           device int *args [[buffer(1)]],
-                           const uint utid_ [[thread_position_in_grid]]) {
+    kernel void clear_list(device byte *runtime_addr[[buffer(0)]],
+                           device int *args[[buffer(1)]],
+                           const uint utid_[[thread_position_in_grid]]) {
       if (utid_ > 0)
         return;
       int child_snode_id = args[1];
@@ -56,11 +56,11 @@ STR(
       clear(&child_list);
     }
 
-    kernel void element_listgen(device byte *runtime_addr [[buffer(0)]],
-                                device byte *root_addr [[buffer(1)]],
-                                device int *args [[buffer(2)]],
-                                const uint utid_ [[thread_position_in_grid]],
-                                const uint grid_size [[threads_per_grid]]) {
+    kernel void element_listgen(device byte *runtime_addr[[buffer(0)]],
+                                device byte *root_addr[[buffer(1)]],
+                                device int *args[[buffer(2)]],
+                                const uint utid_[[thread_position_in_grid]],
+                                const uint grid_size[[threads_per_grid]]) {
       device Runtime *runtime =
           reinterpret_cast<device Runtime *>(runtime_addr);
       device MemoryAllocator *mem_alloc =

--- a/taichi/backends/metal/shaders/runtime_utils.metal.h
+++ b/taichi/backends/metal/shaders/runtime_utils.metal.h
@@ -31,8 +31,8 @@
 // clang-format off
 METAL_BEGIN_RUNTIME_UTILS_DEF
 STR(
-    // clang-format on
-    using PtrOffset = int32_t; constant constexpr int kAlignment = 8;
+    using PtrOffset = int32_t;
+    constant constexpr int kAlignment = 8;
 
     [[maybe_unused]] PtrOffset mtl_memalloc_alloc(device MemoryAllocator * ma,
                                                   int32_t size) {
@@ -208,7 +208,6 @@ STR(
           addr + (meta.num_slots * meta.element_stride));
       return atomic_load_explicit(n_ptr, metal::memory_order_relaxed);
     }
-    // clang-format off
 )
 METAL_END_RUNTIME_UTILS_DEF
 // clang-format on

--- a/taichi/backends/metal/shaders/runtime_utils.metal.h
+++ b/taichi/backends/metal/shaders/runtime_utils.metal.h
@@ -31,38 +31,100 @@
 // clang-format off
 METAL_BEGIN_RUNTIME_UTILS_DEF
 STR(
-    [[maybe_unused]] int num_active(device const ListManager *list) {
-      return list->next;
+    // clang-format on
+    using PtrOffset = int32_t; constant constexpr int kAlignment = 8;
+
+    [[maybe_unused]] PtrOffset mtl_memalloc_alloc(device MemoryAllocator * ma,
+                                                  int32_t size) {
+      size = ((size + kAlignment - 1) / kAlignment) * kAlignment;
+      return atomic_fetch_add_explicit(&ma->next, size,
+                                       metal::memory_order_relaxed);
+    }
+
+    [[maybe_unused]] device char
+        *mtl_memalloc_to_ptr(device MemoryAllocator *ma, PtrOffset offs) {
+          return reinterpret_cast<device char *>(ma + 1) + offs;
+        }
+
+    [[maybe_unused]] int num_active(thread ListManager *l) {
+      return atomic_load_explicit(&(l->lm_data->next),
+                                  metal::memory_order_relaxed);
+    }
+
+    [[maybe_unused]] void clear(thread ListManager *l) {
+      atomic_store_explicit(&(l->lm_data->next), 0,
+                            metal::memory_order_relaxed);
+    }
+
+    [[maybe_unused]] PtrOffset mtl_listmgr_ensure_chunk(thread ListManager *l,
+                                                        int i) {
+      device ListManagerData *list = l->lm_data;
+      PtrOffset offs = 0;
+      const int kChunkBytes =
+          (list->element_stride << list->log2_num_elems_per_chunk);
+
+      while (true) {
+        int stored = 0;
+        // If chunks[i] is unallocated, i.e. 0, mark it as 1 to prevent others
+        // from requesting memory again. Once allocated, set chunks[i] to the
+        // actual address offset, which is guaranteed to be greater than 1.
+        const bool is_me = atomic_compare_exchange_weak_explicit(
+            list->chunks + i, &stored, 1, metal::memory_order_relaxed,
+            metal::memory_order_relaxed);
+        if (is_me) {
+          offs = mtl_memalloc_alloc(l->mem_alloc, kChunkBytes);
+          atomic_store_explicit(list->chunks + i, offs,
+                                metal::memory_order_relaxed);
+          break;
+        } else if (stored > 1) {
+          offs = stored;
+          break;
+        }
+        // |stored| == 1, just spin
+      }
+      return offs;
+    }
+
+    [[maybe_unused]] device char *mtl_listmgr_get_elem_from_chunk(
+        thread ListManager *l,
+        int i,
+        PtrOffset chunk_ptr_offs) {
+      device ListManagerData *list = l->lm_data;
+      device char *chunk_ptr = reinterpret_cast<device char *>(
+          mtl_memalloc_to_ptr(l->mem_alloc, chunk_ptr_offs));
+      const uint32_t mask = ((1 << list->log2_num_elems_per_chunk) - 1);
+      return chunk_ptr + ((i & mask) * list->element_stride);
+    }
+
+    [[maybe_unused]] device char *append(thread ListManager *l) {
+      device ListManagerData *list = l->lm_data;
+      const int elem_idx = atomic_fetch_add_explicit(
+          &list->next, 1, metal::memory_order_relaxed);
+      const int chunk_idx = elem_idx >> list->log2_num_elems_per_chunk;
+      const PtrOffset chunk_ptr_offs = mtl_listmgr_ensure_chunk(l, chunk_idx);
+      return mtl_listmgr_get_elem_from_chunk(l, elem_idx, chunk_ptr_offs);
     }
 
     template <typename T>
-    int append(device ListManager *list,
-               thread const T &elem,
-               device byte *data_addr) {
+    [[maybe_unused]] void append(thread ListManager *l, thread const T &elem) {
+      device char *ptr = append(l);
       thread char *elem_ptr = (thread char *)(&elem);
-      int me = atomic_fetch_add_explicit(
-          reinterpret_cast<device atomic_int *>(&(list->next)), 1,
-          metal::memory_order_relaxed);
-      device byte *ptr =
-          data_addr + list->mem_begin + (me * list->element_stride);
-      for (int i = 0; i < list->element_stride; ++i) {
+
+      for (int i = 0; i < l->lm_data->element_stride; ++i) {
         *ptr = *elem_ptr;
         ++ptr;
         ++elem_ptr;
       }
-      return me;
     }
 
     template <typename T>
-    T get(const device ListManager *list, int i, device const byte *data_addr) {
-      return *reinterpret_cast<device const T *>(data_addr + list->mem_begin +
-                                                 (i * list->element_stride));
-    }
-
-    [[maybe_unused]] void clear(device ListManager *list) {
-      atomic_store_explicit(
-          reinterpret_cast<device atomic_int *>(&(list->next)), 0,
-          metal::memory_order_relaxed);
+    [[maybe_unused]] T get(thread ListManager *l, int i) {
+      device ListManagerData *list = l->lm_data;
+      const int chunk_idx = i >> list->log2_num_elems_per_chunk;
+      const PtrOffset chunk_ptr_offs = atomic_load_explicit(
+          list->chunks + chunk_idx, metal::memory_order_relaxed);
+      return *reinterpret_cast<device T *>(
+          mtl_listmgr_get_elem_from_chunk(l, i, chunk_ptr_offs));
     }
 
     [[maybe_unused]] int is_active(device byte *addr, SNodeMeta meta, int i) {
@@ -70,7 +132,7 @@ STR(
         return true;
       }
       device auto *meta_ptr_begin = reinterpret_cast<device atomic_uint *>(
-              addr + ((meta.num_slots - i) * meta.element_stride));
+          addr + ((meta.num_slots - i) * meta.element_stride));
       if (meta.type == SNodeMeta::Dynamic) {
         device auto *ptr = meta_ptr_begin;
         uint32_t n = atomic_load_explicit(ptr, metal::memory_order_relaxed);
@@ -104,7 +166,7 @@ STR(
         return;
       }
       device auto *meta_ptr_begin = reinterpret_cast<device atomic_uint *>(
-              addr + ((meta.num_slots - i) * meta.element_stride));
+          addr + ((meta.num_slots - i) * meta.element_stride));
       if (meta.type == SNodeMeta::Dynamic) {
         device auto *ptr = meta_ptr_begin;
         // For dynamic, deactivate() applies for all the slots
@@ -130,8 +192,8 @@ STR(
     }
 
     [[maybe_unused]] int dynamic_append(device byte *addr,
-                                         SNodeMeta meta,
-                                         int32_t data) {
+                                        SNodeMeta meta,
+                                        int32_t data) {
       // |addr| always starts at the beginning of the dynamic
       device auto *n_ptr = reinterpret_cast<device atomic_int *>(
           addr + (meta.num_slots * meta.element_stride));
@@ -146,6 +208,7 @@ STR(
           addr + (meta.num_slots * meta.element_stride));
       return atomic_load_explicit(n_ptr, metal::memory_order_relaxed);
     }
+    // clang-format off
 )
 METAL_END_RUNTIME_UTILS_DEF
 // clang-format on


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

This PR has no functionality changes. It just reimplements Metal's `ListManager` via the dynamic memory allocator on the GPU. All the existing tests have passed, and `taichi_sparse.py` ran just fine.

The concrete design is listed in #1174  itself.

Related issue = #1174 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
