### PR TITLE
[opengl] Cache GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS value to prevent glGetInteger per-launch

### DIFF
--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -426,9 +426,11 @@ bool initialize_opengl(bool error_tolerance) {
     TI_ERROR("Your OpenGL does not support GL_ARB_compute_shader extension");
   }
 
-  glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &opengl_threads_per_block);
+  glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS,
+                &opengl_threads_per_block);
   check_opengl_error("glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS)");
-  TI_TRACE("GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS: {}", opengl_threads_per_block);
+  TI_TRACE("GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS: {}",
+           opengl_threads_per_block);
 
   supported = std::make_optional<bool>(true);
   return true;

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -21,6 +21,8 @@ namespace opengl {
 #include "taichi/inc/opengl_extension.inc.h"
 #undef PER_OPENGL_EXTENSION
 
+int opengl_threads_per_block = 1024;
+
 #ifdef TI_WITH_OPENGL
 
 std::string get_opengl_error_string(GLenum err) {
@@ -47,14 +49,6 @@ void check_opengl_error(const std::string &msg = "OpenGL") {
     auto estr = get_opengl_error_string(err);
     TI_ERROR("{}: {}", msg, estr);
   }
-}
-
-int opengl_get_threads_per_group() {
-  int ret = 1000;
-  glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &ret);
-  check_opengl_error("glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS)");
-  TI_TRACE("opengl_get_threads_per_group: {}", ret);
-  return ret;
 }
 
 static std::string add_line_markers(std::string x) {
@@ -312,7 +306,7 @@ ParallelSize::~ParallelSize() {
 }
 
 size_t ParallelSize::get_threads_per_block() const {
-  size_t limit = opengl_get_threads_per_group();
+  size_t limit = opengl_threads_per_block;
   size_t n = threads_per_block.value_or(0);
   return n == 0 ? limit : std::min(n, limit);
 }
@@ -431,6 +425,10 @@ bool initialize_opengl(bool error_tolerance) {
     }
     TI_ERROR("Your OpenGL does not support GL_ARB_compute_shader extension");
   }
+
+  glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &opengl_threads_per_block);
+  check_opengl_error("glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS)");
+  TI_TRACE("GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS: {}", opengl_threads_per_block);
 
   supported = std::make_optional<bool>(true);
   return true;

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -23,6 +23,8 @@ bool is_opengl_api_available();
 #include "taichi/inc/opengl_extension.inc.h"
 #undef PER_OPENGL_EXTENSION
 
+extern int opengl_threads_per_block;
+
 #define TI_OPENGL_REQUIRE(used, x) \
   ([&]() {                         \
     if (opengl_extension_##x) {    \


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Local OpenGL test passed. Will merge once CI passed.