### PR TITLE
[misc] Prevent 'supported_archs()' invocation in 'adaptive_arch_select()' for better compatibility

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -180,6 +180,8 @@ def init(arch=None,
 
     # compiler configurations (ti.cfg):
     for key in dir(ti.cfg):
+        if key in ['arch', 'default_fp', 'default_ip']:
+            continue
         cast = type(getattr(ti.cfg, key))
         if cast is bool:
             cast = None

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -180,8 +180,6 @@ def init(arch=None,
 
     # compiler configurations (ti.cfg):
     for key in dir(ti.cfg):
-        if key in ['arch', 'default_fp', 'default_ip']:
-            continue
         cast = type(getattr(ti.cfg, key))
         if cast is bool:
             cast = None
@@ -386,13 +384,11 @@ def adaptive_arch_select(arch):
     if arch is None:
         return cpu
     import taichi as ti
-    supported = supported_archs()
-    if isinstance(arch, list):
-        for a in arch:
-            if is_arch_supported(a):
-                return a
-    elif arch in supported:
-        return arch
+    if not isinstance(arch, (list, tuple)):
+        arch = [arch]
+    for a in arch:
+        if is_arch_supported(a):
+            return a
     ti.warn(f'Arch={arch} is not supported, falling back to CPU')
     return cpu
 


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1667

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Before: always segf on `ti.init(arch=xxx)`.
After: only segf on `ti.init(arch=ti.opengl)`.

```
(supported-archs-delay) [bate@archit taichi]$ bld
Read prefs: /home/bate/.config/blender/2.83/config/userpref.blend
/run/user/1000/gvfs/ non-existent directory
0  meshes freed
[I 08/08/20 23:25:30.389] [shell.py:_shell_pop_print@138] Graphical python shell detected, using wrapped sys.stdout
[E 08/08/20 23:25:34.110] Received signal 11 (Segmentation fault)


***********************************
* Taichi Compiler Stack Traceback *
***********************************
/tmp/taichi-4mneuoxo/taichi_core.so: taichi::Logger::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)
/tmp/taichi-4mneuoxo/taichi_core.so: taichi::signal_handler(int)
/usr/lib/libc.so.6(+0x3c3e0) [0x7f013443b3e0]
blender(immAttr2f+0x2f) [0x557e65e4e29f]
blender(immVertex2f+0xa) [0x557e65e4e54a]
blender(immRectf+0x44) [0x557e65e4f064]
blender(+0x16daa8b) [0x557e6468ea8b]
blender(textview_draw+0x938) [0x557e65943208]
blender(+0x16dad0e) [0x557e6468ed0e]
blender(console_textview_main+0x33) [0x557e6468ed83]
blender(+0x16da1a9) [0x557e6468e1a9]
blender(ED_region_do_draw+0x8a1) [0x557e642eae61]
blender(wm_draw_update+0x4d5) [0x557e63f79a75]
blender(WM_main+0x34) [0x557e63f77a34]
blender(main+0x36b) [0x557e63c8631b]
/usr/lib/libc.so.6: __libc_start_main
blender(_start+0x2e) [0x557e63cb40fe]

Internal Error occurred, check this page for possible solutions:
https://taichi.readthedocs.io/en/stable/install.html#troubleshooting
```