### PR TITLE
[refactor] Create class TypePromotionMapping for refactoring function promoted_type in lang_util.cpp

### DIFF
--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -324,36 +324,10 @@ bool command_exist(const std::string &command) {
 #endif
 }
 
-DataType promoted_type(DataType a, DataType b) {
-  std::map<std::pair<DataType, DataType>, DataType> mapping;
-  if (mapping.empty()) {
-#define TRY_SECOND(x, y)                                            \
-  mapping[std::make_pair(get_data_type<x>(), get_data_type<y>())] = \
-      get_data_type<decltype(std::declval<x>() + std::declval<y>())>();
-#define TRY_FIRST(x)      \
-  TRY_SECOND(x, float32); \
-  TRY_SECOND(x, float64); \
-  TRY_SECOND(x, int8);    \
-  TRY_SECOND(x, int16);   \
-  TRY_SECOND(x, int32);   \
-  TRY_SECOND(x, int64);   \
-  TRY_SECOND(x, uint8);   \
-  TRY_SECOND(x, uint16);  \
-  TRY_SECOND(x, uint32);  \
-  TRY_SECOND(x, uint64);
+TypePromotionMapping type_promotion_mapping;
 
-    TRY_FIRST(float32);
-    TRY_FIRST(float64);
-    TRY_FIRST(int8);
-    TRY_FIRST(int16);
-    TRY_FIRST(int32);
-    TRY_FIRST(int64);
-    TRY_FIRST(uint8);
-    TRY_FIRST(uint16);
-    TRY_FIRST(uint32);
-    TRY_FIRST(uint64);
-  }
-  return mapping[std::make_pair(a, b)];
+DataType promoted_type(DataType a, DataType b) {
+  return type_promotion_mapping.query(a, b);
 }
 
 std::string TypedConstant::stringify() const {

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -355,13 +355,14 @@ class TypePromotionMapping {
     TRY_FIRST(uint64);
   }
   DataType query(DataType x, DataType y) {
-    return mapping[std::make_pair(x,y)];
+    return mapping[std::make_pair(x, y)];
   }
+
  private:
   std::map<std::pair<DataType, DataType>, DataType> mapping;
 };
 TypePromotionMapping type_promotion_mapping;
-}
+}  // namespace
 
 DataType promoted_type(DataType a, DataType b) {
   return type_promotion_mapping.query(a, b);

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -300,42 +300,6 @@ extern std::string runtime_tmp_dir;
 
 bool command_exist(const std::string &command);
 
-class TypePromotionMapping {
- public:
-  TypePromotionMapping() {
-#define TRY_SECOND(x, y)                                            \
-  mapping[std::make_pair(get_data_type<x>(), get_data_type<y>())] = \
-      get_data_type<decltype(std::declval<x>() + std::declval<y>())>();
-#define TRY_FIRST(x)      \
-  TRY_SECOND(x, float32); \
-  TRY_SECOND(x, float64); \
-  TRY_SECOND(x, int8);    \
-  TRY_SECOND(x, int16);   \
-  TRY_SECOND(x, int32);   \
-  TRY_SECOND(x, int64);   \
-  TRY_SECOND(x, uint8);   \
-  TRY_SECOND(x, uint16);  \
-  TRY_SECOND(x, uint32);  \
-  TRY_SECOND(x, uint64);
-
-    TRY_FIRST(float32);
-    TRY_FIRST(float64);
-    TRY_FIRST(int8);
-    TRY_FIRST(int16);
-    TRY_FIRST(int32);
-    TRY_FIRST(int64);
-    TRY_FIRST(uint8);
-    TRY_FIRST(uint16);
-    TRY_FIRST(uint32);
-    TRY_FIRST(uint64);
-  }
-  DataType query(DataType x, DataType y) {
-    return mapping[std::make_pair(x,y)];
-  }
- private:
-  std::map<std::pair<DataType, DataType>, DataType> mapping;
-};
-
 TLANG_NAMESPACE_END
 
 TI_NAMESPACE_BEGIN

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -300,6 +300,42 @@ extern std::string runtime_tmp_dir;
 
 bool command_exist(const std::string &command);
 
+class TypePromotionMapping {
+ public:
+  TypePromotionMapping() {
+#define TRY_SECOND(x, y)                                            \
+  mapping[std::make_pair(get_data_type<x>(), get_data_type<y>())] = \
+      get_data_type<decltype(std::declval<x>() + std::declval<y>())>();
+#define TRY_FIRST(x)      \
+  TRY_SECOND(x, float32); \
+  TRY_SECOND(x, float64); \
+  TRY_SECOND(x, int8);    \
+  TRY_SECOND(x, int16);   \
+  TRY_SECOND(x, int32);   \
+  TRY_SECOND(x, int64);   \
+  TRY_SECOND(x, uint8);   \
+  TRY_SECOND(x, uint16);  \
+  TRY_SECOND(x, uint32);  \
+  TRY_SECOND(x, uint64);
+
+    TRY_FIRST(float32);
+    TRY_FIRST(float64);
+    TRY_FIRST(int8);
+    TRY_FIRST(int16);
+    TRY_FIRST(int32);
+    TRY_FIRST(int64);
+    TRY_FIRST(uint8);
+    TRY_FIRST(uint16);
+    TRY_FIRST(uint32);
+    TRY_FIRST(uint64);
+  }
+  DataType query(DataType x, DataType y) {
+    return mapping[std::make_pair(x,y)];
+  }
+ private:
+  std::map<std::pair<DataType, DataType>, DataType> mapping;
+};
+
 TLANG_NAMESPACE_END
 
 TI_NAMESPACE_BEGIN


### PR DESCRIPTION
Related issue = #1750

Hi, I tried refactoring function promoted_type by creating a class named TypePromotionMapping and use a global variable for initializing the type map. But I am not sure whether it is good method. Should I use a singleton mode？

