### PR TITLE
[Example] cornell_box: Remove unused sphere

### DIFF
--- a/examples/cornell_box.py
+++ b/examples/cornell_box.py
@@ -41,13 +41,9 @@ lambertian_brdf = 1.0 / math.pi
 # diamond!
 refr_idx = 2.4
 
-# right near sphere
+# right sphere
 sp1_center = ti.Vector([0.4, 0.225, 1.75])
 sp1_radius = 0.22
-# left far sphere
-sp2_center = ti.Vector([-0.28, 0.55, 0.8])
-sp2_radius = 0.32
-
 
 def make_box_transform_matrices():
     rad = math.pi / 8.0

--- a/examples/cornell_box.py
+++ b/examples/cornell_box.py
@@ -45,6 +45,7 @@ refr_idx = 2.4
 sp1_center = ti.Vector([0.4, 0.225, 1.75])
 sp1_radius = 0.22
 
+
 def make_box_transform_matrices():
     rad = math.pi / 8.0
     c, s = math.cos(rad), math.sin(rad)


### PR DESCRIPTION
Hello ! Was playing around with this and found the second sphere position/radius unused, so thought it can be removed. Let me know if it's still needed however, in which case we don't need to merge.

Cheers,
Aaryaman
