### PR TITLE
[Error] Raise TaichiSyntaxError when multiple return path detected

### DIFF
--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -89,9 +89,8 @@ class ASTTransformerBase(ast.NodeTransformer):
     @staticmethod
     def get_decorator(node):
         if not (isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == 'ti'
+                and isinstance(node.func, ast.Attribute) and isinstance(
+                    node.func.value, ast.Name) and node.func.value.id == 'ti'
                 and node.func.attr in ['static', 'grouped', 'ndrange']):
             return ''
         return node.func.attr
@@ -907,7 +906,7 @@ class ASTTransformerChecks(ASTTransformerBase):
             self.has_return = True
         else:
             raise TaichiSyntaxError(
-                    'Taichi functions/kernels cannot have multiple returns!'
-                    ' Consider use a local variable to walk around')
+                'Taichi functions/kernels cannot have multiple returns!'
+                ' Consider use a local variable to walk around')
 
         return node

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -86,6 +86,16 @@ class ASTTransformerBase(ast.NodeTransformer):
             assert isinstance(node.target, ast.Tuple)
             return [name.id for name in node.target.elts]
 
+    @staticmethod
+    def get_decorator(node):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == 'ti'
+                and node.func.attr in ['static', 'grouped', 'ndrange']):
+            return ''
+        return node.func.attr
+
 
 # First-pass transform
 class ASTTransformerPreprocess(ASTTransformerBase):
@@ -342,17 +352,6 @@ if 1:
             raise TaichiSyntaxError(
                 "Variable '{}' is already declared in the outer scope and cannot be used as loop variable"
                 .format(loop_var))
-
-    @staticmethod
-    def get_decorator(iter):
-        if not (isinstance(iter, ast.Call)
-                and isinstance(iter.func, ast.Attribute)
-                and isinstance(iter.func.value, ast.Name)
-                and iter.func.value.id == 'ti' and
-                (iter.func.attr == 'static' or iter.func.attr == 'grouped'
-                 or iter.func.attr == 'ndrange')):
-            return ''
-        return iter.func.attr
 
     def visit_static_for(self, node, is_grouped):
         # for i in ti.static(range(n))
@@ -886,20 +885,11 @@ class ASTTransformerChecks(ASTTransformerBase):
             node.func = self.parse_expr('ti.func_call_with_check')
         return node
 
-    @staticmethod
-    def get_taichi_decorator(node):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name) and node.func.value.id == 'ti':
-            attr = node.func.attr
-            if attr in ['static', 'grouped']:
-                return attr
-
-        return None
-
     def visit_If(self, node):
         node.test = self.visit(node.test)
 
         old_in_static_if = self.in_static_if
-        self.in_static_if = self.get_taichi_decorator(node.test) == 'static'
+        self.in_static_if = self.get_decorator(node.test) == 'static'
 
         node.body = list(map(self.visit, node.body))
         if node.orelse is not None:

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -907,6 +907,6 @@ class ASTTransformerChecks(ASTTransformerBase):
         else:
             raise TaichiSyntaxError(
                 'Taichi functions/kernels cannot have multiple returns!'
-                ' Consider use a local variable to walk around')
+                ' Consider using a local variable to walk around.')
 
         return node

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -877,7 +877,7 @@ if 1:
 class ASTTransformerChecks(ASTTransformerBase):
     def __init__(self, func):
         super().__init__(func)
-        self.had_return = False
+        self.has_return = False
         self.in_static_if = False
 
     def visit_Call(self, node):
@@ -913,20 +913,11 @@ class ASTTransformerChecks(ASTTransformerBase):
         if self.in_static_if:  # we can have multiple return in static-if branches
             return node
 
-        if not self.had_return:
-            self.had_return = True
+        if not self.has_return:
+            self.has_return = True
         else:
             raise TaichiSyntaxError(
                     'Taichi functions/kernels cannot have multiple returns!'
-                    ' Consider use a local variable to walk around:\n'
-'''
-  def safe_sqrt(x):
-    ret = 0.0
-    if x >= 0:
-      ret = ti.sqrt(x)
-    else:
-      ret = 0.0
-    return ret
-''')
+                    ' Consider use a local variable to walk around')
 
         return node

--- a/tests/python/test_syntax_errors.py
+++ b/tests/python/test_syntax_errors.py
@@ -248,7 +248,8 @@ def test_func_multiple_return():
     def kern(a: float):
         print(safe_sqrt(a))
 
-    with pytest.raises(ti.TaichiSyntaxError, match='cannot have multiple returns'):
+    with pytest.raises(ti.TaichiSyntaxError,
+                       match='cannot have multiple returns'):
         kern(-233)
 
 

--- a/tests/python/test_syntax_errors.py
+++ b/tests/python/test_syntax_errors.py
@@ -233,3 +233,36 @@ def test_not_in():
         a = b not in c
 
     func()
+
+
+@ti.test(arch=ti.cpu)
+def test_func_multiple_return():
+    @ti.func
+    def safe_sqrt(a):
+        if a > 0:
+            return ti.sqrt(a)
+        else:
+            return 0.0
+
+    @ti.kernel
+    def kern(a: float):
+        print(safe_sqrt(a))
+
+    with pytest.raises(ti.TaichiSyntaxError, match='cannot have multiple returns'):
+        kern(-233)
+
+
+@ti.test(arch=ti.cpu)
+def test_func_multiple_return_in_static_if():
+    @ti.func
+    def safe_static_sqrt(a: ti.template()):
+        if ti.static(a > 0):
+            return ti.sqrt(a)
+        else:
+            return 0.0
+
+    @ti.kernel
+    def kern():
+        print(safe_static_sqrt(-233))
+
+    kern()


### PR DESCRIPTION
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = fix #1840

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
```py
import taichi as ti

ti.init(print_preprocessed=True)

@ti.func
def sign(x):
    if x > 0:
        return 1
    else:
        return -1

@ti.kernel
def main():
    print(sign(-1))

main()
```
obtains:
```
(err-multiple-return) [bate@archit taichi]$ p a.py
[Taichi] mode=development
[Taichi] preparing sandbox at /tmp/taichi-8c3ueytb
[Taichi] <dev mode>, llvm 10.0.0, commit 09d665f9, linux, python 3.8.3
[Taichi] Starting on arch=x64
[Taichi] materializing...
Initial AST:
def main():
    print(sign(-1))

Preprocessed:
def main():
    import taichi as ti
    ti.ti_print(sign(-1))

Checked:
def main():
    import taichi as ti
    ti.ti_print(sign(-1))

Final AST:
def main():
    import taichi as ti
    ti.ti_print(sign(-1))

Initial AST:
def sign(x):
    if x > 0:
        return 1
    else:
        return -1

Preprocessed:
def sign(x_by_value__):
    import taichi as ti
    x = ti.expr_init_func(x_by_value__)
    if 1:
        __cond = ti.chain_compare([x, 0], ['Gt'])
        ti.begin_frontend_if(__cond)
        ti.core.begin_frontend_if_true()
        return 1
        ti.core.pop_scope()
        ti.core.begin_frontend_if_false()
        return -1
        ti.core.pop_scope()

Traceback (most recent call last):
  File "a.py", line 16, in <module>
    main()
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 574, in wrapped
    return primal(*args, **kwargs)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 501, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 370, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 367, in taichi_ast_generator
    compiled()
  File "a.py", line 14, in main
    print(sign(-1))
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 42, in decorated
    return fun.__call__(*args)
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 86, in __call__
    self.do_compile()
  File "/home/bate/Develop/taichi/python/taichi/lang/kernel.py", line 98, in do_compile
    visitor.visit(tree)
  File "/home/bate/Develop/taichi/python/taichi/lang/transformer.py", line 49, in visit
    self.pass_Checks.visit(tree)
  File "/usr/lib/python3.8/ast.py", line 363, in visit
    return visitor(node)
  File "/usr/lib/python3.8/ast.py", line 439, in generic_visit
    value = self.visit(value)
  File "/usr/lib/python3.8/ast.py", line 363, in visit
    return visitor(node)
  File "/usr/lib/python3.8/ast.py", line 439, in generic_visit
    value = self.visit(value)
  File "/usr/lib/python3.8/ast.py", line 363, in visit
    return visitor(node)
  File "/home/bate/Develop/taichi/python/taichi/lang/transformer.py", line 904, in visit_If
    node.body = list(map(self.visit, node.body))
  File "/usr/lib/python3.8/ast.py", line 363, in visit
    return visitor(node)
  File "/home/bate/Develop/taichi/python/taichi/lang/transformer.py", line 919, in visit_Return
    raise TaichiSyntaxError(
taichi.lang.exception.TaichiSyntaxError: Taichi functions/kernels cannot have multiple returns! Consider use a local variable to walk around:

  def safe_sqrt(x):
    ret = 0.0
    if x >= 0:
      ret = ti.sqrt(x)
    else:
      ret = 0.0
    return ret
```