### PR TITLE
[Lang] Support __len__ and __iter__ on ti.Matrix

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -396,6 +396,8 @@ class Matrix(TaichiOperations):
     @python_scope
     def __setitem__(self, indices, item):
         if self.is_global():
+            if not isinstance(item, (list, tuple)):
+                item = list(item)
             if not isinstance(item[0], (list, tuple)):
                 item = [[i] for i in item]
             for i in range(self.n):
@@ -409,6 +411,15 @@ class Matrix(TaichiOperations):
         i = indices[0]
         j = 0 if len(indices) == 1 else indices[1]
         self.set_entry(i, j, item)
+
+    def __len__(self):
+        return self.n
+
+    def __iter__(self):
+        if self.m == 1:
+            return (self(i) for i in range(self.n))
+        else:
+            return ([self(i, j) for j in range(self.m)] for i in range(self.n))
 
     def empty_copy(self):
         return Matrix.empty(self.n, self.m)

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -159,8 +159,7 @@ def test_taichi_scope_matrix_operations_with_global_matrices(ops):
     assert np.allclose(r2[None].value.to_numpy(), ops(a, c))
 
 
-@ti.host_arch_only
-@ti.must_throw(ti.TaichiSyntaxError)
+@ti.test(arch=ti.cpu)
 def test_matrix_non_constant_index():
     m = ti.Matrix.field(2, 2, ti.i32, 5)
 
@@ -170,10 +169,11 @@ def test_matrix_non_constant_index():
             for j, k in ti.ndrange(2, 2):
                 m[i][j, k] = 12
 
-    func()
+    with pytest.raises(ti.TaichiSyntaxError):
+        func()
 
 
-@ti.host_arch_only
+@ti.test(arch=ti.cpu)
 def test_matrix_constant_index():
     m = ti.Matrix.field(2, 2, ti.i32, 5)
 
@@ -188,7 +188,31 @@ def test_matrix_constant_index():
     assert np.allclose(m.to_numpy(), np.ones((5, 2, 2), np.int32) * 12)
 
 
-@ti.all_archs
+@ti.test(arch=ti.cpu)
+def test_vector_to_list():
+    a = ti.Vector.field(2, float, ())
+
+    data = [2, 3]
+    b = ti.Vector(data)
+    assert list(b) == data
+
+    a[None] = b
+    assert all(a[None].value == ti.Vector(data))
+
+
+@ti.test(arch=ti.cpu)
+def test_matrix_to_list():
+    a = ti.Matrix.field(2, 3, float, ())
+
+    data = [[2, 3, 4], [5, 6, 7]]
+    b = ti.Matrix(data)
+    assert list(b) == data
+
+    a[None] = b
+    assert all(a[None].value == ti.Matrix(data))
+
+
+@ti.test()
 def test_matrix_needs_grad():
     # Just make sure the usage doesn't crash, see https://github.com/taichi-dev/taichi/pull/1545
     n = 8

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -195,6 +195,7 @@ def test_vector_to_list():
     data = [2, 3]
     b = ti.Vector(data)
     assert list(b) == data
+    assert len(b) == len(data)
 
     a[None] = b
     assert all(a[None].value == ti.Vector(data))
@@ -207,6 +208,7 @@ def test_matrix_to_list():
     data = [[2, 3, 4], [5, 6, 7]]
     b = ti.Matrix(data)
     assert list(b) == data
+    assert len(b) == len(data)
 
     a[None] = b
     assert all(a[None].value == ti.Matrix(data))


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = #1188

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

Before this, the following code will result in a confusing error:
```py
import taichi as ti

a = ti.Vector.field(2, float, ())

a[None] = [2, 3]             # OK
a[None] = ti.Vector([2, 3])  # ERROR
```
```
[Taichi] mode=development
[Taichi] preparing sandbox at /tmp/taichi-51ftg4mj
[Taichi] <dev mode>, llvm 10.0.0, commit 41708c5e, linux, python 3.8.3
[Taichi] materializing...
Traceback (most recent call last):
  File "a.py", line 6, in <module>
    a[None] = ti.Vector([2, 3])  # ERROR
  File "/home/bate/Develop/taichi/python/taichi/lang/util.py", line 212, in wrapped
    return func(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 400, in __setitem__
    item = [[i] for i in item]
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 400, in <listcomp>
    item = [[i] for i in item]
  File "/home/bate/Develop/taichi/python/taichi/lang/util.py", line 212, in wrapped
    return func(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 394, in __getitem__
    return self(i, j)
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 229, in __call__
    return self.entries[self.linearize_entry_id(*args)]
  File "/home/bate/Develop/taichi/python/taichi/lang/matrix.py", line 220, in linearize_entry_id
    assert 0 <= args[0] < self.n, \
AssertionError: The 0-th matrix index is out of range: 0 <= 2 < 2
```
Why can't we assign `ti.Vector` to vector field elements?

It seems to be `list(v)` is accessing out of bound, so I fix this by adding a custom `__iter__` and `__len__`, that returns the vector entries.