### PR TITLE
[Lang] Support x.fill(n) and x.copy_from(y) in top-level of Taichi-scope

### DIFF
--- a/examples/tree_gravity.py
+++ b/examples/tree_gravity.py
@@ -2,7 +2,7 @@
 # Author: archibate <1931127624@qq.com>, all left reserved
 import taichi as ti
 import taichi_glsl as tl
-ti.init()
+ti.init(ti.cpu)
 if not hasattr(ti, 'jkl'):
     ti.jkl = ti.indices(1, 2, 3)
 
@@ -266,6 +266,7 @@ def render_arrows(mx: ti.f32, my: ti.f32):
 
 @ti.kernel
 def render_pixels():
+    display_image.fill(0)
     for i in range(particle_table_len[None]):
         position = particle_pos[i].xy
         pix = int(position * kResolution)
@@ -320,8 +321,6 @@ while gui.running:
         substep_tree()
     else:
         substep_raw()
-    if len(kDisplay) and 'trace' not in kDisplay:
-        display_image.fill(0)
     if 'mouse' in kDisplay:
         render_arrows(*gui.get_cursor_pos())
     if 'pixels' in kDisplay:

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -119,7 +119,6 @@ class Expr(TaichiOperations):
         assert node
         node.clear_data()
 
-    @python_scope
     def fill(self, val):
         # TODO: avoid too many template instantiations
         from .meta import fill_tensor
@@ -205,7 +204,6 @@ class Expr(TaichiOperations):
     def from_torch(self, arr):
         self.from_numpy(arr.contiguous())
 
-    @python_scope
     def copy_from(self, other):
         assert isinstance(other, Expr)
         from .meta import tensor_to_tensor

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -630,7 +630,7 @@ class Matrix(TaichiOperations):
         return -ti.cmp_eq(ret, -len(self.entries))
 
     def fill(self, val):
-        if impl.inside_kernel():
+        if impl.inside_kernel() and not self.is_global():
 
             def assign_renamed(x, y):
                 import taichi as ti
@@ -712,7 +712,6 @@ class Matrix(TaichiOperations):
     def from_torch(self, torch_tensor):
         return self.from_numpy(torch_tensor.contiguous())
 
-    @python_scope
     def copy_from(self, other):
         assert isinstance(other, Matrix)
         from .meta import tensor_to_tensor

--- a/python/taichi/lang/meta.py
+++ b/python/taichi/lang/meta.py
@@ -3,7 +3,7 @@ import taichi as ti
 # A set of helper (meta)functions
 
 
-@ti.kernel
+@ti.kernelfunc
 def fill_tensor(tensor: ti.template(), val: ti.template()):
     for I in ti.grouped(tensor):
         tensor[I] = val
@@ -39,7 +39,7 @@ def vector_to_image(mat: ti.template(), arr: ti.ext_arr()):
                 arr[I, 2] = 0
 
 
-@ti.kernel
+@ti.kernelfunc
 def tensor_to_tensor(tensor: ti.template(), other: ti.template()):
     for I in ti.grouped(tensor):
         tensor[I] = other[I]
@@ -82,7 +82,7 @@ def clear_gradients(vars: ti.template()):
             ti.Expr(s)[I] = 0
 
 
-@ti.kernel
+@ti.kernelfunc
 def fill_matrix(mat: ti.template(), vals: ti.template()):
     for I in ti.grouped(mat):
         for p in ti.static(range(mat.n)):
@@ -90,13 +90,13 @@ def fill_matrix(mat: ti.template(), vals: ti.template()):
                 mat[I][p, q] = vals[p][q]
 
 
-@ti.kernel
+@ti.kernelfunc
 def snode_deactivate(b: ti.template()):
     for I in ti.grouped(b):
         ti.deactivate(b, I)
 
 
-@ti.kernel
+@ti.kernelfunc
 def snode_deactivate_dynamic(b: ti.template()):
     for I in ti.grouped(b.parent()):
         ti.deactivate(b, I)

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -87,5 +87,6 @@ def test_fill_taichi_scope():
         y.fill(2)
 
     func()
-    assert ti.approx(x.to_numpy()) == np.ones((5, 7), np.int32) * 2.3 - np.eye(5, 7, dtype=np.int32) * 0.6
+    assert ti.approx(x.to_numpy()) == np.ones(
+        (5, 7), np.int32) * 2.3 - np.eye(5, 7, dtype=np.int32) * 0.6
     assert ti.approx(y.to_numpy()) == np.ones((7, 3, 2, 3), np.float32) * 2

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import numpy as np
 
 
 @ti.all_archs
@@ -68,3 +69,23 @@ def test_fill_matrix_matrix():
             for p in range(2):
                 for q in range(3):
                     assert val[i, j][p, q] == mat.get_entry(p, q)
+
+
+@ti.all_archs
+def test_fill_taichi_scope():
+    x = ti.field(ti.f32, (5, 7))
+    y = ti.Matrix.field(2, 3, ti.i32, (7, 3))
+
+    x.from_numpy(np.random.rand(5, 7))
+    y.from_numpy(np.random.randint(10, 100, (7, 3, 2, 3)))
+
+    @ti.kernel
+    def func():
+        x.fill(2.3)
+        for i in range(5):
+            x[i, i] -= 0.6
+        y.fill(2)
+
+    func()
+    assert ti.approx(x.to_numpy()) == np.ones((5, 7), np.int32) * 2.3 - np.eye(5, 7, dtype=np.int32) * 0.6
+    assert ti.approx(y.to_numpy()) == np.ones((7, 3, 2, 3), np.float32) * 2


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = to make a way for #1820

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Previously we can only call `fill` and `copy_from` in Python-scope, because the meta functions in `lang/meta.py` are defined to be `@ti.kernel`.
But actually if we change it to `@ti.func`, they will still functional when invoked in top-level of Taichi-scope (just can't be nested in parallel for loops).
So I'd like to add a `@ti.kernelfunc` that automatically detect the scope:
- call `@ti.func` when `impl.inside_kernel()`, otherwise call `@ti.kernel`.

I think ultimately we will rename `@ti.kernelfunc` to `@ti.kernel` and deprecate the old `@ti.kernel`, i.e., **allowing kernels to call other kernels**! (may also rename `@ti.pyfunc` to `@ti.func` in the future)
After these two renames, the only difference between `@ti.func` and `@ti.kernel` will be: the latter needs type-hints and the first doesn't.

@k-ye Could you help me with the ODOP inspector for our new `@ti.kernelfunc`? I can't make it work in this PR..
Of course, we won't add this to doc so it's not a public API yet, like `@ti.pyfunc` did.