### PR TITLE
[ir] Remove the usage of kernel from type_check() pass

### DIFF
--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -35,7 +35,7 @@ template = Template
 def decl_scalar_arg(dtype):
     dtype = cook_dtype(dtype)
     id = taichi_lang_core.decl_arg(dtype, False)
-    return Expr(taichi_lang_core.make_arg_load_expr(id))
+    return Expr(taichi_lang_core.make_arg_load_expr(id, dtype))
 
 
 def decl_ext_arr_arg(dtype, dim):

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -866,9 +866,15 @@ if 1:
                 ret_expr = self.parse_expr('ti.cast(ti.Expr(0), 0)')
                 ret_expr.args[0].args[0] = node.value
                 ret_expr.args[1] = self.returns
+                dt_expr = self.parse_expr('ti.cook_dtype(0)')
+                dt_expr.args[0] = self.returns
                 ret_stmt = self.parse_stmt(
-                    'ti.core.create_kernel_return(ret.ptr)')
+                    'ti.core.create_kernel_return(ret.ptr, 0)')
+                # For args[0], it is an ast.Attribute, because it loads the
+                # attribute, |ptr|, of the expression |ret_expr|. Therefore we
+                # only need to replace the object part, i.e. args[0].value
                 ret_stmt.value.args[0].value = ret_expr
+                ret_stmt.value.args[1] = dt_expr
                 return ret_stmt
         return node
 

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -726,7 +726,8 @@ class ArgLoadStmt : public Stmt {
  public:
   int arg_id;
 
-  ArgLoadStmt(int arg_id, bool is_ptr = false) : arg_id(arg_id) {
+  ArgLoadStmt(int arg_id, DataType dt, bool is_ptr = false) : arg_id(arg_id) {
+    this->ret_type = VectorType(1, dt);
     this->is_ptr = is_ptr;
     TI_STMT_REG_FIELDS;
   }
@@ -1336,7 +1337,8 @@ class KernelReturnStmt : public Stmt {
  public:
   Stmt *value;
 
-  KernelReturnStmt(Stmt *value) : value(value) {
+  KernelReturnStmt(Stmt *value, DataType dt) : value(value) {
+    this->ret_type = VectorType(1, dt);
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -346,8 +346,9 @@ void export_lang(py::module &m) {
     current_ast_builder().insert(Stmt::make<FrontendBreakStmt>());
   });
 
-  m.def("create_kernel_return", [&](const Expr &value) {
-    current_ast_builder().insert(Stmt::make<FrontendKernelReturnStmt>(value));
+  m.def("create_kernel_return", [&](const Expr &value, DataType dt) {
+    current_ast_builder().insert(
+        Stmt::make<FrontendKernelReturnStmt>(value, dt));
   });
 
   m.def("insert_continue_stmt", [&]() {
@@ -477,7 +478,8 @@ void export_lang(py::module &m) {
   m.def("make_frontend_assign_stmt",
         Stmt::make<FrontendAssignStmt, const Expr &, const Expr &>);
 
-  m.def("make_arg_load_expr", Expr::make<ArgLoadExpression, int>);
+  m.def("make_arg_load_expr",
+        Expr::make<ArgLoadExpression, int, const DataType &>);
 
   m.def("make_external_tensor_expr",
         Expr::make<ExternalTensorExpression, const DataType &, int, int>);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -346,7 +346,7 @@ void export_lang(py::module &m) {
     current_ast_builder().insert(Stmt::make<FrontendBreakStmt>());
   });
 
-  m.def("create_kernel_return", [&](const Expr &value, DataType dt) {
+  m.def("create_kernel_return", [&](const Expr &value, const DataType &dt) {
     current_ast_builder().insert(
         Stmt::make<FrontendKernelReturnStmt>(value, dt));
   });

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -34,9 +34,11 @@ class ConstantFold : public BasicStmtVisitor {
     }
 
     auto kernel_name = fmt::format("jit_evaluator_{}", cache.size());
-    auto func = [&]() {
-      auto lhstmt = Stmt::make<ArgLoadStmt>(0, false);
-      auto rhstmt = Stmt::make<ArgLoadStmt>(1, false);
+    auto func = [&id]() {
+      auto lhstmt =
+          Stmt::make<ArgLoadStmt>(/*arg_id=*/0, id.lhs, /*is_ptr=*/false);
+      auto rhstmt =
+          Stmt::make<ArgLoadStmt>(/*arg_id=*/1, id.rhs, /*is_ptr=*/false);
       pStmt oper;
       if (id.is_binary) {
         oper = Stmt::make<BinaryOpStmt>(id.binary_op(), lhstmt.get(),
@@ -47,7 +49,7 @@ class ConstantFold : public BasicStmtVisitor {
           oper->cast<UnaryOpStmt>()->cast_type = id.rhs;
         }
       }
-      auto ret = Stmt::make<KernelReturnStmt>(oper.get());
+      auto ret = Stmt::make<KernelReturnStmt>(oper.get(), id.ret);
       current_ast_builder().insert(std::move(lhstmt));
       if (id.is_binary)
         current_ast_builder().insert(std::move(rhstmt));

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -1,15 +1,13 @@
+#include <cmath>
 #include <deque>
 #include <set>
-#include <cmath>
 #include <thread>
 
 #include "taichi/ir/ir.h"
+#include "taichi/ir/snode.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/visitors.h"
 #include "taichi/program/program.h"
-#include "taichi/ir/ir.h"
-#include "taichi/program/program.h"
-#include "taichi/ir/snode.h"
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -321,7 +321,9 @@ class LowerAST : public IRVisitor {
     auto expr = stmt->value;
     auto fctx = make_flatten_ctx();
     expr->flatten(&fctx);
-    fctx.push_back<KernelReturnStmt>(fctx.back_stmt());
+    const auto dt = stmt->element_type();
+    TI_ASSERT(dt != DataType::unknown);
+    fctx.push_back<KernelReturnStmt>(fctx.back_stmt(), dt);
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
     throw IRModified();
   }


### PR DESCRIPTION
Because we know the kernel args and return types when constructing these arg load/kernel return stmts, we don't have to re-infer them inside `type_check()`. This PR removes the necessity of kernel in `type_check` (config is still not handled), so that IR is a bit more decoupled from Kernel.

Related issue = #689

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
