### PR TITLE
[type] Add basic implementations of VectorType and PointerType

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -868,7 +868,7 @@ void CodeGenLLVM::visit(ArgLoadStmt *stmt) {
 }
 
 void CodeGenLLVM::visit(KernelReturnStmt *stmt) {
-  if (stmt->is_ptr) {
+  if (stmt->ret_type.is_pointer()) {
     TI_NOT_IMPLEMENTED
   } else {
     auto intermediate_bits =

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -10,8 +10,6 @@
 
 TLANG_NAMESPACE_BEGIN
 
-using namespace llvm;
-
 class CodeGenLLVM;
 
 class OffloadedTask {
@@ -57,7 +55,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   IRNode *ir;
   Program *prog;
   std::string kernel_name;
-  std::vector<Value *> kernel_args;
+  std::vector<llvm::Value *> kernel_args;
   llvm::Type *context_ty;
   llvm::Type *physical_coordinate_ty;
   llvm::Value *current_coordinates;
@@ -73,7 +71,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   OffloadedStmt *current_offload{nullptr};
   std::unique_ptr<OffloadedTask> current_task;
   std::vector<OffloadedTask> offloaded_tasks;
-  BasicBlock *func_body_bb;
+  llvm::BasicBlock *func_body_bb;
 
   std::unordered_map<const Stmt *, std::vector<llvm::Value *>> loop_vars_llvm;
 
@@ -131,10 +129,11 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void emit_gc(OffloadedStmt *stmt);
 
-  llvm::Value *create_call(llvm::Value *func, std::vector<Value *> args = {});
+  llvm::Value *create_call(llvm::Value *func,
+                           std::vector<llvm::Value *> args = {});
 
   llvm::Value *create_call(std::string func_name,
-                           std::vector<Value *> args = {});
+                           std::vector<llvm::Value *> args = {});
   llvm::Value *call(SNode *snode,
                     llvm::Value *node_ptr,
                     const std::string &method,

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -172,7 +172,6 @@ Stmt::Stmt() : field_manager(this), fields_registered(false) {
   instance_id = instance_id_counter++;
   id = instance_id;
   erased = false;
-  is_ptr = false;
 }
 
 Stmt::Stmt(const Stmt &stmt) : field_manager(this), fields_registered(false) {
@@ -180,7 +179,6 @@ Stmt::Stmt(const Stmt &stmt) : field_manager(this), fields_registered(false) {
   instance_id = instance_id_counter++;
   id = instance_id;
   erased = stmt.erased;
-  is_ptr = stmt.is_ptr;
   tb = stmt.tb;
   ret_type = stmt.ret_type;
 }
@@ -240,7 +238,7 @@ std::string Stmt::type_hint() const {
   if (ret_type.data_type == PrimitiveType::unknown)
     return "";
   else
-    return fmt::format("<{}>{}", ret_type.str(), is_ptr ? "ptr " : " ");
+    return fmt::format("<{}>", ret_type.str());
 }
 
 std::string Stmt::type() {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -530,7 +530,6 @@ class Stmt : public IRNode {
   bool erased;
   bool fields_registered;
   std::string tb;
-  bool is_ptr;
   LegacyVectorType ret_type;
 
   Stmt();

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <variant>
 #include <tuple>
+
 #include "taichi/common/core.h"
 #include "taichi/util/bit.h"
 #include "taichi/lang_util.h"

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -101,6 +101,7 @@ class UnaryOpStmt : public Stmt {
 class ArgLoadStmt : public Stmt {
  public:
   int arg_id;
+  bool is_ptr;
 
   ArgLoadStmt(int arg_id, DataType dt, bool is_ptr = false) : arg_id(arg_id) {
     this->ret_type = LegacyVectorType(1, dt);

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -1,0 +1,45 @@
+#include "taichi/ir/type.h"
+#include "taichi/program/program.h"
+
+TLANG_NAMESPACE_BEGIN
+
+// Note: these primitive types should never be freed. They are supposed to live
+// together with the process. This is a temporary solution. Later we should
+// manage its ownership more systematically.
+
+// This part doesn't look good, but we will remove it soon anyway.
+#define PER_TYPE(x)                                            \
+  DataType PrimitiveType::x =                                  \
+      DataType(Program::get_type_factory().get_primitive_type( \
+          PrimitiveType::primitive_type::x));
+
+#include "taichi/inc/data_type.inc.h"
+#undef PER_TYPE
+
+DataType::DataType() : ptr_(PrimitiveType::unknown.ptr_) {
+}
+
+DataType PrimitiveType::get(PrimitiveType::primitive_type t) {
+  if (false) {
+  }
+#define PER_TYPE(x) else if (t == primitive_type::x) return PrimitiveType::x;
+#include "taichi/inc/data_type.inc.h"
+#undef PER_TYPE
+  else {
+    TI_NOT_IMPLEMENTED
+  }
+}
+
+std::size_t DataType::hash() const {
+  if (auto primitive = dynamic_cast<const PrimitiveType *>(ptr_)) {
+    return (std::size_t)primitive->type;
+  } else {
+    TI_NOT_IMPLEMENTED
+  }
+}
+
+std::string PrimitiveType::to_string() const {
+  return data_type_name(DataType(this));
+}
+
+TLANG_NAMESPACE_END

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "taichi/common/core.h"
+
+TLANG_NAMESPACE_BEGIN
+
+class Type {
+ public:
+  virtual std::string to_string() const = 0;
+  virtual ~Type() {
+  }
+};
+
+// A "Type" handle. This should be removed later.
+class DataType {
+ public:
+  DataType();
+
+  DataType(const Type *ptr) : ptr_(ptr) {
+  }
+
+  bool operator==(const DataType &o) const {
+    return ptr_ == o.ptr_;
+  }
+
+  bool operator!=(const DataType &o) const {
+    return !(*this == o);
+  }
+
+  std::size_t hash() const;
+
+  std::string to_string() const {
+    return ptr_->to_string();
+  };
+
+  // TODO: DataType itself should be a pointer in the future
+  const Type *get_ptr() const {
+    return ptr_;
+  }
+
+ private:
+  const Type *ptr_;
+};
+
+class PrimitiveType : public Type {
+ public:
+  enum class primitive_type : int {
+#define PER_TYPE(x) x,
+#include "taichi/inc/data_type.inc.h"
+#undef PER_TYPE
+  };
+
+#define PER_TYPE(x) static DataType x;
+#include "taichi/inc/data_type.inc.h"
+#undef PER_TYPE
+
+  primitive_type type;
+
+  PrimitiveType(primitive_type type) : type(type) {
+  }
+
+  std::string to_string() const override;
+
+  static DataType get(primitive_type type);
+};
+
+TLANG_NAMESPACE_END

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -64,4 +64,47 @@ class PrimitiveType : public Type {
   static DataType get(primitive_type type);
 };
 
+class PointerType : public Type {
+ public:
+  PointerType(Type *pointee, bool is_bit_pointer)
+      : pointee_(pointee), is_bit_pointer_(is_bit_pointer) {
+  }
+
+  Type *get_pointee_type() const {
+    return pointee_;
+  }
+
+  auto get_addr_space() const {
+    return addr_space_;
+  }
+
+  bool is_bit_pointer() const {
+    return is_bit_pointer_;
+  }
+
+ private:
+  Type *pointee_{nullptr};
+  int addr_space_{0};  // TODO: make this an enum
+  bool is_bit_pointer_{false};
+};
+
+class VectorType : public Type {
+ public:
+  VectorType(int num_elements, Type *element)
+      : num_elements_(num_elements), element_(element) {
+  }
+
+  Type *get_element_type() const {
+    return element_;
+  }
+
+  int get_num_elements() const {
+    return num_elements_;
+  }
+
+ private:
+  int num_elements_{0};
+  Type *element_{nullptr};
+};
+
 TLANG_NAMESPACE_END

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -82,6 +82,10 @@ class PointerType : public Type {
     return is_bit_pointer_;
   }
 
+  std::string to_string() const override {
+    return fmt::format("*{}", pointee_->to_string());
+  };
+
  private:
   Type *pointee_{nullptr};
   int addr_space_{0};  // TODO: make this an enum
@@ -101,6 +105,10 @@ class VectorType : public Type {
   int get_num_elements() const {
     return num_elements_;
   }
+
+  std::string to_string() const override {
+    return fmt::format("[{} x {}]", num_elements_, element_->to_string());
+  };
 
  private:
   int num_elements_{0};

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -1,4 +1,5 @@
 #include "taichi/ir/type_factory.h"
+#include "type_factory.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -10,6 +11,22 @@ Type *TypeFactory::get_primitive_type(PrimitiveType::primitive_type id) {
   }
 
   return primitive_types_[id].get();
+}
+
+Type *TypeFactory::get_vector_type(int num_elements, Type *element) {
+  auto key = std::make_pair(num_elements, element);
+  if (vector_types_.find(key) == vector_types_.end()) {
+    vector_types_[key] = std::make_unique<VectorType>(num_elements, element);
+  }
+  return vector_types_[key].get();
+}
+
+Type *TypeFactory::get_pointer_type(Type *element) {
+  auto key = element;  // may need to add is_bit_ptr later
+  if (pointer_types_.find(key) == pointer_types_.end()) {
+    pointer_types_[key] = std::make_unique<PointerType>(element, false);
+  }
+  return pointer_types_[key].get();
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "taichi/lang_util.h"
 
 #include <mutex>
@@ -8,9 +10,19 @@ class TypeFactory {
  public:
   Type *get_primitive_type(PrimitiveType::primitive_type id);
 
+  Type *get_vector_type(int num_elements, Type *element);
+
+  Type *get_pointer_type(Type *element);
+
  private:
   std::unordered_map<PrimitiveType::primitive_type, std::unique_ptr<Type>>
       primitive_types_;
+
+  // TODO: use unordered map
+  std::map<std::pair<int, Type *>, std::unique_ptr<Type>> vector_types_;
+
+  // TODO: is_bit_ptr?
+  std::map<Type*, std::unique_ptr<Type>> pointer_types_;
 
   std::mutex mut_;
 };

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -22,7 +22,7 @@ class TypeFactory {
   std::map<std::pair<int, Type *>, std::unique_ptr<Type>> vector_types_;
 
   // TODO: is_bit_ptr?
-  std::map<Type*, std::unique_ptr<Type>> pointer_types_;
+  std::map<Type *, std::unique_ptr<Type>> pointer_types_;
 
   std::mutex mut_;
 };

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -30,45 +30,6 @@ real get_cpu_frequency() {
 
 real default_measurement_time = 1;
 
-// Note: these primitive types should never be freed. They are supposed to live
-// together with the process. This is a temporary solution. Later we should
-// manage its ownership more systematically.
-
-// This part doesn't look good, but we will remove it soon anyway.
-#define PER_TYPE(x)                                            \
-  DataType PrimitiveType::x =                                  \
-      DataType(Program::get_type_factory().get_primitive_type( \
-          PrimitiveType::primitive_type::x));
-
-#include "taichi/inc/data_type.inc.h"
-#undef PER_TYPE
-
-DataType::DataType() : ptr_(PrimitiveType::unknown.ptr_) {
-}
-
-DataType PrimitiveType::get(PrimitiveType::primitive_type t) {
-  if (false) {
-  }
-#define PER_TYPE(x) else if (t == primitive_type::x) return PrimitiveType::x;
-#include "taichi/inc/data_type.inc.h"
-#undef PER_TYPE
-  else {
-    TI_NOT_IMPLEMENTED
-  }
-}
-
-std::size_t DataType::hash() const {
-  if (auto primitive = dynamic_cast<const PrimitiveType *>(ptr_)) {
-    return (std::size_t)primitive->type;
-  } else {
-    TI_NOT_IMPLEMENTED
-  }
-}
-
-std::string PrimitiveType::to_string() const {
-  return data_type_name(DataType(this));
-}
-
 real measure_cpe(std::function<void()> target,
                  int64 elements_per_call,
                  real time_second) {

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -4,6 +4,7 @@
 #include "taichi/util/io.h"
 #include "taichi/common/core.h"
 #include "taichi/system/profiler.h"
+#include "taichi/ir/type.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -18,66 +19,6 @@ real measure_cpe(std::function<void()> target,
 struct Context;
 
 using FunctionType = std::function<void(Context &)>;
-
-class Type {
- public:
-  virtual std::string to_string() const = 0;
-  virtual ~Type() {
-  }
-};
-
-// A "Type" handle. This should be removed later.
-class DataType {
- public:
-  DataType();
-
-  DataType(const Type *ptr) : ptr_(ptr) {
-  }
-
-  bool operator==(const DataType &o) const {
-    return ptr_ == o.ptr_;
-  }
-
-  bool operator!=(const DataType &o) const {
-    return !(*this == o);
-  }
-
-  std::size_t hash() const;
-
-  std::string to_string() const {
-    return ptr_->to_string();
-  };
-
-  // TODO: DataType itself should be a pointer in the future
-  const Type *get_ptr() const {
-    return ptr_;
-  }
-
- private:
-  const Type *ptr_;
-};
-
-class PrimitiveType : public Type {
- public:
-  enum class primitive_type : int {
-#define PER_TYPE(x) x,
-#include "taichi/inc/data_type.inc.h"
-#undef PER_TYPE
-  };
-
-#define PER_TYPE(x) static DataType x;
-#include "taichi/inc/data_type.inc.h"
-#undef PER_TYPE
-
-  primitive_type type;
-
-  PrimitiveType(primitive_type type) : type(type) {
-  }
-
-  std::string to_string() const override;
-
-  static DataType get(primitive_type type);
-};
 
 template <typename T>
 inline DataType get_data_type() {


### PR DESCRIPTION
Related issue = #1905

Changes:

- Added basic `VectorType` and `PointerType`
- Updated `TypeFactor` to support creating the two new types
- Removed `using namespace llvm` in `codegen_llvm.h` since now `taichi::lang::PointerType` conflicts with `llvm::PointerType`. Added some necessary `llvm::` prefixes to fix compilation.
- Moved `Stmt::is_ptr` to `ArgLoadStmt::is_ptr` since that's the only subclass that uses the member.
- Moved `Type-`related classes from `taichi/lang_util.h/cpp` to `taichi/ir/type.h/cpp`

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
