### PR TITLE
[type] Add CustomFloatType

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -79,7 +79,7 @@ class Expr(TaichiOperations):
             return
         snode = self.ptr.snode()
 
-        if self.dtype == f32 or self.dtype == f64:
+        if taichi_lang_core.is_real(self.dtype):
 
             def getter(*key):
                 assert len(key) == taichi_lang_core.get_max_num_indices()

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -864,15 +864,12 @@ if 1:
                 ret_expr = self.parse_expr('ti.cast(ti.Expr(0), 0)')
                 ret_expr.args[0].args[0] = node.value
                 ret_expr.args[1] = self.returns
-                dt_expr = self.parse_expr('ti.cook_dtype(0)')
-                dt_expr.args[0] = self.returns
                 ret_stmt = self.parse_stmt(
                     'ti.core.create_kernel_return(ret.ptr, 0)')
                 # For args[0], it is an ast.Attribute, because it loads the
                 # attribute, |ptr|, of the expression |ret_expr|. Therefore we
                 # only need to replace the object part, i.e. args[0].value
                 ret_stmt.value.args[0].value = ret_expr
-                ret_stmt.value.args[1] = dt_expr
                 return ret_stmt
         return node
 

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -865,7 +865,7 @@ if 1:
                 ret_expr.args[0].args[0] = node.value
                 ret_expr.args[1] = self.returns
                 ret_stmt = self.parse_stmt(
-                    'ti.core.create_kernel_return(ret.ptr, 0)')
+                    'ti.core.create_kernel_return(ret.ptr)')
                 # For args[0], it is an ast.Attribute, because it loads the
                 # attribute, |ptr|, of the expression |ret_expr|. Therefore we
                 # only need to replace the object part, i.e. args[0].value

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1116,7 +1116,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
       cit = cft->get_digits_type()->as<CustomIntType>();
       llvm::Value *s = nullptr;
 
-      // Compute int(input * scale + 0.5)
+      // Compute int(input * (1.0 / scale) + 0.5)
       auto s_numeric = 1.0 / cft->get_scale();
       auto compute_type = cft->get_compute_type();
       s = builder->CreateFPCast(
@@ -1197,6 +1197,7 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
       llvm_val[stmt] = load_as_custom_int(stmt->ptr, val_type);
     } else if (auto cft = val_type->cast<CustomFloatType>()) {
       auto digits = load_as_custom_int(stmt->ptr, cft->get_digits_type());
+      // Compute float(digits) * scale
       llvm::Value *cast = nullptr;
       auto compute_type = cft->get_compute_type()->as<PrimitiveType>();
       if (cft->get_digits_type()->cast<CustomIntType>()->get_is_signed()) {

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1106,7 +1106,39 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
   TI_ASSERT(llvm_val[stmt->ptr]);
   auto ptr_type = stmt->ptr->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
-    auto cit = ptr_type->get_pointee_type()->as<CustomIntType>();
+    auto pointee_type = ptr_type->get_pointee_type();
+    llvm::Value *store_value = nullptr;
+    CustomIntType *cit = nullptr;
+    if (auto cit_ = pointee_type->cast<CustomIntType>()) {
+      cit = cit_;
+      store_value = llvm_val[stmt->data];
+    } else if (auto cft = pointee_type->cast<CustomFloatType>()) {
+      cit = cft->get_digits_type()->as<CustomIntType>();
+      llvm::Value *s = nullptr;
+      auto s_numeric = 1.0 / cft->get_scale();
+      auto compute_type = cft->get_compute_type();
+      if (compute_type->is_primitive(PrimitiveTypeID::f32)) {
+        s = llvm::ConstantFP::get(*llvm_context,
+                                  llvm::APFloat(float32(s_numeric)));
+      } else if (compute_type->is_primitive(PrimitiveTypeID::f64)) {
+        s = llvm::ConstantFP::get(*llvm_context,
+                                  llvm::APFloat(float64(s_numeric)));
+      } else {
+        TI_NOT_IMPLEMENTED
+      }
+      auto input_real =
+          builder->CreateFPCast(llvm_val[stmt->data], llvm_type(compute_type));
+      auto scaled = builder->CreateFMul(input_real, s);
+      if (cit->get_is_signed()) {
+        store_value =
+            builder->CreateFPToSI(scaled, llvm_type(cit->get_compute_type()));
+      } else {
+        store_value =
+            builder->CreateFPToUI(scaled, llvm_type(cit->get_compute_type()));
+      }
+    } else {
+      TI_NOT_IMPLEMENTED
+    }
     llvm::Value *byte_ptr = nullptr, *bit_offset = nullptr;
     read_bit_pointer(llvm_val[stmt->ptr], byte_ptr, bit_offset);
     auto func_name = fmt::format("set_partial_bits_b{}",
@@ -1116,7 +1148,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         {builder->CreateBitCast(byte_ptr,
                                 llvm_ptr_type(cit->get_physical_type())),
          bit_offset, tlctx->get_constant(cit->get_num_bits()),
-         builder->CreateIntCast(llvm_val[stmt->data],
+         builder->CreateIntCast(store_value,
                                 llvm_type(cit->get_physical_type()), false)});
   } else {
     builder->CreateStore(llvm_val[stmt->data], llvm_val[stmt->ptr]);
@@ -1165,13 +1197,17 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
       llvm_val[stmt] = load_as_custom_int(stmt->ptr, val_type);
     } else if (auto cft = val_type->cast<CustomFloatType>()) {
       auto digits = load_as_custom_int(stmt->ptr, cft->get_digits_type());
-      llvm::Value *scaled = nullptr;
+      llvm::Value *cast = nullptr;
       auto compute_type = cft->get_compute_type()->as<PrimitiveType>();
       if (cft->get_digits_type()->cast<CustomIntType>()->get_is_signed()) {
-        scaled = builder->CreateSIToFP(digits, llvm_type(compute_type));
+        cast = builder->CreateSIToFP(digits, llvm_type(compute_type));
       } else {
-        scaled = builder->CreateUIToFP(digits, llvm_type(compute_type));
+        cast = builder->CreateUIToFP(digits, llvm_type(compute_type));
       }
+      llvm::Value *s =
+          llvm::ConstantFP::get(*llvm_context, llvm::APFloat(cft->get_scale()));
+      s = builder->CreateFPCast(s, llvm_type(compute_type));
+      auto scaled = builder->CreateFMul(cast, s);
       llvm_val[stmt] = scaled;
     } else {
       TI_NOT_IMPLEMENTED

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1160,7 +1160,7 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   TI_ASSERT(width == 1);
   if (auto ptr_type = stmt->ptr->ret_type->cast<PointerType>();
       ptr_type->is_bit_pointer()) {
-    auto val_type = stmt->ret_type.get_ptr();
+    auto val_type = ptr_type->get_pointee_type();
     if (val_type->is<CustomIntType>()) {
       llvm_val[stmt] = load_as_custom_int(stmt->ptr, val_type);
     } else if (auto cft = val_type->cast<CustomFloatType>()) {
@@ -1173,6 +1173,8 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
         scaled = builder->CreateUIToFP(digits, llvm_type(compute_type));
       }
       llvm_val[stmt] = scaled;
+    } else {
+      TI_NOT_IMPLEMENTED
     }
   } else {
     llvm_val[stmt] = builder->CreateLoad(tlctx->get_data_type(stmt->ret_type),

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -196,6 +196,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(GlobalStoreStmt *stmt) override;
 
+  llvm::Value *load_as_custom_int(GlobalPtrStmt *ptr, Type *load_type);
+
   void visit(GlobalLoadStmt *stmt) override;
 
   void visit(ElementShuffleStmt *stmt) override;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -196,7 +196,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(GlobalStoreStmt *stmt) override;
 
-  llvm::Value *load_as_custom_int(GlobalPtrStmt *ptr, Type *load_type);
+  llvm::Value *load_as_custom_int(Stmt *ptr, Type *load_type);
 
   void visit(GlobalLoadStmt *stmt) override;
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -89,8 +89,8 @@ FrontendForStmt::FrontendForStmt(const Expr &loop_var,
 }
 
 void ArgLoadExpression::flatten(FlattenContext *ctx) {
-  auto argl = std::make_unique<ArgLoadStmt>(arg_id, dt);
-  ctx->push_back(std::move(argl));
+  auto arg_load = std::make_unique<ArgLoadStmt>(arg_id, dt);
+  ctx->push_back(std::move(arg_load));
   stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -202,8 +202,7 @@ class FrontendKernelReturnStmt : public Stmt {
  public:
   Expr value;
 
-  FrontendKernelReturnStmt(const Expr &value, DataType dt) : value(value) {
-    ret_type = TypeFactory::create_vector_or_scalar_type(1, dt);
+  FrontendKernelReturnStmt(const Expr &value) : value(value) {
   }
 
   bool is_container_statement() const override {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -631,8 +631,7 @@ class KernelReturnStmt : public Stmt {
  public:
   Stmt *value;
 
-  KernelReturnStmt(Stmt *value, DataType dt) : value(value) {
-    this->ret_type = TypeFactory::create_vector_or_scalar_type(1, dt);
+  KernelReturnStmt(Stmt *value) : value(value) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -139,8 +139,15 @@ BitStructType::BitStructType(PrimitiveType *physical_type,
   TI_ASSERT(member_types_.size() == member_bit_offsets_.size());
   int physical_type_bits = data_type_bits(physical_type);
   for (auto i = 0; i < member_types_.size(); ++i) {
-    auto bits_end = member_types_[i]->as<CustomIntType>()->get_num_bits() +
-                    member_bit_offsets_[i];
+    CustomIntType *component_cit = nullptr;
+    if (auto cit = member_types_[i]->cast<CustomIntType>()) {
+      component_cit = cit;
+    } else if (auto cft = member_types_[i]->cast<CustomFloatType>()) {
+      component_cit = cft->get_digits_type()->as<CustomIntType>();
+    } else {
+      TI_NOT_IMPLEMENTED
+    }
+    auto bits_end = component_cit->get_num_bits() + member_bit_offsets_[i];
     TI_ASSERT(physical_type_bits >= bits_end)
   }
 }

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -115,10 +115,14 @@ CustomIntType::CustomIntType(int num_bits,
   }
 }
 
-CustomFloatType::CustomFloatType(Type *compute_type,
-                                 Type *digits_type,
+CustomFloatType::CustomFloatType(Type *digits_type,
+                                 Type *compute_type,
                                  float64 scale)
-    : compute_type_(compute_type), digits_type_(digits_type), scale_(scale) {
+    : digits_type_(digits_type), compute_type_(compute_type), scale_(scale) {
+  TI_ASSERT(digits_type->is<CustomIntType>());
+  TI_ASSERT(digits_type->as<CustomIntType>()->get_is_signed());
+  TI_ASSERT(compute_type->is<PrimitiveType>());
+  TI_ASSERT(is_real(compute_type->as<PrimitiveType>()));
 }
 
 std::string CustomFloatType::to_string() const {

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -120,7 +120,6 @@ CustomFloatType::CustomFloatType(Type *digits_type,
                                  float64 scale)
     : digits_type_(digits_type), compute_type_(compute_type), scale_(scale) {
   TI_ASSERT(digits_type->is<CustomIntType>());
-  TI_ASSERT(digits_type->as<CustomIntType>()->get_is_signed());
   TI_ASSERT(compute_type->is<PrimitiveType>());
   TI_ASSERT(is_real(compute_type->as<PrimitiveType>()));
 }

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -1,5 +1,4 @@
 #include "taichi/ir/type.h"
-
 #include "taichi/program/program.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -105,15 +104,26 @@ CustomIntType::CustomIntType(int num_bits,
                              bool is_signed,
                              Type *compute_type,
                              Type *physical_type)
-    : compute_type(compute_type),
-      physical_type(physical_type),
+    : compute_type_(compute_type),
+      physical_type_(physical_type),
       num_bits_(num_bits),
       is_signed_(is_signed) {
   if (compute_type == nullptr) {
     auto type_id = is_signed ? PrimitiveTypeID::i32 : PrimitiveTypeID::u32;
-    this->compute_type =
+    this->compute_type_ =
         TypeFactory::get_instance().get_primitive_type(type_id);
   }
+}
+
+CustomFloatType::CustomFloatType(Type *compute_type,
+                                 Type *digits_type,
+                                 float64 scale)
+    : compute_type_(compute_type), digits_type_(digits_type), scale_(scale) {
+}
+
+std::string CustomFloatType::to_string() const {
+  return fmt::format("cf(d={} c={} s={})", digits_type_->to_string(),
+                     compute_type_->to_string(), scale_);
 }
 
 BitStructType::BitStructType(PrimitiveType *physical_type,

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -221,9 +221,9 @@ class CustomFloatType : public Type {
   }
 
  private:
-  float64 scale_;
   Type *digits_type_{nullptr};
   Type *compute_type_{nullptr};
+  float64 scale_;
 };
 
 class BitStructType : public Type {

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -171,22 +171,18 @@ class CustomIntType : public Type {
                 Type *compute_type = nullptr,
                 Type *physical_type = nullptr);
 
-  ~CustomIntType() override {
-    delete compute_type;
-  }
-
   std::string to_string() const override;
 
-  void set_physical_type(Type *physical_type_) {
-    this->physical_type = physical_type_;
+  void set_physical_type(Type *physical_type) {
+    this->physical_type_ = physical_type;
   }
 
   Type *get_physical_type() {
-    return physical_type;
+    return physical_type_;
   }
 
   Type *get_compute_type() {
-    return compute_type;
+    return compute_type_;
   }
 
   int get_num_bits() const {
@@ -200,10 +196,34 @@ class CustomIntType : public Type {
  private:
   // TODO(type): for now we can uniformly use i32 as the "compute_type". It may
   // be a good idea to make "compute_type" also customizable.
-  Type *compute_type{nullptr};
-  Type *physical_type{nullptr};
+  Type *compute_type_{nullptr};
+  Type *physical_type_{nullptr};
   int num_bits_{32};
   bool is_signed_{true};
+};
+
+class CustomFloatType : public Type {
+ public:
+  CustomFloatType(Type *digits_type, Type *compute_type, float64 scale);
+
+  std::string to_string() const override;
+
+  float64 get_scale() const {
+    return scale_;
+  }
+
+  Type *get_digits_type() {
+    return digits_type_;
+  }
+
+  Type *get_compute_type() {
+    return compute_type_;
+  }
+
+ private:
+  float64 scale_;
+  Type *digits_type_{nullptr};
+  Type *compute_type_{nullptr};
 };
 
 class BitStructType : public Type {

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -41,6 +41,10 @@ class Type {
 
   bool is_primitive(PrimitiveTypeID type) const;
 
+  virtual Type *get_compute_type() {
+    TI_NOT_IMPLEMENTED;
+  }
+
   virtual ~Type() {
   }
 };
@@ -113,6 +117,10 @@ class PrimitiveType : public Type {
 
   std::string to_string() const override;
 
+  virtual Type *get_compute_type() override {
+    return this;
+  }
+
   static DataType get(PrimitiveTypeID type);
 };
 
@@ -181,7 +189,7 @@ class CustomIntType : public Type {
     return physical_type_;
   }
 
-  Type *get_compute_type() {
+  Type *get_compute_type() override {
     return compute_type_;
   }
 
@@ -216,7 +224,7 @@ class CustomFloatType : public Type {
     return digits_type_;
   }
 
-  Type *get_compute_type() {
+  Type *get_compute_type() override {
     return compute_type_;
   }
 

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -49,7 +49,16 @@ Type *TypeFactory::get_custom_int_type(int num_bits,
   return custom_int_types[key].get();
 }
 
-#undef SET_COMPUTE_TYPE
+Type *TypeFactory::get_custom_float_type(Type *digits_type,
+                                         Type *compute_type,
+                                         float64 scale) {
+  auto key = std::make_tuple(digits_type, compute_type, scale);
+  if (custom_float_types.find(key) == custom_float_types.end()) {
+    custom_float_types[key] =
+        std::make_unique<CustomFloatType>(digits_type, compute_type, scale);
+  }
+  return custom_float_types[key].get();
+}
 
 Type *TypeFactory::get_bit_struct_type(PrimitiveType *physical_type,
                                        std::vector<Type *> member_types,

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -25,6 +25,10 @@ class TypeFactory {
                             bool is_signed,
                             int compute_type_bits = 32);
 
+  Type *get_custom_float_type(Type *digits_type,
+                              Type *compute_type,
+                              float64 scale);
+
   Type *get_bit_struct_type(PrimitiveType *physical_type,
                             std::vector<Type *> member_types,
                             std::vector<int> member_bit_offsets);
@@ -50,6 +54,10 @@ class TypeFactory {
 
   // TODO: use unordered map
   std::map<std::tuple<int, int, bool>, std::unique_ptr<Type>> custom_int_types;
+
+  // TODO: use unordered map
+  std::map<std::tuple<Type *, Type *, float64>, std::unique_ptr<Type>>
+      custom_float_types;
 
   // TODO: avoid duplication
   std::vector<std::unique_ptr<Type>> bit_struct_types_;

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -116,7 +116,7 @@ inline bool constexpr is_trigonometric(UnaryOpType op) {
 inline bool is_real(DataType dt) {
   return dt->is_primitive(PrimitiveTypeID::f16) ||
          dt->is_primitive(PrimitiveTypeID::f32) ||
-         dt->is_primitive(PrimitiveTypeID::f64);
+         dt->is_primitive(PrimitiveTypeID::f64) || dt->is<CustomFloatType>();
 }
 
 inline bool is_integral(DataType dt) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -208,11 +208,6 @@ void Kernel::LaunchContextBuilder::set_arg_int(int i, int64 d) {
     ctx_->set_arg(i, (float32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
     ctx_->set_arg(i, (float64)d);
-  } else if (auto cit = dt->cast<CustomIntType>()) {
-    if (cit->get_is_signed())
-      ctx_->set_arg(i, (int32)d);
-    else
-      ctx_->set_arg(i, (uint32)d);
   } else {
     TI_INFO(dt->to_string());
     TI_NOT_IMPLEMENTED
@@ -323,11 +318,21 @@ void Kernel::set_arch(Arch arch) {
 }
 
 int Kernel::insert_arg(DataType dt, bool is_nparray) {
+  if (auto cft = dt->cast<CustomFloatType>()) {
+    dt = cft->get_compute_type();
+  } else if (auto cit = dt->cast<CustomIntType>()) {
+    dt = cit->get_compute_type();
+  }
   args.push_back(Arg{dt, is_nparray, /*size=*/0});
   return args.size() - 1;
 }
 
 int Kernel::insert_ret(DataType dt) {
+  if (auto cft = dt->cast<CustomFloatType>()) {
+    dt = cft->get_compute_type();
+  } else if (auto cit = dt->cast<CustomIntType>()) {
+    dt = cit->get_compute_type();
+  }
   rets.push_back(Ret{dt});
   return rets.size() - 1;
 }

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -257,6 +257,9 @@ Context &Kernel::LaunchContextBuilder::get_context() {
 
 float64 Kernel::get_ret_float(int i) {
   auto dt = rets[i].dt;
+  if (auto cft = dt->cast<CustomFloatType>()) {
+    dt = cft->get_compute_type();
+  }
   if (dt->is_primitive(PrimitiveTypeID::f32)) {
     return (float64)get_current_program().fetch_result<float32>(i);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -251,10 +251,7 @@ Context &Kernel::LaunchContextBuilder::get_context() {
 }
 
 float64 Kernel::get_ret_float(int i) {
-  auto dt = rets[i].dt;
-  if (auto cft = dt->cast<CustomFloatType>()) {
-    dt = cft->get_compute_type();
-  }
+  auto dt = rets[i].dt->get_compute_type();
   if (dt->is_primitive(PrimitiveTypeID::f32)) {
     return (float64)get_current_program().fetch_result<float32>(i);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
@@ -281,7 +278,7 @@ float64 Kernel::get_ret_float(int i) {
 }
 
 int64 Kernel::get_ret_int(int i) {
-  auto dt = rets[i].dt;
+  auto dt = rets[i].dt->get_compute_type();
   if (dt->is_primitive(PrimitiveTypeID::i32)) {
     return (int64)get_current_program().fetch_result<int32>(i);
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
@@ -302,11 +299,6 @@ int64 Kernel::get_ret_int(int i) {
     return (int64)get_current_program().fetch_result<float32>(i);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
     return (int64)get_current_program().fetch_result<float64>(i);
-  } else if (auto cit = dt->cast<CustomIntType>()) {
-    if (cit->get_is_signed())
-      return (int64)get_current_program().fetch_result<int32>(i);
-    else
-      return (int64)get_current_program().fetch_result<uint32>(i);
   } else {
     TI_NOT_IMPLEMENTED
   }
@@ -318,22 +310,12 @@ void Kernel::set_arch(Arch arch) {
 }
 
 int Kernel::insert_arg(DataType dt, bool is_nparray) {
-  if (auto cft = dt->cast<CustomFloatType>()) {
-    dt = cft->get_compute_type();
-  } else if (auto cit = dt->cast<CustomIntType>()) {
-    dt = cit->get_compute_type();
-  }
-  args.push_back(Arg{dt, is_nparray, /*size=*/0});
+  args.push_back(Arg{dt->get_compute_type(), is_nparray, /*size=*/0});
   return args.size() - 1;
 }
 
 int Kernel::insert_ret(DataType dt) {
-  if (auto cft = dt->cast<CustomFloatType>()) {
-    dt = cft->get_compute_type();
-  } else if (auto cit = dt->cast<CustomIntType>()) {
-    dt = cit->get_compute_type();
-  }
-  rets.push_back(Ret{dt});
+  rets.push_back(Ret{dt->get_compute_type()});
   return rets.size() - 1;
 }
 

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -623,8 +623,8 @@ Kernel &Program::get_snode_writer(SNode *snode) {
     for (int i = 0; i < snode->num_active_indices; i++) {
       indices.push_back(Expr::make<ArgLoadExpression>(i, PrimitiveType::i32));
     }
-    (snode->expr)[indices] =
-        Expr::make<ArgLoadExpression>(snode->num_active_indices, snode->dt);
+    (snode->expr)[indices] = Expr::make<ArgLoadExpression>(
+        snode->num_active_indices, snode->dt->get_compute_type());
   });
   ker.set_arch(get_snode_accessor_arch());
   ker.name = kernel_name;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -603,7 +603,7 @@ Kernel &Program::get_snode_reader(SNode *snode) {
       indices.push_back(Expr::make<ArgLoadExpression>(i, PrimitiveType::i32));
     }
     auto ret = Stmt::make<FrontendKernelReturnStmt>(
-        load_if_ptr((snode->expr)[indices]), snode->dt);
+        load_if_ptr((snode->expr)[indices]));
     current_ast_builder().insert(std::move(ret));
   });
   ker.set_arch(get_snode_accessor_arch());

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -89,7 +89,7 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
-      .def("get_ptr", &DataType::get_ptr)
+      .def("get_ptr", &DataType::get_ptr, py::return_value_policy::reference)
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -567,6 +567,7 @@ void export_lang(py::module &m) {
 
   m.def("is_integral", is_integral);
   m.def("is_signed", is_signed);
+  m.def("is_real", is_real);
   m.def("is_unsigned", is_unsigned);
 
   m.def("global_new", static_cast<Expr (*)(Expr, DataType)>(global_new));

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -89,6 +89,7 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
+      .def("get_ptr", &DataType::get_ptr)
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -730,6 +730,9 @@ void export_lang(py::module &m) {
       .def("get_custom_int_type", &TypeFactory::get_custom_int_type,
            py::arg("num_bits"), py::arg("is_signed"),
            py::arg("compute_type_bits") = 32,
+           py::return_value_policy::reference)
+      .def("get_custom_float_type", &TypeFactory::get_custom_float_type,
+           py::arg("digits_type"), py::arg("compute_type"), py::arg("scale"),
            py::return_value_policy::reference);
 
   m.def("get_type_factory_instance", TypeFactory::get_instance,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -394,8 +394,7 @@ void export_lang(py::module &m) {
   });
 
   m.def("create_kernel_return", [&](const Expr &value) {
-    current_ast_builder().insert(
-        Stmt::make<FrontendKernelReturnStmt>(value));
+    current_ast_builder().insert(Stmt::make<FrontendKernelReturnStmt>(value));
   });
 
   m.def("insert_continue_stmt", [&]() {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -393,9 +393,9 @@ void export_lang(py::module &m) {
     current_ast_builder().insert(Stmt::make<FrontendBreakStmt>());
   });
 
-  m.def("create_kernel_return", [&](const Expr &value, const DataType &dt) {
+  m.def("create_kernel_return", [&](const Expr &value) {
     current_ast_builder().insert(
-        Stmt::make<FrontendKernelReturnStmt>(value, dt));
+        Stmt::make<FrontendKernelReturnStmt>(value));
   });
 
   m.def("insert_continue_stmt", [&]() {

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -67,8 +67,16 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
       auto &ch = snode.ch[i];
       ch_types.push_back(ch->dt.get_ptr());
       ch_offsets.push_back(total_offset);
-      total_offset += ch->dt->as<CustomIntType>()->get_num_bits();
-      ch->dt->as<CustomIntType>()->set_physical_type(snode.physical_type);
+      CustomIntType *component_cit = nullptr;
+      if (auto cit = ch->dt->cast<CustomIntType>()) {
+        component_cit = cit;
+      } else if (auto cft = ch->dt->cast<CustomFloatType>()) {
+        component_cit = cft->get_digits_type()->as<CustomIntType>();
+      } else {
+        TI_NOT_IMPLEMENTED
+      }
+      component_cit->set_physical_type(snode.physical_type);
+      total_offset += component_cit->get_num_bits();
     }
 
     snode.dt = TypeFactory::get_instance().get_bit_struct_type(
@@ -77,7 +85,7 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
     DataType container_primitive_type(snode.physical_type);
     body_type = tlctx->get_data_type(container_primitive_type);
   } else if (type == SNodeType::bit_array) {
-    // A bit array SNode should only have one child
+    // A bit array SNode should have only one child
     TI_ASSERT(snode.ch.size() == 1);
     auto &ch = snode.ch[0];
     Type *ch_type = ch->dt.get_ptr();

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -46,7 +46,7 @@ class ConstantFold : public BasicStmtVisitor {
           oper->cast<UnaryOpStmt>()->cast_type = id.rhs;
         }
       }
-      auto ret = Stmt::make<KernelReturnStmt>(oper.get(), id.ret);
+      auto ret = Stmt::make<KernelReturnStmt>(oper.get());
       current_ast_builder().insert(std::move(lhstmt));
       if (id.is_binary)
         current_ast_builder().insert(std::move(rhstmt));

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -323,9 +323,7 @@ class LowerAST : public IRVisitor {
     auto expr = stmt->value;
     auto fctx = make_flatten_ctx();
     expr->flatten(&fctx);
-    const auto dt = stmt->element_type();
-    TI_ASSERT(dt != PrimitiveType::unknown);
-    fctx.push_back<KernelReturnStmt>(fctx.back_stmt(), dt);
+    fctx.push_back<KernelReturnStmt>(fctx.back_stmt());
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
     throw IRModified();
   }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -116,7 +116,6 @@ class TypeCheck : public IRVisitor {
     } else {
       stmt->ret_type = pointee_type;
     }
-    TI_P(stmt->ret_type->to_string());
   }
 
   void visit(SNodeOpStmt *stmt) {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -131,13 +131,8 @@ class TypeCheck : public IRVisitor {
   void visit(GlobalPtrStmt *stmt) {
     stmt->ret_type.set_is_pointer(true);
     if (stmt->snodes) {
-      stmt->ret_type = stmt->snodes[0]->dt.get_ptr();
-      // TODO(type): GlobalPtr should return a pointer type but using the
-      // following crashes the compiler:
-      //
-      // stmt->ret_type =
-      // TypeFactory::get_instance().get_pointer_type(
-      //    stmt->snodes[0]->dt.get_ptr());
+      stmt->ret_type = TypeFactory::get_instance().get_pointer_type(
+          stmt->snodes[0]->dt.get_ptr());
     } else
       TI_WARN("[{}] Type inference failed: snode is nullptr.", stmt->name());
     for (int l = 0; l < stmt->snodes.size(); l++) {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -154,6 +154,8 @@ class TypeCheck : public IRVisitor {
     const auto dst_value_type = stmt->ptr->ret_type.ptr_removed();
     if (dst_value_type->is<CustomIntType>() ||
         dst_value_type->is<CustomFloatType>()) {
+      // TODO(type): maybe we still need some kind of check here. E.g., we
+      // should warn user when he stores int to CustomFloat.
       return;
     }
     auto promoted = promoted_type(dst_value_type, stmt->data->ret_type);

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -109,13 +109,7 @@ class TypeCheck : public IRVisitor {
 
   void visit(GlobalLoadStmt *stmt) {
     auto pointee_type = stmt->ptr->ret_type.ptr_removed();
-    if (auto cit = pointee_type->cast<CustomIntType>()) {
-      stmt->ret_type = cit->get_compute_type();
-    } else if (auto cft = pointee_type->cast<CustomFloatType>()) {
-      stmt->ret_type = cft->get_compute_type();
-    } else {
-      stmt->ret_type = pointee_type;
-    }
+    stmt->ret_type = pointee_type->get_compute_type();
   }
 
   void visit(SNodeOpStmt *stmt) {
@@ -172,7 +166,6 @@ class TypeCheck : public IRVisitor {
               stmt->name(), stmt->ptr->ret_data_type_name(), input_type);
       TI_WARN("\n{}", stmt->tb);
     }
-    stmt->ret_type = dst_value_type;
   }
 
   void visit(RangeForStmt *stmt) {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -150,22 +150,22 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(GlobalStoreStmt *stmt) {
-    if (stmt->ptr->ret_type.ptr_removed()->is<CustomIntType>()) {
+    const auto dst_value_type = stmt->ptr->ret_type.ptr_removed();
+    if (dst_value_type->is<CustomIntType>() ||
+        dst_value_type->is<CustomFloatType>()) {
       return;
     }
-    auto promoted =
-        promoted_type(stmt->ptr->ret_type.ptr_removed(), stmt->data->ret_type);
+    auto promoted = promoted_type(dst_value_type, stmt->data->ret_type);
     auto input_type = stmt->data->ret_data_type_name();
-    if (stmt->ptr->ret_type.ptr_removed() != stmt->data->ret_type) {
-      stmt->data = insert_type_cast_before(stmt, stmt->data,
-                                           stmt->ptr->ret_type.ptr_removed());
+    if (dst_value_type != stmt->data->ret_type) {
+      stmt->data = insert_type_cast_before(stmt, stmt->data, dst_value_type);
     }
-    if (stmt->ptr->ret_type.ptr_removed() != promoted) {
+    if (dst_value_type != promoted) {
       TI_WARN("[{}] Global store may lose precision: {} <- {}, at",
               stmt->name(), stmt->ptr->ret_data_type_name(), input_type);
       TI_WARN("\n{}", stmt->tb);
     }
-    stmt->ret_type = stmt->ptr->ret_type.ptr_removed();
+    stmt->ret_type = dst_value_type;
   }
 
   void visit(RangeForStmt *stmt) {

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -25,3 +25,5 @@ def test_custom_float():
     assert x[None] == approx(0.6)
     x[None] = 0.66
     assert x[None] == approx(0.7)
+
+    # TODO(type): atomic_add

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -1,0 +1,38 @@
+import taichi as ti
+import numpy as np
+
+
+@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+def test_custom_float_load():
+    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
+
+    x = ti.field(dtype=cft)
+
+    ti.root._bit_struct(num_bits=32).place(x)
+
+    ti.get_runtime().materialize()
+
+    return
+
+    @ti.kernel
+    def set_val(idx: ti.i32):
+        x[None] = test_case[idx][0]
+        y[None] = test_case[idx][1]
+        z[None] = test_case[idx][2]
+
+    @ti.kernel
+    def verify_val(idx: ti.i32):
+        assert x[None] == test_case[idx][0]
+        assert y[None] == test_case[idx][1]
+        assert z[None] == test_case[idx][2]
+
+    for idx in range(len(test_case_np)):
+        set_val(idx)
+        verify_val(idx)
+    '''
+    # Test bit_struct SNode read and write in Python-scope by calling the wrapped, untranslated function body
+    for idx in range(len(test_case_np)):
+        set_val.__wrapped__(idx)
+        verify_val.__wrapped__(idx)
+    '''

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -17,6 +17,7 @@ def test_custom_float_load():
 
     @ti.kernel
     def foo():
+        x[None] = 0.7
         print(x[None])
 
     foo()

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -46,5 +46,5 @@ def test_custom_float_load():
     '''
 
 
-ti.init(arch=ti.cpu, debug=True, cfg_optimization=False, print_ir=True)
+ti.init(arch=ti.cpu, debug=True, cfg_optimization=False, print_ir=True, print_accessor_ir=True)
 test_custom_float_load()

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -14,6 +14,12 @@ def test_custom_float_load():
     ti.get_runtime().print_snode_tree()
     ti.get_runtime().materialize()
 
+    @ti.kernel
+    def foo():
+        print(x[None])
+
+    foo()
+    print(x[None])
     return
 
     @ti.kernel
@@ -37,5 +43,7 @@ def test_custom_float_load():
         set_val.__wrapped__(idx)
         verify_val.__wrapped__(idx)
     '''
+
+
 ti.init(arch=ti.cpu, debug=True, cfg_optimization=False)
 test_custom_float_load()

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -2,7 +2,7 @@ import taichi as ti
 import numpy as np
 
 
-@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+# @ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
 def test_custom_float_load():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
@@ -36,3 +36,5 @@ def test_custom_float_load():
         set_val.__wrapped__(idx)
         verify_val.__wrapped__(idx)
     '''
+ti.init(arch=ti.cpu, debug=True, cfg_optimization=False)
+test_custom_float_load()

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -11,6 +11,7 @@ def test_custom_float_load():
 
     ti.root._bit_struct(num_bits=32).place(x)
 
+    ti.get_runtime().print_snode_tree()
     ti.get_runtime().materialize()
 
     return

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -1,14 +1,12 @@
 import taichi as ti
-import numpy as np
+from pytest import approx
 
 
-# @ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
-def test_custom_float_load():
+@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+def test_custom_float():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
-
     cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
     x = ti.field(dtype=cft)
-    # x = ti.field(dtype=ci13)
 
     ti.root._bit_struct(num_bits=32).place(x)
 
@@ -19,17 +17,11 @@ def test_custom_float_load():
     def foo():
         x[None] = 0.7
         print(x[None])
+        x[None] = x[None] + 0.4
 
     foo()
-    print(x[None])
+    assert x[None] == approx(1.1)
     x[None] = 0.64
-    print(x[None])
-    return
-
-
-ti.init(arch=ti.cpu,
-        debug=True,
-        cfg_optimization=False,
-        print_ir=True,
-        print_accessor_ir=True)
-test_custom_float_load()
+    assert x[None] == approx(0.6)
+    x[None] = 0.66
+    assert x[None] == approx(0.7)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -5,10 +5,10 @@ import numpy as np
 # @ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
 def test_custom_float_load():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    
-    # cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
-    # x = ti.field(dtype=cft)
-    x = ti.field(dtype=ci13)
+
+    cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
+    x = ti.field(dtype=cft)
+    # x = ti.field(dtype=ci13)
 
     ti.root._bit_struct(num_bits=32).place(x)
 
@@ -20,31 +20,13 @@ def test_custom_float_load():
         print(x[None])
 
     foo()
-    print(x[None])
+    # print(x[None])
     return
 
-    @ti.kernel
-    def set_val(idx: ti.i32):
-        x[None] = test_case[idx][0]
-        y[None] = test_case[idx][1]
-        z[None] = test_case[idx][2]
 
-    @ti.kernel
-    def verify_val(idx: ti.i32):
-        assert x[None] == test_case[idx][0]
-        assert y[None] == test_case[idx][1]
-        assert z[None] == test_case[idx][2]
-
-    for idx in range(len(test_case_np)):
-        set_val(idx)
-        verify_val(idx)
-    '''
-    # Test bit_struct SNode read and write in Python-scope by calling the wrapped, untranslated function body
-    for idx in range(len(test_case_np)):
-        set_val.__wrapped__(idx)
-        verify_val.__wrapped__(idx)
-    '''
-
-
-ti.init(arch=ti.cpu, debug=True, cfg_optimization=False, print_ir=True, print_accessor_ir=True)
+ti.init(arch=ti.cpu,
+        debug=True,
+        cfg_optimization=False,
+        print_ir=True,
+        print_accessor_ir=True)
 test_custom_float_load()

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -5,9 +5,10 @@ import numpy as np
 # @ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
 def test_custom_float_load():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
-
-    x = ti.field(dtype=cft)
+    
+    # cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
+    # x = ti.field(dtype=cft)
+    x = ti.field(dtype=ci13)
 
     ti.root._bit_struct(num_bits=32).place(x)
 
@@ -45,5 +46,5 @@ def test_custom_float_load():
     '''
 
 
-ti.init(arch=ti.cpu, debug=True, cfg_optimization=False)
+ti.init(arch=ti.cpu, debug=True, cfg_optimization=False, print_ir=True)
 test_custom_float_load()

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -20,7 +20,7 @@ def test_custom_float_load():
         print(x[None])
 
     foo()
-    # print(x[None])
+    print(x[None])
     return
 
 

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -2,16 +2,13 @@ import taichi as ti
 from pytest import approx
 
 
-@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+@ti.test(arch=ti.cpu, cfg_optimization=False)
 def test_custom_float():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
     x = ti.field(dtype=cft)
 
     ti.root._bit_struct(num_bits=32).place(x)
-
-    ti.get_runtime().print_snode_tree()
-    ti.get_runtime().materialize()
 
     @ti.kernel
     def foo():

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -22,6 +22,8 @@ def test_custom_float_load():
 
     foo()
     print(x[None])
+    x[None] = 0.64
+    print(x[None])
     return
 
 


### PR DESCRIPTION
Related issue = #1905

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

Sorry about the large changes.

- Add `CustomFloatType`
- Support global load/store of `CustomFloatType` (`atomid_add` will be done later.)
- `KernelReturnStmt`/`ArgLoadStmt` ctor no longer takes data type. Their return data types are inferred by `type_check` 
- `get_compute_type` is now part of `Type` API. Overriden in derived classes `CustomFloatType`, `CustomIntType`, `PrimitiveType`.
- Return type of `GlobalPtrStmt` is now a pointer type (used to be only the pointee type)
- Refactor/implement SNode reader/writer for `CustomFloat/IntType`
- Add `is_real(DataType)`
- `GlobalStoreStmt` no longer has a return data type

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
