### PR TITLE
[test] Replace ti.var by ti.field in tests starting with h-q

### DIFF
--- a/tests/python/test_image_io.py
+++ b/tests/python/test_image_io.py
@@ -18,7 +18,7 @@ def test_image_io(resx, resy, comp, ext, is_tensor, dt):
     else:
         shape = (resx, resy)
     if is_tensor:
-        pixel_t = ti.var(dt, shape)
+        pixel_t = ti.field(dt, shape)
     pixel = np.random.randint(256, size=shape, dtype=ti.to_numpy_type(dt))
     if is_tensor:
         pixel_t.from_numpy(pixel)

--- a/tests/python/test_immediate_layout.py
+++ b/tests/python/test_immediate_layout.py
@@ -4,7 +4,7 @@ import taichi as ti
 @ti.all_archs
 def test_1D():
     N = 2
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
     ti.root.dense(ti.i, N).place(x)
 
     x[0] = 42

--- a/tests/python/test_indices.py
+++ b/tests/python/test_indices.py
@@ -3,9 +3,9 @@ import taichi as ti
 
 @ti.host_arch_only
 def test_indices():
-    a = ti.var(ti.f32, shape=(128, 32, 8))
+    a = ti.field(ti.f32, shape=(128, 32, 8))
 
-    b = ti.var(ti.f32)
+    b = ti.field(ti.f32)
     ti.root.dense(ti.j, 32).dense(ti.i, 16).place(b)
 
     ti.get_runtime().materialize()
@@ -23,7 +23,7 @@ def test_indices():
 
 @ti.host_arch_only
 def test_float_as_index():
-    a = ti.var(ti.f32, (8, 5))
+    a = ti.field(ti.f32, (8, 5))
 
     @ti.kernel
     def func():

--- a/tests/python/test_kernel_template_mapper.py
+++ b/tests/python/test_kernel_template_mapper.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_kernel_template_mapper():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.f32)
 
     ti.root.place(x, y)
 
@@ -32,8 +32,8 @@ def test_kernel_template_mapper():
 
 @ti.all_archs
 def test_kernel_template_mapper_numpy():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.f32)
 
     ti.root.place(x, y)
 

--- a/tests/python/test_kernel_templates.py
+++ b/tests/python/test_kernel_templates.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_kernel_template_basic():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.f32)
 
     n = 16
 
@@ -34,10 +34,10 @@ def test_kernel_template_basic():
 
 @ti.all_archs
 def test_kernel_template_gradient():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
-    z = ti.var(ti.f32)
-    loss = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
+    z = ti.field(ti.f32)
+    loss = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 16).place(x, y, z)
     ti.root.place(loss)
@@ -68,8 +68,8 @@ def test_kernel_template_gradient():
 
 @ti.all_archs
 def test_func_template():
-    a = [ti.var(dt=ti.f32) for _ in range(2)]
-    b = [ti.var(dt=ti.f32) for _ in range(2)]
+    a = [ti.field(dtype=ti.f32) for _ in range(2)]
+    b = [ti.field(dtype=ti.f32) for _ in range(2)]
 
     for l in range(2):
         ti.root.dense(ti.ij, 16).place(a[l], b[l])
@@ -100,8 +100,8 @@ def test_func_template():
 
 @ti.all_archs
 def test_func_template2():
-    a = ti.var(dt=ti.f32)
-    b = ti.var(dt=ti.f32)
+    a = ti.field(dtype=ti.f32)
+    b = ti.field(dtype=ti.f32)
 
     ti.root.dense(ti.ij, 16).place(a, b)
 

--- a/tests/python/test_lang.py
+++ b/tests/python/test_lang.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_nested_subscript():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     ti.root.dense(ti.i, 1).place(x)
     ti.root.dense(ti.i, 1).place(y)
@@ -23,8 +23,8 @@ def test_nested_subscript():
 
 @ti.all_archs
 def test_norm():
-    val = ti.var(ti.i32)
-    f = ti.var(ti.f32)
+    val = ti.field(ti.i32)
+    f = ti.field(ti.f32)
 
     n = 1024
 
@@ -54,8 +54,8 @@ def test_norm():
 
 @ti.all_archs
 def test_simple2():
-    val = ti.var(ti.i32)
-    f = ti.var(ti.f32)
+    val = ti.field(ti.i32)
+    f = ti.field(ti.f32)
 
     n = 16
 
@@ -92,7 +92,7 @@ def test_recreate():
 @ti.all_archs
 def test_local_atomics():
     n = 32
-    val = ti.var(ti.i32, shape=n)
+    val = ti.field(ti.i32, shape=n)
 
     @ti.kernel
     def test():

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -32,9 +32,9 @@ def test_basic_utils():
     abT = ti.Matrix(3, 2, dt=ti.f32)
     aNormalized = ti.Vector(3, dt=ti.f32)
 
-    normA = ti.var(ti.f32)
-    normSqrA = ti.var(ti.f32)
-    normInvA = ti.var(ti.f32)
+    normA = ti.field(ti.f32)
+    normSqrA = ti.field(ti.f32)
+    normInvA = ti.field(ti.f32)
 
     ti.root.place(a, b, abT, aNormalized, normA, normSqrA, normInvA)
 
@@ -74,7 +74,7 @@ def test_cross():
 
     a2 = ti.Vector(2, dt=ti.f32)
     b2 = ti.Vector(2, dt=ti.f32)
-    c2 = ti.var(dt=ti.f32)
+    c2 = ti.field(dtype=ti.f32)
 
     ti.root.place(a, b, c, a2, b2, c2)
 
@@ -99,11 +99,11 @@ def test_cross():
 def test_dot():
     a = ti.Vector(3, dt=ti.f32)
     b = ti.Vector(3, dt=ti.f32)
-    c = ti.var(dt=ti.f32)
+    c = ti.field(dtype=ti.f32)
 
     a2 = ti.Vector(2, dt=ti.f32)
     b2 = ti.Vector(2, dt=ti.f32)
-    c2 = ti.var(dt=ti.f32)
+    c2 = ti.field(dtype=ti.f32)
 
     ti.root.place(a, b, c, a2, b2, c2)
 
@@ -349,8 +349,8 @@ def test_to_numpy_as_vector_deprecated():
 @ti.all_archs
 def test_any_all():
     a = ti.Matrix(2, 2, dt=ti.i32, shape=())
-    b = ti.var(dt=ti.i32, shape=())
-    c = ti.var(dt=ti.i32, shape=())
+    b = ti.field(dtype=ti.i32, shape=())
+    c = ti.field(dtype=ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -379,8 +379,8 @@ def test_any_all():
 @ti.all_archs
 def test_min_max():
     a = ti.Matrix(2, 2, dt=ti.i32, shape=())
-    b = ti.var(dt=ti.i32, shape=())
-    c = ti.var(dt=ti.i32, shape=())
+    b = ti.field(dtype=ti.i32, shape=())
+    c = ti.field(dtype=ti.i32, shape=())
 
     @ti.kernel
     def func():

--- a/tests/python/test_listgen.py
+++ b/tests/python/test_listgen.py
@@ -4,7 +4,7 @@ from random import randrange
 
 @ti.all_archs
 def test_listgen():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     n = 1024
 
     ti.root.dense(ti.ij, 4).dense(ti.ij, 4).dense(ti.ij,
@@ -34,7 +34,7 @@ def test_listgen():
 
 @ti.all_archs
 def test_nested_3d():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     n = 128
 
     ti.root.dense(ti.ijk, 4).dense(ti.ijk, 4).dense(ti.ijk,

--- a/tests/python/test_local_atomic_opt.py
+++ b/tests/python/test_local_atomic_opt.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_cse():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -18,7 +18,7 @@ def test_cse():
 
 @ti.all_archs
 def test_store_forward():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():

--- a/tests/python/test_local_atomics.py
+++ b/tests/python/test_local_atomics.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_explicit_local_atomic_add():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -18,7 +18,7 @@ def test_explicit_local_atomic_add():
 
 @ti.all_archs
 def test_implicit_local_atomic_add():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -33,7 +33,7 @@ def test_implicit_local_atomic_add():
 
 @ti.all_archs
 def test_explicit_local_atomic_sub():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -48,7 +48,7 @@ def test_explicit_local_atomic_sub():
 
 @ti.all_archs
 def test_implicit_local_atomic_sub():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -63,7 +63,7 @@ def test_implicit_local_atomic_sub():
 
 @ti.all_archs
 def test_explicit_local_atomic_min():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -78,7 +78,7 @@ def test_explicit_local_atomic_min():
 
 @ti.all_archs
 def test_explicit_local_atomic_max():
-    A = ti.var(ti.f32, shape=())
+    A = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def func():
@@ -93,7 +93,7 @@ def test_explicit_local_atomic_max():
 
 @ti.all_archs
 def test_explicit_local_atomic_and():
-    A = ti.var(ti.i32, shape=())
+    A = ti.field(ti.i32, shape=())
     max_int = 2147483647
 
     @ti.kernel
@@ -109,7 +109,7 @@ def test_explicit_local_atomic_and():
 
 @ti.all_archs
 def test_implicit_local_atomic_and():
-    A = ti.var(ti.i32, shape=())
+    A = ti.field(ti.i32, shape=())
     max_int = 2147483647
 
     @ti.kernel
@@ -125,7 +125,7 @@ def test_implicit_local_atomic_and():
 
 @ti.all_archs
 def test_explicit_local_atomic_or():
-    A = ti.var(ti.i32, shape=())
+    A = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -140,7 +140,7 @@ def test_explicit_local_atomic_or():
 
 @ti.all_archs
 def test_implicit_local_atomic_or():
-    A = ti.var(ti.i32, shape=())
+    A = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -155,7 +155,7 @@ def test_implicit_local_atomic_or():
 
 @ti.all_archs
 def test_explicit_local_atomic_xor():
-    A = ti.var(ti.i32, shape=())
+    A = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -170,7 +170,7 @@ def test_explicit_local_atomic_xor():
 
 @ti.all_archs
 def test_implicit_local_atomic_xor():
-    A = ti.var(ti.i32, shape=())
+    A = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():

--- a/tests/python/test_loop_grad.py
+++ b/tests/python/test_loop_grad.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_loop_grad():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     n = 16
     m = 8
@@ -34,7 +34,7 @@ def test_loop_grad():
 @ti.all_archs
 def test_loop_grad_complex():
     return  # This case is not supported yet
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     n = 16
     m = 8

--- a/tests/python/test_loops.py
+++ b/tests/python/test_loops.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_loops():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     N = 512
 
@@ -31,8 +31,8 @@ def test_loops():
 
 @ti.all_archs
 def test_numpy_loops():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     N = 512
 
@@ -64,7 +64,7 @@ def test_numpy_loops():
 @ti.all_archs
 def test_nested_loops():
     # this may crash if any LLVM allocas are called in the loop body
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     n = 2048
 
@@ -81,7 +81,7 @@ def test_nested_loops():
 
 @ti.all_archs
 def test_zero_outer_loop():
-    x = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def test():
@@ -95,7 +95,7 @@ def test_zero_outer_loop():
 
 @ti.all_archs
 def test_zero_inner_loop():
-    x = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def test():
@@ -110,8 +110,8 @@ def test_zero_inner_loop():
 
 @ti.all_archs
 def test_dynamic_loop_range():
-    x = ti.var(ti.i32)
-    c = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    c = ti.field(ti.i32)
     n = 2000
 
     ti.root.dense(ti.i, n).place(x)
@@ -132,7 +132,7 @@ def test_dynamic_loop_range():
 @ti.all_archs
 def test_loop_arg_as_range():
     # Dynamic range loops are intended to make sure global tmps work
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
     n = 1000
 
     ti.root.dense(ti.i, n).place(x)
@@ -156,8 +156,8 @@ def test_loop_arg_as_range():
 @ti.all_archs
 def test_assignment_in_nested_loops():
     # https://github.com/taichi-dev/taichi/issues/1109
-    m = ti.var(ti.f32, 3)
-    x = ti.var(ti.f32, ())
+    m = ti.field(ti.f32, 3)
+    x = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():

--- a/tests/python/test_mod.py
+++ b/tests/python/test_mod.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def _test_py_style_mod(arg1, a, arg2, b, arg3, c):
-    z = ti.var(arg3, shape=())
+    z = ti.field(arg3, shape=())
 
     @ti.kernel
     def func(x: arg1, y: arg2):
@@ -15,7 +15,7 @@ def _test_py_style_mod(arg1, a, arg2, b, arg3, c):
 
 @ti.all_archs
 def _test_c_style_mod(arg1, a, arg2, b, arg3, c):
-    z = ti.var(arg3, shape=())
+    z = ti.field(arg3, shape=())
 
     @ti.kernel
     def func(x: arg1, y: arg2):
@@ -51,8 +51,8 @@ def test_c_style_mod():
 
 @ti.all_archs
 def test_mod_scan():
-    z = ti.var(ti.i32, shape=())
-    w = ti.var(ti.i32, shape=())
+    z = ti.field(ti.i32, shape=())
+    w = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func(x: ti.i32, y: ti.i32):

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -20,9 +20,9 @@ def run_mpm88_test():
     x = ti.Vector(dim, dt=ti.f32, shape=n_particles)
     v = ti.Vector(dim, dt=ti.f32, shape=n_particles)
     C = ti.Matrix(dim, dim, dt=ti.f32, shape=n_particles)
-    J = ti.var(dt=ti.f32, shape=n_particles)
+    J = ti.field(dtype=ti.f32, shape=n_particles)
     grid_v = ti.Vector(dim, dt=ti.f32, shape=(n_grid, n_grid))
-    grid_m = ti.var(dt=ti.f32, shape=(n_grid, n_grid))
+    grid_m = ti.field(dtype=ti.f32, shape=(n_grid, n_grid))
 
     @ti.kernel
     def substep():

--- a/tests/python/test_mpm_particle_list.py
+++ b/tests/python/test_mpm_particle_list.py
@@ -8,9 +8,9 @@ class MPMSolver:
         dim = len(res)
         self.dx = 1 / res[0]
         self.inv_dx = 1.0 / self.dx
-        self.pid = ti.var(ti.i32)
+        self.pid = ti.field(ti.i32)
         self.x = ti.Vector(dim, dt=ti.f32)
-        self.grid_m = ti.var(dt=ti.f32)
+        self.grid_m = ti.field(dtype=ti.f32)
 
         indices = ti.ij
 

--- a/tests/python/test_native_functions.py
+++ b/tests/python/test_native_functions.py
@@ -4,7 +4,7 @@ import numpy as np
 
 @ti.all_archs
 def test_abs():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     N = 16
 
@@ -25,7 +25,7 @@ def test_abs():
 
 @ti.all_archs
 def test_int():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     N = 16
 
@@ -48,11 +48,11 @@ def test_int():
 
 @ti.all_archs
 def test_minmax():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
-    z = ti.var(ti.f32)
-    minimum = ti.var(ti.f32)
-    maximum = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
+    z = ti.field(ti.f32)
+    minimum = ti.field(ti.f32)
+    maximum = ti.field(ti.f32)
 
     N = 16
 

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_1d():
-    x = ti.var(ti.f32, shape=(16))
+    x = ti.field(ti.f32, shape=(16))
 
     @ti.kernel
     def func():
@@ -21,7 +21,7 @@ def test_1d():
 
 @ti.all_archs
 def test_2d():
-    x = ti.var(ti.f32, shape=(16, 32))
+    x = ti.field(ti.f32, shape=(16, 32))
 
     t = 8
 
@@ -42,7 +42,7 @@ def test_2d():
 
 @ti.all_archs
 def test_3d():
-    x = ti.var(ti.f32, shape=(16, 32, 64))
+    x = ti.field(ti.f32, shape=(16, 32, 64))
 
     @ti.kernel
     def func():
@@ -61,7 +61,7 @@ def test_3d():
 
 @ti.all_archs
 def test_static_grouped():
-    x = ti.var(ti.f32, shape=(16, 32, 64))
+    x = ti.field(ti.f32, shape=(16, 32, 64))
 
     @ti.kernel
     def func():

--- a/tests/python/test_new_allocator.py
+++ b/tests/python/test_new_allocator.py
@@ -5,8 +5,8 @@ import taichi as ti
 def test_1d():
     N = 16
 
-    x = ti.var(ti.f32, shape=(N, ))
-    y = ti.var(ti.f32, shape=(N, ))
+    x = ti.field(ti.f32, shape=(N, ))
+    y = ti.field(ti.f32, shape=(N, ))
 
     @ti.kernel
     def func():
@@ -27,8 +27,8 @@ def test_3d():
     N = 2
     M = 2
 
-    x = ti.var(ti.f32, shape=(N, M))
-    y = ti.var(ti.f32, shape=(N, M))
+    x = ti.field(ti.f32, shape=(N, M))
+    y = ti.field(ti.f32, shape=(N, M))
 
     @ti.kernel
     def func():
@@ -69,7 +69,7 @@ def test_matrix():
 @ti.all_archs
 def test_alloc_in_kernel():
     return  # build bots may not have this much memory to tests...
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.pointer(ti.i, 8192).dense(ti.i, 1024 * 1024).place(x)
 

--- a/tests/python/test_no_activate.py
+++ b/tests/python/test_no_activate.py
@@ -4,7 +4,7 @@ import taichi as ti
 @ti.require(ti.extension.sparse)
 @ti.all_archs
 def test_no_activate():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     n = 1024
 

--- a/tests/python/test_no_grad.py
+++ b/tests/python/test_no_grad.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_no_grad():
-    x = ti.var(ti.f32)
-    loss = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    loss = ti.field(ti.f32)
 
     N = 1
 

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 def with_data_type(dt):
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
 
@@ -49,7 +49,7 @@ def test_numpy_i64():
 
 @ti.all_archs
 def test_numpy_2d():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 7
@@ -77,7 +77,7 @@ def test_numpy_2d():
 
 @ti.all_archs
 def test_numpy_2d_transpose():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 8
     m = 8
@@ -104,7 +104,7 @@ def test_numpy_2d_transpose():
 
 @ti.all_archs
 def test_numpy_3d():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 7
@@ -136,7 +136,7 @@ def test_numpy_3d():
 
 @ti.must_throw(IndexError)
 def test_numpy_3d_error():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 7
@@ -180,7 +180,7 @@ def test_numpy_multiple_external_arrays():
 
 @ti.must_throw(AssertionError)
 def test_index_mismatch():
-    val = ti.var(ti.i32, shape=(1, 2, 3))
+    val = ti.field(ti.i32, shape=(1, 2, 3))
     val[0, 0] = 1
 
 

--- a/tests/python/test_numpy_io.py
+++ b/tests/python/test_numpy_io.py
@@ -4,7 +4,7 @@ import numpy as np
 
 @ti.all_archs
 def test_to_numpy_2d():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 7
@@ -25,7 +25,7 @@ def test_to_numpy_2d():
 
 @ti.all_archs
 def test_from_numpy_2d():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 7
@@ -48,7 +48,7 @@ def test_from_numpy_2d():
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_f64():
-    val = ti.var(ti.f64)
+    val = ti.field(ti.f64)
 
     n = 4
     m = 7
@@ -90,7 +90,7 @@ def test_numpy_io_example():
     m = 7
 
     # Taichi tensors
-    val = ti.var(ti.i32, shape=(n, m))
+    val = ti.field(ti.i32, shape=(n, m))
     vec = ti.Vector(3, dt=ti.i32, shape=(n, m))
     mat = ti.Matrix(3, 4, dt=ti.i32, shape=(n, m))
 

--- a/tests/python/test_offload.py
+++ b/tests/python/test_offload.py
@@ -6,9 +6,9 @@ def test_running_loss():
     return
     steps = 16
 
-    total_loss = ti.var(ti.f32)
-    running_loss = ti.var(ti.f32)
-    additional_loss = ti.var(ti.f32)
+    total_loss = ti.field(ti.f32)
+    running_loss = ti.field(ti.f32)
+    additional_loss = ti.field(ti.f32)
 
     ti.root.place(total_loss)
     ti.root.dense(ti.i, steps).place(running_loss)
@@ -32,9 +32,9 @@ def test_running_loss():
 
 @ti.all_archs
 def test_reduce_separate():
-    a = ti.var(ti.f32, shape=(16))
-    b = ti.var(ti.f32, shape=(4))
-    c = ti.var(ti.f32, shape=())
+    a = ti.field(ti.f32, shape=(16))
+    b = ti.field(ti.f32, shape=(4))
+    c = ti.field(ti.f32, shape=())
 
     ti.root.lazy_grad()
 
@@ -60,9 +60,9 @@ def test_reduce_separate():
 
 @ti.all_archs
 def test_reduce_merged():
-    a = ti.var(ti.f32, shape=(16))
-    b = ti.var(ti.f32, shape=(4))
-    c = ti.var(ti.f32, shape=())
+    a = ti.field(ti.f32, shape=(16))
+    b = ti.field(ti.f32, shape=(4))
+    c = ti.field(ti.f32, shape=())
 
     ti.root.lazy_grad()
 

--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_offload_with_cross_block_locals():
-    ret = ti.var(ti.f32)
+    ret = ti.field(ti.f32)
 
     ti.root.place(ret)
 
@@ -21,7 +21,7 @@ def test_offload_with_cross_block_locals():
 
 @ti.all_archs
 def test_offload_with_cross_block_locals2():
-    ret = ti.var(ti.f32)
+    ret = ti.field(ti.f32)
 
     ti.root.place(ret)
 
@@ -42,7 +42,7 @@ def test_offload_with_cross_block_locals2():
 
 @ti.all_archs
 def test_offload_with_cross_block_locals3():
-    ret = ti.var(ti.f32, shape=())
+    ret = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def ker():
@@ -59,7 +59,7 @@ def test_offload_with_cross_block_locals3():
 
 @ti.all_archs
 def test_offload_with_cross_block_locals4():
-    ret = ti.var(ti.f32, shape=())
+    ret = ti.field(ti.f32, shape=())
 
     @ti.kernel
     def ker():
@@ -76,9 +76,9 @@ def test_offload_with_cross_block_locals4():
 
 @ti.all_archs
 def test_offload_with_flexible_bounds():
-    s = ti.var(ti.i32, shape=())
-    lower = ti.var(ti.i32, shape=())
-    upper = ti.var(ti.i32, shape=())
+    s = ti.field(ti.i32, shape=())
+    lower = ti.field(ti.i32, shape=())
+    upper = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def ker():
@@ -94,7 +94,7 @@ def test_offload_with_flexible_bounds():
 
 @ti.all_archs
 def test_offload_with_cross_block_globals():
-    ret = ti.var(ti.f32)
+    ret = ti.field(ti.f32)
 
     ti.root.place(ret)
 

--- a/tests/python/test_offset.py
+++ b/tests/python/test_offset.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_accessor():
-    a = ti.var(dt=ti.i32)
+    a = ti.field(dtype=ti.i32)
 
     ti.root.dense(ti.ijk, 128).place(a, offset=(1024, 2048, 2100))
 
@@ -13,7 +13,7 @@ def test_accessor():
 
 @ti.all_archs
 def test_struct_for_huge_offsets():
-    a = ti.var(dt=ti.i32)
+    a = ti.field(dtype=ti.i32)
 
     offset = 1024, 2048, 2100, 2200
     ti.root.dense(ti.ijkl, 4).place(a, offset=offset)
@@ -34,7 +34,7 @@ def test_struct_for_huge_offsets():
 
 @ti.all_archs
 def test_struct_for_negative():
-    a = ti.var(dt=ti.i32)
+    a = ti.field(dtype=ti.i32)
 
     offset = 16, -16
     ti.root.dense(ti.ij, 32).place(a, offset=offset)
@@ -53,14 +53,14 @@ def test_struct_for_negative():
 
 @ti.all_archs
 def test_offset_for_var():
-    a = ti.var(dt=ti.i32, shape=16, offset=-48)
-    b = ti.var(dt=ti.i32, shape=(16, ), offset=(16, ))
-    c = ti.var(dt=ti.i32, shape=(16, 64), offset=(-16, -64))
-    d = ti.var(dt=ti.i32, shape=(16, 64), offset=None)
+    a = ti.field(dtype=ti.i32, shape=16, offset=-48)
+    b = ti.field(dtype=ti.i32, shape=(16, ), offset=(16, ))
+    c = ti.field(dtype=ti.i32, shape=(16, 64), offset=(-16, -64))
+    d = ti.field(dtype=ti.i32, shape=(16, 64), offset=None)
 
     offset = 4, -4
     shape = 16, 16
-    e = ti.var(dt=ti.i32, shape=shape, offset=offset)
+    e = ti.field(dtype=ti.i32, shape=shape, offset=offset)
 
     @ti.kernel
     def test():
@@ -75,8 +75,8 @@ def test_offset_for_var():
 
 @ti.all_archs
 def test_offset_for_vector():
-    a = ti.var(dt=ti.i32, shape=16, offset=-48)
-    b = ti.var(dt=ti.i32, shape=16, offset=None)
+    a = ti.field(dtype=ti.i32, shape=16, offset=-48)
+    b = ti.field(dtype=ti.i32, shape=16, offset=None)
 
     offset = 16
     shape = 16
@@ -111,8 +111,8 @@ def test_offset_for_matrix():
 
 @ti.must_throw(AssertionError)
 def test_offset_must_throw_var():
-    a = ti.var(dt=ti.float32, shape=3, offset=(3, 4))
-    b = ti.var(dt=ti.float32, shape=None, offset=(3, 4))
+    a = ti.field(dtype=ti.float32, shape=3, offset=(3, 4))
+    b = ti.field(dtype=ti.float32, shape=None, offset=(3, 4))
 
 
 @ti.must_throw(AssertionError)

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -8,7 +8,7 @@ def test_classfunc():
         def __init__(self, n, m):
             self.n = n
             self.m = m
-            self.val = ti.var(ti.f32, shape=(n, m))
+            self.val = ti.field(ti.f32, shape=(n, m))
 
         @ti.func
         def inc(self, i, j):
@@ -40,8 +40,8 @@ def test_oop():
         def __init__(self, n, m, increment):
             self.n = n
             self.m = m
-            self.val = ti.var(ti.f32)
-            self.total = ti.var(ti.f32)
+            self.val = ti.field(ti.f32)
+            self.total = ti.field(ti.f32)
             self.increment = increment
 
             ti.root.dense(ti.ij, (self.n, self.m)).place(self.val)
@@ -64,7 +64,7 @@ def test_oop():
 
     arr = Array2D(128, 128, 3)
 
-    double_total = ti.var(ti.f32)
+    double_total = ti.field(ti.f32)
 
     ti.root.place(double_total)
     ti.root.lazy_grad()
@@ -102,8 +102,8 @@ def test_oop_two_items():
         def __init__(self, n, m, increment, multiplier):
             self.n = n
             self.m = m
-            self.val = ti.var(ti.f32)
-            self.total = ti.var(ti.f32)
+            self.val = ti.field(ti.f32)
+            self.total = ti.field(ti.f32)
             self.increment = increment
             self.multiplier = multiplier
             ti.root.dense(ti.ij, (self.n, self.m)).place(self.val)
@@ -153,8 +153,8 @@ def test_oop_inherit_ok():
     class Array1D(object):
         def __init__(self, n, mul):
             self.n = n
-            self.val = ti.var(ti.f32)
-            self.total = ti.var(ti.f32)
+            self.val = ti.field(ti.f32)
+            self.total = ti.field(ti.f32)
             self.mul = mul
             ti.root.dense(ti.ij, (self.n, )).place(self.val)
             ti.root.place(self.total)
@@ -180,8 +180,8 @@ def test_oop_class_must_be_data_oriented():
     class Array1D(object):
         def __init__(self, n, mul):
             self.n = n
-            self.val = ti.var(ti.f32)
-            self.total = ti.var(ti.f32)
+            self.val = ti.field(ti.f32)
+            self.total = ti.field(ti.f32)
             self.mul = mul
             ti.root.dense(ti.ij, (self.n, )).place(self.val)
             ti.root.place(self.total)
@@ -204,7 +204,7 @@ def test_hook():
     @ti.data_oriented
     class Solver:
         def __init__(self, n, m, hook):
-            self.val = ti.var(ti.f32, shape=(n, m))
+            self.val = ti.field(ti.f32, shape=(n, m))
             self.hook = hook
 
         def run_hook(self):

--- a/tests/python/test_optimization.py
+++ b/tests/python/test_optimization.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_advanced_store_forwarding_nested_loops():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
     ti.root.place(val)
 
     @ti.kernel
@@ -24,7 +24,7 @@ def test_advanced_store_forwarding_nested_loops():
 
 @ti.all_archs
 def test_advanced_unused_store_elimination_if():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
     ti.root.place(val)
 
     @ti.kernel
@@ -50,7 +50,7 @@ def test_advanced_unused_store_elimination_if():
 @ti.all_archs
 def test_local_store_in_nested_for_and_if():
     # See https://github.com/taichi-dev/taichi/pull/862.
-    val = ti.var(ti.i32, shape=(3, 3, 3))
+    val = ti.field(ti.i32, shape=(3, 3, 3))
 
     @ti.kernel
     def func():
@@ -76,7 +76,7 @@ def test_local_store_in_nested_for_and_if():
 
 @ti.all_archs
 def test_advanced_store_forwarding_continue_in_if():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
     ti.root.place(val)
 
     @ti.kernel
@@ -106,7 +106,7 @@ def test_advanced_store_forwarding_continue_in_if():
 
 @ti.all_archs
 def test_advanced_store_elimination_in_loop():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
     ti.root.place(val)
 
     @ti.kernel
@@ -129,7 +129,7 @@ def test_advanced_store_elimination_in_loop():
 
 @ti.all_archs
 def test_parallel_assignment():
-    mat = ti.var(ti.i32, shape=(3, 4))
+    mat = ti.field(ti.i32, shape=(3, 4))
 
     @ti.kernel
     def func():

--- a/tests/python/test_parallel_range_for.py
+++ b/tests/python/test_parallel_range_for.py
@@ -5,7 +5,7 @@ import taichi as ti
 @ti.archs_excluding(ti.opengl)
 def test_parallel_range_for():
     n = 1024 * 1024
-    val = ti.var(ti.i32, shape=(n))
+    val = ti.field(ti.i32, shape=(n))
 
     @ti.kernel
     def fill():

--- a/tests/python/test_pow.py
+++ b/tests/python/test_pow.py
@@ -2,7 +2,7 @@ import taichi as ti
 
 
 def _test_pow_f(dt):
-    z = ti.var(dt, shape=())
+    z = ti.field(dt, shape=())
 
     @ti.kernel
     def func(x: dt, y: dt):
@@ -15,7 +15,7 @@ def _test_pow_f(dt):
 
 
 def _test_pow_i(dt):
-    z = ti.var(dt, shape=())
+    z = ti.field(dt, shape=())
 
     @ti.kernel
     def func(x: dt, y: ti.template()):

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -81,7 +81,7 @@ def test_print_sep_end():
 
 @ti.all_archs
 def test_print_multiple_threads():
-    x = ti.var(dt=ti.f32, shape=(128, ))
+    x = ti.field(dtype=ti.f32, shape=(128, ))
 
     @ti.kernel
     def func(k: ti.f32):

--- a/tests/python/test_ptr_assign.py
+++ b/tests/python/test_ptr_assign.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_ptr_scalar():
-    a = ti.var(dt=ti.f32, shape=())
+    a = ti.field(dtype=ti.f32, shape=())
 
     @ti.kernel
     def func(t: ti.f32):
@@ -35,7 +35,7 @@ def test_ptr_matrix():
 
 @ti.all_archs
 def test_ptr_tensor():
-    a = ti.var(dt=ti.f32, shape=(3, 4))
+    a = ti.field(dtype=ti.f32, shape=(3, 4))
 
     @ti.kernel
     def func(t: ti.f32):
@@ -53,8 +53,8 @@ def test_ptr_tensor():
 
 @ti.all_archs
 def test_pythonish_tuple_assign():
-    a = ti.var(dt=ti.f32, shape=())
-    b = ti.var(dt=ti.f32, shape=())
+    a = ti.field(dtype=ti.f32, shape=())
+    b = ti.field(dtype=ti.f32, shape=())
 
     @ti.kernel
     def func(x: ti.f32, y: ti.f32):
@@ -70,7 +70,7 @@ def test_pythonish_tuple_assign():
 
 @ti.all_archs
 def test_ptr_func():
-    a = ti.var(dt=ti.f32, shape=())
+    a = ti.field(dtype=ti.f32, shape=())
 
     @ti.func
     def add2numbers(x, y):
@@ -90,7 +90,7 @@ def test_ptr_class_func():
     @ti.data_oriented
     class MyClass:
         def __init__(self):
-            self.a = ti.var(dt=ti.f32, shape=())
+            self.a = ti.field(dtype=ti.f32, shape=())
 
         @ti.func
         def add2numbers(self, x, y):


### PR DESCRIPTION
Related issue = #1663

The same as PR #1681 

I rerun these tests on my Ubuntu 18.04, they work well.
# The test script
```
import os
import re
from multiprocessing import Pool


def work_on_test(name):
    cmd = f"pytest {name} 1>/tmp/{name}.log 2>/tmp/{name}.err"
    print(f"[log] begin to test {name}")
    ret = os.system(cmd)
    if ret != 0:
        print(f"[error] error when testing {name}, return {ret}")
    else:
        print(f"[log] testing {name} succ")

if __name__ == '__main__':
    all_files = os.listdir(".")
    pattern = "^test_[h-q].*py$"
    # pattern = "^test_[a-g].*py$"
    target_files = [name for name in all_files if re.search(
        pattern, name) is not None]
    pool = Pool()
    pool.map(work_on_test, target_files)

```
# Verify result
```
[log] begin to test test_loops.py
[log] testing test_loops.py succ
[log] begin to test test_nested_kernel_error.py
[log] testing test_nested_kernel_error.py succ
[log] begin to test test_pow.py
[log] testing test_pow.py succ
[log] begin to test test_local_atomic_opt.py
[log] testing test_local_atomic_opt.py succ
[log] begin to test test_offload_cross.py
[log] testing test_offload_cross.py succ
[log] begin to test test_no_grad.py
[log] testing test_no_grad.py succ
[log] begin to test test_loop_grad.py
[log] testing test_loop_grad.py succ
[log] begin to test test_ptr_assign.py
[log] testing test_ptr_assign.py succ
[log] begin to test test_image_io.py
[log] testing test_image_io.py succ
[log] begin to test test_kernel_templates.py
[log] testing test_kernel_templates.py succ
[log] begin to test test_mpm88.py
[log] testing test_mpm88.py succ
[log] begin to test test_local_atomics.py
[log] testing test_local_atomics.py succ
[log] begin to test test_oop.py
[log] testing test_oop.py succ
[log] begin to test test_numpy.py
[log] testing test_numpy.py succ
[log] begin to test test_ndrange.py
[log] testing test_ndrange.py succ
[log] begin to test test_native_functions.py
[log] testing test_native_functions.py succ
[log] begin to test test_optimization.py
[log] testing test_optimization.py succ
[log] begin to test test_numpy_io.py
[log] testing test_numpy_io.py succ
[log] begin to test test_matrix.py
[log] testing test_matrix.py succ
[log] begin to test test_indices.py
[log] testing test_indices.py succ
[log] begin to test test_offset.py
[log] testing test_offset.py succ
[log] begin to test test_new_allocator.py
[log] testing test_new_allocator.py succ
[log] begin to test test_lexical_scope.py
[log] testing test_lexical_scope.py succ
[log] begin to test test_offload.py
[log] testing test_offload.py succ
[log] begin to test test_lang.py
[log] testing test_lang.py succ
[log] begin to test test_print.py
[log] testing test_print.py succ
[log] begin to test test_mpm_particle_list.py
[log] testing test_mpm_particle_list.py succ
[log] begin to test test_kernel_template_mapper.py
[log] testing test_kernel_template_mapper.py succ
[log] begin to test test_internal_func.py
[log] testing test_internal_func.py succ
[log] begin to test test_parallel_range_for.py
[log] testing test_parallel_range_for.py succ
[log] begin to test test_mod.py
[log] testing test_mod.py succ
[log] begin to test test_no_activate.py
[log] testing test_no_activate.py succ
[log] begin to test test_listgen.py
[log] testing test_listgen.py succ
[log] begin to test test_immediate_layout.py
[log] testing test_immediate_layout.py succ
[log] begin to test test_linalg.py
[log] testing test_linalg.py succ

```
