### PR TITLE
[Opt] [refactor] Move unreachable code elimination to a separate pass

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -25,6 +25,7 @@ bool binary_op_simplify(IRNode *root);
 bool whole_kernel_cse(IRNode *root);
 void variable_optimization(IRNode *root, bool after_lower_access);
 void extract_constant(IRNode *root);
+bool continue_stmt_optimization(IRNode *root);
 void full_simplify(IRNode *root, Kernel *kernel = nullptr);
 void print(IRNode *root, std::string *output = nullptr);
 void lower(IRNode *root);

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -25,7 +25,7 @@ bool binary_op_simplify(IRNode *root);
 bool whole_kernel_cse(IRNode *root);
 void variable_optimization(IRNode *root, bool after_lower_access);
 void extract_constant(IRNode *root);
-bool continue_stmt_optimization(IRNode *root);
+bool unreachable_code_elimination(IRNode *root);
 void full_simplify(IRNode *root, Kernel *kernel = nullptr);
 void print(IRNode *root, std::string *output = nullptr);
 void lower(IRNode *root);

--- a/taichi/transforms/continue_stmt_optimization.cpp
+++ b/taichi/transforms/continue_stmt_optimization.cpp
@@ -45,6 +45,7 @@ class ContinueStmtOptimizer : public BasicStmtVisitor {
         for (int j = block_size - 1; j > i; j--)
           stmt_list->erase(j);
         modified = true;
+        break;
       }
     }
     for (auto &stmt : stmt_list->statements)

--- a/taichi/transforms/continue_stmt_optimization.cpp
+++ b/taichi/transforms/continue_stmt_optimization.cpp
@@ -40,7 +40,7 @@ class ContinueStmtOptimizer : public BasicStmtVisitor {
   void visit(Block *stmt_list) override {
     const int block_size = stmt_list->size();
     for (int i = 0; i < block_size - 1; i++) {
-      if (auto continue_stmt = stmt_list->statements[i]->cast<ContinueStmt>()) {
+      if (stmt_list->statements[i]->is<ContinueStmt>()) {
         // Eliminate statements after ContinueStmt
         for (int j = block_size - 1; j > i; j--)
           stmt_list->erase(j);

--- a/taichi/transforms/continue_stmt_optimization.cpp
+++ b/taichi/transforms/continue_stmt_optimization.cpp
@@ -4,7 +4,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
-// Eliminate useless ContinueStmt
+// Unconditionally eliminate ContinueStmt's at **ends** of loops
 class UselessContinueEliminator : public IRVisitor {
  public:
   bool modified;

--- a/taichi/transforms/continue_stmt_optimization.cpp
+++ b/taichi/transforms/continue_stmt_optimization.cpp
@@ -1,0 +1,95 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/visitors.h"
+#include "taichi/ir/transforms.h"
+
+TLANG_NAMESPACE_BEGIN
+
+// Eliminate useless ContinueStmt
+class UselessContinueEliminator : public IRVisitor {
+ public:
+  bool modified;
+
+  UselessContinueEliminator() : modified(false) {
+    allow_undefined_visitor = true;
+  }
+
+  void visit(ContinueStmt *stmt) override {
+    stmt->parent->erase(stmt);
+    modified = true;
+  }
+
+  void visit(IfStmt *if_stmt) override {
+    if (if_stmt->true_statements && if_stmt->true_statements->size())
+      if_stmt->true_statements->back()->accept(this);
+    if (if_stmt->false_statements && if_stmt->false_statements->size())
+      if_stmt->false_statements->back()->accept(this);
+  }
+};
+
+// Eliminate useless ContinueStmt and the statements after ContinueStmt
+class ContinueStmtOptimizer : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
+  bool modified;
+  UselessContinueEliminator useless_continue_eliminator;
+
+  ContinueStmtOptimizer() : modified(false) {
+    allow_undefined_visitor = true;
+  }
+
+  void visit_loop(Stmt *loop_stmt, Block *body) {
+    const int body_size = body->size();
+    for (int i = 0; i < body_size - 1; i++) {
+      if (auto continue_stmt = body->statements[i]->cast<ContinueStmt>()) {
+        TI_ASSERT(continue_stmt->scope == loop_stmt ||
+                  continue_stmt->scope == nullptr);
+        // Eliminate statements after ContinueStmt
+        for (int j = body_size - 1; j > i; j--)
+          body->erase(j);
+        modified = true;
+      }
+    }
+    if (body->size())
+      body->back()->accept(&useless_continue_eliminator);
+    body->accept(this);
+  }
+
+  void visit(RangeForStmt *stmt) override {
+    visit_loop(stmt, stmt->body.get());
+  }
+
+  void visit(StructForStmt *stmt) override {
+    visit_loop(stmt, stmt->body.get());
+  }
+
+  void visit(WhileStmt *stmt) override {
+    visit_loop(stmt, stmt->body.get());
+  }
+
+  void visit(OffloadedStmt *stmt) override {
+    if (stmt->prologue)
+      stmt->prologue->accept(this);
+    if (stmt->task_type == OffloadedStmt::TaskType::range_for ||
+        stmt->task_type == OffloadedStmt::TaskType::struct_for)
+      visit_loop(stmt, stmt->body.get());
+    else if (stmt->body)
+      stmt->body->accept(this);
+    if (stmt->epilogue)
+      stmt->epilogue->accept(this);
+  }
+
+  static bool run(IRNode *node) {
+    ContinueStmtOptimizer optimizer;
+    node->accept(&optimizer);
+    return optimizer.modified || optimizer.useless_continue_eliminator.modified;
+  }
+};
+
+namespace irpass {
+bool continue_stmt_optimization(IRNode *root) {
+  TI_AUTO_PROF;
+  return ContinueStmtOptimizer::run(root);
+}
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -1219,7 +1219,7 @@ void full_simplify(IRNode *root, Kernel *kernel) {
     while (true) {
       bool modified = false;
       extract_constant(root);
-      if (continue_stmt_optimization(root))
+      if (unreachable_code_elimination(root))
         modified = true;
       if (binary_op_simplify(root))
         modified = true;

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -961,13 +961,7 @@ class BasicBlockSimplify : public IRVisitor {
   }
 
   void visit(ContinueStmt *stmt) override {
-    if (stmt != stmt->parent->back()) {
-      const int location = stmt->parent->locate(stmt);
-      while (location + 1 < (int)stmt->parent->size()) {
-        stmt->parent->erase(location + 1);
-      }
-      throw IRModified();
-    }
+    return;
   }
 
   static bool is_global_write(Stmt *stmt) {
@@ -1225,6 +1219,8 @@ void full_simplify(IRNode *root, Kernel *kernel) {
     while (true) {
       bool modified = false;
       extract_constant(root);
+      if (continue_stmt_optimization(root))
+        modified = true;
       if (binary_op_simplify(root))
         modified = true;
       if (constant_fold(root))


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #656 
Related PR = #1299 

I did this refactoring because the optimization about `ContinueStmt` in `simplify` I added in #1299 probably made removing the exceptions (#1059) in that pass more difficult.

Although the function of this pass is similar to the `DIE` pass, the logic is completely different. So I put it in a separate pass. We can eliminate `ContinueStmt`s like the following in this PR:
```
$1 = for ... {
  $2 = ...
  $3 : if ... {
    $4 = continue
  }
}
```

I'm not sure about how this pass should be named, so feel free to propose better names.


![benchmark20200623_2](https://user-images.githubusercontent.com/22582118/85489604-39f46680-b59e-11ea-87e2-7d13f7b086fe.png)



[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
