### PR TITLE
[doc] Fix code-block render issue in debugging.rst

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -49,23 +49,6 @@ For now, Taichi-scope ``print`` supports string, scalar, vector, and matrix expr
 
 .. warning::
 
-    Note that ``print`` in Taichi-scope can only receive **comma-separated parameter**. Neither f-string nor formatted string should be used. For example:
-    .. code-block:: python
-        import taichi as ti
-        ti.init(arch=ti.cpu)
-        a = ti.var(ti.f32, 4)
-
-
-        @ti.kernel
-        def foo():
-            a[0] = 1.0
-            print('a[0] = ', a[0]) # right
-            print(f'a[0] = {a[0]}') # wrong, f-string is not supported
-            print("a[0] = %f" % a[0]) # wrong, formatted string is not supported
-
-        foo()
-.. note::
-
     For the **OpenGL and CUDA backend**, the printed result will not show up until ``ti.sync()`` is called:
 
     .. code-block:: python
@@ -93,6 +76,26 @@ For now, Taichi-scope ``print`` supports string, scalar, vector, and matrix expr
         after
 
     Please note that host access or program end will also implicitly invoke ``ti.sync()``.
+
+.. note::
+
+    Note that ``print`` in Taichi-scope can only receive **comma-separated parameter**. Neither f-string nor formatted string should be used. For example:
+
+    .. code-block:: python
+
+        import taichi as ti
+        ti.init(arch=ti.cpu)
+        a = ti.var(ti.f32, 4)
+
+
+        @ti.kernel
+        def foo():
+            a[0] = 1.0
+            print('a[0] = ', a[0]) # right
+            print(f'a[0] = {a[0]}') # wrong, f-string is not supported
+            print("a[0] = %f" % a[0]) # wrong, formatted string is not supported
+
+        foo()
 
 
 Compile-time ``ti.static_print``

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -433,7 +433,7 @@ def static(x, *xs):
         return x
     elif isinstance(x, ti.Matrix) and x.is_global():
         return x
-    elif isinstance(x, types.FunctionType) or isinstance(x, types.MethodType):
+    elif isinstance(x, (types.FunctionType, types.MethodType)):
         return x
     else:
         raise ValueError(


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1483

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
1. I made the `ti.sync()` section `note` -> `warning` for #1483.
2. I fixed the `.. code-block:: python` no newline causing render issue in browser (**all people who changed doc please run `ti doc` and see if rendering is correct, thanks :)**)