### PR TITLE
[doc] [Docker] Some minor doc fixes and add a docker build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Travis CI Status](https://img.shields.io/travis/taichi-dev/taichi?logo=Travis&branch=master&label=Travis%20CI)](https://travis-ci.com/taichi-dev/taichi)
 [![AppVeyor Status](https://img.shields.io/appveyor/build/yuanming-hu/taichi?logo=AppVeyor&label=AppVeyor)](https://ci.appveyor.com/project/yuanming-hu/taichi/branch/master)
+[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/taichidev/taichi?label=Docker%20Image&logo=docker)](https://hub.docker.com/r/taichidev/taichi)
 [![Python Codecov Status](https://img.shields.io/codecov/c/github/taichi-dev/taichi?label=Python%20Coverage&logo=codecov)](https://codecov.io/gh/taichi-dev/taichi/src/master)
 [![Latest Release](https://img.shields.io/github/v/release/taichi-dev/taichi?color=blue&label=Latest%20Release)](https://github.com/taichi-dev/taichi/releases/latest)
 

--- a/docs/contributor_guide.rst
+++ b/docs/contributor_guide.rst
@@ -280,4 +280,4 @@ Right now we are targeting CUDA 10. When upgrading CUDA version,
 the file ``external/cuda_libdevice/slim_libdevice.10.bc`` should also be replaced with a newer version.
 
 To generate the slimmed version of libdevice based on a full ``libdevice.X.bc`` file from a CUDA installation,
-use ``ti run make_slim_libdevice [libdevice.X.bc file]``
+use ``ti task make_slim_libdevice [libdevice.X.bc file]``

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -157,8 +157,8 @@ setup the Taichi development environment with CUDA support based on Ubuntu docke
 
 Build the Docker Image
 **********************
-From within the root directory of the taichi Git repository, execute ``docker build -t taichi:master .`` to build a
-Docker image based off the local master branch tagged with *master*. Since this builds the image from source, please
+From within the root directory of the taichi Git repository, execute ``docker build -t taichi:latest .`` to build a
+Docker image based off the local master branch tagged with *latest*. Since this builds the image from source, please
 expect up to 40 mins build time if you don't have cached Docker image layers.
 
 .. note::

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -731,7 +731,7 @@ template llvm::Value *TaichiLLVMContext::get_constant(unsigned long t);
 
 auto make_slim_libdevice = [](const std::vector<std::string> &args) {
   TI_ASSERT_INFO(args.size() == 1,
-                 "Usage: ti run make_slim_libdevice [libdevice.X.bc file]");
+                 "Usage: ti task make_slim_libdevice [libdevice.X.bc file]");
 
   auto ctx = std::make_unique<llvm::LLVMContext>();
   auto libdevice_module = module_from_bitcode_file(args[0], ctx.get());


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = closes #416 (I think by now we have resolved all issues directly about docker)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

- Update the docs about how to use `ti task` over `ti run`
- Add a build badge for Docker automation (🎉  the docker build trigger worked for both master branch and tagged releases [here](https://hub.docker.com/r/taichidev/taichi) thanks to the help from @yuanming-hu )
