### PR TITLE
[Docker] Update the Dockerfile to use up-to-date instructions for Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,73 +1,60 @@
-FROM nvidia/cuda:10.0-devel-ubuntu16.04
+# Taichi Dockerfile for development
+FROM nvidia/cuda:10.0-devel-ubuntu18.04
 
+LABEL maintainer="https://github.com/taichi-dev"
+
+# This installs Python 3.6.9 by default. Once the
+# docker image is upgraded to Ubuntu 20.04 this will
+# install Python 3.8 by default
 RUN apt-get update && \
-    apt-get install -y software-properties-common
+    apt-get install -y software-properties-common \
+                       python3-pip \
+                       libtinfo-dev \
+                       clang-8 \
+                       cmake \
+                       wget \
+                       git \
+                       libx11-dev \
+                       libxrandr-dev \
+                       libxinerama-dev \
+                       libxcursor-dev \
+                       libxi-dev \
+                       libglu1-mesa-dev \
+                       freeglut3-dev \
+                       mesa-common-dev \
+                       libtinfo5
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    cmake \
-    libtinfo-dev \
-    wget \
-    libx11-dev \
-    libsm6 \
-    libxext6 \
-    libxrender-dev \
-    zlib1g-dev \
-    xz-utils \
-    curl \
-    libomp5 \
-    libomp-dev
+# Install Taichi's Python dependencies
+RUN python3 -m pip install --user setuptools astpretty astor pybind11 Pillow dill
+RUN python3 -m pip install --user pytest pytest-rerunfailures pytest-xdist yapf
+RUN python3 -m pip install --user numpy GitPython coverage colorama autograd
 
-RUN curl -SL http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz | tar -xJC . \
-    && cp -r clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-16.04/ /usr/local/clang-7.0.1
-ENV LD_LIBRARY_PATH=/usr/local/clang-7.0.1/lib:$LD_LIBRARY_PATH
-ENV PATH=/usr/local/clang-7.0.1/bin:$PATH
-RUN ldconfig
+# Intall LLVM 10
+ENV CC=/usr/bin/clang-8
+ENV CXX=/usr/bin/clang++-8
+RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz
+RUN tar xvJf llvm-10.0.0.src.tar.xz
+RUN cd llvm-10.0.0.src && mkdir build 
+WORKDIR /llvm-10.0.0.src/build
+RUN cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
+RUN make -j 8
+RUN make install
 
-ENV CC=/usr/local/clang-7.0.1/bin/clang
-ENV CXX=/usr/local/clang-7.0.1/bin/clang++
-RUN curl -SL https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/llvm-8.0.1.src.tar.xz | tar -xJC .
-RUN cd llvm-8.0.1.src && mkdir build && cd build && cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON && make -j `nproc --all` && make install
+# Install Taichi from source
+WORKDIR /taichi-dev
+RUN git clone https://github.com/taichi-dev/taichi --depth=1 --branch=master
+RUN cd taichi && \
+    git submodule update --init --recursive --depth=1 && \
+    mkdir build
+WORKDIR /taichi-dev/taichi/build
+RUN cmake .. -DPYTHON_EXECUTABLE=python3 -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL=True
+RUN make -j 8
 
-# install python 3.6 from source since it is not available on ubuntu 16.04's official repo
-RUN apt install -y build-essential checkinstall
-RUN apt install -y libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
-RUN wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz && \
-    tar xvf Python-3.6.0.tar.xz && \
-    cd Python-3.6.0/ && \
-    ./configure --enable-shared && \
-    make altinstall
-
-WORKDIR /
-# install python dependencies
-RUN curl https://bootstrap.pypa.io/get-pip.py --output ./get-pip.py \
-    && python3.6 ./get-pip.py
-RUN python3.6 -m pip install twine numpy Pillow scipy pybind11 colorama setuptools astor matplotlib pytest autograd 
-
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-RUN apt update
-RUN apt install g++-7 -y
-RUN echo /usr/local/cuda-10.0/compat >> /etc/ld.so.conf.d/cuda-10-0.conf && ldconfig
-
-RUN mkdir /app
-WORKDIR /app
-
-ENV SHELL=bash
-RUN cd /app && git clone https://github.com/yuanming-hu/taichi.git
-RUN mkdir /app/taichi/build
-WORKDIR /app/taichi/build
-RUN export CUDA_BIN_PATH=/usr/local/cuda-10.0 && \
-    cmake .. -DPYTHON_EXECUTABLE=$(which python3.6) -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL="False" && \
-    make -j 15 && \
-    ldd libtaichi_core.so
-
-WORKDIR /app/taichi/python
-ENV PATH="/app/taichi/bin:$PATH"
-ENV TAICHI_REPO_DIR="/app/taichi/"
+# Link Taichi source repo to Python Path
+ENV PATH="/taichi-dev/taichi/bin:$PATH"
+ENV TAICHI_REPO_DIR="/taichi-dev/taichi/"
 ENV PYTHONPATH="$TAICHI_REPO_DIR/python:$PYTHONPATH"
-RUN ti test
+ENV LANG="C.UTF-8"
 
-WORKDIR /app
+WORKDIR /taichi-dev/taichi
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cd taichi && \
     git submodule update --init --recursive --depth=1 && \
     mkdir build
 WORKDIR /taichi-dev/taichi/build
-RUN cmake .. -DPYTHON_EXECUTABLE=python3 -DCUDA_VERSION=10.0 -DTI_WITH_CUDA:BOOL=True
+RUN cmake .. -DPYTHON_EXECUTABLE=python3 -DTI_WITH_CUDA:BOOL=True
 RUN make -j 8
 
 # Link Taichi source repo to Python Path

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -145,6 +145,68 @@ Setting up Taichi for development
 - Execute ``python3 -m taichi test`` to run all the tests. It may take up to 5 minutes to run all tests.
 - Check out ``examples`` for runnable examples. Run them with ``python3``.
 
+Docker
+------
+For those who prefer to use Docker, we also provide a Dockerfile which helps
+setup the Taichi development environment with CUDA support based on Ubuntu docker image.
+
+.. note::
+    In order to follow the instructions in this section, please make sure you have the 
+    `Docker DeskTop (or Engine for Linux) <https://www.docker.com/products/docker-desktop>`_ installed and set up
+    properly.
+
+Build the Docker Image
+**********************
+From within the root directory of the taichi Git repository, execute ``docker build -t taichi:master .`` to build a
+Docker image based off the local master branch tagged with *master*. Since this builds the image from source, please
+expect up to 40 mins build time if you don't have cached Docker image layers.
+
+.. note::
+    In order to save the time on building Docker images, you could always visit our `Docker Hub repository <https://hub.docker.com/r/taichidev/taichi>`_ and pull the
+    versions of pre-built images you would like to use. Currently the builds are triggered per taichi Github release.
+
+    For example, to pull a image built from release v0.6.17, run ``docker pull taichidev/taichi:v0.6.17``
+
+Use Docker Image on macOS (cpu only)
+************************************
+1. Make sure ``XQuartz`` and ``socat`` are installed:
+
+.. code-block:: bash
+
+    brew cask install xquartz
+    brew install socat
+
+2. Temporally disable the xhost access-control: ``xhost +``
+3. Start the Docker container with ``docker run -it -e DISPLAY=$(ipconfig getifaddr en0):0 taichidev/taichi:v0.6.17``
+4. Do whatever you want within the container, e.g. you could run tests or an example, try: ``ti test`` or ``ti example mpm88``
+5. Exit from the container with ``exit`` or ``ctrl+D``
+6. [To keep your xhost safe] Re-enable the xhost access-control: ``xhost -``
+
+Use Docker Image on Ubuntu (with CUDA support)
+**********************************************
+1. Make sure your host machine has CUDA properly installed and configured. Usually you could verify it by running ``nvidia-smi`` 
+2. Make sure ` NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-docker>`_ is properly installed:
+
+.. code-block:: bash
+
+    distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+    curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+    curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+
+    sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+    sudo systemctl restart docker
+
+3. Make sure ``xorg`` is installed: ``sudo apt-get install xorg``
+4. Temporally disable the xhost access-control: ``xhost +``
+5. Start the Docker container with ``sudo docker run -it --gpus all -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix taichidev/taichi:v0.6.17``
+6. Do whatever you want within the container, e.g. you could run tests or an example, try: ``ti test`` or ``ti example mpm88``
+7. Exit from the container with ``exit`` or ``ctrl+D``
+8. [To keep your xhost safe] Re-enable the xhost access-control: ``xhost -``
+
+.. warning::
+    The nature of Docker container determines that no changes to the file system on the container could be preserved
+    once you exit from the container. If you want to use Docker as a persistent development environment, we recommend
+    you `mount the taichi Git repository to the container as a volume <https://docs.docker.com/storage/volumes/>`_ and set the Python path to the mounted directory. 
 
 Troubleshooting
 ---------------

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -151,7 +151,7 @@ For those who prefer to use Docker, we also provide a Dockerfile which helps
 setup the Taichi development environment with CUDA support based on Ubuntu docker image.
 
 .. note::
-    In order to follow the instructions in this section, please make sure you have the 
+    In order to follow the instructions in this section, please make sure you have the
     `Docker DeskTop (or Engine for Linux) <https://www.docker.com/products/docker-desktop>`_ installed and set up
     properly.
 
@@ -184,7 +184,7 @@ Use Docker Image on macOS (cpu only)
 
 Use Docker Image on Ubuntu (with CUDA support)
 **********************************************
-1. Make sure your host machine has CUDA properly installed and configured. Usually you could verify it by running ``nvidia-smi`` 
+1. Make sure your host machine has CUDA properly installed and configured. Usually you could verify it by running ``nvidia-smi``
 2. Make sure ` NVIDIA Container Toolkit <https://github.com/NVIDIA/nvidia-docker>`_ is properly installed:
 
 .. code-block:: bash
@@ -206,7 +206,7 @@ Use Docker Image on Ubuntu (with CUDA support)
 .. warning::
     The nature of Docker container determines that no changes to the file system on the container could be preserved
     once you exit from the container. If you want to use Docker as a persistent development environment, we recommend
-    you `mount the taichi Git repository to the container as a volume <https://docs.docker.com/storage/volumes/>`_ and set the Python path to the mounted directory. 
+    you `mount the taichi Git repository to the container as a volume <https://docs.docker.com/storage/volumes/>`_ and set the Python path to the mounted directory.
 
 Troubleshooting
 ---------------

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -101,8 +101,7 @@ void CFGNode::reaching_definition_analysis(bool after_lower_access) {
     auto data_source_ptr = irpass::analysis::get_store_destination(stmt);
     if (data_source_ptr) {
       // stmt provides a data source
-      if (after_lower_access &&
-          !(stmt->is<AllocaStmt>() || stmt->is<LocalStoreStmt>())) {
+      if (after_lower_access && !(data_source_ptr->is<AllocaStmt>())) {
         // After lower_access, we only analyze local variables.
         continue;
       }


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

(I recently wanted to use taichi through a ssh tunnel on a container cluster and realized the Dockerfile is outdated)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

## Review Instructions:

In order to test this out, please either build the image locally with: `docker build -t taichi:2b181a26 .`(this builds the image from source so may take up to 40 mins) OR pull the image I built and pushed with : `docker run -it rexwangcc/taichi:2b181a26`

- For a quick check, you could run `ti test` within the container. 

- For a more sophisticated test, with `docker`installed properly, please follow:
### On macOS (cpu only)
1. Make sure XQuartz and socat are installed:
```
brew cask install xquartz
brew install socat
```
2. Temporally disable the xhost access-control: `xhost +`
3. Run an example, such as mpm88 with: `docker run -it -e DISPLAY=$(ipconfig getifaddr en0):0 rexwangcc/taichi:2b181a26 ti example mpm88`
4. Re-enable the xhost  access-control: `xhost -`

### On Ubuntu (cuda support)
1. Install NVIDIA container runtime for docker:
```
curl -s -L https://nvidia.github.io/nvidia-container-runtime/gpgkey | sudo apt-key add -
distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
curl -s -L https://nvidia.github.io/nvidia-container-runtime/$distribution/nvidia-container-runtime.list |\
    sudo tee /etc/apt/sources.list.d/nvidia-container-runtime.list
sudo apt-get update
sudo apt-get install nvidia-container-runtime
```
2. Restart docker daemon:
```
sudo systemctl stop docker
sudo systemctl start docker
```
3. Make sure xorg is installed: `sudo apt-get install xorg`
4.  Temporally disable the xhost access-control: `xhost +`
5. Run an example, such as mpm88 with: `sudo docker run -it --gpus all -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix rexwangcc/taichi:2b181a26 ti example mpm88`
6. Re-enable the xhost  access-control: `xhost -`

## Open Questions:

- The Dockerfile this PR updates is effectively a `Dockerfile.dev` which fullfills my own requirements (remote taichi development), But would it bring any value to end-users to have a runtime `Dockerfile` separately?
- Would it be possible to have a repository on Docker Hub so we could set up a free build trigger on Docker Hub side to automatically build tagged images when a new release is cut on Github? 