### PR TITLE
[refactor] Add format_error_message() method

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -23,6 +23,7 @@
 #include "taichi/ir/frontend_ir.h"
 #include "taichi/program/async_engine.h"
 #include "taichi/util/statistics.h"
+#include "taichi/util/str.h"
 #if defined(TI_WITH_CC)
 #include "taichi/backends/cc/struct_cc.h"
 #include "taichi/backends/cc/cc_layout.h"
@@ -428,7 +429,7 @@ void Program::check_runtime_error() {
     // memory), use the device context instead.
     tlctx = llvm_context_device.get();
   }
-  auto runtime_jit_module = tlctx->runtime_jit_module;
+  auto *runtime_jit_module = tlctx->runtime_jit_module;
   runtime_jit_module->call<void *>("runtime_retrieve_and_reset_error_code",
                                    llvm_runtime);
   auto error_code = fetch_result<int64>(taichi_result_buffer_error_id);
@@ -451,31 +452,13 @@ void Program::check_runtime_error() {
     }
 
     if (error_code == 1) {
-      std::string error_message_formatted;
-      int argument_id = 0;
-      for (int i = 0; i < (int)error_message_template.size(); i++) {
-        if (error_message_template[i] != '%') {
-          error_message_formatted += error_message_template[i];
-        } else {
-          auto dtype = error_message_template[i + 1];
-          runtime_jit_module->call<void *>(
-              "runtime_retrieve_error_message_argument", llvm_runtime,
-              argument_id);
-          auto argument = fetch_result<uint64>(taichi_result_buffer_error_id);
-          if (dtype == 'd') {
-            error_message_formatted += fmt::format(
-                "{}", taichi_union_cast_with_different_sizes<int32>(argument));
-          } else if (dtype == 'f') {
-            error_message_formatted += fmt::format(
-                "{}",
-                taichi_union_cast_with_different_sizes<float32>(argument));
-          } else {
-            TI_ERROR("Data type identifier %{} is not supported", dtype);
-          }
-          argument_id += 1;
-          i++;  // skip the dtype char
-        }
-      }
+      const auto error_message_formatted = format_error_message(
+          error_message_template, [runtime_jit_module, this](int argument_id) {
+            runtime_jit_module->call<void *>(
+                "runtime_retrieve_error_message_argument", llvm_runtime,
+                argument_id);
+            return fetch_result<uint64>(taichi_result_buffer_error_id);
+          });
       TI_ERROR("Assertion failure: {}", error_message_formatted);
     } else {
       TI_NOT_IMPLEMENTED

--- a/taichi/util/str.cpp
+++ b/taichi/util/str.cpp
@@ -2,6 +2,8 @@
 
 #include <sstream>
 
+#include "taichi/inc/constants.h"
+
 TLANG_NAMESPACE_BEGIN
 
 std::string c_quoted(std::string const &str) {
@@ -30,6 +32,32 @@ std::string c_quoted(std::string const &str) {
 #undef REG_ESC
   ss << '"';
   return ss.str();
+}
+
+std::string format_error_message(const std::string &error_message_template,
+                                 const std::function<uint64(int)> &fetcher) {
+  std::string error_message_formatted;
+  int argument_id = 0;
+  for (int i = 0; i < (int)error_message_template.size(); i++) {
+    if (error_message_template[i] != '%') {
+      error_message_formatted += error_message_template[i];
+    } else {
+      const auto dtype = error_message_template[i + 1];
+      const auto argument = fetcher(argument_id);
+      if (dtype == 'd') {
+        error_message_formatted += fmt::format(
+            "{}", taichi_union_cast_with_different_sizes<int32>(argument));
+      } else if (dtype == 'f') {
+        error_message_formatted += fmt::format(
+            "{}", taichi_union_cast_with_different_sizes<float32>(argument));
+      } else {
+        TI_ERROR("Data type identifier %{} is not supported", dtype);
+      }
+      argument_id += 1;
+      i++;  // skip the dtype char
+    }
+  }
+  return error_message_formatted;
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/util/str.h
+++ b/taichi/util/str.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <functional>
 
 #include "taichi/lang_util.h"
 
@@ -8,5 +9,8 @@ TLANG_NAMESPACE_BEGIN
 
 // Quote |str| with a pair of ". Escape special characters like \n, \t etc.
 std::string c_quoted(std::string const &str);
+
+std::string format_error_message(const std::string &error_message_template,
+                                 const std::function<uint64(int)> &fetcher);
 
 TLANG_NAMESPACE_END


### PR DESCRIPTION
This is just pulling out the error message formatting part used by LLVM backend into a separate function. This way we can share it on other backends :)

Related issue = #677

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
