### PR TITLE
[refactor] Fix missed ti.var -> ti.field refactors in codebase

### DIFF
--- a/docs/differentiable_programming.rst
+++ b/docs/differentiable_programming.rst
@@ -13,8 +13,8 @@ For example, you have the following kernel:
 
 .. code-block:: python
 
-    x = ti.var(ti.f32, ())
-    y = ti.var(ti.f32, ())
+    x = ti.field(float, ())
+    y = ti.field(float, ())
 
     @ti.kernel
     def compute_y():
@@ -26,9 +26,9 @@ You may want to implement the derivative kernel by yourself:
 
 .. code-block:: python
 
-    x = ti.var(ti.f32, ())
-    y = ti.var(ti.f32, ())
-    dy_dx = ti.var(ti.f32, ())
+    x = ti.field(float, ())
+    y = ti.field(float, ())
+    dy_dx = ti.field(float, ())
 
     @ti.kernel
     def compute_dy_dx():
@@ -57,8 +57,8 @@ What's the most convienent way to obtain a kernel that computes x to dy/dx?
 
 .. code-block:: python
 
-    x = ti.var(ti.f32, (), needs_grad=True)
-    y = ti.var(ti.f32, (), needs_grad=True)
+    x = ti.field(float, (), needs_grad=True)
+    y = ti.field(float, (), needs_grad=True)
 
     @ti.kernel
     def compute_y():
@@ -75,9 +75,9 @@ It's equivalant to:
 
 .. code-block:: python
 
-    x = ti.var(ti.f32, ())
-    y = ti.var(ti.f32, ())
-    dy_dx = ti.var(ti.f32, ())
+    x = ti.field(float, ())
+    y = ti.field(float, ())
+    dy_dx = ti.field(float, ())
 
     @ti.kernel
     def compute_dy_dx():
@@ -111,9 +111,9 @@ Take `examples/ad_gravity.py <https://github.com/taichi-dev/taichi/blob/master/e
     N = 8
     dt = 1e-5
 
-    x = ti.Vector.var(2, ti.f32, N, needs_grad=True)  # position of particles
-    v = ti.Vector.var(2, ti.f32, N)                   # velocity of particles
-    U = ti.var(ti.f32, (), needs_grad=True)           # potential energy
+    x = ti.Vector.field(2, float, N, needs_grad=True)  # position of particles
+    v = ti.Vector.field(2, float, N)  # velocity of particles
+    U = ti.field(float, (), needs_grad=True)  # potential energy
 
 
     @ti.kernel
@@ -130,7 +130,7 @@ Take `examples/ad_gravity.py <https://github.com/taichi-dev/taichi/blob/master/e
         for i in x:
             v[i] += dt * -x.grad[i]  # dv/dt = -dU/dx
         for i in x:
-            x[i] += dt * v[i]        # dx/dt = v
+            x[i] += dt * v[i]  # dx/dt = v
 
 
     def substep():
@@ -138,7 +138,7 @@ Take `examples/ad_gravity.py <https://github.com/taichi-dev/taichi/blob/master/e
             # every kernel invocation within this indent scope
             # will also be accounted into the partial derivate of U
             # with corresponding input variables like x.
-            compute_U()   # will also computes dU/dx and save in x.grad
+            compute_U()  # will also computes dU/dx and save in x.grad
         advance()
 
 

--- a/docs/offset.rst
+++ b/docs/offset.rst
@@ -8,7 +8,7 @@ Coordinate offsets
 
 .. code-block:: python
 
-    a = ti.Matrix(2, 2, dtype=ti.f32, shape=(32, 64), offset=(-16, 8))
+    a = ti.Matrix.field(2, 2, dtype=ti.f32, shape=(32, 64), offset=(-16, 8))
 
 In this way, the field's indices are from ``(-16, 8)`` to ``(16, 72)`` (exclusive).
 

--- a/docs/type.rst
+++ b/docs/type.rst
@@ -114,11 +114,11 @@ for default precisions, e.g.:
 
     ti.init(default_ip=ti.i64, default_fp=ti.f32)
 
-    x = ti.var(float, 5)
-    y = ti.var(int, 5)
+    x = ti.field(float, 5)
+    y = ti.field(int, 5)
     # is equivalent to:
-    x = ti.var(ti.f32, 5)
-    y = ti.var(ti.i64, 5)
+    x = ti.field(ti.f32, 5)
+    y = ti.field(ti.i64, 5)
 
     def func(a: float) -> int:
         ...

--- a/docs/write_test.rst
+++ b/docs/write_test.rst
@@ -35,7 +35,7 @@ Hint: You may pass/return values to/from Taichi-scope using 0-D fields, i.e. ``r
     def test_log10():
         ti.init(arch=ti.cpu)
 
-        r = ti.var(ti.f32, ())
+        r = ti.field(ti.f32, ())
 
         @ti.kernel
         def foo():
@@ -61,7 +61,7 @@ we provide a useful decorator ``@ti.test``:
     # will test against both CPU and CUDA backends
     @ti.test(ti.cpu, ti.cuda)
     def test_log10():
-        r = ti.var(ti.f32, ())
+        r = ti.field(ti.f32, ())
 
         @ti.kernel
         def foo():
@@ -80,7 +80,7 @@ And you may test against **all backends** by simply not specifying the argument:
     # will test against all backends available on your end
     @ti.test()
     def test_log10():
-        r = ti.var(ti.f32, ())
+        r = ti.field(ti.f32, ())
 
         @ti.kernel
         def foo():
@@ -108,7 +108,7 @@ backends, for example ``2.001 == ti.approx(2)`` will return ``True`` on the Open
     # will test against all backends available on your end
     @ti.test()
     def test_log10():
-        r = ti.var(ti.f32, ())
+        r = ti.field(ti.f32, ())
 
         @ti.kernel
         def foo():
@@ -144,7 +144,7 @@ We may test against different input values using the ``@pytest.mark.parametrize`
     @pytest.mark.parametrize('x', [1, 10, 100])
     @ti.test()
     def test_log10(x):
-        r = ti.var(ti.f32, ())
+        r = ti.field(ti.f32, ())
 
         @ti.kernel
         def foo():
@@ -165,8 +165,8 @@ Use a comma-separated list for multiple input values:
     @pytest.mark.parametrize('x,y', [(1, 2), (1, 3), (2, 1)])
     @ti.test()
     def test_atan2(x, y):
-        r = ti.var(ti.f32, ())
-        s = ti.var(ti.f32, ())
+        r = ti.field(ti.f32, ())
+        s = ti.field(ti.f32, ())
 
         @ti.kernel
         def foo():
@@ -190,8 +190,8 @@ Use two separate ``parametrize`` to test **all combinations** of input arguments
     # same as:  .parametrize('x,y', [(1, 1), (1, 2), (2, 1), (2, 2)])
     @ti.test()
     def test_atan2(x, y):
-        r = ti.var(ti.f32, ())
-        s = ti.var(ti.f32, ())
+        r = ti.field(ti.f32, ())
+        s = ti.field(ti.f32, ())
 
         @ti.kernel
         def foo():

--- a/examples/ad_gravity.py
+++ b/examples/ad_gravity.py
@@ -1,5 +1,4 @@
 import taichi as ti
-ti.init()
 
 N = 8
 dt = 1e-5

--- a/examples/odop_solar.py
+++ b/examples/odop_solar.py
@@ -1,5 +1,6 @@
 import taichi as ti
 import math
+ti.init()
 
 
 @ti.data_oriented
@@ -8,9 +9,9 @@ class SolarSystem:
         # initializer of the solar system simulator
         self.n = n
         self.dt = dt
-        self.x = ti.Vector(2, dt=ti.f32, shape=n)
-        self.v = ti.Vector(2, dt=ti.f32, shape=n)
-        self.center = ti.Vector(2, dt=ti.f32, shape=())
+        self.x = ti.Vector.field(2, dtype=float, shape=n)
+        self.v = ti.Vector.field(2, dtype=float, shape=n)
+        self.center = ti.Vector.field(2, dtype=float, shape=())
 
     @staticmethod
     @ti.func

--- a/examples/simple_uv.py
+++ b/examples/simple_uv.py
@@ -3,8 +3,8 @@ import numpy as np
 
 ti.init()
 
-res = 1280, 720
-pixels = ti.Vector(3, dt=ti.f32, shape=res)
+res = (512, 512)
+pixels = ti.Vector.field(3, dtype=float, shape=res)
 
 
 @ti.kernel

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -106,8 +106,8 @@ class Matrix(TaichiOperations):
                 f'Taichi matrices/vectors with {self.n}x{self.m} > 32 entries are not suggested.'
                 ' Matrices/vectors will be automatically unrolled at compile-time for performance.'
                 ' So the compilation time could be extremely long if the matrix size is too big.'
-                ' You may use a tensor to store a large matrix like this, e.g.:\n'
-                f'    x = ti.var(ti.f32, ({self.n}, {self.m})).\n'
+                ' You may use a field to store a large matrix like this, e.g.:\n'
+                f'    x = ti.field(ti.f32, ({self.n}, {self.m})).\n'
                 ' See https://taichi.readthedocs.io/en/stable/tensor_matrix.html#matrix-size'
                 ' for more details.',
                 UserWarning,

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -27,8 +27,8 @@ def grad_test(tifunc, npfunc=None, default_fp=ti.f32):
     @ti.all_archs_with(default_fp=default_fp)
     def impl():
         print(f'arch={ti.cfg.arch} default_fp={ti.cfg.default_fp}')
-        x = ti.var(default_fp)
-        y = ti.var(default_fp)
+        x = ti.field(default_fp)
+        y = ti.field(default_fp)
 
         ti.root.dense(ti.i, 1).place(x, x.grad, y, y.grad)
 
@@ -53,7 +53,7 @@ def grad_test(tifunc, npfunc=None, default_fp=ti.f32):
 @if_has_autograd
 @ti.all_archs
 def test_size1():
-    x = ti.var(ti.i32)
+    x = ti.field(ti.i32)
 
     ti.root.dense(ti.i, 1).place(x)
 
@@ -113,8 +113,8 @@ def test_minmax():
 @if_has_autograd
 @ti.all_archs
 def test_mod():
-    x = ti.var(ti.i32)
-    y = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    y = ti.field(ti.i32)
 
     ti.root.dense(ti.i, 1).place(x, y)
     ti.root.lazy_grad()
@@ -164,8 +164,8 @@ def test_pow_f64():
 
 @ti.all_archs
 def test_obey_kernel_simplicity():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x, y)
     ti.root.lazy_grad()
@@ -189,8 +189,8 @@ def test_obey_kernel_simplicity():
 
 @ti.all_archs
 def test_violate_kernel_simplicity1():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x, y)
     ti.root.lazy_grad()
@@ -208,8 +208,8 @@ def test_violate_kernel_simplicity1():
 
 @ti.all_archs
 def test_violate_kernel_simplicity2():
-    x = ti.var(ti.f32)
-    y = ti.var(ti.f32)
+    x = ti.field(ti.f32)
+    y = ti.field(ti.f32)
 
     ti.root.dense(ti.i, 1).place(x, y)
     ti.root.lazy_grad()
@@ -238,8 +238,8 @@ def test_cast():
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_ad_precision_1():
-    loss = ti.var(ti.f32, shape=())
-    x = ti.var(ti.f64, shape=())
+    loss = ti.field(ti.f32, shape=())
+    x = ti.field(ti.f64, shape=())
 
     ti.root.lazy_grad()
 
@@ -256,8 +256,8 @@ def test_ad_precision_1():
 @ti.require(ti.extension.data64)
 @ti.all_archs
 def test_ad_precision_2():
-    loss = ti.var(ti.f64, shape=())
-    x = ti.var(ti.f32, shape=())
+    loss = ti.field(ti.f64, shape=())
+    x = ti.field(ti.f32, shape=())
 
     ti.root.lazy_grad()
 

--- a/tests/python/test_bitmasked.py
+++ b/tests/python/test_bitmasked.py
@@ -7,9 +7,9 @@ def archs_support_bitmasked(func):
 
 @archs_support_bitmasked
 def test_basic():
-    x = ti.var(ti.i32)
-    c = ti.var(ti.i32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    c = ti.field(ti.i32)
+    s = ti.field(ti.i32)
 
     bm = ti.root.bitmasked(ti.ij, (3, 6)).bitmasked(ti.i, 5)
     bm.place(x)
@@ -36,8 +36,8 @@ def test_basic():
 
 @archs_support_bitmasked
 def test_bitmasked_then_dense():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 128
 
@@ -60,8 +60,8 @@ def test_bitmasked_then_dense():
 
 @archs_support_bitmasked
 def test_bitmasked_bitmasked():
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 128
 
@@ -85,8 +85,8 @@ def test_bitmasked_bitmasked():
 @archs_support_bitmasked
 def test_huge_bitmasked():
     # Mainly for testing Metal listgen's grid-stride loop implementation.
-    x = ti.var(ti.f32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.f32)
+    s = ti.field(ti.i32)
 
     n = 1024
 
@@ -115,8 +115,8 @@ def test_bitmasked_listgen_bounded():
     # elements possible for that SNode. Note that 1) SNode's size is padded
     # to POT, and 2) Metal ListManager's data size is not padded, we need to
     # make sure listgen doesn't go beyond ListManager's capacity.
-    x = ti.var(ti.i32)
-    c = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    c = ti.field(ti.i32)
 
     # A prime that is bit higher than 65536, which is Metal's maximum number of
     # threads for listgen.
@@ -143,11 +143,11 @@ def test_bitmasked_listgen_bounded():
 @archs_support_bitmasked
 def test_deactivate():
     # https://github.com/taichi-dev/taichi/issues/778
-    a = ti.var(ti.i32)
+    a = ti.field(ti.i32)
     a_a = ti.root.bitmasked(ti.i, 4)
     a_b = a_a.dense(ti.i, 4)
     a_b.place(a)
-    c = ti.var(ti.i32)
+    c = ti.field(ti.i32)
     ti.root.place(c)
 
     @ti.kernel
@@ -173,9 +173,9 @@ def test_deactivate():
 
 @archs_support_bitmasked
 def test_sparsity_changes():
-    x = ti.var(ti.i32)
-    c = ti.var(ti.i32)
-    s = ti.var(ti.i32)
+    x = ti.field(ti.i32)
+    c = ti.field(ti.i32)
+    s = ti.field(ti.i32)
 
     bm = ti.root.bitmasked(ti.i, 5).bitmasked(ti.i, 3)
     bm.place(x)
@@ -207,13 +207,13 @@ def test_sparsity_changes():
 
 @archs_support_bitmasked
 def test_bitmasked_offset_child():
-    x = ti.var(ti.i32)
-    x2 = ti.var(ti.i32)
-    y = ti.var(ti.i32)
-    y2 = ti.var(ti.i32)
-    y3 = ti.var(ti.i32)
-    z = ti.var(ti.i32)
-    s = ti.var(ti.i32, shape=())
+    x = ti.field(ti.i32)
+    x2 = ti.field(ti.i32)
+    y = ti.field(ti.i32)
+    y2 = ti.field(ti.i32)
+    y3 = ti.field(ti.i32)
+    z = ti.field(ti.i32)
+    s = ti.field(ti.i32, shape=())
 
     n = 16
     # Offset children:

--- a/tests/python/test_element_wise.py
+++ b/tests/python/test_element_wise.py
@@ -16,11 +16,11 @@ def test_binary_f(lhs_is_mat, rhs_is_mat):
     if lhs_is_mat:
         y = ti.Matrix.field(3, 2, ti.f32, ())
     else:
-        y = ti.var(ti.f32, ())
+        y = ti.field(ti.f32, ())
     if rhs_is_mat:
         z = ti.Matrix.field(3, 2, ti.f32, ())
     else:
-        z = ti.var(ti.f32, ())
+        z = ti.field(ti.f32, ())
 
     if lhs_is_mat:
         y.from_numpy(np.array([[0, 2], [9, 3], [7, 4]], np.float32))
@@ -82,11 +82,11 @@ def test_binary_i(is_mat):
     if lhs_is_mat:
         y = ti.Matrix.field(3, 2, ti.i32, ())
     else:
-        y = ti.var(ti.i32, ())
+        y = ti.field(ti.i32, ())
     if rhs_is_mat:
         z = ti.Matrix.field(3, 2, ti.i32, ())
     else:
-        z = ti.var(ti.i32, ())
+        z = ti.field(ti.i32, ())
 
     if lhs_is_mat:
         y.from_numpy(np.array([[0, 2], [9, 3], [7, 4]], np.int32))
@@ -152,7 +152,7 @@ def test_writeback_binary_f(rhs_is_mat):
     if rhs_is_mat:
         z = ti.Matrix.field(3, 2, ti.f32, ())
     else:
-        z = ti.var(ti.f32, ())
+        z = ti.field(ti.f32, ())
 
     y.from_numpy(np.array([[0, 2], [9, 3], [7, 4]], np.float32))
     if rhs_is_mat:
@@ -199,7 +199,7 @@ def test_writeback_binary_i(rhs_is_mat):
     if rhs_is_mat:
         z = ti.Matrix.field(3, 2, ti.i32, ())
     else:
-        z = ti.var(ti.i32, ())
+        z = ti.field(ti.i32, ())
 
     y.from_numpy(np.array([[0, 2], [9, 3], [7, 4]], np.int32))
     if rhs_is_mat:
@@ -304,15 +304,15 @@ def test_ternary_i(is_mat):
     if cond_is_mat:
         y = ti.Matrix.field(3, 2, ti.i32, ())
     else:
-        y = ti.var(ti.i32, ())
+        y = ti.field(ti.i32, ())
     if lhs_is_mat:
         z = ti.Matrix.field(3, 2, ti.i32, ())
     else:
-        z = ti.var(ti.i32, ())
+        z = ti.field(ti.i32, ())
     if rhs_is_mat:
         w = ti.Matrix.field(3, 2, ti.i32, ())
     else:
-        w = ti.var(ti.i32, ())
+        w = ti.field(ti.i32, ())
 
     if cond_is_mat:
         y.from_numpy(np.array([[0, 2], [9, 0], [7, 4]], np.int32))


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1500

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Now `clear;grep -r ti\\.\\\(Matrix\\\|Vector\\\)\(\[0-9\];grep -r ti.\*\\.var\\\>`:
```
examples/tree_gravity.py:    display_image = ti.Vector(3, ti.f32, (kResolution, kResolution))
examples/export_ply.py:pos = ti.Vector(3, dt=ti.f32, shape=(10, 10, 10))
examples/export_ply.py:rgba = ti.Vector(4, dt=ti.f32, shape=(10, 10, 10))
examples/pbf2d.py:board_states = ti.Vector(2, dt=ti.f32)
examples/euler.py:Q = ti.Vector(4, dt=real,
examples/euler.py:Q_old = ti.Vector(4, dt=real, shape=(N, N))
examples/euler.py:W = ti.Vector(4, dt=real, shape=(N, N))  # [rho, u, v, p] cell avg
examples/euler.py:W_xl = ti.Vector(4, dt=real, shape=(N, N, 3))  # left side of x-face
examples/euler.py:W_xr = ti.Vector(4, dt=real, shape=(N, N, 3))  # right side of x-face
examples/euler.py:W_yl = ti.Vector(4, dt=real, shape=(N, N, 3))  # left side of y-face
examples/euler.py:W_yr = ti.Vector(4, dt=real, shape=(N, N, 3))  # right side of y-face
examples/euler.py:F_x = ti.Vector(4, dt=real, shape=(N, N))  # x-face flux
examples/euler.py:F_y = ti.Vector(4, dt=real, shape=(N, N))  # y-face flux
examples/sdf_renderer.py:color_buffer = ti.Vector(3, dt=ti.f32, shape=res)
examples/cornell_box.py:color_buffer = ti.Vector(3, dt=ti.f32, shape=res)
examples/sdf2d.py:light_pos = ti.Vector(2, dt=ti.f32, shape=())
examples/particle_renderer.py:color_buffer = ti.Vector(3, dt=ti.f32)
examples/particle_renderer.py:bbox = ti.Vector(3, dt=ti.f32, shape=2)
examples/particle_renderer.py:particle_x = ti.Vector(3, dt=ti.f32)
examples/particle_renderer.py:particle_v = ti.Vector(3, dt=ti.f32)
examples/particle_renderer.py:particle_color = ti.Vector(3, dt=ti.f32)
examples/quadtree.py:img = ti.Vector(3, dt=ti.f32, shape=(RES, RES))
benchmarks/mpm2d.py:    x = ti.Vector(2, dt=ti.f32, shape=n_particles)  # position
benchmarks/mpm2d.py:    v = ti.Vector(2, dt=ti.f32, shape=n_particles)  # velocity
benchmarks/mpm2d.py:    C = ti.Matrix(2, 2, dt=ti.f32, shape=n_particles)  # affine velocity field
benchmarks/mpm2d.py:    F = ti.Matrix(2, 2, dt=ti.f32, shape=n_particles)  # deformation gradient
benchmarks/mpm2d.py:    grid_v = ti.Vector(2, dt=ti.f32,
benchmarks/mpm2d.py:    x = ti.Vector(2, dt=ti.f32, shape=n_particles)  # position
benchmarks/mpm2d.py:    v = ti.Vector(2, dt=ti.f32, shape=n_particles)  # velocity
benchmarks/mpm2d.py:    C = ti.Matrix(2, 2, dt=ti.f32, shape=n_particles)  # affine velocity field
benchmarks/mpm2d.py:    F = ti.Matrix(2, 2, dt=ti.f32, shape=n_particles)  # deformation gradient
benchmarks/mpm2d.py:    grid_v = ti.Vector(2, dt=ti.f32,
misc/benchmark_parallel_compilation.py:x = ti.Vector(2, dt=ti.f32, shape=n_particles)  # position
misc/benchmark_parallel_compilation.py:v = ti.Vector(2, dt=ti.f32, shape=n_particles)  # velocity
misc/benchmark_parallel_compilation.py:C = ti.Matrix(2, 2, dt=ti.f32, shape=n_particles)  # affine velocity field
misc/benchmark_parallel_compilation.py:F = ti.Matrix(2, 2, dt=ti.f32, shape=n_particles)  # deformation gradient
misc/benchmark_parallel_compilation.py:grid_v = ti.Vector(2, dt=ti.f32,
examples/export_videos.py:pixels = ti.var(ti.u8, shape=(512, 512, 3))
examples/tree_gravity.py:particle_mass = ti.var(ti.f32)
examples/tree_gravity.py:particle_table_len = ti.var(ti.i32, ())
examples/tree_gravity.py:    trash_particle_id = ti.var(ti.i32)
examples/tree_gravity.py:    trash_base_parent = ti.var(ti.i32)
examples/tree_gravity.py:    trash_base_geo_size = ti.var(ti.f32)
examples/tree_gravity.py:    trash_table_len = ti.var(ti.i32, ())
examples/tree_gravity.py:    node_mass = ti.var(ti.f32)
examples/tree_gravity.py:    node_particle_id = ti.var(ti.i32)
examples/tree_gravity.py:    node_children = ti.var(ti.i32)
examples/tree_gravity.py:    node_table_len = ti.var(ti.i32, ())
examples/tree_gravity.py:    display_image = ti.var(ti.f32, (kResolution, kResolution))
examples/taichi_dynamic.py:x = ti.var(ti.i32)
examples/taichi_dynamic.py:l = ti.var(ti.i32)
examples/waterwave.py:pixels = ti.var(dt=ti.f32, shape=shape)
examples/waterwave.py:background = ti.var(dt=ti.f32, shape=shape)
examples/waterwave.py:height = ti.var(dt=ti.f32, shape=shape)
examples/waterwave.py:velocity = ti.var(dt=ti.f32, shape=shape)
examples/waterwave.py:acceleration = ti.var(dt=ti.f32, shape=shape)
examples/mass_spring_3d.py:vertices = t3.Vertex.var(N**2)
examples/pbf2d.py:grid_num_particles = ti.var(ti.i32)
examples/pbf2d.py:grid2particles = ti.var(ti.i32)
examples/pbf2d.py:particle_num_neighbors = ti.var(ti.i32)
examples/pbf2d.py:particle_neighbors = ti.var(ti.i32)
examples/pbf2d.py:lambdas = ti.var(ti.f32)
examples/euler.py:dt = ti.var(dt=real, shape=())
examples/euler.py:img = ti.var(dt=ti.f32, shape=(res, res))
examples/revert_image_color.py:image = ti.var(ti.u8, input_image.shape)
examples/taichi_autodiff.py:x, y = ti.var(ti.f32), ti.var(ti.f32)
examples/nbody_oscillator.py:pos = ti.Vector.var(2, ti.f32, N)
examples/nbody_oscillator.py:vel = ti.Vector.var(2, ti.f32, N)
examples/taichi_bitmasked.py:x = ti.var(ti.f32)
examples/cornell_box.py:count_var = ti.var(ti.i32, shape=(1, ))
examples/cornell_box.py:            interval / (time.time() - last_t), i, np.var(img)))
examples/game_of_life.py:alive = ti.var(int, shape=(n, n))  # alive = 1, dead = 0
examples/game_of_life.py:count = ti.var(int, shape=(n, n))  # count of neighbours
examples/game_of_life.py:img = ti.var(float, shape=(img_size, img_size))  # image to be displayed
examples/gui_image_io.py:pixel = ti.var(ti.u8, shape=(512, 512, 3))
examples/autodiff_regression.py:x, y = ti.var(ti.f32, shape=N, needs_grad=True), ti.var(ti.f32,
examples/autodiff_regression.py:coeffs = ti.var(ti.f32, shape=number_coeffs, needs_grad=True)
examples/autodiff_regression.py:loss = ti.var(ti.f32, shape=(), needs_grad=True)
examples/mgpcg_advanced.py:        self.r = [ti.var(dt=real) for _ in range(self.n_mg_levels)]  # residual
examples/mgpcg_advanced.py:        self.z = [ti.var(dt=real)
examples/mgpcg_advanced.py:        self.x = ti.var(dt=real)  # solution
examples/mgpcg_advanced.py:        self.p = ti.var(dt=real)  # conjugate gradient
examples/mgpcg_advanced.py:        self.Ap = ti.var(dt=real)  # matrix-vector product
examples/mgpcg_advanced.py:        self.alpha = ti.var(dt=real)  # step size
examples/mgpcg_advanced.py:        self.beta = ti.var(dt=real)  # step size
examples/mgpcg_advanced.py:        self.sum = ti.var(dt=real)  # storage for reductions
examples/mgpcg_advanced.py:        self.pixels = ti.var(dt=real,
examples/autodiff_minimization.py:x = ti.var(dt=ti.f32, shape=n, needs_grad=True)
examples/autodiff_minimization.py:y = ti.var(dt=ti.f32, shape=n)
examples/autodiff_minimization.py:L = ti.var(dt=ti.f32, shape=(), needs_grad=True)
examples/mnist.py:input = ti.var(ti.f32)
examples/mnist.py:weight1 = ti.var(ti.f32)
examples/mnist.py:output1 = ti.var(ti.f32)
examples/mnist.py:output1_nonlinear = ti.var(ti.f32)
examples/mnist.py:weight2 = ti.var(ti.f32)
examples/mnist.py:output = ti.var(ti.f32)
examples/mnist.py:output_exp = ti.var(ti.f32)
examples/mnist.py:output_softmax = ti.var(ti.f32)
examples/mnist.py:softmax_sum = ti.var(ti.f32)
examples/mnist.py:gt = ti.var(ti.f32)
examples/mnist.py:loss = ti.var(ti.f32)
examples/mnist.py:learning_rate = ti.var(ti.f32)
examples/sdf2d.py:img = ti.var(dt=ti.f32, shape=(N, N))
examples/laplace.py:x, y = ti.var(ti.f32), ti.var(ti.f32)
examples/particle_renderer.py:grid_density = ti.var(dt=ti.i32)
examples/particle_renderer.py:voxel_has_particle = ti.var(dt=ti.i32)
examples/particle_renderer.py:pid = ti.var(ti.i32)
examples/particle_renderer.py:num_particles = ti.var(ti.i32, shape=())
examples/mgpcg.py:r = [ti.var(dt=real) for _ in range(n_mg_levels)]  # residual
examples/mgpcg.py:z = [ti.var(dt=real) for _ in range(n_mg_levels)]  # M^-1 r
examples/mgpcg.py:x = ti.var(dt=real)  # solution
examples/mgpcg.py:p = ti.var(dt=real)  # conjugate gradient
examples/mgpcg.py:Ap = ti.var(dt=real)  # matrix-vector product
examples/mgpcg.py:alpha = ti.var(dt=real)  # step size
examples/mgpcg.py:beta = ti.var(dt=real)  # step size
examples/mgpcg.py:sum = ti.var(dt=real)  # storage for reductions
examples/mgpcg.py:pixels = ti.var(dt=real, shape=(N_gui, N_gui))  # image buffer
examples/quadtree.py:qt = ti.var(ti.f32)
benchmarks/memory_bound.py:    a = ti.var(dt=ti.f32, shape=N)
benchmarks/memory_bound.py:    a = ti.var(dt=ti.f32, shape=N)
benchmarks/memory_bound.py:    a = ti.var(dt=ti.f32, shape=N)
benchmarks/memory_bound.py:    b = ti.var(dt=ti.f32, shape=N)
benchmarks/memory_bound.py:    x = ti.var(dt=ti.f32, shape=N)
benchmarks/memory_bound.py:    y = ti.var(dt=ti.f32, shape=N)
benchmarks/memory_bound.py:    z = ti.var(dt=ti.f32, shape=N)
benchmarks/minimal.py:    a = ti.var(dt=ti.f32, shape=())
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32, shape=(N, N))
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32, shape=(N, N))
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32)
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32)
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32)
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32)
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32)
benchmarks/fill_dense.py:    a = ti.var(dt=ti.f32)
benchmarks/mpm2d.py:    material = ti.var(dt=ti.i32, shape=n_particles)  # material id
benchmarks/mpm2d.py:    Jp = ti.var(dt=ti.f32, shape=n_particles)  # plastic deformation
benchmarks/mpm2d.py:    grid_m = ti.var(dt=ti.f32, shape=(n_grid, n_grid))  # grid node mass
benchmarks/mpm2d.py:    material = ti.var(dt=ti.i32, shape=n_particles)  # material id
benchmarks/mpm2d.py:    Jp = ti.var(dt=ti.f32, shape=n_particles)  # plastic deformation
benchmarks/mpm2d.py:    grid_m = ti.var(dt=ti.f32, shape=(n_grid, n_grid))  # grid node mass
benchmarks/fill_sparse.py:    a = ti.var(dt=ti.f32)
benchmarks/fill_sparse.py:    a = ti.var(dt=ti.f32)
misc/benchmark_reduction.py:a = ti.var(ti.i32, shape=N)
misc/benchmark_reduction.py:tot = ti.var(ti.i32, shape=())
misc/benchmark_tensor_access.py:x, y = ti.var(ti.f32), ti.var(ti.f32)
misc/demo_listgen.py:x = ti.var(ti.i32)
misc/demo_external_func.py:x = ti.var(ti.i32, shape=N)
misc/demo_external_func.py:y = ti.var(ti.i32, shape=N)
misc/demo_external_func.py:z = ti.var(ti.i32, shape=N)
misc/benchmark_reduction_tmps.py:a = ti.var(ti.f32, shape=N)
misc/test_async_weaken_access.py:x = ti.var(ti.i32)
misc/test_async_weaken_access.py:y = ti.var(ti.i32)
misc/test_memory_pool.py:mask = ti.var(ti.i32)
misc/test_memory_pool.py:val = ti.var(ti.f32)
misc/benchmark_compile.py:    x = ti.var(ti.f32)
misc/benchmark_compile.py:    y = ti.var(ti.f32)
misc/benchmark_parallel_compilation.py:material = ti.var(dt=ti.i32, shape=n_particles)  # material id
misc/benchmark_parallel_compilation.py:Jp = ti.var(dt=ti.f32, shape=n_particles)  # plastic deformation
misc/benchmark_parallel_compilation.py:grid_m = ti.var(dt=ti.f32, shape=(n_grid, n_grid))  # grid node mass
misc/test_gpu_async.py:a = ti.var(dt=ti.f32, shape=(1024 * 1024 * 1024))
misc/test_without_init.py:    x = ti.var(ti.i32, (2, 3))
misc/demo_oob_ub.py:x = ti.var(ti.i32, N)
misc/test_poly_timed.py:        x = ti.var(default_fp)
misc/test_poly_timed.py:        y = ti.var(default_fp)
python/taichi/lang/matrix.py:    #@deprecated('ti.Matrix.var', 'ti.Matrix.field')
python/taichi/lang/matrix.py:        '''ti.Matrix.var'''
python/taichi/lang/matrix.py:    #@deprecated('ti.Vector.var', 'ti.Vector.field')
python/taichi/lang/matrix.py:        '''ti.Vector.var'''
python/taichi/lang/impl.py:#@deprecated('ti.var', 'ti.field')
```