### PR TITLE
[metal] Fix metal f32 bug in the print buffer

### DIFF
--- a/taichi/backends/metal/shaders/print.metal.h
+++ b/taichi/backends/metal/shaders/print.metal.h
@@ -60,7 +60,7 @@ STR(
       // * Followed by N i32s, one for each print arg. F32 are encoded to I32.
       // For strings, there is a string table on the host side, so that the
       // kernel only needs to store a I32 string ID.
-      enum Type { I32 = 1, U32 = 2, F32 = 2, Str = 3 };
+      enum Type { I32 = 1, U32 = 2, F32 = 3, Str = 4 };
 
       PrintMsg(device int32_t *buf, int num_entries)
           : mask_buf_(buf),


### PR DESCRIPTION
Related issue = #

stable fluids update
fix metal f32 bug

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
