### PR TITLE
[cli] Use "ti task" for run task (legacy), and "ti run" to run script

### DIFF
--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -886,6 +886,22 @@ class TaichiMain:
             return TaichiMain._test_cpp(args)
 
     @register
+    def run(self, arguments: list = sys.argv[2:]):
+        """Run a single script"""
+        parser = argparse.ArgumentParser(prog='ti run',
+                                         description=f"{self.run.__doc__}")
+        parser.add_argument(
+            'filename',
+            help='A single (Python) script to run with Taichi, e.g. render.py'
+        )
+        args = parser.parse_args(arguments)
+
+        # Short circuit for testing
+        if self.test_mode: return args
+
+        runpy.run_path(args.filename)
+
+    @register
     def debug(self, arguments: list = sys.argv[2:]):
         """Debug a single script"""
         parser = argparse.ArgumentParser(prog='ti debug',
@@ -900,18 +916,15 @@ class TaichiMain:
         if self.test_mode: return args
 
         ti.core.set_core_trigger_gdb_when_crash(True)
+        os.environ['TI_DEBUG'] = '1'
 
-        with open(args.filename) as script:
-            script = script.read()
-
-        # FIXME: exec is a security risk here!
-        exec(script, {'__name__': '__main__'})
+        runpy.run_path(args.filename)
 
     @register
-    def run(self, arguments: list = sys.argv[2:]):
+    def task(self, arguments: list = sys.argv[2:]):
         """Run a specific task"""
-        parser = argparse.ArgumentParser(prog='ti run',
-                                         description=f"{self.run.__doc__}")
+        parser = argparse.ArgumentParser(prog='ti task',
+                                         description=f"{self.task.__doc__}")
         parser.add_argument('taskname',
                             help='A single task name to run, e.g. test_math')
         parser.add_argument('taskargs',

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -892,8 +892,7 @@ class TaichiMain:
                                          description=f"{self.run.__doc__}")
         parser.add_argument(
             'filename',
-            help='A single (Python) script to run with Taichi, e.g. render.py'
-        )
+            help='A single (Python) script to run with Taichi, e.g. render.py')
         args = parser.parse_args(arguments)
 
         # Short circuit for testing

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -40,7 +40,7 @@ class IRVerifier : public BasicStmtVisitor {
           found,
           "IR broken: stmt {} cannot have operand {}."
           " Consider adding `ti.core.toggle_advance_optimization(False)`?"
-          " If that fix the problem, please report this bug by opening an"
+          " If that fixes the problem, please report this bug by opening an"
           " issue at https://github.com/taichi-dev/taichi to help us improve,"
           " many thanks!",
           stmt->id, op->id);

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -36,11 +36,14 @@ class IRVerifier : public BasicStmtVisitor {
           break;
         }
       }
-      TI_ASSERT_INFO(found, "IR broken: stmt {} cannot have operand {}."
-                    " Consider adding `ti.core.toggle_advance_optimization(False)`?"
-                    " If that fix the problem, please report this bug by opening an"
-                    " issue at https://github.com/taichi-dev/taichi to help us improve,"
-                    " many thanks!", stmt->id, op->id);
+      TI_ASSERT_INFO(
+          found,
+          "IR broken: stmt {} cannot have operand {}."
+          " Consider adding `ti.core.toggle_advance_optimization(False)`?"
+          " If that fix the problem, please report this bug by opening an"
+          " issue at https://github.com/taichi-dev/taichi to help us improve,"
+          " many thanks!",
+          stmt->id, op->id);
     }
     visible_stmts.back().insert(stmt);
   }

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -36,8 +36,11 @@ class IRVerifier : public BasicStmtVisitor {
           break;
         }
       }
-      TI_ASSERT_INFO(found, "stmt {} cannot have operand {}.", stmt->id,
-                     op->id);
+      TI_ASSERT_INFO(found, "IR broken: stmt {} cannot have operand {}."
+                    " Consider adding `ti.core.toggle_advance_optimization(False)`?"
+                    " If that fix the problem, please report this bug by opening an"
+                    " issue at https://github.com/taichi-dev/taichi to help us improve,"
+                    " many thanks!", stmt->id, op->id);
     }
     visible_stmts.back().insert(stmt);
   }

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -241,7 +241,14 @@ def test_cli_debug():
 
 
 def test_cli_run():
-    with patch_sys_argv_helper(["ti", "run", "test_task", "arg1",
+    with patch_sys_argv_helper(["ti", "run", "a.py"]) as custom_argv:
+        cli = TaichiMain(test_mode=True)
+        args = cli()
+        assert args.filename == "a.py"
+
+
+def test_cli_task():
+    with patch_sys_argv_helper(["ti", "task", "test_task", "arg1",
                                 "arg2"]) as custom_argv:
         cli = TaichiMain(test_mode=True)
         args = cli()


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://forum.taichi.graphics/t/internal-error-occurred/941

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Some user consider `ti run` as running scripts, like `ti debug` does.
So I move it to `ti task` for runing task instead.

Also fixed the `FIXME` in `ti debug` as OFT.