### PR TITLE
[GUI] Add handy ti.imscale(img, w, h) for scaling image

### DIFF
--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -522,3 +522,14 @@ Image I/O
     This function will create an instance of ``ti.GUI`` and show the input image on the screen.
 
     It has the same logic as ``ti.imwrite`` for different datatypes.
+
+.. function:: ti.imscale(img, w=512, h=None):
+
+    :parameter img: (np.array or ti.field) the input image.
+    :parameter w: (optional, scalar) the width after scale.
+    :parameter h: (optional, scalar) the height after scale.
+    :return: (np.array) the output image after scale.
+
+    If ``h`` is not specified, then it will be equal to ``w`` by default.
+
+    The output image shape is: ``(w, h, *img.shape[2:])``.

--- a/examples/game_of_life.py
+++ b/examples/game_of_life.py
@@ -11,7 +11,6 @@ cell_size = 8
 img_size = n * cell_size
 alive = ti.field(int, shape=(n, n))  # alive = 1, dead = 0
 count = ti.field(int, shape=(n, n))  # count of neighbours
-img = ti.field(float, shape=(img_size, img_size))  # image to be displayed
 
 
 @ti.func
@@ -58,13 +57,6 @@ def init():
             alive[i, j] = 0
 
 
-@ti.kernel
-def render():
-    for i, j in alive:
-        for u, v in ti.static(ti.ndrange(cell_size, cell_size)):
-            img[i * cell_size + u, j * cell_size + v] = alive[i, j]
-
-
 gui = ti.GUI('Game of Life', (img_size, img_size))
 gui.fps_limit = 15
 
@@ -91,7 +83,5 @@ while gui.running:
     if not paused:
         run()
 
-    render()
-
-    gui.set_image(img)
+    gui.set_image(ti.imscale(alive, img_size).astype(np.uint8) * 255)
     gui.show()

--- a/python/taichi/misc/image.py
+++ b/python/taichi/misc/image.py
@@ -34,7 +34,11 @@ def imdisplay(img):
     """
     Try to display image in interactive shell.
     """
-    if ti.lang.shell.oinspect.name == ti.lang.shell.ShellType.JUPYTER:
+    try:
+        get_ipython()
+    except:
+        ti.imshow(img)
+    else:
         import PIL.Image
         from io import BytesIO
         import IPython.display
@@ -43,8 +47,20 @@ def imdisplay(img):
         with BytesIO() as f:
             PIL.Image.fromarray(img).save(f, 'png')
             IPython.display.display(IPython.display.Image(data=f.getvalue()))
-    else:
-        ti.imshow(img)
+
+
+def imscale(img, w=512, h=None):
+    """
+    Scale a image into specific size.
+    """
+    if not isinstance(img, np.ndarray):
+        img = img.to_numpy()
+    if h is None:
+        h = w
+    u, v = (img.shape[0] - 1) / (w - 1), (img.shape[1] - 1) / (h - 1)
+    x = np.clip(np.arange(w) * u, 0, img.shape[0] - 1).astype(np.int32)
+    y = np.clip(np.arange(h) * v, 0, img.shape[1] - 1).astype(np.int32)
+    return img[np.meshgrid(x, y)].swapaxes(0, 1)
 
 
 def imwrite(img, filename):
@@ -94,5 +110,6 @@ __all__ = [
     'imshow',
     'imread',
     'imwrite',
+    'imscale',
     'imdisplay',
 ]

--- a/python/taichi/misc/image.py
+++ b/python/taichi/misc/image.py
@@ -60,7 +60,7 @@ def imscale(img, w=512, h=None):
     u, v = (img.shape[0] - 1) / (w - 1), (img.shape[1] - 1) / (h - 1)
     x = np.clip(np.arange(w) * u, 0, img.shape[0] - 1).astype(np.int32)
     y = np.clip(np.arange(h) * v, 0, img.shape[1] - 1).astype(np.int32)
-    return img[np.meshgrid(x, y)].swapaxes(0, 1)
+    return img[tuple(np.meshgrid(x, y))].swapaxes(0, 1)
 
 
 def imwrite(img, filename):


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
When I was debugging MGPCG, I realized that a small resolution is fast but hardly-visible. So it would be great if I could scale that small image up.