### PR TITLE
[Error] Attach a traceback to ti.field when 'Some variable(s) are not placed'

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -215,12 +215,20 @@ class PyTaichi:
         ti.trace('Materializing layout...')
         taichi_lang_core.layout(layout)
         self.materialized = True
+        not_placed = []
         for var in self.global_vars:
             if var.ptr.snode() is None:
-                raise RuntimeError(
-                    'Some variable(s) are not placed.'
-                    ' Did you forget to specify the shape of any field? E.g., the "shape" argument in'
-                    ' ti.field(dtype=ti.f32, shape=(3, 4))')
+                tb = getattr(var, 'declaration_tb', str(var.ptr))
+                not_placed.append(tb)
+
+        if len(not_placed):
+            bar = '=' * 44 + '\n'
+            raise RuntimeError(
+                    f'These field(s) are not placed:\n{bar}' +
+                    f'{bar}'.join(not_placed) +
+                    f'{bar}Consider specify a shape for them, e.g.:' +
+                    '\n\n  x = ti.field(float, shape=(2, 3))'
+                    )
 
     def clear(self):
         if self.prog:
@@ -346,13 +354,14 @@ def field(dtype, shape=None, offset=None, needs_grad=False):
             "No new variables can be declared after materialization, i.e. kernel invocations "
             "or Python-scope field accesses. I.e., data layouts must be specified before "
             "any computation. Try appending ti.init() or ti.reset() "
-            "right after 'import taichi as ti' if you are using Jupyter notebook."
+            "right after 'import taichi as ti' if you are using Jupyter notebook or Blender."
         )
 
     del _taichi_skip_traceback
 
     # primal
     x = Expr(taichi_lang_core.make_id_expr(""))
+    x.declaration_tb = get_traceback(stacklevel=2)
     x.ptr = taichi_lang_core.global_new(x.ptr, dtype)
     x.ptr.set_is_primal(True)
     pytaichi.global_vars.append(x)

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -475,7 +475,7 @@ def assign(a, b):
     return a
 
 
-sqr = obsolete('ti.sqr(x)', 'x**2')
+sqr = obsoleted('ti.sqr(x)', 'x**2')
 
 
 def ti_max(*args):

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -1,5 +1,5 @@
 from .core import taichi_lang_core
-from taichi.misc.util import warning, deprecated, obsolete
+from taichi.misc.util import warning, deprecated, obsoleted, get_traceback
 import numpy as np
 import os
 

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -147,11 +147,11 @@ def deprecated(old, new, type=DeprecationWarning):
     return decorator
 
 
-def obsolete(old, new):
+def obsoleted(old, new):
     '''
-    Mark API as obsolete, with no API wrapper. E.g.,
+    Mark API as obsoleted, with no API wrapper. E.g.,
 
-    sqr = obsolete('ti.sqr(x)', 'x**2')
+    sqr = obsoleted('ti.sqr(x)', 'x**2')
     '''
     def wrapped(*args, **kwargs):
         _taichi_skip_traceback = 1
@@ -165,6 +165,12 @@ def obsolete(old, new):
         raise SyntaxError(msg)
 
     return wrapped
+
+
+def get_traceback(stacklevel=1):
+    import traceback
+    s = traceback.extract_stack()[:-1 - stacklevel]
+    return ''.join(traceback.format_list(s))
 
 
 def get_logging(name):
@@ -243,7 +249,7 @@ __all__ = [
     'core_vec',
     'core_veci',
     'deprecated',
-    'obsolete',
+    'obsoleted',
     'set_gdb_trigger',
     'print_profile_info',
     'set_logging_level',


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1696

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
```py
import taichi as ti


x = ti.field(float)
y = ti.Vector.field(2, float)


def f():
    return ti.field(int)

z = f()


x[None]
```
===
```
(master) [bate@archit taichi]$ p a.py
[Taichi] mode=development
[Taichi] preparing sandbox at /tmp/taichi-a5jnk9ft
[Taichi] <dev mode>, llvm 10.0.0, commit 58b9cde8, linux, python 3.8.3
[Taichi] materializing...
Traceback (most recent call last):
  File "a.py", line 14, in <module>
    x[None]
  File "/home/bate/Develop/taichi/python/taichi/lang/util.py", line 212, in wrapped
    return func(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/expr.py", line 56, in __getitem__
    impl.get_runtime().materialize()
  File "/home/bate/Develop/taichi/python/taichi/lang/impl.py", line 226, in materialize
    raise RuntimeError(
RuntimeError: These field(s) are not placed:
============================================
  File "a.py", line 4, in <module>
    x = ti.field(float)
============================================
  File "a.py", line 5, in <module>
    y = ti.Vector.field(2, float)
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 861, in _Vector_field
    return cls.field(n, 1, dtype, *args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/util.py", line 212, in wrapped
    return func(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 807, in field
    self.entries.append(impl.field(dtype))
============================================
  File "a.py", line 5, in <module>
    y = ti.Vector.field(2, float)
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 861, in _Vector_field
    return cls.field(n, 1, dtype, *args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/util.py", line 212, in wrapped
    return func(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 807, in field
    self.entries.append(impl.field(dtype))
============================================
  File "a.py", line 11, in <module>
    z = f()
  File "a.py", line 9, in f
    return ti.field(int)
============================================
Consider specify a shape for them, e.g.:

  x = ti.field(float, shape=(2, 3))
```