### PR TITLE
[error] Instruct user to use static range when matrix accessed with non constant index

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -5,6 +5,7 @@ import numbers
 import numpy as np
 from .util import taichi_scope, python_scope, deprecated, to_numpy_type, to_pytorch_type, in_python_scope
 from .common_ops import TaichiOperations
+from .exception import TaichiSyntaxError
 from collections.abc import Iterable
 import warnings
 
@@ -181,9 +182,16 @@ class Matrix(TaichiOperations):
         assert 0 <= args[1] < self.m
         # TODO(#1004): See if it's possible to support indexing at runtime
         for i, a in enumerate(args):
-            assert isinstance(
-                a, int
-            ), f'The {i}-th index of a Matrix/Vector must be a compile-time constant integer, got {a}'
+            if not isinstance(a, int):
+                raise TaichiSyntaxError(
+                    f'The {i}-th index of a Matrix/Vector must be a compile-time constant '
+                    'integer, got {a}. This is because matrix operations will be **unrolled**'
+                    ' at compile-time for performance reason.\n'
+                    'If you want to *iterate through matrix elements*, use a static range:\n'
+                    '  for i in ti.static(range(3)):\n'
+                    '    print(i, "-th component is", vec[i])\n'
+                    'See https://taichi.readthedocs.io/en/stable/meta.html#when-to-use-for-loops-with-ti-static for more details.'
+                    )
         return args[0] * self.m + args[1]
 
     def __call__(self, *args, **kwargs):

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -155,3 +155,32 @@ def test_taichi_scope_matrix_operations_with_global_matrices(ops):
 
     assert np.allclose(r1[None].value.to_numpy(), ops(a, b))
     assert np.allclose(r2[None].value.to_numpy(), ops(a, c))
+
+
+@ti.host_arch_only
+@ti.must_throw(ti.TaichiSyntaxError)
+def test_matrix_non_constant_index():
+    m = ti.Matrix(2, 2, ti.i32, 5)
+
+    @ti.kernel
+    def func():
+        for i in range(5):
+            for j, k in ti.ndrange(2, 2):
+                m[i][j, k] = 12
+
+    func()
+
+
+@ti.host_arch_only
+def test_matrix_constant_index():
+    m = ti.Matrix(2, 2, ti.i32, 5)
+
+    @ti.kernel
+    def func():
+        for i in range(5):
+            for j, k in ti.static(ti.ndrange(2, 2)):
+                m[i][j, k] = 12
+
+    func()
+
+    assert np.allclose(m.to_numpy(), np.ones((5, 2, 2), np.int32) * 12)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://forum.taichi.graphics/t/hw0-5-implicit-euler-method-on-mass-spring-system/961/5

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
They may thought Taichi matrix **doesn't support syntax like mat[i, j] at all**..