### PR TITLE
[test] [opengl] Avoid floor division cornor cases by adjusting test data

### DIFF
--- a/tests/python/test_element_wise.py
+++ b/tests/python/test_element_wise.py
@@ -23,9 +23,9 @@ def test_binary_f(lhs_is_mat, rhs_is_mat):
         z = ti.field(ti.f32, ())
 
     if lhs_is_mat:
-        y.from_numpy(np.array([[0, 2], [9, 3], [7, 4]], np.float32))
+        y.from_numpy(np.array([[0, 2], [9, 3.1], [7, 4]], np.float32))
     else:
-        y[None] = 6
+        y[None] = 6.1
     if rhs_is_mat:
         z.from_numpy(np.array([[4, 5], [6, 3], [9, 2]], np.float32))
     else:
@@ -156,7 +156,7 @@ def test_writeback_binary_f(rhs_is_mat):
     else:
         z = ti.field(ti.f32, ())
 
-    y.from_numpy(np.array([[0, 2], [9, 3], [7, 4]], np.float32))
+    y.from_numpy(np.array([[0, 2], [9, 3.1], [7, 4]], np.float32))
     if rhs_is_mat:
         z.from_numpy(np.array([[4, 5], [6, 3], [9, 2]], np.float32))
     else:


### PR DESCRIPTION
Three python tests related to floor division in test_element_wise.py fail on my laptop under OpenGL (Ubuntu 20.04, AMD Ryzen 7 3700U with Radeon Vega Mobile Gfx).
In these tests, 3 / 3 gives 0.99999997 and 3 // 3 gives 0.
The difference between 0.99999997 and 1 is acceptable when doing float divisions, but the floor operation makes the answer totally wrong and makes these three tests fail on my laptop. (3 // 3 should be 1 instead of 0)
