### PR TITLE
[misc] Make check previous CI run only check for Build-and-Test jobs

### DIFF
--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -109,7 +109,8 @@ jobs:
   code_format:
     name: Code Format
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.requested_reviewers.*.login, 'taichi-gardener') }}
+    # Run this job unconditionally -- it is a required check for merging.
+    # if: ${{ !contains(github.event.pull_request.requested_reviewers.*.login, 'taichi-gardener') }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -76,24 +76,63 @@ def locate_workflow_run_id(sha):
     return ''
 
 
+CHECK_STILL_RUNNING = 1
+CHECK_FOUND_FAILED_JOB = 2
+CHECK_ALL_JOBS_SUCCEEDED = 3
+
+def check_all_jobs(jobs):
+    # Denotes if there is still any job that has not completed yet.
+    still_running = False
+    for j in jobs:
+        name = j['name']
+        if not name.startswith('Build and Test'):
+            continue
+
+        job_id = j['id']
+        # https://developer.github.com/v3/checks/runs/#create-a-check-run
+        status = j['status']
+        if status != 'completed':
+            logging.debug(
+                f'  job={job_id} name={name} still running, status={status}')
+            still_running = True
+            continue
+
+        concl = j['conclusion']
+        if concl != 'success':
+            # If we ever find a failed job, the entire check has failed.
+            logging.warning(
+                f'  job={job_id} name={name} failed, conclusion={concl}')
+            return CHECK_FOUND_FAILED_JOB
+
+    return CHECK_STILL_RUNNING if still_running else CHECK_ALL_JOBS_SUCCEEDED
+
+
 def get_status_of_run(run_id):
     """
     Waits for run identified by |run_id| to complete and returns its status.
+
+    Instead of waiting for the result of the entire workflow run, we only wait
+    on those "Build and Test" jobs. The reason is that when jobs like code
+    format failed, the entire workflow run will be marked as failed, yet
+    @taichi-gardener will automatically make another commit to format the code.
+    However, if this check relies on the previous workflow's result, it will be
+    marked as failed again... 
     """
-    url = make_api_url(f'actions/runs/{run_id}')
+    url = make_api_url(f'actions/runs/{run_id}/jobs')
     start = time.time()
     retries = 0
     MAX_TIMEOUT = 60 * 60  # 1 hour
     while True:
         f = send_request(url)
         j = json.loads(f.read())
-        # https://developer.github.com/v3/checks/runs/#create-a-check-run
-        if j['status'] == 'completed':
-            c = j['conclusion']
-            logging.debug(f'run={run_id} conclusion={c}')
-            return c == 'success'
+        check_result = check_all_jobs(j['jobs'])
+        if check_result != CHECK_STILL_RUNNING:
+            ok = check_result == CHECK_ALL_JOBS_SUCCEEDED
+            logging.info(f'Done checking the jobs in run={run_id}. ok={ok}')
+            return ok
 
         if time.time() - start > MAX_TIMEOUT:
+            logging.warning(f'Timed out waiting for run={run_id}')
             return False
         retries += 1
         logging.info(

--- a/misc/ci_check_previous_run.py
+++ b/misc/ci_check_previous_run.py
@@ -80,6 +80,7 @@ CHECK_STILL_RUNNING = 1
 CHECK_FOUND_FAILED_JOB = 2
 CHECK_ALL_JOBS_SUCCEEDED = 3
 
+
 def check_all_jobs(jobs):
     # Denotes if there is still any job that has not completed yet.
     still_running = False
@@ -116,7 +117,7 @@ def get_status_of_run(run_id):
     format failed, the entire workflow run will be marked as failed, yet
     @taichi-gardener will automatically make another commit to format the code.
     However, if this check relies on the previous workflow's result, it will be
-    marked as failed again... 
+    marked as failed again...
     """
     url = make_api_url(f'actions/runs/{run_id}/jobs')
     start = time.time()

--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -15,7 +15,7 @@ MetalDataType to_metal_type(DataType dt) {
     METAL_CASE(i16);
     METAL_CASE(i32);
     METAL_CASE(i64);
-    METAL_CASE(u8);
+    METAL_CASE(u8);   
     METAL_CASE(u16);
     METAL_CASE(u32);
     METAL_CASE(u64);

--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -12,7 +12,7 @@ MetalDataType to_metal_type(DataType dt) {
     METAL_CASE(f32);
     METAL_CASE(f64);
     METAL_CASE(i8);
-    METAL_CASE(i16);
+    METAL_CASE(i16);   
     METAL_CASE(i32);
     METAL_CASE(i64);
     METAL_CASE(u8);

--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -13,7 +13,7 @@ MetalDataType to_metal_type(DataType dt) {
     METAL_CASE(f64);
     METAL_CASE(i8);
     METAL_CASE(i16);
-    METAL_CASE(i32);
+    METAL_CASE(i32);   
     METAL_CASE(i64);
     METAL_CASE(u8);
     METAL_CASE(u16);

--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -12,7 +12,7 @@ MetalDataType to_metal_type(DataType dt) {
     METAL_CASE(f32);
     METAL_CASE(f64);
     METAL_CASE(i8);
-    METAL_CASE(i16);   
+    METAL_CASE(i16);
     METAL_CASE(i32);
     METAL_CASE(i64);
     METAL_CASE(u8);

--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -15,7 +15,7 @@ MetalDataType to_metal_type(DataType dt) {
     METAL_CASE(i16);
     METAL_CASE(i32);
     METAL_CASE(i64);
-    METAL_CASE(u8);   
+    METAL_CASE(u8);
     METAL_CASE(u16);
     METAL_CASE(u32);
     METAL_CASE(u64);

--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -13,7 +13,7 @@ MetalDataType to_metal_type(DataType dt) {
     METAL_CASE(f64);
     METAL_CASE(i8);
     METAL_CASE(i16);
-    METAL_CASE(i32);   
+    METAL_CASE(i32);
     METAL_CASE(i64);
     METAL_CASE(u8);
     METAL_CASE(u16);


### PR DESCRIPTION
When the previous CI run's code format check fails, two thing happens:

1. @taichi-gardener will do a `[skip ci] enforce code format` to automatically correct the things
2. The second commit would still fail because it runs "Check the previous CI workflow" job, which finds that the previous workflow... has failed --> this time it fails again :-/

"Persubmit Checks / Code Format (pull_request)" is triggered unconditionally now, because it is a required check. (Previously it is disabled for @taichi-gardener 's commits)

Related issue = #1809

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
