### PR TITLE
[Opt] Improve the whole kernel CSE pass (stage 2)

### DIFF
--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -793,7 +793,6 @@ class ExternalPtrStmt : public Stmt {
  public:
   LaneAttribute<Stmt *> base_ptrs;
   std::vector<Stmt *> indices;
-  bool activate;
 
   ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
                   const std::vector<Stmt *> &indices);
@@ -802,7 +801,7 @@ class ExternalPtrStmt : public Stmt {
     return false;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, base_ptrs, indices, activate);
+  TI_STMT_DEF_FIELDS(ret_type, base_ptrs, indices);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -572,6 +572,14 @@ class Stmt : public IRNode {
     return true;
   }
 
+  virtual bool dead_instruction_eliminable() const {
+    return !has_global_side_effect();
+  }
+
+  virtual bool common_statement_eliminable() const {
+    return !has_global_side_effect();
+  }
+
   template <typename T, typename... Args>
   static std::unique_ptr<T> make_typed(Args &&... args) {
     return std::make_unique<T>(std::forward<Args>(args)...);
@@ -609,7 +617,11 @@ class AllocaStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
     return false;
   }
 
@@ -678,7 +690,7 @@ class UnaryOpStmt : public Stmt {
   bool same_operation(UnaryOpStmt *o) const;
   bool is_cast() const;
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -695,7 +707,7 @@ class ArgLoadStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -710,7 +722,11 @@ class RandStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
     return false;
   }
 
@@ -730,7 +746,7 @@ class BinaryOpStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -751,7 +767,7 @@ class TernaryOpStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -782,7 +798,7 @@ class ExternalPtrStmt : public Stmt {
   ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
                   const std::vector<Stmt *> &indices);
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -800,7 +816,7 @@ class GlobalPtrStmt : public Stmt {
                 const std::vector<Stmt *> &indices,
                 bool activate = true);
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return activate;
   }
 
@@ -949,6 +965,14 @@ class RangeAssumptionStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool dead_instruction_eliminable() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, input, base, low, high);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
@@ -961,7 +985,11 @@ class GlobalLoadStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
     return false;
   }
 
@@ -975,6 +1003,10 @@ class GlobalStoreStmt : public Stmt {
 
   GlobalStoreStmt(Stmt *ptr, Stmt *data) : ptr(ptr), data(data) {
     TI_STMT_REG_FIELDS;
+  }
+
+  bool common_statement_eliminable() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, ptr, data);
@@ -1006,7 +1038,11 @@ class LocalLoadStmt : public Stmt {
 
   Stmt *previous_store_or_alloca_in_block();
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
     return false;
   }
 
@@ -1022,6 +1058,18 @@ class LocalStoreStmt : public Stmt {
   LocalStoreStmt(Stmt *ptr, Stmt *data) : ptr(ptr), data(data) {
     TI_ASSERT(ptr->is<AllocaStmt>());
     TI_STMT_REG_FIELDS;
+  }
+
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool dead_instruction_eliminable() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, ptr, data);
@@ -1079,7 +1127,7 @@ class ConstStmt : public Stmt {
     val.repeat(factor);
   }
 
-  virtual bool has_global_side_effect() const override {
+  bool has_global_side_effect() const override {
     return false;
   }
 
@@ -1184,10 +1232,6 @@ class FuncCallStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  bool is_container_statement() const override {
-    return false;
-  }
-
   TI_STMT_DEF_FIELDS(ret_type, funcid);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
@@ -1198,10 +1242,6 @@ class KernelReturnStmt : public Stmt {
 
   KernelReturnStmt(Stmt *value) : value(value) {
     TI_STMT_REG_FIELDS;
-  }
-
-  bool is_container_statement() const override {
-    return false;
   }
 
   TI_STMT_DEF_FIELDS(value);

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -291,6 +291,10 @@ class StackAllocaStmt : public Stmt {
     return false;
   }
 
+  bool common_statement_eliminable() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, dt, max_size);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
@@ -306,6 +310,10 @@ class StackLoadTopStmt : public Stmt {
   }
 
   bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
     return false;
   }
 
@@ -327,6 +335,10 @@ class StackLoadTopAdjStmt : public Stmt {
     return false;
   }
 
+  bool common_statement_eliminable() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, stack);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
@@ -339,6 +351,18 @@ class StackPopStmt : public Stmt {
     TI_ASSERT(stack->is<StackAllocaStmt>());
     this->stack = stack;
     TI_STMT_REG_FIELDS;
+  }
+
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool dead_instruction_eliminable() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, stack);
@@ -357,6 +381,18 @@ class StackPushStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool dead_instruction_eliminable() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, stack, v);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
@@ -371,6 +407,18 @@ class StackAccAdjointStmt : public Stmt {
     this->stack = stack;
     this->v = v;
     TI_STMT_REG_FIELDS;
+  }
+
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  bool dead_instruction_eliminable() const override {
+    return false;
+  }
+
+  bool common_statement_eliminable() const override {
+    return false;
   }
 
   TI_STMT_DEF_FIELDS(ret_type, stack, v);

--- a/taichi/transforms/die.cpp
+++ b/taichi/transforms/die.cpp
@@ -51,7 +51,7 @@ class DIE : public IRVisitor {
     if (phase == 0) {
       register_usage(stmt);
     } else {
-      if (!stmt->has_global_side_effect() &&
+      if (stmt->dead_instruction_eliminable() &&
           used.find(stmt->instance_id) == used.end()) {
         stmt->parent->erase(stmt);
         throw IRModified();

--- a/taichi/transforms/whole_kernel_cse.cpp
+++ b/taichi/transforms/whole_kernel_cse.cpp
@@ -2,6 +2,7 @@
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/analysis.h"
 #include "taichi/ir/visitors.h"
+#include <typeindex>
 
 TLANG_NAMESPACE_BEGIN
 
@@ -10,7 +11,8 @@ class WholeKernelCSE : public BasicStmtVisitor {
  private:
   std::unordered_set<int> visited;
   // each scope corresponds to an unordered_set
-  std::vector<std::unordered_set<Stmt *>> visible_stmts;
+  std::vector<std::unordered_map<std::type_index, std::unordered_set<Stmt *>>>
+      visible_stmts;
   DelayedIRModifier modifier;
 
  public:
@@ -30,24 +32,15 @@ class WholeKernelCSE : public BasicStmtVisitor {
   }
 
   void visit(Stmt *stmt) override {
-    if (stmt->has_global_side_effect())
+    if (!stmt->common_statement_eliminable())
       return;
-    if (stmt->is<AllocaStmt>() || stmt->is<LocalStoreStmt>() ||
-        stmt->is<LocalLoadStmt>() || stmt->is<AtomicOpStmt>() ||
-        stmt->is<GlobalLoadStmt>() || stmt->is<GlobalStoreStmt>() ||
-        stmt->is<StackAllocaStmt>() || stmt->is<StackLoadTopStmt>() ||
-        stmt->is<StackLoadTopAdjStmt>() || stmt->is<StackPopStmt>() ||
-        stmt->is<StackPushStmt>() || stmt->is<StackAccAdjointStmt>() ||
-        stmt->is<RandStmt>() || stmt->is<SNodeOpStmt>())
-      return;
-    // Generic visitor for all non-container statements that don't have global
-    // side effect and aren't RandStmt/SNodeOpStmt/related to variables/stacks.
+    // Generic visitor for all CSE-able statements.
     if (is_done(stmt)) {
-      visible_stmts.back().insert(stmt);
+      visible_stmts.back()[std::type_index(typeid(*stmt))].insert(stmt);
       return;
     }
     for (auto &scope : visible_stmts) {
-      for (auto &prev_stmt : scope) {
+      for (auto &prev_stmt : scope[std::type_index(typeid(*stmt))]) {
         if (irpass::analysis::same_statements(stmt, prev_stmt)) {
           stmt->replace_with(prev_stmt);
           modifier.erase(stmt);
@@ -55,7 +48,7 @@ class WholeKernelCSE : public BasicStmtVisitor {
         }
       }
     }
-    visible_stmts.back().insert(stmt);
+    visible_stmts.back()[std::type_index(typeid(*stmt))].insert(stmt);
     set_done(stmt);
   }
 


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related PR = #1180 

Also modifies the `DIE` pass and removes `ExternalPtrStmt::activate`.

Benchmark:
![benchmark20200610_3](https://user-images.githubusercontent.com/22582118/84341071-40cbb400-ab70-11ea-8131-84e9f444d21a.png)


- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)
