### PR TITLE
[metal] Plug in the SNodeRep structs into codegen

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -44,7 +44,6 @@ constexpr char kPrintAllocVarName[] = "print_alloc_";
 constexpr char kLinearLoopIndexName[] = "linear_loop_idx_";
 constexpr char kListgenElemVarName[] = "listgen_elem_";
 constexpr char kRandStateVarName[] = "rand_state_";
-constexpr char kSNodeMetaVarName[] = "sn_meta_";
 constexpr char kMemAllocVarName[] = "mem_alloc_";
 constexpr char kTlsBufferName[] = "tls_buffer_";
 
@@ -183,9 +182,10 @@ class KernelCodegen : public IRVisitor {
   }
 
   void visit(GetChStmt *stmt) override {
-    // E.g. `parent.get*()`
+    // E.g. `parent.get*(runtime, mem_alloc)`
     const auto get_call =
-        fmt::format("{}.get{}()", stmt->input_ptr->raw_name(), stmt->chid);
+        fmt::format("{}.get{}({}, {})", stmt->input_ptr->raw_name(), stmt->chid,
+                    kRuntimeVarName, kMemAllocVarName);
     if (stmt->output_snode->is_place()) {
       emit(R"(device {}* {} = {}.val;)",
            metal_data_type_name(stmt->output_snode->dt), stmt->raw_name(),
@@ -220,21 +220,15 @@ class KernelCodegen : public IRVisitor {
       parent = root_stmt_->raw_name();
     }
     const auto *sn = stmt->snode;
+    const auto snty = sn->type;
     const std::string index_name = stmt->input_index->raw_name();
+
+    if (stmt->activate) {
+      TI_ASSERT(is_supported_sparse_type(snty));
+      emit("{}.activate({});", parent, index_name);
+    }
     emit(R"({}_ch {} = {}.children({});)", sn->node_type_name, stmt->raw_name(),
          parent, index_name);
-    if (stmt->activate) {
-      TI_ASSERT(is_supported_sparse_type(sn->type));
-      emit("{{");
-      {
-        ScopedIndent s(current_appender());
-        current_appender().append_raw(
-            make_sparse_snode_meta(sn, kSNodeMetaVarName));
-        emit("activate({}.addr(), {}, {});", stmt->raw_name(),
-             kSNodeMetaVarName, index_name);
-      }
-      emit("}}");
-    }
   }
 
   void visit(SNodeOpStmt *stmt) override {
@@ -247,8 +241,7 @@ class KernelCodegen : public IRVisitor {
     emit("{{");
     {
       ScopedIndent s(current_appender());
-      current_appender().append_raw(
-          make_sparse_snode_meta(stmt->snode, kSNodeMetaVarName));
+      const auto &parent = stmt->ptr->raw_name();
       const bool is_dynamic = (stmt->snode->type == SNodeType::dynamic);
       std::string ch_id;
       if (is_dynamic &&
@@ -264,24 +257,23 @@ class KernelCodegen : public IRVisitor {
       const std::string ch_addr =
           fmt::format("{}.children({}).addr()", stmt->ptr->raw_name(), ch_id);
       if (opty == SNodeOpType::is_active) {
-        // is_active(device byte *addr, SNodeMeta meta, int i);
-        emit("{} = is_active({}, {}, {});", result_var, ch_addr,
-             kSNodeMetaVarName, ch_id);
+        emit("{} = {}.is_active({});", result_var, parent,
+             stmt->val->raw_name());
       } else if (opty == SNodeOpType::activate) {
-        // activate(device byte *addr, SNodeMeta meta, int i);
-        emit("activate({}, {}, {});", ch_addr, kSNodeMetaVarName, ch_id);
+        emit("{}.activate({});", parent, stmt->val->raw_name());
       } else if (opty == SNodeOpType::deactivate) {
-        // deactivate(device byte *addr, SNodeMeta meta, int i);
-        emit("deactivate({}, {}, {});", ch_addr, kSNodeMetaVarName, ch_id);
+        if (is_dynamic) {
+          emit("{}.deactivate();", parent);
+        } else {
+          emit("{}.deactivate({});", parent, stmt->val->raw_name());
+        }
       } else if (opty == SNodeOpType::append) {
         TI_ASSERT(is_dynamic);
         TI_ASSERT(stmt->ret_type.data_type == DataType::i32);
-        emit("{} = dynamic_append({}, {}, {});", result_var, ch_addr,
-             kSNodeMetaVarName, stmt->val->raw_name());
+        emit("{} = {}.append({});", result_var, parent, stmt->val->raw_name());
       } else if (opty == SNodeOpType::length) {
         TI_ASSERT(is_dynamic);
-        emit("{} = dynamic_length({}, {});", result_var, ch_addr,
-             kSNodeMetaVarName);
+        emit("{} = {}.length();", result_var, parent);
       } else {
         TI_NOT_IMPLEMENTED
       }
@@ -960,17 +952,15 @@ class KernelCodegen : public IRVisitor {
       emit(
           "const auto parent_elem_ = "
           "parent_list.get<ListgenElement>(parent_idx_);");
-
+      emit("device auto *parent_addr_ = {} + parent_elem_.root_mem_offset;",
+           kRootBufferName);
+      emit("if (!is_active(parent_addr_, parent_meta, child_idx_)) continue;");
       emit("ListgenElement {};", kListgenElemVarName);
       // No need to add mem_offset_in_parent, because place() always starts at 0
       emit(
           "{}.root_mem_offset = parent_elem_.root_mem_offset + child_idx_ * "
           "child_stride;",
           kListgenElemVarName);
-      emit(
-          "if (!is_active({} + {}.root_mem_offset, parent_meta, child_idx_)) "
-          "continue;",
-          kRootBufferName, kListgenElemVarName);
       emit(
           "refine_coordinates(parent_elem_, {}->snode_extractors[{}], "
           "child_idx_, &{});",
@@ -1141,27 +1131,6 @@ class KernelCodegen : public IRVisitor {
     }
     emit("    const uint {} [[thread_position_in_grid]]) {{",
          kKernelThreadIdName);
-  }
-
-  std::string make_sparse_snode_meta(const SNode *sn,
-                                     const std::string &var_name) const {
-    const auto &desc =
-        compiled_structs_->snode_descriptors.find(sn->id)->second;
-    LineAppender la = current_appender();
-    // Keep the indentation settings only
-    la.clear_lines();
-
-    la.append("SNodeMeta {};", var_name);
-    la.append("{}.element_stride = {};", var_name, desc.element_stride);
-    la.append("{}.num_slots = {};", var_name, desc.num_slots);
-    if (sn->type == SNodeType::bitmasked) {
-      la.append("{}.type = {};", var_name, (int)shaders::SNodeMeta::Bitmasked);
-    } else if (sn->type == SNodeType::dynamic) {
-      la.append("{}.type = {};", var_name, (int)shaders::SNodeMeta::Dynamic);
-    } else {
-      TI_NOT_IMPLEMENTED;
-    }
-    return la.lines();
   }
 
   void emit_runtime_and_memalloc_def() {

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -43,9 +43,9 @@ struct Runtime {
 METAL_BEGIN_RUNTIME_KERNELS_DEF
 STR(
     // clang-format on
-    kernel void clear_list(device byte *runtime_addr [[buffer(0)]],
-                           device int *args [[buffer(1)]],
-                           const uint utid_ [[thread_position_in_grid]]) {
+    kernel void clear_list(device byte *runtime_addr[[buffer(0)]],
+                           device int *args[[buffer(1)]],
+                           const uint utid_[[thread_position_in_grid]]) {
       if (utid_ > 0)
         return;
       int child_snode_id = args[1];
@@ -56,11 +56,11 @@ STR(
       child_list.clear();
     }
 
-    kernel void element_listgen(device byte *runtime_addr [[buffer(0)]],
-                                device byte *root_addr [[buffer(1)]],
-                                device int *args [[buffer(2)]],
-                                const uint utid_ [[thread_position_in_grid]],
-                                const uint grid_size [[threads_per_grid]]) {
+    kernel void element_listgen(device byte *runtime_addr[[buffer(0)]],
+                                device byte *root_addr[[buffer(1)]],
+                                device int *args[[buffer(2)]],
+                                const uint utid_[[thread_position_in_grid]],
+                                const uint grid_size[[threads_per_grid]]) {
       device Runtime *runtime =
           reinterpret_cast<device Runtime *>(runtime_addr);
       device MemoryAllocator *mem_alloc =

--- a/taichi/backends/metal/shaders/runtime_utils.metal.h
+++ b/taichi/backends/metal/shaders/runtime_utils.metal.h
@@ -263,55 +263,21 @@ STR(
       int32_t meta_offset_ = 0;
     };
 
+    // This is still necessary in listgen and struct-for kernels, where we don't
+    // have the actual SNode structs.
     [[maybe_unused]] int is_active(device byte *addr, SNodeMeta meta, int i) {
       if (meta.type == SNodeMeta::Root || meta.type == SNodeMeta::Dense) {
         return true;
+      } else if (meta.type == SNodeMeta::Dynamic) {
+        SNodeRep_dynamic rep;
+        rep.init(addr, /*meta_offset=*/meta.num_slots * meta.element_stride);
+        return rep.is_active(i);
+      } else if (meta.type == SNodeMeta::Bitmasked) {
+        SNodeRep_bitmasked rep;
+        rep.init(addr, /*meta_offset=*/meta.num_slots * meta.element_stride);
+        return rep.is_active(i);
       }
-      device auto *meta_ptr_begin = reinterpret_cast<device atomic_uint *>(
-          addr + ((meta.num_slots - i) * meta.element_stride));
-      if (meta.type == SNodeMeta::Dynamic) {
-        device auto *ptr = meta_ptr_begin;
-        uint32_t n = atomic_load_explicit(ptr, metal::memory_order_relaxed);
-        return i < n;
-      }
-      device auto *ptr = meta_ptr_begin + (i / (sizeof(uint32_t) * 8));
-      uint32_t bits = atomic_load_explicit(ptr, metal::memory_order_relaxed);
-      return ((bits >> (i % (sizeof(uint32_t) * 8))) & 1);
-    }
-
-    [[maybe_unused]] void activate(device byte *addr, SNodeMeta meta, int i) {
-      if (meta.type == SNodeMeta::Root || meta.type == SNodeMeta::Dense) {
-        return;
-      }
-      device auto *meta_ptr_begin = reinterpret_cast<device atomic_uint *>(
-          addr + ((meta.num_slots - i) * meta.element_stride));
-      if (meta.type == SNodeMeta::Dynamic) {
-        device auto *ptr = meta_ptr_begin;
-        // Unfortunately we cannot check if i + 1 is in bound
-        atomic_fetch_max_explicit(ptr, (uint32_t)(i + 1),
-                                  metal::memory_order_relaxed);
-        return;
-      }
-      device auto *ptr = meta_ptr_begin + (i / (sizeof(uint32_t) * 8));
-      const uint32_t mask = (1 << (i % (sizeof(uint32_t) * 8)));
-      atomic_fetch_or_explicit(ptr, mask, metal::memory_order_relaxed);
-    }
-
-    [[maybe_unused]] void deactivate(device byte *addr, SNodeMeta meta, int i) {
-      if (meta.type == SNodeMeta::Root || meta.type == SNodeMeta::Dense) {
-        return;
-      }
-      device auto *meta_ptr_begin = reinterpret_cast<device atomic_uint *>(
-          addr + ((meta.num_slots - i) * meta.element_stride));
-      if (meta.type == SNodeMeta::Dynamic) {
-        device auto *ptr = meta_ptr_begin;
-        // For dynamic, deactivate() applies for all the slots
-        atomic_store_explicit(ptr, 0u, metal::memory_order_relaxed);
-        return;
-      }
-      device auto *ptr = meta_ptr_begin + (i / (sizeof(uint32_t) * 8));
-      const uint32_t mask = ~(1 << (i % (sizeof(uint32_t) * 8)));
-      atomic_fetch_and_explicit(ptr, mask, metal::memory_order_relaxed);
+      return false;
     }
 
     [[maybe_unused]] void refine_coordinates(
@@ -325,24 +291,6 @@ STR(
         const int addition = (((l >> ex.acc_offset) & mask) << ex.start);
         child_elem->coords[i] = (parent_elem.coords[i] | addition);
       }
-    }
-
-    [[maybe_unused]] int dynamic_append(device byte *addr,
-                                        SNodeMeta meta,
-                                        int32_t data) {
-      // |addr| always starts at the beginning of the dynamic
-      device auto *n_ptr = reinterpret_cast<device atomic_int *>(
-          addr + (meta.num_slots * meta.element_stride));
-      int me = atomic_fetch_add_explicit(n_ptr, 1, metal::memory_order_relaxed);
-      *(reinterpret_cast<device int32_t *>(addr) + me) = data;
-      return me;
-    }
-
-    [[maybe_unused]] int dynamic_length(device byte *addr, SNodeMeta meta) {
-      // |addr| always starts at the beginning of the dynamic
-      device auto *n_ptr = reinterpret_cast<device atomic_int *>(
-          addr + (meta.num_slots * meta.element_stride));
-      return atomic_load_explicit(n_ptr, metal::memory_order_relaxed);
     })
 METAL_END_RUNTIME_UTILS_DEF
 // clang-format on


### PR DESCRIPTION
This is mostly a refactoring of the SNode structs implementation on Metal, with no functional changes.

I added a `SNodeRep_*` for each snode type supported on Metal. It is very similar to the `node_*` files in https://github.com/taichi-dev/taichi/tree/master/taichi/runtime/llvm. Each generated SNode structs will own an `rep_` object.  These `SNodeRep_*` provides the interfaces for operations like checking activation, activating/deactivating and getting a child. 

Advantages:

* `SNodeRep`s make it much easier to implement `listgen` and `struct-for` kernels fo checking activation.
* For `SNodeOpStmt`, before this PR, we had to manually figure out the memory address of the specific cell, then call the global helper function. Now that these functions are implemented inside each `rep`, we can just call the corresponding interface on the generated SNode structs themselves.

The constructor of a generated SNode takes in, in addition to its memory address, `Runtime` and `MemoryAllocator` now. These aren't used for now, but will be for `pointer` SNodes.

Here's an example:

```cpp
class S1_ch {
 public:
  S1_ch(device byte *a) : addr_(a) {}
  S2 get0(device Runtime *rtm, device MemoryAllocator *ma) {
    return {addr_ + (0), rtm, ma};
  }

  device byte *addr() { return addr_; }

  constant static constexpr int stride = 0 + S2::stride;
 private:
  device byte *addr_;
};

struct S1 {
  // bitmasked
  constant static constexpr int n = 128;
  constant static constexpr int elem_stride = S1_ch::stride;
  constant static constexpr int stride = elem_stride * n + /*bitmasked=*/16;

  S1(device byte *addr, device Runtime *rtm, device MemoryAllocator *ma) {
    rep_.init(addr, /*meta_offset=*/elem_stride * n);
  }

  S1_ch children(int i) {
    return {rep_.addr() + (i * elem_stride)};
  }

  inline bool is_active(int i) {
    return rep_.is_active(i);
  }

  inline void activate(int i) {
    rep_.activate(i);
  }

  inline void deactivate(int i) {
    rep_.deactivate(i);
  }

 private:
  SNodeRep_bitmasked rep_;
};
```

Related issue = #1174

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
