### PR TITLE
[refactor] [lang] Restore ODOP support

### DIFF
--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -531,36 +531,42 @@ def kernel(func):
     primal.grad = adjoint
 
     @functools.wraps(func)
-    def wrapped(*_, **__):
-        return primal(*_, **__)
+    def wrapped(*args, **kwargs):
+        _taichi_skip_traceback = 1
+        return primal(*args, **kwargs)
 
     @functools.wraps(func)
-    def wrapped_grad(*_, **__):
-        return adjoint(*_, **__)
+    def wrapped_grad(*args, **kwargs):
+        _taichi_skip_traceback = 1
+        return adjoint(*args, **kwargs)
 
-    if not _inside_class(3):
+    if not _inside_class(level_of_class_stackframe=3):
         wrapped.grad = wrapped_grad
         return wrapped
 
     class BoundKernelProperty(property):
         @functools.wraps(func)
-        def __call__(self, *_, **__):
-            return primal(*_, **__)
+        def __call__(self, *args, **kwargs):
+            _taichi_skip_traceback = 1
+            return primal(*args, **kwargs)
 
         @functools.wraps(func)
-        def grad(self, *_, **__):
-            return adjoint(*_, **__)
+        def grad(self, *args, **kwargs):
+            _taichi_skip_traceback = 1
+            return adjoint(*args, **kwargs)
 
     @functools.wraps(func)
     @BoundKernelProperty
-    def prop_kernel(this):
+    def prop_kernel(self):
         @functools.wraps(func)
-        def wrapped(*_, **__):
-            return primal(this, *_, **__)
+        def wrapped(*args, **kwargs):
+            _taichi_skip_traceback = 1
+            return primal(self, *args, **kwargs)
 
         @functools.wraps(func)
-        def wrapped_grad(*_, **__):
-            return adjoint(this, *_, **__)
+        def wrapped_grad(*args, **kwargs):
+            _taichi_skip_traceback = 1
+            return adjoint(self, *args, **kwargs)
 
         wrapped.grad = wrapped_grad
         return wrapped

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -496,11 +496,11 @@ def kernel(func):
     # Having |primal| contains |grad| makes the tape work.
     primal.grad = adjoint
 
-    @functools.wraps(foo)
+    @functools.wraps(func)
     def wrapped(*_, **__):
         return primal(*_, **__)
 
-    @functools.wraps(foo)
+    @functools.wraps(func)
     def wrapped_grad(*_, **__):
         return adjoint(*_, **__)
 
@@ -509,22 +509,22 @@ def kernel(func):
         return wrapped
 
     class BoundKernelProperty(property):
-        @functools.wraps(foo)
+        @functools.wraps(func)
         def __call__(self, *_, **__):
             return primal(*_, **__)
 
-        @functools.wraps(foo)
+        @functools.wraps(func)
         def grad(self, *_, **__):
             return adjoint(*_, **__)
 
-    @functools.wraps(foo)
+    @functools.wraps(func)
     @BoundKernelProperty
     def prop_kernel(this):
-        @functools.wraps(foo)
+        @functools.wraps(func)
         def wrapped(*_, **__):
             return primal(this, *_, **__)
 
-        @functools.wraps(foo)
+        @functools.wraps(func)
         def wrapped_grad(*_, **__):
             return adjoint(this, *_, **__)
 

--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -266,9 +266,7 @@ class Kernel:
                 )
             annotation = param.annotation
             if param.annotation is inspect.Parameter.empty:
-                _taichi_skip_traceback = 1
-                raise KernelDefError(
-                    'Taichi kernels parameters must be type annotated')
+                annotation = template()
             elif isinstance(annotation, (template, ext_arr)):
                 pass
             elif id(annotation) in type_ids:
@@ -512,6 +510,7 @@ def kernel(func):
 
 
 def data_oriented(cls):
+    cls._data_oriented = True
     return cls
 
 

--- a/tests/python/test_classfunc.py
+++ b/tests/python/test_classfunc.py
@@ -2,7 +2,6 @@ import taichi as ti
 import pytest
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_classfunc():
     @ti.data_oriented

--- a/tests/python/test_complex_kernels.py
+++ b/tests/python/test_complex_kernels.py
@@ -67,7 +67,6 @@ def test_complex_kernels_indirect():
         assert x.grad[0] == 4
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.all_archs
 def test_complex_kernels_oop():
     @ti.data_oriented
@@ -104,7 +103,6 @@ def test_complex_kernels_oop():
         assert a.x.grad[0] == 4
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.all_archs
 def test_complex_kernels_oop2():
     @ti.data_oriented

--- a/tests/python/test_mpm_particle_list.py
+++ b/tests/python/test_mpm_particle_list.py
@@ -3,49 +3,49 @@ import random
 import pytest
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
+@ti.data_oriented
+class MPMSolver:
+    def __init__(self, res):
+        dim = len(res)
+        self.dx = 1 / res[0]
+        self.inv_dx = 1.0 / self.dx
+        self.pid = ti.field(ti.i32)
+        self.x = ti.Vector.field(dim, dtype=ti.f32)
+        self.grid_m = ti.field(dtype=ti.f32)
+
+        indices = ti.ij
+
+        self.grid = ti.root.pointer(indices, 32)
+        block = self.grid.pointer(indices, 16)
+        voxel = block.dense(indices, 8)
+
+        voxel.place(self.grid_m)
+        block.dynamic(ti.indices(dim), 1024 * 1024,
+                      chunk_size=4096).place(self.pid)
+
+        ti.root.dynamic(ti.i, 2**25, 2**20).place(self.x)
+        self.substeps = 0
+
+        for i in range(10000):
+            self.x[i] = [random.random() * 0.5, random.random() * 0.5]
+
+    @ti.kernel
+    def build_pid(self):
+        ti.block_dim(256)
+        for p in self.x:
+            base = ti.floor(self.x[p] * self.inv_dx - 0.5).cast(int)
+            ti.append(self.pid.parent(), base, p)
+
+    def step(self):
+        for i in range(1000):
+            self.substeps += 1
+            self.grid.deactivate_all()
+            self.build_pid()
+
+
 @ti.require(ti.extension.sparse)
 @ti.all_archs_with(use_unified_memory=False, device_memory_GB=0.3)
 def test_mpm_particle_list_no_leakage():
-    @ti.data_oriented
-    class MPMSolver:
-        def __init__(self, res):
-            dim = len(res)
-            self.dx = 1 / res[0]
-            self.inv_dx = 1.0 / self.dx
-            self.pid = ti.field(ti.i32)
-            self.x = ti.Vector.field(dim, dtype=ti.f32)
-            self.grid_m = ti.field(dtype=ti.f32)
-
-            indices = ti.ij
-
-            self.grid = ti.root.pointer(indices, 32)
-            block = self.grid.pointer(indices, 16)
-            voxel = block.dense(indices, 8)
-
-            voxel.place(self.grid_m)
-            block.dynamic(ti.indices(dim), 1024 * 1024,
-                          chunk_size=4096).place(self.pid)
-
-            ti.root.dynamic(ti.i, 2**25, 2**20).place(self.x)
-            self.substeps = 0
-
-            for i in range(10000):
-                self.x[i] = [random.random() * 0.5, random.random() * 0.5]
-
-        @ti.kernel
-        def build_pid(self):
-            ti.block_dim(256)
-            for p in self.x:
-                base = ti.floor(self.x[p] * self.inv_dx - 0.5).cast(int)
-                ti.append(self.pid.parent(), base, p)
-
-        def step(self):
-            for i in range(1000):
-                self.substeps += 1
-                self.grid.deactivate_all()
-                self.build_pid()
-
     # By default Taichi will allocate 0.5 GB for testing.
     mpm = MPMSolver(res=(128, 128))
     mpm.step()

--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -2,7 +2,6 @@ import taichi as ti
 import pytest
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_classfunc():
     @ti.data_oriented
@@ -35,7 +34,6 @@ def test_classfunc():
             assert arr.val[i, j] == i * j * 2
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_oop():
     @ti.data_oriented
@@ -98,7 +96,6 @@ def test_oop():
             assert arr.val.grad[i, j] == 8
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_oop_two_items():
     @ti.data_oriented
@@ -149,7 +146,6 @@ def test_oop_two_items():
             assert arr2.val.grad[i, j] == arr2_mult
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_oop_inherit_ok():
     # Array1D inherits from object, which makes the callstack being 'class Array2D(object)'
@@ -205,7 +201,6 @@ def test_oop_class_must_be_data_oriented():
     arr.reduce()
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.host_arch_only
 def test_hook():
     @ti.data_oriented

--- a/tests/python/test_ptr_assign.py
+++ b/tests/python/test_ptr_assign.py
@@ -86,7 +86,6 @@ def test_ptr_func():
     assert a[None] == 5.0
 
 
-@pytest.mark.xfail(reason='Dropped ODOP support')
 @ti.all_archs
 def test_ptr_class_func():
     @ti.data_oriented


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1827

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
The remove + restore, refactored away the `self.classfunc` and `self.classkernel` property completely.