### PR TITLE
[Metal] Use managed storage mode to improve performance

### DIFF
--- a/taichi/backends/metal/api.h
+++ b/taichi/backends/metal/api.h
@@ -89,8 +89,8 @@ inline void end_encoding(T *encoder) {
 // buffer resources between CPU and GPU.
 //
 // See also:
-// * https://developer.apple.com/documentation/metal/synchronizing_a_managed_resource
-// * https://developer.apple.com/documentation/metal/setting_resource_storage_modes/choosing_a_resource_storage_mode_in_macos
+// https://developer.apple.com/documentation/metal/synchronizing_a_managed_resource
+// https://developer.apple.com/documentation/metal/setting_resource_storage_modes/choosing_a_resource_storage_mode_in_macos
 nsobj_unique_ptr<MTLBuffer> new_mtl_buffer_no_copy(MTLDevice *device,
                                                    void *ptr,
                                                    size_t length);

--- a/taichi/backends/metal/api.h
+++ b/taichi/backends/metal/api.h
@@ -21,6 +21,7 @@ struct MTLComputePipelineState;
 struct MTLCommandQueue;
 struct MTLCommandBuffer;
 struct MTLComputeCommandEncoder;
+struct MTLBlitCommandEncoder;
 struct MTLFunction;
 struct MTLComputePipelineState;
 struct MTLBuffer;
@@ -42,6 +43,9 @@ nsobj_unique_ptr<MTLCommandBuffer> new_command_buffer(MTLCommandQueue *queue);
 nsobj_unique_ptr<MTLComputeCommandEncoder> new_compute_command_encoder(
     MTLCommandBuffer *buffer);
 
+nsobj_unique_ptr<MTLBlitCommandEncoder> new_blit_command_encoder(
+    MTLCommandBuffer *buffer);
+
 // msl_version: Metal Shader Language version. 0 means not set.
 // See https://developer.apple.com/documentation/metal/mtllanguageversion
 nsobj_unique_ptr<MTLLibrary> new_library_with_source(MTLDevice *device,
@@ -61,12 +65,32 @@ inline void set_compute_pipeline_state(
   mac::call(encoder, "setComputePipelineState:", pipeline_state);
 }
 
-inline void end_encoding(MTLComputeCommandEncoder *encoder) {
+inline void synchronize_resource(MTLBlitCommandEncoder *encoder,
+                                 MTLBuffer *buffer) {
+  mac::call(encoder, "synchronizeResource:", buffer);
+}
+
+template <typename T>
+inline void end_encoding(T *encoder) {
+  static_assert(std::is_same_v<T, MTLComputeCommandEncoder> ||
+                std::is_same_v<T, MTLBlitCommandEncoder>);
   mac::call(encoder, "endEncoding");
 }
 
-nsobj_unique_ptr<MTLBuffer> new_mtl_buffer(MTLDevice *device, size_t length);
-
+// The created MTLBuffer has its storege mode being .manged.
+// API ref:
+// https://developer.apple.com/documentation/metal/mtldevice/1433382-makebuffer
+//
+// We initially used .shared storage mode, meaning the GPU and CPU shared the
+// system memory. This turned out to be slow as page fault on GPU was very
+// costly. By switching to .managed mode, on GPUs with discrete memory model,
+// the data will reside in both GPU's VRAM and CPU's system RAM. This made the
+// GPU memory access much faster. But we will need to manually synchronize the
+// buffer resources between CPU and GPU.
+//
+// See also:
+// * https://developer.apple.com/documentation/metal/synchronizing_a_managed_resource
+// * https://developer.apple.com/documentation/metal/setting_resource_storage_modes/choosing_a_resource_storage_mode_in_macos
 nsobj_unique_ptr<MTLBuffer> new_mtl_buffer_no_copy(MTLDevice *device,
                                                    void *ptr,
                                                    size_t length);
@@ -121,6 +145,8 @@ inline void wait_until_completed(MTLCommandBuffer *cmd_buffer) {
 inline void *mtl_buffer_contents(MTLBuffer *buffer) {
   return mac::cast_call<void *>(buffer, "contents");
 }
+
+void did_modify_range(MTLBuffer *buffer, size_t location, size_t length);
 
 size_t get_max_total_threads_per_threadgroup(
     MTLComputePipelineState *pipeline_state);

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -180,6 +180,7 @@ class RuntimeListOpsMtlKernel : public CompiledMtlKernelBase {
     mem[1] = child_snode_id_;
     const auto &sn_descs = *params.snode_descriptors;
     mem[2] = total_num_self_from_root(sn_descs, child_snode_id_);
+    did_modify_range(args_buffer_.get(), /*location=*/0, args_mem_->size());
   }
 
   void launch(InputBuffersMap &input_buffers,
@@ -281,12 +282,15 @@ class CompiledTaichiKernel {
 
 class HostMetalCtxBlitter {
  public:
-  HostMetalCtxBlitter(const KernelContextAttributes *ctx_attribs,
-                      Context *host_ctx,
-                      BufferMemoryView *ctx_buffer_mem)
-      : ctx_attribs_(ctx_attribs),
+  HostMetalCtxBlitter(const CompiledTaichiKernel &kernel, Context *host_ctx)
+      : ctx_attribs_(&kernel.ctx_attribs),
         host_ctx_(host_ctx),
-        kernel_ctx_mem_(ctx_buffer_mem) {
+        kernel_ctx_mem_(kernel.ctx_mem.get()),
+        kernel_ctx_buffer_(kernel.ctx_buffer.get()) {
+  }
+
+  inline MTLBuffer *ctx_buffer() {
+    return kernel_ctx_buffer_;
   }
 
   void host_to_metal() {
@@ -328,6 +332,8 @@ class HostMetalCtxBlitter {
     std::memcpy(device_ptr, host_ctx_->extra_args,
                 ctx_attribs_->extra_args_bytes());
 #undef TO_METAL
+    did_modify_range(kernel_ctx_buffer_, /*location=*/0,
+                     kernel_ctx_mem_->size());
   }
 
   void metal_to_host() {
@@ -386,14 +392,14 @@ class HostMetalCtxBlitter {
     if (kernel.ctx_attribs.empty()) {
       return nullptr;
     }
-    return std::make_unique<HostMetalCtxBlitter>(&kernel.ctx_attribs, ctx,
-                                                 kernel.ctx_mem.get());
+    return std::make_unique<HostMetalCtxBlitter>(kernel, ctx);
   }
 
  private:
   const KernelContextAttributes *const ctx_attribs_;
   Context *const host_ctx_;
   BufferMemoryView *const kernel_ctx_mem_;
+  MTLBuffer *const kernel_ctx_buffer_;
 };
 
 }  // namespace
@@ -488,7 +494,7 @@ class KernelManager::Impl {
     auto &ctk = *compiled_taichi_kernels_.find(taichi_kernel_name)->second;
     auto ctx_blitter = HostMetalCtxBlitter::maybe_make(ctk, ctx);
     if (config_->verbose_kernel_launches) {
-      TI_INFO("Lauching Taichi kernel <{}>", taichi_kernel_name);
+      TI_INFO("Launching Taichi kernel <{}>", taichi_kernel_name);
     }
 
     InputBuffersMap input_buffers = {
@@ -510,7 +516,15 @@ class KernelManager::Impl {
       // TODO(k-ye): One optimization is to synchronize only when we absolutely
       // need to transfer the data back to host. This includes the cases where
       // an arg is 1) an array, or 2) used as return value.
-      synchronize();
+      std::vector<MTLBuffer *> buffers_to_blit;
+      if (ctx_blitter) {
+        buffers_to_blit.push_back(ctx_blitter->ctx_buffer());
+      }
+      if (used_print) {
+        buffers_to_blit.push_back(print_buffer_.get());
+      }
+      blit_buffers_and_sync(buffers_to_blit);
+
       if (ctx_blitter) {
         ctx_blitter->metal_to_host();
       }
@@ -521,11 +535,7 @@ class KernelManager::Impl {
   }
 
   void synchronize() {
-    profiler_->start("metal_synchronize");
-    commit_command_buffer(cur_command_buffer_.get());
-    wait_until_completed(cur_command_buffer_.get());
-    create_new_command_buffer();
-    profiler_->stop();
+    blit_buffers_and_sync();
   }
 
   PrintStringTable *print_strtable() {
@@ -653,11 +663,37 @@ class KernelManager::Impl {
       root_lm.mem_alloc = alloc;
       append(&root_lm, root_elem);
     }
+
+    did_modify_range(runtime_buffer_.get(), /*location=*/0,
+                     runtime_mem_->size());
   }
 
   void init_print_buffer() {
     // This includes setting PrintMsgAllocator::next to zero.
     std::memset(print_mem_->ptr(), 0, print_mem_->size());
+    did_modify_range(print_buffer_.get(), /*location=*/0, print_mem_->size());
+  }
+
+  void blit_buffers_and_sync(
+      const std::vector<MTLBuffer *> &buffers_to_blit = {}) {
+    // Blit the Metal buffers because they are in .managed mode.
+    // We don't have to blit any of the root, global tmps or runtime buffer.
+    // The data in these buffers are purely used inside GPU. When we need to
+    // read back data from root buffer to CPU, it's done through that kernel's
+    // context buffer.
+    if (!buffers_to_blit.empty()) {
+      auto encoder = new_blit_command_encoder(cur_command_buffer_.get());
+      for (auto *b : buffers_to_blit) {
+        synchronize_resource(encoder.get(), b);
+      }
+      end_encoding(encoder.get());
+    }
+    // Sync
+    profiler_->start("metal_synchronize");
+    commit_command_buffer(cur_command_buffer_.get());
+    wait_until_completed(cur_command_buffer_.get());
+    create_new_command_buffer();
+    profiler_->stop();
   }
 
   void flush_print_buffers() {


### PR DESCRIPTION
It turned out the current `.shared` storage mode has made things pretty slow. This PR switched to use the `.managed` storage mode for `MTLBuffer`s, see https://developer.apple.com/documentation/metal/setting_resource_storage_modes/choosing_a_resource_storage_mode_in_macos.

Benchmark result:

| example       | old FPS (.shared) | new FPS (.managed) |
|---------------|-------------------|--------------------|
| mpm88         | 21-22             | 25-28              |
| mpm_lag_force | 11                | 13                 |
| stable_fluid  | 23                | 50                 |
| vortex*        | 1.2               | 6                  |

* I shamelessly copied the vortex example from here https://forum.taichi.graphics/t/vortex-method-demo/775. Note that the original example's `fix_streamfunc` had a global reduction to a kernel temporary variable. This wasn't supported in TLS yet, so I changed that to use a `ti.var` to store the global sum result. Also note that the global reduction here hurt the performance so much that, if I reduce the #threads from 262144 to 65536 (i.e. grid-stride loop), because of TLS and the reduced number of fatomic add, the FPS went to 12.
* The main bottleneck of mpm_lag_force is now GUI (30% of the time on GUI, only 12% on Metal. 4.4% out of that 12% was spent on `Snode::write_float` )

Related issue = #935

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
