### PR TITLE
[refactor] Move c_quoted into taichi/utils/

### DIFF
--- a/taichi/backends/cc/cc_utils.h
+++ b/taichi/backends/cc/cc_utils.h
@@ -10,34 +10,6 @@
 TLANG_NAMESPACE_BEGIN
 namespace cccp {
 
-inline std::string c_quoted(std::string const &str) {
-  // https://zh.cppreference.com/w/cpp/language/escape
-  std::stringstream ss;
-  ss << '"';
-  for (auto const &c : str) {
-    switch (c) {
-#define REG_ESC(x, y) \
-  case x:             \
-    ss << "\\" y;     \
-    break;
-      REG_ESC('\n', "n");
-      REG_ESC('\a', "a");
-      REG_ESC('\b', "b");
-      REG_ESC('\?', "?");
-      REG_ESC('\v', "v");
-      REG_ESC('\t', "t");
-      REG_ESC('\f', "f");
-      REG_ESC('\'', "'");
-      REG_ESC('\"', "\"");
-      REG_ESC('\\', "\\");
-      default:
-        ss << c;
-    }
-  }
-  ss << '"';
-  return ss.str();
-}
-
 inline std::string cc_data_type_name(DataType dt) {
   switch (dt) {
     case DataType::i32:

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -4,6 +4,7 @@
 #include "taichi/ir/ir.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/util/line_appender.h"
+#include "taichi/util/str.h"
 #include "cc_utils.h"
 
 TLANG_NAMESPACE_BEGIN

--- a/taichi/util/str.cpp
+++ b/taichi/util/str.cpp
@@ -1,0 +1,35 @@
+#include "taichi/util/str.h"
+
+#include <sstream>
+
+TLANG_NAMESPACE_BEGIN
+
+std::string c_quoted(std::string const &str) {
+  // https://zh.cppreference.com/w/cpp/language/escape
+  std::stringstream ss;
+  ss << '"';
+  for (auto const &c : str) {
+    switch (c) {
+#define REG_ESC(x, y) \
+  case x:             \
+    ss << "\\" y;     \
+    break;
+      REG_ESC('\n', "n");
+      REG_ESC('\a', "a");
+      REG_ESC('\b', "b");
+      REG_ESC('\?', "?");
+      REG_ESC('\v', "v");
+      REG_ESC('\t', "t");
+      REG_ESC('\f', "f");
+      REG_ESC('\'', "'");
+      REG_ESC('\"', "\"");
+      REG_ESC('\\', "\\");
+      default:
+        ss << c;
+    }
+  }
+  ss << '"';
+  return ss.str();
+}
+
+TLANG_NAMESPACE_END

--- a/taichi/util/str.cpp
+++ b/taichi/util/str.cpp
@@ -28,6 +28,7 @@ std::string c_quoted(std::string const &str) {
         ss << c;
     }
   }
+#undef REG_ESC
   ss << '"';
   return ss.str();
 }

--- a/taichi/util/str.h
+++ b/taichi/util/str.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+#include "taichi/lang_util.h"
+
+TLANG_NAMESPACE_BEGIN
+
+// Quote |str| with a pair of ". Escape special characters like \n, \t etc.
+std::string c_quoted(std::string const &str);
+
+TLANG_NAMESPACE_END


### PR DESCRIPTION
Moving this to a common utils so that IR printer can also use it.

@archibate I don't have a way to test the C backend on Mac. Could you confirm this doesn't break?

Related issue = https://github.com/taichi-dev/taichi/pull/1350#discussion_r448384579

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
