### PR TITLE
[test] Add a benchmark for SFG edges' two-level map

### DIFF
--- a/tests/cpp/benchmark_sfg_edges.cpp
+++ b/tests/cpp/benchmark_sfg_edges.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <chrono>  // std::chrono::system_clock
 #include <random>  // std::default_random_engine
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -43,8 +44,9 @@ void insert(const PairData &d, UnorderedMapSet *m) {
   (*m)[d.first].insert(d.second);
 }
 
-bool lookup(const PairData &d, const UnorderedMapSet &m) {
-  TI_PROFILER("UnorderedMapSet lookup");
+bool lookup(const PairData &d, const UnorderedMapSet &m,
+            const std::string &found) {
+  TI_PROFILER("UnorderedMapSet lookup " + found);
   auto itr = m.find(d.first);
   if (itr == m.end()) {
     return false;
@@ -70,8 +72,8 @@ void insert_vecset(const PairData &d, VecSet *m) {
 }
 
 template <typename VecSet>
-bool lookup_vecset(const PairData &d, const VecSet &m) {
-  auto pname = fmt::format("{} lookup", TypeNameTraits<VecSet>::name);
+bool lookup_vecset(const PairData &d, const VecSet &m, const std::string& found) {
+  auto pname = fmt::format("{} lookup {}", TypeNameTraits<VecSet>::name, found);
   TI_PROFILER(pname);
   int i1 = 0;
   for (; i1 < m.size(); ++i1) {
@@ -110,8 +112,8 @@ void insert_vecvec(const PairData &d, VecVec *m) {
 }
 
 template <typename VecVec>
-bool lookup_vecvec(const PairData &d, const VecVec &m) {
-  auto pname = fmt::format("{} lookup", TypeNameTraits<VecVec>::name);
+bool lookup_vecvec(const PairData &d, const VecVec &m, const std::string& found) {
+  auto pname = fmt::format("{} lookup {}", TypeNameTraits<VecVec>::name, found);
   TI_PROFILER(pname);
   int i1 = 0;
   for (; i1 < m.size(); ++i1) {
@@ -142,12 +144,12 @@ void insert(const PairData &d, C *m) {
 }
 
 template <typename C>
-bool lookup(const PairData &d, const C &m) {
+bool lookup(const PairData &d, const C &m, const std::string& found) {
   if constexpr (std::is_same_v<C, LLVMVecSet> || std::is_same_v<C, StlVecSet>) {
-    return lookup_vecset(d, m);
+    return lookup_vecset(d, m, found);
   } else if constexpr (std::is_same_v<C, LLVMVecVec> ||
                        std::is_same_v<C, StlVecVec>) {
-    return lookup_vecvec(d, m);
+    return lookup_vecvec(d, m, found);
   }
 }
 
@@ -161,12 +163,12 @@ void run_test(const std::vector<PairData> &data,
     }
 
     for (const auto &p : data) {
-      bool l = lookup(p, m);
+      bool l = lookup(p, m, "found");
       TI_CHECK(l);
     }
 
     for (const auto &p : non_exists) {
-      bool l = lookup(p, m);
+      bool l = lookup(p, m, "not found");
       TI_CHECK(!l);
     }
   }

--- a/tests/cpp/benchmark_sfg_edges.cpp
+++ b/tests/cpp/benchmark_sfg_edges.cpp
@@ -44,7 +44,8 @@ void insert(const PairData &d, UnorderedMapSet *m) {
   (*m)[d.first].insert(d.second);
 }
 
-bool lookup(const PairData &d, const UnorderedMapSet &m,
+bool lookup(const PairData &d,
+            const UnorderedMapSet &m,
             const std::string &found) {
   TI_PROFILER("UnorderedMapSet lookup " + found);
   auto itr = m.find(d.first);
@@ -72,7 +73,9 @@ void insert_vecset(const PairData &d, VecSet *m) {
 }
 
 template <typename VecSet>
-bool lookup_vecset(const PairData &d, const VecSet &m, const std::string& found) {
+bool lookup_vecset(const PairData &d,
+                   const VecSet &m,
+                   const std::string &found) {
   auto pname = fmt::format("{} lookup {}", TypeNameTraits<VecSet>::name, found);
   TI_PROFILER(pname);
   int i1 = 0;
@@ -112,7 +115,9 @@ void insert_vecvec(const PairData &d, VecVec *m) {
 }
 
 template <typename VecVec>
-bool lookup_vecvec(const PairData &d, const VecVec &m, const std::string& found) {
+bool lookup_vecvec(const PairData &d,
+                   const VecVec &m,
+                   const std::string &found) {
   auto pname = fmt::format("{} lookup {}", TypeNameTraits<VecVec>::name, found);
   TI_PROFILER(pname);
   int i1 = 0;
@@ -144,7 +149,7 @@ void insert(const PairData &d, C *m) {
 }
 
 template <typename C>
-bool lookup(const PairData &d, const C &m, const std::string& found) {
+bool lookup(const PairData &d, const C &m, const std::string &found) {
   if constexpr (std::is_same_v<C, LLVMVecSet> || std::is_same_v<C, StlVecSet>) {
     return lookup_vecset(d, m, found);
   } else if constexpr (std::is_same_v<C, LLVMVecVec> ||

--- a/tests/cpp/benchmark_sfg_edges.cpp
+++ b/tests/cpp/benchmark_sfg_edges.cpp
@@ -1,0 +1,219 @@
+#include <algorithm>
+#include <chrono>  // std::chrono::system_clock
+#include <random>  // std::default_random_engine
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "taichi/system/profiler.h"
+#include "taichi/util/testing.h"
+
+TLANG_NAMESPACE_BEGIN
+
+using PairData = std::pair<int, int>;
+
+using UnorderedMapSet = std::unordered_map<int, std::unordered_set<int>>;
+using LLVMVecSet = llvm::SmallVector<std::pair<int, llvm::SmallSet<int, 4>>, 4>;
+using LLVMVecVec =
+    llvm::SmallVector<std::pair<int, llvm::SmallVector<int, 4>>, 4>;
+using StlVecSet = std::vector<std::pair<int, std::unordered_set<int>>>;
+using StlVecVec = std::vector<std::pair<int, std::vector<int>>>;
+
+// https://stackoverflow.com/a/1055563/12003165
+// Over-engineering a bit. typeid().name() is mangled and hard to read...
+template <typename T>
+struct TypeNameTraits;
+
+#define REGISTER_TYPE_NAME(X) \
+  template <>                 \
+  struct TypeNameTraits<X> {  \
+    static const char *name;  \
+  };                          \
+  const char *TypeNameTraits<X>::name = #X
+
+REGISTER_TYPE_NAME(LLVMVecSet);
+REGISTER_TYPE_NAME(LLVMVecVec);
+REGISTER_TYPE_NAME(StlVecSet);
+REGISTER_TYPE_NAME(StlVecVec);
+
+void insert(const PairData &d, UnorderedMapSet *m) {
+  TI_PROFILER("UnorderedMapSet insert");
+  (*m)[d.first].insert(d.second);
+}
+
+bool lookup(const PairData &d, const UnorderedMapSet &m) {
+  TI_PROFILER("UnorderedMapSet lookup");
+  auto itr = m.find(d.first);
+  if (itr == m.end()) {
+    return false;
+  }
+  return itr->second.count(d.second) > 0;
+}
+
+template <typename VecSet>
+void insert_vecset(const PairData &d, VecSet *m) {
+  auto pname = fmt::format("{} insert", TypeNameTraits<VecSet>::name);
+  TI_PROFILER(pname);
+  int i1 = 0;
+  for (; i1 < m->size(); ++i1) {
+    if ((*m)[i1].first == d.first) {
+      break;
+    }
+  }
+  if (i1 == m->size()) {
+    m->push_back({});
+    m->back().first = d.first;
+  }
+  (*m)[i1].second.insert(d.second);
+}
+
+template <typename VecSet>
+bool lookup_vecset(const PairData &d, const VecSet &m) {
+  auto pname = fmt::format("{} lookup", TypeNameTraits<VecSet>::name);
+  TI_PROFILER(pname);
+  int i1 = 0;
+  for (; i1 < m.size(); ++i1) {
+    if (m[i1].first == d.first) {
+      break;
+    }
+  }
+  if (i1 == m.size()) {
+    return false;
+  }
+  return m[i1].second.count(d.second) > 0;
+}
+
+template <typename VecVec>
+void insert_vecvec(const PairData &d, VecVec *m) {
+  auto pname = fmt::format("{} insert", TypeNameTraits<VecVec>::name);
+  TI_PROFILER(pname);
+  int i1 = 0;
+  for (; i1 < m->size(); ++i1) {
+    if ((*m)[i1].first == d.first) {
+      break;
+    }
+  }
+  if (i1 == m->size()) {
+    m->push_back({});
+    m->back().first = d.first;
+  }
+
+  auto &v2 = (*m)[i1].second;
+  for (int i2 = 0; i2 < v2.size(); ++i2) {
+    if (v2[i2] == d.second) {
+      return;
+    }
+  }
+  v2.push_back(d.second);
+}
+
+template <typename VecVec>
+bool lookup_vecvec(const PairData &d, const VecVec &m) {
+  auto pname = fmt::format("{} lookup", TypeNameTraits<VecVec>::name);
+  TI_PROFILER(pname);
+  int i1 = 0;
+  for (; i1 < m.size(); ++i1) {
+    if (m[i1].first == d.first) {
+      break;
+    }
+  }
+  if (i1 == m.size()) {
+    return false;
+  }
+  const auto &v2 = m[i1].second;
+  for (int i2 = 0; i2 < v2.size(); ++i2) {
+    if (v2[i2] == d.second) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename C>
+void insert(const PairData &d, C *m) {
+  if constexpr (std::is_same_v<C, LLVMVecSet> || std::is_same_v<C, StlVecSet>) {
+    insert_vecset(d, m);
+  } else if constexpr (std::is_same_v<C, LLVMVecVec> ||
+                       std::is_same_v<C, StlVecVec>) {
+    insert_vecvec(d, m);
+  }
+}
+
+template <typename C>
+bool lookup(const PairData &d, const C &m) {
+  if constexpr (std::is_same_v<C, LLVMVecSet> || std::is_same_v<C, StlVecSet>) {
+    return lookup_vecset(d, m);
+  } else if constexpr (std::is_same_v<C, LLVMVecVec> ||
+                       std::is_same_v<C, StlVecVec>) {
+    return lookup_vecvec(d, m);
+  }
+}
+
+template <typename M>
+void run_test(const std::vector<PairData> &data,
+              const std::vector<PairData> &non_exists) {
+  for (int i = 0; i < 10; ++i) {
+    M m;
+    for (const auto &p : data) {
+      insert(p, &m);
+    }
+
+    for (const auto &p : data) {
+      bool l = lookup(p, m);
+      TI_CHECK(l);
+    }
+
+    for (const auto &p : non_exists) {
+      bool l = lookup(p, m);
+      TI_CHECK(!l);
+    }
+  }
+}
+
+// Basic tests within a basic block
+TI_TEST("benchmark_sfg") {
+  std::vector<PairData> data = {
+      {0, 0}, {0, 2}, {0, 2}, {0, 5},                  // 0
+      {1, 1}, {1, 2}, {1, 3}, {1, 3}, {1, 6}, {1, 6},  // 1
+      {2, 0}, {2, 0}, {2, 2},                          // 2
+      {3, 5}, {3, 6}, {3, 7},                          // 3
+      {5, 0}, {5, 2}, {5, 2}, {5, 2}, {5, 2},          // 5
+      {6, 1}, {6, 2}, {6, 2},                          // 6
+      {9, 9},                                          // 9
+  };
+  std::vector<PairData> non_exists = {
+      {0, 1}, {0, 3},          // 0
+      {1, 4}, {1, 5},          // 1
+      {3, 0}, {3, 1}, {3, 2},  // 3
+      {4, 1},                  // 4
+      {6, 3},                  // 6
+      {7, 8},                  // 7
+  };
+  unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+  std::shuffle(data.begin(), data.end(), std::default_random_engine(seed));
+
+  SECTION("UnorderedMapSet") {
+    run_test<UnorderedMapSet>(data, non_exists);
+  }
+
+  SECTION("LLVMVecSet") {
+    run_test<LLVMVecSet>(data, non_exists);
+  }
+
+  SECTION("LLVMVecVec") {
+    run_test<LLVMVecVec>(data, non_exists);
+  }
+
+  SECTION("StlVecSet") {
+    run_test<StlVecSet>(data, non_exists);
+  }
+
+  SECTION("StlVecVec") {
+    run_test<StlVecVec>(data, non_exists);
+  }
+  Profiling::get_instance().print_profile_info();
+}
+
+TLANG_NAMESPACE_END

--- a/tests/cpp/benchmark_sfg_edges.cpp
+++ b/tests/cpp/benchmark_sfg_edges.cpp
@@ -191,8 +191,10 @@ TI_TEST("benchmark_sfg") {
       {6, 3},                  // 6
       {7, 8},                  // 7
   };
-  unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-  std::shuffle(data.begin(), data.end(), std::default_random_engine(seed));
+  const auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+  std::default_random_engine rng(seed);
+  std::shuffle(data.begin(), data.end(), rng);
+  std::shuffle(non_exists.begin(), non_exists.end(), rng);
 
   SECTION("UnorderedMapSet") {
     run_test<UnorderedMapSet>(data, non_exists);


### PR DESCRIPTION
This adds the benchmark for five kind of map implementations:

```cpp
using UnorderedMapSet = std::unordered_map<int, std::unordered_set<int>>;
using LLVMVecSet = llvm::SmallVector<std::pair<int, llvm::SmallSet<int, 4>>, 4>;
using LLVMVecVec =
    llvm::SmallVector<std::pair<int, llvm::SmallVector<int, 4>>, 4>;
using StlVecSet = std::vector<std::pair<int, std::unordered_set<int>>>;
using StlVecVec = std::vector<std::pair<int, std::vector<int>>>;
```

The test data might not be very representative of the actual use pattern, but it seems to indicate that `llvm::SmallVector<std::pair<Key, llvm::SmallSet<Value>>` is a pretty decent data structure? (I'm too lazy to implement the sorted `Vector<std::pair<Key, Value>>`. That data structure would require us to sort it for every single insert, otherwise the dedupe process would not be very efficient...)


```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
[Profiler thread 0x119f55dc0]
    277.281 us UnorderedMapSet insert        [250 x   1.109 us]
    170.469 us UnorderedMapSet lookup found  [250 x 681.877 ns]
     74.625 us UnorderedMapSet lookup not found [100 x 746.250 ns]
    154.495 us LLVMVecSet insert             [250 x 617.981 ns]
    196.218 us LLVMVecSet lookup found       [250 x 784.874 ns]
     75.340 us LLVMVecSet lookup not found   [100 x 753.403 ns]
    168.562 us LLVMVecVec insert             [250 x 674.248 ns]
    222.445 us LLVMVecVec lookup found       [250 x 889.778 ns]
     92.030 us LLVMVecVec lookup not found   [100 x 920.296 ns]
    367.641 us StlVecSet insert              [250 x   1.471 us]
    216.961 us StlVecSet lookup found        [250 x 867.844 ns]
    110.626 us StlVecSet lookup not found    [100 x   1.106 us]
    319.004 us StlVecVec insert              [250 x   1.276 us]
    234.365 us StlVecVec lookup found        [250 x 937.462 ns]
    121.355 us StlVecVec lookup not found    [100 x   1.214 us]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
```
Related issue = #

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
