### PR TITLE
[Lang] Support printing lists and tuples in Taichi-scope

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -407,14 +407,26 @@ def ti_print(*vars, sep=' ', end='\n'):
         else:
             return Expr(var).ptr
 
+    def list_ti_repr(var):
+        yield '['  # distinguishing tuple & list will increase maintainance cost
+        for i, v in enumerate(var):
+            if i:
+                yield ', '
+            yield v
+        yield ']'
+
     def vars2entries(vars):
         for var in vars:
             if hasattr(var, '__ti_repr__'):
-                repr = var.__ti_repr__()
-                for v in vars2entries(repr):
-                    yield v
+                res = var.__ti_repr__()
+            elif isinstance(var, (list, tuple)):
+                res = list_ti_repr(var)
             else:
                 yield var
+                continue
+
+            for v in vars2entries(res):
+                yield v
 
     def add_separators(vars):
         for i, var in enumerate(vars):

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -300,6 +300,7 @@ def mul(a, b):
 @binary
 def mod(a, b):
     def expr_python_mod(a, b):
+        # a % b = (a // b) * b - a
         quotient = Expr(ti_core.expr_floordiv(a, b))
         multiply = Expr(ti_core.expr_mul(b, quotient.ptr))
         return ti_core.expr_sub(a, multiply.ptr)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -574,12 +574,8 @@ void export_lang(py::module &m) {
 
   m.def("host_arch", host_arch);
 
-  m.def("set_lib_dir", [&](const std::string &dir) {
-    compiled_lib_dir = dir;
-  });
-  m.def("set_tmp_dir", [&](const std::string &dir) {
-    runtime_tmp_dir = dir;
-  });
+  m.def("set_lib_dir", [&](const std::string &dir) { compiled_lib_dir = dir; });
+  m.def("set_tmp_dir", [&](const std::string &dir) { runtime_tmp_dir = dir; });
   m.def("get_runtime_dir", get_runtime_dir);
 
   m.def("get_commit_hash", get_commit_hash);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -575,11 +575,9 @@ void export_lang(py::module &m) {
   m.def("host_arch", host_arch);
 
   m.def("set_lib_dir", [&](const std::string &dir) {
-    TI_INFO("set_lib_dir: [{}]", dir);
     compiled_lib_dir = dir;
   });
   m.def("set_tmp_dir", [&](const std::string &dir) {
-    TI_INFO("set_tmp_dir: [{}]", dir);
     runtime_tmp_dir = dir;
   });
   m.def("get_runtime_dir", get_runtime_dir);

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -40,7 +40,9 @@ class TypeCheck : public IRVisitor {
 
   void visit(IfStmt *if_stmt) {
     // TODO: use DataType::u1 when it's supported
-    TI_ASSERT(if_stmt->cond->ret_type.data_type == DataType::i32);
+    TI_ASSERT_INFO(if_stmt->cond->ret_type.data_type == DataType::i32,
+        "`if` conditions must be of type int32, consider using `if x != 0:` "
+        "instead of `if x:` for float values.");
     if (if_stmt->true_statements)
       if_stmt->true_statements->accept(this);
     if (if_stmt->false_statements) {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -40,7 +40,8 @@ class TypeCheck : public IRVisitor {
 
   void visit(IfStmt *if_stmt) {
     // TODO: use DataType::u1 when it's supported
-    TI_ASSERT_INFO(if_stmt->cond->ret_type.data_type == DataType::i32,
+    TI_ASSERT_INFO(
+        if_stmt->cond->ret_type.data_type == DataType::i32,
         "`if` conditions must be of type int32, consider using `if x != 0:` "
         "instead of `if x:` for float values.");
     if (if_stmt->true_statements)

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -110,7 +110,7 @@ def test_print_list():
         print([1, k**2, k + 1])  # [1, 233.3, 234.3]
         print(z)  # [1]
         print([y[0], z])  # [[0, 0, 0], [1]]
-        print([]) # []
+        print([])  # []
 
     func(233.3)
     ti.sync()

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -103,7 +103,7 @@ def test_print_list():
     @ti.kernel
     def func(k: ti.f32):
         w = [k, x.shape]
-        print(w + [y.n])  # [233.3, 3]
+        print(w + [y.n])  # [233.3, [2, 3], 3]
         print(x.shape)  # [2, 3]
         print(y.shape)  # []
         z = (1, )

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -109,6 +109,7 @@ def test_print_list():
         z = (1, )
         print([1, k**2, k + 1])  # [1, 233.3, 234.3]
         print(z)  # [1]
+        print([y[0], z])  # [[0, 0, 0], [1]]
         print([]) # []
 
     func(233.3)

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -95,6 +95,26 @@ def test_print_multiple_threads():
     ti.sync()
 
 
+@ti.test()
+def test_print_list():
+    x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=(2, 3))
+    y = ti.Vector.field(3, dtype=ti.f32, shape=())
+
+    @ti.kernel
+    def func(k: ti.f32):
+        w = [k, x.shape]
+        print(w + [y.n])  # [233.3, 3]
+        print(x.shape)  # [2, 3]
+        print(y.shape)  # []
+        z = (1, )
+        print([1, k**2, k + 1])  # [1, 233.3, 234.3]
+        print(z)  # [1]
+        print([]) # []
+
+    func(233.3)
+    ti.sync()
+
+
 @ti.test(arch=ti.cpu)
 def test_python_scope_print_field():
     x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=())

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -109,7 +109,7 @@ def test_print_list():
         z = (1, )
         print([1, k**2, k + 1])  # [1, 233.3, 234.3]
         print(z)  # [1]
-        print([y[0], z])  # [[0, 0, 0], [1]]
+        print([y[None], z])  # [[0, 0, 0], [1]]
         print([])  # []
 
     func(233.3)


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1787

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
The elements of list can be either `Expr`, `Matrix`, nested `list`, or any constant types.
This allows us to directly print `x.shape` in #1787.