### PR TITLE
[bug] Fix stable fluid BFECC advection

### DIFF
--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -314,7 +314,7 @@ class MouseDataGen(object):
         # [4:7]: color
         mouse_data = np.zeros(8, dtype=np.float32)
         if gui.is_pressed(ti.GUI.LMB) or frame < 20:
-            if frame < 20:
+            if gui.frame < 20:
                 # print(frame)
                 mxy = np.array([0 + frame*0.01, 0 + frame*0.01],
                                dtype=np.float32) * res
@@ -346,7 +346,6 @@ def reset():
 
 gui = ti.GUI('Stable Fluid', (res, res))
 md_gen = MouseDataGen()
-frame = 0
 while gui.running:
     if gui.get_event(ti.GUI.PRESS):
         e = gui.event
@@ -360,13 +359,12 @@ while gui.running:
         elif e.key == 'd':
             debug = not debug
 
-    frame += 1
 
-    if frame > 4500:
+    if gui.frame > 4500:
         break
 
     if not paused:
-        mouse_data = md_gen(gui, frame)
+        mouse_data = md_gen(gui, gui.frame)
         # if frame < 40:
         #     print(mouse_data)
         step(mouse_data)

--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -68,9 +68,9 @@ def bilerp(vf, p):
     # fract
     fu, fv = s - iu, t - iv
     a = sample(vf, iu, iv)
-    b = sample(vf, iu+1, iv)
-    c = sample(vf, iu, iv+1)
-    d = sample(vf, iu+1, iv+1)
+    b = sample(vf, iu + 1, iv)
+    c = sample(vf, iu, iv + 1)
+    d = sample(vf, iu + 1, iv + 1)
     return lerp(lerp(a, b, fu), lerp(c, d, fu), fv)
 
 
@@ -81,9 +81,9 @@ def sample_minmax(vf, p):
     # floor
     iu, iv = ti.floor(s), ti.floor(t)
     a = sample(vf, iu, iv)
-    b = sample(vf, iu+1, iv)
-    c = sample(vf, iu, iv+1)
-    d = sample(vf, iu+1, iv+1)
+    b = sample(vf, iu + 1, iv)
+    c = sample(vf, iu, iv + 1)
+    d = sample(vf, iu + 1, iv + 1)
     return min(a, b, c, d), max(a, b, c, d)
 
 
@@ -115,8 +115,8 @@ backtrace = backtrace_rk3
 
 
 @ti.kernel
-def advect_semilag(vf: ti.template(), qf: ti.template(),
-                   new_qf: ti.template(), intermedia_qf: ti.template()):
+def advect_semilag(vf: ti.template(), qf: ti.template(), new_qf: ti.template(),
+                   intermedia_qf: ti.template()):
     ti.cache_read_only(qf, vf)
     for i, j in vf:
         p = ti.Vector([i, j]) + 0.5
@@ -125,7 +125,8 @@ def advect_semilag(vf: ti.template(), qf: ti.template(),
 
 
 @ti.kernel
-def advect_bfecc(vf: ti.template(), qf: ti.template(), new_qf: ti.template(), intermedia_qf: ti.template()):
+def advect_bfecc(vf: ti.template(), qf: ti.template(), new_qf: ti.template(),
+                 intermedia_qf: ti.template()):
     ti.cache_read_only(qf, vf)
     for i, j in vf:
         p = ti.Vector([i, j]) + 0.5
@@ -142,7 +143,7 @@ def advect_bfecc(vf: ti.template(), qf: ti.template(), new_qf: ti.template(), in
         q_star = intermedia_qf[i, j]
         new_qf[i, j] = bilerp(intermedia_qf, p_two_star)
 
-        new_qf[i, j] = q_star + 0.5 * (qf[i, j]-new_qf[i, j])
+        new_qf[i, j] = q_star + 0.5 * (qf[i, j] - new_qf[i, j])
 
         min_val, max_val = sample_minmax(qf, p_star)
         cond = min_val < new_qf[i, j] < max_val
@@ -277,10 +278,10 @@ def enhance_vorticity(vf: ti.template(), cf: ti.template()):
 
 
 def step(mouse_data):
-    advect(velocities_pair.cur, velocities_pair.cur,
-           velocities_pair.nxt, _intermedia_velocities)
-    advect(velocities_pair.cur, dyes_pair.cur,
-           dyes_pair.nxt, _intermedia_dye_buffer)
+    advect(velocities_pair.cur, velocities_pair.cur, velocities_pair.nxt,
+           _intermedia_velocities)
+    advect(velocities_pair.cur, dyes_pair.cur, dyes_pair.nxt,
+           _intermedia_dye_buffer)
     velocities_pair.swap()
     dyes_pair.swap()
 

--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -308,23 +308,17 @@ class MouseDataGen(object):
         self.prev_mouse = None
         self.prev_color = None
 
-    def __call__(self, gui, frame):
+    def __call__(self, gui):
         # [0:2]: normalized delta direction
         # [2:4]: current mouse xy
         # [4:7]: color
         mouse_data = np.zeros(8, dtype=np.float32)
-        if gui.is_pressed(ti.GUI.LMB) or frame < 20:
-            if gui.frame < 20:
-                # print(frame)
-                mxy = np.array([0 + frame*0.01, 0 + frame*0.01],
-                               dtype=np.float32) * res
-            else:
-                mxy = np.array(gui.get_cursor_pos(), dtype=np.float32) * res
+        if gui.is_pressed(ti.GUI.LMB):
+            mxy = np.array(gui.get_cursor_pos(), dtype=np.float32) * res
             if self.prev_mouse is None:
                 self.prev_mouse = mxy
                 # Set lower bound to 0.3 to prevent too dark colors
-                # self.prev_color = (np.random.rand(3) * 0.7) + 0.3
-                self.prev_color = np.array([1, 1, 1], dtype=np.float32)
+                self.prev_color = (np.random.rand(3) * 0.7) + 0.3
             else:
                 mdir = mxy - self.prev_mouse
                 mdir = mdir / (np.linalg.norm(mdir) + 1e-5)
@@ -361,23 +355,16 @@ while gui.running:
             paused = not paused
         elif e.key == 'd':
             debug = not debug
-        elif e.key == 'o':
-            v_mngr.make_video(mp4=False, gif=True)
-
-    if gui.frame > 4500:
-        v_mngr.make_video(mp4=False, gif=True)
-        break
 
     if not paused:
-        mouse_data = md_gen(gui, gui.frame)
+        mouse_data = md_gen(gui)
         step(mouse_data)
 
     gui.set_image(dyes_pair.cur)
     # To visualize velocity field:
-    #gui.set_image(velocities_pair.cur.to_numpy() * 0.01 + 0.5)
+    # gui.set_image(velocities_pair.cur.to_numpy() * 0.01 + 0.5)
     # To visualize velocity divergence:
-    #divergence(velocities_pair.cur); gui.set_image(velocity_divs.to_numpy() * 0.1 + 0.5)
+    # divergence(velocities_pair.cur); gui.set_image(velocity_divs.to_numpy() * 0.1 + 0.5)
     # To visualize velocity vorticity:
-    #vorticity(velocities_pair.cur); gui.set_image(velocity_curls.to_numpy() * 0.03 + 0.5)
-    v_mngr.write_frame(dyes_pair.cur)
+    # vorticity(velocities_pair.cur); gui.set_image(velocity_curls.to_numpy() * 0.03 + 0.5)
     gui.show()

--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -135,12 +135,13 @@ def advect_bfecc(vf: ti.template(), qf: ti.template(), new_qf: ti.template(), in
     ti.cache_read_only(intermedia_qf, qf, vf)
     for i, j in vf:
         p = ti.Vector([i, j]) + 0.5
+        # star means the temp value after a back tracing (forward advection)
+        # two star means the temp value after a forward tracing (reverse advection)
         p_two_star = backtrace(vf, p, -dt)
         p_star = backtrace(vf, p, dt)
         q_star = intermedia_qf[i, j]
         new_qf[i, j] = bilerp(intermedia_qf, p_two_star)
 
-        # new
         new_qf[i, j] = q_star + 0.5 * (qf[i, j]-new_qf[i, j])
 
         min_val, max_val = sample_minmax(qf, p_star)
@@ -336,9 +337,6 @@ def reset():
     velocities_pair.cur.fill(0)
     pressures_pair.cur.fill(0)
     dyes_pair.cur.fill(0)
-
-
-v_mngr = ti.VideoManager('./', framerate=24, automatic_build=False)
 
 
 gui = ti.GUI('Stable Fluid', (res, res))

--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -67,10 +67,10 @@ def bilerp(vf, p):
     iu, iv = int(s), int(t)
     # fract
     fu, fv = s - iu, t - iv
-    a = sample(vf, iu + 0.5, iv + 0.5)
-    b = sample(vf, iu + 1.5, iv + 0.5)
-    c = sample(vf, iu + 0.5, iv + 1.5)
-    d = sample(vf, iu + 1.5, iv + 1.5)
+    a = sample(vf, iu, iv)
+    b = sample(vf, iu+1, iv)
+    c = sample(vf, iu, iv+1)
+    d = sample(vf, iu+1, iv+1)
     return lerp(lerp(a, b, fu), lerp(c, d, fu), fv)
 
 
@@ -80,10 +80,10 @@ def sample_minmax(vf, p):
     s, t = u - 0.5, v - 0.5
     # floor
     iu, iv = int(s), int(t)
-    a = sample(vf, iu + 0.5, iv + 0.5)
-    b = sample(vf, iu + 1.5, iv + 0.5)
-    c = sample(vf, iu + 0.5, iv + 1.5)
-    d = sample(vf, iu + 1.5, iv + 1.5)
+    a = sample(vf, iu, iv)
+    b = sample(vf, iu+1, iv)
+    c = sample(vf, iu, iv+1)
+    d = sample(vf, iu+1, iv+1)
     return min(a, b, c, d), max(a, b, c, d)
 
 
@@ -185,13 +185,13 @@ def divergence(vf: ti.template()):
         vt = sample(vf, i, j + 1).y
         vc = sample(vf, i, j)
         if i == 0:
-            vl = -vc.x
+            vl = 0
         if i == res - 1:
-            vr = -vc.x
+            vr = 0
         if j == 0:
-            vb = -vc.y
+            vb = 0
         if j == res - 1:
-            vt = -vc.y
+            vt = 0
         velocity_divs[i, j] = (vr - vl + vt - vb) * 0.5
 
 
@@ -362,7 +362,7 @@ while gui.running:
 
     frame += 1
 
-    if frame > 450:
+    if frame > 4500:
         break
 
     if not paused:

--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -64,7 +64,7 @@ def bilerp(vf, p):
     u, v = p
     s, t = u - 0.5, v - 0.5
     # floor
-    iu, iv = int(s), int(t)
+    iu, iv = ti.floor(s), ti.floor(t)
     # fract
     fu, fv = s - iu, t - iv
     a = sample(vf, iu, iv)
@@ -79,7 +79,7 @@ def sample_minmax(vf, p):
     u, v = p
     s, t = u - 0.5, v - 0.5
     # floor
-    iu, iv = int(s), int(t)
+    iu, iv = ti.floor(s), ti.floor(t)
     a = sample(vf, iu, iv)
     b = sample(vf, iu+1, iv)
     c = sample(vf, iu, iv+1)
@@ -344,6 +344,9 @@ def reset():
     dyes_pair.cur.fill(0)
 
 
+v_mngr = ti.VideoManager('./', framerate=24, automatic_build=False)
+
+
 gui = ti.GUI('Stable Fluid', (res, res))
 md_gen = MouseDataGen()
 while gui.running:
@@ -358,15 +361,15 @@ while gui.running:
             paused = not paused
         elif e.key == 'd':
             debug = not debug
-
+        elif e.key == 'o':
+            v_mngr.make_video(mp4=False, gif=True)
 
     if gui.frame > 4500:
+        v_mngr.make_video(mp4=False, gif=True)
         break
 
     if not paused:
         mouse_data = md_gen(gui, gui.frame)
-        # if frame < 40:
-        #     print(mouse_data)
         step(mouse_data)
 
     gui.set_image(dyes_pair.cur)
@@ -376,4 +379,5 @@ while gui.running:
     #divergence(velocities_pair.cur); gui.set_image(velocity_divs.to_numpy() * 0.1 + 0.5)
     # To visualize velocity vorticity:
     #vorticity(velocities_pair.cur); gui.set_image(velocity_curls.to_numpy() * 0.03 + 0.5)
+    v_mngr.write_frame(dyes_pair.cur)
     gui.show()


### PR DESCRIPTION
Related issue = #1757 

In this PR I plan to fix the BFECC advection in `stable_fluid.py`. Seems that there are several problems tangled inside this one. So let's try to solve them one-by-one. I may need your @yuanming-hu  and @archibate help to review if the errors are from the BFECC or the PPE solving. Thanks a lot,

- [x] Fixed the correction term's symbol.
- [x] Reset Poisson solver to `jacobi_single`.
- [x] Fixed the whole `advect_bfecc` function.
- [x] Fixed the `int()` (with `math.floor()`) which irritates when input is negative

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----