### PR TITLE
[test] [bug] Fix master test failure by #1437

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -217,15 +217,16 @@ def get_runtime():
 
 @taichi_scope
 def make_constant_expr(val):
+    import numpy as np
     _taichi_skip_traceback = 1
-    if isinstance(val, int):
+    if isinstance(val, (int, np.integer)):
         if pytaichi.default_ip == i32:
             return Expr(taichi_lang_core.make_const_expr_i32(val))
         elif pytaichi.default_ip == i64:
             return Expr(taichi_lang_core.make_const_expr_i64(val))
         else:
             assert False
-    elif isinstance(val, float):
+    elif isinstance(val, (float, np.floating, np.ndarray)):
         if pytaichi.default_fp == f32:
             return Expr(taichi_lang_core.make_const_expr_f32(val))
         elif pytaichi.default_fp == f64:

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -134,8 +134,8 @@ def test_numpy_3d():
                 assert a[i, j, k] == i * j * (k + 1) + i + j + k * 2
 
 
-@ti.must_throw(AssertionError)
-def test_numpy_3d():
+@ti.must_throw(IndexError)
+def test_numpy_3d_error():
     val = ti.var(ti.i32)
 
     n = 4


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Sorry about breaking master test :(
But what's the point of using `np.ndarray` in Taichi-scope?

IMO `ti.ext_arr()` is being **edged** and can be easily buggy.. e.g.: https://forum.taichi.graphics/t/hw0-5-implicit-euler-method-on-mass-spring-system/961/13
If we don't maintain `ti.ext_arr()`, how about just deprecate it and do some walk around for `to_numpy`?