### PR TITLE
[test] Skip mpm88 async on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,6 @@ cache:
 
 build_script:
   - set TAICHI_REPO_DIR=C:\taichi
-  - set IS_APPVEYOR=1
   - "%PYTHON% %TAICHI_REPO_DIR%/misc/appveyor_filter.py || appveyor exit 0"
   - cd C:\
   - curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip -LO

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ cache:
 
 build_script:
   - set TAICHI_REPO_DIR=C:\taichi
+  - set IS_APPVEYOR=1
   - "%PYTHON% %TAICHI_REPO_DIR%/misc/appveyor_filter.py || appveyor exit 0"
   - cd C:\
   - curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip -LO

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -114,7 +114,9 @@ def test_mpm88():
 
 
 def _is_appveyor():
-    return int(os.getenv('IS_APPVEYOR', 0)) > 0
+    # AppVeyor adds `APPVEYOR=True` ('true' on Ubuntu)
+    # https://www.appveyor.com/docs/environment-variables/
+    return os.getenv('APPVEYOR', '').lower() == 'true'
 
 
 @pytest.mark.skipif(_is_appveyor(), reason='Stuck on Appveyor.')

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -1,7 +1,7 @@
-import platform
 import pytest
 import taichi as ti
 from taichi import approx
+import os
 
 
 def run_mpm88_test():
@@ -113,8 +113,11 @@ def test_mpm88():
     run_mpm88_test()
 
 
-# @pytest.mark.skipif(platform.system() == 'Windows',
-#                     reason='Stuck on Appveyor?')
+def _is_appveyor():
+    return int(os.getenv('IS_APPVEYOR', 0)) > 0
+
+
+@pytest.mark.skipif(_is_appveyor(), reason='Stuck on Appveyor.')
 @ti.archs_with([ti.cpu], async_mode=True)
 def test_mpm88_async():
     # It seems that all async tests on Appveyor run super slow. For example,


### PR DESCRIPTION
See if this lets us get away with Appveyor. If not, I will skip Win entirely for this test.

Related issue = #1530

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
