### PR TITLE
[linux] Remove glibc2.27 dependency (log2f@glibc2.27)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,7 @@ void build_taichi() {
     cmake .. -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE -DCUDA_VERSION=$CUDA_VERSION
     make -j 8
     ldd libtaichi_core.so
+    objdump -T libtaichi_core.so| grep GLIBC
     cd ../python
     ti test -t 1 -na opengl
     $PYTHON_EXECUTABLE build.py upload

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -90,7 +90,8 @@ if(${LLVM_PACKAGE_VERSION} VERSION_LESS "8.0")
 endif()
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(${LLVM_INCLUDE_DIRS})
-    message("llvm include dirs ${LLVM_INCLUDE_DIRS}")
+message("LLVM include dirs ${LLVM_INCLUDE_DIRS}")
+message("LLVM library dirs ${LLVM_LIBRARY_DIRS}")
 add_definitions(${LLVM_DEFINITIONS})
 
 llvm_map_components_to_libnames(llvm_libs
@@ -134,6 +135,7 @@ if (NOT WIN32)
         # Linux
         target_link_libraries(${CORE_LIBRARY_NAME} stdc++fs X11)
         target_link_libraries(${CORE_LIBRARY_NAME} -static-libgcc -static-libstdc++)
+        target_link_libraries(${CORE_LIBRARY_NAME} -Wl,--wrap=log2f) # Avoid glibc dependencies
     endif()
 endif ()
 message("PYTHON_LIBRARIES" ${PYTHON_LIBRARIES})

--- a/taichi/common/core.cpp
+++ b/taichi/common/core.cpp
@@ -12,6 +12,18 @@
 
 TI_NAMESPACE_BEGIN
 
+extern "C" {
+#if defined(TI_PLATFORM_LINUX) && defined(TI_ARCH_x64)
+// Avoid dependency on glibc 2.27
+// log2f is used by a third party .a file, so we have to define a wrapper.
+// https://stackoverflow.com/questions/8823267/linking-against-older-symbol-version-in-a-so-file
+__asm__(".symver log2f,log2f@GLIBC_2.2.5");
+float __wrap_log2f(float x) {
+  return log2f(x);
+}
+#endif
+}
+
 bool is_release() {
   auto dir = std::getenv("TAICHI_REPO_DIR");
   if (dir == nullptr || std::string(dir) == "") {

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -57,8 +57,8 @@ static_assert(false, "32-bit Windows systems are not supported")
 
 // Avoid dependency on glibc 2.27
 #if defined(TI_PLATFORM_LINUX) && defined(TI_ARCH_x64)
-// objdump -T libtaichi_core.so| grep  GLIBC_2.27
-__asm__(".symver logf,logf@GLIBC_2.2.5");
+    // objdump -T libtaichi_core.so| grep  GLIBC_2.27
+    __asm__(".symver logf,logf@GLIBC_2.2.5");
 __asm__(".symver powf,powf@GLIBC_2.2.5");
 __asm__(".symver expf,expf@GLIBC_2.2.5");
 #endif

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -57,8 +57,8 @@ static_assert(false, "32-bit Windows systems are not supported")
 
 // Avoid dependency on glibc 2.27
 #if defined(TI_PLATFORM_LINUX) && defined(TI_ARCH_x64)
-    // objdump -T libtaichi_core.so| grep  GLIBC_2.27
-    __asm__(".symver logf,logf@GLIBC_2.2.5");
+// objdump -T libtaichi_core.so| grep  GLIBC_2.27
+__asm__(".symver logf,logf@GLIBC_2.2.5");
 __asm__(".symver powf,powf@GLIBC_2.2.5");
 __asm__(".symver expf,expf@GLIBC_2.2.5");
 #endif


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1313 

Since the dependency is not introduced in Taichi, I had to use this trick: https://stackoverflow.com/questions/8823267/linking-against-older-symbol-version-in-a-so-file

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
