### PR TITLE
[cli] Remove the never used 'tid' command

### DIFF
--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -58,9 +58,7 @@ endif()
 # Creating python enters
 file(MAKE_DIRECTORY bin)
 file(WRITE ${CMAKE_SOURCE_DIR}/bin/ti "#!${PYTHON_EXECUTABLE_PATH}\nimport taichi\nexit(taichi.main())")
-file(WRITE ${CMAKE_SOURCE_DIR}/bin/tid "#!${PYTHON_EXECUTABLE_PATH}\nimport taichi\nexit(taichi.main(debug=True))")
 execute_process(COMMAND chmod +x ${CMAKE_SOURCE_DIR}/bin/ti)
-execute_process(COMMAND chmod +x ${CMAKE_SOURCE_DIR}/bin/tid)
 execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/bin/ti ${CMAKE_SOURCE_DIR}/bin/taichi)
 
 

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -57,7 +57,7 @@ endif()
 
 # Creating python enters
 file(MAKE_DIRECTORY bin)
-file(WRITE ${CMAKE_SOURCE_DIR}/bin/ti "#!/usr/bin/env python3\nimport taichi\nexit(taichi.main())")
+file(WRITE ${CMAKE_SOURCE_DIR}/bin/ti "#!${PYTHON_EXECUTABLE}\nimport taichi\nexit(taichi.main())")
 execute_process(COMMAND chmod +x ${CMAKE_SOURCE_DIR}/bin/ti)
 execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/bin/ti ${CMAKE_SOURCE_DIR}/bin/taichi)
 

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -57,7 +57,7 @@ endif()
 
 # Creating python enters
 file(MAKE_DIRECTORY bin)
-file(WRITE ${CMAKE_SOURCE_DIR}/bin/ti "#!${PYTHON_EXECUTABLE_PATH}\nimport taichi\nexit(taichi.main())")
+file(WRITE ${CMAKE_SOURCE_DIR}/bin/ti "#!/usr/bin/env python3\nimport taichi\nexit(taichi.main())")
 execute_process(COMMAND chmod +x ${CMAKE_SOURCE_DIR}/bin/ti)
 execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/bin/ti ${CMAKE_SOURCE_DIR}/bin/taichi)
 

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -57,7 +57,7 @@ endif()
 
 # Creating python enters
 file(MAKE_DIRECTORY bin)
-file(WRITE ${CMAKE_SOURCE_DIR}/bin/ti "#!${PYTHON_EXECUTABLE}\nimport taichi\nexit(taichi.main())")
+file(WRITE ${CMAKE_SOURCE_DIR}/bin/ti "#!${PYTHON_EXECUTABLE_PATH}\nimport taichi\nexit(taichi.main())")
 execute_process(COMMAND chmod +x ${CMAKE_SOURCE_DIR}/bin/ti)
 execute_process(COMMAND cp ${CMAKE_SOURCE_DIR}/bin/ti ${CMAKE_SOURCE_DIR}/bin/taichi)
 

--- a/python/build.py
+++ b/python/build.py
@@ -49,10 +49,6 @@ if platform.system() == 'Linux':
         print('Only the wheel with clang will be released to PyPI.')
         sys.exit(-1)
 
-    if not gpu:
-        print('Linux release must ship with the CUDA backend.')
-        sys.exit(-1)
-
 with open('../setup.py') as fin:
     with open('setup.py', 'w') as fout:
         project_name = 'taichi'

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -50,7 +50,7 @@ def register(func):
 
 @registerableCLI
 class TaichiMain:
-    def __init__(self, debug: bool = False, test_mode: bool = False):
+    def __init__(self, test_mode: bool = False):
         self.banner = f"\n{'*' * 43}\n**      Taichi Programming Language      **\n{'*' * 43}"
         print(self.banner)
 
@@ -62,9 +62,6 @@ class TaichiMain:
                 raise ValueError(
                     "Environment variable TI_DEBUG can only have value 0 or 1."
                 )
-        if debug:
-            print(f"\n{'*' * 17} Debug Mode {'*' * 17}\n")
-            os.environ['TI_DEBUG'] = '1'
 
         parser = argparse.ArgumentParser(description="Taichi CLI",
                                          usage=self._usage())
@@ -1009,11 +1006,6 @@ class TaichiMain:
 
 def main():
     cli = TaichiMain()
-    return cli()
-
-
-def main_debug():
-    cli = TaichiMain(debug=True)
     return cli()
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setuptools.setup(name=project_name,
                  entry_points={
                      'console_scripts': [
                          'ti=taichi.main:main',
-                         'tid=taichi.main:main_debug',
                      ],
                  },
                  classifiers=classifiers,


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
1. Remove the `tid` command:
We already have `ti debug` and the `debug` argument in `main` seems useless...
In fact, it's already not functional at all:
```
root@archlinux ~/taichi (git)-[remove-tid-useless-bin-hook] # tid
[Taichi] mode=development
[Taichi] preparing sandbox at /tmp/taichi-6z2hiodm
[Taichi] <dev mode>, llvm 10.0.0, commit a93efc54, python 3.8.3
Traceback (most recent call last):
  File "/root/taichi/bin/tid", line 4, in <module>
    exit(taichi.main(debug=True))
TypeError: main() got an unexpected keyword argument 'debug'
```

2. Use `#!/usr/bin/env python3` instead of `#!${PYTHON_EXECUTABLE}`:
Well, what if one use anaconda python3?
The PYTHON_EXECUTABLE is determinated by the buildbots, I don't think it's always the same as end-users...
In contrast, `/usr/bin/env` will automatically search for `python3` in current `PATH`, which will make `ti` command work in anaconda python3.
@k-ye Just to confirm, is `/usr/bin/env` always available on Mac?

3. Make Linux users without CUDA able to use `ti dist`.
I thought our Linux buildbot have constant CUDA support? So no need for this confirm?