### PR TITLE
[blender] [example] Fix examples/waterwave.py memory leakage in Blender

### DIFF
--- a/examples/waterwave.py
+++ b/examples/waterwave.py
@@ -11,11 +11,11 @@ depth = 4
 dx = 0.02
 dt = 0.01
 shape = 512, 512
-pixels = ti.field(dtype=ti.f32, shape=shape)
-background = ti.field(dtype=ti.f32, shape=shape)
-height = ti.field(dtype=ti.f32, shape=shape)
-velocity = ti.field(dtype=ti.f32, shape=shape)
-acceleration = ti.field(dtype=ti.f32, shape=shape)
+pixels = ti.field(dtype=float, shape=shape)
+background = ti.field(dtype=float, shape=shape)
+height = ti.field(dtype=float, shape=shape)
+velocity = ti.field(dtype=float, shape=shape)
+acceleration = ti.field(dtype=float, shape=shape)
 
 
 @ti.kernel
@@ -90,11 +90,11 @@ def paint():
 print("[Hint] click on the window to create wavelet")
 
 reset()
-gui = ti.GUI("Water Wave", shape)
-for frame in range(100000):
+gui = ti.GUI('Water Wave', shape)
+while gui.running:
     for e in gui.get_events(ti.GUI.PRESS):
         if e.key in [ti.GUI.ESCAPE, ti.GUI.EXIT]:
-            exit()
+            gui.running = False
         elif e.key == 'r':
             reset()
         elif e.key == ti.GUI.LMB:

--- a/misc/prtags.json
+++ b/misc/prtags.json
@@ -31,5 +31,6 @@
   "ipython"         : "IPython and other shells",
   "cc"              : "C source backend",
   "error"           : "Error messages",
+  "blender"         : "Blender intergration",
   "release"         : "Release"
 }


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://github.com/taichi-dev/taichi/issues/1483#issuecomment-674958231

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
@EaryChow Does removing `exit()` fix the issue?
In fact, simply
```py
exit()
```
can cause Blender to crash.. see https://developer.blender.org/T44127.