### PR TITLE
[ir] [autodiff] Initialize ADStack with a zero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV CC=/usr/bin/clang-8
 ENV CXX=/usr/bin/clang++-8
 RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz
 RUN tar xvJf llvm-10.0.0.src.tar.xz
-RUN cd llvm-10.0.0.src && mkdir build 
+RUN cd llvm-10.0.0.src && mkdir build
 WORKDIR /llvm-10.0.0.src/build
 RUN cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
 RUN make -j 8

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -87,4 +87,3 @@ else ()
 endif ()
 
 include_directories(${PYBIND11_INCLUDE_DIR})
-

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -207,7 +207,7 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
 
       alloc->replace_with(std::move(stack_alloca));
 
-      // Note that unlike AllocStmt, StackAllocaStmt does NOT have an 0 as
+      // Note that unlike AllocaStmt, StackAllocaStmt does NOT have an 0 as
       // initial value. Therefore here we push an initial 0 value.
       auto zero = stack_alloca_ptr->insert_after_me(
           Stmt::make<ConstStmt>(TypedConstant(dtype, 0)));


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = close #1781

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
