### PR TITLE
[IR] Move "lower_access" after "offload"

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -85,22 +85,8 @@ void compile_to_offloads(IRNode *ir,
   print("Access flagged I");
   irpass::analysis::verify(ir);
 
-  if (lower_global_access) {
-    irpass::lower_access(ir, true);
-    print("Access lowered");
-    irpass::analysis::verify(ir);
-
-    irpass::die(ir);
-    print("DIE");
-    irpass::analysis::verify(ir);
-  }
-
   irpass::full_simplify(ir);
   print("Simplified II");
-  irpass::analysis::verify(ir);
-
-  irpass::flag_access(ir);
-  print("Access flagged II");
   irpass::analysis::verify(ir);
 
   irpass::constant_fold(ir);
@@ -110,9 +96,21 @@ void compile_to_offloads(IRNode *ir,
   print("Offloaded");
   irpass::analysis::verify(ir);
 
-  if (!lower_global_access) {
+  irpass::flag_access(ir);
+  print("Access flagged II");
+  irpass::analysis::verify(ir);
+
+  if (lower_global_access) {
+    irpass::lower_access(ir, true);
+    print("Access lowered");
+    irpass::analysis::verify(ir);
+
+    irpass::die(ir);
+    print("DIE");
+    irpass::analysis::verify(ir);
+
     irpass::flag_access(ir);
-    print("Access flagged after offloading");
+    print("Access flagged III");
     irpass::analysis::verify(ir);
   }
 
@@ -123,6 +121,12 @@ void compile_to_offloads(IRNode *ir,
   print("Atomics demoted");
   irpass::analysis::verify(ir);
 
+  irpass::full_simplify(ir);
+  print("Simplified III");
+
+  irpass::extract_constant(ir);
+  print("Constant extracted III");
+
   irpass::variable_optimization(ir, true);
   print("Store forwarded II");
 
@@ -131,7 +135,7 @@ void compile_to_offloads(IRNode *ir,
   irpass::analysis::verify(ir);
 
   irpass::full_simplify(ir);
-  print("Simplified III");
+  print("Simplified IV");
 
   // Final field registration correctness & type checking
   irpass::typecheck(ir);


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related PR = #1180

![benchmark20200608_4](https://user-images.githubusercontent.com/22582118/84103488-27483200-a9e1-11ea-9ab7-1708e918829f.png)

In order to achieve similar performance, I added some optimization passes.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
