### PR TITLE
[Opt] Replace "simplify" with "full_simplify" in "Simplified I"

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -59,12 +59,9 @@ void compile_to_offloads(IRNode *ir,
     print("Loop Split");
     irpass::analysis::verify(ir);
   }
-  irpass::simplify(ir);
+  irpass::full_simplify(ir);
   print("Simplified I");
   irpass::analysis::verify(ir);
-
-  irpass::constant_fold(ir);
-  print("Constant folded I");
 
   if (grad) {
     // Remove local atomics here so that we don't have to handle their gradients
@@ -104,9 +101,6 @@ void compile_to_offloads(IRNode *ir,
   irpass::full_simplify(ir);
   print("Simplified II");
   irpass::analysis::verify(ir);
-
-  irpass::constant_fold(ir);
-  print("Constant folded II");
 
   irpass::offload(ir);
   print("Offloaded");

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -166,6 +166,12 @@ class ConstantFold : public BasicStmtVisitor {
   }
 
   void visit(UnaryOpStmt *stmt) override {
+    if (stmt->is_cast() &&
+        stmt->cast_type == stmt->operand->ret_type.data_type) {
+      stmt->replace_with(stmt->operand);
+      modifier.erase(stmt);
+      return;
+    }
     auto operand = stmt->operand->cast<ConstStmt>();
     if (!operand)
       return;

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -1225,15 +1225,18 @@ void full_simplify(IRNode *root, Kernel *kernel) {
         modified = true;
       if (constant_fold(root))
         modified = true;
+      if (die(root))
+        modified = true;
       if (alg_simp(root))
         modified = true;
-      die(root);
-      if (whole_kernel_cse(root))
+      if (die(root))
         modified = true;
-      die(root);
       if (simplify(root, kernel))
         modified = true;
-      die(root);
+      if (die(root))
+        modified = true;
+      if (whole_kernel_cse(root))
+        modified = true;
       if (!modified)
         break;
     }


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1059 #656 

Also modifies `constant_fold` because `codegen_llvm.cpp` can't handle casting a value to the same type properly. We didn't encounter this issue because `constant_fold` was always after `simplify`, which eliminates this case.

I'll remove the CSE part of `simplify` in another PR.

Benchmark:
**Before this PR**:
```
codegen_accessor_statements: 148.00
codegen_evaluator_statements: 102.00
codegen_kernel_statements: 28573.00
codegen_offloaded_tasks: 53.00
codegen_statements  : 28823.00
1.250  m taichi::lang::Program::compile [27 x   2.779  s]
    1.191  m 95.27%  taichi::lang::irpass::compile_to_offloads [27 x   2.647  s]
        0.353  m 29.62%  taichi::lang::irpass::lower [27 x 784.178 ms]
        0.003  m  0.27%  taichi::lang::irpass::typecheck [108 x   1.781 ms]
        0.002  m  0.17%  taichi::lang::irpass::analysis::verify [459 x 257.669 us]
        0.000  m  0.00%  taichi::lang::irpass::loop_vectorize [27 x   3.778 us]
        0.000  m  0.00%  taichi::lang::irpass::vector_split [27 x   2.259 us]
        0.695  m 58.31%  taichi::lang::irpass::simplify [27 x   1.543  s]
            0.013  s  0.03%  taichi::lang::irpass::typecheck [1394 x   9.309 us]
           41.660  s 99.97%  [unaccounted]
        0.004  m  0.34%  taichi::lang::irpass::constant_fold [54 x   4.449 ms]
          157.404 ms 65.52%  taichi::lang::Program::compile [8 x  19.676 ms]
                0.609 ms  0.39%  taichi::lang::irpass::compile_to_offloads [8 x  76.125 us]
                   86.000 us 14.12%  taichi::lang::irpass::lower [8 x  10.750 us]
                   31.000 us  5.09%  taichi::lang::irpass::typecheck [8 x   3.875 us]
                   62.000 us 10.18%  taichi::lang::irpass::analysis::verify [16 x   3.875 us]
                  412.000 us 67.65%  taichi::lang::irpass::offload [8 x  51.500 us]
                       47.000 us 11.41%  taichi::lang::irpass::typecheck [16 x   2.937 us]
                      365.000 us 88.59%  [unaccounted]
                   18.000 us  2.96%  [unaccounted]
              156.725 ms 99.57%  taichi::lang::KernelCodeGen::compile [8 x  19.591 ms]
           82.821 ms 34.48%  [unaccounted]
        0.047  m  3.91%  taichi::lang::irpass::cfg_optimization [81 x  34.506 ms]
            1.756  s 62.82%  taichi::lang::ControlFlowGraph::store_to_load_forwarding [93 x  18.881 ms]
                1.562  s 88.94%  taichi::lang::ControlFlowGraph::reaching_definition_analysis [93 x  16.793 ms]
                0.194  s 11.06%  [unaccounted]
            0.637  s 22.80%  taichi::lang::ControlFlowGraph::dead_store_elimination [93 x   6.853 ms]
              579.794 ms 90.97%  taichi::lang::ControlFlowGraph::live_variable_analysis [93 x   6.234 ms]
               57.521 ms  9.03%  [unaccounted]
            0.350  s 12.53%  taichi::lang::irpass::die [81 x   4.323 ms]
            0.052  s  1.85%  [unaccounted]
        0.000  m  0.00%  taichi::lang::irpass::flag_access [81 x   8.926 us]
        0.084  m  7.07%  taichi::lang::irpass::full_simplify [54 x  93.600 ms]
            0.045  s  0.89%  taichi::lang::irpass::extract_constant [116 x 385.793 us]
            0.002  s  0.03%  taichi::lang::irpass::unreachable_code_elimination [116 x  14.681 us]
            0.006  s  0.12%  taichi::lang::irpass::binary_op_simplify [116 x  52.853 us]
            0.099  s  1.96%  taichi::lang::irpass::constant_fold [116 x 853.284 us]
               90.703 ms 91.64%  taichi::lang::Program::compile [4 x  22.676 ms]
                    0.405 ms  0.45%  taichi::lang::irpass::compile_to_offloads [4 x 101.250 us]
                       20.000 us  4.94%  taichi::lang::irpass::lower [4 x   5.000 us]
                       31.000 us  7.65%  taichi::lang::irpass::typecheck [4 x   7.750 us]
                       33.000 us  8.15%  taichi::lang::irpass::analysis::verify [8 x   4.125 us]
                      308.000 us 76.05%  taichi::lang::irpass::offload [4 x  77.000 us]
                           32.000 us 10.39%  taichi::lang::irpass::typecheck [8 x   4.000 us]
                          276.000 us 89.61%  [unaccounted]
                       13.000 us  3.21%  [unaccounted]
                   90.259 ms 99.51%  taichi::lang::KernelCodeGen::compile [4 x  22.565 ms]
                8.278 ms  8.36%  [unaccounted]
            0.013  s  0.25%  taichi::lang::irpass::alg_simp [116 x 111.034 us]
            0.049  s  0.97%  taichi::lang::irpass::die [348 x 140.891 us]
            4.280  s 84.67%  taichi::lang::irpass::whole_kernel_cse [116 x  36.893 ms]
            0.561  s 11.10%  taichi::lang::irpass::simplify [116 x   4.835 ms]
               49.959 ms  8.91%  taichi::lang::irpass::typecheck [168 x 297.375 us]
              510.866 ms 91.09%  [unaccounted]
        0.003  m  0.22%  taichi::lang::irpass::offload [27 x   5.900 ms]
           11.047 ms  6.93%  taichi::lang::irpass::typecheck [54 x 204.574 us]
          148.254 ms 93.07%  [unaccounted]
        0.000  m  0.01%  taichi::lang::irpass::make_thread_local [27 x 242.481 us]
            5.863 ms 89.55%  taichi::lang::irpass::typecheck [27 x 217.148 us]
            0.684 ms 10.45%  [unaccounted]
        0.000  m  0.01%  taichi::lang::irpass::die [27 x 302.074 us]
        0.001  m  0.05%  taichi::lang::irpass::demote_atomics [27 x   1.200 ms]
            8.659 ms 26.72%  taichi::lang::irpass::typecheck [27 x 320.704 us]
           23.748 ms 73.28%  [unaccounted]
```

**After this PR**:
```
codegen_accessor_statements: 148.00
codegen_evaluator_statements: 93.00
codegen_kernel_statements: 28572.00
codegen_offloaded_tasks: 52.00
codegen_statements  : 28813.00
1.228  m taichi::lang::Program::compile [27 x   2.729  s]
    1.176  m 95.77%  taichi::lang::irpass::compile_to_offloads [27 x   2.613  s]
        0.338  m 28.71%  taichi::lang::irpass::lower [27 x 750.322 ms]
        0.003  m  0.27%  taichi::lang::irpass::typecheck [108 x   1.793 ms]
        0.002  m  0.15%  taichi::lang::irpass::analysis::verify [459 x 237.028 us]
        0.000  m  0.00%  taichi::lang::irpass::loop_vectorize [27 x   2.926 us]
        0.000  m  0.00%  taichi::lang::irpass::vector_split [27 x   1.556 us]
        0.825  m 70.16%  taichi::lang::irpass::full_simplify [81 x 611.093 ms]
            1.896  s  3.83%  taichi::lang::irpass::extract_constant [159 x  11.922 ms]
            0.006  s  0.01%  taichi::lang::irpass::unreachable_code_elimination [159 x  35.277 us]
            0.020  s  0.04%  taichi::lang::irpass::binary_op_simplify [159 x 123.679 us]
            1.204  s  2.43%  taichi::lang::irpass::constant_fold [159 x   7.572 ms]
                0.213  s 17.65%  taichi::lang::Program::compile [11 x  19.320 ms]
                    0.784 ms  0.37%  taichi::lang::irpass::compile_to_offloads [11 x  71.273 us]
                       55.000 us  7.02%  taichi::lang::irpass::lower [11 x   5.000 us]
                       64.000 us  8.16%  taichi::lang::irpass::typecheck [11 x   5.818 us]
                       87.000 us 11.10%  taichi::lang::irpass::analysis::verify [22 x   3.955 us]
                      522.000 us 66.58%  taichi::lang::irpass::offload [11 x  47.455 us]
                           42.000 us  8.05%  taichi::lang::irpass::typecheck [22 x   1.909 us]
                          480.000 us 91.95%  [unaccounted]
                       56.000 us  7.14%  [unaccounted]
                  211.640 ms 99.58%  taichi::lang::KernelCodeGen::compile [11 x  19.240 ms]
                0.991  s 82.35%  [unaccounted]
            0.476  s  0.96%  taichi::lang::irpass::die [477 x 998.585 us]
            0.425  s  0.86%  taichi::lang::irpass::alg_simp [159 x   2.674 ms]
           39.847  s 80.50%  taichi::lang::irpass::simplify [159 x 250.611 ms]
                0.485  s  1.22%  taichi::lang::irpass::typecheck [2316 x 209.613 us]
               39.362  s 98.78%  [unaccounted]
            5.625  s 11.36%  taichi::lang::irpass::whole_kernel_cse [159 x  35.375 ms]
        0.005  m  0.45%  taichi::lang::irpass::cfg_optimization [81 x   3.943 ms]
          125.241 ms 39.21%  taichi::lang::ControlFlowGraph::store_to_load_forwarding [92 x   1.361 ms]
               72.890 ms 58.20%  taichi::lang::ControlFlowGraph::reaching_definition_analysis [92 x 792.283 us]
               52.351 ms 41.80%  [unaccounted]
          119.052 ms 37.28%  taichi::lang::ControlFlowGraph::dead_store_elimination [92 x   1.294 ms]
               90.086 ms 75.67%  taichi::lang::ControlFlowGraph::live_variable_analysis [92 x 979.196 us]
               28.966 ms 24.33%  [unaccounted]
           70.297 ms 22.01%  taichi::lang::irpass::die [81 x 867.864 us]
            4.792 ms  1.50%  [unaccounted]
        0.000  m  0.00%  taichi::lang::irpass::flag_access [81 x   8.136 us]
        0.002  m  0.16%  taichi::lang::irpass::offload [27 x   4.187 ms]
           10.758 ms  9.52%  taichi::lang::irpass::typecheck [54 x 199.222 us]
          102.289 ms 90.48%  [unaccounted]
        0.000  m  0.01%  taichi::lang::irpass::make_thread_local [27 x 209.407 us]
            4.922 ms 87.05%  taichi::lang::irpass::typecheck [27 x 182.296 us]
            0.732 ms 12.95%  [unaccounted]
        0.000  m  0.01%  taichi::lang::irpass::die [27 x 309.333 us]
        0.001  m  0.04%  taichi::lang::irpass::demote_atomics [27 x   1.123 ms]
            8.544 ms 28.17%  taichi::lang::irpass::typecheck [27 x 316.444 us]
           21.785 ms 71.83%  [unaccounted]
```

**After this PR but without swapping the order of `simplify` and `whole_kernel_cse`**:
```
codegen_accessor_statements: 148.00
codegen_evaluator_statements: 102.00
codegen_kernel_statements: 28574.00
codegen_offloaded_tasks: 53.00
codegen_statements  : 28824.00
1.358  m taichi::lang::Program::compile [27 x   3.018  s]
    1.306  m 96.15%  taichi::lang::irpass::compile_to_offloads [27 x   2.901  s]
        0.343  m 26.24%  taichi::lang::irpass::lower [27 x 761.295 ms]
        0.003  m  0.24%  taichi::lang::irpass::typecheck [108 x   1.760 ms]
        0.002  m  0.14%  taichi::lang::irpass::analysis::verify [459 x 241.070 us]
        0.000  m  0.00%  taichi::lang::irpass::loop_vectorize [27 x   2.741 us]
        0.000  m  0.00%  taichi::lang::irpass::vector_split [27 x   1.296 us]
        0.950  m 72.75%  taichi::lang::irpass::full_simplify [81 x 703.621 ms]
            1.945  s  3.41%  taichi::lang::irpass::extract_constant [158 x  12.311 ms]
            0.005  s  0.01%  taichi::lang::irpass::unreachable_code_elimination [158 x  33.842 us]
            0.021  s  0.04%  taichi::lang::irpass::binary_op_simplify [158 x 131.715 us]
            1.135  s  1.99%  taichi::lang::irpass::constant_fold [158 x   7.185 ms]
                0.232  s 20.40%  taichi::lang::Program::compile [12 x  19.299 ms]
                    0.905 ms  0.39%  taichi::lang::irpass::compile_to_offloads [12 x  75.417 us]
                       57.000 us  6.30%  taichi::lang::irpass::lower [12 x   4.750 us]
                       95.000 us 10.50%  taichi::lang::irpass::typecheck [12 x   7.917 us]
                       73.000 us  8.07%  taichi::lang::irpass::analysis::verify [24 x   3.042 us]
                      625.000 us 69.06%  taichi::lang::irpass::offload [12 x  52.083 us]
                           43.000 us  6.88%  taichi::lang::irpass::typecheck [24 x   1.792 us]
                          582.000 us 93.12%  [unaccounted]
                       55.000 us  6.08%  [unaccounted]
                  230.578 ms 99.57%  taichi::lang::KernelCodeGen::compile [12 x  19.215 ms]
                0.904  s 79.60%  [unaccounted]
            0.431  s  0.76%  taichi::lang::irpass::alg_simp [158 x   2.727 ms]
            0.443  s  0.78%  taichi::lang::irpass::die [474 x 935.426 us]
           19.038  s 33.40%  taichi::lang::irpass::whole_kernel_cse [158 x 120.494 ms]
           33.974  s 59.61%  taichi::lang::irpass::simplify [158 x 215.024 ms]
                0.061  s  0.18%  taichi::lang::irpass::typecheck [1554 x  39.327 us]
               33.913  s 99.82%  [unaccounted]
        0.000  m  0.00%  taichi::lang::irpass::constant_fold [54 x  12.333 us]
        0.005  m  0.41%  taichi::lang::irpass::cfg_optimization [81 x   3.948 ms]
          126.719 ms 39.62%  taichi::lang::ControlFlowGraph::store_to_load_forwarding [92 x   1.377 ms]
               72.953 ms 57.57%  taichi::lang::ControlFlowGraph::reaching_definition_analysis [92 x 792.967 us]
               53.766 ms 42.43%  [unaccounted]
          118.280 ms 36.98%  taichi::lang::ControlFlowGraph::dead_store_elimination [92 x   1.286 ms]
               88.819 ms 75.09%  taichi::lang::ControlFlowGraph::live_variable_analysis [92 x 965.424 us]
               29.461 ms 24.91%  [unaccounted]
           69.964 ms 21.88%  taichi::lang::irpass::die [81 x 863.753 us]
            4.851 ms  1.52%  [unaccounted]
        0.000  m  0.00%  taichi::lang::irpass::flag_access [81 x   8.481 us]
        0.002  m  0.14%  taichi::lang::irpass::offload [27 x   4.016 ms]
            9.900 ms  9.13%  taichi::lang::irpass::typecheck [54 x 183.333 us]
           98.536 ms 90.87%  [unaccounted]
        0.000  m  0.01%  taichi::lang::irpass::make_thread_local [27 x 198.667 us]
            4.694 ms 87.51%  taichi::lang::irpass::typecheck [27 x 173.852 us]
            0.670 ms 12.49%  [unaccounted]
        0.000  m  0.01%  taichi::lang::irpass::die [27 x 333.778 us]
        0.000  m  0.04%  taichi::lang::irpass::demote_atomics [27 x   1.089 ms]
            8.189 ms 27.85%  taichi::lang::irpass::typecheck [27 x 303.296 us]
           21.214 ms 72.15%  [unaccounted]
```

![benchmark20200628](https://user-images.githubusercontent.com/22582118/85962253-d4c5ba00-b97d-11ea-91f2-59563ebe32e4.png)


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
