### PR TITLE
[refactor] Add ASTResolver to properly resolve AST nodes to functions

### DIFF
--- a/python/taichi/lang/ast_resolver.py
+++ b/python/taichi/lang/ast_resolver.py
@@ -1,0 +1,53 @@
+"""Provides helpers to resolve AST nodes."""
+import ast
+
+
+class ASTResolver:
+    """Provides helper methods to resolve AST nodes."""
+    @staticmethod
+    def resolve_to(node, wanted, scope):
+        """Check if symbol ``node`` resolves to ``wanted`` object.
+
+        This is only intended to check if a given AST node resolves to a symbol
+        under some namespaces, e.g. the ``a.b.c.foo`` pattern, but not meant for
+        more complicated expressions like ``(a + b).foo``.
+
+        Args:
+            node (Union[ast.Attribute, ast.Name]): an AST node to be resolved.
+            wanted (Any): The expected python object.
+            scope (Dict[str, Any]): Maps from symbol names to objects, for
+                example, globals()
+
+        Returns:
+            bool: The checked result.
+        """
+        if isinstance(node, ast.Name):
+            return scope.get(node.id) is wanted
+
+        if not isinstance(node, ast.Attribute):
+            return False
+
+        v = node.value
+        chain = [node.attr]
+        while isinstance(v, ast.Attribute):
+            chain.append(v.attr)
+            v = v.value
+        if not isinstance(v, ast.Name):
+            # Example cases that fall under this branch:
+            #
+            # x[i].attr: ast.Subscript
+            # (a + b).attr: ast.BinOp
+            # ...
+            return False
+        chain.append(v.id)
+
+        for attr in reversed(chain):
+            try:
+                if isinstance(scope, dict):
+                    scope = scope[attr]
+                else:
+                    scope = getattr(scope, attr)
+            except (KeyError, AttributeError):
+                return False
+        # The name ``scope`` here could be a bit confusing
+        return scope is wanted

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -2,7 +2,7 @@ import builtins
 import ctypes
 import functools
 import math
-import operator as ops
+import operator as _bt_ops_mod  # bt for builtin
 import traceback
 
 from taichi.lang import impl
@@ -187,7 +187,7 @@ def _ternary_operation(taichi_op, python_op, a, b, c):
 
 @unary
 def neg(a):
-    return _unary_operation(ti_core.expr_neg, ops.neg, a)
+    return _unary_operation(ti_core.expr_neg, _bt_ops_mod.neg, a)
 
 
 @unary
@@ -260,7 +260,7 @@ def abs(a):
 
 @unary
 def bit_not(a):
-    return _unary_operation(ti_core.expr_bit_not, ops.invert, a)
+    return _unary_operation(ti_core.expr_bit_not, _bt_ops_mod.invert, a)
 
 
 @unary
@@ -279,17 +279,17 @@ def random(dtype=float):
 
 @binary
 def add(a, b):
-    return _binary_operation(ti_core.expr_add, ops.add, a, b)
+    return _binary_operation(ti_core.expr_add, _bt_ops_mod.add, a, b)
 
 
 @binary
 def sub(a, b):
-    return _binary_operation(ti_core.expr_sub, ops.sub, a, b)
+    return _binary_operation(ti_core.expr_sub, _bt_ops_mod.sub, a, b)
 
 
 @binary
 def mul(a, b):
-    return _binary_operation(ti_core.expr_mul, ops.mul, a, b)
+    return _binary_operation(ti_core.expr_mul, _bt_ops_mod.mul, a, b)
 
 
 @binary
@@ -300,22 +300,22 @@ def mod(a, b):
         multiply = Expr(ti_core.expr_mul(b, quotient.ptr))
         return ti_core.expr_sub(a, multiply.ptr)
 
-    return _binary_operation(expr_python_mod, ops.mod, a, b)
+    return _binary_operation(expr_python_mod, _bt_ops_mod.mod, a, b)
 
 
 @binary
 def pow(a, b):
-    return _binary_operation(ti_core.expr_pow, ops.pow, a, b)
+    return _binary_operation(ti_core.expr_pow, _bt_ops_mod.pow, a, b)
 
 
 @binary
 def floordiv(a, b):
-    return _binary_operation(ti_core.expr_floordiv, ops.floordiv, a, b)
+    return _binary_operation(ti_core.expr_floordiv, _bt_ops_mod.floordiv, a, b)
 
 
 @binary
 def truediv(a, b):
-    return _binary_operation(ti_core.expr_truediv, ops.truediv, a, b)
+    return _binary_operation(ti_core.expr_truediv, _bt_ops_mod.truediv, a, b)
 
 
 @binary
@@ -390,33 +390,33 @@ def cmp_ne(a, b):
 
 @binary
 def bit_or(a, b):
-    return _binary_operation(ti_core.expr_bit_or, ops.or_, a, b)
+    return _binary_operation(ti_core.expr_bit_or, _bt_ops_mod.or_, a, b)
 
 
 @binary
 def bit_and(a, b):
-    return _binary_operation(ti_core.expr_bit_and, ops.and_, a, b)
+    return _binary_operation(ti_core.expr_bit_and, _bt_ops_mod.and_, a, b)
 
 
 @binary
 def bit_xor(a, b):
-    return _binary_operation(ti_core.expr_bit_xor, ops.xor, a, b)
+    return _binary_operation(ti_core.expr_bit_xor, _bt_ops_mod.xor, a, b)
 
 
 @binary
 def bit_shl(a, b):
-    return _binary_operation(ti_core.expr_bit_shl, ops.lshift, a, b)
+    return _binary_operation(ti_core.expr_bit_shl, _bt_ops_mod.lshift, a, b)
 
 
 @binary
 def bit_sar(a, b):
-    return _binary_operation(ti_core.expr_bit_sar, ops.rshift, a, b)
+    return _binary_operation(ti_core.expr_bit_sar, _bt_ops_mod.rshift, a, b)
 
 
 @taichi_scope
 @binary
 def bit_shr(a, b):
-    return _binary_operation(ti_core.expr_bit_shr, ops.rshift, a, b)
+    return _binary_operation(ti_core.expr_bit_shr, _bt_ops_mod.rshift, a, b)
 
 
 # We don't have logic_and/or instructions yet:

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -538,7 +538,6 @@ if 1:
             if decorator != '' and len(node.iter.args) == 1:
                 double_decorator = self.get_decorator(node.iter.args[0])
             ast.fix_missing_locations(node)
-            print(f'decorator={decorator} double_decorator={double_decorator}')
 
             if decorator == 'static':
                 if double_decorator == 'static':

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -4,6 +4,9 @@ import copy
 from taichi.lang import impl
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.util import to_taichi_type
+from taichi.lang.ast_resolver import ASTResolver
+
+import taichi as ti
 
 
 class ScopeGuard:
@@ -89,12 +92,16 @@ class ASTTransformerBase(ast.NodeTransformer):
 
     @staticmethod
     def get_decorator(node):
-        if not (isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute) and isinstance(
-                    node.func.value, ast.Name) and node.func.value.id == 'ti'
-                and node.func.attr in ['static', 'grouped', 'ndrange']):
+        if not isinstance(node, ast.Call):
             return ''
-        return node.func.attr
+        for wanted, name in [
+            (ti.static, 'static'),
+            (ti.grouped, 'grouped'),
+            (ti.ndrange, 'ndrange'),
+        ]:
+            if ASTResolver.resolve_to(node.func, wanted, globals()):
+                return name
+        return ''
 
 
 # First-pass transform
@@ -191,21 +198,9 @@ class ASTTransformerPreprocess(ASTTransformerBase):
         assert (len(node.targets) == 1)
         self.generic_visit(node)
 
-        decorated = isinstance(node.value, ast.Call) and isinstance(
-            node.value.func, ast.Attribute) and isinstance(node.value.func.value, ast.Name) \
-                    and node.value.func.value.id == 'ti'
-
-        is_static_assign = False
-
-        if decorated:
-            attr = node.value.func
-            if attr.attr == 'static':
-                is_static_assign = True
-            else:
-                # e.g. x = ti.cast(xx) will reach here, but they are not
-                # decorators, so do not raise an error here
-                pass
-
+        is_static_assign = isinstance(
+            node.value, ast.Call) and ASTResolver.resolve_to(
+                node.value.func, ti.static, globals())
         if is_static_assign:
             return node
 
@@ -232,7 +227,7 @@ class ASTTransformerPreprocess(ASTTransformerBase):
                 if is_local and self.is_creation(target.id):
                     var_name = target.id
                     target.ctx = ast.Store()
-                    # Create
+                    # Create, no AST resolution needed
                     init = ast.Attribute(value=ast.Name(id='ti',
                                                         ctx=ast.Load()),
                                          attr='expr_init',
@@ -263,7 +258,7 @@ class ASTTransformerPreprocess(ASTTransformerBase):
             is_local = isinstance(node.targets[0], ast.Name)
             if is_local and self.is_creation(node.targets[0].id):
                 var_name = node.targets[0].id
-                # Create
+                # Create, no AST resolution needed
                 init = ast.Attribute(value=ast.Name(id='ti', ctx=ast.Load()),
                                      attr='expr_init',
                                      ctx=ast.Load())
@@ -543,6 +538,7 @@ if 1:
             if decorator != '' and len(node.iter.args) == 1:
                 double_decorator = self.get_decorator(node.iter.args[0])
             ast.fix_missing_locations(node)
+            print(f'decorator={decorator} double_decorator={double_decorator}')
 
             if decorator == 'static':
                 if double_decorator == 'static':
@@ -623,9 +619,7 @@ if 1:
             return self.parse_stmt('ti.core.insert_continue_stmt()')
 
     def visit_Call(self, node):
-        if not (isinstance(node.func, ast.Attribute)
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == 'ti' and node.func.attr == 'static'):
+        if not ASTResolver.resolve_to(node.func, ti.static, globals()):
             # Do not apply the generic visitor if the function called is ti.static
             self.generic_visit(node)
         if isinstance(node.func, ast.Name):
@@ -666,13 +660,9 @@ if 1:
         assert args.kwonlyargs == []
         assert args.kw_defaults == []
         assert args.kwarg is None
-        import taichi as ti
         if self.is_kernel:  # ti.kernel
             for decorator in node.decorator_list:
-                if (isinstance(decorator, ast.Attribute)
-                        and isinstance(decorator.value, ast.Name)
-                        and decorator.value.id == 'ti'
-                        and decorator.attr == 'func'):
+                if ASTResolver.resolve_to(decorator, ti.func, globals()):
                     raise TaichiSyntaxError(
                         "Function definition not allowed in 'ti.kernel'.")
             # Transform as kernel
@@ -692,7 +682,6 @@ if 1:
                 # such as class instances ("self"), fields, SNodes, etc.
                 if isinstance(self.func.arguments[i], ti.template):
                     continue
-                import taichi as ti
                 if isinstance(self.func.arguments[i], ti.ext_arr):
                     arg_init = self.parse_stmt(
                         'x = ti.lang.kernel_arguments.decl_ext_arr_arg(0, 0)')
@@ -719,10 +708,7 @@ if 1:
 
         else:  # ti.func
             for decorator in node.decorator_list:
-                if (isinstance(decorator, ast.Attribute)
-                        and isinstance(decorator.value, ast.Name)
-                        and decorator.value.id == 'ti'
-                        and decorator.attr == 'func'):
+                if ASTResolver.resolve_to(decorator, ti.func, globals()):
                     raise TaichiSyntaxError(
                         "Function definition not allowed in 'ti.func'.")
             # Transform as func (all parameters passed by value)

--- a/tests/python/test_ast_resolver.py
+++ b/tests/python/test_ast_resolver.py
@@ -1,0 +1,40 @@
+import ast
+from collections import namedtuple
+
+from taichi.lang.ast_resolver import ASTResolver
+
+
+def test_ast_resolver_basic():
+    # import within the function to avoid polluting the global scope
+    import taichi as ti
+    node = ast.parse('ti.kernel', mode='eval').body
+    assert ASTResolver.resolve_to(node, ti.kernel, locals())
+
+
+def test_ast_resolver_direct_import():
+    from taichi import kernel
+    node = ast.parse('kernel', mode='eval').body
+    assert ASTResolver.resolve_to(node, kernel, locals())
+
+
+def test_ast_resolver_alias():
+    import taichi
+    node = ast.parse('taichi.kernel', mode='eval').body
+    assert ASTResolver.resolve_to(node, taichi.kernel, locals())
+
+    import taichi as tc
+    node = ast.parse('tc.kernel', mode='eval').body
+    assert ASTResolver.resolve_to(node, tc.kernel, locals())
+
+
+def test_ast_resolver_chain():
+    import taichi as ti
+    node = ast.parse('ti.lang.ops.atomic_add', mode='eval').body
+    assert ASTResolver.resolve_to(node, ti.atomic_add, locals())
+
+def test_ast_resolver_wrong_ti():
+    import taichi
+    fake_ti = namedtuple('FakeTi', ['kernel'])
+    ti = fake_ti(kernel='fake')
+    node = ast.parse('ti.kernel', mode='eval').body
+    assert not ASTResolver.resolve_to(node, taichi.kernel, locals())

--- a/tests/python/test_ast_resolver.py
+++ b/tests/python/test_ast_resolver.py
@@ -32,6 +32,7 @@ def test_ast_resolver_chain():
     node = ast.parse('ti.lang.ops.atomic_add', mode='eval').body
     assert ASTResolver.resolve_to(node, ti.atomic_add, locals())
 
+
 def test_ast_resolver_wrong_ti():
     import taichi
     fake_ti = namedtuple('FakeTi', ['kernel'])

--- a/tests/python/test_syntax_errors.py
+++ b/tests/python/test_syntax_errors.py
@@ -267,3 +267,31 @@ def test_func_multiple_return_in_static_if():
         print(safe_static_sqrt(-233))
 
     kern()
+
+
+def test_func_def_inside_kernel():
+    @ti.kernel
+    def k():
+        @ti.func
+        def illegal():
+            return 1
+
+    with pytest.raises(ti.TaichiSyntaxError,
+                       match='Function definition not allowed'):
+        k()
+
+
+def test_func_def_inside_func():
+    @ti.func
+    def f():
+        @ti.func
+        def illegal():
+            return 1
+
+    @ti.kernel
+    def k():
+        f()
+
+    with pytest.raises(ti.TaichiSyntaxError,
+                       match='Function definition not allowed'):
+        k()


### PR DESCRIPTION
Related issue = #2223 

The idea is to consult the `globals()` scope to make sure functions like `ti.static` actually resolve to Taichi functions during AST transformation.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
