### PR TITLE
[doc] Fix some typos in our document export_results.rst

### DIFF
--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -86,7 +86,7 @@ Export videos
 
     The video export utilities of Taichi depend on ``ffmpeg``. If ``ffmpeg`` is not installed on your machine, please follow the installation instructions of ``ffmpeg`` at the end of this page.
 
-- ``ti.VideoManger`` can help you export results in ``mp4`` or ``gif`` format. For example,
+- ``ti.VideoManager`` can help you export results in ``mp4`` or ``gif`` format. For example,
 
 .. code-block:: python
 
@@ -102,20 +102,20 @@ Export videos
             pixels[i, j, k] = ti.random() * 255
 
     result_dir = "./results"
-    video_manger = ti.VideoManager(output_dir=result_dir, framerate=24, automatic_build=False)
+    video_manager = ti.VideoManager(output_dir=result_dir, framerate=24, automatic_build=False)
 
     for i in range(50):
         paint()
 
         pixels_img = pixels.to_numpy()
-        video_manger.write_frame(pixels_img)
+        video_manager.write_frame(pixels_img)
         print(f'\rFrame {i+1}/50 is recorded', end='')
 
     print()
     print('Exporting .mp4 and .gif videos...')
-    video_manger.make_video(gif=True, mp4=True)
-    print(f'MP4 video is saved to {video_manger.get_output_filename(".mp4")}')
-    print(f'GIF video is saved to {video_manger.get_output_filename(".gif")}')
+    video_manager.make_video(gif=True, mp4=True)
+    print(f'MP4 video is saved to {video_manager.get_output_filename(".mp4")}')
+    print(f'GIF video is saved to {video_manager.get_output_filename(".gif")}')
 
 After running the code above, you will find the output videos in the ``./results/`` folder.
 

--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -19,7 +19,7 @@ In this way, the tensor's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusi
     a[-16, 64]  # upper left corner
     a[16, 64]   # upper right corner
 
-.. note:: The dimensionality of tensor shapes should **be consistent** with that of the offset. Otherwise, a ``ValueError`` will be raised.
+.. note:: The dimensionality of tensor shapes should **be consistent** with that of the offset. Otherwise, a ``AssertionError`` will be raised.
 
 .. code-block:: python
 

--- a/examples/export_videos.py
+++ b/examples/export_videos.py
@@ -12,7 +12,7 @@ def paint():
 
 
 result_dir = "./results"
-video_manger = ti.VideoManager(output_dir=result_dir,
+video_manager = ti.VideoManager(output_dir=result_dir,
                                framerate=24,
                                automatic_build=False)
 
@@ -20,11 +20,11 @@ for i in range(50):
     paint()
 
     pixels_img = pixels.to_numpy()
-    video_manger.write_frame(pixels_img)
+    video_manager.write_frame(pixels_img)
     print(f'\rFrame {i+1}/50 is recorded', end='')
 
 print()
 print('Exporting .mp4 and .gif videos...')
-video_manger.make_video(gif=True, mp4=True)
-print(f'MP4 video is saved to {video_manger.get_output_filename(".mp4")}')
-print(f'GIF video is saved to {video_manger.get_output_filename(".gif")}')
+video_manager.make_video(gif=True, mp4=True)
+print(f'MP4 video is saved to {video_manager.get_output_filename(".mp4")}')
+print(f'GIF video is saved to {video_manager.get_output_filename(".gif")}')


### PR DESCRIPTION
Fix some typos in the doc `export_results.rst` as @archibate mentioned.