### PR TITLE
[GUI] Support mouse wheel event on Mac Cocoa

### DIFF
--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -118,6 +118,7 @@ constexpr int NSApplicationActivationPolicyRegular = 0;
 constexpr int NSEventTypeKeyDown = 10;
 constexpr int NSEventTypeKeyUp = 11;
 constexpr int NSEventTypeFlagsChanged = 12;
+constexpr int NSEventTypeScrollWheel = 22;
 
 struct ModifierFlagsHandler {
   struct Result {
@@ -370,6 +371,14 @@ void GUI::process_event() {
             key_events.push_back(
                 KeyEvent{KeyEvent::Type::release, key, cursor_pos});
           }
+          break;
+        }
+        case NSEventTypeScrollWheel: {
+          set_mouse_pos(p.x, p.y);
+          const auto dx = (int)cast_call<CGFloat>(event, "scrollingDeltaX");
+          const auto dy = (int)cast_call<CGFloat>(event, "scrollingDeltaY");
+          key_events.push_back(KeyEvent{KeyEvent::Type::move, "Wheel",
+                                        cursor_pos, Vector2i{dx, dy}});
           break;
         }
       }

--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -376,7 +376,8 @@ void GUI::process_event() {
         case NSEventTypeScrollWheel: {
           set_mouse_pos(p.x, p.y);
           const auto dx = (int)cast_call<CGFloat>(event, "scrollingDeltaX");
-          const auto dy = (int)cast_call<CGFloat>(event, "scrollingDeltaY");
+          // Mac trackpad's vertical scroll is reversed.
+          const auto dy = -(int)cast_call<CGFloat>(event, "scrollingDeltaY");
           key_events.push_back(KeyEvent{KeyEvent::Type::move, "Wheel",
                                         cursor_pos, Vector2i{dx, dy}});
           break;


### PR DESCRIPTION
Simpler than i thought..

Related issue = #1150

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

There's a possibility that the vertical scrolling direction of Mac's trackpad is the reverse of that of the mouse wheel.