### PR TITLE
[Bug] [lang] Fix is_global on 0-D vectors

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -114,6 +114,9 @@ class Matrix(TaichiOperations):
                 stacklevel=2)
 
     def is_global(self):
+        # 0-D vectors are considered to be local:
+        if len(self.entries) == 0:
+            return True
         results = [False for _ in self.entries]
         for i, e in enumerate(self.entries):
             if isinstance(e, expr.Expr):
@@ -816,6 +819,7 @@ class Matrix(TaichiOperations):
               needs_grad=False,
               layout=None):  # TODO(archibate): deprecate layout
         '''ti.Matrix.field'''
+        assert n > 0 and m > 0, 'matrix fields must have positive n and m'
         self = cls.empty(n, m)
         self.entries = []
         self.n = n
@@ -828,7 +832,7 @@ class Matrix(TaichiOperations):
         if layout is not None:
             assert shape is not None, 'layout is useless without shape'
         if shape is None:
-            assert offset is None, "shape cannot be None when offset is being set"
+            assert offset is None, 'shape cannot be None when offset is being set'
 
         if shape is not None:
             if isinstance(shape, numbers.Number):
@@ -839,7 +843,7 @@ class Matrix(TaichiOperations):
             if offset is not None:
                 assert len(shape) == len(
                     offset
-                ), f'The dimensionality of shape and offset must be the same  ({len(shape)} != {len(offset)})'
+                ), f'The dimensionality of shape and offset must be the same ({len(shape)} != {len(offset)})'
 
             import taichi as ti
             if layout is None:


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
```py
import taichi as ti

x = ti.Vector([])
print(x)
```
```
root@archecs:~/taichi# python a.py
[Taichi] mode=release
[Taichi] preparing sandbox at /tmp/taichi-hbual7l8
[Taichi] version 0.7.3, llvm 10.0.0, commit d5a00cea, linux, python 3.8.2
Traceback (most recent call last):
  File "a.py", line 4, in <module>
    print(x)
  File "/usr/local/lib/python3.8/dist-packages/taichi/lang/matrix.py", line 765, in __str__
    return str(self.to_numpy())
  File "/usr/local/lib/python3.8/dist-packages/taichi/lang/util.py", line 214, in wrapped
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/taichi/lang/matrix.py", line 685, in to_numpy
    if not self.is_global():
  File "/usr/local/lib/python3.8/dist-packages/taichi/lang/matrix.py", line 124, in is_global
    return results[0]
IndexError: list index out of range
```
This is because 0-D vectors have no entries for is_global to detect, resulting in a confusion error.
But I believe 0-D local vectors can still be useful sometimes, e.g. when applying grouped struct-for on a 0-D field.
While 0-D vector fields, IMO, aganist our sanity, and will fail on x.loop_range().
So let's raise an clear error message on 0-D global vector fields, and **consider 0-D vectors as local**, what do you think?