### PR TITLE
[async] Record the kernel's name in the hash only if it has arguments

### DIFF
--- a/taichi/program/ir_bank.cpp
+++ b/taichi/program/ir_bank.cpp
@@ -17,8 +17,14 @@ uint64 hash(IRNode *stmt) {
   std::string serialized;
   irpass::re_id(stmt);
   irpass::print(stmt, &serialized);
+
   // TODO: separate kernel from IR template
-  serialized += stmt->get_kernel()->name;
+  auto *kernel = stmt->get_kernel();
+  if (!kernel->args.empty()) {
+    // We need to record the kernel's name if it has arguments.
+    serialized += stmt->get_kernel()->name;
+  }
+
   uint64 ret = 0;
   for (uint64 i = 0; i < serialized.size(); i++) {
     ret = ret * 100000007UL + (uint64)serialized[i];


### PR DESCRIPTION
Related issue = #742

This can reduce the number of uncached IR operations.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
