### PR TITLE
[Opt] Dead store and stack-related operation elimination by control-flow graph

### DIFF
--- a/taichi/analysis/build_cfg.cpp
+++ b/taichi/analysis/build_cfg.cpp
@@ -186,7 +186,7 @@ class CFGBuilder : public IRVisitor {
     }
     current_stmt_id = block->size();
     new_node(-1);  // Each block has a deterministic last node.
-    graph->end_node = (int)graph->size() - 1;
+    graph->final_node = (int)graph->size() - 1;
 
     current_block = backup_block;
     last_node_in_current_block = backup_last_node;
@@ -196,11 +196,11 @@ class CFGBuilder : public IRVisitor {
   static std::unique_ptr<ControlFlowGraph> run(IRNode *root) {
     CFGBuilder builder;
     root->accept(&builder);
-    if (!builder.graph->nodes[builder.graph->end_node]->empty()) {
+    if (!builder.graph->nodes[builder.graph->final_node]->empty()) {
       builder.graph->push_back();
-      CFGNode::add_edge(builder.graph->nodes[builder.graph->end_node].get(),
+      CFGNode::add_edge(builder.graph->nodes[builder.graph->final_node].get(),
                         builder.graph->back());
-      builder.graph->end_node = (int)builder.graph->size() - 1;
+      builder.graph->final_node = (int)builder.graph->size() - 1;
     }
     return std::move(builder.graph);
   }

--- a/taichi/analysis/build_cfg.cpp
+++ b/taichi/analysis/build_cfg.cpp
@@ -159,6 +159,7 @@ class CFGBuilder : public IRVisitor {
     }
     current_stmt_id = block->size();
     new_node(-1);  // Each block has a deterministic last node.
+    graph->end_node = (int)graph->size() - 1;
 
     current_block = backup_block;
     last_node_in_current_block = backup_last_node;
@@ -168,6 +169,12 @@ class CFGBuilder : public IRVisitor {
   static std::unique_ptr<ControlFlowGraph> run(IRNode *root) {
     CFGBuilder builder;
     root->accept(&builder);
+    if (!builder.graph->nodes[builder.graph->end_node]->empty()) {
+      builder.graph->push_back(nullptr, -1, -1, nullptr);
+      CFGNode::add_edge(builder.graph->nodes[builder.graph->end_node].get(),
+                        builder.graph->back());
+      builder.graph->end_node = (int)builder.graph->size() - 1;
+    }
     return std::move(builder.graph);
   }
 };

--- a/taichi/analysis/data_source_analysis.cpp
+++ b/taichi/analysis/data_source_analysis.cpp
@@ -6,6 +6,31 @@ TLANG_NAMESPACE_BEGIN
 
 namespace irpass::analysis {
 
+std::vector<Stmt *> get_load_pointers(Stmt *load_stmt) {
+  // If load_stmt loads some variables or a stack, return the pointers of them.
+  if (auto local_load = load_stmt->cast<LocalLoadStmt>()) {
+    std::vector<Stmt *> result;
+    for (auto &address : local_load->ptr.data) {
+      if (std::find(result.begin(), result.end(), address.var) == result.end())
+        result.push_back(address.var);
+    }
+    return result;
+  } else if (auto global_load = load_stmt->cast<GlobalLoadStmt>()) {
+    return std::vector<Stmt *>(1, global_load->ptr);
+  } else if (auto atomic = load_stmt->cast<AtomicOpStmt>()) {
+    return std::vector<Stmt *>(1, atomic->dest);
+  } else if (auto stack_load_top = load_stmt->cast<StackLoadTopStmt>()) {
+    return std::vector<Stmt *>(1, stack_load_top->stack);
+  } else if (auto stack_load_top_adj = load_stmt->cast<StackLoadTopAdjStmt>()) {
+    return std::vector<Stmt *>(1, stack_load_top_adj->stack);
+  } else if (auto stack_acc_adj = load_stmt->cast<StackAccAdjointStmt>()) {
+    // This statement loads and stores the adjoint data.
+    return std::vector<Stmt *>(1, stack_acc_adj->stack);
+  } else {
+    return std::vector<Stmt *>();
+  }
+}
+
 Stmt *get_store_data(Stmt *store_stmt) {
   // If store_stmt provides a data source, return the data.
   if (store_stmt->is<AllocaStmt>()) {

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -63,6 +63,7 @@ std::vector<Stmt *> gather_statements(IRNode *root,
                                       const std::function<bool(Stmt *)> &test);
 std::unique_ptr<std::unordered_set<AtomicOpStmt *>> gather_used_atomics(
     IRNode *root);
+std::vector<Stmt *> get_load_pointers(Stmt *load_stmt);
 Stmt *get_store_data(Stmt *store_stmt);
 Stmt *get_store_destination(Stmt *store_stmt);
 bool has_store_or_atomic(IRNode *root, const std::vector<Stmt *> &vars);

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -523,8 +523,7 @@ void ControlFlowGraph::live_variable_analysis(bool after_lower_access) {
         auto stmt = nodes[i]->block->statements[j].get();
         auto store_ptr = irpass::analysis::get_store_destination(stmt);
         if (store_ptr && !store_ptr->is<AllocaStmt>() &&
-            !store_ptr->is<StackAllocaStmt>() &&
-            !store_ptr->is<GlobalTemporaryStmt>()) {
+            !store_ptr->is<StackAllocaStmt>()) {
           // A global pointer that may be loaded after this kernel.
           nodes[end_node]->live_gen.insert(store_ptr);
         }
@@ -642,7 +641,6 @@ bool ControlFlowGraph::store_to_load_forwarding(bool after_lower_access) {
 bool ControlFlowGraph::dead_store_elimination(bool after_lower_access) {
   TI_AUTO_PROF;
   live_variable_analysis(after_lower_access);
-  print_graph_structure();
   const int num_nodes = size();
   bool modified = false;
   for (int i = 0; i < num_nodes; i++) {

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -432,6 +432,20 @@ void ControlFlowGraph::print_graph_structure() const {
       }
       node_info += fmt::format("; next={{{}}}", fmt::join(indices, ", "));
     }
+    if (!nodes[i]->live_in.empty()) {
+      std::vector<std::string> indices;
+      for (auto stmt : nodes[i]->live_in) {
+        indices.push_back(stmt->name());
+      }
+      node_info += fmt::format("; live_in={{{}}}", fmt::join(indices, ", "));
+    }
+    if (!nodes[i]->live_out.empty()) {
+      std::vector<std::string> indices;
+      for (auto stmt : nodes[i]->live_out) {
+        indices.push_back(stmt->name());
+      }
+      node_info += fmt::format("; live_out={{{}}}", fmt::join(indices, ", "));
+    }
     std::cout << node_info << std::endl;
   }
 }
@@ -628,6 +642,7 @@ bool ControlFlowGraph::store_to_load_forwarding(bool after_lower_access) {
 bool ControlFlowGraph::dead_store_elimination(bool after_lower_access) {
   TI_AUTO_PROF;
   live_variable_analysis(after_lower_access);
+  print_graph_structure();
   const int num_nodes = size();
   bool modified = false;
   for (int i = 0; i < num_nodes; i++) {

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -306,7 +306,7 @@ bool CFGNode::dead_store_elimination(bool after_lower_access) {
       if (!after_lower_access ||
           (store_ptr->is<AllocaStmt>() || store_ptr->is<StackAllocaStmt>())) {
         // After lower_access, we only analyze local variables and stacks.
-        if (!contain_variable(live_out, store_ptr) &&
+        if (!stmt->is<AllocaStmt>() && !contain_variable(live_out, store_ptr) &&
             !contain_variable(live_in_this_node, store_ptr)) {
           // Neither used in other nodes nor used in this node.
           if (auto atomic = stmt->cast<AtomicOpStmt>()) {

--- a/taichi/ir/control_flow_graph.h
+++ b/taichi/ir/control_flow_graph.h
@@ -15,6 +15,9 @@ class CFGNode {
   // for i in [begin_location, end_location).
   Block *block;
   int begin_location, end_location;
+  // Is this node in an offloaded range_for/struct_for?
+  bool is_parallel_executed;
+
   // For updating begin/end locations when modifying the block.
   CFGNode *prev_node_in_same_block;
   CFGNode *next_node_in_same_block;
@@ -33,7 +36,11 @@ class CFGNode {
   CFGNode(Block *block,
           int begin_location,
           int end_location,
-          CFGNode *prev_node_in_same_block = nullptr);
+          bool is_parallel_executed,
+          CFGNode *prev_node_in_same_block);
+
+  // An empty node
+  CFGNode();
 
   static void add_edge(CFGNode *from, CFGNode *to);
   bool empty() const;

--- a/taichi/ir/control_flow_graph.h
+++ b/taichi/ir/control_flow_graph.h
@@ -52,7 +52,8 @@ class CFGNode {
                     bool replace_usages = true);
   bool erase_entire_node();
 
-  static bool contain_variable(const std::unordered_set<Stmt *> &var_set, Stmt *var);
+  static bool contain_variable(const std::unordered_set<Stmt *> &var_set,
+                               Stmt *var);
   void reaching_definition_analysis(bool after_lower_access);
   bool reach_kill_variable(Stmt *var) const;
   Stmt *get_store_forwarding_data(Stmt *var, int position) const;

--- a/taichi/ir/control_flow_graph.h
+++ b/taichi/ir/control_flow_graph.h
@@ -45,13 +45,13 @@ class CFGNode {
                     bool replace_usages = true);
   bool erase_entire_node();
 
+  static bool contain_variable(const std::unordered_set<Stmt *> &var_set, Stmt *var);
   void reaching_definition_analysis(bool after_lower_access);
   bool reach_kill_variable(Stmt *var) const;
   Stmt *get_store_forwarding_data(Stmt *var, int position) const;
   bool store_to_load_forwarding(bool after_lower_access);
 
   void live_variable_analysis(bool after_lower_access);
-  bool live_kill_variable(Stmt *var) const;
   bool dead_store_elimination(bool after_lower_access);
 };
 

--- a/taichi/ir/control_flow_graph.h
+++ b/taichi/ir/control_flow_graph.h
@@ -50,7 +50,6 @@ class CFGNode {
   void replace_with(int location,
                     std::unique_ptr<Stmt> &&new_stmt,
                     bool replace_usages = true);
-  bool erase_entire_node();
 
   static bool contain_variable(const std::unordered_set<Stmt *> &var_set,
                                Stmt *var);
@@ -71,7 +70,7 @@ class ControlFlowGraph {
  public:
   std::vector<std::unique_ptr<CFGNode>> nodes;
   const int start_node = 0;
-  int end_node{0};
+  int final_node{0};
 
   template <typename... Args>
   CFGNode *push_back(Args &&... args) {

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -19,6 +19,8 @@ void cfg_optimization(IRNode *root, bool after_lower_access) {
     if (!modified)
       break;
   }
+  // TODO: implement cfg->dead_instruction_elimination()
+  die(root);  // remove unused allocas
 }
 }  // namespace irpass
 

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -14,8 +14,12 @@ void cfg_optimization(IRNode *root, bool after_lower_access) {
     cfg->simplify_graph();
     if (cfg->store_to_load_forwarding(after_lower_access))
       modified = true;
+    std::cout << "before:" << std::endl;
+    print(root);
     if (cfg->dead_store_elimination(after_lower_access))
       modified = true;
+    std::cout << "after:" << std::endl;
+    print(root);
     if (!modified)
       break;
   }

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -14,12 +14,8 @@ void cfg_optimization(IRNode *root, bool after_lower_access) {
     cfg->simplify_graph();
     if (cfg->store_to_load_forwarding(after_lower_access))
       modified = true;
-    std::cout << "before:" << std::endl;
-    print(root);
     if (cfg->dead_store_elimination(after_lower_access))
       modified = true;
-    std::cout << "after:" << std::endl;
-    print(root);
     if (!modified)
       break;
   }

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -14,6 +14,8 @@ void cfg_optimization(IRNode *root, bool after_lower_access) {
     cfg->simplify_graph();
     if (cfg->store_to_load_forwarding(after_lower_access))
       modified = true;
+    if (cfg->dead_store_elimination(after_lower_access))
+      modified = true;
     if (!modified)
       break;
   }

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -97,10 +97,6 @@ void compile_to_offloads(IRNode *ir,
   print("Optimized by CFG I");
   irpass::analysis::verify(ir);
 
-  irpass::variable_optimization(ir, false);
-  print("Store forwarded");
-  irpass::analysis::verify(ir);
-
   irpass::flag_access(ir);
   print("Access flagged I");
   irpass::analysis::verify(ir);
@@ -150,9 +146,6 @@ void compile_to_offloads(IRNode *ir,
   irpass::cfg_optimization(ir, true);
   print("Optimized by CFG III");
   irpass::analysis::verify(ir);
-
-  irpass::variable_optimization(ir, true);
-  print("Store forwarded II");
 
   irpass::full_simplify(ir);
   print("Simplified III");

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -543,7 +543,7 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(StackPushStmt *stmt) override {
-    print("{}{} = stack push {}, val = {}", stmt->type_hint(), stmt->name(),
+    print("{}{} : stack push {}, val = {}", stmt->type_hint(), stmt->name(),
           stmt->stack->name(), stmt->v->name());
   }
 

--- a/taichi/transforms/variable_optimization.cpp
+++ b/taichi/transforms/variable_optimization.cpp
@@ -618,6 +618,7 @@ class OtherVariableOptimize : public VariableOptimize {
 namespace irpass {
 void variable_optimization(IRNode *root, bool after_lower_access) {
   TI_AUTO_PROF;
+  // This pass has been replaced with cfg_optimization.
   if (!advanced_optimization)
     return;
   AllocaOptimize alloca_optimizer;

--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -1,82 +1,81 @@
 import taichi as ti
 
 
-# @ti.all_archs
-# def test_offload_with_cross_block_locals():
-#     ret = ti.var(ti.f32)
-#
-#     ti.root.place(ret)
-#
-#     @ti.kernel
-#     def ker():
-#         s = 0
-#         for i in range(10):
-#             s += i
-#         ret[None] = s
-#
-#     ker()
-#
-#     assert ret[None] == 45
-#
-#
-# @ti.all_archs
-# def test_offload_with_cross_block_locals2():
-#     ret = ti.var(ti.f32)
-#
-#     ti.root.place(ret)
-#
-#     @ti.kernel
-#     def ker():
-#         s = 0
-#         for i in range(10):
-#             s += i
-#         ret[None] = s
-#         s = ret[None] * 2
-#         for i in range(10):
-#             ti.atomic_add(ret[None], s)
-#
-#     ker()
-#
-#     assert ret[None] == 45 * 21
-#
-#
-# @ti.all_archs
-# def test_offload_with_cross_block_locals3():
-#     ret = ti.var(ti.f32, shape=())
-#
-#     @ti.kernel
-#     def ker():
-#         s = 1
-#         t = s
-#         for i in range(10):
-#             s += i
-#         ret[None] = t
-#
-#     ker()
-#
-#     assert ret[None] == 1
-#
-#
-# @ti.all_archs
-# def test_offload_with_cross_block_locals4():
-#     ret = ti.var(ti.f32, shape=())
-#
-#     @ti.kernel
-#     def ker():
-#         a = 1
-#         b = 0
-#         for i in range(10):
-#             b += a
-#         ret[None] = b
-#
-#     ker()
-#
-#     assert ret[None] == 10
+@ti.all_archs
+def test_offload_with_cross_block_locals():
+    ret = ti.var(ti.f32)
+
+    ti.root.place(ret)
+
+    @ti.kernel
+    def ker():
+        s = 0
+        for i in range(10):
+            s += i
+        ret[None] = s
+
+    ker()
+
+    assert ret[None] == 45
+
+
+@ti.all_archs
+def test_offload_with_cross_block_locals2():
+    ret = ti.var(ti.f32)
+
+    ti.root.place(ret)
+
+    @ti.kernel
+    def ker():
+        s = 0
+        for i in range(10):
+            s += i
+        ret[None] = s
+        s = ret[None] * 2
+        for i in range(10):
+            ti.atomic_add(ret[None], s)
+
+    ker()
+
+    assert ret[None] == 45 * 21
+
+
+@ti.all_archs
+def test_offload_with_cross_block_locals3():
+    ret = ti.var(ti.f32, shape=())
+
+    @ti.kernel
+    def ker():
+        s = 1
+        t = s
+        for i in range(10):
+            s += i
+        ret[None] = t
+
+    ker()
+
+    assert ret[None] == 1
+
+
+@ti.all_archs
+def test_offload_with_cross_block_locals4():
+    ret = ti.var(ti.f32, shape=())
+
+    @ti.kernel
+    def ker():
+        a = 1
+        b = 0
+        for i in range(10):
+            b += a
+        ret[None] = b
+
+    ker()
+
+    assert ret[None] == 10
 
 
 @ti.archs_excluding(ti.opengl)  # OpenGL doesn't support dynamic range for now
 def test_offload_with_flexible_bounds():
-    ti.init(print_ir=True)
     s = ti.var(ti.i32, shape=())
     lower = ti.var(ti.i32, shape=())
     upper = ti.var(ti.i32, shape=())

--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -1,81 +1,82 @@
 import taichi as ti
 
 
-@ti.all_archs
-def test_offload_with_cross_block_locals():
-    ret = ti.var(ti.f32)
-
-    ti.root.place(ret)
-
-    @ti.kernel
-    def ker():
-        s = 0
-        for i in range(10):
-            s += i
-        ret[None] = s
-
-    ker()
-
-    assert ret[None] == 45
-
-
-@ti.all_archs
-def test_offload_with_cross_block_locals2():
-    ret = ti.var(ti.f32)
-
-    ti.root.place(ret)
-
-    @ti.kernel
-    def ker():
-        s = 0
-        for i in range(10):
-            s += i
-        ret[None] = s
-        s = ret[None] * 2
-        for i in range(10):
-            ti.atomic_add(ret[None], s)
-
-    ker()
-
-    assert ret[None] == 45 * 21
-
-
-@ti.all_archs
-def test_offload_with_cross_block_locals3():
-    ret = ti.var(ti.f32, shape=())
-
-    @ti.kernel
-    def ker():
-        s = 1
-        t = s
-        for i in range(10):
-            s += i
-        ret[None] = t
-
-    ker()
-
-    assert ret[None] == 1
-
-
-@ti.all_archs
-def test_offload_with_cross_block_locals4():
-    ret = ti.var(ti.f32, shape=())
-
-    @ti.kernel
-    def ker():
-        a = 1
-        b = 0
-        for i in range(10):
-            b += a
-        ret[None] = b
-
-    ker()
-
-    assert ret[None] == 10
+# @ti.all_archs
+# def test_offload_with_cross_block_locals():
+#     ret = ti.var(ti.f32)
+#
+#     ti.root.place(ret)
+#
+#     @ti.kernel
+#     def ker():
+#         s = 0
+#         for i in range(10):
+#             s += i
+#         ret[None] = s
+#
+#     ker()
+#
+#     assert ret[None] == 45
+#
+#
+# @ti.all_archs
+# def test_offload_with_cross_block_locals2():
+#     ret = ti.var(ti.f32)
+#
+#     ti.root.place(ret)
+#
+#     @ti.kernel
+#     def ker():
+#         s = 0
+#         for i in range(10):
+#             s += i
+#         ret[None] = s
+#         s = ret[None] * 2
+#         for i in range(10):
+#             ti.atomic_add(ret[None], s)
+#
+#     ker()
+#
+#     assert ret[None] == 45 * 21
+#
+#
+# @ti.all_archs
+# def test_offload_with_cross_block_locals3():
+#     ret = ti.var(ti.f32, shape=())
+#
+#     @ti.kernel
+#     def ker():
+#         s = 1
+#         t = s
+#         for i in range(10):
+#             s += i
+#         ret[None] = t
+#
+#     ker()
+#
+#     assert ret[None] == 1
+#
+#
+# @ti.all_archs
+# def test_offload_with_cross_block_locals4():
+#     ret = ti.var(ti.f32, shape=())
+#
+#     @ti.kernel
+#     def ker():
+#         a = 1
+#         b = 0
+#         for i in range(10):
+#             b += a
+#         ret[None] = b
+#
+#     ker()
+#
+#     assert ret[None] == 10
 
 
 @ti.archs_excluding(ti.opengl)  # OpenGL doesn't support dynamic range for now
 def test_offload_with_flexible_bounds():
+    ti.init(print_ir=True)
     s = ti.var(ti.i32, shape=())
     lower = ti.var(ti.i32, shape=())
     upper = ti.var(ti.i32, shape=())


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #926 #656 
Related PR = #932 #1248 
Replaces #859 #857 

Change in `build_cfg`: 
- Add an empty `final_node`. Then assume there are reads to all global pointers after the final node (just like there are writes to all global pointers before the start node), for more convenient analysis on global pointers.
- Tell each `CFGNode` if they are parallel executed (i.e. in an offloaded range_for/struct_for's body).

Change in `CFGNode`:
- Add `replace_with`, deprecate `erase_entire_node`.
- Use `contain_variable` for both `reach_kill_variable` (https://en.wikipedia.org/wiki/Reaching_definition) and `live_kill_variable` (https://en.wikipedia.org/wiki/Live_variable_analysis). Keep the function `reach_kill_variable` because `reach_kill` should contain **definition**s instead of **variable**s by definition, but I store variables in the `unordered_set` for convenience.

Change in `compile_to_offloads`:
- Remove the `variable_optimization` pass. (Faster compilation!)

**Benchmark**:

Compilation time (https://github.com/taichi-dev/taichi/issues/926#issuecomment-649839943):
6.872m -> 1.164m
(codegen_kernel_statements: 29087 -> 28573)

Number of statements:

![benchmark20200625_2](https://user-images.githubusercontent.com/22582118/85798051-ca4fba00-b70a-11ea-8351-776af5a10848.png)

The only case that becomes worse is:
```python
@ti.all_archs
def test_offload_with_cross_block_locals3():
    ret = ti.var(ti.f32, shape=())

    @ti.kernel
    def ker():
        s = 1
        t = s
        for i in range(10):
            s += i
        ret[None] = t

    ker()

    assert ret[None] == 1
```
Previously, we didn't consider global temp as global ptrs, so we could simplify the kernel to `ret[None] = 1`...


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
