### PR TITLE
[Misc] [bug] Catch RuntimeError when detecting backends for better compatibility

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -340,17 +340,30 @@ def stat_write(avg):
 
 def is_arch_supported(arch):
     if arch == cuda:
-        return core.with_cuda()
+        try:
+            return core.with_cuda()
+        except Exception as e:
+            core.warn(f"{e.__class__.__name__}: '{e}' occurred when detecting CUDA API, giving up")
+            return False
     elif arch == metal:
-        return core.with_metal()
+        try:
+            return core.with_metal()
+        except Exception as e:
+            core.warn(f"{e.__class__.__name__}: '{e}' occurred when detecting Metal API, giving up")
+            return False
     elif arch == opengl:
-        return core.with_opengl()
+        try:
+            return core.with_opengl()
+        except Exception as e:
+            core.warn(f"{e.__class__.__name__}: '{e} 'occurred when detecting OpenGL API, giving up")
+            return False
     elif arch == cc:
-        return core.with_cc()
-    elif arch == cpu:
-        return True
-    else:
-        return False
+        try:
+            return core.with_cc()
+        except Exception as e:
+            core.warn(f"{e.__class__.__name__}: '{e} 'occurred when detecting C backend, giving up")
+            return False
+    return arch == cpu
 
 
 def supported_archs():

--- a/python/taichi/testing.py
+++ b/python/taichi/testing.py
@@ -1,7 +1,5 @@
 import taichi as ti
 
-print('[Taichi] loading test module')
-
 ## Helper functions
 def approx(expected, **kwargs):
     '''Tweaked pytest.approx for OpenGL low percisions'''

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -80,8 +80,6 @@ void stop_duplicating_stdout_to_file(const std::string &fn) {
 }
 
 bool is_cuda_api_available() {
-  //*(int*)1=1;
-  TI_ERROR("some cuda runtime error");
 #if defined(TI_WITH_CUDA)
   return lang::CUDADriver::get_instance_without_context().detected();
 #else

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -80,6 +80,8 @@ void stop_duplicating_stdout_to_file(const std::string &fn) {
 }
 
 bool is_cuda_api_available() {
+  //*(int*)1=1;
+  TI_ERROR("some cuda runtime error");
 #if defined(TI_WITH_CUDA)
   return lang::CUDADriver::get_instance_without_context().detected();
 #else


### PR DESCRIPTION
Related issue = WeChat group

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

Despite we still can't catch `Segmentation Fault` as `RuntimeError` for now, it's still a good step towards compatibility :)

----
```
(catch-runtime-error-when-detect) [bate@archit taichi]$ np examples/mpm88.py         
ninja: Entering directory `build'
[1/3] cd /mnt/steam/bate/taichi/build && pyth...e/Develop/taichi/misc/generate_commit_hash.py
Building commit 10789eeef42d488d66bff85968d068144a398751
[3/3] Linking CXX shared library /home/bate/Develop/taichi/build/libtaichi_core.so
[Taichi] mode=development
[Taichi] preparing sandbox at /tmp/taichi-zk3i964u
[Taichi] <dev mode>, llvm 10.0.0, commit 10789eee, python 3.8.3
[E 08/05/20 22:30:54.019] [export_misc.cpp:is_cuda_api_available@84] some cuda runtime error


***********************************
* Taichi Compiler Stack Traceback *                                                          
***********************************                                                          
/tmp/taichi-zk3i964u/taichi_core.so: taichi::Logger::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)                                  
/tmp/taichi-zk3i964u/taichi_core.so: taichi::is_cuda_api_available()                         
/tmp/taichi-zk3i964u/taichi_core.so(+0x6b3bb7) [0x7f0506532bb7]                              
/tmp/taichi-zk3i964u/taichi_core.so(+0x576992) [0x7f05063f5992]                              
/usr/lib/libpython3.8.so.1.0: PyCFunction_Call                                               
/usr/lib/libpython3.8.so.1.0: _PyObject_MakeTpCall                                           
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyFunction_Vectorcall                                         
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyFunction_Vectorcall                                         
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyFunction_Vectorcall                                         
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalCodeWithName                                       
/usr/lib/libpython3.8.so.1.0: _PyFunction_Vectorcall                                         
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalCodeWithName                                       
/usr/lib/libpython3.8.so.1.0: PyEval_EvalCode                                                
/usr/lib/libpython3.8.so.1.0(+0x1d8248) [0x7f050a66b248]                                     
/usr/lib/libpython3.8.so.1.0(+0x1d2483) [0x7f050a665483]                                     
/usr/lib/libpython3.8.so.1.0: PyRun_FileExFlags                                              
/usr/lib/libpython3.8.so.1.0: PyRun_SimpleFileExFlags                                        
/usr/lib/libpython3.8.so.1.0: Py_RunMain                                                     
/usr/lib/libpython3.8.so.1.0: Py_BytesMain                                                   
/usr/lib/libc.so.6: __libc_start_main                                                        
python(_start+0x2e) [0x55fa3031204e]                                                         

Internal Error occurred, check this page for possible solutions:                             
https://taichi.readthedocs.io/en/stable/install.html#troubleshooting                         
[W 08/05/20 22:30:54.021] RuntimeError: '[export_misc.cpp:is_cuda_api_available@84] some cuda runtime error' occurred when detecting cuda, consider add `export TI_WITH_CUDA=0`  to environment variables to dismiss this warning message.
[E 08/05/20 22:30:54.076] [export_misc.cpp:is_cuda_api_available@84] some cuda runtime error


***********************************
* Taichi Compiler Stack Traceback *                                                          
***********************************                                                          
/tmp/taichi-zk3i964u/taichi_core.so: taichi::Logger::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)                                  
/tmp/taichi-zk3i964u/taichi_core.so: taichi::is_cuda_api_available()                         
/tmp/taichi-zk3i964u/taichi_core.so(+0x6b3bb7) [0x7f0506532bb7]                              
/tmp/taichi-zk3i964u/taichi_core.so(+0x576992) [0x7f05063f5992]                              
/usr/lib/libpython3.8.so.1.0: PyCFunction_Call                                               
/usr/lib/libpython3.8.so.1.0: _PyObject_MakeTpCall                                           
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyFunction_Vectorcall                                         
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyFunction_Vectorcall                                         
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalCodeWithName                                       
/usr/lib/libpython3.8.so.1.0: _PyFunction_Vectorcall                                         
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalFrameDefault                                       
/usr/lib/libpython3.8.so.1.0: _PyEval_EvalCodeWithName                                       
/usr/lib/libpython3.8.so.1.0: PyEval_EvalCode                                                
/usr/lib/libpython3.8.so.1.0(+0x1d8248) [0x7f050a66b248]                                     
/usr/lib/libpython3.8.so.1.0(+0x1d2483) [0x7f050a665483]                                     
/usr/lib/libpython3.8.so.1.0: PyRun_FileExFlags                                              
/usr/lib/libpython3.8.so.1.0: PyRun_SimpleFileExFlags                                        
/usr/lib/libpython3.8.so.1.0: Py_RunMain                                                     
/usr/lib/libpython3.8.so.1.0: Py_BytesMain                                                   
/usr/lib/libc.so.6: __libc_start_main                                                        
python(_start+0x2e) [0x55fa3031204e]                                                         

Internal Error occurred, check this page for possible solutions:                             
https://taichi.readthedocs.io/en/stable/install.html#troubleshooting                         
[W 08/05/20 22:30:54.078] RuntimeError: '[export_misc.cpp:is_cuda_api_available@84] some cuda runtime error' occurred when detecting cuda, consider add `export TI_WITH_CUDA=0`  to environment variables to dismiss this warning message.
[Taichi] Starting on arch=opengl
[Taichi] materializing...
```