### PR TITLE
[ir] Rename set_arg_nparray to set_arg_external_array

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -71,8 +71,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
             CUDADriver::get_instance().memcpy_host_to_device(
                 (void *)device_buffers[i], host_buffers[i], args[i].size);
           }
-          ctx_builder.set_arg_nparray(i, (uint64)device_buffers[i],
-                                      args[i].size);
+          ctx_builder.set_arg_external_array(i, (uint64)device_buffers[i],
+                                             args[i].size);
         }
       }
       if (has_buffer) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -170,9 +170,9 @@ Kernel::LaunchContextBuilder::LaunchContextBuilder(Kernel *kernel)
 }
 
 void Kernel::LaunchContextBuilder::set_arg_float(int i, float64 d) {
-  TI_ASSERT_INFO(
-      !kernel_->args[i].is_external_array,
-      "Assigning a scalar value to a numpy array argument is not allowed");
+  TI_ASSERT_INFO(!kernel_->args[i].is_external_array,
+                 "Assigning scalar value to external(numpy) array argument is "
+                 "not allowed.");
 
   ActionRecorder::get_instance().record(
       "set_kernel_arg_float64", {ActionArg("kernel_name", kernel_->name),
@@ -205,9 +205,9 @@ void Kernel::LaunchContextBuilder::set_arg_float(int i, float64 d) {
 }
 
 void Kernel::LaunchContextBuilder::set_arg_int(int i, int64 d) {
-  TI_ASSERT_INFO(
-      !kernel_->args[i].is_external_array,
-      "Assigning scalar value to numpy array argument is not allowed");
+  TI_ASSERT_INFO(!kernel_->args[i].is_external_array,
+                 "Assigning scalar value to external(numpy) array argument is "
+                 "not allowed.");
 
   ActionRecorder::get_instance().record(
       "set_kernel_arg_int64", {ActionArg("kernel_name", kernel_->name),
@@ -244,11 +244,12 @@ void Kernel::LaunchContextBuilder::set_extra_arg_int(int i, int j, int32 d) {
   ctx_->extra_args[i][j] = d;
 }
 
-void Kernel::LaunchContextBuilder::set_arg_nparray(int i,
-                                                   uint64 ptr,
-                                                   uint64 size) {
-  TI_ASSERT_INFO(kernel_->args[i].is_external_array,
-                 "Assigning numpy array to scalar argument is not allowed");
+void Kernel::LaunchContextBuilder::set_arg_external_array(int i,
+                                                          uint64 ptr,
+                                                          uint64 size) {
+  TI_ASSERT_INFO(
+      kernel_->args[i].is_external_array,
+      "Assigning external(numpy) array to scalar argument is not allowed.");
 
   ActionRecorder::get_instance().record(
       "set_kernel_arg_ext_ptr",
@@ -261,9 +262,9 @@ void Kernel::LaunchContextBuilder::set_arg_nparray(int i,
 }
 
 void Kernel::LaunchContextBuilder::set_arg_raw(int i, uint64 d) {
-  TI_ASSERT_INFO(
-      !kernel_->args[i].is_external_array,
-      "Assigning scalar value to numpy array argument is not allowed");
+  TI_ASSERT_INFO(!kernel_->args[i].is_external_array,
+                 "Assigning scalar value to external(numpy) array argument is "
+                 "not allowed.");
 
   if (!kernel_->is_evaluator) {
     ActionRecorder::get_instance().record(

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -169,71 +169,73 @@ Kernel::LaunchContextBuilder::LaunchContextBuilder(Kernel *kernel)
       ctx_(owned_ctx_.get()) {
 }
 
-void Kernel::LaunchContextBuilder::set_arg_float(int i, float64 d) {
-  TI_ASSERT_INFO(!kernel_->args[i].is_external_array,
+void Kernel::LaunchContextBuilder::set_arg_float(int arg_id, float64 d) {
+  TI_ASSERT_INFO(!kernel_->args[arg_id].is_external_array,
                  "Assigning scalar value to external(numpy) array argument is "
                  "not allowed.");
 
   ActionRecorder::get_instance().record(
-      "set_kernel_arg_float64", {ActionArg("kernel_name", kernel_->name),
-                                 ActionArg("arg_id", i), ActionArg("val", d)});
+      "set_kernel_arg_float64",
+      {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", arg_id),
+       ActionArg("val", d)});
 
-  auto dt = kernel_->args[i].dt;
+  auto dt = kernel_->args[arg_id].dt;
   if (dt->is_primitive(PrimitiveTypeID::f32)) {
-    ctx_->set_arg(i, (float32)d);
+    ctx_->set_arg(arg_id, (float32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
-    ctx_->set_arg(i, (float64)d);
+    ctx_->set_arg(arg_id, (float64)d);
   } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
-    ctx_->set_arg(i, (int32)d);
+    ctx_->set_arg(arg_id, (int32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
-    ctx_->set_arg(i, (int64)d);
+    ctx_->set_arg(arg_id, (int64)d);
   } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
-    ctx_->set_arg(i, (int8)d);
+    ctx_->set_arg(arg_id, (int8)d);
   } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
-    ctx_->set_arg(i, (int16)d);
+    ctx_->set_arg(arg_id, (int16)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
-    ctx_->set_arg(i, (uint8)d);
+    ctx_->set_arg(arg_id, (uint8)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
-    ctx_->set_arg(i, (uint16)d);
+    ctx_->set_arg(arg_id, (uint16)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
-    ctx_->set_arg(i, (uint32)d);
+    ctx_->set_arg(arg_id, (uint32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    ctx_->set_arg(i, (uint64)d);
+    ctx_->set_arg(arg_id, (uint64)d);
   } else {
     TI_NOT_IMPLEMENTED
   }
 }
 
-void Kernel::LaunchContextBuilder::set_arg_int(int i, int64 d) {
-  TI_ASSERT_INFO(!kernel_->args[i].is_external_array,
+void Kernel::LaunchContextBuilder::set_arg_int(int arg_id, int64 d) {
+  TI_ASSERT_INFO(!kernel_->args[arg_id].is_external_array,
                  "Assigning scalar value to external(numpy) array argument is "
                  "not allowed.");
 
   ActionRecorder::get_instance().record(
-      "set_kernel_arg_int64", {ActionArg("kernel_name", kernel_->name),
-                               ActionArg("arg_id", i), ActionArg("val", d)});
+      "set_kernel_arg_int64",
+      {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", arg_id),
+       ActionArg("val", d)});
 
-  auto dt = kernel_->args[i].dt;
+  auto dt = kernel_->args[arg_id].dt;
   if (dt->is_primitive(PrimitiveTypeID::i32)) {
-    ctx_->set_arg(i, (int32)d);
+    ctx_->set_arg(arg_id, (int32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
-    ctx_->set_arg(i, (int64)d);
+    ctx_->set_arg(arg_id, (int64)d);
   } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
-    ctx_->set_arg(i, (int8)d);
+    ctx_->set_arg(arg_id, (int8)d);
   } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
-    ctx_->set_arg(i, (int16)d);
+    ctx_->set_arg(arg_id, (int16)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
-    ctx_->set_arg(i, (uint8)d);
+    ctx_->set_arg(arg_id, (uint8)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
-    ctx_->set_arg(i, (uint16)d);
+    ctx_->set_arg(arg_id, (uint16)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
-    ctx_->set_arg(i, (uint32)d);
+    ctx_->set_arg(arg_id, (uint32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    ctx_->set_arg(i, (uint64)d);
+    ctx_->set_arg(arg_id, (uint64)d);
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
-    ctx_->set_arg(i, (float32)d);
+    ctx_->set_arg(arg_id, (float32)d);
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
-    ctx_->set_arg(i, (float64)d);
+    ctx_->set_arg(arg_id, (float64)d);
   } else {
     TI_INFO(dt->to_string());
     TI_NOT_IMPLEMENTED
@@ -244,34 +246,35 @@ void Kernel::LaunchContextBuilder::set_extra_arg_int(int i, int j, int32 d) {
   ctx_->extra_args[i][j] = d;
 }
 
-void Kernel::LaunchContextBuilder::set_arg_external_array(int i,
+void Kernel::LaunchContextBuilder::set_arg_external_array(int arg_id,
                                                           uint64 ptr,
                                                           uint64 size) {
   TI_ASSERT_INFO(
-      kernel_->args[i].is_external_array,
+      kernel_->args[arg_id].is_external_array,
       "Assigning external(numpy) array to scalar argument is not allowed.");
 
   ActionRecorder::get_instance().record(
       "set_kernel_arg_ext_ptr",
-      {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", i),
+      {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", arg_id),
        ActionArg("address", fmt::format("0x{:x}", ptr)),
        ActionArg("array_size_in_bytes", (int64)size)});
 
-  kernel_->args[i].size = size;
-  ctx_->set_arg(i, ptr);
+  kernel_->args[arg_id].size = size;
+  ctx_->set_arg(arg_id, ptr);
 }
 
-void Kernel::LaunchContextBuilder::set_arg_raw(int i, uint64 d) {
-  TI_ASSERT_INFO(!kernel_->args[i].is_external_array,
+void Kernel::LaunchContextBuilder::set_arg_raw(int arg_id, uint64 d) {
+  TI_ASSERT_INFO(!kernel_->args[arg_id].is_external_array,
                  "Assigning scalar value to external(numpy) array argument is "
                  "not allowed.");
 
   if (!kernel_->is_evaluator) {
     ActionRecorder::get_instance().record(
-        "set_arg_raw", {ActionArg("kernel_name", kernel_->name),
-                        ActionArg("arg_id", i), ActionArg("val", (int64)d)});
+        "set_arg_raw",
+        {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", arg_id),
+         ActionArg("val", (int64)d)});
   }
-  ctx_->set_arg<uint64>(i, d);
+  ctx_->set_arg<uint64>(arg_id, d);
 }
 
 Context &Kernel::LaunchContextBuilder::get_context() {

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -67,7 +67,7 @@ class Kernel {
 
     void set_extra_arg_int(int i, int j, int32 d);
 
-    void set_arg_nparray(int i, uint64 ptr, uint64 size);
+    void set_arg_external_array(int i, uint64 ptr, uint64 size);
 
     // Sets the i-th arg in the context to the bits stored in |d|. This ignores
     // the underlying kernel's i-th arg type.

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -61,17 +61,17 @@ class Kernel {
     LaunchContextBuilder(const LaunchContextBuilder &) = delete;
     LaunchContextBuilder &operator=(const LaunchContextBuilder &) = delete;
 
-    void set_arg_float(int i, float64 d);
+    void set_arg_float(int arg_id, float64 d);
 
-    void set_arg_int(int i, int64 d);
+    void set_arg_int(int arg_id, int64 d);
 
     void set_extra_arg_int(int i, int j, int32 d);
 
-    void set_arg_external_array(int i, uint64 ptr, uint64 size);
+    void set_arg_external_array(int arg_id, uint64 ptr, uint64 size);
 
-    // Sets the i-th arg in the context to the bits stored in |d|. This ignores
-    // the underlying kernel's i-th arg type.
-    void set_arg_raw(int i, uint64 d);
+    // Sets the |arg_id|-th arg in the context to the bits stored in |d|.
+    // This ignores the underlying kernel's |arg_id|-th arg type.
+    void set_arg_raw(int arg_id, uint64 d);
 
     Context &get_context();
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -95,9 +95,8 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
-      .def(
-          "get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
-          py::return_value_policy::reference)
+      .def("get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
+           py::return_value_policy::reference)
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.
@@ -195,10 +194,9 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def(
-      "default_compile_config",
-      [&]() -> CompileConfig & { return default_compile_config; },
-      py::return_value_policy::reference);
+  m.def("default_compile_config",
+        [&]() -> CompileConfig & { return default_compile_config; },
+        py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -215,12 +213,11 @@ void export_lang(py::module &m) {
            })
       .def("print_memory_profiler_info", &Program::print_memory_profiler_info)
       .def("finalize", &Program::finalize)
-      .def(
-          "get_root",
-          [&](Program *program) -> SNode * {
-            return program->snode_root.get();
-          },
-          py::return_value_policy::reference)
+      .def("get_root",
+           [&](Program *program) -> SNode * {
+             return program->snode_root.get();
+           },
+           py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("get_snode_num_dynamically_allocated",
@@ -235,10 +232,9 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def(
-      "current_compile_config",
-      [&]() -> CompileConfig & { return get_current_program().config; },
-      py::return_value_policy::reference);
+  m.def("current_compile_config",
+        [&]() -> CompileConfig & { return get_current_program().config; },
+        py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -273,10 +269,9 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def(
-          "get_ch",
-          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-          py::return_value_policy::reference)
+      .def("get_ch",
+           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+           py::return_value_policy::reference)
       .def("lazy_grad",
            [](SNode *snode) {
              make_lazy_grad(snode,
@@ -376,14 +371,13 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def(
-          "define",
-          [](Program::KernelProxy *ker,
-             const std::function<void()> &func) -> Kernel & {
-            py::gil_scoped_release release;
-            return ker->def(func);
-          },
-          py::return_value_policy::reference);
+      .def("define",
+           [](Program::KernelProxy *ker,
+              const std::function<void()> &func) -> Kernel & {
+             py::gil_scoped_release release;
+             return ker->def(func);
+           },
+           py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -336,7 +336,8 @@ void export_lang(py::module &m) {
   py::class_<Kernel::LaunchContextBuilder>(m, "KernelLaunchContext")
       .def("set_arg_int", &Kernel::LaunchContextBuilder::set_arg_int)
       .def("set_arg_float", &Kernel::LaunchContextBuilder::set_arg_float)
-      .def("set_arg_nparray", &Kernel::LaunchContextBuilder::set_arg_nparray)
+      .def("set_arg_nparray",
+           &Kernel::LaunchContextBuilder::set_arg_external_array)
       .def("set_extra_arg_int",
            &Kernel::LaunchContextBuilder::set_extra_arg_int);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -95,8 +95,9 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
-      .def("get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
-           py::return_value_policy::reference)
+      .def(
+          "get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
+          py::return_value_policy::reference)
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.
@@ -194,9 +195,10 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def("default_compile_config",
-        [&]() -> CompileConfig & { return default_compile_config; },
-        py::return_value_policy::reference);
+  m.def(
+      "default_compile_config",
+      [&]() -> CompileConfig & { return default_compile_config; },
+      py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -213,11 +215,12 @@ void export_lang(py::module &m) {
            })
       .def("print_memory_profiler_info", &Program::print_memory_profiler_info)
       .def("finalize", &Program::finalize)
-      .def("get_root",
-           [&](Program *program) -> SNode * {
-             return program->snode_root.get();
-           },
-           py::return_value_policy::reference)
+      .def(
+          "get_root",
+          [&](Program *program) -> SNode * {
+            return program->snode_root.get();
+          },
+          py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("get_snode_num_dynamically_allocated",
@@ -232,9 +235,10 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def("current_compile_config",
-        [&]() -> CompileConfig & { return get_current_program().config; },
-        py::return_value_policy::reference);
+  m.def(
+      "current_compile_config",
+      [&]() -> CompileConfig & { return get_current_program().config; },
+      py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -269,9 +273,10 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def("get_ch",
-           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-           py::return_value_policy::reference)
+      .def(
+          "get_ch",
+          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+          py::return_value_policy::reference)
       .def("lazy_grad",
            [](SNode *snode) {
              make_lazy_grad(snode,
@@ -371,13 +376,14 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def("define",
-           [](Program::KernelProxy *ker,
-              const std::function<void()> &func) -> Kernel & {
-             py::gil_scoped_release release;
-             return ker->def(func);
-           },
-           py::return_value_policy::reference);
+      .def(
+          "define",
+          [](Program::KernelProxy *ker,
+             const std::function<void()> &func) -> Kernel & {
+            py::gil_scoped_release release;
+            return ker->def(func);
+          },
+          py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -109,7 +109,7 @@ TEST(IRBuilder, ExternalPtr) {
   auto ker = std::make_unique<Kernel>(prog, std::move(block));
   ker->insert_arg(get_data_type<int>(), /*is_external_array=*/true);
   auto launch_ctx = ker->make_launch_context();
-  launch_ctx.set_arg_external_array(0, (uint64)array.get(), size);
+  launch_ctx.set_arg_external_array(/*arg_id=*/0, (uint64)array.get(), size);
   (*ker)(launch_ctx);
   EXPECT_EQ(array[0], 2);
   EXPECT_EQ(array[1], 1);

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -109,7 +109,7 @@ TEST(IRBuilder, ExternalPtr) {
   auto ker = std::make_unique<Kernel>(prog, std::move(block));
   ker->insert_arg(get_data_type<int>(), /*is_external_array=*/true);
   auto launch_ctx = ker->make_launch_context();
-  launch_ctx.set_arg_nparray(0, (uint64)array.get(), size);
+  launch_ctx.set_arg_external_array(0, (uint64)array.get(), size);
   (*ker)(launch_ctx);
   EXPECT_EQ(array[0], 2);
   EXPECT_EQ(array[1], 1);


### PR DESCRIPTION
Related issue = #2193

A continuation of #2277. Also renames `i` to `arg_id` in some function signatures.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
