### PR TITLE
[doc] Wrap `for` to avoid confusion

### DIFF
--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -155,10 +155,10 @@ The language used in Taichi kernels and functions looks exactly like Python, yet
 
 Parallel for-loops
 ------------------
-For loops at the outermost scope in a Taichi kernel is **automatically parallelized**.
-For loops can have two forms, i.e. `range-for loops` and `struct-for loops`.
+``for`` loops at the outermost scope in a Taichi kernel is **automatically parallelized**.
+``for`` loops can have two forms, i.e. `range-for loops` and `struct-for loops`.
 
-**Range-for loops** are no different from Python for loops, except that it will be parallelized
+**Range-for loops** are no different from Python ``for`` loops, except that it will be parallelized
 when used at the outermost scope. Range-for loops can be nested.
 
 .. code-block:: python


### PR DESCRIPTION
Wrapped "for" (as in for loop) in double ` marks so they render to monospace font. It may be mistaken for the *English word* "for" (as used grammatically). 

I think "range-for loops" can be left as is because they won't lead to confusion.

Related issue = N/A

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
