### PR TITLE
[Perf] [cuda] Automatically use read-only data cache load

### DIFF
--- a/examples/stable_fluid.py
+++ b/examples/stable_fluid.py
@@ -9,7 +9,7 @@ import numpy as np
 import time
 
 use_mgpcg = False  # True to use multigrid-preconditioned conjugate gradients
-res = 512  # 600 for a larger resoultion
+res = 512
 dt = 0.03
 p_jacobi_iters = 160  # 40 for quicker but not-so-accurate result
 f_strength = 10000.0
@@ -368,7 +368,8 @@ while gui.running:
 
     if not paused:
         mouse_data = md_gen(gui)
-        step(mouse_data)
+        for i in range(10):
+            step(mouse_data)
 
     gui.set_image(dyes_pair.cur)
     # To visualize velocity field:

--- a/misc/benchmark_reduction.py
+++ b/misc/benchmark_reduction.py
@@ -2,13 +2,7 @@ import taichi as ti
 
 # TODO: make this a real benchmark and set up regression
 
-ti.init(arch=ti.gpu,
-        print_ir=True,
-        print_kernel_llvm_ir=True,
-        kernel_profiler=True,
-        print_kernel_llvm_ir_optimized=True)
-# ti.init(kernel_profiler=True)
-# ti.core.toggle_advanced_optimization(False)
+ti.init(arch=ti.gpu)
 
 N = 1024 * 1024 * 1024
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -221,13 +221,15 @@ def no_activate(*args):
 def cache_shared(*args):
     for a in args:
         for v in a.get_field_members():
-            taichi_lang_core.cache(0, v.ptr)
+            taichi_lang_core.insert_snode_access_flag(
+                taichi_lang_core.SNodeAccessFlag.block_local, v.ptr)
 
 
 def cache_read_only(*args):
     for a in args:
         for v in a.get_field_members():
-            taichi_lang_core.cache(0, v.ptr)
+            taichi_lang_core.insert_snode_access_flag(
+                taichi_lang_core.SNodeAccessFlag.read_only, v.ptr)
 
 
 def assume_in_range(val, base, low, high):
@@ -244,7 +246,6 @@ parallelize = core.parallelize
 serialize = lambda: parallelize(1)
 vectorize = core.vectorize
 block_dim = core.block_dim
-cache = core.cache
 
 inversed = deprecated('ti.inversed(a)', 'a.inverse()')(Matrix.inversed)
 transposed = deprecated('ti.transposed(a)', 'a.transpose()')(Matrix.transposed)
@@ -310,7 +311,6 @@ def clear_all_gradients():
     visit(ti.root)
 
 
-schedules = [parallelize, vectorize, block_dim, cache]
 lang_core = core
 
 

--- a/taichi/analysis/gather_snode_read_writes.cpp
+++ b/taichi/analysis/gather_snode_read_writes.cpp
@@ -1,0 +1,45 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/snode.h"
+#include "taichi/ir/visitors.h"
+#include "taichi/ir/analysis.h"
+#include "taichi/ir/statements.h"
+
+TLANG_NAMESPACE_BEGIN
+
+namespace irpass::analysis {
+
+// Returns the set of SNodes that are read or written
+std::pair<std::unordered_set<SNode *>, std::unordered_set<SNode *>>
+gather_snode_read_writes(IRNode *root) {
+  std::pair<std::unordered_set<SNode *>, std::unordered_set<SNode *>> accessed;
+  irpass::analysis::gather_statements(root, [&](Stmt *stmt) {
+    Stmt *ptr = nullptr;
+    bool read = false, write = false;
+    if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
+      read = true;
+      ptr = global_load->ptr;
+    } else if (auto global_store = stmt->cast<GlobalStoreStmt>()) {
+      write = true;
+      ptr = global_store->ptr;
+    } else if (auto global_atomic = stmt->cast<AtomicOpStmt>()) {
+      read = true;
+      write = true;
+      ptr = global_atomic->dest;
+    }
+    if (ptr) {
+      if (GlobalPtrStmt *global_ptr = ptr->cast<GlobalPtrStmt>()) {
+        for (auto &snode : global_ptr->snodes.data) {
+          if (read)
+            accessed.first.emplace(snode);
+          if (write)
+            accessed.second.emplace(snode);
+        }
+      }
+    }
+    return false;
+  });
+  return accessed;
+}
+}  // namespace irpass::analysis
+
+TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -389,7 +389,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     if (auto get_ch = stmt->ptr->cast<GetChStmt>(); get_ch) {
       bool should_cache_as_read_only = false;
       for (auto s : current_offload->scratch_opt) {
-        if (s.first == 1 && get_ch->output_snode == s.second) {
+        if (s.first == SNodeAccessFlag::read_only &&
+            get_ch->output_snode == s.second) {
           should_cache_as_read_only = true;
         }
       }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -585,8 +585,18 @@ void CodeGenLLVM::visit(BinaryOpStmt *stmt) {
 }
 
 llvm::Type *CodeGenLLVM::llvm_type(DataType dt) {
-  if (dt->is_primitive(PrimitiveTypeID::i32)) {
+  if (dt->is_primitive(PrimitiveTypeID::i8) ||
+      dt->is_primitive(PrimitiveTypeID::u8)) {
+    return llvm::Type::getInt8Ty(*llvm_context);
+  } else if (dt->is_primitive(PrimitiveTypeID::i16) ||
+             dt->is_primitive(PrimitiveTypeID::u16)) {
+    return llvm::Type::getInt16Ty(*llvm_context);
+  } else if (dt->is_primitive(PrimitiveTypeID::i32) ||
+             dt->is_primitive(PrimitiveTypeID::u32)) {
     return llvm::Type::getInt32Ty(*llvm_context);
+  } else if (dt->is_primitive(PrimitiveTypeID::i64) ||
+             dt->is_primitive(PrimitiveTypeID::u64)) {
+    return llvm::Type::getInt64Ty(*llvm_context);
   } else if (dt->is_primitive(PrimitiveTypeID::u1)) {
     return llvm::Type::getInt1Ty(*llvm_context);
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -65,6 +65,8 @@ bool definitely_same_address(Stmt *var1, Stmt *var2);
 std::unordered_set<Stmt *> detect_fors_with_break(IRNode *root);
 std::unordered_set<Stmt *> detect_loops_with_continue(IRNode *root);
 std::unordered_set<SNode *> gather_deactivations(IRNode *root);
+std::pair<std::unordered_set<SNode *>, std::unordered_set<SNode *>>
+gather_snode_read_writes(IRNode *root);
 std::vector<Stmt *> gather_statements(IRNode *root,
                                       const std::function<bool(Stmt *)> &test);
 std::unordered_map<SNode *, GlobalPtrStmt *> gather_uniquely_accessed_pointers(

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -158,10 +158,6 @@ void Expr::operator/=(const Expr &o) {
   (*this) = (*this) / load_if_ptr(o);
 }
 
-void Cache(int v, const Expr &var) {
-  dec.scratch_opt.push_back(std::make_pair(v, var.snode()));
-}
-
 Expr load_if_ptr(const Expr &ptr) {
   if (ptr.is<GlobalPtrExpression>()) {
     return load(ptr);

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -132,7 +132,6 @@ inline Expr smart_load(const Expr &var) {
 }
 
 // Begin: legacy frontend functions
-void Cache(int v, const Expr &var);
 Expr Var(const Expr &x);
 // End: legacy frontend functions
 

--- a/taichi/ir/frontend.cpp
+++ b/taichi/ir/frontend.cpp
@@ -22,6 +22,10 @@ Expr global_new(DataType dt, std::string name) {
   return Expr::make<GlobalVariableExpression>(dt, id_expr->id);
 }
 
+void insert_snode_access_flag(SNodeAccessFlag v, const Expr &field) {
+  dec.scratch_opt.push_back(std::make_pair(v, field.snode()));
+}
+
 // Begin: legacy frontend constructs
 
 If::If(const Expr &cond) {

--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -192,6 +192,8 @@ inline Expr LoopUnique(const Expr &input) {
   return Expr::make<LoopUniqueExpression>(load_if_ptr(input));
 }
 
+void insert_snode_access_flag(SNodeAccessFlag v, const Expr &field);
+
 // Begin: legacy frontend constructs
 
 class If {
@@ -227,9 +229,6 @@ class While {
 };
 
 // End: legacy frontend constructs
-
-#define Kernel(x) auto &x = get_current_program().kernel(#x)
-#define Assert(x) InsertAssert(#x, (x))
 
 TLANG_NAMESPACE_END
 

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -17,6 +17,16 @@ TLANG_NAMESPACE_BEGIN
 #define TI_EXPRESSION_IMPLEMENTATION
 #include "expression_ops.h"
 
+std::string snode_access_flag_name(SNodeAccessFlag type) {
+  if (type == SNodeAccessFlag::block_local) {
+    return "block_local";
+  } else if (type == SNodeAccessFlag::read_only) {
+    return "read_only";
+  } else {
+    TI_ERROR("Undefined SNode AccessType (value={})", int(type));
+  }
+}
+
 IRBuilder &current_ast_builder() {
   return context->builder();
 }

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -25,8 +25,11 @@ class Stmt;
 using pStmt = std::unique_ptr<Stmt>;
 
 class SNode;
+
+enum class SNodeAccessFlag : int { block_local, read_only };
+std::string snode_access_flag_name(SNodeAccessFlag type);
 class ScratchPads;
-using ScratchPadOptions = std::vector<std::pair<int, SNode *>>;
+using ScratchPadOptions = std::vector<std::pair<SNodeAccessFlag, SNode *>>;
 
 #define PER_STATEMENT(x) class x;
 #include "taichi/inc/statements.inc.h"

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -60,6 +60,7 @@ void replace_statements_with(IRNode *root,
 void demote_dense_struct_fors(IRNode *root);
 bool demote_atomics(IRNode *root);
 void reverse_segments(IRNode *root);  // for autograd
+void detect_read_only(IRNode *root);
 
 // compile_to_offloads does the basic compilation to create all the offloaded
 // tasks of a Taichi kernel. It's worth pointing out that this doesn't demote

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -35,6 +35,7 @@ CompileConfig::CompileConfig() {
   flatten_if = false;
   make_thread_local = true;
   make_block_local = true;
+  detect_read_only = true;
 
   saturating_grid_dim = 0;
   max_block_dim = 0;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -32,6 +32,7 @@ struct CompileConfig {
   bool flatten_if;
   bool make_thread_local;
   bool make_block_local;
+  bool detect_read_only;
   DataType default_fp;
   DataType default_ip;
   std::string extra_flags;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -155,6 +155,7 @@ void export_lang(py::module &m) {
       .def_readwrite("flatten_if", &CompileConfig::flatten_if)
       .def_readwrite("make_thread_local", &CompileConfig::make_thread_local)
       .def_readwrite("make_block_local", &CompileConfig::make_block_local)
+      .def_readwrite("detect_read_only", &CompileConfig::detect_read_only)
       .def_readwrite("cc_compile_cmd", &CompileConfig::cc_compile_cmd)
       .def_readwrite("cc_link_cmd", &CompileConfig::cc_link_cmd)
       .def_readwrite("async_opt_fusion", &CompileConfig::async_opt_fusion)
@@ -616,7 +617,13 @@ void export_lang(py::module &m) {
   m.def("parallelize", Parallelize);
   m.def("vectorize", Vectorize);
   m.def("block_dim", BlockDim);
-  m.def("cache", Cache);
+
+  py::enum_<SNodeAccessFlag>(m, "SNodeAccessFlag", py::arithmetic())
+      .value("block_local", SNodeAccessFlag::block_local)
+      .value("read_only", SNodeAccessFlag::read_only)
+      .export_values();
+
+  m.def("insert_snode_access_flag", insert_snode_access_flag);
   m.def("no_activate", [](SNode *snode) {
     get_current_program().get_current_kernel().no_activate.push_back(snode);
   });

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -132,6 +132,11 @@ void offload_to_executable(IRNode *ir,
   print("Start offload_to_executable");
   irpass::analysis::verify(ir);
 
+  if (config.detect_read_only) {
+    irpass::detect_read_only(ir);
+    print("Detect read-only accesses");
+  }
+
   if (config.demote_dense_struct_fors) {
     irpass::demote_dense_struct_fors(ir);
     irpass::type_check(ir);

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -9,8 +9,9 @@ TLANG_NAMESPACE_BEGIN
 
 namespace irpass {
 
-void detect_read_only(IRNode *root) {
-  auto offload = root->cast<OffloadedStmt>();
+namespace {
+
+void detect_read_only_offload(OffloadedStmt *offload) {
   auto accessed = irpass::analysis::gather_snode_read_writes(offload);
   for (auto snode : accessed.first) {
     if (accessed.second.count(snode) == 0) {
@@ -21,6 +22,14 @@ void detect_read_only(IRNode *root) {
         offload->scratch_opt.push_back(rec);
       }
     }
+  }
+}
+
+}  // namespace
+
+void detect_read_only(IRNode *root) {
+  for (auto &offload : root->as<Block>()->statements) {
+    detect_read_only_offload(offload->as<OffloadedStmt>());
   }
 }
 

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -15,7 +15,7 @@ void detect_read_only_offload(OffloadedStmt *offload) {
   auto accessed = irpass::analysis::gather_snode_read_writes(offload);
   for (auto snode : accessed.first) {
     if (accessed.second.count(snode) == 0) {
-      // read only SNode
+      // read-only SNode
       auto rec = std::make_pair(SNodeAccessFlag::read_only, snode);
       if (std::find(offload->scratch_opt.begin(), offload->scratch_opt.end(),
                     rec) == offload->scratch_opt.end()) {

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -1,0 +1,29 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+#include "taichi/ir/analysis.h"
+#include "taichi/ir/visitors.h"
+
+#include <algorithm>
+
+TLANG_NAMESPACE_BEGIN
+
+namespace irpass {
+
+void detect_read_only(IRNode *root) {
+  auto offload = root->cast<OffloadedStmt>();
+  auto accessed = irpass::analysis::gather_snode_read_writes(offload);
+  for (auto snode : accessed.first) {
+    if (accessed.second.count(snode) == 0) {
+      // read only SNode
+      auto rec = std::make_pair(SNodeAccessFlag::read_only, snode);
+      if (std::find(offload->scratch_opt.begin(), offload->scratch_opt.end(),
+                    rec) == offload->scratch_opt.end()) {
+        offload->scratch_opt.push_back(rec);
+      }
+    }
+  }
+}
+
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -28,8 +28,12 @@ void detect_read_only_in_task(OffloadedStmt *offload) {
 }  // namespace
 
 void detect_read_only(IRNode *root) {
-  for (auto &offload : root->as<Block>()->statements) {
-    detect_read_only_in_task(offload->as<OffloadedStmt>());
+  if (root->is<Block>()) {
+    for (auto &offload : root->as<Block>()->statements) {
+      detect_read_only_in_task(offload->as<OffloadedStmt>());
+    }
+  } else {
+    detect_read_only_in_task(root->as<OffloadedStmt>());
   }
 }
 

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -11,7 +11,7 @@ namespace irpass {
 
 namespace {
 
-void detect_read_only_offload(OffloadedStmt *offload) {
+void detect_read_only_in_task(OffloadedStmt *offload) {
   auto accessed = irpass::analysis::gather_snode_read_writes(offload);
   for (auto snode : accessed.first) {
     if (accessed.second.count(snode) == 0) {
@@ -29,7 +29,7 @@ void detect_read_only_offload(OffloadedStmt *offload) {
 
 void detect_read_only(IRNode *root) {
   for (auto &offload : root->as<Block>()->statements) {
-    detect_read_only_offload(offload->as<OffloadedStmt>());
+    detect_read_only_in_task(offload->as<OffloadedStmt>());
   }
 }
 

--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -127,7 +127,7 @@ std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *offload) {
   pads = std::make_unique<ScratchPads>();
   if (!offload->scratch_opt.empty()) {
     for (auto &opt : offload->scratch_opt) {
-      if (opt.first == 0 /* shared */) {
+      if (opt.first == SNodeAccessFlag::block_local) {
         pads->insert(opt.second);
       }
     }

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -6,7 +6,6 @@
 #include "taichi/ir/visitors.h"
 #include "taichi/ir/frontend_ir.h"
 #include "taichi/util/str.h"
-#include <typeinfo>
 
 TLANG_NAMESPACE_BEGIN
 
@@ -15,16 +14,8 @@ std::string scratch_pad_info(const ScratchPadOptions &opt) {
   if (!opt.empty()) {
     ser += "scratch_pad [ ";
     for (auto s : opt) {
-      // TODO: standardize scratch pad types
-      std::string type;
-      if (s.first == 0) {
-        type = "block local";
-      } else if (s.first == 1) {
-        type = "read_only";
-      } else {
-        TI_ERROR("scratch type {} not supported", s.first);
-      }
-      ser += s.second->get_node_type_name_hinted() + ":" + type + " ";
+      ser += s.second->get_node_type_name_hinted() + ":" +
+             snode_access_flag_name(s.first) + " ";
     }
     ser += "] ";
   } else {


### PR DESCRIPTION
About read-only data cache on CUDA: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#ldg-function

Note that on newer GPUs the performance seems less pronounced compared to old ones. For example, on `stable_fluid.py`
- on RTX 3090, this optimization leads to no performance gain
- on GTX 1080, this optimization leads to a ~4% performance gain. Compared to the original `stable_fluid.py` with manual hints, the compiler-optimized version is 1% faster. (So I removed the manual hints.)

Also, note that the backend compiler may be able to do this optimization automatically once it finds a memory load is read-only. We are doing it just to enforce the use of `__ldg` instructions. Taichi is able to do this since the `SNode` system is very friendly to aliasing analysis.

Anyway, we can remove the manual `ti.cache_read_only` hints in `stable_fluid.py` since the compiler can do it automatically now, and a 4% automatic performance boost is not bad. I believe there are other cases where read-only caches play a bigger role (I've seen cases where `__ldg` makes the program run 2x faster), but for now, we are just using `stable_fluid` for a quick benchmark.

I also introduced `SNodeAccessFlag`, as a more systematic solution compared to previous `int`-based access flagging.

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
