### PR TITLE
[Lang] Add ti.eig for 2x2 matrices

### DIFF
--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -10,6 +10,7 @@ Matrices
 - ``A.transpose()``
 - ``R, S = ti.polar_decompose(A, ti.f32)``
 - ``U, sigma, V = ti.svd(A, ti.f32)`` (Note that ``sigma`` is a ``3x3`` diagonal matrix)
+- ``eigenvalues, eigenvectors = ti.eig(A, ti.f32)`` (Note that ``eigenvalues`` and ``eigenvectors`` are stored in the form of complex numbers)
 - ``any(A)`` (Taichi-scope only)
 - ``all(A)`` (Taichi-scope only)
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -303,7 +303,7 @@ def eig(A, dt=None):
     -------
     eigenvalues: ti.Matrix(n, 2)
         The eigenvalues in complex form. Each row stores one eigenvalue. The first number
-        of the eigenvalue represents the real part and the second number represents the 
+        of the eigenvalue represents the real part and the second number represents the
         imaginary part.
     eigenvectors: ti.Matrix(n*2, n)
         The eigenvectors in complex form. Each column stores one eigenvector. Each eigenvector

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -289,6 +289,13 @@ def svd(A, dt=None):
     return svd(A, dt)
 
 
+def eig(A, dt=None):
+    if dt is None:
+        dt = impl.get_runtime().default_fp
+    from .linalg import eig
+    return eig(A, dt)
+
+
 def randn(dt=None):
     if dt is None:
         dt = impl.get_runtime().default_fp

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -290,10 +290,32 @@ def svd(A, dt=None):
 
 
 def eig(A, dt=None):
+    """Compute the eigenvalues and right eigenvectors of a real matrix.
+
+    Parameters
+    ----------
+    A: ti.Matrix(n, 2)
+        2D Matrix for which the eigenvalues and right eigenvectors will be computed.
+    dt: Optional[DataType]
+        The datatype for the eigenvalues and right eigenvectors
+
+    Returns
+    -------
+    eigenvalues: ti.Matrix(n, 2)
+        The eigenvalues in complex form. Each row stores one eigenvalue. The first number
+        of the eigenvalue represents the real part and the second number represents the 
+        imaginary part.
+    eigenvectors: ti.Matrix(n*2, n)
+        The eigenvectors in complex form. Each column stores one eigenvector. Each eigenvector
+        consists of n entries, each of which is represented by two numbers for its real part
+        and imaginary part.
+    """
     if dt is None:
         dt = impl.get_runtime().default_fp
-    from .linalg import eig
-    return eig(A, dt)
+    from taichi.lang import linalg
+    if A.n == 2:
+        return linalg.eig2x2(A, dt)
+    raise Exception("Eigen solver only supports 2D matrices.")
 
 
 def randn(dt=None):

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -294,7 +294,7 @@ def eig(A, dt=None):
 
     Parameters
     ----------
-    A: ti.Matrix(n, 2)
+    A: ti.Matrix(n, n)
         2D Matrix for which the eigenvalues and right eigenvectors will be computed.
     dt: Optional[DataType]
         The datatype for the eigenvalues and right eigenvectors

--- a/python/taichi/lang/linalg.py
+++ b/python/taichi/lang/linalg.py
@@ -82,6 +82,46 @@ def svd3d(A, dt, iters=None):
 
 
 @ti.func
+def eig2x2(A, dt):
+    tr = A.trace()
+    det = A.determinant()
+    gap = tr**2 - 4 * det
+    lambda1 = ti.Vector.zero(dt, 2)
+    lambda2 = ti.Vector.zero(dt, 2)
+    v1 = ti.Vector.zero(dt, 4)
+    v2 = ti.Vector.zero(dt, 4)
+    if gap > 0:
+        lambda1 = ti.Vector([tr + ti.sqrt(gap), ti.cast(0.0, dt)]) * 0.5
+        lambda2 = ti.Vector([tr - ti.sqrt(gap), ti.cast(0.0, dt)]) * 0.5
+        A1 = A - lambda1[0] * ti.Matrix.identity(dt, 2)
+        A2 = A - lambda2[0] * ti.Matrix.identity(dt, 2)
+        if all(A1 == ti.Matrix.zero(dt, 2, 2)) and all(
+                A1 == ti.Matrix.zero(dt, 2, 2)):
+            v1 = ti.Vector([0.0, 0.0, 1.0, 0.0]).cast(dt)
+            v2 = ti.Vector([1.0, 0.0, 0.0, 0.0]).cast(dt)
+        else:
+            v1 = ti.Vector([A2[0, 0], 0.0, A2[1, 0],
+                            0.0]).cast(dt).normalized()
+            v2 = ti.Vector([A1[0, 0], 0.0, A1[1, 0],
+                            0.0]).cast(dt).normalized()
+    else:
+        lambda1 = ti.Vector([tr, ti.sqrt(-gap)]) * 0.5
+        lambda2 = ti.Vector([tr, -ti.sqrt(-gap)]) * 0.5
+        A1r = A - lambda1[0] * ti.Matrix.identity(dt, 2)
+        A1i = -lambda1[1] * ti.Matrix.identity(dt, 2)
+        A2r = A - lambda2[0] * ti.Matrix.identity(dt, 2)
+        A2i = -lambda2[1] * ti.Matrix.identity(dt, 2)
+        v1 = ti.Vector([A2r[0, 0], A2i[0, 0], A2r[1, 0],
+                        A2i[1, 0]]).cast(dt).normalized()
+        v2 = ti.Vector([A1r[0, 0], A1i[0, 0], A1r[1, 0],
+                        A1i[1, 0]]).cast(dt).normalized()
+    eigenvalues = ti.Matrix.rows([lambda1, lambda2])
+    eigenvectors = ti.Matrix.cols([v1, v2])
+
+    return eigenvalues, eigenvectors
+
+
+@ti.func
 def svd(A, dt):
     if ti.static(A.n == 2):
         ret = svd2d(A, dt)
@@ -102,3 +142,12 @@ def polar_decompose(A, dt):
     else:
         raise Exception(
             "Polar decomposition only supports 2D and 3D matrices.")
+
+
+@ti.func
+def eig(A, dt):
+    if ti.static(A.n == 2):
+        ret = eig2x2(A, dt)
+        return ret
+    else:
+        raise Exception("Eigen solver only supports 2D matrices.")

--- a/python/taichi/lang/linalg.py
+++ b/python/taichi/lang/linalg.py
@@ -142,12 +142,3 @@ def polar_decompose(A, dt):
     else:
         raise Exception(
             "Polar decomposition only supports 2D and 3D matrices.")
-
-
-@ti.func
-def eig(A, dt):
-    if ti.static(A.n == 2):
-        ret = eig2x2(A, dt)
-        return ret
-    else:
-        raise Exception("Eigen solver only supports 2D matrices.")

--- a/tests/python/test_eig.py
+++ b/tests/python/test_eig.py
@@ -12,7 +12,9 @@ def _eigen_vector_equal(v1, v2, tol):
         try:
             np.testing.assert_allclose(v1, v2, atol=tol, rtol=tol)
         except AssertionError:
-            assert np.allclose(v1, -v2, atol=tol, rtol=tol) or np.allclose(v1, 1.j * v2, atol=tol, rtol=tol) or np.allclose(v1, -1.j * v2, atol=tol, rtol=tol)
+            assert np.allclose(v1, -v2, atol=tol, rtol=tol) or np.allclose(
+                v1, 1.j * v2, atol=tol, rtol=tol) or np.allclose(
+                    v1, -1.j * v2, atol=tol, rtol=tol)
 
 
 def _test_eig2x2_real(dt):

--- a/tests/python/test_eig.py
+++ b/tests/python/test_eig.py
@@ -1,0 +1,87 @@
+import taichi as ti
+import numpy as np
+import pytest
+
+
+def _eigen_vector_equal(v1, v2, tol):
+    if np.linalg.norm(v1) == 0.0:
+        assert np.linalg.norm(v2) == 0.0
+    else:
+        v1 = v1 / np.linalg.norm(v1)
+        v2 = v2 / np.linalg.norm(v2)
+        try:
+            np.testing.assert_allclose(v1, v2, atol=tol, rtol=tol)
+        except AssertionError:
+            assert np.allclose(v1, -v2, atol=tol, rtol=tol) or np.allclose(v1, 1.j * v2, atol=tol, rtol=tol) or np.allclose(v1, -1.j * v2, atol=tol, rtol=tol)
+
+
+def _test_eig2x2_real(dt):
+    A = ti.Matrix.field(2, 2, dtype=dt, shape=())
+    v = ti.Matrix.field(2, 2, dtype=dt, shape=())
+    w = ti.Matrix.field(4, 2, dtype=dt, shape=())
+
+    A[None] = [[1, 1], [2, 3]]
+
+    @ti.kernel
+    def eigen_solve():
+        v[None], w[None] = ti.eig(A)
+
+    tol = 1e-5 if dt == ti.f32 else 1e-12
+    dtype = np.float32 if dt == ti.f32 else np.float64
+
+    eigen_solve()
+    v_np, w_np = np.linalg.eig(A.to_numpy().astype(dtype))
+    v_ti = v.to_numpy()[:, 0].astype(dtype)
+    w_ti = w.to_numpy()[0::2, :].astype(dtype)
+
+    # sort by eigenvalues
+    idx_np = np.argsort(v_np)
+    idx_ti = np.argsort(v_ti)
+
+    np.testing.assert_allclose(v_ti[idx_ti], v_np[idx_np], atol=tol, rtol=tol)
+    _eigen_vector_equal(w_ti[:, idx_ti[0]], w_np[:, idx_np[0]], tol)
+    _eigen_vector_equal(w_ti[:, idx_ti[1]], w_np[:, idx_np[1]], tol)
+
+
+def _test_eig2x2_complex(dt):
+    A = ti.Matrix.field(2, 2, dtype=dt, shape=())
+    v = ti.Matrix.field(2, 2, dtype=dt, shape=())
+    w = ti.Matrix.field(4, 2, dtype=dt, shape=())
+
+    A[None] = [[1, -1], [1, 1]]
+
+    @ti.kernel
+    def eigen_solve():
+        v[None], w[None] = ti.eig(A)
+
+    tol = 1e-5 if dt == ti.f32 else 1e-12
+    dtype = np.float32 if dt == ti.f32 else np.float64
+
+    eigen_solve()
+    v_np, w_np = np.linalg.eig(A.to_numpy().astype(dtype))
+    v_ti = v.to_numpy().astype(dtype)
+    w_ti = w.to_numpy().astype(dtype)
+    v_ti_complex = v_ti[:, 0] + v_ti[:, 1] * 1.j
+    w_ti_complex = w_ti[0::2, :] + w_ti[1::2, :] * 1.j
+
+    # sort by eigenvalues
+    idx_np = np.argsort(v_np)
+    idx_ti = np.argsort(v_ti_complex)
+
+    np.testing.assert_allclose(v_ti_complex[idx_ti],
+                               v_np[idx_np],
+                               atol=tol,
+                               rtol=tol)
+    _eigen_vector_equal(w_ti_complex[:, idx_ti[0]], w_np[:, idx_np[0]], tol)
+    _eigen_vector_equal(w_ti_complex[:, idx_ti[1]], w_np[:, idx_np[1]], tol)
+
+
+def test_eig2x2():
+    for func in [_test_eig2x2_real, _test_eig2x2_complex]:
+        for fp in [ti.f32, ti.f64]:
+
+            @ti.all_archs_with(default_fp=fp, fast_math=False)
+            def wrapped():
+                func(fp)
+
+            wrapped()


### PR DESCRIPTION
Related issue = #2208, #2293 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
This PR aims to implement utility functions `ti.eig()` for 2x2 matrices as described in #2293. 