### PR TITLE
[Refactor] [lang] "ti.sqr(x)" is now fully deprecated

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -385,16 +385,15 @@ too hard. This includes runtime errors such as:
 
 ```RuntimeError: [verify.cpp:basic_verify@40] stmt 8 cannot have operand 7.```
 
-You may use ``ti.core.toggle_advance_optimization(False)`` to turn off advanced
+You may use ``ti.init(advance_optimization=False)`` to turn off advanced
 optimization and see if the issue still exists:
 
 .. code-block:: python
 
     import taichi as ti
 
-    ti.init()
-    ti.core.toggle_advance_optimization(False)
+    ti.init(advance_optimization=False)
 
     ...
 
-If turning off optimization fixes the issue, please report this bug on `GitHub <https://github.com/taichi-dev/taichi/issues/new?labels=potential+bug&template=bug_report.md>`_. Thank you!
+If turning off optimization fixes the issue (or not), please report this bug on `GitHub <https://github.com/taichi-dev/taichi/issues/new?labels=potential+bug&template=bug_report.md>`_. Thank you!

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -396,4 +396,4 @@ optimization and see if the issue still exists:
 
     ...
 
-If turning off optimization fixes the issue (or not), please report this bug on `GitHub <https://github.com/taichi-dev/taichi/issues/new?labels=potential+bug&template=bug_report.md>`_. Thank you!
+Whether or not turning off optimization fixes the issue, please feel free to report this bug on `GitHub <https://github.com/taichi-dev/taichi/issues/new?labels=potential+bug&template=bug_report.md>`_. Thank you!

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -86,8 +86,8 @@ This saves the overhead of those computations at runtime.
  for p in range(0, n_particles):
   base = ti.cast(x[f, p] * inv_dx - 0.5, ti.i32)
   fx = x[f, p] * inv_dx - ti.cast(base, real)
-  w = [0.5 * ti.sqr(1.5 - fx), 0.75 - ti.sqr(fx - 1.0),
-       0.5 * ti.sqr(fx - 0.5)]
+  w = [0.5 * (1.5 - fx) ** 2, 0.75 - (fx - 1.0) ** 2,
+       0.5 * (fx - 0.5) ** 2]
   new_v = ti.Vector([0.0, 0.0])
   new_C = ti.Matrix([[0.0, 0.0], [0.0, 0.0]])
 

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -12,6 +12,7 @@ from taichi.misc.task import Task
 from taichi.misc.test import *
 from taichi.misc import settings as settings
 from taichi.misc.gui import rgb_to_hex
+from taichi.misc.error import *
 from taichi.misc.settings import *
 from taichi.tools.video import VideoManager
 from taichi.tools.file import *

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -1,5 +1,4 @@
 from .impl import *
-from .error import enable_excepthook
 from .util import deprecated
 from .matrix import Matrix, Vector
 from .transformer import TaichiSyntaxError

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -123,11 +123,6 @@ def bit_cast(obj, type):
         return Expr(ti_core.bits_cast(Expr(obj).ptr, type))
 
 
-@deprecated('ti.sqr(x)', 'x ** 2')
-def sqr(obj):
-    return obj * obj
-
-
 def _unary_operation(taichi_op, python_op, a):
     _taichi_skip_traceback = 1
     if is_taichi_expr(a):

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -1,5 +1,4 @@
 from .core import taichi_lang_core
-from .error import no_traceback
 import numpy as np
 import os
 

--- a/python/taichi/misc/error.py
+++ b/python/taichi/misc/error.py
@@ -4,18 +4,6 @@ from colorama import Fore, Style
 import sys
 
 
-def no_traceback(foo):
-    '''
-    Don't include the decorated frame in traceback, if ti.set_excepthook() was called.
-    '''
-    @functools.wraps(foo)
-    def wrapped(*args, **kwargs):
-        _taichi_skip_traceback = 2
-        return foo(*args, **kwargs)
-
-    return wrapped
-
-
 def enable_excepthook():
     def excepthook(exctype, value, tb):
         skip = 0

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -587,6 +587,8 @@ void export_lang(py::module &m) {
 
   // A temporary option which will be removed soon in the future
   m.def("toggle_advanced_optimization", [](bool option) {
+    TI_WARN("`ti.core.toggle_advance_optimization(False)` is deprecated,"
+            " use `ti.init(advanced_optimization=False)` intead");
     get_current_program().config.advanced_optimization = option;
   });
 }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -588,8 +588,8 @@ void export_lang(py::module &m) {
   // A temporary option which will be removed soon in the future
   m.def("toggle_advanced_optimization", [](bool option) {
     TI_WARN(
-        "`ti.core.toggle_advance_optimization(False)` is deprecated,"
-        " use `ti.init(advanced_optimization=False)` intead");
+        "'ti.core.toggle_advance_optimization(False)' is deprecated."
+        " Use 'ti.init(advanced_optimization=False)' instead");
     get_current_program().config.advanced_optimization = option;
   });
 }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -587,8 +587,9 @@ void export_lang(py::module &m) {
 
   // A temporary option which will be removed soon in the future
   m.def("toggle_advanced_optimization", [](bool option) {
-    TI_WARN("`ti.core.toggle_advance_optimization(False)` is deprecated,"
-            " use `ti.init(advanced_optimization=False)` intead");
+    TI_WARN(
+        "`ti.core.toggle_advance_optimization(False)` is deprecated,"
+        " use `ti.init(advanced_optimization=False)` intead");
     get_current_program().config.advanced_optimization = option;
   });
 }


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
