### PR TITLE
[ir] Add RAII guards to IR Builder

### DIFF
--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -4,6 +4,15 @@
 
 TLANG_NAMESPACE_BEGIN
 
+namespace {
+
+inline bool stmt_location_did_not_change(Stmt *stmt, int location) {
+  return location >= 0 && location < stmt->parent->size() &&
+         stmt->parent->statements[location].get() == stmt;
+}
+
+}  // namespace
+
 IRBuilder::IRBuilder() {
   reset();
 }
@@ -45,8 +54,7 @@ void IRBuilder::set_insertion_point_to_false_branch(IfStmt *if_stmt) {
 }
 
 IRBuilder::LoopGuard::~LoopGuard() {
-  if (location_ >= 0 && location_ < loop_->parent->size() &&
-      loop_->parent->statements[location_].get() == loop_) {
+  if (stmt_location_did_not_change(loop_, location_)) {
     // faster than set_insertion_point_to_after()
     builder_.set_insertion_point({loop_->parent, location_ + 1});
   } else {
@@ -67,8 +75,7 @@ IRBuilder::IfGuard::IfGuard(IRBuilder &builder,
 }
 
 IRBuilder::IfGuard::~IfGuard() {
-  if (location_ >= 0 && location_ < if_stmt_->parent->size() &&
-      if_stmt_->parent->statements[location_].get() == if_stmt_) {
+  if (stmt_location_did_not_change(if_stmt_, location_)) {
     // faster than set_insertion_point_to_after()
     builder_.set_insertion_point({if_stmt_->parent, location_ + 1});
   } else {

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -58,7 +58,7 @@ IRBuilder::IfGuard::IfGuard(IRBuilder &builder,
                             IfStmt *if_stmt,
                             bool true_branch)
     : builder_(builder), if_stmt_(if_stmt) {
-  location_ = if_stmt_->parent->size() - 1;
+  location_ = (int)if_stmt_->parent->size() - 1;
   if (true_branch) {
     builder_.set_insertion_point_to_true_branch(if_stmt_);
   } else {

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -64,34 +64,26 @@ class IRBuilder {
    private:
     IRBuilder &builder_;
     Stmt *loop_;
+    int location_;
 
    public:
     template <typename XxxStmt>
     explicit LoopGuard(IRBuilder &builder, XxxStmt *loop)
         : builder_(builder), loop_(loop) {
+      location_ = loop->parent->size() - 1;
       builder_.set_insertion_point_to_loop_begin(loop);
     }
-    ~LoopGuard() {
-      builder_.set_insertion_point_to_after(loop_);
-    }
+    ~LoopGuard();
   };
   class IfGuard {
    private:
     IRBuilder &builder_;
     IfStmt *if_stmt_;
+    int location_;
 
    public:
-    explicit IfGuard(IRBuilder &builder, IfStmt *if_stmt, bool true_branch)
-        : builder_(builder), if_stmt_(if_stmt) {
-      if (true_branch) {
-        builder_.set_insertion_point_to_true_branch(if_stmt_);
-      } else {
-        builder_.set_insertion_point_to_false_branch(if_stmt_);
-      }
-    }
-    ~IfGuard() {
-      builder_.set_insertion_point_to_after(if_stmt_);
-    }
+    explicit IfGuard(IRBuilder &builder, IfStmt *if_stmt, bool true_branch);
+    ~IfGuard();
   };
 
   // Control flows.

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -67,10 +67,10 @@ class IRBuilder {
     int location_;
 
    public:
-    template <typename XxxStmt>
-    explicit LoopGuard(IRBuilder &builder, XxxStmt *loop)
+    template <typename XStmt>
+    explicit LoopGuard(IRBuilder &builder, XStmt *loop)
         : builder_(builder), loop_(loop) {
-      location_ = loop->parent->size() - 1;
+      location_ = (int)loop->parent->size() - 1;
       builder_.set_insertion_point_to_loop_begin(loop);
     }
     ~LoopGuard();

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -33,7 +33,7 @@ class IRBuilder {
   // Insert to a specific insertion point.
   template <typename XStmt>
   static XStmt *insert(std::unique_ptr<XStmt> &&stmt,
-                         InsertPoint *insert_point) {
+                       InsertPoint *insert_point) {
     return insert_point->block
         ->insert(std::move(stmt), insert_point->position++)
         ->template as<XStmt>();

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -59,6 +59,41 @@ class IRBuilder {
     }
   }
 
+  // RAII handles insertion points automatically.
+  class LoopGuard {
+   private:
+    IRBuilder &builder_;
+    Stmt *loop_;
+
+   public:
+    template <typename XxxStmt>
+    explicit LoopGuard(IRBuilder &builder, XxxStmt *loop)
+        : builder_(builder), loop_(loop) {
+      builder_.set_insertion_point_to_loop_begin(loop);
+    }
+    ~LoopGuard() {
+      builder_.set_insertion_point_to_after(loop_);
+    }
+  };
+  class IfGuard {
+   private:
+    IRBuilder &builder_;
+    IfStmt *if_stmt_;
+
+   public:
+    explicit IfGuard(IRBuilder &builder, IfStmt *if_stmt, bool true_branch)
+        : builder_(builder), if_stmt_(if_stmt) {
+      if (true_branch) {
+        builder_.set_insertion_point_to_true_branch(if_stmt_);
+      } else {
+        builder_.set_insertion_point_to_false_branch(if_stmt_);
+      }
+    }
+    ~IfGuard() {
+      builder_.set_insertion_point_to_after(if_stmt_);
+    }
+  };
+
   // Control flows.
   RangeForStmt *create_range_for(Stmt *begin,
                                  Stmt *end,

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -25,18 +25,18 @@ class IRBuilder {
   std::unique_ptr<IRNode> extract_ir();
 
   // General inserter. Returns stmt.get().
-  template <typename XxxStmt>
-  XxxStmt *insert(std::unique_ptr<XxxStmt> &&stmt) {
+  template <typename XStmt>
+  XStmt *insert(std::unique_ptr<XStmt> &&stmt) {
     return insert(std::move(stmt), &insert_point_);
   }
 
   // Insert to a specific insertion point.
-  template <typename XxxStmt>
-  static XxxStmt *insert(std::unique_ptr<XxxStmt> &&stmt,
+  template <typename XStmt>
+  static XStmt *insert(std::unique_ptr<XStmt> &&stmt,
                          InsertPoint *insert_point) {
     return insert_point->block
         ->insert(std::move(stmt), insert_point->position++)
-        ->template as<XxxStmt>();
+        ->template as<XStmt>();
   }
 
   void set_insertion_point(InsertPoint new_insert_point);
@@ -44,9 +44,9 @@ class IRBuilder {
   void set_insertion_point_to_before(Stmt *stmt);
   void set_insertion_point_to_true_branch(IfStmt *if_stmt);
   void set_insertion_point_to_false_branch(IfStmt *if_stmt);
-  template <typename XxxStmt>
-  void set_insertion_point_to_loop_begin(XxxStmt *loop) {
-    using DecayedType = typename std::decay_t<XxxStmt>;
+  template <typename XStmt>
+  void set_insertion_point_to_loop_begin(XStmt *loop) {
+    using DecayedType = typename std::decay_t<XStmt>;
     if constexpr (!std::is_base_of_v<Stmt, DecayedType>) {
       TI_ERROR("The argument is not a statement.");
     }
@@ -85,6 +85,14 @@ class IRBuilder {
     explicit IfGuard(IRBuilder &builder, IfStmt *if_stmt, bool true_branch);
     ~IfGuard();
   };
+
+  template <typename XStmt>
+  LoopGuard get_loop_guard(XStmt *loop) {
+    return LoopGuard(*this, loop);
+  }
+  IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
+    return IfGuard(*this, if_stmt, true_branch);
+  }
 
   // Control flows.
   RangeForStmt *create_range_for(Stmt *begin,
@@ -191,9 +199,9 @@ class IRBuilder {
                                    const std::vector<Stmt *> &indices);
   ExternalPtrStmt *create_external_ptr(ArgLoadStmt *ptr,
                                        const std::vector<Stmt *> &indices);
-  template <typename XxxStmt>
-  GlobalLoadStmt *create_global_load(XxxStmt *ptr) {
-    using DecayedType = typename std::decay_t<XxxStmt>;
+  template <typename XStmt>
+  GlobalLoadStmt *create_global_load(XStmt *ptr) {
+    using DecayedType = typename std::decay_t<XStmt>;
     if constexpr (!std::is_base_of_v<Stmt, DecayedType>) {
       TI_ERROR("The argument is not a statement.");
     }
@@ -204,9 +212,9 @@ class IRBuilder {
       TI_ERROR("Statement {} is not a global pointer.", ptr->name());
     }
   }
-  template <typename XxxStmt>
-  void create_global_store(XxxStmt *ptr, Stmt *data) {
-    using DecayedType = typename std::decay_t<XxxStmt>;
+  template <typename XStmt>
+  void create_global_store(XStmt *ptr, Stmt *data) {
+    using DecayedType = typename std::decay_t<XStmt>;
     if constexpr (!std::is_base_of_v<Stmt, DecayedType>) {
       TI_ERROR("The argument is not a statement.");
     }

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -61,29 +61,35 @@ class IRBuilder {
 
   // RAII handles insertion points automatically.
   class LoopGuard {
-   private:
-    IRBuilder &builder_;
-    Stmt *loop_;
-    int location_;
-
    public:
+    // Set the insertion point to the beginning of the loop body.
     template <typename XStmt>
     explicit LoopGuard(IRBuilder &builder, XStmt *loop)
         : builder_(builder), loop_(loop) {
       location_ = (int)loop->parent->size() - 1;
       builder_.set_insertion_point_to_loop_begin(loop);
     }
+
+    // Set the insertion point to the point after the loop.
     ~LoopGuard();
+
+   private:
+    IRBuilder &builder_;
+    Stmt *loop_;
+    int location_;
   };
   class IfGuard {
+   public:
+    // Set the insertion point to the beginning of the true/false branch.
+    explicit IfGuard(IRBuilder &builder, IfStmt *if_stmt, bool true_branch);
+
+    // Set the insertion point to the point after the if statement.
+    ~IfGuard();
+
    private:
     IRBuilder &builder_;
     IfStmt *if_stmt_;
     int location_;
-
-   public:
-    explicit IfGuard(IRBuilder &builder, IfStmt *if_stmt, bool true_branch);
-    ~IfGuard();
   };
 
   template <typename XStmt>

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -46,10 +46,10 @@ TEST(IRBuilder, RangeFor) {
   auto *loop = builder.create_range_for(zero, ten);
   Stmt *index;
   {
-    IRBuilder::LoopGuard(builder, loop);
+    IRBuilder::LoopGuard _(builder, loop);
     index = builder.get_loop_index(loop, 0);
   }
-  auto *ret = builder.create_return(zero);
+  [[maybe_unused]] auto *ret = builder.create_return(zero);
   EXPECT_EQ(zero->parent->size(), 4);
   ASSERT_TRUE(loop->is<RangeForStmt>());
   auto *loopc = loop->cast<RangeForStmt>();

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -46,7 +46,7 @@ TEST(IRBuilder, RangeFor) {
   auto *loop = builder.create_range_for(zero, ten);
   Stmt *index;
   {
-    IRBuilder::LoopGuard _(builder, loop);
+    auto _ = builder.get_loop_guard(loop);
     index = builder.get_loop_index(loop, 0);
   }
   [[maybe_unused]] auto *ret = builder.create_return(zero);

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -57,6 +57,33 @@ TEST(IRBuilder, RangeFor) {
   EXPECT_EQ(loopc->body->statements[0].get(), index);
 }
 
+TEST(IRBuilder, LoopGuard) {
+  IRBuilder builder;
+  auto *zero = builder.get_int32(0);
+  auto *ten = builder.get_int32(10);
+  auto *loop = builder.create_range_for(zero, ten);
+  Stmt *two;
+  Stmt *one;
+  Stmt *sum;
+  {
+    auto _ = builder.get_loop_guard(loop);
+    one = builder.get_int32(1);
+    builder.set_insertion_point_to_before(loop);
+    two = builder.get_int32(2);
+    builder.set_insertion_point_to_after(one);
+    sum = builder.create_add(one, two);
+  }
+  // The insertion point should be after the loop now.
+  auto *print = builder.create_print(two);
+  EXPECT_EQ(zero->parent->size(), 5);
+  EXPECT_EQ(zero->parent->statements[2].get(), two);
+  EXPECT_EQ(zero->parent->statements[3].get(), loop);
+  EXPECT_EQ(zero->parent->statements[4].get(), print);
+  EXPECT_EQ(loop->body->size(), 2);
+  EXPECT_EQ(loop->body->statements[0].get(), one);
+  EXPECT_EQ(loop->body->statements[1].get(), sum);
+}
+
 TEST(IRBuilder, ExternalPtr) {
   auto prog = Program(arch_from_name("x64"));
   prog.materialize_layout();

--- a/tests/cpp_new/ir/ir_builder_test.cpp
+++ b/tests/cpp_new/ir/ir_builder_test.cpp
@@ -44,9 +44,11 @@ TEST(IRBuilder, RangeFor) {
   auto *zero = builder.get_int32(0);
   auto *ten = builder.get_int32(10);
   auto *loop = builder.create_range_for(zero, ten);
-  builder.set_insertion_point_to_loop_begin(loop);
-  auto *index = builder.get_loop_index(loop, 0);
-  builder.set_insertion_point_to_after(loop);
+  Stmt *index;
+  {
+    IRBuilder::LoopGuard(builder, loop);
+    index = builder.get_loop_index(loop, 0);
+  }
   auto *ret = builder.create_return(zero);
   EXPECT_EQ(zero->parent->size(), 4);
   ASSERT_TRUE(loop->is<RangeForStmt>());


### PR DESCRIPTION
Related issue = #2193

This PR adds `IRBuilder::LoopGuard` and `IRBuilder::IfGuard` to make writing control flows with IR Builder easier.

These classes' objects automatically set the insertion point in O(1) time if the insertion point is never manually set in their lifetime by other functions.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
