### PR TITLE
[type] Support bit-level read and write in Python-scope

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -906,7 +906,7 @@ void CodeGenLLVM::visit(KernelReturnStmt *stmt) {
   if (stmt->ret_type.is_pointer()) {
     TI_NOT_IMPLEMENTED
   } else {
-    auto intermediate_bits = 0 ;
+    auto intermediate_bits = 0;
     if (stmt->value->ret_type->is<CustomIntType>()) {
       intermediate_bits = 32;
     } else {

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -107,8 +107,6 @@ llvm::Type *TaichiLLVMContext::get_data_type(DataType dt) {
     return llvm::Type::getInt32Ty(*ctx);
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
     return llvm::Type::getInt64Ty(*ctx);
-  } else if (dt->is<CustomIntType>()) {
-    return llvm::Type::getInt32Ty(*ctx);
   } else {
     TI_INFO(data_type_name(dt));
     TI_NOT_IMPLEMENTED

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -107,6 +107,8 @@ llvm::Type *TaichiLLVMContext::get_data_type(DataType dt) {
     return llvm::Type::getInt32Ty(*ctx);
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
     return llvm::Type::getInt64Ty(*ctx);
+  } else if (dt->is<CustomIntType>()) {
+    return llvm::Type::getInt32Ty(*ctx);
   } else {
     TI_INFO(data_type_name(dt));
     TI_NOT_IMPLEMENTED

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -305,7 +305,7 @@ int64 Kernel::get_ret_int(int i) {
     if (cit->get_is_signed())
       return (int64)get_current_program().fetch_result<int32>(i);
     else
-      return (uint64)get_current_program().fetch_result<uint32>(i);
+      return (int64)get_current_program().fetch_result<uint32>(i);
   } else {
     TI_NOT_IMPLEMENTED
   }

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -205,7 +205,13 @@ void Kernel::LaunchContextBuilder::set_arg_int(int i, int64 d) {
     ctx_->set_arg(i, (float32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
     ctx_->set_arg(i, (float64)d);
+  } else if (auto cit = dt->cast<CustomIntType>()) {
+    if (cit->get_is_signed())
+      ctx_->set_arg(i, (int32)d);
+    else
+      ctx_->set_arg(i, (uint32)d);
   } else {
+    TI_INFO(dt->to_string());
     TI_NOT_IMPLEMENTED
   }
 }
@@ -295,6 +301,11 @@ int64 Kernel::get_ret_int(int i) {
     return (int64)get_current_program().fetch_result<float32>(i);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
     return (int64)get_current_program().fetch_result<float64>(i);
+  } else if (auto cit = dt->cast<CustomIntType>()) {
+    if (cit->get_is_signed())
+      return (int64)get_current_program().fetch_result<int32>(i);
+    else
+      return (uint64)get_current_program().fetch_result<uint32>(i);
   } else {
     TI_NOT_IMPLEMENTED
   }

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -31,6 +31,10 @@ def test_simple_array():
     set_val()
     verify_val()
 
+    # test bit_struct SNode read and write in python scope
+    set_val.__wrapped__()
+    verify_val.__wrapped__()
+
 
 def test_custom_int_load_and_store():
     ti.init(arch=ti.cpu, debug=True, print_ir=True, cfg_optimization=False)
@@ -66,3 +70,8 @@ def test_custom_int_load_and_store():
     for idx in range(len(test_case_np)):
         set_val(idx)
         verify_val(idx)
+
+    # test bit_struct SNode read and write in python scope
+    for idx in range(len(test_case_np)):
+        set_val.__wrapped__(idx)
+        verify_val.__wrapped__(idx)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -31,7 +31,7 @@ def test_simple_array():
     set_val()
     verify_val()
 
-    # test bit_struct SNode read and write in python scope
+    # Test bit_struct SNode read and write in Python-scope by calling the wrapped, untranslated function body
     set_val.__wrapped__()
     verify_val.__wrapped__()
 
@@ -71,7 +71,7 @@ def test_custom_int_load_and_store():
         set_val(idx)
         verify_val(idx)
 
-    # test bit_struct SNode read and write in python scope
+    # Test bit_struct SNode read and write in Python-scope by calling the wrapped, untranslated function body
     for idx in range(len(test_case_np)):
         set_val.__wrapped__(idx)
         verify_val.__wrapped__(idx)


### PR DESCRIPTION
Related issue = #1905 #1996 

In this pr, we tried to support reading/writing `bit_struct` in python scope.
The key change is : support `CustomIntType` in `get_data_type`, `get_ret_int` and `get_ret_int`

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
