### PR TITLE
[bug] Fix test_fibonacci

### DIFF
--- a/tests/python/test_tuple_assign.py
+++ b/tests/python/test_tuple_assign.py
@@ -6,7 +6,8 @@ def test_fibonacci():
     @ti.kernel
     def ti_fibonacci(n: ti.i32) -> ti.i32:
         a, b = 0, 1
-        if 1:
+        # This is to make the inner for loop serial on purpose...
+        for _ in range(1):
             for i in range(n):
                 a, b = b, a + b
         return b


### PR DESCRIPTION
This is probably more of a workaround. I don't think the IR optimizer should change the semantics of the for loop. That means we need to preserve the top-level `if` if the compile time condition is true, or transform it to a serial kernel, like this PR does..

Maybe we should also have a dedicated method to instruct that the for loop is meant to be executed inside a serial kernel. Right now this `for _ in range(1):` seems hacky..

Related issue = https://github.com/taichi-dev/taichi/pull/1393#issuecomment-653854873

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
