### PR TITLE
[ir] Move struct-for demotion pass after offload pass

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -142,6 +142,7 @@ Program::Program(Arch desired_arch) {
   llvm_runtime = nullptr;
   finalized = false;
   snode_root = std::make_unique<SNode>(0, SNodeType::root);
+  snode_root->is_path_all_dense = true;
 
   if (config.async_mode) {
     TI_WARN("Running in async mode. This is experimental.");

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -8,6 +8,9 @@ TLANG_NAMESPACE_BEGIN
 
 namespace irpass {
 
+// TODO: Rename this to compile_to_executable, since it does two things:
+// 1. compile to offloads
+// 2. offloads to executable (with further optimization)
 void compile_to_offloads(IRNode *ir,
                          const CompileConfig &config,
                          bool vectorize,
@@ -21,7 +24,7 @@ void compile_to_offloads(IRNode *ir,
 
   auto print = [&](const std::string &name) {
     if (verbose) {
-      TI_INFO(name + ":");
+      TI_INFO("[{}] {}:", ir->get_kernel()->name, name);
       std::cout << std::flush;
       irpass::re_id(ir);
       irpass::print(ir);
@@ -75,13 +78,6 @@ void compile_to_offloads(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
-  if (config.demote_dense_struct_fors) {
-    irpass::demote_dense_struct_fors(ir);
-    irpass::typecheck(ir);
-    print("Dense struct-for demoted");
-    irpass::analysis::verify(ir);
-  }
-
   if (config.check_out_of_bound) {
     irpass::check_out_of_bound(ir);
     print("Bound checked");
@@ -108,6 +104,17 @@ void compile_to_offloads(IRNode *ir,
 
   print("Access flagged II");
   irpass::analysis::verify(ir);
+
+  // TODO: This is just a proof that we can demote struct-fors after offloading.
+  // Eventually we might want the order to be TLS/BLS -> demote struct-for.
+  // For now, putting this after TLS will disable TLS, because it can only
+  // handle range-fors at this point.
+  if (config.demote_dense_struct_fors) {
+    irpass::demote_dense_struct_fors(ir);
+    irpass::typecheck(ir);
+    print("Dense struct-for demoted");
+    irpass::analysis::verify(ir);
+  }
 
   if (make_thread_local) {
     irpass::make_thread_local(ir);

--- a/taichi/transforms/demote_dense_struct_fors.cpp
+++ b/taichi/transforms/demote_dense_struct_fors.cpp
@@ -4,11 +4,15 @@
 
 TLANG_NAMESPACE_BEGIN
 
-VecStatement convert_to_range_for(StructForStmt *struct_for) {
-  VecStatement ret;
-  auto lower = ret.push_back<ConstStmt>(TypedConstant(0));
+namespace {
+
+using TaskType = OffloadedStmt::TaskType;
+
+void convert_to_range_for(OffloadedStmt *offloaded) {
+  TI_ASSERT(offloaded->task_type == TaskType::struct_for);
+
   std::vector<SNode *> snodes;
-  auto snode = struct_for->snode;
+  auto *snode = offloaded->snode;
   int total_bits = 0;
   while (snode->type != SNodeType::root) {
     snodes.push_back(snode);
@@ -18,10 +22,13 @@ VecStatement convert_to_range_for(StructForStmt *struct_for) {
   std::reverse(snodes.begin(), snodes.end());
   TI_ASSERT(total_bits <= 30);
 
-  auto upper_bound = 1 << total_bits;
-  auto upper = ret.push_back<ConstStmt>(TypedConstant(upper_bound));
-  auto body = std::move(struct_for->body);
+  offloaded->const_begin = true;
+  offloaded->const_end = true;
+  offloaded->begin_value = 0;
+  offloaded->end_value = 1 << total_bits;
 
+  ////// Begin core transformation
+  auto body = std::move(offloaded->body);
   const int num_loop_vars = snodes.back()->num_active_indices;
   std::vector<Stmt *> new_loop_vars;
 
@@ -83,7 +90,7 @@ VecStatement convert_to_range_for(StructForStmt *struct_for) {
         body.get(),
         [&](Stmt *s) {
           if (auto loop_index = s->cast<LoopIndexStmt>()) {
-            return loop_index->loop == struct_for &&
+            return loop_index->loop == offloaded &&
                    loop_index->index ==
                        snodes.back()->physical_index_position[i];
           }
@@ -101,37 +108,24 @@ VecStatement convert_to_range_for(StructForStmt *struct_for) {
   }
   body->insert(std::move(body_header), 0);
 
-  auto range_for = Stmt::make<RangeForStmt>(
-      lower, upper, std::move(body), struct_for->vectorize,
-      struct_for->parallelize, struct_for->block_dim, false);
-  main_loop_var->loop = range_for.get();
-  ret.push_back(std::move(range_for));
+  offloaded->body = std::move(body);
+  main_loop_var->loop = offloaded;
+  ////// End core transformation
 
-  // TODO: safe guard range
-  return ret;
+  offloaded->task_type = TaskType::range_for;
 }
+
+}  // namespace
 
 namespace irpass {
 
 void demote_dense_struct_fors(IRNode *root) {
   auto *block = dynamic_cast<Block *>(root);
-  std::vector<Stmt *> block_body;
-  for (int i = 0; i < (int)block->statements.size(); i++) {
-    block_body.push_back(block->statements[i].get());
-  }
-  for (int i = 0; i < (int)block_body.size(); i++) {
-    auto s_ = block_body[i];
-    if (auto s = s_->cast<StructForStmt>()) {
-      auto snode = s->snode;
-      bool all_dense = true;
-      while (all_dense && snode->type != SNodeType::root) {
-        if (snode->type != SNodeType::dense) {
-          all_dense = false;
-        }
-        snode = snode->parent;
-      }
-      if (all_dense) {
-        s->parent->replace_with(s, convert_to_range_for(s), false);
+  for (auto &s_ : block->statements) {
+    if (auto *s = s_->cast<OffloadedStmt>()) {
+      if ((s->task_type == TaskType::struct_for) &&
+          s->snode->is_path_all_dense) {
+        convert_to_range_for(s);
       }
     }
   }

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -110,23 +110,29 @@ class Offloader {
 
     auto program = &for_stmt->get_kernel()->program;
 
-    for (int i = 1; i < path.size(); i++) {
-      auto snode_child = path[i];
-      auto offloaded_clear_list =
-          Stmt::make_typed<OffloadedStmt>(OffloadedStmt::TaskType::clear_list);
-      offloaded_clear_list->grid_dim = 1;
-      offloaded_clear_list->block_dim = 1;
-      offloaded_clear_list->snode = snode_child;
-      root_block->insert(std::move(offloaded_clear_list));
-      auto offloaded_listgen =
-          Stmt::make_typed<OffloadedStmt>(OffloadedStmt::TaskType::listgen);
-      offloaded_listgen->snode = snode_child;
-      offloaded_listgen->grid_dim = program->config.saturating_grid_dim;
-      offloaded_listgen->block_dim =
-          std::min(snode_child->max_num_elements(),
-                   std::min(program->default_block_dim(),
-                            program->config.max_block_dim));
-      root_block->insert(std::move(offloaded_listgen));
+    // If |demotable| is true, this will later be demoting into a range-for
+    // task, so we don't need to generate clear/listgen tasks.
+    const bool demotable =
+        (leaf->is_path_all_dense && program->config.demote_dense_struct_fors);
+    if (!demotable) {
+      for (int i = 1; i < path.size(); i++) {
+        auto snode_child = path[i];
+        auto offloaded_clear_list = Stmt::make_typed<OffloadedStmt>(
+            OffloadedStmt::TaskType::clear_list);
+        offloaded_clear_list->grid_dim = 1;
+        offloaded_clear_list->block_dim = 1;
+        offloaded_clear_list->snode = snode_child;
+        root_block->insert(std::move(offloaded_clear_list));
+        auto offloaded_listgen =
+            Stmt::make_typed<OffloadedStmt>(OffloadedStmt::TaskType::listgen);
+        offloaded_listgen->snode = snode_child;
+        offloaded_listgen->grid_dim = program->config.saturating_grid_dim;
+        offloaded_listgen->block_dim =
+            std::min(snode_child->max_num_elements(),
+                     std::min(program->default_block_dim(),
+                              program->config.max_block_dim));
+        root_block->insert(std::move(offloaded_listgen));
+      }
     }
 
     auto offloaded_struct_for =


### PR DESCRIPTION
This PR widens the opportunity for BLS, and also makes fusion more robust. 

I think the only IR substitution we need is `LoopIndexStmt` -> `LocalLoad(Alloca)`, but even this is already handled in the existing implementation. Since this is a flip of the task type from `struct_for` to `range_for`, all the other IRs referencing this task shouldn't need to be modified? 

At last, I forgot to set Root's `is_path_all_dense` in #1538... Doing it here.

Related issue = N/A

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
