### PR TITLE
[async] Filter list operations that are clearly redundant

### DIFF
--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -173,7 +173,7 @@ AsyncEngine::AsyncEngine(Program *program,
                          const BackendExecCompilationFunc &compile_to_backend)
     : queue(&ir_bank_, compile_to_backend),
       program(program),
-      sfg(std::make_unique<StateFlowGraph>(&ir_bank_)) {
+      sfg(std::make_unique<StateFlowGraph>(this, &ir_bank_)) {
 }
 
 void AsyncEngine::launch(Kernel *kernel, Context &context) {
@@ -200,7 +200,7 @@ void AsyncEngine::launch(Kernel *kernel, Context &context) {
     TaskLaunchRecord rec(context, kernel, kmeta.ir_handle_cached[i]);
     records.push_back(rec);
   }
-  sfg->insert_tasks(records);
+  sfg->insert_tasks(records, true);
 }
 
 void AsyncEngine::synchronize() {

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -200,17 +200,7 @@ void AsyncEngine::launch(Kernel *kernel, Context &context) {
     TaskLaunchRecord rec(context, kernel, kmeta.ir_handle_cached[i]);
     records.push_back(rec);
   }
-  enqueue(records);
-}
-
-void AsyncEngine::enqueue(const TaskLaunchRecord &t) {
-  sfg->insert_task(t);
-}
-
-void AsyncEngine::enqueue(const std::vector<TaskLaunchRecord> &records) {
-  for (auto rec : records) {
-    sfg->insert_task(rec);
-  }
+  sfg->insert_tasks(records);
 }
 
 void AsyncEngine::synchronize() {

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -1,6 +1,7 @@
 #include "taichi/program/async_engine.h"
 
 #include <memory>
+
 #include "taichi/program/kernel.h"
 #include "taichi/program/program.h"
 #include "taichi/backends/cpu/codegen_cpu.h"

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -144,10 +144,6 @@ class AsyncEngine {
 
   void launch(Kernel *kernel, Context &context);
 
-  void enqueue(const TaskLaunchRecord &t);
-
-  void enqueue(const std::vector<TaskLaunchRecord> &records);
-
   void synchronize();
 
   void debug_sfg(const std::string &suffix);

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -134,7 +134,6 @@ class AsyncEngine {
   Program *program;
 
   std::unique_ptr<StateFlowGraph> sfg;
-  std::deque<TaskLaunchRecord> task_queue;
 
   explicit AsyncEngine(Program *program,
                        const BackendExecCompilationFunc &compile_to_backend);
@@ -146,6 +145,8 @@ class AsyncEngine {
   void launch(Kernel *kernel, Context &context);
 
   void enqueue(const TaskLaunchRecord &t);
+
+  void enqueue(const std::vector<TaskLaunchRecord> &records);
 
   void synchronize();
 

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -220,14 +220,14 @@ void StateFlowGraph::insert_tasks(const std::vector<TaskLaunchRecord> &records,
 
 void StateFlowGraph::insert_node(std::unique_ptr<StateFlowGraph::Node> &&node) {
   for (auto input_state : node->meta->input_states) {
-    TI_PROFILER("insert_task meta->input_states");
+    // TI_PROFILER("insert_task meta->input_states");
     if (latest_state_owner_.find(input_state) == latest_state_owner_.end()) {
       latest_state_owner_[input_state] = initial_node_;
     }
     insert_edge(latest_state_owner_[input_state], node.get(), input_state);
   }
   for (auto output_state : node->meta->output_states) {
-    TI_PROFILER("insert_task meta->output_states");
+    // TI_PROFILER("insert_task meta->output_states");
     if (get_or_insert(latest_state_readers_, output_state).empty()) {
       if (latest_state_owner_.find(output_state) != latest_state_owner_.end()) {
         // insert a WAW dependency edge
@@ -247,14 +247,14 @@ void StateFlowGraph::insert_node(std::unique_ptr<StateFlowGraph::Node> &&node) {
 
   // Note that this loop must happen AFTER the previous one
   for (auto input_state : node->meta->input_states) {
-    TI_PROFILER("insert_task latest_state_readers_");
+    // TI_PROFILER("insert_task latest_state_readers_");
     insert(latest_state_readers_, input_state, node.get());
   }
   nodes_.push_back(std::move(node));
 }
 
 void StateFlowGraph::insert_edge(Node *from, Node *to, AsyncState state) {
-  TI_AUTO_PROF;
+  // TI_AUTO_PROF;
   TI_ASSERT(from != nullptr);
   TI_ASSERT(to != nullptr);
   insert(from->output_edges, state, to);

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -126,7 +126,7 @@ class StateFlowGraph {
                        int embed_states_threshold = 0);
 
   void insert_tasks(const std::vector<TaskLaunchRecord> &rec,
-                    bool filter_listgen = true);
+                    bool filter_listgen);
 
   void insert_node(std::unique_ptr<Node> &&node);
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -123,7 +123,10 @@ class StateFlowGraph {
   std::string dump_dot(const std::optional<std::string> &rankdir,
                        int embed_states_threshold = 0);
 
-  void insert_task(const TaskLaunchRecord &rec);
+  void insert_tasks(const std::vector<TaskLaunchRecord> &rec,
+                    bool filter = true);
+
+  void insert_node(std::unique_ptr<Node> &&node);
 
   void insert_edge(Node *from, Node *to, AsyncState state);
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -16,6 +16,8 @@
 TLANG_NAMESPACE_BEGIN
 
 class IRBank;
+class AsyncEngine;
+
 class StateFlowGraph {
  public:
   struct Node;
@@ -97,7 +99,7 @@ class StateFlowGraph {
     void disconnect_with(Node *other);
   };
 
-  StateFlowGraph(IRBank *ir_bank);
+  StateFlowGraph(AsyncEngine *engine, IRBank *ir_bank);
 
   std::vector<Node *> get_pending_tasks() const;
 
@@ -174,6 +176,8 @@ class StateFlowGraph {
     return nodes_.size() - first_pending_task_index_;
   }
 
+  void mark_list_as_dirty(SNode *snode);
+
  private:
   std::vector<std::unique_ptr<Node>> nodes_;
   Node *initial_node_;  // The initial node holds all the initial states.
@@ -183,6 +187,9 @@ class StateFlowGraph {
   StateToNodesMap latest_state_readers_;
   std::unordered_map<std::string, int> task_name_to_launch_ids_;
   IRBank *ir_bank_;
+  std::unordered_map<SNode *, bool> list_up_to_date_;
+  [[maybe_unused]] AsyncEngine *engine_;
+  Program *program_;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -126,7 +126,7 @@ class StateFlowGraph {
                        int embed_states_threshold = 0);
 
   void insert_tasks(const std::vector<TaskLaunchRecord> &rec,
-                    bool filter = true);
+                    bool filter_listgen = true);
 
   void insert_node(std::unique_ptr<Node> &&node);
 
@@ -176,6 +176,7 @@ class StateFlowGraph {
     return nodes_.size() - first_pending_task_index_;
   }
 
+  // Recursively mark as dirty the list state of "snode" and all its children
   void mark_list_as_dirty(SNode *snode);
 
  private:


### PR DESCRIPTION
Related issue = #742

... for faster async optimizations

Benchmark on 2D MGPCG:

Before:
- `synchronize`: 7.907
    - `rebuild_graph` in `optimize_listgen`: 2.225

After (33% faster):
- `synchronize`: 5.935
    - `rebuild_graph` in `optimize_listgen`: 1.668



<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
