### PR TITLE
[OpenGL] [perf] Support ti.block_dim as block size hint

### DIFF
--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -51,9 +51,9 @@ void check_opengl_error(const std::string &msg = "OpenGL") {
 
 int opengl_get_threads_per_group() {
   int ret = 1000;
-  return ret;
   glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &ret);
   check_opengl_error("glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS)");
+  TI_TRACE("opengl_get_threads_per_group: {}", ret);
   return ret;
 }
 

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -37,6 +37,7 @@ class ParallelSize {
   // CUDA: stride < thread < block < grid
  public:
   std::optional<size_t> strides_per_thread;
+  std::optional<size_t> threads_per_block;
 
   virtual size_t get_num_strides(GLSLLauncher *launcher) const = 0;
   size_t get_num_threads(GLSLLauncher *launcher) const;

--- a/tests/python/test_parallel_range_for.py
+++ b/tests/python/test_parallel_range_for.py
@@ -1,7 +1,8 @@
 import taichi as ti
 
 
-@ti.all_archs
+# such small block_dim will cause grid_dim too large for OpenGL...
+@ti.archs_excluding(ti.opengl)
 def test_parallel_range_for():
     n = 1024 * 1024
     val = ti.var(ti.i32, shape=(n))


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Applying `ti.block_dim` to P2G & G2P for-loops in `mpm99.py` with `quality = 2`:
blk_dim: mesa, nvidia
128: 12.5 fps, 19.4 fps
1024: 11.1 fps, 18.9 fps
none: 10.9 fps, 18.4 fps
Very tiny performance difference that I had to run many times to confirm it...
But I guess it would be useful in some cases other than mpm, any idea?
@k-ye How does Metal decide block_dim now? Would you add `ti.block_dim` support to Metal later iapr?