### PR TITLE
[Type] Support different element types for Matrix

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -823,6 +823,8 @@ class Matrix(TaichiOperations):
         self.dt = dtype
 
         if isinstance(dtype, (list, tuple, np.ndarray)):
+            # set different dtype for each element in Matrix
+            # see #2135
             if m == 1:
                 assert (len(np.shape(dtype)) == 1 and len(dtype) == n), f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
                 for i in range(n):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -821,8 +821,20 @@ class Matrix(TaichiOperations):
         self.n = n
         self.m = m
         self.dt = dtype
-        for i in range(n * m):
-            self.entries.append(impl.field(dtype))
+
+        if isinstance(dtype, (list, tuple, np.ndarray)):
+            if m == 1:
+                assert (len(np.shape(dtype)) == 1 and len(dtype) == n), f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
+                for i in range(n):
+                    self.entries.append(impl.field(dtype[i]))
+            else:
+                assert (len(np.shape(dtype)) == 2 and len(dtype) == n and len(dtype[0]) == m), f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
+                for i in range(n):
+                    for j in range(m):
+                        self.entries.append(impl.field(dtype[i][j]))
+        else:
+            for _ in range(n * m):
+                self.entries.append(impl.field(dtype))
         self.grad = self.make_grad()
 
         if layout is not None:

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -826,11 +826,16 @@ class Matrix(TaichiOperations):
             # set different dtype for each element in Matrix
             # see #2135
             if m == 1:
-                assert (len(np.shape(dtype)) == 1 and len(dtype) == n), f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
+                assert (
+                    len(np.shape(dtype)) == 1 and len(dtype) == n
+                ), f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
                 for i in range(n):
                     self.entries.append(impl.field(dtype[i]))
             else:
-                assert (len(np.shape(dtype)) == 2 and len(dtype) == n and len(dtype[0]) == m), f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
+                assert (
+                    len(np.shape(dtype)) == 2 and len(dtype) == n
+                    and len(dtype[0]) == m
+                ), f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
                 for i in range(n):
                     for j in range(m):
                         self.entries.append(impl.field(dtype[i][j]))

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -826,11 +826,15 @@ class Matrix(TaichiOperations):
             # set different dtype for each element in Matrix
             # see #2135
             if m == 1:
-                assert len(np.shape(dtype)) == 1 and len(dtype) == n, f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
+                assert len(np.shape(dtype)) == 1 and len(
+                    dtype
+                ) == n, f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
                 for i in range(n):
                     self.entries.append(impl.field(dtype[i]))
             else:
-                assert len(np.shape(dtype)) == 2 and len(dtype) == n and len(dtype[0]) == m, f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
+                assert len(np.shape(dtype)) == 2 and len(dtype) == n and len(
+                    dtype[0]
+                ) == m, f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
                 for i in range(n):
                     for j in range(m):
                         self.entries.append(impl.field(dtype[i][j]))

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -826,16 +826,11 @@ class Matrix(TaichiOperations):
             # set different dtype for each element in Matrix
             # see #2135
             if m == 1:
-                assert (
-                    len(np.shape(dtype)) == 1 and len(dtype) == n
-                ), f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
+                assert len(np.shape(dtype)) == 1 and len(dtype) == n, f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
                 for i in range(n):
                     self.entries.append(impl.field(dtype[i]))
             else:
-                assert (
-                    len(np.shape(dtype)) == 2 and len(dtype) == n
-                    and len(dtype[0]) == m
-                ), f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
+                assert len(np.shape(dtype)) == 2 and len(dtype) == n and len(dtype[0]) == m, f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
                 for i in range(n):
                     for j in range(m):
                         self.entries.append(impl.field(dtype[i][j]))

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -828,13 +828,13 @@ class Matrix(TaichiOperations):
             if m == 1:
                 assert len(np.shape(dtype)) == 1 and len(
                     dtype
-                ) == n, f'Please set correct dtype list for Vector, the shape of dtype list should be ({n}, ) not {np.shape(dtype)}'
+                ) == n, f'Please set correct dtype list for Vector. The shape of dtype list should be ({n}, ) instead of {np.shape(dtype)}'
                 for i in range(n):
                     self.entries.append(impl.field(dtype[i]))
             else:
                 assert len(np.shape(dtype)) == 2 and len(dtype) == n and len(
                     dtype[0]
-                ) == m, f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) not {np.shape(dtype)}'
+                ) == m, f'Please set correct dtype list for Matrix. The shape of dtype list should be ({n}, {m}) instead of {np.shape(dtype)}'
                 for i in range(n):
                     for j in range(m):
                         self.entries.append(impl.field(dtype[i][j]))

--- a/tests/python/test_matrix_different_type.py
+++ b/tests/python/test_matrix_different_type.py
@@ -1,6 +1,7 @@
 import taichi as ti
 from pytest import approx
 
+# TODO: test more matrix operations
 @ti.test()
 def test_vector():
     type_list = [ti.f32, ti.i32]

--- a/tests/python/test_matrix_different_type.py
+++ b/tests/python/test_matrix_different_type.py
@@ -1,0 +1,54 @@
+import taichi as ti
+
+
+@ti.test()
+def test_vector():
+    type_list = [ti.f32, ti.i32]
+
+    a = ti.Vector.field(len(type_list), dtype=type_list, shape=())
+    b = ti.Vector.field(len(type_list), dtype=type_list, shape=())
+    c = ti.Vector.field(len(type_list), dtype=type_list, shape=())
+
+    @ti.kernel
+    def init():
+        a[None] = [1.0, 3]
+        b[None] = [2.0, 4]
+        c[None] = a[None] + b[None]
+
+    def verify():
+        assert isinstance(a[None][0], float)
+        assert isinstance(a[None][1], int)
+        assert isinstance(b[None][0], float)
+        assert isinstance(b[None][1], int)
+        assert c[None][0] == 3.0
+        assert c[None][1] == 7
+
+    init()
+    verify()
+
+
+@ti.test()
+def test_matrix():
+    type_list = [[ti.f32, ti.i32], [ti.i64, ti.f32]]
+    a = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list, shape=())
+    b = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list, shape=()) 
+    c = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list, shape=()) 
+    
+    @ti.kernel
+    def init():
+        a[None] = [[1.0, 3],[1, 3.0]]
+        b[None] = [[2.0, 4],[-2, -3.0]]
+        c[None] = a[None] + b[None]
+
+    def verify():
+        assert isinstance(a[None][0], float)
+        assert isinstance(a[None][1], int)
+        assert isinstance(b[None][0], float)
+        assert isinstance(b[None][1], int)
+        assert c[None][0, 0] == 3.0
+        assert c[None][0, 1] == 7
+        assert c[None][1, 0] == -1
+        assert c[None][1, 1] == 0.0
+
+    init()
+    verify()

--- a/tests/python/test_matrix_different_type.py
+++ b/tests/python/test_matrix_different_type.py
@@ -1,6 +1,7 @@
 import taichi as ti
 from pytest import approx
 
+
 # TODO: test more matrix operations
 @ti.test()
 def test_vector():
@@ -31,14 +32,23 @@ def test_vector():
 @ti.test()
 def test_matrix():
     type_list = [[ti.f32, ti.i32], [ti.i64, ti.f32]]
-    a = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list, shape=())
-    b = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list, shape=()) 
-    c = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list, shape=()) 
-    
+    a = ti.Matrix.field(len(type_list),
+                        len(type_list[0]),
+                        dtype=type_list,
+                        shape=())
+    b = ti.Matrix.field(len(type_list),
+                        len(type_list[0]),
+                        dtype=type_list,
+                        shape=())
+    c = ti.Matrix.field(len(type_list),
+                        len(type_list[0]),
+                        dtype=type_list,
+                        shape=())
+
     @ti.kernel
     def init():
-        a[None] = [[1.0, 3],[1, 3.0]]
-        b[None] = [[2.0, 4],[-2, -3.0]]
+        a[None] = [[1.0, 3], [1, 3.0]]
+        b[None] = [[2.0, 4], [-2, -3.0]]
         c[None] = a[None] + b[None]
 
     def verify():
@@ -77,7 +87,7 @@ def test_custom_type():
         a[0] = [[1, 3.], [2., 1]]
         b[0] = [[2, 4.], [-2., 1]]
         c[0] = a[0] + b[0]
-    
+
     def verify():
         assert c[0][0, 0] == approx(3, 1e-3)
         assert c[0][0, 1] == approx(7.0, 1e-3)

--- a/tests/python/test_matrix_different_type.py
+++ b/tests/python/test_matrix_different_type.py
@@ -29,7 +29,8 @@ def test_vector():
     verify()
 
 
-@ti.test()
+# TODO: Support different element types of Matrix on opengl
+@ti.test(exclude=ti.opengl)
 def test_matrix():
     type_list = [[ti.f32, ti.i32], [ti.i64, ti.f32]]
     a = ti.Matrix.field(len(type_list),


### PR DESCRIPTION
Related issue = #1905
This pr aims to support different length of custom digits in one Vector/Matrix. Now one can code like : 
`
x = ti.Vector.field(2, dtype=[float, int])
`
to get a one Vector/Matrix with different types. Also you can set different custom types in one Vector/Matrix.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
