### PR TITLE
[async] Improve fusion optimization and add StateFlowGraph::verify

### DIFF
--- a/misc/visualize_state_flow_graph.py
+++ b/misc/visualize_state_flow_graph.py
@@ -65,9 +65,7 @@ def test_fusion():
 
 
 def test_write_after_read():
-    ti.init(arch=ti.cpu,
-            async_mode=True,
-            async_opt_intermediate_file="war")
+    ti.init(arch=ti.cpu, async_mode=True, async_opt_intermediate_file="war")
 
     x = ti.field(ti.i32, shape=16)
 

--- a/misc/visualize_state_flow_graph.py
+++ b/misc/visualize_state_flow_graph.py
@@ -65,12 +65,8 @@ def test_fusion():
 
 
 def test_write_after_read():
-    # TODO: @xumingkuan fusion on this case fails
     ti.init(arch=ti.cpu,
             async_mode=True,
-            async_opt_dse=False,
-            async_opt_listgen=False,
-            async_opt_fusion=False,
             async_opt_intermediate_file="war")
 
     x = ti.field(ti.i32, shape=16)

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -374,16 +374,19 @@ void AsyncEngine::synchronize() {
         debug_sfg("listgen");
         modified = true;
       }
+    sfg->verify();
     if (program->config.async_opt_dse)
       while (sfg->optimize_dead_store()) {
         debug_sfg("dse");
         modified = true;
       }
+    sfg->verify();
     if (program->config.async_opt_fusion)
       while (sfg->fuse()) {
         debug_sfg("fuse");
         modified = true;
       }
+    sfg->verify();
   }
   debug_sfg("final");
   auto tasks = sfg->extract();

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -106,7 +106,7 @@ bool StateFlowGraph::optimize_listgen() {
 
   std::vector<std::pair<int, int>> common_pairs;
 
-  // std::unique_ptr<bit::Bitset[]> has_path, has_path_reverse;
+  // std::vector<Bitset> has_path, has_path_reverse;
   // std::tie(has_path, has_path_reverse) = compute_transitive_closure();
 
   for (int i = 0; i < nodes_.size(); i++) {
@@ -175,13 +175,13 @@ bool StateFlowGraph::optimize_listgen() {
   return modified;
 }
 
-std::pair<std::unique_ptr<bit::Bitset[]>, std::unique_ptr<bit::Bitset[]>>
+std::pair<std::vector<bit::Bitset>, std::vector<bit::Bitset>>
 StateFlowGraph::compute_transitive_closure() {
   using bit::Bitset;
   const int n = nodes_.size();
   reid_nodes();
-  auto has_path = std::make_unique<Bitset[]>(n);
-  auto has_path_reverse = std::make_unique<Bitset[]>(n);
+  auto has_path = std::vector<Bitset>(n);
+  auto has_path_reverse = std::vector<Bitset>(n);
   // has_path[i][j] denotes if there is a path from i to j.
   // has_path_reverse[i][j] denotes if there is a path from j to i.
   for (int i = 0; i < n; i++) {
@@ -217,7 +217,7 @@ bool StateFlowGraph::fuse() {
     return false;
   }
 
-  std::unique_ptr<bit::Bitset[]> has_path, has_path_reverse;
+  std::vector<Bitset> has_path, has_path_reverse;
   std::tie(has_path, has_path_reverse) = compute_transitive_closure();
 
   // Cache the result that if each pair is fusable by task types.

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -10,6 +10,7 @@
 #include "taichi/lang_util.h"
 #include "taichi/program/async_utils.h"
 #include "taichi/program/program.h"
+#include "taichi/util/bit.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -98,6 +99,9 @@ class StateFlowGraph {
 
   void insert_state_flow(Node *from, Node *to, AsyncState state);
 
+  std::pair<std::unique_ptr<bit::Bitset[]>, std::unique_ptr<bit::Bitset[]>>
+  compute_transitive_closure();
+
   bool fuse();
 
   bool optimize_listgen();
@@ -108,7 +112,9 @@ class StateFlowGraph {
 
   void reid_nodes();
 
-  void replace_reference(Node *node_a, Node *node_b);
+  void replace_reference(Node *node_a,
+                         Node *node_b,
+                         bool only_output_edges = false);
 
   void topo_sort_nodes();
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -118,6 +118,8 @@ class StateFlowGraph {
 
   void topo_sort_nodes();
 
+  void verify();
+
   // Extract all tasks to execute.
   std::vector<TaskLaunchRecord> extract();
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -99,7 +99,7 @@ class StateFlowGraph {
 
   void insert_state_flow(Node *from, Node *to, AsyncState state);
 
-  std::pair<std::unique_ptr<bit::Bitset[]>, std::unique_ptr<bit::Bitset[]>>
+  std::pair<std::vector<bit::Bitset>, std::vector<bit::Bitset>>
   compute_transitive_closure();
 
   bool fuse();


### PR DESCRIPTION
Related issue = #742

Changes:
1. Let `StateFlowGraph::replace_reference` also replace input edges by default
1. Fix `StateFlowGraph::topo_sort_nodes` not considering nodes without an edge from the initial node
1. Rebuild SFG after each call of `fuse()` if at least one pair of nodes is fused
1. Extract `StateFlowGraph::compute_transitive_closure()` from `StateFlowGraph::fuse()`
1. Use `compute_transitive_closure` to test if there is a path `node_a->node_c->node_b` in `StateFlowGraph::optimize_listgen()` (commented out)
1. Add `StateFlowGraph::verify()`

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
