### PR TITLE
[async] Reduce the inlined edges size from 16 to 8

### DIFF
--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -1492,13 +1492,18 @@ void StateFlowGraph::mark_list_as_dirty(SNode *snode) {
 }
 
 void StateFlowGraph::benchmark_rebuild_graph() {
+  double total_time = 0;
   for (int k = 0; k < 100000; k++) {
     auto t = Time::get_time();
     for (int i = 0; i < 100; i++)
       rebuild_graph(/*sort=*/false);
     auto rebuild_t = Time::get_time() - t;
-    TI_INFO("nodes = {} total time {:.4f} ms; per_node {:.4f} ns",
-            nodes_.size(), rebuild_t * 1e4, 1e7 * rebuild_t / nodes_.size());
+    total_time += rebuild_t;
+    TI_INFO(
+        "nodes = {} total time {:.4f} ms (averaged so far {:.4} ms); per_node "
+        "{:.4f} ns",
+        nodes_.size(), rebuild_t * 1e4, (total_time * 1e4 / (k + 1)),
+        1e7 * rebuild_t / nodes_.size());
   }
 }
 

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -25,10 +25,8 @@ class StateFlowGraph {
 
   // A specialized container for fast edge insertion and lookup
   class StateToNodesMap {
-   private:
-    static constexpr unsigned kNumInlined = 16u;
-
    public:
+    static constexpr unsigned kNumInlined = 8u;
     using Edge = std::pair<AsyncState, Node *>;
     using Container = llvm::SmallVector<Edge, kNumInlined>;
 


### PR DESCRIPTION
Related issue = #742

On my end:

16:

```
...
[I 12/20/20 13:16:02.093] [state_flow_graph.cpp:taichi::lang::StateFlowGraph::benchmark_rebuild_graph@1504] nodes = 1001 total time 866.5100 ms (averaged so far 821.9 ms); per_node 865.6444 ns
[I 12/20/20 13:16:02.184] [state_flow_graph.cpp:taichi::lang::StateFlowGraph::benchmark_rebuild_graph@1504] nodes = 1001 total time 901.1000 ms (averaged so far 822.7 ms); per_node 900.1998 ns
```

8:

```
...
[I 12/20/20 13:16:40.974] [state_flow_graph.cpp:taichi::lang::StateFlowGraph::benchmark_rebuild_graph@1504] nodes = 1001 total time 710.3000 ms (averaged so far 721.0 ms); per_node 709.5904 ns
[I 12/20/20 13:16:41.044] [state_flow_graph.cpp:taichi::lang::StateFlowGraph::benchmark_rebuild_graph@1504] nodes = 1001 total time 701.7100 ms (averaged so far 720.8 ms); per_node 701.0090 ns
```

Note that `averaged so far` went down from `821` ms to `721` ms, so 12% faster..

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
