### PR TITLE
[async] [metal] Support async mode on Metal

### DIFF
--- a/taichi/backends/metal/codegen_metal.h
+++ b/taichi/backends/metal/codegen_metal.h
@@ -16,30 +16,14 @@
 TLANG_NAMESPACE_BEGIN
 namespace metal {
 
-class CodeGen {
- public:
-  struct Config {
-    bool allow_simdgroup = true;
-  };
-
-  CodeGen(Kernel *kernel,
-          KernelManager *kernel_mgr,
-          const CompiledStructs *compiled_structs,
-          const Config &config);
-
-  FunctionType compile();
-
- private:
-  void lower();
-  FunctionType gen(const SNode &root_snode, KernelManager *runtime);
-
-  Kernel *const kernel_;
-  KernelManager *const kernel_mgr_;
-  const CompiledStructs *const compiled_structs_;
-  const int id_;
-  const std::string taichi_kernel_name_;
-  const Config config_;
-};
+// If |offloaded| is nullptr, this compiles the AST in |kernel|. Otherwise it
+// compiles just |offloaded|. These ASTs must have already been lowered at the
+// CHI level.
+FunctionType compile_to_metal_executable(
+    Kernel *kernel,
+    KernelManager *kernel_mgr,
+    const CompiledStructs *compiled_structs,
+    OffloadedStmt *offloaded = nullptr);
 
 }  // namespace metal
 

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -128,7 +128,7 @@ void ExecutionQueue::enqueue(const TaskLaunchRecord &ker) {
     auto cloned_stmt = ker.ir_handle.clone();
     stmt = cloned_stmt->as<OffloadedStmt>();
 
-    compilation_workers.enqueue([async_func, stmt, kernel]() {
+    compilation_workers.enqueue([async_func, stmt, kernel, this]() {
       {
         // Final lowering
         using namespace irpass;
@@ -143,8 +143,7 @@ void ExecutionQueue::enqueue(const TaskLaunchRecord &ker) {
             is_extension_supported(config.arch, Extension::bls) &&
                 config.make_block_local);
       }
-      auto codegen = KernelCodeGen::create(kernel->arch, kernel, stmt);
-      auto func = codegen->codegen();
+      auto func = this->compile_to_backend_(*kernel, stmt);
       async_func->set(func);
     });
     ir_bank_->insert_to_trash_bin(std::move(cloned_stmt));
@@ -161,14 +160,18 @@ void ExecutionQueue::synchronize() {
   launch_worker.flush();
 }
 
-ExecutionQueue::ExecutionQueue(IRBank *ir_bank)
+ExecutionQueue::ExecutionQueue(
+    IRBank *ir_bank,
+    const BackendExecCompilationFunc &compile_to_backend)
     : compilation_workers(4),  // TODO: remove 4
       launch_worker(1),
-      ir_bank_(ir_bank) {
+      ir_bank_(ir_bank),
+      compile_to_backend_(compile_to_backend) {
 }
 
-AsyncEngine::AsyncEngine(Program *program)
-    : queue(&ir_bank_),
+AsyncEngine::AsyncEngine(Program *program,
+                         const BackendExecCompilationFunc &compile_to_backend)
+    : queue(&ir_bank_, compile_to_backend),
       program(program),
       sfg(std::make_unique<StateFlowGraph>(&ir_bank_)) {
 }

--- a/taichi/program/extension.cpp
+++ b/taichi/program/extension.cpp
@@ -17,7 +17,7 @@ bool is_extension_supported(Arch arch, Extension ext) {
       {Arch::cuda,
        {Extension::sparse, Extension::async_mode, Extension::data64,
         Extension::adstack, Extension::bls, Extension::assertion}},
-      {Arch::metal, {Extension::adstack}},
+      {Arch::metal, {Extension::adstack, Extension::async_mode}},
       {Arch::opengl, {Extension::extfunc}},
       {Arch::cc, {Extension::data64, Extension::extfunc, Extension::adstack}},
   };

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -69,9 +69,8 @@ void Kernel::compile() {
 void Kernel::lower(bool to_executable) {  // TODO: is a "Lowerer" class
                                           // necessary for each backend?
   TI_ASSERT(!lowered);
-  if (arch_is_cpu(arch) || arch == Arch::cuda) {
+  if (arch_is_cpu(arch) || arch == Arch::cuda || arch == Arch::metal) {
     CurrentKernelGuard _(program, this);
-    auto codegen = KernelCodeGen::create(arch, this);
     auto config = program.config;
     bool verbose = config.print_ir;
     if ((is_accessor && !config.print_accessor_ir) ||
@@ -81,9 +80,9 @@ void Kernel::lower(bool to_executable) {  // TODO: is a "Lowerer" class
     if (to_executable) {
       irpass::compile_to_executable(
           ir.get(), config, /*vectorize*/ arch_is_cpu(arch), grad,
-          /*ad_use_stack*/ true, verbose, /*lower_global_access*/ to_executable,
-          /*make_thread_local*/ config.make_thread_local,
-          /*make_block_local*/
+          /*ad_use_stack=*/true, verbose, /*lower_global_access=*/to_executable,
+          /*make_thread_local=*/config.make_thread_local,
+          /*make_block_local=*/
           is_extension_supported(config.arch, Extension::bls) &&
               config.make_block_local);
     } else {

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -11,7 +11,6 @@
 #include "taichi/backends/cuda/cuda_context.h"
 #endif
 #include "taichi/backends/metal/codegen_metal.h"
-#include "taichi/backends/metal/env_config.h"
 #include "taichi/backends/opengl/codegen_opengl.h"
 #include "taichi/backends/cpu/codegen_cpu.h"
 #include "taichi/struct/struct.h"
@@ -146,8 +145,11 @@ Program::Program(Arch desired_arch) {
 
   if (config.async_mode) {
     TI_WARN("Running in async mode. This is experimental.");
-    TI_ASSERT(arch_is_cpu(config.arch) || config.arch == Arch::cuda);
-    async_engine = std::make_unique<AsyncEngine>(this);
+    TI_ASSERT(is_extension_supported(config.arch, Extension::async_mode));
+    async_engine = std::make_unique<AsyncEngine>(
+        this, [this](Kernel &kernel, OffloadedStmt *offloaded) {
+          return this->compile_to_backend_executable(kernel, offloaded);
+        });
   }
 
   // TODO: allow users to run in debug mode without out-of-bound checks
@@ -196,17 +198,10 @@ FunctionType Program::compile(Kernel &kernel) {
   auto start_t = Time::get_time();
   TI_AUTO_PROF;
   FunctionType ret = nullptr;
-  if (arch_is_cpu(kernel.arch) || kernel.arch == Arch::cuda) {
+  if (arch_is_cpu(kernel.arch) || kernel.arch == Arch::cuda ||
+      kernel.arch == Arch::metal) {
     kernel.lower();
-    auto codegen = KernelCodeGen::create(kernel.arch, &kernel);
-    ret = codegen->compile();
-  } else if (kernel.arch == Arch::metal) {
-    metal::CodeGen::Config cgen_config;
-    cgen_config.allow_simdgroup =
-        metal::EnvConfig::instance().is_simdgroup_enabled();
-    metal::CodeGen codegen(&kernel, metal_kernel_mgr_.get(),
-                           &metal_compiled_structs_.value(), cgen_config);
-    ret = codegen.compile();
+    ret = compile_to_backend_executable(kernel, /*offloaded=*/nullptr);
   } else if (kernel.arch == Arch::opengl) {
     opengl::OpenglCodeGen codegen(kernel.name, &opengl_struct_compiled_.value(),
                                   opengl_kernel_launcher_.get());
@@ -221,6 +216,20 @@ FunctionType Program::compile(Kernel &kernel) {
   TI_ASSERT(ret);
   total_compilation_time += Time::get_time() - start_t;
   return ret;
+}
+
+FunctionType Program::compile_to_backend_executable(Kernel &kernel,
+                                                    OffloadedStmt *offloaded) {
+  if (arch_is_cpu(kernel.arch) || kernel.arch == Arch::cuda) {
+    auto codegen = KernelCodeGen::create(kernel.arch, &kernel, offloaded);
+    return codegen->compile();
+  } else if (kernel.arch == Arch::metal) {
+    return metal::compile_to_metal_executable(&kernel, metal_kernel_mgr_.get(),
+                                              &metal_compiled_structs_.value(),
+                                              offloaded);
+  }
+  TI_NOT_IMPLEMENTED;
+  return nullptr;
 }
 
 // For CPU and CUDA archs only

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -55,8 +55,8 @@ TLANG_NAMESPACE_END
 namespace std {
 template <>
 struct hash<taichi::lang::JITEvaluatorId> {
-  std::size_t operator()(
-      taichi::lang::JITEvaluatorId const &id) const noexcept {
+  std::size_t operator()(taichi::lang::JITEvaluatorId const &id) const
+      noexcept {
     return ((std::size_t)id.op | ((std::size_t)id.ret << 8) |
             ((std::size_t)id.lhs << 16) | ((std::size_t)id.rhs << 24) |
             ((std::size_t)id.is_binary << 31)) ^

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -55,8 +55,8 @@ TLANG_NAMESPACE_END
 namespace std {
 template <>
 struct hash<taichi::lang::JITEvaluatorId> {
-  std::size_t operator()(taichi::lang::JITEvaluatorId const &id) const
-      noexcept {
+  std::size_t operator()(
+      taichi::lang::JITEvaluatorId const &id) const noexcept {
     return ((std::size_t)id.op | ((std::size_t)id.ret << 8) |
             ((std::size_t)id.lhs << 16) | ((std::size_t)id.rhs << 24) |
             ((std::size_t)id.is_binary << 31)) ^
@@ -181,7 +181,13 @@ class Program {
   void end_function_definition() {
   }
 
+  // TODO: This function is doing two things: 1) compiling CHI IR, and 2)
+  // offloading them to each backend. We should probably separate the logic?
   FunctionType compile(Kernel &kernel);
+
+  // Just does the per-backend executable compilation without kernel lowering.
+  FunctionType compile_to_backend_executable(Kernel &kernel,
+                                             OffloadedStmt *stmt);
 
   void initialize_runtime_system(StructCompiler *scomp);
 

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -3,17 +3,17 @@ from .fuse_test_template import template_fuse_dense_x2y2z, \
     template_fuse_reduction
 
 
-@ti.archs_with([ti.cpu], async_mode=True)
+@ti.test(require=ti.extension.async_mode, async_mode=True)
 def test_fuse_dense_x2y2z():
     template_fuse_dense_x2y2z(size=100 * 1024**2)
 
 
-@ti.archs_with([ti.cpu], async_mode=True)
+@ti.test(require=ti.extension.async_mode, async_mode=True)
 def test_fuse_reduction():
     template_fuse_reduction(size=10 * 1024**2)
 
 
-@ti.archs_with([ti.cpu], async_mode=True)
+@ti.test(require=ti.extension.async_mode, async_mode=True)
 def test_no_fuse_sigs_mismatch():
     n = 4096
     x = ti.field(ti.i32, shape=(n, ))

--- a/tests/python/test_fuse_dynamic.py
+++ b/tests/python/test_fuse_dynamic.py
@@ -53,6 +53,7 @@ def benchmark_fuse_dynamic_x2y2z(size=1024**2, repeat=10, first_n=100):
         assert z[i] == x[i] + 5
 
 
-@ti.archs_with([ti.cpu], async_mode=True)
+@ti.test(require=[ti.extension.async_mode, ti.extension.sparse],
+         async_mode=True)
 def test_fuse_dynamic_x2y2z():
     benchmark_fuse_dynamic_x2y2z()

--- a/tests/python/test_sfg.py
+++ b/tests/python/test_sfg.py
@@ -3,7 +3,8 @@ import numpy as np
 import pytest
 
 
-@ti.test(require=ti.extension.async_mode, async_mode=True)
+@ti.test(require=[ti.extension.async_mode, ti.extension.sparse],
+         async_mode=True)
 def test_remove_clear_list_from_fused_serial():
     x = ti.field(ti.i32)
     y = ti.field(ti.i32)


### PR DESCRIPTION
Added `Program::compile_to_backend_executable()` to dispatch to each backend's codegen, so that it can be shared between sync/async mode.

While we should only benchmark on CUDA, let me include Metal so that I get a sense of what the performance looks like...

Related issue = #742

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
