### PR TITLE
[async] Classify tasks to make fusion 10.6x faster

### DIFF
--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -229,5 +229,4 @@ gui.set_image(pixels)
 gui.show()
 
 ti.kernel_profiler_print()
-ti.core.print_profile_info()
 ti.core.print_stat()

--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -8,7 +8,7 @@ ti.init(default_fp=real,
         async_opt_listgen=True,
         async_opt_dse=True,
         async_opt_activation_demotion=True,
-        async_opt_fusion=False,
+        async_opt_fusion=True,
         kernel_profiler=False
         #, async_opt_intermediate_file="mgpcg"
         )
@@ -229,4 +229,5 @@ gui.set_image(pixels)
 gui.show()
 
 ti.kernel_profiler_print()
+ti.core.print_profile_info()
 ti.core.print_stat()

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -404,6 +404,7 @@ TaskFusionMeta get_task_fusion_meta(IRBank *bank, const TaskLaunchRecord &t) {
   TaskFusionMeta meta{};
   if (t.kernel->is_accessor) {
     // SNode accessors can't be fused.
+    // TODO: just avoid snode accessors going into the async engine
     return fusion_meta_bank[t.ir_handle] = TaskFusionMeta();
   }
   meta.kernel = t.kernel;

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -394,6 +394,51 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
   return &meta_bank[t.ir_handle];
 }
 
+TaskFusionMeta get_task_fusion_meta(IRBank *bank, const TaskLaunchRecord &t) {
+  // TODO: this function should ideally take only an IRNode
+  auto &fusion_meta_bank = bank->fusion_meta_bank_;
+  if (fusion_meta_bank.find(t.ir_handle) != fusion_meta_bank.end()) {
+    return fusion_meta_bank[t.ir_handle];
+  }
+
+  TaskFusionMeta meta{};
+  if (t.kernel->is_accessor) {
+    // SNode accessors can't be fused.
+    return fusion_meta_bank[t.ir_handle] = TaskFusionMeta();
+  }
+  meta.kernel = t.kernel;
+  if (t.kernel->args.empty() && t.kernel->rets.empty()) {
+    meta.kernel = nullptr;
+  }
+
+  auto *task = t.stmt();
+  meta.type = task->task_type;
+  if (task->task_type == OffloadedStmt::struct_for) {
+    meta.snode = task->snode;
+    meta.block_dim = task->block_dim;
+  } else if (task->task_type == OffloadedStmt::range_for) {
+    // TODO: a few problems with the range-for test condition:
+    // 1. This could incorrectly fuse two range-for kernels that have
+    // different sizes, but then the loop ranges get padded to the same
+    // power-of-two (E.g. maybe a side effect when a struct-for is demoted
+    // to range-for).
+    // 2. It has also fused range-fors that have the same linear range,
+    // but are of different dimensions of loop indices, e.g. (16, ) and
+    // (4, 4).
+    if (!task->const_begin || !task->const_end) {
+      // Do not fuse range-for tasks with variable ranges for now.
+      return fusion_meta_bank[t.ir_handle] = TaskFusionMeta();
+    }
+    meta.begin_value = task->begin_value;
+    meta.end_value = task->end_value;
+  } else if (task->task_type != OffloadedStmt::serial) {
+    // Do not fuse gc/listgen tasks.
+    return fusion_meta_bank[t.ir_handle] = TaskFusionMeta();
+  }
+  meta.fusible = true;
+  return fusion_meta_bank[t.ir_handle] = meta;
+}
+
 void AsyncEngine::enqueue(const TaskLaunchRecord &t) {
   sfg->insert_task(t);
   task_queue.push_back(t);

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -32,6 +32,7 @@ class IRBank {
   IRHandle fuse(IRHandle handle_a, IRHandle handle_b, Kernel *kernel);
 
   std::unordered_map<IRHandle, TaskMeta> meta_bank_;
+  std::unordered_map<IRHandle, TaskFusionMeta> fusion_meta_bank_;
 
  private:
   std::unordered_map<IRNode *, uint64> hash_bank_;

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -104,6 +104,40 @@ struct AsyncState {
   }
 };
 
+struct TaskFusionMeta {
+  // meta for task fusion
+  OffloadedStmt::TaskType type{OffloadedStmt::TaskType::serial};
+  SNode *snode{nullptr};  // struct-for only
+  int block_dim{0};       // struct-for only
+  int32 begin_value{0};   // range-for only
+  int32 end_value{0};     // range-for only
+
+  // Merging kernels with different signatures will break invariants.
+  // E.g.
+  // https://github.com/taichi-dev/taichi/blob/a6575fb97557267e2f550591f43b183076b72ac2/taichi/transforms/type_check.cpp#L326
+  //
+  // TODO: we could merge different kernels if their args are the
+  // same. But we have no way to check that for now.
+
+  // We use nullptr for kernels without arguments or return value.
+  // Otherwise, we only fuse tasks with the same kernel.
+  Kernel *kernel{nullptr};
+
+  // If fusible is false, this task can't be fused with any other tasks.
+  bool fusible{false};
+
+  bool operator==(const TaskFusionMeta &other) const {
+    return type == other.type && snode == other.snode &&
+           block_dim == other.block_dim && begin_value == other.begin_value &&
+           end_value == other.end_value && kernel == other.kernel &&
+           fusible == other.fusible;
+  }
+
+  bool operator!=(const TaskFusionMeta &other) const {
+    return !(*this == other);
+  }
+};
+
 TLANG_NAMESPACE_END
 
 namespace std {
@@ -131,6 +165,16 @@ struct hash<taichi::lang::AsyncState> {
   }
 };
 
+template <>
+struct hash<taichi::lang::TaskFusionMeta> {
+  std::size_t operator()(const taichi::lang::TaskFusionMeta &t) const noexcept {
+    std::size_t result = (t.type << 1) ^ t.fusible ^ (std::size_t)t.kernel;
+    result ^= (std::size_t)t.block_dim * 100000007UL + (std::size_t)t.snode;
+    result ^= ((std::size_t)t.begin_value << 32) ^ t.end_value;
+    return result;
+  }
+};
+
 }  // namespace std
 
 TLANG_NAMESPACE_BEGIN
@@ -144,29 +188,6 @@ struct TaskMeta {
   std::unordered_map<SNode *, bool> element_wise;
 
   void print() const;
-};
-
-struct TaskFusionMeta {
-  // meta for task fusion
-  OffloadedStmt::TaskType type{OffloadedStmt::TaskType::serial};
-  SNode *snode{nullptr};  // struct-for only
-  int block_dim{0};       // struct-for only
-  int32 begin_value{0};   // range-for only
-  int32 end_value{0};     // range-for only
-
-  // Merging kernels with different signatures will break invariants.
-  // E.g.
-  // https://github.com/taichi-dev/taichi/blob/a6575fb97557267e2f550591f43b183076b72ac2/taichi/transforms/type_check.cpp#L326
-  //
-  // TODO: we could merge different kernels if their args are the
-  // same. But we have no way to check that for now.
-
-  // We use nullptr for kernels without arguments or return value.
-  // Otherwise, we only fuse tasks with the same kernel.
-  Kernel *kernel{nullptr};
-
-  // If fusible is false, this task can't be fused with any other tasks.
-  bool fusible{false};
 };
 
 class IRBank;

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -146,8 +146,33 @@ struct TaskMeta {
   void print() const;
 };
 
+struct TaskFusionMeta {
+  // meta for task fusion
+  OffloadedStmt::TaskType type{OffloadedStmt::TaskType::serial};
+  SNode *snode{nullptr};  // struct-for only
+  int block_dim{0};       // struct-for only
+  int32 begin_value{0};   // range-for only
+  int32 end_value{0};     // range-for only
+
+  // Merging kernels with different signatures will break invariants.
+  // E.g.
+  // https://github.com/taichi-dev/taichi/blob/a6575fb97557267e2f550591f43b183076b72ac2/taichi/transforms/type_check.cpp#L326
+  //
+  // TODO: we could merge different kernels if their args are the
+  // same. But we have no way to check that for now.
+
+  // We use nullptr for kernels without arguments or return value.
+  // Otherwise, we only fuse tasks with the same kernel.
+  Kernel *kernel{nullptr};
+
+  // If fusible is false, this task can't be fused with any other tasks.
+  bool fusible{false};
+};
+
 class IRBank;
 
 TaskMeta *get_task_meta(IRBank *bank, const TaskLaunchRecord &t);
+
+TaskFusionMeta get_task_fusion_meta(IRBank *bank, const TaskLaunchRecord &t);
 
 TLANG_NAMESPACE_END

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -250,7 +250,6 @@ bool StateFlowGraph::fuse() {
       fusion_set.insert(fusion_set.end(), i);
     }
   }
-  const int kLargeFusionSetThreshold = std::max(n / 32, 4);
 
   std::unordered_set<int> indices_to_delete;
 
@@ -333,6 +332,7 @@ bool StateFlowGraph::fuse() {
     fused[i] = nodes_[i]->rec.empty();
   }
   // The case without an edge: O(sum(size * min(size, n / 64))) = O(n^2 / 64)
+  const int kLargeFusionSetThreshold = std::max(n / 16, 16);
   for (auto &fusion_map : task_fusion_map) {
     std::vector<int> indices(fusion_map.second.begin(),
                              fusion_map.second.end());

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -4,6 +4,7 @@
 #include "taichi/ir/analysis.h"
 #include "taichi/program/async_engine.h"
 
+#include <set>
 #include <sstream>
 #include <unordered_set>
 
@@ -192,6 +193,7 @@ bool StateFlowGraph::optimize_listgen() {
 
 std::pair<std::vector<bit::Bitset>, std::vector<bit::Bitset>>
 StateFlowGraph::compute_transitive_closure() {
+  TI_AUTO_PROF;
   using bit::Bitset;
   const int n = nodes_.size();
   reid_nodes();
@@ -226,6 +228,7 @@ StateFlowGraph::compute_transitive_closure() {
 }
 
 bool StateFlowGraph::fuse() {
+  TI_AUTO_PROF;
   using bit::Bitset;
   const int n = nodes_.size();
   if (n <= 2) {
@@ -235,67 +238,16 @@ bool StateFlowGraph::fuse() {
   std::vector<Bitset> has_path, has_path_reverse;
   std::tie(has_path, has_path_reverse) = compute_transitive_closure();
 
-  // Cache the result that if each pair is fusible by task types.
-  // TODO: improve this
-  auto task_type_fusible = std::make_unique<Bitset[]>(n);
-  for (int i = 0; i < n; i++) {
-    task_type_fusible[i] = Bitset(n);
-  }
+  // Classify tasks by TaskFusionMeta.
+  std::vector<TaskFusionMeta> fusion_meta(n);
+  // It seems that std::set is slightly faster than std::unordered_set here.
+  std::unordered_map<TaskFusionMeta, std::set<int>> task_fusion_map;
   // nodes_[0] is the initial node.
   for (int i = 1; i < n; i++) {
-    auto &rec_i = nodes_[i]->rec;
-    if (rec_i.empty()) {
-      continue;
-    }
-    auto *task_i = rec_i.stmt();
-    for (int j = i + 1; j < n; j++) {
-      auto &rec_j = nodes_[j]->rec;
-      if (rec_j.empty()) {
-        continue;
-      }
-      auto *task_j = rec_j.stmt();
-      bool is_same_struct_for =
-          task_i->task_type == OffloadedStmt::struct_for &&
-          task_j->task_type == OffloadedStmt::struct_for &&
-          task_i->snode == task_j->snode &&
-          task_i->block_dim == task_j->block_dim;
-      // TODO: a few problems with the range-for test condition:
-      // 1. This could incorrectly fuse two range-for kernels that have
-      // different sizes, but then the loop ranges get padded to the same
-      // power-of-two (E.g. maybe a side effect when a struct-for is demoted
-      // to range-for).
-      // 2. It has also fused range-fors that have the same linear range,
-      // but are of different dimensions of loop indices, e.g. (16, ) and
-      // (4, 4).
-      bool is_same_range_for = task_i->task_type == OffloadedStmt::range_for &&
-                               task_j->task_type == OffloadedStmt::range_for &&
-                               task_i->const_begin && task_j->const_begin &&
-                               task_i->const_end && task_j->const_end &&
-                               task_i->begin_value == task_j->begin_value &&
-                               task_i->end_value == task_j->end_value;
-      bool are_both_serial = task_i->task_type == OffloadedStmt::serial &&
-                             task_j->task_type == OffloadedStmt::serial;
-      const bool same_kernel = (rec_i.kernel == rec_j.kernel);
-      bool kernel_args_match = true;
-      if (!same_kernel) {
-        // Merging kernels with different signatures will break invariants.
-        // E.g.
-        // https://github.com/taichi-dev/taichi/blob/a6575fb97557267e2f550591f43b183076b72ac2/taichi/transforms/type_check.cpp#L326
-        //
-        // TODO: we could merge different kernels if their args are the
-        // same. But we have no way to check that for now.
-        auto check = [](const Kernel *k) {
-          return (k->args.empty() && k->rets.empty());
-        };
-        kernel_args_match = (check(rec_i.kernel) && check(rec_j.kernel));
-      }
-      // TODO: avoid snode accessors going into async engine
-      const bool is_snode_accessor =
-          (rec_i.kernel->is_accessor || rec_j.kernel->is_accessor);
-      bool fusible =
-          (is_same_range_for || is_same_struct_for || are_both_serial) &&
-          kernel_args_match && !is_snode_accessor;
-      task_type_fusible[i][j] = fusible;
+    fusion_meta[i] = get_task_fusion_meta(ir_bank_, nodes_[i]->rec);
+    if (fusion_meta[i].fusible) {
+      auto &fusion_set = task_fusion_map[fusion_meta[i]];
+      fusion_set.insert(fusion_set.end(), i);
     }
   }
 
@@ -313,7 +265,10 @@ bool StateFlowGraph::fuse() {
     }
   };
 
+  auto fused = std::vector<bool>(n);
+
   auto do_fuse = [&](int a, int b) {
+    TI_AUTO_PROF;
     auto *node_a = nodes_[a].get();
     auto *node_b = nodes_[b].get();
     // TODO: remove debug output
@@ -341,31 +296,36 @@ bool StateFlowGraph::fuse() {
     insert_edge_for_transitive_closure(b, a);
     if (!already_had_a_to_b_edge)
       insert_edge_for_transitive_closure(a, b);
-  };
 
-  auto fused = std::make_unique<bool[]>(n);
+    fused[a] = fused[b] = true;
+    task_fusion_map[fusion_meta[a]].erase(a);
+    task_fusion_map[fusion_meta[b]].erase(b);
+  };
 
   auto edge_fusible = [&](int a, int b) {
     // Check if a and b are fusible if there is an edge (a, b).
-    if (fused[a] || fused[b] || !task_type_fusible[a][b]) {
+    if (fused[a] || fused[b] || !fusion_meta[a].fusible ||
+        fusion_meta[a] != fusion_meta[b]) {
       return false;
     }
-    if (nodes_[a]->meta->type == OffloadedStmt::TaskType::serial) {
-      return true;
-    }
-    for (auto &state : nodes_[a]->output_edges) {
-      if (state.first.type != AsyncState::Type::value) {
-        // TODO: What checks do we need for edges of mask/list states?
-        continue;
-      }
-      if (state.second.find(nodes_[b].get()) != state.second.end()) {
-        if (!nodes_[a]->meta->element_wise[state.first.snode] ||
-            !nodes_[b]->meta->element_wise[state.first.snode]) {
-          return false;
+    if (nodes_[a]->meta->type != OffloadedStmt::TaskType::serial) {
+      for (auto &state : nodes_[a]->output_edges) {
+        if (state.first.type != AsyncState::Type::value) {
+          // No need to check mask/list states as there must be value states.
+          continue;
+        }
+        if (state.second.find(nodes_[b].get()) != state.second.end()) {
+          if (!nodes_[a]->meta->element_wise[state.first.snode] ||
+              !nodes_[b]->meta->element_wise[state.first.snode]) {
+            return false;
+          }
         }
       }
     }
-    return true;
+    // check if a doesn't have a path to b of length >= 2
+    auto a_has_path_to_b = has_path[a] & has_path_reverse[b];
+    a_has_path_to_b[a] = a_has_path_to_b[b] = false;
+    return a_has_path_to_b.none();
   };
 
   bool modified = false;
@@ -374,6 +334,7 @@ bool StateFlowGraph::fuse() {
     for (int i = 1; i < n; i++) {
       fused[i] = nodes_[i]->rec.empty();
     }
+    // The case with an edge: O(nm / 64)
     for (int i = 1; i < n; i++) {
       if (!fused[i]) {
         bool i_updated = false;
@@ -381,16 +342,10 @@ bool StateFlowGraph::fuse() {
           for (auto &edge : edges.second) {
             const int j = edge->node_id;
             if (edge_fusible(i, j)) {
-              auto i_has_path_to_j = has_path[i] & has_path_reverse[j];
-              i_has_path_to_j[i] = i_has_path_to_j[j] = false;
-              // check if i doesn't have a path to j of length >= 2
-              if (i_has_path_to_j.none()) {
-                do_fuse(i, j);
-                fused[i] = fused[j] = true;
-                i_updated = true;
-                updated = true;
-                break;
-              }
+              do_fuse(i, j);
+              i_updated = true;
+              updated = true;
+              break;
             }
           }
           if (i_updated)
@@ -398,16 +353,22 @@ bool StateFlowGraph::fuse() {
         }
       }
     }
-    // TODO: accelerate this
-    for (int i = 1; i < n; i++) {
-      if (!fused[i]) {
-        for (int j = i + 1; j < n; j++) {
-          if (!fused[j] && task_type_fusible[i][j] && !has_path[i][j] &&
-              !has_path[j][i]) {
-            do_fuse(i, j);
-            fused[i] = fused[j] = true;
-            updated = true;
-            break;
+    // The case without an edge: O(sum(size^2)) = O(n^2)
+    for (auto &fusion_map : task_fusion_map) {
+      // TODO: optimize from O(size^2) to O(size * n / 64) when
+      //  fusion_map.second.size() is large
+      std::vector<int> indices(fusion_map.second.begin(),
+                               fusion_map.second.end());
+      for (int i = 0; i < (int)indices.size(); i++) {
+        const int a = indices[i];
+        if (!fused[a]) {
+          for (int j = i + 1; j < (int)indices.size(); j++) {
+            const int b = indices[j];
+            if (!fused[b] && !has_path[a][b] && !has_path[b][a]) {
+              do_fuse(std::min(a, b), std::max(a, b));
+              updated = true;
+              break;
+            }
           }
         }
       }
@@ -423,8 +384,6 @@ bool StateFlowGraph::fuse() {
   if (modified) {
     // rebuild the graph in topological order
     delete_nodes(indices_to_delete);
-    // TODO: we may want to preserve the original node order. Maybe
-    // topo_sort_nodes() here leads to wrong results.
     topo_sort_nodes();
     auto tasks = extract();
     for (auto &task : tasks) {

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -272,7 +272,6 @@ bool StateFlowGraph::fuse() {
     TI_AUTO_PROF;
     auto *node_a = nodes_[a].get();
     auto *node_b = nodes_[b].get();
-    // TODO: remove debug output
     TI_TRACE("Fuse: nodes_[{}]({}) <- nodes_[{}]({})", a, node_a->string(), b,
              node_b->string());
     auto &rec_a = node_a->rec;

--- a/taichi/util/bit.cpp
+++ b/taichi/util/bit.cpp
@@ -98,7 +98,7 @@ Bitset Bitset::operator~() const {
   return result;
 }
 
-int Bitset::find_first_bit() const {
+int Bitset::find_first_one() const {
   return lower_bound(0);
 }
 

--- a/taichi/util/bit.cpp
+++ b/taichi/util/bit.cpp
@@ -74,6 +74,12 @@ Bitset &Bitset::operator|=(const Bitset &other) {
   return *this;
 }
 
+Bitset Bitset::operator|(const Bitset &other) const {
+  Bitset result = *this;
+  result |= other;
+  return result;
+}
+
 Bitset &Bitset::operator^=(const Bitset &other) {
   const int len = vec_.size();
   TI_ASSERT(len == other.vec_.size());
@@ -83,13 +89,27 @@ Bitset &Bitset::operator^=(const Bitset &other) {
   return *this;
 }
 
+Bitset Bitset::operator~() const {
+  Bitset result(size());
+  const int len = vec_.size();
+  for (int i = 0; i < len; i++) {
+    result.vec_[i] = ~vec_[i];
+  }
+  return result;
+}
+
 int Bitset::find_first_bit() const {
   return lower_bound(0);
 }
 
 int Bitset::lower_bound(int x) const {
   const int len = vec_.size();
-  TI_ASSERT(x >= 0 && x < len * kBits);
+  if (x >= len * kBits) {
+    return -1;
+  }
+  if (x < 0) {
+    x = 0;
+  }
   int i = x / kBits;
   if (x % kBits != 0) {
     if (auto test = vec_[i] & (kMask ^ ((1ULL << (x % kBits)) - 1))) {

--- a/taichi/util/bit.cpp
+++ b/taichi/util/bit.cpp
@@ -83,6 +83,28 @@ Bitset &Bitset::operator^=(const Bitset &other) {
   return *this;
 }
 
+int Bitset::find_first_bit() const {
+  return lower_bound(0);
+}
+
+int Bitset::lower_bound(int x) const {
+  const int len = vec_.size();
+  TI_ASSERT(x >= 0 && x < len * kBits);
+  int i = x / kBits;
+  if (x % kBits != 0) {
+    if (auto test = vec_[i] & (kMask ^ ((1ULL << (x % kBits)) - 1))) {
+      return i * kBits + log2int(lowbit(test));
+    }
+    i++;
+  }
+  for (; i < len; i++) {
+    if (vec_[i]) {
+      return i * kBits + log2int(lowbit(vec_[i]));
+    }
+  }
+  return -1;
+}
+
 std::vector<int> Bitset::or_eq_get_update_list(const Bitset &other) {
   const int len = vec_.size();
   TI_ASSERT(len == other.vec_.size());

--- a/taichi/util/bit.h
+++ b/taichi/util/bit.h
@@ -182,7 +182,9 @@ class Bitset {
   Bitset &operator&=(const Bitset &other);
   Bitset operator&(const Bitset &other) const;
   Bitset &operator|=(const Bitset &other);
+  Bitset operator|(const Bitset &other) const;
   Bitset &operator^=(const Bitset &other);
+  Bitset operator~() const;
 
   // Find the place of the first bit, or return -1 if it doesn't exist.
   int find_first_bit() const;

--- a/taichi/util/bit.h
+++ b/taichi/util/bit.h
@@ -126,6 +126,10 @@ TI_FORCE_INLINE constexpr uint32 ceil_log2int(uint64 value) {
   return log2int(value) + ((value & (value - 1)) != 0);
 }
 
+TI_FORCE_INLINE constexpr uint64 lowbit(uint64 x) {
+  return x & (-x);
+}
+
 template <typename G, typename T>
 constexpr TI_FORCE_INLINE copy_refcv_t<T, G> &&reinterpret_bits(T &&t) {
   TI_STATIC_ASSERT(sizeof(G) == sizeof(T));
@@ -179,6 +183,12 @@ class Bitset {
   Bitset operator&(const Bitset &other) const;
   Bitset &operator|=(const Bitset &other);
   Bitset &operator^=(const Bitset &other);
+
+  // Find the place of the first bit, or return -1 if it doesn't exist.
+  int find_first_bit() const;
+  // Find the place of the first bit which is not before x, or return -1 if
+  // it doesn't exist.
+  int lower_bound(int x) const;
 
   std::vector<int> or_eq_get_update_list(const Bitset &other);
 

--- a/taichi/util/bit.h
+++ b/taichi/util/bit.h
@@ -186,9 +186,9 @@ class Bitset {
   Bitset &operator^=(const Bitset &other);
   Bitset operator~() const;
 
-  // Find the place of the first bit, or return -1 if it doesn't exist.
-  int find_first_bit() const;
-  // Find the place of the first bit which is not before x, or return -1 if
+  // Find the place of the first "1", or return -1 if it doesn't exist.
+  int find_first_one() const;
+  // Find the place of the first "1" which is not before x, or return -1 if
   // it doesn't exist.
   int lower_bound(int x) const;
 


### PR DESCRIPTION
Related issue = #742

Benchmark: async_mgpcg.py, `taichi::lang::StateFlowGraph::fuse`:
Before: `2.815  s`
At commit 691f706: `520.011 ms`
At commit 3c78343: `332.199 ms`
At commit 42da16c: `283.921 ms`
At commit 366af3d (buggy): `197.838 ms`
At commit 826d053: `241.768 ms`
After (at commit 6e6892f): `152.634 ms`

On kun: ~1.03s -> ~97ms (10.6x faster)

The following statistics may change even at the same commit...
Without fusion:
```
codegen_accessor_statements: 20.00
codegen_evaluator_statements: 79.00
codegen_kernel_statements: 4224.00
codegen_offloaded_tasks: 117.00
codegen_statements  : 4323.00
launched_tasks      : 5034.00
launched_tasks_compute: 4990.00
launched_tasks_list_gen: 44.00
launched_tasks_list_op: 44.00
launched_tasks_range_for: 1.00
launched_tasks_serial: 106.00
launched_tasks_struct_for: 4883.00
```
With fusion (before this PR):
```
codegen_accessor_statements: 20.00
codegen_evaluator_statements: 79.00
codegen_kernel_statements: 4529.00
codegen_offloaded_tasks: 101.00
codegen_statements  : 4628.00
launched_tasks      : 4891.00
launched_tasks_compute: 4847.00
launched_tasks_list_gen: 44.00
launched_tasks_list_op: 44.00
launched_tasks_range_for: 1.00
launched_tasks_serial: 37.00
launched_tasks_struct_for: 4809.00
```

With fusion (at commit 691f706):
```
codegen_accessor_statements: 20.00
codegen_evaluator_statements: 79.00
codegen_kernel_statements: 4493.00
codegen_offloaded_tasks: 98.00
codegen_statements  : 4581.00
launched_tasks      : 4889.00
launched_tasks_compute: 4845.00
launched_tasks_list_gen: 44.00
launched_tasks_list_op: 44.00
launched_tasks_range_for: 1.00
launched_tasks_serial: 35.00
launched_tasks_struct_for: 4809.00
```

With fusion (at commit 42da16c):
```
codegen_accessor_statements: 20.00
codegen_evaluator_statements: 79.00
codegen_kernel_statements: 4399.00
codegen_offloaded_tasks: 94.00
codegen_statements  : 4498.00
launched_tasks      : 4880.00
launched_tasks_compute: 4836.00
launched_tasks_list_gen: 44.00
launched_tasks_list_op: 44.00
launched_tasks_range_for: 1.00
launched_tasks_serial: 26.00
launched_tasks_struct_for: 4809.00
```

With fusion (at commit 366af3d):
```
codegen_accessor_statements: 20.00
codegen_evaluator_statements: 79.00
codegen_kernel_statements: 4397.00
codegen_offloaded_tasks: 93.00
codegen_statements  : 4496.00
launched_tasks      : 4879.00
launched_tasks_compute: 4835.00
launched_tasks_list_gen: 44.00
launched_tasks_list_op: 44.00
launched_tasks_range_for: 1.00
launched_tasks_serial: 25.00
launched_tasks_struct_for: 4809.00
```

With fusion (at commit 826d053):
```
codegen_accessor_statements: 20.00
codegen_evaluator_statements: 79.00
codegen_kernel_statements: 4367.00
codegen_offloaded_tasks: 92.00
codegen_statements  : 4466.00
launched_tasks      : 4880.00
launched_tasks_compute: 4836.00
launched_tasks_list_gen: 44.00
launched_tasks_list_op: 44.00
launched_tasks_range_for: 1.00
launched_tasks_serial: 26.00
launched_tasks_struct_for: 4809.00
```

With fusion (at commit 6e6892f):
```
codegen_accessor_statements: 20.00
codegen_evaluator_statements: 79.00
codegen_kernel_statements: 4395.00
codegen_offloaded_tasks: 94.00
codegen_statements  : 4494.00
launched_tasks      : 4880.00
launched_tasks_compute: 4836.00
launched_tasks_list_gen: 44.00
launched_tasks_list_op: 44.00
launched_tasks_range_for: 1.00
launched_tasks_serial: 26.00
launched_tasks_struct_for: 4809.00
```
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
