### PR TITLE
[ir] Add a constructor for the Kernel class to handle CHI IR

### DIFF
--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -45,6 +45,10 @@ Stmt *IRBuilder::create_arg_load(int arg_id, DataType dt, bool is_ptr) {
   return insert(Stmt::make<ArgLoadStmt>(arg_id, dt, is_ptr));
 }
 
+Stmt *IRBuilder::create_return(Stmt *value) {
+  return insert(Stmt::make<KernelReturnStmt>(value));
+}
+
 Stmt *IRBuilder::create_add(Stmt *l, Stmt *r) {
   return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::add, l, r));
 }

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -29,6 +29,9 @@ class IRBuilder {
   // Load kernel arguments.
   Stmt *create_arg_load(int arg_id, DataType dt, bool is_ptr);
 
+  // The return value of the kernel.
+  Stmt *create_return(Stmt *value);
+
   // Binary operations. Returns the result.
   Stmt *create_add(Stmt *l, Stmt *r);
   Stmt *create_sub(Stmt *l, Stmt *r);

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -79,7 +79,8 @@ void compile_to_offloads(IRNode *ir,
                          bool verbose,
                          bool vectorize,
                          bool grad,
-                         bool ad_use_stack);
+                         bool ad_use_stack,
+                         bool start_from_ast);
 
 void offload_to_executable(IRNode *ir,
                            const CompileConfig &config,
@@ -97,7 +98,8 @@ void compile_to_executable(IRNode *ir,
                            bool verbose,
                            bool lower_global_access = true,
                            bool make_thread_local = false,
-                           bool make_block_local = false);
+                           bool make_block_local = false,
+                           bool start_from_ast = true);
 
 }  // namespace irpass
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -74,7 +74,7 @@ Kernel::Kernel(Program &program,
   is_accessor = false;
   is_evaluator = false;
   compiled = nullptr;
-  ir_is_ast = false; // CHI IR
+  ir_is_ast = false;  // CHI IR
   this->ir->as<Block>()->kernel = this;
 
   arch = program.config.arch;
@@ -112,7 +112,8 @@ void Kernel::lower(bool to_executable) {  // TODO: is a "Lowerer" class
           /*make_thread_local=*/config.make_thread_local,
           /*make_block_local=*/
           is_extension_supported(config.arch, Extension::bls) &&
-              config.make_block_local);
+              config.make_block_local,
+          /*start_from_ast=*/ir_is_ast);
     } else {
       irpass::compile_to_offloads(ir.get(), config, verbose,
                                   /*vectorize=*/arch_is_cpu(arch), grad,

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -16,6 +16,7 @@ class Program;
 class Kernel {
  public:
   std::unique_ptr<IRNode> ir;
+  bool ir_is_ast;
   Program &program;
   FunctionType compiled;
   std::string name;
@@ -86,6 +87,11 @@ class Kernel {
 
   Kernel(Program &program,
          const std::function<void()> &func,
+         const std::string &name = "",
+         bool grad = false);
+
+  Kernel(Program &program,
+         std::unique_ptr<IRNode> &&ir,
          const std::string &name = "",
          bool grad = false);
 

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -40,7 +40,7 @@ void compile_to_offloads(IRNode *ir,
   print("Initial IR");
 
   if (grad) {
-    // TODO: Support reverse_segments after lower_ast
+    // TODO(#2193): Support reverse_segments after lower_ast
     TI_ASSERT_INFO(start_from_ast, "CHI does not support autodiff for now.");
     irpass::reverse_segments(ir);
     print("Segment reversed (for autodiff)");


### PR DESCRIPTION
Related issue = #2193 

This PR adds the following ctor:
```
Kernel(Program &program,
         std::unique_ptr<IRNode> &&ir,
         const std::string &name = "",
         bool grad = false);
```
and lets `compile_to_offloads` and `compile_to_executable` to support compilation from CHI IR.

AutoDiff is not yet supported since `reverse_segments` works on the frontend IR(AST).

Also adds `KernelReturnStmt` to the IR builder.

Again, this PR is not unit-tested, so let me know if anything seems not working...

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
