### PR TITLE
[metal] Revise NodeManager's implementation due to weak memory order

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -790,7 +790,7 @@ class KernelManager::Impl {
     if (compiled_structs_.need_snode_lists_data) {
       auto *mem_alloc = reinterpret_cast<MemoryAllocator *>(addr);
       // Make sure the retured memory address is always greater than 1.
-      mem_alloc->next = shaders::kAlignment;
+      mem_alloc->next = shaders::MemoryAllocator::kInitOffset;
       // root list data are static
       ListgenElement root_elem;
       root_elem.mem_offset = 0;

--- a/taichi/backends/metal/shaders/runtime_structs.metal.h
+++ b/taichi/backends/metal/shaders/runtime_structs.metal.h
@@ -31,8 +31,18 @@ STR(
     // clang-format on
     constant constexpr int kTaichiMaxNumIndices = 8;
     constant constexpr int kTaichiNumChunks = 1024;
+    constant constexpr int kAlignment = 8;
+    using PtrOffset = int32_t; 
 
-    struct MemoryAllocator { atomic_int next; };
+    struct MemoryAllocator { 
+      atomic_int next;
+
+      constant constexpr static int kInitOffset = 8;
+
+      static inline bool is_valid(PtrOffset v) {
+        return v >= kInitOffset;
+      }
+    };
 
     // ListManagerData manages a list of elements with adjustable size.
     struct ListManagerData {
@@ -44,6 +54,23 @@ STR(
       atomic_int next;
 
       atomic_int chunks[kTaichiNumChunks];
+
+      struct ReservedElemPtrOffset {
+       public:
+        ReservedElemPtrOffset() = default;
+        explicit ReservedElemPtrOffset(PtrOffset v) : val_(v) {}
+
+        inline bool is_valid() const { return is_valid(val_); }
+
+        inline static bool is_valid(PtrOffset v) { 
+          return MemoryAllocator::is_valid(v); 
+        }
+
+        inline PtrOffset value() const { return val_; }
+
+       private:
+        PtrOffset val_{0};
+      };
     };
 
     // NodeManagerData stores the actual data needed to implement NodeManager
@@ -54,6 +81,7 @@ STR(
     // few lists (ListManagerData). In particular, |data_list| stores the actual
     // data, while |free_list| and |recycle_list| are only meant for GC.
     struct NodeManagerData {
+      using ElemIndex = ListManagerData::ReservedElemPtrOffset;
       // Stores the actual data.
       ListManagerData data_list;
       // For GC
@@ -62,51 +90,6 @@ STR(
       atomic_int free_list_used;
       // Need this field to bookkeep some data during GC
       int recycled_list_size_backup;
-
-      // Use this type instead of the raw index type (int32_t), because the
-      // raw value needs to be shifted by |kIndexOffset| in order for the
-      // spinning memory allocation algorithm to work.
-      struct ElemIndex {
-        // The first 8 index values are reserved to encode special status:
-        // * 0  : nullptr
-        // * 1  : spinning for allocation
-        // * 2-7: unused for now
-        //
-        /// For each allocated index, it is added by |index_offset| to skip over
-        /// these reserved values.
-        constant static constexpr int32_t kIndexOffset = 8;
-
-        ElemIndex() = default;
-
-        static ElemIndex from_index(int i) {
-          return ElemIndex(i + kIndexOffset);
-        }
-
-        static ElemIndex from_raw(int r) {
-          return ElemIndex(r);
-        }
-
-        inline int32_t index() const {
-          return raw_ - kIndexOffset;
-        }
-
-        inline int32_t raw() const {
-          return raw_;
-        }
-
-        inline bool is_valid() const {
-          return raw_ >= kIndexOffset;
-        }
-
-        inline static bool is_valid(int raw) {
-          return ElemIndex::from_raw(raw).is_valid();
-        }
-
-       private:
-        explicit ElemIndex(int r) : raw_(r) {
-        }
-        int32_t raw_ = 0;
-      };
     };
 
     // This class is very similar to metal::SNodeDescriptor

--- a/taichi/backends/metal/shaders/runtime_structs.metal.h
+++ b/taichi/backends/metal/shaders/runtime_structs.metal.h
@@ -32,9 +32,9 @@ STR(
     constant constexpr int kTaichiMaxNumIndices = 8;
     constant constexpr int kTaichiNumChunks = 1024;
     constant constexpr int kAlignment = 8;
-    using PtrOffset = int32_t; 
+    using PtrOffset = int32_t;
 
-    struct MemoryAllocator { 
+    struct MemoryAllocator {
       atomic_int next;
 
       constant constexpr static int kInitOffset = 8;
@@ -58,15 +58,20 @@ STR(
       struct ReservedElemPtrOffset {
        public:
         ReservedElemPtrOffset() = default;
-        explicit ReservedElemPtrOffset(PtrOffset v) : val_(v) {}
-
-        inline bool is_valid() const { return is_valid(val_); }
-
-        inline static bool is_valid(PtrOffset v) { 
-          return MemoryAllocator::is_valid(v); 
+        explicit ReservedElemPtrOffset(PtrOffset v) : val_(v) {
         }
 
-        inline PtrOffset value() const { return val_; }
+        inline bool is_valid() const {
+          return is_valid(val_);
+        }
+
+        inline static bool is_valid(PtrOffset v) {
+          return MemoryAllocator::is_valid(v);
+        }
+
+        inline PtrOffset value() const {
+          return val_;
+        }
 
        private:
         PtrOffset val_{0};


### PR DESCRIPTION
It's turned out that #2000's approach didn't really work, due to Metal's weak memory order guarantee...

**Problem**

Previously, each `pointer` cell stores a `NodeManager::ElemIndex::raw_`. This is basically an index in the `data_list`. The index then gets mapped to a chunk in the list, then a slot within that chunk.

This design has involved two places that would require atomic operations:

1. Reading or allocating the cell's value.
2. Reading or allocating the chunk in `data_list`.

```py
def allocate():
  while cell is not valid:
    if atomic_cas(&cell, 1):  # <-- 1st atomic, `1` means lock
      addr = atomically allocate from `data_list`  # <-- 2nd atomic
      store `addr` into `cell`  # now `cell` is valid

def get():
  idx = atomically read from cell
  atomically load `addr` from `data_list` using `idx`
  return `addr`
```

If `allocate()` is done in thread A, such that `allocate()` in another thread B sees that `cell` is already valid, due to the relaxed memory order, B's `get()` could still observe invalid `addr`...

**Solution**

Just store the allocated pointer offset (32-bit, `ListManagerData::ReservedElemPtrOffs`) into `cell` directly. This avoids the second lookup into `data_list`. Note that to reduce code change, `NodeManager::ElemIndex` is just an alias for `ListManagerData::ReservedElemPtrOffs` now.

Related issue = #1740, #1174 

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
