### PR TITLE
[misc] Add a Github Action workflow to trigger on publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,23 +6,19 @@ on:
 
 jobs:
   build_and_test_cpu:
-    name: Build and Test (CPU)
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') && github.event.sender.login != 'taichi-gardener' }}
+    name: Build and Test (macOS only)
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: macos-latest
             python: 3.6
             with_cc: OFF
           - os: macos-latest
             python: 3.7
             with_cc: OFF
-          - os: ubuntu-16.04  # TODO(archibate): windows-latest
+          - os: macos-latest
             python: 3.8
             with_cc: OFF
-          - os: ubuntu-latest
-            python: 3.8
-            with_cc: ON
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -45,8 +41,6 @@ jobs:
           export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
           export CXX=clang++
           python misc/ci_setup.py ci
-        env:
-          CI_SETUP_CMAKE_ARGS: -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=${{ matrix.with_cc }}
 
       - name: Test
         run: |
@@ -57,4 +51,12 @@ jobs:
           python examples/laplace.py
           ti diagnose
           ti test -vr2 -t2
-        # TODO: upload PyPI
+
+      # TODO(#1580): Upload to PyPI. Need to set up PYPI_PWD in the secrets first.
+      # - name: Upload PyPI
+      #   env:
+      #     # https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow
+      #     PYPI_PWD: ${{ secrets.PYPI_PWD }}
+      #   run: |
+      #     cd python
+      #     python build.py try_upload && bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Publishing Release
+on:
+  release:
+    # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#release
+    types: [published]
+
+jobs:
+  build_and_test_cpu:
+    name: Build and Test (CPU)
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') && github.event.sender.login != 'taichi-gardener' }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: 3.6
+            with_cc: OFF
+          - os: macos-latest
+            python: 3.7
+            with_cc: OFF
+          - os: ubuntu-16.04  # TODO(archibate): windows-latest
+            python: 3.8
+            with_cc: OFF
+          - os: ubuntu-latest
+            python: 3.8
+            with_cc: ON
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Download Pre-Built LLVM 10.0.0
+        run: |
+          python misc/ci_download.py
+          mkdir taichi-llvm
+          cd taichi-llvm
+          unzip ../taichi-llvm.zip
+        env:
+          CI_PLATFORM: ${{ matrix.os }}
+
+      - name: Build
+        run: |
+          export TAICHI_REPO_DIR=`pwd`
+          export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
+          export CXX=clang++
+          python misc/ci_setup.py ci
+        env:
+          CI_SETUP_CMAKE_ARGS: -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=${{ matrix.with_cc }}
+
+      - name: Test
+        run: |
+          export TAICHI_REPO_DIR=`pwd`
+          export PATH=$TAICHI_REPO_DIR/bin:$PATH
+          export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
+          export PYTHONPATH=$TAICHI_REPO_DIR/python
+          python examples/laplace.py
+          ti diagnose
+          ti test -vr2 -t2
+        # TODO: upload PyPI


### PR DESCRIPTION
This PR sets up a GitHub actions workflow upon publishing a new release. Right now it just forks  the "Build and Test (CPU)" job. Later on we can add these:

* [ ] PyPI upload
* [ ] [`macos-11.0`](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources) (I briefly tested this platform. However, it seems to me that this particular resource is limited. The job queued for ~0.5h...)

Related issue = #1580

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
