### PR TITLE
[Doc] Replace tensor by field for files beginning with o to s

### DIFF
--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -3,14 +3,14 @@
 Coordinate offsets
 ==================
 
-- A Taichi tensor can be defined with **coordinate offsets**. The offsets will move tensor bounds so that tensor origins are no longer zero vectors. A typical use case is to support voxels with negative coordinates in physical simulations.
+- A Taichi field can be defined with **coordinate offsets**. The offsets will move field bounds so that field origins are no longer zero vectors. A typical use case is to support voxels with negative coordinates in physical simulations.
 - For example, a matrix of ``32x64`` elements with coordinate offset ``(-16, 8)`` can be defined as the following:
 
 .. code-block:: python
 
     a = ti.Matrix(2, 2, dt=ti.f32, shape=(32, 64), offset=(-16, 8))
 
-In this way, the tensor's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusive).
+In this way, the field's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusive).
 
 .. code-block:: python
 
@@ -19,7 +19,7 @@ In this way, the tensor's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusi
     a[-16, 64]  # upper left corner
     a[16, 64]   # upper right corner
 
-.. note:: The dimensionality of tensor shapes should **be consistent** with that of the offset. Otherwise, a ``AssertionError`` will be raised.
+.. note:: The dimensionality of field shapes should **be consistent** with that of the offset. Otherwise, a ``AssertionError`` will be raised.
 
 .. code-block:: python
 

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -1,7 +1,7 @@
 .. _scalar_tensor:
 
 Fields of scalars
-==================
+=================
 
 
 Declaration

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -1,6 +1,6 @@
 .. _scalar_tensor:
 
-Tensors of scalars
+Fields of scalars
 ==================
 
 
@@ -9,21 +9,21 @@ Declaration
 
 .. function:: ti.field(dtype, shape = None, offset = None)
 
-    :parameter dtype: (DataType) type of the tensor element
-    :parameter shape: (optional, scalar or tuple) the shape of tensor
+    :parameter dtype: (DataType) type of the field element
+    :parameter shape: (optional, scalar or tuple) the shape of field
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a *dense* tensor with four ``int32`` as elements:
+    For example, this creates a *dense* field with four ``int32`` as elements:
     ::
 
         x = ti.field(ti.i32, shape=4)
 
-    This creates a 4x3 *dense* tensor with ``float32`` elements:
+    This creates a 4x3 *dense* field with ``float32`` elements:
     ::
 
         x = ti.field(ti.f32, shape=(4, 3))
 
-    If shape is ``()`` (empty tuple), then a 0-D tensor (scalar) is created:
+    If shape is ``()`` (empty tuple), then a 0-D field (scalar) is created:
     ::
 
         x = ti.field(ti.f32, shape=())
@@ -42,7 +42,7 @@ Declaration
 
 .. note::
 
-    Not providing ``shape`` allows you to *place* the tensor in a layout other than the default *dense*, see :ref:`layout` for more details.
+    Not providing ``shape`` allows you to *place* the field in a layout other than the default *dense*, see :ref:`layout` for more details.
 
 
 .. warning::
@@ -63,34 +63,34 @@ Declaration
 
         func()
         y = ti.field(ti.f32, shape=())
-        # ERROR: cannot create tensor after kernel invocation!
+        # ERROR: cannot create field after kernel invocation!
 
     .. code-block:: python
 
         x = ti.field(ti.f32, shape=())
         x[None] = 1
         y = ti.field(ti.f32, shape=())
-        # ERROR: cannot create tensor after any tensor accesses from the Python-scope!
+        # ERROR: cannot create field after any field accesses from the Python-scope!
 
 
 Accessing components
 --------------------
 
-You can access an element of the Taichi tensor by an index or indices.
+You can access an element of the Taichi field by an index or indices.
 
 .. attribute:: a[p, q, ...]
 
-    :parameter a: (Tensor) the tensor of scalars
-    :parameter p: (scalar) index of the first tensor dimension
-    :parameter q: (scalar) index of the second tensor dimension
+    :parameter a: (Field) the field of scalars
+    :parameter p: (scalar) index of the first field dimension
+    :parameter q: (scalar) index of the second field dimension
     :return: (scalar) the element at ``[p, q, ...]``
 
-    This extracts the element value at index ``[3, 4]`` of tensor ``a``:
+    This extracts the element value at index ``[3, 4]`` of field ``a``:
     ::
 
         x = a[3, 4]
 
-    This sets the element value at index ``2`` of 1D tensor ``b`` to ``5``:
+    This sets the element value at index ``2`` of 1D field ``b`` to ``5``:
     ::
 
         b[2] = 5
@@ -101,7 +101,7 @@ You can access an element of the Taichi tensor by an index or indices.
 
     .. note ::
 
-        The returned value can also be ``Vector`` / ``Matrix`` if ``a`` is a tensor of vector / matrix, see :ref:`vector` for more details.
+        The returned value can also be ``Vector`` / ``Matrix`` if ``a`` is a field of vector / matrix, see :ref:`vector` for more details.
 
 
 Meta data
@@ -110,8 +110,8 @@ Meta data
 
 .. attribute:: a.shape
 
-    :parameter a: (Tensor) the tensor
-    :return: (tuple) the shape of tensor ``a``
+    :parameter a: (Field) the field
+    :return: (tuple) the shape of field ``a``
 
     ::
 
@@ -127,7 +127,7 @@ Meta data
 
 .. function:: a.dtype
 
-    :parameter a: (Tensor) the tensor
+    :parameter a: (Field) the field
     :return: (DataType) the data type of ``a``
 
     ::
@@ -138,7 +138,7 @@ Meta data
 
 .. function:: a.parent(n = 1)
 
-    :parameter a: (Tensor) the tensor
+    :parameter a: (Field) the field
     :parameter n: (optional, scalar) the number of parent steps, i.e. ``n=1`` for parent, ``n=2`` grandparent, etc.
     :return: (SNode) the parent of ``a``'s containing SNode
 

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -63,14 +63,14 @@ Declaration
 
         func()
         y = ti.field(ti.f32, shape=())
-        # ERROR: cannot create field after kernel invocation!
+        # ERROR: cannot create fields after kernel invocation!
 
     .. code-block:: python
 
         x = ti.field(ti.f32, shape=())
         x[None] = 1
         y = ti.field(ti.f32, shape=())
-        # ERROR: cannot create field after any field accesses from the Python-scope!
+        # ERROR: cannot create fields after any field accesses from the Python-scope!
 
 
 Accessing components
@@ -80,7 +80,7 @@ You can access an element of the Taichi field by an index or indices.
 
 .. attribute:: a[p, q, ...]
 
-    :parameter a: (Field) the field of scalars
+    :parameter a: (ti.field) the field of scalars
     :parameter p: (scalar) index of the first field dimension
     :parameter q: (scalar) index of the second field dimension
     :return: (scalar) the element at ``[p, q, ...]``
@@ -110,7 +110,7 @@ Meta data
 
 .. attribute:: a.shape
 
-    :parameter a: (Field) the field
+    :parameter a: (ti.field) the field
     :return: (tuple) the shape of field ``a``
 
     ::

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -127,7 +127,7 @@ Meta data
 
 .. function:: a.dtype
 
-    :parameter a: (Field) the field
+    :parameter a: (ti.field) the field
     :return: (DataType) the data type of ``a``
 
     ::
@@ -138,7 +138,7 @@ Meta data
 
 .. function:: a.parent(n = 1)
 
-    :parameter a: (Field) the field
+    :parameter a: (ti.field) the field
     :parameter n: (optional, scalar) the number of parent steps, i.e. ``n=1`` for parent, ``n=2`` grandparent, etc.
     :return: (SNode) the parent of ``a``'s containing SNode
 

--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -20,7 +20,7 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
 .. function:: snode.place(x, ...)
 
     :parameter snode: (SNode) where to place
-    :parameter x: (field) field(s) to be placed
+    :parameter a: (ti.field) field(s) to be placed
     :return: (SNode) the ``snode`` itself
 
     The following code places two 0-D fields named ``x`` and ``y``:
@@ -35,7 +35,7 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
 
 .. function:: field.shape
 
-    :parameter field: (Field)
+    :parameter a: (ti.field)
     :return: (tuple of integers) the shape of field
 
     Equivalent to ``field.snode().shape``.
@@ -50,7 +50,7 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
 
 .. function:: field.snode()
 
-    :parameter field: (Field)
+    :parameter a: (ti.field)
     :return: (SNode) the structual node where ``field`` is placed
 
     ::

--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -187,7 +187,7 @@ Working with ``dynamic`` SNodes
 
 
 Taichi fields like powers of two
----------------------------------
+--------------------------------
 
 Non-power-of-two field dimensions are promoted into powers of two and thus these fields will occupy more virtual address space.
 For example, a (dense) field of size ``(18, 65)`` will be materialized as ``(32, 128)``.

--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -20,10 +20,10 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
 .. function:: snode.place(x, ...)
 
     :parameter snode: (SNode) where to place
-    :parameter x: (tensor) tensor(s) to be placed
+    :parameter x: (field) field(s) to be placed
     :return: (SNode) the ``snode`` itself
 
-    The following code places two 0-D tensors named ``x`` and ``y``:
+    The following code places two 0-D fields named ``x`` and ``y``:
 
     ::
 
@@ -33,12 +33,12 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
         assert x.snode() == y.snode()
 
 
-.. function:: tensor.shape
+.. function:: field.shape
 
-    :parameter tensor: (Tensor)
-    :return: (tuple of integers) the shape of tensor
+    :parameter field: (Field)
+    :return: (tuple of integers) the shape of field
 
-    Equivalent to ``tensor.snode().shape``.
+    Equivalent to ``field.snode().shape``.
 
     For example,
 
@@ -48,10 +48,10 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
         x.shape # returns (3, 5, 4)
 
 
-.. function:: tensor.snode()
+.. function:: field.snode()
 
-    :parameter tensor: (Tensor)
-    :return: (SNode) the structual node where ``tensor`` is placed
+    :parameter field: (Field)
+    :return: (SNode) the structual node where ``field`` is placed
 
     ::
 
@@ -106,17 +106,17 @@ Node types
 
     :parameter snode: (SNode) parent node where the child is derived from
     :parameter indices: (Index or Indices) indices used for this node
-    :parameter shape: (scalar or tuple) shape the tensor of vectors
+    :parameter shape: (scalar or tuple) shape the field of vectors
     :return: (SNode) the derived child node
 
-    The following code places a 1-D tensor of size ``3``:
+    The following code places a 1-D field of size ``3``:
 
     ::
 
         x = ti.field(dt=ti.i32)
         ti.root.dense(ti.i, 3).place(x)
 
-    The following code places a 2-D tensor of shape ``(3, 4)``:
+    The following code places a 2-D field of shape ``(3, 4)``:
 
     ::
 
@@ -150,7 +150,7 @@ Node types
     ``dynamic`` nodes acts like ``std::vector`` in C++ or ``list`` in Python.
     Taichi's dynamic memory allocation system allocates its memory on the fly.
 
-    The following places a 1-D dynamic tensor of maximum size ``16``:
+    The following places a 1-D dynamic field of maximum size ``16``:
 
     ::
 
@@ -186,11 +186,11 @@ Working with ``dynamic`` SNodes
     Inserts ``val`` into the ``dynamic`` node with indices ``indices``.
 
 
-Taichi tensors like powers of two
+Taichi fields like powers of two
 ---------------------------------
 
-Non-power-of-two tensor dimensions are promoted into powers of two and thus these tensors will occupy more virtual address space.
-For example, a (dense) tensor of size ``(18, 65)`` will be materialized as ``(32, 128)``.
+Non-power-of-two field dimensions are promoted into powers of two and thus these fields will occupy more virtual address space.
+For example, a (dense) field of size ``(18, 65)`` will be materialized as ``(32, 128)``.
 
 
 Indices

--- a/docs/syntax_sugars.rst
+++ b/docs/syntax_sugars.rst
@@ -12,16 +12,16 @@ For example, consider the simple kernel:
 
   @ti.kernel
   def my_kernel():
-    for i, j in tensor_a:
-      tensor_b[i, j] = some_function(tensor_a[i, j])
+    for i, j in field_a:
+      field_b[i, j] = some_function(field_a[i, j])
 
-The tensors and function be aliased to new names with ``ti.static``:
+The fields and function be aliased to new names with ``ti.static``:
 
 .. code-block:: python
 
   @ti.kernel
   def my_kernel():
-    a, b, fun = ti.static(tensor_a, tensor_b, some_function)
+    a, b, fun = ti.static(field_a, field_b, some_function)
     for i,j in a:
       b[i,j] = fun(a[i,j])
 
@@ -29,7 +29,7 @@ The tensors and function be aliased to new names with ``ti.static``:
 
 Aliases can also be created for class members and methods, which can help prevent cluttering objective data-oriented programming code with ``self``.
 
-For example, consider class kernel to compute the 2-D laplacian of some tensor:
+For example, consider class kernel to compute the 2-D laplacian of some field:
 
 .. code-block:: python
 
@@ -54,4 +54,4 @@ Using ``ti.static()``, it can be simplified to:
 
   ``ti.static`` can also be used in combination with ``if`` (compile-time branching) and ``for`` (compile-time unrolling). See :ref:`meta` for more details.
 
-  Here, we are using it for *compile-time const values*, i.e. the **tensor/function handles** are constants at compile time.
+  Here, we are using it for *compile-time const values*, i.e. the **field/function handles** are constants at compile time.


### PR DESCRIPTION
Related issue = #1500 

This PR replaced `tensor` by `field` in the following files
- [x] odop.rst
- [x] offset.rst
- [x] overview.rst
- [x] profiler.rst
- [x] scalar_tensor.rst
- [x] snode.rst
- [x] sparse.rst
- [x] syntax.rst
- [x] syntax_sugars.rst

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
