### PR TITLE
[cli] [test] Add some useful pytest arguments

### DIFF
--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -829,7 +829,7 @@ class TaichiMain:
                             default=None,
                             dest='keys',
                             type=str,
-                            help='Only run tests that matched the keys')
+                            help='Only run tests that match the keys')
         parser.add_argument('-m',
                             '--marks',
                             required=False,
@@ -850,7 +850,7 @@ class TaichiMain:
                             default=None,
                             dest='fail_fast',
                             action='store_true',
-                            help='Exit instantly on first failed test')
+                            help='Exit instantly on the first failed test')
         parser.add_argument('-C',
                             '--coverage',
                             required=False,

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -702,6 +702,14 @@ class TaichiMain:
             pytest_args += ['-s', '-v']
         if args.rerun:
             pytest_args += ['--reruns', args.rerun]
+        if args.keys:
+            pytest_args += ['-k', args.keys]
+        if args.marks:
+            pytest_args += ['-m', args.marks]
+        if args.failed_first:
+            pytest_args += ['--failed-first']
+        if args.fail_fast:
+            pytest_args += ['--exitfirst']
         try:
             if args.coverage:
                 pytest_args += ['--cov-branch', '--cov=python/taichi']
@@ -815,6 +823,34 @@ class TaichiMain:
                             dest='rerun',
                             type=str,
                             help='Rerun failed tests for given times')
+        parser.add_argument('-k',
+                            '--keys',
+                            required=False,
+                            default=None,
+                            dest='keys',
+                            type=str,
+                            help='Only run tests that matched the keys')
+        parser.add_argument('-m',
+                            '--marks',
+                            required=False,
+                            default=None,
+                            dest='marks',
+                            type=str,
+                            help='Only run tests with specific marks')
+        parser.add_argument('-f',
+                            '--failed-first',
+                            required=False,
+                            default=None,
+                            dest='failed_first',
+                            action='store_true',
+                            help='Run the previously failed test first')
+        parser.add_argument('-x',
+                            '--fail-fast',
+                            required=False,
+                            default=None,
+                            dest='fail_fast',
+                            action='store_true',
+                            help='Exit instantly on first failed test')
         parser.add_argument('-C',
                             '--coverage',
                             required=False,


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
e.g.:
`ti test bitmasked -k huge_bitmasked`
will only run the `test_bitmasked.py::test_huge_bitmasked`.

`ti test -x`
will exit immediately after first failure occured.