### PR TITLE
[type] Apply quant_opt_atomic_demotion when storing all components

### DIFF
--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -96,7 +96,8 @@ void CodeGenLLVM::store_masked(llvm::Value *byte_ptr,
                                llvm::Value *value,
                                bool atomic) {
   uint64 full_mask = (~(uint64)0) >> (64 - data_type_bits(physical_type));
-  if ((mask & full_mask) == full_mask) {
+  if ((!atomic || prog->config.quant_opt_atomic_demotion) &&
+      ((mask & full_mask) == full_mask)) {
     builder->CreateStore(value, byte_ptr);
     return;
   }
@@ -170,7 +171,8 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       bit_struct_val = builder->CreateOr(bit_struct_val, val);
     }
   }
-  if (stmt->ch_ids.size() == bit_struct_snode->ch.size()) {
+  if (prog->config.quant_opt_atomic_demotion &&
+      stmt->ch_ids.size() == bit_struct_snode->ch.size()) {
     // Store all the components
     builder->CreateStore(bit_struct_val, llvm_val[stmt->ptr]);
   } else {


### PR DESCRIPTION
Related issue = #1905

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
