### PR TITLE
[llvm] [opt] CSE for LoopIndexStmt

### DIFF
--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -593,8 +593,7 @@ class BasicBlockSimplify : public IRVisitor {
         auto &bstmt_data = *bstmt;
         if (typeid(bstmt_data) == typeid(*stmt)) {
           auto bstmt_ = bstmt->as<LoopIndexStmt>();
-          if (bstmt_->loop == stmt->loop &&
-              bstmt_->index == stmt->index) {
+          if (bstmt_->loop == stmt->loop && bstmt_->index == stmt->index) {
             stmt->replace_with(bstmt.get());
             stmt->parent->erase(current_stmt_id);
             throw IRModified();

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -584,6 +584,27 @@ class BasicBlockSimplify : public IRVisitor {
     set_done(stmt);
   }
 
+  void visit(LoopIndexStmt *stmt) override {
+    if (is_done(stmt))
+      return;
+    for (int i = 0; i < current_stmt_id; i++) {
+      auto &bstmt = block->statements[i];
+      if (stmt->ret_type == bstmt->ret_type) {
+        auto &bstmt_data = *bstmt;
+        if (typeid(bstmt_data) == typeid(*stmt)) {
+          auto bstmt_ = bstmt->as<LoopIndexStmt>();
+          if (bstmt_->loop == stmt->loop &&
+              bstmt_->index == stmt->index) {
+            stmt->replace_with(bstmt.get());
+            stmt->parent->erase(current_stmt_id);
+            throw IRModified();
+          }
+        }
+      }
+    }
+    set_done(stmt);
+  }
+
   void visit(UnaryOpStmt *stmt) override {
     if (is_done(stmt))
       return;


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #1178 

A quick hack to bring down the test case in #1178 from 6ms back to 1.6ms.

This can be removed once the `WholeKernelCSE` pass is back. Note that without `WholeKernelCSE` `taichi_elements` is still very slow.

- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)
