### PR TITLE
[lang] Deprecate ti.raw_pow

### DIFF
--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -207,42 +207,6 @@ def random(dt=None):
     return Expr(ti_core.make_rand_expr(dt))
 
 
-# TODO: move this to a C++ pass (#944)
-def pow(self, power):
-    import taichi as ti
-    if not is_taichi_expr(self) and not is_taichi_expr(power):
-        # Python constant computations (#1188)
-        return raw_pow(self, power)
-    if not isinstance(power, int):
-        return raw_pow(self, power)
-    if power == 0:
-        # TODO: remove the hack, use {Expr,Matrix}.dup().fill(1)
-        # also note that this can be solved by #940
-        return self * 0 + 1
-
-    negative = power < 0
-    # Why not simply use `power = abs(power)`?
-    # Because `abs` is overrided by the `ti.abs` above.
-    if negative:
-        power = -power
-
-    tmp = self
-    ret = None
-    while power:
-        if power & 1:
-            if ret is None:
-                ret = tmp
-            else:
-                ret = ti.expr_init(ret * tmp)
-        tmp = ti.expr_init(tmp * tmp)
-        power >>= 1
-
-    if negative:
-        return 1 / ret
-    else:
-        return ret
-
-
 # NEXT: add matpow(self, power)
 
 
@@ -280,7 +244,7 @@ def mod(a, b):
 
 
 @binary
-def raw_pow(a, b):
+def pow(a, b):
     return _binary_operation(ti_core.expr_pow, ops.pow, a, b)
 
 


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://github.com/taichi-dev/taichi/pull/1188#issuecomment-649578632

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
I removed ti.raw_pow and use pow directly instead, but seems the issue still exists? @k-ye Could you confirm that on your end?