### PR TITLE
[Doc] Remove duplicates in global settings

### DIFF
--- a/docs/global_settings.rst
+++ b/docs/global_settings.rst
@@ -15,7 +15,7 @@ Compilation
 
 - Disable advanced optimization to save compile time & possible erros: ``ti.core.toggle_advanced_optimization(False)`` or ``export TI_ADVANCED_OPTIMIZATION=0``.
 - To print intermediate IR generated: ``export TI_PRINT_IR=1`` or ``ti.init(print_ir=True)``.
-- To print preprocessed Python code: ``export TI_PRINT_PREPROCESSED=1`` or ``ti.init(print_preprocessed=True)``..
+- To print preprocessed Python code: ``export TI_PRINT_PREPROCESSED=1`` or ``ti.init(print_preprocessed=True)``.
 
 Runtime
 *******


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
### Issue
No Related issue;

### Description

Super minor typo in `docs/global_settings.rst`. 
Noticed there's an extra `.` while I was updating the CN version and it kept bugging me so thought I'd remove it lol.

The **last** line in the following photo: 

![lol](https://user-images.githubusercontent.com/38550500/85737158-b8354200-b731-11ea-9ada-402e6fa22976.png)


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

