### PR TITLE
[type] [bug] Fix global load of CustomFloatType on CUDA

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -425,7 +425,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           auto val_type = ptr_type->get_pointee_type();
           llvm::Value *data_ptr = nullptr;
           llvm::Value *bit_offset = nullptr;
-          Type* int_in_mem = nullptr;
+          Type *int_in_mem = nullptr;
           if (auto cit = val_type->cast<CustomIntType>()) {
             int_in_mem = val_type;
             dtype = cit->get_physical_type();

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -427,7 +427,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           llvm::Value *bit_offset = nullptr;
           Type *int_in_mem = nullptr;
           // For CustomIntType "int_in_mem" refers to the type itself;
-          // for CustomFloatType "int_in_mem" refers to the CustomIntType of the digits. 
+          // for CustomFloatType "int_in_mem" refers to the CustomIntType of the
+          // digits.
           if (auto cit = val_type->cast<CustomIntType>()) {
             int_in_mem = val_type;
             dtype = cit->get_physical_type();

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -426,6 +426,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           llvm::Value *data_ptr = nullptr;
           llvm::Value *bit_offset = nullptr;
           Type *int_in_mem = nullptr;
+          // For CustomIntType "int_in_mem" refers to the type itself;
+          // for CustomFloatType "int_in_mem" refers to the CustomIntType of the digits. 
           if (auto cit = val_type->cast<CustomIntType>()) {
             int_in_mem = val_type;
             dtype = cit->get_physical_type();

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -83,6 +83,6 @@ def test_cache_read_only():
         assert x[None] == data
 
     x[None] = 0.7
-    test(0.7)    
+    test(0.7)
     x[None] = 1.2
     test(1.2)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -67,3 +67,22 @@ def test_custom_float_implicit_cast():
 
     foo()
     assert x[None] == approx(10.0)
+
+
+@ti.test(require=ti.extension.quant)
+def test_cache_read_only():
+    ci15 = ti.type_factory_.get_custom_int_type(15, True)
+    cft = ti.type_factory_.get_custom_float_type(ci15, ti.f32.get_ptr(), 0.1)
+    x = ti.field(dtype=cft)
+
+    ti.root._bit_struct(num_bits=32).place(x)
+
+    @ti.kernel
+    def test(data: ti.f32):
+        ti.cache_read_only(x)
+        assert x[None] == data
+
+    x[None] = 0.7
+    test(0.7)    
+    x[None] = 1.2
+    test(1.2)


### PR DESCRIPTION
Related issue = #1905 #2065

Some mistakes were made in global loading on CUDA, which would lead to compilation error. I will point out the bug below.

And also, I added a new test case focusing on this problem in this pr 

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
