### PR TITLE
[Opt] [refactor] Remove the CSE part from the simplify pass

### DIFF
--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -827,7 +827,7 @@ class GlobalPtrStmt : public Stmt {
   bool common_statement_eliminable() const override {
     return true;
   }
-  
+
   TI_STMT_DEF_FIELDS(ret_type, snodes, indices, activate);
   TI_DEFINE_ACCEPT_AND_CLONE
 };

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -1398,4 +1398,8 @@ inline void StmtFieldManager::operator()(const char *key, T &&value) {
         std::make_unique<StmtFieldSNode>(value));
   } else {
     stmt->field_manager.fields.emplace_back(
-       
+        std::make_unique<StmtFieldNumeric<T>>(value));
+  }
+}
+
+TLANG_NAMESPACE_END

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -824,6 +824,10 @@ class GlobalPtrStmt : public Stmt {
     return activate;
   }
 
+  bool common_statement_eliminable() const override {
+    return true;
+  }
+  
   TI_STMT_DEF_FIELDS(ret_type, snodes, indices, activate);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
@@ -1394,8 +1398,4 @@ inline void StmtFieldManager::operator()(const char *key, T &&value) {
         std::make_unique<StmtFieldSNode>(value));
   } else {
     stmt->field_manager.fields.emplace_back(
-        std::make_unique<StmtFieldNumeric<T>>(value));
-  }
-}
-
-TLANG_NAMESPACE_END
+       

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -113,18 +113,15 @@ class SNodeLookupStmt : public Stmt {
   SNode *snode;
   Stmt *input_snode;
   Stmt *input_index;
-  std::vector<Stmt *> global_indices;
   bool activate;
 
   SNodeLookupStmt(SNode *snode,
                   Stmt *input_snode,
                   Stmt *input_index,
-                  bool activate,
-                  const std::vector<Stmt *> &global_indices)
+                  bool activate)
       : snode(snode),
         input_snode(input_snode),
         input_index(input_index),
-        global_indices(global_indices),
         activate(activate) {
     TI_STMT_REG_FIELDS;
   }
@@ -141,7 +138,6 @@ class SNodeLookupStmt : public Stmt {
                      snode,
                      input_snode,
                      input_index,
-                     global_indices,
                      activate);
   TI_DEFINE_ACCEPT_AND_CLONE
 };

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -134,11 +134,7 @@ class SNodeLookupStmt : public Stmt {
     return true;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type,
-                     snode,
-                     input_snode,
-                     input_index,
-                     activate);
+  TI_STMT_DEF_FIELDS(ret_type, snode, input_snode, input_index, activate);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -133,6 +133,10 @@ class SNodeLookupStmt : public Stmt {
     return activate;
   }
 
+  bool common_statement_eliminable() const override {
+    return true;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type,
                      snode,
                      input_snode,

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -28,6 +28,14 @@ class AlgSimp : public BasicStmtVisitor {
       : BasicStmtVisitor(), fast_math(fast_math_) {
   }
 
+  void visit(UnaryOpStmt *stmt) override {
+    if (stmt->is_cast() &&
+        stmt->cast_type == stmt->operand->ret_type.data_type) {
+      stmt->replace_with(stmt->operand);
+      modifier.erase(stmt);
+    }
+  }
+
   void visit(BinaryOpStmt *stmt) override {
     auto lhs = stmt->lhs->cast<ConstStmt>();
     auto rhs = stmt->rhs->cast<ConstStmt>();

--- a/taichi/transforms/lower_access.cpp
+++ b/taichi/transforms/lower_access.cpp
@@ -138,7 +138,7 @@ class LowerAccess : public IRVisitor {
       } else {
         auto lookup = lowered.push_back<SNodeLookupStmt>(
             snode, last, linearized,
-            snode->need_activation() && activate && !on_loop_tree, indices);
+            snode->need_activation() && activate && !on_loop_tree);
         // if snode has no possibility of null child, set activate = false
         int chid = snode->child_id(snodes[i + 1]);
         last = lowered.push_back<GetChStmt>(lookup, chid);

--- a/tests/cpp/test_same_statements.cpp
+++ b/tests/cpp/test_same_statements.cpp
@@ -92,15 +92,15 @@ TI_TEST("same_statements") {
     auto zero = block->push_back<ConstStmt>(LaneAttribute<TypedConstant>(0));
     SNode root(0, SNodeType::root);
     auto &child = root.insert_children(SNodeType::dense);
-    auto lookup1 = block->push_back<SNodeLookupStmt>(
-        &root, get_root, zero, false, std::vector<Stmt *>());
-    auto lookup2 = block->push_back<SNodeLookupStmt>(
-        &root, get_root, zero, false, std::vector<Stmt *>());
-    auto lookup_activate = block->push_back<SNodeLookupStmt>(
-        &root, get_root, zero, true, std::vector<Stmt *>());
+    auto lookup1 =
+        block->push_back<SNodeLookupStmt>(&root, get_root, zero, false);
+    auto lookup2 =
+        block->push_back<SNodeLookupStmt>(&root, get_root, zero, false);
+    auto lookup_activate =
+        block->push_back<SNodeLookupStmt>(&root, get_root, zero, true);
     auto get_child = block->push_back<GetChStmt>(lookup_activate, 0);
-    auto lookup_child = block->push_back<SNodeLookupStmt>(
-        &child, get_child, zero, false, std::vector<Stmt *>());
+    auto lookup_child =
+        block->push_back<SNodeLookupStmt>(&child, get_child, zero, false);
 
     irpass::typecheck(block.get());
     TI_CHECK(block->size() == 7);

--- a/tests/cpp/test_simplify.cpp
+++ b/tests/cpp/test_simplify.cpp
@@ -22,15 +22,14 @@ TI_TEST("simplify") {
         std::vector<Stmt *>(), std::vector<int>());
     SNode root(0, SNodeType::root);
     root.insert_children(SNodeType::dense);
-    auto lookup = block->push_back<SNodeLookupStmt>(
-        &root, get_root, linearized_empty, false, std::vector<Stmt *>());
+    auto lookup = block->push_back<SNodeLookupStmt>(&root, get_root,
+                                                    linearized_empty, false);
     auto get_child = block->push_back<GetChStmt>(lookup, 0);
     auto zero = block->push_back<ConstStmt>(TypedConstant(0));
     auto linearized_zero = block->push_back<LinearizeStmt>(
         std::vector<Stmt *>(2, zero), std::vector<int>({8, 4}));
     auto lookup2 = block->push_back<SNodeLookupStmt>(
-        root.ch[0].get(), get_child, linearized_zero, true,
-        std::vector<Stmt *>());
+        root.ch[0].get(), get_child, linearized_zero, true);
 
     irpass::typecheck(block.get());
     TI_CHECK(block->size() == 7);

--- a/tests/cpp/test_simplify.cpp
+++ b/tests/cpp/test_simplify.cpp
@@ -42,6 +42,7 @@ TI_TEST("simplify") {
     irpass::alg_simp(block.get());
     irpass::die(block.get());  // should eliminate consts
     irpass::simplify(block.get());
+    irpass::whole_kernel_cse(block.get());
     if (kernel->program.config.advanced_optimization) {
       // get root, const 0, lookup, get child, lookup
       TI_CHECK(block->size() == 5);


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://github.com/taichi-dev/taichi/issues/1059#issuecomment-647181953

Notice that `advanced_optimization=False` may not function well after this PR because we assume some optimizations are done after some passes. For example, we assume there's no usage of the return value of atomic operations in `auto_diff`, there's no `GlobalPtrStmt` after the `die` after `lower_access`, and there's no typecast to the same type of the input operand when we generate the code to LLVM.

Update: also removes `SNodeLookupStmt::global_indices`.

![benchmark20200711_3](https://user-images.githubusercontent.com/22582118/87235334-2112f000-c3a9-11ea-8d70-2c011dd208bb.png)



[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
