### PR TITLE
[doc] Fix hyperlink display issue in faq.rst

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -30,7 +30,7 @@ Frequently asked questions
 
 **Q:** Shall we add some handy functions like ``ti.smoothstep`` or ``ti.vec3``?
 
-**A:** No, but we provide them in an extension library `Taichi GLSL <https://taichi-glsl.readthedocs.io>`, install it using:
+**A:** No, but we provide them in an extension library `Taichi GLSL <https://taichi-glsl.readthedocs.io>`_ , install it using:
 
 .. code-block:: bash
 
@@ -39,7 +39,7 @@ Frequently asked questions
 **Q:** How can I **render 3D results** without writing a ray tracer myself?
 
 **A:** You may export it with :ref:`export_ply_files` so that you could view it in Houdini or Blender.
-       Or make use the extension library `Taichi THREE <https://github.com/taichi-dev/taichi_glsl>` to render images and update to GUI in real-time.
+       Or make use the extension library `Taichi THREE <https://github.com/taichi-dev/taichi_glsl>`_ to render images and update to GUI in real-time.
 
 **Q:** How do I declare a tensor with **dynamic length**?
 


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

No related issue;

### Describe the issue

In the current stable version of the documentation, [faq.html](https://taichi.readthedocs.io/en/stable/faq.html), two external links lack the underscore so cannot display properly. See picture below:

##### 1. first broken link:

![Screenshot from 2020-08-03 18-12-38](https://user-images.githubusercontent.com/38550500/89172792-cdfe1880-d5b5-11ea-99c4-7b581d16b71c.png)

##### 2. second broken link:

![Screenshot from 2020-08-03 18-12-52](https://user-images.githubusercontent.com/38550500/89172727-ae66f000-d5b5-11ea-86e0-524ebf224b2c.png)