### PR TITLE
[refactor] Rename 'launched_kernels*' stats to 'launched_tasks*'

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -340,8 +340,8 @@ def benchmark(func, repeat=300, args=()):
                 ti.stat_write('instructions', b)
             if a == 'codegen_offloaded_tasks':
                 ti.stat_write('offloaded_tasks', b)
-            elif a == 'launched_kernels':
-                ti.stat_write('launched_kernels', b)
+            elif a == 'launched_tasks':
+                ti.stat_write('launched_tasks', b)
         # The reason why we run 3 more times is to warm up
         # instruction/data caches. Discussion:
         # https://github.com/taichi-dev/taichi/pull/1002#discussion_r426312136

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -319,21 +319,21 @@ void Kernel::account_for_offloaded(OffloadedStmt *stmt) {
   if (is_evaluator || is_accessor)
     return;
   auto task_type = stmt->task_type;
-  stat.add("launched_kernels", 1.0);
+  stat.add("launched_tasks", 1.0);
   if (task_type == OffloadedStmt::TaskType::listgen) {
-    stat.add("launched_kernels_list_op", 1.0);
-    stat.add("launched_kernels_list_gen", 1.0);
+    stat.add("launched_tasks_list_op", 1.0);
+    stat.add("launched_tasks_list_gen", 1.0);
   } else if (task_type == OffloadedStmt::TaskType::clear_list) {
-    stat.add("launched_kernels_list_op", 1.0);
-    stat.add("launched_kernels_list_clear", 1.0);
+    stat.add("launched_tasks_list_op", 1.0);
+    stat.add("launched_tasks_list_clear", 1.0);
   } else if (task_type == OffloadedStmt::TaskType::range_for) {
-    stat.add("launched_kernels_compute", 1.0);
-    stat.add("launched_kernels_range_for", 1.0);
+    stat.add("launched_tasks_compute", 1.0);
+    stat.add("launched_tasks_range_for", 1.0);
   } else if (task_type == OffloadedStmt::TaskType::struct_for) {
-    stat.add("launched_kernels_compute", 1.0);
-    stat.add("launched_kernels_struct_for", 1.0);
+    stat.add("launched_tasks_compute", 1.0);
+    stat.add("launched_tasks_struct_for", 1.0);
   } else if (task_type == OffloadedStmt::TaskType::gc) {
-    stat.add("launched_kernels_garbage_collect", 1.0);
+    stat.add("launched_tasks_garbage_collect", 1.0);
   }
 }
 


### PR DESCRIPTION
Will rename `KernelLaunchRecord` separately to avoid conflict with #1815 ...

Related issue = N/A

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
