### PR TITLE
[Refactor] "x.snode()" is deprecated, use "x.snode" instead

### DIFF
--- a/docs/snode.rst
+++ b/docs/snode.rst
@@ -30,7 +30,7 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
         x = ti.field(dtype=ti.i32)
         y = ti.field(dtype=ti.f32)
         ti.root.place(x, y)
-        assert x.snode() == y.snode()
+        assert x.snode == y.snode
 
 
 .. function:: field.shape
@@ -38,17 +38,17 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
     :parameter a: (ti.field)
     :return: (tuple of integers) the shape of field
 
-    Equivalent to ``field.snode().shape``.
+    Equivalent to ``field.snode.shape``.
 
     For example,
 
     ::
 
         ti.root.dense(ti.ijk, (3, 5, 4)).place(x)
-        x.shape # returns (3, 5, 4)
+        x.shape  # returns (3, 5, 4)
 
 
-.. function:: field.snode()
+.. function:: field.snode
 
     :parameter a: (ti.field)
     :return: (SNode) the structual node where ``field`` is placed
@@ -57,8 +57,9 @@ See :ref:`layout` for more details. ``ti.root`` is the root node of the data str
 
         x = ti.field(dtype=ti.i32)
         y = ti.field(dtype=ti.f32)
-        ti.root.place(x, y)
-        x.snode()
+        blk1 = ti.root.dense(ti.i, 4)
+        blk1.place(x, y)
+        assert x.snode == blk1
 
 
 .. function:: snode.shape

--- a/examples/comet.py
+++ b/examples/comet.py
@@ -38,7 +38,7 @@ def substep():
         color[i] *= ti.exp(-dt * colordeg)
 
         if not all(-0.1 <= x[i] <= 1.1):
-            ti.deactivate(x.snode().parent(), [i])
+            ti.deactivate(x.snode.parent(), [i])
 
 
 @ti.kernel

--- a/examples/quadtree.py
+++ b/examples/quadtree.py
@@ -18,7 +18,7 @@ B.place(qt)
 
 img = ti.Vector(3, dt=ti.f32, shape=(RES, RES))
 
-print('The quad tree layout is:\n', qt.snode())
+print('The quad tree layout is:\n', qt.snode)
 
 
 @ti.kernel

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -219,7 +219,7 @@ def init(arch=None,
 
 def no_activate(*args):
     for v in args:
-        taichi_lang_core.no_activate(v.snode().ptr)
+        taichi_lang_core.no_activate(v.snode.ptr)
 
 
 def cache_shared(*args):
@@ -271,7 +271,7 @@ def Tape(loss, clear_gradients=True):
     if len(loss.shape) != 0:
         raise RuntimeError(
             'The loss of `Tape` must be a 0-D tensor, i.e. scalar')
-    if not loss.snode().ptr.has_grad():
+    if not loss.snode.ptr.has_grad():
         raise RuntimeError(
             'Gradients of loss are not allocated, please use ti.var(..., needs_grad=True)'
             ' for all tensors that are required by autodiff.')

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -273,7 +273,7 @@ def Tape(loss, clear_gradients=True):
             'The loss of `Tape` must be a 0-D tensor, i.e. scalar')
     if not loss.snode.ptr.has_grad():
         raise RuntimeError(
-            'Gradients of loss are not allocated, please use ti.var(..., needs_grad=True)'
+            'Gradients of loss are not allocated, please use ti.field(..., needs_grad=True)'
             ' for all tensors that are required by autodiff.')
     if clear_gradients:
         clear_all_gradients()

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -234,7 +234,8 @@ def cache_read_only(*args):
 
 def assume_in_range(val, base, low, high):
     return taichi_lang_core.expr_assume_in_range(
-        Expr(val).ptr, Expr(base).ptr, low, high)
+        Expr(val).ptr,
+        Expr(base).ptr, low, high)
 
 
 parallelize = core.parallelize

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -70,7 +70,7 @@ class Expr(TaichiOperations):
     def initialize_accessor(self):
         if self.getter:
             return
-        snode = self.ptr.snode
+        snode = self.ptr.snode()
 
         if self.dtype == f32 or self.dtype == f64:
 
@@ -108,7 +108,7 @@ class Expr(TaichiOperations):
     @python_scope
     def clear(self, deactivate=False):
         assert not deactivate
-        node = self.ptr.snode.parent
+        node = self.ptr.snode().parent
         assert node
         node.clear_data()
 

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -121,22 +121,23 @@ class Expr(TaichiOperations):
     #@deprecated('tensor.parent()', 'tensor.snode().parent()')
     def parent(self, n=1):
         import taichi as ti
-        p = self.snode().parent(n)
+        p = self.snode.parent(n)
         return Expr(ti.core.global_var_expr_from_snode(p.ptr))
 
     def is_global(self):
         return self.ptr.is_global_var() or self.ptr.is_external_var()
 
+    @property
     def snode(self):
         from .snode import SNode
-        return SNode(self.ptr.snode())
+        return SNode(self.ptr.snode)
 
     def __hash__(self):
         return self.ptr.get_raw_address()
 
     @property
     def shape(self):
-        return self.snode().shape
+        return self.snode.shape
 
     @deprecated('x.dim()', 'len(x.shape)')
     def dim(self):
@@ -144,11 +145,11 @@ class Expr(TaichiOperations):
 
     @property
     def dtype(self):
-        return self.snode().dtype
+        return self.snode.dtype
 
     @deprecated('x.data_type()', 'x.dtype')
     def data_type(self):
-        return self.snode().dtype
+        return self.snode.dtype
 
     @python_scope
     def to_numpy(self):

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -130,7 +130,7 @@ class Expr(TaichiOperations):
     @property
     def snode(self):
         from .snode import SNode
-        return SNode(self.ptr.snode)
+        return SNode(self.ptr.snode())
 
     def __hash__(self):
         return self.ptr.get_raw_address()

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -70,7 +70,7 @@ class Expr(TaichiOperations):
     def initialize_accessor(self):
         if self.getter:
             return
-        snode = self.ptr.snode()
+        snode = self.ptr.snode
 
         if self.dtype == f32 or self.dtype == f64:
 
@@ -108,7 +108,7 @@ class Expr(TaichiOperations):
     @python_scope
     def clear(self, deactivate=False):
         assert not deactivate
-        node = self.ptr.snode().parent
+        node = self.ptr.snode.parent
         assert node
         node.clear_data()
 
@@ -118,7 +118,7 @@ class Expr(TaichiOperations):
         from .meta import fill_tensor
         fill_tensor(self, val)
 
-    #@deprecated('tensor.parent()', 'tensor.snode().parent()')
+    #@deprecated('tensor.parent()', 'tensor.snode.parent()')
     def parent(self, n=1):
         import taichi as ti
         p = self.snode.parent(n)

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -215,7 +215,7 @@ class PyTaichi:
         taichi_lang_core.layout(layout)
         self.materialized = True
         for var in self.global_vars:
-            if var.ptr.snode is None:
+            if var.ptr.snode() is None:
                 raise RuntimeError(
                     'Some variable(s) are not placed.'
                     ' Did you forget to specify the shape of any field? E.g., the "shape" argument in'

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -215,7 +215,7 @@ class PyTaichi:
         taichi_lang_core.layout(layout)
         self.materialized = True
         for var in self.global_vars:
-            if var.ptr.snode() is None:
+            if var.ptr.snode is None:
                 raise RuntimeError(
                     'Some variable(s) are not placed.'
                     ' Did you forget to specify the shape of any field? E.g., the "shape" argument in'
@@ -489,7 +489,7 @@ def grouped(x):
 
 
 def stop_grad(x):
-    taichi_lang_core.stop_grad(x.snode().ptr)
+    taichi_lang_core.stop_grad(x.snode.ptr)
 
 
 def current_cfg():

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -575,8 +575,9 @@ class Matrix(TaichiOperations):
     def data_type(self):
         return self.dtype
 
+    @property
     def snode(self):
-        return self.loop_range().snode()
+        return self.loop_range().snode
 
     def make_grad(self):
         ret = self.empty_copy()

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -529,8 +529,8 @@ def asm(source, inputs=[], outputs=[]):
 
 
 def is_active(l, indices):
-    return Expr(
-        ti_core.insert_is_active(l.snode.ptr, make_expr_group(indices)))
+    return Expr(ti_core.insert_is_active(l.snode.ptr,
+                                         make_expr_group(indices)))
 
 
 def activate(l, indices):

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -508,7 +508,7 @@ def ti_all(a):
 def append(l, indices, val):
     import taichi as ti
     a = ti.expr_init(
-        ti_core.insert_append(l.snode().ptr, make_expr_group(indices),
+        ti_core.insert_append(l.snode.ptr, make_expr_group(indices),
                               Expr(val).ptr))
     return a
 
@@ -530,16 +530,16 @@ def asm(source, inputs=[], outputs=[]):
 
 def is_active(l, indices):
     return Expr(
-        ti_core.insert_is_active(l.snode().ptr, make_expr_group(indices)))
+        ti_core.insert_is_active(l.snode.ptr, make_expr_group(indices)))
 
 
 def activate(l, indices):
-    ti_core.insert_activate(l.snode().ptr, make_expr_group(indices))
+    ti_core.insert_activate(l.snode.ptr, make_expr_group(indices))
 
 
 def deactivate(l, indices):
-    ti_core.insert_deactivate(l.snode().ptr, make_expr_group(indices))
+    ti_core.insert_deactivate(l.snode.ptr, make_expr_group(indices))
 
 
 def length(l, indices):
-    return Expr(ti_core.insert_len(l.snode().ptr, make_expr_group(indices)))
+    return Expr(ti_core.insert_len(l.snode.ptr, make_expr_group(indices)))

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -98,6 +98,11 @@ class SNode:
         import taichi as ti
         return ti.Expr(ti.core.global_var_expr_from_snode(self.ptr))
 
+    @deprecated('x.snode()', 'x.snode')
+    def __call__(self):  # TODO: remove this after v0.7.0
+        return self
+
+    @property
     def snode(self):
         return self
 

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -75,11 +75,11 @@ def bls_test_template(dim,
 
     if benchmark:
         for i in range(benchmark):
-            x.snode().parent().deactivate_all()
+            x.snode.parent().deactivate_all()
             if not scatter:
                 populate()
-            y.snode().parent().deactivate_all()
-            y2.snode().parent().deactivate_all()
+            y.snode.parent().deactivate_all()
+            y2.snode.parent().deactivate_all()
             apply(False, y2)
             apply(True, y)
     else:
@@ -246,7 +246,7 @@ def bls_particle_grid(N,
     insert()
 
     for i in range(benchmark):
-        pid.parent(2).snode().deactivate_all()
+        pid.parent(2).snode.deactivate_all()
         insert()
 
     @ti.kernel

--- a/tests/python/test_indices.py
+++ b/tests/python/test_indices.py
@@ -10,11 +10,11 @@ def test_indices():
 
     ti.get_runtime().materialize()
 
-    mapping_a = a.snode().physical_index_position()
+    mapping_a = a.snode.physical_index_position()
 
     assert mapping_a == {0: 0, 1: 1, 2: 2}
 
-    mapping_b = b.snode().physical_index_position()
+    mapping_b = b.snode.physical_index_position()
 
     assert mapping_b == {0: 1, 1: 0}
     # Note that b is column-major:

--- a/tests/python/test_stop_grad.py
+++ b/tests/python/test_stop_grad.py
@@ -41,7 +41,7 @@ def test_stop_grad():
     @ti.kernel
     def func():
         for i in range(n):
-            ti.core.stop_grad(x.snode().ptr)
+            ti.core.stop_grad(x.snode.ptr)
             loss[None] += x[i]**2
 
     for i in range(n):

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -111,6 +111,8 @@ def test_deprecated():
     assert mat.shape() == (n, m, p)
     assert blk3.dim() == 3
     assert blk3.shape() == (n, m, p)
+    assert val.snode().parent() == blk3
+    assert mat.snode().parent() == blk3
 
 
 @ti.all_archs

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -48,21 +48,21 @@ def test_unordered():
 
     assert val.dtype == ti.i32
     assert val.shape == (n, m, p)
-    assert val.snode().parent(0) == val.snode()
-    assert val.snode().parent() == blk3
-    assert val.snode().parent(1) == blk3
-    assert val.snode().parent(2) == blk2
-    assert val.snode().parent(3) == blk1
-    assert val.snode().parent(4) == ti.root
+    assert val.snode.parent(0) == val.snode
+    assert val.snode.parent() == blk3
+    assert val.snode.parent(1) == blk3
+    assert val.snode.parent(2) == blk2
+    assert val.snode.parent(3) == blk1
+    assert val.snode.parent(4) == ti.root
 
-    assert val.snode() in blk3.get_children()
+    assert val.snode in blk3.get_children()
     assert blk3 in blk2.get_children()
     assert blk2 in blk1.get_children()
     assert blk1 in ti.root.get_children()
 
     expected_repr = f'ti.root => dense {[n]} => dense {[n, m]}' \
         f' => dense {[n, m, p]} => place {[n, m, p]}'
-    assert repr(val.snode()) == expected_repr
+    assert repr(val.snode) == expected_repr
 
 
 @ti.all_archs
@@ -80,12 +80,12 @@ def test_unordered_matrix():
 
     assert val.shape == (n, m, p)
     assert val.dtype == ti.i32
-    assert val.loop_range().snode().parent(0) == val.loop_range().snode()
-    assert val.loop_range().snode().parent() == blk3
-    assert val.loop_range().snode().parent(1) == blk3
-    assert val.loop_range().snode().parent(2) == blk2
-    assert val.loop_range().snode().parent(3) == blk1
-    assert val.loop_range().snode().parent(4) == ti.root
+    assert val.loop_range().snode.parent(0) == val.loop_range().snode
+    assert val.loop_range().snode.parent() == blk3
+    assert val.loop_range().snode.parent(1) == blk3
+    assert val.loop_range().snode.parent(2) == blk2
+    assert val.loop_range().snode.parent(3) == blk1
+    assert val.loop_range().snode.parent(4) == ti.root
 
 
 @pytest.mark.filterwarnings('ignore')
@@ -124,10 +124,10 @@ def test_parent_exceeded():
     blk2 = blk1.dense(ti.j, n)
     blk2.place(val)
 
-    assert val.snode().parent() == blk2
-    assert val.snode().parent(2) == blk1
-    assert val.snode().parent(3) == ti.root
-    assert val.snode().parent(4) == None
-    assert val.snode().parent(42) == None
+    assert val.snode.parent() == blk2
+    assert val.snode.parent(2) == blk1
+    assert val.snode.parent(3) == ti.root
+    assert val.snode.parent(4) == None
+    assert val.snode.parent(42) == None
 
     assert ti.root.parent() == None


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
