### PR TITLE
[CI] Support auto cancel workflows of previous commits

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,15 @@
+name: Cancel
+on:
+  workflow_run:
+    workflows: ["Persubmit Checks"]
+    types:
+      - requested
+
+#now test
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -13,5 +13,6 @@ jobs:
           token: ${{ secrets.GARDENER_PAT }}
           reaction-token: ${{ secrets.GARDENER_PAT }}
           repository: taichi-dev/ci_workflows
+          permission: read
           commands: |
             format

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -13,6 +13,6 @@ jobs:
           token: ${{ secrets.GARDENER_PAT }}
           reaction-token: ${{ secrets.GARDENER_PAT }}
           repository: taichi-dev/ci_workflows
-          permission: read
+          permission: triage
           commands: |
             format


### PR DESCRIPTION
Related issue = #
New commit triggered workflows will cancel previous running/pending workflows.
<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
