### PR TITLE
[Lang] Support taichi kernels as class members variables

### DIFF
--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -569,8 +569,10 @@ def data_oriented(cls):
         x = super(cls, self).__getattribute__(item)
         if hasattr(x, '_is_wrapped_kernel'):
             import inspect
-            assert inspect.ismethod(x)
-            wrapped = x.__func__
+            if inspect.ismethod(x):
+                wrapped = x.__func__
+            else:
+                wrapped = x
             assert inspect.isfunction(wrapped)
             if wrapped._is_classkernel:
                 return BoundedDifferentiableMethod(self, wrapped)

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -197,3 +197,26 @@ def test_oop_class_must_be_data_oriented():
 
     # Array1D is not properly decorated, this will raise an Exception
     arr.reduce()
+
+@ti.host_arch_only
+def test_hook():
+    @ti.data_oriented
+    class Solver:
+        def __init__(self, n, m, hook):
+            self.val = ti.var(ti.f32, shape=(n, m))
+            self.hook = hook
+
+        def run_hook(self):
+            self.hook(self.val)
+
+    @ti.kernel
+    def hook(x:ti.template()):
+        for i,j in x:
+            x[i,j] = 1.0
+
+    solver = Solver(32, 32, hook)
+    solver.run_hook()
+
+    for i in range(32):
+        for j in range(32):
+            assert(solver.val[i,j] == 1.0)


### PR DESCRIPTION
It can sometimes be useful to call externally defined kernels from inside a data_oriented class (eg. a hook). To do this we just needed to allow python functions (not just methods) to be called from a data_oriented class. 

LGTM = anyone

- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)
