### PR TITLE
[refactor] Add SNode::GradInfoProvider to isolate SNode from Expr

### DIFF
--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -25,7 +25,11 @@ class Template:
         if isinstance(x, ti.SNode):
             return x.ptr
         if isinstance(x, ti.Expr):
-            return x.ptr
+            return x.ptr.get_underlying_ptr_address()
+        if isinstance(x, ti.core.Expr):
+            return x.get_underlying_ptr_address()
+        if isinstance(x, tuple):
+            return tuple(self.extract(item) for item in x)
         return x
 
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -17,6 +17,7 @@
 #include "taichi/backends/cc/cc_program.h"
 #include "taichi/program/kernel.h"
 #include "taichi/program/kernel_profiler.h"
+#include "taichi/program/snode_expr_utils.h"
 #include "taichi/program/snode_rw_accessors_bank.h"
 #include "taichi/program/context.h"
 #include "taichi/runtime/runtime.h"
@@ -276,17 +277,24 @@ class Program {
 
   ~Program();
 
+  inline SNodeGlobalVarExprMap *get_snode_to_glb_var_exprs() {
+    return &snode_to_glb_var_exprs_;
+  }
+
   inline SNodeRwAccessorsBank &get_snode_rw_accessors_bank() {
     return snode_rw_accessors_bank_;
   }
 
  private:
+  void materialize_snode_expr_attributes();
   // Metal related data structures
   std::optional<metal::CompiledStructs> metal_compiled_structs_;
   std::unique_ptr<metal::KernelManager> metal_kernel_mgr_;
   // OpenGL related data structures
   std::optional<opengl::StructCompiledResult> opengl_struct_compiled_;
   std::unique_ptr<opengl::GLSLLauncher> opengl_kernel_launcher_;
+  // SNode information that requires using Program.
+  SNodeGlobalVarExprMap snode_to_glb_var_exprs_;
   SNodeRwAccessorsBank snode_rw_accessors_bank_;
 
  public:

--- a/taichi/program/snode_expr_utils.cpp
+++ b/taichi/program/snode_expr_utils.cpp
@@ -1,0 +1,110 @@
+#include "taichi/program/snode_expr_utils.h"
+
+namespace taichi {
+namespace lang {
+
+namespace {
+
+class GradInfoImpl final : public SNode::GradInfoProvider {
+ public:
+  explicit GradInfoImpl(GlobalVariableExpression *glb_var) : glb_var_(glb_var) {
+  }
+
+  bool is_primal() const override {
+    return glb_var_->is_primal;
+  }
+
+  SNode *grad_snode() const override {
+    auto &adj = glb_var_->adjoint;
+    if (adj.expr == nullptr) {
+      return nullptr;
+    }
+    return adj.snode();
+  }
+
+ private:
+  GlobalVariableExpression *glb_var_;
+};
+
+}  // namespace
+
+void place_child(Expr *expr_arg,
+                 const std::vector<int> &offset,
+                 SNode *parent,
+                 SNodeGlobalVarExprMap *snode_to_exprs) {
+  if (parent->type == SNodeType::root) {
+    // never directly place to root
+    auto &ds = parent->dense(std::vector<Index>(), {});
+    place_child(expr_arg, offset, &ds, snode_to_exprs);
+  } else {
+    TI_ASSERT(expr_arg->is<GlobalVariableExpression>());
+    auto glb_var_expr = expr_arg->cast<GlobalVariableExpression>();
+    TI_ERROR_IF(glb_var_expr->snode != nullptr,
+                "This variable has been placed.");
+    SNode *new_exp_snode = nullptr;
+    if (auto cft = glb_var_expr->dt->cast<CustomFloatType>()) {
+      if (auto exp = cft->get_exponent_type()) {
+        // Non-empty exponent type. First create a place SNode for the
+        // exponent value.
+        if (parent->placing_shared_exp &&
+            parent->currently_placing_exp_snode != nullptr) {
+          // Reuse existing exponent
+          TI_ASSERT_INFO(parent->currently_placing_exp_snode_dtype == exp,
+                         "CustomFloatTypes with shared exponents must have "
+                         "exactly the same exponent type.");
+          new_exp_snode = parent->currently_placing_exp_snode;
+        } else {
+          auto &exp_node = parent->insert_children(SNodeType::place);
+          exp_node.dt = exp;
+          exp_node.name = glb_var_expr->ident.raw_name() + "_exp";
+          new_exp_snode = &exp_node;
+          if (parent->placing_shared_exp) {
+            parent->currently_placing_exp_snode = new_exp_snode;
+            parent->currently_placing_exp_snode_dtype = exp;
+          }
+        }
+      }
+    }
+    auto &child = parent->insert_children(SNodeType::place);
+    glb_var_expr->set_snode(&child);
+    child.name = glb_var_expr->ident.raw_name();
+    if (glb_var_expr->has_ambient) {
+      glb_var_expr->snode->has_ambient = true;
+      glb_var_expr->snode->ambient_val = glb_var_expr->ambient_value;
+    }
+    glb_var_expr->snode->grad_info =
+        std::make_unique<GradInfoImpl>(glb_var_expr.get());
+    (*snode_to_exprs)[glb_var_expr->snode] = glb_var_expr;
+    if (parent->placing_shared_exp) {
+      child.owns_shared_exponent = true;
+    }
+    child.dt = glb_var_expr->dt;
+    if (new_exp_snode) {
+      child.exp_snode = new_exp_snode;
+      new_exp_snode->exponent_users.push_back(&child);
+    }
+    if (!offset.empty())
+      child.set_index_offsets(offset);
+  }
+}
+
+void make_lazy_grad(SNode *snode, SNodeGlobalVarExprMap *snode_to_exprs) {
+  if (snode->type == SNodeType::place)
+    return;
+  for (auto &c : snode->ch) {
+    make_lazy_grad(c.get(), snode_to_exprs);
+  }
+  std::vector<Expr> new_grads;
+  for (auto &c : snode->ch) {
+    if (c->type == SNodeType::place && c->is_primal() && needs_grad(c->dt) &&
+        !c->has_grad()) {
+      new_grads.push_back(snode_to_exprs->at(c.get())->adjoint);
+    }
+  }
+  for (auto p : new_grads) {
+    place_child(&p, /*offset=*/{}, snode, snode_to_exprs);
+  }
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/program/snode_expr_utils.h
+++ b/taichi/program/snode_expr_utils.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "taichi/ir/snode.h"
+#include "taichi/ir/frontend_ir.h"
+
+// This file groups the set of helpers that need the Expr associated with a
+// given SNode. Expr is part of the frontend, which somehow depends on the
+// files inside "taichi/program". To make SNode fairly low-level and depend
+// on less, we thus move SNode-Expr related utils away from SNode itself.
+namespace taichi {
+namespace lang {
+
+using SNodeGlobalVarExprMap =
+    std::unordered_map<const SNode *,
+                       std::shared_ptr<GlobalVariableExpression>>;
+
+void place_child(Expr *expr_arg,
+                 const std::vector<int> &offset,
+                 SNode *parent,
+                 SNodeGlobalVarExprMap *snode_to_exprs);
+
+void make_lazy_grad(SNode *snode, SNodeGlobalVarExprMap *snode_to_exprs);
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -353,7 +353,17 @@ void export_lang(py::module &m) {
       .def("set_grad", &Expr::set_grad)
       .def("set_attribute", &Expr::set_attribute)
       .def("get_attribute", &Expr::get_attribute)
-      .def("get_raw_address", [](Expr *expr) { return (uint64)expr; });
+      .def("get_raw_address", [](Expr *expr) { return (uint64)expr; })
+      .def("get_underlying_ptr_address", [](Expr *e) {
+        // The reason that there are both get_raw_address() and
+        // get_underlying_ptr_address() is that Expr itself is mostly wrapper
+        // around its underlying |expr| (of type Expression). Expr |e| can be
+        // temporary, while the underlying |expr| is mostly persistant.
+        //
+        // Same get_raw_address() implies that get_underlying_ptr_address() are
+        // also the same. The reverse is not true.
+        return (uint64)e->expr.get();
+      });
 
   py::class_<ExprGroup>(m, "ExprGroup")
       .def(py::init<>())

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -13,6 +13,7 @@
 #include "taichi/ir/statements.h"
 #include "taichi/program/extension.h"
 #include "taichi/program/async_engine.h"
+#include "taichi/program/snode_expr_utils.h"
 #include "taichi/program/snode_rw_accessors_bank.h"
 #include "taichi/common/interface.h"
 #include "taichi/python/export.h"
@@ -264,15 +265,21 @@ void export_lang(py::module &m) {
       .def("bit_struct", &SNode::bit_struct, py::return_value_policy::reference)
       .def("bit_array", &SNode::bit_array, py::return_value_policy::reference)
       .def("place",
-           (void (SNode::*)(Expr &, const std::vector<int> &))(&SNode::place),
-           py::return_value_policy::reference)
+           [](SNode *snode, Expr &expr, const std::vector<int> &offset) {
+             place_child(&expr, offset, snode,
+                         get_current_program().get_snode_to_glb_var_exprs());
+           })
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
       .def("get_ch",
            [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
            py::return_value_policy::reference)
-      .def("lazy_grad", &SNode::lazy_grad)
+      .def("lazy_grad",
+           [](SNode *snode) {
+             make_lazy_grad(snode,
+                            get_current_program().get_snode_to_glb_var_exprs());
+           })
       .def("read_int",
            [](SNode *snode, const std::vector<int> &I) -> int64 {
              return get_snode_rw_accessors(snode).read_int(I);
@@ -288,7 +295,11 @@ void export_lang(py::module &m) {
       .def("has_grad", &SNode::has_grad)
       .def("is_primal", &SNode::is_primal)
       .def("is_place", &SNode::is_place)
-      .def("get_expr", &SNode::get_expr, py::return_value_policy::reference)
+      .def("get_expr",
+           [](SNode *snode) {
+             return Expr(
+                 get_current_program().get_snode_to_glb_var_exprs()->at(snode));
+           })
       .def("write_int",
            [](SNode *snode, const std::vector<int> &I, int64 val) {
              get_snode_rw_accessors(snode).write_int(I, val);

--- a/taichi/struct/struct.cpp
+++ b/taichi/struct/struct.cpp
@@ -2,7 +2,6 @@
 
 #include "taichi/ir/ir.h"
 #include "taichi/ir/expression.h"
-#include "taichi/program/snode_expr_utils.h"
 #include "taichi/program/program.h"
 #include "struct.h"
 

--- a/taichi/struct/struct.cpp
+++ b/taichi/struct/struct.cpp
@@ -2,6 +2,7 @@
 
 #include "taichi/ir/ir.h"
 #include "taichi/ir/expression.h"
+#include "taichi/program/snode_expr_utils.h"
 #include "taichi/program/program.h"
 #include "struct.h"
 
@@ -94,9 +95,6 @@ void StructCompiler::infer_snode_properties(SNode &snode) {
                      "Dynamic SNode can have only one index extractor.");
     }
   }
-
-  if (snode.expr.expr)
-    snode.expr->set_attribute("dim", std::to_string(snode.num_active_indices));
 
   snode.total_num_bits = 0;
   for (int i = 0; i < taichi_max_num_indices; i++) {


### PR DESCRIPTION
Related issue = #2196 

This PR is still about decoupling `SNode` from `taichi/program`. The major issue here is around its member variable `expr`. Because `Expr` is part of the frontend and relies on `taichi/program`, we have to move it out from `SNode`:

* Moved `place()` and `lazy_grad()` from `SNode` itself to a separate file `taichi/program/snode_expr_utils.h/cpp` (i cannot think of a better file name...). Other functions in `SNode` do not depend on `expr`.
* Created a `SNode::GradInfoProvider` abstract class. This is essentially a wrapper around `GlobalVariableExpression`. From what I can tell, `SNode::expr` is mostly used to provide gradient information, e.g. `is_primal()`, `has_grad()`, etc. The actual implementation, `GradInfoImpl`, is in `taichi/program/snode_expr_utils.cpp`.
* Created a map from `SNode*` to `GlobalVariableExpression`. The map is stored inside `Program`. While it is possible to retrieve `GlobalVariableExpression` from `GradInfoImpl`, that involves casting `GradInfoProvider` to `GradInfoImpl` and kind of exposes the implementation detail. I'd like to make `GradInfoProvider` have a single responsibility.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
