### PR TITLE
[Lang] Add @ti.materialize_callback for functions to be called right after root materialization

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -182,6 +182,7 @@ class PyTaichi:
         self.materialized = False
         self.prog = None
         self.layout_functions = []
+        self.materialize_callbacks = []
         self.compiled_functions = {}
         self.compiled_grad_functions = {}
         self.scope_stack = []
@@ -240,6 +241,9 @@ class PyTaichi:
                 f'{bar}Please consider specifying a shape for them. E.g.,' +
                 '\n\n  x = ti.field(float, shape=(2, 3))')
 
+        for func in self.materialize_callbacks:
+            func()
+
     def clear(self):
         if self.prog:
             self.prog.finalize()
@@ -260,6 +264,10 @@ pytaichi = PyTaichi()
 
 def get_runtime():
     return pytaichi
+
+
+def materialize_callback(foo):
+    get_runtime().materialize_callbacks.append(foo)
 
 
 @taichi_scope


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi_three

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
This would allow extension libraries initialize a field on declaration. For example, I have a `Camera` class, I want to initialize the transform matrix with identity matrix by default.