### PR TITLE
[async] Add allocator async state

### DIFF
--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -125,7 +125,9 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
         auto *sn = snode_op->snode;
         if (is_gc_able(sn->type)) {
           meta.input_states.emplace(sn, AsyncState::Type::allocator);
+          meta.input_states.emplace(sn, AsyncState::Type::mask);
           meta.output_states.emplace(sn, AsyncState::Type::allocator);
+          meta.output_states.emplace(sn, AsyncState::Type::mask);
         }
       }
     }
@@ -237,7 +239,9 @@ TaskFusionMeta get_task_fusion_meta(IRBank *bank, const TaskLaunchRecord &t) {
     meta.end_value = task->end_value;
   } else if (task->task_type != OffloadedTaskType::serial) {
     // Do not fuse gc/listgen tasks.
-    return fusion_meta_bank[t.ir_handle] = TaskFusionMeta();
+    meta.fusible = false;
+    meta.snode = task->snode;
+    return fusion_meta_bank[t.ir_handle] = meta;
   }
   meta.fusible = true;
   return fusion_meta_bank[t.ir_handle] = meta;

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -153,8 +153,8 @@ TLANG_NAMESPACE_END
 namespace std {
 template <>
 struct hash<taichi::lang::IRHandle> {
-  std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
-      noexcept {
+  std::size_t operator()(
+      const taichi::lang::IRHandle &ir_handle) const noexcept {
     return ir_handle.hash();
   }
 };

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -153,8 +153,8 @@ TLANG_NAMESPACE_END
 namespace std {
 template <>
 struct hash<taichi::lang::IRHandle> {
-  std::size_t operator()(
-      const taichi::lang::IRHandle &ir_handle) const noexcept {
+  std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
+      noexcept {
     return ir_handle.hash();
   }
 };

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -78,7 +78,7 @@ class TaskLaunchRecord {
 };
 
 struct AsyncState {
-  enum class Type { mask, value, list };
+  enum class Type { mask, value, list, allocator };
 
   AsyncState(SNode *snode, Type type) : snode(snode), type(type) {
   }
@@ -105,6 +105,9 @@ struct AsyncState {
         break;
       case Type::list:
         type_name = "list";
+        break;
+      case Type::allocator:
+        type_name = "allocator";
         break;
     }
     return snode->get_node_type_name_hinted() + "_" + type_name;

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -450,10 +450,12 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
         fusion_meta[a] != fusion_meta[b]) {
       return false;
     }
-    if (nodes[a]->meta->type != OffloadedStmt::TaskType::serial) {
+    if (nodes[a]->meta->type != OffloadedTaskType::serial) {
       for (auto &state : nodes[a]->output_edges) {
-        if (state.first.type != AsyncState::Type::value) {
-          // No need to check mask/list states as there must be value states.
+        const auto sty = state.first.type;
+        if (sty != AsyncState::Type::value && sty != AsyncState::Type::mask) {
+          // No need to check allocator/list states, as they must be accompanied
+          // with either value or mask states.
           continue;
         }
         if (state.second.find(nodes[b]) != state.second.end()) {

--- a/tests/python/test_gc.py
+++ b/tests/python/test_gc.py
@@ -94,3 +94,38 @@ def test_pointer_gc():
 
         # Note that being inactive doesn't mean it's not allocated.
         assert L.num_dynamically_allocated == 1
+
+
+@ti.test(require=[ti.extension.sparse, ti.extension.async_mode],
+         async_mode=True)
+def test_fuse_allocator_state():
+    N = 16
+    x = ti.field(dtype=ti.i32, shape=N)
+    y = ti.field(dtype=ti.i32)
+
+    y_parent = ti.root.pointer(ti.i, N * 2)
+    y_parent.place(y)
+
+    # https://github.com/taichi-dev/taichi/pull/1973#pullrequestreview-511154376
+
+    @ti.kernel
+    def activate_y():
+        for i in x:
+            idx = i + 1
+            y[idx] = idx
+
+    @ti.kernel
+    def deactivate_y():
+        for i in x:
+            ti.deactivate(y_parent, i)
+
+    activate_y()
+    deactivate_y()
+    ti.sync()
+
+    # TODO: assert that activate_y and deactivate_y are not fused.
+    assert y_parent.num_dynamically_allocated == N
+    ys = y.to_numpy()
+    for i, y in enumerate(ys):
+        expected = N if i == N else 0
+        assert y == expected


### PR DESCRIPTION
https://github.com/taichi-dev/taichi/blob/ceea597141bd1f0f0b2a380e5dabd50fb6ed04a6/taichi/lang_util.cpp#L156-L158

Before this PR, `test_block_async()` would actually fail. Here's the SFG. Note that all GC tasks are floating (as expected):

![no-alloc](https://user-images.githubusercontent.com/7481356/96365138-6fd6df80-1179-11eb-8101-e37cafa2c951.png)

With this PR, SFG:

![alloc](https://user-images.githubusercontent.com/7481356/96365147-7f562880-1179-11eb-9b29-75235b6c0ddb.png)

Highlighting the `allocator` state:

![alloc-single](https://user-images.githubusercontent.com/7481356/96365164-939a2580-1179-11eb-87f6-5c95c89d9ab8.png)



Related issue = #742

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
