### PR TITLE
[Doc] Update all global tensor ti.Vector to ti.Vector.field

### DIFF
--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -190,8 +190,8 @@ Export PLY files
     ti.init(arch=ti.cpu)
 
     num_vertices = 1000
-    pos = ti.Vector.field(3, dt=ti.f32, shape=(10, 10, 10))
-    rgba = ti.Vector.field(4, dt=ti.f32, shape=(10, 10, 10))
+    pos = ti.Vector.field(3, dtype=ti.f32, shape=(10, 10, 10))
+    rgba = ti.Vector.field(4, dtype=ti.f32, shape=(10, 10, 10))
 
 
     @ti.kernel

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -69,7 +69,7 @@ To save images without invoking ``ti.GUI.show(filename)``, use ``ti.imwrite(file
         ti.imwrite(pixels.to_numpy(), filename)
         print(f'The image has been saved to {filename}')
 
-- ``ti.imwrite`` can export Taichi tensors (``ti.Matrix``, ``ti.Vector``, ``ti.field``) and numpy tensors ``np.ndarray``.
+- ``ti.imwrite`` can export Taichi tensors (``ti.Matrix``, ``ti.Vector.field``, ``ti.field``) and numpy tensors ``np.ndarray``.
 - Same as above ``ti.GUI.show(filename)``, the image format (``png``, ``jpg`` and ``bmp``) is also controlled by the suffix of ``filename`` in ``ti.imwrite(filename)``.
 - Meanwhile, the resulted image type (grayscale, RGB, or RGBA) is determined by **the number of channels in the input tensor**, i.e., the length of the third dimension (``tensor.shape[2]``).
 - In other words, a tensor that has shape ``(w, h)`` or ``(w, h, 1)`` will be exported as a grayscale image.
@@ -190,8 +190,8 @@ Export PLY files
     ti.init(arch=ti.cpu)
 
     num_vertices = 1000
-    pos = ti.Vector(3, dt=ti.f32, shape=(10, 10, 10))
-    rgba = ti.Vector(4, dt=ti.f32, shape=(10, 10, 10))
+    pos = ti.Vector.field(3, dt=ti.f32, shape=(10, 10, 10))
+    rgba = ti.Vector.field(4, dt=ti.f32, shape=(10, 10, 10))
 
 
     @ti.kernel

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -22,7 +22,7 @@ Use ``to_numpy``/``from_numpy``/``to_torch``/``from_torch``:
 
   # Taichi tensors
   val = ti.field(ti.i32, shape=(n, m))
-  vec = ti.Vector.field(3, dt=ti.i32, shape=(n, m))
+  vec = ti.Vector.field(3, dtype=ti.i32, shape=(n, m))
   mat = ti.Matrix(3, 4, dt=ti.i32, shape=(n, m))
 
   # Scalar

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -22,7 +22,7 @@ Use ``to_numpy``/``from_numpy``/``to_torch``/``from_torch``:
 
   # Taichi tensors
   val = ti.field(ti.i32, shape=(n, m))
-  vec = ti.Vector(3, dt=ti.i32, shape=(n, m))
+  vec = ti.Vector.field(3, dt=ti.i32, shape=(n, m))
   mat = ti.Matrix(3, 4, dt=ti.i32, shape=(n, m))
 
   # Scalar

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -67,7 +67,7 @@ Paint on a window
 
     * ``ti.field(shape=(x, y, 3))``, where `3` is for ``(r, g, b)`` channels
 
-    * ``ti.Vector(3, shape=(x, y))`` (see :ref:`vector`)
+    * ``ti.Vector.field(3, shape=(x, y))`` (see :ref:`vector`)
 
     * ``np.ndarray(shape=(x, y))``
 
@@ -387,7 +387,7 @@ Image I/O
     :parameter img: (Matrix or Expr) the image you want to export
     :parameter filename: (string) the location you want to save to
 
-    Export a ``np.ndarray`` or Taichi tensor (``ti.Matrix``, ``ti.Vector``, or ``ti.field``) to a specified location ``filename``.
+    Export a ``np.ndarray`` or Taichi tensor (``ti.Matrix``, ``ti.Vector.field``, or ``ti.field``) to a specified location ``filename``.
 
     Same as ``ti.GUI.show(filename)``, the format of the exported image is determined by **the suffix of** ``filename`` as well. Now ``ti.imwrite`` supports exporting images to ``png``, ``img`` and ``jpg`` and we recommend using ``png``.
 

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -227,8 +227,8 @@ Examples
 
 .. code-block:: python
 
-  pos = ti.Vector.field(3, dt=ti.f32)
-  vel = ti.Vector.field(3, dt=ti.f32)
+  pos = ti.Vector.field(3, dtype=ti.f32)
+  vel = ti.Vector.field(3, dtype=ti.f32)
   ti.root.dense(ti.i, 1024).place(pos, vel)
   # equivalent to
   ti.root.dense(ti.i, 1024).place(pos(0), pos(1), pos(2), vel(0), vel(1), vel(2))
@@ -237,8 +237,8 @@ Examples
 
 .. code-block:: python
 
-  pos = ti.Vector.field(3, dt=ti.f32)
-  vel = ti.Vector.field(3, dt=ti.f32)
+  pos = ti.Vector.field(3, dtype=ti.f32)
+  vel = ti.Vector.field(3, dtype=ti.f32)
   for i in range(3):
     ti.root.dense(ti.i, 1024).place(pos(i))
   for i in range(3):

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -227,8 +227,8 @@ Examples
 
 .. code-block:: python
 
-  pos = ti.Vector(3, dt=ti.f32)
-  vel = ti.Vector(3, dt=ti.f32)
+  pos = ti.Vector.field(3, dt=ti.f32)
+  vel = ti.Vector.field(3, dt=ti.f32)
   ti.root.dense(ti.i, 1024).place(pos, vel)
   # equivalent to
   ti.root.dense(ti.i, 1024).place(pos(0), pos(1), pos(2), vel(0), vel(1), vel(2))
@@ -237,8 +237,8 @@ Examples
 
 .. code-block:: python
 
-  pos = ti.Vector(3, dt=ti.f32)
-  vel = ti.Vector(3, dt=ti.f32)
+  pos = ti.Vector.field(3, dt=ti.f32)
+  vel = ti.Vector.field(3, dt=ti.f32)
   for i in range(3):
     ti.root.dense(ti.i, 1024).place(pos(i))
   for i in range(3):

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -4,7 +4,7 @@ Matrices
 ========
 
 - ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D tensor of scalars.
-- ``ti.Vector.field`` is the same as ``ti.Matrix``, except that it has only one column.
+- ``ti.Vector`` is the same as ``ti.Matrix``, except that it has only one column.
 - Differentiate element-wise product ``*`` and matrix product ``@``.
 - ``ti.Vector.field(n, dt=ti.f32)`` or ``ti.Matrix(n, m, dt=ti.f32)`` to create tensors of vectors/matrices.
 - ``A.transpose()``

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -4,9 +4,9 @@ Matrices
 ========
 
 - ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D tensor of scalars.
-- ``ti.Vector`` is the same as ``ti.Matrix``, except that it has only one column.
+- ``ti.Vector.field`` is the same as ``ti.Matrix``, except that it has only one column.
 - Differentiate element-wise product ``*`` and matrix product ``@``.
-- ``ti.Vector(n, dt=ti.f32)`` or ``ti.Matrix(n, m, dt=ti.f32)`` to create tensors of vectors/matrices.
+- ``ti.Vector.field(n, dt=ti.f32)`` or ``ti.Matrix(n, m, dt=ti.f32)`` to create tensors of vectors/matrices.
 - ``A.transpose()``
 - ``R, S = ti.polar_decompose(A, ti.f32)``
 - ``U, sigma, V = ti.svd(A, ti.f32)`` (Note that ``sigma`` is a ``3x3`` diagonal matrix)

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -6,7 +6,7 @@ Matrices
 - ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D tensor of scalars.
 - ``ti.Vector`` is the same as ``ti.Matrix``, except that it has only one column.
 - Differentiate element-wise product ``*`` and matrix product ``@``.
-- ``ti.Vector.field(n, dt=ti.f32)`` or ``ti.Matrix(n, m, dt=ti.f32)`` to create tensors of vectors/matrices.
+- ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix(n, m, dt=ti.f32)`` to create tensors of vectors/matrices.
 - ``A.transpose()``
 - ``R, S = ti.polar_decompose(A, ti.f32)``
 - ``U, sigma, V = ti.svd(A, ti.f32)`` (Note that ``sigma`` is a ``3x3`` diagonal matrix)

--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -24,7 +24,7 @@ In this way, the tensor's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusi
 .. code-block:: python
 
     a = ti.Matrix(2, 3, dt=ti.f32, shape=(32,), offset=(-16, ))          # Works!
-    b = ti.Vector.field(3, dt=ti.f32, shape=(16, 32, 64), offset=(7, 3, -4))   # Works!
+    b = ti.Vector.field(3, dtype=ti.f32, shape=(16, 32, 64), offset=(7, 3, -4))   # Works!
     c = ti.Matrix(2, 1, dt=ti.f32, shape=None, offset=(32,))             # AssertionError
     d = ti.Matrix(3, 2, dt=ti.f32, shape=(32, 32), offset=(-16, ))       # AssertionError
     e = ti.field(dt=ti.i32, shape=16, offset=-16)                          # Works!

--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -24,7 +24,7 @@ In this way, the tensor's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusi
 .. code-block:: python
 
     a = ti.Matrix(2, 3, dt=ti.f32, shape=(32,), offset=(-16, ))          # Works!
-    b = ti.Vector(3, dt=ti.f32, shape=(16, 32, 64), offset=(7, 3, -4))   # Works!
+    b = ti.Vector.field(3, dt=ti.f32, shape=(16, 32, 64), offset=(7, 3, -4))   # Works!
     c = ti.Matrix(2, 1, dt=ti.f32, shape=None, offset=(32,))             # AssertionError
     d = ti.Matrix(3, 2, dt=ti.f32, shape=(32, 32), offset=(-16, ))       # AssertionError
     e = ti.field(dt=ti.i32, shape=16, offset=-16)                          # Works!

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -36,7 +36,7 @@ Suppose you have a ``128 x 64`` tensor called ``A``, each element containing a `
 * If you want to get the matrix of grid node ``i, j``, please use ``mat = A[i, j]``. ``mat`` is simply a ``3 x 2`` matrix
 * To get the element on the first row and second column of that matrix, use ``mat[0, 1]`` or ``A[i, j][0, 1]``.
 * As you may have noticed, there are **two** indexing operators ``[]`` when you load an matrix element from a global tensor of matrices: the first is for tensor indexing, the second for matrix indexing.
-* ``ti.Vector.field`` is simply an alias of ``ti.Matrix``.
+* ``ti.Vector`` is simply an alias of ``ti.Matrix``.
 * See :ref:`matrix` for more on matrices.
 
 

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -36,7 +36,7 @@ Suppose you have a ``128 x 64`` tensor called ``A``, each element containing a `
 * If you want to get the matrix of grid node ``i, j``, please use ``mat = A[i, j]``. ``mat`` is simply a ``3 x 2`` matrix
 * To get the element on the first row and second column of that matrix, use ``mat[0, 1]`` or ``A[i, j][0, 1]``.
 * As you may have noticed, there are **two** indexing operators ``[]`` when you load an matrix element from a global tensor of matrices: the first is for tensor indexing, the second for matrix indexing.
-* ``ti.Vector`` is simply an alias of ``ti.Matrix``.
+* ``ti.Vector.field`` is simply an alias of ``ti.Matrix``.
 * See :ref:`matrix` for more on matrices.
 
 

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -16,10 +16,10 @@ Declaration
 As global tensors of vectors
 ++++++++++++++++++++++++++++
 
-.. function:: ti.Vector.field(n, dt, shape = None, offset = None)
+.. function:: ti.Vector.field(n, dtype, shape = None, offset = None)
 
     :parameter n: (scalar) the number of components in the vector
-    :parameter dt: (DataType) data type of the components
+    :parameter dtype: (DataType) data type of the components
     :parameter shape: (optional, scalar or tuple) shape the tensor of vectors, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
@@ -27,7 +27,7 @@ As global tensors of vectors
     ::
 
         # Python-scope
-        a = ti.Vector.field(3, dt=ti.f32, shape=(5, 4))
+        a = ti.Vector.field(3, dtype=ti.f32, shape=(5, 4))
 
 .. note::
 
@@ -236,7 +236,7 @@ Metadata
 
     ::
         # Python-scope
-        a = ti.Vector.field(3, dt=ti.f32, shape=())
+        a = ti.Vector.field(3, dtype=ti.f32, shape=())
         a.n  # 3
 
 TODO: add element wise operations docs

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -16,7 +16,7 @@ Declaration
 As global tensors of vectors
 ++++++++++++++++++++++++++++
 
-.. function:: ti.Vector.var(n, dt, shape = None, offset = None)
+.. function:: ti.Vector.field(n, dt, shape = None, offset = None)
 
     :parameter n: (scalar) the number of components in the vector
     :parameter dt: (DataType) data type of the components
@@ -27,11 +27,11 @@ As global tensors of vectors
     ::
 
         # Python-scope
-        a = ti.Vector.var(3, dt=ti.f32, shape=(5, 4))
+        a = ti.Vector.field(3, dt=ti.f32, shape=(5, 4))
 
 .. note::
 
-    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Vector`` declares tensors of vectors.
+    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Vector.field`` declares tensors of vectors.
 
 
 As a temporary local variable
@@ -236,7 +236,7 @@ Metadata
 
     ::
         # Python-scope
-        a = ti.Vector.var(3, dt=ti.f32, shape=())
+        a = ti.Vector.field(3, dt=ti.f32, shape=())
         a.n  # 3
 
 TODO: add element wise operations docs

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -16,10 +16,10 @@ Declaration
 As global tensors of vectors
 ++++++++++++++++++++++++++++
 
-.. function:: ti.Vector.field(n, dtype, shape = None, offset = None)
+.. function:: ti.Vector.field(n, dt, shape = None, offset = None)
 
     :parameter n: (scalar) the number of components in the vector
-    :parameter dtype: (DataType) data type of the components
+    :parameter dt: (DataType) data type of the components
     :parameter shape: (optional, scalar or tuple) shape the tensor of vectors, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 


### PR DESCRIPTION
Related issue = #1500 

To keep a small change set, this PR simply **replaces all global tensor `ti.Vector` by `ti.Vector.field`.**

Though I try my best to replace all global tensors `ti.Vector`, there can still be some **slippery fish**. If you caught one, please tell me so that I can correct them.

In case of a waste of time, I want to double check these to-dos with you:

- [x] Do we need change `dt` to `dtype` in all `ti.Vector` and `ti.Vector.field`?
- [ ] In `vector.rst`, here are lots of vector operations. I guess they are also compatible to local vars so I kept them the same. If we need to do, please let me know.



[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
