### PR TITLE
[type] [bug] Add rounding for atomic adding of CustomFloatType

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1048,8 +1048,9 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
        bit_offset, tlctx->get_constant(cit->get_num_bits()), val_store});
 }
 
-
-llvm::Value *CodeGenLLVM::float_to_custom_int(CustomFloatType* cft, CustomIntType* cit, llvm::Value* real) {
+llvm::Value *CodeGenLLVM::float_to_custom_int(CustomFloatType *cft,
+                                              CustomIntType *cit,
+                                              llvm::Value *real) {
   llvm::Value *s = nullptr;
 
   // Compute int(input * (1.0 / scale) + 0.5)
@@ -1058,8 +1059,7 @@ llvm::Value *CodeGenLLVM::float_to_custom_int(CustomFloatType* cft, CustomIntTyp
   s = builder->CreateFPCast(
       llvm::ConstantFP::get(*llvm_context, llvm::APFloat(s_numeric)),
       llvm_type(compute_type));
-  auto input_real =
-      builder->CreateFPCast(real, llvm_type(compute_type));
+  auto input_real = builder->CreateFPCast(real, llvm_type(compute_type));
   auto scaled = builder->CreateFMul(input_real, s);
 
   // Add/minus the 0.5 offset for rounding
@@ -2079,6 +2079,5 @@ llvm::Value *CodeGenLLVM::create_xlogue(std::unique_ptr<Block> &block) {
 
   return xlogue;
 }
-
 
 TLANG_NAMESPACE_END

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1038,30 +1038,41 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
                                                   CustomFloatType *cft) {
   llvm::Value *byte_ptr, *bit_offset;
   read_bit_pointer(llvm_val[stmt->dest], byte_ptr, bit_offset);
+  auto val_store = convert_float_to_custom_int(cft, llvm_val[stmt->val]);
   auto cit = cft->get_digits_type()->as<CustomIntType>();
   auto physical_type = cit->get_physical_type();
-  auto compute_type = cft->get_compute_type();
-
-  auto s = builder->CreateFPCast(
-      llvm::ConstantFP::get(*llvm_context,
-                            llvm::APFloat(1.0 / cft->get_scale())),
-      llvm_type(compute_type));
-  auto val_scaled = builder->CreateFMul(llvm_val[stmt->val], s);
-  llvm::Value *val_store = nullptr;
-
-  auto val_rounded = create_call(
-        fmt::format("rounding_prepare_f{}", data_type_bits(compute_type)),
-        {val_scaled});
-  if (cit->get_is_signed()) {
-    val_store = builder->CreateFPToSI(val_rounded, llvm_type(physical_type));
-  } else {
-    val_store = builder->CreateFPToUI(val_rounded, llvm_type(physical_type));
-  }
 
   return create_call(
       fmt::format("atomic_add_partial_bits_b{}", data_type_bits(physical_type)),
       {builder->CreateBitCast(byte_ptr, llvm_ptr_type(physical_type)),
        bit_offset, tlctx->get_constant(cit->get_num_bits()), val_store});
+}
+
+
+llvm::Value *CodeGenLLVM::convert_float_to_custom_int(CustomFloatType* cft, llvm::Value* real) {
+  auto cit = cft->get_digits_type()->as<CustomIntType>();
+  llvm::Value *s = nullptr;
+
+  // Compute int(input * (1.0 / scale) + 0.5)
+  auto s_numeric = 1.0 / cft->get_scale();
+  auto compute_type = cft->get_compute_type();
+  s = builder->CreateFPCast(
+      llvm::ConstantFP::get(*llvm_context, llvm::APFloat(s_numeric)),
+      llvm_type(compute_type));
+  auto input_real =
+      builder->CreateFPCast(real, llvm_type(compute_type));
+  auto scaled = builder->CreateFMul(input_real, s);
+
+  // Add/minus the 0.5 offset for rounding
+  scaled = create_call(
+      fmt::format("rounding_prepare_f{}", data_type_bits(compute_type)),
+      {scaled});
+
+  if (cit->get_is_signed()) {
+    return builder->CreateFPToSI(scaled, llvm_type(cit->get_compute_type()));
+  } else {
+    return builder->CreateFPToUI(scaled, llvm_type(cit->get_compute_type()));
+  }
 }
 
 void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
@@ -1175,31 +1186,32 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
       cit = cit_;
       store_value = llvm_val[stmt->data];
     } else if (auto cft = pointee_type->cast<CustomFloatType>()) {
-      cit = cft->get_digits_type()->as<CustomIntType>();
-      llvm::Value *s = nullptr;
-
-      // Compute int(input * (1.0 / scale) + 0.5)
-      auto s_numeric = 1.0 / cft->get_scale();
-      auto compute_type = cft->get_compute_type();
-      s = builder->CreateFPCast(
-          llvm::ConstantFP::get(*llvm_context, llvm::APFloat(s_numeric)),
-          llvm_type(compute_type));
-      auto input_real =
-          builder->CreateFPCast(llvm_val[stmt->data], llvm_type(compute_type));
-      auto scaled = builder->CreateFMul(input_real, s);
-
-      // Add/minus the 0.5 offset for rounding
-      scaled = create_call(
-          fmt::format("rounding_prepare_f{}", data_type_bits(compute_type)),
-          {scaled});
-
-      if (cit->get_is_signed()) {
-        store_value =
-            builder->CreateFPToSI(scaled, llvm_type(cit->get_compute_type()));
-      } else {
-        store_value =
-            builder->CreateFPToUI(scaled, llvm_type(cit->get_compute_type()));
-      }
+      store_value = convert_float_to_custom_int(cft, llvm_val[stmt->data]);
+//      cit = cft->get_digits_type()->as<CustomIntType>();
+//      llvm::Value *s = nullptr;
+//
+//      // Compute int(input * (1.0 / scale) + 0.5)
+//      auto s_numeric = 1.0 / cft->get_scale();
+//      auto compute_type = cft->get_compute_type();
+//      s = builder->CreateFPCast(
+//          llvm::ConstantFP::get(*llvm_context, llvm::APFloat(s_numeric)),
+//          llvm_type(compute_type));
+//      auto input_real =
+//          builder->CreateFPCast(llvm_val[stmt->data], llvm_type(compute_type));
+//      auto scaled = builder->CreateFMul(input_real, s);
+//
+//      // Add/minus the 0.5 offset for rounding
+//      scaled = create_call(
+//          fmt::format("rounding_prepare_f{}", data_type_bits(compute_type)),
+//          {scaled});
+//
+//      if (cit->get_is_signed()) {
+//        store_value =
+//            builder->CreateFPToSI(scaled, llvm_type(cit->get_compute_type()));
+//      } else {
+//        store_value =
+//            builder->CreateFPToUI(scaled, llvm_type(cit->get_compute_type()));
+//      }
     } else {
       TI_NOT_IMPLEMENTED
     }
@@ -2092,5 +2104,6 @@ llvm::Value *CodeGenLLVM::create_xlogue(std::unique_ptr<Block> &block) {
 
   return xlogue;
 }
+
 
 TLANG_NAMESPACE_END

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1039,7 +1039,7 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
   llvm::Value *byte_ptr, *bit_offset;
   read_bit_pointer(llvm_val[stmt->dest], byte_ptr, bit_offset);
   auto cit = cft->get_digits_type()->as<CustomIntType>();
-  auto val_store = convert_float_to_custom_int(cft, cit, llvm_val[stmt->val]);
+  auto val_store = float_to_custom_int(cft, cit, llvm_val[stmt->val]);
   auto physical_type = cit->get_physical_type();
 
   return create_call(
@@ -1049,7 +1049,7 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
 }
 
 
-llvm::Value *CodeGenLLVM::convert_float_to_custom_int(CustomFloatType* cft, CustomIntType* cit, llvm::Value* real) {
+llvm::Value *CodeGenLLVM::float_to_custom_int(CustomFloatType* cft, CustomIntType* cit, llvm::Value* real) {
   llvm::Value *s = nullptr;
 
   // Compute int(input * (1.0 / scale) + 0.5)
@@ -1186,7 +1186,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
       store_value = llvm_val[stmt->data];
     } else if (auto cft = pointee_type->cast<CustomFloatType>()) {
       cit = cft->get_digits_type()->as<CustomIntType>();
-      store_value = convert_float_to_custom_int(cft, cit, llvm_val[stmt->data]);
+      store_value = float_to_custom_int(cft, cit, llvm_val[stmt->data]);
     } else {
       TI_NOT_IMPLEMENTED
     }

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -197,6 +197,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt,
                                        CustomFloatType *cft);
 
+  llvm::Value *convert_float_to_custom_int(CustomFloatType* cft,
+                                           llvm::Value * real);
+
   void visit(AtomicOpStmt *stmt) override;
 
   void visit(GlobalPtrStmt *stmt) override;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -198,6 +198,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                                        CustomFloatType *cft);
 
   llvm::Value *convert_float_to_custom_int(CustomFloatType* cft,
+                                           CustomIntType* cit,
                                            llvm::Value * real);
 
   void visit(AtomicOpStmt *stmt) override;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -197,9 +197,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt,
                                        CustomFloatType *cft);
 
-  llvm::Value *float_to_custom_int(CustomFloatType* cft,
-                                           CustomIntType* cit,
-                                           llvm::Value * real);
+  llvm::Value *float_to_custom_int(CustomFloatType *cft,
+                                   CustomIntType *cit,
+                                   llvm::Value *real);
 
   void visit(AtomicOpStmt *stmt) override;
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -197,7 +197,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt,
                                        CustomFloatType *cft);
 
-  llvm::Value *convert_float_to_custom_int(CustomFloatType* cft,
+  llvm::Value *float_to_custom_int(CustomFloatType* cft,
                                            CustomIntType* cit,
                                            llvm::Value * real);
 


### PR DESCRIPTION
Related issue = #1905 #2093 #2085 

The current implementation of atomic add of `CustomFloatType` miss the rounding step which may cause some problems.

Thanks to @yuanming-hu 's implementation of `CustomFloatType` rounding in `GlobalStoreStmt`, I can reuse it here and make code clean.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
