### PR TITLE
[misc] Make stack traceback slimer for kernels and functions

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -2,27 +2,33 @@ import taichi as ti
 import traceback
 import sys
 
+
 @ti.func
 def hello1():
     print(a)
+
 
 @ti.func
 def hello2():
     hello1()
 
+
 @ti.func
 def hello3():
     hello2()
 
+
 @ti.kernel
 def main():
     hello3()
+
 
 def excepthook(type, value, tb):
     for frame, lineno in traceback.walk_tb(tb):
         if frame.f_locals.get('_taichi_no_traceback'):
             pass
         traceback.print_stack(frame)
+
 
 sys.excepthook = excepthook
 

--- a/hello.py
+++ b/hello.py
@@ -1,0 +1,29 @@
+import taichi as ti
+import traceback
+import sys
+
+@ti.func
+def hello1():
+    print(a)
+
+@ti.func
+def hello2():
+    hello1()
+
+@ti.func
+def hello3():
+    hello2()
+
+@ti.kernel
+def main():
+    hello3()
+
+def excepthook(type, value, tb):
+    for frame, lineno in traceback.walk_tb(tb):
+        if frame.f_locals.get('_taichi_no_traceback'):
+            pass
+        traceback.print_stack(frame)
+
+sys.excepthook = excepthook
+
+main()

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -410,7 +410,7 @@ def static(x, *xs):
         return x
     elif isinstance(x, ti.lang.expr.Expr) and x.ptr.is_global_var():
         return x
-    elif isinstance(x, ti.Matrix) and x.is_global():
+    elif ti.is_taichi_class(x) and x.is_global():
         return x
     elif isinstance(x, types.FunctionType) or isinstance(x, types.MethodType):
         return x

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -334,7 +334,7 @@ class Kernel:
                     "Kernels cannot call other kernels. I.e., nested kernels are not allowed. Please check if you have direct/indirect invocation of kernels within kernels. Note that some methods provided by the Taichi standard library may invoke kernels, and please move their invocations to Python-scope."
                 )
             self.runtime.inside_kernel = True
-            compiled()  # invoke AST transformed kernel
+            compiled()  # invoke the AST transformed kernel
             self.runtime.inside_kernel = False
 
         taichi_kernel = taichi_kernel.define(taichi_ast_generator)
@@ -524,7 +524,10 @@ def _kernel_impl(func, level_of_class_stackframe, verbose=False):
                 f'Please decorate class {clsobj.__name__} with @data_oriented')
     else:
 
-        wrapped = functools.wraps(func)(primal)
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            return primal(*args, **kwargs)
+
         wrapped.grad = adjoint
 
     wrapped._is_wrapped_kernel = True

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -48,10 +48,6 @@ class Func:
             self.do_compile()
         return self.compiled(*args)
 
-    def compiled(self, *args):
-        self.do_compile()
-        return self.compiled(*args)
-
     def do_compile(self):
         from .impl import get_runtime
         src = remove_indent(oinspect.getsource(self.func))
@@ -331,7 +327,7 @@ class Kernel:
                     "Kernels cannot call other kernels. I.e., nested kernels are not allowed. Please check if you have direct/indirect invocation of kernels within kernels. Note that some methods provided by the Taichi standard library may invoke kernels, and please move their invocations to Python-scope."
                 )
             self.runtime.inside_kernel = True
-            compiled()
+            compiled()  # invoke AST transformed kernel
             self.runtime.inside_kernel = False
 
         taichi_kernel = taichi_kernel.define(taichi_ast_generator)

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -31,12 +31,7 @@ def remove_indent(lines):
 def func(foo):
     is_classfunc = _inside_class(level_of_class_stackframe=3)
     func = Func(foo, classfunc=is_classfunc)
-
-    @functools.wraps(foo)
-    def decorated(*args):
-        return func.__call__(*args)
-
-    return decorated
+    return func
 
 
 class Func:
@@ -51,8 +46,11 @@ class Func:
     def __call__(self, *args):
         if self.compiled is None:
             self.do_compile()
-        ret = self.compiled(*args)
-        return ret
+        return self.compiled(*args)
+
+    def compiled(self, *args):
+        self.do_compile()
+        return self.compiled(*args)
 
     def do_compile(self):
         from .impl import get_runtime
@@ -523,10 +521,7 @@ def _kernel_impl(func, level_of_class_stackframe, verbose=False):
                 f'Please decorate class {clsobj.__name__} with @data_oriented')
     else:
 
-        @functools.wraps(func)
-        def wrapped(*args, **kwargs):
-            return primal(*args, **kwargs)
-
+        wrapped = functools.wraps(func)(primal)
         wrapped.grad = adjoint
 
     wrapped._is_wrapped_kernel = True

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -31,7 +31,14 @@ def remove_indent(lines):
 def func(foo):
     is_classfunc = _inside_class(level_of_class_stackframe=3)
     func = Func(foo, classfunc=is_classfunc)
-    return func
+
+    @functools.wraps(foo)
+    def wrapped(*args):
+        if func.compiled is None:
+            func.do_compile()
+        return func.compiled(*args)
+
+    return wrapped
 
 
 class Func:

--- a/stack.py
+++ b/stack.py
@@ -1,0 +1,19 @@
+import taichi as ti
+
+@ti.func
+def hello1():
+    print(a)
+
+@ti.func
+def hello2():
+    hello1()
+
+@ti.func
+def hello3():
+    hello2()
+
+@ti.kernel
+def main():
+    hello3()
+
+main()

--- a/stack.py
+++ b/stack.py
@@ -1,19 +1,24 @@
 import taichi as ti
 
+
 @ti.func
 def hello1():
     print(a)
+
 
 @ti.func
 def hello2():
     hello1()
 
+
 @ti.func
 def hello3():
     hello2()
 
+
 @ti.kernel
 def main():
     hello3()
+
 
 main()


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
```py
import taichi as ti

@ti.func
def hello1():
    print(a)

@ti.func
def hello2():
    hello1()

@ti.func
def hello3():
    hello2()

@ti.kernel
def main():
    hello3()

main()
```
Before:
```
[Taichi] mode=development
[Taichi] preparing sandbox at /tmp/taichi-fstwqyo_
[Taichi] <dev mode>, llvm 10.0.0, commit e9cecb48, python 3.8.3
Traceback (most recent call last):
  File "stack.py", line 19, in <module>
    main()
  File "/root/taichi/python/taichi/lang/kernel.py", line 528, in wrapped
    return primal(*args, **kwargs)
  File "/root/taichi/python/taichi/lang/kernel.py", line 459, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/root/taichi/python/taichi/lang/kernel.py", line 339, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/root/taichi/python/taichi/lang/kernel.py", line 336, in taichi_ast_generator
    compiled()
  File "stack.py", line 17, in main
    hello3()
  File "/root/taichi/python/taichi/lang/kernel.py", line 37, in decorated
    return func.__call__(*args)
  File "/root/taichi/python/taichi/lang/kernel.py", line 54, in __call__
    ret = self.compiled(*args)
  File "stack.py", line 13, in hello3
    hello2()
  File "/root/taichi/python/taichi/lang/kernel.py", line 37, in decorated
    return func.__call__(*args)
  File "/root/taichi/python/taichi/lang/kernel.py", line 54, in __call__
    ret = self.compiled(*args)
  File "stack.py", line 9, in hello2
    hello1()
  File "/root/taichi/python/taichi/lang/kernel.py", line 37, in decorated
    return func.__call__(*args)
  File "/root/taichi/python/taichi/lang/kernel.py", line 54, in __call__
    ret = self.compiled(*args)
  File "stack.py", line 5, in hello1
    print(a)
NameError: name 'a' is not defined
```
After:
```
[Taichi] mode=development
[Taichi] preparing sandbox at /tmp/taichi-sg3gbs_w
[Taichi] <dev mode>, llvm 10.0.0, commit e9cecb48, python 3.8.3
Traceback (most recent call last):
  File "stack.py", line 19, in <module>
    main()
  File "/root/taichi/python/taichi/lang/kernel.py", line 457, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/root/taichi/python/taichi/lang/kernel.py", line 337, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/root/taichi/python/taichi/lang/kernel.py", line 334, in taichi_ast_generator
    compiled()
  File "stack.py", line 17, in main
    hello3()
  File "/root/taichi/python/taichi/lang/kernel.py", line 49, in __call__
    return self.compiled(*args)
  File "stack.py", line 13, in hello3
    hello2()
  File "/root/taichi/python/taichi/lang/kernel.py", line 49, in __call__
    return self.compiled(*args)
  File "stack.py", line 9, in hello2
    hello1()
  File "/root/taichi/python/taichi/lang/kernel.py", line 49, in __call__
    return self.compiled(*args)
  File "stack.py", line 5, in hello1
    print(a)
NameError: name 'a' is not defined
```