### PR TITLE
[misc] Revert "[Perf] [opengl] Support 'ti.thread_dim(x)' to change invocations per thread for OpenGL (#1676)"

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -248,7 +248,6 @@ parallelize = core.parallelize
 serialize = lambda: parallelize(1)
 vectorize = core.vectorize
 block_dim = core.block_dim
-thread_dim = core.thread_dim
 cache = core.cache
 
 inversed = deprecated('ti.inversed(a)', 'a.inverse()')(Matrix.inversed)

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -712,25 +712,23 @@ class KernelGen : public IRVisitor {
 
   struct ScopedGridStrideLoop {
     KernelGen *gen;
-    OffloadedStmt *stmt;
     std::unique_ptr<ScopedIndent> s;
 
-    ScopedGridStrideLoop(KernelGen *gen, OffloadedStmt *stmt)
-      : gen(gen), stmt(stmt) {
-      size_t thread_dim = stmt->thread_dim;
-      if (gen->used_tls && thread_dim == 0) {
+    ScopedGridStrideLoop(KernelGen *gen) : gen(gen) {
+      size_t stride_size = gen->kernel->program.config.saturating_grid_dim;
+      if (gen->used_tls && stride_size == 0) {
         // automatically enable grid-stride-loop when TLS used:
-        thread_dim = 32;  // seems to be the most optimal number for fem99.py
+        stride_size = 32;  // seems to be the most optimal number for fem99.py
       }
-      if (thread_dim != 0) {
+      if (stride_size != 0) {
         gen->is_grid_stride_loop_ = true;
         gen->emit("int _sid0 = int(gl_GlobalInvocationID.x) * {};",
-                  thread_dim);
+                  stride_size);
         gen->emit("for (int _sid = _sid0; _sid < _sid0 + {}; _sid++) {{",
-                  thread_dim);
+                  stride_size);
         s = std::make_unique<ScopedIndent>(gen->line_appender_);
         TI_ASSERT(gen->ps);
-        gen->ps->strides_per_thread = thread_dim;
+        gen->ps->strides_per_thread = stride_size;
 
       } else {  // zero regression
         gen->emit("int _sid = int(gl_GlobalInvocationID.x);");
@@ -777,7 +775,7 @@ class KernelGen : public IRVisitor {
         end_value = begin_value;
       ps = std::make_unique<ParallelSize_ConstRange>(end_value - begin_value);
       ps->threads_per_block = stmt->block_dim;
-      ScopedGridStrideLoop _gsl(this, stmt);
+      ScopedGridStrideLoop _gsl(this);
       emit("if (_sid >= {}) {};", end_value - begin_value, get_return_stmt());
       emit("int _itv = {} + _sid * {};", begin_value, 1 /* stmt->step? */);
       stmt->body->accept(this);
@@ -792,7 +790,7 @@ class KernelGen : public IRVisitor {
                                                     stmt->end_offset);
       ps = std::make_unique<ParallelSize_DynamicRange>(stmt);
       ps->threads_per_block = stmt->block_dim;
-      ScopedGridStrideLoop _gsl(this, stmt);
+      ScopedGridStrideLoop _gsl(this);
       emit("int _beg = {}, _end = {};", begin_expr, end_expr);
       emit("int _itv = _beg + _sid;");
       emit("if (_itv >= _end) {};", get_return_stmt());
@@ -820,7 +818,7 @@ class KernelGen : public IRVisitor {
       ScopedIndent _s(line_appender_);
       ps = std::make_unique<ParallelSize_StructFor>(stmt);
       ps->threads_per_block = stmt->block_dim;
-      ScopedGridStrideLoop _gsl(this, stmt);
+      ScopedGridStrideLoop _gsl(this);
       emit("if (_sid >= _end) {};", get_return_stmt());
       emit("int _itv = _list_[_sid];");
       stmt->body->accept(this);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -115,7 +115,6 @@ class FrontendForStmt : public Stmt {
   bool strictly_serialized;
   ScratchPadOptions scratch_opt;
   int block_dim;
-  int thread_dim;
 
   bool is_ranged() const {
     if (global_var.expr == nullptr) {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -48,7 +48,6 @@ void DecoratorRecorder::reset() {
   uniform = false;
   scratch_opt.clear();
   block_dim = 0;
-  thread_dim = 0;
   strictly_serialized = false;
 }
 
@@ -455,9 +454,6 @@ FrontendForStmt::FrontendForStmt(const Expr &loop_var,
   parallelize = dec.parallelize;
   strictly_serialized = dec.strictly_serialized;
   block_dim = dec.block_dim;
-  thread_dim = dec.thread_dim;
-  // TODO(archibate): more systematic solution for copying dec?
-  thread_dim = dec.thread_dim;
   auto cfg = get_current_program().config;
   if (cfg.arch == Arch::cuda) {
     vectorize = 1;
@@ -481,7 +477,6 @@ FrontendForStmt::FrontendForStmt(const ExprGroup &loop_var,
   parallelize = dec.parallelize;
   strictly_serialized = dec.strictly_serialized;
   block_dim = dec.block_dim;
-  thread_dim = dec.thread_dim;
   auto cfg = get_current_program().config;
   if (cfg.arch == Arch::cuda) {
     vectorize = 1;
@@ -987,7 +982,6 @@ RangeForStmt::RangeForStmt(Stmt *begin,
                            int vectorize,
                            int parallelize,
                            int block_dim,
-                           int thread_dim,
                            bool strictly_serialized)
     : begin(begin),
       end(end),
@@ -995,7 +989,6 @@ RangeForStmt::RangeForStmt(Stmt *begin,
       vectorize(vectorize),
       parallelize(parallelize),
       block_dim(block_dim),
-      thread_dim(thread_dim),
       strictly_serialized(strictly_serialized) {
   reversed = false;
   TI_STMT_REG_FIELDS;
@@ -1004,7 +997,7 @@ RangeForStmt::RangeForStmt(Stmt *begin,
 std::unique_ptr<Stmt> RangeForStmt::clone() const {
   auto new_stmt = std::make_unique<RangeForStmt>(
       begin, end, body->clone(), vectorize, parallelize, block_dim,
-      thread_dim, strictly_serialized);
+      strictly_serialized);
   new_stmt->reversed = reversed;
   return new_stmt;
 }
@@ -1013,20 +1006,18 @@ StructForStmt::StructForStmt(SNode *snode,
                              std::unique_ptr<Block> &&body,
                              int vectorize,
                              int parallelize,
-                             int block_dim,
-                             int thread_dim)
+                             int block_dim)
     : snode(snode),
       body(std::move(body)),
       vectorize(vectorize),
       parallelize(parallelize),
-      block_dim(block_dim),
-      thread_dim(thread_dim) {
+      block_dim(block_dim) {
   TI_STMT_REG_FIELDS;
 }
 
 std::unique_ptr<Stmt> StructForStmt::clone() const {
   auto new_stmt = std::make_unique<StructForStmt>(
-      snode, body->clone(), vectorize, parallelize, block_dim, thread_dim);
+      snode, body->clone(), vectorize, parallelize, block_dim);
   new_stmt->scratch_opt = scratch_opt;
   return new_stmt;
 }

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -76,7 +76,6 @@ class DecoratorRecorder {
   bool strictly_serialized;
   ScratchPadOptions scratch_opt;
   int block_dim;
-  int thread_dim;
   bool uniform;
 
   DecoratorRecorder() {
@@ -1226,7 +1225,6 @@ class RangeForStmt : public Stmt {
   int vectorize;
   int parallelize;
   int block_dim;
-  int thread_dim;
   bool strictly_serialized;
 
   RangeForStmt(Stmt *begin,
@@ -1235,7 +1233,6 @@ class RangeForStmt : public Stmt {
                int vectorize,
                int parallelize,
                int block_dim,
-               int thread_dim,
                bool strictly_serialized);
 
   bool is_container_statement() const override {
@@ -1254,7 +1251,6 @@ class RangeForStmt : public Stmt {
                      vectorize,
                      parallelize,
                      block_dim,
-                     thread_dim,
                      strictly_serialized);
   TI_DEFINE_ACCEPT
 };
@@ -1270,15 +1266,13 @@ class StructForStmt : public Stmt {
   int vectorize;
   int parallelize;
   int block_dim;
-  int thread_dim;
   ScratchPadOptions scratch_opt;
 
   StructForStmt(SNode *snode,
                 std::unique_ptr<Block> &&body,
                 int vectorize,
                 int parallelize,
-                int block_dim,
-                int thread_dim);
+                int block_dim);
 
   bool is_container_statement() const override {
     return true;
@@ -1291,7 +1285,6 @@ class StructForStmt : public Stmt {
                      vectorize,
                      parallelize,
                      block_dim,
-                     thread_dim,
                      scratch_opt);
   TI_DEFINE_ACCEPT
 };
@@ -1377,11 +1370,6 @@ inline void StrictlySerialize() {
 inline void BlockDim(int v) {
   TI_ASSERT(bit::is_power_of_two(v));
   dec.block_dim = v;
-}
-
-// TODO(archibate): actually ThreadDim?
-inline void ThreadDim(int v) {
-  dec.thread_dim = v;
 }
 
 class VectorElement {

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -69,7 +69,6 @@ std::unique_ptr<Stmt> OffloadedStmt::clone() const {
   new_stmt->end_value = end_value;
   new_stmt->step = step;
   new_stmt->block_dim = block_dim;
-  new_stmt->thread_dim = thread_dim;
   new_stmt->reversed = reversed;
   new_stmt->num_cpu_threads = num_cpu_threads;
   new_stmt->device = device;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -174,7 +174,6 @@ class OffloadedStmt : public Stmt {
   int step;
   int grid_dim{1};
   int block_dim{1};
-  int thread_dim{1};
   bool reversed;
   int num_cpu_threads;
   Arch device;
@@ -222,7 +221,6 @@ class OffloadedStmt : public Stmt {
                      end_value,
                      step /*unused?*/,
                      block_dim,
-                     thread_dim,
                      reversed,
                      num_cpu_threads,
                      device,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -548,11 +548,10 @@ void export_lang(py::module &m) {
     }
   });
   // Schedules
-  m.def("cache", Cache);
   m.def("parallelize", Parallelize);
   m.def("vectorize", Vectorize);
   m.def("block_dim", BlockDim);
-  m.def("thread_dim", ThreadDim);
+  m.def("cache", Cache);
   m.def("no_activate", [](SNode *snode) {
     get_current_program().get_current_kernel().no_activate.push_back(snode);
   });

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -206,8 +206,7 @@ class LowerAST : public IRVisitor {
       if (is_good_range_for) {
         auto &&new_for = std::make_unique<RangeForStmt>(
             begin->stmt, end->stmt, std::move(stmt->body), stmt->vectorize,
-            stmt->parallelize, stmt->block_dim, stmt->thread_dim,
-            stmt->strictly_serialized);
+            stmt->parallelize, stmt->block_dim, stmt->strictly_serialized);
         new_for->body->insert(std::make_unique<LoopIndexStmt>(new_for.get(), 0),
                               0);
         new_for->body->local_var_to_stmt[stmt->loop_var_id[0]] =
@@ -281,7 +280,7 @@ class LowerAST : public IRVisitor {
       }
       auto &&new_for = std::make_unique<StructForStmt>(
           snode, std::move(stmt->body), stmt->vectorize, stmt->parallelize,
-          stmt->block_dim, stmt->thread_dim);
+          stmt->block_dim);
       new_for->index_offsets = offsets;
       VecStatement new_statements;
       for (int i = 0; i < (int)stmt->loop_var_id.size(); i++) {

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -61,7 +61,6 @@ class Offloader {
         } else {
           offloaded->block_dim = s->block_dim;
         }
-        offloaded->thread_dim = s->thread_dim;
         offloaded->body = std::make_unique<Block>();
         if (auto val = s->begin->cast<ConstStmt>()) {
           offloaded->const_begin = true;
@@ -159,7 +158,6 @@ class Offloader {
         offloaded_struct_for->block_dim = for_stmt->block_dim;
       }
     }
-    offloaded_struct_for->thread_dim = for_stmt->thread_dim;
 
     replace_all_usages_with(for_stmt, for_stmt, offloaded_struct_for.get());
 


### PR DESCRIPTION
This reverts commit 11abc8a4478d890707f925bc2ed3d427fee6b0e9.

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = revert #1676

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----