### PR TITLE
[Doc] Replace tensor -> field for docs starting with [a-g]

### DIFF
--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -21,12 +21,12 @@ Let's consider the following simple kernel:
 .. code-block:: python
 
   @ti.kernel
-  def add(tensor: ti.template(), delta: ti.i32):
-    for i in tensor:
-      tensor[i] += delta
+  def add(field: ti.template(), delta: ti.i32):
+    for i in field:
+      field[i] += delta
 
 
-We allocate two 1D tensors to simplify discussion:
+We allocate two 1D fields to simplify discussion:
 
 .. code-block:: python
 

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -169,7 +169,7 @@ For example:
 
     @ti.func
     def copy(dst: ti.template(), src: ti.template()):
-        ti.static_assert(dst.shape == src.shape, "copy() needs src and dst tensors to be same shape")
+        ti.static_assert(dst.shape == src.shape, "copy() needs src and dst fields to be same shape")
         for I in ti.grouped(src):
             dst[I] = src[I]
         return x % 2 == 1

--- a/docs/differentiable_programming.rst
+++ b/docs/differentiable_programming.rst
@@ -9,15 +9,15 @@ The `DiffTaichi repo <https://github.com/yuanming-hu/difftaichi>`_ contains 10 d
 
 .. note::
     Unlike tools such as TensorFlow where **immutable** output buffers are generated,
-    the **imperative** programming paradigm adopted in Taichi allows programmers to freely modify global tensors.
+    the **imperative** programming paradigm adopted in Taichi allows programmers to freely modify global fields.
     To make automatic differentiation well-defined under this setting,
     we make the following assumption on Taichi programs for differentiable programming:
 
     **Global Data Access Rules:**
 
-      - If a global tensor element is written more than once, then starting from the second write, the
+      - If a global field element is written more than once, then starting from the second write, the
         write **must** come in the form of an atomic add (“accumulation", using ``ti.atomic_add`` or simply ``+=``).
-      - No read accesses happen to a global tensor element, until its accumulation is done.
+      - No read accesses happen to a global field element, until its accumulation is done.
 
     **Kernel Simplicity Rule:** Kernel body consists of multiple `simply nested` for-loops.
     I.e., each for-loop can either contain exactly one (nested) for-loop (and no other statements), or a group of statements without loops.

--- a/docs/export_results.rst
+++ b/docs/export_results.rst
@@ -69,15 +69,15 @@ To save images without invoking ``ti.GUI.show(filename)``, use ``ti.imwrite(file
         ti.imwrite(pixels.to_numpy(), filename)
         print(f'The image has been saved to {filename}')
 
-- ``ti.imwrite`` can export Taichi tensors (``ti.Matrix.field``, ``ti.Vector.field``, ``ti.field``) and numpy tensors ``np.ndarray``.
+- ``ti.imwrite`` can export Taichi fields (``ti.Matrix.field``, ``ti.Vector.field``, ``ti.field``) and numpy tensors ``np.ndarray``.
 - Same as above ``ti.GUI.show(filename)``, the image format (``png``, ``jpg`` and ``bmp``) is also controlled by the suffix of ``filename`` in ``ti.imwrite(filename)``.
-- Meanwhile, the resulted image type (grayscale, RGB, or RGBA) is determined by **the number of channels in the input tensor**, i.e., the length of the third dimension (``tensor.shape[2]``).
-- In other words, a tensor that has shape ``(w, h)`` or ``(w, h, 1)`` will be exported as a grayscale image.
-- If you want to export ``RGB`` or ``RGBA`` images instead, the input tensor should have a shape ``(w, h, 3)`` or ``(w, h, 4)`` respectively.
+- Meanwhile, the resulted image type (grayscale, RGB, or RGBA) is determined by **the number of channels in the input field**, i.e., the length of the third dimension (``field.shape[2]``).
+- In other words, a field that has shape ``(w, h)`` or ``(w, h, 1)`` will be exported as a grayscale image.
+- If you want to export ``RGB`` or ``RGBA`` images instead, the input field should have a shape ``(w, h, 3)`` or ``(w, h, 4)`` respectively.
 
 .. note::
 
-    All Taichi tensors have their own data types, such as ``ti.u8`` and ``ti.f32``. Different data types can lead to different behaviors of ``ti.imwrite``. Please check out :ref:`gui` for more details.
+    All Taichi fields have their own data types, such as ``ti.u8`` and ``ti.f32``. Different data types can lead to different behaviors of ``ti.imwrite``. Please check out :ref:`gui` for more details.
 
 - Taichi offers other helper functions that read and show images in addition to ``ti.imwrite``. They are also demonstrated in :ref:`gui`.
 

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -6,7 +6,7 @@ Interacting with external arrays
 **External arrays** refer to ``numpy.ndarray`` or ``torch.Tensor``.
 
 Conversion between Taichi fields and external arrays
------------------------------------------------------
+----------------------------------------------------
 
 Use ``to_numpy``/``from_numpy``/``to_torch``/``from_torch``:
 

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -5,7 +5,7 @@ Interacting with external arrays
 
 **External arrays** refer to ``numpy.ndarray`` or ``torch.Tensor``.
 
-Conversion between Taichi tensors and external arrays
+Conversion between Taichi fields and external arrays
 -----------------------------------------------------
 
 Use ``to_numpy``/``from_numpy``/``to_torch``/``from_torch``:
@@ -20,7 +20,7 @@ Use ``to_numpy``/``from_numpy``/``to_torch``/``from_torch``:
   n = 4
   m = 7
 
-  # Taichi tensors
+  # Taichi fields
   val = ti.field(ti.i32, shape=(n, m))
   vec = ti.Vector.field(3, dtype=ti.i32, shape=(n, m))
   mat = ti.Matrix.field(3, 4, dtype=ti.i32, shape=(n, m))

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -20,9 +20,9 @@ Frequently asked questions
         for i in range(100):  # This loop will not be parallelized
             ...
 
-**Q:** What's the most convinent way to load images / textures into Taichi tensors?
+**Q:** What's the most convinent way to load images / textures into Taichi fields?
 
-**A:** Simply use ``tensor.from_numpy(ti.imread('filename.png'))``.
+**A:** Simply use ``field.from_numpy(ti.imread('filename.png'))``.
 
 **Q:** Can Taichi co-operate with **other Python packages** like ``matplotlib``?
 
@@ -41,10 +41,10 @@ Frequently asked questions
 **A:** You may export it with :ref:`export_ply_files` so that you could view it in Houdini or Blender.
        Or make use the extension library `Taichi THREE <https://github.com/taichi-dev/taichi_glsl>` to render images and update to GUI in real-time.
 
-**Q:** How do I declare a tensor with **dynamic length**?
+**Q:** How do I declare a field with **dynamic length**?
 
-**A:** What you want may be the ``dynamic`` SNode, a kind of sparse tensor, see :ref:`dynamic`.
-       Or simply allocate a dense tensor large enough, and another 0-D tensor ``tensor_len[None]`` for length record.
+**A:** What you want may be the ``dynamic`` SNode, a kind of sparse field, see :ref:`dynamic`.
+       Or simply allocate a dense field large enough, and another 0-D field ``field_len[None]`` for length record.
        But in fact, the ``dynamic`` SNode could be slower than the latter solution, due to the cost of maintaining the sparsity information.
 
 **Q:** Can a user iterate over irregular topologies (e.g., graphs or tetrahedral meshes) instead of regular grids?

--- a/docs/global_settings.rst
+++ b/docs/global_settings.rst
@@ -22,7 +22,7 @@ Compilation
 Runtime
 *******
 
-- Restart the entire Taichi system (destroy all tensors and kernels): ``ti.reset()``.
+- Restart the entire Taichi system (destroy all fields and kernels): ``ti.reset()``.
 - To start program in debug mode: ``ti.init(debug=True)`` or ``ti debug your_script.py``.
 - To disable importing torch on start up: ``export TI_ENABLE_TORCH=0``.
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -53,7 +53,7 @@ Paint on a window
 .. function:: gui.set_image(img)
 
     :parameter gui: (GUI) the window object
-    :parameter img: (np.array or Tensor) tensor containing the image, see notes below
+    :parameter img: (np.array or field) field containing the image, see notes below
 
     Set an image to display on the window.
 
@@ -387,11 +387,11 @@ Image I/O
     :parameter img: (Matrix or Expr) the image you want to export
     :parameter filename: (string) the location you want to save to
 
-    Export a ``np.ndarray`` or Taichi tensor (``ti.Matrix.field``, ``ti.Vector.field``, or ``ti.field``) to a specified location ``filename``.
+    Export a ``np.ndarray`` or Taichi field (``ti.Matrix.field``, ``ti.Vector.field``, or ``ti.field``) to a specified location ``filename``.
 
     Same as ``ti.GUI.show(filename)``, the format of the exported image is determined by **the suffix of** ``filename`` as well. Now ``ti.imwrite`` supports exporting images to ``png``, ``img`` and ``jpg`` and we recommend using ``png``.
 
-    Please make sure that the input image has **a valid shape**. If you want to export a grayscale image, the input shape of tensor should be ``(height, weight)`` or ``(height, weight, 1)``. For example:
+    Please make sure that the input image has **a valid shape**. If you want to export a grayscale image, the input shape of field should be ``(height, weight)`` or ``(height, weight, 1)``. For example:
 
     .. code-block:: python
 
@@ -412,13 +412,13 @@ Image I/O
 
         ti.imwrite(pixels, f"export_u8.png")
 
-    Besides, for RGB or RGBA images, ``ti.imwrite`` needs to receive a tensor which has shape ``(height, width, 3)`` and ``(height, width, 4)`` individually.
+    Besides, for RGB or RGBA images, ``ti.imwrite`` needs to receive a field which has shape ``(height, width, 3)`` and ``(height, width, 4)`` individually.
 
-    Generally the value of the pixels on each channel of a ``png`` image is an integar in [0, 255]. For this reason, ``ti.imwrite`` will **cast tensors** which has different datatypes all **into integars between [0, 255]**. As a result, ``ti.imwrite`` has the following requirements for different datatypes of input tensors:
+    Generally the value of the pixels on each channel of a ``png`` image is an integar in [0, 255]. For this reason, ``ti.imwrite`` will **cast fields** which has different datatypes all **into integars between [0, 255]**. As a result, ``ti.imwrite`` has the following requirements for different datatypes of input fields:
 
-    - For float-type (``ti.f16``, ``ti.f32``, etc) input tensors, **the value of each pixel should be float between [0.0, 1.0]**. Otherwise ``ti.imwrite`` will first clip them into [0.0, 1.0]. Then they are multiplied by 256 and casted to integaters ranging from [0, 255].
+    - For float-type (``ti.f16``, ``ti.f32``, etc) input fields, **the value of each pixel should be float between [0.0, 1.0]**. Otherwise ``ti.imwrite`` will first clip them into [0.0, 1.0]. Then they are multiplied by 256 and casted to integaters ranging from [0, 255].
 
-    - For int-type (``ti.u8``, ``ti.u16``, etc) input tensors, **the value of each pixel can be any valid integer in its own bounds**. These integers in this tensor will be scaled to [0, 255] by being divided over the upper bound of its basic type accordingly.
+    - For int-type (``ti.u8``, ``ti.u16``, etc) input fields, **the value of each pixel can be any valid integer in its own bounds**. These integers in this field will be scaled to [0, 255] by being divided over the upper bound of its basic type accordingly.
 
     Here is another example:
 
@@ -453,7 +453,7 @@ Image I/O
 
     This function loads an image from the target filename and returns it as a ``np.ndarray(dtype=np.uint8)``.
 
-    Each value in this returned tensor is an integer in [0, 255].
+    Each value in this returned field is an integer in [0, 255].
 
 .. function:: ti.imshow(img, windname)
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -53,7 +53,7 @@ Paint on a window
 .. function:: gui.set_image(img)
 
     :parameter gui: (GUI) the window object
-    :parameter img: (np.array or field) field containing the image, see notes below
+    :parameter img: (np.array or ti.field) field containing the image, see notes below
 
     Set an image to display on the window.
 


### PR DESCRIPTION
Related issue = #1500 

In this issue, I replace **all meaningful Taichi `tensor`** by `field`in the text of our document. The involved files are all beginning with "a" to "g" as shown below:
```
acknowledgments.rst
atomic.rst
cli_utilities.rst
compilation.rst
contributor_guide.rst
cpp_style.rst
debugging.rst
dev_install.rst
differentiable_programming.rst
export_results.rst
extension_libraries.rst
external.rst
faq.rst
global_settings.rst
gui.rst
```

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
