### PR TITLE
[opt] Avoid recursively generating indices twice for BLS

### DIFF
--- a/taichi/analysis/value_diff.cpp
+++ b/taichi/analysis/value_diff.cpp
@@ -46,13 +46,15 @@ class ValueDiffLoopIndex : public IRVisitor {
   void visit(LoopIndexStmt *stmt) override {
     results[stmt->instance_id] = DiffRange();
     if (stmt->loop == loop && stmt->index == loop_index) {
-      results[stmt->instance_id] = DiffRange(/*related=*/true, /*coeff=*/1, /*low=*/0);
+      results[stmt->instance_id] =
+          DiffRange(/*related=*/true, /*coeff=*/1, /*low=*/0);
     } else if (auto range_for = stmt->loop->cast<RangeForStmt>()) {
       if (range_for->begin->is<ConstStmt>() &&
           range_for->end->is<ConstStmt>()) {
         results[stmt->instance_id] = DiffRange(
-            true, 0, range_for->begin->as<ConstStmt>()->val[0].val_int(),
-            range_for->end->as<ConstStmt>()->val[0].val_int());
+            /*related=*/true, /*coeff=*/0,
+            /*low=*/range_for->begin->as<ConstStmt>()->val[0].val_int(),
+            /*high=*/range_for->end->as<ConstStmt>()->val[0].val_int());
       }
     }
   }

--- a/taichi/analysis/value_diff.cpp
+++ b/taichi/analysis/value_diff.cpp
@@ -46,7 +46,7 @@ class ValueDiffLoopIndex : public IRVisitor {
   void visit(LoopIndexStmt *stmt) override {
     results[stmt->instance_id] = DiffRange();
     if (stmt->loop == loop && stmt->index == loop_index) {
-      results[stmt->instance_id] = DiffRange(true, 1, 0);
+      results[stmt->instance_id] = DiffRange(/*related=*/true, /*coeff=*/1, /*low=*/0);
     } else if (auto range_for = stmt->loop->cast<RangeForStmt>()) {
       if (range_for->begin->is<ConstStmt>() &&
           range_for->end->is<ConstStmt>()) {

--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -47,7 +47,7 @@ class BLSAnalysis : public BasicStmtVisitor {
 
   // Generate the index bounds in a SNode (block). E.g., a dense(ti.ij, (2, 4))
   // SNode has index bounds [[0, 1], [0, 3]].
-  static void generate_block_indices(SNode *snode, BlockIndices &indices) {
+  static void generate_block_indices(SNode *snode, BlockIndices *indices) {
     // NOTE: Assuming not vectorized
     for (int i = 0; i < snode->num_active_indices; i++) {
       auto j = snode->physical_index_position[i];

--- a/tests/python/test_bls.py
+++ b/tests/python/test_bls.py
@@ -162,10 +162,8 @@ def test_bls_large_block():
         ti.block_local(a)
         for i, j in a:
             for k in range(stencil_length):
-                ik = ti.assume_in_range(i + k, i, 0, stencil_length)
-                jk = ti.assume_in_range(j + k, j, 0, stencil_length)
-                b[i, j] += a[ik, j]  # TODO: use i + k instead
-                b[i, j] += a[i, jk]  # TODO: use j + k instead
+                b[i, j] += a[i + k, j]
+                b[i, j] += a[i, j + k]
 
     foo()
 

--- a/tests/python/test_bls.py
+++ b/tests/python/test_bls.py
@@ -147,8 +147,8 @@ def test_multiple_inputs():
 @ti.all_archs
 def test_bls_large_block():
     n = 2**10
-    block_size = 2**5
-    stencil_length = 2**5
+    block_size = 32
+    stencil_length = 28  # uses 60 * 60 * 4B = 14.0625KiB shared memory
 
     a = ti.field(dtype=ti.f32)
     b = ti.field(dtype=ti.f32)


### PR DESCRIPTION
Related issue = #1394

`generate_block_indices()` generates indices which actually form a cube, so we can use the lower/upper bounds directly without generating the indices.

Also slightly improves value_diff.cpp in the `LoopIndexStmt` case.


<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
