### PR TITLE
[Mac] Experimental Apple Silicon M1 chip support

### DIFF
--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -44,7 +44,7 @@ if ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}"
         message("Setting -march=nehalem for x86_64 processors")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=nehalem -DTI_ARCH_x64")
     endif()
-elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_ARCH_ARM")
 else()
     message(FATAL_ERROR "Unknown processor type ${CMAKE_SYSTEM_PROCESSOR}")

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -131,9 +131,13 @@ llvm_map_components_to_libnames(llvm_libs
         Passes
         ipo
         Analysis
-        AArch64
         )
 target_link_libraries(${LIBRARY_NAME} ${llvm_libs})
+
+if (APPLE AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+    llvm_map_components_to_libnames(llvm_aarch64_libs AArch64)
+    target_link_libraries(${LIBRARY_NAME} ${llvm_aarch64_libs})
+endif()
 
 if (TI_WITH_CUDA)
     llvm_map_components_to_libnames(llvm_ptx_libs NVPTX)

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -131,6 +131,7 @@ llvm_map_components_to_libnames(llvm_libs
         Passes
         ipo
         Analysis
+        AArch64
         )
 target_link_libraries(${LIBRARY_NAME} ${llvm_libs})
 

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -22,6 +22,8 @@ Installing Dependencies
     python3 -m pip install --user setuptools astor pybind11 pylint sourceinspect
     python3 -m pip install --user pytest pytest-rerunfailures pytest-xdist yapf
     python3 -m pip install --user numpy GitPython coverage colorama autograd
+    
+    # To install numpy on Apple M1 devices: python3 -m pip install --user numpy --compile --pre
 
 
 - Make sure you have ``clang`` with version >= 7:
@@ -64,6 +66,7 @@ Installing Dependencies
         cd build
         cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
         # If you are building on NVIDIA Jetson TX2, use -DLLVM_TARGETS_TO_BUILD="ARM;NVPTX"
+        # If you are building on Apple M1, use -DLLVM_TARGETS_TO_BUILD="ARM;AArch64"
 
         make -j 8
         sudo make install

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -65,8 +65,8 @@ Installing Dependencies
         mkdir build
         cd build
         cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
-        # If you are building on NVIDIA Jetson TX2, use -DLLVM_TARGETS_TO_BUILD="ARM;NVPTX"
-        # If you are building on Apple M1, use -DLLVM_TARGETS_TO_BUILD="ARM;AArch64"
+        # If you are building on NVIDIA Jetson TX2, use -DLLVM_TARGETS_TO_BUILD="AArch64;NVPTX"
+        # If you are building on Apple M1, use -DLLVM_TARGETS_TO_BUILD="AArch64"
 
         make -j 8
         sudo make install

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -22,7 +22,7 @@ Installing Dependencies
     python3 -m pip install --user setuptools astor pybind11 pylint sourceinspect
     python3 -m pip install --user pytest pytest-rerunfailures pytest-xdist yapf
     python3 -m pip install --user numpy GitPython coverage colorama autograd
-    
+
     # To install numpy on Apple M1 devices: python3 -m pip install --user numpy --compile --pre
 
 

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -45,6 +45,8 @@ using namespace llvm::orc;
 
 std::pair<JITTargetMachineBuilder, llvm::DataLayout> get_host_target_info() {
 #if defined(TI_PLATFORM_OSX) and defined(TI_ARCH_ARM)
+  // JITTargetMachineBuilder::detectHost() doesn't seem to work properly on Apple M1 yet.
+  // Hence the hardcoded strings here.
   auto jtmb =
       JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
   llvm::DataLayout data_layout("e-m:o-i64:64-i128:128-n32:64-S128");

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -165,7 +165,7 @@ void JITSessionCPU::global_optimize_module_cpu(
     module->print(llvm::errs(), nullptr);
     TI_ERROR("Module broken");
   }
-  auto JTMB = JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
+  auto JTMB = JITTargetMachineBuilder(llvm::Triple("aarch64-unknown-unknown"));
   module->setTargetTriple(JTMB.getTargetTriple().str());
   llvm::Triple triple(module->getTargetTriple());
 
@@ -262,7 +262,7 @@ std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch) {
     TI_ERROR("LLVM TargetMachineBuilder has failed when getting data layout.");
   }
   */
-  auto jtmb = JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
+  auto jtmb = JITTargetMachineBuilder(llvm::Triple("aarch64-unknown-unknown"));
   llvm::DataLayout data_layout("e-m:o-i64:64-i128:128-n32:64-S128");
 
   return std::make_unique<JITSessionCPU>(std::move(jtmb),

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -266,7 +266,6 @@ void JITSessionCPU::global_optimize_module_cpu(
 
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch) {
-  // std::unique_ptr<JITTargetMachineBuilder> jtmb;
   TI_ASSERT(arch_is_cpu(arch));
   auto target_info = get_host_target_info();
   return std::make_unique<JITSessionCPU>(target_info.first, target_info.second);

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -45,7 +45,8 @@ using namespace llvm::orc;
 
 std::pair<JITTargetMachineBuilder, llvm::DataLayout> get_host_target_info() {
 #if defined(TI_PLATFORM_OSX) and defined(TI_ARCH_ARM)
-  auto jtmb = JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
+  auto jtmb =
+      JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
   llvm::DataLayout data_layout("e-m:o-i64:64-i128:128-n32:64-S128");
 #else
   auto expected_jtmb = JITTargetMachineBuilder::detectHost();
@@ -263,7 +264,6 @@ void JITSessionCPU::global_optimize_module_cpu(
     writer.write(module.get());
   }
 }
-
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch) {
   TI_ASSERT(arch_is_cpu(arch));

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -45,8 +45,8 @@ using namespace llvm::orc;
 
 std::pair<JITTargetMachineBuilder, llvm::DataLayout> get_host_target_info() {
 #if defined(TI_PLATFORM_OSX) and defined(TI_ARCH_ARM)
-  // JITTargetMachineBuilder::detectHost() doesn't seem to work properly on Apple M1 yet.
-  // Hence the hardcoded strings here.
+  // JITTargetMachineBuilder::detectHost() doesn't seem to work properly on
+  // Apple M1 yet. Hence the hardcoded strings here.
   auto jtmb =
       JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
   llvm::DataLayout data_layout("e-m:o-i64:64-i128:128-n32:64-S128");

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -165,7 +165,7 @@ void JITSessionCPU::global_optimize_module_cpu(
     module->print(llvm::errs(), nullptr);
     TI_ERROR("Module broken");
   }
-  auto JTMB = JITTargetMachineBuilder(llvm::Triple("aarch64-unknown-unknown"));
+  auto JTMB = JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
   module->setTargetTriple(JTMB.getTargetTriple().str());
   llvm::Triple triple(module->getTargetTriple());
 
@@ -262,7 +262,7 @@ std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch) {
     TI_ERROR("LLVM TargetMachineBuilder has failed when getting data layout.");
   }
   */
-  auto jtmb = JITTargetMachineBuilder(llvm::Triple("aarch64-unknown-unknown"));
+  auto jtmb = JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
   llvm::DataLayout data_layout("e-m:o-i64:64-i128:128-n32:64-S128");
 
   return std::make_unique<JITSessionCPU>(std::move(jtmb),

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -165,16 +165,14 @@ void JITSessionCPU::global_optimize_module_cpu(
     module->print(llvm::errs(), nullptr);
     TI_ERROR("Module broken");
   }
-  auto JTMB = JITTargetMachineBuilder::detectHost();
-  if (!JTMB) {
-    TI_ERROR("Target machine creation failed.");
-  }
-  module->setTargetTriple(JTMB->getTargetTriple().str());
+  auto JTMB = JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
+  module->setTargetTriple(JTMB.getTargetTriple().str());
   llvm::Triple triple(module->getTargetTriple());
 
   std::string err_str;
   const llvm::Target *target =
       TargetRegistry::lookupTarget(triple.str(), err_str);
+  TI_P(triple.str());
   TI_ERROR_UNLESS(target, err_str);
 
   TargetOptions options;
@@ -251,8 +249,9 @@ void JITSessionCPU::global_optimize_module_cpu(
 }
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch) {
-  std::unique_ptr<JITTargetMachineBuilder> jtmb;
+  // std::unique_ptr<JITTargetMachineBuilder> jtmb;
   TI_ASSERT(arch_is_cpu(arch));
+/*
   auto JTMB = JITTargetMachineBuilder::detectHost();
   if (!JTMB)
     TI_ERROR("LLVM TargetMachineBuilder has failed.");
@@ -262,9 +261,12 @@ std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch) {
   if (!data_layout) {
     TI_ERROR("LLVM TargetMachineBuilder has failed when getting data layout.");
   }
+  */
+  auto jtmb = JITTargetMachineBuilder(llvm::Triple("aarch64-apple-macosx11.0.0"));
+  llvm::DataLayout data_layout("e-m:o-i64:64-i128:128-n32:64-S128");
 
-  return std::make_unique<JITSessionCPU>(std::move(*jtmb),
-                                         std::move(*data_layout));
+  return std::make_unique<JITSessionCPU>(std::move(jtmb),
+                                         std::move(data_layout));
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -68,13 +68,17 @@ TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
       nullptr);
 
   if (arch_is_cpu(arch)) {
+    #if defined(TI_PLATFORM_OSX) and defined(TI_ARCH_ARM)
+    // Note that on Apple Silicon (M1), "native" seems to mean arm instead of arm64 (aka AArch64).
+    LLVMInitializeAArch64Target();
+    LLVMInitializeAArch64TargetMC();
+    LLVMInitializeAArch64TargetInfo();
+    LLVMInitializeAArch64AsmPrinter();
+    #else
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     llvm::InitializeNativeTargetAsmParser();
-    llvm::InitializeAllTargets();
-    llvm::InitializeAllTargetMCs();
-    llvm::InitializeAllTargetInfos();
-    llvm::InitializeAllAsmPrinters();
+    #endif
   } else {
 #if defined(TI_WITH_CUDA)
     LLVMInitializeNVPTXTarget();

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -73,6 +73,8 @@ TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
     llvm::InitializeNativeTargetAsmParser();
     llvm::InitializeAllTargets();
     llvm::InitializeAllTargetMCs();
+    llvm::InitializeAllTargetInfos();
+    llvm::InitializeAllAsmPrinters();
   } else {
 #if defined(TI_WITH_CUDA)
     LLVMInitializeNVPTXTarget();

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -68,17 +68,18 @@ TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
       nullptr);
 
   if (arch_is_cpu(arch)) {
-    #if defined(TI_PLATFORM_OSX) and defined(TI_ARCH_ARM)
-    // Note that on Apple Silicon (M1), "native" seems to mean arm instead of arm64 (aka AArch64).
+#if defined(TI_PLATFORM_OSX) and defined(TI_ARCH_ARM)
+    // Note that on Apple Silicon (M1), "native" seems to mean arm instead of
+    // arm64 (aka AArch64).
     LLVMInitializeAArch64Target();
     LLVMInitializeAArch64TargetMC();
     LLVMInitializeAArch64TargetInfo();
     LLVMInitializeAArch64AsmPrinter();
-    #else
+#else
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     llvm::InitializeNativeTargetAsmParser();
-    #endif
+#endif
   } else {
 #if defined(TI_WITH_CUDA)
     LLVMInitializeNVPTXTarget();

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -71,6 +71,8 @@ TaichiLLVMContext::TaichiLLVMContext(Arch arch) : arch(arch) {
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     llvm::InitializeNativeTargetAsmParser();
+    llvm::InitializeAllTargets();
+    llvm::InitializeAllTargetMCs();
   } else {
 #if defined(TI_WITH_CUDA)
     LLVMInitializeNVPTXTarget();


### PR DESCRIPTION
Related issue = #2097 

Known issues:
- `ti test` doesn't work well when using 8 testing threads. 4 threads are fine.
- Warning message needs to be somehow suppressed: `'vortex' is not a recognized processor for this target (ignoring processor)`
- A few tests fail on Metal:
```
FAILED ../tests/python/test_fuse_dense.py::test_no_fuse_sigs_mismatch[metal]
FAILED ../tests/python/test_runtime.py::test_init_arg[use_unified_memory-values13] - AssertionError: assert False == True
FAILED ../tests/python/test_mpm88.py::test_mpm88_async[metal]
```

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
