### PR TITLE
[test] Replace ti.var by ti.field in tests starting with a-g

### DIFF
--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -119,7 +119,7 @@ def bls_particle_grid(N,
 
     max_num_particles_per_block = block_size**2 * 4096
 
-    x = ti.Vector(2, dtype=ti.f32)
+    x = ti.Vector(2, dt=ti.f32)
 
     s1 = ti.field(dtype=ti.f32)
     s2 = ti.field(dtype=ti.f32)

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -11,10 +11,10 @@ def bls_test_template(dim,
                       scatter=False,
                       benchmark=0,
                       dense=False):
-    x, y, y2 = ti.var(ti.i32), ti.var(ti.i32), ti.var(ti.i32)
+    x, y, y2 = ti.field(ti.i32), ti.field(ti.i32), ti.field(ti.i32)
 
     index = ti.indices(*range(dim))
-    mismatch = ti.var(ti.i32, shape=())
+    mismatch = ti.field(ti.i32, shape=())
 
     if not isinstance(bs, (tuple, list)):
         bs = [bs for _ in range(dim)]
@@ -111,19 +111,19 @@ def bls_particle_grid(N,
                       use_offset=True):
     M = N * N * ppc
 
-    m1 = ti.var(ti.f32)
-    m2 = ti.var(ti.f32)
-    m3 = ti.var(ti.f32)
-    pid = ti.var(ti.i32)
-    err = ti.var(ti.i32, shape=())
+    m1 = ti.field(ti.f32)
+    m2 = ti.field(ti.f32)
+    m3 = ti.field(ti.f32)
+    pid = ti.field(ti.i32)
+    err = ti.field(ti.i32, shape=())
 
     max_num_particles_per_block = block_size**2 * 4096
 
-    x = ti.Vector(2, dt=ti.f32)
+    x = ti.Vector(2, dtype=ti.f32)
 
-    s1 = ti.var(dt=ti.f32)
-    s2 = ti.var(dt=ti.f32)
-    s3 = ti.var(dt=ti.f32)
+    s1 = ti.field(dtype=ti.f32)
+    s2 = ti.field(dtype=ti.f32)
+    s3 = ti.field(dtype=ti.f32)
 
     ti.root.dense(ti.i, M).place(x)
     ti.root.dense(ti.i, M).place(s1, s2, s3)

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -121,6 +121,7 @@ def bls_particle_grid(N,
 
     x = ti.Vector(2, dt=ti.f32)
 
+
     s1 = ti.field(dtype=ti.f32)
     s2 = ti.field(dtype=ti.f32)
     s3 = ti.field(dtype=ti.f32)

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -121,7 +121,6 @@ def bls_particle_grid(N,
 
     x = ti.Vector(2, dt=ti.f32)
 
-
     s1 = ti.field(dtype=ti.f32)
     s2 = ti.field(dtype=ti.f32)
     s3 = ti.field(dtype=ti.f32)

--- a/tests/python/grad_test.py
+++ b/tests/python/grad_test.py
@@ -7,8 +7,8 @@ def grad_test(tifunc, npfunc=None):
     if npfunc is None:
         npfunc = tifunc
 
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x, x.grad, y, y.grad)
 

--- a/tests/python/test_abs.py
+++ b/tests/python/test_abs.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_abs():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     N = 16
 

--- a/tests/python/test_ad_atomic.py
+++ b/tests/python/test_ad_atomic.py
@@ -4,8 +4,8 @@ from taichi import approx
 
 @ti.all_archs
 def test_ad_reduce():
-    x = ti.var(ti.f32)
-    loss = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    loss = ti.field(ti.f32)
 
     N = 16
 

--- a/tests/python/test_ad_demote_dense.py
+++ b/tests/python/test_ad_demote_dense.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.archs_excluding(ti.metal, ti.opengl)
 def test_ad_demote_dense():
-    a = ti.var(ti.f32, shape=(7, 3, 19))
+    a = ti.field(ti.f32, shape=(7, 3, 19))
 
     @ti.kernel
     def inc():

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -5,9 +5,9 @@ import taichi as ti
 @ti.all_archs
 def test_ad_sum():
     N = 10
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.i32, shape=N)
-    p = ti.var(ti.f32, shape=N, needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.i32, shape=N)
+    p = ti.field(ti.f32, shape=N, needs_grad=True)
 
     @ti.kernel
     def compute_sum():
@@ -38,9 +38,9 @@ def test_ad_sum():
 def test_ad_sum_local_atomic():
     ti.init(print_ir=True)
     N = 10
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.i32, shape=N)
-    p = ti.var(ti.f32, shape=N, needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.i32, shape=N)
+    p = ti.field(ti.f32, shape=N, needs_grad=True)
 
     @ti.kernel
     def compute_sum():
@@ -70,9 +70,9 @@ def test_ad_sum_local_atomic():
 @ti.all_archs
 def test_ad_power():
     N = 10
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.i32, shape=N)
-    p = ti.var(ti.f32, shape=N, needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.i32, shape=N)
+    p = ti.field(ti.f32, shape=N, needs_grad=True)
 
     @ti.kernel
     def power():
@@ -102,10 +102,10 @@ def test_ad_power():
 @ti.all_archs
 def test_ad_fibonacci():
     N = 15
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.f32, shape=N, needs_grad=True)
-    c = ti.var(ti.i32, shape=N)
-    f = ti.var(ti.f32, shape=N, needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.f32, shape=N, needs_grad=True)
+    c = ti.field(ti.i32, shape=N)
+    f = ti.field(ti.f32, shape=N, needs_grad=True)
 
     @ti.kernel
     def fib():
@@ -142,9 +142,9 @@ def test_ad_fibonacci():
 def test_ad_fibonacci_index():
     N = 5
     M = 10
-    a = ti.var(ti.f32, shape=M, needs_grad=True)
-    b = ti.var(ti.f32, shape=M, needs_grad=True)
-    f = ti.var(ti.f32, shape=(), needs_grad=True)
+    a = ti.field(ti.f32, shape=M, needs_grad=True)
+    b = ti.field(ti.f32, shape=M, needs_grad=True)
+    f = ti.field(ti.f32, shape=(), needs_grad=True)
 
     @ti.kernel
     def fib():
@@ -174,9 +174,9 @@ def test_ad_fibonacci_index():
 @ti.all_archs
 def test_ad_global_ptr():
     N = 5
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.f32, shape=N, needs_grad=True)
-    f = ti.var(ti.f32, shape=(), needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.f32, shape=N, needs_grad=True)
+    f = ti.field(ti.f32, shape=(), needs_grad=True)
 
     @ti.kernel
     def task():
@@ -205,10 +205,10 @@ def test_ad_global_ptr():
 @ti.all_archs
 def test_integer_stack():
     N = 5
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.f32, shape=N, needs_grad=True)
-    c = ti.var(ti.i32, shape=N)
-    f = ti.var(ti.f32, shape=N, needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.f32, shape=N, needs_grad=True)
+    c = ti.field(ti.i32, shape=N)
+    f = ti.field(ti.f32, shape=N, needs_grad=True)
 
     @ti.kernel
     def int_stack():
@@ -245,10 +245,10 @@ def test_integer_stack():
 @ti.all_archs
 def test_double_for_loops():
     N = 5
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.f32, shape=N, needs_grad=True)
-    c = ti.var(ti.i32, shape=N)
-    f = ti.var(ti.f32, shape=N, needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.f32, shape=N, needs_grad=True)
+    c = ti.field(ti.i32, shape=N)
+    f = ti.field(ti.f32, shape=N, needs_grad=True)
 
     @ti.kernel
     def double_for():
@@ -284,10 +284,10 @@ def test_double_for_loops():
 @ti.all_archs
 def test_double_for_loops_more_nests():
     N = 6
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.f32, shape=N, needs_grad=True)
-    c = ti.var(ti.i32, shape=(N, N // 2))
-    f = ti.var(ti.f32, shape=(N, N // 2), needs_grad=True)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.f32, shape=N, needs_grad=True)
+    c = ti.field(ti.i32, shape=(N, N // 2))
+    f = ti.field(ti.f32, shape=(N, N // 2), needs_grad=True)
 
     @ti.kernel
     def double_for():
@@ -331,11 +331,11 @@ def test_double_for_loops_more_nests():
 @ti.all_archs
 def test_complex_body():
     N = 5
-    a = ti.var(ti.f32, shape=N, needs_grad=True)
-    b = ti.var(ti.f32, shape=N, needs_grad=True)
-    c = ti.var(ti.i32, shape=N)
-    f = ti.var(ti.f32, shape=N, needs_grad=True)
-    g = ti.var(ti.f32, shape=N, needs_grad=False)
+    a = ti.field(ti.f32, shape=N, needs_grad=True)
+    b = ti.field(ti.f32, shape=N, needs_grad=True)
+    c = ti.field(ti.i32, shape=N)
+    f = ti.field(ti.f32, shape=N, needs_grad=True)
+    g = ti.field(ti.f32, shape=N, needs_grad=False)
 
     @ti.kernel
     def complex():

--- a/tests/python/test_ad_if.py
+++ b/tests/python/test_ad_if.py
@@ -4,8 +4,8 @@ import taichi as ti
 @ti.require(ti.extension.adstack)
 @ti.all_archs
 def test_ad_if_simple():
-    x = ti.var(ti.f32, shape=())
-    y = ti.var(ti.f32, shape=())
+    x = ti.field(ti.f32, shape=())
+    y = ti.field(ti.f32, shape=())
 
     ti.root.lazy_grad()
 
@@ -26,8 +26,8 @@ def test_ad_if_simple():
 @ti.require(ti.extension.adstack)
 @ti.all_archs
 def test_ad_if():
-    x = ti.var(ti.f32, shape=2)
-    y = ti.var(ti.f32, shape=2)
+    x = ti.field(ti.f32, shape=2)
+    y = ti.field(ti.f32, shape=2)
 
     ti.root.lazy_grad()
 
@@ -56,9 +56,9 @@ def test_ad_if():
 @ti.all_archs
 def test_ad_if_nested():
     n = 20
-    x = ti.var(ti.f32, shape=n)
-    y = ti.var(ti.f32, shape=n)
-    z = ti.var(ti.f32, shape=n)
+    x = ti.field(ti.f32, shape=n)
+    y = ti.field(ti.f32, shape=n)
+    z = ti.field(ti.f32, shape=n)
 
     ti.root.lazy_grad()
 
@@ -94,8 +94,8 @@ def test_ad_if_nested():
 @ti.require(ti.extension.adstack)
 @ti.all_archs
 def test_ad_if_mutable():
-    x = ti.var(ti.f32, shape=2)
-    y = ti.var(ti.f32, shape=2)
+    x = ti.field(ti.f32, shape=2)
+    y = ti.field(ti.f32, shape=2)
 
     ti.root.lazy_grad()
 
@@ -124,8 +124,8 @@ def test_ad_if_mutable():
 @ti.require(ti.extension.adstack)
 @ti.all_archs
 def test_ad_if_parallel():
-    x = ti.var(ti.f32, shape=2)
-    y = ti.var(ti.f32, shape=2)
+    x = ti.field(ti.f32, shape=2)
+    y = ti.field(ti.f32, shape=2)
 
     ti.root.lazy_grad()
 
@@ -153,8 +153,8 @@ def test_ad_if_parallel():
 @ti.require(ti.extension.adstack, ti.extension.data64)
 @ti.all_archs_with(default_fp=ti.f64)
 def test_ad_if_parallel_f64():
-    x = ti.var(ti.f64, shape=2)
-    y = ti.var(ti.f64, shape=2)
+    x = ti.field(ti.f64, shape=2)
+    y = ti.field(ti.f64, shape=2)
 
     ti.root.lazy_grad()
 
@@ -182,8 +182,8 @@ def test_ad_if_parallel_f64():
 @ti.require(ti.extension.adstack)
 @ti.all_archs
 def test_ad_if_parallel_complex():
-    x = ti.var(ti.f32, shape=2)
-    y = ti.var(ti.f32, shape=2)
+    x = ti.field(ti.f32, shape=2)
+    y = ti.field(ti.f32, shape=2)
 
     ti.root.lazy_grad()
 
@@ -211,8 +211,8 @@ def test_ad_if_parallel_complex():
 @ti.require(ti.extension.adstack, ti.extension.data64)
 @ti.all_archs_with(default_fp=ti.f64)
 def test_ad_if_parallel_complex_f64():
-    x = ti.var(ti.f64, shape=2)
-    y = ti.var(ti.f64, shape=2)
+    x = ti.field(ti.f64, shape=2)
+    y = ti.field(ti.f64, shape=2)
 
     ti.root.lazy_grad()
 

--- a/tests/python/test_ad_offload.py
+++ b/tests/python/test_ad_offload.py
@@ -4,9 +4,9 @@ import taichi as ti
 @ti.all_archs
 def test_offload_order():
     n = 128
-    x = ti.var(ti.f32, shape=n, needs_grad=True)
-    y = ti.var(ti.f32, shape=n, needs_grad=True)
-    z = ti.var(ti.f32, shape=(), needs_grad=True)
+    x = ti.field(ti.f32, shape=n, needs_grad=True)
+    y = ti.field(ti.f32, shape=n, needs_grad=True)
+    z = ti.field(ti.f32, shape=(), needs_grad=True)
 
     @ti.kernel
     def forward():

--- a/tests/python/test_arg_check.py
+++ b/tests/python/test_arg_check.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_argument_error():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     ti.root.place(x)
 

--- a/tests/python/test_arg_load.py
+++ b/tests/python/test_arg_load.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_arg_load():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.f32)
 
     ti.root.place(x, y)
 
@@ -32,8 +32,8 @@ def test_arg_load():
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_arg_load_f64():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.f32)
 
     ti.root.place(x, y)
 
@@ -55,7 +55,7 @@ def test_arg_load_f64():
 @ti.all_archs
 def test_ext_arr():
     N = 128
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, N).place(x)
 

--- a/tests/python/test_assert.py
+++ b/tests/python/test_assert.py
@@ -85,7 +85,7 @@ def test_static_assert_vector_n_ok():
 
 @ti.host_arch_only
 def test_static_assert_data_type_ok():
-    x = ti.var(ti.f32, ())
+    x = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -5,9 +5,9 @@ n = 128
 
 
 def run_atomic_add_global_case(vartype, step, valproc=lambda x: x):
-    x = ti.var(vartype)
-    y = ti.var(vartype)
-    c = ti.var(vartype)
+    x = ti.field(vartype)
+    y = ti.field(vartype)
+    c = ti.field(vartype)
 
     ti.root.dense(ti.i, n).place(x, y)
     ti.root.place(c)
@@ -53,7 +53,7 @@ def test_atomic_add_global_f32():
 
 @ti.all_archs
 def test_atomic_add_expr_evaled():
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     step = 42
 
     ti.root.place(c)
@@ -72,8 +72,8 @@ def test_atomic_add_expr_evaled():
 @ti.all_archs
 def test_atomic_add_demoted():
     # Ensure demoted atomics do not crash the program.
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
     step = 42
 
     ti.root.dense(ti.i, n).place(x, y)
@@ -103,8 +103,8 @@ def test_atomic_add_with_local_store_simplify1():
     #
     # Specifically, the second store should not suppress the first one, because
     # atomic_add can return value.
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
     step = 42
 
     ti.root.dense(ti.i, n).place(x, y)
@@ -135,7 +135,7 @@ def test_atomic_add_with_local_store_simplify2():
     #
     # Specifically, the local store should not be removed, because
     # atomic_add can return its value.
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     step = 42
 
     ti.root.dense(ti.i, n).place(x)
@@ -156,7 +156,7 @@ def test_atomic_add_with_local_store_simplify2():
 def test_atomic_add_with_if_simplify():
     # Make sure IfStmt simplification doesn't move stmts depending on the result
     # of atomic_add()
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     step = 42
 
     ti.root.dense(ti.i, n).place(x)
@@ -188,7 +188,7 @@ def test_atomic_add_with_if_simplify():
 
 @ti.all_archs
 def test_local_atomic_with_if():
-    ret = ti.var(dt=ti.i32, shape=())
+    ret = ti.field(dtype=ti.i32, shape=())
 
     @ti.kernel
     def test():
@@ -203,7 +203,7 @@ def test_local_atomic_with_if():
 
 @ti.all_archs
 def test_atomic_sub_expr_evaled():
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     step = 42
 
     ti.root.place(c)
@@ -221,7 +221,7 @@ def test_atomic_sub_expr_evaled():
 
 @ti.all_archs
 def test_atomic_max_expr_evaled():
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     step = 42
 
     ti.root.place(c)
@@ -239,7 +239,7 @@ def test_atomic_max_expr_evaled():
 
 @ti.all_archs
 def test_atomic_min_expr_evaled():
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     step = 42
 
     ti.root.place(c)
@@ -258,7 +258,7 @@ def test_atomic_min_expr_evaled():
 
 @ti.all_archs
 def test_atomic_and_expr_evaled():
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     step = 42
 
     ti.root.place(c)
@@ -279,7 +279,7 @@ def test_atomic_and_expr_evaled():
 
 @ti.all_archs
 def test_atomic_or_expr_evaled():
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     step = 42
 
     ti.root.place(c)
@@ -298,7 +298,7 @@ def test_atomic_or_expr_evaled():
 
 @ti.all_archs
 def test_atomic_xor_expr_evaled():
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     step = 42
 
     ti.root.place(c)

--- a/tests/python/test_basics.py
+++ b/tests/python/test_basics.py
@@ -4,7 +4,7 @@ import taichi as ti
 @ti.all_archs
 def test_simple():
     n = 128
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def func():
@@ -22,7 +22,7 @@ def test_simple():
 @ti.all_archs
 def test_range_loops():
     n = 128
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def func():
@@ -38,7 +38,7 @@ def test_range_loops():
 @ti.all_archs
 def test_python_access():
     n = 128
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     x[3] = 123
     x[4] = 456
@@ -48,7 +48,7 @@ def test_python_access():
 
 @ti.all_archs
 def test_if():
-    x = ti.var(ti.f32, shape=16)
+    x = ti.field(ti.f32, shape=16)
 
     @ti.kernel
     def if_test():
@@ -79,7 +79,7 @@ def test_if():
 
 @ti.all_archs
 def test_if_global_load():
-    x = ti.var(ti.i32, shape=16)
+    x = ti.field(ti.i32, shape=16)
 
     @ti.kernel
     def fill():
@@ -101,8 +101,8 @@ def test_if_global_load():
 
 @ti.all_archs
 def test_while_global_load():
-    x = ti.var(ti.i32, shape=16)
-    y = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32, shape=16)
+    y = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def run():

--- a/tests/python/test_bls.py
+++ b/tests/python/test_bls.py
@@ -4,7 +4,7 @@ import taichi as ti
 @ti.require(ti.extension.bls)
 @ti.all_archs
 def test_simple_1d():
-    x, y = ti.var(ti.f32), ti.var(ti.f32)
+    x, y = ti.field(ti.f32), ti.field(ti.f32)
 
     N = 64
     bs = 16
@@ -32,7 +32,7 @@ def test_simple_1d():
 @ti.require(ti.extension.bls)
 @ti.all_archs
 def test_simple_2d():
-    x, y = ti.var(ti.f32), ti.var(ti.f32)
+    x, y = ti.field(ti.f32), ti.field(ti.f32)
 
     N = 16
     bs = 16
@@ -110,8 +110,8 @@ def test_scatter_2d():
 @ti.require(ti.extension.bls)
 @ti.all_archs
 def test_multiple_inputs():
-    x, y, z, w, w2 = ti.var(ti.i32), ti.var(ti.i32), ti.var(ti.i32), ti.var(
-        ti.i32), ti.var(ti.i32)
+    x, y, z, w, w2 = ti.field(ti.i32), ti.field(ti.i32), ti.field(ti.i32), ti.field(
+        ti.i32), ti.field(ti.i32)
 
     N = 128
     bs = 8

--- a/tests/python/test_bls.py
+++ b/tests/python/test_bls.py
@@ -110,8 +110,8 @@ def test_scatter_2d():
 @ti.require(ti.extension.bls)
 @ti.all_archs
 def test_multiple_inputs():
-    x, y, z, w, w2 = ti.field(ti.i32), ti.field(ti.i32), ti.field(ti.i32), ti.field(
-        ti.i32), ti.field(ti.i32)
+    x, y, z, w, w2 = ti.field(ti.i32), ti.field(ti.i32), ti.field(
+        ti.i32), ti.field(ti.i32), ti.field(ti.i32)
 
     N = 128
     bs = 8

--- a/tests/python/test_cast.py
+++ b/tests/python/test_cast.py
@@ -4,7 +4,7 @@ import pytest
 
 @ti.all_archs
 def test_cast_f32():
-    z = ti.var(ti.i32, shape=())
+    z = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -17,7 +17,7 @@ def test_cast_f32():
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_cast_f64():
-    z = ti.var(ti.i32, shape=())
+    z = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -56,7 +56,7 @@ def test_cast_default_ip(dtype):
 
 @ti.all_archs
 def test_cast_within_while():
-    ret = ti.var(ti.i32, shape=())
+    ret = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -71,9 +71,9 @@ def test_cast_within_while():
 
 @ti.all_archs
 def test_bit_cast():
-    x = ti.var(ti.i32, shape=())
-    y = ti.var(ti.f32, shape=())
-    z = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32, shape=())
+    y = ti.field(ti.f32, shape=())
+    z = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func1():

--- a/tests/python/test_clear_all_gradients.py
+++ b/tests/python/test_clear_all_gradients.py
@@ -3,10 +3,10 @@ import taichi as ti
 
 @ti.all_archs
 def test_clear_all_gradients():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
-    z = ti.var(ti.f32)
-    w = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
+    z = ti.field(ti.f32)
+    w = ti.field(ti.f32)
 
     n = 128
 

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -4,10 +4,10 @@ import taichi as ti
 @ti.require(ti.extension.sparse)
 @ti.all_archs
 def test_compare_basics():
-    a = ti.var(ti.i32)
+    a = ti.field(ti.i32)
     ti.root.dynamic(ti.i, 256).place(a)
-    b = ti.var(ti.i32, shape=())
-    c = ti.var(ti.i32, shape=())
+    b = ti.field(ti.i32, shape=())
+    c = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -44,10 +44,10 @@ def test_compare_basics():
 @ti.require(ti.extension.sparse)
 @ti.all_archs
 def test_compare_equality():
-    a = ti.var(ti.i32)
+    a = ti.field(ti.i32)
     ti.root.dynamic(ti.i, 256).place(a)
-    b = ti.var(ti.i32, shape=())
-    c = ti.var(ti.i32, shape=())
+    b = ti.field(ti.i32, shape=())
+    c = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -84,7 +84,7 @@ def test_compare_equality():
 @ti.require(ti.extension.sparse)
 @ti.all_archs
 def test_no_duplicate_eval():
-    a = ti.var(ti.i32)
+    a = ti.field(ti.i32)
     ti.root.dynamic(ti.i, 256).place(a)
 
     @ti.kernel
@@ -99,8 +99,8 @@ def test_no_duplicate_eval():
 
 @ti.all_archs
 def test_no_duplicate_eval_func():
-    a = ti.var(ti.i32, ())
-    b = ti.var(ti.i32, ())
+    a = ti.field(ti.i32, ())
+    b = ti.field(ti.i32, ())
 
     @ti.func
     def why_this_foo_fail(n):
@@ -121,11 +121,11 @@ def test_no_duplicate_eval_func():
 @ti.require(ti.extension.sparse)
 @ti.all_archs
 def test_chain_compare():
-    a = ti.var(ti.i32)
+    a = ti.field(ti.i32)
     ti.root.dynamic(ti.i, 256).place(a)
-    b = ti.var(ti.i32, shape=())
-    c = ti.var(ti.i32, shape=())
-    d = ti.var(ti.i32, shape=())
+    b = ti.field(ti.i32, shape=())
+    c = ti.field(ti.i32, shape=())
+    d = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():

--- a/tests/python/test_complex_kernels.py
+++ b/tests/python/test_complex_kernels.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_complex_kernels():
-    x = ti.var(ti.f32)
-    total = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    total = ti.field(ti.f32)
 
     n = 128
 
@@ -34,8 +34,8 @@ def test_complex_kernels():
 
 @ti.all_archs
 def test_complex_kernels_indirect():
-    x = ti.var(ti.f32)
-    total = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    total = ti.field(ti.f32)
 
     n = 128
 
@@ -71,8 +71,8 @@ def test_complex_kernels_oop():
     @ti.data_oriented
     class A:
         def __init__(self):
-            self.x = ti.var(ti.f32)
-            self.total = ti.var(ti.f32)
+            self.x = ti.field(ti.f32)
+            self.total = ti.field(ti.f32)
             self.n = 128
 
             ti.root.dense(ti.i, self.n).place(self.x)
@@ -107,8 +107,8 @@ def test_complex_kernels_oop2():
     @ti.data_oriented
     class A:
         def __init__(self):
-            self.x = ti.var(ti.f32)
-            self.total = ti.var(ti.f32)
+            self.x = ti.field(ti.f32)
+            self.total = ti.field(ti.f32)
             self.n = 128
 
             ti.root.dense(ti.i, self.n).place(self.x)

--- a/tests/python/test_continue.py
+++ b/tests/python/test_continue.py
@@ -5,7 +5,7 @@ n = 1000
 
 @ti.all_archs
 def test_for_continue():
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def run():
@@ -25,7 +25,7 @@ def test_for_continue():
 
 @ti.all_archs
 def test_while_continue():
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def run():
@@ -48,7 +48,7 @@ def test_while_continue():
 
 @ti.all_archs
 def test_kernel_continue():
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def run():
@@ -67,7 +67,7 @@ def test_kernel_continue():
 
 @ti.all_archs
 def test_unconditional_continue():
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def run():
@@ -86,7 +86,7 @@ def test_unconditional_continue():
 
 @ti.all_archs
 def test_kernel_continue_in_nested_if():
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def run(a: ti.i32):
@@ -108,7 +108,7 @@ def test_kernel_continue_in_nested_if():
 
 @ti.all_archs
 def test_kernel_continue_in_nested_if_2():
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def run(a: ti.i32):
@@ -129,7 +129,7 @@ def test_kernel_continue_in_nested_if_2():
 
 @ti.all_archs
 def test_kernel_continue_in_nested_if_3():
-    x = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def run(a: ti.i32):

--- a/tests/python/test_copy_from.py
+++ b/tests/python/test_copy_from.py
@@ -5,8 +5,8 @@ import taichi as ti
 def test_scalar():
     n = 16
 
-    x = ti.var(ti.i32, shape=n)
-    y = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32, shape=n)
+    y = ti.field(ti.i32, shape=n)
 
     x[1] = 2
 

--- a/tests/python/test_debug.py
+++ b/tests/python/test_debug.py
@@ -5,7 +5,7 @@ import pytest
 def test_cpu_debug_snode_reader():
     ti.init(arch=ti.x64, debug=True)
 
-    x = ti.var(ti.f32, shape=())
+    x = ti.field(ti.f32, shape=())
     x[None] = 10.0
 
     assert x[None] == 10.0
@@ -16,7 +16,7 @@ def test_cpu_debug_snode_reader():
 def test_cpu_debug_snode_writer_out_of_bound():
     ti.set_gdb_trigger(False)
 
-    x = ti.var(ti.f32, shape=3)
+    x = ti.field(ti.f32, shape=3)
 
     with pytest.raises(RuntimeError):
         x[3] = 10.0
@@ -27,7 +27,7 @@ def test_cpu_debug_snode_writer_out_of_bound():
 def test_cpu_debug_snode_writer_out_of_bound_negative():
     ti.set_gdb_trigger(False)
 
-    x = ti.var(ti.f32, shape=3)
+    x = ti.field(ti.f32, shape=3)
     with pytest.raises(RuntimeError):
         x[-1] = 10.0
 
@@ -37,7 +37,7 @@ def test_cpu_debug_snode_writer_out_of_bound_negative():
 def test_cpu_debug_snode_reader_out_of_bound():
     ti.set_gdb_trigger(False)
 
-    x = ti.var(ti.f32, shape=3)
+    x = ti.field(ti.f32, shape=3)
 
     with pytest.raises(RuntimeError):
         a = x[3]
@@ -48,7 +48,7 @@ def test_cpu_debug_snode_reader_out_of_bound():
 def test_cpu_debug_snode_reader_out_of_bound_negative():
     ti.set_gdb_trigger(False)
 
-    x = ti.var(ti.f32, shape=3)
+    x = ti.field(ti.f32, shape=3)
     with pytest.raises(RuntimeError):
         a = x[-1]
 
@@ -57,7 +57,7 @@ def test_cpu_debug_snode_reader_out_of_bound_negative():
 @ti.all_archs_with(debug=True)
 def test_out_of_bound():
     ti.set_gdb_trigger(False)
-    x = ti.var(ti.i32, shape=(8, 16))
+    x = ti.field(ti.i32, shape=(8, 16))
 
     @ti.kernel
     def func():
@@ -71,7 +71,7 @@ def test_out_of_bound():
 @ti.all_archs_with(debug=True)
 def test_not_out_of_bound():
     ti.set_gdb_trigger(False)
-    x = ti.var(ti.i32, shape=(8, 16))
+    x = ti.field(ti.i32, shape=(8, 16))
 
     @ti.kernel
     def func():
@@ -84,7 +84,7 @@ def test_not_out_of_bound():
 @ti.all_archs_with(debug=True)
 def test_out_of_bound_dynamic():
     ti.set_gdb_trigger(False)
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     ti.root.dynamic(ti.i, 16, 4).place(x)
 
@@ -100,7 +100,7 @@ def test_out_of_bound_dynamic():
 @ti.all_archs_with(debug=True)
 def test_not_out_of_bound_dynamic():
     ti.set_gdb_trigger(False)
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     ti.root.dynamic(ti.i, 16, 4).place(x)
 
@@ -116,7 +116,7 @@ def test_not_out_of_bound_dynamic():
 def test_out_of_bound_with_offset():
     ti.init(debug=True)
     ti.set_gdb_trigger(False)
-    x = ti.var(ti.i32, shape=(8, 16), offset=(-8, -8))
+    x = ti.field(ti.i32, shape=(8, 16), offset=(-8, -8))
 
     @ti.kernel
     def func():
@@ -131,7 +131,7 @@ def test_out_of_bound_with_offset():
 @ti.all_archs_with(debug=True)
 def test_not_out_of_bound_with_offset():
     ti.set_gdb_trigger(False)
-    x = ti.var(ti.i32, shape=(8, 16), offset=(-4, -8))
+    x = ti.field(ti.i32, shape=(8, 16), offset=(-4, -8))
 
     @ti.kernel
     def func():

--- a/tests/python/test_div.py
+++ b/tests/python/test_div.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def _test_floor_div(arg1, a, arg2, b, arg3, c):
-    z = ti.var(arg3, shape=())
+    z = ti.field(arg3, shape=())
 
     @ti.kernel
     def func(x: arg1, y: arg2):
@@ -15,7 +15,7 @@ def _test_floor_div(arg1, a, arg2, b, arg3, c):
 
 @ti.all_archs
 def _test_true_div(arg1, a, arg2, b, arg3, c):
-    z = ti.var(arg3, shape=())
+    z = ti.field(arg3, shape=())
 
     @ti.kernel
     def func(x: arg1, y: arg2):
@@ -59,7 +59,7 @@ def test_true_div():
 @ti.all_archs
 def test_div_default_ip():
     ti.get_runtime().set_default_ip(ti.i64)
-    z = ti.var(ti.f32, shape=())
+    z = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -72,7 +72,7 @@ def test_div_default_ip():
 
 @ti.all_archs
 def test_floor_div_pythonic():
-    z = ti.var(ti.i32, shape=())
+    z = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func(x: ti.i32, y: ti.i32):

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -11,7 +11,7 @@ def ti_support_non_top_dynamic(test):
 
 @ti_support_dynamic
 def test_dynamic():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
     n = 128
 
     ti.root.dynamic(ti.i, n, 32).place(x)
@@ -29,7 +29,7 @@ def test_dynamic():
 
 @ti_support_dynamic
 def test_dynamic2():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
     n = 128
 
     ti.root.dynamic(ti.i, n, 32).place(x)
@@ -70,7 +70,7 @@ def test_dynamic_matrix():
 
 @ti_support_dynamic
 def test_append():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     n = 128
 
     ti.root.dynamic(ti.i, n, 32).place(x)
@@ -92,8 +92,8 @@ def test_append():
 
 @ti_support_dynamic
 def test_length():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.f32, shape=())
+    x = ti.field(ti.i32)
+    y = ti.field(ti.f32, shape=())
     n = 128
 
     ti.root.dynamic(ti.i, n, 32).place(x)
@@ -116,9 +116,9 @@ def test_length():
 
 @ti_support_dynamic
 def test_append_ret_value():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
-    z = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
+    z = ti.field(ti.i32)
     n = 128
 
     ti.root.dynamic(ti.i, n, 32).place(x)
@@ -142,8 +142,8 @@ def test_append_ret_value():
 @ti_support_non_top_dynamic
 def test_dense_dynamic():
     n = 128
-    x = ti.var(ti.i32)
-    l = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32)
+    l = ti.field(ti.i32, shape=n)
 
     ti.root.dense(ti.i, n).dynamic(ti.j, n, 8).place(x)
 
@@ -166,8 +166,8 @@ def test_dense_dynamic():
 @ti_support_non_top_dynamic
 def test_dense_dynamic_len():
     n = 128
-    x = ti.var(ti.i32)
-    l = ti.var(ti.i32, shape=n)
+    x = ti.field(ti.i32)
+    l = ti.field(ti.i32, shape=n)
 
     ti.root.dense(ti.i, n).dynamic(ti.j, n, 32).place(x)
 
@@ -186,8 +186,8 @@ def test_dense_dynamic_len():
 def test_dynamic_activate():
     ti.init(arch=ti.metal)
     # record the lengths
-    l = ti.var(ti.i32, 3)
-    x = ti.var(ti.i32)
+    l = ti.field(ti.i32, 3)
+    x = ti.field(ti.i32)
     xp = ti.root.dynamic(ti.i, 32, 32)
     xp.place(x)
 

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -4,7 +4,6 @@ import taichi as ti
 @ti.all_archs
 def test_fill_scalar():
     val = ti.field(ti.i32)
-    
     n = 4
     m = 7
 

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -4,6 +4,7 @@ import taichi as ti
 @ti.all_archs
 def test_fill_scalar():
     val = ti.field(ti.i32)
+    
     n = 4
     m = 7
 

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -3,8 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_fill_scalar():
-    val = ti.var(ti.i32)
-
+    val = ti.field(ti.i32)
     n = 4
     m = 7
 

--- a/tests/python/test_for_break.py
+++ b/tests/python/test_for_break.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_for_break():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     N, M = 4, 4
     ti.root.dense(ti.ij, (N, M)).place(x)
 
@@ -26,7 +26,7 @@ def test_for_break():
 
 @ti.all_archs
 def test_for_break2():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     N, M = 8, 8
     ti.root.dense(ti.ij, (N, M)).place(x)
 
@@ -49,7 +49,7 @@ def test_for_break2():
 
 @ti.all_archs
 def test_for_break3():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     N, M = 8, 8
     ti.root.dense(ti.ij, (N, M)).place(x)
 
@@ -72,7 +72,7 @@ def test_for_break3():
 
 @ti.all_archs
 def test_for_break_complex():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     N, M = 16, 32
     ti.root.dense(ti.ij, (N, M)).place(x)
 

--- a/tests/python/test_for_group_mismatch.py
+++ b/tests/python/test_for_group_mismatch.py
@@ -4,7 +4,7 @@ import taichi as ti
 @ti.must_throw(IndexError)
 @ti.host_arch_only
 def test_struct_for_mismatch():
-    x = ti.var(ti.f32, (3, 4))
+    x = ti.field(ti.f32, (3, 4))
 
     @ti.kernel
     def func():
@@ -17,7 +17,7 @@ def test_struct_for_mismatch():
 @ti.must_throw(IndexError)
 @ti.host_arch_only
 def test_struct_for_mismatch2():
-    x = ti.var(ti.f32, (3, 4))
+    x = ti.field(ti.f32, (3, 4))
 
     @ti.kernel
     def func():
@@ -34,7 +34,7 @@ def _test_grouped_struct_for_mismatch():
     # need grouped refactor
     # for now, it just throw a unfriendly message:
     # AssertionError: __getitem__ cannot be called in Python-scope
-    x = ti.var(ti.f32, (3, 4))
+    x = ti.field(ti.f32, (3, 4))
 
     @ti.kernel
     def func():

--- a/tests/python/test_function_parameter_by_value.py
+++ b/tests/python/test_function_parameter_by_value.py
@@ -7,7 +7,7 @@ def test_pass_by_value():
     def set_val(x, i):
         x = i
 
-    ret = ti.var(ti.i32, shape=())
+    ret = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def task():

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -5,9 +5,9 @@ import pytest
 
 def benchmark_fuse_dense_x2y2z(size=1024**3, repeat=10, first_n=100):
     # TODO: this can also be made as a benchmark or a regression test
-    x = ti.var(ti.i32, shape=(size, ))
-    y = ti.var(ti.i32, shape=(size, ))
-    z = ti.var(ti.i32, shape=(size, ))
+    x = ti.field(ti.i32, shape=(size, ))
+    y = ti.field(ti.i32, shape=(size, ))
+    z = ti.field(ti.i32, shape=(size, ))
     first_n = min(first_n, size)
 
     @ti.kernel
@@ -50,7 +50,7 @@ def benchmark_fuse_dense_x2y2z(size=1024**3, repeat=10, first_n=100):
 
 def benchmark_fuse_reduction(size=1024**3, repeat=10, first_n=100):
     # TODO: this can also be made as a benchmark or a regression test
-    x = ti.var(ti.i32, shape=(size, ))
+    x = ti.field(ti.i32, shape=(size, ))
     first_n = min(first_n, size)
 
     @ti.kernel

--- a/tests/python/test_fuse_dynamic.py
+++ b/tests/python/test_fuse_dynamic.py
@@ -4,9 +4,9 @@ import pytest
 
 
 def benchmark_fuse_dynamic_x2y2z(size=1024**2, repeat=10, first_n=100):
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
-    z = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
+    z = ti.field(ti.i32)
 
     ti.root.dynamic(ti.i, size, chunk_size=2048).place(x, y, z)
 

--- a/tests/python/test_global_store_grad.py
+++ b/tests/python/test_global_store_grad.py
@@ -9,8 +9,8 @@ def test_global_store_branching():
 
     N = 16
     ti.runtime.print_preprocessed = True
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     ti.root.dense(ti.i, N).place(x)
     ti.root.dense(ti.i, N).place(y)

--- a/tests/python/test_grouped.py
+++ b/tests/python/test_grouped.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_vector_index():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 7
@@ -29,7 +29,7 @@ def test_vector_index():
 
 @ti.all_archs
 def test_grouped():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 8
@@ -52,7 +52,7 @@ def test_grouped():
 
 @ti.all_archs
 def test_grouped_ndrange():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 8
@@ -79,7 +79,7 @@ def test_grouped_ndrange():
 
 @ti.all_archs
 def test_static_grouped_ndrange():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 8
@@ -106,7 +106,7 @@ def test_static_grouped_ndrange():
 
 @ti.all_archs
 def test_grouped_ndrange_starred():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 8
@@ -131,7 +131,7 @@ def test_grouped_ndrange_starred():
 
 @ti.all_archs
 def test_grouped_ndrange_0d():
-    val = ti.var(ti.i32, shape=())
+    val = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def test():
@@ -145,7 +145,7 @@ def test_grouped_ndrange_0d():
 
 @ti.all_archs
 def test_static_grouped_ndrange_0d():
-    val = ti.var(ti.i32, shape=())
+    val = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def test():


### PR DESCRIPTION
Related issue = #1663 

This PR tries to replace all `ti.var` to `ti.field` in `tests/python/test_[a-g].*py`, except these four tests as shown below. Because they cannot be passed on my mac originally.
```
[error] error when testing test_bitmasked.py, return 256
[error] error when testing test_global_store_grad.py, return 1280
[error] error when testing test_ad_basics.py, return 256
[error] error when testing test_element_wise.py, return 256
```
**Is it a common case that some tests failed on my machine?**

Also, I ran the following script to verify that these test files are still valid:
```
import os
import re

files = os.listdir(".")
for name in files:
    cmd = f"pytest {name} 1>/tmp/delete/{name}.log 2>/tmp/delete/{name}.err"
    if re.search("^test_[a-g].*py$", name) is not None:
        print(f"[log] execute {cmd}")
        ret = os.system(cmd)
        if ret != 0:
            print(f"[error] error when testing {name}, return {ret}")
        else:
            print(f"[log] testing {name} succ")
```
