### PR TITLE
[lang] Expose SNode ID to python

### DIFF
--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -100,6 +100,10 @@ class SNode:
         return len(self.shape)
 
     @property
+    def id(self):
+        return self.ptr.id
+
+    @property
     def shape(self):
         impl.get_runtime().materialize()
         dim = self.ptr.num_active_indices()

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -280,6 +280,9 @@ def print_async_stats(include_kernel_profiler=False):
     print(f'Tasks launched:       {int(counters["launched_tasks"])}')
     print(f'Instructions emitted: {int(counters["codegen_statements"])}')
     print(f'Tasks compiled:       {int(counters["codegen_offloaded_tasks"])}')
+    NUM_FUSED_TASKS_KEY = 'num_fused_tasks'
+    if NUM_FUSED_TASKS_KEY in counters:
+        print(f'Tasks fused:          {int(counters["num_fused_tasks"])}')
     print('=======================')
 
 

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -626,6 +626,7 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
     auto *node_b = nodes[b];
     TI_TRACE("Fuse: nodes[{}]({}) <- nodes[{}]({})", a, node_a->string(), b,
              node_b->string());
+    stat.add("num_fused_tasks");
     auto &rec_a = node_a->rec;
     auto &rec_b = node_b->rec;
     rec_a.ir_handle =

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -220,6 +220,7 @@ void export_lang(py::module &m) {
       .def(py::init<>())
       .def_readwrite("parent", &SNode::parent)
       .def_readonly("type", &SNode::type)
+      .def_readonly("id", &SNode::id)
       .def("dense",
            (SNode & (SNode::*)(const std::vector<Index> &,
                                const std::vector<int> &))(&SNode::dense),


### PR DESCRIPTION
It's a bit hard to track the SNodes in the dot graphs, so let's expose the ID to python.

Related issue = #742

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
