### PR TITLE
[misc] Deleted 3 debug messages in codegen_cc.cpp

### DIFF
--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -583,9 +583,6 @@ class CCTransformer : public IRVisitor {
     auto var = define_var(dt_name + " *", adjoint_name);
     emit("{} = ({} *)Ti_ad_stack_top_adjoint({}, {});", var, dt_name,
          stack->raw_name(), stack->element_size_in_bytes());
-    emit("printf(\"%d\\n\", *Ti_ad_stack_n({}));", stack->raw_name());
-    emit("printf(\"%p\\n\", {});", stack->raw_name());
-    emit("printf(\"%p\\n\", {});", adjoint_name);
     emit("*{} += {};", adjoint_name, stmt->v->raw_name());
   }
 


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
There were 3 emit operations in this file that emit print operations to the compiled c file when dumping some gradient kernels. These debug messages won't be helpful to developers that works on gradient kernels.
@yuanming-hu 