### PR TITLE
[misc] Expose kernel statistics to python

### DIFF
--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -269,6 +269,11 @@ def dot_to_pdf(dot, filepath):
         fh.write(pdf_contents)
 
 
+def get_kernel_stats():
+    from taichi.core import ti_core
+    return ti_core.get_kernel_stats()
+
+
 __all__ = [
     'vec',
     'veci',
@@ -278,6 +283,7 @@ __all__ = [
     'dump_dot',
     'dot_to_pdf',
     'obsolete',
+    'get_kernel_stats',
     'get_traceback',
     'set_gdb_trigger',
     'print_profile_info',

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -3,18 +3,19 @@
     The use of this software is governed by the LICENSE file.
 *******************************************************************************/
 
+#include "taichi/backends/metal/api.h"
+#include "taichi/backends/opengl/opengl_api.h"
 #include "taichi/common/core.h"
 #include "taichi/common/task.h"
 #include "taichi/math/math.h"
 #include "taichi/python/exception.h"
-#include "taichi/python/print_buffer.h"
 #include "taichi/python/export.h"
+#include "taichi/python/print_buffer.h"
 #include "taichi/system/benchmark.h"
-#include "taichi/system/profiler.h"
-#include "taichi/system/memory_usage_monitor.h"
 #include "taichi/system/dynamic_loader.h"
-#include "taichi/backends/metal/api.h"
-#include "taichi/backends/opengl/opengl_api.h"
+#include "taichi/system/memory_usage_monitor.h"
+#include "taichi/system/profiler.h"
+#include "taichi/util/statistics.h"
 #if defined(TI_WITH_CUDA)
 #include "taichi/backends/cuda/cuda_driver.h"
 #endif
@@ -173,6 +174,13 @@ void export_misc(py::module &m) {
 #else
   m.def("with_cc", []() { return false; });
 #endif
+
+  py::class_<Statistics>(m, "Statistics")
+      .def(py::init<>())
+      .def("clear", &Statistics::clear)
+      .def("get_counters", &Statistics::get_counters);
+  m.def("get_kernel_stats", []() -> Statistics & { return stat; },
+        py::return_value_policy::reference);
 }
 
 TI_NAMESPACE_END

--- a/taichi/util/statistics.cpp
+++ b/taichi/util/statistics.cpp
@@ -5,19 +5,19 @@ TI_NAMESPACE_BEGIN
 Statistics stat;
 
 void Statistics::add(std::string key, Statistics::value_type value) {
-  counters[key] += value;
+  counters_[key] += value;
 }
 
 void Statistics::print(std::string *output) {
   std::vector<std::string> keys;
-  for (auto const &item : counters)
+  for (auto const &item : counters_)
     keys.push_back(item.first);
 
   std::sort(keys.begin(), keys.end());
 
   std::stringstream ss;
   for (auto const &k : keys)
-    ss << fmt::format("{:20}: {:.2f}\n", k, counters[k]);
+    ss << fmt::format("{:20}: {:.2f}\n", k, counters_[k]);
 
   if (output) {
     *output = ss.str();
@@ -27,7 +27,7 @@ void Statistics::print(std::string *output) {
 }
 
 void Statistics::clear() {
-  counters.clear();
+  counters_.clear();
 }
 
 TI_NAMESPACE_END

--- a/taichi/util/statistics.h
+++ b/taichi/util/statistics.h
@@ -5,12 +5,10 @@
 TI_NAMESPACE_BEGIN
 
 class Statistics {
-  using value_type = float64;
-
- private:
-  std::unordered_map<std::string, value_type> counters;
-
  public:
+  using value_type = float64;
+  using counters_map = std::unordered_map<std::string, value_type>;
+
   Statistics() = default;
 
   void add(std::string key, value_type value = value_type(1));
@@ -18,6 +16,13 @@ class Statistics {
   void print(std::string *output = nullptr);
 
   void clear();
+
+  inline const counters_map &get_counters() {
+    return counters_;
+  }
+
+ private:
+  counters_map counters_;
 };
 
 extern Statistics stat;


### PR DESCRIPTION
This allows us to ensure fusion does work and to detect possible regressions...

As a slightly off-the-topic change, i changed the tests to use `ti.pointer.dense.place()` as suggested in https://github.com/taichi-dev/taichi/pull/1888#discussion_r493668443. `dense(1)` is still pointless, but it eases the activated index computation.

Related issue = #N/A

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
