### PR TITLE
[metal] [autodiff] Fix StackLoadTopStmt codegen in Metal

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -586,7 +586,7 @@ class KernelCodegen : public IRVisitor {
         "{}*>(mtl_ad_stack_top_primal({}, {}));",
         primal_name, metal_data_type_name(stmt->element_type()),
         stack->raw_name(), stack->element_size_in_bytes());
-    emit("{} = *{};", stmt->raw_name(), primal_name);
+    emit("const auto {} = *{};", stmt->raw_name(), primal_name);
   }
 
   void visit(StackLoadTopAdjStmt *stmt) override {
@@ -597,7 +597,7 @@ class KernelCodegen : public IRVisitor {
         "{}*>(mtl_ad_stack_top_adjoint({}, {}));",
         adjoint_name, metal_data_type_name(stmt->element_type()),
         stack->raw_name(), stack->element_size_in_bytes());
-    emit("auto {} = *{};", stmt->raw_name(), adjoint_name);
+    emit("const auto {} = *{};", stmt->raw_name(), adjoint_name);
   }
 
   void visit(StackAccAdjointStmt *stmt) override {

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -327,7 +327,7 @@ def test_double_for_loops_more_nests():
         assert b.grad[i] == total_grad_b
 
 
-@ti.require(ti.extension.adstack)
+@ti.require(ti.extension.adstack, ti.extension.data64)
 @ti.all_archs
 def test_complex_body():
     N = 5


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
I forgot to declare the variable inside the codegen.

Related issue = #1285 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
