### PR TITLE
[type] Support atomic add on CustomFloatType

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -239,11 +239,13 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
               llvm::AtomicRMWInst::BinOp::Add, llvm_val[stmt->dest],
               llvm_val[stmt->val],
               llvm::AtomicOrdering::SequentiallyConsistent);
-        } else if (!dst_type->is<CustomFloatType>() && stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
+        } else if (!dst_type->is<CustomFloatType>() &&
+                   stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
           old_value = builder->CreateAtomicRMW(
               llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
               llvm_val[stmt->val], AtomicOrdering::SequentiallyConsistent);
-        } else if (!dst_type->is<CustomFloatType>() && stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
+        } else if (!dst_type->is<CustomFloatType>() &&
+                   stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
           old_value = builder->CreateAtomicRMW(
               llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
               llvm_val[stmt->val], AtomicOrdering::SequentiallyConsistent);

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -239,16 +239,18 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
               llvm::AtomicRMWInst::BinOp::Add, llvm_val[stmt->dest],
               llvm_val[stmt->val],
               llvm::AtomicOrdering::SequentiallyConsistent);
-        } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
+        } else if (!dst_type->is<CustomFloatType>() && stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
           old_value = builder->CreateAtomicRMW(
               llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
               llvm_val[stmt->val], AtomicOrdering::SequentiallyConsistent);
-        } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
+        } else if (!dst_type->is<CustomFloatType>() && stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
           old_value = builder->CreateAtomicRMW(
               llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
               llvm_val[stmt->val], AtomicOrdering::SequentiallyConsistent);
         } else if (auto cit = dst_type->cast<CustomIntType>()) {
           old_value = atomic_add_custom_int(stmt, cit);
+        } else if (auto cft = dst_type->cast<CustomFloatType>()) {
+          old_value = atomic_add_custom_float(stmt, cft);
         } else {
           TI_NOT_IMPLEMENTED
         }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1045,14 +1045,14 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
   auto s = builder->CreateFPCast(
       llvm::ConstantFP::get(*llvm_context, llvm::APFloat(1.0 / cft->get_scale())),
       llvm_type(compute_type));
+  auto val_scaled = builder->CreateFMul(llvm_val[stmt->val], s);
+  auto val_scaled_int = builder->CreateFPToSI(val_scaled, llvm_type(physical_type));
 
-  auto val_quant = builder->CreateFMul(llvm_val[stmt->val], s);
-  auto val_quant_int = builder->CreateFPToSI(val_quant, llvm_type(physical_type));
   return create_call(
       fmt::format("atomic_add_partial_bits_b{}", data_type_bits(physical_type)),
       {builder->CreateBitCast(byte_ptr, llvm_ptr_type(physical_type)),
        bit_offset, tlctx->get_constant(cit->get_num_bits()),
-       val_quant_int});
+       val_scaled_int});
 }
 
 void CodeGenLLVM::visit(AtomicOpStmt *stmt) {

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1034,6 +1034,27 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_int(AtomicOpStmt *stmt,
                 physical_type)});
 }
 
+llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
+                                                  CustomFloatType *cft) {
+  llvm::Value *byte_ptr, *bit_offset;
+  read_bit_pointer(llvm_val[stmt->dest], byte_ptr, bit_offset);
+  auto cit = cft->get_digits_type()->as<CustomIntType>();
+  auto physical_type = cit->get_physical_type();
+  auto compute_type = cft->get_compute_type();
+
+  auto s = builder->CreateFPCast(
+      llvm::ConstantFP::get(*llvm_context, llvm::APFloat(1.0 / cft->get_scale())),
+      llvm_type(compute_type));
+
+  auto val_quant = builder->CreateFMul(llvm_val[stmt->val], s);
+  auto val_quant_int = builder->CreateFPToSI(val_quant, llvm_type(physical_type));
+  return create_call(
+      fmt::format("atomic_add_partial_bits_b{}", data_type_bits(physical_type)),
+      {builder->CreateBitCast(byte_ptr, llvm_ptr_type(physical_type)),
+       bit_offset, tlctx->get_constant(cit->get_num_bits()),
+       val_quant_int});
+}
+
 void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
   // auto mask = stmt->parent->mask();
   // TODO: deal with mask when vectorized
@@ -1048,17 +1069,19 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
         old_value = builder->CreateAtomicRMW(
             llvm::AtomicRMWInst::BinOp::Add, llvm_val[stmt->dest],
             llvm_val[stmt->val], llvm::AtomicOrdering::SequentiallyConsistent);
-      } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
+      } else if (!dst_type->is<CustomFloatType>() && stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
         old_value =
             builder->CreateCall(get_runtime_function("atomic_add_f32"),
                                 {llvm_val[stmt->dest], llvm_val[stmt->val]});
-      } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
+      } else if (!dst_type->is<CustomFloatType>() && stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
         old_value =
             builder->CreateCall(get_runtime_function("atomic_add_f64"),
                                 {llvm_val[stmt->dest], llvm_val[stmt->val]});
       } else if (auto cit = dst_type->cast<CustomIntType>()) {
         old_value = atomic_add_custom_int(stmt, cit);
-      } else {
+      } else if (auto cft = dst_type->cast<CustomFloatType>()) {
+        old_value = atomic_add_custom_float(stmt, cft);
+      }  else {
         TI_NOT_IMPLEMENTED
       }
     } else if (stmt->op_type == AtomicOpType::min) {
@@ -2056,4 +2079,5 @@ llvm::Value *CodeGenLLVM::create_xlogue(std::unique_ptr<Block> &block) {
 
   return xlogue;
 }
+
 TLANG_NAMESPACE_END

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -194,6 +194,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *atomic_add_custom_int(AtomicOpStmt *stmt, CustomIntType *cit);
 
+  llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt, CustomFloatType *cft);
+
   void visit(AtomicOpStmt *stmt) override;
 
   void visit(GlobalPtrStmt *stmt) override;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -194,7 +194,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *atomic_add_custom_int(AtomicOpStmt *stmt, CustomIntType *cit);
 
-  llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt, CustomFloatType *cft);
+  llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt,
+                                       CustomFloatType *cft);
 
   void visit(AtomicOpStmt *stmt) override;
 


### PR DESCRIPTION
Related issue = #1905 #2078

We try to support atomic add on `CustomFloatType` following the implementation of `CustomIntType` in this pr. 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
