### PR TITLE
[Lang] Support "break" and "continue" in static-fors

### DIFF
--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -228,7 +228,7 @@ if 1:
   else:
     break
   ti.core.pop_scope()
-    '''
+'''
             cond = node.test
             t = ast.parse(template).body[0]
             t.body[1].value = cond
@@ -584,12 +584,12 @@ if 1:
         return node
 
     def visit_Module(self, node):
-        with self.variable_scope(), self.control_scope():
+        with self.variable_scope():
             self.generic_visit(node)
         return node
 
     def visit_Global(self, node):
-        with self.variable_scope(), self.control_scope():
+        with self.variable_scope():
             self.generic_visit(node)
         for name in node.names:
             self.create_variable(name)
@@ -682,7 +682,7 @@ if 1:
                 args.args[i].arg += '_by_value__'
                 arg_decls.append(arg_init)
 
-        with self.variable_scope(), self.control_scope():
+        with self.variable_scope():
             self.generic_visit(node)
 
         node.body = arg_decls + node.body

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -546,12 +546,15 @@ if 1:
 
     def visit_Break(self, node):
         if 'static' in self.current_control_scope():
-            return self.parse_stmt('break')
+            return node
         else:
             return self.parse_stmt('ti.core.insert_break_stmt()')
 
     def visit_Continue(self, node):
-        return self.parse_stmt('ti.core.insert_continue_stmt()')
+        if 'static' in self.current_control_scope():
+            return node
+        else:
+            return self.parse_stmt('ti.core.insert_continue_stmt()')
 
     def visit_Call(self, node):
         if not (isinstance(node.func, ast.Attribute)

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -220,14 +220,14 @@ class ASTTransformer(ast.NodeTransformer):
             self.current_control_scope().append('while')
 
             template = '''
-    if 1:
-      ti.core.begin_frontend_while(ti.Expr(1).ptr)
-      __while_cond = 0
-      if __while_cond:
-        pass
-      else:
-        break
-      ti.core.pop_scope()
+if 1:
+  ti.core.begin_frontend_while(ti.Expr(1).ptr)
+  __while_cond = 0
+  if __while_cond:
+    pass
+  else:
+    break
+  ti.core.pop_scope()
     '''
             cond = node.test
             t = ast.parse(template).body[0]

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -44,8 +44,8 @@ class ASTTransformer(ast.NodeTransformer):
         return ScopeGuard(self.local_scopes, *args)
 
     # e.g.: For, While
-    def control_scope(self, *args):
-        return ScopeGuard(self.control_scopes, *args)
+    def control_scope(self):
+        return ScopeGuard(self.control_scopes)
 
     def current_scope(self):
         return self.local_scopes[-1]

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -488,7 +488,8 @@ if 1:
             if decorator == 'static':
                 if double_decorator == 'static':
                     raise TaichiSyntaxError("'ti.static' cannot be nested")
-                return self.visit_static_for(node, double_decorator == 'grouped')
+                return self.visit_static_for(node,
+                                             double_decorator == 'grouped')
             elif decorator == 'ndrange':
                 if double_decorator != '':
                     raise TaichiSyntaxError(

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -10,7 +10,7 @@ class ScopeGuard:
         self.stmt_block = stmt_block
 
     def __enter__(self):
-        self.local_scopes.append([])
+        self.scopes.append([])
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         local = self.scopes[-1]

--- a/tests/python/test_static.py
+++ b/tests/python/test_static.py
@@ -51,3 +51,35 @@ def test_static_ndrange():
     for i in range(3):
         for j in range(3):
             assert x[i, j][i, j] == i + j * 2
+
+
+@ti.host_arch_only
+def test_static_break():
+    x = ti.var(ti.f32, 5)
+
+    @ti.kernel
+    def func():
+        for i in ti.static(range(5)):
+            x[i] = 1
+            if ti.static(i == 2):
+                break
+
+    func()
+
+    assert x.to_numpy() == np.array([1, 1, 1, 0, 0])
+
+
+@ti.host_arch_only
+def test_static_continue():
+    x = ti.var(ti.f32, 5)
+
+    @ti.kernel
+    def func():
+        for i in ti.static(range(5)):
+            x[i] = 1
+            if ti.static(i == 2):
+                continue
+
+    func()
+
+    assert x.to_numpy() == np.array([1, 1, 0, 1, 1])

--- a/tests/python/test_static.py
+++ b/tests/python/test_static.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import numpy as np
 
 
 @ti.all_archs
@@ -55,7 +56,7 @@ def test_static_ndrange():
 
 @ti.host_arch_only
 def test_static_break():
-    x = ti.var(ti.f32, 5)
+    x = ti.var(ti.i32, 5)
 
     @ti.kernel
     def func():
@@ -66,20 +67,20 @@ def test_static_break():
 
     func()
 
-    assert x.to_numpy() == np.array([1, 1, 1, 0, 0])
+    assert np.allclose(x.to_numpy(), np.array([1, 1, 1, 0, 0]))
 
 
 @ti.host_arch_only
 def test_static_continue():
-    x = ti.var(ti.f32, 5)
+    x = ti.var(ti.i32, 5)
 
     @ti.kernel
     def func():
         for i in ti.static(range(5)):
-            x[i] = 1
             if ti.static(i == 2):
                 continue
+            x[i] = 1
 
     func()
 
-    assert x.to_numpy() == np.array([1, 1, 0, 1, 1])
+    assert np.allclose(x.to_numpy(), np.array([1, 1, 0, 1, 1]))


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1495

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
I added the concept of `control_scope` to detect if the current loop is a static loop, so that we can prevent translating the `break` there to be breaking the grandparent non-static loop.