### PR TITLE
[misc] [refactor] 'ti.vec' and 'ti.veci' is deprecated, directly use a tuple in GUI system instead

### DIFF
--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -166,7 +166,7 @@ Paint on a window
     :parameter rgb: (tuple of 3 floats) The (R, G, B) float values, in range [0, 1]
     :return: (RGB hex or np.array of uint32) The converted hex value
 
-    Convert a (R, G, B) tuple of float into a single hex value, e.g.:
+    Convert a (R, G, B) tuple of floats into a single integer value. E.g.,
 
     .. code-block:: python
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -163,8 +163,8 @@ Paint on a window
 
 .. function:: ti.rgb_to_hex(rgb):
 
-    :parameter rgb: (tuple of 3 floats) The (R, G, B) float values, in range [0, 1)
-    :return: (RGB hex or np.array of uint32) The translated hex value
+    :parameter rgb: (tuple of 3 floats) The (R, G, B) float values, in range [0, 1]
+    :return: (RGB hex or np.array of uint32) The converted hex value
 
     Convert a (R, G, B) tuple of float into a single hex value, e.g.:
 
@@ -176,7 +176,7 @@ Paint on a window
          rgb = np.array([[0.4, 0.8, 1.0], [0.0, 0.5, 1.0]])
          hex = ti.rgb_to_hex(rgb)  # np.array([0x66ccff, 0x007fff])
 
-    This is helpful since the return value could be used in other paint APIs.
+    The return values can be used in GUI drawing APIs.
 
 
 .. _gui_event:

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -161,6 +161,24 @@ Paint on a window
     Draw a line of text on screen.
 
 
+.. function:: ti.rgb_to_hex(rgb):
+
+    :parameter rgb: (tuple of 3 floats) The (R, G, B) float values, in range [0, 1)
+    :return: (RGB hex or np.array of uint32) The translated hex value
+
+    Convert a (R, G, B) tuple of float into a single hex value, e.g.:
+
+    .. code-block:: python
+
+         rgb = (0.4, 0.8, 1.0)
+         hex = ti.rgb_to_hex(rgb)  # 0x66ccff
+
+         rgb = np.array([[0.4, 0.8, 1.0], [0.0, 0.5, 1.0]])
+         hex = ti.rgb_to_hex(rgb)  # np.array([0x66ccff, 0x007fff])
+
+    This is helpful since the return value could be used in other paint APIs.
+
+
 .. _gui_event:
 
 Event processing

--- a/examples/pbf2d.py
+++ b/examples/pbf2d.py
@@ -282,9 +282,8 @@ def render(gui):
         for j in range(dim):
             pos[j] *= screen_to_world_ratio / screen_res[j]
     gui.circles(pos_np, radius=particle_radius, color=particle_color)
-    canvas.rect(ti.vec(
-        0, 0), ti.vec(board_states[None][0] / boundary[0],
-                      1.0)).radius(1.5).color(boundary_color).close().finish()
+    gui.rect((0, 0), (board_states[None][0] / boundary[0],
+                      1.0), radius=1.5, color=boundary_color)
     gui.show()
 
 

--- a/examples/pbf2d.py
+++ b/examples/pbf2d.py
@@ -282,8 +282,9 @@ def render(gui):
         for j in range(dim):
             pos[j] *= screen_to_world_ratio / screen_res[j]
     gui.circles(pos_np, radius=particle_radius, color=particle_color)
-    gui.rect((0, 0), (board_states[None][0] / boundary[0],
-                      1.0), radius=1.5, color=boundary_color)
+    gui.rect((0, 0), (board_states[None][0] / boundary[0], 1.0),
+             radius=1.5,
+             color=boundary_color)
     gui.show()
 
 

--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -1,7 +1,7 @@
 import numbers
 import numpy as np
 from taichi.core import ti_core
-from .util import deprecated
+from .util import deprecated, core_veci
 
 
 class GUI:
@@ -35,14 +35,13 @@ class GUI:
     RELEASE = ti_core.KeyEvent.EType.Release
 
     def __init__(self, name, res=512, background_color=0x0):
-        import taichi as ti
         self.name = name
         if isinstance(res, numbers.Number):
             res = (res, res)
         self.res = res
         # The GUI canvas uses RGBA for storage, therefore we need NxMx4 for an image.
         self.img = np.ascontiguousarray(np.zeros(self.res + (4, ), np.float32))
-        self.core = ti.core.GUI(name, ti.veci(*res))
+        self.core = ti_core.GUI(name, core_veci(*res))
         self.canvas = self.core.get_canvas()
         self.background_color = background_color
         self.key_pressed = set()
@@ -258,9 +257,9 @@ class GUI:
         import taichi as ti
         # TODO: refactor Canvas::text
         font_size = float(font_size)
-        pos = ti.vec(*pos)
-        r, g, b = (color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff
-        color = ti.vec(r / 255, g / 255, b / 255, 1)
+        pos = ti.core_vec(*pos)
+        r, g, b = hex_to_rgb(color)
+        color = ti.core_vec(r, g, b, 1)
         self.canvas.text(content, pos, font_size, color)
 
     def show(self, file=None):
@@ -377,7 +376,13 @@ def rgb_to_hex(c):
     return 65536 * to255(c[0]) + 256 * to255(c[1]) + to255(c[2])
 
 
+def hex_to_rgb(c):
+    r, g, b = (color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff
+    return r / 255, g / 255, b / 255
+
+
 __all__ = [
     'GUI',
     'rgb_to_hex',
+    'hex_to_rgb',
 ]

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -204,6 +204,7 @@ def print_profile_info():
 def vec(*args, **kwargs):
     return core_vec(*args, **kwargs)
 
+
 @deprecated('ti.veci(x, y)', 'a tuple (x, y) for GUI system')
 def veci(*args, **kwargs):
     return core_veci(*args, **kwargs)

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -15,7 +15,7 @@ def config_from_dict(args):
     return ti_core.config_from_dict(d)
 
 
-def veci(*args):
+def core_veci(*args):
     from taichi.core import ti_core
     if isinstance(args[0], ti_core.Vector2i):
         return args[0]
@@ -34,7 +34,7 @@ def veci(*args):
         assert False, type(args[0])
 
 
-def vec(*args):
+def core_vec(*args):
     from taichi.core import ti_core
     if isinstance(args[0], ti_core.Vector2f):
         return args[0]
@@ -200,9 +200,20 @@ def print_profile_info():
     taichi.ti_core.print_profile_info()
 
 
+@deprecated('ti.vec(x, y)', 'a tuple (x, y) for GUI system')
+def vec(*args, **kwargs):
+    return core_vec(*args, **kwargs)
+
+@deprecated('ti.veci(x, y)', 'a tuple (x, y) for GUI system')
+def veci(*args, **kwargs):
+    return core_veci(*args, **kwargs)
+
+
 __all__ = [
     'vec',
     'veci',
+    'core_vec',
+    'core_veci',
     'set_gdb_trigger',
     'print_profile_info',
     'set_logging_level',


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Since some beginners may confuse `ti.vec` as an alias for `ti.Vector`... like `taichi_glsl.vec` does.
Let's rename it to `core_vec` since it's a class exported from `libtaichi_core.so`, any suggestion on the name?
Let's remove it as soon as possible before v0.7.0, since our GUI system is already wrapped by Python and able to take tuple as input.
I used the `@deprecated` mark instead of fully deprecate it because, I see some DiffTaichi examples are still using them in GUI system. @yuanming-hu Could you upgrade DiffTaichi to new syntax (including this change and others)? I found most of them are not able to run now :confused:
OFT: doc `ti.rgb_to_hex`.