### PR TITLE
[Refactor] [lang] 'ti.var' is deprecated, use 'ti.field' instead

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -322,7 +322,7 @@ class Root:
 root = Root()
 
 
-#@deprecated('ti.var', 'ti.field')
+@deprecated('ti.var', 'ti.field')
 def var(dt, shape=None, offset=None, needs_grad=False):
     _taichi_skip_traceback = 1
     return field(dt, shape, offset, needs_grad)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -84,11 +84,11 @@ class Matrix(TaichiOperations):
                 self.m = m
             else:
                 # construct global matrix (deprecated)
-                #warning(  # TODO(archibate): uncomment this when #1500 is complete
-                #    "Declaring global matrices using `ti.Matrix(n, m, dt, shape)` is deprecated, "
-                #    "use `ti.Matrix.field(n, m, dtype, shape)` instead",
-                #    DeprecationWarning,
-                #    stacklevel=2)
+                warning(
+                    "Declaring global matrices using `ti.Matrix(n, m, dt, shape)` is deprecated, "
+                    "use `ti.Matrix.field(n, m, dtype, shape)` instead",
+                    DeprecationWarning,
+                    stacklevel=2)
                 mat = Matrix.field(n=n,
                                    m=m,
                                    dtype=dt,
@@ -848,7 +848,7 @@ class Matrix(TaichiOperations):
 
     @classmethod
     @python_scope
-    #@deprecated('ti.Matrix.var', 'ti.Matrix.field')
+    @deprecated('ti.Matrix.var', 'ti.Matrix.field')
     def var(cls, n, m, dt, *args, **kwargs):
         '''ti.Matrix.var'''
         _taichi_skip_traceback = 1
@@ -861,7 +861,7 @@ class Matrix(TaichiOperations):
         return cls.field(n, 1, dtype, *args, **kwargs)
 
     @classmethod
-    #@deprecated('ti.Vector.var', 'ti.Vector.field')
+    @deprecated('ti.Vector.var', 'ti.Vector.field')
     def _Vector_var(cls, n, dt, *args, **kwargs):
         '''ti.Vector.var'''
         _taichi_skip_traceback = 1

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -139,6 +139,12 @@ def deprecated(old, new, type=DeprecationWarning):
         def wrapped(*args, **kwargs):
             _taichi_skip_traceback = 1
             msg = f'{old} is deprecated, please use {new} instead'
+            try:
+                import locale
+                if 'zh' in locale.getdefaultlocale()[0]:
+                    msg += f'\n{old} 已被废除，请使用 {new} 来替换'
+            except:
+                pass
             warning(msg, type, stacklevel=2)
             return foo(*args, **kwargs)
 
@@ -159,7 +165,7 @@ def obsolete(old, new):
         try:
             import locale
             if 'zh' in locale.getdefaultlocale()[0]:
-                msg += f'\n{old} 已经被彻底移除，请使用 {new} 来替换'
+                msg += f'\n{old} 已被彻底废除，请使用 {new} 来替换'
         except:
             pass
         raise SyntaxError(msg)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1500

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Thanks for the extraordinary works of @Rullec, we can finally officially announce the deprecation.
@yuanming-hu We need you insight about whether to:
1. obsolete `ti.var` after v0.7.0
2. deprecate `ti.var` with an warning after v0.7.0