### PR TITLE
[llvm] [linux] Further improve misc/linker.map to prevent segementation fault when importing in Blender

### DIFF
--- a/misc/linker.map
+++ b/misc/linker.map
@@ -1,10 +1,13 @@
 {
 global:
-	extern "C++" {
-		taichi::*;
-	};
+    extern "C++" {
+        taichi::*;
+    };
+    extern "C" {
+        Py*;
+    };
 local:
-	extern "C++" {
-		llvm::*;
-	};
+    extern "C" {
+        *;
+    };
 };


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://zhuanlan.zhihu.com/p/172585527

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
