### PR TITLE
[async] Stop using std::unordered_multimap as node edges type

### DIFF
--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -40,15 +40,8 @@ void StateFlowGraph::insert_task(const TaskMeta &task_meta) {
 void StateFlowGraph::insert_state_flow(Node *from, Node *to, AsyncState state) {
   TI_ASSERT(from != nullptr);
   TI_ASSERT(to != nullptr);
-  from->output_edges.insert(std::make_pair(state, to));
+  from->output_edges[state].insert(to);
   to->input_edges.insert(std::make_pair(state, from));
-}
-
-void StateFlowGraph::print_edges(const StateFlowGraph::Edges &edges) {
-  for (auto &edge : edges) {
-    auto input_node = edge.second;
-    fmt::print("    {} -> {}\n", edge.first.name(), input_node->string());
-  }
 }
 
 void StateFlowGraph::print() {
@@ -57,11 +50,17 @@ void StateFlowGraph::print() {
     fmt::print("{}\n", node->string());
     if (!node->input_edges.empty()) {
       fmt::print("  Inputs:\n");
-      print_edges(node->input_edges);
+      for (const auto &p : node->input_edges) {
+        fmt::print("    {} <- {}\n", p.first.name(), p.second->string());
+      }
     }
     if (!node->output_edges.empty()) {
       fmt::print("  Outputs:\n");
-      print_edges(node->output_edges);
+      for (const auto &p : node->output_edges) {
+        for (const auto *to : p.second) {
+          fmt::print("    {} -> {}\n", p.first.name(), to->string());
+        }
+      }
     }
   }
   fmt::print("=======================\n");
@@ -104,13 +103,14 @@ std::string StateFlowGraph::dump_dot() {
       if (visited.find(from) == visited.end()) {
         visited.insert(from);
         for (const auto &p : from->output_edges) {
-          auto *to = p.second;
-          stack.push_back(to);
+          for (const auto *to : p.second) {
+            stack.push_back(to);
 
-          ss << "  "
-             << fmt::format("{} -> {} [label=\"{}\"]", node_id(from),
-                            node_id(to), p.first.name())
-             << '\n';
+            ss << "  "
+               << fmt::format("{} -> {} [label=\"{}\"]", node_id(from),
+                              node_id(to), p.first.name())
+               << '\n';
+          }
         }
       }
     }


### PR DESCRIPTION
This was https://bugs.llvm.org/show_bug.cgi?id=16747#c1

---

It seems like `std::unordered_multimap`, introduced in #1843, was way slower than expected, and became a major bottleneck in SFG (at least with clang's libc++ impl..). Profiling showed that ~74% of the time was spent here:

<img width="1127" alt="Screen Shot 2020-09-08 at 21 58 15" src="https://user-images.githubusercontent.com/7481356/92479422-7b4ff600-f21e-11ea-808f-a566106b0eb4.png">

This PR switches to `std::unordered_map<AsyncState, std::unordered_set<Node*>>`, which restores the performance to its prior level on my device.

Off-the-topic change: since I removed `print_edges()`, I used `<-` when printing input nodes...

Related issue = #1843 


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
