### PR TITLE
[ir] Set root block kernel after cloning

### DIFF
--- a/taichi/analysis/clone.cpp
+++ b/taichi/analysis/clone.cpp
@@ -114,14 +114,18 @@ class IRCloner : public IRVisitor {
     if (kernel == nullptr) {
       kernel = root->get_kernel();
     }
+    TI_ASSERT(kernel != nullptr);
     std::unique_ptr<IRNode> new_root = root->clone();
     IRCloner cloner(new_root.get());
     cloner.phase = IRCloner::register_operand_map;
     root->accept(&cloner);
     cloner.phase = IRCloner::replace_operand;
     root->accept(&cloner);
-    irpass::typecheck(new_root.get());
-    irpass::fix_block_parents(new_root.get());
+
+    using namespace irpass;
+    typecheck(new_root.get());
+    fix_block_parents(new_root.get());
+    fix_root_block_kernel(new_root.get(), kernel);
     return new_root;
   }
 };

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -215,6 +215,8 @@ class IRVisitor {
     invoke_default_visitor = false;
   }
 
+  virtual ~IRVisitor() = default;
+
   // default visitor
   virtual void visit(Stmt *stmt) {
     if (!allow_undefined_visitor) {

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -10,6 +10,11 @@ TLANG_NAMESPACE_BEGIN
 // IR passes
 namespace irpass {
 
+// TODO(#1243): Pass kernel to the relevant passes instead of doing this hack
+namespace hack {
+bool use_fast_math(IRNode *root);
+}  // namespace hack
+
 void re_id(IRNode *root);
 void flag_access(IRNode *root);
 void die(IRNode *root);
@@ -34,6 +39,7 @@ void make_adjoint(IRNode *root, bool use_stack = false);
 bool constant_fold(IRNode *root);
 void offload(IRNode *root);
 void fix_block_parents(IRNode *root);
+void fix_root_block_kernel(IRNode *root, Kernel *kernel);
 void replace_statements_with(IRNode *root,
                              std::function<bool(Stmt *)> filter,
                              std::function<std::unique_ptr<Stmt>()> generator);

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -263,9 +263,18 @@ class AlgSimp : public BasicStmtVisitor {
 
 namespace irpass {
 
+namespace hack {
+bool use_fast_math(IRNode *root) {
+  const Kernel *kernel = root->get_kernel();
+  if (!kernel) {
+    return false;
+  }
+  return kernel->program.config.fast_math;
+}
+}  // namespace hack
+
 bool alg_simp(IRNode *root) {
-  const auto &config = root->get_kernel()->program.config;
-  return AlgSimp::run(root, config.fast_math);
+  return AlgSimp::run(root, hack::use_fast_math(root));
 }
 
 }  // namespace irpass

--- a/taichi/transforms/binary_op_simplify.cpp
+++ b/taichi/transforms/binary_op_simplify.cpp
@@ -96,8 +96,7 @@ class BinaryOpSimp : public BasicStmtVisitor {
 namespace irpass {
 
 bool binary_op_simplify(IRNode *root) {
-  const auto &config = root->get_kernel()->program.config;
-  return BinaryOpSimp::run(root, config.fast_math);
+  return BinaryOpSimp::run(root, hack::use_fast_math(root));
 }
 
 }  // namespace irpass

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -1,6 +1,7 @@
 #include "taichi/ir/ir.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/visitors.h"
+#include "taichi/program/kernel.h"
 #include <set>
 
 TLANG_NAMESPACE_BEGIN
@@ -32,7 +33,8 @@ class CheckOutOfBound : public BasicStmtVisitor {
     Stmt *result =
         new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(true));
 
-    std::string msg = "Accessing Tensor of Size [";
+    std::string msg = fmt::format("(kernel={}) Accessing Tensor of Size [",
+                                  stmt->get_kernel()->name);
     std::string offset_msg = "Offset [";
     std::vector<Stmt *> args;
     for (int i = 0; i < stmt->indices.size(); i++) {

--- a/taichi/transforms/fix_root_block_kernel.cpp
+++ b/taichi/transforms/fix_root_block_kernel.cpp
@@ -1,0 +1,40 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/ir/visitors.h"
+
+TLANG_NAMESPACE_BEGIN
+
+namespace {
+
+class FixRootBlockKernel : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
+
+  explicit FixRootBlockKernel(Kernel *kernel) : kernel_(kernel) {
+    allow_undefined_visitor = true;
+    invoke_default_visitor = true;
+  }
+
+  void visit(Block *stmt_list) override {
+    if (stmt_list->parent == nullptr) {
+      stmt_list->kernel = kernel_;
+    }
+    // No need to visit leaves because we have found the root
+  }
+
+ private:
+  Kernel *const kernel_;
+};
+
+}  // namespace
+
+namespace irpass {
+
+void fix_root_block_kernel(IRNode *root, Kernel *kernel) {
+  FixRootBlockKernel f(kernel);
+  root->accept(&f);
+}
+
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -322,6 +322,7 @@ class TypeCheck : public IRVisitor {
     if (current_kernel == nullptr) {
       current_kernel = stmt->get_kernel();
     }
+    TI_ASSERT(current_kernel != nullptr);
     auto &args = current_kernel->args;
     TI_ASSERT(0 <= stmt->arg_id && stmt->arg_id < args.size());
     stmt->ret_type = VectorType(1, args[stmt->arg_id].dt);


### PR DESCRIPTION
I've managed to fix all the `kernel == nullptr` problems that I've found so far. Note that this PR alone doesn't fix all the problems. In order to run `mpm99`, you would still need to disable kernel fusion and constant folding. What's more interesting is that, the main constant folding workflow is fine, the problem was around https://github.com/taichi-dev/taichi/blob/1402c4e5501984e765cacab566117dd07ede07cc/taichi/transforms/constant_fold.cpp#L213-L215

Honestly I think `IRNode::get_kernel()` is mostly broken in the async mode, since it depends on the assumption that root is a block.. 

Related issue = #1243 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
