### PR TITLE
[test] [ir] Add a simple unit test for IRBuilder

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -74,20 +74,42 @@ if (TI_WITH_CC)
   list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CC_SOURCE})
 endif()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # We don't mean to create a dedicated library just for common. Instead, we are
 # trying to identify, refactor and group the core files into a smaller lib. This
 # lib should be mostly self-contained and completely Taichi focused, free from
 # the "application" layer such as pybind11 or GUI.
-file(GLOB TAICHI_TESTABLE_SRC "taichi/common/*.cpp" "taichi/common/*.h")
+file(GLOB TAICHI_TESTABLE_SRC
+      "taichi/common/*.cpp"
+      "taichi/common/*.h"
+      "taichi/ir/ir_builder.*"
+      "taichi/ir/ir.*"
+      "taichi/ir/offloaded_task_type.*"
+      "taichi/ir/snode_types.*"
+      "taichi/ir/snode.*"
+      "taichi/ir/statements.*"
+      "taichi/ir/type_factory.*"
+      "taichi/ir/type_utils.*"
+      "taichi/ir/type.*"
+      "taichi/transforms/statement_usage_replace.cpp"
+      "taichi/program/arch.*"
+      "taichi/program/compile_config.*"
+      "taichi/system/timer.*"
+      "taichi/system/profiler.*"
+)
+
 # TODO(#2196): Maybe we can do the following renaming in the end?
 # taichi_core --> taichi_pylib (this requires python-side refactoring...)
 # taichi_testable_lib --> taichi_core
 set(TAICHI_TESTABLE_LIB taichi_testable_lib)
-add_library(${TAICHI_TESTABLE_LIB} OBJECT ${TAICHI_TESTABLE_SRC})
+add_library(${TAICHI_TESTABLE_LIB} STATIC ${TAICHI_TESTABLE_SRC})
 set_property(TARGET ${TAICHI_TESTABLE_LIB} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_TESTABLE_SRC})
-add_library(${CORE_LIBRARY_NAME} SHARED ${TAICHI_CORE_SOURCE} ${PROJECT_SOURCES} $<TARGET_OBJECTS:${TAICHI_TESTABLE_LIB}>)
+
+add_library(${CORE_LIBRARY_NAME} SHARED ${TAICHI_CORE_SOURCE})
+target_link_libraries(${CORE_LIBRARY_NAME} ${TAICHI_TESTABLE_LIB})
 
 if (APPLE)
     # Ask OS X to minic Linux dynamic linking behavior

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -74,12 +74,16 @@ if (TI_WITH_CC)
   list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CC_SOURCE})
 endif()
 
+# This compiles all the libraries with -fPIC, which is critical to link a static
+# library into a shared lib.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# We don't mean to create a dedicated library just for common. Instead, we are
-# trying to identify, refactor and group the core files into a smaller lib. This
-# lib should be mostly self-contained and completely Taichi focused, free from
-# the "application" layer such as pybind11 or GUI.
+# The short-term goal is to have a sub-library that is mostly Taichi-focused,
+# free from the "application" layer such as pybind11 or GUI. At a minimum, we
+# must decouple from pybind11/python-environment. This sub-lib will then be
+# unit testtable.
+# TODO(#2198): Long-term speaking, we should create a separate library for each
+# sub-module. This way we can guarantee that the lib dependencies form a DAG.
 file(GLOB TAICHI_TESTABLE_SRC
       "taichi/common/*.cpp"
       "taichi/common/*.h"
@@ -104,7 +108,6 @@ file(GLOB TAICHI_TESTABLE_SRC
 # taichi_testable_lib --> taichi_core
 set(TAICHI_TESTABLE_LIB taichi_testable_lib)
 add_library(${TAICHI_TESTABLE_LIB} STATIC ${TAICHI_TESTABLE_SRC})
-set_property(TARGET ${TAICHI_TESTABLE_LIB} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_TESTABLE_SRC})
 

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -15,7 +15,8 @@ include_directories(
     ${PROJECT_SOURCE_DIR},
 )
 
-add_executable(${TESTS_NAME} ${TAICHI_TESTS_SOURCE} $<TARGET_OBJECTS:taichi_testable_lib>)
+add_executable(${TESTS_NAME} ${TAICHI_TESTS_SOURCE})
+target_link_libraries(${TESTS_NAME} taichi_testable_lib)
 target_link_libraries(${TESTS_NAME} gtest_main)
 
 add_test(NAME ${TESTS_NAME} COMMAND ${TESTS_NAME})

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -1,0 +1,22 @@
+#include "gtest/gtest.h"
+
+#include "taichi/ir/ir_builder.h"
+#include "taichi/ir/statements.h"
+
+namespace taichi {
+namespace lang {
+
+TEST(IRBuilder, Basic) {
+  IRBuilder builder;
+  auto *lhs = builder.get_int32(40);
+  auto *rhs = builder.get_int32(2);
+  auto *add = builder.create_add(lhs, rhs);
+  ASSERT_TRUE(add->is<BinaryOpStmt>());
+  auto *addc = add->cast<BinaryOpStmt>();
+  EXPECT_EQ(addc->lhs, lhs);
+  EXPECT_EQ(addc->rhs, rhs);
+  EXPECT_EQ(addc->op_type, BinaryOpType::add);
+}
+
+}  // namespace lang
+}  // namespace taichi


### PR DESCRIPTION
Related issue = #2196, #2193

Note that I've switched from `OBJECT`  to `STATIC` now. It could be too laborious to refactor the whole code base to a point where they are layered nicely. Instead, we should just create a (static) library that is unit testable by excludeing `taichi/python` and being python-free. Most of Taichi's dependencies will be merged into this lib, including LLVM, GLEW, etc. ( `target_link_librariess()` doesn't seem to be effective with an `OBJECT` library)

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
