### PR TITLE
[error] Fix wrong error message when using vector as if condition

### DIFF
--- a/misc/prtags.json
+++ b/misc/prtags.json
@@ -30,5 +30,6 @@
   "perf"            : "Performance improvements",
   "ipython"         : "IPython and other shells",
   "cc"              : "C source backend",
+  "error"           : "Error message",
   "release"         : "Release"
 }

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -682,10 +682,23 @@ class Matrix(TaichiOperations):
                 yield ']'
         yield ']'
 
-    @python_scope
     def __repr__(self):
         """Python scope object print support."""
-        return str(self.to_numpy())
+        if impl.inside_kernel():
+            '''
+            It seems that when pybind11 got an type mismatch, it will try
+            to invoke `repr` to show the object... e.g.:
+
+            TypeError: make_const_expr_f32(): incompatible function arguments. The following argument types are supported:
+                1. (arg0: float) -> taichi_core.Expr
+
+            Invoked with: <Taichi 2x1 Matrix>
+
+            So we have to make it happy with a dummy string...
+            '''
+            return f'<Taichi {self.n}x{self.m} Matrix>'
+        else:
+            return str(self.to_numpy())
 
     @staticmethod
     @taichi_scope


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

It seems that when pybind11 got an type mismatch, it will try to invoke `repr` to show the object...
So we have to make it happy with a dummy string in `Matrix.__repr__` instead of `cannot be called from Python-scope`.


```py
import taichi as ti
ti.init()

@ti.kernel
def func():
    x = ti.Vector([2, 3])
    if x:
        pass

func()
```


Before:
```
Traceback (most recent call last):
  File "w.py", line 12, in <module>
    func()
  File "/root/taichi/python/taichi/lang/kernel.py", line 553, in wrapped
    return primal(*args, **kwargs)
  File "/root/taichi/python/taichi/lang/kernel.py", line 483, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/root/taichi/python/taichi/lang/kernel.py", line 363, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/root/taichi/python/taichi/lang/util.py", line 210, in wrapped
    assert in_python_scope(), \
AssertionError: __repr__ cannot be called in Taichi-scope
```

After:
```
Traceback (most recent call last):
  File "w.py", line 12, in <module>
    func()
  File "/root/taichi/python/taichi/lang/kernel.py", line 553, in wrapped
    return primal(*args, **kwargs)
  File "/root/taichi/python/taichi/lang/kernel.py", line 483, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/root/taichi/python/taichi/lang/kernel.py", line 363, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/root/taichi/python/taichi/lang/kernel.py", line 360, in taichi_ast_generator
    compiled()
  File "w.py", line 8, in func
    if x:
  File "/root/taichi/python/taichi/lang/expr.py", line 29, in __init__
    self.ptr = make_constant_expr(arg).ptr
  File "/root/taichi/python/taichi/lang/util.py", line 200, in wrapped
    return func(*args, **kwargs)
  File "/root/taichi/python/taichi/lang/impl.py", line 224, in make_constant_expr
    return Expr(taichi_lang_core.make_const_expr_f32(val))
TypeError: make_const_expr_f32(): incompatible function arguments. The following argument types are supported:
    1. (arg0: float) -> taichi_core.Expr

Invoked with: <Taichi 2x1 Matrix>
```

@pybind Hi, I know that printing `Invoked with: xxx` is nice to debug, but do you know that it's also possible for the `repr` of `xxx` to fail?
Can we catch it and say: `During processing the above exception, another exception occurred` instead of a corrupt stack backtrace?