### PR TITLE
[cpu] Fix PRNG thread safety on CPUs

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -363,7 +363,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     auto snode_id = tlctx->get_constant(stmt->snode->id);
     {
       init_offloaded_task_function(stmt, "gather_list");
-      call("gc_parallel_0", get_runtime(), snode_id);
+      call("gc_parallel_0", get_context(), snode_id);
       finalize_offloaded_task_function();
       current_task->grid_dim = prog->config.saturating_grid_dim;
       current_task->block_dim = 64;
@@ -372,7 +372,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     }
     {
       init_offloaded_task_function(stmt, "reinit_lists");
-      call("gc_parallel_1", get_runtime(), snode_id);
+      call("gc_parallel_1", get_context(), snode_id);
       finalize_offloaded_task_function();
       current_task->grid_dim = 1;
       current_task->block_dim = 1;
@@ -381,7 +381,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     }
     {
       init_offloaded_task_function(stmt, "zero_fill");
-      call("gc_parallel_2", get_runtime(), snode_id);
+      call("gc_parallel_2", get_context(), snode_id);
       finalize_offloaded_task_function();
       current_task->grid_dim = prog->config.saturating_grid_dim;
       current_task->block_dim = 64;

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -324,12 +324,6 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     }
   }
 
-  void visit(RandStmt *stmt) override {
-    llvm_val[stmt] =
-        create_call(fmt::format("cuda_rand_{}", data_type_name(stmt->ret_type)),
-                    {get_context()});
-  }
-
   void visit(RangeForStmt *for_stmt) override {
     create_naive_range_for(for_stmt);
   }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -139,8 +139,8 @@ void CodeGenLLVM::visit(AllocaStmt *stmt) {
 }
 
 void CodeGenLLVM::visit(RandStmt *stmt) {
-  llvm_val[stmt] =
-      create_call(fmt::format("rand_{}", data_type_name(stmt->ret_type)));
+  llvm_val[stmt] = create_call(
+      fmt::format("rand_{}", data_type_name(stmt->ret_type)), {get_context()});
 }
 
 void CodeGenLLVM::emit_extra_unary(UnaryOpStmt *stmt) {

--- a/taichi/program/context.h
+++ b/taichi/program/context.h
@@ -11,7 +11,7 @@ namespace lang {
 struct LLVMRuntime;
 
 // "Context" holds necessary data for kernel body execution, such as a pointer
-// to the LLVMRuntime struct, and required arguments.
+// to the LLVMRuntime struct, kernel arguments, and the thread id (if on CPU).
 struct Context {
   LLVMRuntime *runtime;
   uint64 args[taichi_max_num_args];

--- a/taichi/program/context.h
+++ b/taichi/program/context.h
@@ -10,12 +10,13 @@ namespace lang {
 
 struct LLVMRuntime;
 
-// "Context" holds necessary data for function calls, such as arguments and
-// LLVMRuntime struct
+// "Context" holds necessary data for kernel body execution, such as a pointer
+// to the LLVMRuntime struct, and required arguments.
 struct Context {
   LLVMRuntime *runtime;
   uint64 args[taichi_max_num_args];
   int32 extra_args[taichi_max_num_args][taichi_max_num_indices];
+  int32 cpu_thread_id;
 
   static constexpr size_t extra_args_size = sizeof(extra_args);
 

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -285,7 +285,7 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
   auto snodes = scomp->snodes;
   int root_id = snode_root->id;
 
-  // Number random states. One per CPU/CUDA thread.
+  // Number of random states. One per CPU/CUDA thread.
   int num_rand_states = 0;
 
   if (config.arch == Arch::cuda) {

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -88,7 +88,7 @@ class Program {
   bool finalized;
   float64 total_compilation_time;
   static std::atomic<int> num_instances;
-  ThreadPool thread_pool;
+  std::unique_ptr<ThreadPool> thread_pool;
   std::unique_ptr<MemoryPool> memory_pool;
   uint64 *result_buffer;             // TODO: move this
   void *preallocated_device_buffer;  // TODO: move this to memory allocator

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -180,39 +180,6 @@ int abs_i32(int a) {
   }
 }
 
-#if ARCH_x64 || ARCH_arm64
-
-u32 rand_u32() {
-  static u32 x = 123456789, y = 362436069, z = 521288629, w = 88675123;
-  u32 t = x ^ (x << 11);
-  x = y;
-  y = z;
-  z = w;
-  return (w = (w ^ (w >> 19)) ^ (t ^ (t >> 8)));
-}
-
-u64 rand_u64() {
-  return ((u64)rand_u32() << 32) + rand_u32();
-}
-
-f32 rand_f32() {
-  return rand_u32() * f32(1 / 4294967296.0);
-}
-
-f64 rand_f64() {
-  return rand_f32();
-}
-
-i32 rand_i32() {
-  return rand_u32();
-}
-
-i64 rand_i64() {
-  return rand_u64();
-}
-
-#endif
-
 i32 floordiv_i32(i32 a, i32 b) {
   return ifloordiv(a, b);
 }
@@ -1444,11 +1411,9 @@ void gc_parallel_2(Context *context, int snode_id) {
 }
 }
 
-#if ARCH_cuda
-
 extern "C" {
 
-u32 cuda_rand_u32(Context *context) {
+u32 rand_u32(Context *context) {
   auto state = &((LLVMRuntime *)context->runtime)
                     ->rand_states[linear_thread_idx(context)];
 
@@ -1467,27 +1432,26 @@ u32 cuda_rand_u32(Context *context) {
                           // it decorrelates streams of PRNGs
 }
 
-uint64 cuda_rand_u64(Context *context) {
-  return ((u64)cuda_rand_u32(context) << 32) + cuda_rand_u32(context);
+uint64 rand_u64(Context *context) {
+  return ((u64)rand_u32(context) << 32) + rand_u32(context);
 }
 
-f32 cuda_rand_f32(Context *context) {
-  return cuda_rand_u32(context) * (1.0f / 4294967296.0f);
+f32 rand_f32(Context *context) {
+  return rand_u32(context) * (1.0f / 4294967296.0f);
 }
 
-f64 cuda_rand_f64(Context *context) {
-  return cuda_rand_f32(context);
+f64 rand_f64(Context *context) {
+  return rand_f32(context);
 }
 
-i32 cuda_rand_i32(Context *context) {
-  return cuda_rand_u32(context);
+i32 rand_i32(Context *context) {
+  return rand_u32(context);
 }
 
-i64 cuda_rand_i64(Context *context) {
-  return cuda_rand_u64(context);
+i64 rand_i64(Context *context) {
+  return rand_u64(context);
 }
 };
-#endif
 
 struct printf_helper {
   char buffer[1024];

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1131,7 +1131,7 @@ struct cpu_block_task_helper_context {
 // TODO: TLS should be directly passed to the scheduler, so that it lives
 // with the threads (instead of blocks).
 
-void block_helper(void *ctx_, int thread_id, int i) {
+void cpu_struct_for_block_helper(void *ctx_, int thread_id, int i) {
   auto ctx = (cpu_block_task_helper_context *)(ctx_);
   int element_id = i / ctx->element_split;
   int part_size = ctx->element_size / ctx->element_split;
@@ -1141,6 +1141,7 @@ void block_helper(void *ctx_, int thread_id, int i) {
   int upper = e.loop_bounds[0] + (part_id + 1) * part_size;
   upper = std::min(upper, e.loop_bounds[1]);
   alignas(8) char tls_buffer[ctx->tls_buffer_size];
+
   Context this_thread_context = *ctx->context;
   this_thread_context.cpu_thread_id = thread_id;
   if (lower < upper) {
@@ -1189,7 +1190,7 @@ void parallel_struct_for(Context *context,
   ctx.tls_buffer_size = tls_buffer_size;
   auto runtime = context->runtime;
   runtime->parallel_for(runtime->thread_pool, list_tail * element_split,
-                        num_threads, &ctx, block_helper);
+                        num_threads, &ctx, cpu_struct_for_block_helper);
 #endif
 }
 

--- a/taichi/system/threading.cpp
+++ b/taichi/system/threading.cpp
@@ -4,9 +4,6 @@
 *******************************************************************************/
 
 #include "taichi/system/threading.h"
-#define TI_RUNTIME_HOST
-#include "taichi/program/context.h"
-#undef TI_RUNTIME_HOST
 
 #if defined(TI_PLATFORM_WINDOWS)
 #include "taichi/platform/windows/windows.h"

--- a/taichi/system/threading.cpp
+++ b/taichi/system/threading.cpp
@@ -3,19 +3,23 @@
     The use of this software is governed by the LICENSE file.
 *******************************************************************************/
 
-#include <algorithm>
-#include <condition_variable>
 #include "taichi/system/threading.h"
-#include <thread>
-#include <vector>
+#define TI_RUNTIME_HOST
+#include "taichi/program/context.h"
+#undef TI_RUNTIME_HOST
+
 #if defined(TI_PLATFORM_WINDOWS)
 #include "taichi/platform/windows/windows.h"
 #else
 // Mac and Linux
 #include "threading.h"
 #include <unistd.h>
-
 #endif
+
+#include <algorithm>
+#include <condition_variable>
+#include <thread>
+#include <vector>
 
 TI_NAMESPACE_BEGIN
 
@@ -133,6 +137,9 @@ void ThreadPool::target() {
         if (task_id >= task_tail)
           break;
       }
+      using Context = lang::Context;
+      Context this_thread_context = *(Context *)context;
+      this_thread_context.cpu_thread_id = thread_id;
       func(context, task_id);
     }
 

--- a/taichi/system/threading.cpp
+++ b/taichi/system/threading.cpp
@@ -136,9 +136,11 @@ void ThreadPool::target() {
         if (task_id >= task_tail)
           break;
       }
+
       using Context = lang::Context;
       Context this_thread_context = *(Context *)context;
       this_thread_context.cpu_thread_id = thread_id;
+
       func(context, task_id);
     }
 

--- a/taichi/system/threading.cpp
+++ b/taichi/system/threading.cpp
@@ -24,7 +24,7 @@
 TI_NAMESPACE_BEGIN
 
 bool test_threading() {
-  auto tp = ThreadPool();
+  auto tp = ThreadPool(20);
   for (int j = 0; j < 100; j++) {
     tp.run(10, j + 1, &j, [](void *j, int i) {
       double ret = 0.0;
@@ -54,7 +54,7 @@ int PID::get_parent_pid() {
 #endif
 }
 
-ThreadPool::ThreadPool() {
+ThreadPool::ThreadPool(int max_num_threads) : max_num_threads(max_num_threads) {
   exiting = false;
   started = false;
   running_threads = 0;
@@ -63,7 +63,6 @@ ThreadPool::ThreadPool() {
   task_head = 0;
   task_tail = 0;
   thread_counter = 0;
-  max_num_threads = std::thread::hardware_concurrency();
   threads.resize((std::size_t)max_num_threads);
   for (int i = 0; i < max_num_threads; i++) {
     threads[i] = std::thread([this] { this->target(); });

--- a/taichi/system/threading.h
+++ b/taichi/system/threading.h
@@ -14,7 +14,7 @@
 
 TI_NAMESPACE_BEGIN
 
-using RangeForTaskFunc = void(void *, int i);
+using RangeForTaskFunc = void(void *, int thread_id, int i);
 using ParallelFor = void(int n, int num_threads, void *, RangeForTaskFunc func);
 
 class PID {
@@ -39,22 +39,25 @@ class ThreadPool {
   bool started;
   bool exiting;
   RangeForTaskFunc *func;
-  void *context;
+  void *range_for_task_context;  // Note: this is a pointer to a
+                                 // range_task_helper_context defined in the
+                                 // LLVM runtime, which is different from
+                                 // taichi::lang::Context.
   int thread_counter;
 
   ThreadPool(int max_num_threads);
 
   void run(int splits,
            int desired_num_threads,
-           void *context,
+           void *range_for_task_context,
            RangeForTaskFunc *func);
 
   static void static_run(ThreadPool *pool,
                          int splits,
                          int desired_num_threads,
-                         void *context,
+                         void *range_for_task_context,
                          RangeForTaskFunc *func) {
-    return pool->run(splits, desired_num_threads, context, func);
+    return pool->run(splits, desired_num_threads, range_for_task_context, func);
   }
 
   void target();

--- a/taichi/system/threading.h
+++ b/taichi/system/threading.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
+#include "taichi/common/core.h"
+
 #include <atomic>
 #include <condition_variable>
 #include <functional>
-#include "taichi/common/core.h"
 #include <thread>
 
 TI_NAMESPACE_BEGIN

--- a/taichi/system/threading.h
+++ b/taichi/system/threading.h
@@ -42,7 +42,7 @@ class ThreadPool {
   void *context;
   int thread_counter;
 
-  ThreadPool();
+  ThreadPool(int max_num_threads);
 
   void run(int splits,
            int desired_num_threads,


### PR DESCRIPTION
Related issue = #1905

Following the CUDA backend design, on CPUs now we have an independent set of PRNG states.
Implemented by adding a `cpu_thread_id` field to `lang::Context`.

@k-ye Does this affect the Metal backend, given now we have 4 more bytes on the `Context` struct?

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
