### PR TITLE
[async] Add TaskLaunchRecord StateFlowGraph::Node::rec

### DIFF
--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -32,11 +32,6 @@ uint64 hash(IRNode *stmt) {
 
 }  // namespace
 
-std::unique_ptr<IRNode> IRHandle::clone() const {
-  // TODO: remove get_kernel() here
-  return irpass::analysis::clone(const_cast<IRNode *>(ir_), ir_->get_kernel());
-}
-
 uint64 IRBank::get_hash(IRNode *ir) {
   auto result_iterator = hash_bank_.find(ir);
   if (result_iterator == hash_bank_.end()) {
@@ -166,13 +161,6 @@ void ParallelExecutor::worker_loop() {
   }
 }
 
-TaskLaunchRecord::TaskLaunchRecord(Context context,
-                                   Kernel *kernel,
-                                   IRHandle ir_handle)
-    : context(context), kernel(kernel), ir_handle(ir_handle) {
-  TI_ASSERT(ir_handle.ir()->get_kernel() != nullptr);
-}
-
 void ExecutionQueue::enqueue(const TaskLaunchRecord &ker) {
   auto h = ker.ir_handle.hash();
   auto *stmt = ker.stmt();
@@ -265,8 +253,7 @@ void AsyncEngine::launch(Kernel *kernel, Context &context) {
   }
 }
 
-TaskMeta AsyncEngine::create_task_meta(
-    const taichi::lang::TaskLaunchRecord &t) {
+TaskMeta AsyncEngine::create_task_meta(const TaskLaunchRecord &t) {
   using namespace irpass::analysis;
   TaskMeta meta;
   // TODO: this is an abuse since it gathers nothing...
@@ -329,7 +316,7 @@ void AsyncEngine::enqueue(const TaskLaunchRecord &t) {
   if (offloaded_metas_.find(t.ir_handle) == offloaded_metas_.end()) {
     offloaded_metas_[t.ir_handle] = create_task_meta(t);
   }
-  sfg->insert_task(offloaded_metas_[t.ir_handle]);
+  sfg->insert_task(t, offloaded_metas_[t.ir_handle]);
   task_queue.push_back(t);
 }
 

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -19,45 +19,6 @@ TLANG_NAMESPACE_BEGIN
 
 // TODO(yuanming-hu): split into multiple files
 
-class IRHandle {
- public:
-  IRHandle(const IRNode *ir, uint64 hash) : ir_(ir), hash_(hash) {
-  }
-
-  std::unique_ptr<IRNode> clone() const;
-
-  const IRNode *ir() const {
-    return ir_;
-  }
-
-  uint64 hash() const {
-    return hash_;
-  }
-
-  // Two IRHandles are considered the same iff their hash values are the same.
-  bool operator==(const IRHandle &other_ir_handle) const {
-    return hash_ == other_ir_handle.hash_;
-  }
-
- private:
-  const IRNode *ir_;  // not owned
-  uint64 hash_;
-};
-
-TLANG_NAMESPACE_END
-
-namespace std {
-template <>
-struct hash<taichi::lang::IRHandle> {
-  std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
-      noexcept {
-    return ir_handle.hash();
-  }
-};
-}  // namespace std
-
-TLANG_NAMESPACE_BEGIN
-
 class IRBank {
  public:
   uint64 get_hash(IRNode *ir);
@@ -123,20 +84,6 @@ class ParallelExecutor {
   // callback upon flush(). The flush() will then block waiting for that
   // callback to be executed?
   std::condition_variable flush_cv_;
-};
-
-// Records the necessary data for launching an offloaded task.
-class TaskLaunchRecord {
- public:
-  Context context;
-  Kernel *kernel;  // TODO: remove this
-  IRHandle ir_handle;
-
-  TaskLaunchRecord(Context context, Kernel *kernel, IRHandle ir_handle);
-
-  inline OffloadedStmt *stmt() const {
-    return const_cast<IRNode *>(ir_handle.ir())->as<OffloadedStmt>();
-  }
 };
 
 // In charge of (parallel) compilation to binary and (serial) kernel launching

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -1,0 +1,29 @@
+#include "taichi/program/async_utils.h"
+
+#include "taichi/ir/analysis.h"
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+
+TLANG_NAMESPACE_BEGIN
+
+std::unique_ptr<IRNode> IRHandle::clone() const {
+  // TODO: remove get_kernel() here
+  return irpass::analysis::clone(const_cast<IRNode *>(ir_), ir_->get_kernel());
+}
+
+TaskLaunchRecord::TaskLaunchRecord() : kernel(nullptr), ir_handle(nullptr, 0) {
+}
+
+TaskLaunchRecord::TaskLaunchRecord(Context context,
+                                   Kernel *kernel,
+                                   IRHandle ir_handle)
+    : context(context), kernel(kernel), ir_handle(ir_handle) {
+  TI_ASSERT(ir_handle.ir()->get_kernel() != nullptr);
+}
+
+OffloadedStmt *TaskLaunchRecord::stmt() const {
+  TI_ASSERT(ir_handle.ir());
+  return const_cast<IRNode *>(ir_handle.ir())->as<OffloadedStmt>();
+}
+
+TLANG_NAMESPACE_END

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -64,7 +64,7 @@ class TaskLaunchRecord {
 
   TaskLaunchRecord(Context context, Kernel *kernel, IRHandle ir_handle);
 
-  inline OffloadedStmt *stmt() const;
+  OffloadedStmt *stmt() const;
 };
 
 struct AsyncState {

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -1,10 +1,71 @@
 #pragma once
 
+#include <unordered_map>
 #include <unordered_set>
 
 #include "taichi/ir/snode.h"
+#define TI_RUNTIME_HOST
+#include "taichi/program/context.h"
+#undef TI_RUNTIME_HOST
 
 TLANG_NAMESPACE_BEGIN
+
+class IRNode;
+
+class IRHandle {
+ public:
+  IRHandle(const IRNode *ir, uint64 hash) : ir_(ir), hash_(hash) {
+  }
+
+  std::unique_ptr<IRNode> clone() const;
+
+  const IRNode *ir() const {
+    return ir_;
+  }
+
+  uint64 hash() const {
+    return hash_;
+  }
+
+  // Two IRHandles are considered the same iff their hash values are the same.
+  bool operator==(const IRHandle &other_ir_handle) const {
+    return hash_ == other_ir_handle.hash_;
+  }
+
+ private:
+  const IRNode *ir_;  // not owned
+  uint64 hash_;
+};
+
+TLANG_NAMESPACE_END
+
+namespace std {
+template <>
+struct hash<taichi::lang::IRHandle> {
+  std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
+      noexcept {
+    return ir_handle.hash();
+  }
+};
+}  // namespace std
+
+TLANG_NAMESPACE_BEGIN
+
+class OffloadedStmt;
+
+// Records the necessary data for launching an offloaded task.
+class TaskLaunchRecord {
+ public:
+  Context context;
+  Kernel *kernel;  // TODO: remove this
+  IRHandle ir_handle;
+
+  TaskLaunchRecord();
+
+  TaskLaunchRecord(Context context, Kernel *kernel, IRHandle ir_handle);
+
+  inline OffloadedStmt *stmt() const;
+};
 
 struct AsyncState {
   enum class Type { mask, value, list };

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -16,8 +16,9 @@ StateFlowGraph::StateFlowGraph() {
   initial_node_->launch_id = 0;
 }
 
-void StateFlowGraph::insert_task(const TaskMeta &task_meta) {
+void StateFlowGraph::insert_task(const TaskLaunchRecord &rec, const TaskMeta &task_meta) {
   auto node = std::make_unique<Node>();
+  node->rec = rec;
   node->task_name = task_meta.kernel_name;
   {
     int &id = task_name_to_launch_ids_[node->task_name];

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -16,7 +16,8 @@ StateFlowGraph::StateFlowGraph() {
   initial_node_->launch_id = 0;
 }
 
-void StateFlowGraph::insert_task(const TaskLaunchRecord &rec, const TaskMeta &task_meta) {
+void StateFlowGraph::insert_task(const TaskLaunchRecord &rec,
+                                 const TaskMeta &task_meta) {
   auto node = std::make_unique<Node>();
   node->rec = rec;
   node->task_name = task_meta.kernel_name;

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -22,8 +22,7 @@ class StateFlowGraph {
   // Before we migrate, the SFG is only used for visualization. Therefore we
   // only store a kernel_name, which is used as the label of the GraphViz node.
   struct Node {
-    //  TODO: make use of IRHandle here
-    IRNode *root;
+    TaskLaunchRecord rec;
     std::string task_name;
     // Incremental ID to identify the i-th launch of the task.
     int launch_id;
@@ -42,7 +41,7 @@ class StateFlowGraph {
 
   std::string dump_dot();
 
-  void insert_task(const TaskMeta &task_meta);
+  void insert_task(const TaskLaunchRecord &rec, const TaskMeta &task_meta);
 
   void insert_state_flow(Node *from, Node *to, AsyncState state);
 


### PR DESCRIPTION
Related issue = #742 

The only real change in this PR is to add `TaskLaunchRecord StateFlowGraph::Node::rec` and pass it into `sfg` in `AsyncEngine::enqueue(const TaskLaunchRecord &t)`.

In order to do this, I moved `IRHandle` and `TaskLaunchRecord` to `async_utils.h`.

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
