### PR TITLE
[async] Use llvm::SmallVector/llvm:SmallSet for latest state readers

### DIFF
--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -177,8 +177,7 @@ class StateFlowGraph {
   int first_pending_task_index_;
   TaskMeta initial_meta_;
   std::unordered_map<AsyncState, Node *> latest_state_owner_;
-  std::unordered_map<AsyncState, std::unordered_set<Node *>>
-      latest_state_readers_;
+  StateToNodesMap latest_state_readers_;
   std::unordered_map<std::string, int> task_name_to_launch_ids_;
   IRBank *ir_bank_;
 };


### PR DESCRIPTION
This is to address https://github.com/taichi-dev/taichi/pull/1936#pullrequestreview-506091734. But TBH, I saw no performance difference... Still good to keep the data structures consistent, though.

I feel like it's fine to keep `lastest_state_owners_` as is because it's not shown as a bottleneck, and it's not multi-leveled.

Related issue = https://github.com/taichi-dev/taichi/pull/1936#pullrequestreview-506091734

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
