### PR TITLE
[opengl] [refactor] Move rand_state from runtime to gtmp to reduce SSBO numbers

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -125,8 +125,10 @@ class KernelGen : public IRVisitor {
     emit("}}");
 
     // clang-format off
+    std::string kernel_header;
 #define __GLSL__
-    std::string kernel_header = (
+    if (used.print)  // the runtime buffer is only used for print now..
+      kernel_header += (
 #include "taichi/backends/opengl/shaders/runtime.h"
         );
     if (used.listman)
@@ -142,14 +144,14 @@ class KernelGen : public IRVisitor {
     if (used.int64)
       kernel_header += "layout(std430, binding = 0) buffer data_i64 { int64_t _data_i64_[]; };\n";
 
-    if (used.buf_gtmp) {
+    if (used.buf_gtmp || used.random) {
       kernel_header +=
-          "layout(std430, binding = 1) buffer gtmp_i32 { int _gtmp_i32_[]; };\n"
-          "layout(std430, binding = 1) buffer gtmp_f32 { float _gtmp_f32_[]; };\n";
+          "layout(std430, binding = 1) buffer gtmp_i32 { int _rand_state_[4]; int _gtmp_i32_[]; };\n"
+          "layout(std430, binding = 1) buffer gtmp_f32 { int _padding1_[4]; float _gtmp_f32_[]; };\n";
       if (used.float64)
-        kernel_header += "layout(std430, binding = 1) buffer gtmp_f64 { double _gtmp_f64_[]; };\n";
+        kernel_header += "layout(std430, binding = 1) buffer gtmp_f64 { int _padding2_[4]; double _gtmp_f64_[]; };\n";
       if (used.int64)
-        kernel_header += "layout(std430, binding = 1) buffer gtmp_i64 { int64_t _gtmp_i64_[]; };\n";
+        kernel_header += "layout(std430, binding = 1) buffer gtmp_i64 { int _padding3_[4]; int64_t _gtmp_i64_[]; };\n";
     }
     if (used.buf_args) {
       kernel_header +=

--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -20,9 +20,6 @@ struct UsedFeature {
   bool int64{false};
   bool float64{false};
 
-  // sparse:
-  bool listman{false};
-
   // buffers:
   bool buf_args{false};
   bool buf_earg{false};
@@ -31,6 +28,7 @@ struct UsedFeature {
 
   // utilties:
   bool fast_pow{false};
+  bool listman{false};
   bool random{false};
   bool print{false};
 

--- a/taichi/backends/opengl/shaders/random.glsl.h
+++ b/taichi/backends/opengl/shaders/random.glsl.h
@@ -2,10 +2,10 @@
 // clang-format off
 #include "taichi/util/macros.h"
 STR(
-uvec4 _rand_;
+uvec4 _rand_;  // per-thread local variable
 
 void _init_rand() {
-  uint i = (54321u + gl_GlobalInvocationID.x) * (12345u + uint(_rand_state_));
+  uint i = (54321u + gl_GlobalInvocationID.x) * (12345u + uint(_rand_state_[0]));
   _rand_.x = 123456789u * i * 1000000007u;
   _rand_.y = 362436069u;
   _rand_.z = 521288629u;
@@ -15,7 +15,7 @@ void _init_rand() {
   // how `_rand_state_` changes, `gl_GlobalInvocationID.x` can still help
   // us to set different seeds for different threads.
   // Discussion: https://github.com/taichi-dev/taichi/pull/912#discussion_r419021918
-  _rand_state_ += 1;
+  _rand_state_[0] += 1;
 }
 
 uint _rand_u32() {
@@ -28,8 +28,6 @@ uint _rand_u32() {
 float _rand_f32() {
   return float(_rand_u32()) * (1.0 / 4294967296.0);
 }
-
-double _rand_f64() { return double(_rand_f32()); }
 
 int _rand_i32() { return int(_rand_u32()); }
 )

--- a/taichi/backends/opengl/shaders/runtime.h
+++ b/taichi/backends/opengl/shaders/runtime.h
@@ -16,10 +16,6 @@ struct _msg_entry_t {
 };
 
 layout(std430, binding = 6) buffer runtime {
-  int _indirect_x_;
-  int _indirect_y_;
-  int _indirect_z_;
-  int _rand_state_;
   int _msg_count_;
   // TODO: move msg buf to gtmp
   _msg_entry_t _msg_buf_[];
@@ -49,10 +45,6 @@ struct GLSLMsgEntry {
 };
 
 struct GLSLRuntime {
-  int indirect_x;
-  int indirect_y;
-  int indirect_z;
-  int rand_state;
   int msg_count;
   GLSLMsgEntry msg_buf[MAX_MESSAGES];
 };


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
This further reduce 1 SSBO when `print` is not used.
I wonder if we could even demote `RandStmt` into `GtmpStmt` and a series of bit operations in the middle end so that random  generators are backend-independent?