### PR TITLE
[async] [IR] More accurate same_value analysis

### DIFF
--- a/taichi/analysis/same_statements.cpp
+++ b/taichi/analysis/same_statements.cpp
@@ -115,15 +115,11 @@ class IRNodeComparator : public IRVisitor {
   }
 
   void basic_check(Stmt *stmt) {
-    if (verbose)
-      std::cout << "checking " << stmt->id << std::endl;
     // type check
     if (typeid(*other_node) != typeid(*stmt)) {
       same = false;
       return;
     }
-    if (verbose)
-      std::cout << "qqq" << std::endl;
     auto other = other_node->as<Stmt>();
 
     // If two identical statements can have different values, return false.
@@ -146,30 +142,18 @@ class IRNodeComparator : public IRVisitor {
               }
             }
             // TODO: other cases?
-          } else if (auto global_store = stmt->cast<GlobalStoreStmt>()) {
-            if (auto global_ptr = global_store->ptr->cast<GlobalPtrStmt>()) {
-              TI_ASSERT(global_ptr->width() == 1);
-              if (possibly_modified_states_.count(ir_bank_->get_async_state(
-                      global_ptr->snodes[0], AsyncState::Type::value)) == 0) {
-                break;
-              }
-            }
           }
           same = false;
           return;
         } while (false);
       }
     }
-    if (verbose)
-      std::cout << "www" << std::endl;
     // Note that we do not need to test !stmt2->common_statement_eliminable()
     // because if this condition does not hold,
     // same_statements(stmt1, stmt2) returns false anyway.
 
     // field check
     if (check_same_value_ && stmt->is<GlobalPtrStmt>()) {
-      if (verbose)
-        std::cout << "eee" << std::endl;
       // Special case: we do not care the "activate" field when checking
       // whether two global pointers share the same value.
       // And we cannot use irpass::analysis::definitely_same_address()
@@ -183,15 +167,11 @@ class IRNodeComparator : public IRVisitor {
         return;
       }
     } else {
-      if (verbose)
-        std::cout << "rrr" << std::endl;
       if (!stmt->field_manager.equal(other->field_manager)) {
         same = false;
         return;
       }
     }
-    if (verbose)
-      std::cout << "ttt" << std::endl;
 
     // operand check
     if (stmt->num_operands() != other->num_operands()) {
@@ -207,8 +187,6 @@ class IRNodeComparator : public IRVisitor {
         continue;
       check_mapping(stmt->operand(i), other->operand(i));
     }
-    if (verbose)
-      std::cout << "yyy" << std::endl;
 
     map_id(stmt->id, other->id);
   }
@@ -295,7 +273,6 @@ class IRNodeComparator : public IRVisitor {
       other_node = other;
     }
   }
-  bool verbose{false};
 
   static bool run(IRNode *root1,
                   IRNode *root2,
@@ -306,8 +283,6 @@ class IRNodeComparator : public IRVisitor {
                   IRBank *ir_bank) {
     IRNodeComparator comparator(root2, id_map, check_same_value,
                                 possibly_modified_states, ir_bank);
-//    if (check_same_value && id_map.has_value())
-//      comparator.verbose = true;
     root1->accept(&comparator);
     return comparator.same;
   }

--- a/taichi/analysis/same_statements.cpp
+++ b/taichi/analysis/same_statements.cpp
@@ -115,11 +115,15 @@ class IRNodeComparator : public IRVisitor {
   }
 
   void basic_check(Stmt *stmt) {
+    if (verbose)
+      std::cout << "checking " << stmt->id << std::endl;
     // type check
     if (typeid(*other_node) != typeid(*stmt)) {
       same = false;
       return;
     }
+    if (verbose)
+      std::cout << "qqq" << std::endl;
     auto other = other_node->as<Stmt>();
 
     // If two identical statements can have different values, return false.
@@ -156,12 +160,16 @@ class IRNodeComparator : public IRVisitor {
         } while (false);
       }
     }
+    if (verbose)
+      std::cout << "www" << std::endl;
     // Note that we do not need to test !stmt2->common_statement_eliminable()
     // because if this condition does not hold,
     // same_statements(stmt1, stmt2) returns false anyway.
 
     // field check
     if (check_same_value_ && stmt->is<GlobalPtrStmt>()) {
+      if (verbose)
+        std::cout << "eee" << std::endl;
       // Special case: we do not care the "activate" field when checking
       // whether two global pointers share the same value.
       // And we cannot use irpass::analysis::definitely_same_address()
@@ -175,11 +183,15 @@ class IRNodeComparator : public IRVisitor {
         return;
       }
     } else {
+      if (verbose)
+        std::cout << "rrr" << std::endl;
       if (!stmt->field_manager.equal(other->field_manager)) {
         same = false;
         return;
       }
     }
+    if (verbose)
+      std::cout << "ttt" << std::endl;
 
     // operand check
     if (stmt->num_operands() != other->num_operands()) {
@@ -195,6 +207,8 @@ class IRNodeComparator : public IRVisitor {
         continue;
       check_mapping(stmt->operand(i), other->operand(i));
     }
+    if (verbose)
+      std::cout << "yyy" << std::endl;
 
     map_id(stmt->id, other->id);
   }
@@ -281,6 +295,7 @@ class IRNodeComparator : public IRVisitor {
       other_node = other;
     }
   }
+  bool verbose{false};
 
   static bool run(IRNode *root1,
                   IRNode *root2,
@@ -291,6 +306,8 @@ class IRNodeComparator : public IRVisitor {
                   IRBank *ir_bank) {
     IRNodeComparator comparator(root2, id_map, check_same_value,
                                 possibly_modified_states, ir_bank);
+//    if (check_same_value && id_map.has_value())
+//      comparator.verbose = true;
     root1->accept(&comparator);
     return comparator.same;
   }

--- a/taichi/analysis/same_statements.cpp
+++ b/taichi/analysis/same_statements.cpp
@@ -131,21 +131,21 @@ class IRNodeComparator : public IRVisitor {
         same = false;
         return;
       } else {
-        // "break" all branches that do not result in "same = false"
-        do {
-          if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
-            if (auto global_ptr = global_load->ptr->cast<GlobalPtrStmt>()) {
-              TI_ASSERT(global_ptr->width() == 1);
-              if (possibly_modified_states_.count(ir_bank_->get_async_state(
-                      global_ptr->snodes[0], AsyncState::Type::value)) == 0) {
-                break;
-              }
+        bool same_value = false;
+        if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
+          if (auto global_ptr = global_load->ptr->cast<GlobalPtrStmt>()) {
+            TI_ASSERT(global_ptr->width() == 1);
+            if (possibly_modified_states_.count(ir_bank_->get_async_state(
+                    global_ptr->snodes[0], AsyncState::Type::value)) == 0) {
+              same_value = true;
             }
-            // TODO: other cases?
           }
+          // TODO: other cases?
+        }
+        if (!same_value) {
           same = false;
           return;
-        } while (false);
+        }
       }
     }
     // Note that we do not need to test !stmt2->common_statement_eliminable()

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -102,7 +102,7 @@ bool same_statements(
  * Test if stmt1 and stmt2 definitely have the same value.
  *
  * @param possibly_modified_states
- *   Only states in possibly_modified_states can be modified
+ *   Assumes that only states in possibly_modified_states can be modified
  *   between stmt1 and stmt2.
  *
  * @param id_map

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -54,6 +54,7 @@ class ControlFlowGraph;
 
 struct TaskMeta;
 class IRBank;
+class AsyncStateSet;
 
 // IR Analysis
 namespace irpass::analysis {
@@ -82,20 +83,44 @@ std::vector<Stmt *> get_store_destination(Stmt *store_stmt);
 bool has_store_or_atomic(IRNode *root, const std::vector<Stmt *> &vars);
 std::pair<bool, Stmt *> last_store_or_atomic(IRNode *root, Stmt *var);
 bool maybe_same_address(Stmt *var1, Stmt *var2);
-/** Test if root1 and root2 are the same, i.e., have the same type,
- *  the same operands, the same fields, and the same containing statements.
+/**
+ * Test if root1 and root2 are the same, i.e., have the same type,
+ * the same operands, the same fields, and the same containing statements.
  *
- *  @param id_map
- *    If id_map is std::nullopt by default, two operands are considered
- *    the same if they have the same id and do not belong to either root,
- *    or they belong to root1 and root2 at the same position in the roots.
- *    Otherwise, this function also recursively check the operands until
- *    ids in the id_map are reached.
+ * @param id_map
+ *   If id_map is std::nullopt by default, two operands are considered
+ *   the same if they have the same id and do not belong to either root,
+ *   or they belong to root1 and root2 at the same position in the roots.
+ *   Otherwise, this function also recursively check the operands until
+ *   ids in the id_map are reached.
  */
 bool same_statements(
     IRNode *root1,
     IRNode *root2,
     const std::optional<std::unordered_map<int, int>> &id_map = std::nullopt);
+/**
+ * Test if stmt1 and stmt2 definitely have the same value.
+ *
+ * @param possibly_modified_states
+ *   Only states in possibly_modified_states can be modified
+ *   between stmt1 and stmt2.
+ *
+ * @param id_map
+ *   Same as in same_statements(root1, root2, id_map).
+ */
+bool same_value(
+    Stmt *stmt1,
+    Stmt *stmt2,
+    const AsyncStateSet &possibly_modified_states,
+    IRBank *ir_bank,
+    const std::optional<std::unordered_map<int, int>> &id_map = std::nullopt);
+/**
+ * Test if stmt1 and stmt2 definitely have the same value.
+ * Any global fields can be modified between stmt1 and stmt2.
+ *
+ * @param id_map
+ *   Same as in same_statements(root1, root2, id_map).
+ */
 bool same_value(
     Stmt *stmt1,
     Stmt *stmt2,

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -215,12 +215,8 @@ void AsyncEngine::synchronize() {
   sfg->reid_pending_nodes();
   sfg->sort_node_edges();
   auto init_size = sfg->size();
-  std::cout << std::flush;
-  TI_INFO("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
+  TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
            sfg->num_pending_tasks());
-  std::cout << std::flush;
-  sfg->print();
-  std::cout << std::flush;
   debug_sfg("initial");
   if (program->config.debug) {
     sfg->verify();
@@ -268,7 +264,6 @@ void AsyncEngine::synchronize() {
   // Clear SFG debug stats
   cur_sync_sfg_debug_counter_ = 0;
   cur_sync_sfg_debug_per_stage_counts_.clear();
-  //TI_ASSERT(init_size <= 20);
 }
 
 void AsyncEngine::debug_sfg(const std::string &stage) {

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -211,13 +211,8 @@ void AsyncEngine::synchronize() {
   sfg->reid_nodes();
   sfg->reid_pending_nodes();
   sfg->sort_node_edges();
-  auto init_size = sfg->size();
-  std::cout << std::flush;
-  TI_INFO("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
+  TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
            sfg->num_pending_tasks());
-  std::cout << std::flush;
-  sfg->print();
-  std::cout << std::flush;
   debug_sfg("initial");
   if (program->config.debug) {
     sfg->verify();
@@ -265,7 +260,6 @@ void AsyncEngine::synchronize() {
   // Clear SFG debug stats
   cur_sync_sfg_debug_counter_ = 0;
   cur_sync_sfg_debug_per_stage_counts_.clear();
-  TI_ASSERT(init_size <= 20);
 }
 
 void AsyncEngine::debug_sfg(const std::string &stage) {

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -214,7 +214,6 @@ void AsyncEngine::synchronize() {
   sfg->reid_nodes();
   sfg->reid_pending_nodes();
   sfg->sort_node_edges();
-  auto init_size = sfg->size();
   TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
            sfg->num_pending_tasks());
   debug_sfg("initial");

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -211,8 +211,13 @@ void AsyncEngine::synchronize() {
   sfg->reid_nodes();
   sfg->reid_pending_nodes();
   sfg->sort_node_edges();
-  TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
+  auto init_size = sfg->size();
+  std::cout << std::flush;
+  TI_INFO("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
            sfg->num_pending_tasks());
+  std::cout << std::flush;
+  sfg->print();
+  std::cout << std::flush;
   debug_sfg("initial");
   if (program->config.debug) {
     sfg->verify();
@@ -260,6 +265,7 @@ void AsyncEngine::synchronize() {
   // Clear SFG debug stats
   cur_sync_sfg_debug_counter_ = 0;
   cur_sync_sfg_debug_per_stage_counts_.clear();
+  TI_ASSERT(init_size <= 20);
 }
 
 void AsyncEngine::debug_sfg(const std::string &stage) {

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -214,8 +214,13 @@ void AsyncEngine::synchronize() {
   sfg->reid_nodes();
   sfg->reid_pending_nodes();
   sfg->sort_node_edges();
-  TI_TRACE("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
+  auto init_size = sfg->size();
+  std::cout << std::flush;
+  TI_INFO("Synchronizing SFG of {} nodes ({} pending)", sfg->size(),
            sfg->num_pending_tasks());
+  std::cout << std::flush;
+  sfg->print();
+  std::cout << std::flush;
   debug_sfg("initial");
   if (program->config.debug) {
     sfg->verify();
@@ -263,6 +268,7 @@ void AsyncEngine::synchronize() {
   // Clear SFG debug stats
   cur_sync_sfg_debug_counter_ = 0;
   cur_sync_sfg_debug_per_stage_counts_.clear();
+  //TI_ASSERT(init_size <= 20);
 }
 
 void AsyncEngine::debug_sfg(const std::string &stage) {

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
@@ -213,6 +214,12 @@ struct TaskMeta {
   std::unordered_map<const SNode *, bool> element_wise;
 
   void print() const;
+};
+
+// A wrapper class for the parameter in bool same_value() in analysis.h.
+class AsyncStateSet {
+ public:
+  std::unordered_set<AsyncState> s;
 };
 
 class IRBank;

--- a/taichi/program/async_utils.h
+++ b/taichi/program/async_utils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>

--- a/taichi/program/ir_bank.cpp
+++ b/taichi/program/ir_bank.cpp
@@ -77,18 +77,20 @@ IRHandle IRBank::fuse(IRHandle handle_a, IRHandle handle_b, Kernel *kernel) {
     return result;
   }
 
-  TI_INFO("Begin uncached fusion");
-  std::cout << handle_a.ir()->get_kernel()->name << " " << (handle_a.ir()->as<OffloadedStmt>()->has_body() ? handle_a.ir()->as<OffloadedStmt>()->body->size() : -1) << std::endl;
-  std::cout << handle_b.ir()->get_kernel()->name << " " << (handle_b.ir()->as<OffloadedStmt>()->has_body() ? handle_b.ir()->as<OffloadedStmt>()->body->size() : -1) << std::endl;
+  TI_TRACE("Begin uncached fusion: [{}(size={})] <- [{}(size={})]",
+           handle_a.ir()->get_kernel()->name,
+           (handle_a.ir()->as<OffloadedStmt>()->has_body()
+                ? handle_a.ir()->as<OffloadedStmt>()->body->size()
+                : -1),
+           handle_b.ir()->get_kernel()->name,
+           (handle_b.ir()->as<OffloadedStmt>()->has_body()
+                ? handle_a.ir()->as<OffloadedStmt>()->body->size()
+                : -1));
   // We are about to change both |task_a| and |task_b|. Clone them first.
   auto cloned_task_a = handle_a.clone();
   auto cloned_task_b = handle_b.clone();
   auto task_a = cloned_task_a->as<OffloadedStmt>();
   auto task_b = cloned_task_b->as<OffloadedStmt>();
-//  std::cout << "before: " << std::endl;
-//  irpass::print((IRNode *)handle_a.ir());
-//  irpass::print((IRNode *)handle_b.ir());
-//  std::cout << std::flush;
   // TODO: in certain cases this optimization can be wrong!
   // Fuse task b into task_a
   for (int j = 0; j < (int)task_b->body->size(); j++) {
@@ -102,9 +104,6 @@ IRHandle IRBank::fuse(IRHandle handle_a, IRHandle handle_b, Kernel *kernel) {
   irpass::full_simplify(task_a, /*after_lower_access=*/false, kernel);
   // For now, re_id is necessary for the hash to be correct.
   irpass::re_id(task_a);
-//  std::cout << "after: " << std::endl;
-//  irpass::print(task_a);
-//  std::cout << std::flush;
 
   auto h = get_hash(task_a);
   result = IRHandle(task_a, h);

--- a/taichi/program/ir_bank.cpp
+++ b/taichi/program/ir_bank.cpp
@@ -77,12 +77,18 @@ IRHandle IRBank::fuse(IRHandle handle_a, IRHandle handle_b, Kernel *kernel) {
     return result;
   }
 
-  TI_TRACE("Begin uncached fusion");
+  TI_INFO("Begin uncached fusion");
+  std::cout << handle_a.ir()->get_kernel()->name << " " << (handle_a.ir()->as<OffloadedStmt>()->has_body() ? handle_a.ir()->as<OffloadedStmt>()->body->size() : -1) << std::endl;
+  std::cout << handle_b.ir()->get_kernel()->name << " " << (handle_b.ir()->as<OffloadedStmt>()->has_body() ? handle_b.ir()->as<OffloadedStmt>()->body->size() : -1) << std::endl;
   // We are about to change both |task_a| and |task_b|. Clone them first.
   auto cloned_task_a = handle_a.clone();
   auto cloned_task_b = handle_b.clone();
   auto task_a = cloned_task_a->as<OffloadedStmt>();
   auto task_b = cloned_task_b->as<OffloadedStmt>();
+//  std::cout << "before: " << std::endl;
+//  irpass::print((IRNode *)handle_a.ir());
+//  irpass::print((IRNode *)handle_b.ir());
+//  std::cout << std::flush;
   // TODO: in certain cases this optimization can be wrong!
   // Fuse task b into task_a
   for (int j = 0; j < (int)task_b->body->size(); j++) {
@@ -96,6 +102,9 @@ IRHandle IRBank::fuse(IRHandle handle_a, IRHandle handle_b, Kernel *kernel) {
   irpass::full_simplify(task_a, /*after_lower_access=*/false, kernel);
   // For now, re_id is necessary for the hash to be correct.
   irpass::re_id(task_a);
+//  std::cout << "after: " << std::endl;
+//  irpass::print(task_a);
+//  std::cout << std::flush;
 
   auto h = get_hash(task_a);
   result = IRHandle(task_a, h);

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -655,31 +655,11 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
   auto edge_fusible = [&](int a, int b) {
     TI_PROFILER("edge_fusible");
     TI_ASSERT(a >= 0 && a < nodes.size() && b >= 0 && b < nodes.size());
-    //std::cout << "fusible " << nodes[a]->rec.id << " " << nodes[b]->rec.id
-    //          << std::endl;
-    bool verbose = (nodes[a]->rec.id == 117 && nodes[b]->rec.id == 124);
-    if (nodes[a]->rec.stmt()->has_body() && nodes[a]->rec.stmt()->body->size() > 100 &&
-    nodes[b]->rec.stmt()->has_body() && nodes[b]->rec.stmt()->body->size() > 100) {
-      verbose = true;
-    } else {
-    }
-    verbose = false;
-    if (verbose) {
-      std::cout << "verbose" << std::endl;
-      std::cout << nodes[a]->rec.stmt()->get_kernel()->name << " " << nodes[a]->rec.id << " " << (nodes[a]->rec.stmt()->has_body() ? nodes[a]->rec.stmt()->body->size() : -1) << std::endl;
-      std::cout << nodes[b]->rec.stmt()->get_kernel()->name << " " << nodes[b]->rec.id << " " << (nodes[b]->rec.stmt()->has_body() ? nodes[b]->rec.stmt()->body->size() : -1) << std::endl;
-      //irpass::print(nodes[a]->rec.stmt());
-      //irpass::print(nodes[b]->rec.stmt());
-    }
-    if (verbose)
-      std::cout << "aaaaa" << std::endl;
     // Check if a and b are fusible if there is an edge (a, b).
     if (fused[a] || fused[b] || !fusion_meta[a].fusible ||
         fusion_meta[a] != fusion_meta[b]) {
       return false;
     }
-    if (verbose)
-      std::cout << "bbbbb" << std::endl;
     if (nodes[a]->meta->type != OffloadedTaskType::serial) {
       std::unordered_map<int, int> offload_map;
       offload_map[0] = 0;
@@ -687,7 +667,8 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
           get_task_meta(ir_bank_, nodes[a]->rec)->output_states;
       std::unordered_set<AsyncState> modified_states_b =
           get_task_meta(ir_bank_, nodes[a]->rec)->output_states;
-      modified_states.insert(modified_states_b.begin(), modified_states_b.end());
+      modified_states.insert(modified_states_b.begin(),
+                             modified_states_b.end());
       AsyncStateSet modified_states_set{modified_states};
       for (auto state_iter = nodes[a]->output_edges.get_state_iterator();
            !state_iter.done(); ++state_iter) {
@@ -705,10 +686,6 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
         if (state_iter.has_edge(nodes[b])) {
           if (nodes[a]->meta->loop_unique.count(snode) == 0 ||
               nodes[b]->meta->loop_unique.count(snode) == 0) {
-            if (verbose) {
-              std::cout << "not loop-unique "
-                        << snode->get_node_type_name_hinted() << std::endl;
-            }
             return false;
           }
           auto same_loop_unique_address = [&](GlobalPtrStmt *ptr1,
@@ -735,25 +712,14 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
           };
           if (!same_loop_unique_address(nodes[a]->meta->loop_unique[snode],
                                         nodes[b]->meta->loop_unique[snode])) {
-            if (verbose) {
-              std::cout << "not loop-unique address "
-                        << snode->get_node_type_name_hinted() << std::endl;
-            }
             return false;
           }
         }
       }
     }
-    if (verbose)
-      std::cout << "ccccc" << std::endl;
     // check if a doesn't have a path to b of length >= 2
     auto a_has_path_to_b = has_path[a] & has_path_reverse[b];
     a_has_path_to_b[a] = a_has_path_to_b[b] = false;
-    if (verbose) {
-      if (a_has_path_to_b.none()) {
-        std::cout << "ddddd" << std::endl;
-      }
-    }
     return a_has_path_to_b.none();
   };
 

--- a/tests/python/test_bit_array_vectorization.py
+++ b/tests/python/test_bit_array_vectorization.py
@@ -23,9 +23,8 @@ def test_vectorized_struct_for():
     @ti.kernel
     def init():
         for i, j in ti.ndrange((boundary_offset, N - boundary_offset),
-                            (boundary_offset, N - boundary_offset)):
+                               (boundary_offset, N - boundary_offset)):
             x[i, j] = ti.random(dtype=ti.i32) % 2
-
 
     @ti.kernel
     def assign_vectorized():
@@ -33,13 +32,11 @@ def test_vectorized_struct_for():
         for i, j in x:
             y[i, j] = x[i, j]
 
-
     @ti.kernel
     def verify():
         for i, j in ti.ndrange((boundary_offset, N - boundary_offset),
-                            (boundary_offset, N - boundary_offset)):
+                               (boundary_offset, N - boundary_offset)):
             assert y[i, j] == x[i, j]
-
 
     init()
     assign_vectorized()


### PR DESCRIPTION
Related issue = #742 #656

```C++
bool same_value(
    Stmt *stmt1,
    Stmt *stmt2,
    const AsyncStateSet &possibly_modified_states,
    IRBank *ir_bank,
    const std::optional<std::unordered_map<int, int>> &id_map = std::nullopt);
```
allows passing in a parameter `possibly_modified_states`, so that we can analyze if two global loads share the same value (same if the value state of the SNode is not modified).

G2P2G running time on my laptop (fusible now, 1.44x faster!):
before:
```
num particles=10086
  frame time 0.210 s
  substep time 4.047 ms
num particles=10251
  frame time 0.341 s
  substep time 6.559 ms
num particles=10416
  frame time 0.248 s
  substep time 4.776 ms
num particles=10581
  frame time 0.327 s
  substep time 6.291 ms
num particles=10746
  frame time 0.294 s
  substep time 5.658 ms
num particles=10911
  frame time 0.281 s
  substep time 5.409 ms
num particles=11076
  frame time 0.235 s
  substep time 4.526 ms
num particles=11241
  frame time 0.264 s
  substep time 5.083 ms
num particles=11406
  frame time 0.255 s
  substep time 4.929 ms
num particles=11571
  frame time 0.313 s
  substep time 6.022 ms
......
num particles=20991
  frame time 0.320 s
  substep time 6.157 ms
num particles=21024
  frame time 0.318 s
  substep time 6.118 ms
num particles=21057
  frame time 0.326 s
  substep time 6.272 ms
num particles=21090
  frame time 0.326 s
  substep time 6.272 ms
num particles=21123
  frame time 0.334 s
  substep time 6.425 ms
```
after:
```
num particles=10086
  frame time 0.187 s
  substep time 3.606 ms
num particles=10251
  frame time 0.187 s
  substep time 3.606 ms
num particles=10416
  frame time 0.189 s
  substep time 3.644 ms
num particles=10581
  frame time 0.190 s
  substep time 3.663 ms
num particles=10746
  frame time 0.190 s
  substep time 3.663 ms
num particles=10911
  frame time 0.193 s
  substep time 3.721 ms
num particles=11076
  frame time 0.192 s
  substep time 3.721 ms
num particles=11241
  frame time 0.194 s
  substep time 3.740 ms
num particles=11406
  frame time 0.197 s
  substep time 3.798 ms
num particles=11571
  frame time 0.198 s
  substep time 3.817 ms
......
num particles=20991
  frame time 0.317 s
  substep time 6.099 ms
num particles=21024
  frame time 0.316 s
  substep time 6.080 ms
num particles=21057
  frame time 0.314 s
  substep time 6.042 ms
num particles=21090
  frame time 0.314 s
  substep time 6.042 ms
num particles=21123
  frame time 0.315 s
  substep time 6.061 ms
```
----
one grid:
```
num particles=10086
  frame time 0.299 s
  substep time 5.754 ms
num particles=10251
  frame time 0.305 s
  substep time 5.869 ms
num particles=10416
  frame time 0.296 s
  substep time 5.696 ms
num particles=10581
  frame time 0.313 s
  substep time 6.022 ms
num particles=10746
  frame time 0.297 s
  substep time 5.715 ms
num particles=10911
  frame time 0.305 s
  substep time 5.888 ms
num particles=11076
  frame time 0.308 s
  substep time 5.926 ms
num particles=11241
  frame time 0.320 s
  substep time 6.157 ms
num particles=11406
  frame time 0.319 s
  substep time 6.137 ms
num particles=11571
  frame time 0.311 s
  substep time 5.984 ms
......
num particles=20991
  frame time 0.460 s
  substep time 8.899 ms
num particles=21024
  frame time 0.424 s
  substep time 8.151 ms
num particles=21057
  frame time 0.434 s
  substep time 8.362 ms
num particles=21090
  frame time 0.418 s
  substep time 8.036 ms
num particles=21123
  frame time 0.433 s
  substep time 8.324 ms
```

sync mode:
```
num particles=10086
  frame time 0.168 s
  substep time 3.241 ms
num particles=10251
  frame time 0.171 s
  substep time 3.280 ms
num particles=10416
  frame time 0.175 s
  substep time 3.356 ms
num particles=10581
  frame time 0.176 s
  substep time 3.376 ms
num particles=10746
  frame time 0.175 s
  substep time 3.356 ms
num particles=10911
  frame time 0.179 s
  substep time 3.433 ms
num particles=11076
  frame time 0.180 s
  substep time 3.452 ms
num particles=11241
  frame time 0.179 s
  substep time 3.433 ms
num particles=11406
  frame time 0.182 s
  substep time 3.491 ms
num particles=11571
  frame time 0.183 s
  substep time 3.510 ms
......
num particles=20991
  frame time 0.305 s
  substep time 5.888 ms
num particles=21024
  frame time 0.306 s
  substep time 5.888 ms
num particles=21057
  frame time 0.305 s
  substep time 5.869 ms
num particles=21090
  frame time 0.305 s
  substep time 5.869 ms
num particles=21123
  frame time 0.305 s
  substep time 5.869 ms
```

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
