### PR TITLE
[ir] [refactor] Reorder FrontAssertStatement's constructor args

### DIFF
--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -155,8 +155,8 @@ inline Expr Append(const Expr &expr,
   return Append(expr.snode(), indices, val);
 }
 
-inline void InsertAssert(const std::string &text, const Expr &expr) {
-  current_ast_builder().insert(Stmt::make<FrontendAssertStmt>(text, expr));
+inline void InsertAssert(const std::string &text, const Expr &cond) {
+  current_ast_builder().insert(Stmt::make<FrontendAssertStmt>(cond, text));
 }
 
 inline void Clear(SNode *snode, const ExprGroup &indices) {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -40,17 +40,17 @@ class FrontendSNodeOpStmt : public Stmt {
 class FrontendAssertStmt : public Stmt {
  public:
   std::string text;
-  Expr val;
+  Expr cond;
   std::vector<Expr> args;
 
-  FrontendAssertStmt(const std::string &text, const Expr &val)
-      : text(text), val(val) {
+  FrontendAssertStmt(const Expr &cond, const std::string &text)
+      : text(text), cond(cond) {
   }
 
-  FrontendAssertStmt(const std::string &text,
-                     const Expr &val,
+  FrontendAssertStmt(const Expr &cond,
+                     const std::string &text,
                      const std::vector<Expr> &args_)
-      : text(text), val(val) {
+      : text(text), cond(cond) {
     for (auto &a : args_) {
       args.push_back(load_if_ptr(a));
     }

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -978,11 +978,6 @@ class AssertStmt : public Stmt {
   std::string text;
   std::vector<Stmt *> args;
 
-  AssertStmt(const std::string &text, Stmt *cond) : cond(cond), text(text) {
-    TI_ASSERT(cond);
-    TI_STMT_REG_FIELDS;
-  }
-
   AssertStmt(Stmt *cond,
              const std::string &text,
              const std::vector<Stmt *> &args)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -290,7 +290,7 @@ void export_lang(py::module &m) {
 
   m.def("create_assert_stmt", [&](const Expr &cond, const std::string &msg,
                                   const std::vector<Expr> &args) {
-    auto stmt_unique = std::make_unique<FrontendAssertStmt>(msg, cond, args);
+    auto stmt_unique = std::make_unique<FrontendAssertStmt>(cond, msg, args);
     current_ast_builder().insert(std::move(stmt_unique));
   });
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -104,7 +104,7 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(FrontendAssertStmt *assert) override {
-    print("{} : assert {}", assert->id, assert->val->serialize());
+    print("{} : assert {}", assert->id, assert->cond->serialize());
   }
 
   void visit(AssertStmt *assert) override {

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -399,8 +399,8 @@ class LowerAST : public IRVisitor {
     // expand rhs
     Stmt *val_stmt = nullptr;
     auto fctx = make_flatten_ctx();
-    if (stmt->val.expr) {
-      auto expr = stmt->val;
+    if (stmt->cond.expr) {
+      auto expr = stmt->cond;
       expr->flatten(&fctx);
       val_stmt = expr->stmt;
     }


### PR DESCRIPTION
* constructor args order will be `(cond, msg, args)`
* renamed `val` to `cond` for consistency

Related issue = #1434

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
