### PR TITLE
[linux] Fix LLVM symbol leakage in release mode by using RTLD_GLOBAL

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -284,7 +284,7 @@ if is_release():
             os.symlink(link_src, link_dst)
     import_ti_core()
     if get_os_name() != 'win':
-        dll = ctypes.CDLL(get_core_shared_object(), mode=ctypes.RTLD_GLOBAL)
+        dll = ctypes.CDLL(get_core_shared_object(), mode=ctypes.RTLD_LOCAL)
 
     ti_core.set_python_package_dir(package_root())
     os.makedirs(ti_core.get_repo_dir(), exist_ok=True)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -203,10 +203,6 @@ class Matrix(TaichiOperations):
         if len(args) == 1:
             args = args + (0, )
         _taichi_skip_traceback = 1
-        assert 0 <= args[0] < self.n, \
-                f"The 0-th matrix index {args[0]} out-of-range, should be < {self.n}"
-        assert 0 <= args[1] < self.m, \
-                f"The 1-th matrix index {args[1]} out-of-range, should be < {self.m}"
         # TODO(#1004): See if it's possible to support indexing at runtime
         for i, a in enumerate(args):
             if not isinstance(a, int):
@@ -220,6 +216,10 @@ class Matrix(TaichiOperations):
                     '    print(i, "-th component is", vec[i])\n'
                     'See https://taichi.readthedocs.io/en/stable/meta.html#when-to-use-for-loops-with-ti-static for more details.'
                 )
+        assert 0 <= args[0] < self.n, \
+                f"The 0-th matrix index is out of range: 0 < {args[0]} < {self.n}"
+        assert 0 <= args[1] < self.m, \
+                f"The 1-th matrix index is out of range: 0 < {args[1]} < {self.m}"
         return args[0] * self.m + args[1]
 
     def __call__(self, *args, **kwargs):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -184,6 +184,7 @@ class Matrix(TaichiOperations):
 
     def __matmul__(self, other):
         _taichi_skip_traceback = 1
+        assert isinstance(other, Matrix), "rhs of `@` is not a matrix / vector"
         assert self.m == other.n, f"Dimension mismatch between shapes ({self.n}, {self.m}), ({other.n}, {other.m})"
         del _taichi_skip_traceback
         ret = Matrix.new(self.n, other.m)
@@ -201,9 +202,11 @@ class Matrix(TaichiOperations):
             args = args[0]
         if len(args) == 1:
             args = args + (0, )
-        assert 0 <= args[0] < self.n
-        assert 0 <= args[1] < self.m
         _taichi_skip_traceback = 1
+        assert 0 <= args[0] < self.n, \
+                f"The 0-th matrix index {args[0]} out-of-range, should be < {self.n}"
+        assert 0 <= args[1] < self.m, \
+                f"The 1-th matrix index {args[1]} out-of-range, should be < {self.m}"
         # TODO(#1004): See if it's possible to support indexing at runtime
         for i, a in enumerate(args):
             if not isinstance(a, int):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -217,9 +217,9 @@ class Matrix(TaichiOperations):
                     'See https://taichi.readthedocs.io/en/stable/meta.html#when-to-use-for-loops-with-ti-static for more details.'
                 )
         assert 0 <= args[0] < self.n, \
-                f"The 0-th matrix index is out of range: 0 < {args[0]} < {self.n}"
+                f"The 0-th matrix index is out of range: 0 <= {args[0]} < {self.n}"
         assert 0 <= args[1] < self.m, \
-                f"The 1-th matrix index is out of range: 0 < {args[1]} < {self.m}"
+                f"The 1-th matrix index is out of range: 0 <= {args[1]} < {self.m}"
         return args[0] * self.m + args[1]
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related PR = #1508

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Why release mode use different code than `import_ti_core` in dev mode... and I found the glfw issue again in release mode.