### PR TITLE
[Bug] [ir] Fix compilation crash when there's a cross-offload global atomic operation

### DIFF
--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -90,3 +90,21 @@ def test_offload_with_flexible_bounds():
     ker()
 
     assert s[None] == 29 * 10 // 2
+
+
+@ti.all_archs
+def test_offload_with_cross_block_globals():
+    ret = ti.var(ti.f32)
+
+    ti.root.place(ret)
+
+    @ti.kernel
+    def ker():
+        ret[None] = 0
+        for i in range(10):
+            ret[None] += i
+        ret[None] += 1
+
+    ker()
+
+    assert ret[None] == 46

--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -74,7 +74,7 @@ def test_offload_with_cross_block_locals4():
     assert ret[None] == 10
 
 
-@ti.archs_excluding(ti.opengl)  # OpenGL doesn't support dynamic range for now
+@ti.all_archs
 def test_offload_with_flexible_bounds():
     s = ti.var(ti.i32, shape=())
     lower = ti.var(ti.i32, shape=())


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = fix #1390 

Global atomic op should call the generic visitor instead of the overloaded one.

Added a test that fails before this PR.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
