### PR TITLE
[Std] [lang] Add ti.rsqrt() and ti.Vector.norm_inv()

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -549,6 +549,11 @@ class Matrix(TaichiOperations):
         return impl.sqrt(self.norm_sqr() + eps)
 
     @taichi_scope
+    def norm_inv(self, l=2, eps=0):
+        assert l == 2
+        return impl.rsqrt(self.norm_sqr() + eps)
+
+    @taichi_scope
     def norm_sqr(self):
         return (self**2).sum()
 

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -137,6 +137,11 @@ def sqrt(expr):
 
 
 @unary
+def rsqrt(expr):
+    return Expr(taichi_lang_core.expr_rsqrt(expr.ptr), tb=stack_info())
+
+
+@unary
 def floor(expr):
     return Expr(taichi_lang_core.expr_floor(expr.ptr), tb=stack_info())
 

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -364,8 +364,8 @@ class KernelGen : public IRVisitor {
       emit("{} {} = {}(-{});", dt_name, stmt->short_name(), dt_name,
            stmt->operand->short_name());
     } else if (stmt->op_type == UnaryOpType::rsqrt) {
-      emit("{} {} = {}(1 / sqrt({}));", dt_name, stmt->short_name(), dt_name,
-           stmt->operand->short_name());
+      emit("{} {} = {}(inversesqrt({}));", dt_name, stmt->short_name(),
+          dt_name, stmt->operand->short_name());
     } else if (stmt->op_type == UnaryOpType::sgn) {
       emit("{} {} = {}(sign({}));", dt_name, stmt->short_name(), dt_name,
            stmt->operand->short_name());

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -364,8 +364,8 @@ class KernelGen : public IRVisitor {
       emit("{} {} = {}(-{});", dt_name, stmt->short_name(), dt_name,
            stmt->operand->short_name());
     } else if (stmt->op_type == UnaryOpType::rsqrt) {
-      emit("{} {} = {}(inversesqrt({}));", dt_name, stmt->short_name(),
-          dt_name, stmt->operand->short_name());
+      emit("{} {} = {}(inversesqrt({}));", dt_name, stmt->short_name(), dt_name,
+           stmt->operand->short_name());
     } else if (stmt->op_type == UnaryOpType::sgn) {
       emit("{} {} = {}(sign({}));", dt_name, stmt->short_name(), dt_name,
            stmt->operand->short_name());

--- a/tests/python/test_element_wise.py
+++ b/tests/python/test_element_wise.py
@@ -246,7 +246,7 @@ def test_writeback_binary_i(rhs_is_mat):
 def test_unary():
     xi = ti.Matrix(3, 2, ti.i32, 4)
     yi = ti.Matrix(3, 2, ti.i32, ())
-    xf = ti.Matrix(3, 2, ti.f32, 13)
+    xf = ti.Matrix(3, 2, ti.f32, 14)
     yf = ti.Matrix(3, 2, ti.f32, ())
 
     yi.from_numpy(np.array([[3, 2], [9, 0], [7, 4]], np.int32))
@@ -271,6 +271,7 @@ def test_unary():
         xf[10] = ti.ceil(yf[None])
         xf[11] = ti.exp(yf[None])
         xf[12] = ti.log(yf[None])
+        xf[13] = ti.rsqrt(yf[None])
 
     func()
     xi = xi.to_numpy()
@@ -293,3 +294,4 @@ def test_unary():
     assert allclose(xf[10], np.ceil(yf))
     assert allclose(xf[11], np.exp(yf))
     assert allclose(xf[12], np.log(yf))
+    assert allclose(xf[13], 1 / np.sqrt(yf))

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -33,8 +33,9 @@ def test_basic_utils():
 
     normA = ti.var(ti.f32)
     normSqrA = ti.var(ti.f32)
+    normInvA = ti.var(ti.f32)
 
-    ti.root.place(a, b, abT, aNormalized, normA, normSqrA)
+    ti.root.place(a, b, abT, aNormalized, normA, normSqrA, normInvA)
 
     @ti.kernel
     def init():
@@ -44,6 +45,7 @@ def test_basic_utils():
 
         normA[None] = a.norm()
         normSqrA[None] = a.norm_sqr()
+        normInvA[None] = a.norm_inv()
 
         aNormalized[None] = a.normalized()
 
@@ -55,7 +57,8 @@ def test_basic_utils():
 
     sqrt14 = np.sqrt(14.0)
     invSqrt14 = 1.0 / sqrt14
-    assert normSqrA[None] == 14.0
+    assert normSqrA[None] == approx(14.0)
+    assert normInvA[None] == approx(invSqrt14)
     assert normA[None] == approx(sqrt14)
     assert aNormalized[None][0] == approx(1.0 * invSqrt14)
     assert aNormalized[None][1] == approx(2.0 * invSqrt14)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1288

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
**I know this will break DiffTaichi if I modify `ti.Vector.normalized()` to use `norm_inv`**, so could you tell me how to make autodiff work for rsqrt?