### PR TITLE
[lang] [bug] Clamp int constant to its native range

### DIFF
--- a/tests/python/test_types.py
+++ b/tests/python/test_types.py
@@ -132,3 +132,25 @@ def test_overflow(dt, n):
 @ti.archs_excluding(ti.opengl)
 def test_overflow64(dt, n):
     _test_overflow(dt, n)
+
+
+@pytest.mark.parametrize('dt,val', [
+    (ti.u32, 0xffffffff),
+    (ti.u64, 0xffffffffffffffff),
+])
+@ti.test(require=ti.extension.data64)
+def test_uint_max(dt, val):
+    # https://github.com/taichi-dev/taichi/issues/2060
+    ti.get_runtime().default_ip = dt
+    N = 16
+    f = ti.field(dt, shape=N)
+
+    @ti.kernel
+    def run():
+        for i in f:
+            f[i] = val
+
+    run()
+    fs = f.to_numpy()
+    for f in fs:
+        assert f == val


### PR DESCRIPTION
I believe the problem is that `pybind11` has strict checks on its input args. Without the constant value knowing the type of the LHS, let's just clamp the constant to its valid range (while keeping the bits same)

Related issue = #2060 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
