### PR TITLE
[async] Make optimization passes iterative

### DIFF
--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -150,7 +150,6 @@ class AsyncEngine {
 
   std::unique_ptr<StateFlowGraph> sfg;
   std::deque<TaskLaunchRecord> task_queue;
-  int debug_sfg_counter{0};
 
   explicit AsyncEngine(Program *program);
 
@@ -185,6 +184,10 @@ class AsyncEngine {
 
   TaskMeta create_task_meta(const TaskLaunchRecord &t);
   std::unordered_map<const Kernel *, KernelMeta> kernel_metas_;
+  // How many times we have synchronized
+  int sync_counter_{0};
+  int cur_sync_sfg_debug_counter_{0};
+  std::unordered_map<std::string, int> cur_sync_sfg_debug_per_stage_counts_;
 };
 
 TLANG_NAMESPACE_END


### PR DESCRIPTION
This is to implement https://github.com/taichi-dev/taichi/pull/1888#pullrequestreview-494761275

Since each pass (stage) could run multiple times, I tweaked the debug filename a bit. It now looks like

`{prefix}_sync{04:d, sync_count}_{04:d, cur_sync_debugs_count}_{stage}{stage_count}?`

E.g.

```
foo_sync0001_0000_initial
foo_sync0001_0001_listgen
foo_sync0001_0002_fuse
foo_sync0001_0003_fuse1
foo_sync0001_0004_final
```

This way it's easier for us to see which graphs belong to the same sync...

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
