### PR TITLE
[async] Cache fusion results

### DIFF
--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -28,14 +28,16 @@ class IRBank {
   void insert_to_trash_bin(std::unique_ptr<IRNode> &&ir);
   IRNode *find(IRHandle ir_handle);
 
+  // Fuse handle_b into handle_a
+  IRHandle fuse(IRHandle handle_a, IRHandle handle_b, Kernel *kernel);
+
   std::unordered_map<IRHandle, TaskMeta> meta_bank_;
 
  private:
   std::unordered_map<IRNode *, uint64> hash_bank_;
   std::unordered_map<IRHandle, std::unique_ptr<IRNode>> ir_bank_;
   std::vector<std::unique_ptr<IRNode>> trash_bin;  // prevent IR from deleted
-  // TODO:
-  //  std::unordered_map<std::pair<IRHandle, IRHandle>, IRHandle> fuse_bank_;
+  std::unordered_map<std::pair<IRHandle, IRHandle>, IRHandle> fuse_bank_;
 };
 
 class ParallelExecutor {

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -15,6 +15,9 @@ struct TaskMeta;
 
 class IRHandle {
  public:
+  IRHandle() : ir_(nullptr), hash_(0) {
+  }
+
   IRHandle(const IRNode *ir, uint64 hash) : ir_(ir), hash_(hash) {
   }
 
@@ -26,6 +29,10 @@ class IRHandle {
 
   uint64 hash() const {
     return hash_;
+  }
+
+  bool empty() const {
+    return ir_ == nullptr;
   }
 
   // Two IRHandles are considered the same iff their hash values are the same.
@@ -46,6 +53,15 @@ struct hash<taichi::lang::IRHandle> {
   std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
       noexcept {
     return ir_handle.hash();
+  }
+};
+
+template <>
+struct hash<std::pair<taichi::lang::IRHandle, taichi::lang::IRHandle>> {
+  std::size_t operator()(
+      const std::pair<taichi::lang::IRHandle, taichi::lang::IRHandle>
+          &ir_handles) const noexcept {
+    return ir_handles.first.hash() * 100000007UL + ir_handles.second.hash();
   }
 };
 }  // namespace std


### PR DESCRIPTION
Related issue = #742 

Move a part of `StateFlowGraph::fuse()::do_fuse()` to `IRBank::fuse()`.

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
