### PR TITLE
[type] Add BitStructStoreStmt and corresponding passes

### DIFF
--- a/misc/benchmark_bit_struct_stores.py
+++ b/misc/benchmark_bit_struct_stores.py
@@ -7,7 +7,7 @@ quant = True
 n = 1024 * 1024 * 256
 
 if quant:
-    ci16 = ti.type_factory_.get_custom_int_type(16, True)
+    ci16 = ti.type_factory.custom_int(16, True)
 
     x = ti.field(dtype=ci16)
     y = ti.field(dtype=ci16)

--- a/misc/benchmark_bit_struct_stores.py
+++ b/misc/benchmark_bit_struct_stores.py
@@ -1,0 +1,33 @@
+import taichi as ti
+
+ti.init(arch=ti.cpu, kernel_profiler=True, print_ir=True)
+
+quant = True
+
+n = 1024 * 1024 * 256
+
+if quant:
+    ci16 = ti.type_factory_.get_custom_int_type(16, True)
+
+    x = ti.field(dtype=ci16)
+    y = ti.field(dtype=ci16)
+
+    ti.root.dense(ti.i, n)._bit_struct(num_bits=32).place(x, y)
+else:
+    x = ti.field(dtype=ti.i16)
+    y = ti.field(dtype=ti.i16)
+
+    ti.root.dense(ti.i, n).place(x, y)
+
+
+@ti.kernel
+def foo():
+    for i in range(n):
+        x[i] = i & 1023
+        y[i] = i & 15
+
+
+for i in range(10):
+    foo()
+
+ti.kernel_profiler_print()

--- a/python/taichi/lang/type_factory.py
+++ b/python/taichi/lang/type_factory.py
@@ -3,8 +3,8 @@ class TypeFactory:
         from taichi.core import ti_core
         self.core = ti_core.get_type_factory_instance()
 
-    def custom_int(self, bits, signed=True):
-        return self.core.get_custom_int_type(bits, signed)
+    def custom_int(self, bits, signed=True, compute_bits=0):
+        return self.core.get_custom_int_type(bits, signed, compute_bits)
 
     def custom_float(self,
                      significand_type,

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1269,14 +1269,30 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
   }
 }
 
+llvm::Value *CodeGenLLVM::custom_type_to_bits(llvm::Value *val,
+                                              Type *input_type,
+                                              Type *output_type) {
+  if (auto cft = input_type->cast<CustomFloatType>()) {
+    TI_ASSERT(cft->get_exponent_type() == nullptr);
+    val = float_to_custom_int(cft, cft->get_digits_type()->as<CustomIntType>(),
+                              val);
+  }
+  val = builder->CreateZExt(val, llvm_type(output_type));
+  return val;
+}
+
 void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
   auto bit_struct_snode = stmt->get_bit_struct_snode();
+  auto bit_struct_physical_type =
+      bit_struct_snode->dt->as<BitStructType>()->get_physical_type();
   if (stmt->ch_ids.size() == bit_struct_snode->ch.size()) {
     // Store all the components
     llvm::Value *bit_struct_val = nullptr;
     for (int i = 0; i < stmt->ch_ids.size(); i++) {
       auto ch_id = stmt->ch_ids[i];
       auto val = llvm_val[stmt->values[i]];
+      auto dtype = bit_struct_snode->ch[ch_id]->dt.get_ptr();
+      val = custom_type_to_bits(val, dtype, bit_struct_physical_type);
       val = builder->CreateShl(val, bit_struct_snode->ch[ch_id]->bit_offset);
       if (bit_struct_val == nullptr) {
         bit_struct_val = val;
@@ -1291,8 +1307,18 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       auto ch_id = stmt->ch_ids[i];
       auto val = stmt->values[i];
       auto &ch = bit_struct_snode->ch[ch_id];
+      auto dtype = ch->dt;
+      CustomIntType *cit = nullptr;
+      if (auto cft = dtype->cast<CustomFloatType>()) {
+        TI_ASSERT(cft->get_exponent_type() == nullptr);
+        cit = cft->get_digits_type()->as<CustomIntType>();
+      } else {
+        cit = dtype->as<CustomIntType>();
+      }
       store_custom_int(llvm_val[stmt->ptr], tlctx->get_constant(ch->bit_offset),
-                       ch->dt->as<CustomIntType>(), llvm_val[val]);
+                       cit,
+                       custom_type_to_bits(llvm_val[val], dtype.get_ptr(),
+                                           bit_struct_physical_type));
     }
   }
 }

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -192,10 +192,10 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_custom_int(AtomicOpStmt *stmt, CustomIntType *cit);
-
   llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt,
                                        CustomFloatType *cft);
+
+  llvm::Value *atomic_add_custom_int(AtomicOpStmt *stmt, CustomIntType *cit);
 
   llvm::Value *float_to_custom_int(CustomFloatType *cft,
                                    CustomIntType *cit,
@@ -215,6 +215,10 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                         llvm::Value *value);
 
   void visit(GlobalStoreStmt *stmt) override;
+
+  llvm::Value *custom_type_to_bits(llvm::Value *val,
+                                   Type *input_type,
+                                   Type *output_type);
 
   void visit(BitStructStoreStmt *stmt) override;
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -209,7 +209,14 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                         CustomIntType *cit,
                         llvm::Value *value);
 
+  void store_custom_int(llvm::Value *byte_ptr,
+                        llvm::Value *bit_offset,
+                        CustomIntType *cit,
+                        llvm::Value *value);
+
   void visit(GlobalStoreStmt *stmt) override;
+
+  void visit(BitStructStoreStmt *stmt) override;
 
   llvm::Value *load_as_custom_int(llvm::Value *ptr, Type *load_type);
 

--- a/taichi/inc/statements.inc.h
+++ b/taichi/inc/statements.inc.h
@@ -82,3 +82,6 @@ PER_STATEMENT(BlockLocalPtrStmt)
 
 // Special
 PER_STATEMENT(InternalFuncStmt)
+
+// Quantization
+PER_STATEMENT(BitStructStoreStmt)

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -391,4 +391,8 @@ int LoopIndexStmt::max_num_bits() const {
   }
 }
 
+SNode *BitStructStoreStmt::get_bit_struct_snode() const {
+  return ptr->as<SNodeLookupStmt>()->snode;
+}
+
 TLANG_NAMESPACE_END

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1165,4 +1165,28 @@ class StackAccAdjointStmt : public Stmt {
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 
+class BitStructStoreStmt : public Stmt {
+ public:
+  Stmt *ptr;
+  std::vector<int> ch_ids;
+  std::vector<Stmt *> values;
+
+  BitStructStoreStmt(Stmt *ptr,
+                     const std::vector<int> &ch_ids,
+                     const std::vector<Stmt *> &values)
+      : ptr(ptr), ch_ids(ch_ids), values(values) {
+    TI_ASSERT(ch_ids.size() == values.size());
+    TI_STMT_REG_FIELDS;
+  }
+
+  SNode *get_bit_struct_snode() const;
+
+  bool common_statement_eliminable() const override {
+    return false;
+  }
+
+  TI_STMT_DEF_FIELDS(ret_type, ptr, ch_ids, values);
+  TI_DEFINE_ACCEPT_AND_CLONE;
+};
+
 TLANG_NAMESPACE_END

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -62,6 +62,7 @@ void demote_dense_struct_fors(IRNode *root);
 bool demote_atomics(IRNode *root);
 void reverse_segments(IRNode *root);  // for autograd
 void detect_read_only(IRNode *root);
+void optimize_bit_struct_stores(IRNode *root);
 
 // compile_to_offloads does the basic compilation to create all the offloaded
 // tasks of a Taichi kernel. It's worth pointing out that this doesn't demote

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -74,8 +74,11 @@ class DataType {
     return ptr_->to_string();
   };
 
-  // TODO: DataType itself should be a pointer in the future
-  Type *get_ptr() const {
+  operator const Type *() const {
+    return ptr_;
+  }
+
+  operator Type *() {
     return ptr_;
   }
 

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -40,6 +40,9 @@ Type *TypeFactory::get_pointer_type(Type *element, bool is_bit_pointer) {
 Type *TypeFactory::get_custom_int_type(int num_bits,
                                        bool is_signed,
                                        int compute_type_bits) {
+  if (compute_type_bits == 0) {
+    compute_type_bits = 32;
+  }
   auto key = std::make_tuple(compute_type_bits, num_bits, is_signed);
   if (custom_int_types.find(key) == custom_int_types.end()) {
     custom_int_types[key] = std::make_unique<CustomIntType>(

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -91,7 +91,7 @@ PrimitiveType *TypeFactory::get_primitive_int_type(int bits, bool is_signed) {
     TI_ERROR("No primitive int type has {} bits", bits);
   }
   if (!is_signed) {
-    int_type = to_unsigned(DataType(int_type)).get_ptr();
+    int_type = to_unsigned(DataType(int_type));
   }
   return int_type->cast<PrimitiveType>();
 }
@@ -101,7 +101,7 @@ DataType TypeFactory::create_vector_or_scalar_type(int width,
                                                    bool element_is_pointer) {
   TI_ASSERT(width == 1);
   if (element_is_pointer) {
-    return TypeFactory::get_instance().get_pointer_type(element.get_ptr());
+    return TypeFactory::get_instance().get_pointer_type(element);
   } else {
     return element;
   }

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -23,7 +23,7 @@ class TypeFactory {
 
   Type *get_custom_int_type(int num_bits,
                             bool is_signed,
-                            int compute_type_bits = 32);
+                            int compute_type_bits = 0);
 
   Type *get_custom_float_type(Type *digits_type,
                               Type *exponent_type,

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -360,8 +360,7 @@ class TypePromotionMapping {
  private:
   std::map<std::pair<PrimitiveTypeID, PrimitiveTypeID>, PrimitiveTypeID>
       mapping;
-  static PrimitiveTypeID to_primitive_type(const DataType d_) {
-    Type *d = d_.get_ptr();
+  static PrimitiveTypeID to_primitive_type(DataType d) {
     if (d->is<PointerType>()) {
       d = d->as<PointerType>()->get_pointee_type();
       TI_WARN("promoted_type got a pointer input.");

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -588,6 +588,8 @@ llvm::Value *TaichiLLVMContext::get_constant(DataType dt, T t) {
 
 template llvm::Value *TaichiLLVMContext::get_constant(DataType dt, int32 t);
 template llvm::Value *TaichiLLVMContext::get_constant(DataType dt, int64 t);
+template llvm::Value *TaichiLLVMContext::get_constant(DataType dt, uint32 t);
+template llvm::Value *TaichiLLVMContext::get_constant(DataType dt, uint64 t);
 template llvm::Value *TaichiLLVMContext::get_constant(DataType dt, float32 t);
 template llvm::Value *TaichiLLVMContext::get_constant(DataType dt, float64 t);
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -573,14 +573,14 @@ llvm::Value *TaichiLLVMContext::get_constant(DataType dt, T t) {
     return llvm::ConstantFP::get(*ctx, llvm::APFloat((float32)t));
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
     return llvm::ConstantFP::get(*ctx, llvm::APFloat((float64)t));
-  } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
-    return llvm::ConstantInt::get(*ctx, llvm::APInt(32, t, true));
-  } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
-    return llvm::ConstantInt::get(*ctx, llvm::APInt(32, t, false));
-  } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
-    return llvm::ConstantInt::get(*ctx, llvm::APInt(64, t, true));
-  } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    return llvm::ConstantInt::get(*ctx, llvm::APInt(64, t, false));
+  } else if (is_integral(dt)) {
+    if (is_signed(dt)) {
+      return llvm::ConstantInt::get(*ctx,
+                                    llvm::APInt(data_type_bits(dt), t, true));
+    } else {
+      return llvm::ConstantInt::get(*ctx,
+                                    llvm::APInt(data_type_bits(dt), t, false));
+    }
   } else {
     TI_NOT_IMPLEMENTED
   }

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -575,11 +575,11 @@ llvm::Value *TaichiLLVMContext::get_constant(DataType dt, T t) {
     return llvm::ConstantFP::get(*ctx, llvm::APFloat((float64)t));
   } else if (is_integral(dt)) {
     if (is_signed(dt)) {
-      return llvm::ConstantInt::get(*ctx,
-                                    llvm::APInt(data_type_bits(dt), t, true));
+      return llvm::ConstantInt::get(
+          *ctx, llvm::APInt(data_type_bits(dt), (uint64_t)t, true));
     } else {
-      return llvm::ConstantInt::get(*ctx,
-                                    llvm::APInt(data_type_bits(dt), t, false));
+      return llvm::ConstantInt::get(
+          *ctx, llvm::APInt(data_type_bits(dt), (uint64_t)t, false));
     }
   } else {
     TI_NOT_IMPLEMENTED

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -89,7 +89,7 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
-      .def("get_ptr", [](const DataType &dtype) -> Type * { return dtype; },
+      .def("get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
            py::return_value_policy::reference)
       .def(py::pickle(
           [](const DataType &dt) {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -741,7 +741,7 @@ void export_lang(py::module &m) {
   py::class_<TypeFactory>(m, "TypeFactory")
       .def("get_custom_int_type", &TypeFactory::get_custom_int_type,
            py::arg("num_bits"), py::arg("is_signed"),
-           py::arg("compute_type_bits") = 32,
+           py::arg("compute_type_bits") = 0,
            py::return_value_policy::reference)
       .def("get_custom_float_type", &TypeFactory::get_custom_float_type,
            py::arg("digits_type"), py::arg("exponent_type"),

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -89,11 +89,13 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
-      .def("get_ptr", &DataType::get_ptr, py::return_value_policy::reference)
+      .def("get_ptr", [](const DataType &dtype) -> Type * { return dtype; },
+           py::return_value_policy::reference)
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.
-            auto primitive = dynamic_cast<const PrimitiveType *>(dt.get_ptr());
+            auto primitive =
+                dynamic_cast<const PrimitiveType *>((const Type *)dt);
             TI_ASSERT(primitive);
             return py::make_tuple((std::size_t)primitive->type);
           },

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -741,8 +741,7 @@ void export_lang(py::module &m) {
   py::class_<TypeFactory>(m, "TypeFactory")
       .def("get_custom_int_type", &TypeFactory::get_custom_int_type,
            py::arg("num_bits"), py::arg("is_signed"),
-           py::arg("compute_type_bits") = 0,
-           py::return_value_policy::reference)
+           py::arg("compute_type_bits") = 0, py::return_value_policy::reference)
       .def("get_custom_float_type", &TypeFactory::get_custom_float_type,
            py::arg("digits_type"), py::arg("exponent_type"),
            py::arg("compute_type"), py::arg("scale"),

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -65,7 +65,7 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
     int total_offset = 0;
     for (int i = 0; i < snode.ch.size(); i++) {
       auto &ch = snode.ch[i];
-      ch_types.push_back(ch->dt.get_ptr());
+      ch_types.push_back(ch->dt);
       ch_offsets.push_back(total_offset);
       CustomIntType *component_cit = nullptr;
       if (auto cit = ch->dt->cast<CustomIntType>()) {
@@ -94,7 +94,7 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
     // A bit array SNode should have only one child
     TI_ASSERT(snode.ch.size() == 1);
     auto &ch = snode.ch[0];
-    Type *ch_type = ch->dt.get_ptr();
+    Type *ch_type = ch->dt;
     ch->dt->as<CustomIntType>()->set_physical_type(snode.physical_type);
     if (!arch_is_cpu(arch)) {
       TI_ERROR_IF(data_type_bits(snode.physical_type) <= 16,

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -3,6 +3,7 @@
 #include "taichi/ir/analysis.h"
 #include "taichi/ir/visitors.h"
 #include "taichi/program/kernel.h"
+#include "taichi/program/extension.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -201,6 +202,11 @@ void offload_to_executable(IRNode *ir,
 
   irpass::full_simplify(ir, lower_global_access);
   print("Simplified IV");
+
+  if (is_extension_supported(config.arch, Extension::quant)) {
+    irpass::optimize_bit_struct_stores(ir);
+    print("Bit struct stores optimized");
+  }
 
   // Final field registration correctness & type checking
   irpass::type_check(ir);

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -609,6 +609,21 @@ class IRPrinter : public IRVisitor {
     print("external_tensor_shape_along_axis {}, arg_id {}", stmt->axis,
           stmt->arg_id);
   }
+
+  void visit(BitStructStoreStmt *stmt) override {
+    std::string ch_ids;
+    std::string values;
+    for (int i = 0; i < stmt->ch_ids.size(); i++) {
+      ch_ids += fmt::format("{}", stmt->ch_ids[i]);
+      values += fmt::format("{}", stmt->values[i]->name());
+      if (i != stmt->ch_ids.size() - 1) {
+        ch_ids += ", ";
+        values += ", ";
+      }
+    }
+    print("{} : bit_struct_store {}, ch_ids=[{}], values=[{}]", stmt->name(),
+          stmt->ptr->name(), ch_ids, values);
+  }
 };
 
 namespace irpass {

--- a/taichi/transforms/loop_vectorize.cpp
+++ b/taichi/transforms/loop_vectorize.cpp
@@ -25,7 +25,7 @@ class LoopVectorize : public IRVisitor {
 
   static void widen_type(DataType &type, int width) {
     if (width != 1) {
-      type = Program::get_type_factory().get_vector_type(width, type.get_ptr());
+      type = Program::get_type_factory().get_vector_type(width, type);
     }
   }
 

--- a/taichi/transforms/optimize_bit_struct_stores.cpp
+++ b/taichi/transforms/optimize_bit_struct_stores.cpp
@@ -1,0 +1,48 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/ir/visitors.h"
+
+namespace {
+
+using namespace taichi;
+using namespace taichi::lang;
+
+class CreateBitStructStores : public BasicStmtVisitor {
+ public:
+  CreateBitStructStores() {
+    allow_undefined_visitor = true;
+    invoke_default_visitor = false;
+  }
+
+  void run(IRNode *root) {
+    root->accept(this);
+  }
+
+  void visit(GlobalStoreStmt *stmt) {
+    auto get_ch = stmt->ptr->cast<GetChStmt>();
+    if (!get_ch || get_ch->input_snode->type != SNodeType::bit_struct)
+      return;
+
+    // We only handle bit_struct pointers here
+    auto s = Stmt::make<BitStructStoreStmt>(get_ch->input_ptr,
+                                            std::vector<int>{get_ch->chid},
+                                            std::vector<Stmt *>{stmt->data});
+    stmt->replace_with(VecStatement(std::move(s)));
+  }
+};
+}  // namespace
+
+TLANG_NAMESPACE_BEGIN
+
+namespace irpass {
+void optimize_bit_struct_stores(IRNode *root) {
+  TI_AUTO_PROF;
+  CreateBitStructStores opt;
+  opt.run(root);
+  die(root);  // remove unused GetCh
+}
+
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/optimize_bit_struct_stores.cpp
+++ b/taichi/transforms/optimize_bit_struct_stores.cpp
@@ -93,6 +93,7 @@ class MergeBitStructStores : public BasicStmtVisitor {
               Stmt::make<BitStructStoreStmt>(ptr, ch_ids, store_values));
           modified_ = true;
         }
+        ptr_to_bit_struct_stores.clear();
         continue;
       }
       if (auto stmt = statements[i]->cast<BitStructStoreStmt>()) {

--- a/taichi/transforms/optimize_bit_struct_stores.cpp
+++ b/taichi/transforms/optimize_bit_struct_stores.cpp
@@ -27,11 +27,16 @@ class CreateBitStructStores : public BasicStmtVisitor {
     if (!get_ch || get_ch->input_snode->type != SNodeType::bit_struct)
       return;
 
-    // We only handle bit_struct pointers here
-    auto s = Stmt::make<BitStructStoreStmt>(get_ch->input_ptr,
-                                            std::vector<int>{get_ch->chid},
-                                            std::vector<Stmt *>{stmt->data});
-    stmt->replace_with(VecStatement(std::move(s)));
+    // We only handle bit_struct pointers here. The currently supported data
+    // types are CustomIntType and CustomFloatType without exponents.
+    auto dtype = get_ch->output_snode->dt;
+    if (dtype->is<CustomIntType>() ||
+        dtype->as<CustomFloatType>()->get_exponent_type() == nullptr) {
+      auto s = Stmt::make<BitStructStoreStmt>(get_ch->input_ptr,
+                                              std::vector<int>{get_ch->chid},
+                                              std::vector<Stmt *>{stmt->data});
+      stmt->replace_with(VecStatement(std::move(s)));
+    }
   }
 };
 

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -481,6 +481,10 @@ class TypeCheck : public IRVisitor {
   void visit(GlobalTemporaryStmt *stmt) {
     stmt->ret_type.set_is_pointer(true);
   }
+
+  void visit(BitStructStoreStmt *stmt) {
+    // do nothing
+  }
 };
 
 namespace irpass {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -129,8 +129,8 @@ class TypeCheck : public IRVisitor {
     }
     stmt->ret_type.set_is_pointer(true);
     if (stmt->snodes) {
-      stmt->ret_type = TypeFactory::get_instance().get_pointer_type(
-          stmt->snodes[0]->dt.get_ptr());
+      stmt->ret_type =
+          TypeFactory::get_instance().get_pointer_type(stmt->snodes[0]->dt);
     } else
       TI_WARN("[{}] Type inference failed: snode is nullptr.", stmt->name());
     for (int l = 0; l < stmt->snodes.size(); l++) {
@@ -400,7 +400,7 @@ class TypeCheck : public IRVisitor {
 
   void visit(SNodeLookupStmt *stmt) {
     if (stmt->snode->type == SNodeType::bit_array) {
-      auto bit_array_type = stmt->snode->dt.get_ptr();
+      auto bit_array_type = stmt->snode->dt;
       auto element_type =
           bit_array_type->cast<BitArrayType>()->get_element_type();
       auto pointer_type =
@@ -425,7 +425,7 @@ class TypeCheck : public IRVisitor {
     // For bit_struct SNodes, their component SNodes must have
     // is_bit_level=true
     auto pointer_type = TypeFactory::get_instance().get_pointer_type(
-        element_type.get_ptr(), stmt->output_snode->is_bit_level);
+        element_type, stmt->output_snode->is_bit_level);
     stmt->ret_type = pointer_type;
   }
 

--- a/taichi/transforms/vector_split.cpp
+++ b/taichi/transforms/vector_split.cpp
@@ -62,8 +62,8 @@ class BasicBlockVectorSplit : public IRVisitor {
         origin2split[stmt] = std::vector<Stmt *>(current_split_factor, nullptr);
         for (int j = 0; j < current_split_factor; j++) {
           current_split[j]->ret_type =
-              Program::get_type_factory().get_vector_type(
-                  max_width, stmt->element_type().get_ptr());
+              Program::get_type_factory().get_vector_type(max_width,
+                                                          stmt->element_type());
           origin2split[stmt][j] = current_split[j].get();
         }
         splits.push_back(std::move(current_split));
@@ -76,8 +76,8 @@ class BasicBlockVectorSplit : public IRVisitor {
         origin2split[stmt] = std::vector<Stmt *>(1, nullptr);
         current_split[0]->element_type() = stmt->element_type();
         current_split[0]->ret_type =
-            Program::get_type_factory().get_vector_type(
-                stmt->width(), stmt->element_type().get_ptr());
+            Program::get_type_factory().get_vector_type(stmt->width(),
+                                                        stmt->element_type());
         origin2split[stmt][0] = current_split[0].get();
         std::vector<pStmt> split;
         split.push_back(std::move(current_split[0]));

--- a/tests/python/test_bit_array.py
+++ b/tests/python/test_bit_array.py
@@ -4,7 +4,7 @@ import numpy as np
 
 @ti.test(require=ti.extension.quant, debug=True)
 def test_1D_bit_array():
-    ci1 = ti.type_factory_.get_custom_int_type(1, False)
+    ci1 = ti.type_factory.custom_int(1, False)
 
     x = ti.field(dtype=ci1)
 
@@ -30,7 +30,7 @@ def test_1D_bit_array():
 
 @ti.test(require=ti.extension.quant, debug=True)
 def test_2D_bit_array():
-    ci1 = ti.type_factory_.get_custom_int_type(1, False)
+    ci1 = ti.type_factory.custom_int(1, False)
 
     x = ti.field(dtype=ci1)
 

--- a/tests/python/test_bit_array_vectorization.py
+++ b/tests/python/test_bit_array_vectorization.py
@@ -4,7 +4,7 @@ import numpy as np
 
 @ti.test(require=ti.extension.quant, debug=True, cfg_optimization=False)
 def test_vectorized_struct_for():
-    ci1 = ti.type_factory_.get_custom_int_type(1, False)
+    ci1 = ti.type_factory.custom_int(1, False)
 
     x = ti.field(dtype=ci1)
     y = ti.field(dtype=ci1)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -77,7 +77,7 @@ def test_custom_int_load_and_store():
         verify_val.__wrapped__(idx)
 
 
-# @ti.test(require=ti.extension.quant)
+@ti.test(require=ti.extension.quant)
 def test_custom_int_full_struct():
     cit = ti.type_factory.custom_int(32, True)
     x = ti.field(dtype=cit)
@@ -89,14 +89,10 @@ def test_custom_int_full_struct():
     x[0] = 12
     assert x[0] == 12
     
-ti.init()
-test_custom_int_full_struct()
-
-
 def test_bit_struct():
     def test_single_bit_struct(physical_type, compute_type, custom_bits,
                                test_case):
-        ti.init(arch=ti.cpu, debug=True, print_ir=False)
+        ti.init(arch=ti.cpu, debug=True)
 
         cit1 = ti.type_factory.custom_int(custom_bits[0], True,
                                                     compute_type)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -88,18 +88,16 @@ def test_custom_int_full_struct():
 
     x[0] = 12
     assert x[0] == 12
-    
+
+
 def test_bit_struct():
     def test_single_bit_struct(physical_type, compute_type, custom_bits,
                                test_case):
         ti.init(arch=ti.cpu, debug=True)
 
-        cit1 = ti.type_factory.custom_int(custom_bits[0], True,
-                                                    compute_type)
-        cit2 = ti.type_factory.custom_int(custom_bits[1], False,
-                                                    compute_type)
-        cit3 = ti.type_factory.custom_int(custom_bits[2], True,
-                                                    compute_type)
+        cit1 = ti.type_factory.custom_int(custom_bits[0], True, compute_type)
+        cit2 = ti.type_factory.custom_int(custom_bits[1], False, compute_type)
+        cit3 = ti.type_factory.custom_int(custom_bits[2], True, compute_type)
 
         a = ti.field(dtype=cit1)
         b = ti.field(dtype=cit2)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -4,8 +4,8 @@ import numpy as np
 
 @ti.test(require=ti.extension.quant, debug=True)
 def test_simple_array():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    cu19 = ti.type_factory_.get_custom_int_type(19, False)
+    ci13 = ti.type_factory.custom_int(13, True)
+    cu19 = ti.type_factory.custom_int(19, False)
 
     x = ti.field(dtype=ci13)
     y = ti.field(dtype=cu19)
@@ -38,9 +38,9 @@ def test_simple_array():
 
 @ti.test(require=ti.extension.quant, debug=True)
 def test_custom_int_load_and_store():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    cu14 = ti.type_factory_.get_custom_int_type(14, False)
-    ci5 = ti.type_factory_.get_custom_int_type(5, True)
+    ci13 = ti.type_factory.custom_int(13, True)
+    cu14 = ti.type_factory.custom_int(14, False)
+    ci5 = ti.type_factory.custom_int(5, True)
 
     x = ti.field(dtype=ci13)
     y = ti.field(dtype=cu14)
@@ -77,32 +77,20 @@ def test_custom_int_load_and_store():
         verify_val.__wrapped__(idx)
 
 
-@ti.test(require=ti.extension.quant, debug=True)
+# @ti.test(require=ti.extension.quant)
 def test_custom_int_full_struct():
-    cit = ti.type_factory_.get_custom_int_type(32, True)
+    cit = ti.type_factory.custom_int(32, True)
     x = ti.field(dtype=cit)
     ti.root.dense(ti.i, 1)._bit_struct(num_bits=32).place(x)
 
-    @ti.kernel
-    def set_val():
-        x[0] = 15
+    x[0] = 15
+    assert x[0] == 15
 
-    @ti.kernel
-    def varify_val1():
-        assert x[0] == 15
-
-    @ti.kernel
-    def set_val2():
-        x[0] = 12
-
-    @ti.kernel
-    def varify_val2():
-        assert x[0] == 12
-
-    set_val()
-    varify_val1()
-    set_val2()
-    varify_val2()
+    x[0] = 12
+    assert x[0] == 12
+    
+ti.init()
+test_custom_int_full_struct()
 
 
 def test_bit_struct():
@@ -110,11 +98,11 @@ def test_bit_struct():
                                test_case):
         ti.init(arch=ti.cpu, debug=True, print_ir=False)
 
-        cit1 = ti.type_factory_.get_custom_int_type(custom_bits[0], True,
+        cit1 = ti.type_factory.custom_int(custom_bits[0], True,
                                                     compute_type)
-        cit2 = ti.type_factory_.get_custom_int_type(custom_bits[1], False,
+        cit2 = ti.type_factory.custom_int(custom_bits[1], False,
                                                     compute_type)
-        cit3 = ti.type_factory_.get_custom_int_type(custom_bits[2], True,
+        cit3 = ti.type_factory.custom_int(custom_bits[2], True,
                                                     compute_type)
 
         a = ti.field(dtype=cit1)

--- a/tests/python/test_cast.py
+++ b/tests/python/test_cast.py
@@ -124,8 +124,8 @@ def test_custom_int_extension():
     x = ti.field(dtype=ti.i32, shape=2)
     y = ti.field(dtype=ti.u32, shape=2)
 
-    ci5 = ti.type_factory_.get_custom_int_type(5, True, 16)
-    cu7 = ti.type_factory_.get_custom_int_type(7, False, 16)
+    ci5 = ti.type_factory.custom_int(5, True, 16)
+    cu7 = ti.type_factory.custom_int(7, False, 16)
 
     a = ti.field(dtype=ci5)
     b = ti.field(dtype=cu7)

--- a/tests/python/test_custom_int.py
+++ b/tests/python/test_custom_int.py
@@ -3,7 +3,7 @@ import taichi as ti
 
 @ti.test(require=ti.extension.quant)
 def test_custom_int_implicit_cast():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    ci13 = ti.type_factory.custom_int(13, True)
     x = ti.field(dtype=ci13)
 
     ti.root._bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_type_atomics.py
+++ b/tests/python/test_custom_type_atomics.py
@@ -4,9 +4,9 @@ from pytest import approx
 
 @ti.test(require=ti.extension.quant, debug=True)
 def test_custom_int_atomics():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    ci5 = ti.type_factory_.get_custom_int_type(5, True)
-    cu2 = ti.type_factory_.get_custom_int_type(2, False)
+    ci13 = ti.type_factory.custom_int(13, True)
+    ci5 = ti.type_factory.custom_int(5, True)
+    cu2 = ti.type_factory.custom_int(2, False)
 
     x = ti.field(dtype=ci13)
     y = ti.field(dtype=ci5)
@@ -38,7 +38,7 @@ def test_custom_int_atomics():
 
 @ti.test(require=ti.extension.quant, debug=True)
 def test_custom_int_atomics_b64():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    ci13 = ti.type_factory.custom_int(13, True)
 
     x = ti.field(dtype=ci13)
 
@@ -62,8 +62,8 @@ def test_custom_int_atomics_b64():
 
 @ti.test(require=ti.extension.quant, debug=True)
 def test_custom_float_atomics():
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
-    ci19 = ti.type_factory_.get_custom_int_type(19, False)
+    ci13 = ti.type_factory.custom_int(13, True)
+    ci19 = ti.type_factory.custom_int(19, False)
     cft13 = ti.type_factory.custom_float(significand_type=ci13, scale=0.1)
     cft19 = ti.type_factory.custom_float(significand_type=ci19, scale=0.1)
 

--- a/tests/python/test_struct_for.py
+++ b/tests/python/test_struct_for.py
@@ -266,7 +266,7 @@ def test_struct_for_pointer_block():
 def test_struct_for_quant():
     n = 8
 
-    ci13 = ti.type_factory_.get_custom_int_type(13, True)
+    ci13 = ti.type_factory.custom_int(13, True)
     x = ti.field(dtype=ci13)
 
     ti.root.dense(ti.i, n)._bit_struct(num_bits=32).place(x)


### PR DESCRIPTION
Related issue = #1905

`benchmark_bit_struct_stores.py`:
- CPU: 805ms -> 271ms
- CUDA: 13.6ms -> 6.73 ms

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
