### PR TITLE
[refactor] Add Kernel::LaunchContextBuilder skeleton code

### DIFF
--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -392,6 +392,7 @@ class Kernel:
             has_external_arrays = False
 
             actual_argument_slot = 0
+            launch_ctx = t_kernel.make_launch_context()
             for i, v in enumerate(args):
                 needed = self.arguments[i]
                 if isinstance(needed, template):
@@ -401,11 +402,11 @@ class Kernel:
                 if id(needed) in real_type_ids:
                     if not isinstance(v, (float, int)):
                         raise KernelArgError(i, needed, provided)
-                    t_kernel.set_arg_float(actual_argument_slot, float(v))
+                    launch_ctx.set_arg_float(actual_argument_slot, float(v))
                 elif id(needed) in integer_type_ids:
                     if not isinstance(v, int):
                         raise KernelArgError(i, needed, provided)
-                    t_kernel.set_arg_int(actual_argument_slot, int(v))
+                    launch_ctx.set_arg_int(actual_argument_slot, int(v))
                 elif self.match_ext_arr(v, needed):
                     has_external_arrays = True
                     has_torch = has_pytorch()
@@ -413,9 +414,9 @@ class Kernel:
                     if is_numpy:
                         tmp = np.ascontiguousarray(v)
                         tmps.append(tmp)  # Purpose: do not GC tmp!
-                        t_kernel.set_arg_nparray(actual_argument_slot,
-                                                 int(tmp.ctypes.data),
-                                                 tmp.nbytes)
+                        launch_ctx.set_arg_nparray(actual_argument_slot,
+                                                   int(tmp.ctypes.data),
+                                                   tmp.nbytes)
                     else:
 
                         def get_call_back(u, v):
@@ -441,7 +442,7 @@ class Kernel:
                                 gpu_v = v.cuda()
                                 tmp = gpu_v
                                 callbacks.append(get_call_back(v, gpu_v))
-                        t_kernel.set_arg_nparray(
+                        launch_ctx.set_arg_nparray(
                             actual_argument_slot, int(tmp.data_ptr()),
                             tmp.element_size() * tmp.nelement())
                     shape = v.shape
@@ -451,7 +452,8 @@ class Kernel:
                     ) <= max_num_indices, "External array cannot have > {} indices".format(
                         max_num_indices)
                     for i, s in enumerate(shape):
-                        t_kernel.set_extra_arg_int(actual_argument_slot, i, s)
+                        launch_ctx.set_extra_arg_int(actual_argument_slot, i,
+                                                     s)
                 else:
                     raise ValueError(
                         f'Argument type mismatch. Expecting {needed}, got {type(v)}.'
@@ -463,7 +465,7 @@ class Kernel:
             if not self.is_grad and self.runtime.target_tape and not self.runtime.inside_complex_kernel:
                 self.runtime.target_tape.insert(self, args)
 
-            t_kernel()
+            t_kernel(launch_ctx)
 
             ret = None
             ret_dt = self.return_type

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -83,7 +83,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       for (auto task : offloaded_local) {
         TI_TRACE("Launching kernel {}<<<{}, {}>>>", task.name, task.grid_dim,
                  task.block_dim);
-        // TODO: Is it safe to use the Context owned
+        // TODO: It seems safe to get the Context pointer from |ctx_builder|?
         cuda_module->launch(task.name, task.grid_dim, task.block_dim,
                             task.shmem_bytes, {&kernel->program.context});
       }

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -249,8 +249,6 @@ class SNode {
 
   int shape_along_axis(int i) const;
 
-  void set_kernel_args(Kernel *kernel, const std::vector<int> &I);
-
   uint64 fetch_reader_result();  // TODO: refactor
 };
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -196,8 +196,8 @@ void Kernel::LaunchContextBuilder::set_extra_arg_int(int i, int j, int32 d) {
 }
 
 void Kernel::LaunchContextBuilder::set_arg_nparray(int i,
-                                                 uint64 ptr,
-                                                 uint64 size) {
+                                                   uint64 ptr,
+                                                   uint64 size) {
   TI_ASSERT_INFO(kernel_->args[i].is_nparray,
                  "Assigning numpy array to scalar argument is not allowed");
 
@@ -215,6 +215,10 @@ void Kernel::LaunchContextBuilder::set_arg_raw(int i, uint64 d) {
   TI_ASSERT_INFO(
       !kernel_->args[i].is_nparray,
       "Assigning scalar value to numpy array argument is not allowed");
+
+  ActionRecorder::get_instance().record(
+      "set_arg_raw", {ActionArg("kernel_name", kernel_->name),
+                      ActionArg("arg_id", i), ActionArg("val", (int64)d)});
   kernel_->program.context.set_arg<uint64>(i, d);
 }
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -97,10 +97,7 @@ void Kernel::operator()(LaunchContextBuilder &launch_ctx) {
     if (!compiled) {
       compile();
     }
-    auto &ctx = launch_ctx.get_context();
-    TI_INFO("Able to get_context");
-    compiled(ctx);
-    TI_INFO("Able to run compiled(ctx)");
+    compiled(launch_ctx.get_context());
     program.sync = (program.sync && arch_is_cpu(arch));
     // Note that Kernel::arch may be different from program.config.arch
     if (program.config.debug && (arch_is_cpu(program.config.arch) ||

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -44,9 +44,13 @@ class Kernel {
   bool is_evaluator;
   bool grad;
 
-  // TODO: Give "context" a more specific name.
+  // TODO: Give "Context" a more specific name.
   class LaunchContextBuilder {
    public:
+    LaunchContextBuilder(Kernel *kernel, Context *ctx)
+        : kernel_(kernel), ctx_(ctx) {
+    }
+
     void set_arg_float(int i, float64 d);
 
     void set_arg_int(int i, int64 d);
@@ -62,11 +66,12 @@ class Kernel {
     Context &get_context();
 
    private:
-    explicit LaunchContextBuilder(Kernel *kernel) : kernel_(kernel) {
-    }
-
-    friend class Kernel;  // So that Kernel can construct us.
     Kernel *const kernel_;
+    // TODO: Right now |ctx_| is borrowed from other places: either the
+    // program's context, or the one in the CUDA launch function. In the future,
+    // this could *own* a Context (possibly through a std::unique_ptr, since we
+    // don't always need to own the Context.)
+    Context *const ctx_;
   };
 
   Kernel(Program &program,

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -44,6 +44,31 @@ class Kernel {
   bool is_evaluator;
   bool grad;
 
+  // TODO: Give "context" a more specific name.
+  class LaunchContextBuilder {
+   public:
+    void set_arg_float(int i, float64 d);
+
+    void set_arg_int(int i, int64 d);
+
+    void set_extra_arg_int(int i, int j, int32 d);
+
+    void set_arg_nparray(int i, uint64 ptr, uint64 size);
+
+    // Sets the i-th arg in the context to the bits stored in |d|. This ignores
+    // the underlying kernel's i-th arg type.
+    void set_arg_raw(int i, uint64 d);
+
+    Context &get_context();
+
+   private:
+    explicit LaunchContextBuilder(Kernel *kernel) : kernel_(kernel) {
+    }
+
+    friend class Kernel;  // So that Kernel can construct us.
+    Kernel *const kernel_;
+  };
+
   Kernel(Program &program,
          std::function<void()> func,
          std::string name = "",
@@ -53,27 +78,17 @@ class Kernel {
 
   void lower(bool to_executable = true);
 
-  void operator()();
+  void operator()(LaunchContextBuilder &launch_ctx);
 
-  std::function<void()> func() {
-    return std::function<void()>([&] { (*this)(); });
-  }
+  LaunchContextBuilder make_launch_context();
 
   int insert_arg(DataType dt, bool is_nparray);
 
   int insert_ret(DataType dt);
 
-  void set_arg_float(int i, float64 d);
-
-  void set_arg_int(int i, int64 d);
-
   float64 get_ret_float(int i);
 
   int64 get_ret_int(int i);
-
-  void set_extra_arg_int(int i, int j, int32 d);
-
-  void set_arg_nparray(int i, uint64 ptr, uint64 size);
 
   void set_arch(Arch arch);
 };

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -127,10 +127,9 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def(
-      "default_compile_config",
-      [&]() -> CompileConfig & { return default_compile_config; },
-      py::return_value_policy::reference);
+  m.def("default_compile_config",
+        [&]() -> CompileConfig & { return default_compile_config; },
+        py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -139,12 +138,11 @@ void export_lang(py::module &m) {
       .def("kernel_profiler_clear", &Program::kernel_profiler_clear)
       .def("print_memory_profiler_info", &Program::print_memory_profiler_info)
       .def("finalize", &Program::finalize)
-      .def(
-          "get_root",
-          [&](Program *program) -> SNode * {
-            return program->snode_root.get();
-          },
-          py::return_value_policy::reference)
+      .def("get_root",
+           [&](Program *program) -> SNode * {
+             return program->snode_root.get();
+           },
+           py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("get_snode_num_dynamically_allocated",
@@ -154,10 +152,9 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def(
-      "current_compile_config",
-      [&]() -> CompileConfig & { return get_current_program().config; },
-      py::return_value_policy::reference);
+  m.def("current_compile_config",
+        [&]() -> CompileConfig & { return get_current_program().config; },
+        py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -187,10 +184,9 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def(
-          "get_ch",
-          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-          py::return_value_policy::reference)
+      .def("get_ch",
+           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+           py::return_value_policy::reference)
       .def("lazy_grad", &SNode::lazy_grad)
       .def("read_int", &SNode::read_int)
       .def("read_uint", &SNode::read_uint)
@@ -253,14 +249,13 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def(
-          "define",
-          [](Program::KernelProxy *ker,
-             const std::function<void()> &func) -> Kernel & {
-            py::gil_scoped_release release;
-            return ker->def(func);
-          },
-          py::return_value_policy::reference);
+      .def("define",
+           [](Program::KernelProxy *ker,
+              const std::function<void()> &func) -> Kernel & {
+             py::gil_scoped_release release;
+             return ker->def(func);
+           },
+           py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -127,9 +127,10 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def("default_compile_config",
-        [&]() -> CompileConfig & { return default_compile_config; },
-        py::return_value_policy::reference);
+  m.def(
+      "default_compile_config",
+      [&]() -> CompileConfig & { return default_compile_config; },
+      py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -138,11 +139,12 @@ void export_lang(py::module &m) {
       .def("kernel_profiler_clear", &Program::kernel_profiler_clear)
       .def("print_memory_profiler_info", &Program::print_memory_profiler_info)
       .def("finalize", &Program::finalize)
-      .def("get_root",
-           [&](Program *program) -> SNode * {
-             return program->snode_root.get();
-           },
-           py::return_value_policy::reference)
+      .def(
+          "get_root",
+          [&](Program *program) -> SNode * {
+            return program->snode_root.get();
+          },
+          py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("get_snode_num_dynamically_allocated",
@@ -152,9 +154,10 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def("current_compile_config",
-        [&]() -> CompileConfig & { return get_current_program().config; },
-        py::return_value_policy::reference);
+  m.def(
+      "current_compile_config",
+      [&]() -> CompileConfig & { return get_current_program().config; },
+      py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -184,9 +187,10 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def("get_ch",
-           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-           py::return_value_policy::reference)
+      .def(
+          "get_ch",
+          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+          py::return_value_policy::reference)
       .def("lazy_grad", &SNode::lazy_grad)
       .def("read_int", &SNode::read_int)
       .def("read_uint", &SNode::read_uint)
@@ -208,16 +212,21 @@ void export_lang(py::module &m) {
            [](SNode *snode) { return snode->num_active_indices; });
 
   py::class_<Kernel>(m, "Kernel")
-      .def("set_arg_int", &Kernel::set_arg_int)
-      .def("set_arg_float", &Kernel::set_arg_float)
-      .def("set_arg_nparray", &Kernel::set_arg_nparray)
-      .def("set_extra_arg_int", &Kernel::set_extra_arg_int)
       .def("get_ret_int", &Kernel::get_ret_int)
       .def("get_ret_float", &Kernel::get_ret_float)
-      .def("__call__", [](Kernel *kernel) {
-        py::gil_scoped_release release;
-        kernel->operator()();
-      });
+      .def("make_launch_context", &Kernel::make_launch_context)
+      .def("__call__",
+           [](Kernel *kernel, Kernel::LaunchContextBuilder &launch_ctx) {
+             py::gil_scoped_release release;
+             kernel->operator()(launch_ctx);
+           });
+
+  py::class_<Kernel::LaunchContextBuilder>(m, "KernelLaunchContext")
+      .def("set_arg_int", &Kernel::LaunchContextBuilder::set_arg_int)
+      .def("set_arg_float", &Kernel::LaunchContextBuilder::set_arg_float)
+      .def("set_arg_nparray", &Kernel::LaunchContextBuilder::set_arg_nparray)
+      .def("set_extra_arg_int",
+           &Kernel::LaunchContextBuilder::set_extra_arg_int);
 
   py::class_<Expr> expr(m, "Expr");
   expr.def("serialize", &Expr::serialize)
@@ -244,13 +253,14 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def("define",
-           [](Program::KernelProxy *ker,
-              const std::function<void()> &func) -> Kernel & {
-             py::gil_scoped_release release;
-             return ker->def(func);
-           },
-           py::return_value_policy::reference);
+      .def(
+          "define",
+          [](Program::KernelProxy *ker,
+             const std::function<void()> &func) -> Kernel & {
+            py::gil_scoped_release release;
+            return ker->def(func);
+          },
+          py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -115,12 +115,12 @@ class ConstantFold : public BasicStmtVisitor {
                       true};
     auto *ker = get_jit_evaluator_kernel(id);
     auto &current_program = stmt->get_kernel()->program;
-    auto &ctx = current_program.get_context();
-    ContextArgSaveGuard _(
-        ctx);  // save input args, prevent override current kernel
-    ctx.set_arg<int64_t>(0, lhs.val_i64);
-    ctx.set_arg<int64_t>(1, rhs.val_i64);
-    (*ker)();
+    // save input args to prevent the current kernel from being overridden.
+    ContextArgSaveGuard _(current_program.get_context());
+    auto launch_ctx = ker->make_launch_context();
+    launch_ctx.set_arg_raw(0, lhs.val_u64);
+    launch_ctx.set_arg_raw(1, rhs.val_u64);
+    (*ker)(launch_ctx);
     ret.val_i64 = current_program.fetch_result<int64_t>(0);
     return true;
   }
@@ -138,11 +138,11 @@ class ConstantFold : public BasicStmtVisitor {
                       false};
     auto *ker = get_jit_evaluator_kernel(id);
     auto &current_program = stmt->get_kernel()->program;
-    auto &ctx = current_program.get_context();
-    ContextArgSaveGuard _(
-        ctx);  // save input args, prevent override current kernel
-    ctx.set_arg<int64_t>(0, operand.val_i64);
-    (*ker)();
+    // save input args to prevent the current kernel from being overridden.
+    ContextArgSaveGuard _(current_program.get_context());
+    auto launch_ctx = ker->make_launch_context();
+    launch_ctx.set_arg_raw(0, operand.val_u64);
+    (*ker)(launch_ctx);
     ret.val_i64 = current_program.fetch_result<int64_t>(0);
     return true;
   }


### PR DESCRIPTION
This is just a wrapper of of the singleton context owned by the program. However, hopefully it outlines the interface we need to resolve #1722?

I found that the generated function on CUDA has to further modify `Context`, since it has to create the host/device buffers. The manipulation there seems a bit brittle 😨 

Related issue = #1722

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
