### PR TITLE
[example] [refactor] Replace global field ti.Vector -> ti.Vector.field in examples

### DIFF
--- a/examples/cornell_box.py
+++ b/examples/cornell_box.py
@@ -6,7 +6,7 @@ from renderer_utils import ray_aabb_intersection, intersect_sphere, ray_plane_in
 
 ti.init(arch=ti.gpu)
 res = (800, 800)
-color_buffer = ti.Vector(3, dt=ti.f32, shape=res)
+color_buffer = ti.Vector.field(3, dtype=ti.f32, shape=res)
 count_var = ti.field(ti.i32, shape=(1, ))
 
 max_ray_depth = 10

--- a/examples/euler.py
+++ b/examples/euler.py
@@ -21,7 +21,7 @@ use_fixed_caxis = 0  # 1: use fixed caxis limits, 0: automatic caxis limits
 fixed_caxis = [0.0, 5.0]  # fixed caxis limits
 
 Q = ti.Vector.field(4, dtype=real,
-              shape=(N, N))  # [rho, rho*u, rho*v, rho*e] consv vars
+                    shape=(N, N))  # [rho, rho*u, rho*v, rho*e] consv vars
 Q_old = ti.Vector.field(4, dtype=real, shape=(N, N))
 W = ti.Vector.field(4, dtype=real, shape=(N, N))  # [rho, u, v, p] cell avg
 W_xl = ti.Vector.field(4, dtype=real, shape=(N, N, 3))  # left side of x-face

--- a/examples/euler.py
+++ b/examples/euler.py
@@ -20,16 +20,16 @@ cmap_name = 'magma_r'  # python colormap
 use_fixed_caxis = 0  # 1: use fixed caxis limits, 0: automatic caxis limits
 fixed_caxis = [0.0, 5.0]  # fixed caxis limits
 
-Q = ti.Vector(4, dt=real,
+Q = ti.Vector.field(4, dtype=real,
               shape=(N, N))  # [rho, rho*u, rho*v, rho*e] consv vars
-Q_old = ti.Vector(4, dt=real, shape=(N, N))
-W = ti.Vector(4, dt=real, shape=(N, N))  # [rho, u, v, p] cell avg
-W_xl = ti.Vector(4, dt=real, shape=(N, N, 3))  # left side of x-face
-W_xr = ti.Vector(4, dt=real, shape=(N, N, 3))  # right side of x-face
-W_yl = ti.Vector(4, dt=real, shape=(N, N, 3))  # left side of y-face
-W_yr = ti.Vector(4, dt=real, shape=(N, N, 3))  # right side of y-face
-F_x = ti.Vector(4, dt=real, shape=(N, N))  # x-face flux
-F_y = ti.Vector(4, dt=real, shape=(N, N))  # y-face flux
+Q_old = ti.Vector.field(4, dtype=real, shape=(N, N))
+W = ti.Vector.field(4, dtype=real, shape=(N, N))  # [rho, u, v, p] cell avg
+W_xl = ti.Vector.field(4, dtype=real, shape=(N, N, 3))  # left side of x-face
+W_xr = ti.Vector.field(4, dtype=real, shape=(N, N, 3))  # right side of x-face
+W_yl = ti.Vector.field(4, dtype=real, shape=(N, N, 3))  # left side of y-face
+W_yr = ti.Vector.field(4, dtype=real, shape=(N, N, 3))  # right side of y-face
+F_x = ti.Vector.field(4, dtype=real, shape=(N, N))  # x-face flux
+F_y = ti.Vector.field(4, dtype=real, shape=(N, N))  # y-face flux
 dt = ti.field(dtype=real, shape=())
 img = ti.field(dtype=ti.f32, shape=(res, res))
 

--- a/examples/export_ply.py
+++ b/examples/export_ply.py
@@ -6,8 +6,8 @@ import os
 ti.init(arch=ti.cpu)
 
 num_vertices = 1000
-pos = ti.Vector(3, dt=ti.f32, shape=(10, 10, 10))
-rgba = ti.Vector(4, dt=ti.f32, shape=(10, 10, 10))
+pos = ti.Vector.field(3, dtype=ti.f32, shape=(10, 10, 10))
+rgba = ti.Vector.field(4, dtype=ti.f32, shape=(10, 10, 10))
 
 
 @ti.kernel

--- a/examples/particle_renderer.py
+++ b/examples/particle_renderer.py
@@ -9,16 +9,16 @@ ti.init(arch=ti.cuda, device_memory_GB=4)
 
 res = 1280, 720
 num_spheres = 1024
-color_buffer = ti.Vector(3, dt=ti.f32)
-bbox = ti.Vector(3, dt=ti.f32, shape=2)
+color_buffer = ti.Vector.field(3, dtype=ti.f32)
+bbox = ti.Vector.field(3, dtype=ti.f32, shape=2)
 grid_density = ti.field(dtype=ti.i32)
 voxel_has_particle = ti.field(dtype=ti.i32)
 max_ray_depth = 4
 use_directional_light = True
 
-particle_x = ti.Vector(3, dt=ti.f32)
-particle_v = ti.Vector(3, dt=ti.f32)
-particle_color = ti.Vector(3, dt=ti.f32)
+particle_x = ti.Vector.field(3, dtype=ti.f32)
+particle_v = ti.Vector.field(3, dtype=ti.f32)
+particle_color = ti.Vector.field(3, dtype=ti.f32)
 pid = ti.field(ti.i32)
 num_particles = ti.field(ti.i32, shape=())
 

--- a/examples/pbf2d.py
+++ b/examples/pbf2d.py
@@ -49,18 +49,18 @@ neighbor_radius = h * 1.05
 poly6_factor = 315.0 / 64.0 / np.pi
 spiky_grad_factor = -45.0 / np.pi
 
-old_positions = ti.Vector(dim, dt=ti.f32)
-positions = ti.Vector(dim, dt=ti.f32)
-velocities = ti.Vector(dim, dt=ti.f32)
+old_positions = ti.Vector.field(dim, dtype=ti.f32)
+positions = ti.Vector.field(dim, dtype=ti.f32)
+velocities = ti.Vector.field(dim, dtype=ti.f32)
 # Once taichi supports clear(), we can get rid of grid_num_particles
 grid_num_particles = ti.field(ti.i32)
 grid2particles = ti.field(ti.i32)
 particle_num_neighbors = ti.field(ti.i32)
 particle_neighbors = ti.field(ti.i32)
 lambdas = ti.field(ti.f32)
-position_deltas = ti.Vector(dim, dt=ti.f32)
+position_deltas = ti.Vector.field(dim, dtype=ti.f32)
 # 0: x-pos, 1: timestep in sin()
-board_states = ti.Vector(2, dt=ti.f32)
+board_states = ti.Vector.field(2, dtype=ti.f32)
 
 ti.root.dense(ti.i, num_particles).place(old_positions, positions, velocities)
 grid_snode = ti.root.dense(ti.ij, grid_size)

--- a/examples/quadtree.py
+++ b/examples/quadtree.py
@@ -16,7 +16,7 @@ for r in range(R):
 qt = ti.field(ti.f32)
 B.place(qt)
 
-img = ti.Vector(3, dt=ti.f32, shape=(RES, RES))
+img = ti.Vector.field(3, dtype=ti.f32, shape=(RES, RES))
 
 print('The quad tree layout is:\n', qt.snode)
 

--- a/examples/sdf2d.py
+++ b/examples/sdf2d.py
@@ -5,7 +5,7 @@ ti.init(arch=ti.opengl)
 
 N = 512
 img = ti.field(dtype=ti.f32, shape=(N, N))
-light_pos = ti.Vector(2, dt=ti.f32, shape=())
+light_pos = ti.Vector.field(2, dtype=ti.f32, shape=())
 
 
 @ti.func

--- a/examples/sdf_renderer.py
+++ b/examples/sdf_renderer.py
@@ -5,7 +5,7 @@ import numpy as np
 
 ti.init(arch=ti.gpu)
 res = 1280, 720
-color_buffer = ti.Vector(3, dt=ti.f32, shape=res)
+color_buffer = ti.Vector.field(3, dtype=ti.f32, shape=res)
 max_ray_depth = 6
 eps = 1e-4
 inf = 1e10

--- a/examples/tree_gravity.py
+++ b/examples/tree_gravity.py
@@ -21,8 +21,8 @@ LEAF = -1
 TREE = -2
 
 particle_mass = ti.field(ti.f32)
-particle_pos = ti.Vector(kDim, ti.f32)
-particle_vel = ti.Vector(kDim, ti.f32)
+particle_pos = ti.Vector.field(kDim, ti.f32)
+particle_vel = ti.Vector.field(kDim, ti.f32)
 particle_table = ti.root.dense(ti.i, kMaxParticles)
 particle_table.place(particle_pos).place(particle_vel).place(particle_mass)
 particle_table_len = ti.field(ti.i32, ())
@@ -30,7 +30,7 @@ particle_table_len = ti.field(ti.i32, ())
 if kUseTree:
     trash_particle_id = ti.field(ti.i32)
     trash_base_parent = ti.field(ti.i32)
-    trash_base_geo_center = ti.Vector(kDim, ti.f32)
+    trash_base_geo_center = ti.Vector.field(kDim, ti.f32)
     trash_base_geo_size = ti.field(ti.f32)
     trash_table = ti.root.dense(ti.i, kMaxDepth)
     trash_table.place(trash_particle_id)
@@ -39,7 +39,7 @@ if kUseTree:
     trash_table_len = ti.field(ti.i32, ())
 
     node_mass = ti.field(ti.f32)
-    node_weighted_pos = ti.Vector(kDim, ti.f32)
+    node_weighted_pos = ti.Vector.field(kDim, ti.f32)
     node_particle_id = ti.field(ti.i32)
     node_children = ti.field(ti.i32)
     node_table = ti.root.dense(ti.i, kMaxNodes)
@@ -48,7 +48,7 @@ if kUseTree:
     node_table_len = ti.field(ti.i32, ())
 
 if 'mouse' in kDisplay:
-    display_image = ti.Vector(3, ti.f32, (kResolution, kResolution))
+    display_image = ti.Vector.field(3, ti.f32, (kResolution, kResolution))
 elif len(kDisplay):
     display_image = ti.field(ti.f32, (kResolution, kResolution))
 


### PR DESCRIPTION
Related issue = #1500 

This PR tries to replace all global field(tensor) `ti.Vector` to `ti.Vector.field`

# Validation
1. Script testing is the same as #1712 
2. Then I watched the examples' result and played with them manually. They look good to me.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
