### PR TITLE
[Perf] Thread local storage for range-for reductions on CPUs

### DIFF
--- a/misc/benchmark_reduce.py
+++ b/misc/benchmark_reduce.py
@@ -1,0 +1,28 @@
+import taichi as ti
+
+# ti.init(print_ir=True, kernel_profiler=True)
+ti.init(kernel_profiler=True)
+
+N = 1024 * 1024
+
+a = ti.var(ti.i32, shape=N)
+tot = ti.var(ti.i32, shape=())
+
+@ti.kernel
+def fill():
+    for i in a:
+        a[i] = 3
+
+@ti.kernel
+def reduce():
+    for i in a:
+        tot[None] += a[i]
+        
+fill()
+
+for i in range(10):
+    reduce()
+
+print(tot[None])
+assert tot[None] == 3 * 10 * N
+ti.kernel_profiler_print()

--- a/misc/benchmark_reduce.py
+++ b/misc/benchmark_reduce.py
@@ -12,7 +12,7 @@ tot = ti.var(ti.i32, shape=())
 @ti.kernel
 def fill():
     for i in a:
-        a[i] = 3
+        a[i] = i
 
 @ti.kernel
 def reduce():
@@ -24,6 +24,6 @@ fill()
 for i in range(10):
     reduce()
 
-print(tot[None])
-assert tot[None] == 3 * 10 * N
+ground_truth = 10 * N * (N - 1) / 2 % 2 ** 32
+assert tot[None] % 2 ** 32 == ground_truth
 ti.kernel_profiler_print()

--- a/misc/benchmark_reduce.py
+++ b/misc/benchmark_reduce.py
@@ -1,5 +1,7 @@
 import taichi as ti
 
+# TODO: make this a real benchmark and set up regression
+
 ti.init(print_ir=True, kernel_profiler=True)
 # ti.init(kernel_profiler=True)
 # ti.core.toggle_advanced_optimization(False)
@@ -9,21 +11,24 @@ N = 1024 * 1024
 a = ti.var(ti.i32, shape=N)
 tot = ti.var(ti.i32, shape=())
 
+
 @ti.kernel
 def fill():
     for i in a:
         a[i] = i
 
+
 @ti.kernel
 def reduce():
     for i in a:
         tot[None] += a[i]
-        
+
+
 fill()
 
 for i in range(10):
     reduce()
 
-ground_truth = 10 * N * (N - 1) / 2 % 2 ** 32
-assert tot[None] % 2 ** 32 == ground_truth
+ground_truth = 10 * N * (N - 1) / 2 % 2**32
+assert tot[None] % 2**32 == ground_truth
 ti.kernel_profiler_print()

--- a/misc/benchmark_reduce.py
+++ b/misc/benchmark_reduce.py
@@ -1,7 +1,8 @@
 import taichi as ti
 
-# ti.init(print_ir=True, kernel_profiler=True)
-ti.init(kernel_profiler=True)
+ti.init(print_ir=True, kernel_profiler=True)
+# ti.init(kernel_profiler=True)
+# ti.core.toggle_advanced_optimization(False)
 
 N = 1024 * 1024
 

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -4,7 +4,6 @@
 
 #include <vector>
 #include <unordered_set>
-#include <taichi/ir/transforms.h>
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <unordered_set>
+#include <taichi/ir/transforms.h>
 
 TLANG_NAMESPACE_BEGIN
 
@@ -97,6 +98,7 @@ class IRVerifier : public BasicStmtVisitor {
 namespace irpass::analysis {
 void verify(IRNode *root) {
   TI_AUTO_PROF;
+  irpass::print(root);
   IRVerifier::run(root);
 }
 }  // namespace irpass::analysis

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -98,7 +98,6 @@ class IRVerifier : public BasicStmtVisitor {
 namespace irpass::analysis {
 void verify(IRNode *root) {
   TI_AUTO_PROF;
-  irpass::print(root);
   IRVerifier::run(root);
 }
 }  // namespace irpass::analysis

--- a/taichi/backends/cpu/codegen_cpu.cpp
+++ b/taichi/backends/cpu/codegen_cpu.cpp
@@ -14,25 +14,8 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
  public:
   using IRVisitor::visit;
 
-  CodeGenLLVMCPU(Kernel *kernel, IRNode *ir)
-      : CodeGenLLVM(kernel, ir){TI_AUTO_PROF}
-
-        llvm::Value
-        *
-        get_tls_base_ptr() {
-    return get_arg(1);
-  }
-
-  void visit(ThreadLocalPtrStmt *stmt) override {
-    auto base = get_tls_base_ptr();
-    TI_ASSERT(stmt->width() == 1);
-    TI_P(type_name(base->getType()));
-    auto ptr = builder->CreateGEP(base, tlctx->get_constant(stmt->offset));
-    TI_P(type_name(ptr->getType()));
-    auto ptr_type = llvm::PointerType::get(
-        tlctx->get_data_type(stmt->ret_type.data_type), 0);
-    TI_P(type_name(ptr_type));
-    llvm_val[stmt] = builder->CreatePointerCast(ptr, ptr_type);
+  CodeGenLLVMCPU(Kernel *kernel, IRNode *ir) : CodeGenLLVM(kernel, ir) {
+    TI_AUTO_PROF
   }
 
   void create_offload_range_for(OffloadedStmt *stmt) override {

--- a/taichi/backends/cpu/codegen_cpu.cpp
+++ b/taichi/backends/cpu/codegen_cpu.cpp
@@ -24,21 +24,13 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
       step = -1;
     }
 
-    auto tls_ptr_type = llvm::Type::getInt8PtrTy(*llvm_context);
-
-    std::vector<llvm::Type *> xlogue_arguments{
-        llvm::PointerType::get(get_runtime_type("Context"), 0), tls_ptr_type};
-
-    auto xlogue_type = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*llvm_context), xlogue_arguments, false);
+    auto xlogue_type = get_xlogue_function_type();
     auto xlogue_ptr_type = llvm::PointerType::get(xlogue_type, 0);
 
     llvm::Value *prologue = nullptr;
     if (stmt->prologue) {
-      auto guard = get_function_creation_guard(xlogue_arguments);
-
+      auto guard = get_function_creation_guard(get_xlogue_argument_types());
       stmt->prologue->accept(this);
-
       prologue = guard.body;
     } else {
       prologue = llvm::ConstantPointerNull::get(xlogue_ptr_type);
@@ -62,10 +54,8 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
 
     llvm::Value *epilogue = nullptr;
     if (stmt->epilogue) {
-      auto guard = get_function_creation_guard(xlogue_arguments);
-
+      auto guard = get_function_creation_guard(get_xlogue_argument_types());
       stmt->epilogue->accept(this);
-
       epilogue = guard.body;
     } else {
       epilogue = llvm::ConstantPointerNull::get(xlogue_ptr_type);

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -350,14 +350,15 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
 
     llvm::Function *body;
 
+    auto tls_ptr_type = llvm::Type::getInt8PtrTy(*llvm_context);
     {
       auto guard = get_function_creation_guard(
-          {llvm::PointerType::get(get_runtime_type("Context"), 0),
+          {llvm::PointerType::get(get_runtime_type("Context"), 0), tls_ptr_type,
            tlctx->get_data_type<int>()});
 
       auto loop_var = create_entry_block_alloca(DataType::i32);
       loop_vars_llvm[stmt].push_back(loop_var);
-      builder->CreateStore(get_arg(1), loop_var);
+      builder->CreateStore(get_arg(2), loop_var);
       stmt->body->accept(this);
 
       body = guard.body;

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1416,6 +1416,15 @@ void CodeGenLLVM::visit(GlobalTemporaryStmt *stmt) {
   llvm_val[stmt] = builder->CreatePointerCast(buffer, ptr_type);
 }
 
+void CodeGenLLVM::visit(ThreadLocalPtrStmt *stmt) {
+  auto base = get_tls_base_ptr();
+  TI_ASSERT(stmt->width() == 1);
+  auto ptr = builder->CreateGEP(base, tlctx->get_constant(stmt->offset));
+  auto ptr_type =
+      llvm::PointerType::get(tlctx->get_data_type(stmt->ret_type.data_type), 0);
+  llvm_val[stmt] = builder->CreatePointerCast(ptr, ptr_type);
+}
+
 void CodeGenLLVM::visit(InternalFuncStmt *stmt) {
   create_call(stmt->func_name, {get_context()});
 }
@@ -1527,6 +1536,10 @@ llvm::Value *CodeGenLLVM::get_arg(int i) {
 
 llvm::Value *CodeGenLLVM::get_context() {
   return get_arg(0);
+}
+
+llvm::Value *CodeGenLLVM::get_tls_base_ptr() {
+  return get_arg(1);
 }
 
 llvm::Value *CodeGenLLVM::get_root() {

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1542,6 +1542,20 @@ llvm::Value *CodeGenLLVM::get_tls_base_ptr() {
   return get_arg(1);
 }
 
+llvm::Type *CodeGenLLVM::get_tls_buffer_type() {
+  return llvm::Type::getInt8PtrTy(*llvm_context);
+}
+
+std::vector<llvm::Type *> CodeGenLLVM::get_xlogue_argument_types() {
+  return {llvm::PointerType::get(get_runtime_type("Context"), 0),
+          get_tls_buffer_type()};
+}
+
+llvm::Type *CodeGenLLVM::get_xlogue_function_type() {
+  return llvm::FunctionType::get(llvm::Type::getVoidTy(*llvm_context),
+                                 get_xlogue_argument_types(), false);
+}
+
 llvm::Value *CodeGenLLVM::get_root() {
   return create_call("LLVMRuntime_get_root", {get_runtime()});
 }

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -91,6 +91,12 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_tls_base_ptr();
 
+  llvm::Type *get_tls_buffer_type();
+
+  std::vector<llvm::Type *> get_xlogue_argument_types();
+
+  llvm::Type *get_xlogue_function_type();
+
   llvm::Value *get_root();
 
   llvm::Value *get_runtime();

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -89,6 +89,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_context();
 
+  llvm::Value *get_tls_base_ptr();
+
   llvm::Value *get_root();
 
   llvm::Value *get_runtime();
@@ -224,6 +226,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   void visit(LoopIndexStmt *stmt) override;
 
   void visit(GlobalTemporaryStmt *stmt) override;
+
+  void visit(ThreadLocalPtrStmt *stmt) override;
 
   void visit(InternalFuncStmt *stmt) override;
 

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -15,6 +15,7 @@ constexpr std::size_t taichi_result_buffer_entries = 32;
 constexpr std::size_t taichi_result_buffer_ret_value_id = 0;
 // slot for error code and error message char *
 constexpr std::size_t taichi_result_buffer_error_id = 1;
+constexpr std::size_t taichi_tls_buffer_size = 128;
 
 template <typename T, typename G>
 T taichi_union_cast_with_different_sizes(G g) {

--- a/taichi/inc/statements.inc.h
+++ b/taichi/inc/statements.inc.h
@@ -69,5 +69,8 @@ PER_STATEMENT(OffloadedStmt)
 PER_STATEMENT(LoopIndexStmt)
 PER_STATEMENT(GlobalTemporaryStmt)
 
+// Thread local storage
+PER_STATEMENT(ThreadLocalPtrStmt)
+
 // Special
 PER_STATEMENT(InternalFuncStmt)

--- a/taichi/ir/basic_stmt_visitor.cpp
+++ b/taichi/ir/basic_stmt_visitor.cpp
@@ -41,8 +41,12 @@ void BasicStmtVisitor::visit(StructForStmt *for_stmt) {
 
 void BasicStmtVisitor::visit(OffloadedStmt *stmt) {
   preprocess_container_stmt(stmt);
+  if (stmt->prologue)
+    stmt->prologue->accept(this);
   if (stmt->body)
     stmt->body->accept(this);
+  if (stmt->epilogue)
+    stmt->epilogue->accept(this);
 }
 
 void BasicStmtVisitor::visit(FuncBodyStmt *stmt) {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -666,7 +666,10 @@ Stmt *Block::insert(std::unique_ptr<Stmt> &&stmt, int location) {
 }
 
 Stmt *Block::insert(VecStatement &&stmt, int location) {
-  auto stmt_ptr = stmt.back().get();
+  Stmt *stmt_ptr = nullptr;
+  if (stmt.size()) {
+    stmt_ptr = stmt.back().get();
+  }
   if (location == -1) {
     location = (int)statements.size() - 1;
   }

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -654,22 +654,26 @@ std::unique_ptr<Stmt> Block::extract(Stmt *stmt) {
   TI_ERROR("stmt not found");
 }
 
-void Block::insert(std::unique_ptr<Stmt> &&stmt, int location) {
+Stmt *Block::insert(std::unique_ptr<Stmt> &&stmt, int location) {
+  auto stmt_ptr = stmt.get();
   stmt->parent = this;
   if (location == -1) {
     statements.push_back(std::move(stmt));
   } else {
     statements.insert(statements.begin() + location, std::move(stmt));
   }
+  return stmt_ptr;
 }
 
-void Block::insert(VecStatement &&stmt, int location) {
+Stmt *Block::insert(VecStatement &&stmt, int location) {
+  auto stmt_ptr = stmt.back().get();
   if (location == -1) {
     location = (int)statements.size() - 1;
   }
   for (int i = 0; i < stmt.size(); i++) {
     insert(std::move(stmt[i]), location + i);
   }
+  return stmt_ptr;
 }
 
 void Block::replace_statements_in_range(int start,

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -850,8 +850,12 @@ class Block : public IRNode {
   void erase(Stmt *stmt);
   std::unique_ptr<Stmt> extract(int location);
   std::unique_ptr<Stmt> extract(Stmt *stmt);
-  void insert(std::unique_ptr<Stmt> &&stmt, int location = -1);
-  void insert(VecStatement &&stmt, int location = -1);
+
+  // Returns stmt.get()
+  Stmt * insert(std::unique_ptr<Stmt> &&stmt, int location = -1);
+  // Returns stmt.back().get()
+  Stmt * insert(VecStatement &&stmt, int location = -1);
+
   void replace_statements_in_range(int start, int end, VecStatement &&stmts);
   void set_statements(VecStatement &&stmts);
   void replace_with(Stmt *old_statement,

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -852,9 +852,10 @@ class Block : public IRNode {
   std::unique_ptr<Stmt> extract(Stmt *stmt);
 
   // Returns stmt.get()
-  Stmt * insert(std::unique_ptr<Stmt> &&stmt, int location = -1);
-  // Returns stmt.back().get()
-  Stmt * insert(VecStatement &&stmt, int location = -1);
+  Stmt *insert(std::unique_ptr<Stmt> &&stmt, int location = -1);
+
+  // Returns stmt.back().get() or nullptr if stmt is empty
+  Stmt *insert(VecStatement &&stmt, int location = -1);
 
   void replace_statements_in_range(int start, int end, VecStatement &&stmts);
   void set_statements(VecStatement &&stmts);

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -258,6 +258,23 @@ class GlobalTemporaryStmt : public Stmt {
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 
+class ThreadLocalPtrStmt : public Stmt {
+ public:
+  std::size_t offset;
+
+  ThreadLocalPtrStmt(std::size_t offset, VectorType ret_type) : offset(offset) {
+    this->ret_type = ret_type;
+    TI_STMT_REG_FIELDS;
+  }
+
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
+  TI_STMT_DEF_FIELDS(ret_type, offset);
+  TI_DEFINE_ACCEPT_AND_CLONE
+};
+
 class InternalFuncStmt : public Stmt {
  public:
   std::string func_name;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -180,7 +180,9 @@ class OffloadedStmt : public Stmt {
   bool reversed;
   int num_cpu_threads;
   Arch device;
+  std::unique_ptr<Block> prologue;
   std::unique_ptr<Block> body;
+  std::unique_ptr<Block> epilogue;
   ScratchPadOptions scratch_opt;
 
   OffloadedStmt(TaskType task_type);

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -35,7 +35,7 @@ void vector_split(IRNode *root, int max_width, bool serial_schedule);
 void replace_all_usages_with(IRNode *root, Stmt *old_stmt, Stmt *new_stmt);
 bool check_out_of_bound(IRNode *root);
 void make_thread_local(IRNode *root);
-void lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
+bool lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
 void auto_diff(IRNode *root, bool use_stack = false);
 bool constant_fold(IRNode *root);
 void offload(IRNode *root);

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -34,7 +34,8 @@ void slp_vectorize(IRNode *root);
 void vector_split(IRNode *root, int max_width, bool serial_schedule);
 void replace_all_usages_with(IRNode *root, Stmt *old_stmt, Stmt *new_stmt);
 bool check_out_of_bound(IRNode *root);
-bool lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
+void make_thread_local(IRNode *root);
+void lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
 void auto_diff(IRNode *root, bool use_stack = false);
 bool constant_fold(IRNode *root);
 void offload(IRNode *root);
@@ -53,7 +54,8 @@ void compile_to_offloads(IRNode *ir,
                          bool grad,
                          bool ad_use_stack,
                          bool verbose,
-                         bool lower_global_access = true);
+                         bool lower_global_access = true,
+                         bool make_thread_local = false);
 
 }  // namespace irpass
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -74,9 +74,14 @@ void Kernel::lower(bool lower_access) {  // TODO: is a "Lowerer" class necessary
     if ((is_accessor && !config.print_accessor_ir) ||
         (is_evaluator && !config.print_evaluator_ir))
       verbose = false;
+
+    // For now we only enable TLS on CPUs
+    bool make_thread_local = arch_is_cpu(arch);
+
     irpass::compile_to_offloads(
         ir.get(), config, /*vectorize*/ arch_is_cpu(arch), grad,
-        /*ad_use_stack*/ true, verbose, /*lower_global_access*/ lower_access);
+        /*ad_use_stack*/ true, verbose, /*lower_global_access*/ lower_access,
+        /*make_thread_local*/ make_thread_local);
   } else {
     TI_NOT_IMPLEMENTED
   }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1099,7 +1099,7 @@ void gpu_parallel_range_for(Context *context,
                             RangeForTaskFunc *func) {
   int idx = thread_idx() + block_dim() * block_idx() + begin;
   while (idx < end) {
-    func(context, nullptr, idx);
+    func(context, /*tls=*/nullptr, idx);
     idx += block_dim() * grid_dim();
   }
 }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1037,9 +1037,7 @@ struct range_task_helper_context {
 
 void parallel_range_for_task(void *range_context, int task_id) {
   auto ctx = *(range_task_helper_context *)range_context;
-  // TODO: TLS here
-  // TODO: rename ctx.task to ctx.body
-  char tls_buffer[4];
+  char tls_buffer[taichi_tls_buffer_size];
   auto tls_ptr = &tls_buffer[0];
   if (ctx.prologue)
     ctx.prologue(ctx.context, tls_ptr);

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -23,7 +23,7 @@ using host_vsnprintf_type = int (*)(char *,
                                     const char *,
                                     std::va_list);
 using vm_allocator_type = void *(*)(void *, std::size_t, std::size_t);
-using RangeForTaskFunc = void(Context *, int i);
+using RangeForTaskFunc = void(Context *, const char *tls, int i);
 using parallel_for_type = void (*)(void *thread_pool,
                                    int splits,
                                    int num_desired_threads,
@@ -1022,12 +1022,12 @@ void for_each_block(Context *context,
 #endif
 }
 
-using range_for_xlogue = void (*)(void *);
+using range_for_xlogue = void (*)(Context *, /*TLS*/ char *tls_base);
 
 struct range_task_helper_context {
   Context *context;
   range_for_xlogue prologue{nullptr};
-  RangeForTaskFunc *task;
+  RangeForTaskFunc *body{nullptr};
   range_for_xlogue epilogue{nullptr};
   int begin;
   int end;
@@ -1039,24 +1039,25 @@ void parallel_range_for_task(void *range_context, int task_id) {
   auto ctx = *(range_task_helper_context *)range_context;
   // TODO: TLS here
   // TODO: rename ctx.task to ctx.body
-  int *tls[4];
+  char tls_buffer[4];
+  auto tls_ptr = &tls_buffer[0];
   if (ctx.prologue)
-    ctx.prologue(tls);
+    ctx.prologue(ctx.context, tls_ptr);
   if (ctx.step == 1) {
     int block_start = ctx.begin + task_id * ctx.block_size;
     int block_end = std::min(block_start + ctx.block_size, ctx.end);
     for (int i = block_start; i < block_end; i++) {
-      ctx.task(ctx.context, i);
+      ctx.body(ctx.context, tls_ptr, i);
     }
   } else if (ctx.step == -1) {
     int block_start = ctx.end - task_id * ctx.block_size;
     int block_end = std::max(ctx.begin, block_start * ctx.block_size);
     for (int i = block_start - 1; i >= block_end; i--) {
-      ctx.task(ctx.context, i);
+      ctx.body(ctx.context, tls_ptr, i);
     }
   }
   if (ctx.epilogue)
-    ctx.epilogue(tls);
+    ctx.epilogue(ctx.context, tls_ptr);
 }
 
 void cpu_parallel_range_for(Context *context,
@@ -1065,10 +1066,14 @@ void cpu_parallel_range_for(Context *context,
                             int end,
                             int step,
                             int block_dim,
-                            RangeForTaskFunc *task) {
+                            range_for_xlogue prologue,
+                            RangeForTaskFunc *body,
+                            range_for_xlogue epilogue) {
   range_task_helper_context ctx;
   ctx.context = context;
-  ctx.task = task;
+  ctx.prologue = prologue;
+  ctx.body = body;
+  ctx.epilogue = epilogue;
   ctx.begin = begin;
   ctx.end = end;
   ctx.step = step;
@@ -1096,7 +1101,7 @@ void gpu_parallel_range_for(Context *context,
                             RangeForTaskFunc *func) {
   int idx = thread_idx() + block_dim() * block_idx() + begin;
   while (idx < end) {
-    func(context, idx);
+    func(context, nullptr, idx);
     idx += block_dim() * grid_dim();
   }
 }

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -126,7 +126,7 @@ void compile_to_offloads(IRNode *ir,
 
   if (make_thread_local) {
     irpass::make_thread_local(ir);
-    print("Access flagged II");
+    print("Make thread local");
   }
 
   if (lower_global_access) {

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -14,7 +14,8 @@ void compile_to_offloads(IRNode *ir,
                          bool grad,
                          bool ad_use_stack,
                          bool verbose,
-                         bool lower_global_access) {
+                         bool lower_global_access,
+                         bool make_thread_local) {
   TI_AUTO_PROF;
 
   auto print = [&](const std::string &name) {
@@ -122,6 +123,11 @@ void compile_to_offloads(IRNode *ir,
   irpass::flag_access(ir);
   print("Access flagged II");
   irpass::analysis::verify(ir);
+
+  if (make_thread_local) {
+    irpass::make_thread_local(ir);
+    print("Access flagged II");
+  }
 
   if (lower_global_access) {
     irpass::lower_access(ir, true);

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -24,6 +24,10 @@ class DemoteAtomics : public BasicStmtVisitor {
         current_offloaded->num_cpu_threads == 1) {
       demote = true;
     }
+    if (current_offloaded && arch_is_cpu(current_offloaded->device) &&
+        stmt->dest->is<ThreadLocalPtrStmt>()) {
+      demote = true;
+    }
     if (stmt->dest->is<AllocaStmt>()) {
       demote = true;
       is_local = true;

--- a/taichi/transforms/die.cpp
+++ b/taichi/transforms/die.cpp
@@ -92,8 +92,12 @@ class DIE : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) {
+    if (stmt->prologue)
+      stmt->prologue->accept(this);
     if (stmt->body)
       stmt->body->accept(this);
+    if (stmt->epilogue)
+      stmt->epilogue->accept(this);
   }
 };
 

--- a/taichi/transforms/fix_block_parents.cpp
+++ b/taichi/transforms/fix_block_parents.cpp
@@ -48,8 +48,12 @@ class FixBlockParents : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) override {
+    if (stmt->prologue)
+      stmt->prologue->accept(this);
     if (stmt->body)
       stmt->body->accept(this);
+    if (stmt->epilogue)
+      stmt->epilogue->accept(this);
   }
 
   void run() {

--- a/taichi/transforms/flag_access.cpp
+++ b/taichi/transforms/flag_access.cpp
@@ -40,8 +40,12 @@ class FlagAccess : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) {
+    if (stmt->prologue)
+      stmt->prologue->accept(this);
     if (stmt->body)
       stmt->body->accept(this);
+    if (stmt->epilogue)
+      stmt->epilogue->accept(this);
   }
 
   // Assuming pointers will be visited before global load/st

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -491,10 +491,21 @@ class IRPrinter : public IRVisitor {
       print("{} = offloaded garbage collect {}", stmt->name(),
             stmt->snode->get_node_type_name_hinted());
     } else {
-      print("{} = offloaded {} {{", stmt->name(), details);
+      print("{} = offloaded {} ", stmt->name(), details);
+      if (stmt->prologue) {
+        print("prologue {{");
+        stmt->body->accept(this);
+        print("}}");
+      }
       TI_ASSERT(stmt->body);
+      print("body {{");
       stmt->body->accept(this);
       print("}}");
+      if (stmt->epilogue) {
+        print("epilogue {{");
+        stmt->body->accept(this);
+        print("}}");
+      }
     }
   }
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -494,7 +494,7 @@ class IRPrinter : public IRVisitor {
       print("{} = offloaded {} ", stmt->name(), details);
       if (stmt->prologue) {
         print("prologue {{");
-        stmt->body->accept(this);
+        stmt->prologue->accept(this);
         print("}}");
       }
       TI_ASSERT(stmt->body);
@@ -503,7 +503,7 @@ class IRPrinter : public IRVisitor {
       print("}}");
       if (stmt->epilogue) {
         print("epilogue {{");
-        stmt->body->accept(this);
+        stmt->epilogue->accept(this);
         print("}}");
       }
     }
@@ -516,6 +516,11 @@ class IRPrinter : public IRVisitor {
 
   void visit(GlobalTemporaryStmt *stmt) override {
     print("{}{} = global tmp var (offset = {} B)", stmt->type_hint(),
+          stmt->name(), stmt->offset);
+  }
+
+  void visit(ThreadLocalPtrStmt *stmt) override {
+    print("{}{} = thread local ptr (offset = {} B)", stmt->type_hint(),
           stmt->name(), stmt->offset);
   }
 

--- a/taichi/transforms/lower_access.cpp
+++ b/taichi/transforms/lower_access.cpp
@@ -35,8 +35,14 @@ class LowerAccess : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) override {
+    if (stmt->prologue) {
+      stmt->prologue->accept(this);
+    }
     if (stmt->body) {
       stmt->body->accept(this);
+    }
+    if (stmt->epilogue) {
+      stmt->epilogue->accept(this);
     }
   }
 

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -133,7 +133,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
   }
 }
 
-}  // namespace 
+}  // namespace
 
 namespace irpass {
 

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -88,7 +88,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
     }
 
     // Step 2:
-    // Make loop body accumulate to TLS
+    // Make loop body accumulate to TLS ptr instead of global ptr
     {
       auto tls_ptr = offload->body->insert(
           Stmt::make<ThreadLocalPtrStmt>(offset, VectorType(1, data_type)), 0);

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -5,8 +5,10 @@
 
 TLANG_NAMESPACE_BEGIN
 
+namespace {
+
 bool is_atomic_op_linear(AtomicOpType op_type) {
-  return op_type == AtomicOpType::add || op_type == AtomicOpType ::sub;
+  return op_type == AtomicOpType::add || op_type == AtomicOpType::sub;
 }
 
 void make_thread_local_offload(OffloadedStmt *offload) {
@@ -130,6 +132,8 @@ void make_thread_local_offload(OffloadedStmt *offload) {
       break;  // Do not overflow TLS buffer.  TODO: make it adaptive
   }
 }
+
+}  // namespace 
 
 namespace irpass {
 

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -92,7 +92,6 @@ void make_thread_local_offload(OffloadedStmt *offload) {
       if (offload->prologue == nullptr) {
         offload->prologue = std::make_unique<Block>();
       }
-      irpass::analysis::clone(dest);
       auto tls_ptr = offload->prologue->push_back<ThreadLocalPtrStmt>(
           tls_offset, VectorType(1, data_type));
       auto zero = offload->prologue->insert(

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -10,7 +10,6 @@ bool is_atomic_op_linear(AtomicOpType op_type) {
 }
 
 void make_thread_local_offload(OffloadedStmt *offload) {
-  irpass::print(offload);
   // TODO: deal with struct for
   if (offload->task_type != offload->range_for)
     return;
@@ -139,8 +138,6 @@ void make_thread_local(IRNode *root) {
   }
   irpass::typecheck(root);
   fix_block_parents(root);
-  TI_INFO("after:");
-  irpass::print(root);
 }
 
 }  // namespace irpass

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -1,0 +1,88 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/ir/analysis.h"
+#include "taichi/ir/visitors.h"
+
+TLANG_NAMESPACE_BEGIN
+
+bool is_atomic_op_linear(AtomicOpType op_type) {
+  return op_type == AtomicOpType::add || op_type == AtomicOpType ::sub;
+}
+
+void make_thread_local_offload(OffloadedStmt *offload) {
+  irpass::print(offload);
+  // TODO: deal with struct for
+  if (offload->task_type != offload->range_for)
+    return;
+
+  // Gather all atomic adds/subs destinations
+  // We do not use std::set to keep an deterministic order here.
+  std::vector<GlobalPtrStmt *> atomic_destinations;
+  // TODO: this is again an abuse since it gathers nothing. Need to design a IR
+  // map/reduce system
+  auto linear_atomics =
+      irpass::analysis::gather_statements(offload, [&](Stmt *stmt) {
+        if (auto atomic_op = stmt->cast<AtomicOpStmt>()) {
+          if (is_atomic_op_linear(atomic_op->op_type)) {
+            // Local atomics does not count
+            if (auto dest = atomic_op->dest->cast<GlobalPtrStmt>()) {
+              if (std::find(atomic_destinations.begin(),
+                            atomic_destinations.end(),
+                            dest) == atomic_destinations.end()) {
+                atomic_destinations.push_back(dest);
+              }
+            }
+          }
+        }
+        return false;
+      });
+
+  std::vector<GlobalPtrStmt *> ptr_to_reduce;
+
+  for (auto dest : atomic_destinations) {
+    // check if there is any other global load/store/atomic operations
+    auto global_mem_ops =
+        irpass::analysis::gather_statements(offload, [&](Stmt *stmt) {
+          if (auto load = stmt->cast<GlobalLoadStmt>()) {
+            if (maybe_same_address(load->ptr, dest)) {
+              return true;
+            }
+          } else if (auto store = stmt->cast<GlobalStoreStmt>()) {
+            if (maybe_same_address(store->ptr, dest)) {
+              return true;
+            }
+          } else if (auto atomic = stmt->cast<AtomicOpStmt>()) {
+            if (maybe_same_address(atomic->dest, dest)) {
+              return !is_atomic_op_linear(atomic->op_type);
+            }
+          }
+          TI_TAG;
+          return false;  // The statement is not related
+        });
+    TI_ASSERT(dest->width() == 1);
+    // We can only optimized reductions to global ptrs with form like loss[None]
+    // for now
+    if (global_mem_ops.empty() && dest->snodes[0]->type == SNodeType::place &&
+        dest->indices.empty()) {
+      ptr_to_reduce.push_back(dest);
+      TI_INFO("Detected reduction:");
+      irpass::print(dest);
+    }
+  }
+}
+
+namespace irpass {
+
+// This pass should happen after offloading but before lower_access
+void make_thread_local(IRNode *root) {
+  TI_AUTO_PROF;
+  auto root_block = root->cast<Block>();
+  TI_ASSERT(root_block);
+  for (auto &offload : root_block->statements) {
+    make_thread_local_offload(offload->cast<OffloadedStmt>());
+  }
+}
+
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -25,7 +25,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
       irpass::analysis::gather_statements(offload, [&](Stmt *stmt) {
         if (auto atomic_op = stmt->cast<AtomicOpStmt>()) {
           if (is_atomic_op_linear(atomic_op->op_type)) {
-            // Local atomics does not count
+            // Local or global tmp atomics does not count
             if (auto dest = atomic_op->dest->cast<GlobalPtrStmt>()) {
               if (std::find(atomic_destinations.begin(),
                             atomic_destinations.end(),
@@ -97,6 +97,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
       auto zero = offload->prologue->insert(
           std::make_unique<ConstStmt>(TypedConstant(data_type, 0)), -1);
       // Zero-fill
+      // TODO: do not use GlobalStore for TLS ptr.
       offload->prologue->push_back<GlobalStoreStmt>(tls_ptr, zero);
     }
 

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -1184,8 +1184,12 @@ class Simplify : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) override {
+    if (stmt->prologue)
+      stmt->prologue->accept(this);
     if (stmt->body)
       stmt->body->accept(this);
+    if (stmt->epilogue)
+      stmt->epilogue->accept(this);
   }
 };
 

--- a/taichi/transforms/statement_usage_replace.cpp
+++ b/taichi/transforms/statement_usage_replace.cpp
@@ -51,8 +51,12 @@ class StatementUsageReplace : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) {
+    if (stmt->prologue)
+      stmt->prologue->accept(this);
     if (stmt->body)
       stmt->body->accept(this);
+    if (stmt->epilogue)
+      stmt->epilogue->accept(this);
   }
 
   static void run(IRNode *node, Stmt *old_stmt, Stmt *new_stmt) {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -362,8 +362,12 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) {
+    if (stmt->prologue)
+      stmt->prologue->accept(this);
     if (stmt->body)
       stmt->body->accept(this);
+    if (stmt->epilogue)
+      stmt->epilogue->accept(this);
   }
 
   void visit(OffsetAndExtractBitsStmt *stmt) {

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -31,8 +31,7 @@ def test_classfunc():
     for i in range(arr.n):
         for j in range(arr.m):
             assert arr.val[i, j] == i * j * 2
-
-
+            
 @ti.host_arch_only
 def test_oop():
     @ti.data_oriented
@@ -77,6 +76,8 @@ def test_oop():
 
     with ti.Tape(loss=arr.total):
         arr.reduce()
+        
+    return
 
     for i in range(arr.n):
         for j in range(arr.m):
@@ -94,6 +95,7 @@ def test_oop():
         for j in range(arr.m):
             assert arr.val.grad[i, j] == 8
 
+test_oop()
 
 @ti.host_arch_only
 def test_oop_two_items():

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -31,7 +31,8 @@ def test_classfunc():
     for i in range(arr.n):
         for j in range(arr.m):
             assert arr.val[i, j] == i * j * 2
-            
+
+
 @ti.host_arch_only
 def test_oop():
     @ti.data_oriented
@@ -76,8 +77,6 @@ def test_oop():
 
     with ti.Tape(loss=arr.total):
         arr.reduce()
-        
-    return
 
     for i in range(arr.n):
         for j in range(arr.m):
@@ -95,7 +94,6 @@ def test_oop():
         for j in range(arr.m):
             assert arr.val.grad[i, j] == 8
 
-test_oop()
 
 @ti.host_arch_only
 def test_oop_two_items():


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

Related issue = #576 

Benchmark:

```python
import taichi as ti

ti.init(print_ir=True, kernel_profiler=True)

N = 1024 * 1024

a = ti.var(ti.i32, shape=N)
tot = ti.var(ti.i32, shape=())


@ti.kernel
def fill():
    for i in a:
        a[i] = i


@ti.kernel
def reduce():
    for i in a:
        tot[None] += a[i]


fill()

for i in range(10):
    reduce()

ground_truth = 10 * N * (N - 1) / 2 % 2**32
assert tot[None] % 2**32 == ground_truth
ti.kernel_profiler_print()
```

Before: *17ms*
After: *0.48ms* (35x faster)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

Design doc:

![image](https://user-images.githubusercontent.com/6553256/85215142-7035aa00-b342-11ea-8c6c-19a4c4824d2f.png)
