### PR TITLE
[ir] Add nodiscard to get_loop_guard/get_if_guard

### DIFF
--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -92,8 +92,7 @@ class IRBuilder {
   template <typename XStmt>
   [[nodiscard]] LoopGuard get_loop_guard(XStmt *loop) {
     return LoopGuard(*this, loop);
-  }
-  [[nodiscard]] IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
+  }[[nodiscard]] IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
     return IfGuard(*this, if_stmt, true_branch);
   }
 
@@ -192,7 +191,7 @@ class IRBuilder {
 
   // Print values and strings. Arguments can be Stmt* or std::string.
   template <typename... Args>
-  PrintStmt *create_print(Args &&...args) {
+  PrintStmt *create_print(Args &&... args) {
     return insert(Stmt::make_typed<PrintStmt>(std::forward<Args>(args)...));
   }
 

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -92,7 +92,8 @@ class IRBuilder {
   template <typename XStmt>
   [[nodiscard]] LoopGuard get_loop_guard(XStmt *loop) {
     return LoopGuard(*this, loop);
-  }[[nodiscard]] IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
+  }
+  [[nodiscard]] IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
     return IfGuard(*this, if_stmt, true_branch);
   }
 
@@ -191,7 +192,7 @@ class IRBuilder {
 
   // Print values and strings. Arguments can be Stmt* or std::string.
   template <typename... Args>
-  PrintStmt *create_print(Args &&... args) {
+  PrintStmt *create_print(Args &&...args) {
     return insert(Stmt::make_typed<PrintStmt>(std::forward<Args>(args)...));
   }
 

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -92,8 +92,7 @@ class IRBuilder {
   template <typename XStmt>
   [[nodiscard]] LoopGuard get_loop_guard(XStmt *loop) {
     return LoopGuard(*this, loop);
-  }
-  [[nodiscard]] IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
+  }[[nodiscard]] IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
     return IfGuard(*this, if_stmt, true_branch);
   }
 

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -90,10 +90,10 @@ class IRBuilder {
   };
 
   template <typename XStmt>
-  LoopGuard get_loop_guard(XStmt *loop) {
+  [[nodiscard]] LoopGuard get_loop_guard(XStmt *loop) {
     return LoopGuard(*this, loop);
   }
-  IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
+  [[nodiscard]] IfGuard get_if_guard(IfStmt *if_stmt, bool true_branch) {
     return IfGuard(*this, if_stmt, true_branch);
   }
 


### PR DESCRIPTION
Related issue = #2193 

This PR warns CHI users when they write `builder.get_loop_guard(loop);` which has no effect. The correct usage is `auto _ = builder.get_loop_guard(loop);`.

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
