### PR TITLE
[Bug] [lang] "ext_arr.shape" should return "ti.Expr" instead of "ti.core.Expr"

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -148,7 +148,7 @@ class Expr(TaichiOperations):
             import taichi as ti
             dim = ti.get_external_tensor_dim(self.ptr)
             ret = [
-                ti.get_external_tensor_shape_along_axis(self.ptr, i)
+                ti.Expr(ti.get_external_tensor_shape_along_axis(self.ptr, i))
                 for i in range(dim)
             ]
             return ret

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -731,6 +731,7 @@ class KernelGen : public IRVisitor {
     std::unique_ptr<ScopedIndent> s;
 
     ScopedGridStrideLoop(KernelGen *gen) : gen(gen) {
+      // TODO(archibate): what's grid dim actually?
       size_t stride_size = gen->kernel->program.config.saturating_grid_dim;
       if (gen->used_tls && stride_size == 0) {
         // automatically enable grid-stride-loop when TLS used:

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -393,7 +393,8 @@ class TypePromotionMapping {
       mapping;
   static PrimitiveType::primitive_type to_primitive_type(const DataType d) {
     auto primitive = dynamic_cast<const PrimitiveType *>(d.get_ptr());
-    TI_ASSERT(primitive);
+    TI_ASSERT_INFO(primitive, "Failed to get primitive type! "
+      "Consider adding `ti.init()` to the first line of your program.");
     return primitive->type;
   };
 };

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -393,8 +393,10 @@ class TypePromotionMapping {
       mapping;
   static PrimitiveType::primitive_type to_primitive_type(const DataType d) {
     auto primitive = dynamic_cast<const PrimitiveType *>(d.get_ptr());
-    TI_ASSERT_INFO(primitive, "Failed to get primitive type! "
-      "Consider adding `ti.init()` to the first line of your program.");
+    TI_ASSERT_INFO(
+        primitive,
+        "Failed to get primitive type! "
+        "Consider adding `ti.init()` to the first line of your program.");
     return primitive->type;
   };
 };


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
To reproduce:
```py
import taichi as ti
import numpy as np

ti.init(print_preprocessed=True)

@ti.kernel
def func(b: ti.ext_arr()):
    b.shape[0] + 4

func(np.array([1, 2]))
```
```py
[Taichi] mode=release
[Taichi] version 0.6.39, llvm 10.0.0, commit 12e02bec, win, python 3.8.5
[Taichi] Starting on arch=x64
[Taichi] materializing...
Initial AST:
def func(b: ti.ext_arr()):
    b.shape[0] + 4

Preprocessed:
def func():
    import taichi as ti
    b = ti.decl_ext_arr_arg(ti.i32, 1)
    ti.subscript(b.shape, 0) + 4

Checked:
def func():
    import taichi as ti
    b = ti.decl_ext_arr_arg(ti.i32, 1)
    ti.subscript(b.shape, 0) + 4

Final AST:
def func():
    import taichi as ti
    b = ti.decl_ext_arr_arg(ti.i32, 1)
    ti.subscript(b.shape, 0) + 4

Traceback (most recent call last):
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "c:\Users\Administrator\.vscode\extensions\ms-python.python-2020.9.114305\pythonFiles\lib\python\debugpy\__main__.py", line 45, in <module>
    cli.main()
  File "c:\Users\Administrator\.vscode\extensions\ms-python.python-2020.9.114305\pythonFiles\lib\python\debugpy/..\debugpy\server\cli.py", line 430, in main
    run()
  File "c:\Users\Administrator\.vscode\extensions\ms-python.python-2020.9.114305\pythonFiles\lib\python\debugpy/..\debugpy\server\cli.py", line 267, in run_file
    runpy.run_path(options.target, run_name=compat.force_str("__main__"))
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\runpy.py", line 265, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "c:\Users\Administrator\taichi_three\a.py", line 10, in <module>
    func(np.array([1, 2]))
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py", line 574, in wrapped
    return primal(*args, **kwargs)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py", line 501, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py", line 370, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py", line 367, in taichi_ast_generator
    compiled()
  File "c:\Users\Administrator\taichi_three\a.py", line 8, in func
    b.shape[0] + 4
TypeError: unsupported operand type(s) for +: 'taichi_core.Expr' and 'int'
```
That's because `taichi_core.Expr`, i.e. `ti.core.Expr`, is a class directly exported from C++, which doesn't have an `__add__` method. We should use the Python wrapped version `ti.Expr` instead.