### PR TITLE
[refactor] Move ASTBuilder and FrontendContext to frontend_ir

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -5,6 +5,42 @@
 
 TLANG_NAMESPACE_BEGIN
 
+ASTBuilder &current_ast_builder() {
+  return context->builder();
+}
+
+Block *ASTBuilder::current_block() {
+  if (stack.empty())
+    return nullptr;
+  else
+    return stack.back();
+}
+
+Stmt *ASTBuilder::get_last_stmt() {
+  TI_ASSERT(!stack.empty());
+  return stack.back()->back();
+}
+
+void ASTBuilder::insert(std::unique_ptr<Stmt> &&stmt, int location) {
+  TI_ASSERT(!stack.empty());
+  stack.back()->insert(std::move(stmt), location);
+}
+
+void ASTBuilder::stop_gradient(SNode *snode) {
+  TI_ASSERT(!stack.empty());
+  stack.back()->stop_gradients.push_back(snode);
+}
+
+std::unique_ptr<ASTBuilder::ScopeGuard> ASTBuilder::create_scope(
+    std::unique_ptr<Block> &list) {
+  TI_ASSERT(list == nullptr);
+  list = std::make_unique<Block>();
+  if (!stack.empty()) {
+    list->parent_stmt = get_last_stmt();
+  }
+  return std::make_unique<ScopeGuard>(this, list.get());
+}
+
 FrontendSNodeOpStmt::FrontendSNodeOpStmt(SNodeOpType op_type,
                                          SNode *snode,
                                          const ExprGroup &indices,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -10,6 +10,62 @@
 
 TLANG_NAMESPACE_BEGIN
 
+class ASTBuilder;
+
+ASTBuilder &current_ast_builder();
+
+class FrontendContext {
+ private:
+  std::unique_ptr<ASTBuilder> current_builder;
+  std::unique_ptr<Block> root_node;
+
+ public:
+  FrontendContext();
+
+  ASTBuilder &builder() {
+    return *current_builder;
+  }
+
+  IRNode *root();
+
+  std::unique_ptr<Block> get_root() {
+    return std::move(root_node);
+  }
+};
+
+extern std::unique_ptr<FrontendContext> context;
+
+// TODO: move to frontend_ir.h
+class ASTBuilder {
+ private:
+  std::vector<Block *> stack;
+
+ public:
+  ASTBuilder(Block *initial) {
+    stack.push_back(initial);
+  }
+
+  void insert(std::unique_ptr<Stmt> &&stmt, int location = -1);
+
+  struct ScopeGuard {
+    ASTBuilder *builder;
+    Block *list;
+    ScopeGuard(ASTBuilder *builder, Block *list)
+        : builder(builder), list(list) {
+      builder->stack.push_back(list);
+    }
+
+    ~ScopeGuard() {
+      builder->stack.pop_back();
+    }
+  };
+
+  std::unique_ptr<ScopeGuard> create_scope(std::unique_ptr<Block> &list);
+  Block *current_block();
+  Stmt *get_last_stmt();
+  void stop_gradient(SNode *);
+};
+
 // Frontend Statements
 
 class FrontendAllocaStmt : public Stmt {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -35,7 +35,6 @@ class FrontendContext {
 
 extern std::unique_ptr<FrontendContext> context;
 
-// TODO: move to frontend_ir.h
 class ASTBuilder {
  private:
   std::vector<Block *> stack;

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -20,10 +20,6 @@ std::string snode_access_flag_name(SNodeAccessFlag type) {
   }
 }
 
-ASTBuilder &current_ast_builder() {
-  return context->builder();
-}
-
 void DecoratorRecorder::reset() {
   vectorize = -1;
   bit_vectorize = -1;
@@ -32,38 +28,6 @@ void DecoratorRecorder::reset() {
   mem_access_opt.clear();
   block_dim = 0;
   strictly_serialized = false;
-}
-
-Block *ASTBuilder::current_block() {
-  if (stack.empty())
-    return nullptr;
-  else
-    return stack.back();
-}
-
-Stmt *ASTBuilder::get_last_stmt() {
-  TI_ASSERT(!stack.empty());
-  return stack.back()->back();
-}
-
-void ASTBuilder::insert(std::unique_ptr<Stmt> &&stmt, int location) {
-  TI_ASSERT(!stack.empty());
-  stack.back()->insert(std::move(stmt), location);
-}
-
-void ASTBuilder::stop_gradient(SNode *snode) {
-  TI_ASSERT(!stack.empty());
-  stack.back()->stop_gradients.push_back(snode);
-}
-
-std::unique_ptr<ASTBuilder::ScopeGuard> ASTBuilder::create_scope(
-    std::unique_ptr<Block> &list) {
-  TI_ASSERT(list == nullptr);
-  list = std::make_unique<Block>();
-  if (!stack.empty()) {
-    list->parent_stmt = get_last_stmt();
-  }
-  return std::make_unique<ScopeGuard>(this, list.get());
 }
 
 int Identifier::id_counter = 0;

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -17,7 +17,6 @@
 
 TLANG_NAMESPACE_BEGIN
 
-class ASTBuilder;
 class IRNode;
 class Block;
 class Stmt;
@@ -71,8 +70,6 @@ class MemoryAccessOptions {
 #include "taichi/inc/statements.inc.h"
 #undef PER_STATEMENT
 
-ASTBuilder &current_ast_builder();
-
 class DecoratorRecorder {
  public:
   int vectorize;
@@ -88,58 +85,6 @@ class DecoratorRecorder {
   }
 
   void reset();
-};
-
-class FrontendContext {
- private:
-  std::unique_ptr<ASTBuilder> current_builder;
-  std::unique_ptr<Block> root_node;
-
- public:
-  FrontendContext();
-
-  ASTBuilder &builder() {
-    return *current_builder;
-  }
-
-  IRNode *root();
-
-  std::unique_ptr<Block> get_root() {
-    return std::move(root_node);
-  }
-};
-
-extern std::unique_ptr<FrontendContext> context;
-
-// TODO: move to frontend_ir.h
-class ASTBuilder {
- private:
-  std::vector<Block *> stack;
-
- public:
-  ASTBuilder(Block *initial) {
-    stack.push_back(initial);
-  }
-
-  void insert(std::unique_ptr<Stmt> &&stmt, int location = -1);
-
-  struct ScopeGuard {
-    ASTBuilder *builder;
-    Block *list;
-    ScopeGuard(ASTBuilder *builder, Block *list)
-        : builder(builder), list(list) {
-      builder->stack.push_back(list);
-    }
-
-    ~ScopeGuard() {
-      builder->stack.pop_back();
-    }
-  };
-
-  std::unique_ptr<ScopeGuard> create_scope(std::unique_ptr<Block> &list);
-  Block *current_block();
-  Stmt *get_last_stmt();
-  void stop_gradient(SNode *);
 };
 
 class Identifier {


### PR DESCRIPTION
Related issue = #2196 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

AST stuff and FrontendContext are coupled with python frontend of Taichi, while the goal of #2196 is to decouple Taichi IR and frontend.
This PR moves ASTBuilder and FrontendContext to frontend files.