### PR TITLE
[lang] Raise an error when struct-for indices number mismatch

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -64,8 +64,7 @@ def begin_frontend_struct_for(group, loop_range):
         raise IndexError(
             'Size mismatch between struct-for indices and loop range: '
             f'{group.size()} != {len(loop_range.shape)}. Maybe you want to '
-            ' use ti.grouped(x) to group all indices into a single vector?'
-            )
+            ' use ti.grouped(x) to group all indices into a single vector?')
     taichi_lang_core.begin_frontend_struct_for(group, loop_range.ptr)
 
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -59,6 +59,16 @@ def expr_init_func(rhs):  # temporary solution to allow passing in tensors as
     return expr_init(rhs)
 
 
+def begin_frontend_struct_for(group, loop_range):
+    if group.size() != len(loop_range.shape):
+        raise IndexError(
+            'Size mismatch between struct-for indices and loop range: '
+            f'{group.size()} != {len(loop_range.shape)}. Maybe you want to '
+            ' use ti.grouped(x) to group all indices into a single vector?'
+            )
+    taichi_lang_core.begin_frontend_struct_for(group, loop_range.ptr)
+
+
 def wrap_scalar(x):
     if type(x) in [int, float]:
         return Expr(x)

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -64,7 +64,8 @@ def begin_frontend_struct_for(group, loop_range):
         raise IndexError(
             'Number of struct-for indices does not match loop variable dimensionality '
             f'({group.size()} != {len(loop_range.shape)}). Maybe you wanted to '
-            'use "for I in ti.grouped(x)" to group all indices into a single vector I?')
+            'use "for I in ti.grouped(x)" to group all indices into a single vector I?'
+        )
     taichi_lang_core.begin_frontend_struct_for(group, loop_range.ptr)
 
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -62,9 +62,9 @@ def expr_init_func(rhs):  # temporary solution to allow passing in tensors as
 def begin_frontend_struct_for(group, loop_range):
     if group.size() != len(loop_range.shape):
         raise IndexError(
-            'Size mismatch between struct-for indices and loop range: '
-            f'{group.size()} != {len(loop_range.shape)}. Maybe you want to '
-            ' use ti.grouped(x) to group all indices into a single vector?')
+            'Number of struct-for indices does not match loop variable dimensionality '
+            f'({group.size()} != {len(loop_range.shape)}). Maybe you wanted to '
+            'use "for I in ti.grouped(x)" to group all indices into a single vector I?')
     taichi_lang_core.begin_frontend_struct_for(group, loop_range.ptr)
 
 

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -437,7 +437,7 @@ if 1:
     ___loop_var = 0
     {} = ti.make_var_vector(size=len(___loop_var.loop_range().shape))
     ___expr_group = ti.make_expr_group({})
-    ti.core.begin_frontend_struct_for(___expr_group, ___loop_var.loop_range().ptr)
+    ti.begin_frontend_struct_for(___expr_group, ___loop_var.loop_range())
     ti.core.end_frontend_range_for()
             '''.format(vars, vars)
             t = ast.parse(template).body[0]
@@ -450,7 +450,7 @@ if 1:
 {}
     ___loop_var = 0
     ___expr_group = ti.make_expr_group({})
-    ti.core.begin_frontend_struct_for(___expr_group, ___loop_var.loop_range().ptr)
+    ti.begin_frontend_struct_for(___expr_group, ___loop_var.loop_range())
     ti.core.end_frontend_range_for()
             '''.format(var_decl, vars)
             t = ast.parse(template).body[0]

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -1177,8 +1177,8 @@ class Simplify : public IRVisitor {
 
   void visit(StructForStmt *for_stmt) override {
     TI_ASSERT_INFO(current_struct_for == nullptr,
-        "nesting struct-for is not supported for now, "
-        "please try use a range-for instead.");
+                   "nesting struct-for is not supported for now, "
+                   "please try use a range-for instead.");
     current_struct_for = for_stmt;
     for_stmt->body->accept(this);
     current_struct_for = nullptr;

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -1176,7 +1176,9 @@ class Simplify : public IRVisitor {
   }
 
   void visit(StructForStmt *for_stmt) override {
-    TI_ASSERT(current_struct_for == nullptr);
+    TI_ASSERT_INFO(current_struct_for == nullptr,
+        "nesting struct-for is not supported for now, "
+        "please try use a range-for instead.");
     current_struct_for = for_stmt;
     for_stmt->body->accept(this);
     current_struct_for = nullptr;

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -1177,8 +1177,8 @@ class Simplify : public IRVisitor {
 
   void visit(StructForStmt *for_stmt) override {
     TI_ASSERT_INFO(current_struct_for == nullptr,
-                   "nesting struct-for is not supported for now, "
-                   "please try use a range-for instead.");
+                   "Nested struct-fors are not supported for now. "
+                   "Please try to use range-fors for inner loops.");
     current_struct_for = for_stmt;
     for_stmt->body->accept(this);
     current_struct_for = nullptr;

--- a/tests/python/test_for_group_mismatch.py
+++ b/tests/python/test_for_group_mismatch.py
@@ -1,0 +1,96 @@
+import taichi as ti
+
+
+@ti.must_throw(IndexError)
+@ti.host_arch_only
+def test_struct_for_mismatch():
+    x = ti.var(ti.f32, (3, 4))
+
+    @ti.kernel
+    def func():
+        for i in x:
+            print(i)
+
+    func()
+
+
+@ti.must_throw(IndexError)
+@ti.host_arch_only
+def test_struct_for_mismatch2():
+    x = ti.var(ti.f32, (3, 4))
+
+    @ti.kernel
+    def func():
+        for i, j, k in x:
+            print(i, j, k)
+
+    func()
+
+
+@ti.must_throw(IndexError)
+@ti.host_arch_only
+def _test_grouped_struct_for_mismatch():
+    # doesn't work for now
+    # need grouped refactor
+    # for now, it just throw a unfriendly message:
+    # AssertionError: __getitem__ cannot be called in Python-scope
+    x = ti.var(ti.f32, (3, 4))
+
+    @ti.kernel
+    def func():
+        for i, j in ti.grouped(x):
+            print(i, j)
+
+    func()
+
+
+@ti.must_throw(IndexError)
+@ti.host_arch_only
+def _test_ndrange_for_mismatch():
+    # doesn't work for now
+    # need ndrange refactor
+    @ti.kernel
+    def func():
+        for i in ti.ndrange(3, 4):
+            print(i)
+
+    func()
+
+
+@ti.must_throw(IndexError)
+@ti.host_arch_only
+def _test_ndrange_for_mismatch2():
+    # doesn't work for now
+    # need ndrange and grouped refactor
+    @ti.kernel
+    def func():
+        for i, j, k in ti.ndrange(3, 4):
+            print(i, j, k)
+
+    func()
+
+
+@ti.must_throw(IndexError)
+@ti.host_arch_only
+def _test_grouped_ndrange_for_mismatch():
+    # doesn't work for now
+    # need ndrange and grouped refactor
+    @ti.kernel
+    def func():
+        for i in ti.grouped(ti.ndrange(3, 4)):
+            print(i)
+
+    func()
+
+
+@ti.must_throw(IndexError)
+@ti.host_arch_only
+def _test_static_ndrange_for_mismatch():
+    # doesn't work for now
+    # need ndrange and static refactor
+    @ti.kernel
+    def func():
+        for i in ti.static(ti.ndrange(3, 4)):
+            print(i)
+
+    func()


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Before this PR, the following code won't raise any error at all:
```py
x = ti.var(ti.f32, (3, 4))

@ti.kernel
def func():
    for i in x:  # either use `for i, j in x` or `for I in ti.grouped(x)` instead!
        print(i)

func()
```

So I'm making struct-for mismatch raise `IndexError` now.

But I apply the same to ndrange-for, cause it seems `ti.ndrange` transformer needs refactoring anyway... IMO it should share the same error checker if we decide to do so.

I think just alerting mismatch struct-for and saying `maybe you want to use ti.grouped() instead` is good enough, since user can see range numbers if using ndrange-for.

---

Btw, I think we may default to `ti.grouped` at this case?