### PR TITLE
[lang] Fix filesystem header not found on older GCC

### DIFF
--- a/taichi/backends/metal/aot_module_builder_impl.cpp
+++ b/taichi/backends/metal/aot_module_builder_impl.cpp
@@ -1,9 +1,17 @@
 #include "taichi/backends/metal/aot_module_builder_impl.h"
 
-#include <filesystem>
 #include <fstream>
 
 #include "taichi/backends/metal/codegen_metal.h"
+
+#if defined(__GNUC__) && (__GNUC__ < 8)
+// https://stackoverflow.com/a/45867491
+#include <experimental/filesystem>
+namespace fs = ::std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace fs = ::std::filesystem;
+#endif
 
 namespace taichi {
 namespace lang {
@@ -16,7 +24,6 @@ AotModuleBuilderImpl::AotModuleBuilderImpl(
 
 void AotModuleBuilderImpl::dump(const std::string &output_dir,
                                 const std::string &filename) const {
-  namespace fs = std::filesystem;
   const fs::path dir{output_dir};
   const fs::path bin_path = dir / fmt::format("{}_metadata.tcb", filename);
   write_to_binary_file(kernels_, bin_path.string());


### PR DESCRIPTION
Related issue = #2372 

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
