### PR TITLE
[Doc] Improve description of the pos parameter in gui

### DIFF
--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -68,7 +68,7 @@ Paint simple geometric objects on a window. Taichi has internal support for line
 
 .. note::
 
-    The position parameter ``pos`` expects an input of a tuple of 2, whose values are the relative position of the object. 
+    The position parameter ``pos`` expects an input of a 2-element tuple, whose values are the relative position of the object. 
     ``(0.0, 0.0)`` stands for the lower left corner of the window, and ``(1.0, 1.0)`` stands for the upper right corner.
 
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -63,6 +63,14 @@ Create a window
 Paint on a window
 -----------------
 
+Paint simple geometric objects on a window. Taichi has internal support for lines, triangles, rectangles, circles and texts.
+
+
+.. note::
+
+    The position parameter ``pos`` expects an input of a tuple of 2, whose values are the relative position of the object. 
+    ``(0.0, 0.0)`` stands for the lower left corner of the window, and ``(1.0, 1.0)`` stands for the upper right corner.
+
 
 .. function:: gui.set_image(img)
 
@@ -202,7 +210,7 @@ Paint on a window
 
     :parameter gui: (GUI) the window object
     :parameter content: (str) the text to draw
-    :parameter pos: (tuple of 2, range [0,1] ) the relative position of the top-left point of the fonts / texts
+    :parameter pos: (tuple of 2) the position of the top-left point of the fonts / texts
     :parameter font_size: (optional, scalar) the size of font (in height)
     :parameter color: (optional, RGB hex) the foreground color of text
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -202,7 +202,7 @@ Paint on a window
 
     :parameter gui: (GUI) the window object
     :parameter content: (str) the text to draw
-    :parameter pos: (tuple of 2) the top-left point position of the fonts / texts
+    :parameter pos: (tuple of 2, range [0,1] ) the relative position of the top-left point of the fonts / texts
     :parameter font_size: (optional, scalar) the size of font (in height)
     :parameter color: (optional, RGB hex) the foreground color of text
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -210,7 +210,7 @@ Paint simple geometric objects on a window. Taichi has internal support for line
 
     :parameter gui: (GUI) the window object
     :parameter content: (str) the text to draw
-    :parameter pos: (tuple of 2) the position of the top-left point of the fonts / texts
+    :parameter pos: (tuple of 2) the top-left point position of the fonts / texts
     :parameter font_size: (optional, scalar) the size of font (in height)
     :parameter color: (optional, RGB hex) the foreground color of text
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -63,7 +63,7 @@ Create a window
 Paint on a window
 -----------------
 
-Paint simple geometric objects on a window. Taichi has internal support for lines, triangles, rectangles, circles and texts.
+Taichi's GUI supports painting simple geometric objects, such as lines, triangles, rectangles, circles, and text.
 
 
 .. note::


### PR DESCRIPTION
The current description of parameter pos in gui.text doesn't explicitly show it's intended value range. 
Same issue exists for other objects. I can make a through chk and update if you think the change is valuable.
Thank you!

Related issue = #

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
