### PR TITLE
[LLVM] Support LLVM 10 on macOS

### DIFF
--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -129,7 +129,11 @@ class JITSessionCPU : public JITSession {
 
   void *lookup(const std::string Name) override {
     std::lock_guard<std::mutex> _(mut);
+#ifdef __APPLE__
+    auto symbol = ES.lookup(all_libs, Mangle(Name));
+#else
     auto symbol = ES.lookup(all_libs, ES.intern(Name));
+#endif
     if (!symbol)
       TI_ERROR("Function \"{}\" not found", Name);
     return (void *)(symbol->getAddress());
@@ -137,7 +141,11 @@ class JITSessionCPU : public JITSession {
 
   void *lookup_in_module(JITDylib *lib, const std::string Name) {
     std::lock_guard<std::mutex> _(mut);
+#ifdef __APPLE__
+    auto symbol = ES.lookup({lib}, Mangle(Name));
+#else
     auto symbol = ES.lookup({lib}, ES.intern(Name));
+#endif
     if (!symbol)
       TI_ERROR("Function \"{}\" not found", Name);
     return (void *)(symbol->getAddress());


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #655 (if any)

- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)

This PR fix name mangling in JIT CPU backend to support LLVM 10 on macOS.