### PR TITLE
[async] Add explicit flush API and async_flush_every

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -793,4 +793,8 @@ def sync():
     get_runtime().sync()
 
 
+def async_flush():
+    get_runtime().prog.async_flush()
+
+
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -275,6 +275,7 @@ void AsyncEngine::flush() {
   for (auto &task : tasks) {
     queue.enqueue(task);
   }
+  flush_counter_++;
 }
 
 void AsyncEngine::debug_sfg(const std::string &stage) {
@@ -289,8 +290,9 @@ void AsyncEngine::debug_sfg(const std::string &stage) {
             debug_limit);
     return;
   }
-  auto dot_fn = fmt::format("{}_sync{:04d}_{:04d}_{}", prefix, sync_counter_,
-                            cur_sync_sfg_debug_counter_++, stage);
+  auto dot_fn =
+      fmt::format("{}_flush{:04d}_sync{:04d}_{:04d}_{}", prefix, flush_counter_,
+                  sync_counter_, cur_sync_sfg_debug_counter_++, stage);
   auto stage_count = cur_sync_sfg_debug_per_stage_counts_[stage]++;
   if (stage_count) {
     dot_fn += std::to_string(stage_count);

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -205,11 +205,29 @@ void AsyncEngine::launch(Kernel *kernel, Context &context) {
     TaskLaunchRecord rec(context, kernel, kmeta.ir_handle_cached[i]);
     records.push_back(rec);
   }
-  sfg->insert_tasks(records, program->config.async_listgen_fast_filtering);
+  const auto &config = program->config;
+  sfg->insert_tasks(records, config.async_listgen_fast_filtering);
+  if ((config.async_flush_every > 0) &&
+      (sfg->num_pending_tasks() >= config.async_flush_every)) {
+    TI_TRACE("Async flushing {} tasks", sfg->num_pending_tasks());
+    flush();
+  }
 }
 
 void AsyncEngine::synchronize() {
   TI_AUTO_PROF;
+  flush();
+  queue.synchronize();
+
+  sync_counter_++;
+  // Clear SFG debug stats
+  cur_sync_sfg_debug_counter_ = 0;
+  cur_sync_sfg_debug_per_stage_counts_.clear();
+}
+
+void AsyncEngine::flush() {
+  TI_AUTO_PROF;
+
   bool modified = true;
   sfg->reid_nodes();
   sfg->reid_pending_nodes();
@@ -257,12 +275,6 @@ void AsyncEngine::synchronize() {
   for (auto &task : tasks) {
     queue.enqueue(task);
   }
-  queue.synchronize();
-
-  sync_counter_++;
-  // Clear SFG debug stats
-  cur_sync_sfg_debug_counter_ = 0;
-  cur_sync_sfg_debug_per_stage_counts_.clear();
 }
 
 void AsyncEngine::debug_sfg(const std::string &stage) {

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -144,6 +144,9 @@ class AsyncEngine {
 
   void launch(Kernel *kernel, Context &context);
 
+  // Flush the tasks only.
+  void flush();
+  // Flush the tasks and block waiting for the GPU device to complete.
   void synchronize();
 
   void debug_sfg(const std::string &suffix);

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -167,6 +167,8 @@ class AsyncEngine {
   };
 
   std::unordered_map<const Kernel *, KernelMeta> kernel_metas_;
+  // How many times we have flushed
+  int flush_counter_{0};
   // How many times we have synchronized
   int sync_counter_{0};
   int cur_sync_sfg_debug_counter_{0};

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "taichi/lang_util.h"
 #include "arch.h"
+#include "taichi/lang_util.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -60,12 +60,14 @@ struct CompileConfig {
   std::string cc_compile_cmd;
   std::string cc_link_cmd;
 
+  // Async options
   bool async_opt_fusion{true};
   bool async_opt_listgen{true};
   bool async_opt_activation_demotion{true};
   bool async_opt_dse{true};
   bool async_listgen_fast_filtering{true};
   std::string async_opt_intermediate_file;
+  int async_flush_every{0};
 
   CompileConfig();
 };

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -495,6 +495,14 @@ void Program::device_synchronize() {
   }
 }
 
+void Program::async_flush() {
+  if (!config.async_mode) {
+    TI_WARN("No point calling async_flush() when async mode is disabled.");
+    return;
+  }
+  async_engine->flush();
+}
+
 std::string capitalize_first(std::string s) {
   s[0] = std::toupper(s[0]);
   return s;

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -141,6 +141,9 @@ class Program {
   // This is more primitive than synchronize(). It directly calls to the
   // targeted GPU backend's synchronization (or commit in Metal's terminology).
   void device_synchronize();
+  // See AsyncEngine::flush().
+  // Only useful when async mode is enabled.
+  void async_flush();
 
   void layout(std::function<void()> func) {
     func();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -169,7 +169,8 @@ void export_lang(py::module &m) {
       .def_readwrite("async_listgen_fast_filtering",
                      &CompileConfig::async_listgen_fast_filtering)
       .def_readwrite("async_opt_intermediate_file",
-                     &CompileConfig::async_opt_intermediate_file);
+                     &CompileConfig::async_opt_intermediate_file)
+      .def_readwrite("async_flush_every", &CompileConfig::async_flush_every);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
@@ -200,7 +201,8 @@ void export_lang(py::module &m) {
            [](Program *program) {
              program->async_engine->sfg->benchmark_rebuild_graph();
            })
-      .def("synchronize", &Program::synchronize);
+      .def("synchronize", &Program::synchronize)
+      .def("async_flush", &Program::async_flush);
 
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);


### PR DESCRIPTION
Related issue = #742

By flushing more frequently, we can have wider CPU-GPU execution overlap. MGPCG (res=512) async E2E execution has been reduced from ~0.25s to ~0.15s when flushing every 50 tasks. 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
