### PR TITLE
[Lang] 'ti.static()' now takes all type of arguments without raising any error

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -460,9 +460,9 @@ index = indices
 
 def static(x, *xs):
     _taichi_skip_traceback = 1
-    if len(xs):  # for python-ish pointer assign: x, y = ti.static(y, x)
-        return [static(x)] + [static(x) for x in xs]
-    return x
+    if len(xs) == 0:
+        return list(x)
+    return [x] + list(xs)
 
 
 @taichi_scope

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -462,21 +462,7 @@ def static(x, *xs):
     _taichi_skip_traceback = 1
     if len(xs):  # for python-ish pointer assign: x, y = ti.static(y, x)
         return [static(x)] + [static(x) for x in xs]
-    import types
-    import taichi as ti
-    if isinstance(x, (bool, int, float, range, list, tuple, enumerate,
-                      ti.ndrange, ti.GroupedNDRange)) or x is None:
-        return x
-    elif isinstance(x, ti.lang.expr.Expr) and x.ptr.is_global_var():
-        return x
-    elif isinstance(x, ti.Matrix) and x.is_global():
-        return x
-    elif isinstance(x, (types.FunctionType, types.MethodType)):
-        return x
-    else:
-        raise ValueError(
-            f'Input to ti.static must be compile-time constants or global pointers, instead of {type(x)}'
-        )
+    return x
 
 
 @taichi_scope


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
1. Currently the ability of static-for is limited by the line length:
```py
if isinstance(x, (bool, int, float, range, list, tuple, enumerate,
-                      ti.ndrange, ti.GroupedNDRange)) or x is None:
```
But it would also be great to support `zip`, `map`, `filter` in static-for too.

2. Currently the ability of static-aliasing is limited by the if-elif-levels:
```
    elif isinstance(x, ti.lang.expr.Expr) and x.ptr.is_global_var():
        return x
    elif isinstance(x, ti.Matrix) and x.is_global():
        return x
```

But it would also be great to static-aliasing non-global variables, e.g., to reduce allocas.
Also it would limit external packages to define their own Taichi classes, like `ts.Complex`.

3. To sum up, I don't think it's wise to **maintain such a long list** in `ti.static` just to raise an error **banning advanced users from their aggressive metaprogramming tricks**.