### PR TITLE
[cc] [refactor] Automatically detect available compiler (clang or gcc)

### DIFF
--- a/taichi/backends/cc/cc_program.cpp
+++ b/taichi/backends/cc/cc_program.cpp
@@ -167,7 +167,7 @@ void CCProgram::smart_choose_compiler() {
     compile_cmd = compiler + " -c -o '{}' '{}'";
 
     linkage_cmd += " -shared -fPIC";
-    compile_cmd += " -O3";
+    compile_cmd += " -O3 -fPIC";
   }
 }
 

--- a/taichi/backends/cc/cc_program.cpp
+++ b/taichi/backends/cc/cc_program.cpp
@@ -146,11 +146,11 @@ CCFuncEntryType *CCProgram::load_kernel(std::string const &name) {
 }
 
 CCProgram::CCProgram(Program *program) : program(program) {
-  cflags = program->config.cc_compile_flags;
-  lflags = program->config.cc_linkage_flags;
+  compile_cmd = program->config.cc_compile_cmd;
+  linkage_cmd = program->config.cc_linkage_cmd;
 
-  linkage_cmd = "gcc -shared -fPIC -o '{}' '{}'";
-  compile_cmd = "gcc -c -o '{}' '{}'";
+  linkage_cmd = "gcc -shared -o '{}' '{}'";
+  compile_cmd = "gcc -O3 -c -o '{}' '{}'";
 
   init_runtime();
 

--- a/taichi/backends/cc/cc_program.cpp
+++ b/taichi/backends/cc/cc_program.cpp
@@ -142,8 +142,7 @@ void CCProgram::init_runtime() {
 }
 
 CCFuncEntryType *CCProgram::load_kernel(std::string const &name) {
-  return reinterpret_cast<CCFuncEntryType *>(
-      dll->load_function("Tk_" + name));
+  return reinterpret_cast<CCFuncEntryType *>(dll->load_function("Tk_" + name));
 }
 
 CCProgram::CCProgram(Program *program) : program(program) {

--- a/taichi/backends/cc/cc_program.cpp
+++ b/taichi/backends/cc/cc_program.cpp
@@ -40,13 +40,11 @@ void CCKernel::launch(Context *ctx) {
                                           });
 
   program->relink();
-  TI_TRACE("[cc] entering kernel [{}]", name);
   auto entry = program->load_kernel(name);
   TI_ASSERT(entry);
   auto *context = program->update_context(ctx);
   (*entry)(context);
   program->context_to_result_buffer();
-  TI_TRACE("[cc] leaving kernel [{}]", name);
 }
 
 size_t CCLayout::compile() {

--- a/taichi/backends/cc/cc_program.h
+++ b/taichi/backends/cc/cc_program.h
@@ -47,13 +47,15 @@ class CCProgram {
 
   Program *const program;
 
+  std::string compile_cmd;
+  std::string linkage_cmd;
+
  private:
+  void smart_choose_compiler();
+
   std::vector<char> args_buf;
   std::vector<char> root_buf;
   std::vector<char> gtmp_buf;
-
-  std::string compile_cmd;
-  std::string linkage_cmd;
 
   std::vector<std::unique_ptr<CCKernel>> kernels;
   std::unique_ptr<CCContext> context;

--- a/taichi/backends/cc/cc_program.h
+++ b/taichi/backends/cc/cc_program.h
@@ -51,10 +51,15 @@ class CCProgram {
   std::vector<char> args_buf;
   std::vector<char> root_buf;
   std::vector<char> gtmp_buf;
+
+  std::string compile_cmd;
+  std::string linkage_cmd;
+
   std::vector<std::unique_ptr<CCKernel>> kernels;
   std::unique_ptr<CCContext> context;
   std::unique_ptr<CCRuntime> runtime;
   std::unique_ptr<CCLayout> layout;
+
   std::unique_ptr<DynamicLoader> dll;
   std::string dll_path;
   bool need_relink{true};

--- a/taichi/backends/cc/cc_runtime.h
+++ b/taichi/backends/cc/cc_runtime.h
@@ -9,8 +9,7 @@ class CCProgram;
 
 class CCRuntime {
  public:
-  CCRuntime(CCProgram *program,
-            std::string const &header)
+  CCRuntime(CCProgram *program, std::string const &header)
       : header(header), program(program) {
   }
 

--- a/taichi/backends/cc/cc_runtime.h
+++ b/taichi/backends/cc/cc_runtime.h
@@ -10,25 +10,14 @@ class CCProgram;
 class CCRuntime {
  public:
   CCRuntime(CCProgram *program,
-            std::string const &header,
-            std::string const &source)
-      : header(header), source(source), program(program) {
+            std::string const &header)
+      : header(header), program(program) {
   }
-
-  std::string get_object() {
-    return obj_path;
-  }
-
-  void compile();
 
   std::string header;
-  std::string source;
 
  private:
   [[maybe_unused]] CCProgram *program;
-
-  std::string src_path;
-  std::string obj_path;
 };
 
 }  // namespace cccp

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -335,7 +335,7 @@ class CCTransformer : public IRVisitor {
 
       } else if (bin->op_type == BinaryOpType::floordiv) {
         TI_WARN(
-            "floordiv called! It should be taken care by demote_operations");
+            "floordiv called! It should be taken care of by demote_operations");
         auto lhs_dt_name = data_type_short_name(bin->lhs->element_type());
         emit("{} = Ti_floordiv_{}({}, {});", var, lhs_dt_name, lhs_name,
              rhs_name);

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -341,7 +341,8 @@ class CCTransformer : public IRVisitor {
         emit("{} = ({}) {} / {};", var, dt_name, lhs_name, rhs_name);
 
       } else if (bin->op_type == BinaryOpType::floordiv) {
-        TI_WARN("floordiv called! It should be taken care by demote_operations");
+        TI_WARN(
+            "floordiv called! It should be taken care by demote_operations");
         auto lhs_dt_name = data_type_short_name(bin->lhs->element_type());
         emit("{} = Ti_floordiv_{}({}, {});", var, lhs_dt_name, lhs_name,
              rhs_name);

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -381,7 +381,6 @@ class CCTransformer : public IRVisitor {
     const auto type = stmt->dest->element_type().ptr_removed();
     auto var = define_var(cc_data_type_name(type), stmt->raw_name());
 
-    std::unique_ptr<ScopedIndent> _s;
     emit("{} = *{};", var, dest_ptr);
 
     if (stmt->op_type == AtomicOpType::max ||
@@ -472,7 +471,6 @@ class CCTransformer : public IRVisitor {
 
   void visit(LoopIndexStmt *stmt) override {
     TI_ASSERT(stmt->index == 0);  // TODO: multiple indices
-
     emit("Ti_i32 {} = {};", stmt->raw_name(), stmt->loop->raw_name());
   }
 

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -30,7 +30,6 @@ class CCTransformer : public IRVisitor {
   GetRootStmt *root_stmt;
 
   bool omp_enabled{false};
-  bool omp_strict_atomics{true};
 
  public:
   CCTransformer(Kernel *kernel, CCLayout *layout)

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -336,18 +336,15 @@ class CCTransformer : public IRVisitor {
       if (is_comparison(bin->op_type)) {
         // XXX(#577): Taichi uses -1 as true due to LLVM i1...
         emit("{} = -({} {} {});", var, lhs_name, binop, rhs_name);
+
       } else if (bin->op_type == BinaryOpType::truediv) {
         emit("{} = ({}) {} / {};", var, dt_name, lhs_name, rhs_name);
+
       } else if (bin->op_type == BinaryOpType::floordiv) {
+        TI_WARN("floordiv called! It should be taken care by demote_operations");
         auto lhs_dt_name = data_type_short_name(bin->lhs->element_type());
-        if (is_integral(bin->lhs->element_type()) &&
-            is_integral(bin->rhs->element_type())) {
-          emit("{} = Ti_floordiv_{}({}, {});", var, lhs_dt_name, lhs_name,
-               rhs_name);
-        } else {
-          emit("{} = Ti_floordiv_{}({}, {});", var, lhs_dt_name, lhs_name,
-               rhs_name);
-        }
+        emit("{} = Ti_floordiv_{}({}, {});", var, lhs_dt_name, lhs_name,
+             rhs_name);
       } else {
         emit("{} = {} {} {};", var, lhs_name, binop, rhs_name);
       }

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -471,7 +471,18 @@ class CCTransformer : public IRVisitor {
 
   void visit(LoopIndexStmt *stmt) override {
     TI_ASSERT(stmt->index == 0);  // TODO: multiple indices
-    emit("Ti_i32 {} = {};", stmt->raw_name(), stmt->loop->raw_name());
+    if (stmt->loop->is<OffloadedStmt>()) {
+      auto type = stmt->loop->as<OffloadedStmt>()->task_type;
+      if (type == OffloadedStmt::TaskType::range_for) {
+        emit("Ti_i32 {} = {};", stmt->raw_name(), stmt->loop->raw_name());
+      } else {
+        TI_NOT_IMPLEMENTED
+      }
+    } else if (stmt->loop->is<RangeForStmt>()) {
+      emit("Ti_i32 {} = {};", stmt->raw_name(), stmt->loop->raw_name());
+    } else {
+      TI_NOT_IMPLEMENTED
+    }
   }
 
   void visit(RangeForStmt *stmt) override {

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -60,9 +60,8 @@ CompileConfig::CompileConfig() {
   device_memory_fraction = 0.0;
 
   // C backend options:
-  cc_compile_cmd = "";
   cc_linkage_cmd = "";
-  cc_extra_options = "";
+  cc_compile_cmd = "";
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -60,8 +60,9 @@ CompileConfig::CompileConfig() {
   device_memory_fraction = 0.0;
 
   // C backend options:
-  cc_compile_cmd = "gcc -Wc99-c11-compat -c -o '{}' '{}' -O3 -fPIC -fopenmp";
-  cc_link_cmd = "gcc -shared -o '{}' '{}' -fPIC -fopenmp";
+  cc_compile_cmd = "gcc -Wc99-c11-compat -c -o '{}' '{}' -O3 -fPIC";
+  cc_link_cmd = "gcc -shared -o '{}' '{}' -fPIC";
+  cc_use_openmp = false;
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -60,8 +60,8 @@ CompileConfig::CompileConfig() {
   device_memory_fraction = 0.0;
 
   // C backend options:
-  cc_compile_cmd = "gcc -Wc99-c11-compat -c -o '{}' '{}' -O3";
-  cc_link_cmd = "gcc -shared -fPIC -o '{}' '{}'";
+  cc_compile_cmd = "gcc -Wc99-c11-compat -c -o '{}' '{}' -O3 -fPIC -fopenmp";
+  cc_link_cmd = "gcc -shared -o '{}' '{}' -fPIC -fopenmp";
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -60,9 +60,9 @@ CompileConfig::CompileConfig() {
   device_memory_fraction = 0.0;
 
   // C backend options:
-  cc_compile_cmd = "gcc -Wc99-c11-compat -c -o '{}' '{}' -O3 -fPIC";
-  cc_link_cmd = "gcc -shared -o '{}' '{}' -fPIC";
-  cc_use_openmp = false;
+  cc_compile_cmd = "";
+  cc_linkage_cmd = "";
+  cc_extra_options = "";
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -59,7 +59,6 @@ struct CompileConfig {
   // C backend options:
   std::string cc_compile_cmd;
   std::string cc_link_cmd;
-  bool cc_use_openmp;
 
   bool async_opt_fusion{true};
   bool async_opt_listgen{true};

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -58,7 +58,7 @@ struct CompileConfig {
 
   // C backend options:
   std::string cc_compile_cmd;
-  std::string cc_link_cmd;
+  std::string cc_linkage_cmd;
 
   bool async_opt_fusion{true};
   bool async_opt_listgen{true};

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -59,6 +59,7 @@ struct CompileConfig {
   // C backend options:
   std::string cc_compile_cmd;
   std::string cc_link_cmd;
+  bool cc_use_openmp;
 
   bool async_opt_fusion{true};
   bool async_opt_listgen{true};

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -723,8 +723,12 @@ void export_lang(py::module &m) {
 
   py::class_<Type>(m, "Type").def("to_string", &Type::to_string);
 
+  // Note that it is important to specify py::return_value_policy::reference for
+  // the factory methods, otherwise pybind11 will delete the Types owned by
+  // TypeFactory on Python-scope pointer destruction.
   py::class_<TypeFactory>(m, "TypeFactory")
-      .def("get_custom_int_type", &TypeFactory::get_custom_int_type);
+      .def("get_custom_int_type", &TypeFactory::get_custom_int_type,
+           py::return_value_policy::reference);
 
   m.def("get_type_factory_instance", TypeFactory::get_instance,
         py::return_value_policy::reference);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -159,7 +159,7 @@ void export_lang(py::module &m) {
       .def_readwrite("make_block_local", &CompileConfig::make_block_local)
       .def_readwrite("detect_read_only", &CompileConfig::detect_read_only)
       .def_readwrite("cc_compile_cmd", &CompileConfig::cc_compile_cmd)
-      .def_readwrite("cc_link_cmd", &CompileConfig::cc_link_cmd)
+      .def_readwrite("cc_linkage_cmd", &CompileConfig::cc_linkage_cmd)
       .def_readwrite("async_opt_fusion", &CompileConfig::async_opt_fusion)
       .def_readwrite("async_opt_listgen", &CompileConfig::async_opt_listgen)
       .def_readwrite("async_opt_activation_demotion",


### PR DESCRIPTION
Related issue = #1644

<!--
Thanks for your PR!
If it's your first time contributing to Taichi, please make sure you have read our Contributor Guideline:
  https://taichi.readthedocs.io/en/latest/contributor_guide.html

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example], e.g.:
    [Lang] Add ti.Complex as Taichi class
- Use a lowercased tag for PRs that are invisible to end-users, i.e., won't be highlighted in changelog:
    [cuda] [test] Fix out-of-memory error while running test
- More details: http://taichi.readthedocs.io/en/latest/contributor_guide.html#prtags

- Please fill the following blank with the issue number this PR related to (if any):
    Related issue = #2345
- If your PR will fix the issue **completely**, use the `close` or `fixes` keyword:
    Related issue = close #2345
- So that when the PR gets merged, GitHub will **automatically** close the issue #2345 for you.
- If the PR doesn't belong to any existing issue, and it's a trivial change, feel free to leave it blank :)
  -->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
We will choose to `clang` by default, `gcc` as fallback.

mpm88:
cc gcc: 18 fps
cc clang: 24 fps
opengl mesa: 25 fps
Amazing! We're almost beating OpenGL on single core CPU! Maybe this's the power of clang's SIMD optimizer?

I also noticed that env option `TI_CC_COMPILER_CMD=xxx` doesn't work, will fix iapr.
Btw, @k-ye would you help me setup the C backend on OS X?