### PR TITLE
[test] Replace ti.var by ti.field in tests starting with r-z

### DIFF
--- a/tests/python/test_random.py
+++ b/tests/python/test_random.py
@@ -11,7 +11,7 @@ def test_random_float():
     for precision in [ti.f32, ti.f64]:
         ti.init()
         n = 1024
-        x = ti.var(ti.f32, shape=(n, n))
+        x = ti.field(ti.f32, shape=(n, n))
 
         @ti.kernel
         def fill():
@@ -30,7 +30,7 @@ def test_random_int():
     for precision in [ti.i32, ti.i64]:
         ti.init()
         n = 1024
-        x = ti.var(ti.f32, shape=(n, n))
+        x = ti.field(ti.f32, shape=(n, n))
 
         @ti.kernel
         def fill():
@@ -51,7 +51,7 @@ def test_random_int():
 @archs_support_random
 def test_random_independent_product():
     n = 1024
-    x = ti.var(ti.f32, shape=n * n)
+    x = ti.field(ti.f32, shape=n * n)
 
     @ti.kernel
     def fill():
@@ -92,7 +92,7 @@ def test_random_2d_dist():
 @archs_support_random
 def test_random_seed_per_launch():
     n = 10
-    x = ti.var(ti.f32, shape=n)
+    x = ti.field(ti.f32, shape=n)
 
     @ti.kernel
     def gen(i: ti.i32):

--- a/tests/python/test_reduction.py
+++ b/tests/python/test_reduction.py
@@ -8,8 +8,8 @@ def _test_reduction_single(dtype, criterion):
         # OpenGL is not capable of such large number in its float32...
         N = 1024 * 16
 
-    a = ti.var(dtype, shape=N)
-    tot = ti.var(dtype, shape=())
+    a = ti.field(dtype, shape=N)
+    tot = ti.field(dtype, shape=())
 
     @ti.kernel
     def fill():
@@ -75,10 +75,10 @@ def test_reduction_single_f64():
 def test_reduction_single():
     N = 1024 * 1024
 
-    a = ti.var(ti.i32, shape=N)
-    b = ti.var(ti.f64, shape=N)
-    tot_a = ti.var(ti.i32, shape=())
-    tot_b = ti.var(ti.f64, shape=())
+    a = ti.field(ti.i32, shape=N)
+    b = ti.field(ti.f64, shape=N)
+    tot_a = ti.field(ti.i32, shape=())
+    tot_b = ti.field(ti.f64, shape=())
 
     @ti.kernel
     def fill():

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -4,7 +4,7 @@ from taichi import approx
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def _test_return_not_last_stmt():  # TODO: make this work
-    x = ti.var(ti.i32, ())
+    x = ti.field(ti.i32, ())
 
     @ti.kernel
     def kernel() -> ti.i32:

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -130,7 +130,7 @@ def test_init_bad_arg():
 @ti.all_archs
 @ti.must_throw(RuntimeError)
 def test_materialization_after_kernel():
-    x = ti.var(ti.f32, (3, 4))
+    x = ti.field(ti.f32, (3, 4))
 
     @ti.kernel
     def func():
@@ -138,27 +138,27 @@ def test_materialization_after_kernel():
 
     func()
 
-    y = ti.var(ti.f32, (2, 3))
+    y = ti.field(ti.f32, (2, 3))
     # ERROR: No new variable should be declared after kernel invocation!
 
 
 @ti.all_archs
 @ti.must_throw(RuntimeError)
 def test_materialization_after_access():
-    x = ti.var(ti.f32, (3, 4))
+    x = ti.field(ti.f32, (3, 4))
 
     print(x[2, 3])
 
-    y = ti.var(ti.f32, (2, 3))
+    y = ti.field(ti.f32, (2, 3))
     # ERROR: No new variable should be declared after Python-scope tensor access!
 
 
 @ti.all_archs
 @ti.must_throw(RuntimeError)
 def test_materialization_after_get_shape():
-    x = ti.var(ti.f32, (3, 4))
+    x = ti.field(ti.f32, (3, 4))
 
     print(x.shape)
 
-    y = ti.var(ti.f32, (2, 3))
+    y = ti.field(ti.f32, (2, 3))
     # ERROR: No new variable should be declared after Python-scope tensor access!

--- a/tests/python/test_scope_errors.py
+++ b/tests/python/test_scope_errors.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.must_throw(UnboundLocalError)
 def test_if():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -20,7 +20,7 @@ def test_if():
 
 @ti.must_throw(UnboundLocalError)
 def test_for():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -35,7 +35,7 @@ def test_for():
 
 @ti.must_throw(UnboundLocalError)
 def test_while():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 

--- a/tests/python/test_sparse_activate.py
+++ b/tests/python/test_sparse_activate.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.archs_support_sparse
 def test_pointer():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 16
 

--- a/tests/python/test_sparse_basics.py
+++ b/tests/python/test_sparse_basics.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.archs_support_sparse
 def test_pointer():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 128
 
@@ -26,8 +26,8 @@ def test_pointer():
 
 @ti.archs_support_sparse
 def test_pointer_is_active():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 128
 
@@ -49,8 +49,8 @@ def test_pointer_is_active():
 
 @ti.archs_support_sparse
 def test_pointer2():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 128
 

--- a/tests/python/test_sparse_deactivate.py
+++ b/tests/python/test_sparse_deactivate.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.archs_support_sparse
 def test_pointer():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 16
 
@@ -36,8 +36,8 @@ def test_pointer():
 
 @ti.archs_support_sparse
 def test_pointer1():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 16
 
@@ -71,7 +71,7 @@ def test_pointer1():
 
 @ti.archs_support_sparse
 def test_pointer2():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     n = 16
 
@@ -109,8 +109,8 @@ def test_pointer2():
 
 @ti.archs_support_sparse
 def test_pointer3():
-    x = ti.var(ti.f32)
-    x_temp = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    x_temp = ti.field(ti.f32)
 
     n = 16
 
@@ -171,8 +171,8 @@ def test_pointer3():
 
 @ti.archs_support_sparse
 def test_dynamic():
-    x = ti.var(ti.i32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    s = ti.field(ti.i32)
 
     n = 16
 

--- a/tests/python/test_sparse_parallel.py
+++ b/tests/python/test_sparse_parallel.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.archs_support_sparse
 def test_pointer():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 128
 
@@ -28,8 +28,8 @@ def test_pointer():
 
 @ti.archs_support_sparse
 def test_pointer2():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 128
 
@@ -54,7 +54,7 @@ def test_pointer2():
 
 @ti.archs_support_sparse
 def test_nested_struct_fill_and_clear():
-    a = ti.var(dt=ti.f32)
+    a = ti.field(dtype=ti.f32)
     N = 512
 
     ti.root.pointer(ti.ij, [N, N]).dense(ti.ij, [8, 8]).place(a)

--- a/tests/python/test_static.py
+++ b/tests/python/test_static.py
@@ -6,7 +6,7 @@ import numpy as np
 def test_static_if():
     for val in [0, 1]:
         ti.init()
-        x = ti.var(ti.i32)
+        x = ti.field(ti.i32)
 
         ti.root.dense(ti.i, 1).place(x)
 
@@ -23,7 +23,7 @@ def test_static_if():
 
 @ti.must_throw(AssertionError)
 def test_static_if_error():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -56,7 +56,7 @@ def test_static_ndrange():
 
 @ti.host_arch_only
 def test_static_break():
-    x = ti.var(ti.i32, 5)
+    x = ti.field(ti.i32, 5)
 
     @ti.kernel
     def func():
@@ -72,7 +72,7 @@ def test_static_break():
 
 @ti.host_arch_only
 def test_static_continue():
-    x = ti.var(ti.i32, 5)
+    x = ti.field(ti.i32, 5)
 
     @ti.kernel
     def func():

--- a/tests/python/test_stencils.py
+++ b/tests/python/test_stencils.py
@@ -4,8 +4,8 @@ import taichi as ti
 @ti.all_archs
 def test_simple():
     # Note: access simplification does not work in this case. Maybe worth fixing.
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 128
 

--- a/tests/python/test_stop_grad.py
+++ b/tests/python/test_stop_grad.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_normal_grad():
-    x = ti.var(ti.f32)
-    loss = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    loss = ti.field(ti.f32)
 
     n = 128
 
@@ -29,8 +29,8 @@ def test_normal_grad():
 
 @ti.all_archs
 def test_stop_grad():
-    x = ti.var(ti.f32)
-    loss = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    loss = ti.field(ti.f32)
 
     n = 128
 
@@ -56,8 +56,8 @@ def test_stop_grad():
 
 @ti.all_archs
 def test_stop_grad2():
-    x = ti.var(ti.f32)
-    loss = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    loss = ti.field(ti.f32)
 
     n = 128
 

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_linear():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 128
 
@@ -27,8 +27,8 @@ def test_linear_repeated():
 
 @ti.all_archs
 def test_linear_nested():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 128
 
@@ -46,8 +46,8 @@ def test_linear_nested():
 
 @ti.all_archs
 def test_linear_nested_aos():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 128
 
@@ -64,7 +64,7 @@ def test_linear_nested_aos():
 
 @ti.all_archs
 def test_2d_nested():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     n = 128
 

--- a/tests/python/test_struct_for.py
+++ b/tests/python/test_struct_for.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_singleton():
-    x = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def fill():
@@ -17,7 +17,7 @@ def test_singleton():
 
 @ti.all_archs
 def test_singleton2():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     ti.root.place(x)
 
@@ -33,8 +33,8 @@ def test_singleton2():
 
 @ti.all_archs
 def test_linear():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 128
 
@@ -56,8 +56,8 @@ def test_linear():
 
 @ti.all_archs
 def test_nested():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 128
 
@@ -79,8 +79,8 @@ def test_nested():
 
 @ti.all_archs
 def test_nested2():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 2048
 
@@ -104,8 +104,8 @@ def test_nested2():
 
 @ti.all_archs
 def test_2d():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n, m = 32, 16
 
@@ -125,8 +125,8 @@ def test_2d():
 
 @ti.all_archs
 def test_2d_non_POT():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32, shape=())
 
     n, m = 13, 17
 
@@ -148,8 +148,8 @@ def test_2d_non_POT():
 
 @ti.all_archs
 def test_nested_2d():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 32
 
@@ -169,8 +169,8 @@ def test_nested_2d():
 
 @ti.all_archs
 def test_nested_2d_more_nests():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     n = 64
 
@@ -193,7 +193,7 @@ def test_nested_2d_more_nests():
 
 @ti.all_archs
 def test_linear_k():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     n = 128
 
@@ -213,8 +213,8 @@ def test_linear_k():
 @ti.archs_support_sparse
 def test_struct_for_branching():
     # Related issue: https://github.com/taichi-dev/taichi/issues/704
-    x = ti.var(dt=ti.i32)
-    y = ti.var(dt=ti.i32)
+    x = ti.field(dtype=ti.i32)
+    y = ti.field(dtype=ti.i32)
     ti.root.pointer(ti.ij, 128 // 4).dense(ti.ij, 4).place(x, y)
 
     @ti.kernel

--- a/tests/python/test_struct_for_dynamic.py
+++ b/tests/python/test_struct_for_dynamic.py
@@ -7,8 +7,8 @@ def ti_support_dynamic(test):
 
 @ti_support_dynamic
 def test_dynamic():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32, shape=())
 
     n = 128
 
@@ -30,7 +30,7 @@ def test_dynamic():
 def test_dense_dynamic():
     n = 128
 
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     ti.root.dense(ti.i, n).dynamic(ti.j, n, 128).place(x)
 

--- a/tests/python/test_struct_for_intermediate.py
+++ b/tests/python/test_struct_for_intermediate.py
@@ -4,7 +4,7 @@ import taichi as ti
 @ti.all_archs
 def test_nested():
     ti.cfg.demote_dense_struct_fors = False
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     p, q = 3, 7
     n, m = 2, 4
@@ -27,7 +27,7 @@ def test_nested():
 def test_nested_demote():
     ti.cfg.demote_dense_struct_fors = True
     ti.cfg.print_ir = True
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     p, q = 3, 7
     n, m = 2, 4

--- a/tests/python/test_struct_for_non_pot.py
+++ b/tests/python/test_struct_for_non_pot.py
@@ -3,8 +3,8 @@ import taichi as ti
 
 @ti.all_archs
 def test_1d():
-    x = ti.var(ti.i32)
-    sum = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    sum = ti.field(ti.i32)
 
     n = 100
 
@@ -24,8 +24,8 @@ def test_1d():
 
 @ti.all_archs
 def test_2d():
-    x = ti.var(ti.i32)
-    sum = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    sum = ti.field(ti.i32)
 
     n = 100
     m = 19

--- a/tests/python/test_svd.py
+++ b/tests/python/test_svd.py
@@ -6,9 +6,9 @@ from taichi import approx
 @ti.require(ti.extension.data64)
 @ti.all_archs_with(fast_math=False)
 def test_precision():
-    u = ti.var(ti.f64, shape=())
-    v = ti.var(ti.f64, shape=())
-    w = ti.var(ti.f64, shape=())
+    u = ti.field(ti.f64, shape=())
+    v = ti.field(ti.f64, shape=())
+    w = ti.field(ti.f64, shape=())
 
     @ti.kernel
     def forward():

--- a/tests/python/test_sync.py
+++ b/tests/python/test_sync.py
@@ -4,8 +4,8 @@ import taichi as ti
 @ti.all_archs
 def test_kernel_sync():
     n = 128
-    x = ti.var(ti.i32, shape=(3, ))
-    y = ti.var(ti.i32, shape=(n, ))
+    x = ti.field(ti.i32, shape=(3, ))
+    y = ti.field(ti.i32, shape=(n, ))
     # These [] calls are all on CPU, so no synchronization needed
     x[0] = 42
     assert x[0] == 42

--- a/tests/python/test_syntax_errors.py
+++ b/tests/python/test_syntax_errors.py
@@ -4,7 +4,7 @@ import pytest
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_try():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -20,7 +20,7 @@ def test_try():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_for_else():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -36,7 +36,7 @@ def test_for_else():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_while_else():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -52,7 +52,7 @@ def test_while_else():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_loop_var_range():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -67,7 +67,7 @@ def test_loop_var_range():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_loop_var_struct():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -82,7 +82,7 @@ def test_loop_var_struct():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_loop_var_struct():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -175,7 +175,7 @@ def test_nested_ndrange():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_static_grouped_struct_for():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     ti.root.dense(ti.ij, (1, 1)).place(val)
 
@@ -189,8 +189,8 @@ def test_static_grouped_struct_for():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_is():
-    b = ti.var(ti.i32, shape=())
-    c = ti.var(ti.i32, shape=())
+    b = ti.field(ti.i32, shape=())
+    c = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -201,8 +201,8 @@ def test_is():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_is_not():
-    b = ti.var(ti.i32, shape=())
-    c = ti.var(ti.i32, shape=())
+    b = ti.field(ti.i32, shape=())
+    c = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -213,8 +213,8 @@ def test_is_not():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_in():
-    b = ti.var(ti.i32, shape=())
-    c = ti.var(ti.i32, shape=())
+    b = ti.field(ti.i32, shape=())
+    c = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():
@@ -225,8 +225,8 @@ def test_in():
 
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_not_in():
-    b = ti.var(ti.i32, shape=())
-    c = ti.var(ti.i32, shape=())
+    b = ti.field(ti.i32, shape=())
+    c = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -4,7 +4,7 @@ import pytest
 
 @ti.all_archs
 def test_POT():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 4
     m = 8
@@ -18,7 +18,7 @@ def test_POT():
 
 @ti.all_archs
 def test_non_POT():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 3
     m = 7
@@ -35,7 +35,7 @@ def test_non_POT():
 
 @ti.all_archs
 def test_unordered():
-    val = ti.var(ti.i32)
+    val = ti.field(ti.i32)
 
     n = 3
     m = 7
@@ -91,7 +91,7 @@ def test_unordered_matrix():
 @pytest.mark.filterwarnings('ignore')
 @ti.host_arch_only
 def test_deprecated():
-    val = ti.var(ti.f32)
+    val = ti.field(ti.f32)
     mat = ti.Matrix(3, 2, ti.i32)
 
     n = 3
@@ -117,7 +117,7 @@ def test_deprecated():
 
 @ti.all_archs
 def test_parent_exceeded():
-    val = ti.var(ti.f32)
+    val = ti.field(ti.f32)
 
     m = 7
     n = 3

--- a/tests/python/test_torch_ad.py
+++ b/tests/python/test_torch_ad.py
@@ -9,8 +9,8 @@ if ti.has_pytorch():
 def test_torch_ad():
     n = 32
 
-    x = ti.var(ti.f32, shape=n, needs_grad=True)
-    y = ti.var(ti.f32, shape=n, needs_grad=True)
+    x = ti.field(ti.f32, shape=n, needs_grad=True)
+    y = ti.field(ti.f32, shape=n, needs_grad=True)
 
     @ti.kernel
     def torch_kernel():
@@ -52,8 +52,8 @@ def test_torch_ad_gpu():
     device = torch.device('cuda:0')
     n = 32
 
-    x = ti.var(ti.f32, shape=n, needs_grad=True)
-    y = ti.var(ti.f32, shape=n, needs_grad=True)
+    x = ti.field(ti.f32, shape=n, needs_grad=True)
+    y = ti.field(ti.f32, shape=n, needs_grad=True)
 
     @ti.kernel
     def torch_kernel():

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -8,7 +8,7 @@ if ti.has_pytorch():
 @ti.torch_test
 def test_io_devices():
     n = 32
-    x = ti.var(dt=ti.i32, shape=n)
+    x = ti.field(dtype=ti.i32, shape=n)
 
     @ti.kernel
     def load(y: ti.ext_arr()):
@@ -132,7 +132,7 @@ def test_io_3d():
 def test_io_simple():
     n = 32
 
-    x1 = ti.var(ti.f32, shape=(n, n))
+    x1 = ti.field(ti.f32, shape=(n, n))
     t1 = torch.tensor(2 * np.ones((n, n), dtype=np.float32))
 
     x2 = ti.Matrix(2, 3, ti.f32, shape=(n, n))

--- a/tests/python/test_trailing_bits.py
+++ b/tests/python/test_trailing_bits.py
@@ -5,8 +5,8 @@ import pytest
 def test_trailing_bits():
     ti.init(arch=ti.cpu, debug=True, print_ir=True)
 
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     block = ti.root.pointer(ti.i, 8)
     block.dense(ti.i, 32).place(x)
@@ -38,9 +38,9 @@ def test_trailing_bits():
 def test_inconsistent_trailing_bits():
     ti.init(arch=ti.cpu, debug=True, print_ir=True)
 
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
-    z = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
+    z = ti.field(ti.f32)
 
     block = ti.root.pointer(ti.i, 8)
 

--- a/tests/python/test_tuple_assign.py
+++ b/tests/python/test_tuple_assign.py
@@ -24,8 +24,8 @@ def test_fibonacci():
 
 @ti.host_arch_only
 def test_assign2():
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -41,8 +41,8 @@ def test_assign2():
 def test_assign2_mismatch3():
     ti.init(print_preprocessed=True)
 
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -56,8 +56,8 @@ def test_assign2_mismatch3():
 def test_assign2_mismatch1():
     ti.init(print_preprocessed=True)
 
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -68,8 +68,8 @@ def test_assign2_mismatch1():
 
 @ti.host_arch_only
 def test_swap2():
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -84,8 +84,8 @@ def test_swap2():
 
 @ti.host_arch_only
 def test_assign2_static():
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -100,9 +100,9 @@ def test_assign2_static():
 
 @ti.host_arch_only
 def test_swap3():
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
-    c = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
+    c = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -119,9 +119,9 @@ def test_swap3():
 
 @ti.host_arch_only
 def test_unpack_from_tuple():
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
-    c = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
+    c = ti.field(ti.f32, ())
 
     list = [2, 3, 4]
 
@@ -139,8 +139,8 @@ def test_unpack_from_tuple():
 @ti.must_throw(ValueError)
 def test_unpack_mismatch_tuple():
     ti.init(print_preprocessed=True)
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     list = [2, 3, 4]
 
@@ -153,9 +153,9 @@ def test_unpack_mismatch_tuple():
 
 @ti.host_arch_only
 def test_unpack_from_vector():
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
-    c = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
+    c = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -172,8 +172,8 @@ def test_unpack_from_vector():
 @ti.must_throw(ValueError)
 def test_unpack_mismatch_vector():
     ti.init(print_preprocessed=True)
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -187,8 +187,8 @@ def test_unpack_mismatch_vector():
 @ti.must_throw(TypeError)
 def test_unpack_mismatch_type():
     ti.init(print_preprocessed=True)
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
 
     bad = 12
 
@@ -203,10 +203,10 @@ def test_unpack_mismatch_type():
 @ti.must_throw(ValueError)
 def test_unpack_mismatch_matrix():
     ti.init(print_preprocessed=True)
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
-    c = ti.var(ti.f32, ())
-    d = ti.var(ti.f32, ())
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
+    c = ti.field(ti.f32, ())
+    d = ti.field(ti.f32, ())
 
     @ti.kernel
     def func():
@@ -218,10 +218,10 @@ def test_unpack_mismatch_matrix():
 
 @ti.host_arch_only
 def test_unpack_from_shape():
-    a = ti.var(ti.f32, ())
-    b = ti.var(ti.f32, ())
-    c = ti.var(ti.f32, ())
-    d = ti.var(ti.f32, (2, 3, 4))
+    a = ti.field(ti.f32, ())
+    b = ti.field(ti.f32, ())
+    c = ti.field(ti.f32, ())
+    d = ti.field(ti.f32, (2, 3, 4))
 
     @ti.kernel
     def func():

--- a/tests/python/test_types.py
+++ b/tests/python/test_types.py
@@ -6,7 +6,7 @@ _TI_64_TYPES = [ti.i64, ti.u64, ti.f64]
 
 
 def _test_type_assign_argument(dt):
-    x = ti.var(dt, shape=())
+    x = ti.field(dt, shape=())
 
     @ti.kernel
     def func(value: dt):
@@ -30,10 +30,10 @@ def test_type_assign_argument64(dt):
 
 
 def _test_type_operator(dt):
-    x = ti.var(dt, shape=())
-    y = ti.var(dt, shape=())
-    add = ti.var(dt, shape=())
-    mul = ti.var(dt, shape=())
+    x = ti.field(dt, shape=())
+    y = ti.field(dt, shape=())
+    add = ti.field(dt, shape=())
+    mul = ti.field(dt, shape=())
 
     @ti.kernel
     def func():
@@ -63,7 +63,7 @@ def test_type_operator64(dt):
 
 
 def _test_type_tensor(dt):
-    x = ti.var(dt, shape=(3, 2))
+    x = ti.field(dt, shape=(3, 2))
 
     @ti.kernel
     def func(i: ti.i32, j: ti.i32):
@@ -89,9 +89,9 @@ def test_type_tensor64(dt):
 
 
 def _test_overflow(dt, n):
-    a = ti.var(dt, shape=())
-    b = ti.var(dt, shape=())
-    c = ti.var(dt, shape=())
+    a = ti.field(dt, shape=())
+    b = ti.field(dt, shape=())
+    c = ti.field(dt, shape=())
 
     @ti.kernel
     def func():

--- a/tests/python/test_unary_ops.py
+++ b/tests/python/test_unary_ops.py
@@ -5,7 +5,7 @@ import numpy as np
 def _test_op(dt, taichi_op, np_op):
     print('arch={} default_fp={}'.format(ti.cfg.arch, ti.cfg.default_fp))
     n = 4
-    val = ti.var(dt, shape=n)
+    val = ti.field(dt, shape=n)
 
     def f(i):
         return i * 0.1 + 0.4

--- a/tests/python/test_while.py
+++ b/tests/python/test_while.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.all_archs
 def test_while():
-    x = ti.var(ti.f32)
+    x = ti.field(ti.f32)
 
     N = 1
 
@@ -24,7 +24,7 @@ def test_while():
 
 @ti.all_archs
 def test_break():
-    ret = ti.var(ti.i32, shape=())
+    ret = ti.field(ti.i32, shape=())
 
     @ti.kernel
     def func():


### PR DESCRIPTION
Related issue = #1663 

The same as #1681 

# 1. Test script
```
import os
import re
from multiprocessing import Pool


def work_on_test(name):
    cmd = f"pytest {name} 1>/tmp/{name}.log 2>/tmp/{name}.err"
    print(f"[log] begin to test {name}")
    ret = os.system(cmd)
    if ret != 0:
        print(f"[error] error when testing {name}, return {ret}")
    else:
        print(f"[log] testing {name} succ")

if __name__ == '__main__':
    all_files = os.listdir(".")
    pattern = "^test_[r-z].*py$"
    # pattern = "^test_[a-g].*py$"
    target_files = [name for name in all_files if re.search(
        pattern, name) is not None]
    pool = Pool()
    pool.map(work_on_test, target_files)

```
# 2. Test result
```
[log] begin to test test_test.py
[log] begin to test test_torch_io.py
[log] begin to test test_return.py
[log] begin to test test_ssa.py
[log] begin to test test_stop_grad.py
[log] begin to test test_struct_for_dynamic.py
[log] begin to test test_struct_for.py
[log] begin to test test_tensor_reflection.py
[log] begin to test test_sparse_parallel.py
[log] begin to test test_scope_errors.py
[log] begin to test test_svd.py
[log] begin to test test_while.py
[log] begin to test test_sparse_activate.py
[log] begin to test test_reduction.py
[log] begin to test test_sparse_basics.py
[log] begin to test test_stencils.py
[log] testing test_torch_io.py succ
[log] begin to test test_random.py
[log] testing test_test.py succ
[log] begin to test test_threading.py
[log] testing test_scope_errors.py succ
[log] begin to test test_runtime.py
[log] testing test_stencils.py succ
[log] begin to test test_struct.py
[log] testing test_threading.py succ
[log] begin to test test_syntax_errors.py
[log] testing test_struct_for_dynamic.py succ
[log] begin to test test_tensor_dimensionality.py
[log] testing test_while.py succ
[log] begin to test test_tuple_assign.py
[log] testing test_sparse_activate.py succ
[log] begin to test test_sync.py
[log] testing test_runtime.py succ
[log] begin to test test_sparse_deactivate.py
[log] testing test_sparse_basics.py succ
[log] begin to test test_static.py
[log] testing test_return.py succ
[log] begin to test test_struct_for_non_pot.py
[log] testing test_stop_grad.py succ
[log] begin to test test_unary_ops.py
[log] testing test_tensor_reflection.py succ
[log] begin to test test_types.py
[log] testing test_ssa.py succ
[log] begin to test test_struct_for_intermediate.py
[log] testing test_sparse_parallel.py succ
[log] begin to test test_trailing_bits.py
[log] testing test_sync.py succ
[log] begin to test test_torch_ad.py
[log] testing test_torch_ad.py succ
[log] testing test_syntax_errors.py succ
[log] testing test_trailing_bits.py succ
[log] testing test_random.py succ
[log] testing test_struct_for_non_pot.py succ
[log] testing test_tuple_assign.py succ
[log] testing test_struct_for_intermediate.py succ
[log] testing test_reduction.py succ
[log] testing test_static.py succ
[log] testing test_tensor_dimensionality.py succ
[log] testing test_svd.py succ
[log] testing test_struct_for.py succ
[log] testing test_unary_ops.py succ
[log] testing test_sparse_deactivate.py succ
[log] testing test_struct.py succ
[log] testing test_types.py succ

```