### PR TITLE
[type] [bug] Remove redundant component of bit pointer struct

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1275,7 +1275,6 @@ llvm::Value *CodeGenLLVM::create_bit_ptr_struct(llvm::Value *byte_ptr_base,
   // };
   auto struct_type = llvm::StructType::get(
       *llvm_context, {llvm::Type::getInt8PtrTy(*llvm_context),
-                      llvm::Type::getInt32Ty(*llvm_context),
                       llvm::Type::getInt32Ty(*llvm_context)});
   // 2. allocate the bit pointer struct
   auto bit_ptr_struct = create_entry_block_alloca(struct_type);


### PR DESCRIPTION
Related issue = #1905 #2047 

Bit pointer struct only needs two components (one for byte pointer and one for offset). But somehow another component was added in #2047. I removed it now.

https://github.com/taichi-dev/taichi/blob/6a969901029815434975a3fd9a3aac1d9324776c/taichi/codegen/codegen_llvm.cpp#L1271-L1279

As the comment described, it is not necessary to allocate two int32 components.

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
