### PR TITLE
[ir] Rename is_np_array to is_external_array except the frontend

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -59,7 +59,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       // want to modify.
       Kernel::LaunchContextBuilder ctx_builder(kernel, &context);
       for (int i = 0; i < (int)args.size(); i++) {
-        if (args[i].is_nparray) {
+        if (args[i].is_external_array) {
           has_buffer = true;
           // replace host buffer with device buffer
           host_buffers[i] = context.get_arg<void *>(i);
@@ -90,7 +90,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
         CUDADriver::get_instance().stream_synchronize(nullptr);
       }
       for (int i = 0; i < (int)args.size(); i++) {
-        if (args[i].is_nparray && args[i].size > 0) {
+        if (args[i].is_external_array && args[i].size > 0) {
           CUDADriver::get_instance().memcpy_device_to_host(
               host_buffers[i], (void *)device_buffers[i], args[i].size);
           CUDADriver::get_instance().mem_free((void *)device_buffers[i]);

--- a/taichi/backends/metal/kernel_util.cpp
+++ b/taichi/backends/metal/kernel_util.cpp
@@ -69,7 +69,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
       TI_ERROR("Metal kernel only supports <= 32-bit data, got {}",
                metal_data_type_name(ma.dt));
     }
-    ma.is_array = ka.is_nparray;
+    ma.is_array = ka.is_external_array;
     ma.stride = ma.is_array ? ka.size : dt_bytes;
     ma.index = arg_attribs_vec_.size();
     arg_attribs_vec_.push_back(ma);

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -461,7 +461,7 @@ struct CompiledProgram::Impl {
     arg_count = kernel->args.size();
     ret_count = kernel->rets.size();
     for (int i = 0; i < arg_count; i++) {
-      if (kernel->args[i].is_nparray) {
+      if (kernel->args[i].is_external_array) {
         ext_arr_map[i] = kernel->args[i].size;
       }
     }

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -171,7 +171,7 @@ Kernel::LaunchContextBuilder::LaunchContextBuilder(Kernel *kernel)
 
 void Kernel::LaunchContextBuilder::set_arg_float(int i, float64 d) {
   TI_ASSERT_INFO(
-      !kernel_->args[i].is_nparray,
+      !kernel_->args[i].is_external_array,
       "Assigning a scalar value to a numpy array argument is not allowed");
 
   ActionRecorder::get_instance().record(
@@ -206,7 +206,7 @@ void Kernel::LaunchContextBuilder::set_arg_float(int i, float64 d) {
 
 void Kernel::LaunchContextBuilder::set_arg_int(int i, int64 d) {
   TI_ASSERT_INFO(
-      !kernel_->args[i].is_nparray,
+      !kernel_->args[i].is_external_array,
       "Assigning scalar value to numpy array argument is not allowed");
 
   ActionRecorder::get_instance().record(
@@ -247,7 +247,7 @@ void Kernel::LaunchContextBuilder::set_extra_arg_int(int i, int j, int32 d) {
 void Kernel::LaunchContextBuilder::set_arg_nparray(int i,
                                                    uint64 ptr,
                                                    uint64 size) {
-  TI_ASSERT_INFO(kernel_->args[i].is_nparray,
+  TI_ASSERT_INFO(kernel_->args[i].is_external_array,
                  "Assigning numpy array to scalar argument is not allowed");
 
   ActionRecorder::get_instance().record(
@@ -262,7 +262,7 @@ void Kernel::LaunchContextBuilder::set_arg_nparray(int i,
 
 void Kernel::LaunchContextBuilder::set_arg_raw(int i, uint64 d) {
   TI_ASSERT_INFO(
-      !kernel_->args[i].is_nparray,
+      !kernel_->args[i].is_external_array,
       "Assigning scalar value to numpy array argument is not allowed");
 
   if (!kernel_->is_evaluator) {
@@ -337,8 +337,8 @@ void Kernel::set_arch(Arch arch) {
   this->arch = arch;
 }
 
-int Kernel::insert_arg(DataType dt, bool is_nparray) {
-  args.push_back(Arg{dt->get_compute_type(), is_nparray, /*size=*/0});
+int Kernel::insert_arg(DataType dt, bool is_external_array) {
+  args.push_back(Arg{dt->get_compute_type(), is_external_array, /*size=*/0});
   return args.size() - 1;
 }
 

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -27,13 +27,13 @@ class Kernel {
 
   struct Arg {
     DataType dt;
-    bool is_nparray;
+    bool is_external_array;
     std::size_t size;
 
     Arg(DataType dt = PrimitiveType::unknown,
-        bool is_nparray = false,
+        bool is_external_array = false,
         std::size_t size = 0)
-        : dt(dt), is_nparray(is_nparray), size(size) {
+        : dt(dt), is_external_array(is_external_array), size(size) {
     }
   };
 
@@ -103,7 +103,7 @@ class Kernel {
 
   LaunchContextBuilder make_launch_context();
 
-  int insert_arg(DataType dt, bool is_nparray);
+  int insert_arg(DataType dt, bool is_external_array);
 
   int insert_ret(DataType dt);
 

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -107,7 +107,7 @@ TEST(IRBuilder, ExternalPtr) {
   builder.create_global_store(a2ptr, a0plusa2);  // a[2] = a[0] + a[2]
   auto block = builder.extract_ir();
   auto ker = std::make_unique<Kernel>(prog, std::move(block));
-  ker->insert_arg(get_data_type<int>(), /*is_nparray=*/true);
+  ker->insert_arg(get_data_type<int>(), /*is_external_array=*/true);
   auto launch_ctx = ker->make_launch_context();
   launch_ctx.set_arg_nparray(0, (uint64)array.get(), size);
   (*ker)(launch_ctx);


### PR DESCRIPTION
Related issue = #2193 

At the CHI level, the name `is_np_array` doesn't make sense since we don't know and don't care if the external array is from numpy. However, at the frontend, the external array is from numpy.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
