### PR TITLE
[Bug] [cli] Fix environment variable TI_ARCH=xxx not work

### DIFF
--- a/examples/mpm128.py
+++ b/examples/mpm128.py
@@ -53,8 +53,8 @@ def substep():
     if material[p] == 0:  # Reset deformation gradient to avoid numerical instability
       F[p] = ti.Matrix.identity(ti.f32, 2) * ti.sqrt(J)
     elif material[p] == 2:
-      F[p] = U @ sig @ V.T() # Reconstruct elastic deformation gradient after plasticity
-    stress = 2 * mu * (F[p] - U @ V.T()) @ F[p].T() + ti.Matrix.identity(ti.f32, 2) * la * J * (J - 1)
+      F[p] = U @ sig @ V.transpose() # Reconstruct elastic deformation gradient after plasticity
+    stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose() + ti.Matrix.identity(ti.f32, 2) * la * J * (J - 1)
     stress = (-dt * p_vol * 4 * inv_dx * inv_dx) * stress
     affine = stress + p_mass * C[p]
     for i, j in ti.static(ti.ndrange(3, 3)): # Loop over 3x3 grid node neighborhood

--- a/examples/mpm99.py
+++ b/examples/mpm99.py
@@ -47,8 +47,8 @@ def substep():
     if material[p] == 0:  # Reset deformation gradient to avoid numerical instability
       F[p] = ti.Matrix.identity(ti.f32, 2) * ti.sqrt(J)
     elif material[p] == 2:
-      F[p] = U @ sig @ V.T() # Reconstruct elastic deformation gradient after plasticity
-    stress = 2 * mu * (F[p] - U @ V.T()) @ F[p].T() + ti.Matrix.identity(ti.f32, 2) * la * J * (J - 1)
+      F[p] = U @ sig @ V.transpose() # Reconstruct elastic deformation gradient after plasticity
+    stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose() + ti.Matrix.identity(ti.f32, 2) * la * J * (J - 1)
     stress = (-dt * p_vol * 4 * inv_dx * inv_dx) * stress
     affine = stress + p_mass * C[p]
     for i, j in ti.static(ti.ndrange(3, 3)): # Loop over 3x3 grid node neighborhood

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -186,7 +186,7 @@ def init(arch=None,
 
     # compiler configurations (ti.cfg):
     for key in dir(ti.cfg):
-        if key in ['default_fp', 'default_ip']:
+        if key in ['arch', 'default_fp', 'default_ip']:
             continue
         cast = type(getattr(ti.cfg, key))
         if cast is bool:

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -117,7 +117,7 @@ def test_init_arch(arch):
         ti.init(arch=arch)
         assert ti.cfg.arch == arch
     with patch_os_environ_helper({'TI_ARCH': ti.core.arch_name(arch)},
-                        excludes=['TI_ARCH']):
+                                 excludes=['TI_ARCH']):
         ti.init(arch=ti.cc)
         assert ti.cfg.arch == arch
 

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -111,6 +111,17 @@ def test_init_arg(key, values):
             test_arg(key, value)
 
 
+@pytest.mark.parametrize('arch', ti.supported_archs())
+def test_init_arch(arch):
+    with patch_os_environ_helper({}, excludes=['TI_ARCH']):
+        ti.init(arch=arch)
+        assert ti.cfg.arch == arch
+    with patch_os_environ_helper({'TI_ARCH': ti.core.arch_name(arch)},
+                        excludes=['TI_ARCH']):
+        ti.init(arch=ti.cc)
+        assert ti.cfg.arch == arch
+
+
 @ti.must_throw(KeyError)
 def test_init_bad_arg():
     ti.init(_test_mode=True, debug=True, foo_bar=233)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
I found `TI_ARCH=opengl` results in an error so I'm fixing this.
OFT: Fix mpm99&mpm128 deprecation warning.