### PR TITLE
[ir] Move uniquely_accessed_bit_structs from compile_to_offloads to AnalysisManager

### DIFF
--- a/taichi/analysis/gather_uniquely_accessed_pointers.cpp
+++ b/taichi/analysis/gather_uniquely_accessed_pointers.cpp
@@ -1,3 +1,4 @@
+#include "taichi/analysis/gather_uniquely_accessed_pointers.h"
 #include "taichi/ir/ir.h"
 #include "taichi/ir/analysis.h"
 #include "taichi/ir/statements.h"
@@ -224,6 +225,9 @@ class UniquelyAccessedBitStructGatherer : public BasicStmtVisitor {
   }
 };
 
+const std::string GatherUniquelyAccessedBitStructsPass::id =
+    "GatherUniquelyAccessedBitStructsPass";
+
 namespace irpass::analysis {
 std::unordered_map<const SNode *, GlobalPtrStmt *>
 gather_uniquely_accessed_pointers(IRNode *root) {
@@ -231,10 +235,9 @@ gather_uniquely_accessed_pointers(IRNode *root) {
   return UniquelyAccessedSNodeSearcher::run(root);
 }
 
-std::unordered_map<OffloadedStmt *,
-                   std::unordered_map<const SNode *, GlobalPtrStmt *>>
-gather_uniquely_accessed_bit_structs(IRNode *root) {
-  return UniquelyAccessedBitStructGatherer::run(root);
+void gather_uniquely_accessed_bit_structs(IRNode *root, AnalysisManager *amgr) {
+  amgr->put_pass_result<GatherUniquelyAccessedBitStructsPass>(
+      {UniquelyAccessedBitStructGatherer::run(root)});
 }
 }  // namespace irpass::analysis
 

--- a/taichi/analysis/gather_uniquely_accessed_pointers.h
+++ b/taichi/analysis/gather_uniquely_accessed_pointers.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "taichi/ir/pass.h"
+
+namespace taichi {
+namespace lang {
+
+class GatherUniquelyAccessedBitStructsPass : public Pass {
+ public:
+  static const PassID id;
+
+  struct Result {
+    std::unordered_map<OffloadedStmt *,
+                       std::unordered_map<const SNode *, GlobalPtrStmt *>>
+        uniquely_accessed_bit_structs;
+  };
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "taichi/ir/ir.h"
+#include "taichi/ir/pass.h"
+#include "taichi/analysis/gather_uniquely_accessed_pointers.h"
 #include <atomic>
 #include <optional>
 #include <unordered_set>
@@ -101,9 +103,7 @@ std::pair<std::unordered_set<SNode *>, std::unordered_set<SNode *>>
 gather_snode_read_writes(IRNode *root);
 std::vector<Stmt *> gather_statements(IRNode *root,
                                       const std::function<bool(Stmt *)> &test);
-std::unordered_map<OffloadedStmt *,
-                   std::unordered_map<const SNode *, GlobalPtrStmt *>>
-gather_uniquely_accessed_bit_structs(IRNode *root);
+void gather_uniquely_accessed_bit_structs(IRNode *root, AnalysisManager *amgr);
 std::unordered_map<const SNode *, GlobalPtrStmt *>
 gather_uniquely_accessed_pointers(IRNode *root);
 std::unique_ptr<std::unordered_set<AtomicOpStmt *>> gather_used_atomics(

--- a/taichi/ir/pass.h
+++ b/taichi/ir/pass.h
@@ -70,8 +70,7 @@ class AnalysisManager {
       return nullptr;
     }
     using ResultModelT = AnalysisResultModel<typename PassT::Result>;
-    return &(
-        static_cast<std::unique_ptr<ResultModelT>>(result->second)->result);
+    return &(static_cast<ResultModelT *>(result->second.get())->result);
   }
 
   template <typename PassT>

--- a/taichi/ir/pass.h
+++ b/taichi/ir/pass.h
@@ -70,7 +70,8 @@ class AnalysisManager {
       return nullptr;
     }
     using ResultModelT = AnalysisResultModel<typename PassT::Result>;
-    return &(static_cast<std::unique_ptr<ResultModelT>>(result.second)->result);
+    return &(
+        static_cast<std::unique_ptr<ResultModelT>>(result->second)->result);
   }
 
   template <typename PassT>

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -7,6 +7,7 @@
 
 #include "taichi/ir/control_flow_graph.h"
 #include "taichi/ir/ir.h"
+#include "taichi/ir/pass.h"
 #include "taichi/transforms/check_out_of_bound.h"
 #include "taichi/transforms/constant_fold.h"
 #include "taichi/transforms/lower_access.h"
@@ -81,12 +82,9 @@ void demote_dense_struct_fors(IRNode *root);
 bool demote_atomics(IRNode *root, const CompileConfig &config);
 void reverse_segments(IRNode *root);  // for autograd
 void detect_read_only(IRNode *root);
-void optimize_bit_struct_stores(
-    IRNode *root,
-    const CompileConfig &config,
-    const std::unordered_map<OffloadedStmt *,
-                             std::unordered_map<const SNode *, GlobalPtrStmt *>>
-        &uniquely_accessed_bit_structs);
+void optimize_bit_struct_stores(IRNode *root,
+                                const CompileConfig &config,
+                                AnalysisManager *amgr);
 
 // compile_to_offloads does the basic compilation to create all the offloaded
 // tasks of a Taichi kernel. It's worth pointing out that this doesn't demote

--- a/taichi/transforms/optimize_bit_struct_stores.cpp
+++ b/taichi/transforms/optimize_bit_struct_stores.cpp
@@ -1,5 +1,6 @@
 #include "taichi/ir/analysis.h"
 #include "taichi/ir/ir.h"
+#include "taichi/ir/pass.h"
 #include "taichi/ir/statements.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/visitors.h"
@@ -200,12 +201,9 @@ class DemoteAtomicBitStructStores : public BasicStmtVisitor {
 TLANG_NAMESPACE_BEGIN
 
 namespace irpass {
-void optimize_bit_struct_stores(
-    IRNode *root,
-    const CompileConfig &config,
-    const std::unordered_map<OffloadedStmt *,
-                             std::unordered_map<const SNode *, GlobalPtrStmt *>>
-        &uniquely_accessed_bit_structs) {
+void optimize_bit_struct_stores(IRNode *root,
+                                const CompileConfig &config,
+                                AnalysisManager *amgr) {
   TI_AUTO_PROF;
   CreateBitStructStores::run(root);
   die(root);  // remove unused GetCh
@@ -213,7 +211,12 @@ void optimize_bit_struct_stores(
     MergeBitStructStores::run(root);
   }
   if (config.quant_opt_atomic_demotion) {
-    DemoteAtomicBitStructStores::run(root, uniquely_accessed_bit_structs);
+    auto *res = amgr->get_pass_result<GatherUniquelyAccessedBitStructsPass>();
+    TI_ASSERT_INFO(res,
+                   "The optimize_bit_struct_stores pass must be after the "
+                   "gather_uniquely_accessed_bit_structs pass when "
+                   "config.quant_opt_atomic_demotion is true.");
+    DemoteAtomicBitStructStores::run(root, res->uniquely_accessed_bit_structs);
   }
 }
 


### PR DESCRIPTION
Related issue = #2193 #2252

It seems that `std::unique_ptr` cannot be `static_cast` in `get_pass_result()` so I cast the raw pointer instead.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
