### PR TITLE
[test] Add a basic unit test using googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,13 @@ include(cmake/TaichiCXXFlags.cmake)
 include(cmake/TaichiCore.cmake)
 include(cmake/TaichiMain.cmake)
 
+option(TI_BUILD_TESTS "Build the CPP tests" OFF)
+
+if (TI_BUILD_TESTS)
+  add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
+  include(cmake/TaichiTests.cmake)
+endif()
+
 message("C++ Flags: ${CMAKE_CXX_FLAGS}")
 message("Build type: ${CMAKE_BUILD_TYPE}")
 

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.0)
+
+set(TESTS_NAME taichi_cpp_tests)
+if (WIN32)
+  message(WARNING "TODO(#2195): Confirm that googletest works on Windows")
+  return()
+endif()
+
+# TODO():
+# 1. "cpp" -> "cpp_legacy", "cpp_new" -> "cpp"
+# 2. Re-implement the legacy CPP tests using googletest
+file(GLOB_RECURSE TAICHI_TESTS_SOURCE "tests/cpp_new/*.cpp")
+
+include_directories(
+    ${PROJECT_SOURCE_DIR},
+)
+
+add_executable(${TESTS_NAME} ${TAICHI_TESTS_SOURCE} $<TARGET_OBJECTS:taichi_testable_lib>)
+target_link_libraries(${TESTS_NAME} gtest_main)
+
+add_test(NAME ${TESTS_NAME} COMMAND ${TESTS_NAME})

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -6,7 +6,7 @@ if (WIN32)
   return()
 endif()
 
-# TODO():
+# TODO(#2195):
 # 1. "cpp" -> "cpp_legacy", "cpp_new" -> "cpp"
 # 2. Re-implement the legacy CPP tests using googletest
 file(GLOB_RECURSE TAICHI_TESTS_SOURCE "tests/cpp_new/*.cpp")

--- a/taichi/common/core.cpp
+++ b/taichi/common/core.cpp
@@ -5,8 +5,6 @@
 
 #include "taichi/common/core.h"
 
-#include "llvm/Config/llvm-config.h"
-
 #include "taichi/common/version.h"
 #include "taichi/common/commit_hash.h"
 
@@ -89,10 +87,6 @@ std::string get_commit_hash() {
 
 std::string get_cuda_version_string() {
   return TI_CUDAVERSION;
-}
-
-std::string get_llvm_version_string() {
-  return LLVM_VERSION_STRING;
 }
 
 TI_NAMESPACE_END

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -373,5 +373,4 @@ std::string get_commit_hash();
 
 std::string get_cuda_version_string();
 
-std::string get_llvm_version_string();
 TI_NAMESPACE_END

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -3,6 +3,8 @@
 #include <optional>
 #include <string>
 
+#include "llvm/Config/llvm-config.h"
+
 #include "pybind11/functional.h"
 #include "pybind11/pybind11.h"
 
@@ -687,7 +689,7 @@ void export_lang(py::module &m) {
   m.def("get_version_major", get_version_major);
   m.def("get_version_minor", get_version_minor);
   m.def("get_version_patch", get_version_patch);
-  m.def("get_llvm_version_string", get_llvm_version_string);
+  m.def("get_llvm_version_string", [] { return LLVM_VERSION_STRING; });
   m.def("test_printf", [] { printf("test_printf\n"); });
   m.def("test_logging", [] { TI_INFO("test_logging"); });
   m.def("trigger_crash", [] { *(int *)(1) = 0; });

--- a/taichi/system/traceback.h
+++ b/taichi/system/traceback.h
@@ -3,4 +3,5 @@
 namespace taichi {
 
 TI_EXPORT void print_traceback();
-}
+
+}  // namespace taichi

--- a/tests/cpp_new/common/core_test.cpp
+++ b/tests/cpp_new/common/core_test.cpp
@@ -4,7 +4,7 @@
 
 namespace taichi {
 
-TEST(StatementsTest, Basic) {
+TEST(CoreTest, Basic) {
   EXPECT_EQ(trim_string("hello taichi  "), "hello taichi");
 }
 

--- a/tests/cpp_new/common/core_test.cpp
+++ b/tests/cpp_new/common/core_test.cpp
@@ -1,0 +1,11 @@
+#include "gtest/gtest.h"
+
+#include "taichi/common/core.h"
+
+namespace taichi {
+
+TEST(StatementsTest, Basic) {
+  EXPECT_EQ(trim_string("hello taichi  "), "hello taichi");
+}
+
+}  // namespace taichi


### PR DESCRIPTION
Related issue = #2195 

This PR adds `tests/cpp_new/common/core_test.cpp`. It is just an illustration of how we can write C++ unit tests, with no real valuable test in it. In the future, the directory tree of `tests/cpp_new` can mirror that of `taichi/` (Within Google the tests are usually directly placed along with the source files. Go is also designed like so. But it seems more common to have a separate directory for tests in other places..)

TODO:

Right now we have to manually trigger the test with `./taichi_cpp_tests`. Integrate this into the `ti` CLI.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
