### PR TITLE
[type] Improve bit struct store fusion and atomic demotion

### DIFF
--- a/taichi/analysis/gather_uniquely_accessed_pointers.cpp
+++ b/taichi/analysis/gather_uniquely_accessed_pointers.cpp
@@ -185,7 +185,7 @@ class UniquelyAccessedBitStructGatherer : public BasicStmtVisitor {
           irpass::analysis::gather_uniquely_accessed_pointers(stmt);
       for (auto &it : loop_unique_ptr) {
         auto *snode = it.first;
-        auto *ptr = it.second;
+        auto *ptr1 = it.second;
         if (snode->is_bit_level) {
           // Find the nearest non-bit-level ancestor
           while (snode->is_bit_level) {
@@ -194,11 +194,15 @@ class UniquelyAccessedBitStructGatherer : public BasicStmtVisitor {
           // Check whether uniquely accessed
           auto accessed_ptr = loop_unique_bit_struct.find(snode);
           if (accessed_ptr == loop_unique_bit_struct.end()) {
-            loop_unique_bit_struct[snode] = ptr;
+            loop_unique_bit_struct[snode] = ptr1;
           } else {
-            if (!irpass::analysis::definitely_same_address(accessed_ptr->second,
-                                                           ptr)) {
-              accessed_ptr->second = nullptr;  // not uniquely accessed
+            auto *ptr2 = accessed_ptr->second;
+            TI_ASSERT(ptr1->indices.size() == ptr2->indices.size());
+            for (int id = 0; id < (int)ptr1->indices.size(); id++) {
+              if (!irpass::analysis::same_value(ptr1->indices[id],
+                                                ptr2->indices[id])) {
+                accessed_ptr->second = nullptr;  // not uniquely accessed
+              }
             }
           }
         }

--- a/taichi/analysis/gather_uniquely_accessed_pointers.cpp
+++ b/taichi/analysis/gather_uniquely_accessed_pointers.cpp
@@ -196,6 +196,10 @@ class UniquelyAccessedBitStructGatherer : public BasicStmtVisitor {
           if (accessed_ptr == loop_unique_bit_struct.end()) {
             loop_unique_bit_struct[snode] = ptr1;
           } else {
+            if (ptr1 == nullptr) {
+              accessed_ptr->second = nullptr;
+              continue;
+            }
             auto *ptr2 = accessed_ptr->second;
             TI_ASSERT(ptr1->indices.size() == ptr2->indices.size());
             for (int id = 0; id < (int)ptr1->indices.size(); id++) {

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -76,6 +76,7 @@ struct CompileConfig {
   // Setting 0 effectively means unlimited
   int async_max_fuse_per_task{1};
 
+  bool quant_opt_store_fusion{true};
   bool quant_opt_atomic_demotion{true};
 
   CompileConfig();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -181,6 +181,8 @@ void export_lang(py::module &m) {
       .def_readwrite("async_flush_every", &CompileConfig::async_flush_every)
       .def_readwrite("async_max_fuse_per_task",
                      &CompileConfig::async_max_fuse_per_task)
+      .def_readwrite("quant_opt_store_fusion",
+                     &CompileConfig::quant_opt_store_fusion)
       .def_readwrite("quant_opt_atomic_demotion",
                      &CompileConfig::quant_opt_atomic_demotion);
 

--- a/taichi/transforms/optimize_bit_struct_stores.cpp
+++ b/taichi/transforms/optimize_bit_struct_stores.cpp
@@ -207,7 +207,9 @@ void optimize_bit_struct_stores(
   TI_AUTO_PROF;
   CreateBitStructStores::run(root);
   die(root);  // remove unused GetCh
-  MergeBitStructStores::run(root);
+  if (root->get_config().quant_opt_store_fusion) {
+    MergeBitStructStores::run(root);
+  }
   if (root->get_config().quant_opt_atomic_demotion) {
     DemoteAtomicBitStructStores::run(root, uniquely_accessed_bit_structs);
   }


### PR DESCRIPTION
Related issue = #1905 #2171 #2174

Test case (there are no atomic operations when either one of the optimizations is enabled):
fusion=False, atomic_demotion=False: 1.171s
fusion=False, atomic_demotion=True: 0.355s
fusion=True, atomic_demotion=False: 0.356s
fusion=True, atomic_demotion=True: 0.358s
```python
import taichi as ti

ti.init(arch=ti.cpu, kernel_profiler=True, print_ir=False,
        quant_opt_store_fusion=True, quant_opt_atomic_demotion=True)

quant = True

n = 1024 * 1024 * 256

if quant:
    ci16 = ti.quant.int(16, True)

    x = ti.field(dtype=ci16)
    y = ti.field(dtype=ci16)

    ti.root.dense(ti.i, n).bit_struct(num_bits=32).place(x, y)
else:
    x = ti.field(dtype=ti.i16)
    y = ti.field(dtype=ti.i16)

    ti.root.dense(ti.i, n).place(x, y)


@ti.kernel
def foo():
    for i in range(n):
        x[i] = i & 1023
        y[i] = i & 15


for i in range(10):
    foo()

ti.kernel_profiler_print()
```

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
