### PR TITLE
[perf] Fix block local storage transform performance

### DIFF
--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -45,26 +45,26 @@ class BLSAnalysis : public BasicStmtVisitor {
   }
 
   // Recursively (dimension by dimension) generate the indices in a SNode
-  // (block) E.g., a dense(ti.ij, (2, 4)) SNode has indices
+  // (block). E.g., a dense(ti.ij, (2, 4)) SNode has indices
   // [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
   void generate_block_indices(SNode *snode,
                               BlockIndices &block_indices,
                               std::vector<int> index,
-                              int s) {
+                              int index_id) {
     // NOTE: Assuming not vectorized
-    if (s == taichi_max_num_indices) {
+    if (index_id == taichi_max_num_indices) {
       block_indices.push_back(index);
       return;
     }
 
-    if (snode->extractors[s].active) {
-      for (int i = 0; i < (1 << snode->extractors[s].num_bits); i++) {
+    if (snode->extractors[index_id].active) {
+      for (int i = 0; i < (1 << snode->extractors[index_id].num_bits); i++) {
         auto new_index = index;
         new_index.push_back(i);
-        generate_block_indices(snode, block_indices, new_index, s + 1);
+        generate_block_indices(snode, block_indices, new_index, index_id + 1);
       }
     } else {
-      generate_block_indices(snode, block_indices, index, s + 1);
+      generate_block_indices(snode, block_indices, index, index_id + 1);
     }
   }
 

--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -71,8 +71,7 @@ class BLSAnalysis : public BasicStmtVisitor {
   void visit(GlobalPtrStmt *stmt) override {
   }
 
-  // TODO: rename to mark_access
-  void access(Stmt *stmt, AccessFlag flag) {
+  void record_access(Stmt *stmt, AccessFlag flag) {
     if (!stmt->is<GlobalPtrStmt>())
       return;  // local alloca
     auto ptr = stmt->as<GlobalPtrStmt>();
@@ -119,17 +118,17 @@ class BLSAnalysis : public BasicStmtVisitor {
   // Do not eliminate global data access
   void visit(GlobalLoadStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
-    access(stmt->ptr, AccessFlag::read);
+    record_access(stmt->ptr, AccessFlag::read);
   }
 
   void visit(GlobalStoreStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
-    access(stmt->ptr, AccessFlag::write);
+    record_access(stmt->ptr, AccessFlag::write);
   }
 
   void visit(AtomicOpStmt *stmt) override {
     if (stmt->op_type == AtomicOpType::add) {
-      access(stmt->dest, AccessFlag::accumulate);
+      record_access(stmt->dest, AccessFlag::accumulate);
     }
   }
 

--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -11,7 +11,7 @@ TLANG_NAMESPACE_BEGIN
 // scratch_pad term
 
 // Figure out accessed SNodes, and their ranges in this for stmt
-class AccessAnalysis : public BasicStmtVisitor {
+class BLSAnalysis : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
 
  public:
@@ -20,7 +20,7 @@ class AccessAnalysis : public BasicStmtVisitor {
 
   std::vector<std::vector<int>> block_indices;
 
-  AccessAnalysis(OffloadedStmt *for_stmt, ScratchPads *pads)
+  BLSAnalysis(OffloadedStmt *for_stmt, ScratchPads *pads)
       : for_stmt(for_stmt), pads(pads) {
     TI_AUTO_PROF;
     allow_undefined_visitor = true;
@@ -37,8 +37,8 @@ class AccessAnalysis : public BasicStmtVisitor {
     }
   }
 
-  // Recursively (dimension by dimension) generate the indices in a SNode (block)
-  // E.g., a dense(ti.ij, (2, 4)) SNode has indices
+  // Recursively (dimension by dimension) generate the indices in a SNode
+  // (block) E.g., a dense(ti.ij, (2, 4)) SNode has indices
   // [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
   void generate_block_indices(SNode *snode, std::vector<int> index, int s) {
     TI_AUTO_PROF
@@ -140,7 +140,7 @@ std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *offload) {
       pads->insert(opt.second);
     }
   }
-  AccessAnalysis _(offload, pads.get());
+  BLSAnalysis _(offload, pads.get());
   pads->finalize();
   return pads;
 }

--- a/taichi/transforms/make_block_local.cpp
+++ b/taichi/transforms/make_block_local.cpp
@@ -2,7 +2,6 @@
 #include "taichi/ir/statements.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/analysis.h"
-#include "taichi/ir/visitors.h"
 #include "taichi/ir/scratch_pad.h"
 #include "taichi/program/kernel.h"
 #include "taichi/program/program.h"

--- a/taichi/transforms/make_block_local.cpp
+++ b/taichi/transforms/make_block_local.cpp
@@ -17,7 +17,9 @@ void make_block_local_offload(OffloadedStmt *offload) {
 
   bool debug = offload->get_kernel()->program.config.debug;
 
+  TI_TAG;
   auto pads = irpass::initialize_scratch_pad(offload);
+  TI_TAG;
 
   std::size_t bls_offset = 0;
 
@@ -44,6 +46,7 @@ void make_block_local_offload(OffloadedStmt *offload) {
     std::vector<int> bls_strides(dim);
     block_strides[dim - 1] = 1;
     bls_strides[dim - 1] = 1;
+    TI_TAG;
     for (int i = dim - 2; i >= 0; i--) {
       // TODO: fix the virtual/physical index correspondence here
       // TODO: rename "pad"
@@ -51,11 +54,13 @@ void make_block_local_offload(OffloadedStmt *offload) {
       block_strides[i] = block_strides[i + 1] * pad.second.block_size[i + 1];
       bls_strides[i] = bls_strides[i + 1] * pad.second.pad_size[i + 1];
     }
+    TI_TAG;
 
     // TODO: improve IR builder to make this part easier to read
 
     // Ensure BLS alignment
     bls_offset += (dtype_size - bls_offset % dtype_size) % dtype_size;
+    TI_TAG;
 
     // This lambda is used for both BLS prologue and epilogue creation
     auto create_xlogue =
@@ -63,6 +68,7 @@ void make_block_local_offload(OffloadedStmt *offload) {
             const std::function<void(
                 Block * element_block, std::vector<Stmt *> global_indices,
                 Stmt * bls_element_offset_bytes)> &operation) {
+          TI_TAG;
           if (block == nullptr) {
             block = std::make_unique<Block>();
             block->parent_stmt = offload;
@@ -106,6 +112,7 @@ void make_block_local_offload(OffloadedStmt *offload) {
             bls_element_offset_bytes = block->push_back<BinaryOpStmt>(
                 BinaryOpType::add, bls_element_offset_bytes,
                 block->push_back<ConstStmt>(TypedConstant((int32)bls_offset)));
+            TI_TAG;
 
             if (loop_offset + block_dim > bls_num_elements) {
               // Need to create an IfStmt to safeguard since bls size may not be
@@ -149,6 +156,7 @@ void make_block_local_offload(OffloadedStmt *offload) {
                   element_block->push_back<BlockCornerIndexStmt>(offload, i));
 
               global_indices[i] = global_index;
+              TI_TAG;
             }
 
             operation(element_block, global_indices, bls_element_offset_bytes);
@@ -156,8 +164,10 @@ void make_block_local_offload(OffloadedStmt *offload) {
 
             loop_offset += block_dim;
           }
+          TI_TAG;
         };
 
+    TI_TAG;
     // Step 1:
     // Fetch to BLS
     {
@@ -186,6 +196,7 @@ void make_block_local_offload(OffloadedStmt *offload) {
           });
     }
 
+    TI_TAG;
     // Step 2:
     // Make loop body load from BLS instead of global fields
     {
@@ -295,10 +306,12 @@ void make_block_local_offload(OffloadedStmt *offload) {
                                                    global_pointer, bls_val);
           });
     }
+    TI_TAG;
 
     // allocate storage for the BLS variable
     bls_offset += dtype_size * bls_num_elements;
   }
+  TI_TAG;
 
   offload->bls_size = std::max(std::size_t(1), bls_offset);
 }
@@ -311,13 +324,20 @@ namespace irpass {
 void make_block_local(IRNode *root) {
   TI_AUTO_PROF;
 
+  TI_TAG;
   if (auto root_block = root->cast<Block>()) {
+    TI_TAG;
     for (auto &offload : root_block->statements) {
+      TI_TAG;
       make_block_local_offload(offload->cast<OffloadedStmt>());
     }
+    TI_TAG;
   } else {
+    TI_TAG;
     make_block_local_offload(root->as<OffloadedStmt>());
+    TI_TAG;
   }
+  TI_TAG;
   type_check(root);
 }
 


### PR DESCRIPTION
Performance bug by the `read_only` detection pass (#1998)

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
