### PR TITLE
[bug] [lang] Fix an issue which breaks the binary operations between global Vectors in Taichi-scope 

### DIFF
--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -19,6 +19,23 @@ def test_python_scope_vector_operations():
 
 
 @ti.host_arch_only
+def test_taichi_scope_vector_operations_with_global_vectors():
+    for ops in vector_operation_types:
+        ti.reset()
+        a, b = test_vector_arrays
+        m1, m2 = ti.Vector(a), ti.Vector(b)
+        c = ti.Vector(2, dt=ti.i32, shape=())
+
+        @ti.kernel
+        def run():
+            c = ops(m1, m2)
+
+        run()
+
+        # assert np.allclose(c.at(None).to_numpy(), ops(a, b))
+
+
+@ti.host_arch_only
 def test_python_scope_matrix_operations():
     for ops in operation_types:
         a, b = test_matrix_arrays


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #... (if any)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
