### PR TITLE
[async] Draw nodes as record shape, allow embedding states into nodes

### DIFF
--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -249,9 +249,9 @@ def veci(*args, **kwargs):
     return core_veci(*args, **kwargs)
 
 
-def dump_dot(filepath=None, rankdir=None):
+def dump_dot(filepath=None, rankdir=None, embed_states_threshold=0):
     from taichi.core import ti_core
-    d = ti_core.dump_dot(rankdir)
+    d = ti_core.dump_dot(rankdir, embed_states_threshold)
     if filepath is not None:
         with open(filepath, 'w') as fh:
             fh.write(d)

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -30,18 +30,6 @@ uint64 hash(IRNode *stmt) {
   return ret;
 }
 
-inline const SNode *get_snode_in_clear_list_task(const OffloadedStmt *task) {
-  TI_ASSERT(is_clear_list_task(task));
-  return task->body->back()->as<ClearListStmt>()->snode;
-}
-
-inline SNode *get_snode_in_clear_list_task(OffloadedStmt *task) {
-  // Avoid duplication: https://stackoverflow.com/a/123995/12003165
-  const auto *sn =
-      get_snode_in_clear_list_task(static_cast<const OffloadedStmt *>(task));
-  return const_cast<SNode *>(sn);
-}
-
 }  // namespace
 
 uint64 IRBank::get_hash(IRNode *ir) {

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -91,9 +91,16 @@ class StateFlowGraph {
 
   void print();
 
-  // Returns a string representing a DOT graph
+  // Returns a string representing a DOT graph.
+  //
+  // |embed_states_threshold|: We can choose to embed the states into the task
+  // node itself, if there aren't too many output states. This defines the
+  // maximum number of output states a task can have for the states to be
+  // embedded in the node.
+  //
   // TODO: In case we add more and more DOT configs, create a struct?
-  std::string dump_dot(const std::optional<std::string> &rankdir);
+  std::string dump_dot(const std::optional<std::string> &rankdir,
+                       int embed_states_threshold = 0);
 
   void insert_task(const TaskLaunchRecord &rec);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -31,7 +31,8 @@ TLANG_NAMESPACE_BEGIN
 
 void async_print_sfg();
 
-std::string async_dump_dot(std::optional<std::string> rankdir);
+std::string async_dump_dot(std::optional<std::string> rankdir,
+                           int embed_states_threshold);
 
 std::string compiled_lib_dir;
 std::string runtime_tmp_dir;
@@ -664,7 +665,8 @@ void export_lang(py::module &m) {
   });
 
   m.def("print_sfg", async_print_sfg);
-  m.def("dump_dot", async_dump_dot, py::arg("rankdir").none(true));
+  m.def("dump_dot", async_dump_dot, py::arg("rankdir").none(true),
+        py::arg("embed_states_threshold"));
 }
 
 TI_NAMESPACE_END


### PR DESCRIPTION
Sorry to put additional burdens on you guys...  Thought you preferred the rectangular shape a bit more. I also allowed states to be embedded into the nodes, if the number of states is below a certain threshold (default to `0`).

* fusion_0000_initial
<img width="998" alt="Screen Shot 2020-09-16 at 22 18 02" src="https://user-images.githubusercontent.com/7481356/93342756-ad8ad480-f86a-11ea-97dc-7c90104ef7a2.png">

* fusion_0000_initial embedded

<img width="1129" alt="Screen Shot 2020-09-16 at 22 17 50" src="https://user-images.githubusercontent.com/7481356/93342775-b24f8880-f86a-11ea-857f-b7cb61d3f9f8.png">

* fusion_0003_dse

<img width="1138" alt="Screen Shot 2020-09-16 at 22 18 31" src="https://user-images.githubusercontent.com/7481356/93342796-b9769680-f86a-11ea-82f4-7040c7ae3d93.png">

* fusion_0003_dse embedded

<img width="1010" alt="Screen Shot 2020-09-16 at 22 18 21" src="https://user-images.githubusercontent.com/7481356/93342804-bc718700-f86a-11ea-8cc7-d67aeeb98cfb.png">


Related issue = N/A


[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
