### PR TITLE
[misc] Automatically cancel the previous Github workflow run

### DIFF
--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -7,14 +7,14 @@ jobs:
   cancel_prev_runs:
     # This action in the market doesn't work...
     # https://github.com/marketplace/actions/cancel-workflow-action
+    name: Cancel Previous Runs
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
-          with:
-            python-version: 3.8
-        - name: Check the previous run
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Check the previous run
         env:
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Check the previous run
+      - name: Find and cancel the previous run
         env:
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -4,9 +4,32 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  cancel_prev_runs:
+    # This action in the market doesn't work...
+    # https://github.com/marketplace/actions/cancel-workflow-action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        - uses: actions/checkout@v2
+        - uses: actions/setup-python@v2
+          with:
+            python-version: 3.8
+        - name: Check the previous run
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          # https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
+          # https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
+          # Do not leak the secret
+          OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python misc/ci_cancel_previous_run.py --pr "${PR}" --sha "${SHA}" --token "${OAUTH_TOKEN}"
+
   build_and_test_cpu:
     name: Build and Test (CPU)
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') && github.event.sender.login != 'taichi-gardener' }}
+    needs: cancel_prev_runs
+    # Trigger this unconditionally since we the previous CI can be cancelled automatically.
+    # if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') && github.event.sender.login != 'taichi-gardener' }}
     strategy:
       matrix:
         include:
@@ -59,7 +82,9 @@ jobs:
 
   build_and_test_cuda:
     name: Build and Test (CUDA)
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') && github.event.sender.login != 'taichi-gardener' }}
+    needs: cancel_prev_runs
+    # Trigger this unconditionally since we the previous CI can be cancelled automatically.
+    # if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') && github.event.sender.login != 'taichi-gardener' }}
     runs-on: [zhen]
     steps:
       - uses: actions/checkout@v2
@@ -86,25 +111,25 @@ jobs:
           ti diagnose
           ti test -vr2 -t2
 
-  check_previous_run:
-    name: Checks the Workflow Run of the Previous Commit
-    runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'skip ci') || github.event.sender.login == 'taichi-gardener' }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Check the previous run
-        env:
-          PR: ${{ github.event.pull_request.number }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-          # https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
-          # https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
-          # Do not leak the secret
-          OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python misc/ci_check_previous_run.py --pr "${PR}" --sha "${SHA}" --token "${OAUTH_TOKEN}"
+  # check_previous_run:
+  #   name: Checks the Workflow Run of the Previous Commit
+  #   runs-on: ubuntu-latest
+  #   if: ${{ contains(github.event.pull_request.labels.*.name, 'skip ci') || github.event.sender.login == 'taichi-gardener' }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.8
+  #     - name: Check the previous run
+  #       env:
+  #         PR: ${{ github.event.pull_request.number }}
+  #         SHA: ${{ github.event.pull_request.head.sha }}
+  #         # https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
+  #         # https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
+  #         # Do not leak the secret
+  #         OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         python misc/ci_check_previous_run.py --pr "${PR}" --sha "${SHA}" --token "${OAUTH_TOKEN}"
 
   code_format:
     name: Code Format

--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -111,26 +111,6 @@ jobs:
           ti diagnose
           ti test -vr2 -t2
 
-  # check_previous_run:
-  #   name: Checks the Workflow Run of the Previous Commit
-  #   runs-on: ubuntu-latest
-  #   if: ${{ contains(github.event.pull_request.labels.*.name, 'skip ci') || github.event.sender.login == 'taichi-gardener' }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.8
-  #     - name: Check the previous run
-  #       env:
-  #         PR: ${{ github.event.pull_request.number }}
-  #         SHA: ${{ github.event.pull_request.head.sha }}
-  #         # https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
-  #         # https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
-  #         # Do not leak the secret
-  #         OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       run: |
-  #         python misc/ci_check_previous_run.py --pr "${PR}" --sha "${SHA}" --token "${OAUTH_TOKEN}"
-
   code_format:
     name: Code Format
     runs-on: ubuntu-latest

--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -20,7 +20,7 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha }}
           # https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
           # https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
-          # Do not leak the secret
+          # Do not leak the secret!
           OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python misc/ci_cancel_previous_run.py --pr "${PR}" --sha "${SHA}" --token "${OAUTH_TOKEN}"

--- a/misc/ci_cancel_previous_run.py
+++ b/misc/ci_cancel_previous_run.py
@@ -24,8 +24,8 @@ def send_request(url):
     # https://docs.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
     rl = res.getheader('X-Ratelimit-Limit', None)
     rl_remain = res.getheader('X-Ratelimit-Remaining', None)
-    logging.debug(
-        'request=%s rate_limit=%s rate_limit_remaining=%s', url, rl, rl_remain)
+    logging.debug('request=%s rate_limit=%s rate_limit_remaining=%s', url, rl,
+                  rl_remain)
     return res
 
 
@@ -98,15 +98,18 @@ def cancel_workflow_run(run_id):
     for r in range(MAX_RETRIES):
         f = send_request(url)
         j = json.loads(f.read())
-        
+
         status = j['status']
         if status not in {'queued', 'in_progress'}:
-          logging.info('Wrkflow run=%s done, conclusion=%s', run_id, j['conclusion'])
-          return True
-        
+            logging.info('Wrkflow run=%s done, conclusion=%s', run_id,
+                         j['conclusion'])
+            return True
+
         cancel_url = j['cancel_url']
         f = send_request(cancel_url)
-        logging.debug('[%d] Issued cancel requeest (url=%s) to workflow run=%s, waiting for the status...', r, cancel_url, run_id)
+        logging.debug(
+            '[%d] Issued cancel requeest (url=%s) to workflow run=%s, waiting for the status...',
+            r, cancel_url, run_id)
         time.sleep(30)
     return False
 

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -53,7 +53,7 @@ class KernelManager {
   // Launch the given |taichi_kernel_name|.
   // Kernel launching is asynchronous, therefore the Metal memory is not valid
   // to access until after a synchronize() call.
-  void launch_taichi_kernel(const std::string &taichi_kernel_name,     
+  void launch_taichi_kernel(const std::string &taichi_kernel_name,
                             Context *ctx);
 
   // Synchronize the memory content from Metal to host (x86_64).

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -53,7 +53,7 @@ class KernelManager {
   // Launch the given |taichi_kernel_name|.
   // Kernel launching is asynchronous, therefore the Metal memory is not valid
   // to access until after a synchronize() call.
-  void launch_taichi_kernel(const std::string &taichi_kernel_name,
+  void launch_taichi_kernel(const std::string &taichi_kernel_name,     
                             Context *ctx);
 
   // Synchronize the memory content from Metal to host (x86_64).


### PR DESCRIPTION
Related issue = #1809 

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
