### PR TITLE
[cli] Add path to Python executable to 'ti diagnose'

### DIFF
--- a/python/taichi/diagnose.py
+++ b/python/taichi/diagnose.py
@@ -83,7 +83,8 @@ def main():
         print(f'{nvidia_smi.decode()}')
 
     try:
-        ti_header = subprocess.check_output([executable, '-c', 'import taichi'])
+        ti_header = subprocess.check_output(
+            [executable, '-c', 'import taichi'])
     except Exception as e:
         print(f'`import taichi` failed: {e}')
     else:

--- a/python/taichi/diagnose.py
+++ b/python/taichi/diagnose.py
@@ -8,8 +8,11 @@ def main():
     import platform
     import subprocess
 
+    executable = sys.executable
+
     print(f'python: {sys.version}')
     print(f'system: {sys.platform}')
+    print(f'executable: {executable}')
     print(f'platform: {platform.platform()}')
     print(f'architecture: {" ".join(platform.architecture())}')
     try:
@@ -40,7 +43,7 @@ def main():
     def try_print(tag, expr):
         try:
             cmd = f'import taichi as ti; print("===="); print({expr}, end="")'
-            ret = subprocess.check_output(['python', '-c', cmd]).decode()
+            ret = subprocess.check_output([executable, '-c', cmd]).decode()
             ret = ret.split('====\n', maxsplit=1)[1]
             print(f'{tag}: {ret}')
         except Exception as e:
@@ -80,7 +83,7 @@ def main():
         print(f'{nvidia_smi.decode()}')
 
     try:
-        ti_header = subprocess.check_output(['python', '-c', 'import taichi'])
+        ti_header = subprocess.check_output([executable, '-c', 'import taichi'])
     except Exception as e:
         print(f'`import taichi` failed: {e}')
     else:
@@ -88,7 +91,7 @@ def main():
 
     try:
         ti_init_test = subprocess.check_output(
-            ['python', '-c', 'import taichi as ti; ti.init()'])
+            [executable, '-c', 'import taichi as ti; ti.init()'])
     except Exception as e:
         print(f'`ti.init()` failed: {e}')
     else:
@@ -96,7 +99,7 @@ def main():
 
     try:
         ti_opengl_test = subprocess.check_output(
-            ['python', '-c', 'import taichi as ti; ti.init(arch=ti.opengl)'])
+            [executable, '-c', 'import taichi as ti; ti.init(arch=ti.opengl)'])
     except Exception as e:
         print(f'Taichi OpenGL test failed: {e}')
     else:
@@ -104,7 +107,7 @@ def main():
 
     try:
         ti_cuda_test = subprocess.check_output(
-            ['python', '-c', 'import taichi as ti; ti.init(arch=ti.cuda)'])
+            [executable, '-c', 'import taichi as ti; ti.init(arch=ti.cuda)'])
     except Exception as e:
         print(f'Taichi CUDA test failed: {e}')
     else:
@@ -112,7 +115,7 @@ def main():
 
     try:
         ti_laplace = subprocess.check_output(
-            ['python', '-m', 'taichi', 'example', 'minimal'])
+            [executable, '-m', 'taichi', 'example', 'minimal'])
     except Exception as e:
         print(f'`examples/laplace.py` failed: {e}')
     else:


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = closes #1792

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

This PR adds Python executable path to `ti diagnose`, as mention in #1792.

There is another change: I found that running `ti diagnose` in development mode will cause syntax errors on macOS because `python` still refers to Python 2.7.16, and current executable will always be the correct one with Taichi installed. So I replaced `'python'` with the executable path.
