### PR TITLE
[type] Use zext instruction to cast unsigned int

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -333,8 +333,13 @@ void CodeGenLLVM::visit(UnaryOpStmt *stmt) {
         from_size = data_type_size(from);
       }
       if (from_size < data_type_size(to)) {
-        llvm_val[stmt] = builder->CreateSExt(
-            llvm_val[stmt->operand], tlctx->get_data_type(stmt->cast_type));
+        if (is_signed(from)) {
+          llvm_val[stmt] = builder->CreateSExt(
+              llvm_val[stmt->operand], tlctx->get_data_type(stmt->cast_type));
+        } else {
+          llvm_val[stmt] = builder->CreateZExt(
+              llvm_val[stmt->operand], tlctx->get_data_type(stmt->cast_type));
+        }
       } else {
         llvm_val[stmt] = builder->CreateTrunc(
             llvm_val[stmt->operand], tlctx->get_data_type(stmt->cast_type));

--- a/tests/python/test_cast.py
+++ b/tests/python/test_cast.py
@@ -89,7 +89,7 @@ def test_bit_cast():
     assert z[None] == 2333
 
 
-@ti.test(arch=ti.cpu)
+@ti.test(ti.cpu, ti.cuda, cfg_optimization=False)
 def test_int_extension():
     x = ti.field(dtype=ti.i32, shape=1)
     y = ti.field(dtype=ti.u16, shape=1)
@@ -107,7 +107,8 @@ def test_int_extension():
     assert x[0] == 0x8234
 
 
-@ti.test(arch=ti.cpu)
+# TODO: add arch=ti.cuda after bit-pointer is supported on cuda
+@ti.test(ti.cpu, cfg_optimization=False)
 def test_custom_int_extension():
     x = ti.field(dtype=ti.i32, shape=2)
 

--- a/tests/python/test_cast.py
+++ b/tests/python/test_cast.py
@@ -89,28 +89,40 @@ def test_bit_cast():
     assert z[None] == 2333
 
 
-@ti.test(ti.cpu, ti.cuda, cfg_optimization=False)
+@ti.test(arch=ti.cpu)
 def test_int_extension():
-    x = ti.field(dtype=ti.i32, shape=1)
-    y = ti.field(dtype=ti.u16, shape=1)
+    x = ti.field(dtype=ti.i32, shape=2)
+    y = ti.field(dtype=ti.u32, shape=2)
+
+    a = ti.field(dtype=ti.i8, shape=1)
+    b = ti.field(dtype=ti.u8, shape=1)
 
     @ti.kernel
-    def run_cast():
-        x[0] = ti.cast(y[0], ti.i32)
+    def run_cast_i32():
+        x[0] = ti.cast(a[0], ti.i32)
+        x[1] = ti.cast(b[0], ti.i32)
 
-    y[0] = 0xFFFF
-    run_cast()
-    assert x[0] == 0xFFFF
+    @ti.kernel
+    def run_cast_u32():
+        y[0] = ti.cast(a[0], ti.u32)
+        y[1] = ti.cast(b[0], ti.u32)
 
-    y[0] = 0x8234
-    run_cast()
-    assert x[0] == 0x8234
+    a[0] = -128
+    b[0] = -128
+
+    run_cast_i32()
+    assert x[0] == -128
+    assert x[1] == 128
+
+    run_cast_u32()
+    assert y[0] == 0xFFFFFF80
+    assert y[1] == 128
 
 
-# TODO: add arch=ti.cuda after bit-pointer being supported on cuda
-@ti.test(ti.cpu, cfg_optimization=False)
+@ti.test(arch=ti.cpu)
 def test_custom_int_extension():
     x = ti.field(dtype=ti.i32, shape=2)
+    y = ti.field(dtype=ti.u32, shape=2)
 
     ci5 = ti.type_factory_.get_custom_int_type(5, True, 16)
     cu7 = ti.type_factory_.get_custom_int_type(7, False, 16)
@@ -121,12 +133,22 @@ def test_custom_int_extension():
     ti.root._bit_struct(num_bits=32).place(a, b)
 
     @ti.kernel
-    def run_cast():
+    def run_cast_int():
         x[0] = ti.cast(a[None], ti.i32)
         x[1] = ti.cast(b[None], ti.i32)
 
-    a[None] = 0x1F
-    b[None] = 0x3F
-    run_cast()
-    assert x[0] == -1
-    assert x[1] == 0x3F
+    @ti.kernel
+    def run_cast_uint():
+        y[0] = ti.cast(a[None], ti.u32)
+        y[1] = ti.cast(b[None], ti.u32)
+
+    a[None] = -16
+    b[None] = -64
+
+    run_cast_int()
+    assert x[0] == -16
+    assert x[1] == 64
+
+    run_cast_uint()
+    assert y[0] == 0xFFFFFFF0
+    assert y[1] == 64

--- a/tests/python/test_cast.py
+++ b/tests/python/test_cast.py
@@ -107,7 +107,7 @@ def test_int_extension():
     assert x[0] == 0x8234
 
 
-# TODO: add arch=ti.cuda after bit-pointer is supported on cuda
+# TODO: add arch=ti.cuda after bit-pointer being supported on cuda
 @ti.test(ti.cpu, cfg_optimization=False)
 def test_custom_int_extension():
     x = ti.field(dtype=ti.i32, shape=2)


### PR DESCRIPTION
Related issue = #1905 #1996
In this pr, I try to determine which extension instruction should be used when casting integers. According to my understanding, we should use `zext` for unsigned int, and `sext` for signed int.

Please note that, the original goal of this pr is to determine the instruction for `CustomIntType`.  One `CustomIntType` should be loaded through `GlobalLoadStmt` first before casting. After loading, the `CustomIntType` would be a "normal"
 integer type (the same type as its `ComputeType`). That is to say, we can simply treat the `CustomIntType`  and primitive integer type equally here.



<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
