### PR TITLE
[Doc] Update our documents from ti.var to ti.field

### DIFF
--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -30,8 +30,8 @@ We allocate two 1D tensors to simplify discussion:
 
 .. code-block:: python
 
-  x = ti.var(dt=ti.f32, shape=128)
-  y = ti.var(dt=ti.f32, shape=16)
+  x = ti.field(dt=ti.f32, shape=128)
+  y = ti.field(dt=ti.f32, shape=16)
 
 
 Kernel registration

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -85,7 +85,7 @@ For now, Taichi-scope ``print`` supports string, scalar, vector, and matrix expr
 
         import taichi as ti
         ti.init(arch=ti.cpu)
-        a = ti.var(ti.f32, 4)
+        a = ti.field(ti.f32, 4)
 
 
         @ti.kernel
@@ -107,7 +107,7 @@ It is similar to Python-scope ``print``.
 
 .. code-block:: python
 
-    x = ti.var(ti.f32, (2, 3))
+    x = ti.field(ti.f32, (2, 3))
     y = 1
 
     @ti.kernel
@@ -140,7 +140,7 @@ For performance reason, ``assert`` only works when ``debug`` mode is on, For exa
 
     ti.init(arch=ti.cpu, debug=True)
 
-    x = ti.var(ti.f32, 128)
+    x = ti.field(ti.f32, 128)
 
     @ti.kernel
     def do_sqrt_all():

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -26,7 +26,7 @@ Export images using ``ti.GUI.show``
 
     ti.init()
 
-    pixels = ti.var(ti.u8, shape=(512, 512, 3))
+    pixels = ti.field(ti.u8, shape=(512, 512, 3))
 
     @ti.kernel
     def paint():
@@ -57,7 +57,7 @@ To save images without invoking ``ti.GUI.show(filename)``, use ``ti.imwrite(file
 
         ti.init()
 
-        pixels = ti.var(ti.u8, shape=(512, 512, 3))
+        pixels = ti.field(ti.u8, shape=(512, 512, 3))
 
         @ti.kernel
         def set_pixels():
@@ -69,7 +69,7 @@ To save images without invoking ``ti.GUI.show(filename)``, use ``ti.imwrite(file
         ti.imwrite(pixels.to_numpy(), filename)
         print(f'The image has been saved to {filename}')
 
-- ``ti.imwrite`` can export Taichi tensors (``ti.Matrix``, ``ti.Vector``, ``ti.var``) and numpy tensors ``np.ndarray``.
+- ``ti.imwrite`` can export Taichi tensors (``ti.Matrix``, ``ti.Vector``, ``ti.field``) and numpy tensors ``np.ndarray``.
 - Same as above ``ti.GUI.show(filename)``, the image format (``png``, ``jpg`` and ``bmp``) is also controlled by the suffix of ``filename`` in ``ti.imwrite(filename)``.
 - Meanwhile, the resulted image type (grayscale, RGB, or RGBA) is determined by **the number of channels in the input tensor**, i.e., the length of the third dimension (``tensor.shape[2]``).
 - In other words, a tensor that has shape ``(w, h)`` or ``(w, h, 1)`` will be exported as a grayscale image.
@@ -96,7 +96,7 @@ Export videos
 
     ti.init()
 
-    pixels = ti.var(ti.u8, shape=(512, 512, 3))
+    pixels = ti.field(ti.u8, shape=(512, 512, 3))
 
     @ti.kernel
     def paint():

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -21,7 +21,7 @@ Use ``to_numpy``/``from_numpy``/``to_torch``/``from_torch``:
   m = 7
 
   # Taichi tensors
-  val = ti.var(ti.i32, shape=(n, m))
+  val = ti.field(ti.i32, shape=(n, m))
   vec = ti.Vector(3, dt=ti.i32, shape=(n, m))
   mat = ti.Matrix(3, 4, dt=ti.i32, shape=(n, m))
 
@@ -74,7 +74,7 @@ Note that struct-for's on external arrays are not supported.
   n = 4
   m = 7
 
-  val = ti.var(ti.i32, shape=(n, m))
+  val = ti.field(ti.i32, shape=(n, m))
 
   @ti.kernel
   def test_numpy(arr: ti.ext_arr()):

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -63,9 +63,9 @@ Paint on a window
 
     If the window size is ``(x, y)``, then ``img`` must be one of:
 
-    * ``ti.var(shape=(x, y))``, a grey-scale image
+    * ``ti.field(shape=(x, y))``, a grey-scale image
 
-    * ``ti.var(shape=(x, y, 3))``, where `3` is for ``(r, g, b)`` channels
+    * ``ti.field(shape=(x, y, 3))``, where `3` is for ``(r, g, b)`` channels
 
     * ``ti.Vector(3, shape=(x, y))`` (see :ref:`vector`)
 
@@ -387,7 +387,7 @@ Image I/O
     :parameter img: (Matrix or Expr) the image you want to export
     :parameter filename: (string) the location you want to save to
 
-    Export a ``np.ndarray`` or Taichi tensor (``ti.Matrix``, ``ti.Vector``, or ``ti.var``) to a specified location ``filename``.
+    Export a ``np.ndarray`` or Taichi tensor (``ti.Matrix``, ``ti.Vector``, or ``ti.field``) to a specified location ``filename``.
 
     Same as ``ti.GUI.show(filename)``, the format of the exported image is determined by **the suffix of** ``filename`` as well. Now ``ti.imwrite`` supports exporting images to ``png``, ``img`` and ``jpg`` and we recommend using ``png``.
 
@@ -401,7 +401,7 @@ Image I/O
 
         shape = (512, 512)
         type = ti.u8
-        pixels = ti.var(dt=type, shape=shape)
+        pixels = ti.field(dt=type, shape=shape)
 
         @ti.kernel
         def draw():

--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -17,7 +17,7 @@ Running the Taichi code below (``python3 fractal.py`` or ``ti example fractal``)
     ti.init(arch=ti.gpu)
 
     n = 320
-    pixels = ti.var(dt=ti.f32, shape=(n * 2, n))
+    pixels = ti.field(dt=ti.f32, shape=(n * 2, n))
 
 
     @ti.func
@@ -107,7 +107,7 @@ Taichi programs run on either CPUs or GPUs. Initialize Taichi according to your 
 Taichi is a data-oriented programming language where dense or spatially-sparse tensors are the first-class citizens.
 See :ref:`sparse` for more details on sparse tensors.
 
-In the code above, ``pixels = ti.var(dt=ti.f32, shape=(n * 2, n))`` allocates a 2D dense tensor named ``pixels`` of
+In the code above, ``pixels = ti.field(dt=ti.f32, shape=(n * 2, n))`` allocates a 2D dense tensor named ``pixels`` of
 size ``(640, 320)`` and element data type ``ti.f32`` (i.e. ``float`` in C).
 
 Functions and kernels
@@ -247,7 +247,7 @@ For example, to access a single pixel of the rendered image in Python-scope, sim
 .. code-block:: python
 
   import taichi as ti
-  pixels = ti.var(ti.f32, (1024, 512))
+  pixels = ti.field(ti.f32, (1024, 512))
 
   pixels[42, 11] = 0.7  # store data into pixels
   print(pixels[42, 11]) # prints 0.7
@@ -262,7 +262,7 @@ So that you can also use your favorite Python packages (e.g. ``numpy``, ``pytorc
 .. code-block:: python
 
     import taichi as ti
-    pixels = ti.var(ti.f32, (1024, 512))
+    pixels = ti.field(ti.f32, (1024, 512))
 
     import numpy as np
     arr = np.random.rand(1024, 512)

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -31,7 +31,7 @@ For example,
 
     ti.init(print_ir=True)
 
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     ti.root.dense(ti.i, 4).bitmasked(ti.i, 4).place(x)
 
     @ti.kernel
@@ -156,7 +156,7 @@ correspond to?
 Each ``SNode`` can have a different virtual-to-physical mapping. ``physical_index_position[i] == -1``
 means the ``i``-th virtual index does not corrspond to any physical index in this ``SNode``.
 
-``SNode`` s in handy dense tensors (i.e., ``a = ti.var(ti.i32, shape=(128, 256, 512))``)
+``SNode`` s in handy dense tensors (i.e., ``a = ti.field(ti.i32, shape=(128, 256, 512))``)
 have **trivial** virtual-to-physical mapping, e.g. ``physical_index_position[i] = i``.
 
 However, more complex data layouts, such as column-major 2D tensors can lead to ``SNodes`` with
@@ -164,9 +164,9 @@ However, more complex data layouts, such as column-major 2D tensors can lead to 
 
 .. code-block:: python
 
-    a = ti.var(ti.f32, shape=(128, 32, 8))
+    a = ti.field(ti.f32, shape=(128, 32, 8))
 
-    b = ti.var(ti.f32)
+    b = ti.field(ti.f32)
     ti.root.dense(ti.j, 32).dense(ti.i, 16).place(b)
 
     ti.get_runtime().materialize()

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -6,7 +6,7 @@ Advanced dense layouts
 Tensors (:ref:`scalar_tensor`) can be *placed* in a specific shape and *layout*.
 Defining a proper layout can be critical to performance, especially for memory-bound applications. A carefully designed data layout can significantly improve cache/TLB-hit rates and cacheline utilization. Although when performance is not the first priority, you probably don't have to worry about it.
 
-In Taichi, the layout is defined in a recursive manner. See :ref:`snode` for more details about how this works. We suggest starting with the default layout specification (simply by specifying ``shape`` when creating tensors using ``ti.var/Vector/Matrix``),
+In Taichi, the layout is defined in a recursive manner. See :ref:`snode` for more details about how this works. We suggest starting with the default layout specification (simply by specifying ``shape`` when creating tensors using ``ti.field/Vector/Matrix``),
 and then migrate to more advanced layouts using the ``ti.root.X`` syntax if necessary.
 
 Taichi decouples algorithms from data layouts, and the Taichi compiler automatically optimizes data accesses on a specific data layout. These Taichi features allow programmers to quickly experiment with different data layouts and figure out the most efficient one on a specific task and computer architecture.
@@ -19,28 +19,28 @@ For example, this declares a 0-D tensor:
 
 .. code-block:: python
 
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
     ti.root.place(x)
     # is equivalent to:
-    x = ti.var(ti.f32, shape=())
+    x = ti.field(ti.f32, shape=())
 
 This declares a 1D tensor of size ``3``:
 
 .. code-block:: python
 
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
     ti.root.dense(ti.i, 3).place(x)
     # is equivalent to:
-    x = ti.var(ti.f32, shape=3)
+    x = ti.field(ti.f32, shape=3)
 
 This declares a 2D tensor of shape ``(3, 4)``:
 
 .. code-block:: python
 
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
     ti.root.dense(ti.ij, (3, 4)).place(x)
     # is equivalent to:
-    x = ti.var(ti.f32, shape=(3, 4))
+    x = ti.field(ti.f32, shape=(3, 4))
 
 You may wonder, why not simply specify the ``shape`` of the tensor? Why bother using the more complex version?
 Good question, let go forward and figure out why.
@@ -137,8 +137,8 @@ Take a simple 1D wave equation solver for example:
 .. code-block:: python
 
     N = 200000
-    pos = ti.var(ti.f32)
-    vel = ti.var(ti.f32)
+    pos = ti.field(ti.f32)
+    vel = ti.field(ti.f32)
     ti.root.dense(ti.i, N).place(pos)
     ti.root.dense(ti.i, N).place(vel)
 
@@ -161,11 +161,11 @@ Then ``vel[i]`` is placed right next to ``pos[i]``, this can increase the cache-
 Flat layouts versus hierarchical layouts
 ----------------------------------------
 
-By default, when allocating a ``ti.var``, it follows the simplest data layout.
+By default, when allocating a ``ti.field``, it follows the simplest data layout.
 
 .. code-block:: python
 
-  val = ti.var(ti.f32, shape=(32, 64, 128))
+  val = ti.field(ti.f32, shape=(32, 64, 128))
   # C++ equivalent: float val[32][64][128]
 
 However, at times this data layout can be suboptimal for certain types of computer graphics tasks.
@@ -175,7 +175,7 @@ A better layout might be
 
 .. code-block:: python
 
-  val = ti.var(ti.f32)
+  val = ti.field(ti.f32)
   ti.root.dense(ti.ijk, (8, 16, 32)).dense(ti.ijk, (4, 4, 4)).place(val)
 
 This organizes ``val`` in ``4x4x4`` blocks, so that with high probability ``val[i, j, k]`` and its neighbours are close to each other (i.e., in the same cacheline or memory page).
@@ -205,21 +205,21 @@ Examples
 
 .. code-block:: python
 
-  A = ti.var(ti.f32)
+  A = ti.field(ti.f32)
   ti.root.dense(ti.ij, (256, 256)).place(A)
 
 2D matrix, column-major
 
 .. code-block:: python
 
-  A = ti.var(ti.f32)
+  A = ti.field(ti.f32)
   ti.root.dense(ti.ji, (256, 256)).place(A) # Note ti.ji instead of ti.ij
 
 `8x8` blocked 2D array of size `1024x1024`
 
 .. code-block:: python
 
-  density = ti.var(ti.f32)
+  density = ti.field(ti.f32)
   ti.root.dense(ti.ij, (128, 128)).dense(ti.ij, (8, 8)).place(density)
 
 

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -42,7 +42,7 @@ As global tensors of matrices
 
 .. note::
 
-    In Python-scope, ``ti.var`` declares :ref:`scalar_tensor`, while ``ti.Matrix`` declares tensors of matrices.
+    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Matrix`` declares tensors of matrices.
 
 
 As a temporary local variable

--- a/docs/odop.rst
+++ b/docs/odop.rst
@@ -22,8 +22,8 @@ A brief example:
     def __init__(self, n, m, increment):
       self.n = n
       self.m = m
-      self.val = ti.var(ti.f32)
-      self.total = ti.var(ti.f32)
+      self.val = ti.field(ti.f32)
+      self.total = ti.field(ti.f32)
       self.increment = increment
       ti.root.dense(ti.ij, (self.n, self.m)).place(self.val)
       ti.root.place(self.total)
@@ -50,7 +50,7 @@ A brief example:
 
   arr = Array2D(128, 128, 3)
 
-  double_total = ti.var(ti.f32, shape=())
+  double_total = ti.field(ti.f32, shape=())
 
   ti.root.lazy_grad()
 

--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -27,6 +27,6 @@ In this way, the tensor's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusi
     b = ti.Vector(3, dt=ti.f32, shape=(16, 32, 64), offset=(7, 3, -4))   # Works!
     c = ti.Matrix(2, 1, dt=ti.f32, shape=None, offset=(32,))             # AssertionError
     d = ti.Matrix(3, 2, dt=ti.f32, shape=(32, 32), offset=(-16, ))       # AssertionError
-    e = ti.var(dt=ti.i32, shape=16, offset=-16)                          # Works!
-    f = ti.var(dt=ti.i32, shape=None, offset=-16)                        # AssertionError
-    g = ti.var(dt=ti.i32, shape=(16, 32), offset=-16)                    # AssertionError
+    e = ti.field(dt=ti.i32, shape=16, offset=-16)                          # Works!
+    f = ti.field(dt=ti.i32, shape=None, offset=-16)                        # AssertionError
+    g = ti.field(dt=ti.i32, shape=(16, 32), offset=-16)                    # AssertionError

--- a/docs/profiler.rst
+++ b/docs/profiler.rst
@@ -16,7 +16,7 @@ ScopedProfiler
     import taichi as ti
 
     ti.init(arch=ti.cpu)
-    var = ti.var(ti.f32, shape=1)
+    var = ti.field(ti.f32, shape=1)
 
 
     @ti.kernel
@@ -48,7 +48,7 @@ KernelProfiler
     import taichi as ti
 
     ti.init(ti.cpu, kernel_profiler=True)
-    var = ti.var(ti.f32, shape=1)
+    var = ti.field(ti.f32, shape=1)
 
 
     @ti.kernel

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -7,7 +7,7 @@ Tensors of scalars
 Declaration
 -----------
 
-.. function:: ti.var(dt, shape = None, offset = None)
+.. function:: ti.field(dt, shape = None, offset = None)
 
     :parameter dt: (DataType) type of the tensor element
     :parameter shape: (optional, scalar or tuple) the shape of tensor
@@ -16,17 +16,17 @@ Declaration
     For example, this creates a *dense* tensor with four ``int32`` as elements:
     ::
 
-        x = ti.var(ti.i32, shape=4)
+        x = ti.field(ti.i32, shape=4)
 
     This creates a 4x3 *dense* tensor with ``float32`` elements:
     ::
 
-        x = ti.var(ti.f32, shape=(4, 3))
+        x = ti.field(ti.f32, shape=(4, 3))
 
     If shape is ``()`` (empty tuple), then a 0-D tensor (scalar) is created:
     ::
 
-        x = ti.var(ti.f32, shape=())
+        x = ti.field(ti.f32, shape=())
 
     Then access it by passing ``None`` as index:
     ::
@@ -36,9 +36,9 @@ Declaration
     If shape is **not provided** or ``None``, the user must manually ``place`` it afterwards:
     ::
 
-        x = ti.var(ti.f32)
+        x = ti.field(ti.f32)
         ti.root.dense(ti.ij, (4, 3)).place(x)
-        # equivalent to: x = ti.var(ti.f32, shape=(4, 3))
+        # equivalent to: x = ti.field(ti.f32, shape=(4, 3))
 
 .. note::
 
@@ -51,25 +51,25 @@ Declaration
 
     .. code-block:: python
 
-        x = ti.var(ti.f32)
+        x = ti.field(ti.f32)
         x[None] = 1 # ERROR: x not placed!
 
     .. code-block:: python
 
-        x = ti.var(ti.f32, shape=())
+        x = ti.field(ti.f32, shape=())
         @ti.kernel
         def func():
             x[None] = 1
 
         func()
-        y = ti.var(ti.f32, shape=())
+        y = ti.field(ti.f32, shape=())
         # ERROR: cannot create tensor after kernel invocation!
 
     .. code-block:: python
 
-        x = ti.var(ti.f32, shape=())
+        x = ti.field(ti.f32, shape=())
         x[None] = 1
-        y = ti.var(ti.f32, shape=())
+        y = ti.field(ti.f32, shape=())
         # ERROR: cannot create tensor after any tensor accesses from the Python-scope!
 
 
@@ -114,13 +114,13 @@ Meta data
 
     ::
 
-        x = ti.var(ti.i32, (6, 5))
+        x = ti.field(ti.i32, (6, 5))
         x.dim()  # 2
 
-        y = ti.var(ti.i32, 6)
+        y = ti.field(ti.i32, 6)
         y.dim()  # 1
 
-        z = ti.var(ti.i32, ())
+        z = ti.field(ti.i32, ())
         z.dim()  # 0
 
 
@@ -131,13 +131,13 @@ Meta data
 
     ::
 
-        x = ti.var(ti.i32, (6, 5))
+        x = ti.field(ti.i32, (6, 5))
         x.shape()  # (6, 5)
 
-        y = ti.var(ti.i32, 6)
+        y = ti.field(ti.i32, 6)
         y.shape()  # (6,)
 
-        z = ti.var(ti.i32, ())
+        z = ti.field(ti.i32, ())
         z.shape()  # ()
 
 
@@ -148,7 +148,7 @@ Meta data
 
     ::
 
-        x = ti.var(ti.i32, (2, 3))
+        x = ti.field(ti.i32, (2, 3))
         x.data_type()  # ti.i32
 
 
@@ -160,8 +160,8 @@ Meta data
 
     ::
 
-        x = ti.var(ti.i32)
-        y = ti.var(ti.i32)
+        x = ti.field(ti.i32)
+        y = ti.field(ti.i32)
         blk1 = ti.root.dense(ti.ij, (6, 5))
         blk2 = blk1.dense(ti.ij, (3, 2))
         blk1.place(x)

--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -27,8 +27,8 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
 
     ::
 
-        x = ti.var(dt=ti.i32)
-        y = ti.var(dt=ti.f32)
+        x = ti.field(dt=ti.i32)
+        y = ti.field(dt=ti.f32)
         ti.root.place(x, y)
         assert x.snode() == y.snode()
 
@@ -68,8 +68,8 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
 
     ::
 
-        x = ti.var(dt=ti.i32)
-        y = ti.var(dt=ti.f32)
+        x = ti.field(dt=ti.i32)
+        y = ti.field(dt=ti.f32)
         ti.root.place(x, y)
         x.snode()
 
@@ -135,14 +135,14 @@ Node types
 
     ::
 
-        x = ti.var(dt=ti.i32)
+        x = ti.field(dt=ti.i32)
         ti.root.dense(ti.i, 3).place(x)
 
     The following code places a 2-D tensor of shape ``(3, 4)``:
 
     ::
 
-        x = ti.var(dt=ti.i32)
+        x = ti.field(dt=ti.i32)
         ti.root.dense(ti.ij, (3, 4)).place(x)
 
     .. note::

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -31,7 +31,7 @@ As global tensors of vectors
 
 .. note::
 
-    In Python-scope, ``ti.var`` declares :ref:`scalar_tensor`, while ``ti.Vector`` declares tensors of vectors.
+    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Vector`` declares tensors of vectors.
 
 
 As a temporary local variable


### PR DESCRIPTION
Related issue = #1500

In this PR, documents are mainly updated  for `ti.var`->`ti.field`

TO-DO
- [ ] Test all code examples of our doc, after the new APIs are been implemented well.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
