### PR TITLE
[Bug] [lang] Fix outer_product output matrix shape

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -865,7 +865,7 @@ class Matrix(TaichiOperations):
             impl.static_assert(other.m == 1,
                                "rhs for outer_product is not a vector"))
         ret = Matrix([[self[i] * other[j] for j in range(other.n)]
-                      for i in range(other.n)])
+                      for i in range(self.n)])
         return ret
 
 

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -28,8 +28,8 @@ def test_const_init():
 @ti.all_archs
 def test_basic_utils():
     a = ti.Vector(3, dt=ti.f32)
-    b = ti.Vector(3, dt=ti.f32)
-    abT = ti.Matrix(3, 3, dt=ti.f32)
+    b = ti.Vector(2, dt=ti.f32)
+    abT = ti.Matrix(3, 2, dt=ti.f32)
     aNormalized = ti.Vector(3, dt=ti.f32)
 
     normA = ti.var(ti.f32)
@@ -41,7 +41,7 @@ def test_basic_utils():
     @ti.kernel
     def init():
         a[None] = ti.Vector([1.0, 2.0, 3.0])
-        b[None] = ti.Vector([4.0, 5.0, 6.0])
+        b[None] = ti.Vector([4.0, 5.0])
         abT[None] = a[None].outer_product(b[None])
 
         normA[None] = a[None].norm()
@@ -53,7 +53,7 @@ def test_basic_utils():
     init()
 
     for i in range(3):
-        for j in range(3):
+        for j in range(2):
             assert abT[None][i, j] == a[None][i] * b[None][j]
 
     sqrt14 = np.sqrt(14.0)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = fixes #1460 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Thank @gmh14 for reporting!
I made the test to use different size in rhs and lhs to prevent regression.