### PR TITLE
[test] Let pytest-rerunfailures pytest-xdist to be hard dependences

### DIFF
--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -19,8 +19,9 @@ Installing Depedencies
 
   .. code-block:: bash
 
-    python3 -m pip install --user setuptools astpretty astor pytest opencv-python pybind11
-    python3 -m pip install --user Pillow numpy scipy GitPython yapf colorama psutil autograd
+    python3 -m pip install --user setuptools astpretty astor pybind11 opencv-python
+    python3 -m pip install --user pytest pytest-rerunfailures pytest-xdist yapf Pillow
+    python3 -m pip install --user numpy scipy GitPython colorama psutil autograd
 
 * (If on Ubuntu) Execute ``sudo apt install libtinfo-dev clang-8``. (``clang-7`` should work as well).
 

--- a/misc/empty_pytest.py
+++ b/misc/empty_pytest.py
@@ -1,2 +1,0 @@
-def test_notest():
-    pass

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -660,8 +660,7 @@ class TaichiMain:
 
         try:
             from multiprocessing import cpu_count
-            threads = min(8,
-                          cpu_count())  # To prevent running out of memory
+            threads = min(8, cpu_count())  # To prevent running out of memory
         except NotImplementedError:
             threads = 2
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = (reported by GAMES 201 students)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
