### PR TITLE
[Bug] [lang] Fix error when subscripting a dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ __pycache__
 *.jpg
 *.egg-info
 .tlang_cache
-.tidle_*
 /taichi/common/version.h
 /taichi/common/commit_hash.h
 /python/test_env

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -535,8 +535,9 @@ def static(x, *xs):
         return [static(x)] + [static(x) for x in xs]
     import types
     import taichi as ti
-    if isinstance(x, (bool, int, float, range, list, tuple, enumerate,
-                      ti.ndrange, ti.GroupedNDRange, zip, filter, map)) or x is None:
+    if isinstance(x,
+                  (bool, int, float, range, list, tuple, enumerate, ti.ndrange,
+                   ti.GroupedNDRange, zip, filter, map)) or x is None:
         return x
     elif isinstance(x, (ti.Expr, ti.Matrix)) and x.is_global():
         return x

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -97,7 +97,7 @@ def subscript(value, *indices):
     if isinstance(value, np.ndarray):
         return value.__getitem__(*indices)
 
-    if isinstance(value, tuple) or isinstance(value, list):
+    if isinstance(value, (tuple, list, dict)):
         assert len(indices) == 1
         return value[indices[0]]
 
@@ -243,6 +243,7 @@ class PyTaichi:
 
         for func in self.materialize_callbacks:
             func()
+        self.materialize_callbacks = []
 
     def clear(self):
         if self.prog:
@@ -535,11 +536,9 @@ def static(x, *xs):
     import types
     import taichi as ti
     if isinstance(x, (bool, int, float, range, list, tuple, enumerate,
-                      ti.ndrange, ti.GroupedNDRange)) or x is None:
+                      ti.ndrange, ti.GroupedNDRange, zip, filter, map)) or x is None:
         return x
-    elif isinstance(x, ti.lang.expr.Expr) and x.ptr.is_global_var():
-        return x
-    elif isinstance(x, ti.Matrix) and x.is_global():
+    elif isinstance(x, (ti.Expr, ti.Matrix)) and x.is_global():
         return x
     elif isinstance(x, (types.FunctionType, types.MethodType)):
         return x

--- a/python/taichi/lang/ndrange.py
+++ b/python/taichi/lang/ndrange.py
@@ -3,7 +3,7 @@ class ndrange:
         args = list(args)
         for i in range(len(args)):
             if isinstance(args[i], list):
-                args[i] = list(args[i])
+                args[i] = tuple(args[i])
             if not isinstance(args[i], tuple):
                 args[i] = (0, args[i])
             assert len(args[i]) == 2


### PR DESCRIPTION
Related issue = #

A collection of several random yet trivial fixes.

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
```py
import taichi as ti

x = dict(a=1, b=2)

@ti.kernel
def func():
    ti.static_print(x['a'])

func()
```
---
```
[Taichi] mode=release
[Taichi] version 0.6.40, llvm 10.0.0, commit 78231814, win, python 3.8.5
[Taichi] materializing...
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-1-95603a473205> in <module>
      7     ti.static_print(x['a'])
      8 
----> 9 func()

~\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py in wrapped(*args, **kwargs)
    572         def wrapped(*args, **kwargs):
    573             _taichi_skip_traceback = 1
--> 574             return primal(*args, **kwargs)
    575 
    576         wrapped.grad = adjoint

~\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\shell.py in new_call(*args, **kwargs)
     34     def new_call(*args, **kwargs):
     35         _taichi_skip_traceback = 1
---> 36         ret = old_call(*args, **kwargs)
     37         # print's in kernel won't take effect until ti.sync(), discussion:
     38         # https://github.com/taichi-dev/taichi/pull/1303#discussion_r444897102

~\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py in __call__(self, *args, **kwargs)
    499         instance_id, arg_features = self.mapper.lookup(args)
    500         key = (self.func, instance_id)
--> 501         self.materialize(key=key, args=args, arg_features=arg_features)
    502         return self.compiled_functions[key](*args)
    503 

~\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py in materialize(self, key, args, arg_features)
    368             self.runtime.inside_kernel = False
    369 
--> 370         taichi_kernel = taichi_kernel.define(taichi_ast_generator)
    371 
    372         assert key not in self.compiled_functions

~\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\kernel.py in taichi_ast_generator()
    365                 )
    366             self.runtime.inside_kernel = True
--> 367             compiled()
    368             self.runtime.inside_kernel = False
    369 

<ipython-input-1-95603a473205> in func()
      5 @ti.kernel
      6 def func():
----> 7     ti.static_print(x['a'])
      8 
      9 func()

~\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\util.py in wrapped(*args, **kwargs)
    197         assert in_taichi_scope(), \
    198                 f'{func.__name__} cannot be called in Python-scope'
--> 199         return func(*args, **kwargs)
    200 
    201     return wrapped

~\AppData\Local\Programs\Python\Python38\lib\site-packages\taichi\lang\impl.py in subscript(value, *indices)
    128         return Expr(taichi_lang_core.subscript(value.ptr, indices_expr_group))
    129     else:
--> 130         return value[indices]
    131 
    132 

KeyError: ('a',)
```