### PR TITLE
[Docker] Fix the docker build by bumping CMake version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && \
                        python3-pip \
                        libtinfo-dev \
                        clang-8 \
-                       cmake \
                        wget \
                        git \
                        libx11-dev \
@@ -22,14 +21,27 @@ RUN apt-get update && \
                        libglu1-mesa-dev \
                        freeglut3-dev \
                        mesa-common-dev \
-                       libtinfo5
+                       libtinfo5 \
+                       build-essential \
+                       libssl-dev
 
 # Install Taichi's Python dependencies
 RUN python3 -m pip install --user setuptools astor pybind11 pylint sourceinspect
 RUN python3 -m pip install --user pytest pytest-rerunfailures pytest-xdist yapf
 RUN python3 -m pip install --user numpy GitPython coverage colorama autograd
 
+# Install the latest version of CMAKE v3.20.2 from source
+RUN apt purge --auto-remove cmake
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2.tar.gz
+RUN tar -zxvf cmake-3.20.2.tar.gz
+RUN cd cmake-3.20.2
+WORKDIR /cmake-3.20.2
+RUN ./bootstrap
+RUN make -j 8
+RUN make install
+
 # Intall LLVM 10
+WORKDIR /
 ENV CC=/usr/bin/clang-8
 ENV CXX=/usr/bin/clang++-8
 RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,7 @@ ENV TAICHI_REPO_DIR="/taichi-dev/taichi/"
 ENV PYTHONPATH="$TAICHI_REPO_DIR/python:$PYTHONPATH"
 ENV LANG="C.UTF-8"
 
+# Add Docker specific ENV
+ENV TI_IN_DOCKER=true
 WORKDIR /taichi-dev/taichi
 CMD /bin/bash


### PR DESCRIPTION
Related issue = #

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----

It seems the docker build trigger has been failing on Docker Hub for a couple of weeks... This PR fixes the docker build by using the latest CMake (v3.20.2). A few points I want to flag:

- The `ti test` passed the second time I ran them, while it failed the first time on `test_fuse_dense_x2y2z[x64]` reporting `[snode_types.cpp:snode_type_name@18] Not supported`, I assumed it's transient.
- Ubuntu LTS's `apt` does not ship the latest packages such CMake, which is the root cause of this issue, I switched to use a pinned version of CMake and build fro source, but not sure if the latest (v3.20.2) is too aggressively new?
- I just discovered `python/taichi/core/util.py` has this `in_docker` predicate function which relies on `TI_IN_DOCKER`, so I added it to the Dockerfile. I'm not sure what it was used for (maybe no one is using it which can explain why we never ran into issues).
- I guess, unfortunately, in order to test whether this fixes the post-ci, we have to merge it?

I have tested the newly built docker image works on Ubuntu with CUDA support, following https://taichi.readthedocs.io/en/latest/dev_install.html?highlight=docker#use-docker-image-on-ubuntu-with-cuda-support