### PR TITLE
[cli] Fix "AttributeError" of pytest arguments

### DIFF
--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -718,19 +718,19 @@ class TaichiMain:
             pytest_args += ['-s', '-v']
         if args.rerun:
             pytest_args += ['--reruns', args.rerun]
-        if args.keys:
-            pytest_args += ['-k', args.keys]
-        if args.marks:
-            pytest_args += ['-m', args.marks]
-        if args.failed_first:
-            pytest_args += ['--failed-first']
-        if args.fail_fast:
-            pytest_args += ['--exitfirst']
         try:
             if args.coverage:
                 pytest_args += ['--cov-branch', '--cov=python/taichi']
             if args.cov_append:
                 pytest_args += ['--cov-append']
+            if args.keys:
+                pytest_args += ['-k', args.keys]
+            if args.marks:
+                pytest_args += ['-m', args.marks]
+            if args.failed_first:
+                pytest_args += ['--failed-first']
+            if args.fail_fast:
+                pytest_args += ['--exitfirst']
         except AttributeError:
             pass
 


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1216 #1465 

`args` doesn't have these attributes on my end.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
