### PR TITLE
[opengl] [refactor] Reduce SSBO numbers: merge earg with args

### DIFF
--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -12,6 +12,8 @@ class SNode;
 
 namespace opengl {
 
+constexpr int taichi_opengl_earg_base = taichi_max_num_args * sizeof(uint64_t);
+
 struct UsedFeature {
   // types:
   bool simulated_atomic_float{false};
@@ -60,7 +62,6 @@ enum class GLBufId {
   Listman = 7,
   Gtmp = 1,
   Args = 2,
-  Earg = 3,
   Extr = 4,
 };
 


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
The limit of SSBOs can be down to 8 for OpenGL core, or 4 for OpenGL ES.
So we want to reduce the number of SSBO used to improve compatibility on low-end machines.
This PR merges the `earg` SSBO with `args` SSBO.