### PR TITLE
[Bug] [opt] Fix compilation crash when there is a container statement after an unconditional continue

### DIFF
--- a/taichi/ir/control_flow_graph.h
+++ b/taichi/ir/control_flow_graph.h
@@ -65,6 +65,7 @@ class ControlFlowGraph {
   void reaching_definition_analysis(bool after_lower_access);
 
   void simplify_graph();
+  // This pass cannot eliminate container statements properly for now.
   bool unreachable_code_elimination();
   bool store_to_load_forwarding(bool after_lower_access);
 };

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -665,7 +665,7 @@ void Block::insert(std::unique_ptr<Stmt> &&stmt, int location) {
 
 void Block::insert(VecStatement &&stmt, int location) {
   if (location == -1) {
-    location = (int)statements.size() - 1;
+    location = (int)statements.size();
   }
   for (int i = 0; i < stmt.size(); i++) {
     insert(std::move(stmt[i]), location + i);

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -12,8 +12,6 @@ void cfg_optimization(IRNode *root, bool after_lower_access) {
   while (true) {
     bool modified = false;
     cfg->simplify_graph();
-    if (cfg->unreachable_code_elimination())
-      modified = true;
     if (cfg->store_to_load_forwarding(after_lower_access))
       modified = true;
     if (!modified)

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -250,7 +250,8 @@ class IRPrinter : public IRVisitor {
 
   void visit(ContinueStmt *stmt) override {
     if (stmt->scope) {
-      print("{} continue (scope={})", stmt->name(), stmt->name());
+      print("{} continue (scope={})", stmt->name(),
+            stmt->scope->name());
     } else {
       print("{} continue", stmt->name());
     }

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -250,8 +250,7 @@ class IRPrinter : public IRVisitor {
 
   void visit(ContinueStmt *stmt) override {
     if (stmt->scope) {
-      print("{} continue (scope={})", stmt->name(),
-            stmt->scope->name());
+      print("{} continue (scope={})", stmt->name(), stmt->scope->name());
     } else {
       print("{} continue", stmt->name());
     }

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -958,7 +958,13 @@ class BasicBlockSimplify : public IRVisitor {
   }
 
   void visit(ContinueStmt *stmt) override {
-    return;
+    if (stmt != stmt->parent->back()) {
+      const int location = stmt->parent->locate(stmt);
+      while (location + 1 < (int)stmt->parent->size()) {
+        stmt->parent->erase(location + 1);
+      }
+      throw IRModified();
+    }
   }
 
   static bool is_global_write(Stmt *stmt) {
@@ -1201,6 +1207,8 @@ bool simplify(IRNode *root, Kernel *kernel) {
     else
       break;
   }
+  if (modified)
+    fix_block_parents(root);
   return modified;
 }
 

--- a/tests/python/test_continue.py
+++ b/tests/python/test_continue.py
@@ -82,3 +82,67 @@ def test_unconditional_continue():
     xs = x.to_numpy()
     for i in range(n):
         assert xs[i] == 0
+
+
+@ti.all_archs
+def test_kernel_continue_in_nested_if():
+    x = ti.var(ti.i32, shape=n)
+
+    @ti.kernel
+    def run(a: ti.i32):
+        for i in range(1):
+            if a:
+                if a:
+                    continue
+            if a:
+                if a:
+                    continue
+            x[i] = i
+
+    x[0] = 1
+    run(1)
+    assert x[0] == 1
+    run(0)
+    assert x[0] == 0
+
+
+@ti.all_archs
+def test_kernel_continue_in_nested_if_2():
+    x = ti.var(ti.i32, shape=n)
+
+    @ti.kernel
+    def run(a: ti.i32):
+        for i in range(1):
+            if a:
+                if a:
+                    continue
+            if a:
+                continue
+            x[i] = i
+
+    x[0] = 1
+    run(1)
+    assert x[0] == 1
+    run(0)
+    assert x[0] == 0
+
+
+@ti.all_archs
+def test_kernel_continue_in_nested_if_3():
+    x = ti.var(ti.i32, shape=n)
+
+    @ti.kernel
+    def run(a: ti.i32):
+        for i in range(1):
+            if a:
+                continue
+            if a:
+                if a:
+                    continue
+            x[i] = i
+
+    x[0] = 1
+    run(1)
+    assert x[0] == 1
+    run(0)
+    assert x[0] == 0


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = fix #1297 

I moved the unreachable code elimination pass from `cfg_optimization` to `simplify` because the former can't eliminate container statements properly. I tried writing something like `std::vector<Stmt *> not_in_any_nodes` in the CFG, but it's hard to know whether a `ContinueStmt` can be eliminated in the CFG, so an `IfStmt` with only one `ContinueStmt` in it can't be eliminated easily too.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
