### PR TITLE
[test] Add a test for range analysis of indices of reversed loops

### DIFF
--- a/taichi/analysis/value_diff.cpp
+++ b/taichi/analysis/value_diff.cpp
@@ -51,10 +51,12 @@ class ValueDiffLoopIndex : public IRVisitor {
     } else if (auto range_for = stmt->loop->cast<RangeForStmt>()) {
       if (range_for->begin->is<ConstStmt>() &&
           range_for->end->is<ConstStmt>()) {
+        auto begin_val = range_for->begin->as<ConstStmt>()->val[0].val_int();
+        auto end_val = range_for->end->as<ConstStmt>()->val[0].val_int();
         results[stmt->instance_id] = DiffRange(
             /*related=*/true, /*coeff=*/0,
-            /*low=*/range_for->begin->as<ConstStmt>()->val[0].val_int(),
-            /*high=*/range_for->end->as<ConstStmt>()->val[0].val_int());
+            /*low=*/std::min(begin_val, end_val - 1),
+            /*high=*/std::max(begin_val + 1, end_val));
       }
     }
   }

--- a/taichi/analysis/value_diff.cpp
+++ b/taichi/analysis/value_diff.cpp
@@ -53,10 +53,10 @@ class ValueDiffLoopIndex : public IRVisitor {
           range_for->end->is<ConstStmt>()) {
         auto begin_val = range_for->begin->as<ConstStmt>()->val[0].val_int();
         auto end_val = range_for->end->as<ConstStmt>()->val[0].val_int();
+        // We have begin_val <= end_val even when range_for->reversed is true:
+        // in that case, the loop is iterated from end_val - 1 to begin_val.
         results[stmt->instance_id] = DiffRange(
-            /*related=*/true, /*coeff=*/0,
-            /*low=*/std::min(begin_val, end_val - 1),
-            /*high=*/std::max(begin_val + 1, end_val));
+            /*related=*/true, /*coeff=*/0, /*low=*/begin_val, /*high=*/end_val);
       }
     }
   }


### PR DESCRIPTION
Related issue = #2272

Reversed loops only appear in AutoDiff for now, and BLS uses `value_diff` to analyze the BLS range, so I write a test for AutoDiff + BLS.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
