### PR TITLE
[Opt] Make full_simplify iterative when advanced_optimization=True

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -13,7 +13,7 @@ namespace irpass {
 void re_id(IRNode *root);
 void flag_access(IRNode *root);
 void die(IRNode *root);
-void simplify(IRNode *root, Kernel *kernel = nullptr);
+bool simplify(IRNode *root, Kernel *kernel = nullptr);
 void cfg_optimization(IRNode *root);
 bool alg_simp(IRNode *root);
 bool whole_kernel_cse(IRNode *root);
@@ -30,7 +30,7 @@ void replace_all_usages_with(IRNode *root, Stmt *old_stmt, Stmt *new_stmt);
 void check_out_of_bound(IRNode *root);
 void lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
 void make_adjoint(IRNode *root, bool use_stack = false);
-void constant_fold(IRNode *root);
+bool constant_fold(IRNode *root);
 void offload(IRNode *root);
 void fix_block_parents(IRNode *root);
 void replace_statements_with(IRNode *root,

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -73,10 +73,6 @@ void compile_to_offloads(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
-  irpass::extract_constant(ir);
-  print("Constant extracted");
-  irpass::analysis::verify(ir);
-
   irpass::variable_optimization(ir, false);
   print("Store forwarded");
   irpass::analysis::verify(ir);
@@ -114,18 +110,9 @@ void compile_to_offloads(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
-  irpass::extract_constant(ir);
-  print("Constant extracted II");
-
   irpass::demote_atomics(ir);
   print("Atomics demoted");
   irpass::analysis::verify(ir);
-
-  irpass::full_simplify(ir);
-  print("Simplified III");
-
-  irpass::extract_constant(ir);
-  print("Constant extracted III");
 
   irpass::variable_optimization(ir, true);
   print("Store forwarded II");
@@ -135,7 +122,7 @@ void compile_to_offloads(IRNode *ir,
   irpass::analysis::verify(ir);
 
   irpass::full_simplify(ir);
-  print("Simplified IV");
+  print("Simplified III");
 
   // Final field registration correctness & type checking
   irpass::typecheck(ir);


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = N/A

This PR offers shorter compilation time when `advanced_optimization=False` (by removing a `full_simplify` pass), and makes `full_simplify` more "full simplified".

Benchmark: the running time of a large program.
- advanced_optimization=True:
  - Before: total running time = 6m51s, compilation time of a large kernel = 6m37s
    ```
    codegen_accessor_statements: 148.00
    codegen_evaluator_statements: 102.00
    codegen_kernel_statements: 29020.00
    codegen_offloaded_tasks: 53.00
    codegen_statements  : 29270.00
    ```
  - After: total running time = 6m51s, compilation time of a large kernel = 6m35s
    ```
    codegen_accessor_statements: 148.00
    codegen_evaluator_statements: 102.00
    codegen_kernel_statements: 29020.00
    codegen_offloaded_tasks: 53.00
    codegen_statements  : 29270.00
    ```
- advanced_optimization=False:
  - Before: total running time = 3m21s, compilation time of a large kernel = 3m7s
    ```
    codegen_accessor_statements: 175.00
    codegen_kernel_statements: 59287.00
    codegen_offloaded_tasks: 41.00
    codegen_statements  : 59462.00
    ```
  - After: total running time = 2m59s, compilation time of a large kernel = 2m46s
    ```
    codegen_accessor_statements: 175.00
    codegen_kernel_statements: 59288.00
    codegen_offloaded_tasks: 42.00
    codegen_statements  : 59463.00
    ```

![benchmark20200611](https://user-images.githubusercontent.com/22582118/84458183-615c4280-ac32-11ea-93fd-8d5f34630ce2.png)


TODO (not urgent): make each IR transform pass return whether it modifies the IR (can be done together with #1059 )

- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)
