### PR TITLE
[doc] Use "atan2(y, x)" instead of "atan2(x, y)" (#1816)

### DIFF
--- a/docs/arithmetics.rst
+++ b/docs/arithmetics.rst
@@ -77,7 +77,7 @@ Trigonometric functions
 .. function:: ti.tan(x)
 .. function:: ti.asin(x)
 .. function:: ti.acos(x)
-.. function:: ti.atan2(x, y)
+.. function:: ti.atan2(y, x)
 .. function:: ti.tanh(x)
 
 Other arithmetic functions

--- a/docs/write_test.rst
+++ b/docs/write_test.rst
@@ -166,7 +166,7 @@ Use a comma-separated list for multiple input values:
 
     @pytest.mark.parametrize('x,y', [(1, 2), (1, 3), (2, 1)])
     @ti.test()
-    def test_atan2(x, y):
+    def test_atan2(y, x):
         r = ti.field(ti.f32, ())
         s = ti.field(ti.f32, ())
 
@@ -177,7 +177,7 @@ Use a comma-separated list for multiple input values:
         r[None] = x
         s[None] = y
         foo()
-        assert r[None] == math.atan2(x, y)
+        assert r[None] == math.atan2(y, x)
 
 Use two separate ``parametrize`` to test **all combinations** of input arguments:
 
@@ -191,7 +191,7 @@ Use two separate ``parametrize`` to test **all combinations** of input arguments
     @pytest.mark.parametrize('y', [1, 2])
     # same as:  .parametrize('x,y', [(1, 1), (1, 2), (2, 1), (2, 2)])
     @ti.test()
-    def test_atan2(x, y):
+    def test_atan2(y, x):
         r = ti.field(ti.f32, ())
         s = ti.field(ti.f32, ())
 
@@ -202,7 +202,7 @@ Use two separate ``parametrize`` to test **all combinations** of input arguments
         r[None] = x
         s[None] = y
         foo()
-        assert r[None] == math.atan2(x, y)
+        assert r[None] == math.atan2(y, x)
 
 Specifying ``ti.init`` configurations
 *************************************

--- a/docs/write_test.rst
+++ b/docs/write_test.rst
@@ -172,7 +172,7 @@ Use a comma-separated list for multiple input values:
 
         @ti.kernel
         def foo():
-            r[None] = ti.atan2(r[None])
+            r[None] = ti.atan2(r[None], s[None])
 
         r[None] = x
         s[None] = y
@@ -197,7 +197,7 @@ Use two separate ``parametrize`` to test **all combinations** of input arguments
 
         @ti.kernel
         def foo():
-            r[None] = ti.atan2(r[None])
+            r[None] = ti.atan2(r[None], s[None])
 
         r[None] = y
         s[None] = x

--- a/docs/write_test.rst
+++ b/docs/write_test.rst
@@ -164,7 +164,7 @@ Use a comma-separated list for multiple input values:
     import pytest
     import math
 
-    @pytest.mark.parametrize('x,y', [(1, 2), (1, 3), (2, 1)])
+    @pytest.mark.parametrize('y,x', [(1, 2), (1, 3), (2, 1)])
     @ti.test()
     def test_atan2(y, x):
         r = ti.field(ti.f32, ())
@@ -189,7 +189,7 @@ Use two separate ``parametrize`` to test **all combinations** of input arguments
 
     @pytest.mark.parametrize('x', [1, 2])
     @pytest.mark.parametrize('y', [1, 2])
-    # same as:  .parametrize('x,y', [(1, 1), (1, 2), (2, 1), (2, 2)])
+    # same as:  .parametrize('y,x', [(1, 1), (1, 2), (2, 1), (2, 2)])
     @ti.test()
     def test_atan2(y, x):
         r = ti.field(ti.f32, ())
@@ -199,8 +199,8 @@ Use two separate ``parametrize`` to test **all combinations** of input arguments
         def foo():
             r[None] = ti.atan2(r[None])
 
-        r[None] = x
-        s[None] = y
+        r[None] = y
+        s[None] = x
         foo()
         assert r[None] == math.atan2(y, x)
 


### PR DESCRIPTION
Related issue = #1816 
Modified  one "atan2(x, y)" in "docs/arithmetics.rst" and four "atan2(x, y)" in "docs/write_test.rst"
