### PR TITLE
[cuda] Support numpy and torch tensors with zeros in shapes (e.g., (5, 0, 5))

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -67,8 +67,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           // replace host buffer with device buffer
           host_buffers[i] = get_current_program().context.get_arg<void *>(i);
           if (args[i].size > 0) {
-            // Note: both numpy and PyTorch supports arrays/tensors with zeros
-            // in shape, e.g., shape=(0) or shape=(100, 0, 200). This makes
+            // Note: both numpy and PyTorch support arrays/tensors with zeros
+            // in shapes, e.g., shape=(0) or shape=(100, 0, 200). This makes
             // args[i].size = 0.
             CUDADriver::get_instance().malloc(&device_buffers[i], args[i].size);
             CUDADriver::get_instance().memcpy_host_to_device(

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -9,6 +9,7 @@
 #include "taichi/program/program.h"
 #include "taichi/lang_util.h"
 #include "taichi/backends/cuda/cuda_driver.h"
+#include "taichi/backends/cuda/cuda_context.h"
 #include "taichi/codegen/codegen_llvm.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -57,18 +58,23 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
             kernel = this->kernel](Context &context) {
       // copy data to GRAM
       auto args = kernel->args;
-      std::vector<void *> host_buffers(args.size());
-      std::vector<void *> device_buffers(args.size());
+      std::vector<void *> host_buffers(args.size(), nullptr);
+      std::vector<void *> device_buffers(args.size(), nullptr);
       bool has_buffer = false;
       for (int i = 0; i < (int)args.size(); i++) {
         if (args[i].is_nparray) {
           has_buffer = true;
-          CUDADriver::get_instance().malloc(&device_buffers[i], args[i].size);
           // replace host buffer with device buffer
           host_buffers[i] = get_current_program().context.get_arg<void *>(i);
+          if (args[i].size > 0) {
+            // Note: both numpy and PyTorch supports arrays/tensors with zeros
+            // in shape, e.g., shape=(0) or shape=(100, 0, 200). This makes
+            // args[i].size = 0.
+            CUDADriver::get_instance().malloc(&device_buffers[i], args[i].size);
+            CUDADriver::get_instance().memcpy_host_to_device(
+                (void *)device_buffers[i], host_buffers[i], args[i].size);
+          }
           kernel->set_arg_nparray(i, (uint64)device_buffers[i], args[i].size);
-          CUDADriver::get_instance().memcpy_host_to_device(
-              (void *)device_buffers[i], host_buffers[i], args[i].size);
         }
       }
       if (has_buffer) {
@@ -87,7 +93,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
         CUDADriver::get_instance().stream_synchronize(nullptr);
       }
       for (int i = 0; i < (int)args.size(); i++) {
-        if (args[i].is_nparray) {
+        if (args[i].is_nparray && args[i].size > 0) {
           CUDADriver::get_instance().memcpy_device_to_host(
               host_buffers[i], (void *)device_buffers[i], args[i].size);
           CUDADriver::get_instance().mem_free((void *)device_buffers[i]);

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -182,3 +182,14 @@ def test_numpy_multiple_external_arrays():
 def test_index_mismatch():
     val = ti.var(ti.i32, shape=(1, 2, 3))
     val[0, 0] = 1
+
+
+@ti.all_archs
+def test_numpy_zero():
+    @ti.kernel
+    def test_numpy(arr: ti.ext_arr()):
+        pass
+
+    test_numpy(np.empty(shape=(0), dtype=np.int32))
+    test_numpy(np.empty(shape=(0, 5), dtype=np.int32))
+    test_numpy(np.empty(shape=(5, 0), dtype=np.int32))

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -223,3 +223,14 @@ def test_shape_vector():
     X1 = x.to_torch()
 
     assert (X == X1).all()
+
+
+@ti.torch_test
+def test_torch_zero():
+    @ti.kernel
+    def test_torch(arr: ti.ext_arr()):
+        pass
+
+    test_torch(torch.zeros((0), dtype=torch.int32))
+    test_torch(torch.zeros((0, 5), dtype=torch.int32))
+    test_torch(torch.zeros((5, 0, 5), dtype=torch.int32))


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

Clarification: passing a numpy array with 0 bytes will make cudaMalloc fail because it doesn't support allocating GPU buffers with 0 bytes.

Not sure if OpenGL or Metal needs similar patches.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
