### PR TITLE
[ir] Remove a temporary "fix_block_parents"

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -74,9 +74,6 @@ void compile_to_offloads(IRNode *ir,
     irpass::auto_diff(ir, ad_use_stack);
     irpass::full_simplify(ir);
     print("Gradient");
-    // TODO: removing the following line break the verify pass. Need to figure
-    // out why.
-    irpass::fix_block_parents(ir);
     irpass::analysis::verify(ir);
   }
 


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related PR = #1285 

I believe this is fixed in #1299. @yuanming-hu Could you please double-check if the demos work now which didn't work without the pass?

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
