### PR TITLE
[async] Clone offloaded tasks lazily by caching the AST

### DIFF
--- a/taichi/analysis/clone.cpp
+++ b/taichi/analysis/clone.cpp
@@ -123,9 +123,9 @@ class IRCloner : public IRVisitor {
     root->accept(&cloner);
 
     using namespace irpass;
-    typecheck(new_root.get());
     fix_block_parents(new_root.get());
     fix_root_block_kernel(new_root.get(), kernel);
+    typecheck(new_root.get());
     return new_root;
   }
 };

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -106,6 +106,9 @@ void compile_to_offloads(IRNode *ir,
 
   print("Access flagged II");
   irpass::analysis::verify(ir);
+
+  irpass::full_simplify(ir, /*after_lower_access=*/false);
+  print("Simplified III");
 }
 
 void compile_to_executable(IRNode *ir,
@@ -166,7 +169,7 @@ void compile_to_executable(IRNode *ir,
   irpass::analysis::verify(ir);
 
   irpass::full_simplify(ir, lower_global_access);
-  print("Simplified III");
+  print("Simplified IV");
 
   // Final field registration correctness & type checking
   irpass::typecheck(ir);


### PR DESCRIPTION
To avoid having to clone the offloaded task upon every kernel launch, I've cached the cloned offloaded AST as well. The cached AST, along with its hash, is put inside a struct called `OffloadedCachedData`, and is used as a *read-only* template. This optimization works because for most of the times, we are just reading the offloaded task AST without any modification.

For places that do change the AST, the clone is done via a copy-on-write way. This clone is necessary so as to keep the template untouched. Please see `KernelLaunchRecord::clone_stmt_on_write()`.

For now, we only have two places that will modify the AST:

1. The first time an AST gets compiled in `compilation_workers`. Some IR passes will modify it.
2. When two ASTs are fused.

FPS improvement:

* `mpm88`: 6 -> 11
* `mpm99`: 12 -> 26

Profiling shows that clone is no longer a hotspot:

<img width="983" alt="Screen Shot 2020-07-31 at 21 20 08" src="https://user-images.githubusercontent.com/7481356/89034373-c94a2200-d373-11ea-897b-f7aba1cea498.png">

---

Another thing is that, I found that #1593 has actually prevented the fusion in the test cases in `test_fuse_dense.py` (probably `test_fuse_dynamic.py` as well, but i didn't test). This was because the kernel wasn't fully simplified, and contained an empty `serial` task:

```
kernel {
  $0 = offloaded  
  body {
  }
  $1 = offloaded struct_for(S1dense) grid_dim=0 block_dim=1024 bls= 
  body {
    <i32 x1> $2 = loop $1 index 0
    <i32*x1> $3 = global ptr [S2place_i32], index [$2] activate=false
    <i32 x1> $4 = global load $3
    <i32 x1> $5 = const [1]
    <i32 x1> $6 = add $4 $5
    <i32*x1> $7 : global store [$3 <- $6]
  }
}
```

I fixed this by adding another `fully_simplify()` pass in the end of `compile_to_offloads()`, but I wonder which specific pass can get rid of that empty offloaded..? @xumingkuan 

---

I'm not sure how much you like this template notion. Personally I think it's a not-very-intuitive but necessary workaround. Let me know your ideas :)

Related issue = #1608 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
