### PR TITLE
[async] [benchmark] Enable optimization for global variables after fusion

### DIFF
--- a/benchmarks/async_cases.py
+++ b/benchmarks/async_cases.py
@@ -31,8 +31,8 @@ def benchmark_async(func):
 @benchmark_async
 def fuse_dense_x2y2z(scale):
     template_fuse_dense_x2y2z(size=scale * 10 * 1024**2,
-                              repeat=10,
-                              benchmark_repeat=10,
+                              repeat=1,
+                              benchmark_repeat=100,
                               benchmark=True)
 
 
@@ -53,7 +53,11 @@ def fill_1d(scale):
         for i in a:
             a[i] = 1.0
 
-    ti.benchmark(fill, repeat=10)
+    def repeated_fill():
+        for _ in range(10):
+            fill()
+
+    ti.benchmark(repeated_fill, repeat=10)
 
 
 @benchmark_async
@@ -64,7 +68,11 @@ def fill_scalar(scale):
     def fill():
         a[None] = 1.0
 
-    ti.benchmark(fill, repeat=1000)
+    def repeated_fill():
+        for _ in range(1000):
+            fill()
+
+    ti.benchmark(repeated_fill, repeat=5)
 
 
 @benchmark_async

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -342,15 +342,16 @@ def benchmark(func, repeat=300, args=()):
                 ti.stat_write('offloaded_tasks', b)
             elif a == 'launched_kernels':
                 ti.stat_write('launched_kernels', b)
-        # The reason why we run 4 times is to warm up instruction/data caches.
-        # Discussion: https://github.com/taichi-dev/taichi/pull/1002#discussion_r426312136
-        for i in range(4):
+        # The reason why we run 3 more times is to warm up
+        # instruction/data caches. Discussion:
+        # https://github.com/taichi-dev/taichi/pull/1002#discussion_r426312136
+        for i in range(3):
             func(*args)
-        ti.sync()
+            ti.sync()
         t = time.time()
         for n in range(repeat):
             func(*args)
-        ti.sync()
+            ti.sync()
         elapsed = time.time() - t
         avg = elapsed / repeat
         ti.stat_write('running_time', avg)

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -424,7 +424,7 @@ bool AsyncEngine::fuse() {
       irpass::fix_block_parents(task_a);
 
       auto kernel = task_queue[i].kernel;
-      irpass::full_simplify(task_a, true, kernel);
+      irpass::full_simplify(task_a, /*after_lower_access=*/false, kernel);
       task_queue[i].h = hash(task_a);
 
       modified = true;

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -303,6 +303,8 @@ int Kernel::insert_ret(DataType dt) {
 }
 
 void Kernel::account_for_offloaded(OffloadedStmt *stmt) {
+  if (is_evaluator || is_accessor)
+    return;
   auto task_type = stmt->task_type;
   stat.add("launched_kernels", 1.0);
   if (task_type == OffloadedStmt::TaskType::listgen) {


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #742 

`after_lower_access=false` allows `cfg_optimization` to optimize for global variables.

Also removes evaluators and accessors from #kernel_launches in the statistics.

Also adds `ti.sync()` after each run when benchmarking, and adjust the `repeat` parameters in `async_cases` accordingly.

![benchmark20200825](https://user-images.githubusercontent.com/22582118/91153205-7fdebf80-e6f2-11ea-9543-80e00c17b663.png)


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
