### PR TITLE
[ir] Add global variables to IR Builder

### DIFF
--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -313,11 +313,15 @@ void IRBuilder::create_local_store(AllocaStmt *ptr, Stmt *data) {
   insert(Stmt::make_typed<LocalStoreStmt>(ptr, data));
 }
 
-GlobalPtrStmt *IRBuilder::create_global_ptr(SNode *snode, const std::vector<Stmt *> &indices) {
+GlobalPtrStmt *IRBuilder::create_global_ptr(
+    SNode *snode,
+    const std::vector<Stmt *> &indices) {
   return insert(Stmt::make_typed<GlobalPtrStmt>(snode, indices));
 }
 
-ExternalPtrStmt *IRBuilder::create_external_ptr(ArgLoadStmt *ptr, const std::vector<Stmt *> &indices) {
+ExternalPtrStmt *IRBuilder::create_external_ptr(
+    ArgLoadStmt *ptr,
+    const std::vector<Stmt *> &indices) {
   return insert(Stmt::make_typed<ExternalPtrStmt>(ptr, indices));
 }
 

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -313,4 +313,12 @@ void IRBuilder::create_local_store(AllocaStmt *ptr, Stmt *data) {
   insert(Stmt::make_typed<LocalStoreStmt>(ptr, data));
 }
 
+GlobalPtrStmt *IRBuilder::create_global_ptr(SNode *snode, const std::vector<Stmt *> &indices) {
+  return insert(Stmt::make_typed<GlobalPtrStmt>(snode, indices));
+}
+
+ExternalPtrStmt *IRBuilder::create_external_ptr(ArgLoadStmt *ptr, const std::vector<Stmt *> &indices) {
+  return insert(Stmt::make_typed<ExternalPtrStmt>(ptr, indices));
+}
+
 TLANG_NAMESPACE_END

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -2,6 +2,7 @@
 
 #include "taichi/ir/ir_builder.h"
 #include "taichi/ir/statements.h"
+#include "taichi/program/program.h"
 
 namespace taichi {
 namespace lang {
@@ -52,6 +53,38 @@ TEST(IRBuilder, RangeFor) {
   auto *loopc = loop->cast<RangeForStmt>();
   EXPECT_EQ(loopc->body->size(), 1);
   EXPECT_EQ(loopc->body->statements[0].get(), index);
+}
+
+TEST(IRBuilder, ExternalPtr) {
+  auto prog = Program(arch_from_name("x64"));
+  prog.materialize_layout();
+  IRBuilder builder;
+  const int size = 10;
+  auto array = std::make_unique<int[]>(size);
+  array[0] = 2;
+  array[2] = 40;
+  auto *arg = builder.create_arg_load(/*arg_id=*/0, get_data_type<int>(),
+                                      /*is_ptr=*/true);
+  auto *zero = builder.get_int32(0);
+  auto *one = builder.get_int32(1);
+  auto *two = builder.get_int32(2);
+  auto *a1ptr = builder.create_external_ptr(arg, std::vector<Stmt *>(1, one));
+  builder.create_global_store(a1ptr, one);  // a[1] = 1
+  auto *a0 = builder.create_global_load(
+      builder.create_external_ptr(arg, std::vector<Stmt *>(1, zero)));
+  auto *a2ptr = builder.create_external_ptr(arg, std::vector<Stmt *>(1, two));
+  auto *a2 = builder.create_global_load(a2ptr);
+  auto *a0plusa2 = builder.create_add(a0, a2);
+  builder.create_global_store(a2ptr, a0plusa2);  // a[2] = a[0] + a[2]
+  auto block = builder.extract_ir();
+  auto ker = std::make_unique<Kernel>(prog, std::move(block));
+  ker->insert_arg(get_data_type<int>(), /*is_nparray=*/true);
+  auto launch_ctx = ker->make_launch_context();
+  launch_ctx.set_arg_nparray(0, (uint64)array.get(), size);
+  (*ker)(launch_ctx);
+  EXPECT_EQ(array[0], 2);
+  EXPECT_EQ(array[1], 1);
+  EXPECT_EQ(array[2], 42);
 }
 }  // namespace lang
 }  // namespace taichi

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -68,11 +68,11 @@ TEST(IRBuilder, ExternalPtr) {
   auto *zero = builder.get_int32(0);
   auto *one = builder.get_int32(1);
   auto *two = builder.get_int32(2);
-  auto *a1ptr = builder.create_external_ptr(arg, std::vector<Stmt *>(1, one));
+  auto *a1ptr = builder.create_external_ptr(arg, {one});
   builder.create_global_store(a1ptr, one);  // a[1] = 1
   auto *a0 = builder.create_global_load(
-      builder.create_external_ptr(arg, std::vector<Stmt *>(1, zero)));
-  auto *a2ptr = builder.create_external_ptr(arg, std::vector<Stmt *>(1, two));
+      builder.create_external_ptr(arg, {zero}));
+  auto *a2ptr = builder.create_external_ptr(arg, {two});
   auto *a2 = builder.create_global_load(a2ptr);
   auto *a0plusa2 = builder.create_add(a0, a2);
   builder.create_global_store(a2ptr, a0plusa2);  // a[2] = a[0] + a[2]

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -70,8 +70,8 @@ TEST(IRBuilder, ExternalPtr) {
   auto *two = builder.get_int32(2);
   auto *a1ptr = builder.create_external_ptr(arg, {one});
   builder.create_global_store(a1ptr, one);  // a[1] = 1
-  auto *a0 = builder.create_global_load(
-      builder.create_external_ptr(arg, {zero}));
+  auto *a0 =
+      builder.create_global_load(builder.create_external_ptr(arg, {zero}));
   auto *a2ptr = builder.create_external_ptr(arg, {two});
   auto *a2 = builder.create_global_load(a2ptr);
   auto *a0plusa2 = builder.create_add(a0, a2);


### PR DESCRIPTION
Related issue = #2193

This PR adds `GlobalPtrStmt` and `ExternalPtrStmt` and related statements to IR Builder. It also adds a test of external ptr as an example of using the external ptr. Maybe we should rename stuff like `is_nparray` since it's not related to numpy at this level...

The `SNode` needed by `GlobalPtrStmt` can only be created by hand using APIs provided in snode.h for now.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
