### PR TITLE
[async] Switch to llvm::SmallVector<llvm::SmallSet> for edges

### DIFF
--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -28,6 +28,7 @@ SFGStateToNodes::iterator find(SFGStateToNodes &m, const AsyncState &s) {
       m.begin(), m.end(),
       [&s](const SFGStateToNodes::value_type &v) { return v.first == s; });
 }
+
 std::pair<SFGStateToNodes::value_type::second_type *, bool> insert(
     SFGStateToNodes &m,
     const AsyncState &s) {

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -5,6 +5,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "taichi/ir/ir.h"
 #include "taichi/ir/statements.h"
 #include "taichi/lang_util.h"
@@ -18,7 +20,8 @@ class IRBank;
 class StateFlowGraph {
  public:
   struct Node;
-  using StateToNodeMapping = std::unordered_map<AsyncState, Node *>;
+  using StateToNodesMap =
+      llvm::SmallVector<std::pair<AsyncState, llvm::SmallSet<Node *, 8>>, 4>;
 
   // Each node is a task
   // Note: after SFG is done, each node here should hold a TaskLaunchRecord.
@@ -40,10 +43,11 @@ class StateFlowGraph {
     // For executed tasks (including the initial node), pending_node_id is -1.
     int pending_node_id{0};
 
-    // Profiling showed horrible performance using std::unordered_multimap (at
-    // least on Mac with clang-1103.0.32.62)...
-    std::unordered_map<AsyncState, std::unordered_set<Node *>> output_edges,
-        input_edges;
+    // Performance hits
+    // * std::unordered_multimap: Slow on clang + libc++, see #1855
+    // * std::unordered_map<., std::unordered_set<.>>: slow due to frequent
+    //   allocation, see #1927.
+    StateToNodesMap input_edges, output_edges;
 
     bool pending() const {
       return pending_node_id >= 0;
@@ -173,7 +177,7 @@ class StateFlowGraph {
   Node *initial_node_;  // The initial node holds all the initial states.
   int first_pending_task_index_;
   TaskMeta initial_meta_;
-  StateToNodeMapping latest_state_owner_;
+  std::unordered_map<AsyncState, Node *> latest_state_owner_;
   std::unordered_map<AsyncState, std::unordered_set<Node *>>
       latest_state_readers_;
   std::unordered_map<std::string, int> task_name_to_launch_ids_;


### PR DESCRIPTION
According to #1927, `llvm::SmallVector<llvm::SmallSet>` seems to be the most performant.

Here's the profiling data for `async_mgpcg.py`:

* Before this change: `13.418 s + 18.605 s + 20.120 s`

```
     54.404  s synchronize                   [8 x   6.800  s]
         11.333  s 20.83%  optimize_listgen      [75 x 151.111 ms]
              ... ...
              8.523  s 75.21%  rebuild_graph         [44 x 193.713 ms]
                  6.988  s 81.98%  insert_task           [397621 x  17.574 us]
                      0.180  s  2.57%  get_task_meta         [397621 x 451.757 ns]
                      2.874  s 41.14%  insert_task meta->input_states [1149493 x   2.501 us]
                          2.069  s 71.96%  insert_edge           [1149493 x   1.800 us]
                          0.806  s 28.04%  [unaccounted]
                      2.053  s 29.38%  insert_task meta->output_states [409654 x   5.011 us]
                          1.286  s 62.63%  insert_edge           [1063555 x   1.209 us]
                          0.767  s 37.37%  [unaccounted]
                      1.007  s 14.41%  insert_task latest_state_readers_ [1149493 x 876.057 ns]
                      0.874  s 12.50%  [unaccounted]
                  0.005  s  0.06%  reid_nodes            [44 x 108.058 us]
                  0.002  s  0.03%  reid_pending_nodes    [44 x  53.108 us]
                  1.529  s 17.93%  [unaccounted]
              ... ...
          ... ...
          9.339  s 17.17%  demote_activation     [71 x 131.542 ms]
              ... ...
              8.576  s 91.82%  rebuild_graph         [40 x 214.396 ms]
                  7.055  s 82.27%  insert_task           [393579 x  17.925 us]
                      0.177  s  2.51%  get_task_meta         [393579 x 449.787 ns]
                      2.950  s 41.81%  insert_task meta->input_states [1178512 x   2.503 us]
                          2.123  s 71.96%  insert_edge           [1178512 x   1.801 us]
                          0.827  s 28.04%  [unaccounted]
                      2.018  s 28.61%  insert_task meta->output_states [406848 x   4.960 us]
                          1.379  s 68.33%  insert_edge           [1120853 x   1.230 us]
                          0.639  s 31.67%  [unaccounted]
                      1.031  s 14.61%  insert_task latest_state_readers_ [1178512 x 874.833 ns]
                      0.879  s 12.46%  [unaccounted]
                  0.004  s  0.05%  reid_nodes            [40 x 107.372 us]
                  0.002  s  0.02%  reid_pending_nodes    [40 x  49.353 us]
                  1.515  s 17.66%  [unaccounted]
              0.419  s  4.48%  [unaccounted]
```

* After this change: `11.009 s + 14.249 s + 14.891 s`

```
42.394  s synchronize                   [8 x   5.299  s]
          7.644  s 18.03%  optimize_listgen      [75 x 101.920 ms]
              ... ...
              5.227  s 68.38%  rebuild_graph         [44 x 118.793 ms]
                  4.890  s 93.55%  insert_task           [397621 x  12.298 us]
                      0.185  s  3.79%  get_task_meta         [397621 x 466.267 ns]
                      1.459  s 29.84%  insert_task meta->input_states [1149493 x   1.269 us]
                          0.653  s 44.79%  insert_edge           [1149493 x 568.482 ns]
                          0.806  s 55.21%  [unaccounted]
                      1.285  s 26.27%  insert_task meta->output_states [409654 x   3.136 us]
                          0.494  s 38.47%  insert_edge           [1063555 x 464.718 ns]
                          0.790  s 61.53%  [unaccounted]
                      1.048  s 21.44%  insert_task latest_state_readers_ [1149493 x 912.139 ns]
                      0.912  s 18.65%  [unaccounted]
                  0.005  s  0.09%  reid_nodes            [44 x 108.621 us]
                  0.002  s  0.04%  reid_pending_nodes    [44 x  48.941 us]
                  0.330  s  6.31%  [unaccounted]
              ... ...
          ... ...
          6.117  s 14.43%  demote_activation     [73 x  83.791 ms]
              ... ...
              5.414  s 88.52%  rebuild_graph         [42 x 128.916 ms]
                  5.079  s 93.81%  insert_task           [415641 x  12.220 us]
                      0.189  s  3.72%  get_task_meta         [415641 x 454.920 ns]
                      1.564  s 30.80%  insert_task meta->input_states [1244758 x   1.257 us]
                          0.701  s 44.82%  insert_edge           [1244758 x 563.253 ns]
                          0.863  s 55.18%  [unaccounted]
                      1.232  s 24.26%  insert_task meta->output_states [429700 x   2.867 us]
                          0.550  s 44.61%  insert_edge           [1184969 x 463.830 ns]
                          0.682  s 55.39%  [unaccounted]
                      1.126  s 22.17%  insert_task latest_state_readers_ [1244758 x 904.753 ns]
                      0.968  s 19.05%  [unaccounted]
                  0.005  s  0.09%  reid_nodes            [42 x 121.593 us]
                  0.002  s  0.04%  reid_pending_nodes    [42 x  47.105 us]
                  0.328  s  6.06%  [unaccounted]
              0.337  s  5.52%  [unaccounted]
```

Unfortunately, it could be due to the recent macOS 10.15.7 upgrade, the GUI has become much slower on my end recently. I wasn't able to perceive improvements just by looking at some of the examples...

Related issue = #742

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
