### PR TITLE
[error] [opengl] Better error message when int64 or sparse SNode not supported for OpenGL

### DIFF
--- a/taichi/backends/metal/struct_metal.cpp
+++ b/taichi/backends/metal/struct_metal.cpp
@@ -227,8 +227,10 @@ class StructCompiler {
       emit("  SNodeRep_{} rep_;", snty_name);
       emit("}};");
     } else {
-      TI_ERROR("SNodeType={} not supported on Metal", snode_type_name(snty));
-      TI_NOT_IMPLEMENTED;
+      TI_ERROR("SNodeType={} not supported on OpenGL\n"
+               "Consider use ti.init(ti.cpu) or ti.init(ti.cuda) if you "
+               "want to use sparse data structures",
+               snode_type_name(snode.type));
     }
     emit("");
   }

--- a/taichi/backends/metal/struct_metal.cpp
+++ b/taichi/backends/metal/struct_metal.cpp
@@ -227,10 +227,11 @@ class StructCompiler {
       emit("  SNodeRep_{} rep_;", snty_name);
       emit("}};");
     } else {
-      TI_ERROR("SNodeType={} not supported on OpenGL\n"
-               "Consider use ti.init(ti.cpu) or ti.init(ti.cuda) if you "
-               "want to use sparse data structures",
-               snode_type_name(snode.type));
+      TI_ERROR(
+          "SNodeType={} not supported on OpenGL\n"
+          "Consider use ti.init(ti.cpu) or ti.init(ti.cuda) if you "
+          "want to use sparse data structures",
+          snode_type_name(snode.type));
     }
     emit("");
   }

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -105,7 +105,7 @@ class KernelGen : public IRVisitor {
   // data type, but also **records** the usage of `i64` and `f64`.
   std::string opengl_data_type_short_name(DataType dt) {
     if (dt == DataType::i64) {
-      if (!TI_OPENGL_REQUIRE(ARB_gpu_shader_int64)) {
+      if (!TI_OPENGL_REQUIRE(used, GL_ARB_gpu_shader_int64)) {
         TI_ERROR("Extension GL_ARB_gpu_shader_int64 not supported on your OpenGL");
       }
       used.int64 = true;

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -815,6 +815,7 @@ class KernelGen : public IRVisitor {
 
   void generate_struct_for_kernel(OffloadedStmt *stmt) {
     TI_ASSERT(stmt->task_type == OffloadedStmt::TaskType::struct_for);
+    used.listman = true;
     const std::string glsl_kernel_name = make_kernel_name();
     emit("void {}()", glsl_kernel_name);
     this->glsl_kernel_name_ = glsl_kernel_name;
@@ -833,6 +834,7 @@ class KernelGen : public IRVisitor {
 
   void generate_clear_list_kernel(OffloadedStmt *stmt) {
     TI_ASSERT(stmt->task_type == OffloadedStmt::TaskType::clear_list);
+    used.listman = true;
     const std::string glsl_kernel_name = make_kernel_name();
     emit("void {}()", glsl_kernel_name);
     this->glsl_kernel_name_ = glsl_kernel_name;

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -106,7 +106,8 @@ class KernelGen : public IRVisitor {
   std::string opengl_data_type_short_name(DataType dt) {
     if (dt == DataType::i64) {
       if (!TI_OPENGL_REQUIRE(used, GL_ARB_gpu_shader_int64)) {
-        TI_ERROR("Extension GL_ARB_gpu_shader_int64 not supported on your OpenGL");
+        TI_ERROR(
+            "Extension GL_ARB_gpu_shader_int64 not supported on your OpenGL");
       }
       used.int64 = true;
     }

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -104,8 +104,12 @@ class KernelGen : public IRVisitor {
   // Note that the following two functions not only returns the corresponding
   // data type, but also **records** the usage of `i64` and `f64`.
   std::string opengl_data_type_short_name(DataType dt) {
-    if (dt == DataType::i64)
+    if (dt == DataType::i64) {
+      if (!TI_OPENGL_REQUIRE(ARB_gpu_shader_int64)) {
+        TI_ERROR("Extension GL_ARB_gpu_shader_int64 not supported on your OpenGL");
+      }
       used.int64 = true;
+    }
     if (dt == DataType::f64)
       used.float64 = true;
     return data_type_short_name(dt);

--- a/taichi/backends/opengl/struct_opengl.cpp
+++ b/taichi/backends/opengl/struct_opengl.cpp
@@ -72,10 +72,11 @@ void OpenglStructCompiler::generate_types(const SNode &snode) {
     snode_info.stride = snode_child_info.stride * n + extension;  // my stride
     snode_info.elem_stride = snode_child_info.stride;  // my child stride
   } else {
-    TI_ERROR("SNodeType={} not supported on OpenGL\n"
-             "Consider use ti.init(ti.cpu) or ti.init(ti.cuda) if you "
-             "want to use sparse data structures",
-             snode_type_name(snode.type));
+    TI_ERROR(
+        "SNodeType={} not supported on OpenGL\n"
+        "Consider use ti.init(ti.cpu) or ti.init(ti.cuda) if you "
+        "want to use sparse data structures",
+        snode_type_name(snode.type));
     TI_NOT_IMPLEMENTED;
   }
 }

--- a/taichi/backends/opengl/struct_opengl.cpp
+++ b/taichi/backends/opengl/struct_opengl.cpp
@@ -72,7 +72,9 @@ void OpenglStructCompiler::generate_types(const SNode &snode) {
     snode_info.stride = snode_child_info.stride * n + extension;  // my stride
     snode_info.elem_stride = snode_child_info.stride;  // my child stride
   } else {
-    TI_ERROR("SNodeType={} not supported on OpenGL",
+    TI_ERROR("SNodeType={} not supported on OpenGL\n"
+             "Consider use ti.init(ti.cpu) or ti.init(ti.cuda) if you "
+             "want to use sparse data structures",
              snode_type_name(snode.type));
     TI_NOT_IMPLEMENTED;
   }


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://github.com/taichi-dev/taichi/issues/1678#issuecomment-680824646

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
