### PR TITLE
[Opt] Add error if bls analysis failed

### DIFF
--- a/taichi/analysis/bls_analyzer.cpp
+++ b/taichi/analysis/bls_analyzer.cpp
@@ -18,12 +18,6 @@ BLSAnalyzer::BLSAnalyzer(OffloadedStmt *for_stmt, ScratchPads *pads)
       generate_block_indices(block, &block_indices_[block]);
     }
   }
-
-  const auto &block = for_stmt->body;
-
-  for (int i = 0; i < (int)block->statements.size(); i++) {
-    block->statements[i]->accept(this);
-  }
 }
 
 // static
@@ -37,6 +31,9 @@ void BLSAnalyzer::generate_block_indices(SNode *snode, BlockIndices *indices) {
 }
 
 void BLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
+  if (!analysis_ok_) {
+    return;
+  }
   if (!stmt->is<GlobalPtrStmt>())
     return;  // local alloca
   auto ptr = stmt->as<GlobalPtrStmt>();
@@ -57,6 +54,7 @@ void BLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
         offsets[i].high = diff.high;
       } else {
         matching_indices = false;
+        analysis_ok_ = false;
       }
     }
     if (matching_indices) {
@@ -99,6 +97,16 @@ void BLSAnalyzer::visit(AtomicOpStmt *stmt) {
 
 void BLSAnalyzer::visit(Stmt *stmt) {
   TI_ASSERT(!stmt->is_container_statement());
+}
+
+bool BLSAnalyzer::run() {
+  const auto &block = for_stmt_->body;
+
+  for (int i = 0; i < (int)block->statements.size(); i++) {
+    block->statements[i]->accept(this);
+  }
+
+  return analysis_ok_;
 }
 
 }  // namespace lang

--- a/taichi/analysis/bls_analyzer.h
+++ b/taichi/analysis/bls_analyzer.h
@@ -33,6 +33,12 @@ class BLSAnalyzer : public BasicStmtVisitor {
 
   void visit(Stmt *stmt) override;
 
+  /**
+   * Run the block local analysis
+   * @return: true if the block range could be successfully inferred
+   */
+  bool run();
+
  private:
   // Generate the index bounds in a SNode (block). E.g., a dense(ti.ij, (2, 4))
   // SNode has index bounds [[0, 1], [0, 3]].
@@ -43,6 +49,11 @@ class BLSAnalyzer : public BasicStmtVisitor {
   OffloadedStmt *for_stmt_{nullptr};
   ScratchPads *pads_{nullptr};
   std::unordered_map<SNode *, BlockIndices> block_indices_;
+  // true means analysis is OK for now
+  // it could be failed by any of the following reasons
+  // compiler could not infer the scratch pad range at compile time
+  // ...
+  bool analysis_ok_{true};
 };
 
 }  // namespace lang

--- a/taichi/transforms/insert_scratch_pad.cpp
+++ b/taichi/transforms/insert_scratch_pad.cpp
@@ -22,7 +22,11 @@ std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *offload) {
            SNodeAccessFlag::block_local)) {
     pads->insert(snode);
   }
-  BLSAnalyzer _(offload, pads.get());
+  BLSAnalyzer bls_analyzer(offload, pads.get());
+  bool analysis_ok = bls_analyzer.run();
+  if (!analysis_ok) {
+    TI_ERROR("BLS analysis failed !");
+  }
   pads->finalize();
   return pads;
 }

--- a/tests/cpp/analysis/bls_analyzer_test.cpp
+++ b/tests/cpp/analysis/bls_analyzer_test.cpp
@@ -65,6 +65,8 @@ TEST_F(BLSAnalyzerTest, Basic) {
   builder_.create_global_load(glb_ptr);
 
   BLSAnalyzer bls(for_stmt_.get(), &pads_);
+  bool analysis_ok = bls.run();
+  ASSERT_TRUE(analysis_ok);
   pads_.finalize();
   const auto &pad = pads_.get(child_snode_);
   EXPECT_EQ(pad.bounds.size(), 2);


### PR DESCRIPTION
Related issue = #2327 
Using `ti.block_local` could be hard for new Taichi Users.  So we add an error when `ti.block_local` could not infer the scratch pad range.
<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
