### PR TITLE
[metal] Support pointer SNode in codegen

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -557,7 +557,8 @@ class KernelManager::Impl {
     TI_ASSERT(global_tmps_buffer_ != nullptr);
 
     TI_ASSERT(compiled_structs_.runtime_size > 0);
-    const int mem_pool_bytes = (config_->device_memory_GB * 1024 * 1024 * 1024);
+    const size_t mem_pool_bytes =
+        (config_->device_memory_GB * 1024 * 1024 * 1024ULL);
     runtime_mem_ = std::make_unique<BufferMemoryView>(
         compiled_structs_.runtime_size + mem_pool_bytes, mem_pool_);
     runtime_buffer_ = new_mtl_buffer_no_copy(device_.get(), runtime_mem_->ptr(),
@@ -709,6 +710,9 @@ class KernelManager::Impl {
         case SNodeType::dynamic:
           rtm_meta->type = SNodeMeta::Dynamic;
           break;
+        case SNodeType::pointer:
+          rtm_meta->type = SNodeMeta::Pointer;
+          break;
         default:
           TI_ERROR("Unsupported SNode type={}",
                    snode_type_name(sn_meta.snode->type));
@@ -771,6 +775,11 @@ class KernelManager::Impl {
     addr += addr_offset;
     TI_DEBUG("Initialized ListManagerData, size={} accumulated={}", addr_offset,
              (addr - addr_begin));
+    // TODO(k-ye): Initialize these
+    addr_offset = sizeof(NodeManagerData) * max_snodes;
+    addr += addr_offset;
+    addr_offset = sizeof(NodeManagerData::ElemIndex) * max_snodes;
+    addr += addr_offset;
     // init rand_seeds
     // TODO(k-ye): Provide a way to use a fixed seed in dev mode.
     std::mt19937 generator(

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -88,7 +88,7 @@ STR(
             // * Y is `dense`, but Z is a `pointer`: Z's memory location is
             //   known at compile time! So Z itself still lives in the `root`
             //   buffer! However, each Z cell stores the pointer allocated from
-            //   the runtime memory pool. 
+            //   the runtime memory pool.
             child_elem.belonged_nodemgr = parent_elem.belonged_nodemgr;
             child_elem.mem_offset =
                 parent_elem.mem_offset + child_idx * child_stride;

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -33,7 +33,6 @@ static_assert(false, "Do not include");
 // clang-format off
 METAL_BEGIN_RUNTIME_KERNELS_DEF
 STR(
-    // clang-format on
     kernel void element_listgen(device byte *runtime_addr[[buffer(0)]],
                                 device byte *root_addr[[buffer(1)]],
                                 device int *args[[buffer(2)]],
@@ -110,9 +109,7 @@ STR(
           child_list.append(child_elem);
         }
       }
-    }
-    // clang-format off
-)
+    })
 METAL_END_RUNTIME_KERNELS_DEF
 // clang-format on
 

--- a/taichi/backends/metal/shaders/runtime_structs.metal.h
+++ b/taichi/backends/metal/shaders/runtime_structs.metal.h
@@ -145,7 +145,9 @@ STR(
       };
       BelongedNodeManager belonged_nodemgr;
 
-      inline bool in_root_buffer() const { return belonged_nodemgr.id < 0; }
+      inline bool in_root_buffer() const {
+        return belonged_nodemgr.id < 0;
+      }
     };
     // clang-format off
 )

--- a/taichi/backends/metal/shaders/runtime_structs.metal.h
+++ b/taichi/backends/metal/shaders/runtime_structs.metal.h
@@ -99,7 +99,13 @@ STR(
 
     // This class is very similar to metal::SNodeDescriptor
     struct SNodeMeta {
-      enum Type { Root = 0, Dense = 1, Bitmasked = 2, Dynamic = 3 };
+      enum Type {
+        Root = 0,
+        Dense = 1,
+        Bitmasked = 2,
+        Dynamic = 3,
+        Pointer = 4,
+      };
       int32_t element_stride = 0;
       int32_t num_slots = 0;
       int32_t mem_offset_in_parent = 0;
@@ -126,10 +132,20 @@ STR(
       // * O/W this is from the |id|-th NodeManager's |elem_idx|-th element.
       int32_t mem_offset = 0;
 
-      inline bool in_root_buffer() const {
-        // Placeholder impl
-        return true;
-      }
+      struct BelongedNodeManager {
+        // Index of the *NodeManager itself* in the runtime buffer.
+        // If -1, the memory where this cell lives isn't in a particular
+        // NodeManager's dynamically allocated memory. Instead, it is at a fixed
+        // location in the root buffer.
+        //
+        // For {dense, bitmasked}, this should always be -1.
+        int32_t id = -1;
+        // Index of the element within the NodeManager.
+        NodeManagerData::ElemIndex elem_idx;
+      };
+      BelongedNodeManager belonged_nodemgr;
+
+      inline bool in_root_buffer() const { return belonged_nodemgr.id < 0; }
     };
     // clang-format off
 )

--- a/taichi/backends/metal/shaders/runtime_utils.metal.h
+++ b/taichi/backends/metal/shaders/runtime_utils.metal.h
@@ -40,6 +40,7 @@ struct Runtime {
 
 #endif  // TI_INSIDE_METAL_CODEGEN
 
+// clang-format off
 METAL_BEGIN_RUNTIME_UTILS_DEF
 STR(
     [[maybe_unused]] PtrOffset mtl_memalloc_alloc(device MemoryAllocator *ma,
@@ -205,19 +206,21 @@ STR(
     // * init(), instead of doing initiliaztion in the constructor.
     class SNodeRep_dense {
      public:
-      void init(device byte *addr) {
-        addr_ = addr;
-      }
+      void init(device byte * addr) { addr_ = addr; }
 
       inline device byte *addr() {
         return addr_;
       }
 
-      inline bool is_active(int) { return true; }
+      inline bool is_active(int) {
+        return true;
+      }
 
-      inline void activate(int) {}
+      inline void activate(int) {
+      }
 
-      inline void deactivate(int) {}
+      inline void deactivate(int) {
+      }
 
      private:
       device byte *addr_ = nullptr;
@@ -229,7 +232,7 @@ STR(
      public:
       constant static constexpr int kBitsPerMask = (sizeof(uint32_t) * 8);
 
-      void init(device byte *addr, int meta_offset) {
+      void init(device byte * addr, int meta_offset) {
         addr_ = addr;
         meta_offset_ = meta_offset;
       }
@@ -268,7 +271,7 @@ STR(
 
     class SNodeRep_dynamic {
      public:
-      void init(device byte *addr, int meta_offset) {
+      void init(device byte * addr, int meta_offset) {
         addr_ = addr;
         meta_offset_ = meta_offset;
       }
@@ -333,7 +336,9 @@ STR(
         return nm_.get(nm_idx);
       }
 
-      inline bool is_active(int i) { return is_active(addr_, i); }
+      inline bool is_active(int i) {
+        return is_active(addr_, i);
+      }
 
       void activate(int i) {
         device auto *nm_idx_ptr = to_nodemgr_idx_ptr(addr_, i);


### PR DESCRIPTION
This teaches the Metal codegen how to use `SNodeRep_pointer` in the generated classes. For example:

```cpp
struct S1 {
  // pointer
  constant static constexpr int n = 4096;
  constant static constexpr int elem_stride = /*pointer ElemIndex=*/4;
  constant static constexpr int stride = elem_stride * n;

  S1(device byte *addr, device Runtime *rtm, device MemoryAllocator *ma) {
    NodeManager nm;
    nm.nm_data = (rtm->snode_allocators + 1);  // 1 is the SNode ID
    nm.mem_alloc = ma;
    const auto amb_idx = rtm->ambient_indices[1];  // 1 is the SNode ID
    rep_.init(addr, nm, amb_idx);
  }

  S1_ch children(int i) {
    return {rep_.child_or_ambient_addr(i)};
  }

  inline bool is_active(int i) {
    return rep_.is_active(i);
  }

  inline void activate(int i) {
    rep_.activate(i);
  }

  inline void deactivate(int i) {
    rep_.deactivate(i);
  }

  SNodeRep_pointer rep_;
};
```

It also handles the `listgen` tasks properly for `pointer` SNodes now. I've inlined some explanation/docs in the Metal shader files themselves...

Things that will be added later:

* Initializing the node allocators, ambient elements are runtime
* GC

Related issue = #1740, #1174 

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
