### PR TITLE
[ir] Add the case of bit_shr to binary_op_type_symbol

### DIFF
--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -253,6 +253,7 @@ std::string binary_op_type_symbol(BinaryOpType type) {
     REGISTER_TYPE(pow, pow);
     REGISTER_TYPE(bit_shl, <<);
     REGISTER_TYPE(bit_sar, >>);
+    REGISTER_TYPE(bit_shr, shr);
 
 #undef REGISTER_TYPE
     default:


### PR DESCRIPTION
Related issue = #1871 

`binary_op_type_symbol` is used when printing initial (frontend) IR, and an IR with `bit_shr` will crash if that case is not supported :-)

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
