### PR TITLE
[async] Add element-wise info into TaskMeta for fusion

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -406,6 +406,27 @@ GlobalPtrStmt::GlobalPtrStmt(const LaneAttribute<SNode *> &snodes,
   TI_STMT_REG_FIELDS;
 }
 
+bool GlobalPtrStmt::is_element_wise(SNode *snode) const {
+  if (snode == nullptr) {
+    // check all snodes
+    for (const auto &snode_i : snodes.data) {
+      if (!is_element_wise(snode_i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  // check if this statement is element-wise on snode
+  for (int i = 0; i < (int)indices.size(); i++) {
+    if (auto loop_index_i = indices[i]->cast<LoopIndexStmt>();
+        !(loop_index_i && loop_index_i->loop->is<OffloadedStmt>() &&
+          loop_index_i->index == snode->physical_index_position[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 std::string GlobalPtrExpression::serialize() {
   std::string s = fmt::format("{}[", var.serialize());
   for (int i = 0; i < (int)indices.size(); i++) {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -416,7 +416,8 @@ bool GlobalPtrStmt::is_element_wise(SNode *snode) const {
     }
     return true;
   }
-  // check if this statement is element-wise on a specific SNode, i.e., argument "snode"
+  // check if this statement is element-wise on a specific SNode, i.e., argument
+  // "snode"
   for (int i = 0; i < (int)indices.size(); i++) {
     if (auto loop_index_i = indices[i]->cast<LoopIndexStmt>();
         !(loop_index_i && loop_index_i->loop->is<OffloadedStmt>() &&

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -408,7 +408,7 @@ GlobalPtrStmt::GlobalPtrStmt(const LaneAttribute<SNode *> &snodes,
 
 bool GlobalPtrStmt::is_element_wise(SNode *snode) const {
   if (snode == nullptr) {
-    // check all snodes
+    // check every SNode when "snode" is nullptr
     for (const auto &snode_i : snodes.data) {
       if (!is_element_wise(snode_i)) {
         return false;
@@ -416,7 +416,7 @@ bool GlobalPtrStmt::is_element_wise(SNode *snode) const {
     }
     return true;
   }
-  // check if this statement is element-wise on snode
+  // check if this statement is element-wise on a specific SNode, i.e., argument "snode"
   for (int i = 0; i < (int)indices.size(); i++) {
     if (auto loop_index_i = indices[i]->cast<LoopIndexStmt>();
         !(loop_index_i && loop_index_i->loop->is<OffloadedStmt>() &&

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -851,6 +851,8 @@ class GlobalPtrStmt : public Stmt {
                 const std::vector<Stmt *> &indices,
                 bool activate = true);
 
+  bool is_element_wise(SNode *snode) const;
+
   bool has_global_side_effect() const override {
     return activate;
   }

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -362,6 +362,15 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
           }
         }
       }
+      for (auto &snode : ptr->snodes.data) {
+        if (ptr->is_element_wise(snode)) {
+          if (meta.element_wise.find(snode) == meta.element_wise.end()) {
+            meta.element_wise[snode] = true;
+          }
+        } else {
+          meta.element_wise[snode] = false;
+        }
+      }
     }
     if (auto clear_list = stmt->cast<ClearListStmt>()) {
       meta.output_states.emplace(clear_list->snode, AsyncState::Type::list);

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -55,6 +55,28 @@ void TaskMeta::print() const {
     }
     fmt::print("\n");
   }
+  std::vector<SNode *> element_wise_snodes, non_element_wise_snodes;
+  for (auto s : element_wise) {
+    if (s.second) {
+      element_wise_snodes.push_back(s.first);
+    } else {
+      non_element_wise_snodes.push_back(s.first);
+    }
+  }
+  if (!element_wise_snodes.empty()) {
+    fmt::print("  element-wise snodes:\n    ");
+    for (auto s : element_wise_snodes) {
+      fmt::print("{} ", s->get_node_type_name_hinted());
+    }
+    fmt::print("\n");
+  }
+  if (!non_element_wise_snodes.empty()) {
+    fmt::print("  non-element-wise snodes:\n    ");
+    for (auto s : non_element_wise_snodes) {
+      fmt::print("{} ", s->get_node_type_name_hinted());
+    }
+    fmt::print("\n");
+  }
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -50,29 +50,6 @@ class IRHandle {
   uint64 hash_;
 };
 
-TLANG_NAMESPACE_END
-
-namespace std {
-template <>
-struct hash<taichi::lang::IRHandle> {
-  std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
-      noexcept {
-    return ir_handle.hash();
-  }
-};
-
-template <>
-struct hash<std::pair<taichi::lang::IRHandle, taichi::lang::IRHandle>> {
-  std::size_t operator()(
-      const std::pair<taichi::lang::IRHandle, taichi::lang::IRHandle>
-          &ir_handles) const noexcept {
-    return ir_handles.first.hash() * 100000007UL + ir_handles.second.hash();
-  }
-};
-}  // namespace std
-
-TLANG_NAMESPACE_BEGIN
-
 // Records the necessary data for launching an offloaded task.
 class TaskLaunchRecord {
  public:
@@ -127,19 +104,43 @@ struct AsyncState {
   }
 };
 
-class AsyncStateHash {
- public:
-  size_t operator()(const AsyncState &s) const {
-    return (uint64)s.snode ^ (uint64)s.type;
+TLANG_NAMESPACE_END
+
+namespace std {
+template <>
+struct hash<taichi::lang::IRHandle> {
+  std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
+      noexcept {
+    return ir_handle.hash();
   }
 };
+
+template <>
+struct hash<std::pair<taichi::lang::IRHandle, taichi::lang::IRHandle>> {
+  std::size_t operator()(
+      const std::pair<taichi::lang::IRHandle, taichi::lang::IRHandle>
+          &ir_handles) const noexcept {
+    return ir_handles.first.hash() * 100000007UL + ir_handles.second.hash();
+  }
+};
+
+template <>
+struct hash<taichi::lang::AsyncState> {
+  std::size_t operator()(const taichi::lang::AsyncState &s) const noexcept {
+    return (std::size_t)s.snode ^ (std::size_t)s.type;
+  }
+};
+
+}  // namespace std
+
+TLANG_NAMESPACE_BEGIN
 
 struct TaskMeta {
   std::string name;
   OffloadedStmt::TaskType type{OffloadedStmt::TaskType::serial};
   SNode *snode{nullptr};  // struct-for and listgen only
-  std::unordered_set<AsyncState, AsyncStateHash> input_states;
-  std::unordered_set<AsyncState, AsyncStateHash> output_states;
+  std::unordered_set<AsyncState> input_states;
+  std::unordered_set<AsyncState> output_states;
 
   void print() const;
 };

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -141,6 +141,7 @@ struct TaskMeta {
   SNode *snode{nullptr};  // struct-for and listgen only
   std::unordered_set<AsyncState> input_states;
   std::unordered_set<AsyncState> output_states;
+  std::unordered_map<SNode *, bool> element_wise;
 
   void print() const;
 };

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -350,6 +350,9 @@ bool StateFlowGraph::fuse() {
     if (fused[a] || fused[b] || !task_type_fusible[a][b]) {
       return false;
     }
+    if (nodes_[a]->meta->type == OffloadedStmt::TaskType::serial) {
+      return true;
+    }
     for (auto &state : nodes_[a]->output_edges) {
       if (state.first.type != AsyncState::Type::value) {
         // TODO: What checks do we need for edges of mask/list states?

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -18,8 +18,7 @@ class IRBank;
 class StateFlowGraph {
  public:
   struct Node;
-  using StateToNodeMapping =
-      std::unordered_map<AsyncState, Node *, AsyncStateHash>;
+  using StateToNodeMapping = std::unordered_map<AsyncState, Node *>;
 
   // Each node is a task
   // Note: after SFG is done, each node here should hold a TaskLaunchRecord.
@@ -39,8 +38,8 @@ class StateFlowGraph {
 
     // Profiling showed horrible performance using std::unordered_multimap (at
     // least on Mac with clang-1103.0.32.62)...
-    std::unordered_map<AsyncState, std::unordered_set<Node *>, AsyncStateHash>
-        output_edges, input_edges;
+    std::unordered_map<AsyncState, std::unordered_set<Node *>> output_edges,
+        input_edges;
 
     std::string string() const;
 
@@ -140,7 +139,7 @@ class StateFlowGraph {
   Node *initial_node_;  // The initial node holds all the initial states.
   TaskMeta initial_meta_;
   StateToNodeMapping latest_state_owner_;
-  std::unordered_map<AsyncState, std::unordered_set<Node *>, AsyncStateHash>
+  std::unordered_map<AsyncState, std::unordered_set<Node *>>
       latest_state_readers_;
   std::unordered_map<std::string, int> task_name_to_launch_ids_;
   IRBank *ir_bank_;


### PR DESCRIPTION
Related issue = #742 

Changes: 
- Add `std::unordered_map<SNode *, bool> TaskMeta::element_wise`
- Refactor `AsyncStateHash` into `std::hash<AsyncState>` because I think we don't need other hashes of `AsyncState`
- Fix typo "fusable" -> "fusible"

Question:
- How does the element-wise info affect mask/list states?

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
