### PR TITLE
[OpenGL] [perf] Support TLS to improve reduction performance

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -1232,7 +1232,7 @@ FunctionType CodeGen::compile() {
                               /*vectorize=*/false, kernel_->grad,
                               /*ad_use_stack=*/true, config.print_ir,
                               /*lower_global_access=*/true,
-                              /*make_thread_local=*/true);
+                              /*make_thread_local=*/config.make_thread_local);
 
   KernelCodegen codegen(
       taichi_kernel_name_, kernel_->program.snode_root->node_type_name, kernel_,

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -1037,7 +1037,7 @@ void OpenglCodeGen::lower() {
                               /*vectorize=*/false, kernel_->grad,
                               /*ad_use_stack=*/false, config.print_ir,
                               /*lower_global_access=*/true,
-                              /*make_thread_local=*/true);
+                              /*make_thread_local=*/config.make_thread_local);
 #ifdef _GLSL_DEBUG
   irpass::print(ir);
 #endif

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -61,33 +61,36 @@ class KernelGen : public IRVisitor {
             std::string kernel_name,
             StructCompiledResult *struct_compiled)
       : kernel(kernel),
-        compiled_program_(std::make_unique<CompiledProgram>(kernel)),
         struct_compiled_(struct_compiled),
         kernel_name_(kernel_name),
         glsl_kernel_prefix_(kernel_name),
+        compiled_program_(std::make_unique<CompiledProgram>(kernel)),
         ps(std::make_unique<ParallelSize_ConstRange>(0)) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
   }
 
  private:
-  std::unique_ptr<CompiledProgram> compiled_program_;
-
+  // constants:
   StructCompiledResult *struct_compiled_;
   const SNode *root_snode_;
   GetRootStmt *root_stmt_;
   std::string kernel_name_;
-  std::string glsl_kernel_name_;
   std::string root_snode_type_name_;
   std::string glsl_kernel_prefix_;
-  int glsl_kernel_count_{0};
 
+  // throughout variables:
+  int glsl_kernel_count_{0};
   bool is_top_level_{true};
-  bool is_grid_stride_loop_{false};
+  std::unique_ptr<CompiledProgram> compiled_program_;
+  UsedFeature used;  // TODO: is this actually per-offload?
+
+  // per-offload variables:
   LineAppender line_appender_;
   LineAppender line_appender_header_;
+  std::string glsl_kernel_name_;
   std::unique_ptr<ParallelSize> ps;
-  UsedFeature used;
+  bool is_grid_stride_loop_{false};
   size_t max_tls_size{0};
 
   template <typename... Args>
@@ -166,18 +169,6 @@ class KernelGen : public IRVisitor {
       kernel_header +=
           "layout(std430, binding = 3) buffer earg_i32 { int _earg_i32_[]; };\n";
     }
-    if (used.buf_thls) {
-      kernel_header +=
-        fmt::format("int _thls_i32_[{}];\n", max_tls_size);
-      kernel_header +=
-        fmt::format("float _thls_f32_[{}];\n", max_tls_size);
-      if (used.float64)
-        kernel_header +=
-          fmt::format("double _thls_f64_[{}];\n", max_tls_size);
-      if (used.int64)
-        kernel_header +=
-          fmt::format("int64_t _thls_i64_[{}];\n", max_tls_size);
-    }
     if (used.buf_extr) {
       kernel_header +=
           "layout(std430, binding = 4) buffer extr_i32 { int _extr_i32_[]; };\n"
@@ -186,6 +177,18 @@ class KernelGen : public IRVisitor {
         kernel_header += "layout(std430, binding = 4) buffer extr_f64 { double _extr_f64_[]; };\n";
       if (used.int64)
         kernel_header += "layout(std430, binding = 4) buffer extr_i64 { int64_t _extr_i64_[]; };\n";
+    }
+    if (max_tls_size != 0) {
+      kernel_header +=
+        fmt::format("int _tls_i32_[{}];\n", max_tls_size);
+      kernel_header +=
+        fmt::format("float _tls_f32_[{}];\n", max_tls_size);
+      if (used.float64)
+        kernel_header +=
+          fmt::format("double _tls_f64_[{}];\n", max_tls_size);
+      if (used.int64)
+        kernel_header +=
+          fmt::format("int64_t _tls_i64_[{}];\n", max_tls_size);
     }
     // clang-format on
     if (used.simulated_atomic_float) {
@@ -237,6 +240,7 @@ class KernelGen : public IRVisitor {
     line_appender_header_.clear_all();
     line_appender_.clear_all();
     ps = std::make_unique<ParallelSize_ConstRange>(0);
+    max_tls_size = 0;
   }
 
   void visit(Block *stmt) override {
@@ -891,10 +895,9 @@ class KernelGen : public IRVisitor {
 
   void visit(ThreadLocalPtrStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    used.buf_thls = true;
     max_tls_size = stmt->offset + 1;
     emit("int {} = {};", stmt->short_name(), stmt->offset);
-    ptr_signats[stmt->id] = "thls";
+    ptr_signats[stmt->id] = "tls";
   }
 
   void visit(LoopIndexStmt *stmt) override {

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -255,8 +255,7 @@ struct GLBuffer : GLSSBO {
     bind_index((int)index);
   }
 
-  GLBuffer(GLBufId index)
-      : index(index), base(nullptr), size(0) {
+  GLBuffer(GLBufId index) : index(index), base(nullptr), size(0) {
     bind_index((int)index);
   }
 

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -436,7 +436,9 @@ bool initialize_opengl(bool error_tolerance) {
 void display_kernel_info(std::string const &kernel_name,
                          std::string const &kernel_source_code) {
   bool is_accessor = taichi::starts_with(kernel_name, "snode_") ||
-                     taichi::starts_with(kernel_name, "tensor_") ||
+                     taichi::starts_with(kernel_name, "tensor_to_") ||
+                     taichi::starts_with(kernel_name, "matrix_to_") ||
+                     taichi::starts_with(kernel_name, "ext_arr_to_") ||
                      taichi::starts_with(kernel_name, "jit_evaluator_");
   if (!is_accessor)
     TI_DEBUG("source of kernel [{}]:\n{}", kernel_name, kernel_source_code);

--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -26,7 +26,6 @@ struct UsedFeature {
   bool buf_earg{false};
   bool buf_extr{false};
   bool buf_gtmp{false};
-  bool buf_thls{false};
 
   // utilties:
   bool fast_pow{false};

--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -26,6 +26,7 @@ struct UsedFeature {
   bool buf_earg{false};
   bool buf_extr{false};
   bool buf_gtmp{false};
+  bool buf_thls{false};
 
   // utilties:
   bool fast_pow{false};

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -35,6 +35,7 @@ CompileConfig::CompileConfig() {
   fast_math = true;
   async_mode = false;
   flatten_if = false;
+  make_thread_local = true;
 
 #if defined(TI_PLATFORM_WINDOWS) or defined(TI_ARCH_ARM)
   use_unified_memory = false;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -35,6 +35,7 @@ struct CompileConfig {
   bool use_unified_memory;
   bool async_mode;
   bool flatten_if;
+  bool make_thread_local;
   DataType default_fp;
   DataType default_ip;
   std::string extra_flags;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -119,7 +119,8 @@ void export_lang(py::module &m) {
                      &CompileConfig::advanced_optimization)
       .def_readwrite("ad_stack_size", &CompileConfig::ad_stack_size)
       .def_readwrite("async_mode", &CompileConfig::async_mode)
-      .def_readwrite("flatten_if", &CompileConfig::flatten_if);
+      .def_readwrite("flatten_if", &CompileConfig::flatten_if)
+      .def_readwrite("make_thread_local", &CompileConfig::make_thread_local);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });


### PR DESCRIPTION
Related PR = #1336

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

Running on my poor Intel card:
fem99: 4.6 -> 40 (!!!!)
fem128: 18 -> 26
mpm_lagrangian_forces: 3.8 -> 15.7
misc/benchmark_reduction.py: `GL_OUT_OF_MEMORY` :(

No performance difference observed on the NV card, seems NV's compiler is already capable of doing TLS optimization for us?

(Partial) OFT:
[cli] [opengl] [metal] TI_MAKE_THREAD_LOCAL=0 to disable TLS on OpenGL/Metal.