### PR TITLE
[async] Do not keep latest state readers in SFG

### DIFF
--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -139,16 +139,11 @@ void StateFlowGraph::clear() {
 void StateFlowGraph::mark_pending_tasks_as_executed() {
   std::vector<std::unique_ptr<Node>> new_nodes;
   std::unordered_set<Node *> state_owners;
-  std::unordered_set<Node *> state_readers;
   for (auto &owner : latest_state_owner_) {
     state_owners.insert(state_owners.end(), owner.second);
   }
-  for (auto &reader : latest_state_readers_) {
-    state_readers.insert(reader.second.begin(), reader.second.end());
-  }
   for (auto &node : nodes_) {
-    if (node->is_initial_node || state_owners.count(node.get()) > 0 ||
-        state_readers.count(node.get()) > 0) {
+    if (node->is_initial_node || state_owners.count(node.get()) > 0) {
       node->mark_executed();
       new_nodes.push_back(std::move(node));
     }


### PR DESCRIPTION
Related issue = #742 

There can be thousands of tasks reading a state.

IIRC we don't need the latest state readers in any of the SFG optimizations?

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
