### PR TITLE
[type] [bug] Support atomic add negative numbers for custom types

### DIFF
--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1553,6 +1553,7 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
 
 #include "internal_functions.h"
 
+// TODO: make here less repetitious.
 #define DEFINE_SET_PARTIAL_BITS(N)                                            \
   void set_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits, u##N value) {   \
     u##N mask = ((((u##N)1 << bits) - 1) << offset);                          \

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1569,11 +1569,13 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
                                                                               \
   u##N atomic_add_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits,          \
                                     u##N value) {                             \
+    u##N mask = ((((u##N)1 << bits) - 1) << offset);                          \
     u##N new_value = 0;                                                       \
     u##N old_value = *ptr;                                                    \
     do {                                                                      \
       old_value = *ptr;                                                       \
       new_value = old_value + (value << offset);                              \
+      new_value = (old_value & (~mask)) | (new_value & mask);                 \
     } while (                                                                 \
         !__atomic_compare_exchange(ptr, &old_value, &new_value, true,         \
                                    std::memory_order::memory_order_seq_cst,   \

--- a/tests/python/test_custom_type_atomics.py
+++ b/tests/python/test_custom_type_atomics.py
@@ -5,28 +5,35 @@ from pytest import approx
 @ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
 def test_custom_int_atomics():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    ci5 = ti.type_factory_.get_custom_int_type(5, True)
     cu2 = ti.type_factory_.get_custom_int_type(2, False)
 
     x = ti.field(dtype=ci13)
-    y = ti.field(dtype=cu2)
+    y = ti.field(dtype=ci5)
+    z = ti.field(dtype=cu2)
 
-    ti.root._bit_struct(num_bits=32).place(x, y)
+    ti.root._bit_struct(num_bits=32).place(x, y, z)
 
     x[None] = 3
-    y[None] = 0
+    y[None] = 2
+    z[None] = 0
 
     @ti.kernel
     def foo():
         for i in range(10):
             x[None] += 4
 
-        for j in range(3):
-            y[None] += 1
+        for j in range(5):
+            y[None] -= 1
+
+        for k in range(3):
+            z[None] += 1
 
     foo()
 
     assert x[None] == 43
-    assert y[None] == 3
+    assert y[None] == -3
+    assert z[None] == 3
 
 
 @ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
@@ -70,9 +77,9 @@ def test_custom_float_atomics():
         x[None] = 0.7
         y[None] = 123.4
         for _ in range(10):
-            x[None] += 0.4
+            x[None] -= 0.4
             y[None] += 100.1
 
     foo()
-    assert x[None] == approx(4.7)
+    assert x[None] == approx(-3.3)
     assert y[None] == approx(1124.4)


### PR DESCRIPTION
Related issue = #1905 #2078 #2085 

**Atomic add may crash when adding negative numbers.** It is because we didn't partially set the value to memory using mask after we do the addition. Adding negative numbers may cause the change of the higher bits. 

For example: if we pack `a` (ci3) and `b`(ci5) in a bit_struct(num=8), and set them all zero at beginning(`a` is the lower 3-bits, and `b` is the higher 5-bits). Then we add `-1` to `a`, and we will find that `b` will be changed too.

So, a possible solution might be partially setting value to memory with mask in `runtime.cpp` just like `set_partial_bits_b` which only affects the bits of `a` in the former example .

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
