### PR TITLE
[perf] Loop-invariant code motion

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -44,6 +44,7 @@ bool whole_kernel_cse(IRNode *root);
 void variable_optimization(IRNode *root, bool after_lower_access);
 bool extract_constant(IRNode *root, const CompileConfig &config);
 bool unreachable_code_elimination(IRNode *root);
+bool loop_invariant_code_motion(IRNode *root, const CompileConfig &config);
 void full_simplify(IRNode *root,
                    const CompileConfig &config,
                    const FullSimplifyPass::Args &args);

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -24,6 +24,7 @@ CompileConfig::CompileConfig() {
   simplify_before_lower_access = true;
   lower_access = true;
   simplify_after_lower_access = true;
+  move_loop_invariant_outside_if = false;
   default_fp = PrimitiveType::f32;
   default_ip = PrimitiveType::i32;
   verbose_kernel_launches = false;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -22,6 +22,7 @@ struct CompileConfig {
   bool simplify_before_lower_access;
   bool lower_access;
   bool simplify_after_lower_access;
+  bool move_loop_invariant_outside_if;
   bool demote_dense_struct_fors;
   bool advanced_optimization;
   bool use_llvm;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -95,8 +95,9 @@ void export_lang(py::module &m) {
       .def(py::self == py::self)
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
-      .def("get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
-           py::return_value_policy::reference)
+      .def(
+          "get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
+          py::return_value_policy::reference)
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.
@@ -139,6 +140,8 @@ void export_lang(py::module &m) {
       .def_readwrite("simplify_after_lower_access",
                      &CompileConfig::simplify_after_lower_access)
       .def_readwrite("lower_access", &CompileConfig::lower_access)
+      .def_readwrite("move_loop_invariant_outside_if",
+                     &CompileConfig::move_loop_invariant_outside_if)
       .def_readwrite("default_cpu_block_dim",
                      &CompileConfig::default_cpu_block_dim)
       .def_readwrite("default_gpu_block_dim",
@@ -195,9 +198,10 @@ void export_lang(py::module &m) {
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });
 
-  m.def("default_compile_config",
-        [&]() -> CompileConfig & { return default_compile_config; },
-        py::return_value_policy::reference);
+  m.def(
+      "default_compile_config",
+      [&]() -> CompileConfig & { return default_compile_config; },
+      py::return_value_policy::reference);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -214,11 +218,12 @@ void export_lang(py::module &m) {
            })
       .def("print_memory_profiler_info", &Program::print_memory_profiler_info)
       .def("finalize", &Program::finalize)
-      .def("get_root",
-           [&](Program *program) -> SNode * {
-             return program->snode_root.get();
-           },
-           py::return_value_policy::reference)
+      .def(
+          "get_root",
+          [&](Program *program) -> SNode * {
+            return program->snode_root.get();
+          },
+          py::return_value_policy::reference)
       .def("get_total_compilation_time", &Program::get_total_compilation_time)
       .def("print_snode_tree", &Program::print_snode_tree)
       .def("get_snode_num_dynamically_allocated",
@@ -233,9 +238,10 @@ void export_lang(py::module &m) {
   m.def("get_current_program", get_current_program,
         py::return_value_policy::reference);
 
-  m.def("current_compile_config",
-        [&]() -> CompileConfig & { return get_current_program().config; },
-        py::return_value_policy::reference);
+  m.def(
+      "current_compile_config",
+      [&]() -> CompileConfig & { return get_current_program().config; },
+      py::return_value_policy::reference);
 
   py::class_<Index>(m, "Index").def(py::init<int>());
   py::class_<SNode>(m, "SNode")
@@ -270,9 +276,10 @@ void export_lang(py::module &m) {
       .def("data_type", [](SNode *snode) { return snode->dt; })
       .def("get_num_ch",
            [](SNode *snode) -> int { return (int)snode->ch.size(); })
-      .def("get_ch",
-           [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
-           py::return_value_policy::reference)
+      .def(
+          "get_ch",
+          [](SNode *snode, int i) -> SNode * { return snode->ch[i].get(); },
+          py::return_value_policy::reference)
       .def("lazy_grad",
            [](SNode *snode) {
              make_lazy_grad(snode,
@@ -372,13 +379,14 @@ void export_lang(py::module &m) {
 
   py::class_<Stmt>(m, "Stmt");
   py::class_<Program::KernelProxy>(m, "KernelProxy")
-      .def("define",
-           [](Program::KernelProxy *ker,
-              const std::function<void()> &func) -> Kernel & {
-             py::gil_scoped_release release;
-             return ker->def(func);
-           },
-           py::return_value_policy::reference);
+      .def(
+          "define",
+          [](Program::KernelProxy *ker,
+             const std::function<void()> &func) -> Kernel & {
+            py::gil_scoped_release release;
+            return ker->def(func);
+          },
+          py::return_value_policy::reference);
 
   m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
     return Deactivate(snode, indices);

--- a/taichi/transforms/loop_invariant_code_motion.cpp
+++ b/taichi/transforms/loop_invariant_code_motion.cpp
@@ -63,9 +63,6 @@ class LoopInvariantCodeMotion : public BasicStmtVisitor {
       }
     }
 
-    //if (can_be_moved)
-    //  TI_WARN("stmt can be moved");
-
     return can_be_moved;
   }
 

--- a/taichi/transforms/loop_invariant_code_motion.cpp
+++ b/taichi/transforms/loop_invariant_code_motion.cpp
@@ -39,7 +39,8 @@ class LoopInvariantCodeMotion : public BasicStmtVisitor {
       if (config.move_loop_invariant_outside_if &&
           stmt->parent != loop_blocks.top()) {
         // If we enable moving code from a nested if block, we need to check
-        // visibility Example: for i in range(10):
+        // visibility. Example:
+        // for i in range(10):
         //   a = x[0]
         //   if b:
         //     c = a + 1

--- a/taichi/transforms/loop_invariant_code_motion.cpp
+++ b/taichi/transforms/loop_invariant_code_motion.cpp
@@ -1,0 +1,160 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/ir/visitors.h"
+#include "taichi/system/profiler.h"
+
+#include <stack>
+
+TLANG_NAMESPACE_BEGIN
+
+class LoopInvariantCodeMotion : public BasicStmtVisitor {
+ public:
+  std::stack<Block *> loop_blocks;
+
+  const CompileConfig &config;
+
+  DelayedIRModifier modifier;
+
+  LoopInvariantCodeMotion(const CompileConfig &config) : config(config) {
+    allow_undefined_visitor = true;
+  }
+
+  bool stmt_can_be_moved(Stmt *stmt) {
+    if (loop_blocks.size() <= 1 || (!config.move_loop_invariant_outside_if &&
+                                    stmt->parent != loop_blocks.top()))
+      return false;
+
+    bool can_be_moved = true;
+
+    Block *current_scope = stmt->parent;
+
+    for (Stmt *operand : stmt->get_operands()) {
+      if (operand->parent == current_scope) {
+        // This statement has an operand that is in the current scope,
+        // so it can not be moved out of the scope.
+        can_be_moved = false;
+        break;
+      }
+      if (config.move_loop_invariant_outside_if &&
+          stmt->parent != loop_blocks.top()) {
+        // If we enable moving code from a nested if block, we need to check
+        // visibility Example: for i in range(10):
+        //   a = x[0]
+        //   if b:
+        //     c = a + 1
+        // Since we are moving statements outside the cloest for scope,
+        // We need to check the scope of the operand
+        Stmt *operand_parent = operand;
+        while (operand_parent && operand_parent->parent) {
+          operand_parent = operand_parent->parent->parent_stmt;
+          if (!operand_parent) break;
+          // If the one of the parent of the operand is the top loop scope
+          // Then it will not be visible if we move it outside the top loop
+          // scope
+          if (operand_parent == loop_blocks.top()->parent_stmt) {
+            can_be_moved = false;
+            break;
+          }
+        }
+        if (!can_be_moved)
+          break;
+      }
+    }
+
+    //if (can_be_moved)
+    //  TI_WARN("stmt can be moved");
+
+    return can_be_moved;
+  }
+
+  void visit(BinaryOpStmt *stmt) override {
+    if (stmt_can_be_moved(stmt)) {
+      auto replacement = stmt->clone();
+      stmt->replace_with(replacement.get());
+
+      modifier.insert_before(stmt->parent->parent_stmt, std::move(replacement));
+      modifier.erase(stmt);
+    }
+  }
+
+  void visit(UnaryOpStmt *stmt) override {
+    if (stmt_can_be_moved(stmt)) {
+      auto replacement = stmt->clone();
+      stmt->replace_with(replacement.get());
+
+      modifier.insert_before(stmt->parent->parent_stmt, std::move(replacement));
+      modifier.erase(stmt);
+    }
+  }
+
+  void visit(Block *stmt_list) override {
+    for (auto &stmt : stmt_list->statements)
+      stmt->accept(this);
+  }
+
+  void visit_loop(Block *body) {
+    loop_blocks.push(body);
+
+    body->accept(this);
+
+    loop_blocks.pop();
+  }
+
+  void visit(RangeForStmt *stmt) override {
+    visit_loop(stmt->body.get());
+  }
+
+  void visit(StructForStmt *stmt) override {
+    visit_loop(stmt->body.get());
+  }
+
+  void visit(WhileStmt *stmt) override {
+    visit_loop(stmt->body.get());
+  }
+
+  void visit(OffloadedStmt *stmt) override {
+    if (stmt->tls_prologue)
+      stmt->tls_prologue->accept(this);
+
+    if (stmt->bls_prologue)
+      stmt->bls_prologue->accept(this);
+
+    if (stmt->body)
+      if (stmt->task_type == OffloadedStmt::TaskType::range_for ||
+          stmt->task_type == OffloadedStmt::TaskType::struct_for)
+        visit_loop(stmt->body.get());
+      else
+        stmt->body->accept(this);
+
+    if (stmt->bls_epilogue)
+      stmt->bls_epilogue->accept(this);
+
+    if (stmt->tls_epilogue)
+      stmt->tls_epilogue->accept(this);
+  }
+
+  static bool run(IRNode *node, const CompileConfig &config) {
+    bool modified = false;
+
+    while (true) {
+      LoopInvariantCodeMotion eliminator(config);
+      node->accept(&eliminator);
+      if (eliminator.modifier.modify_ir())
+        modified = true;
+      else
+        break;
+    };
+
+    return modified;
+  }
+};
+
+namespace irpass {
+bool loop_invariant_code_motion(IRNode *root, const CompileConfig &config) {
+  TI_AUTO_PROF;
+  return LoopInvariantCodeMotion::run(root, config);
+}
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -640,6 +640,8 @@ void full_simplify(IRNode *root,
         modified = true;
       if (alg_simp(root, config))
         modified = true;
+      if (loop_invariant_code_motion(root, config))
+        modified = true;
       if (die(root))
         modified = true;
       if (simplify(root, config, {args.kernel}))


### PR DESCRIPTION
Performance Observations:
Complicated. Check the related issue.

Structural Observations:
1. Many programs contain loops and certainly graphis programs contain a lot of them. It is very often that the loop is going over the same data structure and the same computations, just with different data
2. If the operands of a statement that has no side effects are all not from the current scope, it can only be from all the previous scopes. (If we assume the IR is well formed, and we have access to those operands)
3. Moving a statement in a loop, that does not depend on anything within the loop, one layer up, will result in less redundant computations. The more iterations a loop has, the more redundancy is removed.
4. Doing so may or may not increase register pressure. In the case of all operands are still in use after the moved statement, we have increased register pressure in the loop up until  the moved statement. If the operands are not used later, we have in fact decreased or maintained the same register pressure.

Related issue = #2324
