### PR TITLE
[linux] [llvm] Remove LLVM's dependency on GLIB 2.27

### DIFF
--- a/taichi/common/core.cpp
+++ b/taichi/common/core.cpp
@@ -12,6 +12,11 @@
 
 TI_NAMESPACE_BEGIN
 
+// Remove LLVM's denendency on GLIB 2.27
+#if defined(__linux__)
+__asm__(".symver log2f,log2f@GLIBC_2.2.5");
+#endif
+
 bool is_release() {
   auto dir = std::getenv("TAICHI_REPO_DIR");
   if (dir == nullptr || std::string(dir) == "") {


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1313

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
I'm using the #931 attempt. @yuanming-hu Could you confirm that the symbol `log2f@GLIBC_2.27` is gone in `libtaichi_core.so`? Thanks.