### PR TITLE
[GUI] Support saving image without GUI showing a window

### DIFF
--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -36,9 +36,9 @@ class GUI:
 
     def __init__(self,
                  name='Taichi',
-                 show_gui=True,
                  res=512,
-                 background_color=0x0):
+                 background_color=0x0,
+                 show_gui=True):
         self.name = name
         if isinstance(res, numbers.Number):
             res = (res, res)

--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -36,7 +36,7 @@ class GUI:
 
     def __init__(self,
                  name='Taichi',
-                 show_GUI=True,
+                 show_gui=True,
                  res=512,
                  background_color=0x0):
         self.name = name
@@ -45,10 +45,10 @@ class GUI:
         self.res = res
         # The GUI canvas uses RGBA for storage, therefore we need NxMx4 for an image.
         self.img = np.ascontiguousarray(np.zeros(self.res + (4, ), np.float32))
-        self.show_GUI = show_GUI
+        self.show_gui = show_gui
         self.core = ti_core.GUI(name, core_veci(*res))
-        if self.show_GUI:
-            self.core.initialise_window()
+        if self.show_gui:
+            self.core.initialize_window()
         self.canvas = self.core.get_canvas()
         self.background_color = background_color
         self.key_pressed = set()
@@ -363,7 +363,7 @@ class GUI:
         self.arrows(base, dir, radius=radius, color=color, **kwargs)
 
     def show(self, file=None):
-        if self.show_GUI:
+        if self.show_gui:
             self.core.update()
         if file:
             self.core.screenshot(file)

--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -34,14 +34,17 @@ class GUI:
     PRESS = ti_core.KeyEvent.EType.Press
     RELEASE = ti_core.KeyEvent.EType.Release
 
-    def __init__(self, name='Taichi', res=512, background_color=0x0):
+    def __init__(self, name='Taichi', show_GUI=True, res=512, background_color=0x0):
         self.name = name
         if isinstance(res, numbers.Number):
             res = (res, res)
         self.res = res
         # The GUI canvas uses RGBA for storage, therefore we need NxMx4 for an image.
         self.img = np.ascontiguousarray(np.zeros(self.res + (4, ), np.float32))
+        self.show_GUI = show_GUI
         self.core = ti_core.GUI(name, core_veci(*res))
+        if self.show_GUI:
+            self.core.initialise_window()
         self.canvas = self.core.get_canvas()
         self.background_color = background_color
         self.key_pressed = set()
@@ -356,7 +359,8 @@ class GUI:
         self.arrows(base, dir, radius=radius, color=color, **kwargs)
 
     def show(self, file=None):
-        self.core.update()
+        if self.show_GUI:
+            self.core.update()
         if file:
             self.core.screenshot(file)
         self.frame += 1

--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -45,10 +45,7 @@ class GUI:
         self.res = res
         # The GUI canvas uses RGBA for storage, therefore we need NxMx4 for an image.
         self.img = np.ascontiguousarray(np.zeros(self.res + (4, ), np.float32))
-        self.show_gui = show_gui
-        self.core = ti_core.GUI(name, core_veci(*res))
-        if self.show_gui:
-            self.core.initialize_window()
+        self.core = ti_core.GUI(name, core_veci(*res), show_gui)
         self.canvas = self.core.get_canvas()
         self.background_color = background_color
         self.key_pressed = set()
@@ -363,8 +360,7 @@ class GUI:
         self.arrows(base, dir, radius=radius, color=color, **kwargs)
 
     def show(self, file=None):
-        if self.show_gui:
-            self.core.update()
+        self.core.update()
         if file:
             self.core.screenshot(file)
         self.frame += 1

--- a/python/taichi/misc/gui.py
+++ b/python/taichi/misc/gui.py
@@ -34,7 +34,11 @@ class GUI:
     PRESS = ti_core.KeyEvent.EType.Press
     RELEASE = ti_core.KeyEvent.EType.Release
 
-    def __init__(self, name='Taichi', show_GUI=True, res=512, background_color=0x0):
+    def __init__(self,
+                 name='Taichi',
+                 show_GUI=True,
+                 res=512,
+                 background_color=0x0):
         self.name = name
         if isinstance(res, numbers.Number):
             res = (res, res)

--- a/taichi/gui/gui.h
+++ b/taichi/gui/gui.h
@@ -431,7 +431,7 @@ class Canvas {
   ~Canvas() {
   }
 
-  void set_idendity_transform_matrix() {
+  void set_identity_transform_matrix() {
     transform_matrix = Matrix3(1);
   }
 };
@@ -772,7 +772,7 @@ class GUI : public GUIBase {
     create_window();
     set_title(window_name);
     if (!normalized_coord) {
-      canvas->set_idendity_transform_matrix();
+      canvas->set_identity_transform_matrix();
     }
     widget_height = 0;
   }
@@ -795,7 +795,7 @@ class GUI : public GUIBase {
 
   void redraw_widgets() {
     auto old_transform_matrix = canvas->transform_matrix;
-    canvas->set_idendity_transform_matrix();
+    canvas->set_identity_transform_matrix();
     for (auto &w : widgets) {
       w->set_hover(w->inside(cursor_pos));
       w->redraw(*canvas);

--- a/taichi/gui/gui.h
+++ b/taichi/gui/gui.h
@@ -783,7 +783,7 @@ class GUI : public GUIBase {
 
   void create_window();
 
-  void initialise_window() {
+  void initialize_window() {
     create_window();
     set_title(window_name);
   }

--- a/taichi/gui/gui.h
+++ b/taichi/gui/gui.h
@@ -833,13 +833,13 @@ class GUI : public GUIBase {
             "to exit gracefully)");
       }
     }
-    while (last_frame_interval.size() > 30) {
-      last_frame_interval.erase(last_frame_interval.begin());
-    }
-    auto real_fps = last_frame_interval.size() /
-                    (std::accumulate(last_frame_interval.begin(),
-                                     last_frame_interval.end(), 0.0_f));
     if (show_gui) {
+      while (last_frame_interval.size() > 30) {
+        last_frame_interval.erase(last_frame_interval.begin());
+      }
+      auto real_fps = last_frame_interval.size() /
+                      (std::accumulate(last_frame_interval.begin(),
+                                       last_frame_interval.end(), 0.0_f));
       update_gui(real_fps);
     }
   }

--- a/taichi/gui/gui.h
+++ b/taichi/gui/gui.h
@@ -769,8 +769,6 @@ class GUI : public GUIBase {
     buffer.initialize(Vector2i(width, height));
     canvas = std::make_unique<Canvas>(buffer);
     last_frame_time = taichi::Time::get_time();
-    create_window();
-    set_title(window_name);
     if (!normalized_coord) {
       canvas->set_identity_transform_matrix();
     }
@@ -784,6 +782,11 @@ class GUI : public GUIBase {
   }
 
   void create_window();
+
+  void initialise_window() {
+    create_window();
+    set_title(window_name);
+  }
 
   Canvas &get_canvas() {
     return *canvas;

--- a/taichi/gui/win32.cpp
+++ b/taichi/gui/win32.cpp
@@ -221,8 +221,10 @@ void GUI::set_title(std::string title) {
 
 GUI::~GUI() {
   std::free(data);
-  DeleteDC(src);
-  gui_from_hwnd.erase(hwnd);
+  if (show_gui) {
+    DeleteDC(src);
+    gui_from_hwnd.erase(hwnd);
+  }
 }
 
 TI_NAMESPACE_END

--- a/taichi/gui/win32.cpp
+++ b/taichi/gui/win32.cpp
@@ -220,8 +220,8 @@ void GUI::set_title(std::string title) {
 }
 
 GUI::~GUI() {
-  std::free(data);
   if (show_gui) {
+    std::free(data);
     DeleteDC(src);
     gui_from_hwnd.erase(hwnd);
   }

--- a/taichi/gui/x11.cpp
+++ b/taichi/gui/x11.cpp
@@ -166,7 +166,9 @@ void GUI::set_title(std::string title) {
 }
 
 GUI::~GUI() {
-  XCloseDisplay((Display *)display);
+  if (show_gui) {
+    XCloseDisplay((Display *)display);
+  }
   delete img;
 }
 

--- a/taichi/gui/x11.cpp
+++ b/taichi/gui/x11.cpp
@@ -168,8 +168,8 @@ void GUI::set_title(std::string title) {
 GUI::~GUI() {
   if (show_gui) {
     XCloseDisplay((Display *)display);
+    delete img;
   }
-  delete img;
 }
 
 TI_NAMESPACE_END

--- a/taichi/python/export_visual.cpp
+++ b/taichi/python/export_visual.cpp
@@ -29,6 +29,7 @@ void export_visual(py::module &m) {
       .def_readwrite("frame_delta_limit", &GUI::frame_delta_limit)
       .def_readwrite("should_close", &GUI::should_close)
       .def("get_canvas", &GUI::get_canvas, py::return_value_policy::reference)
+      .def("initialise_window", [](GUI *gui) { gui->initialise_window(); })
       .def("set_img",
            [&](GUI *gui, std::size_t ptr) {
              auto &img = gui->canvas->img;

--- a/taichi/python/export_visual.cpp
+++ b/taichi/python/export_visual.cpp
@@ -25,11 +25,10 @@ void export_visual(py::module &m) {
       .value("Press", Type::press)
       .value("Release", Type::release);
   py::class_<GUI>(m, "GUI")
-      .def(py::init<std::string, Vector2i>())
+      .def(py::init<std::string, Vector2i, bool>())
       .def_readwrite("frame_delta_limit", &GUI::frame_delta_limit)
       .def_readwrite("should_close", &GUI::should_close)
       .def("get_canvas", &GUI::get_canvas, py::return_value_policy::reference)
-      .def("initialize_window", [](GUI *gui) { gui->initialize_window(); })
       .def("set_img",
            [&](GUI *gui, std::size_t ptr) {
              auto &img = gui->canvas->img;

--- a/taichi/python/export_visual.cpp
+++ b/taichi/python/export_visual.cpp
@@ -29,7 +29,7 @@ void export_visual(py::module &m) {
       .def_readwrite("frame_delta_limit", &GUI::frame_delta_limit)
       .def_readwrite("should_close", &GUI::should_close)
       .def("get_canvas", &GUI::get_canvas, py::return_value_policy::reference)
-      .def("initialise_window", [](GUI *gui) { gui->initialise_window(); })
+      .def("initialize_window", [](GUI *gui) { gui->initialize_window(); })
       .def("set_img",
            [&](GUI *gui, std::size_t ptr) {
              auto &img = gui->canvas->img;

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -15,7 +15,7 @@ def test_save_image_without_window(dtype):
         for i, j, k in pixels:
             pixels[i, j, k] = c
 
-    gui = ti.GUI("Test", show_gui=False, res=(n, n))
+    gui = ti.GUI("Test", res=(n, n), show_gui=False)
     for i in [0, 32, 64, 128, 255]:
         if dtype is ti.u8:
             paint(i)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -1,0 +1,29 @@
+from taichi import make_temp_file
+import taichi as ti
+import numpy as np
+from PIL import Image
+import pytest
+
+@ti.host_arch_only
+@pytest.mark.parametrize('dtype', [ti.u8, ti.f32])
+def test_save_image_without_window(dtype):
+    n = 255
+    pixels = ti.field(dtype=dtype, shape=(n, n, 3))
+
+    @ti.kernel
+    def paint(c: dtype):
+        for i, j, k in pixels:
+            pixels[i, j, k] = c
+
+    gui = ti.GUI("Test", show_GUI=False, res=(n, n))
+    for i in [0, 32, 64, 128, 255]:
+        if dtype is ti.u8:
+            paint(i)
+        else:
+            paint(i*1.0/n)
+        gui.set_image(pixels)
+        image_path = make_temp_file(suffix='.jpg')
+        gui.show(image_path)
+        image = np.array(Image.open(image_path))
+        delta = (image - i).sum()
+        assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(delta)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -1,7 +1,6 @@
 from taichi import make_temp_file
 import taichi as ti
 import numpy as np
-from PIL import Image
 import pytest
 
 

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -16,7 +16,7 @@ def test_save_image_without_window(dtype):
         for i, j, k in pixels:
             pixels[i, j, k] = c
 
-    gui = ti.GUI("Test", show_GUI=False, res=(n, n))
+    gui = ti.GUI("Test", show_gui=False, res=(n, n))
     for i in [0, 32, 64, 128, 255]:
         if dtype is ti.u8:
             paint(i)
@@ -25,7 +25,7 @@ def test_save_image_without_window(dtype):
         gui.set_image(pixels)
         image_path = make_temp_file(suffix='.jpg')
         gui.show(image_path)
-        image = np.array(Image.open(image_path))
+        image = ti.imread(image_path)
         delta = (image - i).sum()
         assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(
             delta)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -4,6 +4,7 @@ import numpy as np
 from PIL import Image
 import pytest
 
+
 @ti.host_arch_only
 @pytest.mark.parametrize('dtype', [ti.u8, ti.f32])
 def test_save_image_without_window(dtype):
@@ -20,10 +21,11 @@ def test_save_image_without_window(dtype):
         if dtype is ti.u8:
             paint(i)
         else:
-            paint(i*1.0/n)
+            paint(i * 1.0 / n)
         gui.set_image(pixels)
         image_path = make_temp_file(suffix='.jpg')
         gui.show(image_path)
         image = np.array(Image.open(image_path))
         delta = (image - i).sum()
-        assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(delta)
+        assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(
+            delta)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -22,7 +22,7 @@ def test_save_image_without_window(dtype):
         else:
             paint(i * 1.0 / n)
         gui.set_image(pixels)
-        image_path = make_temp_file(suffix='.jpg')
+        image_path = make_temp_file(suffix='.png')
         gui.show(image_path)
         image = ti.imread(image_path)
         delta = (image - i).sum()


### PR DESCRIPTION
Fixes #1616. cc @archibate @yuanming-hu.

# Description
As mentioned in #1616 by @ehannigan, saving the screenshot of a GUI without an actual window will throw 

`"RuntimeError: [x11.cpp:create_window@139] Taichi fails to create a window. This is probably due to the lack of an X11 GUI environment. If you are using ssh, try ssh -XY."`

It is possible to do this with `matplotlib` however it would be better to have a native solution. This PR provides the functionality to save an image without showing a GUI as well as correcting instances of `idendity`.

# Concerns
1. Since I'm putting a `if` statement around `self.core.update()`, is it a concern that the internal `GUI` class has a different state from `ti.GUI` class?

    Original version is shown here: https://github.com/taichi-dev/taichi/blob/6052a541bed7e2645110f21379a7266c5ce21624/python/taichi/misc/gui.py#L358-L363


2. I made a `test_gui.py` but there is also another `test_gui.py` in `misc/`. 
3. It could be better to recommend that if `show_GUI` is `False`, that users use `gui.core.screenshot("filename.jpg")` instead of altering the `show` function. 
