### PR TITLE
[Example] Fix stable_fluid.py boundary broken: int -> ti.floor, and make mpm3d.py 3x faster on CUDA

### DIFF
--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -62,7 +62,8 @@ def bilerp(vf, p):
     u, v = p
     s, t = u - 0.5, v - 0.5
     # floor
-    iu, iv = int(s), int(t)
+    iu, iv = ti.floor(s), ti.floor(t)
+    iu, iv = int(s + 1) - 1, int(t + 1) - 1
     # fract
     fu, fv = s - iu, t - iv
     a = sample(vf, iu + 0.5, iv + 0.5)

--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -63,7 +63,6 @@ def bilerp(vf, p):
     s, t = u - 0.5, v - 0.5
     # floor
     iu, iv = ti.floor(s), ti.floor(t)
-    iu, iv = int(s + 1) - 1, int(t + 1) - 1
     # fract
     fu, fv = s - iu, t - iv
     a = sample(vf, iu + 0.5, iv + 0.5)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1757 replace #1764 break_down #1691

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----