### PR TITLE
[workflow] Improve PR title checker for the release tag

### DIFF
--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Run PR Title Checker
         run: |
+          pip install semver GitPython
           python misc/check_pr_title.py "$PR_TITLE"
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/misc/check_pr_title.py
+++ b/misc/check_pr_title.py
@@ -1,4 +1,16 @@
-import sys, os, json
+import sys, os, json, semver, git
+
+def get_old_ver():
+    repo = git.Repo('.')
+    for c in repo.iter_commits('master', max_count=200):
+        if c.summary.startswith('[release]'):
+            ver = c.summary.split(']', maxsplit=1)[1]
+            if ver[0] == 'v':
+                ver = ver[1:]
+            ver = ver.split(' ')[0]
+            oldver = semver.VersionInfo.parse(ver)
+            return oldver
+    raise ValueError('Could not find old version!')
 
 title = sys.argv[1]
 print(f'Checking PR title: {title}')
@@ -26,10 +38,6 @@ for x in title.split(']')[1:]:
     if x[1] == ' ':
         exit(f'Extra space before: {x[2:]}')
 
-x = title.split(']')[-1].strip()
-if x[0].islower():
-    exit(f'PR title should be uppercase at: {x}')
-
 had_upper = False
 for x in title.split('] ')[:-1]:
     if x[0] != '[':
@@ -42,5 +50,33 @@ for x in title.split('] ')[:-1]:
         if had_upper:
             exit(f'At most 1 uppercase tag expected, got: [{x[1:]}]')
         had_upper = True
+
+is_release = False
+for x in title.split('] ')[:-1]:
+    x = x[1:]
+    if x.lower() == 'release':
+        is_release = True
+        if not x.islower():
+            exit(f'[release] must be lowercase, got: [{x}]')
+
+if is_release:
+    ts = title.split(']')
+    if len(ts) != 2:
+        exit(f'Release PRs must have only one tag "[release]", got: {title}')
+    ver = ts[1][1:]
+    if ver[0] != 'v':
+        exit(f'Release version must be prepended with "v", got: {ver}')
+    ver = ver[1:]
+    try:
+        ver = semver.VersionInfo.parse(ver)
+    except ValueError:
+        exit(f'Invalid SemVer version: {ver}')
+    oldver = get_old_ver()
+    if ver not in [oldver.bump_minor(), oldver.bump_patch()]:
+        exit(f'Version bump incorrect: {oldver} -> {ver}')
+else:
+    x = title.split(']')[-1].strip()
+    if x[0].islower():
+        exit(f'PR title should be uppercase at: {x}')
 
 print('OK!')

--- a/misc/check_pr_title.py
+++ b/misc/check_pr_title.py
@@ -11,7 +11,7 @@ def get_old_ver():
             ver = ver.split(' ')[0]
             oldver = semver.VersionInfo.parse(ver)
             return oldver
-    raise ValueError('Could not find old version!')
+    raise ValueError('Could not find an old version!')
 
 
 title = sys.argv[1]
@@ -67,7 +67,7 @@ if is_release:
         exit(f'Release PRs must have only one tag "[release]", got: {title}')
     ver = ts[1][1:]
     if ver[0] != 'v':
-        exit(f'Release version must be prepended with "v", got: {ver}')
+        exit(f'Release version must start with "v", got: {ver}')
     ver = ver[1:]
     try:
         ver = semver.VersionInfo.parse(ver)
@@ -79,6 +79,6 @@ if is_release:
 else:
     x = title.split(']')[-1].strip()
     if x[0].islower():
-        exit(f'PR title should be uppercase at: {x}')
+        exit(f'PR titles must start with uppercase letters: {x}')
 
 print('OK!')

--- a/misc/check_pr_title.py
+++ b/misc/check_pr_title.py
@@ -1,5 +1,6 @@
 import sys, os, json, semver, git
 
+
 def get_old_ver():
     repo = git.Repo('.')
     for c in repo.iter_commits('master', max_count=200):
@@ -11,6 +12,7 @@ def get_old_ver():
             oldver = semver.VersionInfo.parse(ver)
             return oldver
     raise ValueError('Could not find old version!')
+
 
 title = sys.argv[1]
 print(f'Checking PR title: {title}')


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you :)
- If the PR doesn't belong to any existing issue, and this is a trivial change, feel free to leave it blank :)
  -->
Related issue = #1241

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
`[release] v0.6.10`, here `v` is lowercase, so error comes.
We only want to make other PRs to be uppercased like `[lang] Hello world` but not for `[release]`.
I tweaked PR title checker to make it support a separate checking logic for `[release]` PRs.
It also support semver bump checking in case we make wrong :) @FantasyVR 
e.g.: `v0.6.10 -> v0.6.12` ERROR! `v0.6.` ERROR!