### PR TITLE
[mac] Add NSAutoreleasePool to manage obj-c objects' lifetime

### DIFF
--- a/taichi/backends/metal/api.cpp
+++ b/taichi/backends/metal/api.cpp
@@ -21,6 +21,7 @@ using mac::cast_call;
 using mac::clscall;
 using mac::nsobj_unique_ptr;
 using mac::wrap_as_nsobj_unique_ptr;
+using mac::retain_and_wrap_as_nsobj_unique_ptr;
 
 }  // namespace
 
@@ -45,21 +46,21 @@ nsobj_unique_ptr<MTLCommandQueue> new_command_queue(MTLDevice *dev) {
 
 nsobj_unique_ptr<MTLCommandBuffer> new_command_buffer(MTLCommandQueue *queue) {
   auto *buffer = cast_call<MTLCommandBuffer *>(queue, "commandBuffer");
-  return wrap_as_nsobj_unique_ptr(buffer);
+  return retain_and_wrap_as_nsobj_unique_ptr(buffer);
 }
 
 nsobj_unique_ptr<MTLComputeCommandEncoder> new_compute_command_encoder(
     MTLCommandBuffer *buffer) {
   auto *encoder =
       cast_call<MTLComputeCommandEncoder *>(buffer, "computeCommandEncoder");
-  return wrap_as_nsobj_unique_ptr(encoder);
+  return retain_and_wrap_as_nsobj_unique_ptr(encoder);
 }
 
 nsobj_unique_ptr<MTLBlitCommandEncoder> new_blit_command_encoder(
     MTLCommandBuffer *buffer) {
   auto *encoder =
       cast_call<MTLBlitCommandEncoder *>(buffer, "blitCommandEncoder");
-  return wrap_as_nsobj_unique_ptr(encoder);
+  return retain_and_wrap_as_nsobj_unique_ptr(encoder);
 }
 
 nsobj_unique_ptr<MTLLibrary> new_library_with_source(MTLDevice *device,

--- a/taichi/backends/metal/api.cpp
+++ b/taichi/backends/metal/api.cpp
@@ -20,8 +20,8 @@ using mac::call;
 using mac::cast_call;
 using mac::clscall;
 using mac::nsobj_unique_ptr;
-using mac::wrap_as_nsobj_unique_ptr;
 using mac::retain_and_wrap_as_nsobj_unique_ptr;
+using mac::wrap_as_nsobj_unique_ptr;
 
 }  // namespace
 

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -606,6 +606,7 @@ class KernelManager::Impl {
 
   void launch_taichi_kernel(const std::string &taichi_kernel_name,
                             Context *ctx) {
+    mac::ScopedAutoreleasePool pool;
     auto &ctk = *compiled_taichi_kernels_.find(taichi_kernel_name)->second;
     auto ctx_blitter =
         HostMetalCtxBlitter::maybe_make(ctk, ctx, taichi_kernel_name);
@@ -651,6 +652,7 @@ class KernelManager::Impl {
   }
 
   void synchronize() {
+    mac::ScopedAutoreleasePool pool;
     blit_buffers_and_sync();
   }
 

--- a/taichi/platform/mac/objc_api.cpp
+++ b/taichi/platform/mac/objc_api.cpp
@@ -29,6 +29,25 @@ void ns_log_object(id obj) {
   NSLog(reinterpret_cast<id>(ns_str.get()), obj);
 }
 
+TI_NSAutoreleasePool *create_autorelease_pool() {
+  return cast_call<TI_NSAutoreleasePool *>(
+      clscall("NSAutoreleasePool", "alloc"), "init");
+}
+
+void drain_autorelease_pool(TI_NSAutoreleasePool *pool) {
+  // "drain" is same as "release", so we don't need to release |pool| itself.
+  // https://developer.apple.com/documentation/foundation/nsautoreleasepool
+  call(pool, "drain");
+}
+
+ScopedAutoreleasePool::ScopedAutoreleasePool() {
+  pool_ = create_autorelease_pool();
+}
+
+ScopedAutoreleasePool::~ScopedAutoreleasePool() {
+  drain_autorelease_pool(pool_);
+}
+
 }  // namespace mac
 }  // namespace taichi
 

--- a/taichi/platform/mac/objc_api.h
+++ b/taichi/platform/mac/objc_api.h
@@ -69,7 +69,8 @@ nsobj_unique_ptr<O> retain_and_wrap_as_nsobj_unique_ptr(O *nsobj) {
   // 2. autoreleasepool releases all the tracked objects upon thread exit.
   //
   // * https://stackoverflow.com/a/51080781/12003165
-  // * https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-SW1
+  // *
+  // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-SW1
   call(nsobj, "retain");
   return wrap_as_nsobj_unique_ptr(nsobj);
 }
@@ -96,9 +97,9 @@ void ns_log_object(id obj);
 
 struct TI_NSAutoreleasePool;
 
-TI_NSAutoreleasePool* create_autorelease_pool();
+TI_NSAutoreleasePool *create_autorelease_pool();
 
-void drain_autorelease_pool(TI_NSAutoreleasePool* pool);
+void drain_autorelease_pool(TI_NSAutoreleasePool *pool);
 
 class ScopedAutoreleasePool {
  public:

--- a/taichi/platform/mac/objc_api.h
+++ b/taichi/platform/mac/objc_api.h
@@ -50,6 +50,30 @@ nsobj_unique_ptr<O> wrap_as_nsobj_unique_ptr(O *nsobj) {
   return nsobj_unique_ptr<O>(nsobj);
 }
 
+template <typename O>
+nsobj_unique_ptr<O> retain_and_wrap_as_nsobj_unique_ptr(O *nsobj) {
+  // On creating an object, it could be either the caller or the callee's
+  // responsibility to take the ownership of the object. By convention, method
+  // names with "alloc", "new", "create" imply that the caller owns the object.
+  // Otherwise, the object is tracked by an autoreleasepool before the callee
+  // returns it.
+  //
+  // For an object that is owned by the callee (released by autoreleasepool), if
+  // we want to *own* a reference to it, we must call [retain] to increment the
+  // reference counting.
+  //
+  // In pratice, we find that each pthread (non main-thread) creates its own
+  // autoreleasepool. Without retaining the object, it has caused double-free
+  // on thread exit:
+  // 1. nsobj_unique_ptr calls [release] in its destructor.
+  // 2. autoreleasepool releases all the tracked objects upon thread exit.
+  //
+  // * https://stackoverflow.com/a/51080781/12003165
+  // * https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-SW1
+  call(nsobj, "retain");
+  return wrap_as_nsobj_unique_ptr(nsobj);
+}
+
 // Prepend "TI_" to native ObjC type names, otherwise clang-format thinks this
 // is an ObjC file and is not happy formatting it.
 struct TI_NSString;
@@ -69,6 +93,21 @@ R ns_array_object_at_index(TI_NSArray *na, int i) {
 }
 
 void ns_log_object(id obj);
+
+struct TI_NSAutoreleasePool;
+
+TI_NSAutoreleasePool* create_autorelease_pool();
+
+void drain_autorelease_pool(TI_NSAutoreleasePool* pool);
+
+class ScopedAutoreleasePool {
+ public:
+  ScopedAutoreleasePool();
+  ~ScopedAutoreleasePool();
+
+ private:
+  TI_NSAutoreleasePool *pool_;
+};
 
 }  // namespace mac
 }  // namespace taichi


### PR DESCRIPTION
When I worked on supporting async for Metal, it has turned out that each pthread has its own `autoreleasepool`. This has caused double-free upon thread exit (we call `[obj release]` via `~nsobj_unique_ptr()`, and the pool releases it twice). So we need to retain the objects created from the obj-c runtime. However, we only need to retain the objects that are created *without `alloc`, `new` in its creation method name*. From what I understand:

1. If you create the obj-c object like `[[Foo alloc] init]`, this is like `malloc` a raw-pointer, and the caller owns this object. In this case, we do **not** need to call an additional `retain`.
2. Otherwise, if you create the object like `bar = [foo getBar]`, then before `getBar` returns, the returned object is registered into an `autoreleasepool`, so that the caller won't take the ownership. This is analogous to a shared_ptr. We have to use `retain` to increment its reference count, so that when the autorelease pool runs, it doesn't over-release.

The convention of who has the owner ship is in the method naming, i.e. whether it has words like `alloc`, `new`, `create`... See https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-SW1.

For `MTLCommandBuffer`, `MTLComputeCommandEncoder` and `MTLBlitCommandEncoder`, since their creation methods fall into the second case, we have to `retain` them.

---

Not sure why this wasn't a problem all this time. Maybe the default NSApp's autoreleasepool is not drained until the process exists, so we are too late to catch that overrelease..?

I confirmed that the memory usage stayed stable in both default & async mode.

#Issue=N/A
