### PR TITLE
[Bug] [linux] [opengl] Use RTLD_LOCAL to prevent LLVM symbol conflict with GLX

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -30,7 +30,7 @@ def import_ti_core(tmp_dir=None):
     global ti_core
     if get_os_name() != 'win':
         old_flags = sys.getdlopenflags()
-        sys.setdlopenflags(258)  # 258 = RTLD_NOW | RTLD_GLOBAL
+        sys.setdlopenflags(2)    # 2 = RTLD_NOW
     else:
         pyddir = os.path.join(package_root(), 'lib')
         os.environ['PATH'] += ';' + pyddir


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #958 close #1100 close #1106 close #1113 close #1325 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Specifying `RTLD_GLOBAL` will expose Taichi-customized LLVM symbols to other modules that may depends on other LLVM versions, e.g. GLX depends on LLVM and cause the issues above.

@Eydcao @TroyZhai This issue is finally solved systematically!!! Please confirm that if this PR works when you have time :)