### PR TITLE
[misc] Make taichi-gardener also run the required CI jobs

### DIFF
--- a/.github/workflows/persubmit.yml
+++ b/.github/workflows/persubmit.yml
@@ -4,16 +4,57 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  build_and_test_cpu_required:
+    # This job will be required to pass before merging to master branch.
+    name: Required Build and Test (CPU)
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: 3.6
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Download Pre-Built LLVM 10.0.0
+        run: |
+          python misc/ci_download.py
+          mkdir taichi-llvm
+          cd taichi-llvm
+          unzip ../taichi-llvm.zip
+        env:
+          CI_PLATFORM: ${{ matrix.os }}
+
+      - name: Build
+        run: |
+          export TAICHI_REPO_DIR=`pwd`
+          export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
+          export CXX=clang++
+          python misc/ci_setup.py ci
+        env:
+          CI_SETUP_CMAKE_ARGS: -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=ON -DTI_BUILD_TESTS:BOOL=ON
+
+      - name: Test
+        run: |
+          export TAICHI_REPO_DIR=`pwd`
+          export PATH=$TAICHI_REPO_DIR/bin:$PATH
+          export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
+          export PYTHONPATH=$TAICHI_REPO_DIR/python
+          python examples/laplace.py
+          ti diagnose
+          ./build/taichi_cpp_tests
+          ti test -vr2 -t2
+
   build_and_test_cpu:
     name: Build and Test (CPU)
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip ci') && github.event.sender.login != 'taichi-gardener' }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            python: 3.6
-            with_cc: OFF
-            with_cpp_tests: ON
           - os: macos-latest
             python: 3.7
             with_cc: OFF
@@ -118,8 +159,7 @@ jobs:
   code_format:
     name: Code Format
     runs-on: ubuntu-latest
-    # Run this job unconditionally -- it is a required check for merging.
-    # if: ${{ !contains(github.event.pull_request.requested_reviewers.*.login, 'taichi-gardener') }}
+    # This job will be required to pass before merging to master branch.
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Related issue = #2219

* Before this change, @taichi-gardener  won't trigger the *required* "Ubuntu 3.6 Build and Test (CPU)" --> We have to do another push.
* After this change, @taichi-gardener 's CI will be slower (maybe by another 20 minutes). But we can at least merge PRs if there are no other issue.

Long term speaking, I see that TiDB's workflow is to manually trigger the CI by replying some magic keywords (e.g. "/run-all-tests"), which the bots will listen to. Maybe that's a better way to utilize CI resources.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
