### PR TITLE
[Example] Upgrade mass_spring_3d.py to Taichi THREE v0.0.3 API

### DIFF
--- a/examples/mass_spring_3d.py
+++ b/examples/mass_spring_3d.py
@@ -49,7 +49,8 @@ def substep():
         v[i] += stiffness * acc * dt
     for i in ti.grouped(x):
         v[i].y -= gravity * dt
-        v[i] = tl.ballBoundReflect(x[i], v[i], tl.vec(+0.0, +0.2, -0.0), 0.4, 6)
+        v[i] = tl.ballBoundReflect(x[i], v[i], tl.vec(+0.0, +0.2, -0.0), 0.4,
+                                   6)
     for i in ti.grouped(x):
         v[i] *= ti.exp(-damping * dt)
         x[i] += dt * v[i]

--- a/examples/mass_spring_3d.py
+++ b/examples/mass_spring_3d.py
@@ -6,12 +6,13 @@ try:
 except ImportError:
     print('This example needs the extension library Taichi THREE to work.'
           'Please run `pip install --user taichi_three` to install it.')
+assert t3.__version__ == (0, 0, 3)
 
 ti.init(arch=ti.gpu)
 
 ### Parameters
 
-N = 128
+N = 256
 NN = N, N
 W = 1
 L = W / N
@@ -57,8 +58,7 @@ def substep():
 ### Rendering GUI
 
 scene = t3.Scene()
-model = t3.Model(f_n=(N - 1)**2 * 4, vi_n=N**2, vt_n=N**2, f_m=1,
-                 tex=ti.imread('assets/cloth.jpg'))
+model = t3.Model(f_n=(N - 1)**2 * 4, vi_n=N**2, vt_n=N**2, f_m=1)
 scene.add_model(model)
 camera = t3.Camera(fov=24, pos=[0, 1.1, -1.5], target=[0, 0.25, 0])
 scene.add_camera(camera)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://github.com/taichi-dev/taichi_three

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Thank @victoriacity and @DSaurus for their contribution, we can now control the camera in better ways in Taichi THREE:
1. LMB for orbiting the target.
2. RMB or mouse wheel for scaling distance to target.
3. MMB for moving target position.

Since API breaking change is made in v0.0.2 -> v0.0.3, so I'd like to update the mass_spring_3d.py in Taichi main repo too.