### PR TITLE
[CUDA] [llvm] Format CUDA assertions and access out-of-bound errors on the host

### DIFF
--- a/taichi/backends/cpu/codegen_cpu.cpp
+++ b/taichi/backends/cpu/codegen_cpu.cpp
@@ -18,22 +18,6 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
     TI_AUTO_PROF
   }
 
-  void visit(AssertStmt *stmt) override {
-    if (stmt->args.empty()) {
-      CodeGenLLVM::visit(stmt);
-    } else {
-      std::vector<Value *> args;
-      args.emplace_back(get_runtime());
-      args.emplace_back(llvm_val[stmt->cond]);
-      args.emplace_back(builder->CreateGlobalStringPtr(stmt->text));
-      for (auto arg : stmt->args) {
-        TI_ASSERT(llvm_val[arg]);
-        args.emplace_back(llvm_val[arg]);
-      }
-      llvm_val[stmt] = create_call("taichi_assert_format", args);
-    }
-  }
-
   void create_offload_range_for(OffloadedStmt *stmt) override {
     int step = 1;
 

--- a/taichi/backends/cuda/jit_cuda.cpp
+++ b/taichi/backends/cuda/jit_cuda.cpp
@@ -46,7 +46,7 @@ class JITModuleCUDA : public JITModule {
     auto t = Time::get_time();
     CUDADriver::get_instance().module_get_function(&func, module, name.c_str());
     t = Time::get_time() - t;
-    TI_TRACE("Kernel {} compilation time: {}ms", name, t * 1000);
+    TI_TRACE("CUDA module_get_function {} costs {} ms", name, t * 1000);
     return func;
   }
 

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -889,42 +889,38 @@ void CodeGenLLVM::visit(LocalStoreStmt *stmt) {
 }
 
 void CodeGenLLVM::visit(AssertStmt *stmt) {
-  if (stmt->args.empty()) {
-    llvm_val[stmt] = call("taichi_assert", get_context(), llvm_val[stmt->cond],
-                          builder->CreateGlobalStringPtr(stmt->text));
-  } else {
-    auto argument_buffer_size = llvm::ArrayType::get(
-        llvm::Type::getInt64Ty(*llvm_context), stmt->args.size());
-    // TODO: maybe let all asserts in a single offload share a single buffer?
-    auto arguments = create_entry_block_alloca(argument_buffer_size);
+  TI_ASSERT((int)stmt->args.size() <= taichi_error_message_max_num_arguments);
+  auto argument_buffer_size = llvm::ArrayType::get(
+      llvm::Type::getInt64Ty(*llvm_context), stmt->args.size());
+  // TODO: maybe let all asserts in a single offload share a single buffer?
+  auto arguments = create_entry_block_alloca(argument_buffer_size);
 
-    std::vector<Value *> args;
-    args.emplace_back(get_runtime());
-    args.emplace_back(llvm_val[stmt->cond]);
-    args.emplace_back(builder->CreateGlobalStringPtr(stmt->text));
+  std::vector<Value *> args;
+  args.emplace_back(get_runtime());
+  args.emplace_back(llvm_val[stmt->cond]);
+  args.emplace_back(builder->CreateGlobalStringPtr(stmt->text));
 
-    for (int i = 0; i < stmt->args.size(); i++) {
-      auto arg = stmt->args[i];
-      TI_ASSERT(llvm_val[arg]);
+  for (int i = 0; i < stmt->args.size(); i++) {
+    auto arg = stmt->args[i];
+    TI_ASSERT(llvm_val[arg]);
 
-      auto cast_type = llvm::Type::getIntNTy(
-          *llvm_context,
-          8 * (std::size_t)data_type_size(arg->ret_type.data_type));
-      auto cast_int = builder->CreateBitCast(llvm_val[arg], cast_type);
-      auto cast_int64 =
-          builder->CreateZExt(cast_int, llvm::Type::getInt64Ty(*llvm_context));
+    auto cast_type = llvm::Type::getIntNTy(
+        *llvm_context,
+        8 * (std::size_t)data_type_size(arg->ret_type.data_type));
+    auto cast_int = builder->CreateBitCast(llvm_val[arg], cast_type);
+    auto cast_int64 =
+        builder->CreateZExt(cast_int, llvm::Type::getInt64Ty(*llvm_context));
 
-      builder->CreateStore(
-          cast_int64, builder->CreateGEP(arguments, {tlctx->get_constant(0),
-                                                     tlctx->get_constant(i)}));
-    }
-
-    args.emplace_back(tlctx->get_constant((int)stmt->args.size()));
-    args.emplace_back(builder->CreateGEP(
-        arguments, {tlctx->get_constant(0), tlctx->get_constant(0)}));
-
-    llvm_val[stmt] = create_call("taichi_assert_format", args);
+    builder->CreateStore(
+        cast_int64, builder->CreateGEP(arguments, {tlctx->get_constant(0),
+                                                   tlctx->get_constant(i)}));
   }
+
+  args.emplace_back(tlctx->get_constant((int)stmt->args.size()));
+  args.emplace_back(builder->CreateGEP(
+      arguments, {tlctx->get_constant(0), tlctx->get_constant(0)}));
+
+  llvm_val[stmt] = create_call("taichi_assert_format", args);
 }
 
 void CodeGenLLVM::visit(SNodeOpStmt *stmt) {

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -9,8 +9,8 @@ constexpr int taichi_max_gpu_block_dim = 1024;
 constexpr std::size_t taichi_global_tmp_buffer_size = 1024 * 1024;
 constexpr int taichi_max_num_mem_requests = 1024 * 64;
 constexpr std::size_t taichi_page_size = 4096;
-constexpr std::size_t taichi_max_message_length = 2048;
-constexpr std::size_t taichi_max_message_num_arguments = 32;
+constexpr std::size_t taichi_error_message_max_length = 2048;
+constexpr std::size_t taichi_error_message_max_num_arguments = 32;
 constexpr std::size_t taichi_result_buffer_entries = 32;
 // slot for kernel return value
 constexpr std::size_t taichi_result_buffer_ret_value_id = 0;

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -10,6 +10,7 @@ constexpr std::size_t taichi_global_tmp_buffer_size = 1024 * 1024;
 constexpr int taichi_max_num_mem_requests = 1024 * 64;
 constexpr std::size_t taichi_page_size = 4096;
 constexpr std::size_t taichi_max_message_length = 2048;
+constexpr std::size_t taichi_max_message_num_arguments = 32;
 constexpr std::size_t taichi_result_buffer_entries = 32;
 // slot for kernel return value
 constexpr std::size_t taichi_result_buffer_ret_value_id = 0;

--- a/taichi/llvm/llvm_codegen_utils.cpp
+++ b/taichi/llvm/llvm_codegen_utils.cpp
@@ -16,7 +16,9 @@ void check_func_call_signature(llvm::Value *func,
   if (func_type->isFunctionVarArg()) {
     TI_ASSERT(num_params <= arglist.size());
   } else {
-    TI_ASSERT(num_params == arglist.size());
+    TI_ERROR_IF(num_params != arglist.size(),
+                "Function requires {} arguments but {} provided", num_params,
+                arglist.size());
   }
 
   for (int i = 0; i < num_params; i++) {

--- a/taichi/llvm/llvm_codegen_utils.h
+++ b/taichi/llvm/llvm_codegen_utils.h
@@ -64,7 +64,6 @@ class LLVMModuleBuilder {
     TI_ASSERT(this->module != nullptr);
     TI_ASSERT(&this->module->getContext() == tlctx->get_this_thread_context());
   }
-
   llvm::Value *create_entry_block_alloca(llvm::Type *type,
                                          std::size_t alignment = 0) {
     llvm::IRBuilderBase::InsertPointGuard guard(*builder);

--- a/taichi/llvm/llvm_codegen_utils.h
+++ b/taichi/llvm/llvm_codegen_utils.h
@@ -64,6 +64,7 @@ class LLVMModuleBuilder {
     TI_ASSERT(this->module != nullptr);
     TI_ASSERT(&this->module->getContext() == tlctx->get_this_thread_context());
   }
+
   llvm::Value *create_entry_block_alloca(llvm::Type *type,
                                          std::size_t alignment = 0) {
     llvm::IRBuilderBase::InsertPointGuard guard(*builder);

--- a/taichi/runtime/llvm/internal_functions.h
+++ b/taichi/runtime/llvm/internal_functions.h
@@ -1,12 +1,12 @@
 // Note that TI_ASSERT provided by runtime doesn't check fail immediately. As
 // a hack, we just check the last error code whenever we call TI_ASSERT.
-#define TI_TEST_CHECK(cond, r)                             \
-  do {                                                     \
-    TI_ASSERT(cond);                                       \
-    if ((r)->error_code) {                                 \
-      taichi_printf((r), "%s", (r)->error_message_buffer); \
-      abort();                                             \
-    }                                                      \
+#define TI_TEST_CHECK(cond, r)                               \
+  do {                                                       \
+    TI_ASSERT(cond);                                         \
+    if ((r)->error_code) {                                   \
+      taichi_printf((r), "%s", (r)->error_message_template); \
+      abort();                                               \
+    }                                                        \
   } while (0)
 
 i32 do_nothing(Context *context) {

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -674,8 +674,11 @@ void taichi_assert_format(LLVMRuntime *runtime,
   locked_task(&runtime->error_message_lock, [&] {
     if (!runtime->error_code) {
       runtime->error_code = 1;  // Assertion failure
+
+      memset(runtime->error_message_template, 0,
+             taichi_error_message_max_length);
       memcpy(runtime->error_message_template, format,
-             std::min(strlen(format), taichi_error_message_max_length));
+             std::min(strlen(format), taichi_error_message_max_length - 1));
       for (int i = 0; i < num_arguments; i++) {
         runtime->error_message_arguments[i] = arguments[i];
       }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -516,7 +516,9 @@ struct LLVMRuntime {
 
   template <typename T>
   void set_result(std::size_t i, T t) {
-    ((u64 *)result_buffer)[i] = taichi_union_cast<uint64>(t);
+    static_assert(sizeof(T) <= sizeof(uint64));
+    ((u64 *)result_buffer)[i] =
+        taichi_union_cast_with_different_sizes<uint64>(t);
   }
 
   template <typename T, typename... Args>
@@ -639,9 +641,9 @@ void runtime_retrieve_error_code(LLVMRuntime *runtime) {
   runtime->set_result(taichi_result_buffer_error_id, runtime->error_code);
 }
 
-void runtime_retrieve_error_message(LLVMRuntime *runtime) {
+void runtime_retrieve_error_message(LLVMRuntime *runtime, int i) {
   runtime->set_result(taichi_result_buffer_error_id,
-                      runtime->error_message_template);
+                      runtime->error_message_template[i]);
 }
 
 void runtime_retrieve_error_message_argument(LLVMRuntime *runtime,

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1,9 +1,6 @@
 // This file will only be compiled into llvm bitcode by clang.
 // The generated bitcode will likely get inlined for performance.
 
-// TODO: rename error message buffer to format buffer
-// TODO: remove host_vnsprintf
-
 #if !defined(TI_INCLUDED) || !defined(_WIN32)
 
 #include <atomic>
@@ -520,7 +517,7 @@ struct LLVMRuntime {
   void (*profiler_start)(Ptr, Ptr);
   void (*profiler_stop)(Ptr);
 
-  char error_message_buffer[taichi_max_message_length];
+  char error_message_template[taichi_max_message_length];
   uint64 error_message_arguments[taichi_max_message_length];
   i32 error_message_lock = 0;
   i64 error_code = 0;
@@ -657,7 +654,7 @@ void runtime_retrieve_error_code(LLVMRuntime *runtime) {
 
 void runtime_retrieve_error_message(LLVMRuntime *runtime) {
   runtime->set_result(taichi_result_buffer_error_id,
-                      runtime->error_message_buffer);
+                      runtime->error_message_template);
 }
 
 void runtime_retrieve_error_message_argument(LLVMRuntime *runtime,
@@ -679,7 +676,7 @@ void taichi_assert_runtime(LLVMRuntime *runtime, i32 test, const char *msg) {
       locked_task(&runtime->error_message_lock, [&] {
         if (!runtime->error_code) {
           runtime->error_code = 1;  // Assertion failure
-          memcpy(runtime->error_message_buffer, msg,
+          memcpy(runtime->error_message_template, msg,
                  std::min(strlen(msg), taichi_max_message_length));
         }
       });
@@ -693,7 +690,7 @@ void taichi_assert_runtime(LLVMRuntime *runtime, i32 test, const char *msg) {
   locked_task(&runtime->error_message_lock, [&] {
     if (!runtime->error_code) {
       runtime->error_code = 1;  // Assertion failure
-      memcpy(runtime->error_message_buffer, msg,
+      memcpy(runtime->error_message_template, msg,
              std::min(strlen(msg), taichi_max_message_length));
     }
   });
@@ -718,7 +715,7 @@ void taichi_assert_format(LLVMRuntime *runtime,
   locked_task(&runtime->error_message_lock, [&] {
     if (!runtime->error_code) {
       runtime->error_code = 1;  // Assertion failure
-      memcpy(runtime->error_message_buffer, format,
+      memcpy(runtime->error_message_template, format,
              std::min(strlen(format), taichi_max_message_length));
       for (int i = 0; i < num_arguments; i++) {
         runtime->error_message_arguments[i] = arguments[i];

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -40,7 +40,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
 
     std::string msg = fmt::format("(kernel={}) Accessing Tensor of size [",
                                   stmt->get_kernel()->name);
-    std::string offset_msg = "Offset [";
+    std::string offset_msg = "offset [";
     std::vector<Stmt *> args;
     for (int i = 0; i < stmt->indices.size(); i++) {
       int offset_i = has_offset ? snode->index_offsets[i] : 0;
@@ -69,8 +69,8 @@ class CheckOutOfBound : public BasicStmtVisitor {
       offset_msg += std::to_string(offset_i);
       args.emplace_back(stmt->indices[i]);
     }
-    offset_msg += "]";
-    msg += "] " + (has_offset ? offset_msg : "") + " with indices (";
+    offset_msg += "] ";
+    msg += "] " + (has_offset ? offset_msg : "") + "with indices (";
     for (int i = 0; i < stmt->indices.size(); i++) {
       if (i > 0)
         msg += ", ";

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -38,7 +38,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
     Stmt *result =
         new_stmts.push_back<ConstStmt>(LaneAttribute<TypedConstant>(true));
 
-    std::string msg = fmt::format("(kernel={}) Accessing Tensor of Size [",
+    std::string msg = fmt::format("(kernel={}) Accessing Tensor of size [",
                                   stmt->get_kernel()->name);
     std::string offset_msg = "Offset [";
     std::vector<Stmt *> args;


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

 - `error_message_buffer` is renamed to `error_message_template` since it's no longer formatted on the backend device

Maybe it's time to think about unifying the `print`/`assert` functionalities on LLVM/Metal/OpenGL backends. https://github.com/taichi-dev/taichi/issues/1434 may worth considering when designing the shared infrastructure.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
