### PR TITLE
[misc] Prettify KernelProfiler outputs

### DIFF
--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -23,6 +23,8 @@ struct KernelProfileRecord {
   }
 
   void insert_sample(double t);
+
+  bool operator<(const KernelProfileRecord &o) const;
 };
 
 class KernelProfilerBase {


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

Before
```
[  0.18%] copy_dynamic_c24_1_kernel_83_listgen_S24dynamic    min   5.534 ms   avg   5.541 ms   max   5.553 ms   total   0.017 s [      3x]
[  0.01%] copy_dynamic_c24_1_kernel_84_struct_for     min   0.173 ms   avg   0.174 ms   max   0.176 ms   total   0.001 s [      3x]
[  0.00%] copy_dynamic_nd_c22_0_kernel_73_clear_list_S24dynamic    min   0.093 ms   avg   0.111 ms   max   0.133 ms   total   0.000 s [      3x]
[  0.18%] copy_dynamic_nd_c22_0_kernel_74_listgen_S24dynamic    min   5.470 ms   avg   5.524 ms   max   5.553 ms   total   0.017 s [      3x]
[  0.01%] copy_dynamic_nd_c22_0_kernel_75_struct_for    min   0.408 ms   avg   0.411 ms   max   0.417 ms   total   0.001 s [      3x]
[  0.00%] copy_dynamic_nd_c22_1_kernel_76_clear_list_S24dynamic    min   0.093 ms   avg   0.120 ms   max   0.136 ms   total   0.000 s [      3x]
[  0.19%] copy_dynamic_nd_c22_1_kernel_77_listgen_S24dynamic    min   5.472 ms   avg   5.758 ms   max   6.093 ms   total   0.017 s [      3x]
```

After
```
CUDA Profiler
=========================================================================
[      %     total   count |      min       avg       max   ] Kernel name
[ 65.90%   2.829 s   2080x |    0.672     1.360     3.494 ms] build_pid_c4_0_kernel_37_struct_for
[  8.04%   0.345 s      1x |  345.204   345.204   345.204 ms] runtime_initialize
[  2.35%   0.101 s   2080x |    0.004     0.048     9.407 ms] snode_deactivate_c50_0_kernel_25_struct_for
[  2.25%   0.097 s   2080x |    0.031     0.046     0.585 ms] p2g_c6_0_kernel_46_struct_for
[  1.61%   0.069 s   2080x |    0.004     0.033     0.333 ms] snode_deactivate_dynamic_c52_0_kernel_17_struct_for
[  1.21%   0.052 s   2080x |    0.023     0.025     1.462 ms] snode_deactivate_c50_1_kernel_31_struct_for

```
[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
