### PR TITLE
[Bug] [opt] Fix compiler error when flattening if(0) and if(1)

### DIFF
--- a/taichi/transforms/unreachable_code_elimination.cpp
+++ b/taichi/transforms/unreachable_code_elimination.cpp
@@ -135,6 +135,9 @@ class UnreachableCodeEliminator : public BasicStmtVisitor {
         break;
       }
     }
+    if (modified) {
+      irpass::fix_block_parents(node);
+    }
     return modified;
   }
 };


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = fix #1604 

Introduced in #1393. 
```
kernel {
  $1 : if 0 {
    $2 : for ... {
      $3 : ...
    }
  }
}
```
`$2->body->parent` is `$1->body`. When flattening the if, we automatically set `$2->parent` to top-level, but not `$2->body->parent`.

If `$2->body->parent` were `$2` (a container `Stmt`), there'll be no need to call `fix_block_parents`...

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
