### PR TITLE
[Lang] Support formatted string with args in assert

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -455,6 +455,15 @@ def ti_print(*vars, sep=' ', end='\n'):
 
 
 @taichi_scope
+def ti_assert(cond, msg, extra_args):
+    # Mostly a wrapper to help us convert from ti.Expr (defined in Python) to
+    # taichi_lang_core.Expr (defined in C++)
+    import taichi as ti
+    taichi_lang_core.create_assert_stmt(
+        ti.Expr(cond).ptr, msg, [ti.Expr(x).ptr for x in extra_args])
+
+
+@taichi_scope
 def ti_int(var):
     _taichi_skip_traceback = 1
     if hasattr(var, '__ti_int__'):

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -41,9 +41,19 @@ class FrontendAssertStmt : public Stmt {
  public:
   std::string text;
   Expr val;
+  std::vector<Expr> args;
 
   FrontendAssertStmt(const std::string &text, const Expr &val)
       : text(text), val(val) {
+  }
+
+  FrontendAssertStmt(const std::string &text,
+                     const Expr &val,
+                     const std::vector<Expr> &args_)
+      : text(text), val(val) {
+    for (auto &a : args_) {
+      args.push_back(load_if_ptr(a));
+    }
   }
 
   TI_DEFINE_ACCEPT

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -288,8 +288,9 @@ void export_lang(py::module &m) {
     return Length(snode, indices);
   });
 
-  m.def("create_assert_stmt", [&](const Expr &cond, const std::string &msg) {
-    auto stmt_unique = std::make_unique<FrontendAssertStmt>(msg, cond);
+  m.def("create_assert_stmt", [&](const Expr &cond, const std::string &msg,
+                                  const std::vector<Expr> &args) {
+    auto stmt_unique = std::make_unique<FrontendAssertStmt>(msg, cond, args);
     current_ast_builder().insert(std::move(stmt_unique));
   });
 

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -404,7 +404,14 @@ class LowerAST : public IRVisitor {
       expr->flatten(&fctx);
       val_stmt = expr->stmt;
     }
-    fctx.push_back<AssertStmt>(stmt->text, val_stmt);
+
+    auto &fargs = stmt->args;  // frontend stmt args
+    std::vector<Stmt *> args_stmts(fargs.size());
+    for (int i = 0; i < (int)fargs.size(); ++i) {
+      fargs[i]->flatten(&fctx);
+      args_stmts[i] = fargs[i]->stmt;
+    }
+    fctx.push_back<AssertStmt>(val_stmt, stmt->text, args_stmts);
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
     throw IRModified();
   }

--- a/tests/python/test_assert.py
+++ b/tests/python/test_assert.py
@@ -66,6 +66,10 @@ def test_assert_message_formatted():
     with pytest.raises(RuntimeError, match=r'y = 0.5'):
         assert_float()
 
+    # success case
+    x[10] = 0
+    assert_formatted()
+
 
 @ti.require(ti.extension.assertion)
 @ti.all_archs_with(debug=True, gdb_trigger=False)

--- a/tests/python/test_assert.py
+++ b/tests/python/test_assert.py
@@ -17,6 +17,7 @@ def test_assert_minimal():
 
     with pytest.raises(RuntimeError):
         func()
+    with pytest.raises(RuntimeError):
         func2()
 
 


### PR DESCRIPTION
This allows us to write 

```py
assert cond(), 'foo=%d bar=%f' % (foo, bar)
``` 

I think we can apply the same strategy to `print`, but let me focus on `assert` in this PR.

Related issue = #1434

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
