### PR TITLE
[Lang] [test] Add ti.get_rel_eps() for maximal relative error tolerance on current backend

### DIFF
--- a/python/taichi/testing.py
+++ b/python/taichi/testing.py
@@ -2,6 +2,17 @@ import taichi as ti
 
 
 # Helper functions
+def default_epsilon_of_arch(arch):
+    if arch == ti.opengl:
+        return 1e-3
+    elif arch == ti.metal:
+        # Debatable, different hardware could yield different precisions
+        # On AMD Radeon Pro 5500M, 1e-6 works fine...
+        # https://github.com/taichi-dev/taichi/pull/1779
+        return 1e-4
+    return 1e-6
+
+
 def approx(expected, **kwargs):
     '''Tweaked pytest.approx for OpenGL low percisions'''
     import pytest
@@ -19,11 +30,8 @@ def approx(expected, **kwargs):
     if isinstance(expected, bool):
         return boolean_integer(expected)
 
-    if ti.cfg.arch == ti.opengl:
-        kwargs['rel'] = max(kwargs.get('rel', 1e-6), 1e-3)
-
-    if ti.cfg.arch == ti.metal:
-        kwargs['rel'] = max(kwargs.get('rel', 1e-6), 1e-4)
+    default_eps = default_epsilon_of_arch(ti.cfg.arch)
+    kwargs['rel'] = max(kwargs.get('rel', 1e-6), default_eps)
 
     return pytest.approx(expected, **kwargs)
 
@@ -109,6 +117,7 @@ def test(*args, **kwargs):
 
 
 __all__ = [
+    'default_epsilon_of_arch',
     'approx',
     'allclose',
     'make_temp_file',

--- a/python/taichi/testing.py
+++ b/python/taichi/testing.py
@@ -2,7 +2,8 @@ import taichi as ti
 
 
 # Helper functions
-def default_epsilon_of_arch(arch):
+def get_rel_eps():
+    arch = ti.cfg.arch
     if arch == ti.opengl:
         return 1e-3
     elif arch == ti.metal:
@@ -30,8 +31,7 @@ def approx(expected, **kwargs):
     if isinstance(expected, bool):
         return boolean_integer(expected)
 
-    default_eps = default_epsilon_of_arch(ti.cfg.arch)
-    kwargs['rel'] = max(kwargs.get('rel', 1e-6), default_eps)
+    kwargs['rel'] = max(kwargs.get('rel', 1e-6), get_rel_eps())
 
     return pytest.approx(expected, **kwargs)
 
@@ -117,7 +117,7 @@ def test(*args, **kwargs):
 
 
 __all__ = [
-    'default_epsilon_of_arch',
+    'get_rel_eps',
     'approx',
     'allclose',
     'make_temp_file',

--- a/tests/python/test_test.py
+++ b/tests/python/test_test.py
@@ -75,7 +75,7 @@ def test_require_extensions_2():
 @pytest.mark.parametrize('allclose',
                          [ti.allclose, lambda x, y: x == ti.approx(y)])
 def test_allclose_rel(x, allclose):
-    rel = 1e-3 if ti.cfg.arch == ti.opengl else 1e-6
+    rel = ti.default_epsilon_of_arch(ti.cfg.arch)
     assert not allclose(x + x * rel * 3.0, x)
     assert not allclose(x + x * rel * 1.2, x)
     assert allclose(x + x * rel * 0.9, x)
@@ -92,7 +92,7 @@ def test_allclose_rel(x, allclose):
 @pytest.mark.parametrize('allclose',
                          [ti.allclose, lambda x, y: x == ti.approx(y)])
 def test_allclose_rel_reordered1(x, allclose):
-    rel = 1e-3 if ti.cfg.arch == ti.opengl else 1e-6
+    rel = ti.default_epsilon_of_arch(ti.cfg.arch)
     assert not allclose(x + x * rel * 3.0, x)
     assert not allclose(x + x * rel * 1.2, x)
     assert allclose(x + x * rel * 0.9, x)
@@ -109,7 +109,7 @@ def test_allclose_rel_reordered1(x, allclose):
                          [ti.allclose, lambda x, y: x == ti.approx(y)])
 @ti.test()
 def test_allclose_rel_reordered2(x, allclose):
-    rel = 1e-3 if ti.cfg.arch == ti.opengl else 1e-6
+    rel = ti.default_epsilon_of_arch(ti.cfg.arch)
     assert not allclose(x + x * rel * 3.0, x)
     assert not allclose(x + x * rel * 1.2, x)
     assert allclose(x + x * rel * 0.9, x)

--- a/tests/python/test_test.py
+++ b/tests/python/test_test.py
@@ -75,7 +75,7 @@ def test_require_extensions_2():
 @pytest.mark.parametrize('allclose',
                          [ti.allclose, lambda x, y: x == ti.approx(y)])
 def test_allclose_rel(x, allclose):
-    rel = ti.default_epsilon_of_arch(ti.cfg.arch)
+    rel = ti.get_rel_eps()
     assert not allclose(x + x * rel * 3.0, x)
     assert not allclose(x + x * rel * 1.2, x)
     assert allclose(x + x * rel * 0.9, x)
@@ -92,7 +92,7 @@ def test_allclose_rel(x, allclose):
 @pytest.mark.parametrize('allclose',
                          [ti.allclose, lambda x, y: x == ti.approx(y)])
 def test_allclose_rel_reordered1(x, allclose):
-    rel = ti.default_epsilon_of_arch(ti.cfg.arch)
+    rel = ti.get_rel_eps()
     assert not allclose(x + x * rel * 3.0, x)
     assert not allclose(x + x * rel * 1.2, x)
     assert allclose(x + x * rel * 0.9, x)
@@ -109,7 +109,7 @@ def test_allclose_rel_reordered1(x, allclose):
                          [ti.allclose, lambda x, y: x == ti.approx(y)])
 @ti.test()
 def test_allclose_rel_reordered2(x, allclose):
-    rel = ti.default_epsilon_of_arch(ti.cfg.arch)
+    rel = ti.get_rel_eps()
     assert not allclose(x + x * rel * 3.0, x)
     assert not allclose(x + x * rel * 1.2, x)
     assert allclose(x + x * rel * 0.9, x)


### PR DESCRIPTION
It turns out that #1779 doesn't play well on my device. Adding this to make the `allclose` tests pass again on Metal.

Related issue = #1779

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
