### PR TITLE
[type] Atomic demotion for bit struct stores

### DIFF
--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -221,7 +221,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   void store_masked(llvm::Value *byte_ptr,
                     uint64 mask,
                     Type *physical_type,
-                    llvm::Value *value);
+                    llvm::Value *value,
+                    bool atomic);
 
   void visit(GlobalStoreStmt *stmt) override;
 

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -72,6 +72,9 @@ std::pair<std::unordered_set<SNode *>, std::unordered_set<SNode *>>
 gather_snode_read_writes(IRNode *root);
 std::vector<Stmt *> gather_statements(IRNode *root,
                                       const std::function<bool(Stmt *)> &test);
+std::unordered_map<OffloadedStmt *,
+                   std::unordered_map<const SNode *, GlobalPtrStmt *>>
+gather_uniquely_accessed_bit_structs(IRNode *root);
 std::unordered_map<const SNode *, GlobalPtrStmt *>
 gather_uniquely_accessed_pointers(IRNode *root);
 std::unique_ptr<std::unordered_set<AtomicOpStmt *>> gather_used_atomics(

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1182,11 +1182,12 @@ class BitStructStoreStmt : public Stmt {
   Stmt *ptr;
   std::vector<int> ch_ids;
   std::vector<Stmt *> values;
+  bool is_atomic;
 
   BitStructStoreStmt(Stmt *ptr,
                      const std::vector<int> &ch_ids,
                      const std::vector<Stmt *> &values)
-      : ptr(ptr), ch_ids(ch_ids), values(values) {
+      : ptr(ptr), ch_ids(ch_ids), values(values), is_atomic(true) {
     TI_ASSERT(ch_ids.size() == values.size());
     TI_STMT_REG_FIELDS;
   }
@@ -1197,7 +1198,7 @@ class BitStructStoreStmt : public Stmt {
     return false;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, ptr, ch_ids, values);
+  TI_STMT_DEF_FIELDS(ret_type, ptr, ch_ids, values, is_atomic);
   TI_DEFINE_ACCEPT_AND_CLONE;
 };
 

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -62,7 +62,11 @@ void demote_dense_struct_fors(IRNode *root);
 bool demote_atomics(IRNode *root);
 void reverse_segments(IRNode *root);  // for autograd
 void detect_read_only(IRNode *root);
-void optimize_bit_struct_stores(IRNode *root);
+void optimize_bit_struct_stores(
+    IRNode *root,
+    const std::unordered_map<OffloadedStmt *,
+                             std::unordered_map<const SNode *, GlobalPtrStmt *>>
+        &uniquely_accessed_bit_structs);
 
 // compile_to_offloads does the basic compilation to create all the offloaded
 // tasks of a Taichi kernel. It's worth pointing out that this doesn't demote

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -76,6 +76,8 @@ struct CompileConfig {
   // Setting 0 effectively means unlimited
   int async_max_fuse_per_task{1};
 
+  bool quant_opt_atomic_demotion{true};
+
   CompileConfig();
 };
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -180,7 +180,9 @@ void export_lang(py::module &m) {
                      &CompileConfig::async_opt_intermediate_file)
       .def_readwrite("async_flush_every", &CompileConfig::async_flush_every)
       .def_readwrite("async_max_fuse_per_task",
-                     &CompileConfig::async_max_fuse_per_task);
+                     &CompileConfig::async_max_fuse_per_task)
+      .def_readwrite("quant_opt_atomic_demotion",
+                     &CompileConfig::quant_opt_atomic_demotion);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1581,6 +1581,11 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
 #define DEFINE_SET_PARTIAL_BITS(N)                                            \
   void set_mask_b##N(u##N *ptr, u64 mask, u##N value) {                       \
     u##N mask_N = (u##N)mask;                                                 \
+    *ptr = (*ptr & (~mask_N)) | value;                                        \
+  }                                                                           \
+                                                                              \
+  void atomic_set_mask_b##N(u##N *ptr, u64 mask, u##N value) {                \
+    u##N mask_N = (u##N)mask;                                                 \
     u##N new_value = 0;                                                       \
     u##N old_value = *ptr;                                                    \
     do {                                                                      \
@@ -1594,7 +1599,7 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
                                                                               \
   void set_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits, u##N value) {   \
     u##N mask = ((~(u##N)0) << (N - bits)) >> (N - offset - bits);            \
-    set_mask_b##N(ptr, mask, value << offset);                                \
+    atomic_set_mask_b##N(ptr, mask, value << offset);                         \
   }                                                                           \
                                                                               \
   u##N atomic_add_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits,          \

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -177,6 +177,15 @@ void offload_to_executable(IRNode *ir,
   print("Atomics demoted II");
   irpass::analysis::verify(ir);
 
+  std::unordered_map<OffloadedStmt *,
+                     std::unordered_map<const SNode *, GlobalPtrStmt *>>
+      uniquely_accessed_bit_structs;
+  if (is_extension_supported(config.arch, Extension::quant) &&
+      ir->get_config().quant_opt_atomic_demotion) {
+    uniquely_accessed_bit_structs =
+        irpass::analysis::gather_uniquely_accessed_bit_structs(ir);
+  }
+
   irpass::remove_range_assumption(ir);
   print("Remove range assumption");
 
@@ -205,7 +214,7 @@ void offload_to_executable(IRNode *ir,
   print("Simplified IV");
 
   if (is_extension_supported(config.arch, Extension::quant)) {
-    irpass::optimize_bit_struct_stores(ir);
+    irpass::optimize_bit_struct_stores(ir, uniquely_accessed_bit_structs);
     print("Bit struct stores optimized");
   }
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -630,8 +630,8 @@ class IRPrinter : public IRVisitor {
         values += ", ";
       }
     }
-    print("{} : bit_struct_store {}, ch_ids=[{}], values=[{}]", stmt->name(),
-          stmt->ptr->name(), ch_ids, values);
+    print("{} : {}bit_struct_store {}, ch_ids=[{}], values=[{}]", stmt->name(),
+          stmt->is_atomic ? "atomic " : "", stmt->ptr->name(), ch_ids, values);
   }
 };
 


### PR DESCRIPTION
Related issue = #1905

Test case(0.75s -> 0.42s)
```python
import taichi as ti

ti.init(arch=ti.cpu, kernel_profiler=True, print_ir=True, quant_opt_atomic_demotion=True)

quant = True

n = 1024 * 1024 * 256

if quant:
    ci16 = ti.quant.int(16, True)

    x = ti.field(dtype=ci16)
    y = ti.field(dtype=ci16)

    ti.root.dense(ti.i, n).bit_struct(num_bits=32).place(x, y)
else:
    x = ti.field(dtype=ti.i16)
    y = ti.field(dtype=ti.i16)

    ti.root.dense(ti.i, n).place(x, y)


@ti.kernel
def foo():
    for i in range(n):
        x[i] = 1


for i in range(10):
    foo()

ti.kernel_profiler_print()
```
<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
