### PR TITLE
[test] [bug] Use runpy in test_runtime.py to fix #1406

### DIFF
--- a/python/taichi/misc/test.py
+++ b/python/taichi/misc/test.py
@@ -31,3 +31,10 @@ def make_temp_file(*args, **kwargs):
     fd, name = mkstemp(*args, **kwargs)
     os.close(fd)
     return name
+
+
+def run_in_sandbox(content):
+    filename = make_temp_file()
+    with open(filename, 'w') as f:
+        f.write(content)
+    return runpy.run_path(filename)

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -1,13 +1,14 @@
 import taichi as ti
-from taichi import make_temp_file
+from taichi import run_in_sandbox
 import sys, os
+import runpy
 
 
 def test_without_init():
     # We want to check if Taichi works well without ``ti.init()``.
     # But in test ``ti.init()`` will always be called in last ``@ti.all_archs``.
     # So we have to create a new Taichi instance, i.e. test in a sandbox.
-    content = '''
+    run_in_sandbox('''
 import taichi as ti
 assert ti.cfg.arch == ti.cpu
 
@@ -16,11 +17,7 @@ assert x.shape == (2, 3)
 
 x[1, 2] = 4
 assert x[1, 2] == 4
-'''
-    filename = make_temp_file()
-    with open(filename, 'w') as f:
-        f.write(content)
-    assert os.system(f'{sys.executable} {filename}') == 0
+''')
 
 
 @ti.all_archs


### PR DESCRIPTION


<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1406

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
@xumingkuan Could you confirm the issue is gone?