### PR TITLE
[misc] Add auto-profiling to IR passes

### DIFF
--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -95,6 +95,7 @@ class IRVerifier : public BasicStmtVisitor {
 
 namespace irpass::analysis {
 void verify(IRNode *root) {
+  TI_AUTO_PROF;
   IRVerifier::run(root);
 }
 }  // namespace irpass::analysis

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -274,6 +274,7 @@ bool use_fast_math(IRNode *root) {
 }  // namespace hack
 
 bool alg_simp(IRNode *root) {
+  TI_AUTO_PROF;
   return AlgSimp::run(root, hack::use_fast_math(root));
 }
 

--- a/taichi/transforms/binary_op_simplify.cpp
+++ b/taichi/transforms/binary_op_simplify.cpp
@@ -96,6 +96,7 @@ class BinaryOpSimp : public BasicStmtVisitor {
 namespace irpass {
 
 bool binary_op_simplify(IRNode *root) {
+  TI_AUTO_PROF;
   return BinaryOpSimp::run(root, hack::use_fast_math(root));
 }
 

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -7,6 +7,7 @@ TLANG_NAMESPACE_BEGIN
 
 namespace irpass {
 void cfg_optimization(IRNode *root) {
+  TI_AUTO_PROF;
   auto cfg = analysis::build_cfg(root);
   while (true) {
     bool modified = false;

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -97,6 +97,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
 namespace irpass {
 
 bool check_out_of_bound(IRNode *root) {
+  TI_AUTO_PROF;
   return CheckOutOfBound::run(root);
 }
 

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -94,9 +94,6 @@ void compile_to_offloads(IRNode *ir,
   print("Simplified II");
   irpass::analysis::verify(ir);
 
-  irpass::constant_fold(ir);
-  print("Constant folded");
-
   irpass::offload(ir);
   print("Offloaded");
   irpass::analysis::verify(ir);

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -200,6 +200,7 @@ class ConstantFold : public BasicStmtVisitor {
 namespace irpass {
 
 bool constant_fold(IRNode *root) {
+  TI_AUTO_PROF;
   // @archibate found that `debug=True` will cause JIT kernels
   // failed to evaluate correctly (always return 0), so we simply
   // disable constant_fold when config.debug is turned on.

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -99,6 +99,7 @@ class DemoteAtomics : public BasicStmtVisitor {
 namespace irpass {
 
 void demote_atomics(IRNode *root) {
+  TI_AUTO_PROF;
   DemoteAtomics::run(root);
   typecheck(root);
 }

--- a/taichi/transforms/die.cpp
+++ b/taichi/transforms/die.cpp
@@ -98,6 +98,7 @@ class DIE : public IRVisitor {
 namespace irpass {
 
 void die(IRNode *root) {
+  TI_AUTO_PROF;
   DIE instance(root);
 }
 

--- a/taichi/transforms/extract_constant.cpp
+++ b/taichi/transforms/extract_constant.cpp
@@ -51,6 +51,7 @@ class ExtractConstant : public BasicStmtVisitor {
 
 namespace irpass {
 void extract_constant(IRNode *root) {
+  TI_AUTO_PROF;
   if (advanced_optimization)
     ExtractConstant::run(root);
 }

--- a/taichi/transforms/flag_access.cpp
+++ b/taichi/transforms/flag_access.cpp
@@ -150,6 +150,7 @@ class WeakenAccess : public BasicStmtVisitor {
 namespace irpass {
 
 void flag_access(IRNode *root) {
+  TI_AUTO_PROF;
   FlagAccess flag_access(root);
   WeakenAccess weaken_access(root);
 }

--- a/taichi/transforms/loop_vectorize.cpp
+++ b/taichi/transforms/loop_vectorize.cpp
@@ -154,6 +154,7 @@ class LoopVectorize : public IRVisitor {
 namespace irpass {
 
 void loop_vectorize(IRNode *root) {
+  TI_AUTO_PROF;
   return LoopVectorize::run(root);
 }
 

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -421,6 +421,7 @@ class LowerAST : public IRVisitor {
 namespace irpass {
 
 void lower(IRNode *root) {
+  TI_AUTO_PROF;
   LowerAST::run(root);
 }
 

--- a/taichi/transforms/make_adjoint.cpp
+++ b/taichi/transforms/make_adjoint.cpp
@@ -583,6 +583,7 @@ class BackupSSA : public BasicStmtVisitor {
 namespace irpass {
 
 void make_adjoint(IRNode *root, bool use_stack) {
+  TI_AUTO_PROF;
   if (use_stack) {
     fix_block_parents(root);
     ConvertLocalVar converter;

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -598,6 +598,7 @@ class AssociateContinueScope : public BasicStmtVisitor {
 }  // namespace
 
 void offload(IRNode *root) {
+  TI_AUTO_PROF;
   auto offloaded_ranges = Offloader::run(root);
   typecheck(root);
   fix_block_parents(root);

--- a/taichi/transforms/reverse_segments.cpp
+++ b/taichi/transforms/reverse_segments.cpp
@@ -26,6 +26,7 @@ class GatherStmts : public BasicStmtVisitor {
 };
 
 void reverse_segments(IRNode *root) {
+  TI_AUTO_PROF;
   auto block = dynamic_cast<Block *>(root);
   std::vector<std::vector<pStmt>> statement_blocks(1);
   bool has_for = false;

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -1192,6 +1192,7 @@ class Simplify : public IRVisitor {
 namespace irpass {
 
 bool simplify(IRNode *root, Kernel *kernel) {
+  TI_AUTO_PROF;
   bool modified = false;
   while (true) {
     Simplify pass(root, kernel);
@@ -1204,6 +1205,7 @@ bool simplify(IRNode *root, Kernel *kernel) {
 }
 
 void full_simplify(IRNode *root, Kernel *kernel) {
+  TI_AUTO_PROF;
   if (advanced_optimization) {
     while (true) {
       bool modified = false;

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -422,6 +422,7 @@ class TypeCheck : public IRVisitor {
 namespace irpass {
 
 void typecheck(IRNode *root) {
+  TI_AUTO_PROF;
   analysis::check_fields_registered(root);
   TypeCheck inst(root);
   root->accept(&inst);

--- a/taichi/transforms/variable_optimization.cpp
+++ b/taichi/transforms/variable_optimization.cpp
@@ -617,6 +617,7 @@ class OtherVariableOptimize : public VariableOptimize {
 
 namespace irpass {
 void variable_optimization(IRNode *root, bool after_lower_access) {
+  TI_AUTO_PROF;
   if (!advanced_optimization)
     return;
   AllocaOptimize alloca_optimizer;

--- a/taichi/transforms/vector_split.cpp
+++ b/taichi/transforms/vector_split.cpp
@@ -322,6 +322,7 @@ class VectorSplit : public IRVisitor {
 namespace irpass {
 
 void vector_split(IRNode *root, int max_width, bool serial_schedule) {
+  TI_AUTO_PROF;
   VectorSplit(root, max_width, serial_schedule);
 }
 

--- a/taichi/transforms/whole_kernel_cse.cpp
+++ b/taichi/transforms/whole_kernel_cse.cpp
@@ -126,6 +126,7 @@ class WholeKernelCSE : public BasicStmtVisitor {
 
 namespace irpass {
 bool whole_kernel_cse(IRNode *root) {
+  TI_AUTO_PROF;
   return WholeKernelCSE::run(root);
 }
 }  // namespace irpass


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #926 

Usage: `ti.core.print_profile_info()`

Example:
taichi_elements/demo_2d.py
```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
[Profiler thread 5444]
      1.674  s taichi::lang::TaichiLLVMContext::clone_runtime_module [1 x   1.674  s]
          1.581  s 94.43%  taichi::lang::compile_runtime_bitcode [1 x   1.581  s]
          0.033  s  1.95%  taichi::lang::module_from_bitcode_file [1 x  32.674 ms]
          0.060  s  3.60%  clone module          [1 x  60.314 ms]
    605.888 ms taichi::lang::StructCompilerLLVM::run [1 x 605.888 ms]
          0.217 ms  0.04%  taichi::lang::StructCompilerLLVM::generate_types [33 x   6.576 us]
          0.458 ms  0.08%  taichi::lang::StructCompilerLLVM::generate_child_accessors [1 x 458.000 us]
             71.000 us 15.50%  taichi::lang::StructCompilerLLVM::generate_refine_coordinates [1 x  71.000 us]
            384.000 us 83.84%  taichi::lang::StructCompilerLLVM::generate_child_accessors [7 x  54.857 us]
                192.000 us 50.00%  taichi::lang::StructCompilerLLVM::generate_refine_coordinates [7 x  27.429 us]
                139.000 us 36.20%  taichi::lang::StructCompilerLLVM::generate_child_accessors [25 x   5.560 us]
                 53.000 us 13.80%  [unaccounted]
              3.000 us  0.66%  [unaccounted]
         13.805 ms  2.28%  taichi::lang::TaichiLLVMContext::clone_struct_module [1 x  13.805 ms]
          2.006 ms  0.33%  taichi::lang::TaichiLLVMContext::eliminate_unused_functions [1 x   2.006 ms]
        414.628 ms 68.43%  taichi::lang::JITSessionCPU::global_optimize_module_cpu [1 x 414.628 ms]
             10.094 ms  2.43%  llvm_function_pass    [1 x  10.094 ms]
            398.991 ms 96.23%  llvm_module_pass      [1 x 398.991 ms]
              5.543 ms  1.34%  [unaccounted]
        174.774 ms 28.85%  [unaccounted]
      4.163  s taichi::lang::Program::compile [19 x 219.123 ms]
          1.498  s 35.98%  taichi::lang::irpass::compile_to_offloads [19 x  78.841 ms]
              0.101  s  6.72%  taichi::lang::irpass::lower [19 x   5.300 ms]
              0.022  s  1.45%  taichi::lang::irpass::typecheck [76 x 285.053 us]
              0.028  s  1.89%  taichi::lang::irpass::analysis::verify [304 x  93.352 us]
              0.000  s  0.00%  taichi::lang::irpass::loop_vectorize [19 x   3.421 us]
              0.000  s  0.00%  taichi::lang::irpass::vector_split [19 x   2.421 us]
              0.312  s 20.84%  taichi::lang::irpass::simplify [19 x  16.434 ms]
                  0.807 ms  0.26%  taichi::lang::irpass::typecheck [84 x   9.607 us]
                311.438 ms 99.74%  [unaccounted]
              0.342  s 22.80%  taichi::lang::irpass::variable_optimization [38 x   8.989 ms]
              0.000  s  0.03%  taichi::lang::irpass::flag_access [57 x   7.807 us]
              0.650  s 43.41%  taichi::lang::irpass::full_simplify [38 x  17.113 ms]
                  2.777 ms  0.43%  taichi::lang::irpass::extract_constant [79 x  35.152 us]
                  1.253 ms  0.19%  taichi::lang::irpass::binary_op_simplify [79 x  15.861 us]
                 61.359 ms  9.44%  taichi::lang::irpass::constant_fold [79 x 776.696 us]
                     56.805 ms 92.58%  taichi::lang::Program::compile [2 x  28.403 ms]
                          0.295 ms  0.52%  taichi::lang::irpass::compile_to_offloads [2 x 147.500 us]
                             11.000 us  3.73%  taichi::lang::irpass::lower [2 x   5.500 us]
                             10.000 us  3.39%  taichi::lang::irpass::typecheck [2 x   5.000 us]
                             21.000 us  7.12%  taichi::lang::irpass::analysis::verify [4 x   5.250 us]
                            245.000 us 83.05%  taichi::lang::irpass::offload [2 x 122.500 us]
                                 13.000 us  5.31%  taichi::lang::irpass::typecheck [4 x   3.250 us]
                                232.000 us 94.69%  [unaccounted]
                              8.000 us  2.71%  [unaccounted]
                         56.487 ms 99.44%  taichi::lang::KernelCodeGen::compile [2 x  28.244 ms]
                             56.483 ms 99.99%  taichi::lang::CodeGenCPU::codegen [2 x  28.242 ms]
                                 26.030 ms 46.08%  taichi::lang::TaichiLLVMContext::clone_struct_module [2 x  13.015 ms]
                                  0.004 ms  0.01%  taichi::lang::CodeGenLLVMCPU::CodeGenLLVMCPU [2 x   2.000 us]
                                  0.165 ms  0.29%  taichi::lang::CodeGenLLVM::emit_to_module [2 x  82.500 us]
                                 30.249 ms 53.55%  taichi::lang::CodeGenLLVM::compile_module_to_executable [2 x  15.125 ms]
                                      3.346 ms 11.06%  taichi::lang::TaichiLLVMContext::eliminate_unused_functions [2 x   1.673 ms]
                                     21.673 ms 71.65%  taichi::lang::JITSessionCPU::global_optimize_module_cpu [2 x  10.837 ms]
                                          4.268 ms 19.69%  llvm_function_pass    [2 x   2.134 ms]
                                         11.527 ms 53.19%  llvm_module_pass      [2 x   5.764 ms]
                                          5.878 ms 27.12%  [unaccounted]
                                      5.230 ms 17.29%  [unaccounted]
                      4.554 ms  7.42%  [unaccounted]
                  2.298 ms  0.35%  taichi::lang::irpass::alg_simp [79 x  29.089 us]
                 29.233 ms  4.50%  taichi::lang::irpass::die [237 x 123.346 us]
                462.993 ms 71.20%  taichi::lang::irpass::whole_kernel_cse [79 x   5.861 ms]
                 89.967 ms 13.83%  taichi::lang::irpass::simplify [79 x   1.139 ms]
                     16.684 ms 18.54%  taichi::lang::irpass::typecheck [74 x 225.459 us]
                     73.283 ms 81.46%  [unaccounted]
              0.020  s  1.31%  taichi::lang::irpass::offload [19 x   1.030 ms]
                  5.742 ms 29.33%  taichi::lang::irpass::typecheck [38 x 151.105 us]
                 13.836 ms 70.67%  [unaccounted]
              0.005  s  0.34%  taichi::lang::irpass::die [19 x 269.053 us]
              0.007  s  0.46%  taichi::lang::irpass::demote_atomics [19 x 362.789 us]
                  3.390 ms 49.18%  taichi::lang::irpass::typecheck [19 x 178.421 us]
                  3.503 ms 50.82%  [unaccounted]
              0.000  s  0.03%  taichi::lang::irpass::cfg_optimization [19 x  23.421 us]
              0.011  s  0.70%  [unaccounted]
          2.665  s 64.01%  taichi::lang::KernelCodeGen::compile [19 x 140.262 ms]
              2.665  s 100.00%  taichi::lang::CodeGenCPU::codegen [19 x 140.260 ms]
                  0.291  s 10.90%  taichi::lang::TaichiLLVMContext::clone_struct_module [19 x  15.293 ms]
                  0.000  s  0.00%  taichi::lang::CodeGenLLVMCPU::CodeGenLLVMCPU [19 x   1.368 us]
                  0.007  s  0.28%  taichi::lang::CodeGenLLVM::emit_to_module [19 x 387.789 us]
                  2.367  s 88.80%  taichi::lang::CodeGenLLVM::compile_module_to_executable [19 x 124.553 ms]
                      0.037  s  1.58%  taichi::lang::TaichiLLVMContext::eliminate_unused_functions [19 x   1.970 ms]
                      1.929  s 81.51%  taichi::lang::JITSessionCPU::global_optimize_module_cpu [19 x 101.523 ms]
                          0.093  s  4.82%  llvm_function_pass    [19 x   4.896 ms]
                          1.777  s 92.13%  llvm_module_pass      [19 x  93.535 ms]
                          0.059  s  3.05%  [unaccounted]
                      0.400  s 16.91%  [unaccounted]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
```

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
