### PR TITLE
[ir] Remove "kernel" when printing ReturnStmt

### DIFF
--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -388,12 +388,12 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(FrontendReturnStmt *stmt) override {
-    print("{}{} : kernel return {}", stmt->type_hint(), stmt->name(),
+    print("{}{} : return {}", stmt->type_hint(), stmt->name(),
           stmt->value->serialize());
   }
 
   void visit(ReturnStmt *stmt) override {
-    print("{}{} : kernel return {}", stmt->type_hint(), stmt->name(),
+    print("{}{} : return {}", stmt->type_hint(), stmt->name(),
           stmt->value->name());
   }
 


### PR DESCRIPTION
Related issue = a continuation of #2349

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
