### PR TITLE
[example] Make jacobi iteration 2x faster in stable_fluid.py

### DIFF
--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -227,10 +227,9 @@ def pressure_jacobi_dual(pf: ti.template(), new_pf: ti.template()):
         divr = sample(velocity_divs, i + 1, j)
         divb = sample(velocity_divs, i, j - 1)
         divt = sample(velocity_divs, i, j + 1)
-        new_pf[i, j] = (pll + prr + pbb + ptt
-                - divl - divr - divb - divt - div
-                + (plt + prt + prb + plb) * 2
-                + pcc * 4) * 0.0625
+        new_pf[i,
+               j] = (pll + prr + pbb + ptt - divl - divr - divb - divt - div +
+                     (plt + prt + prb + plb) * 2 + pcc * 4) * 0.0625
 
 
 pressure_jacobi = pressure_jacobi_dual


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = [数据删除]

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
The `pressure_jacobi` is highly memory-bound.
So I fuse two `pressure_jacobi` into one, resulting in 2x performance (FPS didn't change without `p_jacobi_iters //= 2`).
However, fusing 3 or 4 stencils did't yield anymore performance since it's becoming compute-bound, at lest on my end.

Not sure if we could provide an option to switch to `from mgpcg_advanced import MGPCG` iapr.
@KLozes Would you mind to make the cool `MGPCG` class more generic so that people could reuse it when necessary?