### PR TITLE
[async] Highlight user kernels in the DOT graph, allows configuring rankdir

### DIFF
--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -249,9 +249,9 @@ def veci(*args, **kwargs):
     return core_veci(*args, **kwargs)
 
 
-def dump_dot(filepath=None):
+def dump_dot(filepath=None, rankdir=None):
     from taichi.core import ti_core
-    d = ti_core.dump_dot()
+    d = ti_core.dump_dot(rankdir)
     if filepath is not None:
         with open(filepath, 'w') as fh:
             fh.write(d)

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -260,6 +260,7 @@ TaskMeta AsyncEngine::create_task_meta(const TaskLaunchRecord &t) {
   auto *root_stmt = t.stmt();
   meta.kernel_name = t.kernel->name + "_" +
                      OffloadedStmt::task_type_name(root_stmt->task_type);
+  meta.type = root_stmt->task_type;
   gather_statements(root_stmt, [&](Stmt *stmt) {
     if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
       if (auto ptr = global_load->ptr->cast<GlobalPtrStmt>()) {

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -4,13 +4,12 @@
 #include <unordered_set>
 
 #include "taichi/ir/snode.h"
+#include "taichi/ir/statements.h"
 #define TI_RUNTIME_HOST
 #include "taichi/program/context.h"
 #undef TI_RUNTIME_HOST
 
 TLANG_NAMESPACE_BEGIN
-
-class IRNode;
 
 class IRHandle {
  public:
@@ -50,8 +49,6 @@ struct hash<taichi::lang::IRHandle> {
 }  // namespace std
 
 TLANG_NAMESPACE_BEGIN
-
-class OffloadedStmt;
 
 // Records the necessary data for launching an offloaded task.
 class TaskLaunchRecord {
@@ -110,6 +107,7 @@ class AsyncStateHash {
 
 struct TaskMeta {
   std::string kernel_name;
+  OffloadedStmt::TaskType type;
   SNode *loop_snode{nullptr};  // struct-for only
   std::unordered_set<AsyncState, AsyncStateHash> input_states;
   std::unordered_set<AsyncState, AsyncStateHash> output_states;

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -1,13 +1,15 @@
 #pragma once
 
+#include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "taichi/ir/ir.h"
 #include "taichi/ir/statements.h"
 #include "taichi/lang_util.h"
-#include "taichi/program/program.h"
 #include "taichi/program/async_utils.h"
+#include "taichi/program/program.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -26,6 +28,7 @@ class StateFlowGraph {
   struct Node {
     TaskLaunchRecord rec;
     std::string task_name;
+    OffloadedStmt::TaskType task_type;
     // Incremental ID to identify the i-th launch of the task.
     int launch_id;
     bool is_initial_node{false};
@@ -80,7 +83,9 @@ class StateFlowGraph {
 
   void print();
 
-  std::string dump_dot();
+  // Returns a string representing a DOT graph
+  // TODO: In case we add more and more DOT configs, create a struct?
+  std::string dump_dot(const std::optional<std::string> &rankdir);
 
   void insert_task(const TaskLaunchRecord &rec, const TaskMeta &task_meta);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1,5 +1,8 @@
 // Bindings for the python frontend
 
+#include <optional>
+#include <string>
+
 #include "pybind11/functional.h"
 #include "pybind11/pybind11.h"
 
@@ -650,7 +653,11 @@ void export_lang(py::module &m) {
 
   m.def("print_sfg", [] { get_current_program().async_engine->sfg->print(); });
   m.def("dump_dot",
-        [] { return get_current_program().async_engine->sfg->dump_dot(); });
+        [](std::optional<std::string> rankdir) -> std::string {
+          // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#allow-prohibiting-none-arguments
+          return get_current_program().async_engine->sfg->dump_dot(rankdir);
+        },
+        py::arg("rankdir").none(true));
 }
 
 TI_NAMESPACE_END


### PR DESCRIPTION
Example:

<img width="1868" alt="Screen Shot 2020-09-13 at 13 08 16" src="https://user-images.githubusercontent.com/7481356/93009991-3fbc7f80-f5c2-11ea-881e-24782c66c61c.png">

I'll look into more on how we can better represent the nodes/edges..

Related issue = #1855

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
