### PR TITLE
[test] Fix test_field.py

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -823,10 +823,10 @@ class Matrix(TaichiOperations):
         return cls.field(n, m, dt, *args, **kwargs)
 
     @classmethod
-    def _Vector_field(cls, n, dt, *args, **kwargs):
+    def _Vector_field(cls, n, dtype, *args, **kwargs):
         '''ti.Vector.field'''
         _taichi_skip_traceback = 1
-        return cls.field(n, 1, dt, *args, **kwargs)
+        return cls.field(n, 1, dtype, *args, **kwargs)
 
     @classmethod
     #@deprecated('ti.Vector.var', 'ti.Vector.field')

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -31,7 +31,7 @@ def test_scalar_field(dtype, shape):
 @pytest.mark.parametrize('shape', field_shapes)
 @ti.host_arch_only
 def test_vector_field(n, dtype, shape):
-    x = ti.Vector.field(n, dt=dtype, shape=shape)
+    x = ti.Vector.field(n, dtype=dtype, shape=shape)
 
     if isinstance(shape, tuple):
         assert x.shape == shape

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -31,7 +31,7 @@ def test_scalar_field(dtype, shape):
 @pytest.mark.parametrize('shape', field_shapes)
 @ti.host_arch_only
 def test_vector_field(n, dtype, shape):
-    x = ti.Vector.field(n, dtype=dtype, shape=shape)
+    x = ti.Vector.field(n, dt=dtype, shape=shape)
 
     if isinstance(shape, tuple):
         assert x.shape == shape
@@ -47,7 +47,7 @@ def test_vector_field(n, dtype, shape):
 @pytest.mark.parametrize('dtype', data_types)
 @pytest.mark.parametrize('shape', field_shapes)
 @ti.host_arch_only
-def test_matrix_field(n, M, dtype, shape):
+def test_matrix_field(n, m, dtype, shape):
     x = ti.Matrix.field(n, m, dtype=dtype, shape=shape)
 
     if isinstance(shape, tuple):


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related PR = #1502 

Code formatting can often lead to a new commit that doesn't trigger CI, which may hide some test failures if we only look at the build state of the final commit.

I was getting
```
FAILED tests/python/test_field.py::test_vector_field[shape0-dtype1-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[8-dtype1-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[8-dtype1-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape2-dtype0-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape0-dtype0-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape2-dtype0-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[8-dtype0-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape2-dtype1-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape3-dtype0-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape2-dtype1-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape3-dtype1-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape3-dtype0-2] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape3-dtype1-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape0-dtype1-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[shape0-dtype0-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
FAILED tests/python/test_field.py::test_vector_field[8-dtype0-3] - TypeError: _Vector_field() missing 1 required positional argument: 'dt'
```
 and 
```
In test_matrix_field: function uses no argument 'm'
```

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
