### PR TITLE
[refactor] Separate SNode read/write kernels into a dedicated class

### DIFF
--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -7,18 +7,6 @@
 
 TLANG_NAMESPACE_BEGIN
 
-// namespace {
-
-// void set_kernel_args(const std::vector<int> &I,
-//                      int num_active_indices,
-//                      Kernel::LaunchContextBuilder *launch_ctx) {
-//   for (int i = 0; i < num_active_indices; i++) {
-//     launch_ctx->set_arg_int(i, I[i]);
-//   }
-// }
-
-// }  // namespace
-
 std::atomic<int> SNode::counter{0};
 
 SNode &SNode::insert_children(SNodeType t) {
@@ -196,63 +184,6 @@ SNode *SNode::get_least_sparse_ancestor() const {
   }
   return result;
 }
-
-// for float and double
-// void SNode::write_float(const std::vector<int> &I, float64 val) {
-//   if (writer_kernel == nullptr) {
-//     writer_kernel = &get_current_program().get_snode_writer(this);
-//   }
-//   auto launch_ctx = writer_kernel->make_launch_context();
-//   set_kernel_args(I, num_active_indices, &launch_ctx);
-//   for (int i = 0; i < num_active_indices; i++) {
-//     launch_ctx.set_arg_int(i, I[i]);
-//   }
-//   launch_ctx.set_arg_float(num_active_indices, val);
-//   get_current_program().synchronize();
-//   (*writer_kernel)(launch_ctx);
-// }
-
-// float64 SNode::read_float(const std::vector<int> &I) {
-//   if (reader_kernel == nullptr) {
-//     reader_kernel = &get_current_program().get_snode_reader(this);
-//   }
-//   get_current_program().synchronize();
-//   auto launch_ctx = reader_kernel->make_launch_context();
-//   set_kernel_args(I, num_active_indices, &launch_ctx);
-//   (*reader_kernel)(launch_ctx);
-//   get_current_program().synchronize();
-//   auto ret = reader_kernel->get_ret_float(0);
-//   return ret;
-// }
-
-// for int32 and int64
-// void SNode::write_int(const std::vector<int> &I, int64 val) {
-//   if (writer_kernel == nullptr) {
-//     writer_kernel = &get_current_program().get_snode_writer(this);
-//   }
-//   auto launch_ctx = writer_kernel->make_launch_context();
-//   set_kernel_args(I, num_active_indices, &launch_ctx);
-//   launch_ctx.set_arg_int(num_active_indices, val);
-//   get_current_program().synchronize();
-//   (*writer_kernel)(launch_ctx);
-// }
-
-// int64 SNode::read_int(const std::vector<int> &I) {
-//   if (reader_kernel == nullptr) {
-//     reader_kernel = &get_current_program().get_snode_reader(this);
-//   }
-//   get_current_program().synchronize();
-//   auto launch_ctx = reader_kernel->make_launch_context();
-//   set_kernel_args(I, num_active_indices, &launch_ctx);
-//   (*reader_kernel)(launch_ctx);
-//   get_current_program().synchronize();
-//   auto ret = reader_kernel->get_ret_int(0);
-//   return ret;
-// }
-
-// uint64 SNode::read_uint(const std::vector<int> &I) {
-//   return (uint64)read_int(I);
-// }
 
 int SNode::shape_along_axis(int i) const {
   const auto &extractor = extractors[physical_index_position[i]];

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -7,17 +7,17 @@
 
 TLANG_NAMESPACE_BEGIN
 
-namespace {
+// namespace {
 
-void set_kernel_args(const std::vector<int> &I,
-                     int num_active_indices,
-                     Kernel::LaunchContextBuilder *launch_ctx) {
-  for (int i = 0; i < num_active_indices; i++) {
-    launch_ctx->set_arg_int(i, I[i]);
-  }
-}
+// void set_kernel_args(const std::vector<int> &I,
+//                      int num_active_indices,
+//                      Kernel::LaunchContextBuilder *launch_ctx) {
+//   for (int i = 0; i < num_active_indices; i++) {
+//     launch_ctx->set_arg_int(i, I[i]);
+//   }
+// }
 
-}  // namespace
+// }  // namespace
 
 std::atomic<int> SNode::counter{0};
 
@@ -198,61 +198,61 @@ SNode *SNode::get_least_sparse_ancestor() const {
 }
 
 // for float and double
-void SNode::write_float(const std::vector<int> &I, float64 val) {
-  if (writer_kernel == nullptr) {
-    writer_kernel = &get_current_program().get_snode_writer(this);
-  }
-  auto launch_ctx = writer_kernel->make_launch_context();
-  set_kernel_args(I, num_active_indices, &launch_ctx);
-  for (int i = 0; i < num_active_indices; i++) {
-    launch_ctx.set_arg_int(i, I[i]);
-  }
-  launch_ctx.set_arg_float(num_active_indices, val);
-  get_current_program().synchronize();
-  (*writer_kernel)(launch_ctx);
-}
+// void SNode::write_float(const std::vector<int> &I, float64 val) {
+//   if (writer_kernel == nullptr) {
+//     writer_kernel = &get_current_program().get_snode_writer(this);
+//   }
+//   auto launch_ctx = writer_kernel->make_launch_context();
+//   set_kernel_args(I, num_active_indices, &launch_ctx);
+//   for (int i = 0; i < num_active_indices; i++) {
+//     launch_ctx.set_arg_int(i, I[i]);
+//   }
+//   launch_ctx.set_arg_float(num_active_indices, val);
+//   get_current_program().synchronize();
+//   (*writer_kernel)(launch_ctx);
+// }
 
-float64 SNode::read_float(const std::vector<int> &I) {
-  if (reader_kernel == nullptr) {
-    reader_kernel = &get_current_program().get_snode_reader(this);
-  }
-  get_current_program().synchronize();
-  auto launch_ctx = reader_kernel->make_launch_context();
-  set_kernel_args(I, num_active_indices, &launch_ctx);
-  (*reader_kernel)(launch_ctx);
-  get_current_program().synchronize();
-  auto ret = reader_kernel->get_ret_float(0);
-  return ret;
-}
+// float64 SNode::read_float(const std::vector<int> &I) {
+//   if (reader_kernel == nullptr) {
+//     reader_kernel = &get_current_program().get_snode_reader(this);
+//   }
+//   get_current_program().synchronize();
+//   auto launch_ctx = reader_kernel->make_launch_context();
+//   set_kernel_args(I, num_active_indices, &launch_ctx);
+//   (*reader_kernel)(launch_ctx);
+//   get_current_program().synchronize();
+//   auto ret = reader_kernel->get_ret_float(0);
+//   return ret;
+// }
 
 // for int32 and int64
-void SNode::write_int(const std::vector<int> &I, int64 val) {
-  if (writer_kernel == nullptr) {
-    writer_kernel = &get_current_program().get_snode_writer(this);
-  }
-  auto launch_ctx = writer_kernel->make_launch_context();
-  set_kernel_args(I, num_active_indices, &launch_ctx);
-  launch_ctx.set_arg_int(num_active_indices, val);
-  get_current_program().synchronize();
-  (*writer_kernel)(launch_ctx);
-}
+// void SNode::write_int(const std::vector<int> &I, int64 val) {
+//   if (writer_kernel == nullptr) {
+//     writer_kernel = &get_current_program().get_snode_writer(this);
+//   }
+//   auto launch_ctx = writer_kernel->make_launch_context();
+//   set_kernel_args(I, num_active_indices, &launch_ctx);
+//   launch_ctx.set_arg_int(num_active_indices, val);
+//   get_current_program().synchronize();
+//   (*writer_kernel)(launch_ctx);
+// }
 
-int64 SNode::read_int(const std::vector<int> &I) {
-  if (reader_kernel == nullptr) {
-    reader_kernel = &get_current_program().get_snode_reader(this);
-  }
-  get_current_program().synchronize();
-  auto launch_ctx = reader_kernel->make_launch_context();
-  set_kernel_args(I, num_active_indices, &launch_ctx);
-  (*reader_kernel)(launch_ctx);
-  get_current_program().synchronize();
-  auto ret = reader_kernel->get_ret_int(0);
-  return ret;
-}
+// int64 SNode::read_int(const std::vector<int> &I) {
+//   if (reader_kernel == nullptr) {
+//     reader_kernel = &get_current_program().get_snode_reader(this);
+//   }
+//   get_current_program().synchronize();
+//   auto launch_ctx = reader_kernel->make_launch_context();
+//   set_kernel_args(I, num_active_indices, &launch_ctx);
+//   (*reader_kernel)(launch_ctx);
+//   get_current_program().synchronize();
+//   auto ret = reader_kernel->get_ret_int(0);
+//   return ret;
+// }
 
-uint64 SNode::read_uint(const std::vector<int> &I) {
-  return (uint64)read_int(I);
-}
+// uint64 SNode::read_uint(const std::vector<int> &I) {
+//   return (uint64)read_int(I);
+// }
 
 int SNode::shape_along_axis(int i) const {
   const auto &extractor = extractors[physical_index_position[i]];

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -203,15 +203,6 @@ class SNode {
     return *this;
   }
 
-  // // for float and double
-  // void write_float(const std::vector<int> &I, float64);
-  // float64 read_float(const std::vector<int> &I);
-
-  // // for int32 and int64
-  // void write_int(const std::vector<int> &I, int64);
-  // int64 read_int(const std::vector<int> &I);
-  // uint64 read_uint(const std::vector<int> &I);
-
   int child_id(SNode *c) {
     for (int i = 0; i < (int)ch.size(); i++) {
       if (ch[i].get() == c) {

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -203,14 +203,14 @@ class SNode {
     return *this;
   }
 
-  // for float and double
-  void write_float(const std::vector<int> &I, float64);
-  float64 read_float(const std::vector<int> &I);
+  // // for float and double
+  // void write_float(const std::vector<int> &I, float64);
+  // float64 read_float(const std::vector<int> &I);
 
-  // for int32 and int64
-  void write_int(const std::vector<int> &I, int64);
-  int64 read_int(const std::vector<int> &I);
-  uint64 read_uint(const std::vector<int> &I);
+  // // for int32 and int64
+  // void write_int(const std::vector<int> &I, int64);
+  // int64 read_int(const std::vector<int> &I);
+  // uint64 read_uint(const std::vector<int> &I);
 
   int child_id(SNode *c) {
     for (int i = 0; i < (int)ch.size(); i++) {

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -66,7 +66,7 @@ inline uint64 *allocate_result_buffer_default(Program *prog) {
 Program *current_program = nullptr;
 std::atomic<int> Program::num_instances;
 
-Program::Program(Arch desired_arch) {
+Program::Program(Arch desired_arch) : snode_rw_accessors_bank_(this) {
   TI_TRACE("Program initializing...");
 
   // For performance considerations and correctness of CustomFloatType

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -56,8 +56,8 @@ TLANG_NAMESPACE_END
 namespace std {
 template <>
 struct hash<taichi::lang::JITEvaluatorId> {
-  std::size_t operator()(
-      taichi::lang::JITEvaluatorId const &id) const noexcept {
+  std::size_t operator()(taichi::lang::JITEvaluatorId const &id) const
+      noexcept {
     return ((std::size_t)id.op | (id.ret.hash() << 8) | (id.lhs.hash() << 16) |
             (id.rhs.hash() << 24) | ((std::size_t)id.is_binary << 31)) ^
            (std::hash<std::thread::id>{}(id.thread_id) << 32);

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -17,6 +17,7 @@
 #include "taichi/backends/cc/cc_program.h"
 #include "taichi/program/kernel.h"
 #include "taichi/program/kernel_profiler.h"
+#include "taichi/program/snode_rw_accessors_bank.h"
 #include "taichi/program/context.h"
 #include "taichi/runtime/runtime.h"
 #include "taichi/backends/metal/struct_metal.h"
@@ -55,8 +56,8 @@ TLANG_NAMESPACE_END
 namespace std {
 template <>
 struct hash<taichi::lang::JITEvaluatorId> {
-  std::size_t operator()(taichi::lang::JITEvaluatorId const &id) const
-      noexcept {
+  std::size_t operator()(
+      taichi::lang::JITEvaluatorId const &id) const noexcept {
     return ((std::size_t)id.op | (id.ret.hash() << 8) | (id.lhs.hash() << 16) |
             (id.rhs.hash() << 24) | ((std::size_t)id.is_binary << 31)) ^
            (std::hash<std::thread::id>{}(id.thread_id) << 32);
@@ -275,6 +276,10 @@ class Program {
 
   ~Program();
 
+  inline SNodeRwAccessorsBank &get_snode_rw_accessors_bank() {
+    return snode_rw_accessors_bank_;
+  }
+
  private:
   // Metal related data structures
   std::optional<metal::CompiledStructs> metal_compiled_structs_;
@@ -282,6 +287,7 @@ class Program {
   // OpenGL related data structures
   std::optional<opengl::StructCompiledResult> opengl_struct_compiled_;
   std::unique_ptr<opengl::GLSLLauncher> opengl_kernel_launcher_;
+  SNodeRwAccessorsBank snode_rw_accessors_bank_;
 
  public:
 #ifdef TI_WITH_CC

--- a/taichi/program/snode_rw_accessors_bank.cpp
+++ b/taichi/program/snode_rw_accessors_bank.cpp
@@ -1,0 +1,86 @@
+#include "taichi/program/snode_rw_accessors_bank.h"
+
+#include "taichi/program/program.h"
+
+namespace taichi {
+namespace lang {
+
+namespace {
+void set_kernel_args(const std::vector<int> &I,
+                     int num_active_indices,
+                     Kernel::LaunchContextBuilder *launch_ctx) {
+  for (int i = 0; i < num_active_indices; i++) {
+    launch_ctx->set_arg_int(i, I[i]);
+  }
+}
+}  // namespace
+
+SNodeRwAccessorsBank::Accessors SNodeRwAccessorsBank::get(SNode *snode) {
+  auto &kernels = snode_to_kernels_[snode];
+  if (kernels.reader == nullptr) {
+    kernels.reader = &(program_->get_snode_reader(snode));
+  }
+  if (kernels.writer == nullptr) {
+    kernels.writer = &(program_->get_snode_writer(snode));
+  }
+  return Accessors(snode, kernels, program_);
+}
+
+SNodeRwAccessorsBank::Accessors::Accessors(const SNode *snode,
+                                           const RwKernels &kernels,
+                                           Program *prog)
+    : snode_(snode),
+      prog_(prog),
+      reader_(kernels.reader),
+      writer_(kernels.writer) {
+  TI_ASSERT(reader_ != nullptr);
+  TI_ASSERT(writer_ != nullptr);
+}
+void SNodeRwAccessorsBank::Accessors::write_float(const std::vector<int> &I,
+                                                  float64 val) {
+  auto launch_ctx = writer_->make_launch_context();
+  set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
+  for (int i = 0; i < snode_->num_active_indices; i++) {
+    launch_ctx.set_arg_int(i, I[i]);
+  }
+  launch_ctx.set_arg_float(snode_->num_active_indices, val);
+  prog_->synchronize();
+  (*writer_)(launch_ctx);
+}
+
+float64 SNodeRwAccessorsBank::Accessors::read_float(const std::vector<int> &I) {
+  prog_->synchronize();
+  auto launch_ctx = reader_->make_launch_context();
+  set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
+  (*reader_)(launch_ctx);
+  prog_->synchronize();
+  auto ret = reader_->get_ret_float(0);
+  return ret;
+}
+
+// for int32 and int64
+void SNodeRwAccessorsBank::Accessors::write_int(const std::vector<int> &I,
+                                                int64 val) {
+  auto launch_ctx = writer_->make_launch_context();
+  set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
+  launch_ctx.set_arg_int(snode_->num_active_indices, val);
+  prog_->synchronize();
+  (*writer_)(launch_ctx);
+}
+
+int64 SNodeRwAccessorsBank::Accessors::read_int(const std::vector<int> &I) {
+  prog_->synchronize();
+  auto launch_ctx = reader_->make_launch_context();
+  set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
+  (*reader_)(launch_ctx);
+  prog_->synchronize();
+  auto ret = reader_->get_ret_int(0);
+  return ret;
+}
+
+uint64 SNodeRwAccessorsBank::Accessors::read_uint(const std::vector<int> &I) {
+  return (uint64)read_int(I);
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/program/snode_rw_accessors_bank.h
+++ b/taichi/program/snode_rw_accessors_bank.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "taichi/program/kernel.h"
+#include "taichi/ir/snode.h"
+
+namespace taichi {
+namespace lang {
+
+class Program;
+
+/** A mapping from an SNode to its read/write access kernels.
+ *
+ * The main purpose of this class is to decouple the accessor kernels from the
+ * SNode class itself. Ideally, SNode should be nothing more than a group of
+ * plain data.
+ */
+class SNodeRwAccessorsBank {
+ private:
+  struct RwKernels {
+    Kernel *reader{nullptr};
+    Kernel *writer{nullptr};
+  };
+
+ public:
+  class Accessors {
+   public:
+    explicit Accessors(const SNode *snode,
+                       const RwKernels &kernels,
+                       Program *prog);
+
+    // for float and double
+    void write_float(const std::vector<int> &I, float64 val);
+    float64 read_float(const std::vector<int> &I);
+
+    // for int32 and int64
+    void write_int(const std::vector<int> &I, int64 val);
+    int64 read_int(const std::vector<int> &I);
+    uint64 read_uint(const std::vector<int> &I);
+
+   private:
+    const SNode *snode_;
+    Program *prog_;
+    Kernel *reader_;
+    Kernel *writer_;
+  };
+
+  explicit SNodeRwAccessorsBank(Program *program) : program_(program) {
+  }
+
+  Accessors get(SNode *snode);
+
+ private:
+  Program *const program_;
+  std::unordered_map<const SNode *, RwKernels> snode_to_kernels_;
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -97,9 +97,8 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
-      .def(
-          "get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
-          py::return_value_policy::reference)
+      .def("get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
+           py::return_value_policy::reference)
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.
@@ -197,10 +196,9 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def(
-      "default_compile_config",
-      [&]() -> CompileConfig & { return default_compile_config; },
-      py::return_value_policy::reference);
+  m.def("default_compile_config",
+        [&]() -> CompileConfig & { return default_compile_config; },
+        py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -217,12 +215,11 @@ void export_lang(py::module &m) {
            })
       .def("print_memory_profiler_info", &Program::print_memory_profiler_info)
       .def("finalize", &Program::finalize)
-      .def(
-          "get_root",
-          [&](Program *program) -> SNode * {
-            return program->snode_root.get();
-          },
-          py::return_value_policy::reference)
+      .def("get_root",
+           [&](Program *program) -> SNode * {
+             return program->snode_root.get();
+           },
+           py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("get_snode_num_dynamically_allocated",
@@ -237,10 +234,9 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def(
-      "current_compile_config",
-      [&]() -> CompileConfig & { return get_current_program().config; },
-      py::return_value_policy::reference);
+  m.def("current_compile_config",
+        [&]() -> CompileConfig & { return get_current_program().config; },
+        py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -273,10 +269,9 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def(
-          "get_ch",
-          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-          py::return_value_policy::reference)
+      .def("get_ch",
+           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+           py::return_value_policy::reference)
       .def("lazy_grad", &SNode::lazy_grad)
       .def("read_int",
            [](SNode *snode, const std::vector<int> &I) -> int64 {
@@ -357,14 +352,13 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def(
-          "define",
-          [](Program::KernelProxy *ker,
-             const std::function<void()> &func) -> Kernel & {
-            py::gil_scoped_release release;
-            return ker->def(func);
-          },
-          py::return_value_policy::reference);
+      .def("define",
+           [](Program::KernelProxy *ker,
+              const std::function<void()> &func) -> Kernel & {
+             py::gil_scoped_release release;
+             return ker->def(func);
+           },
+           py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);


### PR DESCRIPTION
Related issue = #2196 

### Purpose

This is one of the steps to decouple `SNode` from `taichi/program`. Because many files inside `taichi/ir` depend on SNode, they transitively depend on `taichi/program` as well. `taichi/program` is very high level, and almost depends on everything in the codebase. So without breaking the tie, it is very hard for us to separate out IR.

Note that this PR alone is not enough (actually, far from enough) for modularizing the IR. I'm thinking of moving out `SNode::expr` later (we may have to have a similar mapping from `SNode` to `expr`). The reason is similar:

1. `expr` is an `Expr`, which depends on the expression and the frontend IR
2. Frontend IR depends on `taichi/program`.

As a short-term goal, I think it will be good enough if we can make `ir.h/cpp`, `statements.h/cpp`, `snode.h/cpp` self contained.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
