### PR TITLE
[async] Disable profiler macros in release mode

### DIFF
--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -12,6 +12,9 @@
 #include "taichi/ir/transforms.h"
 #include "taichi/program/extension.h"
 
+// Keep this include in the end!
+#include "taichi/program/async_profiler_switch.h"
+
 TLANG_NAMESPACE_BEGIN
 
 ParallelExecutor::ParallelExecutor(int num_threads)

--- a/taichi/program/async_profiler_switch.h
+++ b/taichi/program/async_profiler_switch.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define ASYNC_ENGINE_RELEASE_MODE
+
+#ifdef ASYNC_ENGINE_RELEASE_MODE
+#undef TI_PROFILER
+#undef TI_AUTO_PROF
+
+#define TI_PROFILER(name)
+#define TI_AUTO_PROF
+#endif  // ASYNC_ENGINE_RELEASE_MODE

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -10,6 +10,9 @@
 #include "taichi/program/ir_bank.h"
 #include "taichi/program/kernel.h"
 
+// Keep this include in the end!
+#include "taichi/program/async_profiler_switch.h"
+
 TLANG_NAMESPACE_BEGIN
 
 std::unique_ptr<IRNode> IRHandle::clone() const {

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -12,6 +12,9 @@
 #include "taichi/program/async_engine.h"
 #include "taichi/util/statistics.h"
 
+// Keep this include in the end!
+#include "taichi/program/async_profiler_switch.h"
+
 TLANG_NAMESPACE_BEGIN
 
 namespace {
@@ -1321,6 +1324,7 @@ bool StateFlowGraph::optimize_dead_store() {
 }
 
 void StateFlowGraph::verify(bool also_verify_ir) const {
+#ifndef ASYNC_ENGINE_RELEASE_MODE
   TI_AUTO_PROF
   // Check nodes
   const int n = nodes_.size();
@@ -1419,6 +1423,7 @@ void StateFlowGraph::verify(bool also_verify_ir) const {
       irpass::analysis::verify(nodes_[i]->rec.stmt());
     }
   }
+#endif  // ASYNC_ENGINE_RELEASE_MODE
 }
 
 bool StateFlowGraph::demote_activation() {

--- a/taichi/system/profiler.cpp
+++ b/taichi/system/profiler.cpp
@@ -158,11 +158,11 @@ void ProfilerRecords::print(ProfilerRecordNode *node, int depth) {
   if (depth == 0)
     level_color = fmt::color::red;
   else if (depth == 1)
-    level_color = fmt::color::green;
+    level_color = fmt::color::light_green;
   else if (depth == 2)
     level_color = fmt::color::yellow;
   else if (depth == 3)
-    level_color = fmt::color::blue;
+    level_color = fmt::color::light_blue;
   else if (depth >= 4)
     level_color = fmt::color::magenta;
   if (depth == 0) {


### PR DESCRIPTION
Related issue = #742

It has turned out that the scoped profilers have a huge overhead. E2E time when benchmarking MGPCG at 512 resolution:

1. Before this PR: 0.49s
2. With this PR: **0.27s**

(A slightly off the topic change is to tweak the color, the default blue are green colors are a bit hard to read with Ubuntu's purple background... That said, these stats won't be helpful now, and we should resort to the lower-overhead perf solutions like `perf` and vtune..)

![Screenshot from 2020-12-25 21-47-31](https://user-images.githubusercontent.com/7481356/103135416-92e2ba00-46fb-11eb-9f6c-6099853b3b81.png)

![Screenshot from 2020-12-25 21-47-17](https://user-images.githubusercontent.com/7481356/103135422-95ddaa80-46fb-11eb-962d-068b8b0332ea.png)



<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
