### PR TITLE
[async] Optimize StateFlowGraph::optimize_listgen

### DIFF
--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -144,6 +144,7 @@ def apply_preconditioner():
             smooth(l, 1)
             smooth(l, 0)
 
+
 init()
 
 sum[None] = 0.0
@@ -209,13 +210,14 @@ def iterate():
 
     # p = z + beta p
     update_p()
-    
+
+
 def loud_sync():
     t = time.time()
     ti.sync()
     print(f'{time.time() - t:.3f} s (compilation + execution)')
-    
-    
+
+
 ti.sync()
 for i in range(10):
     iterate()

--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -233,4 +233,4 @@ loud_sync()
 
 ti.kernel_profiler_print()
 ti.core.print_stat()
-# ti.print_profile_info()
+ti.print_profile_info()

--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -219,17 +219,10 @@ def loud_sync():
 
 
 ti.sync()
-for i in range(10):
-    iterate()
-loud_sync()
-
-for i in range(10):
-    iterate()
-loud_sync()
-
-for i in range(10):
-    iterate()
-loud_sync()
+for _ in range(3):
+    for i in range(10):
+        iterate()
+    loud_sync()
 
 ti.kernel_profiler_print()
 ti.core.print_stat()

--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -1,5 +1,6 @@
 import numpy as np
 import taichi as ti
+import time
 
 real = ti.f32
 ti.init(default_fp=real,
@@ -9,13 +10,12 @@ ti.init(default_fp=real,
         async_opt_dse=True,
         async_opt_activation_demotion=True,
         async_opt_fusion=True,
-        kernel_profiler=False
+        kernel_profiler=True
         #, async_opt_intermediate_file="mgpcg"
         )
 
 # grid parameters
 N = 128
-N_gui = 512  # gui resolution
 
 n_mg_levels = 5
 pre_and_post_smoothing = 2
@@ -35,7 +35,6 @@ Ap = ti.field(dtype=real)  # matrix-vector product
 alpha = ti.field(dtype=real)  # step size
 beta = ti.field(dtype=real)  # step size
 sum = ti.field(dtype=real)  # storage for reductions
-pixels = ti.field(dtype=real, shape=(N_gui, N_gui))  # image buffer
 rTr = ti.field(dtype=real, shape=())
 old_zTr = ti.field(dtype=real, shape=())
 new_zTr = ti.field(dtype=real, shape=())
@@ -145,18 +144,6 @@ def apply_preconditioner():
             smooth(l, 1)
             smooth(l, 0)
 
-
-@ti.kernel
-def paint():
-    kk = N_tot * 3 // 8
-    for i, j in pixels:
-        ii = int(i * N / N_gui) + N_ext
-        jj = int(j * N / N_gui) + N_ext
-        pixels[i, j] = x[ii, jj, kk] / N_tot
-
-
-gui = ti.GUI("mgpcg", res=(N_gui, N_gui))
-
 init()
 
 sum[None] = 0.0
@@ -193,8 +180,7 @@ def update_beta():
     old_zTr[None] = new_zTr[None]
 
 
-# CG
-for i in range(10):
+def iterate():
     # alpha = rTr / pTAp
     compute_Ap()
     reduce(p, Ap, pAp)
@@ -223,10 +209,26 @@ for i in range(10):
 
     # p = z + beta p
     update_p()
+    
+def loud_sync():
+    t = time.time()
+    ti.sync()
+    print(f'{time.time() - t:.3f} s (compilation + execution)')
+    
+    
+ti.sync()
+for i in range(10):
+    iterate()
+loud_sync()
 
-paint()
-gui.set_image(pixels)
-gui.show()
+for i in range(10):
+    iterate()
+loud_sync()
+
+for i in range(10):
+    iterate()
+loud_sync()
 
 ti.kernel_profiler_print()
 ti.core.print_stat()
+# ti.print_profile_info()

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -75,7 +75,7 @@ IRHandle IRBank::fuse(IRHandle handle_a, IRHandle handle_b, Kernel *kernel) {
     return result;
   }
 
-  TI_INFO("Begin uncached fusion");
+  TI_TRACE("Begin uncached fusion");
   // We are about to change both |task_a| and |task_b|. Clone them first.
   auto cloned_task_a = handle_a.clone();
   auto cloned_task_b = handle_b.clone();

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -382,6 +382,7 @@ void AsyncEngine::launch(Kernel *kernel, Context &context) {
 }
 
 TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
+  TI_AUTO_PROF
   // TODO: this function should ideally take only an IRNode
   static std::mutex mut;
 
@@ -485,6 +486,7 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
 }
 
 TaskFusionMeta get_task_fusion_meta(IRBank *bank, const TaskLaunchRecord &t) {
+  TI_AUTO_PROF
   // TODO: this function should ideally take only an IRNode
   auto &fusion_meta_bank = bank->fusion_meta_bank_;
   if (fusion_meta_bank.find(t.ir_handle) != fusion_meta_bank.end()) {
@@ -536,6 +538,7 @@ void AsyncEngine::enqueue(const TaskLaunchRecord &t) {
 }
 
 void AsyncEngine::synchronize() {
+  TI_AUTO_PROF
   bool modified = true;
   TI_TRACE("Synchronizing SFG of {} nodes", sfg->size());
   debug_sfg("initial");

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -7,6 +7,7 @@
 TLANG_NAMESPACE_BEGIN
 
 std::unique_ptr<IRNode> IRHandle::clone() const {
+  TI_AUTO_PROF
   // TODO: remove get_kernel() here
   return irpass::analysis::clone(const_cast<IRNode *>(ir_), ir_->get_kernel());
 }

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -103,30 +103,29 @@ class DefaultProfiler : public KernelProfilerBase {
 class KernelProfilerCUDA : public KernelProfilerBase {
  public:
 #if defined(TI_WITH_CUDA)
-  void *current_stop;
 
   std::map<std::string, std::vector<std::pair<void *, void *>>>
       outstanding_events;
 #endif
 
-  void start(const std::string &kernel_name) override {
+  TaskHandle start_with_handle(const std::string &kernel_name) override {
 #if defined(TI_WITH_CUDA)
     void *start, *stop;
     CUDADriver::get_instance().event_create(&start, CU_EVENT_DEFAULT);
     CUDADriver::get_instance().event_create(&stop, CU_EVENT_DEFAULT);
     CUDADriver::get_instance().event_record(start, 0);
     outstanding_events[kernel_name].push_back(std::make_pair(start, stop));
-    current_stop = stop;
+    return stop;
 #else
-    printf("CUDA Profiler not implemented;\n");
+    TI_NOT_IMPLEMENTED;
 #endif
   }
 
-  virtual void stop() override {
+  virtual void stop(TaskHandle handle) override {
 #if defined(TI_WITH_CUDA)
-    CUDADriver::get_instance().event_record(current_stop, 0);
+    CUDADriver::get_instance().event_record(handle, 0);
 #else
-    printf("CUDA Profiler not implemented;\n");
+    TI_NOT_IMPLEMENTED;
 #endif
   }
 

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -33,6 +33,9 @@ class KernelProfilerBase {
   double total_time;
 
  public:
+  // Needed for the CUDA backend since we need to know which task to "stop"
+  using TaskHandle = void *;
+
   void clear() {
     total_time = 0;
     records.clear();
@@ -42,12 +45,18 @@ class KernelProfilerBase {
 
   virtual std::string title() const = 0;
 
-  virtual void start(const std::string &kernel_name) = 0;
+  // TODO: remove start and always use start_with_handle
+  virtual void start(const std::string &kernel_name){TI_NOT_IMPLEMENTED};
+
+  virtual TaskHandle start_with_handle(const std::string &kernel_name){
+      TI_NOT_IMPLEMENTED};
 
   static void profiler_start(KernelProfilerBase *profiler,
                              const char *kernel_name);
 
-  virtual void stop() = 0;
+  virtual void stop(){TI_NOT_IMPLEMENTED};
+
+  virtual void stop(TaskHandle){TI_NOT_IMPLEMENTED};
 
   static void profiler_stop(KernelProfilerBase *profiler);
 

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -120,7 +120,8 @@ bool StateFlowGraph::optimize_listgen() {
     // Thanks to the dependency edges, the order of nodes in listgens is
     // UNIQUE. (Consider the list state of the SNode.)
 
-    // We can only replace a continuous subset of listgen entries
+    // We can only replace a continuous subset of listgen entries.
+    // So the nested loop below is actually O(n).
     for (int i = 0; i < listgens.size(); i++) {
       auto node_a = listgens[i];
 

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -193,8 +193,6 @@ bool StateFlowGraph::optimize_listgen() {
     }
   }
 
-  TI_ASSERT(nodes_to_delete.size() % 2 == 0);
-
   if (!nodes_to_delete.empty()) {
     modified = true;
     delete_nodes(nodes_to_delete);


### PR DESCRIPTION
Related issue = #742

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

`StateFlowGraph::optimize_listgen` now does more job each iteration. Previously it very conservatively `break`s after modifying a single SFG node. This change also seems to eliminate more `ClearListStmt` for some reason. After this change `optimize_listgen` is ~2x faster on mgpcg.

Offtopic change: the CUDA profiler now returns a handle when calling `start_with_handle()`. We need the handle (which is essentially a CUDA event pointer) to mark the end of a kernel launch.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
