### PR TITLE
[Perf] Improve dynamic listgen and access performance

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -222,6 +222,9 @@ def init(arch=None,
     # create a new program:
     ti.get_runtime().create_program()
 
+def no_activate(*args):
+    for v in args:
+        taichi_lang_core.no_activate(v.ptr)
 
 def cache_shared(*args):
     for v in args:

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -222,9 +222,11 @@ def init(arch=None,
     # create a new program:
     ti.get_runtime().create_program()
 
+
 def no_activate(*args):
     for v in args:
         taichi_lang_core.no_activate(v.ptr)
+
 
 def cache_shared(*args):
     for v in args:

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -749,7 +749,13 @@ void CodeGenLLVM::emit_list_gen(OffloadedStmt *listgen) {
   auto snode_parent = listgen->snode->parent;
   auto meta_child = cast_pointer(emit_struct_meta(snode_child), "StructMeta");
   auto meta_parent = cast_pointer(emit_struct_meta(snode_parent), "StructMeta");
-  call("element_listgen", get_runtime(), meta_parent, meta_child);
+  if (snode_parent->type == SNodeType::root) {
+    // Since there's only one container to expand, we need a special kernel for
+    // more parallelism.
+    call("element_listgen_root", get_runtime(), meta_parent, meta_child);
+  } else {
+    call("element_listgen_nonroot", get_runtime(), meta_parent, meta_child);
+  }
 }
 
 void CodeGenLLVM::emit_gc(OffloadedStmt *stmt) {

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1327,6 +1327,7 @@ void CodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt, bool spmd) {
     parent_coordinates = element.get_ptr("pcoord");
 
     if (stmt->bls_prologue) {
+      call("block_barrier");  // "__syncthreads()"
       stmt->bls_prologue->accept(this);
       call("block_barrier");  // "__syncthreads()"
     }
@@ -1428,6 +1429,7 @@ void CodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt, bool spmd) {
     if (stmt->bls_epilogue) {
       call("block_barrier");  // "__syncthreads()"
       stmt->bls_epilogue->accept(this);
+      call("block_barrier");  // "__syncthreads()"
     }
   }
 

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -41,7 +41,7 @@ void make_thread_local(IRNode *root);
 std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *root);
 void make_block_local(IRNode *root);
 bool remove_range_assumption(IRNode *root);
-bool lower_access(IRNode *root, bool lower_atomic, Kernel *kernel = nullptr);
+bool lower_access(IRNode *root, bool lower_atomic);
 void auto_diff(IRNode *root, bool use_stack = false);
 bool constant_fold(IRNode *root);
 void offload(IRNode *root);

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -65,7 +65,7 @@ void ExecutionQueue::enqueue(KernelLaunchRecord &&ker) {
         using namespace irpass;
 
         flag_access(stmt);
-        lower_access(stmt, true, kernel);
+        lower_access(stmt, true);
         flag_access(stmt);
         full_simplify(stmt, true, kernel);
         // analysis::verify(stmt);

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -14,6 +14,7 @@ class Kernel {
   Program &program;
   FunctionType compiled;
   std::string name;
+  std::vector<SNode *> no_activate;
   Arch arch;
   bool lowered;  // lower inital AST all the way down to a bunch of
                  // OffloadedStmt for async execution

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -539,6 +539,9 @@ void export_lang(py::module &m) {
   m.def("vectorize", Vectorize);
   m.def("block_dim", BlockDim);
   m.def("cache", Cache);
+  m.def("no_activate", [](SNode *snode) {
+    get_current_program().get_current_kernel().no_activate.push_back(snode);
+  });
   m.def("stop_grad",
         [](SNode *snode) { current_ast_builder().stop_gradient(snode); });
 

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -943,10 +943,10 @@ void element_listgen_root(LLVMRuntime *runtime,
   auto child_get_num_elements = child->get_num_elements;
   auto child_from_parent_element = child->from_parent_element;
 #if ARCH_cuda
-  // Each block processes a parent container
+  // All blocks share the only root container, which has only one child container.
   int j_start = block_idx();
   int j_step = grid_dim();
-  // Each thread processes an element of the parent container
+  // Each thread processes a subset of the child container for more parallelism.
   int c_start = thread_idx();
   int c_step = block_dim();
 #else

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -943,7 +943,8 @@ void element_listgen_root(LLVMRuntime *runtime,
   auto child_get_num_elements = child->get_num_elements;
   auto child_from_parent_element = child->from_parent_element;
 #if ARCH_cuda
-  // All blocks share the only root container, which has only one child container.
+  // All blocks share the only root container, which has only one child
+  // container.
   int j_start = block_idx();
   int j_step = grid_dim();
   // Each thread processes a subset of the child container for more parallelism.

--- a/tests/python/test_no_activate.py
+++ b/tests/python/test_no_activate.py
@@ -1,0 +1,32 @@
+import taichi as ti
+
+
+@ti.require(ti.extension.sparse)
+@ti.all_archs
+def test_no_activate():
+    x = ti.var(ti.f32)
+
+    n = 1024
+
+    d = ti.root.dynamic(ti.i, n, chunk_size=32)
+    d.place(x)
+
+    @ti.kernel
+    def initialize():
+        for i in range(n):
+            x[i] = 1
+
+    @ti.kernel
+    def func():
+        ti.no_activate(d)
+        for i in range(n // 2):
+            x[i * 2 + 1] += 1
+    
+    initialize()
+        
+    func()
+    
+    for i in range(n):
+        assert x[i] == i % 2 + 1
+        
+

--- a/tests/python/test_no_activate.py
+++ b/tests/python/test_no_activate.py
@@ -21,12 +21,10 @@ def test_no_activate():
         ti.no_activate(d)
         for i in range(n // 2):
             x[i * 2 + 1] += 1
-    
+
     initialize()
-        
+
     func()
-    
+
     for i in range(n):
         assert x[i] == i % 2 + 1
-        
-


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

We now
 -  use a special list generation kernel for very long `ti.root.dynamic` SNodes
 - introduce a `ti.no_activate` hint to tell the compiler not to activate the `dynamic` node (or any other sparse SNode) on write, when you know it's already activated.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
