### PR TITLE
[Lang] Support sep and end in print()

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -313,7 +313,7 @@ def layout(func):
 
 
 @taichi_scope
-def ti_print(*vars):
+def ti_print(*vars, sep=' '):
     def entry2content(var):
         if isinstance(var, str):
             return var
@@ -330,12 +330,8 @@ def ti_print(*vars):
                 yield var
 
     def add_separators(vars):
-        prev_is_str = True
-        for var in vars:
-            cur_is_str = isinstance(var, str)
-            if not (prev_is_str or cur_is_str):
-                yield ' '
-            prev_is_str = cur_is_str
+        for i, var in enumerate(vars):
+            if i: yield sep
             yield var
 
     def fused_string(entries):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -313,7 +313,7 @@ def layout(func):
 
 
 @taichi_scope
-def ti_print(*vars, sep=' '):
+def ti_print(*vars, sep=' ', end='\n'):
     def entry2content(var):
         if isinstance(var, str):
             return var
@@ -333,6 +333,7 @@ def ti_print(*vars, sep=' '):
         for i, var in enumerate(vars):
             if i: yield sep
             yield var
+        yield end
 
     def fused_string(entries):
         accumated = ''

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -334,7 +334,7 @@ def ti_print(*vars):
         for var in vars:
             cur_is_str = isinstance(var, str)
             if not (prev_is_str or cur_is_str):
-              yield ' '
+                yield ' '
             prev_is_str = cur_is_str
             yield var
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -330,8 +330,12 @@ def ti_print(*vars):
                 yield var
 
     def add_separators(vars):
-        for i, var in enumerate(vars):
-            if i: yield ' '
+        prev_is_str = True
+        for var in vars:
+            cur_is_str = isinstance(var, str)
+            if not (prev_is_str or cur_is_str):
+              yield ' '
+            prev_is_str = cur_is_str
             yield var
 
     def fused_string(entries):

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -138,7 +138,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       }
     }
 
-    auto format_str = formats + "\n";
+    auto format_str = formats;
     auto stype = llvm::StructType::get(*llvm_context, types, false);
     auto value_arr = builder->CreateAlloca(stype);
     for (int i = 0; i < values.size(); i++) {

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -484,7 +484,6 @@ struct CompiledProgram::Impl {
         };
         std::cout << str;
       }
-      std::cout << std::endl;
     }
     rt_buf->msg_count = 0;
     launcher->impl->runtime_ssbo->unmap();

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -653,8 +653,8 @@ void CodeGenLLVM::visit(PrintStmt *stmt) {
     }
   }
   auto runtime_printf = call("LLVMRuntime_get_host_printf", get_runtime());
-  args.insert(args.begin(), builder->CreateGlobalStringPtr(
-                                (formats + "\n").c_str(), "format_string"));
+  args.insert(args.begin(),
+              builder->CreateGlobalStringPtr(formats.c_str(), "format_string"));
 
   llvm_val[stmt] = builder->CreateCall(runtime_printf, args);
 }

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -55,3 +55,16 @@ def test_print_matrix():
 
     func(233.3)
     ti.sync()
+
+
+@ti.archs_excluding(ti.metal)
+def test_print_sep():
+    @ti.kernel
+    def func():
+        # hello 42 world!
+        print('hello', 42, 'world!')
+        # hello42world!
+        print('hello', 42, 'world!', sep='')
+
+    func()
+    ti.sync()

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -63,6 +63,9 @@ def test_print_sep():
     def func():
         # hello 42 world!
         print('hello', 42, 'world!')
+        # hello 42 Taichi 233 world!
+        print('hello', 42, 'Tai', end='')
+        print('chi', 233, 'world!')
         # hello42world!
         print('hello', 42, 'world!', sep='')
 


### PR DESCRIPTION
I found that `print` would add a ` ` between every two args. This could be very useful in cases like `print(x, y, z)` --> `1 2 3`. However, for cases like `print('x[', i, ']=', x[i])`, it results in `x[ i ]= 42`. I think the expected outcome should be `x[i]=42`.

Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
