### PR TITLE
[type] [opt] Use BitStructStoreStmt for CustomFloatType with non-shared exponents

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1137,6 +1137,8 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
   TI_ASSERT(llvm_val[stmt->dest]);
   auto ptr_type = stmt->dest->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
+    // TODO: Remove the support of bit struct stores here and
+    //  force to use BitStructStoreStmt instead.
     auto pointee_type = ptr_type->get_pointee_type();
     llvm::Value *store_value = nullptr;
     CustomIntType *cit = nullptr;
@@ -1197,7 +1199,8 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         auto exponent_bit_ptr =
             offset_bit_ptr(llvm_val[stmt->dest], exponent_snode->bit_offset -
                                                      digits_snode->bit_offset);
-        store_custom_int(exponent_bit_ptr, exponent_cit, exponent_bits);
+        store_custom_int(exponent_bit_ptr, exponent_cit, exponent_bits,
+                         /*atomic=*/true);
         store_value = digit_bits;
 
         // Here we implement flush to zero (FTZ): if exponent is zero, we force
@@ -1217,7 +1220,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
     } else {
       TI_NOT_IMPLEMENTED
     }
-    store_custom_int(llvm_val[stmt->dest], cit, store_value);
+    store_custom_int(llvm_val[stmt->dest], cit, store_value, /*atomic=*/true);
   } else {
     builder->CreateStore(llvm_val[stmt->val], llvm_val[stmt->dest]);
   }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1137,89 +1137,21 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
   TI_ASSERT(llvm_val[stmt->dest]);
   auto ptr_type = stmt->dest->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
-    // TODO: Remove the support of bit struct stores here and
-    //  force to use BitStructStoreStmt instead.
     auto pointee_type = ptr_type->get_pointee_type();
-    llvm::Value *store_value = nullptr;
-    CustomIntType *cit = nullptr;
-    if (auto cit_ = pointee_type->cast<CustomIntType>()) {
-      cit = cit_;
-      store_value = llvm_val[stmt->val];
-    } else if (auto cft = pointee_type->cast<CustomFloatType>()) {
-      llvm::Value *digit_bits = nullptr;
-      auto digits_cit = cft->get_digits_type()->as<CustomIntType>();
-      if (auto exp = cft->get_exponent_type()) {
-        // Extract exponent and digits from compute type (assumed to be f32 for
-        // now).
-        TI_ASSERT(cft->get_compute_type()->is_primitive(PrimitiveTypeID::f32));
-
-        // f32 = 1 sign bit + 8 exponent bits + 23 fraction bits
-
-        auto f32_bits = builder->CreateBitCast(
-            llvm_val[stmt->val], llvm::Type::getInt32Ty(*llvm_context));
-        // Rounding to nearest here. Note that if the digits overflows then the
-        // carry-on will contribute to the exponent, which is desired.
-        if (cft->get_digit_bits() < 23) {
-          f32_bits = builder->CreateAdd(
-              f32_bits, tlctx->get_constant(1 << (22 - cft->get_digit_bits())));
-        }
-
-        auto exponent_bits = builder->CreateAShr(f32_bits, 23);
-        exponent_bits = builder->CreateAnd(exponent_bits,
-                                           tlctx->get_constant((1 << 8) - 1));
-        auto value_bits = builder->CreateAShr(
-            f32_bits, tlctx->get_constant(23 - cft->get_digit_bits()));
-
-        digit_bits = builder->CreateAnd(
-            value_bits,
-            tlctx->get_constant((1 << (cft->get_digit_bits())) - 1));
-
-        if (cft->get_is_signed()) {
-          // extract the sign bit
-          auto sign_bit =
-              builder->CreateAnd(f32_bits, tlctx->get_constant(0x80000000u));
-          // insert the sign bit to digit bits
-          digit_bits = builder->CreateOr(
-              digit_bits,
-              builder->CreateLShr(sign_bit, 31 - cft->get_digit_bits()));
-        }
-
-        auto exponent_cit = exp->as<CustomIntType>();
-
-        auto digits_snode = stmt->dest->as<GetChStmt>()->output_snode;
-        auto exponent_snode = digits_snode->exp_snode;
-
-        auto exponent_offset = get_exponent_offset(exponent_bits, cft);
-        exponent_bits = builder->CreateSub(exponent_bits, exponent_offset);
-        exponent_bits =
-            create_call("max_i32", {exponent_bits, tlctx->get_constant(0)});
-
-        // Compute the bit pointer of the exponent bits.
-        TI_ASSERT(digits_snode->parent == exponent_snode->parent);
-        auto exponent_bit_ptr =
-            offset_bit_ptr(llvm_val[stmt->dest], exponent_snode->bit_offset -
-                                                     digits_snode->bit_offset);
-        store_custom_int(exponent_bit_ptr, exponent_cit, exponent_bits,
-                         /*atomic=*/true);
-        store_value = digit_bits;
-
-        // Here we implement flush to zero (FTZ): if exponent is zero, we force
-        // the digits to be zero.
-        // TODO: it seems that this can be more efficiently implemented using a
-        // bit_and.
-        auto exp_non_zero =
-            builder->CreateICmp(llvm::CmpInst::Predicate::ICMP_NE,
-                                exponent_bits, tlctx->get_constant(0));
-        store_value = builder->CreateSelect(exp_non_zero, store_value,
-                                            tlctx->get_constant(0));
+    if (!pointee_type->is<CustomIntType>()) {
+      if (stmt->dest->as<GetChStmt>()->input_snode->type ==
+          SNodeType::bit_struct) {
+        TI_ERROR(
+            "Bit struct stores with type {} should have been "
+            "handled by BitStructStoreStmt.",
+            pointee_type->to_string());
       } else {
-        digit_bits = llvm_val[stmt->val];
-        store_value = float_to_custom_int(cft, digits_cit, digit_bits);
+        TI_ERROR("Bit array only supports custom int type.");
       }
-      cit = digits_cit;
-    } else {
-      TI_NOT_IMPLEMENTED
     }
+    llvm::Value *store_value = nullptr;
+    auto *cit = pointee_type->as<CustomIntType>();
+    store_value = llvm_val[stmt->val];
     store_custom_int(llvm_val[stmt->dest], cit, store_value, /*atomic=*/true);
   } else {
     builder->CreateStore(llvm_val[stmt->val], llvm_val[stmt->dest]);

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -211,12 +211,14 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void store_custom_int(llvm::Value *bit_ptr,
                         CustomIntType *cit,
-                        llvm::Value *value);
+                        llvm::Value *value,
+                        bool atomic);
 
   void store_custom_int(llvm::Value *byte_ptr,
                         llvm::Value *bit_offset,
                         CustomIntType *cit,
-                        llvm::Value *value);
+                        llvm::Value *value,
+                        bool atomic);
 
   void store_masked(llvm::Value *byte_ptr,
                     uint64 mask,

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -148,18 +148,14 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       bit_struct_snode->dt->as<BitStructType>()->get_physical_type();
 
   bool has_shared_exponent = false;
-  bool has_non_shared_exponent = false;
   for (auto ch_id : stmt->ch_ids) {
     if (bit_struct_snode->ch[ch_id]->owns_shared_exponent) {
       has_shared_exponent = true;
-    } else {
-      has_non_shared_exponent = true;
     }
   }
 
   if (has_shared_exponent) {
     store_floats_with_shared_exponents(stmt);
-    return;
   }
 
   llvm::Value *bit_struct_val = nullptr;

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -69,19 +69,21 @@ llvm::Value *CodeGenLLVM::float_to_custom_int(CustomFloatType *cft,
 
 void CodeGenLLVM::store_custom_int(llvm::Value *bit_ptr,
                                    CustomIntType *cit,
-                                   llvm::Value *value) {
+                                   llvm::Value *value,
+                                   bool atomic) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(bit_ptr);
-  store_custom_int(byte_ptr, bit_offset, cit, value);
+  store_custom_int(byte_ptr, bit_offset, cit, value, atomic);
 }
 
 void CodeGenLLVM::store_custom_int(llvm::Value *byte_ptr,
                                    llvm::Value *bit_offset,
                                    CustomIntType *cit,
-                                   llvm::Value *value) {
+                                   llvm::Value *value,
+                                   bool atomic) {
   // TODO(type): CUDA only supports atomicCAS on 32- and 64-bit integers.
   // Try to support CustomInt/FloatType with 8/16-bit physical
   // types.
-  create_call(fmt::format("set_partial_bits_b{}",
+  create_call(fmt::format("{}set_partial_bits_b{}", atomic ? "atomic_" : "",
                           data_type_bits(cit->get_physical_type())),
               {builder->CreateBitCast(byte_ptr,
                                       llvm_ptr_type(cit->get_physical_type())),
@@ -146,9 +148,12 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       bit_struct_snode->dt->as<BitStructType>()->get_physical_type();
 
   bool has_shared_exponent = false;
+  bool has_non_shared_exponent = false;
   for (auto ch_id : stmt->ch_ids) {
     if (bit_struct_snode->ch[ch_id]->owns_shared_exponent) {
       has_shared_exponent = true;
+    } else {
+      has_non_shared_exponent = true;
     }
   }
 
@@ -162,9 +167,87 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
     auto ch_id = stmt->ch_ids[i];
     auto val = llvm_val[stmt->values[i]];
     auto &ch = bit_struct_snode->ch[ch_id];
+    if (ch->owns_shared_exponent) {
+      // already handled in store_floats_with_shared_exponents
+      continue;
+    }
     auto dtype = ch->dt;
-    val = custom_type_to_bits(val, dtype, bit_struct_physical_type);
-    val = builder->CreateShl(val, bit_struct_snode->ch[ch_id]->bit_offset);
+
+    if (dtype->is<CustomFloatType>() &&
+        dtype->as<CustomFloatType>()->get_exponent_type() != nullptr) {
+      // Custom float type with non-shared exponent.
+      auto cft = dtype->as<CustomFloatType>();
+      llvm::Value *digit_bits = nullptr;
+      // Extract exponent and digits from compute type (assumed to be f32 for
+      // now).
+      TI_ASSERT(cft->get_compute_type()->is_primitive(PrimitiveTypeID::f32));
+
+      // f32 = 1 sign bit + 8 exponent bits + 23 fraction bits
+
+      auto f32_bits =
+          builder->CreateBitCast(val, llvm::Type::getInt32Ty(*llvm_context));
+      // Rounding to nearest here. Note that if the digits overflows then the
+      // carry-on will contribute to the exponent, which is desired.
+      if (cft->get_digit_bits() < 23) {
+        f32_bits = builder->CreateAdd(
+            f32_bits, tlctx->get_constant(1 << (22 - cft->get_digit_bits())));
+      }
+
+      auto exponent_bits = builder->CreateAShr(f32_bits, 23);
+      exponent_bits =
+          builder->CreateAnd(exponent_bits, tlctx->get_constant((1 << 8) - 1));
+      auto value_bits = builder->CreateAShr(
+          f32_bits, tlctx->get_constant(23 - cft->get_digit_bits()));
+
+      digit_bits = builder->CreateAnd(
+          value_bits, tlctx->get_constant((1 << (cft->get_digit_bits())) - 1));
+
+      if (cft->get_is_signed()) {
+        // extract the sign bit
+        auto sign_bit =
+            builder->CreateAnd(f32_bits, tlctx->get_constant(0x80000000u));
+        // insert the sign bit to digit bits
+        digit_bits = builder->CreateOr(
+            digit_bits,
+            builder->CreateLShr(sign_bit, 31 - cft->get_digit_bits()));
+      }
+
+      auto digits_snode = ch.get();
+      auto exponent_snode = digits_snode->exp_snode;
+
+      auto exponent_offset = get_exponent_offset(exponent_bits, cft);
+      exponent_bits = builder->CreateSub(exponent_bits, exponent_offset);
+      exponent_bits =
+          create_call("max_i32", {exponent_bits, tlctx->get_constant(0)});
+
+      // Compute the bit pointer of the exponent bits.
+      TI_ASSERT(digits_snode->parent == exponent_snode->parent);
+
+      val = builder->CreateBitCast(exponent_bits,
+                                   llvm_type(bit_struct_physical_type));
+      val = builder->CreateShl(val, exponent_snode->bit_offset);
+
+      if (bit_struct_val == nullptr) {
+        bit_struct_val = val;
+      } else {
+        bit_struct_val = builder->CreateOr(bit_struct_val, val);
+      }
+      // Here we implement flush to zero (FTZ): if exponent is zero, we force
+      // the digits to be zero.
+      // TODO: it seems that this can be more efficiently implemented using a
+      // bit_and.
+      auto exp_non_zero =
+          builder->CreateICmp(llvm::CmpInst::Predicate::ICMP_NE, exponent_bits,
+                              tlctx->get_constant(0));
+      val = builder->CreateSelect(exp_non_zero, value_bits,
+                                  tlctx->get_constant(0));
+      val = builder->CreateBitCast(val, llvm_type(bit_struct_physical_type));
+      val = builder->CreateShl(val, digits_snode->bit_offset);
+    } else {
+      val = custom_type_to_bits(val, dtype, bit_struct_physical_type);
+      val = builder->CreateShl(val, bit_struct_snode->ch[ch_id]->bit_offset);
+    }
+
     if (bit_struct_val == nullptr) {
       bit_struct_val = val;
     } else {
@@ -183,13 +266,18 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       auto dtype = ch->dt;
       CustomIntType *cit = nullptr;
       if (auto cft = dtype->cast<CustomFloatType>()) {
-        TI_ASSERT(cft->get_exponent_type() == nullptr);
+        if (cft->get_exponent_type() != nullptr) {
+          auto exp = cft->get_exponent_type();
+          auto exponent_cit = exp->as<CustomIntType>();
+          auto exponent_snode = ch->exp_snode;
+          update_mask(mask, exponent_cit->get_num_bits(),
+                      exponent_snode->bit_offset);
+        }
         cit = cft->get_digits_type()->as<CustomIntType>();
       } else {
         cit = dtype->as<CustomIntType>();
       }
-      update_mask(mask, cit->get_num_bits(),
-                  bit_struct_snode->ch[ch_id]->bit_offset);
+      update_mask(mask, cit->get_num_bits(), ch->bit_offset);
     }
     store_masked(llvm_val[stmt->ptr], mask, bit_struct_physical_type,
                  bit_struct_val, stmt->is_atomic);
@@ -302,6 +390,9 @@ void CodeGenLLVM::store_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
   }
   store_masked(llvm_val[stmt->ptr], mask, bit_struct_physical_type, masked_val,
                stmt->is_atomic);
+  // TODO: make sure stmt->is_atomic is false when there are also
+  //  non-shared exponent floats in this bit struct store and we store the
+  //  whole bit struct.
 }
 
 llvm::Value *CodeGenLLVM::extract_exponent_from_float(llvm::Value *f) {

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -97,8 +97,6 @@ void CodeGenLLVM::store_masked(llvm::Value *byte_ptr,
                                Type *physical_type,
                                llvm::Value *value,
                                bool atomic) {
-  TI_INFO("store_masked {} {} {} {}", mask, physical_type->to_string(),
-          data_type_bits(physical_type), atomic);
   if (!mask) {
     // do not store anything
     return;

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1599,6 +1599,12 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
                                                                               \
   void set_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits, u##N value) {   \
     u##N mask = ((~(u##N)0) << (N - bits)) >> (N - offset - bits);            \
+    set_mask_b##N(ptr, mask, value << offset);                                \
+  }                                                                           \
+                                                                              \
+  void atomic_set_partial_bits_b##N(u##N *ptr, u32 offset, u32 bits,          \
+                                    u##N value) {                             \
+    u##N mask = ((~(u##N)0) << (N - bits)) >> (N - offset - bits);            \
     atomic_set_mask_b##N(ptr, mask, value << offset);                         \
   }                                                                           \
                                                                               \

--- a/taichi/transforms/optimize_bit_struct_stores.cpp
+++ b/taichi/transforms/optimize_bit_struct_stores.cpp
@@ -29,21 +29,12 @@ class CreateBitStructStores : public BasicStmtVisitor {
     if (!get_ch || get_ch->input_snode->type != SNodeType::bit_struct)
       return;
 
-    // We only handle bit_struct pointers here. The currently supported data
-    // types are
-    // - CustomIntType
-    // - CustomFloatType without exponents
-    // - CustomFloatType with shared exponents
+    // We only handle bit_struct pointers here.
 
-    auto dtype = get_ch->output_snode->dt;
-    if (dtype->is<CustomIntType>() ||
-        dtype->as<CustomFloatType>()->get_exponent_type() == nullptr ||
-        get_ch->output_snode->owns_shared_exponent) {
-      auto s = Stmt::make<BitStructStoreStmt>(get_ch->input_ptr,
-                                              std::vector<int>{get_ch->chid},
-                                              std::vector<Stmt *>{stmt->val});
-      stmt->replace_with(VecStatement(std::move(s)));
-    }
+    auto s = Stmt::make<BitStructStoreStmt>(get_ch->input_ptr,
+                                            std::vector<int>{get_ch->chid},
+                                            std::vector<Stmt *>{stmt->val});
+    stmt->replace_with(VecStatement(std::move(s)));
   }
 };
 


### PR DESCRIPTION
Related issue = #1905 #2128

This PR adds support of CustomFloatType with non-shared exponents in BitStructStoreStmt.

Now the codegen workflow of BitStructStoreStmt looks like the follows:
1. Generate the code for all shared-exponent floating type stores (do not generate the code for non-shared exponent floating type stores here).
2. For each other store, generate the code, and bit_or it to `bit_struct_val`. For CustomFloatType with non-shared exponents, we need to generate the code of storing both the exponent and the fraction (code mainly copied from `visit(GlobalStoreStmt *)`).
3. Generate the mask of the bits stored in step 2.
4. If the mask is full, or if the BitStructStoreStmt itself is not atomic (probably because it's the only access to a loop index), generate a masked store; otherwise, generate an `__atomic_compare_exchange`.

We can remove the support of custom float type in GlobalStoreStmt to make the codebase cleaner <del>in the future</del> in this PR.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
