### PR TITLE
[type] [cuda] Support bit-level pointer on cuda backend

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -433,7 +433,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           auto data = create_intrinsic_load(dtype, data_ptr);
           llvm_val[stmt] = extract_custom_int(data, bit_offset, val_type);
           if (val_type->is<CustomFloatType>()) {
-            llvm_val[stmt] = restore_custom_float(llvm_val[stmt], val_type);
+            llvm_val[stmt] = reconstruct_custom_float(llvm_val[stmt], val_type);
           }
         } else {
           llvm_val[stmt] = create_intrinsic_load(dtype, llvm_val[stmt->ptr]);

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -321,7 +321,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
         fmt::format("cuda_rand_{}", data_type_short_name(stmt->ret_type)),
         {get_context()});
   }
-  
+
   void visit(RangeForStmt *for_stmt) override {
     create_naive_range_for(for_stmt);
   }
@@ -386,7 +386,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     return true;  // on CUDA, pass the argument by value
   }
 
-  llvm::Value *create_intrinsic_load(const DataType& dtype, llvm::Value* data_ptr) {
+  llvm::Value *create_intrinsic_load(const DataType &dtype,
+                                     llvm::Value *data_ptr) {
     auto llvm_dtype = llvm_type(dtype);
     auto llvm_dtype_ptr = llvm::PointerType::get(llvm_type(dtype), 0);
     llvm::Intrinsic::ID intrin;
@@ -396,8 +397,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       intrin = llvm::Intrinsic::nvvm_ldg_global_i;
     }
     return builder->CreateIntrinsic(
-            intrin, {llvm_dtype, llvm_dtype_ptr},
-            {data_ptr, tlctx->get_constant(data_type_size(dtype))});
+        intrin, {llvm_dtype, llvm_dtype_ptr},
+        {data_ptr, tlctx->get_constant(data_type_size(dtype))});
   }
 
   void visit(GlobalLoadStmt *stmt) override {
@@ -413,14 +414,17 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
         // Issue an CUDA "__ldg" instruction so that data are cached in
         // the CUDA read-only data cache.
         auto dtype = stmt->ret_type;
-        if (auto ptr_type = stmt->ptr->ret_type->cast<PointerType>(); ptr_type->is_bit_pointer()) {
+        if (auto ptr_type = stmt->ptr->ret_type->cast<PointerType>();
+            ptr_type->is_bit_pointer()) {
           auto val_type = ptr_type->get_pointee_type();
           llvm::Value *data_ptr = nullptr;
           llvm::Value *bit_offset = nullptr;
           if (auto cit = val_type->cast<CustomIntType>()) {
             dtype = cit->get_physical_type();
           } else if (auto cft = val_type->cast<CustomFloatType>()) {
-            dtype = cft->get_compute_type()->as<CustomIntType>()->get_physical_type();
+            dtype = cft->get_compute_type()
+                        ->as<CustomIntType>()
+                        ->get_physical_type();
           } else {
             TI_NOT_IMPLEMENTED;
           }

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -414,7 +414,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
         // Issue an CUDA "__ldg" instruction so that data are cached in
         // the CUDA read-only data cache.
         auto dtype = stmt->ret_type;
-        if (auto ptr_type = stmt->ptr->ret_type->cast<PointerType>();
+        if (auto ptr_type = stmt->ptr->ret_type->as<PointerType>();
             ptr_type->is_bit_pointer()) {
           auto val_type = ptr_type->get_pointee_type();
           llvm::Value *data_ptr = nullptr;

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1198,7 +1198,7 @@ llvm::Value *CodeGenLLVM::extract_custom_int(llvm::Value *physical_value,
 }
 
 llvm::Value *CodeGenLLVM::reconstruct_custom_float(llvm::Value *digits,
-                                               Type *load_type) {
+                                                   Type *load_type) {
   // Compute float(digits) * scale
   auto cft = load_type->as<CustomFloatType>();
   llvm::Value *cast = nullptr;

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1141,7 +1141,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
     }
     llvm::Value *byte_ptr = nullptr, *bit_offset = nullptr;
     read_bit_pointer(llvm_val[stmt->ptr], byte_ptr, bit_offset);
-    // TODO(type): cuda only supports atomic CAS on 32 and 64 bit integer 
+    // TODO(type): cuda only supports atomic CAS on 32 and 64 bit integer
     // try to support CustomInt/Float Type with 16-bits or 8-bits physical type
     auto func_name = fmt::format("set_partial_bits_b{}",
                                  data_type_bits(cit->get_physical_type()));

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1163,11 +1163,13 @@ llvm::Value *CodeGenLLVM::load_as_custom_int(Stmt *ptr, Type *load_type) {
 
   auto bit_level_container = builder->CreateLoad(builder->CreateBitCast(
       byte_ptr, llvm_ptr_type(cit->get_physical_type())));
-  
-  return extract_custom_int(bit_level_container, bit_offset, load_type);
-} 
 
-llvm::Value *CodeGenLLVM::extract_custom_int(llvm::Value* physical_value, llvm::Value* bit_offset, Type* load_type) {
+  return extract_custom_int(bit_level_container, bit_offset, load_type);
+}
+
+llvm::Value *CodeGenLLVM::extract_custom_int(llvm::Value *physical_value,
+                                             llvm::Value *bit_offset,
+                                             Type *load_type) {
   //  bit shifting
   //    first left shift `physical_type - (offset + num_bits)`
   //    then right shift `physical_type - num_bits`
@@ -1193,7 +1195,8 @@ llvm::Value *CodeGenLLVM::extract_custom_int(llvm::Value* physical_value, llvm::
                                 cit->get_is_signed());
 }
 
-llvm::Value *CodeGenLLVM::restore_custom_float(llvm::Value* digits, Type* load_type) {
+llvm::Value *CodeGenLLVM::restore_custom_float(llvm::Value *digits,
+                                               Type *load_type) {
   // Compute float(digits) * scale
   auto cft = load_type->as<CustomFloatType>();
   llvm::Value *cast = nullptr;

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1141,7 +1141,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
     }
     llvm::Value *byte_ptr = nullptr, *bit_offset = nullptr;
     read_bit_pointer(llvm_val[stmt->ptr], byte_ptr, bit_offset);
-    // TODO(type): cuda only supports atomic CAS on 32 and 64 bit integer
+    // TODO(type): CUDA only supports atomicCAS on 32- and 64-bit integers
     // try to support CustomInt/Float Type with 16-bits or 8-bits physical type
     auto func_name = fmt::format("set_partial_bits_b{}",
                                  data_type_bits(cit->get_physical_type()));

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1141,6 +1141,8 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
     }
     llvm::Value *byte_ptr = nullptr, *bit_offset = nullptr;
     read_bit_pointer(llvm_val[stmt->ptr], byte_ptr, bit_offset);
+    // TODO(type): cuda only supports atomic CAS on 32 and 64 bit integer 
+    // try to support CustomInt/Float Type with 16-bits or 8-bits physical type
     auto func_name = fmt::format("set_partial_bits_b{}",
                                  data_type_bits(cit->get_physical_type()));
     builder->CreateCall(

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1197,7 +1197,7 @@ llvm::Value *CodeGenLLVM::extract_custom_int(llvm::Value *physical_value,
                                 cit->get_is_signed());
 }
 
-llvm::Value *CodeGenLLVM::restore_custom_float(llvm::Value *digits,
+llvm::Value *CodeGenLLVM::reconstruct_custom_float(llvm::Value *digits,
                                                Type *load_type) {
   // Compute float(digits) * scale
   auto cft = load_type->as<CustomFloatType>();
@@ -1224,7 +1224,7 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
       llvm_val[stmt] = load_as_custom_int(stmt->ptr, val_type);
     } else if (auto cft = val_type->cast<CustomFloatType>()) {
       auto digits = load_as_custom_int(stmt->ptr, cft->get_digits_type());
-      llvm_val[stmt] = restore_custom_float(digits, val_type);
+      llvm_val[stmt] = reconstruct_custom_float(digits, val_type);
     } else {
       TI_NOT_IMPLEMENTED
     }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1217,8 +1217,8 @@ llvm::Value *CodeGenLLVM::reconstruct_custom_float(llvm::Value *digits,
 void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   int width = stmt->width();
   TI_ASSERT(width == 1);
-  if (auto ptr_type = stmt->ptr->ret_type->cast<PointerType>();
-      ptr_type->is_bit_pointer()) {
+  auto ptr_type = stmt->ptr->ret_type->as<PointerType>();
+  if (ptr_type->is_bit_pointer()) {
     auto val_type = ptr_type->get_pointee_type();
     if (val_type->is<CustomIntType>()) {
       llvm_val[stmt] = load_as_custom_int(stmt->ptr, val_type);

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -198,6 +198,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *load_as_custom_int(Stmt *ptr, Type *load_type);
 
+  llvm::Value *extract_custom_int(llvm::Value* physical_value, llvm::Value* bit_offset, Type* load_type);
+
   void visit(GlobalLoadStmt *stmt) override;
 
   void visit(ElementShuffleStmt *stmt) override;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -198,10 +198,12 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *load_as_custom_int(Stmt *ptr, Type *load_type);
 
-  llvm::Value *extract_custom_int(llvm::Value* physical_value, llvm::Value* bit_offset, Type* load_type);
+  llvm::Value *extract_custom_int(llvm::Value *physical_value,
+                                  llvm::Value *bit_offset,
+                                  Type *load_type);
 
-  llvm::Value *restore_custom_float(llvm::Value* digits, Type* load_type);
-  
+  llvm::Value *restore_custom_float(llvm::Value *digits, Type *load_type);
+
   void visit(GlobalLoadStmt *stmt) override;
 
   void visit(ElementShuffleStmt *stmt) override;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -202,7 +202,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                                   llvm::Value *bit_offset,
                                   Type *load_type);
 
-  llvm::Value *restore_custom_float(llvm::Value *digits, Type *load_type);
+  llvm::Value *reconstruct_custom_float(llvm::Value *digits, Type *load_type);
 
   void visit(GlobalLoadStmt *stmt) override;
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -200,6 +200,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *extract_custom_int(llvm::Value* physical_value, llvm::Value* bit_offset, Type* load_type);
 
+  llvm::Value *restore_custom_float(llvm::Value* digits, Type* load_type);
+  
   void visit(GlobalLoadStmt *stmt) override;
 
   void visit(ElementShuffleStmt *stmt) override;

--- a/tests/python/test_bit_array.py
+++ b/tests/python/test_bit_array.py
@@ -2,7 +2,7 @@ import taichi as ti
 import numpy as np
 
 
-@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
 def test_1D_bit_array():
     ci1 = ti.type_factory_.get_custom_int_type(1, False)
 
@@ -28,7 +28,7 @@ def test_1D_bit_array():
     verify_val()
 
 
-@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
 def test_2D_bit_array():
     ci1 = ti.type_factory_.get_custom_int_type(1, False)
 

--- a/tests/python/test_bit_array.py
+++ b/tests/python/test_bit_array.py
@@ -2,7 +2,7 @@ import taichi as ti
 import numpy as np
 
 
-@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
 def test_1D_bit_array():
     ci1 = ti.type_factory_.get_custom_int_type(1, False)
 
@@ -28,7 +28,7 @@ def test_1D_bit_array():
     verify_val()
 
 
-@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
 def test_2D_bit_array():
     ci1 = ti.type_factory_.get_custom_int_type(1, False)
 

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -36,7 +36,7 @@ def test_simple_array():
     verify_val.__wrapped__()
 
 
-@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
+@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
 def test_custom_int_load_and_store():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu14 = ti.type_factory_.get_custom_int_type(14, False)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -2,7 +2,7 @@ import taichi as ti
 import numpy as np
 
 
-@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
 def test_simple_array():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu19 = ti.type_factory_.get_custom_int_type(19, False)
@@ -36,7 +36,7 @@ def test_simple_array():
     verify_val.__wrapped__()
 
 
-@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
 def test_custom_int_load_and_store():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu14 = ti.type_factory_.get_custom_int_type(14, False)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -36,7 +36,7 @@ def test_simple_array():
     verify_val.__wrapped__()
 
 
-@ti.test(arch=ti.cpu, debug=True, cfg_optimization=False)
+@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
 def test_custom_int_load_and_store():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu14 = ti.type_factory_.get_custom_int_type(14, False)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -2,7 +2,7 @@ import taichi as ti
 import numpy as np
 
 
-@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
 def test_simple_array():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu19 = ti.type_factory_.get_custom_int_type(19, False)
@@ -36,7 +36,7 @@ def test_simple_array():
     verify_val.__wrapped__()
 
 
-@ti.test(ti.cpu, ti.cuda, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
 def test_custom_int_load_and_store():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu14 = ti.type_factory_.get_custom_int_type(14, False)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -2,7 +2,7 @@ import taichi as ti
 from pytest import approx
 
 
-@ti.test(arch=ti.cpu, cfg_optimization=False)
+@ti.test(ti.cpu, ti.cuda, cfg_optimization=False)
 def test_custom_float():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -2,7 +2,7 @@ import taichi as ti
 from pytest import approx
 
 
-@ti.test(ti.cpu, ti.cuda, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, cfg_optimization=False)
 def test_custom_float():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)


### PR DESCRIPTION
Related issue = #1905 

In this pr, we want to support bit-level pointer on coda backend. 
For now, most test cases passed, but the CustomInt/Float type with 16-bits or 8-bits physical type would fail. The error occurs in JIT module, which I know very little about. @yuanming-hu could you please have a look? I will left the error message and reproducing code in JIRA. Thanks a lot! 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
