### PR TITLE
[misc] Support Python 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
           - os: macos-latest
             python: 3.8
             with_cc: OFF
+          - os: macos-latest
+            python: 3.9
+            with_cc: OFF
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.8.1 && PYTHON=python3"
 
-
 skip_commits:
   files:
     - '*.md'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
     osx_image: xcode10.3
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.8.1 && PYTHON=python3"
+  - name: "OS X + Python 3.9"
+    if: commit_message =~ /^\[release\]/
+    os: osx
+    osx_image: xcode10.3
+    env:
+      - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.9.1 && PYTHON=python3"
 
 skip_commits:
   files:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,7 @@ matrix:
     osx_image: xcode10.3
     env:
       - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.8.1 && PYTHON=python3"
-  - name: "OS X + Python 3.9"
-    if: commit_message =~ /^\[release\]/
-    os: osx
-    osx_image: xcode10.3
-    env:
-      - MATRIX_EVAL="CC=clang && CXX=clang++ && PYTHON_VERSION=3.9.1 && PYTHON=python3"
+
 
 skip_commits:
   files:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Advanced features of Taichi include [spatially sparse computing](https://taichi.
 python3 -m pip install taichi
 ```
 
-**Supported OS**: Windows, Linux, Mac OS X; **Python**: 3.6/3.7/3.8 (64-bit only); **Backends**: x64 CPUs, CUDA, Apple Metal, OpenGL Compute Shaders.
+**Supported OS**: Windows, Linux, Mac OS X; **Python**: 3.6/3.7/3.8 (64-bit only)/3.9 (64-bit only); **Backends**: x64 CPUs, CUDA, Apple Metal, OpenGL Compute Shaders.
 
 Please build from source for other configurations (e.g., your CPU is ARM, or you want to try out our experimental C backend).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ environment:
     - PYTHON: C:\Python36-x64\python.exe
     - PYTHON: C:\Python37-x64\python.exe
     - PYTHON: C:\Python38-x64\python.exe
+    - PYTHON: C:\Python39-x64\python.exe
 
 skip_commits:
   files:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
 ]
 
 data_files = glob.glob('python/lib/*')


### PR DESCRIPTION
Related issue = #1057

If there exist no compatibility problems like issue #1057, taichi can possibly support python3.9.  

Since the version of the python interpreter of some softwares (like Blender 2.93) has updated to 3.9, it will facilitate the development of taichi-based addons if python3.9 can be officially supported by taichi . For now, given taichi cannot be installed with python3.9 by pip, addon developers have to build and pack taichi with python3.9 by themselves, which blocks the distribution of taichi-based products.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #1057
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
