### PR TITLE
[type] Improve GlobalStoreStmt precision on custom floats

### DIFF
--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1585,6 +1585,29 @@ DEFINE_SET_PARTIAL_BITS(8);
 DEFINE_SET_PARTIAL_BITS(16);
 DEFINE_SET_PARTIAL_BITS(32);
 DEFINE_SET_PARTIAL_BITS(64);
+
+f32 rounding_prepare_f32(f32 f) {
+  /* slower (but clearer) version with branching:
+  if (f > 0)
+    return f + 0.5;
+  else
+    return f - 0.5;
+  */
+
+  // Branch-free implementation: copy the sign bit of "f" to "0.5"
+  i32 delta_bits =
+      (taichi_union_cast<i32>(f) & 0x80000000) | taichi_union_cast<i32>(0.5f);
+  f32 delta = taichi_union_cast<f32>(delta_bits);
+  return f + delta;
+}
+
+f64 rounding_prepare_f64(f64 f) {
+  // Same as above
+  i64 delta_bits = (taichi_union_cast<i64>(f) & 0x8000000000000000LL) |
+                   taichi_union_cast<i64>(0.5);
+  f64 delta = taichi_union_cast<f64>(delta_bits);
+  return f + delta;
+}
 }
 
 #endif

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -22,3 +22,25 @@ def test_custom_float():
     assert x[None] == approx(0.6)
     x[None] = 0.66
     assert x[None] == approx(0.7)
+    
+@ti.test(require=ti.extension.quant, cfg_optimization=False)
+def test_custom_matrix():
+    ci13 = ti.type_factory_.get_custom_int_type(8, True)
+    cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
+    
+    x = ti.Matrix.field(2, 2, dtype=cft)
+    
+    ti.root._bit_struct(num_bits=32).place(x)
+    
+    @ti.kernel
+    def foo():
+        x[None] = 0.7
+        print(x[None])
+        x[None] = x[None] + 0.4
+    
+    foo()
+    assert x[None] == approx(1.1)
+    x[None] = 0.64
+    assert x[None] == approx(0.6)
+    x[None] = 0.66
+    assert x[None] == approx(0.7)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import math
 from pytest import approx
 
 
@@ -22,25 +23,31 @@ def test_custom_float():
     assert x[None] == approx(0.6)
     x[None] = 0.66
     assert x[None] == approx(0.7)
-    
+
+
 @ti.test(require=ti.extension.quant, cfg_optimization=False)
-def test_custom_matrix():
-    ci13 = ti.type_factory_.get_custom_int_type(8, True)
-    cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
-    
+def test_custom_matrix_rotation():
+    ci16 = ti.type_factory_.get_custom_int_type(16, True)
+    cft = ti.type_factory_.get_custom_float_type(ci16, ti.f32.get_ptr(),
+                                                 1.2 / (2**15))
+
     x = ti.Matrix.field(2, 2, dtype=cft)
-    
-    ti.root._bit_struct(num_bits=32).place(x)
-    
+
+    ti.root._bit_struct(num_bits=32).place(x(0, 0), x(0, 1))
+    ti.root._bit_struct(num_bits=32).place(x(1, 0), x(1, 1))
+
+    x[None] = [[1.0, 0.0], [0.0, 1.0]]
+
     @ti.kernel
-    def foo():
-        x[None] = 0.7
-        print(x[None])
-        x[None] = x[None] + 0.4
-    
-    foo()
-    assert x[None] == approx(1.1)
-    x[None] = 0.64
-    assert x[None] == approx(0.6)
-    x[None] = 0.66
-    assert x[None] == approx(0.7)
+    def rotate_18_degrees():
+        angle = math.pi / 10
+        x[None] = x[None] @ ti.Matrix(
+            [[ti.cos(angle), ti.sin(angle)], [-ti.sin(angle),
+                                              ti.cos(angle)]])
+
+    for i in range(5):
+        rotate_18_degrees()
+    assert x[None][0, 0] == approx(0, abs=1e-4)
+    assert x[None][0, 1] == approx(1, abs=1e-4)
+    assert x[None][1, 0] == approx(-1, abs=1e-4)
+    assert x[None][1, 1] == approx(0, abs=1e-4)


### PR DESCRIPTION
Related issue = #1905

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
