### PR TITLE
[Error] Improve error message when using non-global variables in global operations

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -125,7 +125,7 @@ class Expr(TaichiOperations):
         return Expr(ti.core.global_var_expr_from_snode(p.ptr))
 
     def is_global(self):
-        return self.ptr.is_global_var()
+        return self.ptr.is_global_var() or self.ptr.is_external_var()
 
     def snode(self):
         from .snode import SNode

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -124,6 +124,9 @@ class Expr(TaichiOperations):
         p = self.snode().parent(n)
         return Expr(ti.core.global_var_expr_from_snode(p.ptr))
 
+    def is_global(self):
+        return self.ptr.is_global_var()
+
     def snode(self):
         from .snode import SNode
         return SNode(self.ptr.snode())

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -61,7 +61,7 @@ def expr_init_func(rhs):  # temporary solution to allow passing in tensors as
 
 def begin_frontend_struct_for(group, loop_range):
     if not isinstance(loop_range, Expr) or not loop_range.is_global():
-        raise TypeError('can only iterate through global variables/fields')
+        raise TypeError('Can only iterate through global variables/fields')
     if group.size() != len(loop_range.shape):
         raise IndexError(
             'Number of struct-for indices does not match loop variable dimensionality '

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -60,6 +60,8 @@ def expr_init_func(rhs):  # temporary solution to allow passing in tensors as
 
 
 def begin_frontend_struct_for(group, loop_range):
+    if not isinstance(loop_range, Expr) or not loop_range.is_global():
+        raise TypeError('can only iterate through global variables/fields')
     if group.size() != len(loop_range.shape):
         raise IndexError(
             'Number of struct-for indices does not match loop variable dimensionality '
@@ -95,9 +97,12 @@ def subscript(value, *indices):
             ind = [indices[i]]
         flattened_indices += ind
     indices = tuple(flattened_indices)
+
     if is_taichi_class(value):
         return value.subscript(*indices)
-    else:
+    elif isinstance(value, Expr):
+        if not value.is_global():
+            raise TypeError('Cannot subscript a scalar expression')
         if isinstance(indices,
                       tuple) and len(indices) == 1 and indices[0] is None:
             indices = []
@@ -109,6 +114,8 @@ def subscript(value, *indices):
                 f'Tensor with dim {tensor_dim} accessed with indices of dim {index_dim}'
             )
         return Expr(taichi_lang_core.subscript(value.ptr, indices_expr_group))
+    else:
+        return value[indices]
 
 
 @taichi_scope

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -117,7 +117,7 @@ class Matrix(TaichiOperations):
         results = [False for _ in self.entries]
         for i, e in enumerate(self.entries):
             if isinstance(e, expr.Expr):
-                if e.ptr.is_global_var():
+                if e.is_global():
                     results[i] = True
             assert results[i] == results[0], \
                 "Matrices with mixed global/local entries are not allowed"

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -141,7 +141,7 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
 #endif
 
 #define TI_STATIC_ASSERT(x) static_assert((x), #x);
-#define TI_ASSERT(x) TI_ASSERT_INFO((x), #x)
+#define TI_ASSERT(x) TI_ASSERT_INFO((x), "Assertion failure: " #x)
 #define TI_ASSERT_INFO(x, ...)             \
   {                                        \
     bool ___ret___ = static_cast<bool>(x); \

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -73,14 +73,14 @@ Expr &Expr::operator=(const Expr &o) {
 
 Expr Expr::parent() const {
   TI_ASSERT_INFO(is<GlobalVariableExpression>(),
-                 "cannot get snode parent of non-global variables.");
+                 "Cannot get snode parent of non-global variables.");
   return Expr::make<GlobalVariableExpression>(
       cast<GlobalVariableExpression>()->snode->parent);
 }
 
 SNode *Expr::snode() const {
   TI_ASSERT_INFO(is<GlobalVariableExpression>(),
-                 "cannot get snode of non-global variables.");
+                 "Cannot get snode of non-global variables.");
   return cast<GlobalVariableExpression>()->snode;
 }
 

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -73,14 +73,14 @@ Expr &Expr::operator=(const Expr &o) {
 
 Expr Expr::parent() const {
   TI_ASSERT_INFO(is<GlobalVariableExpression>(),
-      "cannot get snode parent of non-global variables.");
+                 "cannot get snode parent of non-global variables.");
   return Expr::make<GlobalVariableExpression>(
       cast<GlobalVariableExpression>()->snode->parent);
 }
 
 SNode *Expr::snode() const {
   TI_ASSERT_INFO(is<GlobalVariableExpression>(),
-      "cannot get snode of non-global variables.");
+                 "cannot get snode of non-global variables.");
   return cast<GlobalVariableExpression>()->snode;
 }
 

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -72,13 +72,15 @@ Expr &Expr::operator=(const Expr &o) {
 }
 
 Expr Expr::parent() const {
-  TI_ASSERT(is<GlobalVariableExpression>());
+  TI_ASSERT_INFO(is<GlobalVariableExpression>(),
+      "cannot get snode parent of non-global variables.");
   return Expr::make<GlobalVariableExpression>(
       cast<GlobalVariableExpression>()->snode->parent);
 }
 
 SNode *Expr::snode() const {
-  TI_ASSERT(is<GlobalVariableExpression>());
+  TI_ASSERT_INFO(is<GlobalVariableExpression>(),
+      "cannot get snode of non-global variables.");
   return cast<GlobalVariableExpression>()->snode;
 }
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -219,6 +219,8 @@ void export_lang(py::module &m) {
       .def("snode", &Expr::snode, py::return_value_policy::reference)
       .def("is_global_var",
            [](Expr *expr) { return expr->is<GlobalVariableExpression>(); })
+      .def("is_external_var",
+           [](Expr *expr) { return expr->is<ExternalTensorExpression>(); })
       .def("set_tb", &Expr::set_tb)
       .def("set_is_primal",
            [&](Expr *expr, bool v) {

--- a/tests/python/test_lexical_scope.py
+++ b/tests/python/test_lexical_scope.py
@@ -4,20 +4,16 @@ ti.init()
 
 @ti.host_arch_only
 def test_func_closure():
-    # TODO: remove this after #1344 is merged:
-    def static_assert(x):
-        assert x
-
     def my_test():
         a = 32
 
         @ti.func
         def foo():
-            static_assert(a == 32)
+            ti.static_assert(a == 32)
 
         @ti.kernel
         def func():
-            static_assert(a == 32)
+            ti.static_assert(a == 32)
             foo()
 
         def dummy():


### PR DESCRIPTION
Related issue = https://forum.taichi.graphics/t/runtimeerror-ir-cpp-get-attribute-293-attribute-dim-not-found/1045

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

The main reason for these confusing errors are originated by the fact that we use `Expr` for both local variables and global fields.

----
```py
x = 0
print(x[0])
```
Before:
`RuntimeError: [ir.cpp:get_attribute@293] Attribute dim not found`
After:
`TypeError: Cannot subscript a scalar expression`
```py
x = 0
for i in x:
```
Before:
`RuntimeError: [expr.cpp:snode@81] is<GlobalVariableExpression>()`
After:
`TypeError: can only iterate through global variables/fields`