### PR TITLE
[Metal] Support ti.block_dim() and ti.cfg.saturating_grid_dim

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -806,7 +806,7 @@ class KernelCodegen : public IRVisitor {
     ka.name = mtl_kernel_name;
     ka.task_type = stmt->task_type;
     ka.buffers = get_common_buffers();
-    ka.advisory_num_threads = 1;
+    ka.advisory_total_num_threads = 1;
     ka.advisory_num_threads_per_group = 1;
 
     emit_mtl_kernel_sig(mtl_kernel_name, ka.buffers);
@@ -868,7 +868,7 @@ class KernelCodegen : public IRVisitor {
       // sdf_renderer.py benchmark for setting |num_threads|
       // - num_elemnts: ~20 samples/s
       // - kMaxNumThreadsGridStrideLoop: ~12 samples/s
-      ka.advisory_num_threads = num_elems;
+      ka.advisory_total_num_threads = num_elems;
     } else {
       emit("// range_for, range known at runtime");
       begin_expr = stmt->const_begin
@@ -878,7 +878,7 @@ class KernelCodegen : public IRVisitor {
                                 ? std::to_string(stmt->end_value)
                                 : inject_load_global_tmp(stmt->end_offset);
       emit("const int {} = {} - {};", total_elems_name, end_expr, begin_expr);
-      ka.advisory_num_threads = kMaxNumThreadsGridStrideLoop;
+      ka.advisory_total_num_threads = kMaxNumThreadsGridStrideLoop;
     }
     ka.advisory_num_threads_per_group = stmt->block_dim;
     // begin_ = thread_id   + begin_expr
@@ -951,7 +951,7 @@ class KernelCodegen : public IRVisitor {
     const int total_num_elems_from_root =
         compiled_structs_->snode_descriptors.find(sn_id)
             ->second.total_num_elems_from_root;
-    ka.advisory_num_threads =
+    ka.advisory_total_num_threads =
         std::min(total_num_elems_from_root, kMaxNumThreadsGridStrideLoop);
     ka.advisory_num_threads_per_group = stmt->block_dim;
 
@@ -1023,7 +1023,7 @@ class KernelCodegen : public IRVisitor {
     if (type == Type::listgen) {
       // listgen kernels use grid-stride loops
       const auto &sn_descs = compiled_structs_->snode_descriptors;
-      ka.advisory_num_threads = std::min(
+      ka.advisory_total_num_threads = std::min(
           sn_descs.find(sn->id)->second.total_num_self_from_root(sn_descs),
           kMaxNumThreadsGridStrideLoop);
       ka.advisory_num_threads_per_group = stmt->block_dim;

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -237,7 +237,8 @@ class RuntimeListOpsMtlKernel : public CompiledMtlKernelBase {
         "parent_snode={} "
         "child_snode={} max_num_elems={} ",
         params.kernel_attribs->name,
-        params.kernel_attribs->advisory_total_num_threads, mem[0], mem[1], mem[2]);
+        params.kernel_attribs->advisory_total_num_threads, mem[0], mem[1],
+        mem[2]);
     did_modify_range(args_buffer_.get(), /*location=*/0, args_mem_->size());
   }
 

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -116,7 +116,7 @@ class CompiledMtlKernelBase {
 
   void launch_if_not_empty(BindBuffers buffers,
                            MTLCommandBuffer *command_buffer) {
-    const int num_threads = kernel_attribs_.advisory_num_threads;
+    const int num_threads = kernel_attribs_.advisory_total_num_threads;
     if (num_threads == 0) {
       return;
     }
@@ -195,7 +195,7 @@ class UserMtlKernel : public CompiledMtlKernelBase {
   void launch(InputBuffersMap &input_buffers,
               MTLCommandBuffer *command_buffer) override {
     // 0 is valid for |num_threads|!
-    TI_ASSERT(kernel_attribs_.advisory_num_threads >= 0);
+    TI_ASSERT(kernel_attribs_.advisory_total_num_threads >= 0);
     BindBuffers buffers;
     for (const auto b : kernel_attribs_.buffers) {
       buffers.push_back({input_buffers.find(b)->second, b});
@@ -237,7 +237,7 @@ class RuntimeListOpsMtlKernel : public CompiledMtlKernelBase {
         "parent_snode={} "
         "child_snode={} max_num_elems={} ",
         params.kernel_attribs->name,
-        params.kernel_attribs->advisory_num_threads, mem[0], mem[1], mem[2]);
+        params.kernel_attribs->advisory_total_num_threads, mem[0], mem[1], mem[2]);
     did_modify_range(args_buffer_.get(), /*location=*/0, args_mem_->size());
   }
 

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -116,7 +116,7 @@ class CompiledMtlKernelBase {
 
   void launch_if_not_empty(BindBuffers buffers,
                            MTLCommandBuffer *command_buffer) {
-    const int num_threads = kernel_attribs_.num_threads;
+    const int num_threads = kernel_attribs_.advisory_num_threads;
     if (num_threads == 0) {
       return;
     }
@@ -133,7 +133,8 @@ class CompiledMtlKernelBase {
       set_mtl_buffer(encoder.get(), b.first, /*offset=*/0, bi);
     }
 
-    const auto tgs = get_thread_grid_settings(num_threads);
+    const auto tgs = get_thread_grid_settings(
+        num_threads, kernel_attribs_.advisory_num_threads_per_group);
     if (!is_jit_evalutor_) {
       ActionRecorder::get_instance().record(
           "launch_kernel",
@@ -152,7 +153,9 @@ class CompiledMtlKernelBase {
     int num_threadgroups;
   };
 
-  ThreadGridSettings get_thread_grid_settings(int num_threads) {
+  ThreadGridSettings get_thread_grid_settings(
+      int advisory_num_threads,
+      int advisory_num_threads_per_group) {
     int num_threads_per_group =
         get_max_total_threads_per_threadgroup(pipeline_state_.get());
     // Sometimes it is helpful to limit the maximum GPU block dim for the
@@ -162,17 +165,20 @@ class CompiledMtlKernelBase {
       num_threads_per_group =
           std::min(num_threads_per_group, prescribed_block_dim);
     }
+    if (advisory_num_threads_per_group > 0) {
+      num_threads_per_group =
+          std::min(num_threads_per_group, advisory_num_threads_per_group);
+    }
     // Cap by |num_threads| in case this is a very small kernel.
-    num_threads_per_group = std::min(num_threads_per_group, num_threads);
+    num_threads_per_group =
+        std::min(num_threads_per_group, advisory_num_threads);
 
-    int num_threadgroups =
-        ((num_threads + num_threads_per_group - 1) / num_threads_per_group);
-    // TODO(k-ye): Make sure |saturating_grid_dim| is configurable in ti.init()
-    // before enabling this.
-    // const int prescribed_grid_dim = config_->saturating_grid_dim;
-    // if (prescribed_grid_dim > 0) {
-    //   num_threadgroups = std::min(num_threadgroups, prescribed_grid_dim);
-    // }
+    int num_threadgroups = ((advisory_num_threads + num_threads_per_group - 1) /
+                            num_threads_per_group);
+    const int prescribed_grid_dim = config_->saturating_grid_dim;
+    if (prescribed_grid_dim > 0) {
+      num_threadgroups = std::min(num_threadgroups, prescribed_grid_dim);
+    }
     return {num_threads_per_group, num_threadgroups};
   }
 
@@ -189,7 +195,7 @@ class UserMtlKernel : public CompiledMtlKernelBase {
   void launch(InputBuffersMap &input_buffers,
               MTLCommandBuffer *command_buffer) override {
     // 0 is valid for |num_threads|!
-    TI_ASSERT(kernel_attribs_.num_threads >= 0);
+    TI_ASSERT(kernel_attribs_.advisory_num_threads >= 0);
     BindBuffers buffers;
     for (const auto b : kernel_attribs_.buffers) {
       buffers.push_back({input_buffers.find(b)->second, b});
@@ -230,8 +236,8 @@ class RuntimeListOpsMtlKernel : public CompiledMtlKernelBase {
         "Registered RuntimeListOpsMtlKernel: name={} num_threads={} "
         "parent_snode={} "
         "child_snode={} max_num_elems={} ",
-        params.kernel_attribs->name, params.kernel_attribs->num_threads, mem[0],
-        mem[1], mem[2]);
+        params.kernel_attribs->name,
+        params.kernel_attribs->advisory_num_threads, mem[0], mem[1], mem[2]);
     did_modify_range(args_buffer_.get(), /*location=*/0, args_mem_->size());
   }
 

--- a/taichi/backends/metal/kernel_util.cpp
+++ b/taichi/backends/metal/kernel_util.cpp
@@ -43,7 +43,7 @@ std::string KernelAttributes::debug_string() const {
   result += fmt::format(
       "<KernelAttributes name={} num_threads={} num_threads_per_group={} "
       "task_type={} buffers=[ ",
-      name, advisory_num_threads, advisory_num_threads_per_group,
+      name, advisory_total_num_threads, advisory_num_threads_per_group,
       OffloadedStmt::task_type_name(task_type));
   for (auto b : buffers) {
     result += buffers_name(b) + " ";

--- a/taichi/backends/metal/kernel_util.cpp
+++ b/taichi/backends/metal/kernel_util.cpp
@@ -41,8 +41,10 @@ std::string KernelAttributes::buffers_name(Buffers b) {
 std::string KernelAttributes::debug_string() const {
   std::string result;
   result += fmt::format(
-      "<KernelAttributes name={} num_threads={} task_type={} buffers=[ ", name,
-      num_threads, OffloadedStmt::task_type_name(task_type));
+      "<KernelAttributes name={} num_threads={} num_threads_per_group={} "
+      "task_type={} buffers=[ ",
+      name, advisory_num_threads, advisory_num_threads_per_group,
+      OffloadedStmt::task_type_name(task_type));
   for (auto b : buffers) {
     result += buffers_name(b) + " ";
   }

--- a/taichi/backends/metal/kernel_util.h
+++ b/taichi/backends/metal/kernel_util.h
@@ -42,7 +42,13 @@ struct KernelAttributes {
     Print,
   };
   std::string name;
-  int num_threads;
+  // Number of threasd to launch. Note that this is only advisory, because
+  // eventually the number of threads is also determined by the runtime config.
+  // This works because grid strided loop is supported.
+  int advisory_num_threads;
+  // Block size in CUDA's terminology. On Metal, it is called a threadgroup.
+  int advisory_num_threads_per_group;
+
   OffloadedStmt::TaskType task_type;
 
   struct RangeForAttributes {

--- a/taichi/backends/metal/kernel_util.h
+++ b/taichi/backends/metal/kernel_util.h
@@ -42,10 +42,10 @@ struct KernelAttributes {
     Print,
   };
   std::string name;
-  // Number of threasd to launch. Note that this is only advisory, because
-  // eventually the number of threads is also determined by the runtime config.
-  // This works because grid strided loop is supported.
-  int advisory_num_threads;
+  // Total number of threads to launch (i.e. threads per grid). Note that this
+  // is only advisory, because eventually this numb er is also determined by the
+  // runtime config. This works because grid strided loop is supported.
+  int advisory_total_num_threads;
   // Block size in CUDA's terminology. On Metal, it is called a threadgroup.
   int advisory_num_threads_per_group;
 


### PR DESCRIPTION
* `range_for`: this defaults to 128 because of (`default_block_dim = 128` for GPU):

 https://github.com/taichi-dev/taichi/blob/1b024a08027e5852c14390e512e69584586f8eb5/taichi/transforms/offload.cpp#L62

* `struct_for`: this defaults to `0` (`max_block_dim = 0`), so Metal picks the maximum threads per threadgroup allowed per kernel.
https://github.com/taichi-dev/taichi/blob/1b024a08027e5852c14390e512e69584586f8eb5/taichi/transforms/offload.cpp#L155-L156

Related issue = #677 
<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
