### PR TITLE
[misc] Fix ti.init argument parsing when corresponding environment variable presents

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -104,7 +104,9 @@ class _EnvironmentConfigurator:
         if len(value):
             self[key] = cast(value)
             if key in self.kwargs:
-                core.warn(f'ti.init argument "{key}" overridden by environment variable "{name}"={value}')
+                core.warn(
+                    f'ti.init argument "{key}" overridden by environment variable "{name}"={value}'
+                )
                 del self.kwargs[key]  # mark as recognized
         elif key in self.kwargs:
             self[key] = self.kwargs[key]

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -103,12 +103,12 @@ class _EnvironmentConfigurator:
         value = os.environ.get(name, '')
         if len(value):
             self[key] = cast(value)
-            # TODO: maybe use a WARNING since it's
             if key in self.kwargs:
-                del self.kwargs[key]  # pop out
+                core.warn(f'ti.init argument "{key}" overridden by environment variable "{name}"={value}')
+                del self.kwargs[key]  # mark as recognized
         elif key in self.kwargs:
             self[key] = self.kwargs[key]
-            del self.kwargs[key]  # pop out
+            del self.kwargs[key]  # mark_as_recognized
 
     def __getitem__(self, key):
         return getattr(self.cfg, key)

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -103,6 +103,9 @@ class _EnvironmentConfigurator:
         value = os.environ.get(name, '')
         if len(value):
             self[key] = cast(value)
+            # TODO: maybe use a WARNING since it's
+            if key in self.kwargs:
+                del self.kwargs[key]  # pop out
         elif key in self.kwargs:
             self[key] = self.kwargs[key]
             del self.kwargs[key]  # pop out
@@ -180,7 +183,6 @@ def init(arch=None,
     env_spec.add('excepthook')
 
     # compiler configurations (ti.cfg):
-    # to somewhere like ti.cuda_cfg so that user don't get confused?
     for key in dir(ti.cfg):
         if key in ['default_fp', 'default_ip']:
             continue

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -110,7 +110,7 @@ class _EnvironmentConfigurator:
                 del self.kwargs[key]  # mark as recognized
         elif key in self.kwargs:
             self[key] = self.kwargs[key]
-            del self.kwargs[key]  # mark_as_recognized
+            del self.kwargs[key]  # mark as recognized
 
     def __getitem__(self, key):
         return getattr(self.cfg, key)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

There's a minor issue: if the user sets `TI_USE_UNIFIED_MEMORY=0` and then use `ti.init(use_unified_memory=False)`, Taichi will report an error saying `use_unified_memory` is not recognized. This PR fixes that, and adds a warning in this case:
```
[W 07/17/20 00:15:41.272] ti.init argument "use_unified_memory" overridden by environment variable "TI_USE_UNIFIED_MEMORY"=0
```

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
