### PR TITLE
[opt] Enable dead instruction elimination for RangeAssumptionStmt

### DIFF
--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -1003,10 +1003,6 @@ class RangeAssumptionStmt : public Stmt {
     return false;
   }
 
-  bool dead_instruction_eliminable() const override {
-    return false;
-  }
-
   TI_STMT_DEF_FIELDS(ret_type, input, base, low, high);
   TI_DEFINE_ACCEPT_AND_CLONE
 };


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://github.com/taichi-dev/taichi/pull/1497#discussion_r455256790

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
