### PR TITLE
[Refactor] "ti.field" now always take shape argument, specify "ti.field(dtype, shape=None)" for **advanced layout**

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -213,8 +213,11 @@ class PyTaichi:
         taichi_lang_core.layout(layout)
         self.materialized = True
         for var in self.global_vars:
-            assert var.ptr.snode(
-            ) is not None, 'Some variable(s) are not placed'
+            if var.ptr.snode() is None:
+                raise RuntimeError(
+                    'Some variable(s) are not placed.'
+                    ' Did you forget to specify shape for a field? e.g.:\n'
+                    '  ti.field(ti.f32, shape=(3, 4))')
 
     def clear(self):
         if self.prog:
@@ -316,7 +319,7 @@ def var(dt, shape=None, offset=None, needs_grad=False):
 
 
 @python_scope
-def field(dtype, shape=None, offset=None, needs_grad=False):
+def field(dtype, shape, offset=None, needs_grad=False):
     _taichi_skip_traceback = 1
     if isinstance(shape, numbers.Number):
         shape = (shape, )

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -215,9 +215,11 @@ class PyTaichi:
         for var in self.global_vars:
             if var.ptr.snode() is None:
                 raise RuntimeError(
-                    'Some variable(s) are not placed.'
-                    ' Did you forget to specify shape for a field? e.g.:\n'
-                    '  ti.field(ti.f32, shape=(3, 4))')
+                    'Some fields(s) are not placed.'
+                    ' Did you forget to place a no shape field? e.g.:\n'
+                    '  x = ti.field(ti.f32)\n'
+                    '  ti.root.dense(ti.ij, (3, 4)).place(x)'
+                    )
 
     def clear(self):
         if self.prog:

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -787,7 +787,7 @@ class Matrix(TaichiOperations):
               n,
               m,
               dtype,
-              shape=None,
+              shape,
               offset=None,
               needs_grad=False,
               layout=None):  # TODO(archibate): deprecate layout
@@ -798,7 +798,7 @@ class Matrix(TaichiOperations):
         self.m = m
         self.dt = dtype
         for i in range(n * m):
-            self.entries.append(impl.field(dtype))
+            self.entries.append(impl.field(dtype, None))
         self.grad = self.make_grad()
 
         if layout is not None:
@@ -843,23 +843,23 @@ class Matrix(TaichiOperations):
     @classmethod
     @python_scope
     #@deprecated('ti.Matrix.var', 'ti.Matrix.field')
-    def var(cls, n, m, dt, *args, **kwargs):
+    def var(cls, n, m, dt, shape, *args, **kwargs):
         '''ti.Matrix.var'''
         _taichi_skip_traceback = 1
-        return cls.field(n, m, dt, *args, **kwargs)
+        return cls.field(n, m, dt, shape, *args, **kwargs)
 
     @classmethod
-    def _Vector_field(cls, n, dtype, *args, **kwargs):
+    def _Vector_field(cls, n, dtype, shape, *args, **kwargs):
         '''ti.Vector.field'''
         _taichi_skip_traceback = 1
-        return cls.field(n, 1, dtype, *args, **kwargs)
+        return cls.field(n, 1, dtype, shape, *args, **kwargs)
 
     @classmethod
     #@deprecated('ti.Vector.var', 'ti.Vector.field')
-    def _Vector_var(cls, n, dt, *args, **kwargs):
+    def _Vector_var(cls, n, dt, shape, *args, **kwargs):
         '''ti.Vector.var'''
         _taichi_skip_traceback = 1
-        return cls._Vector_field(n, dt, *args, **kwargs)
+        return cls._Vector_field(n, dt, shape, *args, **kwargs)
 
     @staticmethod
     def rows(rows):

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -5,11 +5,34 @@ To test our new `ti.field` API is functional (#1500)
 import taichi as ti
 import pytest
 
-# TODO(archibate): add 64-bit dtypes after #1462
 data_types = [ti.i32, ti.f32]
 field_shapes = [(), 8, (8, ), (6, 12)]
-vector_dims = [2, 3]
-matrix_dims = [(1, 2), (3, 1), (4, 3), (2, 2)]
+vector_dims = [3]
+matrix_dims = [(1, 2), (3, 1), (4, 3)]
+fieldfuncs = [ti.field,
+        lambda *args, **kwargs: ti.Matrix.field(3, 2, *args, **kwargs),
+        lambda *args, **kwargs: ti.Vector.field(3, *args, **kwargs)]
+
+
+@ti.host_arch_only
+@pytest.mark.parametrize('fieldfunc', fieldfuncs)
+def test_error_not_placed(fieldfunc):
+    x = fieldfunc(ti.i32, None)
+    y = fieldfunc(ti.i32, (233, 666))
+
+    with pytest.raises(RuntimeError, match='not placed'):
+        print(y.shape)
+
+
+@ti.host_arch_only
+@pytest.mark.parametrize('fieldfunc', fieldfuncs)
+def test_advanced_layout(fieldfunc):
+    x = fieldfunc(ti.i32, None)
+    y = fieldfunc(ti.i32, None)
+    ti.root.dense(ti.ij, 5).place(x).dense(ti.j, 3).place(y)
+
+    assert x.shape == (5, 20)  # why??? snode trailing? @yuanming-hu
+    assert y.shape == (5, 15)
 
 
 @pytest.mark.parametrize('dtype', data_types)
@@ -27,7 +50,7 @@ def test_scalar_field(dtype, shape):
 
 
 @pytest.mark.parametrize('n', vector_dims)
-@pytest.mark.parametrize('dtype', data_types)
+@pytest.mark.parametrize('dtype', [ti.f32])
 @pytest.mark.parametrize('shape', field_shapes)
 @ti.host_arch_only
 def test_vector_field(n, dtype, shape):
@@ -44,7 +67,7 @@ def test_vector_field(n, dtype, shape):
 
 
 @pytest.mark.parametrize('n,m', matrix_dims)
-@pytest.mark.parametrize('dtype', data_types)
+@pytest.mark.parametrize('dtype', [ti.i32])
 @pytest.mark.parametrize('shape', field_shapes)
 @ti.host_arch_only
 def test_matrix_field(n, m, dtype, shape):


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1614

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
