### PR TITLE
[misc] Fix uninitialized print_kernel_nvptx field of CompileConfig

### DIFF
--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -14,6 +14,7 @@ CompileConfig::CompileConfig() {
   use_llvm = true;
   print_struct_llvm_ir = false;
   print_kernel_llvm_ir = false;
+  print_kernel_nvptx = false;
   print_kernel_llvm_ir_optimized = false;
   demote_dense_struct_fors = true;
   max_vector_width = 8;


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)
