### PR TITLE
[misc] Check the previous Github workflow run status if CI is skipped

### DIFF
--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -58,9 +58,9 @@ jobs:
           ti test -vr2 -t2
 
   check_previous_run:
-    name: Checks the Workflow Run Conclusion of the Previous Commit
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'skip ci') || github.event.sender.login == 'taichi-gardener' }}
+    name: Checks the Workflow Run of the Previous Commit
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'skip ci') || github.event.sender.login == 'taichi-gardener' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -57,6 +57,21 @@ jobs:
           ti diagnose
           ti test -vr2 -t2
 
+  check_previous_run:
+    name: Checks the Workflow Run Conclusion of the Previous Commit
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'skip ci') || github.event.sender.login == 'taichi-gardener' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Check the previous run
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          SHA=${{ github.event.pull_request.head.sha }}
+          python misc/ci_check_previous_run.py --pr ${PR} --sha ${SHA}
+
   code_format:
     name: Code Format
     runs-on: ubuntu-latest

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -37,20 +37,22 @@ def locate_previous_commit_sha(commits, head_sha):
     return commits[-2][SHA]
 
 
-def is_desired_workflow(wf_url):
-    f = send_request(wf_url)
-    j = json.loads(f.read())
-    p = j['path']
-    logging.debug(f'workflow_url={wf_url} path={p}')
-    # TODO: s/persubmit/presubmit...?
-    return p.endswith('persubmit.yml')
-
-
 def get_workflow_runs(page_id):
     # https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
     url = make_api_url(f'actions/runs?page={page_id}')
     f = send_request(url)
     return json.loads(f.read())
+
+
+def is_desired_workflow(run_json):
+    """
+    Checks if this run is for the "Presubmit Checks" workflow.
+    """
+    # Each workflow has a fixed ID.
+    # For the "Persubmit Checks" workflow, it is:
+    # https://api.github.com/repos/taichi-dev/taichi/actions/workflows/1291024
+    DESIRED_ID = 1291024
+    return run_json['workflow_id'] == DESIRED_ID
 
 
 def locate_workflow_run_id(sha):
@@ -60,7 +62,7 @@ def locate_workflow_run_id(sha):
         # Note that the REST API to get runs paginates the results.
         runs = get_workflow_runs(page_id)['workflow_runs']
         for r in runs:
-            if r['head_sha'] == sha and is_desired_workflow(r['workflow_url']):
+            if r['head_sha'] == sha and is_desired_workflow(r):
                 return r['id']
         page_id += 1
     return ''

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -48,7 +48,7 @@ def locate_workflow_run_id(sha):
     done = False
     page_id = 0
     while not done:
-        # Note that the REST  API to get runs paginates the results.
+        # Note that the REST API to get runs paginates the results.
         runs = get_workflow_runs(page_id)['workflow_runs']
         for r in runs:
             if r['head_sha'] == sha:

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -18,10 +18,7 @@ def send_request(url):
     return ur.urlopen(url)
 
 
-def get_commits(pr):
-    """
-    Gets the commits of |pr|.
-    """
+def get_commits(pr):  
     url = make_api_url(f'pulls/{pr}/commits')
     f = send_request(url)
     return json.loads(f.read())

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -1,0 +1,125 @@
+import argparse
+import json
+import logging
+import time
+import urllib.request as ur
+import sys
+
+API_PREFIX = 'https://api.github.com/repos/taichi-dev/taichi'
+SHA = 'sha'
+
+
+def make_api_url(p):
+    return f'{API_PREFIX}/{p}'
+
+
+def send_request(url):
+    logging.debug(f'request={url}')
+    return ur.urlopen(url)
+
+
+def get_commits(pr):
+    """
+    Gets the commits of |pr|.
+    """
+    url = make_api_url(f'pulls/{pr}/commits')
+    f = send_request(url)
+    return json.loads(f.read())
+
+
+def locate_previous_commit_sha(commits, head_sha):
+    """
+    Returns the previous commit of |head_sha| in PR's |commits|.
+    """
+    assert commits[-1][SHA] == head_sha
+    if len(commits) < 2:
+        return None
+    return commits[-2][SHA]
+
+
+def get_workflow_runs(page_id):
+    # https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
+    url = make_api_url(f'actions/runs?page={page_id}')
+    f = send_request(url)
+    return json.loads(f.read())
+
+
+def locate_workflow_run_id(sha):
+    done = False
+    page_id = 0
+    while not done:
+        # Note that the REST API to get runs paginates the results.
+        runs = get_workflow_runs(page_id)['workflow_runs']
+        for r in runs:
+            if r['head_sha'] == sha:
+                return r['id']
+        page_id += 1
+    return ''
+
+
+def get_status_of_run(run_id):
+    """
+    Waits for run identified by |run_id| to complete and returns its status.
+    """
+    url = make_api_url(f'actions/runs/{run_id}')
+    start = time.time()
+    retries = 0
+    MAX_TIMEOUT = 60 * 60  # 1 hour
+    while True:
+        f = send_request(url)
+        j = json.loads(f.read())
+        # https://developer.github.com/v3/checks/runs/#create-a-check-run
+        if j['status'] == 'completed':
+            c = j['conclusion']
+            logging.debug(f'run={run_id} conclusion={c}')
+            return c == 'success'
+
+        if time.time() - start > MAX_TIMEOUT:
+            return False
+        retries += 1
+        logging.info(
+            f'Waiting to get the status of run={run_id} (url={url}). retries={retries}'
+        )
+        time.sleep(15)
+    return False
+
+
+def get_cmd_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pr', help='PR number')
+    parser.add_argument('--sha', help='Head commit SHA in the PR')
+    return parser.parse_args()
+
+
+def main():
+    logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s',
+                        level=logging.DEBUG,
+                        datefmt='%Y-%m-%d %H:%M:%S')
+    args = get_cmd_args()
+
+    pr = args.pr
+    commits = get_commits(pr)
+    num_commits = len(commits)
+    logging.debug(f'\nPR={pr} #commits={num_commits}')
+
+    head_sha = args.sha
+    prev_sha = locate_previous_commit_sha(commits, head_sha)
+    logging.debug(f'SHA: head={head_sha} prev={prev_sha}')
+    if prev_sha is None:
+        logging.info(f'First commit in PR={pr}, no previous run to check')
+        # First commit in the PR
+        return 0
+
+    run_id = locate_workflow_run_id(prev_sha)
+    if not run_id:
+        logging.warning(f'Could not find the workflow run for SHA={prev_sha}')
+        return 0
+
+    logging.info(f'Prev commit: SHA={prev_sha} workflow_run_id={run_id}')
+    run_ok = get_status_of_run(run_id)
+    logging.info(f'workflow_run_id={run_id} ok={run_ok}')
+    return 0 if run_ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -18,7 +18,7 @@ def send_request(url):
     return ur.urlopen(url)
 
 
-def get_commits(pr):  
+def get_commits(pr):
     url = make_api_url(f'pulls/{pr}/commits')
     f = send_request(url)
     return json.loads(f.read())

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -37,6 +37,15 @@ def locate_previous_commit_sha(commits, head_sha):
     return commits[-2][SHA]
 
 
+def is_desired_workflow(wf_url):
+    f = send_request(wf_url)
+    j = json.loads(f.read())
+    p = j['path']
+    logging.debug(f'workflow_url={wf_url} path={p}')
+    # TODO: s/persubmit/presubmit...?
+    return p.endswith('persubmit.yml')
+
+
 def get_workflow_runs(page_id):
     # https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository
     url = make_api_url(f'actions/runs?page={page_id}')
@@ -51,7 +60,7 @@ def locate_workflow_run_id(sha):
         # Note that the REST API to get runs paginates the results.
         runs = get_workflow_runs(page_id)['workflow_runs']
         for r in runs:
-            if r['head_sha'] == sha:
+            if r['head_sha'] == sha and is_desired_workflow(r['workflow_url']):
                 return r['id']
         page_id += 1
     return ''

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -48,7 +48,7 @@ def locate_workflow_run_id(sha):
     done = False
     page_id = 0
     while not done:
-        # Note that the REST API to get runs paginates the results.
+        # Note that the REST  API to get runs paginates the results.
         runs = get_workflow_runs(page_id)['workflow_runs']
         for r in runs:
             if r['head_sha'] == sha:

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -15,10 +15,9 @@ template <typename T>
 std::vector<T *> make_raw_pointer_list(
     const std::vector<std::unique_ptr<T>> &unique_pointers) {
   std::vector<T *> raw_pointers;
-  for (auto &ptr : unique_pointers) {
+  for (auto &ptr : unique_pointers)
     raw_pointers.push_back(ptr.get());
-  }
-  return raw_pointers
+  return raw_pointers;
 }
 
 }  // namespace

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -15,9 +15,9 @@ template <typename T>
 std::vector<T *> make_raw_pointer_list(
     const std::vector<std::unique_ptr<T>> &unique_pointers) {
   std::vector<T *> raw_pointers;
-  for (auto &ptr : unique_pointers)
-    raw_pointers.push_back(ptr.get());
-  return raw_pointers;
+  for (auto &ptr : unique_pointers){
+    raw_pointers.push_back(   ptr.get());   }     
+  return raw_pointers
 }
 
 }  // namespace

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -15,8 +15,9 @@ template <typename T>
 std::vector<T *> make_raw_pointer_list(
     const std::vector<std::unique_ptr<T>> &unique_pointers) {
   std::vector<T *> raw_pointers;
-  for (auto &ptr : unique_pointers){
-    raw_pointers.push_back(   ptr.get());   }     
+  for (auto &ptr : unique_pointers) {
+    raw_pointers.push_back(ptr.get());
+  }
   return raw_pointers
 }
 


### PR DESCRIPTION
Test test test

---

Adds a `check_previous_run` job to our presubmit workflow, so that when `skip ci` is enabled, the job will use the previous workflow run status. If the previous run hasn't finished, this job will poll the status every 15s, with a deadline of 1 hour.

The idea is described in https://github.com/taichi-dev/taichi/issues/1809#issuecomment-686538091. Basically:

1. Find the previous commit of this one in the current PR
2. Find the workflow run corresponding to the previous commit
3. Check the status of the run.

**Future TODOs**

* Now that we have the workflow run ID of the previous commit, we can actually instruct to cancel the run ([`cancel` doc](https://docs.github.com/en/rest/reference/actions#cancel-a-workflow-run)).
* Unfortunately, `[skip ci]` in the commit message is actually not working in Github Actions (see https://github.community/t/github-actions-does-not-respect-skip-ci/17325). Instead, the commit message is only useful to skip Travis and Appveyor. 

  We can add a step to extract the head commit's message, and use that to decide whether to trigger the subsequent steps.

See also https://github.com/k-ye/test_gh_action/pull/4

<img width="944" alt="Screen Shot 2020-09-05 at 17 14 21" src="https://user-images.githubusercontent.com/7481356/92301068-54ce5880-ef9b-11ea-9e69-0a70ba20f869.png">

Related issue = #1809

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
