### PR TITLE
[Linux] [llvm] Fix LLVM symbol leakage to prevent conflict with other libs using LLVM like GLX

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -153,10 +153,11 @@ if (NOT WIN32)
         # Linux
         target_link_libraries(${CORE_LIBRARY_NAME} stdc++fs X11)
         target_link_libraries(${CORE_LIBRARY_NAME} -static-libgcc -static-libstdc++)
+        target_link_libraries(${CORE_LIBRARY_NAME} -Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/misc/linker.map)
         target_link_libraries(${CORE_LIBRARY_NAME} -Wl,--wrap=log2f) # Avoid glibc dependencies
     endif()
 endif ()
-message("PYTHON_LIBRARIES" ${PYTHON_LIBRARIES})
+message("PYTHON_LIBRARIES: " ${PYTHON_LIBRARIES})
 
 foreach (source IN LISTS TAICHI_CORE_SOURCE)
     file(RELATIVE_PATH source_rel ${CMAKE_CURRENT_LIST_DIR} ${source})

--- a/misc/linker.map
+++ b/misc/linker.map
@@ -1,0 +1,10 @@
+{
+global:
+	extern "C++" {
+		taichi::*;
+	};
+local:
+	extern "C++" {
+		llvm::*;
+	};
+};


### PR DESCRIPTION
Related issue = fix #958

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
By using `libLLVM*.a`, we not only export `taichi::*` in our `libtaichi_core.so`, but also export `llvm::*`.
So that some symbols in `libLLVM-10.so` (also `llvm::*`) somehow gets replaced by those one in `libtaichi_core.so`, which is our **RTTI configured** LLVM, causing the conflict.
So, this PR uses a [LD version script](http://ftp.gnu.org/old-gnu/Manuals/ld-2.9.1/html_node/ld_25.html), to **prevent symbols in `llvm::*` being exported to global symbol table**, therefore fix the leakage conflict, ultimately.