### PR TITLE
[type] Fix struct-for block dim on bit_structs

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -2041,13 +2041,11 @@ void CodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt, bool spmd) {
   llvm::Function *body = nullptr;
   auto leaf_block = stmt->snode;
 
-  // When looping over bit_arrays and bit_structs, we generate struct for on
-  // their parent node (usually "dense") instead of itself for higher
+  // When looping over bit_arrays, we always vectorize and generate struct for
+  // on their parent node (usually "dense") instead of itself for higher
   // performance. Also, note that the loop must be bit_vectorized for
   // bit_arrays, and their parent must be "dense".
-  if (leaf_block->type == SNodeType::bit_struct) {
-    leaf_block = leaf_block->parent;
-  } else if (leaf_block->type == SNodeType::bit_array) {
+  if (leaf_block->type == SNodeType::bit_array) {
     if (leaf_block->parent->type == SNodeType::dense) {
       leaf_block = leaf_block->parent;
     } else {

--- a/taichi/transforms/flag_access.cpp
+++ b/taichi/transforms/flag_access.cpp
@@ -103,7 +103,8 @@ class WeakenAccess : public BasicStmtVisitor {
 
   static SNode *least_sparse_ancestor(SNode *a) {
     while (a->type == SNodeType::place || a->type == SNodeType::dense ||
-           a->type == SNodeType::bit_struct) {
+           a->type == SNodeType::bit_struct ||
+           a->type == SNodeType::bit_array) {
       a = a->parent;
     }
     return a;

--- a/taichi/transforms/flag_access.cpp
+++ b/taichi/transforms/flag_access.cpp
@@ -102,7 +102,8 @@ class WeakenAccess : public BasicStmtVisitor {
   }
 
   static SNode *least_sparse_ancestor(SNode *a) {
-    while (a->type == SNodeType::place || a->type == SNodeType::dense) {
+    while (a->type == SNodeType::place || a->type == SNodeType::dense ||
+           a->type == SNodeType::bit_struct) {
       a = a->parent;
     }
     return a;

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -281,6 +281,14 @@ class LowerAST : public IRVisitor {
         offsets = snode->index_offsets;
         snode = snode->parent;
       }
+
+      // Climb up one more level if inside bit_struct.
+      // Note that when looping over bit_structs, we generate
+      // struct for on their parent node instead of itself for
+      // higher performance.
+      if (snode->type == SNodeType::bit_struct)
+        snode = snode->parent;
+
       auto &&new_for = std::make_unique<StructForStmt>(
           snode, std::move(stmt->body), stmt->vectorize, stmt->bit_vectorize,
           stmt->parallelize, stmt->block_dim);


### PR DESCRIPTION
Related issue = #1905

The changes may seem unrelated but since `offloaded->snode` is changed, in `offload.cpp` the block dim query now happens on the dense node instead of the bit_struct. 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
