### PR TITLE
[Misc] (WIP) Automatic release pipeline

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ def parse_semver(
         return major, minor, patch
     return tuple(map(_intify_version, (major, minor, patch)))
 
+
 # CMakeLists.txt is the only source of the truth when forging
 # the version, this script always reads from it, parses the version
 # and dump the version string to `version` file.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,20 +13,65 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
+# import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import re
+from functools import partial
+from pathlib import Path
+from typing import Callable, Match, Tuple, Union
+
+
+# -- Version forge -----------------------------------------------------------
+# Note this section has some duplicate code which
+# is directly copied from /misc.
+def _semver_matcher() -> Callable:
+    """Return a func performs regex matching for semantic versions.
+       The regex uses word_boundry and is sensitive to the changes
+       to the contents of the CMakeLists.txt file. The match should
+       have 3 matched groups:
+       1. `SET(TI_VERSION_MAJOR `
+       2. the corresponding version number
+       3. `)`
+    """
+    return lambda s, w: re.search(rf"(\bSET\(TI_VERSION_{w} )(\d+)(\b\))", s)
+
+
+def _intify_version(v: Match) -> int:
+    """Convert matched group v to integer."""
+    return int(v.group(2))
+
+
+def parse_semver(
+    cmakelist_path: str,
+    return_match_groups: bool = False
+) -> Union[Tuple[int, int, int], Tuple[Match[str], Match[str], Match[str]]]:
+    """Parse and return the major, minor and patch version numbers
+       (or matched groups) from CMakeLists.txt given CMAKELIST_PATH.
+    """
+    with open(cmakelist_path, "r") as fp:
+        cmakelist = fp.read()
+    matcher = partial(_semver_matcher(), cmakelist)
+    major, minor, patch = map(matcher, ["MAJOR", "MINOR", "PATCH"])
+    if return_match_groups:
+        return major, minor, patch
+    return tuple(map(_intify_version, (major, minor, patch)))
+
+# CMakeLists.txt is the only source of the truth when forging
+# the version, this script always reads from it, parses the version
+# and dump the version string to `version` file.
+cmake_file = Path(__file__).resolve().parents[1].joinpath('CMakeLists.txt')
+major, minor, patch = parse_semver(cmakelist_path=str(cmake_file))
+version_file = Path(__file__).resolve().parent.joinpath("version")
+taichi_version = f"{major}.{minor}.{patch}"
+with version_file.open('w') as f:
+    f.write(f"{taichi_version}\n")
+    print('Building doc version', taichi_version)
 
 # -- Project information -----------------------------------------------------
 
 project = 'taichi'
 copyright = '2020, Taichi Developers'
 author = 'Taichi Developers'
-
-version_fn = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          'version')
-with open(version_fn) as f:
-    taichi_version = f.readline().strip()
-    print('Building doc version', taichi_version)
 
 # The short X.Y version
 version = taichi_version

--- a/misc/ci_release_pipeline.py
+++ b/misc/ci_release_pipeline.py
@@ -249,7 +249,7 @@ def main(args):
     # 0. Initialize release metadata
     logger.info("=> 0. Initialize release metadata")
     repo = git.Repo(".")
-    author = committer = git.Actor(args.name, args.email)
+    author = committer = git.Actor(args. author, args.email)
 
     # TODO: CONVERT TO USE OAUTH TOKEN
     authentication = HTTPBasicAuth("PERSON", "PERSONAL TOKEN")
@@ -313,6 +313,7 @@ def main(args):
         f"=>\tRelease PR #{pull_request} has been merged as commit {merge_commit}"
     )
 
+    # TODO: NEED TO WAIT THE BUILDBOTS TO PASS BEFORE RELEASE
     # 7. Update stable branch to point to the latest release commit
     logger.info(
         "=> 7. Update stable branch to point to the latest release commit")

--- a/misc/ci_release_pipeline.py
+++ b/misc/ci_release_pipeline.py
@@ -1,0 +1,340 @@
+import argparse
+import functools
+import logging
+import re
+import subprocess
+from functools import partial, reduce
+from pathlib import Path
+from typing import Callable, List, Match, Tuple, Union
+
+import git
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+API_PREFIX = 'https://api.github.com/repos/taichi-dev/taichi'
+logger = logging.getLogger(__name__)
+
+
+def make_api_url(p):
+    return f'{API_PREFIX}/{p}'
+
+
+def generate_changelog() -> str:
+    # redirect the stdout to DEVNULL to make it less noisy
+    subprocess.run(["ti changelog --save"],
+                   shell=True,
+                   check=True,
+                   stdout=subprocess.DEVNULL)
+    # need to make sure call from the root of the taichi repo
+    with open("CHANGELOG.md", "r") as fp:
+        changelog = fp.read()
+    return changelog
+
+
+def regenerate_docs():
+    # redirect both stdout and stderr to DEVNULL to make it less noisy
+    subprocess.run(["cmake ."],
+                   shell=True,
+                   check=True,
+                   stdout=subprocess.DEVNULL,
+                   stderr=subprocess.DEVNULL)
+
+
+def _semver_matcher() -> Callable:
+    """Return a func performs regex matching for semantic versions.
+       The regex uses word_boundry and is sensitive to the changes
+       to the contents of the CMakeLists.txt file. The match should
+       have 3 matched groups:
+       1. `SET(TI_VERSION_MAJOR `
+       2. the corresponding version number
+       3. `)`
+    """
+    return lambda s, w: re.search(rf"(\bSET\(TI_VERSION_{w} )(\d+)(\b\))", s)
+
+
+def _intify_version(v: Match) -> int:
+    """Convert matched group v to integer."""
+    return int(v.group(2))
+
+
+def parse_semver(
+    cmakelist_path: str,
+    return_match_groups: bool = False
+) -> Union[Tuple[int, int, int], Tuple[Match[str], Match[str], Match[str]]]:
+    """Parse and return the major, minor and patch version numbers
+       (or matched groups) from CMakeLists.txt given CMAKELIST_PATH.
+    """
+    with open(cmakelist_path, "r") as fp:
+        cmakelist = fp.read()
+    matcher = partial(_semver_matcher(), cmakelist)
+    major, minor, patch = map(matcher, ["MAJOR", "MINOR", "PATCH"])
+    if return_match_groups:
+        return major, minor, patch
+    return tuple(map(_intify_version, (major, minor, patch)))
+
+
+def bump_major(cmakelist_path: str) -> Tuple[int, int, int]:
+    """Semantically bump the major version in CMakeLists.txt given CMAKELIST_PATH
+       in-place as side-effect, return the result semVer."""
+    major, minor, patch = parse_semver(cmakelist_path=cmakelist_path,
+                                       return_match_groups=True)
+    patterns = (
+        (major.re, rf"\g<1>{_intify_version(major) + 1}\g<3>"),
+        (minor.re, rf"\g<1>0\g<3>"),
+        (patch.re, rf"\g<1>0\g<3>"),
+    )
+    new_cmakelist_content = reduce(
+        lambda content, pattern: re.sub(*pattern, content), patterns,
+        major.string)
+    with open(cmakelist_path, "w") as fp:
+        fp.write(new_cmakelist_content)
+    return _intify_version(major) + 1, 0, 0
+
+
+def bump_minor(cmakelist_path: str) -> Tuple[int, int, int]:
+    """Semantically bump the minor version in CMakeLists.txt given CMAKELIST_PATH
+       in-place as side-effect, return the result semVer."""
+    major, minor, patch = parse_semver(cmakelist_path=cmakelist_path,
+                                       return_match_groups=True)
+    patterns = (
+        (minor.re, rf"\g<1>{_intify_version(minor) + 1}\g<3>"),
+        (patch.re, rf"\g<1>0\g<3>"),
+    )
+    new_cmakelist_content = reduce(
+        lambda content, pattern: re.sub(*pattern, content), patterns,
+        minor.string)
+    with open(cmakelist_path, "w") as fp:
+        fp.write(new_cmakelist_content)
+    return _intify_version(major), _intify_version(minor) + 1, 0
+
+
+def bump_patch(cmakelist_path: str) -> Tuple[int, int, int]:
+    """Semantically bump the patch version in CMakeLists.txt given CMAKELIST_PATH
+       in-place as side-effect, return the result semVer."""
+    major, minor, patch = parse_semver(cmakelist_path=cmakelist_path,
+                                       return_match_groups=True)
+    new_cmakelist_content = re.sub(patch.re,
+                                   rf"\g<1>{_intify_version(patch) + 1}\g<3>",
+                                   patch.string)
+    with open(cmakelist_path, "w") as fp:
+        fp.write(new_cmakelist_content)
+    return (*map(_intify_version, [major, minor]), _intify_version(patch) + 1)
+
+
+def create_branch_and_push_ref(repo: git.Repo, feature_branch: str):
+    """Create a new FEATURE_BRANCH in REPO and push the ref to its remote origin."""
+    origin = repo.remotes.origin
+    repo.create_head(feature_branch).checkout()
+    repo.git.push("--set-upstream", origin, repo.head.ref)
+
+
+def commit_files_and_push(repo: git.Repo, message: str, author: git.Actor,
+                          committer: git.Actor, files: List[str]):
+    """Add local FILES to git, commit them to REPO's remote origin with MESSAGE,
+       AUTHOR and COMMITTER info."""
+    origin = repo.remotes.origin
+    repo.index.add(files)
+    repo.index.commit(message=message, author=author, committer=committer)
+    origin.push()
+
+
+def make_pull_request(auth_info: HTTPBasicAuth,
+                      title: str,
+                      feature_branch: str,
+                      content: str,
+                      base_branch: str = "master") -> int:
+    """Make a pull request from FEATURE_BRANCH to BASE_BRANCH with TITLE and CONTENT,
+       AuthN is done via AUTH_INFO. Return the number of the pull request or
+       throw HTTPError. This is not idempotent."""
+    url = make_api_url("pulls")
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    payload = {
+        "title": title,
+        "head": feature_branch,
+        "base": base_branch,
+        "body": content,
+        "maintainer_can_modify": True,
+        "draft": False,
+    }
+    response = requests.post(url=url,
+                             headers=headers,
+                             json=payload,
+                             auth=auth_info)
+    response.raise_for_status()
+    return response.json()["number"]
+
+
+def merge_pull_request(auth_info: HTTPBasicAuth, pull_number: int) -> str:
+    """Squash and merge a pull request identified by PULL_NUMBER, AuthN is done
+       via AUTH_INFO. Return the merge commit SHA hash or throw HTTPError.
+       This is not idempotent."""
+    url = make_api_url(f"pulls/{pull_number}/merge")
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    payload = {
+        "merge_method": "squash",
+    }
+    response = requests.put(url=url,
+                            headers=headers,
+                            json=payload,
+                            auth=auth_info)
+    response.raise_for_status()
+    return response.json()["sha"]
+
+
+def update_branch_ref(auth_info: HTTPBasicAuth,
+                      commit_hash: str,
+                      target_branch: str = "stable",
+                      force: bool = True):
+    """Update the ref of TARGET_BRANCH to point to COMMIT_HASH,
+       AuthN is done via AUTH_INFO. This is idempotent."""
+    url = make_api_url(f"git/refs/heads/{target_branch}")
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    payload = {"sha": commit_hash, "force": force}
+    response = requests.patch(url=url,
+                              headers=headers,
+                              json=payload,
+                              auth=auth_info)
+    response.raise_for_status()
+
+
+def create_release(auth_info: HTTPBasicAuth, tag_name: str, name: str,
+                   commit_hash: str, content: str):
+    """Create a new release with NAME and CONTENT points at COMMIT_HASH and
+       tagged as TAG_NAME, AuthN is done via AUTH_INFO. This is not idempotent."""
+    url = make_api_url("releases")
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    payload = {
+        "tag_name": tag_name,
+        # using commit hash than "master" here prevents race conditions from happening
+        "target_commitish": commit_hash,
+        "name": name,
+        "body": content,
+        "draft": False,
+        "prerelease": False,
+    }
+    response = requests.post(url=url,
+                             headers=headers,
+                             json=payload,
+                             auth=auth_info)
+    response.raise_for_status()
+
+
+def get_cmd_args():
+    parser = argparse.ArgumentParser(
+        description="Taichi release automation cli")
+    parser.add_argument("release_type",
+                        choices=["major", "minor", "patch"],
+                        help="The type of the semantic release")
+    parser.add_argument(
+        "-t",
+        "--token",
+        type=str,
+        required=True,
+        help="OAuth token to send authenticated requests to Github API")
+    parser.add_argument("-a",
+                        "--author",
+                        type=str,
+                        default="Taichi Gardener",
+                        help="The name of the author of the release")
+    parser.add_argument("-e",
+                        "--email",
+                        type=str,
+                        default="taichigardener@gmail.com",
+                        help="The email of the author of the release")
+    return parser.parse_args()
+
+
+def main(args):
+    # 0. Initialize release metadata
+    logger.info("=> 0. Initialize release metadata")
+    repo = git.Repo(".")
+    author = committer = git.Actor(args.name, args.email)
+
+    # TODO: CONVERT TO USE OAUTH TOKEN
+    authentication = HTTPBasicAuth("PERSON", "PERSONAL TOKEN")
+    # TODO: ALSO NEED TO SETUP GIT CLIENT
+
+    # Parse out the semantic versions
+    major_, minor_, patch_ = parse_semver(cmakelist_path="./CMakeLists.txt",
+                                          return_match_groups=False)
+
+    # 1. Dispatch on release types, bump the version and regenerate docs
+    logger.info(
+        f"=> 1. Bump the {args.release_type} version and regenerate docs")
+    if args.release_type == "major":
+        major, minor, patch = bump_major(cmakelist_path="./CMakeLists.txt")
+    elif args.release_type == "minor":
+        major, minor, patch = bump_minor(cmakelist_path="./CMakeLists.txt")
+    else:
+        major, minor, patch = bump_patch(cmakelist_path="./CMakeLists.txt")
+    regenerate_docs()
+    logger.info(
+        f"=>\tThe version is bumped from {major_}.{minor_}.{patch_} to {major}.{minor}.{patch}"
+    )
+
+    # 2. Create a branch for the release
+    logger.info("=> 2. Create a branch for the release")
+    release_branch = f"release-{major}.{minor}.{patch}"
+    create_branch_and_push_ref(repo=repo, feature_branch=release_branch)
+    logger.info(f"=>\tBranch {release_branch} has been created")
+
+    # 3. Add, commit and push changes
+    logger.info("=> 3. Add, commit and push changes")
+    files = ["docs", "CMakeLists.txt"]
+    commit_files_and_push(repo=repo,
+                          message=f"[release] v{major}.{minor}.{patch}",
+                          author=author,
+                          committer=committer,
+                          files=files)
+
+    # 4. Generate the changelog
+    logger.info("=> 4. Generate the changelog")
+    changelog = generate_changelog()
+
+    # 5. Make the release PR
+    logger.info("=> 5. Make the release PR")
+    pull_request = make_pull_request(
+        title=f"[release] v{major}.{minor}.{patch}",
+        feature_branch=release_branch,
+        content=changelog,
+        auth_info=authentication,
+        base_branch="master")
+    logger.info(f"=>\tA release PR #{pull_request} has been created")
+
+    # TODO: NEED TO WAIT THE TESTS TO PASS TO MERGE
+
+    # TODO: EITHER WAIT FOR A FEW SECONDS OR KEEP CHECKING MERGEABLITY WITH RETRIES AND TIMEOUTS
+    # 6. Merge the release PR
+    logger.info("=> 6. Merge the release PR")
+    merge_commit = merge_pull_request(auth_info=authentication,
+                                      pull_number=pull_request)
+    logger.info(
+        f"=>\tRelease PR #{pull_request} has been merged as commit {merge_commit}"
+    )
+
+    # 7. Update stable branch to point to the latest release commit
+    logger.info(
+        "=> 7. Update stable branch to point to the latest release commit")
+    update_branch_ref(auth_info=authentication,
+                      commit_hash=merge_commit,
+                      target_branch="stable")
+    logger.info(f"=>\tThe stable branch has been updated to {merge_commit}")
+
+    # 8. Create the official release
+    logger.info("=> 8. Create the official release")
+    create_release(auth_info=authentication,
+                   tag_name=f"v{major}.{minor}.{patch}",
+                   name=f"v{major}.{minor}.{patch}",
+                   commit_hash=merge_commit,
+                   content=changelog)
+    logger.info(
+        f"=>\tA Github release v{major}.{minor}.{patch} has been created")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s',
+                        level=logging.INFO,
+                        datefmt='%Y-%m-%d %H:%M:%S')
+    arguments = get_cmd_args()
+    main(args=arguments)

--- a/misc/ci_release_pipeline.py
+++ b/misc/ci_release_pipeline.py
@@ -11,7 +11,6 @@ import git
 import requests
 from requests.auth import HTTPBasicAuth
 
-
 API_PREFIX = 'https://api.github.com/repos/taichi-dev/taichi'
 logger = logging.getLogger(__name__)
 
@@ -30,15 +29,6 @@ def generate_changelog() -> str:
     with open("CHANGELOG.md", "r") as fp:
         changelog = fp.read()
     return changelog
-
-
-def regenerate_docs():
-    # redirect both stdout and stderr to DEVNULL to make it less noisy
-    subprocess.run(["cmake ."],
-                   shell=True,
-                   check=True,
-                   stdout=subprocess.DEVNULL,
-                   stderr=subprocess.DEVNULL)
 
 
 def _semver_matcher() -> Callable:
@@ -259,16 +249,15 @@ def main(args):
     major_, minor_, patch_ = parse_semver(cmakelist_path="./CMakeLists.txt",
                                           return_match_groups=False)
 
-    # 1. Dispatch on release types, bump the version and regenerate docs
+    # 1. Dispatch on release types, bump the version
     logger.info(
-        f"=> 1. Bump the {args.release_type} version and regenerate docs")
+        f"=> 1. Bump the {args.release_type} version")
     if args.release_type == "major":
         major, minor, patch = bump_major(cmakelist_path="./CMakeLists.txt")
     elif args.release_type == "minor":
         major, minor, patch = bump_minor(cmakelist_path="./CMakeLists.txt")
     else:
         major, minor, patch = bump_patch(cmakelist_path="./CMakeLists.txt")
-    regenerate_docs()
     logger.info(
         f"=>\tThe version is bumped from {major_}.{minor_}.{patch_} to {major}.{minor}.{patch}"
     )

--- a/misc/ci_release_pipeline.py
+++ b/misc/ci_release_pipeline.py
@@ -249,7 +249,7 @@ def main(args):
     # 0. Initialize release metadata
     logger.info("=> 0. Initialize release metadata")
     repo = git.Repo(".")
-    author = committer = git.Actor(args. author, args.email)
+    author = committer = git.Actor(args.author, args.email)
 
     # TODO: CONVERT TO USE OAUTH TOKEN
     authentication = HTTPBasicAuth("PERSON", "PERSONAL TOKEN")


### PR DESCRIPTION
Related issue = #1674 

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

## [1. The Current Release Process](https://taichi.readthedocs.io/en/stable/versioning_releases.html?highlight=release#versioning-and-releases)

![image](https://user-images.githubusercontent.com/14366016/92824432-66996c80-f39c-11ea-9aa8-340cb865e180.png)

**Potential Problems:**
- The whole process is manual and requires a substantial amount of developer's focus and effort.
- The process is not transactional, failures at any step require developer interfere and potential rollback operations. This can confuse developers and is not scalable as it limits the release process to a small set of experienced core developers.
- The process takes a wide span of time, and can be affected by other git operations happening during the process.
- The release process bounces between different CI/CD providers and hosts (namely Jenkins, Github [Actions], readthedocs and PyPI) thus becomes error prone.

## 2. Implementation Plan

_The actual release automation shall be implemented iteratively, so the migration is more smooth._

1. Implement a CLI system that 
    - [ ] Triggers the build (in Jenkins?)
    - [x] Updates the version in CMakeList.txt
    - [ ] ~Runs CMake to re-generate docs~ AS @yuanming-hu suggested, a more portable way (so the runner does not have to setup CMAKE in order to run `cmake .`) is to port the logic that reads CMakeLists.txt to `docs/conf.py` so it can generate and dump the `version` file on its own. Implementing it right now. (cross-referencing the functions is tricky given the unorganized nature of `misc` directory. Since there're some refactor plans for `v0.8.0`, I'm simply copy-pasting duplicate code between `conf.py` and `misc/` for now)
    - [x] Generates the changelog content automatically.
    - [x] Creates the release PR and commits automatically.
    - [ ] ~Waits for developers’ merge~ OR waits for the builds on PR to pass and merge (this could be done via https://github.com/pascalgn/automerge-action)
    - [x] Automatic way to merge the PR
    - [x] Bumps the stable branch
    - [x] Cuts off a new release
    - [ ] Publishes a new package on PyPI
2. The “release” CLI command is called by a cron job periodically, for instance, twice a week.
3. Github Action that can be triggered manually and developers can choose from (major, minor, patch)
4. Notifies the developers when things have gone wrong through emails or other methods.
5. Turn on release automation.

## 3. Open Questions
1. How to deal with the situation when some PRs get merged to master while the release workflow starts but not yet finished?
    - This cli uses commit hash whenever possible so this race condition won't happen.
2. How to distinguish between major, minor and bug fixes?
    - (weekly) Cron Job always makes patch releases, minor and major can only be triggered manually.
3. Semantic versioning is complicated, should we really automate it?
4. Do we delete release branches after merge?
5. Do we consider release candidates (e.g. vx.y.z-rc1) in addition to `vMAJOR.MINOR.PATCH`?
6. (unrelated) I noticed that `misc/` is becoming more and more like a trash bin, and barely maintained/organized, would it be more useful to refactor it to some extent, at least some code in `misc` can be re-used cross modules?

## Alternatives

1. Github action: https://github.com/marketplace/actions/create-pull-request
    - This action does not provide a way to dynamically render the content of the release PR, instead only takes static strings. Let alone we need to run `CMAKE` before making the PR.

