### PR TITLE
[GUI] Support gui.arrow() and gui.arrows()

### DIFF
--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -10,10 +10,10 @@ Create a window
 ---------------
 
 
-.. function:: ti.GUI(title, res, bgcolor = 0x000000)
+.. function:: ti.GUI(title = 'Taichi', res = (512, 512), bgcolor = 0x000000)
 
-    :parameter title: (string) the window title
-    :parameter res: (scalar or tuple) resolution / size of the window
+    :parameter title: (optional, string) the window title
+    :parameter res: (optional, scalar or tuple) resolution / size of the window
     :parameter bgcolor: (optional, RGB hex) background color of the window
     :return: (GUI) an object represents the window
 

--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -34,7 +34,7 @@ class GUI:
     PRESS = ti_core.KeyEvent.EType.Press
     RELEASE = ti_core.KeyEvent.EType.Release
 
-    def __init__(self, name, res=512, background_color=0x0):
+    def __init__(self, name='Taichi', res=512, background_color=0x0):
         self.name = name
         if isinstance(res, numbers.Number):
             res = (res, res)
@@ -285,6 +285,30 @@ class GUI:
     def line(self, begin, end, radius=1, color=0xFFFFFF):
         self.canvas.path_single(begin[0], begin[1], end[0], end[1], color,
                                 radius)
+
+    @staticmethod
+    def _arrow_to_lines(orig, major, tip_scale=0.2, angle=45):
+        import math
+        angle = math.radians(180 - angle)
+        c, s = math.cos(angle), math.sin(angle)
+        minor1 = np.array([major[:, 0] * c - major[:, 1] * s,
+                           major[:, 0] * s + major[:, 1] * c]).swapaxes(0, 1)
+        minor2 = np.array([major[:, 0] * c + major[:, 1] * s,
+                          -major[:, 0] * s + major[:, 1] * c]).swapaxes(0, 1)
+        end = orig + major
+        return [(orig, end),
+                (end, end + minor1 * tip_scale),
+                (end, end + minor2 * tip_scale)]
+
+    def arrows(self, orig, dir, radius=1, color=0xffffff, **kwargs):
+        for begin, end in self._arrow_to_lines(orig, dir, **kwargs):
+            self.lines(begin, end, radius, color)
+
+    def arrow(self, orig, dir, radius=1, color=0xffffff, **kwargs):
+        orig = np.array([orig])
+        dir = np.array([dir])
+        for begin, end in self._arrow_to_lines(orig, dir, **kwargs):
+            self.line(begin[0], end[0], radius, color)
 
     def rect(self, topleft, bottomright, radius=1, color=0xFFFFFF):
         a = topleft[0], topleft[1]

--- a/python/taichi/misc/image.py
+++ b/python/taichi/misc/image.py
@@ -71,7 +71,7 @@ def imread(filename, channels=0):
     return img.swapaxes(0, 1)[:, ::-1, :]
 
 
-def imshow(img, window_name='Taichi'):
+def imshow(img, window_name='imshow'):
     """
     Show image in a Taichi GUI.
     """


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
This could be useful when visualizing a vector field, particle velocities and forces.
It's completely based on `gui.lines()`, so no C++ changes involved. It's just handy for users so they don't have to hand-write that much numpy ad-hoc operations on their own.

To test:
```py
import taichi as ti
import numpy as np

gui = ti.GUI()

orig = np.array([[0.5, 0.3], [0.3, 0.8]], dtype=np.float32)
dir = np.array([[-0.1, 0.4], [0.4, -0.2]], dtype=np.float32)

while gui.running and not gui.get_event(gui.ESCAPE):
    gui.arrows(orig, dir, radius=2, angle=25, tip_scale=0.4)
    #gui.arrow(orig[0], dir[0], radius=2)
    gui.show()
```

OFT: I assigned a default value `title='Taichi'` for `ti.GUI` since thinking about a title is often mind-taking, at least to me.