### PR TITLE
[Example] Reduce c calculation from pixel loop

### DIFF
--- a/examples/fractal.py
+++ b/examples/fractal.py
@@ -13,8 +13,8 @@ def complex_sqr(z):
 
 @ti.kernel
 def paint(t: float):
+    c = ti.Vector([-0.8, ti.cos(t) * 0.2])
     for i, j in pixels:  # Parallized over all pixels
-        c = ti.Vector([-0.8, ti.cos(t) * 0.2])
         z = ti.Vector([i / n - 1, j / n - 0.5]) * 2
         iterations = 0
         while z.norm() < 20 and iterations < 50:


### PR DESCRIPTION
value `c` is not dependent on pixels, moving it outside of pixel loop to reduce calculation needed.