### PR TITLE
[async] Support global temporaries value state

### DIFF
--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -39,6 +39,30 @@ bool TaskLaunchRecord::empty() const {
   return ir_handle.ir() == nullptr;
 }
 
+std::string AsyncState::name() const {
+  std::string type_name;
+  switch (type) {
+    case Type::mask:
+      type_name = "mask";
+      break;
+    case Type::value:
+      type_name = "value";
+      break;
+    case Type::list:
+      type_name = "list";
+      break;
+    case Type::allocator:
+      type_name = "allocator";
+      break;
+  }
+  const auto prefix =
+      holds_snode()
+          ? std::get<SNode *>(snode_or_global_tmp)->get_node_type_name_hinted()
+          : fmt::format("global_tmp[{}]",
+                        std::get<Kernel *>(snode_or_global_tmp)->name);
+  return prefix + "_" + type_name;
+}
+
 void TaskMeta::print() const {
   fmt::print("TaskMeta\n  name {}\n", name);
   fmt::print("  type {}\n", offloaded_task_type_name(type));
@@ -69,7 +93,7 @@ void TaskMeta::print() const {
     }
     fmt::print("\n");
   }
-  std::vector<SNode *> element_wise_snodes, non_element_wise_snodes;
+  std::vector<const SNode *> element_wise_snodes, non_element_wise_snodes;
   for (auto &s : element_wise) {
     if (s.second) {
       element_wise_snodes.push_back(s.first);
@@ -119,18 +143,33 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
 
   // TODO: this is an abuse since it gathers nothing...
   gather_statements(root_stmt, [&](Stmt *stmt) {
+    if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
+      // For a global load, GlobalPtrStmt has already been handled in
+      // get_meta_input_value_states().
+      if (global_load->ptr->is<GlobalTemporaryStmt>()) {
+        meta.input_states.insert(AsyncState::for_global_tmp(t.kernel));
+      }
+    }
     if (auto global_store = stmt->cast<GlobalStoreStmt>()) {
       if (auto ptr = global_store->ptr->cast<GlobalPtrStmt>()) {
         for (auto &snode : ptr->snodes.data) {
           meta.output_states.emplace(snode, AsyncState::Type::value);
         }
+      } else if (global_store->ptr->is<GlobalTemporaryStmt>()) {
+        meta.output_states.insert(AsyncState::for_global_tmp(t.kernel));
       }
     }
     if (auto global_atomic = stmt->cast<AtomicOpStmt>()) {
       if (auto ptr = global_atomic->dest->cast<GlobalPtrStmt>()) {
         for (auto &snode : ptr->snodes.data) {
+          // input_state is already handled in
+          // get_meta_input_value_states().
           meta.output_states.emplace(snode, AsyncState::Type::value);
         }
+      } else if (global_atomic->dest->is<GlobalTemporaryStmt>()) {
+        auto as = AsyncState::for_global_tmp(t.kernel);
+        meta.input_states.insert(as);
+        meta.output_states.insert(as);
       }
     }
 
@@ -269,9 +308,10 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
   // accesses (e.g., a = x[i + 1]), we don't treat it as completely
   // overwriting the value state (e.g., for i in x: x[i] = 0).
   for (auto &state : meta.output_states) {
-    if (state.type == AsyncState::Type::value) {
-      if (meta.element_wise.find(state.snode) == meta.element_wise.end() ||
-          !meta.element_wise[state.snode]) {
+    if (state.type == AsyncState::Type::value && state.holds_snode()) {
+      const auto *sn = state.snode();
+      if (meta.element_wise.find(sn) == meta.element_wise.end() ||
+          !meta.element_wise[sn]) {
         meta.input_states.insert(state);
       }
     }

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -162,8 +162,8 @@ TLANG_NAMESPACE_END
 namespace std {
 template <>
 struct hash<taichi::lang::IRHandle> {
-  std::size_t operator()(
-      const taichi::lang::IRHandle &ir_handle) const noexcept {
+  std::size_t operator()(const taichi::lang::IRHandle &ir_handle) const
+      noexcept {
     return ir_handle.hash();
   }
 };


### PR DESCRIPTION
I've extended `AsyncNode::snode` to hold a `std::variant<SNode*, Kernel*>`, because global temporaries can be identified by its enclosing kernel. (I feel like this is more intuitive than having a `global_tmp` in the enum class. Otherwise, what should the SNode be?)

Related issue = #2024 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
