### PR TITLE
[metal] Pass back return values via result_buffer

### DIFF
--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -27,6 +27,7 @@ class KernelManager {
     CompiledStructs compiled_structs;
     CompileConfig *config;
     MemoryPool *mem_pool;
+    uint64_t *host_result_buffer;
     KernelProfilerBase *profiler;
     int root_id;
   };

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -38,6 +38,8 @@ TI_NAMESPACE_END
 
 TLANG_NAMESPACE_BEGIN
 
+namespace {
+
 void assert_failed_host(const char *msg) {
   TI_ERROR("Assertion failure: {}", msg);
 }
@@ -47,6 +49,13 @@ void *taichi_allocate_aligned(Program *prog,
                               std::size_t alignment) {
   return prog->memory_pool->allocate(size, alignment);
 }
+
+inline uint64 *allocate_result_buffer_default(Program *prog) {
+  return (uint64 *)taichi_allocate_aligned(
+      prog, sizeof(uint64) * taichi_result_buffer_entries, 8);
+}
+
+}  // namespace
 
 Program *current_program = nullptr;
 std::atomic<int> Program::num_instances;
@@ -246,8 +255,7 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
     TI_NOT_IMPLEMENTED
 #endif
   } else {
-    result_buffer = (uint64 *)taichi_allocate_aligned(
-        this, sizeof(uint64) * taichi_result_buffer_entries, 8);
+    result_buffer = allocate_result_buffer_default(this);
     tlctx = llvm_context_host.get();
   }
   auto runtime = tlctx->runtime_jit_module;
@@ -360,10 +368,14 @@ void Program::materialize_layout() {
                    "Metal arch requires that LLVM being enabled");
     metal_compiled_structs_ = metal::compile_structs(*snode_root);
     if (metal_kernel_mgr_ == nullptr) {
+      TI_ASSERT(result_buffer == nullptr);
+      result_buffer = allocate_result_buffer_default(this);
+
       metal::KernelManager::Params params;
       params.compiled_structs = metal_compiled_structs_.value();
       params.config = &config;
       params.mem_pool = memory_pool.get();
+      params.host_result_buffer = result_buffer;
       params.profiler = profiler.get();
       params.root_id = snode_root->id;
       metal_kernel_mgr_ =
@@ -628,7 +640,7 @@ uint64 Program::fetch_result_uint64(int i) {
 #else
     TI_NOT_IMPLEMENTED;
 #endif
-  } else if (arch_is_cpu(arch)) {
+  } else if (arch_is_cpu(arch) || arch == Arch::metal) {
     ret = result_buffer[i];
   } else {
     ret = context.get_arg_as_uint64(i);


### PR DESCRIPTION
This allows us to decouple the return value from `Context`.

Related issue = #N/A

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
