### PR TITLE
[type] Use a single atomicCAS for BitStructStoreStmt

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1437,8 +1437,6 @@ void CodeGenLLVM::store_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
     llvm::Value *max_exp_bits = nullptr;
     for (auto f : floats) {
       // TODO: we only support f32 here.
-      //  Shall we set the return type of extract_exponent_from_float to
-      //  bit_struct_physical_type?
       auto exp_bits = extract_exponent_from_float(f);
       if (max_exp_bits) {
         max_exp_bits = create_call("max_u32", {max_exp_bits, exp_bits});
@@ -1504,8 +1502,7 @@ void CodeGenLLVM::store_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
       }
 
       // store the digits
-      val = builder->CreateZExt(
-          digits, llvm_type(bit_struct_physical_type->get_compute_type()));
+      val = builder->CreateZExt(digits, llvm_type(bit_struct_physical_type));
       val = builder->CreateShl(val, digits_bit_offset);
       masked_val = builder->CreateOr(masked_val, val);
       auto num_digit_bits =

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -218,6 +218,11 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                         CustomIntType *cit,
                         llvm::Value *value);
 
+  void store_masked(llvm::Value *byte_ptr,
+                    uint64 mask,
+                    Type *physical_type,
+                    llvm::Value *value);
+
   void visit(GlobalStoreStmt *stmt) override;
 
   llvm::Value *custom_type_to_bits(llvm::Value *val,


### PR DESCRIPTION
Related issue = #1905

Test case: (1.66s->0.74s)
```python
import taichi as ti

ti.init(arch=ti.cpu, kernel_profiler=True, print_ir=True)

quant = True

n = 1024 * 1024 * 256

if quant:
    ci8 = ti.quant.int(8, True)

    x = ti.field(dtype=ci8)
    y = ti.field(dtype=ci8)
    z = ti.field(dtype=ci8)
    w = ti.field(dtype=ci8)

    ti.root.dense(ti.i, n).bit_struct(num_bits=32).place(x, y, z, w)
else:
    x = ti.field(dtype=ti.i8)
    y = ti.field(dtype=ti.i8)
    z = ti.field(dtype=ti.i8)
    w = ti.field(dtype=ti.i8)

    ti.root.dense(ti.i, n).place(x, y, z, w)

w[0] = 1


@ti.kernel
def foo():
    for i in range(n):
        x[i] = i & 127
        y[i] = i & 31
        z[i] = i & 7
        # do not store w[i]


for i in range(10):
    foo()

ti.kernel_profiler_print()
assert w[0] == 1
```

Test case (1.66s->0.84s):
```python
import taichi as ti

ti.init(arch=ti.cpu, kernel_profiler=True, print_ir=False)

quant = True

n = 1024 * 1024 * 128

exp = ti.type_factory.custom_int(8, False)
cit = ti.type_factory.custom_int(14, True)
cft = ti.type_factory.custom_float(significand_type=cit, exponent_type=exp, scale=1)

x = ti.field(dtype=cft)
y = ti.field(dtype=cft)
z = ti.field(dtype=cft)
w = ti.field(dtype=cft)

ti.root.dense(ti.i, n).bit_struct(num_bits=64).place(x, y, z, w, shared_exponent=True)

w[0] = 1.0


@ti.kernel
def foo():
    for i in range(n):
        x[i] = i * 0.1
        y[i] = i * 0.2
        z[i] = i * 0.3
        # do not store w[i]


for i in range(10):
    foo()

ti.kernel_profiler_print()
assert w[0] == 1.0
assert x[1] == ti.approx(0.1, rel=1e-3)
```

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
