### PR TITLE
[Error] [ipython] Use print directly instead of builtin warnings module to prevent being supressed

### DIFF
--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -110,18 +110,18 @@ def get_line_number(asc=0):
     return inspect.stack()[1 + asc][2]
 
 
+# The builtin `warnings` module is unreliable as it may be supressed
+# by other packages, e.g. IPython.
 def warning(msg, type=UserWarning, stacklevel=1):
-    import warnings
+    from colorama import Fore, Back, Style
     import traceback
     import taichi as ti
-    use_spdlog = False
-    if use_spdlog:
-        s = traceback.extract_stack()[:-stacklevel]
-        raw = ''.join(traceback.format_list(s))
-        ti.warn(f'{type.__name__}: {msg}')
-        ti.warn(f'\n{raw}')
-    else:
-        warnings.warn(msg, type, stacklevel=stacklevel + 1)
+    s = traceback.extract_stack()[:-stacklevel]
+    raw = ''.join(traceback.format_list(s))
+    print(Fore.YELLOW + Style.BRIGHT, end='')
+    print(f'{type.__name__}: {msg}')
+    print(f'\n{raw}')
+    print(Style.RESET_ALL, end='')
 
 
 def deprecated(old, new, type=DeprecationWarning):


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/677#issuecomment-710742766

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
It seems that if I use IPython (`ti repl`), the warning is depressed. If I use raw Python shell (`python`), the warning is shown.
So IPython is setting `warnings.filterwarnings('ignore')` on their own? Anyway, the built-in warning system seems unreliable.
Let's switch to standard `print` for warning instead.