### PR TITLE
[Opt] [ir] [refactor] Remove exceptions from IR check_out_of_bound and constant_fold

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -28,7 +28,7 @@ void loop_vectorize(IRNode *root);
 void slp_vectorize(IRNode *root);
 void vector_split(IRNode *root, int max_width, bool serial_schedule);
 void replace_all_usages_with(IRNode *root, Stmt *old_stmt, Stmt *new_stmt);
-void check_out_of_bound(IRNode *root);
+bool check_out_of_bound(IRNode *root);
 void lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
 void make_adjoint(IRNode *root, bool use_stack = false);
 bool constant_fold(IRNode *root);

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -9,6 +9,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
   std::set<int> visited;
+  DelayedIRModifier modifier;
 
   CheckOutOfBound() : BasicStmtVisitor(), visited() {
   }
@@ -72,29 +73,28 @@ class CheckOutOfBound : public BasicStmtVisitor {
     msg += ")";
 
     new_stmts.push_back<AssertStmt>(result, msg, args);
-    stmt->parent->insert_before(stmt, std::move(new_stmts));
+    modifier.insert_before(stmt, std::move(new_stmts));
     set_done(stmt);
-    throw IRModified();
   }
 
-  static void run(IRNode *node) {
+  static bool run(IRNode *node) {
     CheckOutOfBound checker;
+    bool modified = false;
     while (true) {
-      bool modified = false;
-      try {
-        node->accept(&checker);
-      } catch (IRModified) {
+      node->accept(&checker);
+      if (checker.modifier.modify_ir()) {
         modified = true;
-      }
-      if (!modified)
+      } else {
         break;
+      }
     }
+    return modified;
   }
 };
 
 namespace irpass {
 
-void check_out_of_bound(IRNode *root) {
+bool check_out_of_bound(IRNode *root) {
   return CheckOutOfBound::run(root);
 }
 


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you :)
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1059

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
