### PR TITLE
[Doc] Update new allocation APIs' definitions in the documents

### DIFF
--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -30,7 +30,7 @@ As global tensors of matrices
 
     :parameter n: (scalar) the number of rows in the matrix
     :parameter m: (scalar) the number of columns in the matrix
-    :parameter dt: (DataType) data type of the components
+    :parameter dtype: (DataType) data type of the components
     :parameter shape: (optional, scalar or tuple) shape the tensor of vectors, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -27,10 +27,10 @@ as a type hint to pass a tensor as an argument. For example:
         for i in x:
             y[i] = x[i]
 
-    a = ti.var(ti.f32, 4)
-    b = ti.var(ti.f32, 4)
-    c = ti.var(ti.f32, 12)
-    d = ti.var(ti.f32, 12)
+    a = ti.field(ti.f32, 4)
+    b = ti.field(ti.f32, 4)
+    c = ti.field(ti.f32, 12)
+    d = ti.field(ti.f32, 12)
     copy(a, b)
     copy(c, d)
 

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -9,7 +9,7 @@ Declaration
 
 .. function:: ti.field(dt, shape = None, offset = None)
 
-    :parameter dt: (DataType) type of the tensor element
+    :parameter dtype: (DataType) type of the tensor element
     :parameter shape: (optional, scalar or tuple) the shape of tensor
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -7,7 +7,7 @@ Tensors of scalars
 Declaration
 -----------
 
-.. function:: ti.field(dt, shape = None, offset = None)
+.. function:: ti.field(dtype, shape = None, offset = None)
 
     :parameter dtype: (DataType) type of the tensor element
     :parameter shape: (optional, scalar or tuple) the shape of tensor

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -16,10 +16,10 @@ Declaration
 As global tensors of vectors
 ++++++++++++++++++++++++++++
 
-.. function:: ti.Vector.field(n, dt, shape = None, offset = None)
+.. function:: ti.Vector.field(n, dtype, shape = None, offset = None)
 
     :parameter n: (scalar) the number of components in the vector
-    :parameter dt: (DataType) data type of the components
+    :parameter dtype: (DataType) data type of the components
     :parameter shape: (optional, scalar or tuple) shape the tensor of vectors, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 


### PR DESCRIPTION
Related issue = #1500 

In this issue: The definition of `ti.field`, `ti.Vector.field` and `ti.Matrix.field` are all maintained.


Also, I noticed that in `meta.rst` there are some new-added `ti.var`, so I replace them by `ti.field` as well. Hope this won't break the consistency.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
