### PR TITLE
[misc][gui] Resolve deprecation warning (img.shape)

### DIFF
--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -85,8 +85,8 @@ class GUI:
                 self.img = self.cook_image(img.to_numpy())
             else:
                 # Type matched! We can use an optimized copy kernel.
-                assert img.shape(
-                ) == self.res, "Image resolution does not match GUI resolution"
+                assert img.shape \
+                 == self.res, "Image resolution does not match GUI resolution"
                 from taichi.lang.meta import tensor_to_image
                 tensor_to_image(img, self.img)
                 ti.sync()
@@ -96,8 +96,8 @@ class GUI:
                 self.img = self.cook_image(img.to_numpy())
             else:
                 # Type matched! We can use an optimized copy kernel.
-                assert img.shape(
-                ) == self.res, "Image resolution does not match GUI resolution"
+                assert img.shape \
+                 == self.res, "Image resolution does not match GUI resolution"
                 assert img.n in [
                     3, 4
                 ], "Only greyscale, RGB or RGBA images are supported in GUI.set_image"


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
----
Since `img.shape()` in function `set_image` has been deprecated, changed to `img.shape` in order to get rid of DeprecationWarning. 