### PR TITLE
[lang] Remove serializer's variadic template API

### DIFF
--- a/taichi/common/serialization.h
+++ b/taichi/common/serialization.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <fstream>
@@ -13,6 +14,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -54,71 +56,93 @@ using is_unit = typename std::is_base_of<Unit, remove_cvref_t<T>>;
 
 template <typename T>
 using is_unit_t = typename is_unit<T>::type;
+
 }  // namespace type
 
-#define TI_IO_DECL_INST                               \
-  void binary_io(BinaryOutputSerializer &ser) const { \
-    ser(*this);                                       \
-  }                                                   \
-  void binary_io(BinaryInputSerializer &ser) const {  \
-    ser(*this);                                       \
-  }
+namespace detail {
 
-#define TI_IO_DECL_INST_VIRT                                  \
-  virtual void binary_io(BinaryOutputSerializer &ser) const { \
-    ser(*this);                                               \
-  }                                                           \
-  virtual void binary_io(BinaryInputSerializer &ser) const {  \
-    ser(*this);                                               \
+template <size_t N>
+constexpr size_t count_delim(const char (&str)[N], char delim) {
+  size_t count = 1;
+  for (const char &ch : str) {
+    if (ch == delim) {
+      ++count;
+    }
   }
+  return count;
+}
 
-#define TI_IO_DECL_INST_VIRT_OVERRIDE                                  \
-  virtual void binary_io(BinaryOutputSerializer &ser) const override { \
-    ser(*this);                                                        \
-  }                                                                    \
-  virtual void binary_io(BinaryInputSerializer &ser) const override {  \
-    ser(*this);                                                        \
+template <size_t DelimN>
+struct StrDelimSplitter {
+  template <size_t StrsN>
+  static constexpr std::array<std::string_view, DelimN> make(
+      const char (&str)[StrsN],
+      char delim) {
+    std::array<std::string_view, DelimN> res;
+    const char *head = &(str[0]);
+    size_t si = 0;
+    size_t cur_head_i = 0;
+    size_t ri = 0;
+    while (si < StrsN) {
+      if (str[si] != delim) {
+        si += 1;
+      } else {
+        res[ri] = {head, (si - cur_head_i)};
+        ++ri;
+        si += 2;  // skip ", "
+        cur_head_i = si;
+        head = &(str[cur_head_i]);
+      }
+    }
+    // `StrsN - 1` because the last char is '\0'.
+    res[ri] = {head, (StrsN - 1 - cur_head_i)};
+    return res;
   }
+};
+
+template <typename SER, size_t N, typename T>
+void serialize_kv_impl(SER &ser,
+                       const std::array<std::string_view, N> &keys,
+                       T &&val) {
+  std::string key{keys[N - 1]};
+  ser(key.c_str(), val);
+}
+
+template <typename SER, size_t N, typename T, typename... Args>
+void serialize_kv_impl(SER &ser,
+                       const std::array<std::string_view, N> &keys,
+                       T &&head,
+                       Args &&... rest) {
+  constexpr auto i = (N - sizeof...(Args));
+  std::string key{keys[i]};
+  ser(key.c_str(), head);
+  serialize_kv_impl(ser, keys, rest...);
+}
+
+}  // namespace detail
 
 #define TI_IO_DECL      \
-  TI_IO_DECL_INST       \
   template <typename S> \
-  void io(S &serializer) const
-
-#define TI_IO_DECL_VIRT \
-  TI_IO_DECL_INST_VIRT  \
-  template <typename S> \
-  void io(S &serializer) const
-
-#define TI_IO_DECL_VIRT_OVERRIDE \
-  TI_IO_DECL_INST_VIRT_OVERRIDE  \
-  template <typename S>          \
   void io(S &serializer) const
 
 #define TI_IO_DEF(...)           \
-  TI_IO_DECL_INST                \
   template <typename S>          \
   void io(S &serializer) const { \
-    TI_IO(__VA_ARGS__)           \
+    TI_IO(__VA_ARGS__);          \
   }
 
-#define TI_IO_DEF_VIRT(...)      \
-  TI_IO_DECL_INST_VIRT           \
-  template <typename S>          \
-  void io(S &serializer) const { \
-    TI_IO(__VA_ARGS__)           \
-  }
-
-#define TI_IO_DEF_WITH_BASE(...) \
-  TI_IO_DECL_INST_VIRT_OVERRIDE  \
-  template <typename S>          \
-  void io(S &serializer) const { \
-    Base::io(serializer);        \
-    TI_IO(__VA_ARGS__)           \
-  }
-
-#define TI_IO(...) \
-  { serializer(#__VA_ARGS__, __VA_ARGS__); }
+// This macro serializes each field with its name by doing the following:
+// 1. Stringifies __VA_ARGS__, then split the stringified result by ',' at
+// compile time.
+// 2. Invoke serializer::operator("arg", arg) for each arg in __VA_ARGS__. This
+// is implemented inside detail::serialize_kv_impl.
+#define TI_IO(...)                                                     \
+  do {                                                                 \
+    constexpr size_t kDelimN = detail::count_delim(#__VA_ARGS__, ','); \
+    constexpr auto kSplitStrs =                                        \
+        detail::StrDelimSplitter<kDelimN>::make(#__VA_ARGS__, ',');    \
+    detail::serialize_kv_impl(serializer, kSplitStrs, __VA_ARGS__);    \
+  } while (0)
 
 #define TI_SERIALIZER_IS(T)                                                 \
   (std::is_same<typename std::remove_reference<decltype(serializer)>::type, \
@@ -313,25 +337,36 @@ class BinarySerializer : public Serializer {
     }
   }
 
+  template <typename T>
+  void operator()(const char *, const T &val) {
+    this->process(val);
+  }
+
+  template <typename T>
+  void operator()(const T &val) {
+    this->process(val);
+  }
+
+ private:
   // std::string
-  void operator()(const char *, const std::string &val_) {
+  void process(const std::string &val_) {
     auto &val = get_writable(val_);
     if (writing) {
       std::vector<char> val_vector(val.begin(), val.end());
-      this->operator()(nullptr, val_vector);
+      this->process(val_vector);
     } else {
       std::vector<char> val_vector;
-      this->operator()(nullptr, val_vector);
+      this->process(val_vector);
       val = std::string(val_vector.begin(), val_vector.end());
     }
   }
 
   // C-array
   template <typename T, std::size_t n>
-  void operator()(const char *, const TArray<T, n> &val) {
+  void process(const TArray<T, n> &val) {
     if (writing) {
       for (std::size_t i = 0; i < n; i++) {
-        this->operator()("", val[i]);
+        this->process(val[i]);
       }
     } else {
       // TODO: why do I have to let it write to tmp, otherwise I get Sig Fault?
@@ -341,7 +376,7 @@ class BinarySerializer : public Serializer {
           std::conditional_t<std::is_same<Traw, bool>::value, uint8, Traw>>
           tmp(n);
       for (std::size_t i = 0; i < n; i++) {
-        this->operator()("", tmp[i]);
+        this->process(tmp[i]);
       }
       std::memcpy(const_cast<typename std::remove_cv<T>::type *>(val), &tmp[0],
                   sizeof(tmp[0]) * tmp.size());
@@ -350,8 +385,7 @@ class BinarySerializer : public Serializer {
 
   // Elementary data types
   template <typename T>
-  typename std::enable_if<is_elementary_type_v<T>, void>::type operator()(
-      const char *,
+  typename std::enable_if_t<is_elementary_type_v<T>, void> process(
       const T &val) {
     static_assert(!std::is_reference<T>::value, "T cannot be reference");
     static_assert(!std::is_const<T>::value, "T cannot be const");
@@ -382,32 +416,29 @@ class BinarySerializer : public Serializer {
   }
 
   template <typename T>
-  typename std::enable_if<has_io<T>::value, void>::type operator()(
-      const char *,
-      const T &val) {
+  std::enable_if_t<has_io<T>::value, void> process(const T &val) {
     val.io(*this);
   }
 
   // Unique Pointers to non-taichi-unit Types
   template <typename T>
-  typename std::enable_if<!type::is_unit<T>::value, void>::type operator()(
-      const char *,
+  typename std::enable_if<!type::is_unit<T>::value, void>::type process(
       const std::unique_ptr<T> &val_) {
     auto &val = get_writable(val_);
     if (writing) {
-      this->operator()(ptr_to_int(val.get()));
+      this->process(ptr_to_int(val.get()));
       if (val.get() != nullptr) {
-        this->operator()("", *val);
+        this->process(*val);
         // Just for checking future raw pointers
         assets.insert(std::make_pair(ptr_to_int(val.get()), val.get()));
       }
     } else {
       std::size_t original_addr;
-      this->operator()("", original_addr);
+      this->process(original_addr);
       if (original_addr != 0) {
         val = std::make_unique<T>();
         assets.insert(std::make_pair(original_addr, val.get()));
-        this->operator()("", *val);
+        this->process(*val);
       }
     }
   }
@@ -419,39 +450,37 @@ class BinarySerializer : public Serializer {
 
   // Unique Pointers to taichi-unit Types
   template <typename T>
-  typename std::enable_if<type::is_unit<T>::value, void>::type operator()(
-      const char *,
+  typename std::enable_if<type::is_unit<T>::value, void>::type process(
       const std::unique_ptr<T> &val_) {
     auto &val = get_writable(val_);
     if (writing) {
-      this->operator()(val->get_name());
-      this->operator()(ptr_to_int(val.get()));
+      this->process(val->get_name());
+      this->process(ptr_to_int(val.get()));
       if (val.get() != nullptr) {
-        val->binary_io(*this);
+        val->binary_io(nullptr, *this);
         // Just for checking future raw pointers
         assets.insert(std::make_pair(ptr_to_int(val.get()), val.get()));
       }
     } else {
       std::string name;
       std::size_t original_addr;
-      this->operator()("", name);
-      this->operator()("", original_addr);
+      this->process(name);
+      this->process(original_addr);
       if (original_addr != 0) {
         val = create_instance_unique<T>(name);
         assets.insert(std::make_pair(original_addr, val.get()));
-        val->binary_io(*this);
+        val->binary_io(nullptr, *this);
       }
     }
   }
 
   // Raw pointers (no ownership)
   template <typename T>
-  typename std::enable_if<std::is_pointer<T>::value, void>::type operator()(
-      const char *,
+  typename std::enable_if<std::is_pointer<T>::value, void>::type process(
       const T &val_) {
     auto &val = get_writable(val_);
     if (writing) {
-      this->operator()("", ptr_to_int(val));
+      this->process(ptr_to_int(val));
       if (val != nullptr) {
         TI_ASSERT_INFO(assets.find(ptr_to_int(val)) != assets.end(),
                        "Cannot find the address with a smart pointer pointing "
@@ -460,7 +489,7 @@ class BinarySerializer : public Serializer {
       }
     } else {
       std::size_t val_ptr = 0;
-      this->operator()("", val_ptr);
+      this->process(val_ptr);
       if (val_ptr != 0) {
         TI_ASSERT(assets.find(val_ptr) != assets.end());
         val = reinterpret_cast<typename std::remove_pointer<T>::type *>(
@@ -471,106 +500,92 @@ class BinarySerializer : public Serializer {
 
   // enum class
   template <typename T>
-  typename std::enable_if<std::is_enum_v<T>, void>::type operator()(
-      const char *,
-      const T &val) {
+  typename std::enable_if<std::is_enum_v<T>, void>::type process(const T &val) {
     using UT = std::underlying_type_t<T>;
     // https://stackoverflow.com/a/62688905/12003165
     if constexpr (writing) {
-      this->operator()(nullptr, static_cast<UT>(val));
+      this->process(static_cast<UT>(val));
     } else {
       auto &wval = get_writable(val);
       UT &underlying_wval = reinterpret_cast<UT &>(wval);
-      this->operator()(nullptr, underlying_wval);
+      this->process(underlying_wval);
     }
   }
 
   // std::vector
   template <typename T>
-  void operator()(const char *, const std::vector<T> &val_) {
+  void process(const std::vector<T> &val_) {
     auto &val = get_writable(val_);
     if (writing) {
-      this->operator()("", val.size());
+      this->process(val.size());
     } else {
       std::size_t n = 0;
-      this->operator()("", n);
+      this->process(n);
       val.resize(n);
     }
     for (std::size_t i = 0; i < val.size(); i++) {
-      this->operator()("", val[i]);
+      this->process(val[i]);
     }
   }
 
   // std::pair
   template <typename T, typename G>
-  void operator()(const char *, const std::pair<T, G> &val) {
-    this->operator()(nullptr, val.first);
-    this->operator()(nullptr, val.second);
+  void process(const std::pair<T, G> &val) {
+    this->process(val.first);
+    this->process(val.second);
   }
 
   // std::map
   template <typename K, typename V>
-  void operator()(const char *, const std::map<K, V> &val) {
+  void process(const std::map<K, V> &val) {
     handle_associative_container(val);
   }
 
   // std::unordered_map
   template <typename K, typename V>
-  void operator()(const char *, const std::unordered_map<K, V> &val) {
+  void process(const std::unordered_map<K, V> &val) {
     handle_associative_container(val);
   }
 
   // std::optional
   template <typename T>
-  void operator()(const char *, const std::optional<T> &val) {
+  void process(const std::optional<T> &val) {
     if constexpr (writing) {
-      this->operator()(nullptr, val.has_value());
+      this->process(val.has_value());
       if (val.has_value()) {
-        this->operator()(nullptr, val.value());
+        this->process(val.value());
       }
     } else {
       bool has_value{false};
-      this->operator()(nullptr, has_value);
+      this->process(has_value);
       auto &wval = get_writable(val);
       if (!has_value) {
         wval.reset();
       } else {
         T new_val;
-        this->operator()(nullptr, new_val);
+        this->process(new_val);
         wval = std::move(new_val);
       }
     }
   }
 
-  template <typename T, typename... Args>
-  void operator()(const char *, const T &t, Args &&... rest) {
-    this->operator()(nullptr, t);
-    this->operator()(nullptr, std::forward<Args>(rest)...);
-  }
-
-  template <typename T>
-  void operator()(const T &val) {
-    this->operator()(nullptr, val);
-  }
-
- private:
   template <typename M>
   void handle_associative_container(const M &val) {
     if constexpr (writing) {
-      this->operator()(nullptr, val.size());
+      this->process(val.size());
       for (auto iter : val) {
         auto first = iter.first;
-        this->operator()(nullptr, first);
-        this->operator()(nullptr, iter.second);
+        this->process(first);
+        this->process(iter.second);
       }
     } else {
       auto &wval = get_writable(val);
       wval.clear();
       std::size_t n = 0;
-      this->operator()(nullptr, n);
+      this->process(n);
       for (std::size_t i = 0; i < n; i++) {
         typename M::value_type record;
-        this->operator()(nullptr, record);
+        this->process(record);
         wval.insert(record);
       }
     }
@@ -609,6 +624,186 @@ class TextSerializer : public Serializer {
     first_line = false;
   }
 
+  template <typename T>
+  static std::string serialize(const char *key, const T &t) {
+    TextSerializer ser;
+    ser(key, t);
+    return ser.data;
+  }
+
+  template <typename T>
+  void operator()(const char *key, const T &t) {
+    this->process(key, t);
+  }
+
+ private:
+  void process(const char *key, const std::string &val) {
+    add_line(std::string(key) + ": " + val);
+  }
+
+  template <typename T, std::size_t n>
+  using is_compact =
+      typename std::integral_constant<bool,
+                                      std::is_arithmetic<T>::value && (n < 7)>;
+
+  // C-array
+  template <typename T, std::size_t n>
+  std::enable_if_t<is_compact<T, n>::value, void> process(
+      const char *key,
+      const TArray<T, n> &val) {
+    std::stringstream ss;
+    ss << "[";
+    for (std::size_t i = 0; i < n; i++) {
+      ss << val[i];
+      if (i != n - 1) {
+        ss << ", ";
+      }
+    }
+    ss << "]";
+    add_line(key, ss.str());
+  }
+
+  // C-array
+  template <typename T, std::size_t n>
+  std::enable_if_t<!is_compact<T, n>::value, void> process(
+      const char *key,
+      const TArray<T, n> &val) {
+    add_line(key, "[");
+    indent++;
+    for (std::size_t i = 0; i < n; i++) {
+      this->process(("[" + std::to_string(i) + "]").c_str(), val[i]);
+    }
+    indent--;
+    add_line("]");
+  }
+
+  // std::array
+  template <typename T, std::size_t n>
+  std::enable_if_t<is_compact<T, n>::value, void> process(
+      const char *key,
+      const StdTArray<T, n> &val) {
+    std::stringstream ss;
+    ss << "[";
+    for (std::size_t i = 0; i < n; i++) {
+      ss << val[i];
+      if (i != n - 1) {
+        ss << ", ";
+      }
+    }
+    ss << "]";
+    add_line(key, ss.str());
+  }
+
+  // std::array
+  template <typename T, std::size_t n>
+  std::enable_if_t<!is_compact<T, n>::value, void> process(
+      const char *key,
+      const StdTArray<T, n> &val) {
+    add_line(key, "[");
+    indent++;
+    for (std::size_t i = 0; i < n; i++) {
+      this->process(("[" + std::to_string(i) + "]").c_str(), val[i]);
+    }
+    indent--;
+    add_line("]");
+  }
+
+  // Elementary data types
+  template <typename T>
+  std::enable_if_t<is_elementary_type_v<T>, void> process(const char *key,
+                                                          const T &val) {
+    static_assert(!has_io<T>::value, "");
+    std::stringstream ss;
+    ss << std::boolalpha << val;
+    add_line(key, ss.str());
+  }
+
+  template <typename T>
+  std::enable_if_t<has_io<T>::value, void> process(const char *key,
+                                                   const T &val) {
+    add_line(key, "{");
+    indent++;
+    val.io(*this);
+    indent--;
+    add_line("}");
+  }
+
+  template <typename T>
+  std::enable_if_t<has_free_io<T>::value, void> process(const char *key,
+                                                        const T &val) {
+    add_line(key, "{");
+    indent++;
+    IO<typename type::remove_cvref_t<T>, decltype(*this)>()(*this, val);
+    indent--;
+    add_line("}");
+  }
+
+  template <typename T>
+  std::enable_if_t<std::is_enum_v<T>, void> process(const char *key,
+                                                    const T &val) {
+    using UT = std::underlying_type_t<T>;
+    this->process(key, static_cast<UT>(val));
+  }
+
+  template <typename T>
+  void process(const char *key, const std::vector<T> &val) {
+    add_line(key, "[");
+    indent++;
+    for (std::size_t i = 0; i < val.size(); i++) {
+      this->process(("[" + std::to_string(i) + "]").c_str(), val[i]);
+    }
+    indent--;
+    add_line("]");
+  }
+
+  template <typename T, typename G>
+  void process(const char *key, const std::pair<T, G> &val) {
+    add_line(key, "(");
+    indent++;
+    this->process("first", val.first);
+    this->process("second", val.second);
+    indent--;
+    add_line(")");
+  }
+
+  // std::map
+  template <typename K, typename V>
+  void process(const char *key, const std::map<K, V> &val) {
+    handle_associative_container(key, val);
+  }
+
+  // std::unordered_map
+  template <typename K, typename V>
+  void process(const char *key, const std::unordered_map<K, V> &val) {
+    handle_associative_container(key, val);
+  }
+
+  // std::optional
+  template <typename T>
+  void process(const char *key, const std::optional<T> &val) {
+    add_line(key, "{");
+    indent++;
+    this->process("has_value", val.has_value());
+    if (val.has_value()) {
+      this->process("value", val.value());
+    }
+    indent--;
+    add_line("}");
+  }
+
+  template <typename M>
+  void handle_associative_container(const char *key, const M &val) {
+    add_line(key, "{");
+    indent++;
+    for (auto iter : val) {
+      auto first = iter.first;
+      this->process("key", first);
+      this->process("value", iter.second);
+    }
+    indent--;
+    add_line("}");
+  }
+
   void add_line(const std::string &str) {
     if (first_line) {
       first_line = false;
@@ -620,196 +815,6 @@ class TextSerializer : public Serializer {
 
   void add_line(const std::string &key, const std::string &value) {
     add_line(key + ": " + value);
-  }
-
-  template <typename T>
-  static std::string serialize(const char *key, const T &t) {
-    TextSerializer ser;
-    ser(key, t);
-    return ser.data;
-  }
-
-  void operator()(const char *key, const std::string &val) {
-    add_line(std::string(key) + ": " + val);
-  }
-
-  template <typename T, std::size_t n>
-  using is_compact =
-      typename std::integral_constant<bool,
-                                      std::is_arithmetic<T>::value && (n < 7)>;
-
-  // C-array
-  template <typename T, std::size_t n>
-  typename std::enable_if<is_compact<T, n>::value, void>::type operator()(
-      const char *key,
-      const TArray<T, n> &val) {
-    std::stringstream ss;
-    ss << "[";
-    for (std::size_t i = 0; i < n; i++) {
-      ss << val[i];
-      if (i != n - 1) {
-        ss << ", ";
-      }
-    }
-    ss << "]";
-    add_line(key, ss.str());
-  }
-
-  // C-array
-  template <typename T, std::size_t n>
-  typename std::enable_if<!is_compact<T, n>::value, void>::type operator()(
-      const char *key,
-      const TArray<T, n> &val) {
-    add_line(key, "[");
-    indent++;
-    for (std::size_t i = 0; i < n; i++) {
-      this->operator()(("[" + std::to_string(i) + "]").c_str(), val[i]);
-    }
-    indent--;
-    add_line("]");
-  }
-
-  // std::array
-  template <typename T, std::size_t n>
-  typename std::enable_if<is_compact<T, n>::value, void>::type operator()(
-      const char *key,
-      const StdTArray<T, n> &val) {
-    std::stringstream ss;
-    ss << "[";
-    for (std::size_t i = 0; i < n; i++) {
-      ss << val[i];
-      if (i != n - 1) {
-        ss << ", ";
-      }
-    }
-    ss << "]";
-    add_line(key, ss.str());
-  }
-
-  // std::array
-  template <typename T, std::size_t n>
-  typename std::enable_if<!is_compact<T, n>::value, void>::type operator()(
-      const char *key,
-      const StdTArray<T, n> &val) {
-    add_line(key, "[");
-    indent++;
-    for (std::size_t i = 0; i < n; i++) {
-      this->operator()(("[" + std::to_string(i) + "]").c_str(), val[i]);
-    }
-    indent--;
-    add_line("]");
-  }
-
-  // Elementary data types
-  template <typename T>
-  typename std::enable_if<is_elementary_type_v<T>, void>::type operator()(
-      const char *key,
-      const T &val) {
-    static_assert(!has_io<T>::value, "");
-    std::stringstream ss;
-    ss << std::boolalpha << val;
-    add_line(key, ss.str());
-  }
-
-  template <typename T>
-  typename std::enable_if<has_io<T>::value, void>::type operator()(
-      const char *key,
-      const T &val) {
-    add_line(key, "{");
-    indent++;
-    val.io(*this);
-    indent--;
-    add_line("}");
-  }
-
-  template <typename T>
-  typename std::enable_if<has_free_io<T>::value, void>::type operator()(
-      const char *key,
-      const T &val) {
-    add_line(key, "{");
-    indent++;
-    IO<typename type::remove_cvref_t<T>, decltype(*this)>()(*this, val);
-    indent--;
-    add_line("}");
-  }
-
-  template <typename T>
-  typename std::enable_if<std::is_enum_v<T>, void>::type operator()(
-      const char *key,
-      const T &val) {
-    using UT = std::underlying_type_t<T>;
-    this->operator()(key, static_cast<UT>(val));
-  }
-
-  template <typename T>
-  void operator()(const char *key, const std::vector<T> &val) {
-    add_line(key, "[");
-    indent++;
-    for (std::size_t i = 0; i < val.size(); i++) {
-      this->operator()(("[" + std::to_string(i) + "]").c_str(), val[i]);
-    }
-    indent--;
-    add_line("]");
-  }
-
-  template <typename T, typename G>
-  void operator()(const char *key, const std::pair<T, G> &val) {
-    add_line(key, "(");
-    indent++;
-    this->operator()("[0]", val.first);
-    this->operator()("[1]", val.second);
-    indent--;
-    add_line(")");
-  }
-
-  // std::map
-  template <typename T, typename G>
-  void operator()(const char *key, const std::map<T, G> &val) {
-    handle_associative_container(key, val);
-  }
-
-  // std::unordered_map
-  template <typename T, typename G>
-  void operator()(const char *key, const std::unordered_map<T, G> &val) {
-    handle_associative_container(key, val);
-  }
-
-  // std::optional
-  template <typename T>
-  void operator()(const char *key, const std::optional<T> &val) {
-    add_line(key, "{");
-    indent++;
-    this->operator()("has_value", val.has_value());
-    if (val.has_value()) {
-      this->operator()("value", val.value());
-    }
-    indent--;
-    add_line("}");
-  }
-
-  template <typename T, typename... Args>
-  void operator()(const char *key_, const T &t, Args &&... rest) {
-    std::string key(key_);
-    size_t pos = key.find(",");
-    std::string first_name = key.substr(0, pos);
-    std::string rest_names =
-        key.substr(pos + 2, int(key.size()) - (int)pos - 2);
-    this->operator()(first_name.c_str(), t);
-    this->operator()(rest_names.c_str(), std::forward<Args>(rest)...);
-  }
-
- private:
-  template <typename M>
-  void handle_associative_container(const char *key, const M &val) {
-    add_line(key, "{");
-    indent++;
-    for (auto iter : val) {
-      auto first = iter.first;
-      this->operator()("key", first);
-      this->operator()("value", iter.second);
-    }
-    indent--;
-    add_line("}");
   }
 };
 

--- a/tests/cpp/common/serialization_test.cpp
+++ b/tests/cpp/common/serialization_test.cpp
@@ -22,6 +22,10 @@ class BinIoPair {
     BinaryInputSerializer is;
     is.initialize(os.data.data());
     is(res);  // deserialize
+
+    // This is just to make sure TextSerializer also works
+    TextSerializer ts;
+    ts("val", val);
     return res;
   }
 };
@@ -50,6 +54,21 @@ struct Parent {
 
   TI_IO_DEF(b, c);
 };
+
+TEST(Serialization, SplitStr) {
+  using namespace detail;
+
+#define STR(...) #__VA_ARGS__
+  constexpr auto kDelimN = count_delim(STR(a, bc, def, gh), ',');
+  constexpr auto kArr =
+      StrDelimSplitter<kDelimN>::make(STR(a, bc, def, gh), ',');
+  const std::vector<std::string> expected = {"a", "bc", "def", "gh"};
+  EXPECT_EQ(kArr.size(), expected.size());
+  for (int i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(kArr[i], expected[i]);
+  }
+#undef STR
+}
 
 TEST(Serialization, Basic) {
   BinIoPair bp;
@@ -96,6 +115,11 @@ TEST(Serialization, Basic) {
   par.b->c = true;
   par.c = "hello";
   EXPECT_EQ(bp.run(par), par);
+
+  // TODO: Have a proper way to test this...
+  TextSerializer ts;
+  ts("par", par);
+  ts.print();
 }
 
 }  // namespace


### PR DESCRIPTION
Related issue = Follow up of #2350 

Previous implementation of the serializer's variadic template API:

https://github.com/taichi-dev/taichi/blob/284f75eddd0e172b17b144e4f60d443f32a5520e/taichi/common/serialization.h#L545-L550

https://github.com/taichi-dev/taichi/blob/284f75eddd0e172b17b144e4f60d443f32a5520e/taichi/common/serialization.h#L790-L799

Caused a problems where a struct that doesn't satisfy any of the parameter type known by the serializer *can still be accepted by the serializers*. When none of the known parameter type matches, the C++ compiler will just fallback to this template API. Through a series of template instantiation, this would lead to unterminated recursive calls and stackoverflow at runtime. This is bad as we are supposed to catch such errors at compile time.

This PR refactors how `TI_IO(...)` is implemented, by splitting the stringified `__VA_ARGS__` by `','` at compile time, then invoking  `serializer::operatpr()("arg", arg)` on each args. This way we can remove the variadic template API from the serializers, and detect the aforementioned problem at compile time.

Another fix is that I've completely removed the set of `TI_IO_DECL_INST` macros. These macros define `io()` methods that accepts `Binary{Input|Output}Serializer`, and are (indirectly) called by most CHI IR stmts via `TI_STMT_DEF_FIELDS`.  It has turned out that these stmts are not serializable, because they contain unserializable types like `DataType` (which contains a pointer to the polymorphic `Type` API). Serializing/Deserializing a polymorphic type is not a trivial thing in C++. So let's just remove this functionality since nobody is using it. If we ever need to restore this, we should consider using 3rd party libraries.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
