### PR TITLE
[GUI] Fix issue with triangles not showing up when they are drawn clockwisely

### DIFF
--- a/taichi/gui/gui.cpp
+++ b/taichi/gui/gui.cpp
@@ -61,7 +61,12 @@ void Canvas::triangle(Vector2 a, Vector2 b, Vector2 c, Vector4 color) {
       bool inside_a = cross(pixel - a, b - a) <= 0;
       bool inside_b = cross(pixel - b, c - b) <= 0;
       bool inside_c = cross(pixel - c, a - c) <= 0;
-      if (inside_a && inside_b && inside_c && img.inside(i, j)) {
+
+      // cover both clockwise and counterclockwise case for vertices [a, b, c]
+      bool inside_triangle =
+          (inside_a == inside_b) ? (inside_a == inside_c) : false;
+
+      if (inside_triangle && img.inside(i, j)) {
         img[i][j] = color;
       }
     }

--- a/taichi/gui/gui.cpp
+++ b/taichi/gui/gui.cpp
@@ -64,7 +64,7 @@ void Canvas::triangle(Vector2 a, Vector2 b, Vector2 c, Vector4 color) {
 
       // cover both clockwise and counterclockwise case for vertices [a, b, c]
       bool inside_triangle =
-          (inside_a == inside_b) ? (inside_a == inside_c) : false;
+          (inside_a == inside_b) && (inside_a == inside_c);
 
       if (inside_triangle && img.inside(i, j)) {
         img[i][j] = color;

--- a/taichi/gui/gui.cpp
+++ b/taichi/gui/gui.cpp
@@ -63,8 +63,7 @@ void Canvas::triangle(Vector2 a, Vector2 b, Vector2 c, Vector4 color) {
       bool inside_c = cross(pixel - c, a - c) <= 0;
 
       // cover both clockwise and counterclockwise case for vertices [a, b, c]
-      bool inside_triangle =
-          (inside_a == inside_b) && (inside_a == inside_c);
+      bool inside_triangle = (inside_a == inside_b) && (inside_a == inside_c);
 
       if (inside_triangle && img.inside(i, j)) {
         img[i][j] = color;


### PR DESCRIPTION
Hi all,

   One of our classmate in GAMES201 from Wechat found that ONLY when  [va, vb, vc] is in counterclockwise order can `ti.gui.triangle(va, vb, vc)` manage to display it. If the offered vertices are in clockwise, our `ti.GUI` simply ignore it.

   For example, if I say
```
    triangle=[(0.3,0.5),(0.4,0.7),(0.5,0.55)]
    gui.triangle(*triangle,color=0xff0000)
```
  This triangle won't be drawn.

   If it is a designed feature, maybe we can try to doc it?
   If not, here is one possible solution.

HDYT? Maybe we can have a better solution.