### PR TITLE
[test] Enable cfg_optimization in all tests

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -102,6 +102,8 @@ void compile_to_offloads(IRNode *ir,
   print("Offloaded");
   irpass::analysis::verify(ir);
 
+  // TODO: This pass may be redundant as cfg_optimization() is already called
+  //  in full_simplify().
   if (config.cfg_optimization) {
     irpass::cfg_optimization(ir, false);
     print("Optimized by CFG");

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -614,6 +614,7 @@ void full_simplify(IRNode *root, bool after_lower_access, Kernel *kernel) {
       if ((first_iteration || modified) && whole_kernel_cse(root))
         modified = true;
       if ((first_iteration || modified) &&
+          root->get_config().cfg_optimization &&
           cfg_optimization(root, after_lower_access))
         modified = true;
       first_iteration = false;

--- a/tests/python/test_bit_array.py
+++ b/tests/python/test_bit_array.py
@@ -2,7 +2,7 @@ import taichi as ti
 import numpy as np
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_1D_bit_array():
     ci1 = ti.type_factory_.get_custom_int_type(1, False)
 
@@ -28,7 +28,7 @@ def test_1D_bit_array():
     verify_val()
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_2D_bit_array():
     ci1 = ti.type_factory_.get_custom_int_type(1, False)
 

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -2,7 +2,7 @@ import taichi as ti
 import numpy as np
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_simple_array():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu19 = ti.type_factory_.get_custom_int_type(19, False)
@@ -36,7 +36,7 @@ def test_simple_array():
     verify_val.__wrapped__()
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_custom_int_load_and_store():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cu14 = ti.type_factory_.get_custom_int_type(14, False)
@@ -77,7 +77,7 @@ def test_custom_int_load_and_store():
         verify_val.__wrapped__(idx)
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_custom_int_full_struct():
     cit = ti.type_factory_.get_custom_int_type(32, True)
     x = ti.field(dtype=cit)
@@ -110,8 +110,7 @@ def test_bit_struct():
                                test_case):
         ti.init(arch=ti.cpu,
                 debug=True,
-                print_ir=False,
-                cfg_optimization=False)
+                print_ir=False)
 
         cit1 = ti.type_factory_.get_custom_int_type(custom_bits[0], True,
                                                     compute_type)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -3,7 +3,7 @@ import math
 from pytest import approx
 
 
-@ti.test(require=ti.extension.quant, cfg_optimization=False)
+@ti.test(require=ti.extension.quant)
 def test_custom_float():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
@@ -25,7 +25,7 @@ def test_custom_float():
     assert x[None] == approx(0.7)
 
 
-@ti.test(require=ti.extension.quant, cfg_optimization=False)
+@ti.test(require=ti.extension.quant)
 def test_custom_matrix_rotation():
     ci16 = ti.type_factory_.get_custom_int_type(16, True)
     cft = ti.type_factory_.get_custom_float_type(ci16, ti.f32.get_ptr(),

--- a/tests/python/test_custom_type_atomics.py
+++ b/tests/python/test_custom_type_atomics.py
@@ -2,7 +2,7 @@ import taichi as ti
 from pytest import approx
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_custom_int_atomics():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     ci5 = ti.type_factory_.get_custom_int_type(5, True)
@@ -36,7 +36,7 @@ def test_custom_int_atomics():
     assert z[None] == 3
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_custom_int_atomics_b64():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
 
@@ -60,7 +60,7 @@ def test_custom_int_atomics_b64():
     assert x[2] == 315
 
 
-@ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
+@ti.test(require=ti.extension.quant, debug=True)
 def test_custom_float_atomics():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     ci19 = ti.type_factory_.get_custom_int_type(19, False)


### PR DESCRIPTION
Related issue = #1905

All the tests passed on my end. I'm not sure in which way will the control-flow graph optimizations incompatible with the new type system?

BTW, in `compile_to_offloads.cpp`, this part may be redundant and may not perform the check it intends to:
https://github.com/taichi-dev/taichi/blob/e251ca7616f28002430e868022ddb861a7c16ba1/taichi/transforms/compile_to_offloads.cpp#L105-L109

-- this is because `cfg_optimization` is already called in `full_simplify` without checking compile config here:
https://github.com/taichi-dev/taichi/blob/e251ca7616f28002430e868022ddb861a7c16ba1/taichi/transforms/simplify.cpp#L616-L618

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
