### PR TITLE
[ir] Add more statements and tests to IR Builder

### DIFF
--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -49,6 +49,86 @@ Stmt *IRBuilder::create_return(Stmt *value) {
   return insert(Stmt::make<KernelReturnStmt>(value));
 }
 
+Stmt *IRBuilder::create_cast(Stmt *value, DataType output_type) {
+  auto &&result = Stmt::make_typed<UnaryOpStmt>(UnaryOpType::cast_value, value);
+  result->cast_type = output_type;
+  return insert(std::move(result));
+}
+
+Stmt *IRBuilder::create_bit_cast(Stmt *value, DataType output_type) {
+  auto &&result = Stmt::make_typed<UnaryOpStmt>(UnaryOpType::cast_bits, value);
+  result->cast_type = output_type;
+  return insert(std::move(result));
+}
+
+Stmt *IRBuilder::create_neg(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::neg, value));
+}
+
+Stmt *IRBuilder::create_not(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::bit_not, value));
+}
+
+Stmt *IRBuilder::create_logical_not(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::logic_not, value));
+}
+
+Stmt *IRBuilder::create_floor(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::floor, value));
+}
+
+Stmt *IRBuilder::create_ceil(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::ceil, value));
+}
+
+Stmt *IRBuilder::create_abs(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::abs, value));
+}
+
+Stmt *IRBuilder::create_sgn(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::sgn, value));
+}
+
+Stmt *IRBuilder::create_sqrt(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::sqrt, value));
+}
+
+Stmt *IRBuilder::create_rsqrt(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::rsqrt, value));
+}
+
+Stmt *IRBuilder::create_sin(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::sin, value));
+}
+
+Stmt *IRBuilder::create_asin(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::asin, value));
+}
+
+Stmt *IRBuilder::create_cos(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::cos, value));
+}
+
+Stmt *IRBuilder::create_acos(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::acos, value));
+}
+
+Stmt *IRBuilder::create_tan(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::tan, value));
+}
+
+Stmt *IRBuilder::create_tanh(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::tanh, value));
+}
+
+Stmt *IRBuilder::create_exp(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::exp, value));
+}
+
+Stmt *IRBuilder::create_log(Stmt *value) {
+  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::log, value));
+}
+
 Stmt *IRBuilder::create_add(Stmt *l, Stmt *r) {
   return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::add, l, r));
 }
@@ -71,6 +151,81 @@ Stmt *IRBuilder::create_floordiv(Stmt *l, Stmt *r) {
 
 Stmt *IRBuilder::create_truediv(Stmt *l, Stmt *r) {
   return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::truediv, l, r));
+}
+
+Stmt *IRBuilder::create_mod(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::mod, l, r));
+}
+
+Stmt *IRBuilder::create_max(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::max, l, r));
+}
+
+Stmt *IRBuilder::create_min(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::min, l, r));
+}
+
+Stmt *IRBuilder::create_atan2(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::atan2, l, r));
+}
+
+Stmt *IRBuilder::create_pow(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::pow, l, r));
+}
+
+Stmt *IRBuilder::create_and(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_and, l, r));
+}
+
+Stmt *IRBuilder::create_or(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_or, l, r));
+}
+
+Stmt *IRBuilder::create_xor(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_xor, l, r));
+}
+
+Stmt *IRBuilder::create_shl(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_shl, l, r));
+}
+
+Stmt *IRBuilder::create_shr(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_shr, l, r));
+}
+
+Stmt *IRBuilder::create_sar(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_sar, l, r));
+}
+
+Stmt *IRBuilder::create_cmp_lt(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_lt, l, r));
+}
+
+Stmt *IRBuilder::create_cmp_le(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_le, l, r));
+}
+
+Stmt *IRBuilder::create_cmp_gt(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_gt, l, r));
+}
+
+Stmt *IRBuilder::create_cmp_ge(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_ge, l, r));
+}
+
+Stmt *IRBuilder::create_cmp_eq(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_eq, l, r));
+}
+
+Stmt *IRBuilder::create_cmp_ne(Stmt *l, Stmt *r) {
+  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_ne, l, r));
+}
+
+Stmt *IRBuilder::create_select(Stmt *cond,
+                               Stmt *true_result,
+                               Stmt *false_result) {
+  return insert(Stmt::make<TernaryOpStmt>(TernaryOpType::select, cond,
+                                          true_result, false_result));
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -20,15 +20,6 @@ std::unique_ptr<IRNode> IRBuilder::extract_ir() {
   return std::move(result);
 }
 
-Stmt *IRBuilder::insert(std::unique_ptr<Stmt> &&stmt) {
-  return insert(std::move(stmt), &insert_point_);
-}
-
-Stmt *IRBuilder::insert(std::unique_ptr<Stmt> &&stmt,
-                        InsertPoint *insert_point) {
-  return insert_point->block->insert(std::move(stmt), insert_point->position++);
-}
-
 void IRBuilder::set_insertion_point(InsertPoint new_insert_point) {
   insert_point_ = new_insert_point;
 }
@@ -41,290 +32,285 @@ void IRBuilder::set_insertion_point_to_before(Stmt *stmt) {
   set_insertion_point({stmt->parent, stmt->parent->locate(stmt)});
 }
 
-void IRBuilder::set_insertion_point_to_loop_begin(Stmt *loop) {
-  if (auto range_for = loop->cast<RangeForStmt>()) {
-    set_insertion_point({range_for->body.get(), 0});
-  } else if (auto struct_for = loop->cast<StructForStmt>()) {
-    set_insertion_point({struct_for->body.get(), 0});
-  } else if (auto while_stmt = loop->cast<WhileStmt>()) {
-    set_insertion_point({while_stmt->body.get(), 0});
-  } else {
-    TI_ERROR("Statement {} is not a loop.", loop->name());
-  }
+void IRBuilder::set_insertion_point_to_true_branch(IfStmt *if_stmt) {
+  if (!if_stmt->true_statements)
+    if_stmt->set_true_statements(std::make_unique<Block>());
+  set_insertion_point({if_stmt->true_statements.get(), 0});
 }
 
-void IRBuilder::set_insertion_point_to_true_branch(Stmt *if_stmt) {
-  TI_ASSERT(if_stmt->is<IfStmt>());
-  set_insertion_point({if_stmt->as<IfStmt>()->true_statements.get(), 0});
+void IRBuilder::set_insertion_point_to_false_branch(IfStmt *if_stmt) {
+  if (!if_stmt->false_statements)
+    if_stmt->set_false_statements(std::make_unique<Block>());
+  set_insertion_point({if_stmt->false_statements.get(), 0});
 }
 
-void IRBuilder::set_insertion_point_to_false_branch(Stmt *if_stmt) {
-  TI_ASSERT(if_stmt->is<IfStmt>());
-  set_insertion_point({if_stmt->as<IfStmt>()->false_statements.get(), 0});
+RangeForStmt *IRBuilder::create_range_for(Stmt *begin,
+                                          Stmt *end,
+                                          int vectorize,
+                                          int bit_vectorize,
+                                          int parallelize,
+                                          int block_dim,
+                                          bool strictly_serialized) {
+  return insert(Stmt::make_typed<RangeForStmt>(
+      begin, end, std::make_unique<Block>(), vectorize, bit_vectorize,
+      parallelize, block_dim, strictly_serialized));
 }
 
-Stmt *IRBuilder::create_range_for(Stmt *begin,
-                                  Stmt *end,
-                                  int vectorize,
-                                  int bit_vectorize,
-                                  int parallelize,
-                                  int block_dim,
-                                  bool strictly_serialized) {
-  return insert(Stmt::make<RangeForStmt>(begin, end, std::make_unique<Block>(),
-                                         vectorize, bit_vectorize, parallelize,
-                                         block_dim, strictly_serialized));
-}
-
-Stmt *IRBuilder::create_struct_for(SNode *snode,
+StructForStmt *IRBuilder::create_struct_for(SNode *snode,
                                    int vectorize,
                                    int bit_vectorize,
                                    int parallelize,
                                    int block_dim) {
-  return insert(Stmt::make<StructForStmt>(snode, std::make_unique<Block>(),
+  return insert(Stmt::make_typed<StructForStmt>(snode, std::make_unique<Block>(),
                                           vectorize, bit_vectorize, parallelize,
                                           block_dim));
 }
 
-Stmt *IRBuilder::create_while_true() {
-  return insert(Stmt::make<WhileStmt>(std::make_unique<Block>()));
+WhileStmt *IRBuilder::create_while_true() {
+  return insert(Stmt::make_typed<WhileStmt>(std::make_unique<Block>()));
 }
 
-Stmt *IRBuilder::create_if(Stmt *cond) {
-  auto &&result = Stmt::make_typed<IfStmt>(cond);
-  result->set_true_statements(std::make_unique<Block>());
-  result->set_false_statements(std::make_unique<Block>());
-  return insert(std::move(result));
+IfStmt *IRBuilder::create_if(Stmt *cond) {
+  return insert(Stmt::make_typed<IfStmt>(cond));
 }
 
-Stmt *IRBuilder::create_break() {
-  return insert(Stmt::make<WhileControlStmt>(nullptr, get_int32(0)));
+WhileControlStmt *IRBuilder::create_break() {
+  return insert(Stmt::make_typed<WhileControlStmt>(nullptr, get_int32(0)));
 }
 
-Stmt *IRBuilder::create_continue() {
-  return insert(Stmt::make<ContinueStmt>());
+ContinueStmt *IRBuilder::create_continue() {
+  return insert(Stmt::make_typed<ContinueStmt>());
 }
 
-Stmt *IRBuilder::get_loop_index(Stmt *loop, int index) {
-  return insert(Stmt::make<LoopIndexStmt>(loop, index));
+LoopIndexStmt *IRBuilder::get_loop_index(Stmt *loop, int index) {
+  return insert(Stmt::make_typed<LoopIndexStmt>(loop, index));
 }
 
-Stmt *IRBuilder::get_int32(int32 value) {
+ConstStmt *IRBuilder::get_int32(int32 value) {
   return insert(
-      Stmt::make<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
+      Stmt::make_typed<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
           TypeFactory::get_instance().get_primitive_type(PrimitiveTypeID::i32),
           value))));
 }
 
-Stmt *IRBuilder::get_int64(int64 value) {
+ConstStmt *IRBuilder::get_int64(int64 value) {
   return insert(
-      Stmt::make<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
+      Stmt::make_typed<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
           TypeFactory::get_instance().get_primitive_type(PrimitiveTypeID::i64),
           value))));
 }
 
-Stmt *IRBuilder::get_float32(float32 value) {
+ConstStmt *IRBuilder::get_float32(float32 value) {
   return insert(
-      Stmt::make<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
+      Stmt::make_typed<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
           TypeFactory::get_instance().get_primitive_type(PrimitiveTypeID::f32),
           value))));
 }
 
-Stmt *IRBuilder::get_float64(float64 value) {
+ConstStmt *IRBuilder::get_float64(float64 value) {
   return insert(
-      Stmt::make<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
+      Stmt::make_typed<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(
           TypeFactory::get_instance().get_primitive_type(PrimitiveTypeID::f64),
           value))));
 }
 
-Stmt *IRBuilder::create_arg_load(int arg_id, DataType dt, bool is_ptr) {
-  return insert(Stmt::make<ArgLoadStmt>(arg_id, dt, is_ptr));
+ArgLoadStmt *IRBuilder::create_arg_load(int arg_id, DataType dt, bool is_ptr) {
+  return insert(Stmt::make_typed<ArgLoadStmt>(arg_id, dt, is_ptr));
 }
 
-Stmt *IRBuilder::create_return(Stmt *value) {
-  return insert(Stmt::make<KernelReturnStmt>(value));
+KernelReturnStmt *IRBuilder::create_return(Stmt *value) {
+  return insert(Stmt::make_typed<KernelReturnStmt>(value));
 }
 
-Stmt *IRBuilder::create_cast(Stmt *value, DataType output_type) {
+UnaryOpStmt *IRBuilder::create_cast(Stmt *value, DataType output_type) {
   auto &&result = Stmt::make_typed<UnaryOpStmt>(UnaryOpType::cast_value, value);
   result->cast_type = output_type;
   return insert(std::move(result));
 }
 
-Stmt *IRBuilder::create_bit_cast(Stmt *value, DataType output_type) {
+UnaryOpStmt *IRBuilder::create_bit_cast(Stmt *value, DataType output_type) {
   auto &&result = Stmt::make_typed<UnaryOpStmt>(UnaryOpType::cast_bits, value);
   result->cast_type = output_type;
   return insert(std::move(result));
 }
 
-Stmt *IRBuilder::create_neg(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::neg, value));
+UnaryOpStmt *IRBuilder::create_neg(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::neg, value));
 }
 
-Stmt *IRBuilder::create_not(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::bit_not, value));
+UnaryOpStmt *IRBuilder::create_not(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::bit_not, value));
 }
 
-Stmt *IRBuilder::create_logical_not(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::logic_not, value));
+UnaryOpStmt *IRBuilder::create_logical_not(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::logic_not, value));
 }
 
-Stmt *IRBuilder::create_floor(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::floor, value));
+UnaryOpStmt *IRBuilder::create_floor(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::floor, value));
 }
 
-Stmt *IRBuilder::create_ceil(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::ceil, value));
+UnaryOpStmt *IRBuilder::create_ceil(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::ceil, value));
 }
 
-Stmt *IRBuilder::create_abs(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::abs, value));
+UnaryOpStmt *IRBuilder::create_abs(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::abs, value));
 }
 
-Stmt *IRBuilder::create_sgn(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::sgn, value));
+UnaryOpStmt *IRBuilder::create_sgn(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::sgn, value));
 }
 
-Stmt *IRBuilder::create_sqrt(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::sqrt, value));
+UnaryOpStmt *IRBuilder::create_sqrt(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::sqrt, value));
 }
 
-Stmt *IRBuilder::create_rsqrt(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::rsqrt, value));
+UnaryOpStmt *IRBuilder::create_rsqrt(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::rsqrt, value));
 }
 
-Stmt *IRBuilder::create_sin(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::sin, value));
+UnaryOpStmt *IRBuilder::create_sin(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::sin, value));
 }
 
-Stmt *IRBuilder::create_asin(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::asin, value));
+UnaryOpStmt *IRBuilder::create_asin(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::asin, value));
 }
 
-Stmt *IRBuilder::create_cos(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::cos, value));
+UnaryOpStmt *IRBuilder::create_cos(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::cos, value));
 }
 
-Stmt *IRBuilder::create_acos(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::acos, value));
+UnaryOpStmt *IRBuilder::create_acos(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::acos, value));
 }
 
 Stmt *IRBuilder::create_tan(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::tan, value));
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::tan, value));
 }
 
-Stmt *IRBuilder::create_tanh(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::tanh, value));
+UnaryOpStmt *IRBuilder::create_tanh(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::tanh, value));
 }
 
-Stmt *IRBuilder::create_exp(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::exp, value));
+UnaryOpStmt *IRBuilder::create_exp(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::exp, value));
 }
 
-Stmt *IRBuilder::create_log(Stmt *value) {
-  return insert(Stmt::make<UnaryOpStmt>(UnaryOpType::log, value));
+UnaryOpStmt *IRBuilder::create_log(Stmt *value) {
+  return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::log, value));
 }
 
-Stmt *IRBuilder::create_add(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::add, l, r));
+BinaryOpStmt *IRBuilder::create_add(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, l, r));
 }
 
-Stmt *IRBuilder::create_sub(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::sub, l, r));
+BinaryOpStmt *IRBuilder::create_sub(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, l, r));
 }
 
-Stmt *IRBuilder::create_mul(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::mul, l, r));
+BinaryOpStmt *IRBuilder::create_mul(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::mul, l, r));
 }
 
-Stmt *IRBuilder::create_div(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::div, l, r));
+BinaryOpStmt *IRBuilder::create_div(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::div, l, r));
 }
 
-Stmt *IRBuilder::create_floordiv(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::floordiv, l, r));
+BinaryOpStmt *IRBuilder::create_floordiv(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::floordiv, l, r));
 }
 
-Stmt *IRBuilder::create_truediv(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::truediv, l, r));
+BinaryOpStmt *IRBuilder::create_truediv(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::truediv, l, r));
 }
 
-Stmt *IRBuilder::create_mod(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::mod, l, r));
+BinaryOpStmt *IRBuilder::create_mod(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::mod, l, r));
 }
 
-Stmt *IRBuilder::create_max(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::max, l, r));
+BinaryOpStmt *IRBuilder::create_max(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::max, l, r));
 }
 
-Stmt *IRBuilder::create_min(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::min, l, r));
+BinaryOpStmt *IRBuilder::create_min(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, l, r));
 }
 
-Stmt *IRBuilder::create_atan2(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::atan2, l, r));
+BinaryOpStmt *IRBuilder::create_atan2(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::atan2, l, r));
 }
 
-Stmt *IRBuilder::create_pow(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::pow, l, r));
+BinaryOpStmt *IRBuilder::create_pow(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::pow, l, r));
 }
 
-Stmt *IRBuilder::create_and(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_and, l, r));
+BinaryOpStmt *IRBuilder::create_and(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::bit_and, l, r));
 }
 
-Stmt *IRBuilder::create_or(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_or, l, r));
+BinaryOpStmt *IRBuilder::create_or(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::bit_or, l, r));
 }
 
-Stmt *IRBuilder::create_xor(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_xor, l, r));
+BinaryOpStmt *IRBuilder::create_xor(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::bit_xor, l, r));
 }
 
-Stmt *IRBuilder::create_shl(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_shl, l, r));
+BinaryOpStmt *IRBuilder::create_shl(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::bit_shl, l, r));
 }
 
-Stmt *IRBuilder::create_shr(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_shr, l, r));
+BinaryOpStmt *IRBuilder::create_shr(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::bit_shr, l, r));
 }
 
-Stmt *IRBuilder::create_sar(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::bit_sar, l, r));
+BinaryOpStmt *IRBuilder::create_sar(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::bit_sar, l, r));
 }
 
-Stmt *IRBuilder::create_cmp_lt(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_lt, l, r));
+BinaryOpStmt *IRBuilder::create_cmp_lt(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::cmp_lt, l, r));
 }
 
-Stmt *IRBuilder::create_cmp_le(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_le, l, r));
+BinaryOpStmt *IRBuilder::create_cmp_le(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::cmp_le, l, r));
 }
 
-Stmt *IRBuilder::create_cmp_gt(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_gt, l, r));
+BinaryOpStmt *IRBuilder::create_cmp_gt(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::cmp_gt, l, r));
 }
 
-Stmt *IRBuilder::create_cmp_ge(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_ge, l, r));
+BinaryOpStmt *IRBuilder::create_cmp_ge(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::cmp_ge, l, r));
 }
 
-Stmt *IRBuilder::create_cmp_eq(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_eq, l, r));
+BinaryOpStmt *IRBuilder::create_cmp_eq(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::cmp_eq, l, r));
 }
 
-Stmt *IRBuilder::create_cmp_ne(Stmt *l, Stmt *r) {
-  return insert(Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_ne, l, r));
+BinaryOpStmt *IRBuilder::create_cmp_ne(Stmt *l, Stmt *r) {
+  return insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::cmp_ne, l, r));
 }
 
-Stmt *IRBuilder::create_select(Stmt *cond,
+TernaryOpStmt *IRBuilder::create_select(Stmt *cond,
                                Stmt *true_result,
                                Stmt *false_result) {
-  return insert(Stmt::make<TernaryOpStmt>(TernaryOpType::select, cond,
+  return insert(Stmt::make_typed<TernaryOpStmt>(TernaryOpType::select, cond,
                                           true_result, false_result));
 }
 
-Stmt *IRBuilder::create_local_var(DataType dt) {
-  return insert(Stmt::make<AllocaStmt>(dt));
+AllocaStmt *IRBuilder::create_local_var(DataType dt) {
+  return insert(Stmt::make_typed<AllocaStmt>(dt));
+}
+
+LocalLoadStmt *IRBuilder::create_local_load(AllocaStmt *ptr) {
+  return insert(Stmt::make_typed<LocalLoadStmt>(LocalAddress(ptr, 0)));
+}
+
+void IRBuilder::create_local_store(AllocaStmt *ptr, Stmt *data) {
+  insert(Stmt::make_typed<LocalStoreStmt>(ptr, data));
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -5,9 +5,19 @@
 TLANG_NAMESPACE_BEGIN
 
 IRBuilder::IRBuilder() {
+  reset();
+}
+
+void IRBuilder::reset() {
   root_ = std::make_unique<Block>();
   insert_point_.block = root_->as<Block>();
   insert_point_.position = 0;
+}
+
+std::unique_ptr<IRNode> IRBuilder::extract_ir() {
+  auto &&result = std::move(root_);
+  reset();
+  return std::move(result);
 }
 
 Stmt *IRBuilder::insert(std::unique_ptr<Stmt> &&stmt) {

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -66,13 +66,13 @@ Stmt *IRBuilder::create_range_for(Stmt *begin,
 }
 
 Stmt *IRBuilder::create_struct_for(SNode *snode,
-                                  int vectorize,
-                                  int bit_vectorize,
-                                  int parallelize,
-                                  int block_dim) {
+                                   int vectorize,
+                                   int bit_vectorize,
+                                   int parallelize,
+                                   int block_dim) {
   return insert(Stmt::make<StructForStmt>(snode, std::make_unique<Block>(),
-                                         vectorize, bit_vectorize, parallelize,
-                                         block_dim));
+                                          vectorize, bit_vectorize, parallelize,
+                                          block_dim));
 }
 
 Stmt *IRBuilder::create_while_true() {

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -57,13 +57,13 @@ RangeForStmt *IRBuilder::create_range_for(Stmt *begin,
 }
 
 StructForStmt *IRBuilder::create_struct_for(SNode *snode,
-                                   int vectorize,
-                                   int bit_vectorize,
-                                   int parallelize,
-                                   int block_dim) {
-  return insert(Stmt::make_typed<StructForStmt>(snode, std::make_unique<Block>(),
-                                          vectorize, bit_vectorize, parallelize,
-                                          block_dim));
+                                            int vectorize,
+                                            int bit_vectorize,
+                                            int parallelize,
+                                            int block_dim) {
+  return insert(Stmt::make_typed<StructForStmt>(
+      snode, std::make_unique<Block>(), vectorize, bit_vectorize, parallelize,
+      block_dim));
 }
 
 WhileStmt *IRBuilder::create_while_true() {
@@ -295,10 +295,10 @@ BinaryOpStmt *IRBuilder::create_cmp_ne(Stmt *l, Stmt *r) {
 }
 
 TernaryOpStmt *IRBuilder::create_select(Stmt *cond,
-                               Stmt *true_result,
-                               Stmt *false_result) {
+                                        Stmt *true_result,
+                                        Stmt *false_result) {
   return insert(Stmt::make_typed<TernaryOpStmt>(TernaryOpType::select, cond,
-                                          true_result, false_result));
+                                                true_result, false_result));
 }
 
 AllocaStmt *IRBuilder::create_local_var(DataType dt) {

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -94,6 +94,10 @@ Stmt *IRBuilder::create_continue() {
   return insert(Stmt::make<ContinueStmt>());
 }
 
+Stmt *IRBuilder::get_loop_index(Stmt *loop, int index) {
+  return insert(Stmt::make<LoopIndexStmt>(loop, index));
+}
+
 Stmt *IRBuilder::get_int32(int32 value) {
   return insert(
       Stmt::make<ConstStmt>(LaneAttribute<TypedConstant>(TypedConstant(

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -186,7 +186,7 @@ UnaryOpStmt *IRBuilder::create_acos(Stmt *value) {
   return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::acos, value));
 }
 
-Stmt *IRBuilder::create_tan(Stmt *value) {
+UnaryOpStmt *IRBuilder::create_tan(Stmt *value) {
   return insert(Stmt::make_typed<UnaryOpStmt>(UnaryOpType::tan, value));
 }
 

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -12,7 +12,7 @@ class IRBuilder {
   };
 
  private:
-  std::unique_ptr<IRNode> root_;
+  std::unique_ptr<IRNode> root_{nullptr};
   InsertPoint insert_point_;
 
  public:

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -89,10 +89,8 @@ class IRBuilder {
   // Print values and strings. Arguments can be Stmt* or std::string.
   template <typename... Args>
   Stmt *create_print(Args &&... args) {
-    return insert(Stmt::make<PrintStmt>(std::forward(args)...));
+    return insert(Stmt::make<PrintStmt>(std::forward<Args>(args)...));
   }
-
-
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -34,8 +34,9 @@ class IRBuilder {
   template <typename XxxStmt>
   static XxxStmt *insert(std::unique_ptr<XxxStmt> &&stmt,
                          InsertPoint *insert_point) {
-    return insert_point->block->insert(std::move(stmt),
-                                       insert_point->position++);
+    return insert_point->block
+        ->insert(std::move(stmt), insert_point->position++)
+        ->template as<XxxStmt>();
   }
 
   void set_insertion_point(InsertPoint new_insert_point);

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -5,12 +5,13 @@
 TLANG_NAMESPACE_BEGIN
 
 class IRBuilder {
- private:
+ public:
   struct InsertPoint {
     Block *block;
     int position;
   };
 
+ private:
   std::unique_ptr<IRNode> root_;
   InsertPoint insert_point_;
 
@@ -19,6 +20,33 @@ class IRBuilder {
 
   // General inserter. Returns stmt.get().
   Stmt *insert(std::unique_ptr<Stmt> &&stmt);
+  // Insert to a specific insertion point.
+  static Stmt *insert(std::unique_ptr<Stmt> &&stmt, InsertPoint *insert_point);
+
+  void set_insertion_point(InsertPoint new_insert_point);
+  void set_insertion_point_to_after(Stmt *stmt);
+  void set_insertion_point_to_before(Stmt *stmt);
+  void set_insertion_point_to_loop_begin(Stmt *loop);
+  void set_insertion_point_to_true_branch(Stmt *if_stmt);
+  void set_insertion_point_to_false_branch(Stmt *if_stmt);
+
+  // Control flows.
+  Stmt *create_range_for(Stmt *begin,
+                         Stmt *end,
+                         int vectorize = -1,
+                         int bit_vectorize = -1,
+                         int parallelize = 0,
+                         int block_dim = 0,
+                         bool strictly_serialized = false);
+  Stmt *create_struct_for(SNode *snode,
+                          int vectorize = -1,
+                          int bit_vectorize = -1,
+                          int parallelize = 0,
+                          int block_dim = 0);
+  Stmt *create_while_true();
+  Stmt *create_if(Stmt *cond);
+  Stmt *create_break();
+  Stmt *create_continue();
 
   // Constants. TODO: add more types
   Stmt *get_int32(int32 value);
@@ -91,6 +119,9 @@ class IRBuilder {
   Stmt *create_print(Args &&... args) {
     return insert(Stmt::make<PrintStmt>(std::forward<Args>(args)...));
   }
+
+  // Local variable.
+  Stmt *create_local_var(DataType dt);
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -142,7 +142,9 @@ class IRBuilder {
   BinaryOpStmt *create_cmp_ne(Stmt *l, Stmt *r);
 
   // Ternary operations. Returns the result.
-  TernaryOpStmt *create_select(Stmt *cond, Stmt *true_result, Stmt *false_result);
+  TernaryOpStmt *create_select(Stmt *cond,
+                               Stmt *true_result,
+                               Stmt *false_result);
 
   // Print values and strings. Arguments can be Stmt* or std::string.
   template <typename... Args>

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -25,112 +25,135 @@ class IRBuilder {
   std::unique_ptr<IRNode> extract_ir();
 
   // General inserter. Returns stmt.get().
-  Stmt *insert(std::unique_ptr<Stmt> &&stmt);
+  template <typename XxxStmt>
+  XxxStmt *insert(std::unique_ptr<XxxStmt> &&stmt) {
+    return insert(std::move(stmt), &insert_point_);
+  }
+
   // Insert to a specific insertion point.
-  static Stmt *insert(std::unique_ptr<Stmt> &&stmt, InsertPoint *insert_point);
+  template <typename XxxStmt>
+  static XxxStmt *insert(std::unique_ptr<XxxStmt> &&stmt,
+                         InsertPoint *insert_point) {
+    return insert_point->block->insert(std::move(stmt),
+                                       insert_point->position++);
+  }
 
   void set_insertion_point(InsertPoint new_insert_point);
   void set_insertion_point_to_after(Stmt *stmt);
   void set_insertion_point_to_before(Stmt *stmt);
-  void set_insertion_point_to_loop_begin(Stmt *loop);
-  void set_insertion_point_to_true_branch(Stmt *if_stmt);
-  void set_insertion_point_to_false_branch(Stmt *if_stmt);
+  void set_insertion_point_to_true_branch(IfStmt *if_stmt);
+  void set_insertion_point_to_false_branch(IfStmt *if_stmt);
+  template <typename XxxStmt>
+  void set_insertion_point_to_loop_begin(XxxStmt *loop) {
+    if constexpr (!std::is_base_of_v<Stmt, XxxStmt>) {
+      TI_ERROR("The argument is not a statement.");
+    }
+    if constexpr (std::is_same_v<XxxStmt, RangeForStmt> ||
+                  std::is_same_v<XxxStmt, StructForStmt> ||
+                  std::is_same_v<XxxStmt, WhileStmt>) {
+      set_insertion_point({loop->body.get(), 0});
+    } else {
+      TI_ERROR("Statement {} is not a loop.", loop->name());
+    }
+  }
 
   // Control flows.
-  Stmt *create_range_for(Stmt *begin,
-                         Stmt *end,
-                         int vectorize = -1,
-                         int bit_vectorize = -1,
-                         int parallelize = 0,
-                         int block_dim = 0,
-                         bool strictly_serialized = false);
-  Stmt *create_struct_for(SNode *snode,
-                          int vectorize = -1,
-                          int bit_vectorize = -1,
-                          int parallelize = 0,
-                          int block_dim = 0);
-  Stmt *create_while_true();
-  Stmt *create_if(Stmt *cond);
-  Stmt *create_break();
-  Stmt *create_continue();
+  RangeForStmt *create_range_for(Stmt *begin,
+                                 Stmt *end,
+                                 int vectorize = -1,
+                                 int bit_vectorize = -1,
+                                 int parallelize = 0,
+                                 int block_dim = 0,
+                                 bool strictly_serialized = false);
+  StructForStmt *create_struct_for(SNode *snode,
+                                   int vectorize = -1,
+                                   int bit_vectorize = -1,
+                                   int parallelize = 0,
+                                   int block_dim = 0);
+  WhileStmt *create_while_true();
+  IfStmt *create_if(Stmt *cond);
+  WhileControlStmt *create_break();
+  ContinueStmt *create_continue();
 
   // Loop index.
-  Stmt *get_loop_index(Stmt *loop, int index = 0);
+  LoopIndexStmt *get_loop_index(Stmt *loop, int index = 0);
 
   // Constants. TODO: add more types
-  Stmt *get_int32(int32 value);
-  Stmt *get_int64(int64 value);
-  Stmt *get_float32(float32 value);
-  Stmt *get_float64(float64 value);
+  ConstStmt *get_int32(int32 value);
+  ConstStmt *get_int64(int64 value);
+  ConstStmt *get_float32(float32 value);
+  ConstStmt *get_float64(float64 value);
 
   // Load kernel arguments.
-  Stmt *create_arg_load(int arg_id, DataType dt, bool is_ptr);
+  ArgLoadStmt *create_arg_load(int arg_id, DataType dt, bool is_ptr);
 
   // The return value of the kernel.
-  Stmt *create_return(Stmt *value);
+  KernelReturnStmt *create_return(Stmt *value);
 
   // Unary operations. Returns the result.
-  Stmt *create_cast(Stmt *value, DataType output_type);  // cast by value
-  Stmt *create_bit_cast(Stmt *value, DataType output_type);
-  Stmt *create_neg(Stmt *value);
-  Stmt *create_not(Stmt *value);  // bitwise
-  Stmt *create_logical_not(Stmt *value);
-  Stmt *create_floor(Stmt *value);
-  Stmt *create_ceil(Stmt *value);
-  Stmt *create_abs(Stmt *value);
-  Stmt *create_sgn(Stmt *value);
-  Stmt *create_sqrt(Stmt *value);
-  Stmt *create_rsqrt(Stmt *value);
-  Stmt *create_sin(Stmt *value);
-  Stmt *create_asin(Stmt *value);
-  Stmt *create_cos(Stmt *value);
-  Stmt *create_acos(Stmt *value);
-  Stmt *create_tan(Stmt *value);
-  Stmt *create_tanh(Stmt *value);
-  Stmt *create_exp(Stmt *value);
-  Stmt *create_log(Stmt *value);
+  UnaryOpStmt *create_cast(Stmt *value, DataType output_type);  // cast by value
+  UnaryOpStmt *create_bit_cast(Stmt *value, DataType output_type);
+  UnaryOpStmt *create_neg(Stmt *value);
+  UnaryOpStmt *create_not(Stmt *value);  // bitwise
+  UnaryOpStmt *create_logical_not(Stmt *value);
+  UnaryOpStmt *create_floor(Stmt *value);
+  UnaryOpStmt *create_ceil(Stmt *value);
+  UnaryOpStmt *create_abs(Stmt *value);
+  UnaryOpStmt *create_sgn(Stmt *value);
+  UnaryOpStmt *create_sqrt(Stmt *value);
+  UnaryOpStmt *create_rsqrt(Stmt *value);
+  UnaryOpStmt *create_sin(Stmt *value);
+  UnaryOpStmt *create_asin(Stmt *value);
+  UnaryOpStmt *create_cos(Stmt *value);
+  UnaryOpStmt *create_acos(Stmt *value);
+  UnaryOpStmt *create_tan(Stmt *value);
+  UnaryOpStmt *create_tanh(Stmt *value);
+  UnaryOpStmt *create_exp(Stmt *value);
+  UnaryOpStmt *create_log(Stmt *value);
 
   // Binary operations. Returns the result.
-  Stmt *create_add(Stmt *l, Stmt *r);
-  Stmt *create_sub(Stmt *l, Stmt *r);
-  Stmt *create_mul(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_add(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_sub(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_mul(Stmt *l, Stmt *r);
   // l / r in C++
-  Stmt *create_div(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_div(Stmt *l, Stmt *r);
   // floor(1.0 * l / r) in C++
-  Stmt *create_floordiv(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_floordiv(Stmt *l, Stmt *r);
   // 1.0 * l / r in C++
-  Stmt *create_truediv(Stmt *l, Stmt *r);
-  Stmt *create_mod(Stmt *l, Stmt *r);
-  Stmt *create_max(Stmt *l, Stmt *r);
-  Stmt *create_min(Stmt *l, Stmt *r);
-  Stmt *create_atan2(Stmt *l, Stmt *r);
-  Stmt *create_pow(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_truediv(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_mod(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_max(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_min(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_atan2(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_pow(Stmt *l, Stmt *r);
   // Bitwise operations. TODO: add logical operations when we support them
-  Stmt *create_and(Stmt *l, Stmt *r);
-  Stmt *create_or(Stmt *l, Stmt *r);
-  Stmt *create_xor(Stmt *l, Stmt *r);
-  Stmt *create_shl(Stmt *l, Stmt *r);
-  Stmt *create_shr(Stmt *l, Stmt *r);
-  Stmt *create_sar(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_and(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_or(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_xor(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_shl(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_shr(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_sar(Stmt *l, Stmt *r);
   // Comparisons.
-  Stmt *create_cmp_lt(Stmt *l, Stmt *r);
-  Stmt *create_cmp_le(Stmt *l, Stmt *r);
-  Stmt *create_cmp_gt(Stmt *l, Stmt *r);
-  Stmt *create_cmp_ge(Stmt *l, Stmt *r);
-  Stmt *create_cmp_eq(Stmt *l, Stmt *r);
-  Stmt *create_cmp_ne(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_cmp_lt(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_cmp_le(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_cmp_gt(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_cmp_ge(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_cmp_eq(Stmt *l, Stmt *r);
+  BinaryOpStmt *create_cmp_ne(Stmt *l, Stmt *r);
 
   // Ternary operations. Returns the result.
-  Stmt *create_select(Stmt *cond, Stmt *true_result, Stmt *false_result);
+  TernaryOpStmt *create_select(Stmt *cond, Stmt *true_result, Stmt *false_result);
 
   // Print values and strings. Arguments can be Stmt* or std::string.
   template <typename... Args>
-  Stmt *create_print(Args &&... args) {
-    return insert(Stmt::make<PrintStmt>(std::forward<Args>(args)...));
+  PrintStmt *create_print(Args &&... args) {
+    return insert(Stmt::make_typed<PrintStmt>(std::forward<Args>(args)...));
   }
 
   // Local variable.
-  Stmt *create_local_var(DataType dt);
+  AllocaStmt *create_local_var(DataType dt);
+  LocalLoadStmt *create_local_load(AllocaStmt *ptr);
+  void create_local_store(AllocaStmt *ptr, Stmt *data);
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -7,8 +7,8 @@ TLANG_NAMESPACE_BEGIN
 class IRBuilder {
  public:
   struct InsertPoint {
-    Block *block;
-    int position;
+    Block *block{nullptr};
+    int position{0};
   };
 
  private:

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -32,23 +32,67 @@ class IRBuilder {
   // The return value of the kernel.
   Stmt *create_return(Stmt *value);
 
+  // Unary operations. Returns the result.
+  Stmt *create_cast(Stmt *value, DataType output_type);  // cast by value
+  Stmt *create_bit_cast(Stmt *value, DataType output_type);
+  Stmt *create_neg(Stmt *value);
+  Stmt *create_not(Stmt *value);  // bitwise
+  Stmt *create_logical_not(Stmt *value);
+  Stmt *create_floor(Stmt *value);
+  Stmt *create_ceil(Stmt *value);
+  Stmt *create_abs(Stmt *value);
+  Stmt *create_sgn(Stmt *value);
+  Stmt *create_sqrt(Stmt *value);
+  Stmt *create_rsqrt(Stmt *value);
+  Stmt *create_sin(Stmt *value);
+  Stmt *create_asin(Stmt *value);
+  Stmt *create_cos(Stmt *value);
+  Stmt *create_acos(Stmt *value);
+  Stmt *create_tan(Stmt *value);
+  Stmt *create_tanh(Stmt *value);
+  Stmt *create_exp(Stmt *value);
+  Stmt *create_log(Stmt *value);
+
   // Binary operations. Returns the result.
   Stmt *create_add(Stmt *l, Stmt *r);
   Stmt *create_sub(Stmt *l, Stmt *r);
   Stmt *create_mul(Stmt *l, Stmt *r);
-
   // l / r in C++
   Stmt *create_div(Stmt *l, Stmt *r);
   // floor(1.0 * l / r) in C++
   Stmt *create_floordiv(Stmt *l, Stmt *r);
   // 1.0 * l / r in C++
   Stmt *create_truediv(Stmt *l, Stmt *r);
+  Stmt *create_mod(Stmt *l, Stmt *r);
+  Stmt *create_max(Stmt *l, Stmt *r);
+  Stmt *create_min(Stmt *l, Stmt *r);
+  Stmt *create_atan2(Stmt *l, Stmt *r);
+  Stmt *create_pow(Stmt *l, Stmt *r);
+  // Bitwise operations. TODO: add logical operations when we support them
+  Stmt *create_and(Stmt *l, Stmt *r);
+  Stmt *create_or(Stmt *l, Stmt *r);
+  Stmt *create_xor(Stmt *l, Stmt *r);
+  Stmt *create_shl(Stmt *l, Stmt *r);
+  Stmt *create_shr(Stmt *l, Stmt *r);
+  Stmt *create_sar(Stmt *l, Stmt *r);
+  // Comparisons.
+  Stmt *create_cmp_lt(Stmt *l, Stmt *r);
+  Stmt *create_cmp_le(Stmt *l, Stmt *r);
+  Stmt *create_cmp_gt(Stmt *l, Stmt *r);
+  Stmt *create_cmp_ge(Stmt *l, Stmt *r);
+  Stmt *create_cmp_eq(Stmt *l, Stmt *r);
+  Stmt *create_cmp_ne(Stmt *l, Stmt *r);
+
+  // Ternary operations. Returns the result.
+  Stmt *create_select(Stmt *cond, Stmt *true_result, Stmt *false_result);
 
   // Print values and strings. Arguments can be Stmt* or std::string.
   template <typename... Args>
   Stmt *create_print(Args &&... args) {
     return insert(Stmt::make<PrintStmt>(std::forward(args)...));
   }
+
+
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -18,6 +18,12 @@ class IRBuilder {
  public:
   IRBuilder();
 
+  // Clear the IR and the insertion point.
+  void reset();
+
+  // Extract the IR.
+  std::unique_ptr<IRNode> extract_ir();
+
   // General inserter. Returns stmt.get().
   Stmt *insert(std::unique_ptr<Stmt> &&stmt);
   // Insert to a specific insertion point.

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -48,6 +48,9 @@ class IRBuilder {
   Stmt *create_break();
   Stmt *create_continue();
 
+  // Loop index.
+  Stmt *get_loop_index(Stmt *loop, int index = 0);
+
   // Constants. TODO: add more types
   Stmt *get_int32(int32 value);
   Stmt *get_int64(int64 value);

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -35,5 +35,20 @@ TEST(IRBuilder, Print) {
   EXPECT_EQ(std::get<Stmt *>(print->contents[2]), one);
 }
 
+TEST(IRBuilder, For) {
+  IRBuilder builder;
+  auto *zero = builder.get_int32(0);
+  auto *ten = builder.get_int32(10);
+  auto *loop = builder.create_range_for(zero, ten);
+  builder.set_insertion_point_to_loop_begin(loop);
+  auto *print = builder.create_print("message");
+  builder.set_insertion_point_to_after(loop);
+  auto *ret = builder.create_return(zero);
+  EXPECT_EQ(zero->parent->size(), 4);
+  ASSERT_TRUE(loop->is<RangeForStmt>());
+  auto *loopc = loop->cast<RangeForStmt>();
+  EXPECT_EQ(loopc->body->size(), 1);
+  EXPECT_EQ(loopc->body->statements[0], print);
+}
 }  // namespace lang
 }  // namespace taichi

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -26,7 +26,7 @@ TEST(IRBuilder, Print) {
   auto *result = builder.create_print(one, message, one);
   ASSERT_TRUE(result->is<PrintStmt>());
   auto *print = result->cast<PrintStmt>();
-  EXPECT_EQ(print->contents->size(), 3);
+  EXPECT_EQ(print->contents.size(), 3);
   ASSERT_TRUE(std::holds_alternative<Stmt *>(print->contents[0]));
   EXPECT_EQ(std::get<Stmt *>(print->contents[0]), one);
   ASSERT_TRUE(std::holds_alternative<std::string>(print->contents[1]));

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -35,7 +35,7 @@ TEST(IRBuilder, Print) {
   EXPECT_EQ(std::get<Stmt *>(print->contents[2]), one);
 }
 
-TEST(IRBuilder, For) {
+TEST(IRBuilder, RangeFor) {
   IRBuilder builder;
   auto *zero = builder.get_int32(0);
   auto *ten = builder.get_int32(10);

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -41,14 +41,14 @@ TEST(IRBuilder, RangeFor) {
   auto *ten = builder.get_int32(10);
   auto *loop = builder.create_range_for(zero, ten);
   builder.set_insertion_point_to_loop_begin(loop);
-  auto *print = builder.create_print("message");
+  auto *index = builder.get_loop_index(loop, 0);
   builder.set_insertion_point_to_after(loop);
   auto *ret = builder.create_return(zero);
   EXPECT_EQ(zero->parent->size(), 4);
   ASSERT_TRUE(loop->is<RangeForStmt>());
   auto *loopc = loop->cast<RangeForStmt>();
   EXPECT_EQ(loopc->body->size(), 1);
-  EXPECT_EQ(loopc->body->statements[0], print);
+  EXPECT_EQ(loopc->body->statements[0].get(), index);
 }
 }  // namespace lang
 }  // namespace taichi

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -18,5 +18,22 @@ TEST(IRBuilder, Basic) {
   EXPECT_EQ(addc->op_type, BinaryOpType::add);
 }
 
+TEST(IRBuilder, Print) {
+  IRBuilder builder;
+  auto *one = builder.get_int32(1);
+  ASSERT_TRUE(one->is<ConstStmt>());
+  std::string message = "message";
+  auto *result = builder.create_print(one, message, one);
+  ASSERT_TRUE(result->is<PrintStmt>());
+  auto *print = result->cast<PrintStmt>();
+  EXPECT_EQ(print->contents->size(), 3);
+  ASSERT_TRUE(std::holds_alternative<Stmt *>(print->contents[0]));
+  EXPECT_EQ(std::get<Stmt *>(print->contents[0]), one);
+  ASSERT_TRUE(std::holds_alternative<std::string>(print->contents[1]));
+  EXPECT_EQ(std::get<std::string>(print->contents[1]), message);
+  ASSERT_TRUE(std::holds_alternative<Stmt *>(print->contents[2]));
+  EXPECT_EQ(std::get<Stmt *>(print->contents[2]), one);
+}
+
 }  // namespace lang
 }  // namespace taichi


### PR DESCRIPTION
Related issue = #2193 

This PR adds these statements to the IR Builder:
- All UnaryOpStmts
- All BinaryOpStmts
- TernaryOpStmt
- RangeForStmt, StructForStmt, WhileStmt, IfStmt
- WhileControlStmt, ContinueStmt
- AllocaStmt, LocalLoadStmt, LocalStoreStmt
- LoopIndexStmt

And add the following tests:
- PrintStmt test
- RangeFor test

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
