### PR TITLE
[ir] Make BLSAnalyzer testable

### DIFF
--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -10,7 +10,7 @@ endif()
 # TODO(#2195):
 # 1. "cpp" -> "cpp_legacy", "cpp_new" -> "cpp"
 # 2. Re-implement the legacy CPP tests using googletest
-file(GLOB_RECURSE TAICHI_TESTS_SOURCE "tests/cpp/common/*.cpp" "tests/cpp/ir/*.cpp")
+file(GLOB_RECURSE TAICHI_TESTS_SOURCE "tests/cpp/analysis/*.cpp" "tests/cpp/common/*.cpp" "tests/cpp/ir/*.cpp")
 
 include_directories(
     ${PROJECT_SOURCE_DIR},

--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -155,10 +155,10 @@ The language used in Taichi kernels and functions looks exactly like Python, yet
 
 Parallel for-loops
 ------------------
-For loops at the outermost scope in a Taichi kernel is **automatically parallelized**.
-For loops can have two forms, i.e. `range-for loops` and `struct-for loops`.
+``for`` loops at the outermost scope in a Taichi kernel is **automatically parallelized**.
+``for`` loops can have two forms, i.e. `range-for loops` and `struct-for loops`.
 
-**Range-for loops** are no different from Python for loops, except that it will be parallelized
+**Range-for loops** are no different from Python ``for`` loops, except that it will be parallelized
 when used at the outermost scope. Range-for loops can be nested.
 
 .. code-block:: python

--- a/taichi/analysis/bls_analyzer.cpp
+++ b/taichi/analysis/bls_analyzer.cpp
@@ -1,0 +1,105 @@
+#include "taichi/analysis/bls_analyzer.h"
+
+#include "taichi/system/profiler.h"
+#include "taichi/ir/analysis.h"
+
+namespace taichi {
+namespace lang {
+
+BLSAnalyzer::BLSAnalyzer(OffloadedStmt *for_stmt, ScratchPads *pads)
+    : for_stmt_(for_stmt), pads_(pads) {
+  TI_AUTO_PROF;
+  allow_undefined_visitor = true;
+  invoke_default_visitor = false;
+  for (auto &snode : for_stmt->mem_access_opt.get_snodes_with_flag(
+           SNodeAccessFlag::block_local)) {
+    auto *block = snode->parent;
+    if (block_indices_.find(block) == block_indices_.end()) {
+      generate_block_indices(block, &block_indices_[block]);
+    }
+  }
+
+  const auto &block = for_stmt->body;
+
+  for (int i = 0; i < (int)block->statements.size(); i++) {
+    block->statements[i]->accept(this);
+  }
+}
+
+// static
+void BLSAnalyzer::generate_block_indices(SNode *snode, BlockIndices *indices) {
+  // NOTE: Assuming not vectorized
+  for (int i = 0; i < snode->num_active_indices; i++) {
+    auto j = snode->physical_index_position[i];
+    indices->push_back(
+        {/*low=*/0, /*high=*/(1 << snode->extractors[j].num_bits) - 1});
+  }
+}
+
+void BLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
+  if (!stmt->is<GlobalPtrStmt>())
+    return;  // local alloca
+  auto ptr = stmt->as<GlobalPtrStmt>();
+  for (int l = 0; l < stmt->width(); l++) {
+    auto snode = ptr->snodes[l];
+    if (!pads_->has(snode)) {
+      continue;
+    }
+    bool matching_indices = true;
+    std::vector<IndexRange> offsets;
+    offsets.resize(ptr->indices.size());
+    const int num_indices = (int)ptr->indices.size();
+    for (int i = 0; i < num_indices; i++) {
+      auto diff = irpass::analysis::value_diff_loop_index(ptr->indices[i],
+                                                          for_stmt_, i);
+      if (diff.linear_related()) {
+        offsets[i].low = diff.low;
+        offsets[i].high = diff.high;
+      } else {
+        matching_indices = false;
+      }
+    }
+    if (matching_indices) {
+      auto *block = snode->parent;
+      const auto &index_bounds = block_indices_[block];
+      std::vector<int> index(num_indices, 0);
+      std::function<void(int)> visit = [&](int dimension) {
+        if (dimension == num_indices) {
+          pads_->access(snode, index, flag);
+          return;
+        }
+        for (int i = (index_bounds[dimension].low + offsets[dimension].low);
+             i < (index_bounds[dimension].high + offsets[dimension].high);
+             i++) {
+          index[dimension] = i;
+          visit(dimension + 1);
+        }
+      };
+      visit(0);
+    }
+  }
+}
+
+// Do not eliminate global data access
+void BLSAnalyzer::visit(GlobalLoadStmt *stmt) {
+  TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
+  record_access(stmt->src, AccessFlag::read);
+}
+
+void BLSAnalyzer::visit(GlobalStoreStmt *stmt) {
+  TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
+  record_access(stmt->dest, AccessFlag::write);
+}
+
+void BLSAnalyzer::visit(AtomicOpStmt *stmt) {
+  if (stmt->op_type == AtomicOpType::add) {
+    record_access(stmt->dest, AccessFlag::accumulate);
+  }
+}
+
+void BLSAnalyzer::visit(Stmt *stmt) {
+  TI_ASSERT(!stmt->is_container_statement());
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/analysis/bls_analyzer.h
+++ b/taichi/analysis/bls_analyzer.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "taichi/ir/visitors.h"
+#include "taichi/ir/statements.h"
+#include "taichi/ir/scratch_pad.h"
+
+namespace taichi {
+namespace lang {
+
+// Figure out accessed SNodes, and their ranges in this for stmt
+class BLSAnalyzer : public BasicStmtVisitor {
+  using BasicStmtVisitor::visit;
+
+ public:
+  // The lowest and highest index in each dimension.
+  struct IndexRange {
+    int low{0};
+    int high{0};
+  };
+  using BlockIndices = std::vector<IndexRange>;
+
+  BLSAnalyzer(OffloadedStmt *for_stmt, ScratchPads *pads);
+
+  void visit(GlobalPtrStmt *stmt) override {
+  }
+
+  // Do not eliminate global data access
+  void visit(GlobalLoadStmt *stmt) override;
+
+  void visit(GlobalStoreStmt *stmt) override;
+
+  void visit(AtomicOpStmt *stmt) override;
+
+  void visit(Stmt *stmt) override;
+
+ private:
+  // Generate the index bounds in a SNode (block). E.g., a dense(ti.ij, (2, 4))
+  // SNode has index bounds [[0, 1], [0, 3]].
+  static void generate_block_indices(SNode *snode, BlockIndices *indices);
+
+  void record_access(Stmt *stmt, AccessFlag flag);
+
+  OffloadedStmt *for_stmt_{nullptr};
+  ScratchPads *pads_{nullptr};
+  std::unordered_map<SNode *, BlockIndices> block_indices_;
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -35,6 +35,12 @@ struct IndexExtractor {
   }
 };
 
+/**
+ * Index of a given dimension.
+ * 
+ * For example, in the frontend we have ti.ij, which is translated to
+ * {Index{0}, Index{1}}.
+ */
 class Index {
  public:
   int value;

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -37,7 +37,7 @@ struct IndexExtractor {
 
 /**
  * Index of a given dimension.
- * 
+ *
  * For example, in the frontend we have ti.ij, which is translated to
  * {Index{0}, Index{1}}.
  */

--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -1,8 +1,8 @@
+#include "taichi/analysis/bls_analyzer.h"
 #include "taichi/ir/ir.h"
 #include "taichi/ir/statements.h"
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/analysis.h"
-#include "taichi/ir/visitors.h"
 #include "taichi/ir/scratch_pad.h"
 #include "taichi/system/profiler.h"
 
@@ -10,119 +10,6 @@ TLANG_NAMESPACE_BEGIN
 
 // TODO: rename scratch_pad to block_local_cache? Need to get rid of the
 // scratch_pad term
-
-// Figure out accessed SNodes, and their ranges in this for stmt
-class BLSAnalysis : public BasicStmtVisitor {
-  using BasicStmtVisitor::visit;
-
- public:
-  OffloadedStmt *for_stmt;
-  ScratchPads *pads;
-
-  // The lowest and highest index in each dimension.
-  using BlockIndices = std::vector<std::pair<int, int>>;
-
-  std::unordered_map<SNode *, BlockIndices> block_indices;
-
-  BLSAnalysis(OffloadedStmt *for_stmt, ScratchPads *pads)
-      : for_stmt(for_stmt), pads(pads) {
-    TI_AUTO_PROF;
-    allow_undefined_visitor = true;
-    invoke_default_visitor = false;
-
-    for (auto &snode : for_stmt->mem_access_opt.get_snodes_with_flag(
-             SNodeAccessFlag::block_local)) {
-      auto block = snode->parent;
-      if (block_indices.find(block) == block_indices.end()) {
-        generate_block_indices(block, &block_indices[block]);
-      }
-    }
-
-    const auto &block = for_stmt->body;
-
-    for (int i = 0; i < (int)block->statements.size(); i++) {
-      block->statements[i]->accept(this);
-    }
-  }
-
-  // Generate the index bounds in a SNode (block). E.g., a dense(ti.ij, (2, 4))
-  // SNode has index bounds [[0, 1], [0, 3]].
-  static void generate_block_indices(SNode *snode, BlockIndices *indices) {
-    // NOTE: Assuming not vectorized
-    for (int i = 0; i < snode->num_active_indices; i++) {
-      auto j = snode->physical_index_position[i];
-      indices->emplace_back(0, (1 << snode->extractors[j].num_bits) - 1);
-    }
-  }
-
-  void visit(GlobalPtrStmt *stmt) override {
-  }
-
-  void record_access(Stmt *stmt, AccessFlag flag) {
-    if (!stmt->is<GlobalPtrStmt>())
-      return;  // local alloca
-    auto ptr = stmt->as<GlobalPtrStmt>();
-    for (int l = 0; l < stmt->width(); l++) {
-      auto snode = ptr->snodes[l];
-      if (!pads->has(snode)) {
-        continue;
-      }
-      bool matching_indices = true;
-      std::vector<std::pair<int, int>> offsets;
-      offsets.resize(ptr->indices.size());
-      int num_indices = (int)ptr->indices.size();
-      for (int i = 0; i < num_indices; i++) {
-        auto diff = irpass::analysis::value_diff_loop_index(ptr->indices[i],
-                                                            for_stmt, i);
-        if (diff.linear_related()) {
-          offsets[i].first = diff.low;
-          offsets[i].second = diff.high;
-        } else {
-          matching_indices = false;
-        }
-      }
-      if (matching_indices) {
-        auto block = snode->parent;
-        const auto &index_bounds = block_indices[block];
-        std::vector<int> index(num_indices, 0);
-        std::function<void(int)> visit = [&](int dimension) {
-          if (dimension == num_indices) {
-            pads->access(snode, index, flag);
-            return;
-          }
-          for (int i = index_bounds[dimension].first + offsets[dimension].first;
-               i < index_bounds[dimension].second + offsets[dimension].second;
-               i++) {
-            index[dimension] = i;
-            visit(dimension + 1);
-          }
-        };
-        visit(0);
-      }
-    }
-  }
-
-  // Do not eliminate global data access
-  void visit(GlobalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
-    record_access(stmt->src, AccessFlag::read);
-  }
-
-  void visit(GlobalStoreStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
-    record_access(stmt->dest, AccessFlag::write);
-  }
-
-  void visit(AtomicOpStmt *stmt) override {
-    if (stmt->op_type == AtomicOpType::add) {
-      record_access(stmt->dest, AccessFlag::accumulate);
-    }
-  }
-
-  void visit(Stmt *stmt) override {
-    TI_ASSERT(!stmt->is_container_statement());
-  }
-};
 
 namespace irpass {
 
@@ -135,7 +22,7 @@ std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *offload) {
            SNodeAccessFlag::block_local)) {
     pads->insert(snode);
   }
-  BLSAnalysis _(offload, pads.get());
+  BLSAnalyzer _(offload, pads.get());
   pads->finalize();
   return pads;
 }

--- a/tests/cpp/analysis/bls_analyzer_test.cpp
+++ b/tests/cpp/analysis/bls_analyzer_test.cpp
@@ -1,0 +1,95 @@
+#include "taichi/analysis/bls_analyzer.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "taichi/ir/ir_builder.h"
+#include "taichi/ir/scratch_pad.h"
+#include "taichi/ir/snode.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/struct/struct.h"
+
+namespace taichi {
+namespace lang {
+namespace {
+
+class TestStructCompiler : public StructCompiler {
+ public:
+  TestStructCompiler() : StructCompiler(/*prog=*/nullptr) {
+  }
+  void generate_types(SNode &) override {
+  }
+
+  void generate_child_accessors(SNode &) override {
+  }
+
+  void run(SNode &, bool) override {
+  }
+};
+
+constexpr int kBlockSize = 8;
+
+class BLSAnalyzerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const std::vector<Index> indices = {Index{0}, Index{1}};
+    root_snode_ = std::make_unique<SNode>(/*depth=*/0, /*t=*/SNodeType::root);
+    parent_snode_ = &(root_snode_->dense(indices, /*sizes=*/kBlockSize));
+    child_snode_ = &(parent_snode_->insert_children(SNodeType::place));
+    child_snode_->dt = PrimitiveType::i32;
+
+    TestStructCompiler sc;
+    sc.infer_snode_properties(*root_snode_);
+
+    for_stmt_ = std::make_unique<OffloadedStmt>(
+        /*task_type=*/OffloadedTaskType::struct_for,
+        /*arch=*/Arch::x64);
+    for_stmt_->mem_access_opt.add_flag(child_snode_,
+                                       SNodeAccessFlag::block_local);
+    pads_.insert(child_snode_);
+
+    builder_.set_insertion_point(
+        {/*block=*/for_stmt_->body.get(), /*position=*/0});
+  }
+
+  std::unique_ptr<SNode> root_snode_{nullptr};
+  SNode *parent_snode_{nullptr};
+  SNode *child_snode_{nullptr};
+  std::unique_ptr<OffloadedStmt> for_stmt_{nullptr};
+  ScratchPads pads_;
+
+  IRBuilder builder_;
+  LoopIndexStmt *loop_index_{nullptr};
+};
+
+TEST_F(BLSAnalyzerTest, Basic) {
+  auto *loop_idx0_ = builder_.get_loop_index(for_stmt_.get(), /*index=*/0);
+  auto *loop_idx1_ = builder_.get_loop_index(for_stmt_.get(), /*index=*/1);
+  auto *c1 = builder_.get_int32(/*value=*/1);
+  // x[i + 1, j]
+  auto *idx = builder_.create_add(loop_idx0_, c1);
+  auto *glb_ptr = builder_.create_global_ptr(child_snode_,
+                                             /*indices=*/{idx, loop_idx1_});
+  builder_.create_global_load(glb_ptr);
+  // x[i, j - 3]
+  auto *c3 = builder_.get_int32(/*value=*/3);
+  idx = builder_.create_sub(loop_idx1_, c3);
+  glb_ptr = builder_.create_global_ptr(child_snode_,
+                                       /*indices=*/{loop_idx0_, idx});
+  builder_.create_global_load(glb_ptr);
+
+  BLSAnalyzer bls(for_stmt_.get(), &pads_);
+  pads_.finalize();
+  const auto &pad = pads_.get(child_snode_);
+  EXPECT_EQ(pad.bounds[0].size(), 2);
+  constexpr int kLow = 0;
+  constexpr int kHigh = 1;
+  EXPECT_EQ(pad.bounds[kLow][0], 0);
+  EXPECT_EQ(pad.bounds[kHigh][0], 1 + kBlockSize);
+  EXPECT_EQ(pad.bounds[kLow][1], -3);
+  EXPECT_EQ(pad.bounds[kHigh][1], kBlockSize);
+}
+
+}  // namespace
+}  // namespace lang
+}  // namespace taichi


### PR DESCRIPTION
Related issue = #2177 

Hi @KLozes ,

Sorry this PR might cause more conflicts to your #2248 , but I believe this is a necessary step to allow us to better test the BLS code and make it more robust. Albeit the large change, it simply pulls out the `BLSAnalysis` class so that we can add test around it.

A few issues:

1. We don't see to handle this case correctly: when there are two GlobalPtrs, `BLSAnalyzer` can infer the BLS access pattern for one but not the other. Right now the scratch pads will be partially accessed, which seems wrong?
2. Make the interface of `BLSAnalysis` expose the result of whether BLS pads are initialized.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
