### PR TITLE
[type] [bug] Correct mask used in setting bits partially

### DIFF
--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1554,6 +1554,11 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
 #include "internal_functions.h"
 
 // TODO: make here less repetitious.
+// Original implementation is
+// u##N mask = ((((u##N)1 << bits) - 1) << offset);
+// When N equals bits equals 32, 32 times of left shifting will be carried on
+// which is an undefined behavior.
+// see #2096 for more details
 #define DEFINE_SET_PARTIAL_BITS(N)                                            \
   void set_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits, u##N value) {   \
     u##N mask = ((~(u##N)0) << (N - bits)) >> (N - offset - bits);            \

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1556,7 +1556,7 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
 // TODO: make here less repetitious.
 #define DEFINE_SET_PARTIAL_BITS(N)                                            \
   void set_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits, u##N value) {   \
-    u##N mask = ((((u##N)1 << bits) - 1) << offset);                          \
+    u##N mask = ((~(u##N)0) << (N - bits)) >> (N - offset - bits);            \
     u##N new_value = 0;                                                       \
     u##N old_value = *ptr;                                                    \
     do {                                                                      \
@@ -1570,7 +1570,7 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
                                                                               \
   u##N atomic_add_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits,          \
                                     u##N value) {                             \
-    u##N mask = ((((u##N)1 << bits) - 1) << offset);                          \
+    u##N mask = ((~(u##N)0) << (N - bits)) >> (N - offset - bits);            \
     u##N new_value = 0;                                                       \
     u##N old_value = *ptr;                                                    \
     do {                                                                      \

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -81,7 +81,7 @@ def test_custom_int_load_and_store():
 def test_custom_int_full_struct():
     cit = ti.type_factory_.get_custom_int_type(32, True)
     x = ti.field(dtype=cit)
-    ti.root.dense(ti.i, 2)._bit_struct(num_bits=32).place(x)
+    ti.root.dense(ti.i, 1)._bit_struct(num_bits=32).place(x)
 
     @ti.kernel
     def set_val():

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -83,15 +83,26 @@ def test_custom_int_full_struct():
     x = ti.field(dtype=cit)
     ti.root.dense(ti.i, 2)._bit_struct(num_bits=32).place(x)
 
-    x[0] = 5
     @ti.kernel
     def set_val():
-        x[0]= 15
-        x[1] = 0xFFFFFFFF
+        x[0] = 15
+
+    @ti.kernel
+    def varify_val1():
+        assert x[0] == 15
+
+    @ti.kernel
+    def set_val2():
+        x[0] = 12
+
+    @ti.kernel
+    def varify_val2():
+        assert x[0] == 12
 
     set_val()
-    assert x[0] == 15
-    assert x[1] == -1
+    varify_val1()
+    set_val2()
+    varify_val2()
 
 
 def test_bit_struct():

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -77,6 +77,22 @@ def test_custom_int_load_and_store():
         verify_val.__wrapped__(idx)
 
 
+@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+def test_custom_int_full_struct():
+    cit = ti.type_factory_.get_custom_int_type(32, True)
+    x = ti.field(dtype=cit)
+    ti.root.dense(ti.i, 2)._bit_struct(num_bits=32).place(x)
+
+    @ti.kernel
+    def set_val():
+        x[0] = 5
+        x[1] = 0xFFFFFFFF
+
+    set_val()
+    assert x[0] == 5
+    assert x[1] == -1
+
+
 def test_bit_struct():
     def test_single_bit_struct(physical_type, compute_type, custom_bits,
                                test_case):

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -83,13 +83,14 @@ def test_custom_int_full_struct():
     x = ti.field(dtype=cit)
     ti.root.dense(ti.i, 2)._bit_struct(num_bits=32).place(x)
 
+    x[0] = 5
     @ti.kernel
     def set_val():
-        x[0] = 5
+        x[0]= 15
         x[1] = 0xFFFFFFFF
 
     set_val()
-    assert x[0] == 5
+    assert x[0] == 15
     assert x[1] == -1
 
 


### PR DESCRIPTION
Related issue = #1905 #2091 

The current way we create mask in `set_partial_bits_b` may cause the problem of `shift count >= width of type`. For example, we will do a left shifting for 32 times when we want to set a 32-bits `CustomIntType` which is exactly placed in a 32-bits `BitStruct`.

Please refer to the test case in this pr to see more details.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
