### PR TITLE
[async] Support SFG-level DSE for scalar SNodes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,6 +62,7 @@ build_script:
   - '%PYTHON% -c "import taichi"'
   - "%PYTHON% examples/laplace.py"
   - "%PYTHON% bin/taichi diagnose"
+  - "%PYTHON% bin/taichi test test_sfg.py -v"
   - "%PYTHON% bin/taichi test -Cvr2 -t2"
   - "cd python && %PYTHON% build.py try_upload"
   - "cd %TAICHI_REPO_DIR% && bash <(curl -s https://codecov.io/bash)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,6 @@ build_script:
   - '%PYTHON% -c "import taichi"'
   - "%PYTHON% examples/laplace.py"
   - "%PYTHON% bin/taichi diagnose"
-  - "%PYTHON% bin/taichi test test_sfg.py -v"
   - "%PYTHON% bin/taichi test -Cvr2 -t2"
   - "cd python && %PYTHON% build.py try_upload"
   - "cd %TAICHI_REPO_DIR% && bash <(curl -s https://codecov.io/bash)"

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -640,7 +640,7 @@ void ControlFlowGraph::live_variable_analysis(
     }
     if (auto *gptr = stmt->cast<GlobalPtrStmt>();
         gptr && config_opt.has_value()) {
-      TI_ASSERT(gptr->snodes.size() == 1);  // Correct assumption?
+      TI_ASSERT(gptr->snodes.size() == 1);
       const bool res =
           (config_opt->eliminable_snodes.count(gptr->snodes[0]) == 0);
       return res;

--- a/taichi/ir/control_flow_graph.h
+++ b/taichi/ir/control_flow_graph.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <optional>
+#include <unordered_set>
+
 #include "taichi/ir/ir.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -70,6 +73,12 @@ class ControlFlowGraph {
   void erase(int node_id);
 
  public:
+  struct LiveVarAnalysisConfig {
+    // This is mostly useful for SFG task-level dead store elimination. SFG may
+    // detect certain cases where writes to one or more SNodes in a task are
+    // eliminable.
+    std::unordered_set<const SNode *> eliminable_snodes;
+  };
   std::vector<std::unique_ptr<CFGNode>> nodes;
   const int start_node = 0;
   int final_node{0};
@@ -85,7 +94,9 @@ class ControlFlowGraph {
 
   void print_graph_structure() const;
   void reaching_definition_analysis(bool after_lower_access);
-  void live_variable_analysis(bool after_lower_access);
+  void live_variable_analysis(
+      bool after_lower_access,
+      const std::optional<LiveVarAnalysisConfig> &config_opt);
 
   void simplify_graph();
 
@@ -96,7 +107,9 @@ class ControlFlowGraph {
   bool store_to_load_forwarding(bool after_lower_access);
 
   // Also performs identical load elimination.
-  bool dead_store_elimination(bool after_lower_access);
+  bool dead_store_elimination(
+      bool after_lower_access,
+      const std::optional<LiveVarAnalysisConfig> &lva_config_opt);
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -120,6 +120,10 @@ bool SNode::is_place() const {
   return type == SNodeType::place;
 }
 
+bool SNode::is_scalar() const {
+  return is_place() && (num_active_indices == 0);
+}
+
 bool SNode::has_grad() const {
   auto adjoint = expr.cast<GlobalVariableExpression>()->adjoint;
   return is_primal() && adjoint.expr != nullptr &&

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -217,6 +217,8 @@ class SNode {
 
   bool is_place() const;
 
+  bool is_scalar() const;
+
   const Expr &get_expr() const {
     return expr;
   }

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "taichi/ir/ir.h"
 #include <atomic>
-#include <unordered_set>
+#include <optional>
 #include <unordered_map>
+#include <unordered_set>
+
+#include "taichi/ir/control_flow_graph.h"
+#include "taichi/ir/ir.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -19,7 +22,11 @@ void re_id(IRNode *root);
 void flag_access(IRNode *root);
 bool die(IRNode *root);
 bool simplify(IRNode *root, Kernel *kernel = nullptr);
-bool cfg_optimization(IRNode *root, bool after_lower_access);
+bool cfg_optimization(
+    IRNode *root,
+    bool after_lower_access,
+    const std::optional<ControlFlowGraph::LiveVarAnalysisConfig>
+        &lva_config_opt = std::nullopt);
 bool alg_simp(IRNode *root);
 bool demote_operations(IRNode *root);
 bool binary_op_simplify(IRNode *root);

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -127,7 +127,10 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
     if (auto global_store = stmt->cast<GlobalStoreStmt>()) {
       if (auto ptr = global_store->ptr->cast<GlobalPtrStmt>()) {
         for (auto &snode : ptr->snodes.data) {
-          meta.input_states.emplace(snode, AsyncState::Type::value);
+          if (!snode->is_scalar()) {
+            // TODO: This is ad-hoc, use value killing analysis
+            meta.input_states.emplace(snode, AsyncState::Type::value);
+          }
           meta.output_states.emplace(snode, AsyncState::Type::value);
         }
       }

--- a/taichi/program/ir_bank.cpp
+++ b/taichi/program/ir_bank.cpp
@@ -199,18 +199,12 @@ IRHandle IRBank::optimize_dse(IRHandle handle,
 
   std::unique_ptr<IRNode> new_ir = handle.clone();
 
-  std::vector<std::string> snodes_str;
-  for (const auto *sn : snodes) {
-    snodes_str.push_back(sn->get_name());
-  }
   // TI_INFO("  before CFG");
   // irpass::print(new_ir.get());
-
   ControlFlowGraph::LiveVarAnalysisConfig lva_config;
   lva_config.eliminable_snodes = {snodes.begin(), snodes.end()};
   const bool modified = irpass::cfg_optimization(
       new_ir.get(), /*after_lower_access=*/false, lva_config);
-
   // TI_INFO("  after CFG, modified={}", modified);
   // irpass::print(new_ir.get());
 

--- a/taichi/program/ir_bank.cpp
+++ b/taichi/program/ir_bank.cpp
@@ -189,34 +189,41 @@ IRHandle IRBank::demote_activation(IRHandle handle) {
   return result;
 }
 
-IRHandle IRBank::optimize_dse(IRHandle handle,
-                              const std::set<const SNode *> &snodes) {
+std::pair<IRHandle, bool> IRBank::optimize_dse(
+    IRHandle handle,
+    const std::set<const SNode *> &snodes,
+    bool verbose) {
   const OptimizeDseKey key(handle, snodes);
-  auto &result = optimize_dse_bank_[key];
-  if (!result.empty()) {
-    return result;
+  auto &ret_handle = optimize_dse_bank_[key];
+  if (!ret_handle.empty()) {
+    // Already cached
+    return std::make_pair(ret_handle, true);
   }
 
   std::unique_ptr<IRNode> new_ir = handle.clone();
 
-  // TI_INFO("  before CFG");
-  // irpass::print(new_ir.get());
+  if (verbose) {
+    TI_INFO("  DSE: before CFG");
+    irpass::print(new_ir.get());
+  }
   ControlFlowGraph::LiveVarAnalysisConfig lva_config;
   lva_config.eliminable_snodes = {snodes.begin(), snodes.end()};
   const bool modified = irpass::cfg_optimization(
       new_ir.get(), /*after_lower_access=*/false, lva_config);
-  // TI_INFO("  after CFG, modified={}", modified);
-  // irpass::print(new_ir.get());
+  if (verbose) {
+    TI_INFO("  DSE: after CFG, modified={}", modified);
+    irpass::print(new_ir.get());
+  }
 
   if (!modified) {
     // Nothing demoted. Simply delete new_ir when this function returns.
-    result = handle;
-    return result;
+    ret_handle = handle;
+    return std::make_pair(ret_handle, false);
   }
 
-  result = IRHandle(new_ir.get(), get_hash(new_ir.get()));
-  insert(std::move(new_ir), result.hash());
-  return result;
+  ret_handle = IRHandle(new_ir.get(), get_hash(new_ir.get()));
+  insert(std::move(new_ir), ret_handle.hash());
+  return std::make_pair(ret_handle, false);
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/ir_bank.h
+++ b/taichi/program/ir_bank.h
@@ -1,3 +1,7 @@
+#include <set>
+#include <unordered_map>
+#include <vector>
+
 #include "taichi/program/async_utils.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -16,6 +20,8 @@ class IRBank {
 
   IRHandle demote_activation(IRHandle handle);
 
+  IRHandle optimize_dse(IRHandle handle, const std::set<const SNode *> &snodes);
+
   std::unordered_map<IRHandle, TaskMeta> meta_bank_;
   std::unordered_map<IRHandle, TaskFusionMeta> fusion_meta_bank_;
 
@@ -25,6 +31,38 @@ class IRBank {
   std::vector<std::unique_ptr<IRNode>> trash_bin;  // prevent IR from deleted
   std::unordered_map<std::pair<IRHandle, IRHandle>, IRHandle> fuse_bank_;
   std::unordered_map<IRHandle, IRHandle> demote_activation_bank_;
+
+  struct OptimizeDseKey {
+    IRHandle task_ir;
+    // Intentionally use (ordered) set so that hash is deterministic.
+    std::set<const SNode *> eliminable_snodes;
+
+    OptimizeDseKey(const IRHandle task_ir,
+                   const std::set<const SNode *> &snodes)
+        : task_ir(task_ir), eliminable_snodes(snodes) {
+    }
+
+    bool operator==(const OptimizeDseKey &other) const {
+      return (task_ir == other.task_ir) &&
+             (eliminable_snodes == other.eliminable_snodes);
+    }
+
+    bool operator!=(const OptimizeDseKey &other) const {
+      return !(*this == other);
+    }
+
+    struct Hash {
+      std::size_t operator()(const OptimizeDseKey &k) const {
+        std::size_t ret = k.task_ir.hash();
+        for (const auto *s : k.eliminable_snodes) {
+          ret = ret * 100000007UL + reinterpret_cast<uintptr_t>(s);
+        }
+        return ret;
+      }
+    };
+  };
+  std::unordered_map<OptimizeDseKey, IRHandle, OptimizeDseKey::Hash>
+      optimize_dse_bank_;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/program/ir_bank.h
+++ b/taichi/program/ir_bank.h
@@ -21,7 +21,7 @@ class IRBank {
   IRHandle demote_activation(IRHandle handle);
 
   // Try running DSE optimization on the IR identified by |handle|. |snodes|
-  // denotes the set of SNodes whose store are safe to eliminate.
+  // denotes the set of SNodes whose stores are safe to eliminate.
   //
   // Returns:
   // * IRHandle: the (possibly) DSE-optimized IRHandle

--- a/taichi/program/ir_bank.h
+++ b/taichi/program/ir_bank.h
@@ -20,7 +20,15 @@ class IRBank {
 
   IRHandle demote_activation(IRHandle handle);
 
-  IRHandle optimize_dse(IRHandle handle, const std::set<const SNode *> &snodes);
+  // Try running DSE optimization on the IR identified by |handle|. |snodes|
+  // denotes the set of SNodes whose store are safe to eliminate.
+  //
+  // Returns:
+  // * IRHandle: the (possibly) DSE-optimized IRHandle
+  // * bool: whether the result is already cached.
+  std::pair<IRHandle, bool> optimize_dse(IRHandle handle,
+                                         const std::set<const SNode *> &snodes,
+                                         bool verbose);
 
   std::unordered_map<IRHandle, TaskMeta> meta_bank_;
   std::unordered_map<IRHandle, TaskFusionMeta> fusion_meta_bank_;
@@ -32,6 +40,9 @@ class IRBank {
   std::unordered_map<std::pair<IRHandle, IRHandle>, IRHandle> fuse_bank_;
   std::unordered_map<IRHandle, IRHandle> demote_activation_bank_;
 
+  // For DSE optimization, the input key is (IRHandle, [SNode*]). This is
+  // because it is possible that the same IRHandle may have different sets of
+  // SNode stores that are eliminable.
   struct OptimizeDseKey {
     IRHandle task_ir;
     // Intentionally use (ordered) set so that hash is deterministic.

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -873,9 +873,11 @@ bool StateFlowGraph::optimize_dead_store() {
     auto &meta = *nodes_[i]->meta;
     auto ir = nodes_[i]->rec.ir_handle.ir()->cast<OffloadedStmt>();
     const auto mt = meta.type;
-    if (ir->body->statements.empty() &&
-        (mt == OffloadedStmt::serial || mt == OffloadedStmt::struct_for ||
-         mt == OffloadedStmt::range_for)) {
+    // Do NOT check ir->body->statements first! |ir->body| could be done when
+    // |mt| is not the desired type.
+    if ((mt == OffloadedStmt::serial || mt == OffloadedStmt::struct_for ||
+         mt == OffloadedStmt::range_for) &&
+        ir->body->statements.empty()) {
       to_delete.insert(i);
     }
   }

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -6,7 +6,11 @@
 TLANG_NAMESPACE_BEGIN
 
 namespace irpass {
-bool cfg_optimization(IRNode *root, bool after_lower_access) {
+bool cfg_optimization(
+    IRNode *root,
+    bool after_lower_access,
+    const std::optional<ControlFlowGraph::LiveVarAnalysisConfig>
+        &lva_config_opt) {
   TI_AUTO_PROF;
   auto cfg = analysis::build_cfg(root);
   bool result_modified = false;
@@ -15,7 +19,7 @@ bool cfg_optimization(IRNode *root, bool after_lower_access) {
     cfg->simplify_graph();
     if (cfg->store_to_load_forwarding(after_lower_access))
       modified = true;
-    if (cfg->dead_store_elimination(after_lower_access))
+    if (cfg->dead_store_elimination(after_lower_access, lva_config_opt))
       modified = true;
     if (modified)
       result_modified = true;

--- a/tests/python/test_sfg.py
+++ b/tests/python/test_sfg.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import numpy as np
 import pytest
 
 
@@ -58,3 +59,50 @@ def test_remove_clear_list_from_fused_serial():
         else:
             assert ys[i] == i + 2
             assert xs[i] == 0
+
+
+@ti.test(require=ti.extension.async_mode, async_mode=True)
+def test_sfg_dead_store_elimination():
+    ti.init(arch=ti.cpu,
+            async_mode=True,
+            async_opt_intermediate_file="simple_diff")
+    n = 32
+
+    x = ti.field(dtype=float, shape=n, needs_grad=True)
+    total_energy = ti.field(dtype=float, shape=(), needs_grad=True)
+    unused = ti.field(dtype=float, shape=())
+
+    @ti.kernel
+    def gather():
+        for i in x:
+            e = x[i]**2
+            total_energy[None] += e
+
+    @ti.kernel
+    def scatter():
+        for i in x:
+            unused[None] += x[i]
+
+    xnp = np.arange(n, dtype=np.float32)
+    x.from_numpy(xnp)
+    ti.sync()
+
+    stats = ti.get_kernel_stats()
+    stats.clear()
+
+    for _ in range(5):
+        with ti.Tape(total_energy):
+            # Do the forward computation of total energy and backward propagation for x.grad, which is later used in p2g
+            gather()
+            # It's OK not to use the computed total_energy at all, since we only need x.grad
+        scatter()
+
+    ti.sync()
+    counters = stats.get_counters()
+
+    # gather() should be DSE'ed
+    assert counters['sfg_dse_tasks'] > 0
+
+    x_grad = x.grad.to_numpy()
+    for i in range(n):
+        assert ti.approx(x_grad[i]) == 2.0 * i

--- a/tests/python/test_sfg.py
+++ b/tests/python/test_sfg.py
@@ -64,8 +64,7 @@ def test_remove_clear_list_from_fused_serial():
 @ti.test(require=ti.extension.async_mode, async_mode=True)
 def test_sfg_dead_store_elimination():
     ti.init(arch=ti.cpu,
-            async_mode=True,
-            async_opt_intermediate_file="simple_diff")
+            async_mode=True)
     n = 32
 
     x = ti.field(dtype=float, shape=n, needs_grad=True)

--- a/tests/python/test_sfg.py
+++ b/tests/python/test_sfg.py
@@ -92,9 +92,7 @@ def test_sfg_dead_store_elimination():
 
     for _ in range(5):
         with ti.Tape(total_energy):
-            # Do the forward computation of total energy and backward propagation for x.grad, which is later used in p2g
             gather()
-            # It's OK not to use the computed total_energy at all, since we only need x.grad
         scatter()
 
     ti.sync()

--- a/tests/python/test_sfg.py
+++ b/tests/python/test_sfg.py
@@ -63,8 +63,7 @@ def test_remove_clear_list_from_fused_serial():
 
 @ti.test(require=ti.extension.async_mode, async_mode=True)
 def test_sfg_dead_store_elimination():
-    ti.init(arch=ti.cpu,
-            async_mode=True)
+    ti.init(arch=ti.cpu, async_mode=True)
     n = 32
 
     x = ti.field(dtype=float, shape=n, needs_grad=True)


### PR DESCRIPTION
Sorry for this large change. It shouldn't be as complicated as the size implies.. The approach is basically to find out those **scalar** SNodes whose values are not read by the successor tasks. We then pass in these SNodes to the CFG pass, and instruct the live variable analysis **not to** add them into the final node's `live_gen`.

There are a few special handlings for scalar SNodes here:

1. Upon seeing a `GlobalStoreStmt` when constructing the task meta, we add the SNode to the input (reader) states, iff. it is *not* a scalar. https://github.com/taichi-dev/taichi/blob/3aeff7c01f1dff6def9602b7f4a0005fc54b4c22/taichi/program/async_utils.cpp#L127-L130
1. In `SFG::optimize_dead_store()`, if the state forms a flow edge, we also check if it's a scalar and if the successor task actually reads it. https://github.com/taichi-dev/taichi/blob/3aeff7c01f1dff6def9602b7f4a0005fc54b4c22/taichi/program/state_flow_graph.cpp#L800-L801
1. atomic demotion for global values are only enabled for `serial` tasks. I also made them handle scalars as well. https://github.com/taichi-dev/taichi/blob/3aeff7c01f1dff6def9602b7f4a0005fc54b4c22/taichi/ir/control_flow_graph.cpp#L403

Finally, the optimization result is cached, much like what @xumingkuan  has done in #1889.

Related issue = #742

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
