### PR TITLE
[refactor] Drop ODOP support temporary (rullecized)

### DIFF
--- a/tests/python/test_classfunc.py
+++ b/tests/python/test_classfunc.py
@@ -1,6 +1,8 @@
 import taichi as ti
+import pytest
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_classfunc():
     @ti.data_oriented

--- a/tests/python/test_complex_kernels.py
+++ b/tests/python/test_complex_kernels.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import pytest
 
 
 @ti.all_archs
@@ -66,6 +67,7 @@ def test_complex_kernels_indirect():
         assert x.grad[0] == 4
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.all_archs
 def test_complex_kernels_oop():
     @ti.data_oriented
@@ -102,6 +104,7 @@ def test_complex_kernels_oop():
         assert a.x.grad[0] == 4
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.all_archs
 def test_complex_kernels_oop2():
     @ti.data_oriented

--- a/tests/python/test_mpm_particle_list.py
+++ b/tests/python/test_mpm_particle_list.py
@@ -1,50 +1,51 @@
 import taichi as ti
 import random
+import pytest
 
 
-@ti.data_oriented
-class MPMSolver:
-    def __init__(self, res):
-        dim = len(res)
-        self.dx = 1 / res[0]
-        self.inv_dx = 1.0 / self.dx
-        self.pid = ti.field(ti.i32)
-        self.x = ti.Vector.field(dim, dtype=ti.f32)
-        self.grid_m = ti.field(dtype=ti.f32)
-
-        indices = ti.ij
-
-        self.grid = ti.root.pointer(indices, 32)
-        block = self.grid.pointer(indices, 16)
-        voxel = block.dense(indices, 8)
-
-        voxel.place(self.grid_m)
-        block.dynamic(ti.indices(dim), 1024 * 1024,
-                      chunk_size=4096).place(self.pid)
-
-        ti.root.dynamic(ti.i, 2**25, 2**20).place(self.x)
-        self.substeps = 0
-
-        for i in range(10000):
-            self.x[i] = [random.random() * 0.5, random.random() * 0.5]
-
-    @ti.kernel
-    def build_pid(self):
-        ti.block_dim(256)
-        for p in self.x:
-            base = ti.floor(self.x[p] * self.inv_dx - 0.5).cast(int)
-            ti.append(self.pid.parent(), base, p)
-
-    def step(self):
-        for i in range(1000):
-            self.substeps += 1
-            self.grid.deactivate_all()
-            self.build_pid()
-
-
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.require(ti.extension.sparse)
 @ti.all_archs_with(use_unified_memory=False, device_memory_GB=0.3)
 def test_mpm_particle_list_no_leakage():
+    @ti.data_oriented
+    class MPMSolver:
+        def __init__(self, res):
+            dim = len(res)
+            self.dx = 1 / res[0]
+            self.inv_dx = 1.0 / self.dx
+            self.pid = ti.field(ti.i32)
+            self.x = ti.Vector.field(dim, dtype=ti.f32)
+            self.grid_m = ti.field(dtype=ti.f32)
+
+            indices = ti.ij
+
+            self.grid = ti.root.pointer(indices, 32)
+            block = self.grid.pointer(indices, 16)
+            voxel = block.dense(indices, 8)
+
+            voxel.place(self.grid_m)
+            block.dynamic(ti.indices(dim), 1024 * 1024,
+                          chunk_size=4096).place(self.pid)
+
+            ti.root.dynamic(ti.i, 2**25, 2**20).place(self.x)
+            self.substeps = 0
+
+            for i in range(10000):
+                self.x[i] = [random.random() * 0.5, random.random() * 0.5]
+
+        @ti.kernel
+        def build_pid(self):
+            ti.block_dim(256)
+            for p in self.x:
+                base = ti.floor(self.x[p] * self.inv_dx - 0.5).cast(int)
+                ti.append(self.pid.parent(), base, p)
+
+        def step(self):
+            for i in range(1000):
+                self.substeps += 1
+                self.grid.deactivate_all()
+                self.build_pid()
+
     # By default Taichi will allocate 0.5 GB for testing.
     mpm = MPMSolver(res=(128, 128))
     mpm.step()

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -1,6 +1,8 @@
 import taichi as ti
+import pytest
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_classfunc():
     @ti.data_oriented
@@ -33,6 +35,7 @@ def test_classfunc():
             assert arr.val[i, j] == i * j * 2
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_oop():
     @ti.data_oriented
@@ -95,6 +98,7 @@ def test_oop():
             assert arr.val.grad[i, j] == 8
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_oop_two_items():
     @ti.data_oriented
@@ -145,6 +149,7 @@ def test_oop_two_items():
             assert arr2.val.grad[i, j] == arr2_mult
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_oop_inherit_ok():
     # Array1D inherits from object, which makes the callstack being 'class Array2D(object)'
@@ -174,6 +179,7 @@ def test_oop_inherit_ok():
         assert arr.val.grad[i] == 42
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.must_throw(ti.KernelDefError)
 @ti.host_arch_only
 def test_oop_class_must_be_data_oriented():
@@ -199,6 +205,7 @@ def test_oop_class_must_be_data_oriented():
     arr.reduce()
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_hook():
     @ti.data_oriented

--- a/tests/python/test_ptr_assign.py
+++ b/tests/python/test_ptr_assign.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import pytest
 
 
 @ti.all_archs
@@ -85,6 +86,7 @@ def test_ptr_func():
     assert a[None] == 5.0
 
 
+@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.all_archs
 def test_ptr_class_func():
     @ti.data_oriented


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
As @yuanming-hu said in his final lecture in GAMES 201, *simplicity matters*.
I noticed that our ODOP implementation is getting too complicated that developers can hardly maintain them.
Although not found in Python Zen, I think I will add *serialized is better than parallelized* and *don't put things too tight together*.
Currently `is_classfunc` is embed into `Kernel` and `Func`, which is lossening the focus IMO.
The module `re` is actually completely unrelated to the rest part of `kernel.py`, but linked by our ODOP implementation.
I'm thinking if it's possible to move that outside of `Kernel` and `Func`, or even implement class inspection via an external package?
So I'd like to remove these codes for now, and completely reimplement it in a much simpler way, in a following PR.
Using the same workflow as @Rullec did in `rullec-field`, I merge this PR into a temp branch called `archibate-odop`, so `master` won't suffer regressions on ODOP, what a smart idea! And will only merge `archibate-odop` to `master` after everything is done. I'd like to call this cool workflow `rullecized PRs` as it's first used by @Rullec, WDYT about the name?
@k-ye I **promise** I'll add it back in another PR, except for increasing maintainability, so please don't feel upset :) Your work is still valuable to me. So please approve if you think the change doesn't break non-ODOP behaviors, will add it back iapr and your implementation is an important reference for implementing a decoupled version ODOP.