### PR TITLE
[async] Partial SFG node GC (keep latest state writers/readers)

### DIFF
--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -240,7 +240,7 @@ void AsyncEngine::synchronize() {
     sfg->verify();
   }
   debug_sfg("final");
-  auto tasks = sfg->extract();
+  auto tasks = sfg->extract_to_execute();
   TI_TRACE("Ended up with {} nodes", tasks.size());
   for (auto &task : tasks) {
     queue.enqueue(task);

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -938,7 +938,7 @@ bool StateFlowGraph::optimize_dead_store() {
         // only focus on "value" states.
         continue;
       }
-      if (latest_state_owner_[s] == task.get()) {
+      if (latest_state_owner_[s] == task) {
         // Cannot eliminate the latest write, because it may form a state-flow
         // with the later kernel launches.
         //

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -123,6 +123,7 @@ void StateFlowGraph::mark_pending_tasks_as_executed() {
 }
 
 void StateFlowGraph::insert_task(const TaskLaunchRecord &rec) {
+  TI_AUTO_PROF;
   auto node = std::make_unique<Node>();
   node->rec = rec;
   node->meta = get_task_meta(ir_bank_, rec);

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -890,6 +890,7 @@ void StateFlowGraph::delete_nodes(
   std::unordered_set<Node *> nodes_to_delete;
 
   for (auto &i : indices_to_delete) {
+    TI_ASSERT(nodes_[i]->pending());
     nodes_[i]->disconnect_all();
     nodes_to_delete.insert(nodes_[i].get());
   }
@@ -1016,9 +1017,9 @@ bool StateFlowGraph::optimize_dead_store() {
 
   if (!to_delete.empty()) {
     modified = true;
+    delete_nodes(to_delete);
+    rebuild_graph(/*sort=*/false);
   }
-
-  delete_nodes(to_delete);
 
   return modified;
 }

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -1005,16 +1005,16 @@ bool StateFlowGraph::optimize_dead_store() {
 
   std::unordered_set<int> to_delete;
   // erase empty blocks
-  for (int i = first_pending_task_index_; i < (int)nodes_.size(); i++) {
-    auto &meta = *nodes_[i]->meta;
-    auto ir = nodes_[i]->rec.ir_handle.ir()->cast<OffloadedStmt>();
+  for (int i = 0; i < (int)nodes.size(); i++) {
+    auto &meta = *nodes[i]->meta;
+    auto ir = nodes[i]->rec.ir_handle.ir()->cast<OffloadedStmt>();
     const auto mt = meta.type;
     // Do NOT check ir->body->statements first! |ir->body| could be done when
     // |mt| is not the desired type.
     if ((mt == OffloadedStmt::serial || mt == OffloadedStmt::struct_for ||
          mt == OffloadedStmt::range_for) &&
         ir->body->statements.empty()) {
-      to_delete.insert(i);
+      to_delete.insert(i + first_pending_task_index_);
     }
   }
 

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -357,7 +357,7 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
   auto fused = std::vector<bool>(n);
 
   auto do_fuse = [&](int a, int b) {
-    TI_AUTO_PROF;
+    TI_PROFILER("do_fuse");
     TI_ASSERT(0 <= a && a < b && b < n);
     auto *node_a = nodes[a];
     auto *node_b = nodes[b];
@@ -394,6 +394,7 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
   };
 
   auto edge_fusible = [&](int a, int b) {
+    TI_PROFILER("edge_fusible");
     // Check if a and b are fusible if there is an edge (a, b).
     if (fused[a] || fused[b] || !fusion_meta[a].fusible ||
         fusion_meta[a] != fusion_meta[b]) {

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -539,8 +539,21 @@ bool StateFlowGraph::fuse() {
           num_optimized_tasks, num_optimized_tasks + 2 * kMaxFusionDistance);
       if (num_deleted_tasks)
         modified = true;
-      num_optimized_tasks += std::min(
-          kMaxFusionDistance, 2 * kMaxFusionDistance - num_deleted_tasks);
+      num_optimized_tasks += 2 * kMaxFusionDistance - num_deleted_tasks;
+    }
+  }
+  num_optimized_tasks = kMaxFusionDistance;
+  while (num_optimized_tasks < num_pending_tasks()) {
+    if (num_optimized_tasks + 2 * kMaxFusionDistance >= num_pending_tasks()) {
+      if (fuse_range(num_optimized_tasks, num_pending_tasks()))
+        modified = true;
+      break;
+    } else {
+      int num_deleted_tasks = fuse_range(
+          num_optimized_tasks, num_optimized_tasks + 2 * kMaxFusionDistance);
+      if (num_deleted_tasks)
+        modified = true;
+      num_optimized_tasks += 2 * kMaxFusionDistance - num_deleted_tasks;
     }
   }
 

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -319,10 +319,10 @@ int StateFlowGraph::fuse_range(int begin, int end) {
     return false;
   }
 
-  auto nodes = get_pending_tasks(begin, end);
-
   std::vector<Bitset> has_path, has_path_reverse;
   std::tie(has_path, has_path_reverse) = compute_transitive_closure(begin, end);
+
+  auto nodes = get_pending_tasks(begin, end);
 
   // Classify tasks by TaskFusionMeta.
   std::vector<TaskFusionMeta> fusion_meta(n);
@@ -354,6 +354,7 @@ int StateFlowGraph::fuse_range(int begin, int end) {
 
   auto do_fuse = [&](int a, int b) {
     TI_AUTO_PROF;
+    TI_ASSERT(0 <= a && a < b && b < n);
     auto *node_a = nodes[a];
     auto *node_b = nodes[b];
     TI_TRACE("Fuse: nodes[{}]({}) <- nodes[{}]({})", a, node_a->string(), b,
@@ -482,8 +483,8 @@ int StateFlowGraph::fuse_range(int begin, int end) {
       bool i_updated = false;
       for (auto &edges : nodes[i]->output_edges) {
         for (auto &edge : edges.second) {
-          const int j = edge->node_id;
-          if (edge_fusible(i, j)) {
+          const int j = edge->pending_node_id;
+          if (j != -1 && edge_fusible(i, j)) {
             do_fuse(i, j);
             // Iterators of nodes[i]->output_edges may be invalidated
             i_updated = true;

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -161,7 +161,6 @@ bool StateFlowGraph::optimize_listgen() {
   std::vector<std::pair<int, int>> common_pairs;
 
   topo_sort_nodes();
-  reid_nodes();
 
   std::unordered_map<SNode *, std::vector<Node *>> listgen_nodes;
 
@@ -828,6 +827,7 @@ void StateFlowGraph::topo_sort_nodes() {
 
   TI_ASSERT(previous_size == nodes_.size());
   reid_nodes();
+  reid_pending_nodes();
 }
 
 void StateFlowGraph::reid_nodes() {
@@ -840,9 +840,6 @@ void StateFlowGraph::reid_nodes() {
 
 void StateFlowGraph::reid_pending_nodes() {
   TI_AUTO_PROF
-  for (int i = 0; i < first_pending_task_index_; i++) {
-    nodes_[i]->pending_node_id = -1;
-  }
   for (int i = first_pending_task_index_; i < nodes_.size(); i++) {
     nodes_[i]->pending_node_id = i - first_pending_task_index_;
   }

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -539,7 +539,8 @@ bool StateFlowGraph::fuse() {
           num_optimized_tasks, num_optimized_tasks + 2 * kMaxFusionDistance);
       if (num_deleted_tasks)
         modified = true;
-      num_optimized_tasks += std::min(kMaxFusionDistance, 2 * kMaxFusionDistance - num_deleted_tasks);
+      num_optimized_tasks += std::min(
+          kMaxFusionDistance, 2 * kMaxFusionDistance - num_deleted_tasks);
     }
   }
 

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -155,6 +155,7 @@ void StateFlowGraph::insert_task(const TaskLaunchRecord &rec) {
 }
 
 void StateFlowGraph::insert_state_flow(Node *from, Node *to, AsyncState state) {
+  TI_AUTO_PROF;
   TI_ASSERT(from != nullptr);
   TI_ASSERT(to != nullptr);
   from->output_edges[state].insert(to);

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -273,6 +273,11 @@ StateFlowGraph::compute_transitive_closure() {
   return std::make_pair(std::move(has_path), std::move(has_path_reverse));
 }
 
+bool StateFlowGraph::fuse_range(int begin, int end) {
+  // TODO: implement
+  return false;
+}
+
 bool StateFlowGraph::fuse() {
   TI_AUTO_PROF;
   using bit::Bitset;

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -520,9 +520,10 @@ bool StateFlowGraph::fuse() {
   // times with (end - begin) <= 2 * kMaxFusionDistance.
   std::unordered_set<int> indices_to_delete;
   const int n = num_pending_tasks();
-  if (n <= kMaxFusionDistance * 2) {
+  if (true) {
     indices_to_delete = fuse_range(0, n);
   } else {
+    // TODO: fuse by range
     for (int i = 0; i < n; i += kMaxFusionDistance * 2) {
       auto indices = fuse_range(i, std::min(n, i + kMaxFusionDistance * 2));
       indices_to_delete.insert(indices.begin(), indices.end());
@@ -539,7 +540,7 @@ bool StateFlowGraph::fuse() {
   // TODO: Do we need a trash bin here?
   if (modified) {
     // Rebuild the graph in topological order.
-    // The original order may not be a topological order.
+    // The original order may not be a correct topological order.
     delete_nodes(indices_to_delete);
     rebuild_graph(/*sort=*/true);
   }

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -85,7 +85,11 @@ class StateFlowGraph {
 
   StateFlowGraph(IRBank *ir_bank);
 
+  std::vector<Node *> get_pending_tasks();
+
   void clear();
+
+  void mark_pending_tasks_as_executed();
 
   void print();
 
@@ -127,8 +131,11 @@ class StateFlowGraph {
 
   void verify();
 
+  // Extract all pending tasks and insert them in topological/original order.
+  void rebuild_graph(bool sort);
+
   // Extract all tasks to execute.
-  std::vector<TaskLaunchRecord> extract(bool sort = true);
+  std::vector<TaskLaunchRecord> extract_to_execute();
 
   std::size_t size() {
     return nodes_.size();
@@ -137,6 +144,7 @@ class StateFlowGraph {
  private:
   std::vector<std::unique_ptr<Node>> nodes_;
   Node *initial_node_;  // The initial node holds all the initial states.
+  int first_pending_task_index_;
   TaskMeta initial_meta_;
   StateToNodeMapping latest_state_owner_;
   std::unordered_map<AsyncState, std::unordered_set<Node *>>

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -96,9 +96,8 @@ class StateFlowGraph {
 
   std::vector<Node *> get_pending_tasks() const;
 
-  // Returns get_pending_tasks()[begin, end) and set their pending_node_id
-  // to [0, end - begin).
-  std::vector<Node *> get_pending_tasks(int begin, int end);
+  // Returns get_pending_tasks()[begin, end).
+  std::vector<Node *> get_pending_tasks(int begin, int end) const;
 
   std::vector<std::unique_ptr<Node>> extract_pending_tasks();
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -37,6 +37,10 @@ class StateFlowGraph {
     // keep it up-to-date.
     int node_id{0};
 
+    // Returns the position in get_pending_tasks() or extract_pending_tasks().
+    // Invoke StateFlowGraph::reid_pending_nodes() to keep it up-to-date.
+    int pending_node_id{0};
+
     // Profiling showed horrible performance using std::unordered_multimap (at
     // least on Mac with clang-1103.0.32.62)...
     std::unordered_map<AsyncState, std::unordered_set<Node *>> output_edges,
@@ -132,6 +136,8 @@ class StateFlowGraph {
   void delete_nodes(const std::unordered_set<int> &indices_to_delete);
 
   void reid_nodes();
+
+  void reid_pending_nodes();
 
   void replace_reference(Node *node_a,
                          Node *node_b,

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -128,8 +128,8 @@ class StateFlowGraph {
   compute_transitive_closure(int begin, int end);
 
   // Fuse tasks in get_pending_tasks()[begin, end),
-  // return the number of deleted tasks.
-  int fuse_range(int begin, int end);
+  // return the indices to delete.
+  std::unordered_set<int> fuse_range(int begin, int end);
 
   bool fuse();
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -111,6 +111,9 @@ class StateFlowGraph {
   std::pair<std::vector<bit::Bitset>, std::vector<bit::Bitset>>
   compute_transitive_closure();
 
+  // Fuse tasks in get_pending_tasks()[begin, end).
+  bool fuse_range(int begin, int end);
+
   bool fuse();
 
   bool optimize_listgen();
@@ -137,8 +140,12 @@ class StateFlowGraph {
   // Extract all tasks to execute.
   std::vector<TaskLaunchRecord> extract_to_execute();
 
-  std::size_t size() {
+  std::size_t size() const {
     return nodes_.size();
+  }
+
+  int num_pending_tasks() const {
+    return nodes_.size() - first_pending_task_index_;
   }
 
  private:

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -42,6 +42,10 @@ class StateFlowGraph {
     std::unordered_map<AsyncState, std::unordered_set<Node *>> output_edges,
         input_edges;
 
+    bool pending() const {
+      return !is_initial_node && !executed;
+    }
+
     std::string string() const;
 
     // Note: there are two types of edges A->B:
@@ -86,7 +90,9 @@ class StateFlowGraph {
 
   StateFlowGraph(IRBank *ir_bank);
 
-  std::vector<Node *> get_pending_tasks();
+  std::vector<Node *> get_pending_tasks() const;
+
+  std::vector<std::unique_ptr<Node>> extract_pending_tasks();
 
   void clear();
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -31,6 +31,7 @@ class StateFlowGraph {
     TaskMeta *meta{nullptr};
     // Incremental ID to identify the i-th launch of the task.
     bool is_initial_node{false};
+    bool executed{false};
 
     // Returns the position in nodes_. Invoke StateFlowGraph::reid_nodes() to
     // keep it up-to-date.

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -96,6 +96,10 @@ class StateFlowGraph {
 
   std::vector<Node *> get_pending_tasks() const;
 
+  // Returns get_pending_tasks()[begin, end) and set their pending_node_id
+  // to [0, end - begin).
+  std::vector<Node *> get_pending_tasks(int begin, int end);
+
   std::vector<std::unique_ptr<Node>> extract_pending_tasks();
 
   void clear();
@@ -123,8 +127,9 @@ class StateFlowGraph {
   std::pair<std::vector<bit::Bitset>, std::vector<bit::Bitset>>
   compute_transitive_closure(int begin, int end);
 
-  // Fuse tasks in get_pending_tasks()[begin, end).
-  bool fuse_range(int begin, int end);
+  // Fuse tasks in get_pending_tasks()[begin, end),
+  // return the number of deleted tasks.
+  int fuse_range(int begin, int end);
 
   bool fuse();
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -119,8 +119,9 @@ class StateFlowGraph {
 
   void insert_state_flow(Node *from, Node *to, AsyncState state);
 
+  // Compute transitive closure for tasks in get_pending_tasks()[begin, end).
   std::pair<std::vector<bit::Bitset>, std::vector<bit::Bitset>>
-  compute_transitive_closure();
+  compute_transitive_closure(int begin, int end);
 
   // Fuse tasks in get_pending_tasks()[begin, end).
   bool fuse_range(int begin, int end);

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -31,14 +31,13 @@ class StateFlowGraph {
     TaskMeta *meta{nullptr};
     // Incremental ID to identify the i-th launch of the task.
     bool is_initial_node{false};
-    bool executed{false};
 
     // Returns the position in nodes_. Invoke StateFlowGraph::reid_nodes() to
     // keep it up-to-date.
     int node_id{0};
 
     // Returns the position in get_pending_tasks() or extract_pending_tasks().
-    // Invoke StateFlowGraph::reid_pending_nodes() to keep it up-to-date.
+    // For executed tasks (including the initial node), pending_node_id is -1.
     int pending_node_id{0};
 
     // Profiling showed horrible performance using std::unordered_multimap (at
@@ -47,7 +46,15 @@ class StateFlowGraph {
         input_edges;
 
     bool pending() const {
-      return !is_initial_node && !executed;
+      return pending_node_id >= 0;
+    }
+
+    bool executed() const {
+      return pending_node_id == -1;
+    }
+
+    void mark_executed() {
+      pending_node_id = -1;
     }
 
     std::string string() const;
@@ -150,7 +157,7 @@ class StateFlowGraph {
 
   void topo_sort_nodes();
 
-  void verify();
+  void verify() const;
 
   // Extract all pending tasks and insert them in topological/original order.
   void rebuild_graph(bool sort);


### PR DESCRIPTION
Related issue = #742 

This PR keeps the latest state writers/readers in the SFG when all nodes are extracted to execute.

Most functions of the SFG need to be modified. This PR modifies
- [x] fuse()
- [x] optimize_dead_store()
- [x] optimize_listgen()
- [x] topo_sort_nodes()
- [x] verify()

This PR doesn't modify
- print()
- dump_dot()

These functions don't need to be modified:
- demote_activation()

----
This PR also tried to modify `fuse()` so that only tasks that are "near" in the topological order (i.e., position in `nodes_` differ by `< 512`) are fused. This improves the complexity of a single invocation of `fuse()` from O(nm/64) to O(min(n, 512*4)*m/64 + nm/512)...

Benchmark: async_mgpcg.py, time of `fuse()` on kun: 0.746s (0.355s unaccounted) -> 1.334s (0.800s rebuild graph, 0.559s insert task)
(2.760s at commit c691248, 1.387s at commit da2a0f2 (0.920s rebuild graph), 1.243s at commit bc6f17f (0.704s rebuild graph))

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
