### PR TITLE
[async] Use monospace font for DOT graph

### DIFF
--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -202,7 +202,7 @@ void AsyncEngine::launch(Kernel *kernel, Context &context) {
     TaskLaunchRecord rec(context, kernel, kmeta.ir_handle_cached[i]);
     records.push_back(rec);
   }
-  sfg->insert_tasks(records, true);
+  sfg->insert_tasks(records, program->config.async_listgen_fast_filtering);
 }
 
 void AsyncEngine::synchronize() {

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -21,7 +21,8 @@ std::unique_ptr<IRNode> IRHandle::clone() const {
 TaskLaunchRecord::TaskLaunchRecord() : kernel(nullptr), ir_handle(nullptr, 0) {
 }
 
-std::atomic<int> TaskLaunchRecord::task_counter = 0;
+// Initial node has rec.id == 0, so we start from rec.id == 1.
+std::atomic<int> TaskLaunchRecord::task_counter = 1;
 
 TaskLaunchRecord::TaskLaunchRecord(Context context,
                                    Kernel *kernel,

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -64,6 +64,7 @@ struct CompileConfig {
   bool async_opt_listgen{true};
   bool async_opt_activation_demotion{true};
   bool async_opt_dse{true};
+  bool async_listgen_fast_filtering{true};
   std::string async_opt_intermediate_file;
 
   CompileConfig();

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -888,7 +888,8 @@ void StateFlowGraph::print() {
 }
 
 std::string StateFlowGraph::dump_dot(const std::optional<std::string> &rankdir,
-                                     int embed_states_threshold) {
+                                     int embed_states_threshold,
+                                     bool include_hash) {
   using SFGNode = StateFlowGraph::Node;
   using TaskType = OffloadedStmt::TaskType;
   std::stringstream ss;
@@ -898,6 +899,10 @@ std::string StateFlowGraph::dump_dot(const std::optional<std::string> &rankdir,
       get_async_state(nullptr, AsyncState::Type::value);
 
   ss << "digraph {\n";
+  const std::string fontname = "consolas";
+  ss << "  graph [fontname = \"" << fontname << "\"]\n";
+  ss << "  node [fontname = \"" << fontname << "\"]\n";
+  ss << "  edge [fontname = \"" << fontname << "\"]\n";
   auto node_id = [](const SFGNode *n) {
     // https://graphviz.org/doc/info/lang.html ID naming
     return fmt::format("n_{}_{}", n->meta->name, n->rec.id);
@@ -958,7 +963,7 @@ std::string StateFlowGraph::dump_dot(const std::optional<std::string> &rankdir,
     std::stringstream labels;
     // No states embedded.
     labels << escaped_label(n->string());
-    if (!n->is_initial_node) {
+    if (include_hash && !n->is_initial_node) {
       labels << fmt::format("\\nhash: 0x{:08x}", n->rec.ir_handle.hash());
     }
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -248,7 +248,8 @@ class StateFlowGraph {
   //
   // TODO: In case we add more and more DOT configs, create a struct?
   std::string dump_dot(const std::optional<std::string> &rankdir,
-                       int embed_states_threshold = 0);
+                       int embed_states_threshold = 0,
+                       bool include_hash = false);
 
   void insert_tasks(const std::vector<TaskLaunchRecord> &rec,
                     bool filter_listgen);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -166,6 +166,8 @@ void export_lang(py::module &m) {
       .def_readwrite("async_opt_activation_demotion",
                      &CompileConfig::async_opt_activation_demotion)
       .def_readwrite("async_opt_dse", &CompileConfig::async_opt_dse)
+      .def_readwrite("async_listgen_fast_filtering",
+                     &CompileConfig::async_listgen_fast_filtering)
       .def_readwrite("async_opt_intermediate_file",
                      &CompileConfig::async_opt_intermediate_file);
 


### PR DESCRIPTION
Related issue = #742

Also removes hash in DOT graph, adds `CompileConfig::async_listgen_fast_filtering`, increases `TaskLaunchRecord::id` by one.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
