### PR TITLE
[opt] [async] Fix constant folding in async mode

### DIFF
--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -210,10 +210,17 @@ void AsyncEngine::enqueue(const TaskLaunchRecord &t) {
 void AsyncEngine::synchronize() {
   TI_AUTO_PROF
   bool modified = true;
-  TI_TRACE("Synchronizing SFG of {} nodes", sfg->size());
-  debug_sfg("initial");
   sfg->reid_nodes();
   sfg->reid_pending_nodes();
+  TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
+           sfg->num_pending_tasks());
+  std::cout << std::flush;
+  sfg->print();
+  for (auto i : sfg->get_pending_tasks()) {
+    irpass::print(i->rec.stmt());
+  }
+  std::cout << std::flush;
+  debug_sfg("initial");
   if (program->config.debug) {
     sfg->verify();
   }
@@ -249,6 +256,13 @@ void AsyncEngine::synchronize() {
     sfg->verify();
   }
   debug_sfg("final");
+  TI_TRACE("final");
+  std::cout << std::flush;
+  sfg->print();
+  for (auto i : sfg->get_pending_tasks()) {
+    irpass::print(i->rec.stmt());
+  }
+  std::cout << std::flush;
   auto tasks = sfg->extract_to_execute();
   TI_TRACE("Ended up with {} nodes", tasks.size());
   for (auto &task : tasks) {

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -214,12 +214,6 @@ void AsyncEngine::synchronize() {
   sfg->reid_pending_nodes();
   TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
            sfg->num_pending_tasks());
-  std::cout << std::flush;
-  sfg->print();
-  for (auto i : sfg->get_pending_tasks()) {
-    irpass::print(i->rec.stmt());
-  }
-  std::cout << std::flush;
   debug_sfg("initial");
   if (program->config.debug) {
     sfg->verify();
@@ -256,13 +250,6 @@ void AsyncEngine::synchronize() {
     sfg->verify();
   }
   debug_sfg("final");
-  TI_TRACE("final");
-  std::cout << std::flush;
-  sfg->print();
-  for (auto i : sfg->get_pending_tasks()) {
-    irpass::print(i->rec.stmt());
-  }
-  std::cout << std::flush;
   auto tasks = sfg->extract_to_execute();
   TI_TRACE("Ended up with {} nodes", tasks.size());
   for (auto &task : tasks) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -31,8 +31,8 @@ class CurrentKernelGuard {
 }  // namespace
 
 Kernel::Kernel(Program &program,
-               std::function<void()> func,
-               std::string primal_name,
+               const std::function<void()> &func,
+               const std::string &primal_name,
                bool grad)
     : program(program), lowered(false), grad(grad) {
   program.initialize_device_llvm_context();
@@ -43,6 +43,9 @@ Kernel::Kernel(Program &program,
   ir = taichi::lang::context->get_root();
 
   {
+    // Note: this is NOT a mutex. If we want to call Kernel::Kernel()
+    // concurrently, we need to lock this block of code together with
+    // taichi::lang::context with a mutex.
     CurrentKernelGuard _(program, this);
     program.start_function_definition(this);
     func();

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -84,8 +84,8 @@ class Kernel {
   };
 
   Kernel(Program &program,
-         std::function<void()> func,
-         std::string name = "",
+         const std::function<void()> &func,
+         const std::string &name = "",
          bool grad = false);
 
   void compile();

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -22,15 +22,13 @@ class ConstantFold : public BasicStmtVisitor {
 
   static Kernel *get_jit_evaluator_kernel(JITEvaluatorId const &id) {
     auto &cache = get_current_program().jit_evaluator_cache;
-    {
-      // Discussion:
-      // https://github.com/taichi-dev/taichi/pull/954#discussion_r423442606
-      std::lock_guard<std::mutex> _(
-          get_current_program().jit_evaluator_cache_mut);
-      auto it = cache.find(id);
-      if (it != cache.end())  // cached?
-        return it->second.get();
-    }
+    // Discussion:
+    // https://github.com/taichi-dev/taichi/pull/954#discussion_r423442606
+    std::lock_guard<std::mutex> _(
+        get_current_program().jit_evaluator_cache_mut);
+    auto it = cache.find(id);
+    if (it != cache.end())  // cached?
+      return it->second.get();
 
     auto kernel_name = fmt::format("jit_evaluator_{}", cache.size());
     auto func = [&id]() {
@@ -65,11 +63,7 @@ class ConstantFold : public BasicStmtVisitor {
     auto *ker_ptr = ker.get();
     TI_TRACE("Saving JIT evaluator cache entry id={}",
              std::hash<JITEvaluatorId>{}(id));
-    {
-      std::lock_guard<std::mutex> _(
-          get_current_program().jit_evaluator_cache_mut);
-      cache[id] = std::move(ker);
-    }
+    cache[id] = std::move(ker);
     return ker_ptr;
   }
 

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -3,26 +3,19 @@ from .fuse_test_template import template_fuse_dense_x2y2z, \
     template_fuse_reduction
 
 
-# @ti.test(require=ti.extension.async_mode, async_mode=True)
-# def test_fuse_dense_x2y2z():
-#     template_fuse_dense_x2y2z(size=100 * 1024**2)
-#
-#
-# @ti.test(require=ti.extension.async_mode, async_mode=True)
-# def test_fuse_reduction():
-#     template_fuse_reduction(size=10 * 1024**2)
+@ti.test(require=ti.extension.async_mode, async_mode=True)
+def test_fuse_dense_x2y2z():
+    template_fuse_dense_x2y2z(size=100 * 1024**2)
 
 
-@ti.test(require=ti.extension.async_mode, async_mode=True,
-         async_opt_fusion=False,
-         async_opt_listgen=False,
-         async_opt_dse=False,
-         async_opt_activation_demotion=False,
-         arch=ti.cpu,
-         print_ir=True,
-         print_accessor_ir=True)
+@ti.test(require=ti.extension.async_mode, async_mode=True)
+def test_fuse_reduction():
+    template_fuse_reduction(size=10 * 1024**2)
+
+
+@ti.test(require=ti.extension.async_mode, async_mode=True)
 def test_no_fuse_sigs_mismatch():
-    n = 1
+    n = 4096
     x = ti.field(ti.i32, shape=(n, ))
 
     @ti.kernel
@@ -35,8 +28,11 @@ def test_no_fuse_sigs_mismatch():
         for i in x:
             x[i] += k
 
-    inc_i()
-    inc_by(0)
+    repeat = 5
+    for i in range(repeat):
+        inc_i()
+        inc_by(i)
 
     x = x.to_numpy()
-    assert x[0] == 0
+    for i in range(n):
+        assert x[i] == i * repeat + ((repeat - 1) * repeat // 2)

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -33,11 +33,8 @@ def test_no_fuse_sigs_mismatch():
         for i in x:
             x[i] += k
 
-    repeat = 1
-    for i in range(repeat):
-        inc_i()
-        inc_by(i)
+    inc_i()
+    inc_by(0)
 
     x = x.to_numpy()
-    for i in range(n):
-        assert x[i] == i * repeat + ((repeat - 1) * repeat // 2)
+    assert x[0] == 0

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -18,7 +18,9 @@ from .fuse_test_template import template_fuse_dense_x2y2z, \
          async_opt_listgen=False,
          async_opt_dse=False,
          async_opt_activation_demotion=False,
-         arch=ti.cpu)
+         arch=ti.cpu,
+         print_ir=True,
+         print_accessor_ir=True)
 def test_no_fuse_sigs_mismatch():
     n = 1
     x = ti.field(ti.i32, shape=(n, ))

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -3,17 +3,17 @@ from .fuse_test_template import template_fuse_dense_x2y2z, \
     template_fuse_reduction
 
 
-@ti.test(require=ti.extension.async_mode, async_mode=True)
-def test_fuse_dense_x2y2z():
-    template_fuse_dense_x2y2z(size=100 * 1024**2)
+# @ti.test(require=ti.extension.async_mode, async_mode=True)
+# def test_fuse_dense_x2y2z():
+#     template_fuse_dense_x2y2z(size=100 * 1024**2)
+#
+#
+# @ti.test(require=ti.extension.async_mode, async_mode=True)
+# def test_fuse_reduction():
+#     template_fuse_reduction(size=10 * 1024**2)
 
 
-@ti.test(require=ti.extension.async_mode, async_mode=True)
-def test_fuse_reduction():
-    template_fuse_reduction(size=10 * 1024**2)
-
-
-@ti.test(require=ti.extension.async_mode, async_mode=True)
+@ti.test(require=ti.extension.async_mode, async_mode=True, arch=ti.cpu)
 def test_no_fuse_sigs_mismatch():
     n = 4096
     x = ti.field(ti.i32, shape=(n, ))
@@ -28,7 +28,7 @@ def test_no_fuse_sigs_mismatch():
         for i in x:
             x[i] += k
 
-    repeat = 5
+    repeat = 2
     for i in range(repeat):
         inc_i()
         inc_by(i)

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -13,7 +13,12 @@ from .fuse_test_template import template_fuse_dense_x2y2z, \
 #     template_fuse_reduction(size=10 * 1024**2)
 
 
-@ti.test(require=ti.extension.async_mode, async_mode=True, arch=ti.cpu)
+@ti.test(require=ti.extension.async_mode, async_mode=True,
+         async_opt_fusion=False,
+         async_opt_listgen=False,
+         async_opt_dse=False,
+         async_opt_activation_demotion=False,
+         arch=ti.cpu)
 def test_no_fuse_sigs_mismatch():
     n = 4096
     x = ti.field(ti.i32, shape=(n, ))

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -20,7 +20,7 @@ from .fuse_test_template import template_fuse_dense_x2y2z, \
          async_opt_activation_demotion=False,
          arch=ti.cpu)
 def test_no_fuse_sigs_mismatch():
-    n = 4096
+    n = 1
     x = ti.field(ti.i32, shape=(n, ))
 
     @ti.kernel

--- a/tests/python/test_fuse_dense.py
+++ b/tests/python/test_fuse_dense.py
@@ -33,7 +33,7 @@ def test_no_fuse_sigs_mismatch():
         for i in x:
             x[i] += k
 
-    repeat = 2
+    repeat = 1
     for i in range(repeat):
         inc_i()
         inc_by(i)


### PR DESCRIPTION
Related issue = #954 #2032

`Kernel::Kernel()` does not support multi-threads unless we lock the following part with a mutex:
```C++
  taichi::lang::context = std::make_unique<FrontendContext>();
  ir = taichi::lang::context->get_root();

  {
    CurrentKernelGuard _(program, this);
    program.start_function_definition(this);
    func();
    program.end_function_definition();
    ir->as<Block>()->kernel = this;
  }
```

This PR simply locks `get_jit_evaluator_kernel()` monolithically to prevent two threads from calling `Kernel::Kernel()` concurrently.

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
