### PR TITLE
[Lang] Support ti.zero(x) and ti.one(x) for making zero/one value for the same type with x

### DIFF
--- a/examples/mpm3d.py
+++ b/examples/mpm3d.py
@@ -35,7 +35,7 @@ neighbour = (3, ) * dim
 @ti.kernel
 def substep():
     for I in ti.grouped(grid_m):
-        grid_v[I] = grid_v[I] * 0
+        grid_v[I] = ti.zero(grid_v[I])
         grid_m[I] = 0
     ti.block_dim(n_grid)
     for p in x:
@@ -65,8 +65,8 @@ def substep():
         base = int(Xp - 0.5)
         fx = Xp - base
         w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
-        new_v = v[p] * 0
-        new_C = C[p] * 0
+        new_v = ti.zero(v[p])
+        new_C = ti.zero(C[p])
         for offset in ti.static(ti.grouped(ti.ndrange(*neighbour))):
             dpos = (offset - fx) * dx
             weight = 1.0

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -493,6 +493,17 @@ def ti_float(var):
 
 
 @taichi_scope
+def zero(x):
+    # TODO: get dtype from Expr and Matrix:
+    return x * 0
+
+
+@taichi_scope
+def one(x):
+    return zero(x) + 1
+
+
+@taichi_scope
 def get_external_tensor_dim(var):
     return taichi_lang_core.get_external_tensor_dim(var)
 

--- a/tests/python/test_lang.py
+++ b/tests/python/test_lang.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import pytest
 
 
 @ti.all_archs
@@ -131,3 +132,29 @@ def test_loop_var_life_double_iters():
         print(i)
 
     test()
+
+
+@ti.test(require=ti.extension.data64)
+@pytest.mark.parametrize('dt', [ti.i32, ti.f32, ti.i64, ti.f64])
+def test_meta_zero(dt):
+    @ti.kernel
+    def func(x: dt) -> dt:
+        return ti.zero(x)
+
+    for x in [-1, -2.3, 1.2, 2, 3]:
+        if ti.core.is_integral(dt):
+            x = int(x)
+        assert func(x) == 0  # intentionally not using ti.approx here
+
+
+@ti.test(require=ti.extension.data64)
+@pytest.mark.parametrize('dt', [ti.i32, ti.f32, ti.i64, ti.f64])
+def test_meta_one(dt):
+    @ti.kernel
+    def func(x: dt) -> dt:
+        return ti.one(x)
+
+    for x in [-1, -2.3, 1.2, 2, 3]:
+        if ti.core.is_integral(dt):
+            x = int(x)
+        assert func(x) == 1

--- a/tests/python/test_reduction.py
+++ b/tests/python/test_reduction.py
@@ -23,7 +23,7 @@ def _test_reduction_single(dtype, criterion):
 
     @ti.kernel
     def reduce_tmp() -> dtype:
-        s = tot[None] * 0  # Hack to get |s| to the correct type...
+        s = ti.zero(tot[None])
         for i in a:
             s += a[i]
         return s


### PR DESCRIPTION
Related issue = http://www.jlhub.com/julia/manual/en/function/zero

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
Yeah it's still using `x * 0` since we seems can't get the data type of an expr from python-scope.. maybe iapr, let's set up the API here imutating the Julia zero/one.