### PR TITLE
[Bug] [ir] Fix a bug in "offload"

### DIFF
--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -247,26 +247,6 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     }
   }
 
-  void visit(LocalLoadStmt *stmt) override {
-    TI_ASSERT(current_offloaded);
-    TI_ASSERT(stmt->width() == 1);
-    test_and_allocate(stmt->ptr[0].var);
-  }
-
-  void visit(LocalStoreStmt *stmt) override {
-    TI_ASSERT(current_offloaded);
-    TI_ASSERT(stmt->width() == 1);
-    test_and_allocate(stmt->ptr);
-  }
-
-  void visit(AtomicOpStmt *stmt) override {
-    TI_ASSERT(current_offloaded);
-    TI_ASSERT(stmt->width() == 1);
-    if (stmt->dest->is<AllocaStmt>()) {
-      test_and_allocate(stmt->dest);
-    }
-  }
-
   void visit(Stmt *stmt) override {
     int n_op = stmt->num_operands();
     for (int i = 0; i < n_op; i++) {

--- a/tests/python/test_loops.py
+++ b/tests/python/test_loops.py
@@ -151,3 +151,23 @@ def test_loop_arg_as_range():
         test(b, e)
         for i in range(b, e):
             assert x[i - b] == i
+
+
+@ti.all_archs
+def test_assignment_in_nested_loops():
+    # https://github.com/taichi-dev/taichi/issues/1109
+    m = ti.var(ti.f32, 3)
+    x = ti.var(ti.f32, ())
+
+    @ti.kernel
+    def func():
+        a = x[None]
+        for i in m:
+            b = a
+            for j in range(1):
+                b = b
+            x[None] = b
+
+    x[None] = 1
+    func()
+    assert x[None] == 1


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = fix #1109

For LocalStoreStmt, we should consider not only `stmt->ptr` but also `stmt->data`. I think we can just use the generic visitor.

- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)
