### PR TITLE
[type] Support exponents in CustomFloatType

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -3,6 +3,7 @@ from .util import deprecated
 from .matrix import Matrix, Vector
 from .transformer import TaichiSyntaxError
 from .ndrange import ndrange, GroupedNDRange
+from .type_factory import TypeFactory
 from copy import deepcopy as _deepcopy
 import functools
 import os
@@ -46,9 +47,11 @@ kernel_profiler_clear = lambda: get_runtime().prog.kernel_profiler_clear()
 kernel_profiler_total_time = lambda: get_runtime(
 ).prog.kernel_profiler_total_time()
 
-# Unstable API
+# Legacy API
 type_factory_ = core.get_type_factory_instance()
 
+# Unstable API
+type_factory = TypeFactory()
 
 def memory_profiler_print():
     get_runtime().materialize()

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -53,6 +53,7 @@ type_factory_ = core.get_type_factory_instance()
 # Unstable API
 type_factory = TypeFactory()
 
+
 def memory_profiler_print():
     get_runtime().materialize()
     get_runtime().prog.print_memory_profiler_info()

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -42,7 +42,7 @@ class SNode:
             dimensions = [dimensions] * len(indices)
         return SNode(self.ptr.bit_array(indices, dimensions, num_bits))
 
-    def place(self, *args, offset=None):
+    def place(self, *args, offset=None, shared_exponent=False):
         from .expr import Expr
         from .util import is_taichi_class
         if offset is None:
@@ -50,6 +50,7 @@ class SNode:
         if isinstance(offset, numbers.Number):
             offset = (offset, )
         for arg in args:
+            assert shared_exponent == False
             if isinstance(arg, Expr):
                 self.ptr.place(Expr(arg).ptr, offset)
             elif isinstance(arg, list):

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -51,6 +51,8 @@ class SNode:
             offset = (offset, )
         for arg in args:
             assert shared_exponent == False
+            # TODO: implement shared exponent
+
             if isinstance(arg, Expr):
                 self.ptr.place(Expr(arg).ptr, offset)
             elif isinstance(arg, list):

--- a/python/taichi/lang/type_factory.py
+++ b/python/taichi/lang/type_factory.py
@@ -1,0 +1,10 @@
+class TypeFactory:
+    def __init__(self):
+        from taichi.core import ti_core
+        self.core = ti_core.get_type_factory_instance()
+    
+    def custom_float(self, significand_type, exponent_type=None, compute_type=None, scale=1.0):
+        import taichi as ti
+        if compute_type is None:
+            compute_type = ti.get_runtime().get_default_fp().get_ptr()
+        return self.core.get_custom_float_type(significand_type, exponent_type, compute_type, scale=scale)

--- a/python/taichi/lang/type_factory.py
+++ b/python/taichi/lang/type_factory.py
@@ -2,9 +2,16 @@ class TypeFactory:
     def __init__(self):
         from taichi.core import ti_core
         self.core = ti_core.get_type_factory_instance()
-    
-    def custom_float(self, significand_type, exponent_type=None, compute_type=None, scale=1.0):
+
+    def custom_float(self,
+                     significand_type,
+                     exponent_type=None,
+                     compute_type=None,
+                     scale=1.0):
         import taichi as ti
         if compute_type is None:
             compute_type = ti.get_runtime().get_default_fp().get_ptr()
-        return self.core.get_custom_float_type(significand_type, exponent_type, compute_type, scale=scale)
+        return self.core.get_custom_float_type(significand_type,
+                                               exponent_type,
+                                               compute_type,
+                                               scale=scale)

--- a/python/taichi/lang/type_factory.py
+++ b/python/taichi/lang/type_factory.py
@@ -10,7 +10,7 @@ class TypeFactory:
                      scale=1.0):
         import taichi as ti
         if compute_type is None:
-            compute_type = ti.get_runtime().get_default_fp().get_ptr()
+            compute_type = ti.get_runtime().default_fp.get_ptr()
         return self.core.get_custom_float_type(significand_type,
                                                exponent_type,
                                                compute_type,

--- a/python/taichi/lang/type_factory.py
+++ b/python/taichi/lang/type_factory.py
@@ -3,6 +3,9 @@ class TypeFactory:
         from taichi.core import ti_core
         self.core = ti_core.get_type_factory_instance()
 
+    def custom_int(self, bits, signed=True):
+        return self.core.get_custom_int_type(bits, signed)
+
     def custom_float(self,
                      significand_type,
                      exponent_type=None,

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1211,7 +1211,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         TI_ASSERT(cft->get_compute_type()->is_primitive(PrimitiveTypeID::f32));
         // TODO: handle negative digits (sign bit) and negative exponents
         auto f32_bits = builder->CreateBitCast(
-            llvm_val[stmt->data], llvm::Type::getFloatTy(*llvm_context));
+            llvm_val[stmt->data], llvm::Type::getInt32Ty(*llvm_context));
         auto exponent_bits = builder->CreateAShr(f32_bits, 23);
         // f32 = 1 sign bit + 8 exponent bits + 23 fraction bits
         auto value_bits = builder->CreateAShr(
@@ -1231,11 +1231,12 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
             offset_bit_ptr(llvm_val[stmt->ptr], exponent_snode->bit_offset -
                                                     digits_snode->bit_offset);
         store_custom_int(exponent_bit_ptr, exponent_cit, exponent_bits);
+        store_value = digit_bits;
       } else {
         digit_bits = llvm_val[stmt->data];
+        store_value = float_to_custom_int(cft, digits_cit, digit_bits);
       }
       cit = digits_cit;
-      store_value = float_to_custom_int(cft, digits_cit, digit_bits);
     } else {
       TI_NOT_IMPLEMENTED
     }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1343,8 +1343,16 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
           auto fraction_bits = builder->CreateAnd(digits, (1 << 22) - 1);
           auto f32_bits = builder->CreateOr(
               sign_bit, builder->CreateOr(exponent_bits, fraction_bits));
+
+          // TODO: remove this hack...
+          f32_bits =
+              builder->CreateOr(f32_bits, tlctx->get_constant(0x40000000));
           llvm_val[stmt] = builder->CreateBitCast(
               f32_bits, llvm::Type::getFloatTy(*llvm_context));
+          create_print("Loaded f32 bits",
+                       TypeFactory::get_instance().get_primitive_type(
+                           PrimitiveTypeID::i32),
+                       f32_bits);
         } else {
           TI_NOT_IMPLEMENTED;
         }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1229,11 +1229,9 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
           auto sign_bit =
               builder->CreateAnd(f32_bits, tlctx->get_constant(0x80000000u));
           // insert the sign bit to digit bits
-          create_print("digits bits:", PrimitiveType::u32, digit_bits);
           digit_bits = builder->CreateOr(
               digit_bits,
               builder->CreateLShr(sign_bit, 31 - cft->get_digit_bits()));
-          create_print("digits bits:", PrimitiveType::u32, digit_bits);
         }
 
         auto exponent_cit = exp->as<CustomIntType>();
@@ -1371,10 +1369,8 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
               (1u
                << cft->get_digits_type()->as<CustomIntType>()->get_num_bits()) -
                   1);
-          create_print("digits initial:", PrimitiveType::u32, digits);
           digits = builder->CreateShl(
               digits, tlctx->get_constant(23 - cft->get_digit_bits()));
-          TI_P(23 - cft->get_digit_bits());
 
           auto fraction_bits = builder->CreateAnd(digits, (1u << 23) - 1);
 
@@ -1386,8 +1382,6 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
 
             sign_bit =
                 builder->CreateShl(sign_bit, tlctx->get_constant(31 - (23)));
-            create_print("digits:", PrimitiveType::u32, digits);
-            create_print("sign bit:", PrimitiveType::u32, sign_bit);
             f32_bits = builder->CreateOr(f32_bits, sign_bit);
           }
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -205,6 +205,10 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(GlobalPtrStmt *stmt) override;
 
+  void store_custom_int(llvm::Value *bit_ptr,
+                        CustomIntType *cit,
+                        llvm::Value *value);
+
   void visit(GlobalStoreStmt *stmt) override;
 
   llvm::Value *load_as_custom_int(llvm::Value *ptr, Type *load_type);

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -219,6 +219,10 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *reconstruct_custom_float(llvm::Value *digits, Type *load_type);
 
+  llvm::Value *load_custom_float_with_exponent(llvm::Value *digits_bit_ptr,
+                                               llvm::Value *exponent_bit_ptr,
+                                               CustomFloatType *cft);
+
   void visit(GlobalLoadStmt *stmt) override;
 
   void visit(ElementShuffleStmt *stmt) override;

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -207,7 +207,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(GlobalStoreStmt *stmt) override;
 
-  llvm::Value *load_as_custom_int(Stmt *ptr, Type *load_type);
+  llvm::Value *load_as_custom_int(llvm::Value *ptr, Type *load_type);
 
   llvm::Value *extract_custom_int(llvm::Value *physical_value,
                                   llvm::Value *bit_offset,

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -227,8 +227,10 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(IntegerOffsetStmt *stmt) override;
 
-  llvm::Value *create_bit_ptr_struct(llvm::Value *byte_ptr_base,
-                                     llvm::Value *bit_offset);
+  llvm::Value *create_bit_ptr_struct(llvm::Value *byte_ptr_base = nullptr,
+                                     llvm::Value *bit_offset = nullptr);
+
+  llvm::Value *offset_bit_ptr(llvm::Value *input_bit_ptr, int bit_offset_delta);
 
   void visit(SNodeLookupStmt *stmt) override;
 

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -45,8 +45,8 @@ void SNode::place(Expr &expr_, const std::vector<int> &offset) {
     SNode *new_exp_snode = nullptr;
     if (auto cft = expr->dt->cast<CustomFloatType>()) {
       if (auto exp = cft->get_exponent_type()) {
-        // Non-empty exponent type. Create another place SNode to store the
-        // exponent type.
+        // Non-empty exponent type. First create a place SNode for the
+        // exponent value.
         auto &exp_node = insert_children(SNodeType::place);
         exp_node.dt = exp;
         exp_node.name = expr->ident.raw_name() + "_exp";

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -63,7 +63,7 @@ void SNode::place(Expr &expr_, const std::vector<int> &offset) {
     expr->snode->expr.set(Expr(expr));
     child.dt = expr->dt;
     if (new_exp_snode) {
-      this->exp_snode = new_exp_snode;
+      child.exp_snode = new_exp_snode;
     }
     if (!offset.empty())
       child.set_index_offsets(offset);
@@ -296,7 +296,11 @@ void SNode::print() {
   for (int i = 0; i < depth; i++) {
     fmt::print("  ");
   }
-  fmt::print("{}\n", get_node_type_name_hinted());
+  fmt::print("{}", get_node_type_name_hinted());
+  if (exp_snode) {
+    fmt::print(" exp={}\n", exp_snode->get_node_type_name());
+  }
+  fmt::print("\n");
   for (auto &c : ch) {
     c->print();
   }

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -85,6 +85,7 @@ class SNode {
   Kernel *reader_kernel{};
   Kernel *writer_kernel{};
   Expr expr;
+  SNode *exp_snode{};  // for CustomFloatType with exponent bits
 
   // is_bit_level=false: the SNode is not bitpacked
   // is_bit_level=true: the SNode is bitpacked (i.e., strictly inside bit_struct

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -86,7 +86,7 @@ class SNode {
   Kernel *writer_kernel{};
   Expr expr;
   SNode *exp_snode{};  // for CustomFloatType with exponent bits
-  int bit_offset{0};   // for bit_struct only
+  int bit_offset{0};   // for children of bit_struct only
 
   // is_bit_level=false: the SNode is not bitpacked
   // is_bit_level=true: the SNode is bitpacked (i.e., strictly inside bit_struct

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -86,6 +86,7 @@ class SNode {
   Kernel *writer_kernel{};
   Expr expr;
   SNode *exp_snode{};  // for CustomFloatType with exponent bits
+  int bit_offset{0};   // for bit_struct only
 
   // is_bit_level=false: the SNode is not bitpacked
   // is_bit_level=true: the SNode is bitpacked (i.e., strictly inside bit_struct

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -124,6 +124,11 @@ CustomFloatType::CustomFloatType(Type *digits_type,
       compute_type_(compute_type),
       scale_(scale) {
   TI_ASSERT(digits_type->is<CustomIntType>());
+
+  // Exponent must be unsigned custom int
+  TI_ASSERT(exponent_type->is<CustomIntType>());
+  TI_ASSERT(exponent_type->as<CustomIntType>()->get_is_signed() == false);
+
   TI_ASSERT(compute_type->is<PrimitiveType>());
   TI_ASSERT(is_real(compute_type->as<PrimitiveType>()));
 }
@@ -131,6 +136,22 @@ CustomFloatType::CustomFloatType(Type *digits_type,
 std::string CustomFloatType::to_string() const {
   return fmt::format("cf(d={} c={} s={})", digits_type_->to_string(),
                      compute_type_->to_string(), scale_);
+}
+
+int CustomFloatType::get_exponent_conversion_offset() const {
+  TI_ASSERT(compute_type_->is_primitive(PrimitiveTypeID::f32));
+  // Note that f32 has exponent offset -127
+  return 127 -
+         (1 << (exponent_type_->as<CustomIntType>()->get_num_bits() - 1)) + 1;
+}
+
+int CustomFloatType::get_digit_bits() const {
+  return digits_type_->as<CustomIntType>()->get_num_bits() -
+         (int)get_is_signed();
+}
+
+bool CustomFloatType::get_is_signed() const {
+  return digits_type_->as<CustomIntType>()->get_is_signed();
 }
 
 BitStructType::BitStructType(PrimitiveType *physical_type,

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -116,9 +116,13 @@ CustomIntType::CustomIntType(int num_bits,
 }
 
 CustomFloatType::CustomFloatType(Type *digits_type,
+                                 Type *exponent_type,
                                  Type *compute_type,
                                  float64 scale)
-    : digits_type_(digits_type), compute_type_(compute_type), scale_(scale) {
+    : digits_type_(digits_type),
+      exponent_type_(exponent_type),
+      compute_type_(compute_type),
+      scale_(scale) {
   TI_ASSERT(digits_type->is<CustomIntType>());
   TI_ASSERT(compute_type->is<PrimitiveType>());
   TI_ASSERT(is_real(compute_type->as<PrimitiveType>()));

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -124,13 +124,17 @@ CustomFloatType::CustomFloatType(Type *digits_type,
       compute_type_(compute_type),
       scale_(scale) {
   TI_ASSERT(digits_type->is<CustomIntType>());
-
-  // Exponent must be unsigned custom int
-  TI_ASSERT(exponent_type->is<CustomIntType>());
-  TI_ASSERT(exponent_type->as<CustomIntType>()->get_is_signed() == false);
-
   TI_ASSERT(compute_type->is<PrimitiveType>());
   TI_ASSERT(is_real(compute_type->as<PrimitiveType>()));
+
+  if (exponent_type_) {
+    // We only support f32 as compute type when when using exponents
+    TI_ASSERT(compute_type_->is_primitive(PrimitiveTypeID::f32));
+    // Exponent must be unsigned custom int
+    TI_ASSERT(exponent_type->is<CustomIntType>());
+    TI_ASSERT(exponent_type->as<CustomIntType>()->get_num_bits() <= 8);
+    TI_ASSERT(get_digit_bits() <= 23);
+  }
 }
 
 std::string CustomFloatType::to_string() const {
@@ -139,7 +143,6 @@ std::string CustomFloatType::to_string() const {
 }
 
 int CustomFloatType::get_exponent_conversion_offset() const {
-  TI_ASSERT(compute_type_->is_primitive(PrimitiveTypeID::f32));
   // Note that f32 has exponent offset -127
   return 127 -
          (1 << (exponent_type_->as<CustomIntType>()->get_num_bits() - 1)) + 1;

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -231,6 +231,12 @@ class CustomFloatType : public Type {
     return exponent_type_;
   }
 
+  int get_exponent_conversion_offset() const;
+
+  int get_digit_bits() const;
+
+  bool get_is_signed() const;
+
   Type *get_compute_type() override {
     return compute_type_;
   }

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -212,7 +212,10 @@ class CustomIntType : public Type {
 
 class CustomFloatType : public Type {
  public:
-  CustomFloatType(Type *digits_type, Type *compute_type, float64 scale);
+  CustomFloatType(Type *digits_type,
+                  Type *exponent_type,
+                  Type *compute_type,
+                  float64 scale);
 
   std::string to_string() const override;
 
@@ -230,6 +233,7 @@ class CustomFloatType : public Type {
 
  private:
   Type *digits_type_{nullptr};
+  Type *exponent_type_{nullptr};
   Type *compute_type_{nullptr};
   float64 scale_;
 };

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -227,6 +227,10 @@ class CustomFloatType : public Type {
     return digits_type_;
   }
 
+  Type *get_exponent_type() {
+    return exponent_type_;
+  }
+
   Type *get_compute_type() override {
     return compute_type_;
   }

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -50,12 +50,13 @@ Type *TypeFactory::get_custom_int_type(int num_bits,
 }
 
 Type *TypeFactory::get_custom_float_type(Type *digits_type,
+                                         Type *exponent_type,
                                          Type *compute_type,
                                          float64 scale) {
-  auto key = std::make_tuple(digits_type, compute_type, scale);
+  auto key = std::make_tuple(digits_type, exponent_type, compute_type, scale);
   if (custom_float_types.find(key) == custom_float_types.end()) {
-    custom_float_types[key] =
-        std::make_unique<CustomFloatType>(digits_type, compute_type, scale);
+    custom_float_types[key] = std::make_unique<CustomFloatType>(
+        digits_type, exponent_type, compute_type, scale);
   }
   return custom_float_types[key].get();
 }

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -26,6 +26,7 @@ class TypeFactory {
                             int compute_type_bits = 32);
 
   Type *get_custom_float_type(Type *digits_type,
+                              Type *exponent_type,
                               Type *compute_type,
                               float64 scale);
 
@@ -56,7 +57,7 @@ class TypeFactory {
   std::map<std::tuple<int, int, bool>, std::unique_ptr<Type>> custom_int_types;
 
   // TODO: use unordered map
-  std::map<std::tuple<Type *, Type *, float64>, std::unique_ptr<Type>>
+  std::map<std::tuple<Type *, Type *, Type *, float64>, std::unique_ptr<Type>>
       custom_float_types;
 
   // TODO: avoid duplication

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -68,11 +68,19 @@ real measure_cpe(std::function<void()> target,
 std::string data_type_format(DataType dt) {
   if (dt->is_primitive(PrimitiveTypeID::i32)) {
     return "%d";
+  } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
+    return "%u";
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
 #if defined(TI_PLATFORM_UNIX)
     return "%lld";
 #else
     return "%I64d";
+#endif
+  } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
+#if defined(TI_PLATFORM_UNIX)
+    return "%llu";
+#else
+    return "%I64u";
 #endif
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
     return "%f";
@@ -87,8 +95,8 @@ std::string data_type_format(DataType dt) {
 
 int data_type_size(DataType t) {
   // TODO:
-  //  1. Ensure in the old code, pointer attributes of t are correct (by setting
-  //  a loud failure on pointers);
+  //  1. Ensure in the old code, pointer attributes of t are correct (by
+  //  setting a loud failure on pointers);
   //  2. Support pointer types here.
   t.set_is_pointer(false);
   if (false) {

--- a/taichi/llvm/llvm_codegen_utils.h
+++ b/taichi/llvm/llvm_codegen_utils.h
@@ -126,6 +126,7 @@ class LLVMModuleBuilder {
     return call(this->builder.get(), func_name, std::forward<Args>(args)...);
   }
 
+  // TODO(type): return with std::tuple
   void read_bit_pointer(llvm::Value *ptr,
                         llvm::Value *&byte_ptr,
                         llvm::Value *&bit_offset) {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -739,7 +739,8 @@ void export_lang(py::module &m) {
            py::arg("compute_type_bits") = 32,
            py::return_value_policy::reference)
       .def("get_custom_float_type", &TypeFactory::get_custom_float_type,
-           py::arg("digits_type"), py::arg("compute_type"), py::arg("scale"),
+           py::arg("digits_type"), py::arg("exponent_type"),
+           py::arg("compute_type"), py::arg("scale"),
            py::return_value_policy::reference);
 
   m.def("get_type_factory_instance", TypeFactory::get_instance,

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -77,7 +77,7 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
       }
       component_cit->set_physical_type(snode.physical_type);
       if (!arch_is_cpu(arch)) {
-        TI_ERROR_IF(data_type_bits(snode.physical_type) <= 16,
+        TI_ERROR_IF(data_type_bits(snode.physical_type) < 32,
                     "bit_struct physical type must be at least 32 bits on "
                     "non-CPU backends.");
       }

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -81,6 +81,7 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
                     "bit_struct physical type must be at least 32 bits on "
                     "non-CPU backends.");
       }
+      ch->bit_offset = total_offset;
       total_offset += component_cit->get_num_bits();
     }
 

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -73,7 +73,7 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
       } else if (auto cft = ch->dt->cast<CustomFloatType>()) {
         component_cit = cft->get_digits_type()->as<CustomIntType>();
       } else {
-        TI_NOT_IMPLEMENTED
+        TI_ERROR("Type {} not supported.", ch->dt->to_string());
       }
       component_cit->set_physical_type(snode.physical_type);
       if (!arch_is_cpu(arch)) {

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -6,7 +6,7 @@ from pytest import approx
 @ti.test(require=ti.extension.quant)
 def test_custom_float():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
+    cft = ti.type_factory.custom_float(significand_type=ci13, scale=0.1)
     x = ti.field(dtype=cft)
 
     ti.root._bit_struct(num_bits=32).place(x)
@@ -28,8 +28,8 @@ def test_custom_float():
 @ti.test(require=ti.extension.quant)
 def test_custom_matrix_rotation():
     ci16 = ti.type_factory_.get_custom_int_type(16, True)
-    cft = ti.type_factory_.get_custom_float_type(ci16, ti.f32.get_ptr(),
-                                                 1.2 / (2**15))
+    cft = ti.type_factory.custom_float(significand_type=ci16,
+                                       scale=1.2 / (2**15))
 
     x = ti.Matrix.field(2, 2, dtype=cft)
 
@@ -56,7 +56,7 @@ def test_custom_matrix_rotation():
 @ti.test(require=ti.extension.quant)
 def test_custom_float_implicit_cast():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    cft = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
+    cft = ti.type_factory.custom_float(significand_type=ci13, scale=0.1)
     x = ti.field(dtype=cft)
 
     ti.root._bit_struct(num_bits=32).place(x)
@@ -72,7 +72,7 @@ def test_custom_float_implicit_cast():
 @ti.test(require=ti.extension.quant)
 def test_cache_read_only():
     ci15 = ti.type_factory_.get_custom_int_type(15, True)
-    cft = ti.type_factory_.get_custom_float_type(ci15, ti.f32.get_ptr(), 0.1)
+    cft = ti.type_factory.custom_float(significand_type=ci15, scale=0.1)
     x = ti.field(dtype=cft)
 
     ti.root._bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -5,7 +5,7 @@ from pytest import approx
 
 @ti.test(require=ti.extension.quant)
 def test_custom_float():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    ci13 = ti.type_factory.custom_int(bits=13)
     cft = ti.type_factory.custom_float(significand_type=ci13, scale=0.1)
     x = ti.field(dtype=cft)
 
@@ -27,7 +27,7 @@ def test_custom_float():
 
 @ti.test(require=ti.extension.quant)
 def test_custom_matrix_rotation():
-    ci16 = ti.type_factory_.get_custom_int_type(16, True)
+    ci16 = ti.type_factory.custom_int(bits=16)
     cft = ti.type_factory.custom_float(significand_type=ci16,
                                        scale=1.2 / (2**15))
 
@@ -55,7 +55,7 @@ def test_custom_matrix_rotation():
 
 @ti.test(require=ti.extension.quant)
 def test_custom_float_implicit_cast():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    ci13 = ti.type_factory.custom_int(bits=13)
     cft = ti.type_factory.custom_float(significand_type=ci13, scale=0.1)
     x = ti.field(dtype=cft)
 
@@ -71,7 +71,7 @@ def test_custom_float_implicit_cast():
 
 @ti.test(require=ti.extension.quant)
 def test_cache_read_only():
-    ci15 = ti.type_factory_.get_custom_int_type(15, True)
+    ci15 = ti.type_factory.custom_int(bits=15)
     cft = ti.type_factory.custom_float(significand_type=ci15, scale=0.1)
     x = ti.field(dtype=cft)
 

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -67,25 +67,33 @@ def test_custom_float_precision(digits_bits):
             assert x[None] == pytest.approx(v, rel=3e-7)
 
 
+@pytest.mark.parametrize('signed', [True, False])
 @ti.test(require=ti.extension.quant)
-def test_custom_float_truncation():
-    return
-    cu24 = ti.type_factory_.get_custom_int_type(3, True)
-    exp = ti.type_factory_.get_custom_int_type(8, False)
-    cft = ti.type_factory.custom_float(significand_type=cu24,
+def test_custom_float_truncation(signed):
+    cit = ti.type_factory_.get_custom_int_type(2, signed)
+    exp = ti.type_factory_.get_custom_int_type(5, False)
+    cft = ti.type_factory.custom_float(significand_type=cit,
                                        exponent_type=exp,
                                        scale=1)
     x = ti.field(dtype=cft)
 
     ti.root._bit_struct(num_bits=32).place(x)
 
-    tests = [np.float32(np.pi)]
-
-    for v in tests:
+    # Sufficient digits
+    for v in [1, 1.5]:
         x[None] = v
-        if digits_bits == 24:
-            assert x[None] == v
-        else:
-            # Insufficient digits
-            assert x[None] != v
-            assert x[None] == pytest.approx(v)
+        assert x[None] == v
+
+    # Insufficent digits
+    x[None] = 1.75
+    if signed:
+        assert x[None] == 1.5
+    else:
+        assert x[None] == 1.75
+
+    # Insufficent digits
+    x[None] = 1.875
+    if signed:
+        assert x[None] == 1.5
+    else:
+        assert x[None] == 1.75

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -21,10 +21,7 @@ def main():
     ti.get_runtime().materialize()
     ti.get_runtime().print_snode_tree()
 
-    x[None] = 3
-    print(x[None])
-    return
-    for v in [128, 256, 512, 1024]:
+    for v in [3, 4, 5, 6, 7, 128, 256, 512, 1024]:
         x[None] = v
         print(x[None])
         assert x[None] == v

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -21,7 +21,12 @@ def main():
     ti.get_runtime().materialize()
     ti.get_runtime().print_snode_tree()
 
-    for v in [1 / 1024, 1.75 / 1024, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 6, 7, 128, 256, 512, 1024]:
+    tests = [
+        1 / 1024, 1.75 / 1024, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 6, 7, 128, 256,
+        512, 1024
+    ]
+
+    for v in tests:
         x[None] = v
         print(v, x[None])
         assert x[None] == v

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -35,11 +35,14 @@ def test_custom_float_signed():
 
     ti.root._bit_struct(num_bits=32).place(x)
 
-    tests = [-2, -4, -6, -7, -8, -9]
+    tests = [-0.125, -0.5, -2, -4, -6, -7, -8, -9]
 
     for v in tests:
         x[None] = v
         assert x[None] == v
+
+        x[None] = -v
+        assert x[None] == -v
 
 
 @pytest.mark.parametrize('digits_bits', [23, 24])
@@ -59,10 +62,10 @@ def test_custom_float_precision(digits_bits):
     for v in tests:
         x[None] = v
         if digits_bits == 24:
+            # Sufficient digits
             assert x[None] == v
         else:
-            # The binary representation of np.float32(np.pi) ends with 1, so removing one digit will result in a different number
-            # Insufficient digits
+            # The binary representation of np.float32(np.pi) ends with 1, so removing one digit will result in a different number.
             assert x[None] != v
             assert x[None] == pytest.approx(v, rel=3e-7)
 
@@ -84,11 +87,12 @@ def test_custom_float_truncation(signed):
         x[None] = v
         assert x[None] == v
 
-    # Insufficient digits
     x[None] = 1.75
     if signed:
+        # Insufficient digits
         assert x[None] == 1.5
     else:
+        # Sufficient digits
         assert x[None] == 1.75
 
     # Insufficient digits

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -1,14 +1,8 @@
 import taichi as ti
-import math
-from pytest import approx
-
-# @ti.test(require=ti.extension.quant)
-# def test_custom_float():
 
 
-def main():
-    ti.init(print_ir=True)
-    # Note: digits_type must be unsigned with using exponent
+@ti.test(require=ti.extension.quant)
+def test_custom_float_unsigned():
     cu13 = ti.type_factory_.get_custom_int_type(13, False)
     exp = ti.type_factory_.get_custom_int_type(6, False)
     cft = ti.type_factory.custom_float(significand_type=cu13,
@@ -18,13 +12,28 @@ def main():
 
     ti.root._bit_struct(num_bits=32).place(x)
 
-    ti.get_runtime().materialize()
-    ti.get_runtime().print_snode_tree()
-
     tests = [
         1 / 1024, 1.75 / 1024, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 6, 7, 128, 256,
         512, 1024
     ]
+
+    for v in tests:
+        x[None] = v
+        assert x[None] == v
+
+
+def main():
+    ti.init()
+    cu13 = ti.type_factory_.get_custom_int_type(13, True)
+    exp = ti.type_factory_.get_custom_int_type(6, False)
+    cft = ti.type_factory.custom_float(significand_type=cu13,
+                                       exponent_type=exp,
+                                       scale=1)
+    x = ti.field(dtype=cft)
+
+    ti.root._bit_struct(num_bits=32).place(x)
+
+    tests = [-2, -4, 6, 7, -6, -7, -8]
 
     for v in tests:
         x[None] = v

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -8,9 +8,9 @@ from pytest import approx
 def main():
     ti.init(print_ir=True)
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    ci8 = ti.type_factory_.get_custom_int_type(8, True)
+    exp = ti.type_factory_.get_custom_int_type(6, True)
     cft = ti.type_factory.custom_float(significand_type=ci13,
-                                       exponent_type=ci8, scale=1)
+                                       exponent_type=exp, scale=1)
     x = ti.field(dtype=cft)
 
     ti.root._bit_struct(num_bits=32).place(x)
@@ -19,19 +19,7 @@ def main():
     ti.get_runtime().print_snode_tree()
 
 
-    @ti.kernel
-    def foo():
-        x[None] = 0.7
-        # print(x[None])
-        # x[None] = x[None] + 0.4
-
-
-    foo()
+    x[None] = 1024
     print(x[None])
-    exit(0)
-    assert x[None] == approx(1.1)
-    x[None] = 0.64
-
-    # next step: implement load/store of cft with exponents in the codegen.
 
 main()

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -54,16 +54,17 @@ def test_custom_float_precision(digits_bits):
 
     ti.root._bit_struct(num_bits=32).place(x)
 
-    tests = [np.float32(np.pi), np.float32(np.pi * 1e38)]
+    tests = [np.float32(np.pi), np.float32(np.pi * (1 << 100))]
 
     for v in tests:
         x[None] = v
         if digits_bits == 24:
             assert x[None] == v
         else:
+            # The binary representation of np.float32(np.pi) ends with 1, so removing one digit will result in a different number
             # Insufficient digits
             assert x[None] != v
-            assert x[None] == pytest.approx(v)
+            assert x[None] == pytest.approx(v, rel=3e-7)
 
 
 @ti.test(require=ti.extension.quant)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -21,9 +21,9 @@ def main():
     ti.get_runtime().materialize()
     ti.get_runtime().print_snode_tree()
 
-    for v in [3, 4, 5, 6, 7, 128, 256, 512, 1024]:
+    for v in [1 / 1024, 1.75 / 1024, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 6, 7, 128, 256, 512, 1024]:
         x[None] = v
-        print(x[None])
+        print(v, x[None])
         assert x[None] == v
 
 

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -10,7 +10,7 @@ def main():
     ti.init(print_ir=True)
     # Note: digits_type must be unsigned with using exponent
     cu13 = ti.type_factory_.get_custom_int_type(13, False)
-    exp = ti.type_factory_.get_custom_int_type(6, True)
+    exp = ti.type_factory_.get_custom_int_type(6, False)
     cft = ti.type_factory.custom_float(significand_type=cu13,
                                        exponent_type=exp,
                                        scale=1)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -27,4 +27,4 @@ foo()
 assert x[None] == approx(1.1)
 x[None] = 0.64
 
-# next step: implement struct compiler and implement load/store of cft with exponents in the codegen.
+# next step: implement load/store of cft with exponents in the codegen.

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -5,30 +5,31 @@ from pytest import approx
 # @ti.test(require=ti.extension.quant)
 # def test_custom_float():
 
-ti.init()
-ci13 = ti.type_factory_.get_custom_int_type(13, True)
-ci8 = ti.type_factory_.get_custom_int_type(8, True)
-cft = ti.type_factory.custom_float(significand_type=ci13,
-                                   exponent_type=ci8,
-                                   compute_type=ti.f32.get_ptr(),
-                                   scale=0.1)
-x = ti.field(dtype=cft)
+def main():
+    ti.init(print_ir=True)
+    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    ci8 = ti.type_factory_.get_custom_int_type(8, True)
+    cft = ti.type_factory.custom_float(significand_type=ci13,
+                                       exponent_type=ci8, scale=1)
+    x = ti.field(dtype=cft)
 
-ti.root._bit_struct(num_bits=32).place(x)
+    ti.root._bit_struct(num_bits=32).place(x)
 
-ti.get_runtime().materialize()
-ti.get_runtime().print_snode_tree()
-
-
-@ti.kernel
-def foo():
-    x[None] = 0.7
-    print(x[None])
-    x[None] = x[None] + 0.4
+    ti.get_runtime().materialize()
+    ti.get_runtime().print_snode_tree()
 
 
-foo()
-assert x[None] == approx(1.1)
-x[None] = 0.64
+    @ti.kernel
+    def foo():
+        x[None] = 0.7
+        print(x[None])
+        x[None] = x[None] + 0.4
 
-# next step: implement load/store of cft with exponents in the codegen.
+
+    foo()
+    assert x[None] == approx(1.1)
+    x[None] = 0.64
+
+    # next step: implement load/store of cft with exponents in the codegen.
+
+main()

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -5,12 +5,14 @@ from pytest import approx
 # @ti.test(require=ti.extension.quant)
 # def test_custom_float():
 
+
 def main():
     ti.init(print_ir=True)
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     exp = ti.type_factory_.get_custom_int_type(6, True)
     cft = ti.type_factory.custom_float(significand_type=ci13,
-                                       exponent_type=exp, scale=1)
+                                       exponent_type=exp,
+                                       scale=1)
     x = ti.field(dtype=cft)
 
     ti.root._bit_struct(num_bits=32).place(x)
@@ -18,8 +20,10 @@ def main():
     ti.get_runtime().materialize()
     ti.get_runtime().print_snode_tree()
 
+    for v in [128, 256, 512, 1024]:
+        x[None] = v
+        print(x[None])
+        assert x[None] == v
 
-    x[None] = 1024
-    print(x[None])
 
 main()

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -1,6 +1,6 @@
 import taichi as ti
 import math
-# from pytest import approx
+from pytest import approx
 
 
 # @ti.test(require=ti.extension.quant)
@@ -11,10 +11,11 @@ ci13 = ti.type_factory_.get_custom_int_type(13, True)
 ci8 = ti.type_factory_.get_custom_int_type(8, True)
 cft = ti.type_factory.custom_float(significand_type=ci13, compute_type=ti.f32.get_ptr(), scale=0.1)
 x = ti.field(dtype=cft)
-y = ti.field(dtype=cft)
-z = ti.field(dtype=cft)
 
-ti.root._bit_struct(num_bits=32).place(x, y, z, shared_exponent=True)
+ti.root._bit_struct(num_bits=32).place(x)
+
+ti.get_runtime().materialize()
+ti.get_runtime().print_snode_tree()
 
 @ti.kernel
 def foo():
@@ -25,6 +26,5 @@ def foo():
 foo()
 assert x[None] == approx(1.1)
 x[None] = 0.64
-assert x[None] == approx(0.6)
-x[None] = 0.66
-assert x[None] == approx(0.7)
+
+# next step: implement struct compiler and implement load/store of cft with exponents in the codegen.

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -9,7 +9,7 @@ from pytest import approx
 ti.init()
 ci13 = ti.type_factory_.get_custom_int_type(13, True)
 ci8 = ti.type_factory_.get_custom_int_type(8, True)
-cft = ti.type_factory.custom_float(significand_type=ci13, compute_type=ti.f32.get_ptr(), scale=0.1)
+cft = ti.type_factory.custom_float(significand_type=ci13, exponent_type=ci8, compute_type=ti.f32.get_ptr(), scale=0.1)
 x = ti.field(dtype=cft)
 
 ti.root._bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -20,6 +20,9 @@ def main():
     ti.get_runtime().materialize()
     ti.get_runtime().print_snode_tree()
 
+    x[None] = 3
+    print(x[None])
+    return
     for v in [128, 256, 512, 1024]:
         x[None] = v
         print(x[None])

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -1,0 +1,30 @@
+import taichi as ti
+import math
+# from pytest import approx
+
+
+# @ti.test(require=ti.extension.quant)
+# def test_custom_float():
+
+ti.init()
+ci13 = ti.type_factory_.get_custom_int_type(13, True)
+ci8 = ti.type_factory_.get_custom_int_type(8, True)
+cft = ti.type_factory.custom_float(significand_type=ci13, compute_type=ti.f32.get_ptr(), scale=0.1)
+x = ti.field(dtype=cft)
+y = ti.field(dtype=cft)
+z = ti.field(dtype=cft)
+
+ti.root._bit_struct(num_bits=32).place(x, y, z, shared_exponent=True)
+
+@ti.kernel
+def foo():
+    x[None] = 0.7
+    print(x[None])
+    x[None] = x[None] + 0.4
+
+foo()
+assert x[None] == approx(1.1)
+x[None] = 0.64
+assert x[None] == approx(0.6)
+x[None] = 0.66
+assert x[None] == approx(0.7)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -5,8 +5,8 @@ import pytest
 
 @ti.test(require=ti.extension.quant)
 def test_custom_float_unsigned():
-    cu13 = ti.type_factory_.get_custom_int_type(13, False)
-    exp = ti.type_factory_.get_custom_int_type(6, False)
+    cu13 = ti.type_factory.custom_int(13, False)
+    exp = ti.type_factory.custom_int(6, False)
     cft = ti.type_factory.custom_float(significand_type=cu13,
                                        exponent_type=exp,
                                        scale=1)
@@ -26,8 +26,8 @@ def test_custom_float_unsigned():
 
 @ti.test(require=ti.extension.quant)
 def test_custom_float_signed():
-    cu13 = ti.type_factory_.get_custom_int_type(13, True)
-    exp = ti.type_factory_.get_custom_int_type(6, False)
+    cu13 = ti.type_factory.custom_int(13, True)
+    exp = ti.type_factory.custom_int(6, False)
     cft = ti.type_factory.custom_float(significand_type=cu13,
                                        exponent_type=exp,
                                        scale=1)
@@ -45,8 +45,8 @@ def test_custom_float_signed():
 @pytest.mark.parametrize('digits_bits', [23, 24])
 @ti.test(require=ti.extension.quant)
 def test_custom_float_precision(digits_bits):
-    cu24 = ti.type_factory_.get_custom_int_type(digits_bits, True)
-    exp = ti.type_factory_.get_custom_int_type(8, False)
+    cu24 = ti.type_factory.custom_int(digits_bits, True)
+    exp = ti.type_factory.custom_int(8, False)
     cft = ti.type_factory.custom_float(significand_type=cu24,
                                        exponent_type=exp,
                                        scale=1)
@@ -70,8 +70,8 @@ def test_custom_float_precision(digits_bits):
 @pytest.mark.parametrize('signed', [True, False])
 @ti.test(require=ti.extension.quant)
 def test_custom_float_truncation(signed):
-    cit = ti.type_factory_.get_custom_int_type(2, signed)
-    exp = ti.type_factory_.get_custom_int_type(5, False)
+    cit = ti.type_factory.custom_int(2, signed)
+    exp = ti.type_factory.custom_int(5, False)
     cft = ti.type_factory.custom_float(significand_type=cit,
                                        exponent_type=exp,
                                        scale=1)
@@ -84,14 +84,14 @@ def test_custom_float_truncation(signed):
         x[None] = v
         assert x[None] == v
 
-    # Insufficent digits
+    # Insufficient digits
     x[None] = 1.75
     if signed:
         assert x[None] == 1.5
     else:
         assert x[None] == 1.75
 
-    # Insufficent digits
+    # Insufficient digits
     x[None] = 1.875
     if signed:
         assert x[None] == 1.5

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -22,11 +22,13 @@ def main():
     @ti.kernel
     def foo():
         x[None] = 0.7
-        print(x[None])
-        x[None] = x[None] + 0.4
+        # print(x[None])
+        # x[None] = x[None] + 0.4
 
 
     foo()
+    print(x[None])
+    exit(0)
     assert x[None] == approx(1.1)
     x[None] = 0.64
 

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -2,14 +2,16 @@ import taichi as ti
 import math
 from pytest import approx
 
-
 # @ti.test(require=ti.extension.quant)
 # def test_custom_float():
 
 ti.init()
 ci13 = ti.type_factory_.get_custom_int_type(13, True)
 ci8 = ti.type_factory_.get_custom_int_type(8, True)
-cft = ti.type_factory.custom_float(significand_type=ci13, exponent_type=ci8, compute_type=ti.f32.get_ptr(), scale=0.1)
+cft = ti.type_factory.custom_float(significand_type=ci13,
+                                   exponent_type=ci8,
+                                   compute_type=ti.f32.get_ptr(),
+                                   scale=0.1)
 x = ti.field(dtype=cft)
 
 ti.root._bit_struct(num_bits=32).place(x)
@@ -17,11 +19,13 @@ ti.root._bit_struct(num_bits=32).place(x)
 ti.get_runtime().materialize()
 ti.get_runtime().print_snode_tree()
 
+
 @ti.kernel
 def foo():
     x[None] = 0.7
     print(x[None])
     x[None] = x[None] + 0.4
+
 
 foo()
 assert x[None] == approx(1.1)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -8,9 +8,10 @@ from pytest import approx
 
 def main():
     ti.init(print_ir=True)
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    # Note: digits_type must be unsigned with using exponent
+    cu13 = ti.type_factory_.get_custom_int_type(13, False)
     exp = ti.type_factory_.get_custom_int_type(6, True)
-    cft = ti.type_factory.custom_float(significand_type=ci13,
+    cft = ti.type_factory.custom_float(significand_type=cu13,
                                        exponent_type=exp,
                                        scale=1)
     x = ti.field(dtype=cft)

--- a/tests/python/test_custom_type_atomics.py
+++ b/tests/python/test_custom_type_atomics.py
@@ -64,8 +64,8 @@ def test_custom_int_atomics_b64():
 def test_custom_float_atomics():
     ci13 = ti.type_factory_.get_custom_int_type(13, True)
     ci19 = ti.type_factory_.get_custom_int_type(19, False)
-    cft13 = ti.type_factory_.get_custom_float_type(ci13, ti.f32.get_ptr(), 0.1)
-    cft19 = ti.type_factory_.get_custom_float_type(ci19, ti.f32.get_ptr(), 0.1)
+    cft13 = ti.type_factory.custom_float(significand_type=ci13, scale=0.1)
+    cft19 = ti.type_factory.custom_float(significand_type=ci19, scale=0.1)
 
     x = ti.field(dtype=cft13)
     y = ti.field(dtype=cft19)


### PR DESCRIPTION
Related issue = #1905

- Add `TypeFactory` Python class
- `CustomFloatType` now supports exponents (`GlobalLoad/Store`)
- `shared_exponent` API (implementation in the next PR)
- LLVM codegen refactorings
- `place(CustomFloatType)` SNodes now has a pointer to its exponent SNode
- Children of `bit_struct` SNode now has `bit_offset`

(This is, unfortunately, a lot of implementation details and "magic" numbers, especially the conversion between `CustomFloatType` and IEEE 754 `f32`).

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
