### PR TITLE
[GUI] Fix ti.GUI.MOVE not working on win32 and cocoa

### DIFF
--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -360,6 +360,8 @@ void GUI::process_event() {
         case 7:   // NSRightMouseDragged
         case 27:  // NSNSOtherMouseDragged
           set_mouse_pos(p.x, p.y);
+          key_events.push_back(
+              GUI::KeyEvent{GUI::KeyEvent::Type::move, "Motion", cursor_pos});
           mouse_event(MouseEvent{MouseEvent::Type::move, Vector2i(p.x, p.y)});
           break;
         case NSEventTypeKeyDown:

--- a/taichi/gui/win32.cpp
+++ b/taichi/gui/win32.cpp
@@ -100,6 +100,8 @@ LRESULT CALLBACK WindowProc(HWND hwnd,
     case WM_MOUSEMOVE:
       p = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
       gui->set_mouse_pos(p.x, gui->height - 1 - p.y);
+      gui->key_events.push_back(
+          GUI::KeyEvent{GUI::KeyEvent::Type::move, "Motion", gui->cursor_pos});
       gui->mouse_event(
           GUI::MouseEvent{GUI::MouseEvent::Type::move, gui->cursor_pos});
       break;


### PR DESCRIPTION
Related issue = A windows Taichi THREE user reports

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
To reproduce:
```
import taichi as ti

gui = ti.GUI()
while gui.running:
    for e in gui.get_events():
        print(e.type, e.key)
    gui.show()
```
You should see no `Motion` event when your mouse is moving above the window. (Didn't have a win env to reproduce yet, but I let that win user to help me confirmed that this is reproduced)
But this works fine on X11:
```
EType.Move Motion
EType.Move Motion
EType.Move Motion
EType.Move Motion
EType.Move Motion
...
```
Please merge this fix soon so that windows and mac users could enjoy orbiting camera around in Taichi THREE :smiley: 

@k-ye Would you mind help me confirm the cocoa part works (by using the reproduce code)? Thank in advance!