### PR TITLE
[bug] [opt] Fix CFG ignoring local atomics after lower_access

### DIFF
--- a/taichi/analysis/build_cfg.cpp
+++ b/taichi/analysis/build_cfg.cpp
@@ -15,7 +15,7 @@ class CFGBuilder : public IRVisitor {
   int current_stmt_id;
   int begin_location;
   std::vector<CFGNode *> prev_nodes;
-  bool in_offloaded_for;
+  bool in_parallel_for;
 
  public:
   CFGBuilder()
@@ -23,7 +23,7 @@ class CFGBuilder : public IRVisitor {
         last_node_in_current_block(nullptr),
         current_stmt_id(-1),
         begin_location(-1),
-        in_offloaded_for(false) {
+        in_parallel_for(false) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
     graph = std::make_unique<ControlFlowGraph>();
@@ -40,7 +40,7 @@ class CFGBuilder : public IRVisitor {
 
   CFGNode *new_node(int next_begin_location) {
     auto node = graph->push_back(current_block, begin_location, current_stmt_id,
-                                 in_offloaded_for, last_node_in_current_block);
+                                 in_parallel_for, last_node_in_current_block);
     for (auto &prev_node : prev_nodes) {
       CFGNode::add_edge(prev_node, node);
     }
@@ -125,11 +125,17 @@ class CFGBuilder : public IRVisitor {
   }
 
   void visit(RangeForStmt *stmt) override {
+    auto old_in_parallel_for = in_parallel_for;
+    in_parallel_for = true;
     visit_loop(stmt->body.get(), new_node(-1), false);
+    in_parallel_for = old_in_parallel_for;
   }
 
   void visit(StructForStmt *stmt) override {
+    auto old_in_parallel_for = in_parallel_for;
+    in_parallel_for = true;
     visit_loop(stmt->body.get(), new_node(-1), false);
+    in_parallel_for = old_in_parallel_for;
   }
 
   void visit(OffloadedStmt *stmt) override {
@@ -149,10 +155,10 @@ class CFGBuilder : public IRVisitor {
       auto block_begin_index = graph->size();
       if (stmt->task_type == OffloadedStmt::TaskType::range_for ||
           stmt->task_type == OffloadedStmt::TaskType::struct_for) {
-        in_offloaded_for = true;
+        in_parallel_for = true;
       }
       stmt->body->accept(this);
-      in_offloaded_for = false;
+      in_parallel_for = false;
       prev_nodes.push_back(graph->back());
       // Container statements don't belong to any CFGNodes.
       begin_location = offload_stmt_id + 1;

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -101,8 +101,7 @@ void CFGNode::reaching_definition_analysis(bool after_lower_access) {
     auto data_source_ptr = irpass::analysis::get_store_destination(stmt);
     if (data_source_ptr) {
       // stmt provides a data source
-      if (after_lower_access &&
-          !(stmt->is<AllocaStmt>() || stmt->is<LocalStoreStmt>())) {
+      if (after_lower_access && !(data_source_ptr->is<AllocaStmt>())) {
         // After lower_access, we only analyze local variables.
         continue;
       }


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = N/A

`stmt->is<AllocaStmt>() || stmt->is<LocalStoreStmt>()` is not enough -- it didn't cover the local atomics' case.

Also considers range_for and struct_for as parallel for-loops before the `offload` pass.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
