### PR TITLE
[Lang] Add ti.sym_eig for 2x2 matrices

### DIFF
--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -11,6 +11,7 @@ Matrices
 - ``R, S = ti.polar_decompose(A, ti.f32)``
 - ``U, sigma, V = ti.svd(A, ti.f32)`` (Note that ``sigma`` is a ``3x3`` diagonal matrix)
 - ``eigenvalues, eigenvectors = ti.eig(A, ti.f32)`` (Note that ``eigenvalues`` and ``eigenvectors`` are stored in the form of complex numbers)
+- ``eigenvalues, eigenvectors = ti.sym_eig(A, ti.f32)`` (For symmetric matrices, ``eigenvalues`` and ``eigenvectors`` are stored in the form of real numbers)
 - ``any(A)`` (Taichi-scope only)
 - ``all(A)`` (Taichi-scope only)
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -335,11 +335,11 @@ def sym_eig(A, dt=None):
     eigenvectors: ti.Matrix(n, n)
         The eigenvectors. Each column stores one eigenvector.
     """
+    assert all(A == A.transpose()), "A needs to be symmetric"
     if dt is None:
         dt = impl.get_runtime().default_fp
     from taichi.lang import linalg
     if A.n == 2:
-        assert A[0, 1] == A[1, 0], "A needs to be symmetric"
         return linalg.sym_eig2x2(A, dt)
     raise Exception("Symmetric eigen solver only supports 2D matrices.")
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -318,6 +318,32 @@ def eig(A, dt=None):
     raise Exception("Eigen solver only supports 2D matrices.")
 
 
+def sym_eig(A, dt=None):
+    """Compute the eigenvalues and right eigenvectors of a real symmetric matrix.
+
+    Parameters
+    ----------
+    A: ti.Matrix(n, n)
+        Symmetric Matrix for which the eigenvalues and right eigenvectors will be computed.
+    dt: Optional[DataType]
+        The datatype for the eigenvalues and right eigenvectors
+
+    Returns
+    -------
+    eigenvalues: ti.Vector(n)
+        The eigenvalues. Each entry store one eigen value.
+    eigenvectors: ti.Matrix(n, n)
+        The eigenvectors. Each column stores one eigenvector.
+    """
+    if dt is None:
+        dt = impl.get_runtime().default_fp
+    from taichi.lang import linalg
+    if A.n == 2:
+        assert A[0, 1] == A[1, 0], "A needs to be symmetric"
+        return linalg.sym_eig2x2(A, dt)
+    raise Exception("Symmetric eigen solver only supports 2D matrices.")
+
+
 def randn(dt=None):
     if dt is None:
         dt = impl.get_runtime().default_fp

--- a/python/taichi/lang/linalg.py
+++ b/python/taichi/lang/linalg.py
@@ -132,6 +132,8 @@ def sym_eig2x2(A, dt):
 
     A1 = A - lambda1 * ti.Matrix.identity(dt, 2)
     A2 = A - lambda2 * ti.Matrix.identity(dt, 2)
+    v1 = ti.Vector.zero(dt, 2)
+    v2 = ti.Vector.zero(dt, 2)
     if all(A1 == ti.Matrix.zero(dt, 2, 2)) and all(
             A1 == ti.Matrix.zero(dt, 2, 2)):
         v1 = ti.Vector([0.0, 1.0]).cast(dt)

--- a/python/taichi/lang/linalg.py
+++ b/python/taichi/lang/linalg.py
@@ -122,6 +122,28 @@ def eig2x2(A, dt):
 
 
 @ti.func
+def sym_eig2x2(A, dt):
+    tr = A.trace()
+    det = A.determinant()
+    gap = tr**2 - 4 * det
+    lambda1 = (tr + ti.sqrt(gap)) * 0.5
+    lambda2 = (tr - ti.sqrt(gap)) * 0.5
+    eigenvalues = ti.Vector([lambda1, lambda2]).cast(dt)
+
+    A1 = A - lambda1 * ti.Matrix.identity(dt, 2)
+    A2 = A - lambda2 * ti.Matrix.identity(dt, 2)
+    if all(A1 == ti.Matrix.zero(dt, 2, 2)) and all(
+            A1 == ti.Matrix.zero(dt, 2, 2)):
+        v1 = ti.Vector([0.0, 1.0]).cast(dt)
+        v2 = ti.Vector([1.0, 0.0]).cast(dt)
+    else:
+        v1 = ti.Vector([A2[0, 0], A2[1, 0]]).cast(dt).normalized()
+        v2 = ti.Vector([A1[0, 0], A1[1, 0]]).cast(dt).normalized()
+    eigenvectors = ti.Matrix.cols([v1, v2])
+    return eigenvalues, eigenvectors
+
+
+@ti.func
 def svd(A, dt):
     if ti.static(A.n == 2):
         ret = svd2d(A, dt)

--- a/tests/python/test_eig.py
+++ b/tests/python/test_eig.py
@@ -87,7 +87,7 @@ def _test_sym_eig2x2(dt):
 
     @ti.kernel
     def eigen_solve():
-        v[None], w[None] = ti.sym_eig(A)
+        v[None], w[None] = ti.sym_eig(A[None])
 
     tol = 1e-5 if dt == ti.f32 else 1e-12
     dtype = np.float32 if dt == ti.f32 else np.float64

--- a/tests/python/test_eig.py
+++ b/tests/python/test_eig.py
@@ -78,8 +78,47 @@ def _test_eig2x2_complex(dt):
     _eigen_vector_equal(w_ti_complex[:, idx_ti[1]], w_np[:, idx_np[1]], tol)
 
 
+def _test_sym_eig2x2(dt):
+    A = ti.Matrix.field(2, 2, dtype=dt, shape=())
+    v = ti.Vector.field(2, dtype=dt, shape=())
+    w = ti.Matrix.field(2, 2, dtype=dt, shape=())
+
+    A[None] = [[5, 3], [3, 2]]
+
+    @ti.kernel
+    def eigen_solve():
+        v[None], w[None] = ti.sym_eig(A)
+
+    tol = 1e-5 if dt == ti.f32 else 1e-12
+    dtype = np.float32 if dt == ti.f32 else np.float64
+
+    eigen_solve()
+    v_np, w_np = np.linalg.eig(A.to_numpy().astype(dtype))
+    v_ti = v.to_numpy().astype(dtype)
+    w_ti = w.to_numpy().astype(dtype)
+
+    # sort by eigenvalues
+    idx_np = np.argsort(v_np)
+    idx_ti = np.argsort(v_ti)
+
+    np.testing.assert_allclose(v_ti[idx_ti], v_np[idx_np], atol=tol, rtol=tol)
+    _eigen_vector_equal(w_ti[:, idx_ti[0]], w_np[:, idx_np[0]], tol)
+    _eigen_vector_equal(w_ti[:, idx_ti[1]], w_np[:, idx_np[1]], tol)
+
+
 def test_eig2x2():
     for func in [_test_eig2x2_real, _test_eig2x2_complex]:
+        for fp in [ti.f32, ti.f64]:
+
+            @ti.all_archs_with(default_fp=fp, fast_math=False)
+            def wrapped():
+                func(fp)
+
+            wrapped()
+
+
+def test_sym_eig2x2():
+    for func in [_test_sym_eig2x2]:
         for fp in [ti.f32, ti.f64]:
 
             @ti.all_archs_with(default_fp=fp, fast_math=False)


### PR DESCRIPTION
Related issue = #2208, #2293  

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
This PR aims to add another utility function `ti.sym_eig` as described in #2293 and implement the corresponding solver for 2x2 matrices.

Similar to `np.linalg.eigs`, `ti.sym_eig` solves the eigenvalues and eigenvectors for symmetric matrices. Unlike `ti.eig` which stores the eigenvalue and eigenvector results as complex numbers,  `ti.sym_eig` returns real number results for simplicity. The interface design of `ti.sym_eig` is showed below:
```python
def sym_eig(A, dt=None):
    """Compute the eigenvalues and right eigenvectors of a real symmetric matrix.
    
    Parameters
    ----------
    A: ti.Matrix(n, n)
        Symmetric Matrix for which the eigenvalues and right eigenvectors will be computed.
    dt: Optional[DataType]
        The datatype for the eigenvalues and right eigenvectors
    
    Returns
    -------
    eigenvalues: ti.Vector(n)
        The eigenvalues. Each entry stores one eigenvalue.
    eigenvectors: ti.Matrix(n, n)
        The eigenvectors. Each column stores one eigenvector.
    """
```