### PR TITLE
[lang] Replaced usage of taichi.lang.core with taichi.core.util.ti_core.

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -22,7 +22,7 @@ from taichi.lang.util import (has_pytorch, is_taichi_class, python_scope,
 import taichi as ti
 
 # TODO(#2223): Remove
-core = taichi_lang_core
+core = _ti_core
 
 runtime = impl.get_runtime()
 

--- a/python/taichi/lang/core.py
+++ b/python/taichi/lang/core.py
@@ -1,3 +1,0 @@
-from taichi.core import util
-
-taichi_lang_core = util.ti_core

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -50,8 +50,7 @@ class Expr(TaichiOperations):
         if not isinstance(key, (tuple, list)):
             key = (key, )
         assert len(key) == len(self.shape)
-        key = key + ((0, ) *
-                     (_ti_core.get_max_num_indices() - len(key)))
+        key = key + ((0, ) * (_ti_core.get_max_num_indices() - len(key)))
         self.setter(value, *key)
 
     @python_scope
@@ -62,8 +61,7 @@ class Expr(TaichiOperations):
             key = ()
         if not isinstance(key, (tuple, list)):
             key = (key, )
-        key = key + ((0, ) *
-                     (_ti_core.get_max_num_indices() - len(key)))
+        key = key + ((0, ) * (_ti_core.get_max_num_indices() - len(key)))
         return self.getter(*key)
 
     def loop_range(self):

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -1,6 +1,6 @@
+from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl
 from taichi.lang.common_ops import TaichiOperations
-from taichi.lang.core import taichi_lang_core
 from taichi.lang.util import (is_taichi_class, python_scope, to_numpy_type,
                               to_pytorch_type)
 from taichi.misc.util import deprecated
@@ -16,7 +16,7 @@ class Expr(TaichiOperations):
         self.setter = None
         self.tb = tb
         if len(args) == 1:
-            if isinstance(args[0], taichi_lang_core.Expr):
+            if isinstance(args[0], _ti_core.Expr):
                 self.ptr = args[0]
             elif isinstance(args[0], Expr):
                 self.ptr = args[0].ptr
@@ -51,7 +51,7 @@ class Expr(TaichiOperations):
             key = (key, )
         assert len(key) == len(self.shape)
         key = key + ((0, ) *
-                     (taichi_lang_core.get_max_num_indices() - len(key)))
+                     (_ti_core.get_max_num_indices() - len(key)))
         self.setter(value, *key)
 
     @python_scope
@@ -63,7 +63,7 @@ class Expr(TaichiOperations):
         if not isinstance(key, (tuple, list)):
             key = (key, )
         key = key + ((0, ) *
-                     (taichi_lang_core.get_max_num_indices() - len(key)))
+                     (_ti_core.get_max_num_indices() - len(key)))
         return self.getter(*key)
 
     def loop_range(self):
@@ -82,29 +82,29 @@ class Expr(TaichiOperations):
             return
         snode = self.ptr.snode()
 
-        if taichi_lang_core.is_real(self.dtype):
+        if _ti_core.is_real(self.dtype):
 
             def getter(*key):
-                assert len(key) == taichi_lang_core.get_max_num_indices()
+                assert len(key) == _ti_core.get_max_num_indices()
                 return snode.read_float(key)
 
             def setter(value, *key):
-                assert len(key) == taichi_lang_core.get_max_num_indices()
+                assert len(key) == _ti_core.get_max_num_indices()
                 snode.write_float(key, value)
         else:
-            if taichi_lang_core.is_signed(self.dtype):
+            if _ti_core.is_signed(self.dtype):
 
                 def getter(*key):
-                    assert len(key) == taichi_lang_core.get_max_num_indices()
+                    assert len(key) == _ti_core.get_max_num_indices()
                     return snode.read_int(key)
             else:
 
                 def getter(*key):
-                    assert len(key) == taichi_lang_core.get_max_num_indices()
+                    assert len(key) == _ti_core.get_max_num_indices()
                     return snode.read_uint(key)
 
             def setter(value, *key):
-                assert len(key) == taichi_lang_core.get_max_num_indices()
+                assert len(key) == _ti_core.get_max_num_indices()
                 snode.write_int(key, value)
 
         self.getter = getter
@@ -130,7 +130,7 @@ class Expr(TaichiOperations):
 
     def parent(self, n=1):
         p = self.snode.parent(n)
-        return Expr(taichi_lang_core.global_var_expr_from_snode(p.ptr))
+        return Expr(_ti_core.global_var_expr_from_snode(p.ptr))
 
     def is_global(self):
         return self.ptr.is_global_var() or self.ptr.is_external_var()
@@ -230,7 +230,7 @@ class Expr(TaichiOperations):
 def make_var_vector(size):
     exprs = []
     for _ in range(size):
-        exprs.append(taichi_lang_core.make_id_expr(''))
+        exprs.append(_ti_core.make_id_expr(''))
     return ti.Vector(exprs)
 
 
@@ -242,7 +242,7 @@ def make_expr_group(*exprs):
             mat = exprs[0]
             assert mat.m == 1
             exprs = mat.entries
-    expr_group = taichi_lang_core.ExprGroup()
+    expr_group = _ti_core.ExprGroup()
     for i in exprs:
         expr_group.push_back(Expr(i).ptr)
     return expr_group

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -1,4 +1,4 @@
-from taichi.lang.core import taichi_lang_core
+from taichi.core.util import ti_core as _ti_core
 from taichi.lang.expr import Expr
 from taichi.lang.snode import SNode
 from taichi.lang.util import cook_dtype, to_taichi_type
@@ -25,7 +25,7 @@ class Template:
             return x.ptr
         if isinstance(x, Expr):
             return x.ptr.get_underlying_ptr_address()
-        if isinstance(x, taichi_lang_core.Expr):
+        if isinstance(x, _ti_core.Expr):
             return x.get_underlying_ptr_address()
         if isinstance(x, tuple):
             return tuple(self.extract(item) for item in x)
@@ -37,16 +37,16 @@ template = Template
 
 def decl_scalar_arg(dtype):
     dtype = cook_dtype(dtype)
-    arg_id = taichi_lang_core.decl_arg(dtype, False)
-    return Expr(taichi_lang_core.make_arg_load_expr(arg_id, dtype))
+    arg_id = _ti_core.decl_arg(dtype, False)
+    return Expr(_ti_core.make_arg_load_expr(arg_id, dtype))
 
 
 def decl_ext_arr_arg(dtype, dim):
     dtype = cook_dtype(dtype)
-    arg_id = taichi_lang_core.decl_arg(dtype, True)
-    return Expr(taichi_lang_core.make_external_tensor_expr(dtype, dim, arg_id))
+    arg_id = _ti_core.decl_arg(dtype, True)
+    return Expr(_ti_core.make_external_tensor_expr(dtype, dim, arg_id))
 
 
 def decl_scalar_ret(dtype):
     dtype = cook_dtype(dtype)
-    return taichi_lang_core.decl_ret(dtype)
+    return _ti_core.decl_ret(dtype)

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -8,7 +8,7 @@ import numpy as np
 from taichi.core import primitive_types
 from taichi.lang import impl, util
 from taichi.lang.ast_checker import KernelSimplicityASTChecker
-from taichi.lang.core import taichi_lang_core
+from taichi.core.util import ti_core as _ti_core
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.kernel_arguments import ext_arr, template
 from taichi.lang.shell import _shell_pop_print, oinspect
@@ -352,7 +352,7 @@ class Kernel:
                     mode='exec'), global_vars, local_vars)
         compiled = local_vars[self.func.__name__]
 
-        taichi_kernel = taichi_lang_core.create_kernel(kernel_name,
+        taichi_kernel = _ti_core.create_kernel(kernel_name,
                                                        self.is_grad)
 
         # Do not change the name of 'taichi_ast_generator'
@@ -426,14 +426,14 @@ class Kernel:
 
                         if str(v.device).startswith('cuda'):
                             # External tensor on cuda
-                            if taichi_arch != taichi_lang_core.Arch.cuda:
+                            if taichi_arch != _ti_core.Arch.cuda:
                                 # copy data back to cpu
                                 host_v = v.to(device='cpu', copy=True)
                                 tmp = host_v
                                 callbacks.append(get_call_back(v, host_v))
                         else:
                             # External tensor on cpu
-                            if taichi_arch == taichi_lang_core.Arch.cuda:
+                            if taichi_arch == _ti_core.Arch.cuda:
                                 gpu_v = v.cuda()
                                 tmp = gpu_v
                                 callbacks.append(get_call_back(v, gpu_v))
@@ -441,7 +441,7 @@ class Kernel:
                             actual_argument_slot, int(tmp.data_ptr()),
                             tmp.element_size() * tmp.nelement())
                     shape = v.shape
-                    max_num_indices = taichi_lang_core.get_max_num_indices()
+                    max_num_indices = _ti_core.get_max_num_indices()
                     assert len(
                         shape
                     ) <= max_num_indices, "External array cannot have > {} indices".format(

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -352,8 +352,7 @@ class Kernel:
                     mode='exec'), global_vars, local_vars)
         compiled = local_vars[self.func.__name__]
 
-        taichi_kernel = _ti_core.create_kernel(kernel_name,
-                                                       self.is_grad)
+        taichi_kernel = _ti_core.create_kernel(kernel_name, self.is_grad)
 
         # Do not change the name of 'taichi_ast_generator'
         # The warning system needs this identifier to remove unnecessary messages

--- a/python/taichi/lang/linalg.py
+++ b/python/taichi/lang/linalg.py
@@ -1,4 +1,4 @@
-from taichi.core import util as cutil
+from taichi.core.util import ti_core as _ti_core
 from taichi.lang.impl import expr_init
 
 import taichi as ti
@@ -63,9 +63,9 @@ def svd3d(A, dt, iters=None):
         else:
             iters = 8
     if dt == ti.f32:
-        rets = cutil.ti_core.sifakis_svd_f32(*inputs, iters)
+        rets = _ti_core.sifakis_svd_f32(*inputs, iters)
     else:
-        rets = cutil.ti_core.sifakis_svd_f64(*inputs, iters)
+        rets = _ti_core.sifakis_svd_f64(*inputs, iters)
     assert len(rets) == 21
     U_entries = rets[:9]
     V_entries = rets[9:18]

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -308,7 +308,8 @@ def pow(a, b):
 
 @binary
 def floordiv(a, b):
-    return _binary_operation(_ti_core.expr_floordiv, _bt_ops_mod.floordiv, a, b)
+    return _binary_operation(_ti_core.expr_floordiv, _bt_ops_mod.floordiv, a,
+                             b)
 
 
 @binary
@@ -358,8 +359,8 @@ def cmp_lt(a, b):
 
 @binary
 def cmp_le(a, b):
-    return _binary_operation(_ti_core.expr_cmp_le, lambda a, b: -int(a <= b), a,
-                             b)
+    return _binary_operation(_ti_core.expr_cmp_le, lambda a, b: -int(a <= b),
+                             a, b)
 
 
 @binary
@@ -370,20 +371,20 @@ def cmp_gt(a, b):
 
 @binary
 def cmp_ge(a, b):
-    return _binary_operation(_ti_core.expr_cmp_ge, lambda a, b: -int(a >= b), a,
-                             b)
+    return _binary_operation(_ti_core.expr_cmp_ge, lambda a, b: -int(a >= b),
+                             a, b)
 
 
 @binary
 def cmp_eq(a, b):
-    return _binary_operation(_ti_core.expr_cmp_eq, lambda a, b: -int(a == b), a,
-                             b)
+    return _binary_operation(_ti_core.expr_cmp_eq, lambda a, b: -int(a == b),
+                             a, b)
 
 
 @binary
 def cmp_ne(a, b):
-    return _binary_operation(_ti_core.expr_cmp_ne, lambda a, b: -int(a != b), a,
-                             b)
+    return _binary_operation(_ti_core.expr_cmp_ne, lambda a, b: -int(a != b),
+                             a, b)
 
 
 @binary
@@ -514,25 +515,25 @@ def ti_all(a):
 def append(l, indices, val):
     a = impl.expr_init(
         _ti_core.insert_append(l.snode.ptr, make_expr_group(indices),
-                              Expr(val).ptr))
+                               Expr(val).ptr))
     return a
 
 
 def external_func_call(func, args=[], outputs=[]):
     func_addr = ctypes.cast(func, ctypes.c_void_p).value
     _ti_core.insert_external_func_call(func_addr, '', make_expr_group(args),
-                                      make_expr_group(outputs))
+                                       make_expr_group(outputs))
 
 
 def asm(source, inputs=[], outputs=[]):
 
     _ti_core.insert_external_func_call(0, source, make_expr_group(inputs),
-                                      make_expr_group(outputs))
+                                       make_expr_group(outputs))
 
 
 def is_active(l, indices):
-    return Expr(_ti_core.insert_is_active(l.snode.ptr,
-                                         make_expr_group(indices)))
+    return Expr(
+        _ti_core.insert_is_active(l.snode.ptr, make_expr_group(indices)))
 
 
 def activate(l, indices):

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -8,11 +8,9 @@ import traceback
 from taichi.lang import impl
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.expr import Expr, make_expr_group
-from taichi.lang.util import (cook_dtype, is_taichi_class, taichi_lang_core,
-                              taichi_scope)
+from taichi.lang.util import (cook_dtype, is_taichi_class, taichi_scope)
+from taichi.core.util import ti_core as _ti_core
 
-# TODO(#2223): Please stop abusing so many ti_cores
-ti_core = taichi_lang_core
 unary_ops = []
 
 
@@ -147,7 +145,7 @@ def cast(obj, dtype):
         # TODO: unify with element_wise_unary
         return obj.cast(dtype)
     else:
-        return Expr(ti_core.value_cast(Expr(obj).ptr, dtype))
+        return Expr(_ti_core.value_cast(Expr(obj).ptr, dtype))
 
 
 def bit_cast(obj, dtype):
@@ -156,7 +154,7 @@ def bit_cast(obj, dtype):
     if is_taichi_class(obj):
         raise ValueError('Cannot apply bit_cast on Taichi classes')
     else:
-        return Expr(ti_core.bits_cast(Expr(obj).ptr, dtype))
+        return Expr(_ti_core.bits_cast(Expr(obj).ptr, dtype))
 
 
 def _unary_operation(taichi_op, python_op, a):
@@ -187,32 +185,32 @@ def _ternary_operation(taichi_op, python_op, a, b, c):
 
 @unary
 def neg(a):
-    return _unary_operation(ti_core.expr_neg, _bt_ops_mod.neg, a)
+    return _unary_operation(_ti_core.expr_neg, _bt_ops_mod.neg, a)
 
 
 @unary
 def sin(a):
-    return _unary_operation(ti_core.expr_sin, math.sin, a)
+    return _unary_operation(_ti_core.expr_sin, math.sin, a)
 
 
 @unary
 def cos(a):
-    return _unary_operation(ti_core.expr_cos, math.cos, a)
+    return _unary_operation(_ti_core.expr_cos, math.cos, a)
 
 
 @unary
 def asin(a):
-    return _unary_operation(ti_core.expr_asin, math.asin, a)
+    return _unary_operation(_ti_core.expr_asin, math.asin, a)
 
 
 @unary
 def acos(a):
-    return _unary_operation(ti_core.expr_acos, math.acos, a)
+    return _unary_operation(_ti_core.expr_acos, math.acos, a)
 
 
 @unary
 def sqrt(a):
-    return _unary_operation(ti_core.expr_sqrt, math.sqrt, a)
+    return _unary_operation(_ti_core.expr_sqrt, math.sqrt, a)
 
 
 @unary
@@ -220,57 +218,57 @@ def rsqrt(a):
     def _rsqrt(a):
         return 1 / math.sqrt(a)
 
-    return _unary_operation(ti_core.expr_rsqrt, _rsqrt, a)
+    return _unary_operation(_ti_core.expr_rsqrt, _rsqrt, a)
 
 
 @unary
 def floor(a):
-    return _unary_operation(ti_core.expr_floor, math.floor, a)
+    return _unary_operation(_ti_core.expr_floor, math.floor, a)
 
 
 @unary
 def ceil(a):
-    return _unary_operation(ti_core.expr_ceil, math.ceil, a)
+    return _unary_operation(_ti_core.expr_ceil, math.ceil, a)
 
 
 @unary
 def tan(a):
-    return _unary_operation(ti_core.expr_tan, math.tan, a)
+    return _unary_operation(_ti_core.expr_tan, math.tan, a)
 
 
 @unary
 def tanh(a):
-    return _unary_operation(ti_core.expr_tanh, math.tanh, a)
+    return _unary_operation(_ti_core.expr_tanh, math.tanh, a)
 
 
 @unary
 def exp(a):
-    return _unary_operation(ti_core.expr_exp, math.exp, a)
+    return _unary_operation(_ti_core.expr_exp, math.exp, a)
 
 
 @unary
 def log(a):
-    return _unary_operation(ti_core.expr_log, math.log, a)
+    return _unary_operation(_ti_core.expr_log, math.log, a)
 
 
 @unary
 def abs(a):
-    return _unary_operation(ti_core.expr_abs, builtins.abs, a)
+    return _unary_operation(_ti_core.expr_abs, builtins.abs, a)
 
 
 @unary
 def bit_not(a):
-    return _unary_operation(ti_core.expr_bit_not, _bt_ops_mod.invert, a)
+    return _unary_operation(_ti_core.expr_bit_not, _bt_ops_mod.invert, a)
 
 
 @unary
 def logical_not(a):
-    return _unary_operation(ti_core.expr_logic_not, lambda x: int(not x), a)
+    return _unary_operation(_ti_core.expr_logic_not, lambda x: int(not x), a)
 
 
 def random(dtype=float):
     dtype = cook_dtype(dtype)
-    x = Expr(ti_core.make_rand_expr(dtype))
+    x = Expr(_ti_core.make_rand_expr(dtype))
     return impl.expr_init(x)
 
 
@@ -279,58 +277,58 @@ def random(dtype=float):
 
 @binary
 def add(a, b):
-    return _binary_operation(ti_core.expr_add, _bt_ops_mod.add, a, b)
+    return _binary_operation(_ti_core.expr_add, _bt_ops_mod.add, a, b)
 
 
 @binary
 def sub(a, b):
-    return _binary_operation(ti_core.expr_sub, _bt_ops_mod.sub, a, b)
+    return _binary_operation(_ti_core.expr_sub, _bt_ops_mod.sub, a, b)
 
 
 @binary
 def mul(a, b):
-    return _binary_operation(ti_core.expr_mul, _bt_ops_mod.mul, a, b)
+    return _binary_operation(_ti_core.expr_mul, _bt_ops_mod.mul, a, b)
 
 
 @binary
 def mod(a, b):
     def expr_python_mod(a, b):
         # a % b = (a // b) * b - a
-        quotient = Expr(ti_core.expr_floordiv(a, b))
-        multiply = Expr(ti_core.expr_mul(b, quotient.ptr))
-        return ti_core.expr_sub(a, multiply.ptr)
+        quotient = Expr(_ti_core.expr_floordiv(a, b))
+        multiply = Expr(_ti_core.expr_mul(b, quotient.ptr))
+        return _ti_core.expr_sub(a, multiply.ptr)
 
     return _binary_operation(expr_python_mod, _bt_ops_mod.mod, a, b)
 
 
 @binary
 def pow(a, b):
-    return _binary_operation(ti_core.expr_pow, _bt_ops_mod.pow, a, b)
+    return _binary_operation(_ti_core.expr_pow, _bt_ops_mod.pow, a, b)
 
 
 @binary
 def floordiv(a, b):
-    return _binary_operation(ti_core.expr_floordiv, _bt_ops_mod.floordiv, a, b)
+    return _binary_operation(_ti_core.expr_floordiv, _bt_ops_mod.floordiv, a, b)
 
 
 @binary
 def truediv(a, b):
-    return _binary_operation(ti_core.expr_truediv, _bt_ops_mod.truediv, a, b)
+    return _binary_operation(_ti_core.expr_truediv, _bt_ops_mod.truediv, a, b)
 
 
 @binary
 def max(a, b):
-    return _binary_operation(ti_core.expr_max, builtins.max, a, b)
+    return _binary_operation(_ti_core.expr_max, builtins.max, a, b)
 
 
 @binary
 def min(a, b):
-    return _binary_operation(ti_core.expr_min, builtins.min, a, b)
+    return _binary_operation(_ti_core.expr_min, builtins.min, a, b)
 
 
 @binary
 def atan2(a, b):
-    return _binary_operation(ti_core.expr_atan2, math.atan2, a, b)
+    return _binary_operation(_ti_core.expr_atan2, math.atan2, a, b)
 
 
 @binary
@@ -341,7 +339,7 @@ def raw_div(a, b):
         else:
             return a / b
 
-    return _binary_operation(ti_core.expr_div, c_div, a, b)
+    return _binary_operation(_ti_core.expr_div, c_div, a, b)
 
 
 @binary
@@ -349,74 +347,74 @@ def raw_mod(a, b):
     def c_mod(a, b):
         return a - b * int(float(a) / b)
 
-    return _binary_operation(ti_core.expr_mod, c_mod, a, b)
+    return _binary_operation(_ti_core.expr_mod, c_mod, a, b)
 
 
 @binary
 def cmp_lt(a, b):
-    return _binary_operation(ti_core.expr_cmp_lt, lambda a, b: -int(a < b), a,
+    return _binary_operation(_ti_core.expr_cmp_lt, lambda a, b: -int(a < b), a,
                              b)
 
 
 @binary
 def cmp_le(a, b):
-    return _binary_operation(ti_core.expr_cmp_le, lambda a, b: -int(a <= b), a,
+    return _binary_operation(_ti_core.expr_cmp_le, lambda a, b: -int(a <= b), a,
                              b)
 
 
 @binary
 def cmp_gt(a, b):
-    return _binary_operation(ti_core.expr_cmp_gt, lambda a, b: -int(a > b), a,
+    return _binary_operation(_ti_core.expr_cmp_gt, lambda a, b: -int(a > b), a,
                              b)
 
 
 @binary
 def cmp_ge(a, b):
-    return _binary_operation(ti_core.expr_cmp_ge, lambda a, b: -int(a >= b), a,
+    return _binary_operation(_ti_core.expr_cmp_ge, lambda a, b: -int(a >= b), a,
                              b)
 
 
 @binary
 def cmp_eq(a, b):
-    return _binary_operation(ti_core.expr_cmp_eq, lambda a, b: -int(a == b), a,
+    return _binary_operation(_ti_core.expr_cmp_eq, lambda a, b: -int(a == b), a,
                              b)
 
 
 @binary
 def cmp_ne(a, b):
-    return _binary_operation(ti_core.expr_cmp_ne, lambda a, b: -int(a != b), a,
+    return _binary_operation(_ti_core.expr_cmp_ne, lambda a, b: -int(a != b), a,
                              b)
 
 
 @binary
 def bit_or(a, b):
-    return _binary_operation(ti_core.expr_bit_or, _bt_ops_mod.or_, a, b)
+    return _binary_operation(_ti_core.expr_bit_or, _bt_ops_mod.or_, a, b)
 
 
 @binary
 def bit_and(a, b):
-    return _binary_operation(ti_core.expr_bit_and, _bt_ops_mod.and_, a, b)
+    return _binary_operation(_ti_core.expr_bit_and, _bt_ops_mod.and_, a, b)
 
 
 @binary
 def bit_xor(a, b):
-    return _binary_operation(ti_core.expr_bit_xor, _bt_ops_mod.xor, a, b)
+    return _binary_operation(_ti_core.expr_bit_xor, _bt_ops_mod.xor, a, b)
 
 
 @binary
 def bit_shl(a, b):
-    return _binary_operation(ti_core.expr_bit_shl, _bt_ops_mod.lshift, a, b)
+    return _binary_operation(_ti_core.expr_bit_shl, _bt_ops_mod.lshift, a, b)
 
 
 @binary
 def bit_sar(a, b):
-    return _binary_operation(ti_core.expr_bit_sar, _bt_ops_mod.rshift, a, b)
+    return _binary_operation(_ti_core.expr_bit_sar, _bt_ops_mod.rshift, a, b)
 
 
 @taichi_scope
 @binary
 def bit_shr(a, b):
-    return _binary_operation(ti_core.expr_bit_shr, _bt_ops_mod.rshift, a, b)
+    return _binary_operation(_ti_core.expr_bit_shr, _bt_ops_mod.rshift, a, b)
 
 
 # We don't have logic_and/or instructions yet:
@@ -432,54 +430,54 @@ def select(cond, a, b):
     def py_select(cond, a, b):
         return a * cond + b * (1 - cond)
 
-    return _ternary_operation(ti_core.expr_select, py_select, cond, a, b)
+    return _ternary_operation(_ti_core.expr_select, py_select, cond, a, b)
 
 
 @writeback_binary
 def atomic_add(a, b):
     return impl.expr_init(
-        Expr(ti_core.expr_atomic_add(a.ptr, b.ptr), tb=stack_info()))
+        Expr(_ti_core.expr_atomic_add(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_sub(a, b):
     return impl.expr_init(
-        Expr(ti_core.expr_atomic_sub(a.ptr, b.ptr), tb=stack_info()))
+        Expr(_ti_core.expr_atomic_sub(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_min(a, b):
     return impl.expr_init(
-        Expr(ti_core.expr_atomic_min(a.ptr, b.ptr), tb=stack_info()))
+        Expr(_ti_core.expr_atomic_min(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_max(a, b):
     return impl.expr_init(
-        Expr(ti_core.expr_atomic_max(a.ptr, b.ptr), tb=stack_info()))
+        Expr(_ti_core.expr_atomic_max(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_and(a, b):
     return impl.expr_init(
-        Expr(ti_core.expr_atomic_bit_and(a.ptr, b.ptr), tb=stack_info()))
+        Expr(_ti_core.expr_atomic_bit_and(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_or(a, b):
     return impl.expr_init(
-        Expr(ti_core.expr_atomic_bit_or(a.ptr, b.ptr), tb=stack_info()))
+        Expr(_ti_core.expr_atomic_bit_or(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_xor(a, b):
     return impl.expr_init(
-        Expr(ti_core.expr_atomic_bit_xor(a.ptr, b.ptr), tb=stack_info()))
+        Expr(_ti_core.expr_atomic_bit_xor(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def assign(a, b):
-    ti_core.expr_assign(a.ptr, b.ptr, stack_info())
+    _ti_core.expr_assign(a.ptr, b.ptr, stack_info())
     return a
 
 
@@ -515,35 +513,35 @@ def ti_all(a):
 
 def append(l, indices, val):
     a = impl.expr_init(
-        ti_core.insert_append(l.snode.ptr, make_expr_group(indices),
+        _ti_core.insert_append(l.snode.ptr, make_expr_group(indices),
                               Expr(val).ptr))
     return a
 
 
 def external_func_call(func, args=[], outputs=[]):
     func_addr = ctypes.cast(func, ctypes.c_void_p).value
-    ti_core.insert_external_func_call(func_addr, '', make_expr_group(args),
+    _ti_core.insert_external_func_call(func_addr, '', make_expr_group(args),
                                       make_expr_group(outputs))
 
 
 def asm(source, inputs=[], outputs=[]):
 
-    ti_core.insert_external_func_call(0, source, make_expr_group(inputs),
+    _ti_core.insert_external_func_call(0, source, make_expr_group(inputs),
                                       make_expr_group(outputs))
 
 
 def is_active(l, indices):
-    return Expr(ti_core.insert_is_active(l.snode.ptr,
+    return Expr(_ti_core.insert_is_active(l.snode.ptr,
                                          make_expr_group(indices)))
 
 
 def activate(l, indices):
-    ti_core.insert_activate(l.snode.ptr, make_expr_group(indices))
+    _ti_core.insert_activate(l.snode.ptr, make_expr_group(indices))
 
 
 def deactivate(l, indices):
-    ti_core.insert_deactivate(l.snode.ptr, make_expr_group(indices))
+    _ti_core.insert_deactivate(l.snode.ptr, make_expr_group(indices))
 
 
 def length(l, indices):
-    return Expr(ti_core.insert_len(l.snode.ptr, make_expr_group(indices)))
+    return Expr(_ti_core.insert_len(l.snode.ptr, make_expr_group(indices)))

--- a/python/taichi/lang/shell.py
+++ b/python/taichi/lang/shell.py
@@ -3,7 +3,7 @@ import functools
 import os
 import sys
 
-from taichi.lang.core import taichi_lang_core
+from taichi.core.util import ti_core as _ti_core
 
 import taichi as ti
 
@@ -24,7 +24,7 @@ if not _env_enable_pybuf or int(_env_enable_pybuf):
     # While sys.__stdout__ should always be the raw console stdout.
     pybuf_enabled = sys.stdout is not sys.__stdout__
 
-taichi_lang_core.toggle_python_print_buffer(pybuf_enabled)
+_ti_core.toggle_python_print_buffer(pybuf_enabled)
 
 
 def _shell_pop_print(old_call):
@@ -40,7 +40,7 @@ def _shell_pop_print(old_call):
         ret = old_call(*args, **kwargs)
         # print's in kernel won't take effect until ti.sync(), discussion:
         # https://github.com/taichi-dev/taichi/pull/1303#discussion_r444897102
-        print(taichi_lang_core.pop_python_print_buffer(), end='')
+        print(_ti_core.pop_python_print_buffer(), end='')
         return ret
 
     return new_call

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -4,7 +4,7 @@ import numbers
 # object within it, is that ti_core is stateful. While in practice ti_core is
 # loaded during the import procedure, it's probably still good to delay the
 # access to it.
-from taichi.core import util as cutil
+from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl
 from taichi.lang.expr import Expr
 from taichi.lang.util import is_taichi_class
@@ -89,7 +89,7 @@ class SNode:
             n -= 1
         if p is None:
             return None
-        if p.type == cutil.ti_core.SNodeType.root:
+        if p.type == _ti_core.SNodeType.root:
             return impl.root
         return SNode(p)
 
@@ -128,7 +128,7 @@ class SNode:
         return self.shape[i]
 
     def loop_range(self):
-        return Expr(cutil.ti_core.global_var_expr_from_snode(self.ptr))
+        return Expr(_ti_core.global_var_expr_from_snode(self.ptr))
 
     @deprecated('x.snode()', 'x.snode')
     def __call__(self):  # TODO: remove this after v0.7.0
@@ -160,7 +160,7 @@ class SNode:
         ch = self.get_children()
         for c in ch:
             c.deactivate_all()
-        SNodeType = cutil.ti_core.SNodeType
+        SNodeType = _ti_core.SNodeType
         from taichi.lang import meta
         if self.ptr.type == SNodeType.pointer or self.ptr.type == SNodeType.bitmasked:
             meta.snode_deactivate(self)

--- a/python/taichi/lang/type_factory_impl.py
+++ b/python/taichi/lang/type_factory_impl.py
@@ -1,15 +1,15 @@
-from taichi.core import util as cutil
+from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl
 
 
 class TypeFactory:
     def __init__(self):
-        self.core = cutil.ti_core.get_type_factory_instance()
+        self.core = _ti_core.get_type_factory_instance()
 
     def custom_int(self, bits, signed=True, compute_type=None):
         if compute_type is None:
             compute_type = impl.get_runtime().default_ip
-        if isinstance(compute_type, cutil.ti_core.DataType):
+        if isinstance(compute_type, _ti_core.DataType):
             compute_type = compute_type.get_ptr()
         return self.core.get_custom_int_type(bits, signed, compute_type)
 
@@ -20,7 +20,7 @@ class TypeFactory:
                      scale=1.0):
         if compute_type is None:
             compute_type = impl.get_runtime().default_fp
-        if isinstance(compute_type, cutil.ti_core.DataType):
+        if isinstance(compute_type, _ti_core.DataType):
             compute_type = compute_type.get_ptr()
         return self.core.get_custom_float_type(significand_type,
                                                exponent_type,

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -3,7 +3,7 @@ import os
 
 import numpy as np
 from taichi.lang import impl
-from taichi.lang.core import taichi_lang_core
+from taichi.core.util import ti_core as _ti_core
 
 import taichi as ti
 
@@ -83,7 +83,7 @@ def to_pytorch_type(dt):
 
 
 def to_taichi_type(dt):
-    if type(dt) == taichi_lang_core.DataType:
+    if type(dt) == _ti_core.DataType:
         return dt
 
     if dt == np.float32:
@@ -134,10 +134,10 @@ def to_taichi_type(dt):
 
 def cook_dtype(dtype):
     _taichi_skip_traceback = 1
-    if isinstance(dtype, taichi_lang_core.DataType):
+    if isinstance(dtype, _ti_core.DataType):
         return dtype
-    elif isinstance(dtype, taichi_lang_core.Type):
-        return taichi_lang_core.DataType(dtype)
+    elif isinstance(dtype, _ti_core.Type):
+        return _ti_core.DataType(dtype)
     elif dtype is float:
         return impl.get_runtime().default_fp
     elif dtype is int:


### PR DESCRIPTION
Issue=#2223

The way we use ti_core is not clear and a bit confusing. Multiple repeat imports can make code redundant and hard to understand. This PR refactor the part in python/taichi/lang by:
Deleted core.py in under python/taichi/lang and replaced all usage of taichi_lang_core with _ti_core imported from taichi.core.util.ti_core. 
@k-ye 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
