### PR TITLE
[misc] [refactor] Add fully_deprecated mark for future use

### DIFF
--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -475,6 +475,9 @@ def assign(a, b):
     return a
 
 
+sqr = fully_deprecated('ti.sqr(x)', 'x**2')
+
+
 def ti_max(*args):
     num_args = len(args)
     assert num_args >= 1

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -1,5 +1,5 @@
 from .core import taichi_lang_core
-from taichi.misc.util import warning, deprecated
+from taichi.misc.util import warning, deprecated, fully_deprecated
 import numpy as np
 import os
 

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -131,6 +131,8 @@ Announce a pending deprecation with an API wrapper, usage:
 def sqr(x):
     return x**2
 '''
+
+
 def deprecated(old, new, type=DeprecationWarning):
     import functools
 
@@ -146,11 +148,14 @@ def deprecated(old, new, type=DeprecationWarning):
 
     return decorator
 
+
 '''
 Announce a full deprecateion, with no API wrapper, usage:
 
 sqr = fully_deprecated('ti.sqr(x)', 'x**2')
 '''
+
+
 def fully_deprecated(old, new):
     def wrapped(*args, **kwargs):
         _taichi_skip_traceback = 1

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -124,16 +124,14 @@ def warning(msg, type=UserWarning, stacklevel=1):
         warnings.warn(msg, type, stacklevel=stacklevel + 1)
 
 
-'''
-Announce a pending deprecation with an API wrapper, usage:
-
-@deprecated('ti.sqr(x)', 'x**2')
-def sqr(x):
-    return x**2
-'''
-
-
 def deprecated(old, new, type=DeprecationWarning):
+    '''
+    Announce a pending deprecation with an API wrapper, usage:
+
+    @deprecated('ti.sqr(x)', 'x**2')
+    def sqr(x):
+        return x**2
+    '''
     import functools
 
     def decorator(foo):
@@ -149,14 +147,12 @@ def deprecated(old, new, type=DeprecationWarning):
     return decorator
 
 
-'''
-Announce a full deprecateion, with no API wrapper, usage:
-
-sqr = fully_deprecated('ti.sqr(x)', 'x**2')
-'''
-
-
 def fully_deprecated(old, new):
+    '''
+    Announce a full deprecateion, with no API wrapper, usage:
+
+    sqr = fully_deprecated('ti.sqr(x)', 'x**2')
+    '''
     def wrapped(*args, **kwargs):
         _taichi_skip_traceback = 1
         msg = f'{old} is fully deprecated, please use {new} instead'

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -124,7 +124,14 @@ def warning(msg, type=UserWarning, stacklevel=1):
         warnings.warn(msg, type, stacklevel=stacklevel + 1)
 
 
-def deprecated(old, new):
+'''
+Announce a pending deprecation with an API wrapper, usage:
+
+@deprecated('ti.sqr(x)', 'x**2')
+def sqr(x):
+    return x**2
+'''
+def deprecated(old, new, type=DeprecationWarning):
     import functools
 
     def decorator(foo):
@@ -132,12 +139,31 @@ def deprecated(old, new):
         def wrapped(*args, **kwargs):
             _taichi_skip_traceback = 1
             msg = f'{old} is deprecated, please use {new} instead'
-            warning(msg, DeprecationWarning, stacklevel=2)
+            warning(msg, type, stacklevel=2)
             return foo(*args, **kwargs)
 
         return wrapped
 
     return decorator
+
+'''
+Announce a full deprecateion, with no API wrapper, usage:
+
+sqr = fully_deprecated('ti.sqr(x)', 'x**2')
+'''
+def fully_deprecated(old, new):
+    def wrapped(*args, **kwargs):
+        _taichi_skip_traceback = 1
+        msg = f'{old} is fully deprecated, please use {new} instead'
+        try:
+            import locale
+            if 'zh' in locale.getdefaultlocale()[0]:
+                msg += f'\n{old} 已经被彻底移除，请使用 {new} 来替换'
+        except:
+            pass
+        raise SyntaxError(msg)
+
+    return wrapped
 
 
 def get_logging(name):
@@ -215,6 +241,8 @@ __all__ = [
     'veci',
     'core_vec',
     'core_veci',
+    'deprecated',
+    'fully_deprecated',
     'set_gdb_trigger',
     'print_profile_info',
     'set_logging_level',


### PR DESCRIPTION
Related issue = #1500

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
# My refactor plan:

## Currently:

`fully_deprecated`:
- `ti.sqr`

`deprecated`:

- `x.dim()`
- `ti.outer_product`
- `ti.dot`
- `ti.veci`
- `@ti.classfunc`
- `@ti.classkernel`
- `x.shape()` (the bracket)
- `x.dim()`
- `@ti.layout`

commented to be `deprecated`:
- `ti.var`
- `ti.Matrix.var`
- `ti.Matrix` for global matrix fields

## After v0.7.0:

`fully_deprecated`:
- `ti.outer_product`
- `ti.dot`
- `ti.veci`
- `@ti.classfunc`
- `@ti.classkernel`
- `x.shape()` (the bracket)
- `x.dim()`
- `@ti.layout`
- ...

`deprecated`:
- `ti.var`
- `ti.Matrix.var`
- `ti.Matrix` for global matrix fields

## After v0.8.0, or some point within v0.7.x:

`fully_deprecated`:
- `ti.var`
- `ti.Matrix.var`
- `ti.Matrix` for global matrix fields