### PR TITLE
[opt] Simplify bit_cast of bit_cast

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -595,6 +595,10 @@ bool DelayedIRModifier::modify_ir() {
   return true;
 }
 
+bool DelayedIRModifier::mark_as_modified() {
+  modified_ = true;
+}
+
 LocalAddress::LocalAddress(Stmt *var, int offset) : var(var), offset(offset) {
   TI_ASSERT(var->is<AllocaStmt>());
 }

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -595,7 +595,7 @@ bool DelayedIRModifier::modify_ir() {
   return true;
 }
 
-bool DelayedIRModifier::mark_as_modified() {
+void DelayedIRModifier::mark_as_modified() {
   modified_ = true;
 }
 

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -571,9 +571,11 @@ void DelayedIRModifier::replace_with(Stmt *stmt,
 }
 
 bool DelayedIRModifier::modify_ir() {
+  bool force_modified = modified_;
+  modified_ = false;
   if (to_insert_before.empty() && to_insert_after.empty() && to_erase.empty() &&
       to_replace_with.empty())
-    return false;
+    return force_modified;
   for (auto &i : to_insert_before) {
     i.first->parent->insert_before(i.first, std::move(i.second));
   }

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -729,6 +729,7 @@ class DelayedIRModifier {
   std::vector<std::pair<Stmt *, VecStatement>> to_insert_after;
   std::vector<std::tuple<Stmt *, VecStatement, bool>> to_replace_with;
   std::vector<Stmt *> to_erase;
+  bool modified_{false};
 
  public:
   ~DelayedIRModifier();
@@ -741,6 +742,9 @@ class DelayedIRModifier {
                     VecStatement &&new_statements,
                     bool replace_usages = true);
   bool modify_ir();
+
+  // Force the next call of modify_ir() to return true.
+  bool mark_as_modified();
 };
 
 struct LocalAddress {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -744,7 +744,7 @@ class DelayedIRModifier {
   bool modify_ir();
 
   // Force the next call of modify_ir() to return true.
-  bool mark_as_modified();
+  void mark_as_modified();
 };
 
 struct LocalAddress {

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -48,9 +48,19 @@ class AlgSimp : public BasicStmtVisitor {
   }
 
   void visit(UnaryOpStmt *stmt) override {
-    if (stmt->is_cast() && stmt->cast_type == stmt->operand->ret_type) {
-      stmt->replace_with(stmt->operand);
-      modifier.erase(stmt);
+    if (stmt->is_cast()) {
+      if (stmt->cast_type == stmt->operand->ret_type) {
+        stmt->replace_with(stmt->operand);
+        modifier.erase(stmt);
+      } else if (stmt->operand->is<UnaryOpStmt>() &&
+                 stmt->operand->as<UnaryOpStmt>()->is_cast()) {
+        auto prev_cast = stmt->operand->as<UnaryOpStmt>();
+        if (stmt->op_type == UnaryOpType::cast_bits &&
+            prev_cast->op_type == UnaryOpType::cast_bits) {
+          stmt->operand = prev_cast->operand;
+          modifier.mark_as_modified();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Related issue = #656 

Also adds `DelayedIRModifier::mark_as_modified()` because this pattern (modifying IR, not through DelayedIRModifier, but need to record if the IR is modified) repeats in some other passes.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
