### PR TITLE
[Doc] Replace ti.Matrix to ti.Matrix.field in the documents

### DIFF
--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -69,7 +69,7 @@ To save images without invoking ``ti.GUI.show(filename)``, use ``ti.imwrite(file
         ti.imwrite(pixels.to_numpy(), filename)
         print(f'The image has been saved to {filename}')
 
-- ``ti.imwrite`` can export Taichi tensors (``ti.Matrix``, ``ti.Vector.field``, ``ti.field``) and numpy tensors ``np.ndarray``.
+- ``ti.imwrite`` can export Taichi tensors (``ti.Matrix.field``, ``ti.Vector.field``, ``ti.field``) and numpy tensors ``np.ndarray``.
 - Same as above ``ti.GUI.show(filename)``, the image format (``png``, ``jpg`` and ``bmp``) is also controlled by the suffix of ``filename`` in ``ti.imwrite(filename)``.
 - Meanwhile, the resulted image type (grayscale, RGB, or RGBA) is determined by **the number of channels in the input tensor**, i.e., the length of the third dimension (``tensor.shape[2]``).
 - In other words, a tensor that has shape ``(w, h)`` or ``(w, h, 1)`` will be exported as a grayscale image.

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -23,7 +23,7 @@ Use ``to_numpy``/``from_numpy``/``to_torch``/``from_torch``:
   # Taichi tensors
   val = ti.field(ti.i32, shape=(n, m))
   vec = ti.Vector.field(3, dtype=ti.i32, shape=(n, m))
-  mat = ti.Matrix(3, 4, dt=ti.i32, shape=(n, m))
+  mat = ti.Matrix.field(3, 4, dtype=ti.i32, shape=(n, m))
 
   # Scalar
   arr = np.ones(shape=(n, m), dtype=np.int32)

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -387,7 +387,7 @@ Image I/O
     :parameter img: (Matrix or Expr) the image you want to export
     :parameter filename: (string) the location you want to save to
 
-    Export a ``np.ndarray`` or Taichi tensor (``ti.Matrix``, ``ti.Vector.field``, or ``ti.field``) to a specified location ``filename``.
+    Export a ``np.ndarray`` or Taichi tensor (``ti.Matrix.field``, ``ti.Vector.field``, or ``ti.field``) to a specified location ``filename``.
 
     Same as ``ti.GUI.show(filename)``, the format of the exported image is determined by **the suffix of** ``filename`` as well. Now ``ti.imwrite`` supports exporting images to ``png``, ``img`` and ``jpg`` and we recommend using ``png``.
 
@@ -431,7 +431,7 @@ Image I/O
         shape = (512, 512)
         channels = 3
         type = ti.f32
-        pixels = ti.Matrix(channels, dt=type, shape=shape)
+        pixels = ti.Matrix.field(channels, dtype=type, shape=shape)
 
         @ti.kernel
         def draw():

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -30,7 +30,7 @@ As global tensors of matrices
 
     :parameter n: (scalar) the number of rows in the matrix
     :parameter m: (scalar) the number of columns in the matrix
-    :parameter dtype: (DataType) data type of the components
+    :parameter dt: (DataType) data type of the components
     :parameter shape: (optional, scalar or tuple) shape the tensor of vectors, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -6,7 +6,7 @@ Matrices
 - ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D tensor of scalars.
 - ``ti.Vector`` is the same as ``ti.Matrix``, except that it has only one column.
 - Differentiate element-wise product ``*`` and matrix product ``@``.
-- ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix(n, m, dt=ti.f32)`` to create tensors of vectors/matrices.
+- ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix.field(n, m, dtype=ti.f32)`` to create tensors of vectors/matrices.
 - ``A.transpose()``
 - ``R, S = ti.polar_decompose(A, ti.f32)``
 - ``U, sigma, V = ti.svd(A, ti.f32)`` (Note that ``sigma`` is a ``3x3`` diagonal matrix)
@@ -26,11 +26,11 @@ Declaration
 As global tensors of matrices
 +++++++++++++++++++++++++++++
 
-.. function:: ti.Matrix.var(n, m, dt, shape = None, offset = None)
+.. function:: ti.Matrix.field(n, m, dtype, shape = None, offset = None)
 
     :parameter n: (scalar) the number of rows in the matrix
     :parameter m: (scalar) the number of columns in the matrix
-    :parameter dt: (DataType) data type of the components
+    :parameter dtype: (DataType) data type of the components
     :parameter shape: (optional, scalar or tuple) shape the tensor of vectors, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
@@ -38,11 +38,11 @@ As global tensors of matrices
     ::
 
         # Python-scope
-        a = ti.Matrix.var(3, 3, dt=ti.f32, shape=(5, 4))
+        a = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(5, 4))
 
 .. note::
 
-    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Matrix`` declares tensors of matrices.
+    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Matrix.field`` declares tensors of matrices.
 
 
 As a temporary local variable

--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -23,10 +23,10 @@ In this way, the tensor's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusi
 
 .. code-block:: python
 
-    a = ti.Matrix(2, 3, dt=ti.f32, shape=(32,), offset=(-16, ))          # Works!
+    a = ti.Matrix.field(2, 3, dtype=ti.f32, shape=(32,), offset=(-16, ))          # Works!
     b = ti.Vector.field(3, dtype=ti.f32, shape=(16, 32, 64), offset=(7, 3, -4))   # Works!
-    c = ti.Matrix(2, 1, dt=ti.f32, shape=None, offset=(32,))             # AssertionError
-    d = ti.Matrix(3, 2, dt=ti.f32, shape=(32, 32), offset=(-16, ))       # AssertionError
+    c = ti.Matrix.field(2, 1, dtype=ti.f32, shape=None, offset=(32,))             # AssertionError
+    d = ti.Matrix.field(3, 2, dtype=ti.f32, shape=(32, 32), offset=(-16, ))       # AssertionError
     e = ti.field(dt=ti.i32, shape=16, offset=-16)                          # Works!
     f = ti.field(dt=ti.i32, shape=None, offset=-16)                        # AssertionError
     g = ti.field(dt=ti.i32, shape=(16, 32), offset=-16)                    # AssertionError

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -31,7 +31,7 @@ Tensors of matrices
 -------------------
 Tensor elements can also be matrices.
 
-Suppose you have a ``128 x 64`` tensor called ``A``, each element containing a ``3 x 2`` matrix. To allocate a ``128 x 64`` tensor of ``3 x 2`` matrix, use the statement ``A = ti.Matrix(3, 2, dt=ti.f32, shape=(128, 64))``.
+Suppose you have a ``128 x 64`` tensor called ``A``, each element containing a ``3 x 2`` matrix. To allocate a ``128 x 64`` tensor of ``3 x 2`` matrix, use the statement ``A = ti.Matrix.field(3, 2, dtype=ti.f32, shape=(128, 64))``.
 
 * If you want to get the matrix of grid node ``i, j``, please use ``mat = A[i, j]``. ``mat`` is simply a ``3 x 2`` matrix
 * To get the element on the first row and second column of that matrix, use ``mat[0, 1]`` or ``A[i, j][0, 1]``.
@@ -50,5 +50,5 @@ For example, ``2x1``, ``3x3``, ``4x4`` matrices are fine, yet ``32x6`` is probab
   Due to the unrolling mechanisms, operating on large matrices (e.g. ``32x128``) can lead to very long compilation time and low performance.
 
 If you have a dimension that is too large (e.g. ``64``), it's better to declare a tensor of size ``64``.
-E.g., instead of declaring ``ti.Matrix(64, 32, dt=ti.f32, shape=(3, 2))``, declare ``ti.Matrix(3, 2, dt=ti.f32, shape=(64, 32))``.
+E.g., instead of declaring ``ti.Matrix.field(64, 32, dtype=ti.f32, shape=(3, 2))``, declare ``ti.Matrix.field(3, 2, dtype=ti.f32, shape=(64, 32))``.
 Try to put large dimensions to tensors instead of matrices.


### PR DESCRIPTION
Related issue = #1500 

Good news: this PR has a quite small changeset. 

I do the following stuff in it:
- [x] Replace all global tensor `ti.Matrix` to `ti.Matrix.field`, and keep the local allocation the same as before.
- [x] Replace `dt` by `dtype` for all `ti.Matrix`

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
