### PR TITLE
[opengl] [refactor] Use result_buffer for return value

### DIFF
--- a/taichi/backends/opengl/opengl_kernel_launcher.h
+++ b/taichi/backends/opengl/opengl_kernel_launcher.h
@@ -15,8 +15,9 @@ struct GLSLLauncher {
   std::unique_ptr<GLSLLauncherImpl> impl;
   GLSLLauncher(size_t size);
   ~GLSLLauncher();
-
   void keep(std::unique_ptr<CompiledProgram> program);
+
+  void *result_buffer;
 };
 
 }  // namespace opengl


### PR DESCRIPTION
Related issue = #1722

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
@k-ye Is this what you want? Note that I don't make a `GLBufId::Resu` but still reusing `GLBufId::Args` is because some OpenGL 'implementations' have **limited number of SSBOs**, the limit is 8 on @Eydcao's machine for example. Not to say we need `args_i32` and `args_f32` for simulating union. Not to say my ultra-secret [数据删除] project with @yuanming-hu. We actually can't turn on all 7 SSBOs at the same time on these machines at all.