### PR TITLE
[lang] Return None when parent() exceeds its maximum depth

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -256,10 +256,6 @@ class Root:
     def __repr__(self):
         return 'ti.root'
 
-    def parent(self, n=0):
-        # |n| is ignored. This just keeps the interface consistent with SNode.
-        return None
-
 
 root = Root()
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -256,6 +256,10 @@ class Root:
     def __repr__(self):
         return 'ti.root'
 
+    def parent(self, n=0):
+        # |n| is ignored. This just keeps the interface consistent with SNode.
+        return None
+
 
 root = Root()
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -75,8 +75,7 @@ class SNode:
     def shape(self):
         impl.get_runtime().try_materialize()
         dim = self.ptr.num_active_indices()
-        ret = [
-            self.ptr.get_num_elements_along_axis(i) for i in range(dim)]
+        ret = [self.ptr.get_num_elements_along_axis(i) for i in range(dim)]
 
         class callable_tuple(tuple):
             @deprecated('x.shape()', 'x.shape')

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -55,12 +55,14 @@ class SNode:
     def parent(self, n=1):
         impl.get_runtime().try_materialize()
         p = self.ptr
-        for i in range(n):
+        while p and n > 0:
             p = p.parent
+            n -= 1
+        if p is None:
+            return None
         if p.type == impl.taichi_lang_core.SNodeType.root:
             return impl.root
-        else:
-            return SNode(p)
+        return SNode(p)
 
     def data_type(self):
         return self.ptr.data_type()

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -89,3 +89,23 @@ def test_unordered_matrix():
     assert val.loop_range().snode().parent(2) == blk2
     assert val.loop_range().snode().parent(3) == blk1
     assert val.loop_range().snode().parent(4) == ti.root
+
+
+@ti.all_archs
+def test_parent_exceeded():
+    val = ti.var(ti.f32)
+
+    m = 7
+    n = 3
+
+    blk1 = ti.root.dense(ti.i, m)
+    blk2 = blk1.dense(ti.j, n)
+    blk2.place(val)
+
+    assert val.snode().parent() == blk2
+    assert val.snode().parent(2) == blk1
+    assert val.snode().parent(3) == ti.root
+    assert val.snode().parent(4) == None
+    assert val.snode().parent(42) == None
+
+    assert ti.root.parent() == None

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -110,6 +110,7 @@ def test_deprecated():
     assert blk3.dim() == 3
     assert blk3.shape() == (n, m, p)
 
+
 @ti.all_archs
 def test_parent_exceeded():
     val = ti.var(ti.f32)


### PR DESCRIPTION
Seems like https://github.com/taichi-dev/taichi/pull/1214/files#r440768343 wasn't addressed. I'd suggest us not to make root circular and keep the parent chain linear. Following parent until null is a fairly common op, e.g. https://github.com/taichi-dev/taichi/blob/37976e750e1579ff9328f3d25f1a63cb3b3292e2/taichi/transforms/offload.cpp#L87-L95

This PR also handles the case where `n` exceeds the hierarchy depth.

Related issue = #1214

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
