### PR TITLE
[opt] Add irpass::analysis::same_value

### DIFF
--- a/taichi/analysis/same_statements.cpp
+++ b/taichi/analysis/same_statements.cpp
@@ -211,9 +211,12 @@ bool same_value(Stmt *stmt1, Stmt *stmt2) {
     return true;
   if (!stmt1 || !stmt2)
     return false;
-  // If two same statements can have different values, return false.
+  // If two identical statements can have different values, return false.
   if (!stmt1->common_statement_eliminable())
     return false;
+  // Note that we do not need to test !stmt2->common_statement_eliminable()
+  // because if this condition does not hold,
+  // same_statements(stmt1, stmt2) returns false anyway.
   return same_statements(stmt1, stmt2);
 }
 }  // namespace irpass::analysis

--- a/taichi/analysis/same_statements.cpp
+++ b/taichi/analysis/same_statements.cpp
@@ -205,6 +205,17 @@ bool same_statements(IRNode *root1, IRNode *root2) {
     return false;
   return IRNodeComparator::run(root1, root2);
 }
+bool same_value(Stmt *stmt1, Stmt *stmt2) {
+  // Test if two statements must have the same value.
+  if (stmt1 == stmt2)
+    return true;
+  if (!stmt1 || !stmt2)
+    return false;
+  // If two same statements can have different values, return false.
+  if (!stmt1->common_statement_eliminable())
+    return false;
+  return same_statements(stmt1, stmt2);
+}
 }  // namespace irpass::analysis
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -74,7 +74,7 @@ bool has_store_or_atomic(IRNode *root, const std::vector<Stmt *> &vars);
 std::pair<bool, Stmt *> last_store_or_atomic(IRNode *root, Stmt *var);
 bool maybe_same_address(Stmt *var1, Stmt *var2);
 bool same_statements(IRNode *root1, IRNode *root2);
-DiffRange value_diff(Stmt *stmt, int lane, Stmt *alloca);
+bool same_value(Stmt *stmt1, Stmt *stmt2);
 DiffRange value_diff_loop_index(Stmt *stmt, Stmt *loop, int index_id);
 std::pair<bool, int> value_diff_ptr_index(Stmt *val1, Stmt *val2);
 void verify(IRNode *root);

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -167,7 +167,7 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
         block->statements[last_def_position].get());
     if (!var->is<AllocaStmt>()) {
       for (int i = last_def_position + 1; i < position; i++) {
-        if (!irpass::analysis::same_statements(
+        if (!irpass::analysis::same_value(
                 result,
                 irpass::analysis::get_store_data(block->statements[i].get()))) {
           if (may_contain_address(block->statements[i].get(), var)) {
@@ -199,7 +199,7 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
       result_visible = visible(data);
       return true;  // continue the following loops
     }
-    if (!irpass::analysis::same_statements(result, data)) {
+    if (!irpass::analysis::same_value(result, data)) {
       // check the special case of alloca (initialized to 0)
       if (!(result->is<AllocaStmt>() && data->is<ConstStmt>() &&
             data->width() == 1 &&
@@ -300,7 +300,7 @@ bool CFGNode::store_to_load_forwarding(bool after_lower_access) {
           }
         } else {
           // not alloca
-          if (irpass::analysis::same_statements(result, local_store->data)) {
+          if (irpass::analysis::same_value(result, local_store->data)) {
             erase(i);  // This causes end_location--
             i--;       // to cancel i++ in the for loop
             modified = true;
@@ -310,7 +310,7 @@ bool CFGNode::store_to_load_forwarding(bool after_lower_access) {
     } else if (auto global_store = stmt->cast<GlobalStoreStmt>()) {
       if (!after_lower_access) {
         result = get_store_forwarding_data(global_store->ptr, i);
-        if (irpass::analysis::same_statements(result, global_store->data)) {
+        if (irpass::analysis::same_value(result, global_store->data)) {
           erase(i);  // This causes end_location--
           i--;       // to cancel i++ in the for loop
           modified = true;


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1741 #1248 

Store-to-load forwarding needs to check if two statements (must) have the same value. `same_statements` may be incorrect when there are two statements loading the same `alloca`.

`value_diff` can do a better job than `same_value`, but it's too expensive (slow) for this usage, and I think `same_value` is enough if other optimizations like constant folding are done.

TODO: rename `common_statement_eliminable`.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
