### PR TITLE
[opt] Do not consider each GlobalPtrStmt as a data source in store forwarding

### DIFF
--- a/taichi/analysis/build_cfg.cpp
+++ b/taichi/analysis/build_cfg.cpp
@@ -25,6 +25,9 @@ class CFGBuilder : public IRVisitor {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
     graph = std::make_unique<ControlFlowGraph>();
+    // Make an empty start node.
+    auto start_node = graph->push_back(nullptr, -1, -1, nullptr);
+    prev_nodes.push_back(start_node);
   }
 
   void visit(Stmt *stmt) override {
@@ -145,7 +148,7 @@ class CFGBuilder : public IRVisitor {
     auto backup_last_node = last_node_in_current_block;
     auto backup_stmt_id = current_stmt_id;
     TI_ASSERT(begin_location == -1);
-    TI_ASSERT(prev_nodes.empty());
+    TI_ASSERT(prev_nodes.empty() || graph->size() == 1);
     current_block = block;
     last_node_in_current_block = nullptr;
     begin_location = 0;

--- a/taichi/analysis/data_source_analysis.cpp
+++ b/taichi/analysis/data_source_analysis.cpp
@@ -8,8 +8,9 @@ namespace irpass::analysis {
 
 Stmt *get_store_data(Stmt *store_stmt) {
   // If store_stmt provides a data source, return the data.
-  // For convenience, return store_stmt if store_stmt is an AllocaStmt.
   if (store_stmt->is<AllocaStmt>()) {
+    // For convenience, return store_stmt instead of the const [0] it actually
+    // stores.
     return store_stmt;
   } else if (auto local_store = store_stmt->cast<LocalStoreStmt>()) {
     return local_store->data;
@@ -22,9 +23,8 @@ Stmt *get_store_data(Stmt *store_stmt) {
 
 Stmt *get_store_destination(Stmt *store_stmt) {
   // If store_stmt provides a data source, return the pointer of the data.
-  if (store_stmt->is<AllocaStmt>() || store_stmt->is<GlobalTemporaryStmt>() ||
-      store_stmt->is<GlobalPtrStmt>() || store_stmt->is<ExternalPtrStmt>()) {
-    // The statement itself provides a data source.
+  if (store_stmt->is<AllocaStmt>()) {
+    // The statement itself provides a data source (const [0]).
     return store_stmt;
   } else if (auto local_store = store_stmt->cast<LocalStoreStmt>()) {
     return local_store->ptr;

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -178,8 +178,9 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
   for (auto stmt : reach_in) {
     // var == stmt is for the case that a global ptr is never stored.
     // In this case, stmt is from nodes[start_node]->reach_gen.
-    if (var == stmt || maybe_same_address(
-        var, irpass::analysis::get_store_destination(stmt))) {
+    if (var == stmt ||
+        maybe_same_address(var,
+                           irpass::analysis::get_store_destination(stmt))) {
       if (!update_result(stmt))
         return nullptr;
     }
@@ -329,7 +330,7 @@ void ControlFlowGraph::reaching_definition_analysis(bool after_lower_access) {
     for (int i = 0; i < num_nodes; i++) {
       for (int j = nodes[i]->begin_location; j < nodes[i]->end_location; j++) {
         if (auto global_load =
-            nodes[i]->block->statements[j]->cast<GlobalLoadStmt>()) {
+                nodes[i]->block->statements[j]->cast<GlobalLoadStmt>()) {
           nodes[start_node]->reach_gen.insert(global_load->ptr);
         }
       }


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
A continuation of #1248

This PR creates an empty start node in the CFG, and let it be the data source of everything to be loaded in any `GlobalLoadStmt`s in the IR.

This PR also does this optimization https://github.com/taichi-dev/taichi/pull/1248#discussion_r441791450.

Benchmark on the number of statements: unchanged.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
