### PR TITLE
[llvm] [ir] Wrap struct-for's single coordinate computation into another function

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1375,7 +1375,7 @@ void CodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt, bool spmd) {
       llvm::Function *single_coord_func = nullptr;
       {
         auto single_index_guard = get_function_creation_guard({
-            runtime_context_ty, // The first arg is expected to be Context.
+            runtime_context_ty,  // The first arg is expected to be Context.
             llvm::PointerType::get(physical_coordinate_ty, 0),
         });
         single_coord_func = single_index_guard.body;

--- a/tests/python/test_continue.py
+++ b/tests/python/test_continue.py
@@ -148,7 +148,7 @@ def test_kernel_continue_in_nested_if_3():
     assert x[0] == 0
 
 
-@ti.all_archs
+@ti.archs_excluding(ti.opengl)
 def test_kernel_continue_bitmasked():
     N = 32
     x = ti.var(ti.f32)


### PR DESCRIPTION
I'm taking the first approach here, but I wonder if this can be inlined automatically? @yuanming-hu 

Related issue = #1377

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
