### PR TITLE
[llvm] Well-behaved float64 random number generator for CPU and CUDA backends

### DIFF
--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1489,7 +1489,7 @@ f32 rand_f32(Context *context) {
 }
 
 f64 rand_f64(Context *context) {
-  return rand_f32(context);
+  return rand_u64(context) * (1.0 / 18446744073709551616.0);
 }
 
 i32 rand_i32(Context *context) {

--- a/tests/python/test_random.py
+++ b/tests/python/test_random.py
@@ -114,7 +114,7 @@ def test_random_f64():
     see #2251 for explanation.
     '''
     import numpy as np
-    n = int(2 ** 23)
+    n = int(2**23)
     x = ti.field(ti.f64, shape=n)
 
     @ti.kernel

--- a/tests/python/test_random.py
+++ b/tests/python/test_random.py
@@ -110,8 +110,8 @@ def test_random_seed_per_launch():
 @ti.test(arch=[ti.cpu, ti.cuda])
 def test_random_f64():
     '''
-    Tests the generation of well-behaved Float64 random numbers by granularity,
-    see #2251 for explanation.
+    Tests the granularity of float64 random numbers.
+    See https://github.com/taichi-dev/taichi/issues/2251 for an explanation.
     '''
     import numpy as np
     n = int(2**23)
@@ -123,5 +123,5 @@ def test_random_f64():
             x[i] = ti.random(dtype=ti.f64)
 
     foo()
-    diff = np.diff(np.sort(x.to_numpy()), 1)
-    assert np.min(diff) > 0
+    frac, _ = np.modf(x.to_numpy() * 4294967296)
+    assert np.max(frac) > 0


### PR DESCRIPTION
Related issue = #2251

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

- Added a test as described in #2251 for float64 random numbers.
- Changed `rand_f64(Context *context)` into the implementation similar to `rand_f32()`. 

Now both float32 and float64 uses multiplying the reciprocal of UINT_MAX + 1 method to obtain floating point numbers between 0 and 1 from unsigned integers. If necessary we can also discuss the specific choice of implementation of `rand_f32()` and `rand_f64()`. 
