### PR TITLE
[blender] Fix inspect.stack() not working in Blender with sourceinspect 0.0.4

### DIFF
--- a/python/taichi/lang/kernel.py
+++ b/python/taichi/lang/kernel.py
@@ -522,8 +522,7 @@ _KERNEL_CLASS_STACKFRAME_STMT_RES = [
 
 
 def _inside_class(level_of_class_stackframe):
-    import inspect
-    frames = inspect.stack()
+    frames = oinspect.stack()
     try:
         maybe_class_frame = frames[level_of_class_stackframe]
         statement_list = maybe_class_frame[4]
@@ -615,7 +614,6 @@ def data_oriented(cls):
         _taichi_skip_traceback = 1
         x = super(cls, self).__getattribute__(item)
         if hasattr(x, '_is_wrapped_kernel'):
-            import inspect
             if inspect.ismethod(x):
                 wrapped = x.__func__
             else:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(name=project_name,
                  install_requires=[
                      'numpy',
                      'pybind11>=2.5.0',
-                     'sourceinspect>=0.0.3',
+                     'sourceinspect>=0.0.4',
                      'colorama',
                      'astor',
                  ],


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
I found that ODOP is not working properly in Blender.