### PR TITLE
[test] [refactor] Replace global field ti.Matrix or ti.Matrix.var -> ti.Matrix.field in python tests

### DIFF
--- a/tests/python/test_classfunc.py
+++ b/tests/python/test_classfunc.py
@@ -6,7 +6,7 @@ def test_classfunc():
     @ti.data_oriented
     class Foo:
         def __init__(self):
-            self.val = ti.Matrix(n=3, m=3, dt=ti.f32, shape=3)
+            self.val = ti.Matrix.field(n=3, m=3, dtype=ti.f32, shape=3)
 
         @ti.func
         def add_mat(self, a, b):

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -47,7 +47,7 @@ def test_dynamic2():
 
 @ti_support_dynamic
 def test_dynamic_matrix():
-    x = ti.Matrix(2, 1, dt=ti.i32)
+    x = ti.Matrix.field(2, 1, dtype=ti.i32)
     n = 8192
 
     ti.root.dynamic(ti.i, n, chunk_size=128).place(x)

--- a/tests/python/test_element_wise.py
+++ b/tests/python/test_element_wise.py
@@ -12,13 +12,13 @@ def _c_mod(a, b):
                                                    (False, True)])
 @ti.all_archs_with(fast_math=False)
 def test_binary_f(lhs_is_mat, rhs_is_mat):
-    x = ti.Matrix(3, 2, ti.f32, 16)
+    x = ti.Matrix.field(3, 2, ti.f32, 16)
     if lhs_is_mat:
-        y = ti.Matrix(3, 2, ti.f32, ())
+        y = ti.Matrix.field(3, 2, ti.f32, ())
     else:
         y = ti.var(ti.f32, ())
     if rhs_is_mat:
-        z = ti.Matrix(3, 2, ti.f32, ())
+        z = ti.Matrix.field(3, 2, ti.f32, ())
     else:
         z = ti.var(ti.f32, ())
 
@@ -78,13 +78,13 @@ def test_binary_f(lhs_is_mat, rhs_is_mat):
 def test_binary_i(is_mat):
     lhs_is_mat, rhs_is_mat = is_mat
 
-    x = ti.Matrix(3, 2, ti.i32, 19)
+    x = ti.Matrix.field(3, 2, ti.i32, 19)
     if lhs_is_mat:
-        y = ti.Matrix(3, 2, ti.i32, ())
+        y = ti.Matrix.field(3, 2, ti.i32, ())
     else:
         y = ti.var(ti.i32, ())
     if rhs_is_mat:
-        z = ti.Matrix(3, 2, ti.i32, ())
+        z = ti.Matrix.field(3, 2, ti.i32, ())
     else:
         z = ti.var(ti.i32, ())
 
@@ -147,10 +147,10 @@ def test_binary_i(is_mat):
 @pytest.mark.parametrize('rhs_is_mat', [True, False])
 @ti.all_archs_with(fast_math=False)
 def test_writeback_binary_f(rhs_is_mat):
-    x = ti.Matrix(3, 2, ti.f32, 9)
-    y = ti.Matrix(3, 2, ti.f32, ())
+    x = ti.Matrix.field(3, 2, ti.f32, 9)
+    y = ti.Matrix.field(3, 2, ti.f32, ())
     if rhs_is_mat:
-        z = ti.Matrix(3, 2, ti.f32, ())
+        z = ti.Matrix.field(3, 2, ti.f32, ())
     else:
         z = ti.var(ti.f32, ())
 
@@ -194,10 +194,10 @@ def test_writeback_binary_f(rhs_is_mat):
 @pytest.mark.parametrize('rhs_is_mat', [(True, True), (True, False)])
 @ti.all_archs
 def test_writeback_binary_i(rhs_is_mat):
-    x = ti.Matrix(3, 2, ti.i32, 12)
-    y = ti.Matrix(3, 2, ti.i32, ())
+    x = ti.Matrix.field(3, 2, ti.i32, 12)
+    y = ti.Matrix.field(3, 2, ti.i32, ())
     if rhs_is_mat:
-        z = ti.Matrix(3, 2, ti.i32, ())
+        z = ti.Matrix.field(3, 2, ti.i32, ())
     else:
         z = ti.var(ti.i32, ())
 
@@ -241,10 +241,10 @@ def test_writeback_binary_i(rhs_is_mat):
 
 @ti.all_archs
 def test_unary():
-    xi = ti.Matrix(3, 2, ti.i32, 4)
-    yi = ti.Matrix(3, 2, ti.i32, ())
-    xf = ti.Matrix(3, 2, ti.f32, 14)
-    yf = ti.Matrix(3, 2, ti.f32, ())
+    xi = ti.Matrix.field(3, 2, ti.i32, 4)
+    yi = ti.Matrix.field(3, 2, ti.i32, ())
+    xf = ti.Matrix.field(3, 2, ti.f32, 14)
+    yf = ti.Matrix.field(3, 2, ti.f32, ())
 
     yi.from_numpy(np.array([[3, 2], [9, 0], [7, 4]], np.int32))
     yf.from_numpy(np.array([[0.3, 0.2], [0.9, 0.1], [0.7, 0.4]], np.float32))
@@ -300,17 +300,17 @@ def test_unary():
 @ti.all_archs
 def test_ternary_i(is_mat):
     cond_is_mat, lhs_is_mat, rhs_is_mat = is_mat
-    x = ti.Matrix(3, 2, ti.i32, 1)
+    x = ti.Matrix.field(3, 2, ti.i32, 1)
     if cond_is_mat:
-        y = ti.Matrix(3, 2, ti.i32, ())
+        y = ti.Matrix.field(3, 2, ti.i32, ())
     else:
         y = ti.var(ti.i32, ())
     if lhs_is_mat:
-        z = ti.Matrix(3, 2, ti.i32, ())
+        z = ti.Matrix.field(3, 2, ti.i32, ())
     else:
         z = ti.var(ti.i32, ())
     if rhs_is_mat:
-        w = ti.Matrix(3, 2, ti.i32, ())
+        w = ti.Matrix.field(3, 2, ti.i32, ())
     else:
         w = ti.var(ti.i32, ())
 

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -22,7 +22,7 @@ def test_fill_scalar():
 
 @ti.all_archs
 def test_fill_matrix_scalar():
-    val = ti.Matrix(2, 3, ti.i32)
+    val = ti.Matrix.field(2, 3, ti.i32)
 
     n = 4
     m = 7
@@ -46,7 +46,7 @@ def test_fill_matrix_scalar():
 
 @ti.all_archs
 def test_fill_matrix_matrix():
-    val = ti.Matrix(2, 3, ti.i32)
+    val = ti.Matrix.field(2, 3, ti.i32)
 
     n = 4
     m = 7

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -7,7 +7,7 @@ import math
 
 @ti.all_archs
 def test_const_init():
-    a = ti.Matrix(2, 3, dt=ti.i32, shape=())
+    a = ti.Matrix.field(2, 3, dtype=ti.i32, shape=())
     b = ti.Vector(3, dt=ti.i32, shape=())
 
     @ti.kernel
@@ -29,7 +29,7 @@ def test_const_init():
 def test_basic_utils():
     a = ti.Vector(3, dt=ti.f32)
     b = ti.Vector(2, dt=ti.f32)
-    abT = ti.Matrix(3, 2, dt=ti.f32)
+    abT = ti.Matrix.field(3, 2, dtype=ti.f32)
     aNormalized = ti.Vector(3, dt=ti.f32)
 
     normA = ti.field(ti.f32)
@@ -125,7 +125,7 @@ def test_dot():
 @ti.all_archs
 def test_transpose():
     dim = 3
-    m = ti.Matrix(dim, dim, ti.f32)
+    m = ti.Matrix.field(dim, dim, ti.f32)
 
     ti.root.place(m)
 
@@ -146,11 +146,11 @@ def test_transpose():
 
 
 def _test_polar_decomp(dim, dt):
-    m = ti.Matrix(dim, dim, dt)
-    r = ti.Matrix(dim, dim, dt)
-    s = ti.Matrix(dim, dim, dt)
-    I = ti.Matrix(dim, dim, dt)
-    D = ti.Matrix(dim, dim, dt)
+    m = ti.Matrix.field(dim, dim, dt)
+    r = ti.Matrix.field(dim, dim, dt)
+    s = ti.Matrix.field(dim, dim, dt)
+    I = ti.Matrix.field(dim, dim, dt)
+    D = ti.Matrix.field(dim, dim, dt)
 
     ti.root.place(m, r, s, I, D)
 
@@ -194,7 +194,7 @@ def test_polar_decomp():
 
 @ti.all_archs
 def test_matrix():
-    x = ti.Matrix(2, 2, dt=ti.i32)
+    x = ti.Matrix.field(2, 2, dtype=ti.i32)
 
     ti.root.dense(ti.i, 16).place(x)
 
@@ -218,7 +218,7 @@ def test_matrix():
 
 @ti.all_archs
 def _test_mat_inverse_size(n):
-    m = ti.Matrix(n, n, dt=ti.f32, shape=())
+    m = ti.Matrix.field(n, n, dtype=ti.f32, shape=())
     M = np.empty(shape=(n, n), dtype=np.float32)
     for i in range(n):
         for j in range(n):
@@ -245,8 +245,8 @@ def test_mat_inverse():
 @ti.all_archs
 def test_matrix_factories():
     a = ti.Vector.var(3, dt=ti.i32, shape=3)
-    b = ti.Matrix.var(2, 2, dt=ti.f32, shape=2)
-    c = ti.Matrix.var(2, 3, dt=ti.f32, shape=2)
+    b = ti.Matrix.field(2, 2, dtype=ti.f32, shape=2)
+    c = ti.Matrix.field(2, 3, dtype=ti.f32, shape=2)
 
     @ti.kernel
     def fill():
@@ -276,10 +276,10 @@ def test_matrix_factories():
 
 @ti.all_archs
 def test_init_matrix_from_vectors():
-    m1 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
-    m2 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
-    m3 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
-    m4 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
+    m1 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
+    m2 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
+    m3 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
+    m4 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
 
     @ti.kernel
     def fill():
@@ -308,10 +308,10 @@ def test_init_matrix_from_vectors():
 @pytest.mark.filterwarnings('ignore')
 @ti.host_arch_only
 def test_init_matrix_from_vectors_deprecated():
-    m1 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
-    m2 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
-    m3 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
-    m4 = ti.Matrix(3, 3, dt=ti.f32, shape=(3))
+    m1 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
+    m2 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
+    m3 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
+    m4 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=(3))
 
     @ti.kernel
     def fill():
@@ -348,7 +348,7 @@ def test_to_numpy_as_vector_deprecated():
 
 @ti.all_archs
 def test_any_all():
-    a = ti.Matrix(2, 2, dt=ti.i32, shape=())
+    a = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
     b = ti.field(dtype=ti.i32, shape=())
     c = ti.field(dtype=ti.i32, shape=())
 
@@ -378,7 +378,7 @@ def test_any_all():
 
 @ti.all_archs
 def test_min_max():
-    a = ti.Matrix(2, 2, dt=ti.i32, shape=())
+    a = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
     b = ti.field(dtype=ti.i32, shape=())
     c = ti.field(dtype=ti.i32, shape=())
 
@@ -403,7 +403,7 @@ def test_min_max():
 @ti.all_archs
 def test_matrix_list_assign():
 
-    m = ti.Matrix(2, 2, dt=ti.i32, shape=(2, 2, 1))
+    m = ti.Matrix.field(2, 2, dtype=ti.i32, shape=(2, 2, 1))
     v = ti.Vector(2, dt=ti.i32, shape=(2, 2, 1))
 
     m[1, 0, 0] = [[4, 3], [6, 7]]
@@ -449,7 +449,7 @@ def test_vector_xyzw_accessor():
 
 @ti.host_arch_only
 def test_diag():
-    m1 = ti.Matrix(3, 3, dt=ti.f32, shape=())
+    m1 = ti.Matrix.field(3, 3, dtype=ti.f32, shape=())
 
     @ti.kernel
     def fill():

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -57,8 +57,8 @@ def test_python_scope_vector_tensor(ops):
 @pytest.mark.parametrize('ops', vector_operation_types)
 @ti.host_arch_only
 def test_python_scope_matrix_tensor(ops):
-    t1 = ti.Matrix(2, 2, dt=ti.i32, shape=())
-    t2 = ti.Matrix(2, 2, dt=ti.i32, shape=())
+    t1 = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
+    t2 = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
     a, b = test_matrix_arrays[:2]
     # ndarray not supported here
     t1[None], t2[None] = a.tolist(), b.tolist()
@@ -143,8 +143,8 @@ def test_taichi_scope_vector_operations_with_global_vectors(ops):
 def test_taichi_scope_matrix_operations_with_global_matrices(ops):
     a, b, c = test_matrix_arrays[:3]
     m1, m2 = ti.Matrix(a), ti.Matrix(b)
-    r1 = ti.Matrix(2, 2, dt=ti.i32, shape=())
-    r2 = ti.Matrix(2, 2, dt=ti.i32, shape=())
+    r1 = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
+    r2 = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
     m3 = ti.Matrix(2, 2, dt=ti.i32, shape=())
     m3.from_numpy(c)
 
@@ -162,7 +162,7 @@ def test_taichi_scope_matrix_operations_with_global_matrices(ops):
 @ti.host_arch_only
 @ti.must_throw(ti.TaichiSyntaxError)
 def test_matrix_non_constant_index():
-    m = ti.Matrix(2, 2, ti.i32, 5)
+    m = ti.Matrix.field(2, 2, ti.i32, 5)
 
     @ti.kernel
     def func():
@@ -175,7 +175,7 @@ def test_matrix_non_constant_index():
 
 @ti.host_arch_only
 def test_matrix_constant_index():
-    m = ti.Matrix(2, 2, ti.i32, 5)
+    m = ti.Matrix.field(2, 2, ti.i32, 5)
 
     @ti.kernel
     def func():

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -145,7 +145,7 @@ def test_taichi_scope_matrix_operations_with_global_matrices(ops):
     m1, m2 = ti.Matrix(a), ti.Matrix(b)
     r1 = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
     r2 = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
-    m3 = ti.Matrix(2, 2, dt=ti.i32, shape=())
+    m3 = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())
     m3.from_numpy(c)
 
     @ti.kernel

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -19,7 +19,7 @@ def run_mpm88_test():
 
     x = ti.Vector(dim, dt=ti.f32, shape=n_particles)
     v = ti.Vector(dim, dt=ti.f32, shape=n_particles)
-    C = ti.Matrix(dim, dim, dt=ti.f32, shape=n_particles)
+    C = ti.Matrix.field(dim, dim, dtype=ti.f32, shape=n_particles)
     J = ti.field(dtype=ti.f32, shape=n_particles)
     grid_v = ti.Vector(dim, dt=ti.f32, shape=(n_grid, n_grid))
     grid_m = ti.field(dtype=ti.f32, shape=(n_grid, n_grid))

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -80,7 +80,7 @@ def test_static_grouped():
 
 @ti.all_archs
 def test_static_grouped_static():
-    x = ti.Matrix(2, 3, dt=ti.f32, shape=(16, 4))
+    x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=(16, 4))
 
     @ti.kernel
     def func():

--- a/tests/python/test_new_allocator.py
+++ b/tests/python/test_new_allocator.py
@@ -50,7 +50,7 @@ def test_3d():
 def test_matrix():
     N = 16
 
-    x = ti.Matrix(2, 2, dt=ti.f32, shape=(N, ), layout=ti.AOS)
+    x = ti.Matrix.field(2, 2, dtype=ti.f32, shape=(N, ), layout=ti.AOS)
 
     @ti.kernel
     def func():

--- a/tests/python/test_numpy_io.py
+++ b/tests/python/test_numpy_io.py
@@ -70,7 +70,7 @@ def test_f64():
 def test_matrix():
     n = 4
     m = 7
-    val = ti.Matrix(2, 3, ti.f32, shape=(n, m))
+    val = ti.Matrix.field(2, 3, ti.f32, shape=(n, m))
 
     nparr = np.empty(shape=(n, m, 2, 3), dtype=np.float32)
     for i in range(n):
@@ -92,7 +92,7 @@ def test_numpy_io_example():
     # Taichi tensors
     val = ti.field(ti.i32, shape=(n, m))
     vec = ti.Vector(3, dt=ti.i32, shape=(n, m))
-    mat = ti.Matrix(3, 4, dt=ti.i32, shape=(n, m))
+    mat = ti.Matrix.field(3, 4, dtype=ti.i32, shape=(n, m))
 
     # Scalar
     arr = np.ones(shape=(n, m), dtype=np.int32)

--- a/tests/python/test_offset.py
+++ b/tests/python/test_offset.py
@@ -94,7 +94,11 @@ def test_offset_for_vector():
 
 @ti.all_archs
 def test_offset_for_matrix():
-    a = ti.Matrix.field(3, 3, shape=(16, 16), offset=(-16, 16), dtype=ti.float32)
+    a = ti.Matrix.field(3,
+                        3,
+                        shape=(16, 16),
+                        offset=(-16, 16),
+                        dtype=ti.float32)
 
     @ti.kernel
     def test():

--- a/tests/python/test_offset.py
+++ b/tests/python/test_offset.py
@@ -94,7 +94,7 @@ def test_offset_for_vector():
 
 @ti.all_archs
 def test_offset_for_matrix():
-    a = ti.Matrix(3, 3, shape=(16, 16), offset=(-16, 16), dt=ti.float32)
+    a = ti.Matrix.field(3, 3, shape=(16, 16), offset=(-16, 16), dtype=ti.float32)
 
     @ti.kernel
     def test():
@@ -123,5 +123,5 @@ def test_offset_must_throw_vector():
 
 @ti.must_throw(AssertionError)
 def test_offset_must_throw_matrix():
-    c = ti.Matrix(3, 3, dt=ti.i32, shape=(32, 16, 8), offset=(32, 16))
-    d = ti.Matrix(3, 3, dt=ti.i32, shape=None, offset=(32, 16))
+    c = ti.Matrix.field(3, 3, dtype=ti.i32, shape=(32, 16, 8), offset=(32, 16))
+    d = ti.Matrix.field(3, 3, dtype=ti.i32, shape=None, offset=(32, 16))

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -45,7 +45,7 @@ def test_print_string():
 
 @ti.all_archs
 def test_print_matrix():
-    x = ti.Matrix(2, 3, dt=ti.f32, shape=())
+    x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=())
     y = ti.Vector(3, dt=ti.f32, shape=3)
 
     @ti.kernel

--- a/tests/python/test_ptr_assign.py
+++ b/tests/python/test_ptr_assign.py
@@ -20,7 +20,7 @@ def test_ptr_scalar():
 
 @ti.all_archs
 def test_ptr_matrix():
-    a = ti.Matrix(2, 2, dt=ti.f32, shape=())
+    a = ti.Matrix.field(2, 2, dtype=ti.f32, shape=())
 
     @ti.kernel
     def func(t: ti.f32):

--- a/tests/python/test_ssa.py
+++ b/tests/python/test_ssa.py
@@ -12,7 +12,7 @@ import math
 @ti.all_archs
 def test_matrix_self_assign():
     a = ti.Vector(2, ti.f32, ())
-    b = ti.Matrix(2, 2, ti.f32, ())
+    b = ti.Matrix.field(2, 2, ti.f32, ())
     c = ti.Vector(2, ti.f32, ())
 
     @ti.kernel

--- a/tests/python/test_static.py
+++ b/tests/python/test_static.py
@@ -40,7 +40,7 @@ def test_static_if_error():
 @ti.all_archs
 def test_static_ndrange():
     n = 3
-    x = ti.Matrix(n, n, dt=ti.f32, shape=(n, n))
+    x = ti.Matrix.field(n, n, dtype=ti.f32, shape=(n, n))
 
     @ti.kernel
     def fill():

--- a/tests/python/test_svd.py
+++ b/tests/python/test_svd.py
@@ -28,13 +28,13 @@ def _test_svd(dt, n):
     print(
         f'arch={ti.cfg.arch} default_fp={ti.cfg.default_fp} fast_math={ti.cfg.fast_math} dim={n}'
     )
-    A = ti.Matrix(n, n, dt=dt, shape=())
-    A_reconstructed = ti.Matrix(n, n, dt=dt, shape=())
-    U = ti.Matrix(n, n, dt=dt, shape=())
-    UtU = ti.Matrix(n, n, dt=dt, shape=())
-    sigma = ti.Matrix(n, n, dt=dt, shape=())
-    V = ti.Matrix(n, n, dt=dt, shape=())
-    VtV = ti.Matrix(n, n, dt=dt, shape=())
+    A = ti.Matrix.field(n, n, dtype=dt, shape=())
+    A_reconstructed = ti.Matrix.field(n, n, dtype=dt, shape=())
+    U = ti.Matrix.field(n, n, dtype=dt, shape=())
+    UtU = ti.Matrix.field(n, n, dtype=dt, shape=())
+    sigma = ti.Matrix.field(n, n, dtype=dt, shape=())
+    V = ti.Matrix.field(n, n, dtype=dt, shape=())
+    VtV = ti.Matrix.field(n, n, dtype=dt, shape=())
 
     @ti.kernel
     def run():
@@ -74,10 +74,10 @@ def test_svd():
 
 @ti.all_archs
 def test_transpose_no_loop():
-    A = ti.Matrix(3, 3, dt=ti.f32, shape=())
-    U = ti.Matrix(3, 3, dt=ti.f32, shape=())
-    sigma = ti.Matrix(3, 3, dt=ti.f32, shape=())
-    V = ti.Matrix(3, 3, dt=ti.f32, shape=())
+    A = ti.Matrix.field(3, 3, dtype=ti.f32, shape=())
+    U = ti.Matrix.field(3, 3, dtype=ti.f32, shape=())
+    sigma = ti.Matrix.field(3, 3, dtype=ti.f32, shape=())
+    V = ti.Matrix.field(3, 3, dtype=ti.f32, shape=())
 
     @ti.kernel
     def run():

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -67,7 +67,7 @@ def test_unordered():
 
 @ti.all_archs
 def test_unordered_matrix():
-    val = ti.Matrix(3, 2, ti.i32)
+    val = ti.Matrix.field(3, 2, ti.i32)
 
     n = 3
     m = 7
@@ -92,7 +92,7 @@ def test_unordered_matrix():
 @ti.host_arch_only
 def test_deprecated():
     val = ti.field(ti.f32)
-    mat = ti.Matrix(3, 2, ti.i32)
+    mat = ti.Matrix.field(3, 2, ti.i32)
 
     n = 3
     m = 7

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -135,7 +135,7 @@ def test_io_simple():
     x1 = ti.field(ti.f32, shape=(n, n))
     t1 = torch.tensor(2 * np.ones((n, n), dtype=np.float32))
 
-    x2 = ti.Matrix(2, 3, ti.f32, shape=(n, n))
+    x2 = ti.Matrix.field(2, 3, ti.f32, shape=(n, n))
     t2 = torch.tensor(2 * np.ones((n, n, 2, 3), dtype=np.float32))
 
     x1.from_torch(t1)
@@ -156,7 +156,7 @@ def test_io_simple():
 
 @ti.torch_test
 def test_io_simple():
-    mat = ti.Matrix(2, 6, dt=ti.f32, shape=(), needs_grad=True)
+    mat = ti.Matrix.field(2, 6, dt=ti.f32, shape=(), needs_grad=True)
     zeros = torch.zeros((2, 6))
     zeros[1, 2] = 3
     mat.from_torch(zeros + 1)
@@ -170,7 +170,7 @@ def test_io_simple():
 @ti.torch_test
 def test_fused_kernels():
     n = 12
-    X = ti.Matrix(3, 2, ti.f32, shape=(n, n, n))
+    X = ti.Matrix.field(3, 2, ti.f32, shape=(n, n, n))
     s = ti.get_runtime().get_num_compiled_functions()
     t = X.to_torch()
     assert ti.get_runtime().get_num_compiled_functions() == s + 1
@@ -181,7 +181,7 @@ def test_fused_kernels():
 @ti.torch_test
 def test_device():
     n = 12
-    X = ti.Matrix(3, 2, ti.f32, shape=(n, n, n))
+    X = ti.Matrix.field(3, 2, ti.f32, shape=(n, n, n))
     assert X.to_torch(device='cpu').device == torch.device('cpu')
 
     if torch.cuda.is_available():
@@ -191,7 +191,7 @@ def test_device():
 @ti.torch_test
 def test_shape_matrix():
     n = 12
-    x = ti.Matrix(3, 2, ti.f32, shape=(n, n))
+    x = ti.Matrix.field(3, 2, ti.f32, shape=(n, n))
     X = x.to_torch()
     for i in range(n):
         for j in range(n):


### PR DESCRIPTION
Related issue = #1500

In this PR, all global fields `ti.Matrix` or possible `ti.Matrix.var` is replaced to `ti.Matrix.field` in `tests/python/*`. Local-allocated `ti.Matrix` are kept the same as before.

# Test script
```
import os
import re
from multiprocessing import Pool


def work_on_test(name):
    cmd = f"pytest {name} 1>/tmp/{name}.log 2>/tmp/{name}.err"
    print(f"[log] begin to test {name}")
    ret = os.system(cmd)
    if ret != 0:
        print(f"[error] error when testing {name}, return {ret}")
    else:
        print(f"[log] testing {name} succ")


if __name__ == '__main__':
    all_files = os.listdir(".")
    # pattern = "^test_[r-z].*py$"
    # # pattern = "^test_[a-g].*py$"
    # target_files = [name for name in all_files if re.search(
    #     pattern, name) is not None]
    target_files = os.popen(
        "git diff --name-only master| awk -F \"/\" '{print $3}' ").read().strip().split("\n")
    pool = Pool()
    pool.map(work_on_test, target_files)
```

# Verify result
```
[log] begin to test test_static.py
[log] testing test_static.py succ
[log] begin to test test_new_allocator.py
[log] testing test_new_allocator.py succ
[log] begin to test test_torch_io.py
[log] testing test_torch_io.py succ
[log] begin to test test_fill.py
[log] testing test_fill.py succ
[log] begin to test test_matrix.py
[log] testing test_matrix.py succ
[log] begin to test test_ssa.py
[log] testing test_ssa.py succ
[log] begin to test test_classfunc.py
[log] testing test_classfunc.py succ
[log] begin to test test_tensor_reflection.py
[log] testing test_tensor_reflection.py succ
[log] begin to test test_offset.py
[log] testing test_offset.py succ
[log] begin to test test_numpy_io.py
[log] testing test_numpy_io.py succ
[log] begin to test test_ptr_assign.py
[log] testing test_ptr_assign.py succ
[log] begin to test test_print.py
[log] testing test_print.py succ
[log] begin to test test_dynamic.py
[log] testing test_dynamic.py succ
[log] begin to test test_ndrange.py
[log] testing test_ndrange.py succ
[log] begin to test test_mpm88.py
[log] testing test_mpm88.py succ
[log] begin to test test_svd.py
[log] testing test_svd.py succ
[log] begin to test test_linalg.py
[log] testing test_linalg.py succ
[log] begin to test test_element_wise.py
[log] testing test_element_wise.py succ
```
[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
