### PR TITLE
[Infra] Support Timelines as a multithreading profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ _build
 *.bc
 *.yml
 *.dot
+*.json

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -46,6 +46,8 @@ kernel_profiler_print = lambda: get_runtime().prog.kernel_profiler_print()
 kernel_profiler_clear = lambda: get_runtime().prog.kernel_profiler_clear()
 kernel_profiler_total_time = lambda: get_runtime(
 ).prog.kernel_profiler_total_time()
+timeline_clear = lambda: get_runtime().prog.timeline_clear()
+timeline_save = lambda f: get_runtime().prog.timeline_save(f)
 
 # Legacy API
 type_factory_ = core.get_type_factory_instance()

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -47,7 +47,7 @@ kernel_profiler_clear = lambda: get_runtime().prog.kernel_profiler_clear()
 kernel_profiler_total_time = lambda: get_runtime(
 ).prog.kernel_profiler_total_time()
 timeline_clear = lambda: get_runtime().prog.timeline_clear()
-timeline_save = lambda f: get_runtime().prog.timeline_save(f)
+timeline_save = lambda fn: get_runtime().prog.timeline_save(fn)
 
 # Legacy API
 type_factory_ = core.get_type_factory_instance()

--- a/taichi/backends/cuda/cuda_driver_functions.inc.h
+++ b/taichi/backends/cuda/cuda_driver_functions.inc.h
@@ -43,7 +43,9 @@ PER_CUDA_FUNCTION(stream_synchronize, cuStreamSynchronize, void *);
 
 // Event management
 PER_CUDA_FUNCTION(event_create, cuEventCreate, void **, uint32)
+PER_CUDA_FUNCTION(event_destroy, cuEventDestroy, void *)
 PER_CUDA_FUNCTION(event_record, cuEventRecord, void *, void *)
+PER_CUDA_FUNCTION(event_synchronize, cuEventSynchronize, void *);
 PER_CUDA_FUNCTION(event_elapsed_time, cuEventElapsedTime, float *, void *, void *);
 
 // clang-format on

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -4,6 +4,7 @@
 
 #include "taichi/program/kernel.h"
 #include "taichi/program/program.h"
+#include "taichi/system/timeline.h"
 #include "taichi/backends/cpu/codegen_cpu.h"
 #include "taichi/util/testing.h"
 #include "taichi/util/statistics.h"
@@ -134,6 +135,7 @@ void ExecutionQueue::enqueue(const TaskLaunchRecord &ker) {
 
     compilation_workers.enqueue([async_func, stmt, kernel, this]() {
       {
+        TI_TIMELINE("compile");
         // Final lowering
         using namespace irpass;
 
@@ -154,6 +156,7 @@ void ExecutionQueue::enqueue(const TaskLaunchRecord &ker) {
   }
 
   launch_worker.enqueue([async_func, context = ker.context]() mutable {
+    TI_TIMELINE("launch");
     auto func = async_func->get();
     func(context);
   });
@@ -227,6 +230,7 @@ void AsyncEngine::synchronize() {
 
 void AsyncEngine::flush() {
   TI_AUTO_PROF;
+  TI_AUTO_TIMELINE;
 
   bool modified = true;
   sfg->reid_nodes();

--- a/taichi/program/async_engine.cpp
+++ b/taichi/program/async_engine.cpp
@@ -72,8 +72,12 @@ bool ParallelExecutor::flush_cv_cond() {
 void ParallelExecutor::worker_loop() {
   TI_DEBUG("Starting worker thread.");
   auto thread_id = thread_counter++;
-  Timeline::get_this_thread_instance().set_name(
-      fmt::format("{}_{}", name_, thread_id));
+
+  std::string thread_name = name_;
+  if (num_threads != 1)
+    thread_name += fmt::format("_{}", thread_id);
+  Timeline::get_this_thread_instance().set_name(thread_name);
+
   {
     std::unique_lock<std::mutex> lock(mut);
     while (status == ExecutorStatus::uninitialized) {

--- a/taichi/program/async_engine.h
+++ b/taichi/program/async_engine.h
@@ -24,7 +24,7 @@ class ParallelExecutor {
  public:
   using TaskType = std::function<void()>;
 
-  explicit ParallelExecutor(int num_threads);
+  explicit ParallelExecutor(const std::string &name, int num_threads);
   ~ParallelExecutor();
 
   void enqueue(const TaskType &func);
@@ -47,7 +47,9 @@ class ParallelExecutor {
   // Must be called while holding |mut|.
   bool flush_cv_cond();
 
+  std::string name_;
   int num_threads;
+  std::atomic<int> thread_counter{0};
   std::mutex mut;
 
   // All guarded by |mut|

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -27,6 +27,7 @@ struct CompileConfig {
   bool use_llvm;
   bool verbose_kernel_launches;
   bool kernel_profiler;
+  bool timeline{false};
   bool verbose;
   bool fast_math;
   bool async_mode;

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -174,16 +174,18 @@ class KernelProfilerCUDA : public KernelProfilerBase {
       for (auto &item : list) {
         auto start = item.first, stop = item.second;
         float kernel_time, time_since_base;
-        CUDADriver::get_instance().event_elapsed_time(&time_since_base,
-                                                      base_event, start);
         CUDADriver::get_instance().event_elapsed_time(&kernel_time, start,
                                                       stop);
 
-        timeline.insert_event(
-            {map_elem.first, true, base_time + time_since_base * 1e-3, "cuda"});
-        timeline.insert_event(
-            {map_elem.first, false,
-             base_time + (time_since_base + kernel_time) * 1e-3, "cuda"});
+        if (Timelines::get_instance().get_enabled()) {
+          CUDADriver::get_instance().event_elapsed_time(&time_since_base,
+                                                        base_event, start);
+          timeline.insert_event({map_elem.first, true,
+                                 base_time + time_since_base * 1e-3, "cuda"});
+          timeline.insert_event(
+              {map_elem.first, false,
+               base_time + (time_since_base + kernel_time) * 1e-3, "cuda"});
+        }
 
         auto it = std::find_if(
             records.begin(), records.end(),

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -197,6 +197,10 @@ class KernelProfilerCUDA : public KernelProfilerBase {
         }
         it->insert_sample(kernel_time);
         total_time_ms += kernel_time;
+
+        // TODO: the following two lines seem to increases profiler overhead a
+        // little bit. Is there a way to avoid the overhead while not creating
+        // too many events?
         CUDADriver::get_instance().event_destroy(start);
         CUDADriver::get_instance().event_destroy(stop);
       }

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -137,10 +137,13 @@ class KernelProfilerCUDA : public KernelProfilerBase {
         auto final_t = Time::get_time();
         if (i == n_iters - 1) {
           base_event_ = e;
+          // TODO: figure out a better way to synchronize CPU and GPU time.
+          constexpr float64 cuda_time_offset = 3e-4;
           // Since event recording and synchronization can take 5 us, it's hard
-          // to exactly measure the real event time. We use final_t as event
-          // time for now.
-          base_time_ = final_t;
+          // to exactly measure the real event time. Also note there seems to be
+          // a systematic time offset on CUDA, so adjust for that using a 3e-4 s
+          // magic number.
+          base_time_ = final_t + cuda_time_offset;
         } else {
           CUDADriver::get_instance().event_destroy(e);
         }

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -180,10 +180,10 @@ class KernelProfilerCUDA : public KernelProfilerBase {
                                                       stop);
 
         timeline.insert_event(
-            {map_elem.first, true, base_time + time_since_base * 1e-3, 0});
+            {map_elem.first, true, base_time + time_since_base * 1e-3, "cuda"});
         timeline.insert_event(
             {map_elem.first, false,
-             base_time + (time_since_base + kernel_time) * 1e-3, 0});
+             base_time + (time_since_base + kernel_time) * 1e-3, "cuda"});
 
         auto it = std::find_if(
             records.begin(), records.end(),

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -19,6 +19,7 @@
 #include "taichi/backends/metal/struct_metal.h"
 #include "taichi/backends/opengl/struct_opengl.h"
 #include "taichi/system/unified_allocator.h"
+#include "taichi/system/timeline.h"
 #include "taichi/ir/snode.h"
 #include "taichi/ir/frontend_ir.h"
 #include "taichi/program/async_engine.h"
@@ -216,6 +217,8 @@ Program::Program(Arch desired_arch) {
   }
 
   stat.clear();
+
+  Timelines::get_instance().set_enabled(config.timeline);
 
   TI_TRACE("Program ({}) arch={} initialized.", fmt::ptr(this),
            arch_name(arch));

--- a/taichi/program/state_flow_graph.cpp
+++ b/taichi/program/state_flow_graph.cpp
@@ -11,6 +11,7 @@
 #include "taichi/ir/transforms.h"
 #include "taichi/program/async_engine.h"
 #include "taichi/util/statistics.h"
+#include "taichi/system/timeline.h"
 
 // Keep this include in the end!
 #include "taichi/program/async_profiler_switch.h"
@@ -20,13 +21,6 @@ TLANG_NAMESPACE_BEGIN
 namespace {
 
 using LatestStateReaders = StateFlowGraph::LatestStateReaders;
-
-// TODO(k-ye): remove these over-engineering...
-LatestStateReaders::iterator find(LatestStateReaders &m, const AsyncState &s) {
-  return std::find_if(
-      m.begin(), m.end(),
-      [&s](const LatestStateReaders::value_type &v) { return v.first == s; });
-}
 
 std::pair<LatestStateReaders::value_type::second_type *, bool> insert(
     LatestStateReaders &m,
@@ -420,6 +414,7 @@ void StateFlowGraph::insert_edge(Node *from, Node *to, AsyncState state) {
 
 bool StateFlowGraph::optimize_listgen() {
   TI_AUTO_PROF;
+  TI_AUTO_TIMELINE;
   bool modified = false;
 
   std::vector<std::pair<int, int>> common_pairs;
@@ -813,6 +808,7 @@ std::unordered_set<int> StateFlowGraph::fuse_range(int begin, int end) {
 
 bool StateFlowGraph::fuse() {
   TI_AUTO_PROF;
+  TI_AUTO_TIMELINE;
   using bit::Bitset;
   // Only guarantee to fuse tasks with indices in nodes_ differ by less than
   // kMaxFusionDistance if there are too many tasks.
@@ -852,6 +848,7 @@ bool StateFlowGraph::fuse() {
 
 void StateFlowGraph::rebuild_graph(bool sort) {
   TI_AUTO_PROF;
+  TI_AUTO_TIMELINE;
   if (sort)
     topo_sort_nodes();
   std::vector<TaskLaunchRecord> tasks;
@@ -1236,6 +1233,7 @@ void StateFlowGraph::delete_nodes(
 
 bool StateFlowGraph::optimize_dead_store() {
   TI_AUTO_PROF
+  TI_AUTO_TIMELINE;
   bool modified = false;
 
   auto nodes = get_pending_tasks();
@@ -1442,6 +1440,7 @@ void StateFlowGraph::verify(bool also_verify_ir) const {
 
 bool StateFlowGraph::demote_activation() {
   TI_AUTO_PROF
+  TI_AUTO_TIMELINE;
   bool modified = false;
 
   topo_sort_nodes();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -191,7 +191,8 @@ void export_lang(py::module &m) {
       .def("kernel_profiler_total_time",
            [](Program *program) { return program->profiler->get_total_time(); })
       .def("kernel_profiler_clear", &Program::kernel_profiler_clear)
-      .def("timeline_clear", [] { Timelines::get_instance().clear(); })
+      .def("timeline_clear",
+           [](Program *) { Timelines::get_instance().clear(); })
       .def("timeline_save",
            [](Program *, const std::string &fn) {
              Timelines::get_instance().save(fn);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -149,6 +149,7 @@ void export_lang(py::module &m) {
                      &CompileConfig::demote_dense_struct_fors)
       .def_readwrite("use_unified_memory", &CompileConfig::use_unified_memory)
       .def_readwrite("kernel_profiler", &CompileConfig::kernel_profiler)
+      .def_readwrite("timeline", &CompileConfig::timeline)
       .def_readwrite("default_fp", &CompileConfig::default_fp)
       .def_readwrite("default_ip", &CompileConfig::default_ip)
       .def_readwrite("device_memory_GB", &CompileConfig::device_memory_GB)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -17,6 +17,7 @@
 #include "taichi/math/svd.h"
 #include "taichi/util/statistics.h"
 #include "taichi/util/action_recorder.h"
+#include "taichi/system/timeline.h"
 
 #if defined(TI_WITH_CUDA)
 #include "taichi/backends/cuda/cuda_context.h"
@@ -190,6 +191,11 @@ void export_lang(py::module &m) {
       .def("kernel_profiler_total_time",
            [](Program *program) { return program->profiler->get_total_time(); })
       .def("kernel_profiler_clear", &Program::kernel_profiler_clear)
+      .def("timeline_clear", [] { Timelines::get_instance().clear(); })
+      .def("timeline_save",
+           [](Program *, const std::string &fn) {
+             Timelines::get_instance().save(fn);
+           })
       .def("print_memory_profiler_info", &Program::print_memory_profiler_info)
       .def("finalize", &Program::finalize)
       .def("get_root",

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -766,7 +766,7 @@ Ptr LLVMRuntime::allocate_aligned(std::size_t size, std::size_t alignment) {
 }
 
 Ptr LLVMRuntime::allocate_from_buffer(std::size_t size, std::size_t alignment) {
-  Ptr ret;
+  Ptr ret = nullptr;
   bool success = false;
   locked_task(&allocator_lock, [&] {
     auto alignment_bytes =

--- a/taichi/system/timeline.cpp
+++ b/taichi/system/timeline.cpp
@@ -67,8 +67,8 @@ void Timelines::insert_events(const std::vector<TimelineEvent> &events,
 }
 
 Timelines &taichi::Timelines::get_instance() {
-  static Timelines instance;
-  return instance;
+  static auto instance = new Timelines();
+  return *instance;
 }
 
 void Timelines::clear() {

--- a/taichi/system/timeline.cpp
+++ b/taichi/system/timeline.cpp
@@ -60,9 +60,9 @@ void Timelines::insert_events(const std::vector<TimelineEvent> &events,
                               bool lock) {
   if (lock) {
     std::lock_guard<std::mutex> _(mut_);
-    events_.insert(events_.begin(), events.begin(), events.end());
+    events_.insert(events_.end(), events.begin(), events.end());
   } else {
-    events_.insert(events_.begin(), events.begin(), events.end());
+    events_.insert(events_.end(), events.begin(), events.end());
   }
 }
 
@@ -81,6 +81,9 @@ void Timelines::clear() {
 
 void Timelines::save(const std::string &filename) {
   std::lock_guard<std::mutex> _(mut_);
+  std::sort(timelines_.begin(), timelines_.end(), [](Timeline *a, Timeline *b) {
+    return a->get_name() < b->get_name();
+  });
   for (auto timeline : timelines_) {
     insert_events(timeline->fetch_events(), false);
   }

--- a/taichi/system/timeline.cpp
+++ b/taichi/system/timeline.cpp
@@ -56,14 +56,14 @@ Timeline::Guard::~Guard() {
   timeline.insert_event({name_, false, Time::get_time(), timeline.tid_});
 }
 
-void Timelines::insert_events(const std::vector<TimelineEvent> &events,
-                              bool lock) {
-  if (lock) {
-    std::lock_guard<std::mutex> _(mut_);
-    events_.insert(events_.end(), events.begin(), events.end());
-  } else {
-    events_.insert(events_.end(), events.begin(), events.end());
-  }
+void Timelines::insert_events(const std::vector<TimelineEvent> &events) {
+  std::lock_guard<std::mutex> _(mut_);
+  insert_events_without_locking(events);
+}
+
+void Timelines::insert_events_without_locking(
+    const std::vector<TimelineEvent> &events) {
+  events_.insert(events_.end(), events.begin(), events.end());
 }
 
 Timelines &taichi::Timelines::get_instance() {
@@ -85,7 +85,7 @@ void Timelines::save(const std::string &filename) {
     return a->get_name() < b->get_name();
   });
   for (auto timeline : timelines_) {
-    insert_events(timeline->fetch_events(), false);
+    insert_events_without_locking(timeline->fetch_events());
   }
   if (!ends_with(filename, ".json")) {
     TI_WARN("Timeline filename {} should end with '.json'.", filename);

--- a/taichi/system/timeline.cpp
+++ b/taichi/system/timeline.cpp
@@ -33,6 +33,8 @@ void Timeline::clear() {
   events_.clear();
 }
 void Timeline::insert_event(const TimelineEvent &e) {
+  if (!Timelines::get_instance().get_enabled())
+    return;
   std::lock_guard<std::mutex> _(mut_);
   events_.push_back(e);
 }
@@ -108,6 +110,14 @@ void Timelines::insert_timeline(Timeline *timeline) {
 void Timelines::remove_timeline(Timeline *timeline) {
   std::lock_guard<std::mutex> _(mut_);
   trash(std::remove(timelines_.begin(), timelines_.end(), timeline));
+}
+
+bool Timelines::get_enabled() {
+  return enabled_;
+}
+
+void Timelines::set_enabled(bool enabled) {
+  enabled_ = enabled;
 }
 
 TI_NAMESPACE_END

--- a/taichi/system/timeline.cpp
+++ b/taichi/system/timeline.cpp
@@ -1,0 +1,87 @@
+#include "taichi/system/timeline.h"
+
+TI_NAMESPACE_BEGIN
+
+std::string TimelineEvent::to_json() {
+  std::string json{"{"};
+  json += fmt::format("\"cat\":\"taichi\",");
+  json += fmt::format("\"pid\":0,");
+  json += fmt::format("\"tid\":\"{}\",", tid);
+  json += fmt::format("\"ph\":\"{}\",", begin ? "B" : "E");
+  json += fmt::format("\"name\":\"{}\",", name);
+  json += fmt::format("\"ts\":\"{}\"", uint64(time * 1000000));
+  json += "}";
+  return json;
+}
+
+Timeline::Timeline() : tid_("unnamed") {
+  Timelines::get_instance().insert_timeline(this);
+}
+
+Timeline &Timeline::get_this_thread_instance() {
+  thread_local Timeline instance;
+  return instance;
+}
+
+Timeline::~Timeline() {
+  Timelines::get_instance().insert_events(fetch_events());
+  Timelines::get_instance().remove_timeline(this);
+}
+
+Timeline::Guard::Guard(const std::string &name) : name_(name) {
+  auto &timeline = Timeline::get_this_thread_instance();
+  timeline.insert_event({name, true, Time::get_time(), timeline.tid_});
+}
+
+Timeline::Guard::~Guard() {
+  auto &timeline = Timeline::get_this_thread_instance();
+  timeline.insert_event({name_, false, Time::get_time(), timeline.tid_});
+}
+
+void Timelines::insert_events(const std::vector<TimelineEvent> &events,
+                              bool lock) {
+  if (lock) {
+    std::lock_guard<std::mutex> _(mut_);
+    events_.insert(events_.begin(), events.begin(), events.end());
+  } else {
+    events_.insert(events_.begin(), events.begin(), events.end());
+  }
+}
+
+Timelines &taichi::Timelines::get_instance() {
+  static Timelines instance;
+  return instance;
+}
+
+void Timelines::clear() {
+  // TODO: also clear events of each time line
+  std::lock_guard<std::mutex> _(mut_);
+  events_.clear();
+  for (auto timeline : timelines_) {
+    timeline->clear();
+  }
+}
+
+void Timelines::save(const std::string &filename) {
+  std::lock_guard<std::mutex> _(mut_);
+  for (auto timeline : timelines_) {
+    insert_events(timeline->fetch_events(), false);
+  }
+  if (!ends_with(filename, ".json")) {
+    TI_WARN("Timeline filename {} should end with '.json'.", filename);
+  }
+  std::ofstream fout(filename);
+  fout << "[";
+  bool first = true;
+  for (auto &e : events_) {
+    if (first) {
+      first = false;
+    } else {
+      fout << ",";
+    }
+    fout << e.to_json() << std::endl;
+  }
+  fout << "]";
+}
+
+TI_NAMESPACE_END

--- a/taichi/system/timeline.cpp
+++ b/taichi/system/timeline.cpp
@@ -72,7 +72,6 @@ Timelines &taichi::Timelines::get_instance() {
 }
 
 void Timelines::clear() {
-  // TODO: also clear events of each time line
   std::lock_guard<std::mutex> _(mut_);
   events_.clear();
   for (auto timeline : timelines_) {

--- a/taichi/system/timeline.h
+++ b/taichi/system/timeline.h
@@ -1,8 +1,3 @@
-/*******************************************************************************
-    Copyright (c) The Taichi Authors (2016- ). All Rights Reserved.
-    The use of this software is governed by the LICENSE file.
-*******************************************************************************/
-
 #pragma once
 
 #include <vector>

--- a/taichi/system/timeline.h
+++ b/taichi/system/timeline.h
@@ -29,6 +29,10 @@ class Timeline {
     tid_ = tid;
   }
 
+  std::string get_name() {
+    return tid_;
+  }
+
   void clear();
 
   void insert_event(const TimelineEvent &e);

--- a/taichi/system/timeline.h
+++ b/taichi/system/timeline.h
@@ -34,22 +34,11 @@ class Timeline {
     tid_ = tid;
   }
 
-  void clear() {
-    std::lock_guard<std::mutex> _(mut_);
-    events_.clear();
-  }
+  void clear();
 
-  void insert_event(const TimelineEvent &e) {
-    std::lock_guard<std::mutex> _(mut_);
-    events_.push_back(e);
-  }
+  void insert_event(const TimelineEvent &e);
 
-  std::vector<TimelineEvent> fetch_events() {
-    std::lock_guard<std::mutex> _(mut_);
-    std::vector<TimelineEvent> fetched;
-    std::swap(fetched, events_);
-    return fetched;
-  }
+  std::vector<TimelineEvent> fetch_events();
 
   class Guard {
    public:
@@ -70,24 +59,18 @@ class Timeline {
 // A timeline system for multi-threaded applications
 class Timelines {
  public:
+  static Timelines &get_instance();
+
   void insert_events(const std::vector<TimelineEvent> &events,
                      bool lock = true);
 
-  static Timelines &get_instance();
+  void insert_timeline(Timeline *timeline);
+
+  void remove_timeline(Timeline *timeline);
 
   void clear();
 
   void save(const std::string &filename);
-
-  void insert_timeline(Timeline *timeline) {
-    std::lock_guard<std::mutex> _(mut_);
-    timelines_.push_back(timeline);
-  }
-
-  void remove_timeline(Timeline *timeline) {
-    std::lock_guard<std::mutex> _(mut_);
-    std::remove(timelines_.begin(), timelines_.end(), timeline);
-  }
 
  private:
   std::mutex mut_;

--- a/taichi/system/timeline.h
+++ b/taichi/system/timeline.h
@@ -60,8 +60,9 @@ class Timelines {
  public:
   static Timelines &get_instance();
 
-  void insert_events(const std::vector<TimelineEvent> &events,
-                     bool lock = true);
+  void insert_events(const std::vector<TimelineEvent> &events);
+
+  void insert_events_without_locking(const std::vector<TimelineEvent> &events);
 
   void insert_timeline(Timeline *timeline);
 

--- a/taichi/system/timeline.h
+++ b/taichi/system/timeline.h
@@ -72,10 +72,15 @@ class Timelines {
 
   void save(const std::string &filename);
 
+  bool get_enabled();
+
+  void set_enabled(bool enabled);
+
  private:
   std::mutex mut_;
   std::vector<TimelineEvent> events_;
   std::vector<Timeline *> timelines_;
+  bool enabled_{false};
 };
 
 #define TI_TIMELINE(name) \

--- a/taichi/system/timeline.h
+++ b/taichi/system/timeline.h
@@ -1,0 +1,128 @@
+/*******************************************************************************
+    Copyright (c) The Taichi Authors (2016- ). All Rights Reserved.
+    The use of this software is governed by the LICENSE file.
+*******************************************************************************/
+
+#pragma once
+
+#include <vector>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "taichi/common/core.h"
+#include "taichi/system/timer.h"
+#include "spdlog/fmt/bundled/color.h"
+
+TI_NAMESPACE_BEGIN
+
+// TODO: cppize
+struct TimelineEvent {
+  std::string name;
+  bool begin;
+  float64 time;
+  std::string tid;
+
+  std::string to_json() {
+    std::string json{"{"};
+    json += fmt::format("\"cat\":\"taichi\",");
+    json += fmt::format("\"pid\":0,");
+    json += fmt::format("\"tid\":\"{}\",", tid);
+    json += fmt::format("\"ph\":\"{}\",", begin ? "B" : "E");
+    json += fmt::format("\"name\":\"{}\",", name);
+    json += fmt::format("\"ts\":\"{}\"", uint64(time * 1000000));
+    json += "}";
+    return json;
+  }
+};
+
+class Timeline {
+ public:
+  Timeline() : tid_("unnamed") {
+  }
+
+  void set_name(const std::string &tid) {
+    tid_ = tid;
+  }
+
+  static Timeline &get_this_thread_instance() {
+    thread_local Timeline instance;
+    return instance;
+  }
+
+  ~Timeline();
+
+  void insert_event(const TimelineEvent &e) {
+    events_.push_back(e);
+  }
+
+  class Guard {
+   public:
+    Guard(const std::string &name) : name_(name) {
+      auto &timeline = Timeline::get_this_thread_instance();
+      timeline.insert_event({name, true, Time::get_time(), timeline.tid_});
+    }
+
+    ~Guard() {
+      auto &timeline = Timeline::get_this_thread_instance();
+      timeline.insert_event({name_, false, Time::get_time(), timeline.tid_});
+    }
+
+   private:
+    std::string name_;
+  };
+
+ private:
+  std::string tid_;
+  std::vector<TimelineEvent> events_;
+};
+
+// A timeline system for multi-threaded applications
+class Timelines {
+ public:
+  void clear() {
+    std::lock_guard<std::mutex> _(mut_);
+    events_.clear();
+  }
+
+  void insert_events(const std::vector<TimelineEvent> &events) {
+    std::lock_guard<std::mutex> _(mut_);
+    events_.insert(events_.begin(), events.begin(), events.end());
+  }
+
+  static Timelines &get_instance() {
+    static Timelines instance;
+    return instance;
+  }
+
+  ~Timelines() {
+    std::ofstream fout("timeline.json");
+    fout << "[";
+    bool first = true;
+    for (auto &e : events_) {
+      if (first) {
+        first = false;
+      } else {
+        fout << ",";
+      }
+      fout << e.to_json() << std::endl;
+    }
+    fout << "]";
+  }
+
+ private:
+  std::mutex mut_;
+  std::vector<TimelineEvent> events_;
+};
+
+inline Timeline::~Timeline() {
+  Timelines::get_instance().insert_events(events_);
+}
+
+#define TI_TIMELINE(name) \
+  taichi::Timeline::Guard _timeline_guard_##__LINE__(name);
+
+#define TI_AUTO_TIMELINE TI_TIMELINE(__FUNCTION__)
+
+TI_NAMESPACE_END

--- a/tests/cpp/test_alg_simp.cpp
+++ b/tests/cpp/test_alg_simp.cpp
@@ -25,7 +25,7 @@ TI_TEST("alg_simp") {
         block->push_back<BinaryOpStmt>(BinaryOpType::add, global_load, zero);
     auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
         4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
-    auto global_store =
+    [[maybe_unused]] auto global_store =
         block->push_back<GlobalStoreStmt>(global_store_addr, add);
 
     irpass::type_check(block.get());
@@ -64,7 +64,7 @@ TI_TEST("alg_simp") {
     auto sub = block->push_back<BinaryOpStmt>(BinaryOpType::sub, mul2, div);
     auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
         4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::f32));
-    auto global_store =
+    [[maybe_unused]] auto global_store =
         block->push_back<GlobalStoreStmt>(global_store_addr, sub);
 
     irpass::type_check(block.get());
@@ -160,7 +160,7 @@ TI_TEST("alg_simp") {
                                                      minus_one, global_load);
     auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
         4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
-    auto global_store =
+    [[maybe_unused]] auto global_store =
         block->push_back<GlobalStoreStmt>(global_store_addr, and_result);
 
     auto func = []() {};

--- a/tests/cpp/test_parallel_executor.cpp
+++ b/tests/cpp/test_parallel_executor.cpp
@@ -5,13 +5,13 @@ TLANG_NAMESPACE_BEGIN
 
 TI_TEST("parallel_executor") {
   SECTION("create_and_destruct") {
-    ParallelExecutor exec(10);
+    ParallelExecutor exec("test", 10);
   }
   SECTION("parallel_print") {
     int N = 100;
     std::vector<int> buffer(N, 0);
     {
-      ParallelExecutor exec(10);
+      ParallelExecutor exec("test", 10);
       for (int i = 0; i < N; i++) {
         exec.enqueue([i = i, &buffer]() { buffer[i] = i + 1; });
       }

--- a/tests/cpp/test_simplify.cpp
+++ b/tests/cpp/test_simplify.cpp
@@ -29,7 +29,7 @@ TI_TEST("simplify") {
     auto zero = block->push_back<ConstStmt>(TypedConstant(0));
     auto linearized_zero = block->push_back<LinearizeStmt>(
         std::vector<Stmt *>(2, zero), std::vector<int>({8, 4}));
-    auto lookup2 = block->push_back<SNodeLookupStmt>(
+    [[maybe_unused]] auto lookup2 = block->push_back<SNodeLookupStmt>(
         root.ch[0].get(), get_child, linearized_zero, true);
 
     irpass::type_check(block.get());


### PR DESCRIPTION
Related issue = #742

The generated timeline json can be view via Chrome: https://slack.engineering/chrome-tracing-for-fun-and-profit/#:~:text=Chrome%20Tracing%20lets%20you%20record,is%20waiting%20on%20another%20process.

- C++-side API: `TI_TIMELINE` and `TI_AUTO_TIMELINE`
- Python-side API: `ti.init(timeline=True)`, `ti.timeline_clear()` and `ti.timeline_save(fn)`

There are other tools that do similar things, but they tend to expose too much information.

Demo:
![Screenshot from 2021-01-19 00-52-57](https://user-images.githubusercontent.com/6553256/104993355-b6460f80-59f0-11eb-9cf9-2a5473a5cd2a.png)


- Parallel compilation:
![Screenshot from 2021-01-19 00-52-23](https://user-images.githubusercontent.com/6553256/104993300-a4fd0300-59f0-11eb-8cde-b4f7fdf57535.png)

- Flamechart of `flush`:
![Screenshot from 2021-01-19 00-53-45](https://user-images.githubusercontent.com/6553256/104993435-d4ac0b00-59f0-11eb-803c-d4f29027e718.png)

- CPU blocking GPU:
![Screenshot from 2021-01-19 01-00-18](https://user-images.githubusercontent.com/6553256/104994007-c3afc980-59f1-11eb-8f3a-12771649ed68.png)


<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
