### PR TITLE
[IR] [refactor] Unify field names in load/store/atomic statements

### DIFF
--- a/taichi/analysis/data_source_analysis.cpp
+++ b/taichi/analysis/data_source_analysis.cpp
@@ -10,13 +10,13 @@ std::vector<Stmt *> get_load_pointers(Stmt *load_stmt) {
   // If load_stmt loads some variables or a stack, return the pointers of them.
   if (auto local_load = load_stmt->cast<LocalLoadStmt>()) {
     std::vector<Stmt *> result;
-    for (auto &address : local_load->ptr.data) {
+    for (auto &address : local_load->src.data) {
       if (std::find(result.begin(), result.end(), address.var) == result.end())
         result.push_back(address.var);
     }
     return result;
   } else if (auto global_load = load_stmt->cast<GlobalLoadStmt>()) {
-    return std::vector<Stmt *>(1, global_load->ptr);
+    return std::vector<Stmt *>(1, global_load->src);
   } else if (auto atomic = load_stmt->cast<AtomicOpStmt>()) {
     return std::vector<Stmt *>(1, atomic->dest);
   } else if (auto stack_load_top = load_stmt->cast<StackLoadTopStmt>()) {
@@ -46,9 +46,9 @@ Stmt *get_store_data(Stmt *store_stmt) {
     // stores.
     return store_stmt;
   } else if (auto local_store = store_stmt->cast<LocalStoreStmt>()) {
-    return local_store->data;
+    return local_store->val;
   } else if (auto global_store = store_stmt->cast<GlobalStoreStmt>()) {
-    return global_store->data;
+    return global_store->val;
   } else {
     return nullptr;
   }
@@ -60,9 +60,9 @@ std::vector<Stmt *> get_store_destination(Stmt *store_stmt) {
     // The statement itself provides a data source (const [0]).
     return std::vector<Stmt *>(1, store_stmt);
   } else if (auto local_store = store_stmt->cast<LocalStoreStmt>()) {
-    return std::vector<Stmt *>(1, local_store->ptr);
+    return std::vector<Stmt *>(1, local_store->dest);
   } else if (auto global_store = store_stmt->cast<GlobalStoreStmt>()) {
-    return std::vector<Stmt *>(1, global_store->ptr);
+    return std::vector<Stmt *>(1, global_store->dest);
   } else if (auto atomic = store_stmt->cast<AtomicOpStmt>()) {
     return std::vector<Stmt *>(1, atomic->dest);
   } else if (auto external_func = store_stmt->cast<ExternalFuncCallStmt>()) {

--- a/taichi/analysis/gather_snode_read_writes.cpp
+++ b/taichi/analysis/gather_snode_read_writes.cpp
@@ -17,17 +17,17 @@ gather_snode_read_writes(IRNode *root) {
     bool read = false, write = false;
     if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
       read = true;
-      ptr = global_load->ptr;
+      ptr = global_load->src;
     } else if (auto global_store = stmt->cast<GlobalStoreStmt>()) {
       write = true;
-      ptr = global_store->ptr;
+      ptr = global_store->dest;
     } else if (auto global_atomic = stmt->cast<AtomicOpStmt>()) {
       read = true;
       write = true;
       ptr = global_atomic->dest;
     }
     if (ptr) {
-      if (GlobalPtrStmt *global_ptr = ptr->cast<GlobalPtrStmt>()) {
+      if (auto *global_ptr = ptr->cast<GlobalPtrStmt>()) {
         for (auto &snode : global_ptr->snodes.data) {
           if (read)
             accessed.first.emplace(snode);

--- a/taichi/analysis/has_store_or_atomic.cpp
+++ b/taichi/analysis/has_store_or_atomic.cpp
@@ -25,7 +25,7 @@ class LocalStoreSearcher : public BasicStmtVisitor {
 
   void visit(LocalStoreStmt *stmt) override {
     for (auto var : vars) {
-      if (stmt->ptr == var) {
+      if (stmt->dest == var) {
         result = true;
         break;
       }

--- a/taichi/analysis/last_store_or_atomic.cpp
+++ b/taichi/analysis/last_store_or_atomic.cpp
@@ -24,7 +24,7 @@ class LocalStoreForwarder : public BasicStmtVisitor {
   }
 
   void visit(LocalStoreStmt *stmt) override {
-    if (stmt->ptr == var) {
+    if (stmt->dest == var) {
       is_valid = true;
       result = stmt;
     }
@@ -70,8 +70,8 @@ class LocalStoreForwarder : public BasicStmtVisitor {
     } else {
       TI_ASSERT(true_stmt->is<LocalStoreStmt>());
       TI_ASSERT(false_stmt->is<LocalStoreStmt>());
-      if (true_stmt->as<LocalStoreStmt>()->data !=
-          false_stmt->as<LocalStoreStmt>()->data) {
+      if (true_stmt->as<LocalStoreStmt>()->val !=
+          false_stmt->as<LocalStoreStmt>()->val) {
         // two branches finally store the variable differently
         is_valid = false;
       } else {

--- a/taichi/analysis/same_statements.cpp
+++ b/taichi/analysis/same_statements.cpp
@@ -152,7 +152,7 @@ class IRNodeComparator : public IRVisitor {
       } else {
         bool same_value = false;
         if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
-          if (auto global_ptr = global_load->ptr->cast<GlobalPtrStmt>()) {
+          if (auto global_ptr = global_load->src->cast<GlobalPtrStmt>()) {
             TI_ASSERT(global_ptr->width() == 1);
             if (possibly_modified_states_.count(ir_bank_->get_async_state(
                     global_ptr->snodes[0], AsyncState::Type::value)) == 0) {

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -104,13 +104,13 @@ class IRVerifier : public BasicStmtVisitor {
   void visit(LocalLoadStmt *stmt) override {
     basic_verify(stmt);
     for (int i = 0; i < stmt->width(); i++) {
-      TI_ASSERT(stmt->ptr[i].var->is<AllocaStmt>());
+      TI_ASSERT(stmt->src[i].var->is<AllocaStmt>());
     }
   }
 
   void visit(LocalStoreStmt *stmt) override {
     basic_verify(stmt);
-    TI_ASSERT(stmt->ptr->is<AllocaStmt>());
+    TI_ASSERT(stmt->dest->is<AllocaStmt>());
   }
 
   void visit(LoopIndexStmt *stmt) override {

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -126,12 +126,12 @@ class CCTransformer : public IRVisitor {
     TI_ASSERT(stmt->width() == 1);
     emit("{} = *{};",
          define_var(cc_data_type_name(stmt->element_type()), stmt->raw_name()),
-         stmt->ptr->raw_name());
+         stmt->src->raw_name());
   }
 
   void visit(GlobalStoreStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    emit("*{} = {};", stmt->ptr->raw_name(), stmt->data->raw_name());
+    emit("*{} = {};", stmt->dest->raw_name(), stmt->val->raw_name());
   }
 
   void visit(GlobalTemporaryStmt *stmt) override {
@@ -202,21 +202,21 @@ class CCTransformer : public IRVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     bool linear_index = true;
-    for (int i = 0; i < (int)stmt->ptr.size(); i++) {
-      if (stmt->ptr[i].offset != i) {
+    for (int i = 0; i < (int)stmt->src.size(); i++) {
+      if (stmt->src[i].offset != i) {
         linear_index = false;
       }
     }
     TI_ASSERT(stmt->same_source() && linear_index &&
-              stmt->width() == stmt->ptr[0].var->width());
+              stmt->width() == stmt->src[0].var->width());
 
     auto var =
         define_var(cc_data_type_name(stmt->element_type()), stmt->raw_name());
-    emit("{} = {};", var, stmt->ptr[0].var->raw_name());
+    emit("{} = {};", var, stmt->src[0].var->raw_name());
   }
 
   void visit(LocalStoreStmt *stmt) override {
-    emit("{} = {};", stmt->ptr->raw_name(), stmt->data->raw_name());
+    emit("{} = {};", stmt->dest->raw_name(), stmt->val->raw_name());
   }
 
   void visit(ExternalFuncCallStmt *stmt) override {

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1196,7 +1196,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         TI_ASSERT(digits_snode->parent == exponent_snode->parent);
         auto exponent_bit_ptr =
             offset_bit_ptr(llvm_val[stmt->dest], exponent_snode->bit_offset -
-                                                    digits_snode->bit_offset);
+                                                     digits_snode->bit_offset);
         store_custom_int(exponent_bit_ptr, exponent_cit, exponent_bits);
         store_value = digit_bits;
 

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -957,7 +957,7 @@ void CodeGenLLVM::visit(KernelReturnStmt *stmt) {
 
 void CodeGenLLVM::visit(LocalLoadStmt *stmt) {
   TI_ASSERT(stmt->width() == 1);
-  llvm_val[stmt] = builder->CreateLoad(llvm_val[stmt->ptr[0].var]);
+  llvm_val[stmt] = builder->CreateLoad(llvm_val[stmt->src[0].var]);
 }
 
 void CodeGenLLVM::visit(LocalStoreStmt *stmt) {
@@ -965,7 +965,7 @@ void CodeGenLLVM::visit(LocalStoreStmt *stmt) {
   if (mask && stmt->width() != 1) {
     TI_NOT_IMPLEMENTED
   } else {
-    builder->CreateStore(llvm_val[stmt->data], llvm_val[stmt->ptr]);
+    builder->CreateStore(llvm_val[stmt->val], llvm_val[stmt->dest]);
   }
 }
 
@@ -1133,16 +1133,16 @@ void CodeGenLLVM::visit(GlobalPtrStmt *stmt) {
 
 void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
   TI_ASSERT(!stmt->parent->mask() || stmt->width() == 1);
-  TI_ASSERT(llvm_val[stmt->data]);
-  TI_ASSERT(llvm_val[stmt->ptr]);
-  auto ptr_type = stmt->ptr->ret_type->as<PointerType>();
+  TI_ASSERT(llvm_val[stmt->val]);
+  TI_ASSERT(llvm_val[stmt->dest]);
+  auto ptr_type = stmt->dest->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
     auto pointee_type = ptr_type->get_pointee_type();
     llvm::Value *store_value = nullptr;
     CustomIntType *cit = nullptr;
     if (auto cit_ = pointee_type->cast<CustomIntType>()) {
       cit = cit_;
-      store_value = llvm_val[stmt->data];
+      store_value = llvm_val[stmt->val];
     } else if (auto cft = pointee_type->cast<CustomFloatType>()) {
       llvm::Value *digit_bits = nullptr;
       auto digits_cit = cft->get_digits_type()->as<CustomIntType>();
@@ -1154,7 +1154,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         // f32 = 1 sign bit + 8 exponent bits + 23 fraction bits
 
         auto f32_bits = builder->CreateBitCast(
-            llvm_val[stmt->data], llvm::Type::getInt32Ty(*llvm_context));
+            llvm_val[stmt->val], llvm::Type::getInt32Ty(*llvm_context));
         // Rounding to nearest here. Note that if the digits overflows then the
         // carry-on will contribute to the exponent, which is desired.
         if (cft->get_digit_bits() < 23) {
@@ -1184,7 +1184,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
 
         auto exponent_cit = exp->as<CustomIntType>();
 
-        auto digits_snode = stmt->ptr->as<GetChStmt>()->output_snode;
+        auto digits_snode = stmt->dest->as<GetChStmt>()->output_snode;
         auto exponent_snode = digits_snode->exp_snode;
 
         auto exponent_offset = get_exponent_offset(exponent_bits, cft);
@@ -1195,7 +1195,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         // Compute the bit pointer of the exponent bits.
         TI_ASSERT(digits_snode->parent == exponent_snode->parent);
         auto exponent_bit_ptr =
-            offset_bit_ptr(llvm_val[stmt->ptr], exponent_snode->bit_offset -
+            offset_bit_ptr(llvm_val[stmt->dest], exponent_snode->bit_offset -
                                                     digits_snode->bit_offset);
         store_custom_int(exponent_bit_ptr, exponent_cit, exponent_bits);
         store_value = digit_bits;
@@ -1210,36 +1210,36 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         store_value = builder->CreateSelect(exp_non_zero, store_value,
                                             tlctx->get_constant(0));
       } else {
-        digit_bits = llvm_val[stmt->data];
+        digit_bits = llvm_val[stmt->val];
         store_value = float_to_custom_int(cft, digits_cit, digit_bits);
       }
       cit = digits_cit;
     } else {
       TI_NOT_IMPLEMENTED
     }
-    store_custom_int(llvm_val[stmt->ptr], cit, store_value);
+    store_custom_int(llvm_val[stmt->dest], cit, store_value);
   } else {
-    builder->CreateStore(llvm_val[stmt->data], llvm_val[stmt->ptr]);
+    builder->CreateStore(llvm_val[stmt->val], llvm_val[stmt->dest]);
   }
 }
 
 void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   int width = stmt->width();
   TI_ASSERT(width == 1);
-  auto ptr_type = stmt->ptr->ret_type->as<PointerType>();
+  auto ptr_type = stmt->src->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
     auto val_type = ptr_type->get_pointee_type();
     if (val_type->is<CustomIntType>()) {
-      llvm_val[stmt] = load_as_custom_int(llvm_val[stmt->ptr], val_type);
+      llvm_val[stmt] = load_as_custom_int(llvm_val[stmt->src], val_type);
     } else if (auto cft = val_type->cast<CustomFloatType>()) {
-      TI_ASSERT(stmt->ptr->is<GetChStmt>());
-      llvm_val[stmt] = load_custom_float(stmt->ptr);
+      TI_ASSERT(stmt->src->is<GetChStmt>());
+      llvm_val[stmt] = load_custom_float(stmt->src);
     } else {
       TI_NOT_IMPLEMENTED
     }
   } else {
     llvm_val[stmt] = builder->CreateLoad(tlctx->get_data_type(stmt->ret_type),
-                                         llvm_val[stmt->ptr]);
+                                         llvm_val[stmt->src]);
   }
 }
 

--- a/taichi/ir/state_machine.cpp
+++ b/taichi/ir/state_machine.cpp
@@ -29,14 +29,14 @@ bool StateMachine::same_data(Stmt *store_stmt1, Stmt *store_stmt2) {
     if (!store_stmt2->is<LocalStoreStmt>())
       return false;
     return irpass::analysis::same_statements(
-        store_stmt1->as<LocalStoreStmt>()->data,
-        store_stmt2->as<LocalStoreStmt>()->data);
+        store_stmt1->as<LocalStoreStmt>()->val,
+        store_stmt2->as<LocalStoreStmt>()->val);
   } else {
     if (!store_stmt2->is<GlobalStoreStmt>())
       return false;
     return irpass::analysis::same_statements(
-        store_stmt1->as<GlobalStoreStmt>()->data,
-        store_stmt2->as<GlobalStoreStmt>()->data);
+        store_stmt1->as<GlobalStoreStmt>()->val,
+        store_stmt2->as<GlobalStoreStmt>()->val);
   }
 }
 
@@ -146,9 +146,9 @@ void StateMachine::load(Stmt *load_stmt) {
   if (last_store_forwardable) {
     // store-forwarding
     if (last_store->is<LocalStoreStmt>())
-      load_stmt->replace_with(last_store->as<LocalStoreStmt>()->data);
+      load_stmt->replace_with(last_store->as<LocalStoreStmt>()->val);
     else
-      load_stmt->replace_with(last_store->as<GlobalStoreStmt>()->data);
+      load_stmt->replace_with(last_store->as<GlobalStoreStmt>()->val);
     load_stmt->parent->erase(load_stmt);
     throw IRModified();
   }

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -155,14 +155,14 @@ Stmt *LocalLoadStmt::previous_store_or_alloca_in_block() {
     if (parent->statements[i]->is<LocalStoreStmt>()) {
       auto store = parent->statements[i]->as<LocalStoreStmt>();
       // TI_ASSERT(store->width() == 1);
-      if (store->ptr == this->ptr[0].var) {
+      if (store->dest == this->src[0].var) {
         // found
         return store;
       }
     } else if (parent->statements[i]->is<AllocaStmt>()) {
       auto alloca = parent->statements[i]->as<AllocaStmt>();
       // TI_ASSERT(alloca->width() == 1);
-      if (alloca == this->ptr[0].var) {
+      if (alloca == this->src[0].var) {
         return alloca;
       }
     }
@@ -171,8 +171,8 @@ Stmt *LocalLoadStmt::previous_store_or_alloca_in_block() {
 }
 
 bool LocalLoadStmt::same_source() const {
-  for (int i = 1; i < (int)ptr.size(); i++) {
-    if (ptr[i].var != ptr[0].var)
+  for (int i = 1; i < (int)src.size(); i++) {
+    if (src[i].var != src[0].var)
       return false;
   }
   return true;
@@ -180,7 +180,7 @@ bool LocalLoadStmt::same_source() const {
 
 bool LocalLoadStmt::has_source(Stmt *alloca) const {
   for (int i = 0; i < width(); i++) {
-    if (ptr[i].var == alloca)
+    if (src[i].var == alloca)
       return true;
   }
   return false;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -364,9 +364,9 @@ class LoopUniqueStmt : public Stmt {
 
 class GlobalLoadStmt : public Stmt {
  public:
-  Stmt *ptr;
+  Stmt *src;
 
-  GlobalLoadStmt(Stmt *ptr) : ptr(ptr) {
+  GlobalLoadStmt(Stmt *src) : src(src) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -378,15 +378,15 @@ class GlobalLoadStmt : public Stmt {
     return false;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, ptr);
+  TI_STMT_DEF_FIELDS(ret_type, src);
   TI_DEFINE_ACCEPT_AND_CLONE;
 };
 
 class GlobalStoreStmt : public Stmt {
  public:
-  Stmt *ptr, *data;
+  Stmt *dest, *val;
 
-  GlobalStoreStmt(Stmt *ptr, Stmt *data) : ptr(ptr), data(data) {
+  GlobalStoreStmt(Stmt *dest, Stmt *val) : dest(dest), val(val) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -394,15 +394,15 @@ class GlobalStoreStmt : public Stmt {
     return false;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, ptr, data);
+  TI_STMT_DEF_FIELDS(ret_type, dest, val);
   TI_DEFINE_ACCEPT_AND_CLONE;
 };
 
 class LocalLoadStmt : public Stmt {
  public:
-  LaneAttribute<LocalAddress> ptr;
+  LaneAttribute<LocalAddress> src;
 
-  LocalLoadStmt(const LaneAttribute<LocalAddress> &ptr) : ptr(ptr) {
+  LocalLoadStmt(const LaneAttribute<LocalAddress> &src) : src(src) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -419,17 +419,17 @@ class LocalLoadStmt : public Stmt {
     return false;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, ptr);
+  TI_STMT_DEF_FIELDS(ret_type, src);
   TI_DEFINE_ACCEPT_AND_CLONE;
 };
 
 class LocalStoreStmt : public Stmt {
  public:
-  Stmt *ptr;
-  Stmt *data;
+  Stmt *dest;
+  Stmt *val;
 
-  LocalStoreStmt(Stmt *ptr, Stmt *data) : ptr(ptr), data(data) {
-    TI_ASSERT(ptr->is<AllocaStmt>());
+  LocalStoreStmt(Stmt *dest, Stmt *val) : dest(dest), val(val) {
+    TI_ASSERT(dest->is<AllocaStmt>());
     TI_STMT_REG_FIELDS;
   }
 
@@ -445,7 +445,7 @@ class LocalStoreStmt : public Stmt {
     return false;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, ptr, data);
+  TI_STMT_DEF_FIELDS(ret_type, dest, val);
   TI_DEFINE_ACCEPT_AND_CLONE;
 };
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -384,7 +384,8 @@ class GlobalLoadStmt : public Stmt {
 
 class GlobalStoreStmt : public Stmt {
  public:
-  Stmt *dest, *val;
+  Stmt *dest;
+  Stmt *val;
 
   GlobalStoreStmt(Stmt *dest, Stmt *val) : dest(dest), val(val) {
     TI_STMT_REG_FIELDS;

--- a/taichi/program/async_utils.cpp
+++ b/taichi/program/async_utils.cpp
@@ -159,16 +159,16 @@ TaskMeta *get_task_meta(IRBank *ir_bank, const TaskLaunchRecord &t) {
     // For a global load, GlobalPtrStmt has already been handled in
     // get_meta_input_value_states().
     if (auto global_store = stmt->cast<GlobalStoreStmt>()) {
-      if (auto ptr = global_store->ptr->cast<GlobalPtrStmt>()) {
-        for (auto &snode : ptr->snodes.data) {
+      if (auto dest = global_store->dest->cast<GlobalPtrStmt>()) {
+        for (auto &snode : dest->snodes.data) {
           meta.output_states.insert(
               ir_bank->get_async_state(snode, AsyncState::Type::value));
         }
       }
     }
     if (auto global_atomic = stmt->cast<AtomicOpStmt>()) {
-      if (auto ptr = global_atomic->dest->cast<GlobalPtrStmt>()) {
-        for (auto &snode : ptr->snodes.data) {
+      if (auto dest = global_atomic->dest->cast<GlobalPtrStmt>()) {
+        for (auto &snode : dest->snodes.data) {
           // input_state is already handled in
           // get_meta_input_value_states().
           meta.output_states.insert(

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -188,16 +188,18 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
 
   void visit(AllocaStmt *alloc) override {
     TI_ASSERT(alloc->width() == 1);
-    bool load_only =
-        irpass::analysis::gather_statements(alloc->parent, [&](Stmt *s) {
-          if (auto store = s->cast<LocalStoreStmt>())
-            return store->dest == alloc;
-          else if (auto atomic = s->cast<AtomicOpStmt>()) {
-            return atomic->dest == alloc;
-          } else {
-            return false;
-          }
-        }).empty();
+    bool load_only = irpass::analysis::gather_statements(
+                         alloc->parent,
+                         [&](Stmt *s) {
+                           if (auto store = s->cast<LocalStoreStmt>())
+                             return store->dest == alloc;
+                           else if (auto atomic = s->cast<AtomicOpStmt>()) {
+                             return atomic->dest == alloc;
+                           } else {
+                             return false;
+                           }
+                         })
+                         .empty();
     if (!load_only) {
       auto dtype = alloc->ret_type;
       auto stack_alloca = Stmt::make<StackAllocaStmt>(

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -188,18 +188,16 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
 
   void visit(AllocaStmt *alloc) override {
     TI_ASSERT(alloc->width() == 1);
-    bool load_only = irpass::analysis::gather_statements(
-                         alloc->parent,
-                         [&](Stmt *s) {
-                           if (auto store = s->cast<LocalStoreStmt>())
-                             return store->dest == alloc;
-                           else if (auto atomic = s->cast<AtomicOpStmt>()) {
-                             return atomic->dest == alloc;
-                           } else {
-                             return false;
-                           }
-                         })
-                         .empty();
+    bool load_only =
+        irpass::analysis::gather_statements(alloc->parent, [&](Stmt *s) {
+          if (auto store = s->cast<LocalStoreStmt>())
+            return store->dest == alloc;
+          else if (auto atomic = s->cast<AtomicOpStmt>()) {
+            return atomic->dest == alloc;
+          } else {
+            return false;
+          }
+        }).empty();
     if (!load_only) {
       auto dtype = alloc->ret_type;
       auto stack_alloca = Stmt::make<StackAllocaStmt>(

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -48,11 +48,11 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
     // TODO: remove this abuse since it *gathers nothing*
     irpass::analysis::gather_statements(block, [&](Stmt *stmt) -> bool {
       if (auto local_load = stmt->cast<LocalLoadStmt>(); local_load) {
-        for (auto &lane : local_load->ptr.data) {
+        for (auto &lane : local_load->src.data) {
           touched_allocas.insert(lane.var->as<AllocaStmt>());
         }
       } else if (auto local_store = stmt->cast<LocalStoreStmt>(); local_store) {
-        touched_allocas.insert(local_store->ptr->as<AllocaStmt>());
+        touched_allocas.insert(local_store->dest->as<AllocaStmt>());
       }
       return false;
     });
@@ -192,7 +192,7 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
                          alloc->parent,
                          [&](Stmt *s) {
                            if (auto store = s->cast<LocalStoreStmt>())
-                             return store->ptr == alloc;
+                             return store->dest == alloc;
                            else if (auto atomic = s->cast<AtomicOpStmt>()) {
                              return atomic->dest == alloc;
                            } else {
@@ -218,13 +218,13 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    if (stmt->ptr[0].var->is<StackAllocaStmt>())
-      stmt->replace_with(Stmt::make<StackLoadTopStmt>(stmt->ptr[0].var));
+    if (stmt->src[0].var->is<StackAllocaStmt>())
+      stmt->replace_with(Stmt::make<StackLoadTopStmt>(stmt->src[0].var));
   }
 
   void visit(LocalStoreStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    stmt->replace_with(Stmt::make<StackPushStmt>(stmt->ptr, stmt->data));
+    stmt->replace_with(Stmt::make<StackPushStmt>(stmt->dest, stmt->val));
   }
 };
 
@@ -647,9 +647,9 @@ class MakeAdjoint : public IRVisitor {
 
   void visit(GlobalLoadStmt *stmt) override {
     // issue global store to adjoint
-    GlobalPtrStmt *ptr = stmt->ptr->as<GlobalPtrStmt>();
-    TI_ASSERT(ptr->width() == 1);
-    auto snodes = ptr->snodes;
+    GlobalPtrStmt *src = stmt->src->as<GlobalPtrStmt>();
+    TI_ASSERT(src->width() == 1);
+    auto snodes = src->snodes;
     if (!snodes[0]->has_grad()) {
       // No adjoint SNode. Do nothing
       return;
@@ -660,36 +660,36 @@ class MakeAdjoint : public IRVisitor {
     }
     TI_ASSERT(snodes[0]->get_grad() != nullptr);
     snodes[0] = snodes[0]->get_grad();
-    auto adj_ptr = insert<GlobalPtrStmt>(snodes, ptr->indices);
+    auto adj_ptr = insert<GlobalPtrStmt>(snodes, src->indices);
     insert<AtomicOpStmt>(AtomicOpType::add, adj_ptr, load(adjoint(stmt)));
   }
 
   void visit(GlobalStoreStmt *stmt) override {
     // erase and replace with global load adjoint
-    GlobalPtrStmt *ptr = stmt->ptr->as<GlobalPtrStmt>();
-    TI_ASSERT(ptr->width() == 1);
-    auto snodes = ptr->snodes;
+    GlobalPtrStmt *dest = stmt->dest->as<GlobalPtrStmt>();
+    TI_ASSERT(dest->width() == 1);
+    auto snodes = dest->snodes;
     if (!snodes[0]->has_grad()) {
       // no gradient (likely integer types)
       return;
     }
     TI_ASSERT(snodes[0]->get_grad() != nullptr);
     snodes[0] = snodes[0]->get_grad();
-    auto adjoint_ptr = insert<GlobalPtrStmt>(snodes, ptr->indices);
+    auto adjoint_ptr = insert<GlobalPtrStmt>(snodes, dest->indices);
     auto load = insert<GlobalLoadStmt>(adjoint_ptr);
-    accumulate(stmt->data, load);
+    accumulate(stmt->val, load);
     stmt->parent->erase(stmt);
   }
 
   void visit(AtomicOpStmt *stmt) override {
     // erase and replace with global load adjoint
-    GlobalPtrStmt *ptr = stmt->dest->as<GlobalPtrStmt>();
-    TI_ASSERT(ptr->width() == 1);
-    auto snodes = ptr->snodes;
+    GlobalPtrStmt *dest = stmt->dest->as<GlobalPtrStmt>();
+    TI_ASSERT(dest->width() == 1);
+    auto snodes = dest->snodes;
     if (snodes[0]->has_grad()) {
       TI_ASSERT(snodes[0]->get_grad() != nullptr);
       snodes[0] = snodes[0]->get_grad();
-      auto adjoint_ptr = insert<GlobalPtrStmt>(snodes, ptr->indices);
+      auto adjoint_ptr = insert<GlobalPtrStmt>(snodes, dest->indices);
       accumulate(stmt->val, insert<GlobalLoadStmt>(adjoint_ptr));
     } else {
       // no gradient (likely integer types)

--- a/taichi/transforms/flag_access.cpp
+++ b/taichi/transforms/flag_access.cpp
@@ -51,8 +51,8 @@ class FlagAccess : public IRVisitor {
   }
 
   void visit(GlobalStoreStmt *stmt) {
-    if (stmt->ptr->is<GlobalPtrStmt>()) {
-      stmt->ptr->as<GlobalPtrStmt>()->activate = true;
+    if (stmt->dest->is<GlobalPtrStmt>()) {
+      stmt->dest->as<GlobalPtrStmt>()->activate = true;
     }
   }
 

--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -118,12 +118,12 @@ class BLSAnalysis : public BasicStmtVisitor {
   // Do not eliminate global data access
   void visit(GlobalLoadStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
-    record_access(stmt->ptr, AccessFlag::read);
+    record_access(stmt->src, AccessFlag::read);
   }
 
   void visit(GlobalStoreStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
-    record_access(stmt->ptr, AccessFlag::write);
+    record_access(stmt->dest, AccessFlag::write);
   }
 
   void visit(AtomicOpStmt *stmt) override {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -390,22 +390,22 @@ class IRPrinter : public IRVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     print("{}{} = local load [{}]", stmt->type_hint(), stmt->name(),
-          to_string(stmt->ptr));
+          to_string(stmt->src));
   }
 
   void visit(LocalStoreStmt *stmt) override {
     print("{}{} : local store [{} <- {}]", stmt->type_hint(), stmt->name(),
-          stmt->ptr->name(), stmt->data->name());
+          stmt->dest->name(), stmt->val->name());
   }
 
   void visit(GlobalLoadStmt *stmt) override {
     print("{}{} = global load {}", stmt->type_hint(), stmt->name(),
-          stmt->ptr->name());
+          stmt->src->name());
   }
 
   void visit(GlobalStoreStmt *stmt) override {
     print("{}{} : global store [{} <- {}]", stmt->type_hint(), stmt->name(),
-          stmt->ptr->name(), stmt->data->name());
+          stmt->dest->name(), stmt->val->name());
   }
 
   void visit(ElementShuffleStmt *stmt) override {

--- a/taichi/transforms/loop_vectorize.cpp
+++ b/taichi/transforms/loop_vectorize.cpp
@@ -89,17 +89,17 @@ class LoopVectorize : public IRVisitor {
       return;
     int original_width = stmt->width();
     widen_type(stmt->ret_type, vectorize);
-    stmt->ptr.repeat(vectorize);
+    stmt->src.repeat(vectorize);
     // TODO: this can be buggy
-    int stride = stmt->ptr[original_width - 1].offset + 1;
-    if (stmt->ptr[0].var->width() != 1) {
+    int stride = stmt->src[original_width - 1].offset + 1;
+    if (stmt->src[0].var->width() != 1) {
       for (int i = 0; i < vectorize; i++) {
         for (int j = 0; j < original_width; j++) {
-          stmt->ptr[i * original_width + j].offset += i * stride;
+          stmt->src[i * original_width + j].offset += i * stride;
         }
       }
     }
-    if (loop_var && stmt->same_source() && stmt->ptr[0].var == loop_var) {
+    if (loop_var && stmt->same_source() && stmt->src[0].var == loop_var) {
       // insert_before_me
       LaneAttribute<TypedConstant> const_offsets;
       const_offsets.resize(vectorize * original_width);

--- a/taichi/transforms/lower_access.cpp
+++ b/taichi/transforms/lower_access.cpp
@@ -197,21 +197,21 @@ class LowerAccess : public IRVisitor {
   }
 
   void visit(GlobalLoadStmt *stmt) override {
-    if (stmt->ptr->is<GlobalPtrStmt>()) {
+    if (stmt->src->is<GlobalPtrStmt>()) {
       // No need to activate for all read accesses
-      auto lowered = lower_vector_ptr(stmt->ptr->as<GlobalPtrStmt>(), false);
-      stmt->ptr = lowered.back().get();
+      auto lowered = lower_vector_ptr(stmt->src->as<GlobalPtrStmt>(), false);
+      stmt->src = lowered.back().get();
       modifier.insert_before(stmt, std::move(lowered));
     }
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    if (stmt->ptr->is<GlobalPtrStmt>()) {
-      auto ptr = stmt->ptr->as<GlobalPtrStmt>();
+    if (stmt->dest->is<GlobalPtrStmt>()) {
+      auto ptr = stmt->dest->as<GlobalPtrStmt>();
       // If ptr already has activate = false, no need to activate all the
       // generated micro-access ops. Otherwise, activate the nodes.
       auto lowered = lower_vector_ptr(ptr, ptr->activate);
-      stmt->ptr = lowered.back().get();
+      stmt->dest = lowered.back().get();
       modifier.insert_before(stmt, std::move(lowered));
     }
   }
@@ -246,9 +246,9 @@ class LowerAccess : public IRVisitor {
   }
 
   void visit(LocalStoreStmt *stmt) override {
-    if (stmt->data->is<GlobalPtrStmt>()) {
-      auto lowered = lower_vector_ptr(stmt->data->as<GlobalPtrStmt>(), true);
-      stmt->data = lowered.back().get();
+    if (stmt->val->is<GlobalPtrStmt>()) {
+      auto lowered = lower_vector_ptr(stmt->val->as<GlobalPtrStmt>(), true);
+      stmt->val = lowered.back().get();
       modifier.insert_before(stmt, std::move(lowered));
     }
   }

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -54,11 +54,11 @@ std::vector<T *> find_global_reduction_destinations(
     auto related_global_mem_ops =
         irpass::analysis::gather_statements(offload, [&](Stmt *stmt) {
           if (auto load = stmt->cast<GlobalLoadStmt>()) {
-            if (irpass::analysis::maybe_same_address(load->ptr, dest)) {
+            if (irpass::analysis::maybe_same_address(load->src, dest)) {
               return true;
             }
           } else if (auto store = stmt->cast<GlobalStoreStmt>()) {
-            if (irpass::analysis::maybe_same_address(store->ptr, dest)) {
+            if (irpass::analysis::maybe_same_address(store->dest, dest)) {
               return true;
             }
           } else if (auto atomic = stmt->cast<AtomicOpStmt>()) {

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -434,7 +434,7 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
   // Replace local LD/ST with global LD/ST
   void visit(LocalLoadStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    auto alloca = stmt->ptr[0].var;
+    auto alloca = stmt->src[0].var;
     if (local_to_global_offset.find(alloca) == local_to_global_offset.end())
       return;
 
@@ -450,10 +450,10 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
   }
 
   void visit(LocalStoreStmt *stmt) override {
-    if (visit_operand(stmt, stmt->locate_operand(&stmt->data)))
+    if (visit_operand(stmt, stmt->locate_operand(&stmt->val)))
       throw IRModified();
     TI_ASSERT(stmt->width() == 1);
-    auto alloca = stmt->ptr;
+    auto alloca = stmt->dest;
     if (local_to_global_offset.find(alloca) == local_to_global_offset.end())
       return;
 
@@ -462,7 +462,7 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
 
     auto ptr = replacement.push_back<GlobalTemporaryStmt>(
         local_to_global_offset[alloca], ret_type);
-    replacement.push_back<GlobalStoreStmt>(ptr, stmt->data);
+    replacement.push_back<GlobalStoreStmt>(ptr, stmt->val);
 
     stmt->parent->replace_with(stmt, std::move(replacement));
     throw IRModified();

--- a/taichi/transforms/optimize_bit_struct_stores.cpp
+++ b/taichi/transforms/optimize_bit_struct_stores.cpp
@@ -25,7 +25,7 @@ class CreateBitStructStores : public BasicStmtVisitor {
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    auto get_ch = stmt->ptr->cast<GetChStmt>();
+    auto get_ch = stmt->dest->cast<GetChStmt>();
     if (!get_ch || get_ch->input_snode->type != SNodeType::bit_struct)
       return;
 
@@ -41,7 +41,7 @@ class CreateBitStructStores : public BasicStmtVisitor {
         get_ch->output_snode->owns_shared_exponent) {
       auto s = Stmt::make<BitStructStoreStmt>(get_ch->input_ptr,
                                               std::vector<int>{get_ch->chid},
-                                              std::vector<Stmt *>{stmt->data});
+                                              std::vector<Stmt *>{stmt->val});
       stmt->replace_with(VecStatement(std::move(s)));
     }
   }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -81,35 +81,35 @@ class TypeCheck : public IRVisitor {
 
   void visit(LocalLoadStmt *stmt) {
     TI_ASSERT(stmt->width() == 1);
-    auto lookup = stmt->ptr[0].var->ret_type;
+    auto lookup = stmt->src[0].var->ret_type;
     stmt->ret_type = lookup;
   }
 
   void visit(LocalStoreStmt *stmt) {
-    if (stmt->ptr->ret_type->is_primitive(PrimitiveTypeID::unknown)) {
+    if (stmt->dest->ret_type->is_primitive(PrimitiveTypeID::unknown)) {
       // Infer data type for alloca
-      stmt->ptr->ret_type = stmt->data->ret_type;
+      stmt->dest->ret_type = stmt->val->ret_type;
     }
     auto common_container_type =
-        promoted_type(stmt->ptr->ret_type, stmt->data->ret_type);
+        promoted_type(stmt->dest->ret_type, stmt->val->ret_type);
 
-    auto old_data = stmt->data;
-    if (stmt->ptr->ret_type != stmt->data->ret_type) {
-      stmt->data =
-          insert_type_cast_before(stmt, stmt->data, stmt->ptr->ret_type);
+    auto old_data = stmt->val;
+    if (stmt->dest->ret_type != stmt->val->ret_type) {
+      stmt->val =
+          insert_type_cast_before(stmt, stmt->val, stmt->dest->ret_type);
     }
-    if (stmt->ptr->ret_type != common_container_type) {
+    if (stmt->dest->ret_type != common_container_type) {
       TI_WARN(
           "[{}] Local store may lose precision (target = {}, value = {}) at",
-          stmt->name(), stmt->ptr->ret_data_type_name(),
+          stmt->name(), stmt->dest->ret_data_type_name(),
           old_data->ret_data_type_name(), stmt->id);
       TI_WARN("\n{}", stmt->tb);
     }
-    stmt->ret_type = stmt->ptr->ret_type;
+    stmt->ret_type = stmt->dest->ret_type;
   }
 
   void visit(GlobalLoadStmt *stmt) {
-    auto pointee_type = stmt->ptr->ret_type.ptr_removed();
+    auto pointee_type = stmt->src->ret_type.ptr_removed();
     if (auto bit_struct = pointee_type->cast<BitStructType>()) {
       stmt->ret_type = bit_struct->get_physical_type();
     } else {
@@ -159,21 +159,21 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(GlobalStoreStmt *stmt) {
-    auto dst_value_type = stmt->ptr->ret_type.ptr_removed();
+    auto dst_value_type = stmt->dest->ret_type.ptr_removed();
     if (dst_value_type->is<CustomIntType>() ||
         dst_value_type->is<CustomFloatType>()) {
       // We force the value type to be the compute_type of the bit pointer.
       // Casting from compute_type to physical_type is handled in codegen.
       dst_value_type = dst_value_type->get_compute_type();
     }
-    auto promoted = promoted_type(dst_value_type, stmt->data->ret_type);
-    auto input_type = stmt->data->ret_data_type_name();
-    if (dst_value_type != stmt->data->ret_type) {
-      stmt->data = insert_type_cast_before(stmt, stmt->data, dst_value_type);
+    auto promoted = promoted_type(dst_value_type, stmt->val->ret_type);
+    auto input_type = stmt->val->ret_data_type_name();
+    if (dst_value_type != stmt->val->ret_type) {
+      stmt->val = insert_type_cast_before(stmt, stmt->val, dst_value_type);
     }
     // TODO: do not use "promoted" here since u8 + u8 = i32 in C++ and storing
     // u8 to u8 leads to extra warnings.
-    if (dst_value_type != promoted && dst_value_type != stmt->data->ret_type) {
+    if (dst_value_type != promoted && dst_value_type != stmt->val->ret_type) {
       TI_WARN("[{}] Global store may lose precision: {} <- {}, at",
               stmt->name(), dst_value_type->to_string(), input_type);
       TI_WARN("\n{}", stmt->tb);

--- a/taichi/transforms/variable_optimization.cpp
+++ b/taichi/transforms/variable_optimization.cpp
@@ -134,18 +134,18 @@ class AllocaOptimize : public VariableOptimize {
 
   void visit(LocalStoreStmt *stmt) override {
     if (maybe_run)
-      get_state_machine(stmt->ptr).maybe_store(stmt);
+      get_state_machine(stmt->dest).maybe_store(stmt);
     else
-      get_state_machine(stmt->ptr).store(stmt);
+      get_state_machine(stmt->dest).store(stmt);
   }
 
   void visit(LocalLoadStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    TI_ASSERT(stmt->ptr[0].offset == 0);
+    TI_ASSERT(stmt->src[0].offset == 0);
     if (maybe_run)
-      get_state_machine(stmt->ptr[0].var).maybe_load();
+      get_state_machine(stmt->src[0].var).maybe_load();
     else
-      get_state_machine(stmt->ptr[0].var).load(stmt);
+      get_state_machine(stmt->src[0].var).load(stmt);
   }
 
   void visit(IfStmt *if_stmt) override {
@@ -248,21 +248,21 @@ class GlobalTempOptimize : public VariableOptimize {
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    if (!stmt->ptr->is<GlobalTemporaryStmt>())
+    if (!stmt->dest->is<GlobalTemporaryStmt>())
       return;
     if (maybe_run)
-      get_state_machine(stmt->ptr).maybe_store(stmt);
+      get_state_machine(stmt->dest).maybe_store(stmt);
     else
-      get_state_machine(stmt->ptr).store(stmt);
+      get_state_machine(stmt->dest).store(stmt);
   }
 
   void visit(GlobalLoadStmt *stmt) override {
-    if (!stmt->ptr->is<GlobalTemporaryStmt>())
+    if (!stmt->src->is<GlobalTemporaryStmt>())
       return;
     if (maybe_run)
-      get_state_machine(stmt->ptr).maybe_load();
+      get_state_machine(stmt->src).maybe_load();
     else
-      get_state_machine(stmt->ptr).load(stmt);
+      get_state_machine(stmt->src).load(stmt);
   }
 
   void visit(IfStmt *if_stmt) override {
@@ -393,13 +393,13 @@ class GlobalPtrOptimize : public VariableOptimize {
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    if (!stmt->ptr->is<GlobalPtrStmt>())
+    if (!stmt->dest->is<GlobalPtrStmt>())
       return;
     if (maybe_run)
-      get_state_machine(stmt->ptr).maybe_store(stmt);
+      get_state_machine(stmt->dest).maybe_store(stmt);
     else
-      get_state_machine(stmt->ptr).store(stmt);
-    auto dest = stmt->ptr->as<GlobalPtrStmt>();
+      get_state_machine(stmt->dest).store(stmt);
+    auto dest = stmt->dest->as<GlobalPtrStmt>();
     for (auto &var : state_machines[dest->snodes[0]->id]) {
       if (var.first != dest &&
           irpass::analysis::maybe_same_address(dest, var.first)) {
@@ -409,13 +409,13 @@ class GlobalPtrOptimize : public VariableOptimize {
   }
 
   void visit(GlobalLoadStmt *stmt) override {
-    if (!stmt->ptr->is<GlobalPtrStmt>())
+    if (!stmt->src->is<GlobalPtrStmt>())
       return;
     if (maybe_run)
-      get_state_machine(stmt->ptr).maybe_load();
+      get_state_machine(stmt->src).maybe_load();
     else
-      get_state_machine(stmt->ptr).load(stmt);
-    auto dest = stmt->ptr->as<GlobalPtrStmt>();
+      get_state_machine(stmt->src).load(stmt);
+    auto dest = stmt->src->as<GlobalPtrStmt>();
     for (auto &var : state_machines[dest->snodes[0]->id]) {
       if (var.first != dest &&
           irpass::analysis::maybe_same_address(dest, var.first)) {
@@ -540,30 +540,30 @@ class OtherVariableOptimize : public VariableOptimize {
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    if (stmt->ptr->is<GlobalTemporaryStmt>())
+    if (stmt->dest->is<GlobalTemporaryStmt>())
       return;
     if (maybe_run)
-      get_state_machine(stmt->ptr).maybe_store(stmt);
+      get_state_machine(stmt->dest).maybe_store(stmt);
     else
-      get_state_machine(stmt->ptr).store(stmt);
+      get_state_machine(stmt->dest).store(stmt);
     for (auto &var : state_machines) {
-      if (var.first != stmt->ptr &&
-          irpass::analysis::maybe_same_address(stmt->ptr, var.first)) {
+      if (var.first != stmt->dest &&
+          irpass::analysis::maybe_same_address(stmt->dest, var.first)) {
         var.second.maybe_store(stmt);
       }
     }
   }
 
   void visit(GlobalLoadStmt *stmt) override {
-    if (stmt->ptr->is<GlobalTemporaryStmt>())
+    if (stmt->src->is<GlobalTemporaryStmt>())
       return;
     if (maybe_run)
-      get_state_machine(stmt->ptr).maybe_load();
+      get_state_machine(stmt->src).maybe_load();
     else
-      get_state_machine(stmt->ptr).load(stmt);
+      get_state_machine(stmt->src).load(stmt);
     for (auto &var : state_machines) {
-      if (var.first != stmt->ptr &&
-          irpass::analysis::maybe_same_address(stmt->ptr, var.first)) {
+      if (var.first != stmt->src &&
+          irpass::analysis::maybe_same_address(stmt->src, var.first)) {
         var.second.maybe_load();
       }
     }

--- a/taichi/transforms/vector_split.cpp
+++ b/taichi/transforms/vector_split.cpp
@@ -118,12 +118,12 @@ class BasicBlockVectorSplit : public IRVisitor {
       if (stmt_->is<LocalLoadStmt>()) {
         auto stmt = stmt_->as<LocalLoadStmt>();
         for (int l = 0; l < stmt->width(); l++) {
-          auto *old_var = stmt->ptr[l].var;
+          auto *old_var = stmt->src[l].var;
           if (origin2split.find(old_var) != origin2split.end()) {
             auto new_var =
-                origin2split[old_var][stmt->ptr[l].offset / max_width];
-            stmt->ptr[l].var = new_var;
-            stmt->ptr[l].offset %= max_width;
+                origin2split[old_var][stmt->src[l].offset / max_width];
+            stmt->src[l].var = new_var;
+            stmt->src[l].offset %= max_width;
             // TI_WARN("replaced...");
           }
         }
@@ -183,7 +183,7 @@ class BasicBlockVectorSplit : public IRVisitor {
       int new_width = need_split ? max_width : stmt->width();
       ptr.reserve(new_width);
       for (int j = 0; j < new_width; j++) {
-        LocalAddress addr(stmt->ptr[lane_start(i) + j]);
+        LocalAddress addr(stmt->src[lane_start(i) + j]);
         if (origin2split.find(addr.var) == origin2split.end()) {
           ptr.push_back(addr);
         } else {
@@ -197,21 +197,21 @@ class BasicBlockVectorSplit : public IRVisitor {
 
   void visit(LocalStoreStmt *stmt) override {
     for (int i = 0; i < current_split_factor; i++) {
-      current_split[i] = Stmt::make<LocalStoreStmt>(lookup(stmt->ptr, i),
-                                                    lookup(stmt->data, i));
+      current_split[i] = Stmt::make<LocalStoreStmt>(lookup(stmt->dest, i),
+                                                    lookup(stmt->val, i));
     }
   }
 
   void visit(GlobalLoadStmt *stmt) override {
     for (int i = 0; i < current_split_factor; i++) {
-      current_split[i] = Stmt::make<GlobalLoadStmt>(lookup(stmt->ptr, i));
+      current_split[i] = Stmt::make<GlobalLoadStmt>(lookup(stmt->src, i));
     }
   }
 
   void visit(GlobalStoreStmt *stmt) override {
     for (int i = 0; i < current_split_factor; i++) {
-      current_split[i] = Stmt::make<GlobalStoreStmt>(lookup(stmt->ptr, i),
-                                                     lookup(stmt->data, i));
+      current_split[i] = Stmt::make<GlobalStoreStmt>(lookup(stmt->dest, i),
+                                                     lookup(stmt->val, i));
     }
   }
 


### PR DESCRIPTION
Related issue = #2193

This PR renames `GlobalLoadStmt/LocalLoadStmt::ptr -> src`, `GlobalStoreStmt/LocalStoreStmt::ptr -> dest`, `GlobalStoreStmt/LocalStoreStmt::data -> val`.

Also renames some local variables using these fields and changes a few comments.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
