### PR TITLE
[Opt] Eliminate useless OffsetAndExtractBitsStmt of a LoopIndexStmt

### DIFF
--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -207,6 +207,13 @@ std::string SNode::get_node_type_name_hinted() const {
   return fmt::format("S{}{}{}", id, snode_type_name(type), suffix);
 }
 
+int SNode::get_num_bits(int physical_index) const {
+  if (extractors[physical_index].num_bits)
+    return extractors[physical_index].num_bits;
+  TI_ASSERT(parent);
+  return parent->get_num_bits(physical_index);
+}
+
 void SNode::print() {
   for (int i = 0; i < depth; i++) {
     fmt::print("  ");

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -208,10 +208,13 @@ std::string SNode::get_node_type_name_hinted() const {
 }
 
 int SNode::get_num_bits(int physical_index) const {
-  if (extractors[physical_index].num_bits)
-    return extractors[physical_index].num_bits;
-  TI_ASSERT(parent);
-  return parent->get_num_bits(physical_index);
+  int result = 0;
+  const SNode *snode = this;
+  while (snode) {
+    result += extractors[physical_index].num_bits;
+    snode = snode->parent;
+  }
+  return result;
 }
 
 void SNode::print() {

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -98,6 +98,8 @@ class SNode {
 
   std::string get_node_type_name_hinted() const;
 
+  int get_num_bits(int physical_index) const;
+
   SNode &insert_children(SNodeType t) {
     ch.push_back(create(depth + 1, t));
     // Note: parent will not be set until structural nodes are compiled!

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -1,6 +1,7 @@
 // TODO: gradually cppize statements.h
 #include "statements.h"
 #include "taichi/program/program.h"
+#include "taichi/util/bit.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -75,6 +76,40 @@ std::unique_ptr<Stmt> OffloadedStmt::clone() const {
   if (body)
     new_stmt->body = body->clone();
   return new_stmt;
+}
+
+int LoopIndexStmt::max_num_bits() const {
+  if (auto range_for = loop->cast<RangeForStmt>()) {
+    // Return the max number of bits only if both begin and end are
+    // non-negative consts.
+    if (!range_for->begin->is<ConstStmt>() || !range_for->end->is<ConstStmt>())
+      return -1;
+    auto begin = range_for->begin->as<ConstStmt>();
+    for (int i = 0; i < (int)begin->val.size(); i++) {
+      if (begin->val[i].val_int() < 0)
+        return -1;
+    }
+    auto end = range_for->end->as<ConstStmt>();
+    int result = 0;
+    for (int i = 0; i < (int)end->val.size(); i++) {
+      result = std::max(result, (int)bit::ceil_log2int(end->val[i].val_int()));
+    }
+    return result;
+  } else if (auto struct_for = loop->cast<StructForStmt>()) {
+    return struct_for->snode->get_num_bits(index);
+  } else if (auto offload = loop->cast<OffloadedStmt>()) {
+    if (offload->task_type == OffloadedStmt::TaskType::range_for) {
+      if (!offload->const_begin || !offload->const_end)
+        return -1;
+      return bit::ceil_log2int(offload->end_offset);
+    } else if (offload->task_type == OffloadedStmt::TaskType::struct_for) {
+      return offload->snode->get_num_bits(index);
+    } else {
+      TI_NOT_IMPLEMENTED
+    }
+  } else {
+    TI_NOT_IMPLEMENTED
+  }
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -101,7 +101,9 @@ int LoopIndexStmt::max_num_bits() const {
     if (offload->task_type == OffloadedStmt::TaskType::range_for) {
       if (!offload->const_begin || !offload->const_end)
         return -1;
-      return bit::ceil_log2int(offload->end_offset);
+      if (offload->begin_value < 0)
+        return -1;
+      return bit::ceil_log2int(offload->end_value);
     } else if (offload->task_type == OffloadedStmt::TaskType::struct_for) {
       return offload->snode->get_num_bits(index);
     } else {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -230,6 +230,9 @@ class LoopIndexStmt : public Stmt {
     return false;
   }
 
+  // Return the number of bits of the loop, or -1 if unknown.
+  int max_num_bits() const;
+
   TI_STMT_DEF_FIELDS(ret_type, loop, index);
   TI_DEFINE_ACCEPT_AND_CLONE
 };

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -721,7 +721,7 @@ class BasicBlockSimplify : public IRVisitor {
         stmt->input->is<LoopIndexStmt>()) {
       auto bstmt = stmt->input->as<LoopIndexStmt>();
       const int max_num_bits = bstmt->max_num_bits();
-      if (max_num_bits != -1 && stmt->bit_end == max_num_bits) {
+      if (max_num_bits != -1 && stmt->bit_end >= max_num_bits) {
         stmt->replace_with(bstmt);
         stmt->parent->erase(current_stmt_id);
         throw IRModified();

--- a/taichi/util/bit.h
+++ b/taichi/util/bit.h
@@ -122,6 +122,7 @@ TI_FORCE_INLINE constexpr uint32 log2int(uint64 value) {
 }
 
 TI_FORCE_INLINE constexpr uint32 ceil_log2int(uint64 value) {
+  // Returns ceil(log2(value)). When value == 0, it returns 0.
   return log2int(value) + ((value & (value - 1)) != 0);
 }
 

--- a/taichi/util/bit.h
+++ b/taichi/util/bit.h
@@ -121,6 +121,10 @@ TI_FORCE_INLINE constexpr uint32 log2int(uint64 value) {
   return ret;
 }
 
+TI_FORCE_INLINE constexpr uint32 ceil_log2int(uint64 value) {
+  return log2int(value) + ((value & (value - 1)) != 0);
+}
+
 template <typename G, typename T>
 constexpr TI_FORCE_INLINE copy_refcv_t<T, G> &&reinterpret_bits(T &&t) {
   TI_STATIC_ASSERT(sizeof(G) == sizeof(T));


### PR DESCRIPTION
<!-- Thank for your PR! If it's your first time contributing to Taichi, please make sure you have read Contributor Guideline(https://taichi.readthedocs.io/en/latest/contributor_guide.html) (last update: March 26, 2019). -->

<!-- Please always prepend your PR title with tags such as [Metal], [CUDA], [Doc], [Example]. Use a lowercased tag (e.g. [cuda]), for PRs that are invisible to end-users (e.g. intermediate implementation). More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags -->

Related issue = #1178 

This PR does **not** solve the issue of strong access of dynamic SNodes. It only eliminates the OffsetAndExtractBitsStmt.

Test case:
```python
import taichi as ti

ti.init(print_ir=True, print_preprocessed=True)

a = ti.var(ti.i32)
ti.root.dynamic(ti.j, 16).dynamic(ti.i, 8).place(a)

@ti.kernel
def kern():
  for I in ti.grouped(a):
    a[I] = 1

# activate
for i in range(16):
  for j in range(8):
    a[i, j] = 0

kern()

for i in range(16):
  for j in range(8):
    assert a[i, j] == 1
```
Before:
```
kernel {
  $0 = offloaded clear_list S1dynamic
  $1 = offloaded listgen S0root->S1dynamic
  $2 = offloaded clear_list S2dynamic
  $3 = offloaded listgen S1dynamic->S2dynamic
  $4 = offloaded struct_for(S2dynamic) block_dim=0 {
    <i32 x1> $5 = loop $4 index 1
    <i32 x1> $6 = loop $4 index 0
    <i32 x1> $7 = const [1]
    <gen*x1> $8 = get root
    <i32 x1> $9 = const [0]
    <gen*x1> $10 = [S0root][root]::lookup($8, $9) activate = false
    <gen*x1> $11 = get child [S0root->S1dynamic] $10
    <i32 x1> $12 = bit_extract($5 + 0, 0~4)
    <gen*x1> $13 = [S1dynamic][dynamic]::lookup($11, $12) activate = true
    <gen*x1> $14 = get child [S1dynamic->S2dynamic] $13
    <i32 x1> $15 = bit_extract($5 + 0, 0~0)
    <i32 x1> $16 = bit_extract($6 + 0, 0~3)
    <i32 x1> $17 = const [8]
    <i32 x1> $18 = mul $15 $17
    <i32 x1> $19 = add $16 $18
    <gen*x1> $20 = [S2dynamic][dynamic]::lookup($14, $19) activate = true
    <i32*x1> $21 = get child [S2dynamic->S3place_i32] $20
    <i32 x1> $22 : global store [$21 <- $7]
  }
}
```
After:
```
kernel {
  $0 = offloaded clear_list S1dynamic
  $1 = offloaded listgen S0root->S1dynamic
  $2 = offloaded clear_list S2dynamic
  $3 = offloaded listgen S1dynamic->S2dynamic
  $4 = offloaded struct_for(S2dynamic) block_dim=0 {
    <i32 x1> $5 = loop $4 index 1
    <i32 x1> $6 = loop $4 index 0
    <i32 x1> $7 = const [1]
    <gen*x1> $8 = get root
    <i32 x1> $9 = const [0]
    <gen*x1> $10 = [S0root][root]::lookup($8, $9) activate = false
    <gen*x1> $11 = get child [S0root->S1dynamic] $10
    <gen*x1> $12 = [S1dynamic][dynamic]::lookup($11, $5) activate = true
    <gen*x1> $13 = get child [S1dynamic->S2dynamic] $12
    <gen*x1> $14 = [S2dynamic][dynamic]::lookup($13, $6) activate = true
    <i32*x1> $15 = get child [S2dynamic->S3place_i32] $14
    <i32 x1> $16 : global store [$15 <- $7]
  }
}
```

![benchmark20200612](https://user-images.githubusercontent.com/22582118/84549559-3f1c0080-acd6-11ea-8e29-fdd2609d4df9.png)

- [[Click here for the format server]](http://kun.csail.mit.edu:31415/)
- [[Click here for coverage report]](http://codecov.io/gh/taichi-dev/taichi/)
