### PR TITLE
[Doc] Replace fields of xxx by xxx field

### DIFF
--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -424,7 +424,7 @@ Image I/O
 
 .. function:: ti.imwrite(img, filename)
 
-    :parameter img: (ti.Matrix.field or Expr) the image you want to export
+    :parameter img: (ti.Vector.field or ti.field) the image you want to export
     :parameter filename: (string) the location you want to save to
 
     Export a ``np.ndarray`` or Taichi field (``ti.Matrix.field``, ``ti.Vector.field``, or ``ti.field``) to a specified location ``filename``.
@@ -497,7 +497,7 @@ Image I/O
 
 .. function:: ti.imshow(img, windname)
 
-    :parameter img: (ti.Matrix.field or Expr) the image to show in the GUI
+    :parameter img: (ti.Vector.field or ti.field) the image to show in the GUI
     :parameter windname: (string) the name of the GUI window
 
     This function will create an instance of ``ti.GUI`` and show the input image on the screen.

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -424,7 +424,7 @@ Image I/O
 
 .. function:: ti.imwrite(img, filename)
 
-    :parameter img: (Matrix or Expr) the image you want to export
+    :parameter img: (ti.Matrix.field or Expr) the image you want to export
     :parameter filename: (string) the location you want to save to
 
     Export a ``np.ndarray`` or Taichi field (``ti.Matrix.field``, ``ti.Vector.field``, or ``ti.field``) to a specified location ``filename``.
@@ -497,7 +497,7 @@ Image I/O
 
 .. function:: ti.imshow(img, windname)
 
-    :parameter img: (Matrix or Expr) the image to show in the GUI
+    :parameter img: (ti.Matrix.field or Expr) the image to show in the GUI
     :parameter windname: (string) the name of the GUI window
 
     This function will create an instance of ``ti.GUI`` and show the input image on the screen.

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -3,10 +3,10 @@
 Matrices
 ========
 
-- ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D field of scalars.
+- ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D sclar field.
 - ``ti.Vector`` is the same as ``ti.Matrix``, except that it has only one column.
 - Differentiate element-wise product ``*`` and matrix product ``@``.
-- ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix.field(n, m, dtype=ti.f32)`` to create fields of vectors/matrices.
+- ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix.field(n, m, dtype=ti.f32)`` to create vector/matrice fields.
 - ``A.transpose()``
 - ``R, S = ti.polar_decompose(A, ti.f32)``
 - ``U, sigma, V = ti.svd(A, ti.f32)`` (Note that ``sigma`` is a ``3x3`` diagonal matrix)
@@ -23,18 +23,18 @@ A matrix in Taichi can have two forms:
 Declaration
 -----------
 
-As global fields of matrices
-++++++++++++++++++++++++++++
+As global matrix fields
++++++++++++++++++++++++
 
 .. function:: ti.Matrix.field(n, m, dtype, shape = None, offset = None)
 
     :parameter n: (scalar) the number of rows in the matrix
     :parameter m: (scalar) the number of columns in the matrix
     :parameter dtype: (DataType) data type of the components
-    :parameter shape: (optional, scalar or tuple) shape the field of vectors, see :ref:`tensor`
+    :parameter shape: (optional, scalar or tuple) shape the vector fields, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a 5x4 field of 3x3 matrices:
+    For example, this creates a 5x4 matrix field which has 3x3 matrix on each entry:
     ::
 
         # Python-scope
@@ -42,7 +42,7 @@ As global fields of matrices
 
 .. note::
 
-    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Matrix.field`` declares fields of matrices.
+    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Matrix.field`` declares matrix fields.
 
 
 As a temporary local variable
@@ -90,11 +90,11 @@ As a temporary local variable
 Accessing components
 --------------------
 
-As global fields of vectors
-+++++++++++++++++++++++++++
+As global vector fields
++++++++++++++++++++++++
 .. attribute:: a[p, q, ...][i, j]
 
-    :parameter a: (field of matrices) the field of matrices
+    :parameter a: (ti.Matrix.field) the matrix field
     :parameter p: (scalar) index of the first field dimension
     :parameter q: (scalar) index of the second field dimension
     :parameter i: (scalar) row index of the matrix
@@ -111,12 +111,12 @@ As global fields of vectors
 
 .. note::
 
-    **Always** use two pair of square brackets to access scalar elements from fields of matrices.
+    **Always** use two pair of square brackets to access scalar elements from matrix fields.
 
-     - The indices in the first pair of brackets locate the matrix inside the field of matrices;
+     - The indices in the first pair of brackets locate the matrix inside the matrix fields;
      - The indices in the second pair of brackets locate the scalar element inside the matrix.
 
-    For 0-D fields of matrices, indices in the first pair of brackets should be ``[None]``.
+    For 0-D matrix fields, indices in the first pair of brackets should be ``[None]``.
 
 
 
@@ -144,8 +144,8 @@ Methods
 
 .. function:: a.transpose()
 
-    :parameter a: (Matrix) the matrix
-    :return: (Matrix) the transposed matrix of ``a``.
+    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
+    :return: (ti.Matrix or ti.Matrix.field) the transposed matrix of ``a``.
 
     For example::
 
@@ -160,7 +160,7 @@ Methods
 
 .. function:: a.trace()
 
-    :parameter a: (Matrix) the matrix
+    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
     :return: (scalar) the trace of matrix ``a``.
 
     The return value can be computed as ``a[0, 0] + a[1, 1] + ...``.
@@ -168,7 +168,7 @@ Methods
 
 .. function:: a.determinant()
 
-    :parameter a: (Matrix) the matrix
+    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
     :return: (scalar) the determinant of matrix ``a``.
 
     .. note::
@@ -180,8 +180,8 @@ Methods
 
 .. function:: a.inverse()
 
-    :parameter a: (Matrix) the matrix
-    :return: (Matrix) the inverse of matrix ``a``.
+    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
+    :return: (ti.Matrix or ti.Matrix.field) the inverse of matrix ``a``.
 
     .. note::
 

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -3,7 +3,7 @@
 Matrices
 ========
 
-- ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D sclar field.
+- ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D scalar field.
 - ``ti.Vector`` is the same as ``ti.Matrix``, except that it has only one column.
 - Differentiate element-wise product ``*`` and matrix product ``@``.
 - ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix.field(n, m, dtype=ti.f32)`` to create vector/matrix fields.
@@ -31,10 +31,10 @@ As global matrix fields
     :parameter n: (scalar) the number of rows in the matrix
     :parameter m: (scalar) the number of columns in the matrix
     :parameter dtype: (DataType) data type of the components
-    :parameter shape: (optional, scalar or tuple) shape the vector fields, see :ref:`tensor`
+    :parameter shape: (optional, scalar or tuple) shape of the vector fields, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a 5x4 matrix field which has a 3x3 matrix on each entry:
+    For example, this creates a 5x4 matrix field with each entry being a 3x3 matrix:
     ::
 
         # Python-scope
@@ -42,7 +42,7 @@ As global matrix fields
 
 .. note::
 
-    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Matrix.field`` declares matrix fields.
+    In Python-scope, ``ti.field`` declares a :ref:`scalar_tensor`, while ``ti.Matrix.field`` declares a matrix field.
 
 
 As a temporary local variable

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -31,7 +31,7 @@ As global matrix fields
     :parameter n: (scalar) the number of rows in the matrix
     :parameter m: (scalar) the number of columns in the matrix
     :parameter dtype: (DataType) data type of the components
-    :parameter shape: (optional, scalar or tuple) shape of the vector fields, see :ref:`tensor`
+    :parameter shape: (optional, scalar or tuple) shape of the matrix field, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
     For example, this creates a 5x4 matrix field with each entry being a 3x3 matrix:

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -144,8 +144,8 @@ Methods
 
 .. function:: a.transpose()
 
-    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
-    :return: (ti.Matrix or ti.Matrix.field) the transposed matrix of ``a``.
+    :parameter a: (ti.Matrix) the matrix
+    :return: (ti.Matrix) the transposed matrix of ``a``.
 
     For example::
 
@@ -160,7 +160,7 @@ Methods
 
 .. function:: a.trace()
 
-    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
+    :parameter a: (ti.Matrix) the matrix
     :return: (scalar) the trace of matrix ``a``.
 
     The return value can be computed as ``a[0, 0] + a[1, 1] + ...``.
@@ -168,7 +168,7 @@ Methods
 
 .. function:: a.determinant()
 
-    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
+    :parameter a: (ti.Matrix) the matrix
     :return: (scalar) the determinant of matrix ``a``.
 
     .. note::
@@ -180,8 +180,8 @@ Methods
 
 .. function:: a.inverse()
 
-    :parameter a: (ti.Matrix or ti.Matrix.field) the matrix
-    :return: (ti.Matrix or ti.Matrix.field) the inverse of matrix ``a``.
+    :parameter a: (ti.Matrix) the matrix
+    :return: (ti.Matrix) the inverse of matrix ``a``.
 
     .. note::
 

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -90,7 +90,7 @@ As a temporary local variable
 Accessing components
 --------------------
 
-As global vector fields
+As global matrix fields
 +++++++++++++++++++++++
 .. attribute:: a[p, q, ...][i, j]
 

--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -6,7 +6,7 @@ Matrices
 - ``ti.Matrix`` is for small matrices (e.g. `3x3`) only. If you have `64x64` matrices, you should consider using a 2D sclar field.
 - ``ti.Vector`` is the same as ``ti.Matrix``, except that it has only one column.
 - Differentiate element-wise product ``*`` and matrix product ``@``.
-- ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix.field(n, m, dtype=ti.f32)`` to create vector/matrice fields.
+- ``ti.Vector.field(n, dtype=ti.f32)`` or ``ti.Matrix.field(n, m, dtype=ti.f32)`` to create vector/matrix fields.
 - ``A.transpose()``
 - ``R, S = ti.polar_decompose(A, ti.f32)``
 - ``U, sigma, V = ti.svd(A, ti.f32)`` (Note that ``sigma`` is a ``3x3`` diagonal matrix)
@@ -34,7 +34,7 @@ As global matrix fields
     :parameter shape: (optional, scalar or tuple) shape the vector fields, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a 5x4 matrix field which has 3x3 matrix on each entry:
+    For example, this creates a 5x4 matrix field which has a 3x3 matrix on each entry:
     ::
 
         # Python-scope

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -168,7 +168,7 @@ When to use for loops with ``ti.static``
 There are several reasons why ``ti.static`` for loops should be used.
 
  - Loop unrolling for performance.
- - Loop over vector/matrix elements. Indices into Taichi matrices must be a compile-time constant. Indexing into taichi fields can be run-time variables. For example, if ``x`` is a 1-D vector field which has 3-D vector on each entry, accessed as ``x[field_index][matrix_index]``. The first index can be variable, yet the second must be a constant.
+ - Loop over vector/matrix elements. Indices into Taichi matrices must be a compile-time constant. Indexing into taichi fields can be run-time variables. For example, if you want to access a vector field ``x``, accessed as ``x[field_index][vector_component_index]``. The first index can be variable, yet the second must be a constant.
 
 For example, code for resetting this vector fields should be
 

--- a/docs/meta.rst
+++ b/docs/meta.rst
@@ -168,9 +168,9 @@ When to use for loops with ``ti.static``
 There are several reasons why ``ti.static`` for loops should be used.
 
  - Loop unrolling for performance.
- - Loop over vector/matrix elements. Indices into Taichi matrices must be a compile-time constant. Indexing into taichi fields can be run-time variables. For example, if ``x`` is a 1-D field of 3D vector, accessed as ``x[field_index][matrix_index]``. The first index can be variable, yet the second must be a constant.
+ - Loop over vector/matrix elements. Indices into Taichi matrices must be a compile-time constant. Indexing into taichi fields can be run-time variables. For example, if ``x`` is a 1-D vector field which has 3-D vector on each entry, accessed as ``x[field_index][matrix_index]``. The first index can be variable, yet the second must be a constant.
 
-For example, code for resetting this field of vectors should be
+For example, code for resetting this vector fields should be
 
 .. code-block:: python
 

--- a/docs/scalar_tensor.rst
+++ b/docs/scalar_tensor.rst
@@ -1,7 +1,7 @@
 .. _scalar_tensor:
 
-Fields of scalars
-=================
+Scalar fields
+=============
 
 
 Declaration
@@ -80,7 +80,7 @@ You can access an element of the Taichi field by an index or indices.
 
 .. attribute:: a[p, q, ...]
 
-    :parameter a: (ti.field) the field of scalars
+    :parameter a: (ti.field) the sclar field
     :parameter p: (scalar) index of the first field dimension
     :parameter q: (scalar) index of the second field dimension
     :return: (scalar) the element at ``[p, q, ...]``
@@ -101,7 +101,7 @@ You can access an element of the Taichi field by an index or indices.
 
     .. note ::
 
-        The returned value can also be ``Vector`` / ``Matrix`` if ``a`` is a field of vector / matrix, see :ref:`vector` for more details.
+        The returned value can also be ``Vector`` / ``Matrix`` if ``a`` is a vector/matrix field, see :ref:`vector` for more details.
 
 
 Meta data

--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -106,7 +106,7 @@ Node types
 
     :parameter snode: (SNode) parent node where the child is derived from
     :parameter indices: (Index or Indices) indices used for this node
-    :parameter shape: (scalar or tuple) shape the field of vectors
+    :parameter shape: (scalar or tuple) shape of the vector field
     :return: (SNode) the derived child node
 
     The following code places a 1-D field of size ``3``:

--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -106,7 +106,7 @@ Node types
 
     :parameter snode: (SNode) parent node where the child is derived from
     :parameter indices: (Index or Indices) indices used for this node
-    :parameter shape: (scalar or tuple) shape of the vector field
+    :parameter shape: (scalar or tuple) shape of the field
     :return: (SNode) the derived child node
 
     The following code places a 1-D field of size ``3``:

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -1,7 +1,7 @@
 .. _tensor:
 
 Matrix fields
-===================
+=============
 
 Fields are global variables provided by Taichi. Fields can be either sparse or dense.
 An element of a field can be either a scalar or a vector/matrix.
@@ -12,7 +12,7 @@ An element of a field can be either a scalar or a vector/matrix.
     Matrices can be used as field elements, so you can have fields with each element being a matrix.
 
 Scalar fields
------------------
+-------------
 * Every global variable is an N-dimensional field.
 
   - Global ``scalars`` are treated as 0-D scalar fields.
@@ -28,7 +28,7 @@ Scalar fields
 
 
 Matrix fields
-------------------
+-------------
 Field elements can also be matrices.
 
 Suppose you have a ``128 x 64`` field called ``A``, each element containing a ``3 x 2`` matrix. To allocate a ``128 x 64`` matrix field which has a ``3 x 2`` matrix for each of its entry, use the statement ``A = ti.Matrix.field(3, 2, dtype=ti.f32, shape=(128, 64))``.

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -11,11 +11,11 @@ An element of a field can be either a scalar or a vector/matrix.
     Although mathematically matrices are treated as 2D fields, in Taichi, **field** and **matrix** are two completely different concepts.
     Matrices can be used as field elements, so you can have fields with each element being a matrix.
 
-Scalar field
+Scalar fields
 -----------------
 * Every global variable is an N-dimensional field.
 
-  - Global ``scalars`` are treated as 0-D scalar field.
+  - Global ``scalars`` are treated as 0-D scalar fields.
 
 * Fields are always accessed using indices
 

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -1,6 +1,6 @@
 .. _tensor:
 
-Fields and matrices
+Matrix fields
 ===================
 
 Fields are global variables provided by Taichi. Fields can be either sparse or dense.
@@ -11,15 +11,15 @@ An element of a field can be either a scalar or a vector/matrix.
     Although mathematically matrices are treated as 2D fields, in Taichi, **field** and **matrix** are two completely different concepts.
     Matrices can be used as field elements, so you can have fields with each element being a matrix.
 
-Fields of scalars
+Scalar field
 -----------------
 * Every global variable is an N-dimensional field.
 
-  - Global ``scalars`` are treated as 0-D fields of scalars.
+  - Global ``scalars`` are treated as 0-D scalar field.
 
 * Fields are always accessed using indices
 
-   - E.g. ``x[i, j, k]`` if ``x`` is a scalar 3D field.
+   - E.g. ``x[i, j, k]`` if ``x`` is a 3D scalar field.
    - Even when accessing 0-D field ``x``, use ``x[None] = 0`` instead of ``x = 0``. Please **always** use indexing to access entries in fields.
 
 * Field values are initially zero.
@@ -27,16 +27,16 @@ Fields of scalars
 * See :ref:`scalar_tensor` for more details.
 
 
-Fields of matrices
+Matrix fields
 ------------------
 Field elements can also be matrices.
 
-Suppose you have a ``128 x 64`` field called ``A``, each element containing a ``3 x 2`` matrix. To allocate a ``128 x 64`` field of ``3 x 2`` matrix, use the statement ``A = ti.Matrix.field(3, 2, dtype=ti.f32, shape=(128, 64))``.
+Suppose you have a ``128 x 64`` field called ``A``, each element containing a ``3 x 2`` matrix. To allocate a ``128 x 64`` matrix field which has a ``3 x 2`` matrix for each of its entry, use the statement ``A = ti.Matrix.field(3, 2, dtype=ti.f32, shape=(128, 64))``.
 
 * If you want to get the matrix of grid node ``i, j``, please use ``mat = A[i, j]``. ``mat`` is simply a ``3 x 2`` matrix
 * To get the element on the first row and second column of that matrix, use ``mat[0, 1]`` or ``A[i, j][0, 1]``.
-* As you may have noticed, there are **two** indexing operators ``[]`` when you load an matrix element from a global field of matrices: the first is for field indexing, the second for matrix indexing.
-* ``ti.Vector`` is simply an alias of ``ti.Matrix``.
+* As you may have noticed, there are **two** indexing operators ``[]`` when you load an matrix element from a global matrix field: the first is for field indexing, the second for matrix indexing.
+* ``ti.Vector.field`` is simply an alias of ``ti.Matrix.field``.
 * See :ref:`matrix` for more on matrices.
 
 

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -36,7 +36,7 @@ Suppose you have a ``128 x 64`` field called ``A``, each element containing a ``
 * If you want to get the matrix of grid node ``i, j``, please use ``mat = A[i, j]``. ``mat`` is simply a ``3 x 2`` matrix
 * To get the element on the first row and second column of that matrix, use ``mat[0, 1]`` or ``A[i, j][0, 1]``.
 * As you may have noticed, there are **two** indexing operators ``[]`` when you load an matrix element from a global matrix field: the first is for field indexing, the second for matrix indexing.
-* ``ti.Vector.field`` is simply an alias of ``ti.Matrix.field``.
+* ``ti.Vector.field`` is simply an alias of ``ti.Matrix.field``, as well as `ti.Vector` and `ti.Matrix`.
 * See :ref:`matrix` for more on matrices.
 
 

--- a/docs/tensor_matrix.rst
+++ b/docs/tensor_matrix.rst
@@ -36,7 +36,7 @@ Suppose you have a ``128 x 64`` field called ``A``, each element containing a ``
 * If you want to get the matrix of grid node ``i, j``, please use ``mat = A[i, j]``. ``mat`` is simply a ``3 x 2`` matrix
 * To get the element on the first row and second column of that matrix, use ``mat[0, 1]`` or ``A[i, j][0, 1]``.
 * As you may have noticed, there are **two** indexing operators ``[]`` when you load an matrix element from a global matrix field: the first is for field indexing, the second for matrix indexing.
-* ``ti.Vector.field`` is simply an alias of ``ti.Matrix.field``, as well as `ti.Vector` and `ti.Matrix`.
+* ``ti.Vector`` is simply an alias of ``ti.Matrix``.
 * See :ref:`matrix` for more on matrices.
 
 

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -224,7 +224,7 @@ Metadata
 
 .. attribute:: a.n
 
-   :parameter a: (ti.Vector)
+   :parameter a: (ti.Vector or ti.Vector.field)
    :return: (scalar) return the dimensionality of vector ``a``
 
     E.g.,

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -23,7 +23,7 @@ As global vector fields
     :parameter shape: (optional, scalar or tuple) shape of the vector field, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a ``5x4`` vector field which has a 3 component vector on each entry:
+    For example, this creates a 3-d vector field of the shape of ``5x4``:
     ::
 
         # Python-scope
@@ -106,7 +106,7 @@ Methods
 
 .. function:: a.norm(eps = 0)
 
-    :parameter a: (ti.Vector or ti.Vector.field)
+    :parameter a: (ti.Vector)
     :parameter eps: (optional, scalar) a safe-guard value for ``sqrt``, usually 0. See the note below.
     :return: (scalar) the magnitude / length / norm of vector
 
@@ -124,7 +124,7 @@ Methods
 
 .. function:: a.norm_sqr()
 
-    :parameter a: (ti.Vector or ti.Vector.field)
+    :parameter a: (ti.Vector)
     :return: (scalar) the square of the magnitude / length / norm of vector
 
     For example,
@@ -138,8 +138,8 @@ Methods
 
 .. function:: a.normalized()
 
-    :parameter a: (ti.Vector or ti.Vector.field)
-    :return: (ti.Vector or ti.Vector.field) the normalized / unit vector of ``a``
+    :parameter a: (ti.Vector)
+    :return: (ti.Vector) the normalized / unit vector of ``a``
 
     For example,
     ::
@@ -152,8 +152,8 @@ Methods
 
 .. function:: a.dot(b)
 
-    :parameter a: (ti.Vector or ti.Vector.field)
-    :parameter b: (ti.Vector or ti.Vector.field)
+    :parameter a: (ti.Vector)
+    :parameter b: (ti.Vector)
     :return: (scalar) the dot (inner) product of ``a`` and ``b``
 
     E.g.,
@@ -166,8 +166,8 @@ Methods
 
 .. function:: a.cross(b)
 
-    :parameter a: (ti.Vector or ti.Vector.field, 2 or 3 components)
-    :parameter b: (ti.Vector or ti.Vector.field of the same size as a)
+    :parameter a: (ti.Vector, 2 or 3 components)
+    :parameter b: (ti.Vector of the same size as a)
     :return: (scalar (for 2D inputs), or 3D Vector (for 3D inputs)) the cross product of ``a`` and ``b``
 
     We use a right-handed coordinate system. E.g.,
@@ -186,9 +186,9 @@ Methods
 
 .. function:: a.outer_product(b)
 
-    :parameter a: (ti.Vector or ti.Vector.field)
-    :parameter b: (ti.Vector or ti.Vector.field)
-    :return: (ti.Matrix or ti.Matrix.field) the outer product of ``a`` and ``b``
+    :parameter a: (ti.Vector)
+    :parameter b: (ti.Vector)
+    :return: (ti.Matrix) the outer product of ``a`` and ``b``
 
     E.g.,
     ::
@@ -204,9 +204,9 @@ Methods
 
 .. function:: a.cast(dt)
 
-    :parameter a: (ti.Vector or ti.Vector.field)
+    :parameter a: (ti.Vector)
     :parameter dt: (DataType)
-    :return: (ti.Vector or ti.Vector.field) vector with all components of ``a`` casted into type ``dt``
+    :return: (ti.Vector) vector with all components of ``a`` casted into type ``dt``
 
     E.g.,
     ::
@@ -224,7 +224,7 @@ Metadata
 
 .. attribute:: a.n
 
-   :parameter a: (Vector or Vector field)
+   :parameter a: (Vector)
    :return: (scalar) return the dimensionality of vector ``a``
 
     E.g.,

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -13,17 +13,17 @@ In fact, ``Vector`` is simply an alias of ``Matrix``, just with ``m = 1``. See :
 Declaration
 -----------
 
-As global fields of vectors
+As global vector fields
 +++++++++++++++++++++++++++
 
 .. function:: ti.Vector.field(n, dtype, shape = None, offset = None)
 
     :parameter n: (scalar) the number of components in the vector
     :parameter dtype: (DataType) data type of the components
-    :parameter shape: (optional, scalar or tuple) shape the field of vectors, see :ref:`tensor`
+    :parameter shape: (optional, scalar or tuple) shape of the vector field, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a 5x4 field of 3 component vectors:
+    For example, this creates a ``5x4`` vector field which has a vector of 3 component on each entry:
     ::
 
         # Python-scope
@@ -31,7 +31,7 @@ As global fields of vectors
 
 .. note::
 
-    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Vector.field`` declares fields of vectors.
+    In Python-scope, ``ti.field`` declares :ref:`scalar_tensor`, while ``ti.Vector.field`` declares vector fields.
 
 
 As a temporary local variable
@@ -52,11 +52,11 @@ As a temporary local variable
 Accessing components
 --------------------
 
-As global fields of vectors
+As global vector fields
 +++++++++++++++++++++++++++
 .. attribute:: a[p, q, ...][i]
 
-    :parameter a: (field of Vector) the vector
+    :parameter a: (Vector field) the vector
     :parameter p: (scalar) index of the first field dimension
     :parameter q: (scalar) index of the second field dimension
     :parameter i: (scalar) index of the vector component
@@ -72,12 +72,12 @@ As global fields of vectors
 
 .. note::
 
-    **Always** use two pairs of square brackets to access scalar elements from fields of vectors.
+    **Always** use two pairs of square brackets to access scalar elements from vector fields.
 
-     - The indices in the first pair of brackets locate the vector inside the field of vectors;
+     - The indices in the first pair of brackets locate the vector inside the vector fields;
      - The indices in the second pair of brackets locate the scalar element inside the vector.
 
-    For 0-D fields of vectors, indices in the first pair of brackets should be ``[None]``.
+    For 0-D vector fields, indices in the first pair of brackets should be ``[None]``.
 
 
 
@@ -224,17 +224,18 @@ Metadata
 
 .. attribute:: a.n
 
-   :parameter a: (Vector or field of Vector)
+   :parameter a: (Vector or Vector field)
    :return: (scalar) return the dimensionality of vector ``a``
 
-    E.g.,
+    E.g.
     ::
 
         # Taichi-scope
         a = ti.Vector([1, 2, 3])
         a.n  # 3
-
+        
     ::
+    
         # Python-scope
         a = ti.Vector.field(3, dtype=ti.f32, shape=())
         a.n  # 3

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -14,7 +14,7 @@ Declaration
 -----------
 
 As global vector fields
-+++++++++++++++++++++++++++
+++++++++++++++++++++++++
 
 .. function:: ti.Vector.field(n, dtype, shape = None, offset = None)
 
@@ -56,7 +56,7 @@ As global vector fields
 +++++++++++++++++++++++++++
 .. attribute:: a[p, q, ...][i]
 
-    :parameter a: (Vector field) the vector
+    :parameter a: (ti.Vector.field) the vector
     :parameter p: (scalar) index of the first field dimension
     :parameter q: (scalar) index of the second field dimension
     :parameter i: (scalar) index of the vector component

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -106,7 +106,7 @@ Methods
 
 .. function:: a.norm(eps = 0)
 
-    :parameter a: (Vector)
+    :parameter a: (ti.Vector or ti.Vector.field)
     :parameter eps: (optional, scalar) a safe-guard value for ``sqrt``, usually 0. See the note below.
     :return: (scalar) the magnitude / length / norm of vector
 
@@ -124,7 +124,7 @@ Methods
 
 .. function:: a.norm_sqr()
 
-    :parameter a: (Vector)
+    :parameter a: (ti.Vector or ti.Vector.field)
     :return: (scalar) the square of the magnitude / length / norm of vector
 
     For example,
@@ -138,8 +138,8 @@ Methods
 
 .. function:: a.normalized()
 
-    :parameter a: (Vector)
-    :return: (Vector) the normalized / unit vector of ``a``
+    :parameter a: (ti.Vector or ti.Vector.field)
+    :return: (ti.Vector or ti.Vector.field) the normalized / unit vector of ``a``
 
     For example,
     ::
@@ -152,8 +152,8 @@ Methods
 
 .. function:: a.dot(b)
 
-    :parameter a: (Vector)
-    :parameter b: (Vector)
+    :parameter a: (ti.Vector or ti.Vector.field)
+    :parameter b: (ti.Vector or ti.Vector.field)
     :return: (scalar) the dot (inner) product of ``a`` and ``b``
 
     E.g.,
@@ -166,8 +166,8 @@ Methods
 
 .. function:: a.cross(b)
 
-    :parameter a: (Vector, 2 or 3 components)
-    :parameter b: (Vector of the same size as a)
+    :parameter a: (ti.Vector or ti.Vector.field, 2 or 3 components)
+    :parameter b: (ti.Vector or ti.Vector.field of the same size as a)
     :return: (scalar (for 2D inputs), or 3D Vector (for 3D inputs)) the cross product of ``a`` and ``b``
 
     We use a right-handed coordinate system. E.g.,
@@ -186,9 +186,9 @@ Methods
 
 .. function:: a.outer_product(b)
 
-    :parameter a: (Vector)
-    :parameter b: (Vector)
-    :return: (Matrix) the outer product of ``a`` and ``b``
+    :parameter a: (ti.Vector or ti.Vector.field)
+    :parameter b: (ti.Vector or ti.Vector.field)
+    :return: (ti.Matrix or ti.Matrix.field) the outer product of ``a`` and ``b``
 
     E.g.,
     ::
@@ -204,9 +204,9 @@ Methods
 
 .. function:: a.cast(dt)
 
-    :parameter a: (Vector)
+    :parameter a: (ti.Vector or ti.Vector.field)
     :parameter dt: (DataType)
-    :return: (Vector) vector with all components of ``a`` casted into type ``dt``
+    :return: (ti.Vector or ti.Vector.field) vector with all components of ``a`` casted into type ``dt``
 
     E.g.,
     ::

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -23,7 +23,7 @@ As global vector fields
     :parameter shape: (optional, scalar or tuple) shape of the vector field, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a 3-d vector field of the shape of ``5x4``:
+    For example, this creates a 3-D vector field of the shape of ``5x4``:
     ::
 
         # Python-scope

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -224,7 +224,7 @@ Metadata
 
 .. attribute:: a.n
 
-   :parameter a: (Vector)
+   :parameter a: (ti.Vector)
    :return: (scalar) return the dimensionality of vector ``a``
 
     E.g.,

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -14,7 +14,7 @@ Declaration
 -----------
 
 As global vector fields
-++++++++++++++++++++++++
++++++++++++++++++++++++
 
 .. function:: ti.Vector.field(n, dtype, shape = None, offset = None)
 
@@ -53,7 +53,7 @@ Accessing components
 --------------------
 
 As global vector fields
-+++++++++++++++++++++++++++
++++++++++++++++++++++++
 .. attribute:: a[p, q, ...][i]
 
     :parameter a: (ti.Vector.field) the vector

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -23,7 +23,7 @@ As global vector fields
     :parameter shape: (optional, scalar or tuple) shape of the vector field, see :ref:`tensor`
     :parameter offset: (optional, scalar or tuple) see :ref:`offset`
 
-    For example, this creates a ``5x4`` vector field which has a vector of 3 component on each entry:
+    For example, this creates a ``5x4`` vector field which has a 3 component vector on each entry:
     ::
 
         # Python-scope
@@ -227,15 +227,15 @@ Metadata
    :parameter a: (Vector or Vector field)
    :return: (scalar) return the dimensionality of vector ``a``
 
-    E.g.
+    E.g.,
     ::
 
         # Taichi-scope
         a = ti.Vector([1, 2, 3])
         a.n  # 3
-        
+
     ::
-    
+
         # Python-scope
         a = ti.Vector.field(3, dtype=ti.f32, shape=())
         a.n  # 3


### PR DESCRIPTION
Related issue = #1500 

As we suggested, this PR tries to replace `field of vector/matrix/scalar` to `vector/matrix/scalar field`. 

During the replacement, I kept the first part of phrases as singular. In another word, always write `vector field/fields` but not `vectors field/fields`.

~~It is still drafted because some of its modifications can only be done after `PR1577` and `PR1578` are merged.~~

Here is a to do list,

- [x] replace `field of scalar` to `sclar field` in `tensor_matrix.rst`
- [x] replace `field of matrix` to `matrix field` in `tensor_matrix.rst`
- [x] replace `field of vector` in `vector.rst`
- [x] fix some existing typos
- [x] replace these vars in `matrix.rst`, `scalar_tensor.rst` after other PRs are being merged.
- [x] double-check the whole documents for other rested cases.
- [x] make some API definitions more specified

Looking forward to your feedback! ;-)

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)
