### PR TITLE
[async] [bug] Fix missing memory access options in async mode

### DIFF
--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -326,10 +326,30 @@ std::unique_ptr<Stmt> OffloadedStmt::clone() const {
   new_stmt->reversed = reversed;
   new_stmt->num_cpu_threads = num_cpu_threads;
   new_stmt->device = device;
+  new_stmt->index_offsets = index_offsets;
+  if (tls_prologue) {
+    new_stmt->tls_prologue = tls_prologue->clone();
+    new_stmt->tls_prologue->parent_stmt = new_stmt.get();
+  }
+  if (bls_prologue) {
+    new_stmt->bls_prologue = bls_prologue->clone();
+    new_stmt->bls_prologue->parent_stmt = new_stmt.get();
+  }
   if (body) {
     new_stmt->body = body->clone();
     new_stmt->body->parent_stmt = new_stmt.get();
   }
+  if (bls_epilogue) {
+    new_stmt->bls_epilogue = bls_epilogue->clone();
+    new_stmt->bls_epilogue->parent_stmt = new_stmt.get();
+  }
+  if (tls_epilogue) {
+    new_stmt->tls_epilogue = tls_epilogue->clone();
+    new_stmt->tls_epilogue->parent_stmt = new_stmt.get();
+  }
+  new_stmt->tls_size = tls_size;
+  new_stmt->bls_size = bls_size;
+  new_stmt->mem_access_opt = mem_access_opt;
   return new_stmt;
 }
 

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -372,6 +372,7 @@ TaskFusionMeta get_task_fusion_meta(IRBank *bank, const TaskLaunchRecord &t) {
   if (task->task_type == OffloadedTaskType::struct_for) {
     meta.snode = task->snode;
     meta.block_dim = task->block_dim;
+    // TODO: What about index_offsets?
   } else if (task->task_type == OffloadedTaskType::range_for) {
     // TODO: a few problems with the range-for test condition:
     // 1. This could incorrectly fuse two range-for kernels that have

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -372,7 +372,7 @@ TaskFusionMeta get_task_fusion_meta(IRBank *bank, const TaskLaunchRecord &t) {
   if (task->task_type == OffloadedTaskType::struct_for) {
     meta.snode = task->snode;
     meta.block_dim = task->block_dim;
-    // TODO: What about index_offsets?
+    // We don't need to record index_offsets because it's not used anymore.
   } else if (task->task_type == OffloadedTaskType::range_for) {
     // TODO: a few problems with the range-for test condition:
     // 1. This could incorrectly fuse two range-for kernels that have


### PR DESCRIPTION
Related issue = #742

Fixes `OffloadedStmt::clone()`, and merges `OffloadedStmt::mem_access_opt`s when fusing.

Off-topic: I'm not sure if two struct-fors with different index offsets can be fused together.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
