### PR TITLE
[misc] Change SNode max_num_elements to use int64

### DIFF
--- a/taichi/backends/cpu/codegen_cpu.cpp
+++ b/taichi/backends/cpu/codegen_cpu.cpp
@@ -73,8 +73,8 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
     } else if (stmt->task_type == Type::range_for) {
       create_offload_range_for(stmt);
     } else if (stmt->task_type == Type::struct_for) {
-      stmt->block_dim =
-          std::min(stmt->snode->parent->max_num_elements(), stmt->block_dim);
+      stmt->block_dim = std::min(stmt->snode->parent->max_num_elements(),
+                                 (int64)stmt->block_dim);
       create_offload_struct_for(stmt);
     } else if (stmt->task_type == Type::listgen) {
       emit_list_gen(stmt);

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -238,7 +238,7 @@ void CodeGenLLVM::emit_struct_meta_base(const std::string &name,
   common.set("snode_id", tlctx->get_constant(snode->id));
   common.set("element_size", tlctx->get_constant((uint64)element_size));
   common.set("max_num_elements",
-             tlctx->get_constant(1 << snode->total_num_bits));
+             tlctx->get_constant(snode->max_num_elements()));
   common.set("context", get_context());
 
   /*
@@ -2250,8 +2250,8 @@ void CodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt, bool spmd) {
     }
   }
 
-  int list_element_size =
-      std::min(leaf_block->max_num_elements(), taichi_listgen_max_element_size);
+  int list_element_size = std::min(leaf_block->max_num_elements(),
+                                   (int64)taichi_listgen_max_element_size);
   int num_splits = std::max(1, list_element_size / stmt->block_dim);
 
   auto struct_for_func = get_runtime_function("parallel_struct_for");

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -73,10 +73,11 @@ class SNode {
   int depth{};
 
   std::string name;
-  int64 n{};
-  int total_num_bits{}, total_bit_start{};
-  int chunk_size{};
-  std::size_t cell_size_bytes{};
+  int64 n{0};
+  int total_num_bits{0};
+  int total_bit_start{0};
+  int chunk_size{0};
+  std::size_t cell_size_bytes{0};
   PrimitiveType *physical_type;  // for bit_struct and bit_array only
   DataType dt;
   bool has_ambient{};
@@ -267,8 +268,8 @@ class SNode {
     return fmt::format("{}_refine_coordinates", get_name());
   }
 
-  int max_num_elements() const {
-    return 1 << total_num_bits;
+  int64 max_num_elements() const {
+    return int64(1) << total_num_bits;
   }
 
   int shape_along_axis(int i) const;

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -313,7 +313,7 @@ int32 Context_get_extra_args(Context *ctx, int32 i, int32 j) {
 struct StructMeta {
   i32 snode_id;
   std::size_t element_size;
-  i32 max_num_elements;
+  i64 max_num_elements;
 
   Ptr (*lookup_element)(Ptr, Ptr, int i);
 

--- a/taichi/struct/struct.cpp
+++ b/taichi/struct/struct.cpp
@@ -102,6 +102,13 @@ void StructCompiler::infer_snode_properties(SNode &snode) {
   for (int i = 0; i < taichi_max_num_indices; i++) {
     snode.total_num_bits += snode.extractors[i].num_bits;
   }
+  // The highest bit is for the sign.
+  constexpr int kMaxTotalNumBits = 64;
+  TI_ERROR_IF(
+      snode.total_num_bits >= kMaxTotalNumBits,
+      "SNode={}: total_num_bits={} exceeded limit={}. This implies that "
+      "your requested shape is too large.",
+      snode.id, snode.total_num_bits, kMaxTotalNumBits);
 
   if (snode.has_null()) {
     ambient_snodes.push_back(&snode);

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -142,8 +142,8 @@ class Offloader {
         offloaded_listgen->grid_dim = program->config.saturating_grid_dim;
         offloaded_listgen->block_dim =
             std::min(snode_child->max_num_elements(),
-                     std::min(program->default_block_dim(),
-                              program->config.max_block_dim));
+                     (int64)std::min(program->default_block_dim(),
+                                     program->config.max_block_dim));
         root_block->insert(std::move(offloaded_listgen));
       }
     }
@@ -155,11 +155,11 @@ class Offloader {
 
     offloaded_struct_for->grid_dim = program->config.saturating_grid_dim;
 
-    auto snode_num_elements = for_stmt->snode->max_num_elements();
+    const auto snode_num_elements = for_stmt->snode->max_num_elements();
     if (for_stmt->block_dim == 0) {
       // adaptive
-      offloaded_struct_for->block_dim =
-          std::min(snode_num_elements, program->config.default_gpu_block_dim);
+      offloaded_struct_for->block_dim = std::min(
+          snode_num_elements, (int64)program->config.default_gpu_block_dim);
     } else {
       if (for_stmt->block_dim > snode_num_elements) {
         TI_WARN(


### PR DESCRIPTION
Related issue = #2146

Hi,

I'm changing the return type of `SNode::max_num_elements()` to `int64` to avoid overflow in #2146. @TH3CHARLie please let me know if this also fixes your problem, thx!

Note that this is NOT a thorough fix for #2146, as I still prefer that we dump a huge warning when the requested size is impractically large. (WIth this patch, the reproducer still segfaulted without dumping more information.) I will take a look tmr...

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
