### PR TITLE
[error] Better error message when vector used as if's condition variable

### DIFF
--- a/docs/arithmetics.rst
+++ b/docs/arithmetics.rst
@@ -26,7 +26,7 @@ Arithmetic operators
     print(2 % 3)   # 2
     print(-2 % 3)  # 1
 
-  For C-style mod, please use ``ti.raw_mod``:
+  For C style mod, please use ``ti.raw_mod``:
 
   .. code-block:: python
 

--- a/docs/vector.rst
+++ b/docs/vector.rst
@@ -215,7 +215,10 @@ Methods
         a = ti.Vector([1.6, 2.3])
         a.cast(ti.i32) # [2, 3]
 
+    See :ref:`type` for more details.
+
 .. note::
+
     Vectors are special matrices with only 1 column. In fact, ``ti.Vector`` is just an alias of ``ti.Matrix``.
 
 
@@ -239,5 +242,7 @@ Metadata
         # Python-scope
         a = ti.Vector.field(3, dtype=ti.f32, shape=())
         a.n  # 3
+
+    See :ref:`meta` for more details.
 
 TODO: add element wise operations docs

--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -4,11 +4,6 @@ class TaichiOperations:
         _taichi_skip_traceback = 1
         return ti.neg(self)
 
-    def __abs__(self):
-        import taichi as ti
-        _taichi_skip_traceback = 1
-        return ti.abs(self)
-
     def __add__(self, other):
         import taichi as ti
         _taichi_skip_traceback = 1

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -72,6 +72,18 @@ def begin_frontend_struct_for(group, loop_range):
     taichi_lang_core.begin_frontend_struct_for(group, loop_range.ptr)
 
 
+def begin_frontend_if(cond):
+    if is_taichi_class(cond):
+        raise ValueError(
+        'The truth value of vectors / matrices is ambiguous.\n'
+        'Consider using `any` or `all` when comparing vectors:\n'
+        '    if all(x == y):\n'
+        'or\n'
+        '    if any(x != y):\n'
+        )
+    taichi_lang_core.begin_frontend_if(Expr(cond).ptr)
+
+
 def wrap_scalar(x):
     if type(x) in [int, float]:
         return Expr(x)

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -75,12 +75,11 @@ def begin_frontend_struct_for(group, loop_range):
 def begin_frontend_if(cond):
     if is_taichi_class(cond):
         raise ValueError(
-        'The truth value of vectors / matrices is ambiguous.\n'
-        'Consider using `any` or `all` when comparing vectors:\n'
-        '    if all(x == y):\n'
-        'or\n'
-        '    if any(x != y):\n'
-        )
+            'The truth value of vectors / matrices is ambiguous.\n'
+            'Consider using `any` or `all` when comparing vectors:\n'
+            '    if all(x == y):\n'
+            'or\n'
+            '    if any(x != y):\n')
     taichi_lang_core.begin_frontend_if(Expr(cond).ptr)
 
 

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -324,7 +324,7 @@ if 1:
         template = '''
 if 1:
   __cond = 0
-  ti.core.begin_frontend_if(ti.Expr(__cond).ptr)
+  ti.begin_frontend_if(__cond)
   ti.core.begin_frontend_if_true()
   ti.core.pop_scope()
   ti.core.begin_frontend_if_false()


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1064

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Before:
```
Traceback (most recent call last):
  File "a.py", line 11, in <module>
    func()
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 574, in wrapped
    return primal(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 501, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 370, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 367, in taichi_ast_generator
    compiled()
  File "a.py", line 7, in func
    if x == 0:
  File "/home/bate/Develop/taichi/python/taichi/lang/expr.py", line 22, in __init__
    raise ValueError('cannot initialize scalar expression from '
ValueError: cannot initialize scalar expression from taichi class: <class 'taichi.lang.matrix.Matrix'>
```
After:
```
Traceback (most recent call last):
  File "a.py", line 11, in <module>
    func()
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 574, in wrapped
    return primal(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 501, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 370, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 367, in taichi_ast_generator
    compiled()
  File "a.py", line 7, in func
    if x == 0:
  File "/home/bate/Develop/taichi/python/taichi/lang/impl.py", line 77, in begin_frontend_if
    raise ValueError(
ValueError: The truth value of vectors / matrices is ambiguous.
Consider using `any` or `all` when comparing vectors:
    if all(x == y):
or
    if any(x != y):
```