### PR TITLE
[Misc] Add experimental Python 3.9 support

### DIFF
--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -16,8 +16,8 @@ jobs:
           - os: macos-latest
             python: 3.7
             with_cc: OFF
-          - os: ubuntu-16.04  # TODO(archibate): windows-latest
-            python: 3.8
+          - os: ubuntu-latest
+            python: 3.9
             with_cc: OFF
           - os: ubuntu-latest
             python: 3.8

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -221,7 +221,7 @@ class ASTTransformerPreprocess(ASTTransformerBase):
             def tuple_indexed(i):
                 indexing = self.parse_stmt('__tmp_tuple[0]')
                 self.set_subscript_index(indexing.value,
-                        self.parse_expr("{}".format(i)))
+                                         self.parse_expr("{}".format(i)))
                 return indexing.value
 
             for i, target in enumerate(targets):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+setuptools
+astor
+pybind11
+pylint
+sourceinspect
+pytest
+pytest-rerunfailures
+pytest-xdist
+yapf
+numpy
+GitPython
+coverage
+colorama
+autograd


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
The only issue seems to be the deprecated `ast.Index`, fixed in this Pr - now Python 3.9 can pass all the tests!
We may discuss if we should officially release Python 3.9 wheel on PyPI, FYI Arch Linux has officially make Python 3.9 the default version after a full system upgrade, it seems the Blender bundled Python is also 3.9 now.. I know you are busy with a interesting research projects of SIGGRAPH (let me know more details after that!), so please let me take some responsbilities if you'd like to :smile: