### PR TITLE
[async] Implement basic StateFlowGraph

### DIFF
--- a/misc/visualize_state_flow_graph.py
+++ b/misc/visualize_state_flow_graph.py
@@ -4,19 +4,23 @@ ti.init(arch=ti.cpu, async_mode=True)
 
 x = ti.field(ti.i32)
 y = ti.field(ti.i32)
+z = ti.field(ti.i32)
 
-ti.root.pointer(ti.i, 128).dense(ti.i, 16).place(x, y)
+ti.root.pointer(ti.i, 128).dense(ti.i, 16).place(x, y, z)
+
 
 @ti.kernel
 def foo():
     for i in x:
-        y[i] = x[i]
-        
+        y[i] = x[i] + 1
+
+
 @ti.kernel
 def bar():
     for i in y:
-        y[i] = x[i] + 1
-        
+        z[i] = y[i] + 1
+
+
 foo()
 bar()
 

--- a/misc/visualize_state_flow_graph.py
+++ b/misc/visualize_state_flow_graph.py
@@ -1,0 +1,21 @@
+import taichi as ti
+
+x = ti.field(ti.i32)
+y = ti.field(ti.i32)
+
+ti.root.pointer(ti.i, 128).dense(ti.i, 16).place(x, y)
+
+@ti.kernel
+def foo():
+    for i in x:
+        y[i] = x[i]
+        
+@ti.kernel
+def bar():
+    for i in y:
+        y[i] = x[i] + 1
+        
+foo()
+bar()
+
+ti.core.print_sfg()

--- a/misc/visualize_state_flow_graph.py
+++ b/misc/visualize_state_flow_graph.py
@@ -1,5 +1,7 @@
 import taichi as ti
 
+ti.init(arch=ti.cpu, async_mode=True)
+
 x = ti.field(ti.i32)
 y = ti.field(ti.i32)
 

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -6,15 +6,18 @@
 #include <thread>
 #include <unordered_map>
 
-#define TI_RUNTIME_HOST
 #include "taichi/ir/ir.h"
 #include "taichi/ir/statements.h"
 #include "taichi/lang_util.h"
+#define TI_RUNTIME_HOST
 #include "taichi/program/context.h"
+#undef TI_RUNTIME_HOST
+#include "taichi/program/async_utils.h"
 
 TLANG_NAMESPACE_BEGIN
 
 // TODO(yuanming-hu): split into multiple files
+
 class ParallelExecutor {
  public:
   using TaskType = std::function<void()>;
@@ -77,7 +80,7 @@ class TaskLaunchRecord {
                    OffloadedStmt *stmt,
                    uint64 h);
 
-  inline OffloadedStmt *stmt() {
+  inline OffloadedStmt *stmt() const {
     return stmt_;
   }
 
@@ -212,10 +215,7 @@ class AsyncEngine {
     bool initialized{false};
   };
 
-  struct TaskMeta {
-    std::unordered_set<SNode *> input_snodes, output_snodes;
-    std::unordered_set<SNode *> activation_snodes;
-  };
+  TaskMeta create_task_meta(const TaskLaunchRecord &t);
 
   // In async mode, the root of an AST is an OffloadedStmt instead of a Block.
   // This map provides a dummy Block root for these OffloadedStmt, so that

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -69,7 +69,7 @@ class ParallelExecutor {
   std::condition_variable flush_cv_;
 };
 
-// Records the necessary data for launching an offloaed task.
+// Records the necessary data for launching an offloaded task.
 class TaskLaunchRecord {
  public:
   Context context;
@@ -162,8 +162,8 @@ class AsyncEngine {
   std::unique_ptr<StateFlowGraph> sfg;
   std::deque<TaskLaunchRecord> task_queue;
 
-  AsyncEngine(Program *program) : program(program) {
-    sfg = std::make_unique<StateFlowGraph>();
+  AsyncEngine(Program *program)
+      : program(program), sfg(std::make_unique<StateFlowGraph>()) {
   }
 
   bool optimize_listgen();  // return true when modified

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -13,6 +13,7 @@
 #include "taichi/program/context.h"
 #undef TI_RUNTIME_HOST
 #include "taichi/program/async_utils.h"
+#include "taichi/program/state_flow_graph.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -156,10 +157,13 @@ class AsyncEngine {
   // TODO: state machine
 
   ExecutionQueue queue;
+  Program *program;
 
+  std::unique_ptr<StateFlowGraph> sfg;
   std::deque<TaskLaunchRecord> task_queue;
 
-  AsyncEngine() {
+  AsyncEngine(Program *program) : program(program) {
+    sfg = std::make_unique<StateFlowGraph>();
   }
 
   bool optimize_listgen();  // return true when modified

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "taichi/ir/snode.h"
+
+TLANG_NAMESPACE_BEGIN
+
+struct AsyncState {
+  enum class Type { mask, value, list };
+
+  AsyncState(SNode *snode, Type type) : snode(snode), type(type) {
+  }
+
+  SNode *snode;
+  Type type;
+
+  bool operator<(const AsyncState &other) const {
+    return snode < other.snode || (snode == other.snode && type < other.type);
+  }
+};
+
+struct TaskMeta {
+  SNode *loop_snode{nullptr};
+  std::vector<AsyncState> input_states;
+  std::vector<AsyncState> output_states;
+};
+
+TLANG_NAMESPACE_END

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -22,6 +22,22 @@ struct AsyncState {
   bool operator==(const AsyncState &other) const {
     return snode == other.snode && type == other.type;
   }
+
+  std::string name() const {
+    std::string type_name;
+    switch (type) {
+      case Type::mask:
+        type_name = "mask";
+        break;
+      case Type::value:
+        type_name = "value";
+        break;
+      case Type::list:
+        type_name = "list";
+        break;
+    }
+    return snode->get_node_type_name_hinted() + "_" + type_name;
+  }
 };
 
 class AsyncStateHash {
@@ -33,7 +49,7 @@ class AsyncStateHash {
 
 struct TaskMeta {
   std::string kernel_name;
-  SNode *loop_snode{nullptr}; // struct-for only
+  SNode *loop_snode{nullptr};  // struct-for only
   std::vector<AsyncState> input_states;
   std::vector<AsyncState> output_states;
 };

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -18,10 +18,22 @@ struct AsyncState {
   bool operator<(const AsyncState &other) const {
     return snode < other.snode || (snode == other.snode && type < other.type);
   }
+
+  bool operator==(const AsyncState &other) const {
+    return snode == other.snode && type == other.type;
+  }
+};
+
+class AsyncStateHash {
+ public:
+  size_t operator()(const AsyncState &s) const {
+    return (uint64)s.snode ^ (uint64)s.type;
+  }
 };
 
 struct TaskMeta {
-  SNode *loop_snode{nullptr};
+  std::string kernel_name;
+  SNode *loop_snode{nullptr}; // struct-for only
   std::vector<AsyncState> input_states;
   std::vector<AsyncState> output_states;
 };

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -147,7 +147,7 @@ Program::Program(Arch desired_arch) {
   if (config.async_mode) {
     TI_WARN("Running in async mode. This is experimental.");
     TI_ASSERT(arch_is_cpu(config.arch) || config.arch == Arch::cuda);
-    async_engine = std::make_unique<AsyncEngine>();
+    async_engine = std::make_unique<AsyncEngine>(this);
   }
 
   // TODO: allow users to run in debug mode without out-of-bound checks

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -2,14 +2,26 @@
 
 TLANG_NAMESPACE_BEGIN
 
-Node *StateFlowGraph::insert_task() {
-  std::unique_ptr<Node> node;
+void StateFlowGraph::insert_task(TaskMeta task_meta) {
+  auto node = std::make_unique<Node>();
+  node->kernel_name = task_meta.kernel_name;
+  for (auto input_state : task_meta.input_states) {
+    if (latest_state_owner.find(input_state) == latest_state_owner.end()) {
+      latest_state_owner[input_state] = initial_node;
+    }
+    insert_state_flow(latest_state_owner[input_state], node.get(), input_state);
+  }
+  for (auto output_state : task_meta.output_states) {
+    latest_state_owner[output_state] = node.get();
+  }
   nodes.push_back(std::move(node));
 }
 
 void StateFlowGraph::insert_state_flow(Node *from, Node *to, AsyncState state) {
-  from->output_edges.insert(state, to);
-  to->input_edges.insert(state, from);
+  TI_ASSERT(from != nullptr);
+  TI_ASSERT(to != nullptr);
+  from->output_edges.insert(std::make_pair(state, to));
+  to->input_edges.insert(std::make_pair(state, from));
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -1,0 +1,15 @@
+#include "taichi/program/state_flow_graph.h"
+
+TLANG_NAMESPACE_BEGIN
+
+Node *StateFlowGraph::insert_task() {
+  std::unique_ptr<Node> node;
+  nodes.push_back(std::move(node));
+}
+
+void StateFlowGraph::insert_state_flow(Node *from, Node *to, AsyncState state) {
+  from->output_edges.insert(state, to);
+  to->input_edges.insert(state, from);
+}
+
+TLANG_NAMESPACE_END

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -2,7 +2,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
-void StateFlowGraph::insert_task(TaskMeta task_meta) {
+void StateFlowGraph::insert_task(const TaskMeta &task_meta) {
   auto node = std::make_unique<Node>();
   node->kernel_name = task_meta.kernel_name;
   for (auto input_state : task_meta.input_states) {

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -25,8 +25,7 @@ void StateFlowGraph::insert_state_flow(Node *from, Node *to, AsyncState state) {
 }
 
 void StateFlowGraph::print_edges(
-    const std::unordered_map<AsyncState, StateFlowGraph::Node *, AsyncStateHash>
-        &edges) {
+    const StateFlowGraph::StateToNodeMapping &edges) {
   for (auto &edge : edges) {
     auto input_node = edge.second;
     fmt::print("    {}: node {} @ {}\n", edge.first.name(),

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -24,4 +24,30 @@ void StateFlowGraph::insert_state_flow(Node *from, Node *to, AsyncState state) {
   to->input_edges.insert(std::make_pair(state, from));
 }
 
+void StateFlowGraph::print_edges(
+    const std::unordered_map<AsyncState, StateFlowGraph::Node *, AsyncStateHash>
+        &edges) {
+  for (auto &edge : edges) {
+    auto input_node = edge.second;
+    fmt::print("    {}: node {} @ {}\n", edge.first.name(),
+               input_node->kernel_name, (void *)input_node);
+  }
+}
+
+void StateFlowGraph::print() {
+  fmt::print("=== State Flow Graph ===\n");
+  for (auto &node : nodes) {
+    fmt::print("Node {} {}\n", node->kernel_name, (void *)node.get());
+    if (!node->input_edges.empty()) {
+      fmt::print("  Inputs:\n", node->kernel_name, (void *)node.get());
+      print_edges(node->input_edges);
+    }
+    if (!node->output_edges.empty()) {
+      fmt::print("  Outputs:\n", node->kernel_name, (void *)node.get());
+      print_edges(node->output_edges);
+    }
+  }
+  fmt::print("=======================\n");
+}
+
 TLANG_NAMESPACE_END

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -1,40 +1,46 @@
+#pragma once
 
 #include "taichi/ir/ir.h"
 #include "taichi/ir/statements.h"
 #include "taichi/lang_util.h"
-#include "taichi/program/context.h"
+#include "taichi/program/program.h"
 #include "taichi/program/async_utils.h"
 
 TLANG_NAMESPACE_BEGIN
 
 class StateFlowGraph {
  public:
-  // TODO: maybe unordered_map is better?
-  std::map<AsyncState, Node *> latest_state_owner;
-
   // Each node is a task
   // Note: after SFG is done, each node here should hold a TaskLaunchRecord.
   // Optimization should happen fully on the SFG, instead of the queue in
   // AsyncEngine.
   // Before we migrate, the SFG is only used for visualization. Therefore we
-  // only store a kernel_name.
+  // only store a kernel_name, which is used as the label of the GraphViz node.
   struct Node {
     //  TODO: make use of IRHandle here
     IRNode *root;
     std::string kernel_name;
-    std::unordered_map<AsyncState, Node *> input_edges, output_edges;
+    std::unordered_map<AsyncState, Node *, AsyncStateHash> input_edges,
+        output_edges;
   };
+
+  std::unordered_map<AsyncState, Node *, AsyncStateHash> latest_state_owner;
 
   std::vector<std::unique_ptr<Node>> nodes;
 
+  Node *initial_node;  // The initial node holds all the initial states.
+
   StateFlowGraph() {
+    nodes.push_back(std::make_unique<Node>());
+    initial_node = nodes.back().get();
+    initial_node->kernel_name = "initial_state";
   }
 
-  void export(const std::string &fn) {
+  void dump_dot(const std::string &fn) {
     // TODO: export the graph to Dot format for GraphViz
   }
 
-  Node *insert_task();
+  void insert_task(TaskMeta task_meta);
 
   void insert_state_flow(Node *from, Node *to, AsyncState state);
 };

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -38,25 +38,9 @@ class StateFlowGraph {
     initial_node->kernel_name = "initial_state";
   }
 
-  void print_edges(const StateToNodeMappnig &edges) {
-    for (auto &edge : edges) {
-      auto input_node = edge.second;
-      fmt::print("    {}: node {} @ {}", edge.first.name(),
-                 input_node->kernel_name, (void *)input_node);
-    }
-  }
+  void print_edges(const StateToNodeMappnig &edges);
 
-  void print() {
-    fmt::print("=== State Flow Graph ===");
-    for (auto &node : nodes) {
-      fmt::print("Node {} {}", node->kernel_name, (void *)node.get());
-      fmt::print("  Inputs:", node->kernel_name, (void *)node.get());
-      print_edges(node->input_edges);
-      fmt::print("  Outputs:", node->kernel_name, (void *)node.get());
-      print_edges(node->output_edges);
-    }
-    fmt::print("=======================");
-  }
+  void print();
 
   void dump_dot(const std::string &fn) {
     // TODO: export the graph to Dot format for GraphViz

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -11,7 +11,7 @@ TLANG_NAMESPACE_BEGIN
 class StateFlowGraph {
  public:
   struct Node;
-  using StateToNodeMappnig =
+  using StateToNodeMapping =
       std::unordered_map<AsyncState, Node *, AsyncStateHash>;
   // Each node is a task
   // Note: after SFG is done, each node here should hold a TaskLaunchRecord.
@@ -23,10 +23,10 @@ class StateFlowGraph {
     //  TODO: make use of IRHandle here
     IRNode *root;
     std::string kernel_name;
-    StateToNodeMappnig input_edges, output_edges;
+    StateToNodeMapping input_edges, output_edges;
   };
 
-  StateToNodeMappnig latest_state_owner;
+  StateToNodeMapping latest_state_owner;
 
   std::vector<std::unique_ptr<Node>> nodes;
 
@@ -38,7 +38,7 @@ class StateFlowGraph {
     initial_node->kernel_name = "initial_state";
   }
 
-  void print_edges(const StateToNodeMappnig &edges);
+  void print_edges(const StateToNodeMapping &edges);
 
   void print();
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -46,7 +46,7 @@ class StateFlowGraph {
     // TODO: export the graph to Dot format for GraphViz
   }
 
-  void insert_task(TaskMeta task_meta);
+  void insert_task(const TaskMeta &task_meta);
 
   void insert_state_flow(Node *from, Node *to, AsyncState state);
 };

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -1,0 +1,42 @@
+
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+#include "taichi/lang_util.h"
+#include "taichi/program/context.h"
+#include "taichi/program/async_utils.h"
+
+TLANG_NAMESPACE_BEGIN
+
+class StateFlowGraph {
+ public:
+  // TODO: maybe unordered_map is better?
+  std::map<AsyncState, Node *> latest_state_owner;
+
+  // Each node is a task
+  // Note: after SFG is done, each node here should hold a TaskLaunchRecord.
+  // Optimization should happen fully on the SFG, instead of the queue in
+  // AsyncEngine.
+  // Before we migrate, the SFG is only used for visualization. Therefore we
+  // only store a kernel_name.
+  struct Node {
+    //  TODO: make use of IRHandle here
+    IRNode *root;
+    std::string kernel_name;
+    std::unordered_map<AsyncState, Node *> input_edges, output_edges;
+  };
+
+  std::vector<std::unique_ptr<Node>> nodes;
+
+  StateFlowGraph() {
+  }
+
+  void export(const std::string &fn) {
+    // TODO: export the graph to Dot format for GraphViz
+  }
+
+  Node *insert_task();
+
+  void insert_state_flow(Node *from, Node *to, AsyncState state);
+};
+
+TLANG_NAMESPACE_END

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -6,6 +6,7 @@
 #include "taichi/ir/frontend.h"
 #include "taichi/ir/frontend_ir.h"
 #include "taichi/program/extension.h"
+#include "taichi/program/async_engine.h"
 #include "taichi/common/interface.h"
 #include "taichi/python/export.h"
 #include "taichi/gui/gui.h"
@@ -644,6 +645,8 @@ void export_lang(py::module &m) {
       TI_ERROR("Key {} not supported in query_int64", key);
     }
   });
+
+  m.def("print_sfg", [] { get_current_program().async_engine->sfg->print(); });
 }
 
 TI_NAMESPACE_END


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #742

Running `misc/visualize_state_flow_graph.py` gives you
```
=== State Flow Graph ===
Node initial_state 0x561f94a55de0
  Outputs:
    S3place_i32_value: node foo_c4_0 @ 0x561f94aee000
Node foo_c4_0 0x561f94aedf40
Node foo_c4_0 0x561f94e94e70
Node foo_c4_0 0x561f94efb920
Node foo_c4_0 0x561f94c6dff0
Node foo_c4_0 0x561f94aee000
  Inputs:
    S3place_i32_value: node initial_state @ 0x561f94a55de0
  Outputs:
    S4place_i32_value: node bar_c6_0 @ 0x561f94c68900
Node foo_c4_0 0x561f94e354e0
Node foo_c4_0 0x561f94e53bf0
Node foo_c4_0 0x561f94aaf160
Node foo_c4_0 0x561f94e0cd50
Node bar_c6_0 0x561f94c68900
  Inputs:
    S4place_i32_value: node foo_c4_0 @ 0x561f94aee000
=======================
```

Note that we support value state for now. The nodes without any input/output states are clear list/list generation nodes, that work on list state/mask state. I'll track more states tomorrow.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
