### PR TITLE
[metal] Refactor sparse shader impl in prep for pointer SNode

### DIFF
--- a/taichi/backends/metal/data_types.cpp
+++ b/taichi/backends/metal/data_types.cpp
@@ -21,7 +21,7 @@ MetalDataType to_metal_type(DataType dt) {
   METAL_CASE(u64);
   METAL_CASE(unknown);
   else {
-    TI_NOT_IMPLEMENTED;
+    TI_ERROR("[Metal] type={} not supported", data_type_name(dt));
   }
 #undef METAL_CASE
   return MetalDataType::unknown;

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -793,9 +793,9 @@ class KernelManager::Impl {
       mem_alloc->next = shaders::kAlignment;
       // root list data are static
       ListgenElement root_elem;
-      root_elem.root_mem_offset = 0;
+      root_elem.mem_offset = 0;
       for (int i = 0; i < taichi_max_num_indices; ++i) {
-        root_elem.coords[i] = 0;
+        root_elem.coords.at[i] = 0;
       }
       ListManager root_lm;
       root_lm.lm_data = rtm_list_begin + root_id;
@@ -880,6 +880,7 @@ class KernelManager::Impl {
         print_mem_->ptr() + shaders::kMetalAssertBufferSize);
     const int used_sz =
         std::min(pa->next, shaders::kMetalPrintMsgsMaxQueueSize);
+    TI_TRACE("Print buffer used bytes: {}", used_sz);
     using MsgType = shaders::PrintMsg::Type;
     char *buf = reinterpret_cast<char *>(pa + 1);
     const char *buf_end = buf + used_sz;

--- a/taichi/backends/metal/shaders/runtime_structs.metal.h
+++ b/taichi/backends/metal/shaders/runtime_structs.metal.h
@@ -135,7 +135,7 @@ STR(
       ElementCoords coords;
       // Memory offset from a given address.
       // * If in_root_buffer() is true, this is from the root buffer address.
-      // * O.W. this is from the |id|-th NodeManager's |elem_idx|-th element.
+      // * O/W this is from the |id|-th NodeManager's |elem_idx|-th element.
       int32_t mem_offset = 0;
 
       inline bool in_root_buffer() const {


### PR DESCRIPTION
Hi,

This PR contains mostly refactors and tweaks needed for `pointer`.

* Make `NodeManagerData:: ElemIndex` a strong type instead of an alias for `int32_t`. This is because we have to shift the raw `int32_t` index allocated from `NodeManagerData`'s lists (aka `ListManager`s), in order for the spinning memory allocation (#1174) to work. Using a plain `int32_t` is dangerous, as I have forgotten about the shift in allocation or recycle previously...
* Pull out `ListgenElement::coords` into a separate type: `ElementCoords`. The generated struct-for kernel only needs to know the coordinates, but not other info inside `ListgenElement` (which will be expanded later).

Related issue = #1740, #1174 

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
