### PR TITLE
[misc] Fix check previous run by using GITHUB_TOKEN to authenticate APIs

### DIFF
--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -67,10 +67,15 @@ jobs:
         with:
           python-version: 3.8
       - name: Check the previous run
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          # https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
+          # https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
+          # Do not leak the secret
+          OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR=${{ github.event.pull_request.number }}
-          SHA=${{ github.event.pull_request.head.sha }}
-          python misc/ci_check_previous_run.py --pr ${PR} --sha ${SHA}
+          python misc/ci_check_previous_run.py --pr "${PR}" --sha "${SHA}" --token "${OAUTH_TOKEN}"
 
   code_format:
     name: Code Format

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -99,7 +99,7 @@ def get_status_of_run(run_id):
         logging.info(
             f'Waiting to get the status of run={run_id} (url={url}). retries={retries}'
         )
-        time.sleep(15)
+        time.sleep(60)
     return False
 
 

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -7,6 +7,7 @@ import sys
 
 API_PREFIX = 'https://api.github.com/repos/taichi-dev/taichi'
 SHA = 'sha'
+OAUTH_TOKEN = None
 
 
 def make_api_url(p):
@@ -14,8 +15,18 @@ def make_api_url(p):
 
 
 def send_request(url):
-    logging.debug(f'request={url}')
-    return ur.urlopen(url)
+    # https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#example-calling-the-rest-api
+    hdrs = {'Authorization': f'Bearer {OAUTH_TOKEN}'}
+    # https://stackoverflow.com/a/47029281/12003165
+    req = ur.Request(url, headers=hdrs)
+    res = ur.urlopen(req)
+    # Headers are defined in https://developer.github.com/v3/rate_limit/
+    # https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
+    rl = res.getheader('X-Ratelimit-Limit', None)
+    rl_remain = res.getheader('X-Ratelimit-Remaining', None)
+    logging.debug(
+        f'request={url} rate_limit={rl} rate_limit_remaining={rl_remain}')
+    return res
 
 
 def get_commits(pr):
@@ -96,6 +107,7 @@ def get_cmd_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--pr', help='PR number')
     parser.add_argument('--sha', help='Head commit SHA in the PR')
+    parser.add_argument('--token', help='OAuth token')
     return parser.parse_args()
 
 
@@ -104,6 +116,8 @@ def main():
                         level=logging.DEBUG,
                         datefmt='%Y-%m-%d %H:%M:%S')
     args = get_cmd_args()
+    global OAUTH_TOKEN
+    OAUTH_TOKEN = args.token
 
     pr = args.pr
     commits = get_commits(pr)

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -813,7 +813,7 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 
 Program::~Program() {
   if (!finalized)
-    finalize();
-}
+    finalize();   
+}  
 
 TLANG_NAMESPACE_END

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -813,7 +813,7 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 
 Program::~Program() {
   if (!finalized)
-    finalize();   
-}  
+    finalize();
+}
 
 TLANG_NAMESPACE_END


### PR DESCRIPTION
* For authenticated requests on Github Actions, its rate limit is 1000 per hour: https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
* Slowed down the periodical poll from 15s to 1min.

Intentionally mess up the cpp code to make taichi-gardener work.

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->
Related issue = https://github.com/taichi-dev/taichi/pull/1844#issuecomment-687720574, #1837 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
