### PR TITLE
[Bug] [lang] Fix AST not being transformed inside ti.ndrange

### DIFF
--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -428,7 +428,8 @@ if ti.static(1):
         t = ast.parse(template).body[0]
         t.body[0].value = node.iter
         t_loop = t.body[1]
-        t_loop.iter.args[0] = self.parse_expr(f'__ndrange{id(node)}.acc_dimensions[0]')
+        t_loop.iter.args[0] = self.parse_expr(
+            f'__ndrange{id(node)}.acc_dimensions[0]')
         targets = self.get_targets(node)
         targets_tmp = ['__' + name for name in targets]
         loop_body = t_loop.body

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -421,30 +421,30 @@ if 1:
         # for i, j in ti.ndrange(n)
         template = f'''
 if ti.static(1):
-    __ndrange = ti.static(0)
+    __ndrange{id(node)} = 0
     for __ndrange_I{id(node)} in range(0):
         __I = __ndrange_I{id(node)}
         '''
         t = ast.parse(template).body[0]
-        t.body[0].value.args[0] = node.iter
+        t.body[0].value = node.iter
         t_loop = t.body[1]
-        t_loop.iter.args[0] = self.parse_expr('__ndrange.acc_dimensions[0]')
+        t_loop.iter.args[0] = self.parse_expr(f'__ndrange{id(node)}.acc_dimensions[0]')
         targets = self.get_targets(node)
         targets_tmp = ['__' + name for name in targets]
         loop_body = t_loop.body
         for i in range(len(targets)):
             if i + 1 < len(targets):
-                stmt = '{} = __I // __ndrange.acc_dimensions[{}]'.format(
-                    targets_tmp[i], i + 1)
+                stmt = '{} = __I // __ndrange{}.acc_dimensions[{}]'.format(
+                    targets_tmp[i], id(node), i + 1)
             else:
                 stmt = '{} = __I'.format(targets_tmp[i])
             loop_body.append(self.parse_stmt(stmt))
-            stmt = '{} = {} + __ndrange.bounds[{}][0]'.format(
-                targets[i], targets_tmp[i], i)
+            stmt = '{} = {} + __ndrange{}.bounds[{}][0]'.format(
+                targets[i], targets_tmp[i], id(node), i)
             loop_body.append(self.parse_stmt(stmt))
             if i + 1 < len(targets):
-                stmt = '__I = __I - {} * __ndrange.acc_dimensions[{}]'.format(
-                    targets_tmp[i], i + 1)
+                stmt = '__I = __I - {} * __ndrange{}.acc_dimensions[{}]'.format(
+                    targets_tmp[i], id(node), i + 1)
                 loop_body.append(self.parse_stmt(stmt))
         loop_body += node.body
 

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -160,3 +160,33 @@ def test_nested_ndrange():
                 for l in range(n):
                     r = i * n**3 + j * n**2 + k * n + l
                     assert A[i, j, k, l] == r
+
+
+@ti.test(ti.cpu)
+def test_ndrange_ast_transform():
+    n, u, v = 4, 3, 2
+
+    a = ti.field(ti.i32, ())
+    b = ti.field(ti.i32, ())
+    A = ti.field(ti.i32, (n, n))
+
+    @ti.kernel
+    def func():
+        # `__getitem__ cannot be called from Python-scope` will be raised if
+        # `a[None]` is not transformed to `ti.subscript(a, None)` in ti.ndrange:
+        for i, j in ti.ndrange(a[None], b[None]):
+            r = i * n + j + 1
+            A[i, j] = r
+
+    a[None] = u
+    b[None] = v
+
+    func()
+
+    for i in range(n):
+        for j in range(n):
+            if i < u and j < v:
+                r = i * n + j + 1
+            else:
+                r = 0
+            assert A[i, j] == r


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
To reproduce:
```py
import taichi as ti

ti.init(print_preprocessed=True)

a = ti.field(int, ())
b = ti.field(int, ())

@ti.kernel
def func_ok():
    for i in range(a[None]):
        print(i)

@ti.kernel
def func_err():
    for i, j in ti.ndrange(a[None], b[None]):
        print(i, j)

a[None] = 3
b[None] = 3
func_err()
```
Running it will raises `AssertionError: __getitem__ cannot be called in Taichi-scope`.

This is because `a[None]` not being transformed into `ti.subscript(a, None)`.
This is an unexpected error introduced since #2081, which generates:
```py
__ndrange = ti.static(ti.ndrange(a[None], b[None]))
```
Here I was mean to assign statically to prevent symbol leakage, but `ti.static` leads to another side effect that 'do not transform the AST inside'. And `a[None]` no longer being transformed into `ti.subscript(a, None)`.
Sorry for not considering enough test cases! So in this PR I removed `ti.static` and use
```py
__ndrange{id(node)} = ti.ndrange(a[None], b[None])
```
instead, where `id(node)` is the unique id for each node, so that `a[None]` will be further transformed into `ti.subscript(a, None)` to prevent the above issue, while still allow nested ndrange as #2081 does.

---
BTW how do you think if we deprecate `ti.subscript`? We can always distinguish when `Expr.subscript` or `Expr.__getitem__` should be called by detecting `ti.inside_kernel()`, so why not just merge them into `Expr.__getitem__`?