### PR TITLE
[async] Call sort_edges() once during graph rebuilding

### DIFF
--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -157,7 +157,7 @@ void ExecutionQueue::enqueue(const TaskLaunchRecord &ker) {
 }
 
 void ExecutionQueue::synchronize() {
-  TI_AUTO_PROF
+  TI_AUTO_PROF;
   launch_worker.flush();
 }
 
@@ -206,10 +206,9 @@ void AsyncEngine::launch(Kernel *kernel, Context &context) {
 }
 
 void AsyncEngine::synchronize() {
-  TI_AUTO_PROF
+  TI_AUTO_PROF;
   bool modified = true;
-  sfg->reid_nodes();
-  sfg->reid_pending_nodes();
+  sfg->rebuild_graph(/*sort=*/false);
   TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
            sfg->num_pending_tasks());
   debug_sfg("initial");
@@ -262,6 +261,7 @@ void AsyncEngine::synchronize() {
 }
 
 void AsyncEngine::debug_sfg(const std::string &stage) {
+  TI_TRACE("Ran {}, counter={}", stage, cur_sync_sfg_debug_counter_);
   auto prefix = program->config.async_opt_intermediate_file;
   if (prefix.empty())
     return;

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -118,13 +118,25 @@ class StateFlowGraph {
     };
 
     StateIterator get_state_iterator() {
-      maybe_sort();
+      TI_ASSERT(sorted_);
       return StateIterator(data_);
     }
 
-   private:
-    void maybe_sort();
+    // After this, one cannot insert edges anymore (unless using
+    // insert_edge_sorted()).
+    // |allow_already_sorted| is a backdoor for the initial node.
+    void sort_edges(bool allow_already_sorted = false);
 
+    // It's unfortunate to have this method. But without this, we cannot support
+    // executed but retained nodes.
+    void unsort_edges() {
+      // TODO(mask): Handle masks
+      sorted_ = false;
+    }
+    // For debugging purpose
+    int node_id = -1;
+
+   private:
     bool matches(const Container::iterator &it, const Edge &e) {
       return (it != data_.end()) && (*it == e);
     }


### PR DESCRIPTION
This is a follow up of #2080. I've managed to pull out `sort_edges()` and only call it once in `rebuild_graph()`, so that the rest of the methods can just assume the data are sorted.

Unfortunately, to play along with partially GCed nodes, I had to add another `unsort_edges()`... So that upon the next launch (after synchronization in this round), it is possible to insert edges to these executed but retained nodes.

Issue= Follow up #2080 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
