### PR TITLE
[IPython] 'ti.sync()' is no longer needed for 'print()' in OpenGL and Metal backend

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -42,14 +42,11 @@ For now, Taichi-scope ``print`` supports string, scalar, vector, and matrix expr
 
 .. warning::
 
-    For the **CPU, CUDA, and Metal backend**, ``print`` will not work in Graphical Python Shells
-    including IDLE and Jupyter notebook. This is because these backends print the outputs to the console instead of the GUI.
-    Taichi developers are trying to solve this now. Use the **OpenGL backend** if you wish to
-    use ``print`` in IDLE / Jupyter.
+    For the **CPU and CUDA backend**, ``print`` will not work in Graphical Python Shells including IDLE and Jupyter notebook. This is because these backends print the outputs to the console instead of the GUI. Use the **OpenGL or Metal backend** if you wish to use ``print`` in IDLE / Jupyter.
 
 .. warning::
 
-    For the **OpenGL and CUDA backend**, the printed result will not show up until ``ti.sync()`` is called:
+    For the **CUDA backend**, the printed result will not show up until ``ti.sync()`` is called:
 
     .. code-block:: python
 
@@ -73,9 +70,9 @@ For now, Taichi-scope ``print`` supports string, scalar, vector, and matrix expr
         before kernel
         after kernel
         inside kernel
-        after
+        after sync
 
-    Please note that host access or program end will also implicitly invoke ``ti.sync()``.
+    Note that host access or program end will also implicitly invoke ``ti.sync()``.
 
 .. note::
 

--- a/misc/test_print.py
+++ b/misc/test_print.py
@@ -1,0 +1,9 @@
+import taichi as ti
+
+ti.init(ti.opengl)
+
+@ti.kernel
+def func():
+    print(42)
+
+func()

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -222,9 +222,6 @@ class PyTaichi:
     def sync(self):
         self.materialize()
         self.prog.synchronize()
-        # print's in kernel won't take effect until ti.sync(), discussion:
-        # https://github.com/taichi-dev/taichi/pull/1303#discussion_r444897102
-        print(taichi_lang_core.pop_python_print_buffer(), end='')
 
 
 pytaichi = PyTaichi()

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -4,7 +4,7 @@ from .transformer import ASTTransformer
 import ast
 from .kernel_arguments import *
 from .util import *
-from .shell import oinspect
+from .shell import oinspect, _shell_pop_print
 from . import impl
 import functools
 
@@ -139,7 +139,6 @@ def classfunc(foo):
     @functools.wraps(foo)
     def decorated(*args):
         return func.__call__(*args)
-
     return decorated
 
 
@@ -461,6 +460,7 @@ class Kernel:
 
     # For small kernels (< 3us), the performance can be pretty sensitive to overhead in __call__
     # Thus this part needs to be fast. (i.e. < 3us on a 4 GHz x64 CPU)
+    @_shell_pop_print
     def __call__(self, *args, **kwargs):
         _taichi_skip_traceback = 1
         assert len(kwargs) == 0, 'kwargs not supported for Taichi kernels'

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -158,6 +158,7 @@ void export_misc(py::module &m) {
     printf("test was successful.\n");
   });
   m.def("pop_python_print_buffer", []() { return py_cout.pop_content(); });
+  m.def("toggle_python_print_buffer", [](bool opt) { py_cout.enabled = opt; });
   m.def("with_cuda", is_cuda_api_available);
   m.def("with_metal", taichi::lang::metal::is_metal_api_available);
   m.def("with_opengl", taichi::lang::opengl::is_opengl_api_available);

--- a/taichi/python/print_buffer.h
+++ b/taichi/python/print_buffer.h
@@ -1,16 +1,21 @@
 #pragma once
 
 #include <sstream>
+#include <iostream>
 
 TI_NAMESPACE_BEGIN
 
 struct PythonPrintBuffer {
   /* holds kernel print result before switching back to python */
   std::stringstream ss;
+  bool enabled{false};
 
   template <typename T>
   PythonPrintBuffer &operator<<(const T &t) {
-    ss << t;
+    if (enabled)
+      ss << t;
+    else
+      std::cout << t;
     return *this;
   }
   std::string pop_content() {


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1483

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
