### PR TITLE
[Lang] Make tensor indicing automatically cast to int32 and raise an warning

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -97,11 +97,9 @@ def subscript(value, *indices):
     if is_taichi_class(value):
         return value.subscript(*indices)
     else:
-        if isinstance(indices,
-                      tuple) and len(indices) == 1 and indices[0] is None:
-            indices_expr_group = make_expr_group()
-        else:
-            indices_expr_group = make_expr_group(*indices)
+        if isinstance(indices, tuple) and len(indices) == 1 and indices[0] is None:
+            indices = []
+        indices_expr_group = make_expr_group(*indices)
         tensor_dim = int(value.ptr.get_attribute("dim"))
         index_dim = indices_expr_group.size()
         assert tensor_dim == index_dim, f'Tensor with dim {tensor_dim} accessed with indices of dim {index_dim}'

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -97,7 +97,8 @@ def subscript(value, *indices):
     if is_taichi_class(value):
         return value.subscript(*indices)
     else:
-        if isinstance(indices, tuple) and len(indices) == 1 and indices[0] is None:
+        if isinstance(indices,
+                      tuple) and len(indices) == 1 and indices[0] is None:
             indices = []
         indices_expr_group = make_expr_group(*indices)
         tensor_dim = int(value.ptr.get_attribute("dim"))

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -128,9 +128,11 @@ class TypeCheck : public IRVisitor {
     }
     for (int i = 0; i < stmt->indices.size(); i++) {
       if (!is_integral(stmt->indices[i]->ret_type.data_type)) {
-        TI_WARN("[{}] Tensor index {} not integral, casting into int32 implicitly",
-                        stmt->name(), i);
-        stmt->indices[i] = insert_type_cast_before(stmt, stmt->indices[i], DataType::i32);
+        TI_WARN(
+            "[{}] Tensor index {} not integral, casting into int32 implicitly",
+            stmt->name(), i);
+        stmt->indices[i] =
+            insert_type_cast_before(stmt, stmt->indices[i], DataType::i32);
       }
       TI_ASSERT(stmt->indices[i]->ret_type.width == stmt->snodes.size());
     }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -127,13 +127,11 @@ class TypeCheck : public IRVisitor {
       }
     }
     for (int i = 0; i < stmt->indices.size(); i++) {
-      TI_ASSERT_INFO(
-          is_integral(stmt->indices[i]->ret_type.data_type),
-          "[{}] Taichi tensors must be accessed with integral indices (e.g., "
-          "i32/i64). It seems that you have used something else as "
-          "an index. You can cast a float-pointer number to an integer using "
-          "int(). Also note that ti.floor(ti.f32) returns f32.",
-          stmt->name());
+      if (!is_integral(stmt->indices[i]->ret_type.data_type)) {
+        TI_WARN("[{}] Tensor accessed with non-integral indices (e.g., "
+                "i32/i64), casting into i32 by default...", stmt->name());
+        stmt->indices[i] = insert_type_cast_before(stmt, stmt->indices[i], DataType::i32);
+      }
       TI_ASSERT(stmt->indices[i]->ret_type.width == stmt->snodes.size());
     }
   }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -94,10 +94,10 @@ class TypeCheck : public IRVisitor {
     }
     if (stmt->ptr->ret_type.data_type != common_container_type) {
       TI_WARN(
-          "[{}] Local store may lose precision (target = {}, value = {}, at",
+          "[{}] Local store may lose precision (target = {}, value = {}) at",
           stmt->name(), stmt->ptr->ret_data_type_name(),
           old_data->ret_data_type_name(), stmt->id);
-      fmt::print(stmt->tb);
+      TI_WARN("\n{}", stmt->tb);
     }
     stmt->ret_type = stmt->ptr->ret_type;
   }
@@ -128,8 +128,8 @@ class TypeCheck : public IRVisitor {
     }
     for (int i = 0; i < stmt->indices.size(); i++) {
       if (!is_integral(stmt->indices[i]->ret_type.data_type)) {
-        TI_WARN("[{}] Tensor accessed with non-integral indices (e.g., "
-                "i32/i64), casting into i32 by default...", stmt->name());
+        TI_WARN("[{}] Tensor index {} not integral, casting into int32 implicitly",
+                        stmt->name(), i);
         stmt->indices[i] = insert_type_cast_before(stmt, stmt->indices[i], DataType::i32);
       }
       TI_ASSERT(stmt->indices[i]->ret_type.width == stmt->snodes.size());
@@ -146,8 +146,8 @@ class TypeCheck : public IRVisitor {
     }
     if (stmt->ptr->ret_type.data_type != promoted) {
       TI_WARN("[{}] Global store may lose precision: {} <- {}, at",
-              stmt->name(), stmt->ptr->ret_data_type_name(), input_type,
-              stmt->tb);
+              stmt->name(), stmt->ptr->ret_data_type_name(), input_type);
+      TI_WARN("\n{}", stmt->tb);
     }
     stmt->ret_type = stmt->ptr->ret_type;
   }
@@ -227,7 +227,7 @@ class TypeCheck : public IRVisitor {
       } else {
         TI_WARN("[{}] {} at", stmt->name(), comment);
       }
-      fmt::print(stmt->tb);
+      TI_WARN("\n{}", stmt->tb);
       TI_WARN("Compilation stopped due to type mismatch.");
       throw std::runtime_error("Binary operator type mismatch");
     };

--- a/tests/python/test_indices.py
+++ b/tests/python/test_indices.py
@@ -21,7 +21,6 @@ def test_indices():
     # the virtual first index exposed to the user comes second in memory layout.
 
 
-
 @ti.host_arch_only
 def test_float_as_index():
     a = ti.var(ti.f32, (8, 5))
@@ -37,5 +36,5 @@ def test_float_as_index():
 
     func()
 
-    assert a[6, 3] == 233 
+    assert a[6, 3] == 233
     assert a[3, 4] == 666

--- a/tests/python/test_indices.py
+++ b/tests/python/test_indices.py
@@ -19,3 +19,23 @@ def test_indices():
     assert mapping_b == {0: 1, 1: 0}
     # Note that b is column-major:
     # the virtual first index exposed to the user comes second in memory layout.
+
+
+
+@ti.host_arch_only
+def test_float_as_index():
+    a = ti.var(ti.f32, (8, 5))
+
+    @ti.kernel
+    def func():
+        i = 6.66
+        j = 3
+        I = ti.Vector([2, 1])
+        for _ in range(1):  # prevent constant fold
+            a[i, j] = 233
+            a[I + ti.Vector([1, 3.0])] = 666
+
+    func()
+
+    assert a[6, 3] == 233 
+    assert a[3, 4] == 666


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1360

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
IIUC the index to tensor should always be int32 no matter what default_ip is?