### PR TITLE
[Metal] Make file names dumped from aot configurable

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -79,5 +79,5 @@ class Module:
         # kernel AOT
         self._kernels.append(kernel)
 
-    def save(self, filepath):
-        self._aot_builder.dump(filepath)
+    def save(self, filepath, filename):
+        self._aot_builder.dump(filepath, filename)

--- a/taichi/backends/metal/aot_module_builder_impl.cpp
+++ b/taichi/backends/metal/aot_module_builder_impl.cpp
@@ -14,20 +14,19 @@ AotModuleBuilderImpl::AotModuleBuilderImpl(
     : compiled_structs_(compiled_structs) {
 }
 
-void AotModuleBuilderImpl::dump(const std::string &output_dir) const {
+void AotModuleBuilderImpl::dump(const std::string &output_dir, const std::string &filename) const {
   namespace fs = std::filesystem;
   const fs::path dir{output_dir};
-  // TODO: Make the file names configurable?
-  const fs::path bin_path = dir / "metadata.tcb";
+  const fs::path bin_path = dir / fmt::format("{}_metadata.tcb", filename);
   write_to_binary_file(kernels_, bin_path.string());
   // The txt file is mostly for debugging purpose.
-  const fs::path txt_path = dir / "metadata.txt";
+  const fs::path txt_path = dir / fmt::format("{}_metadata.txt", filename);
   TextSerializer ts;
   ts("kernels", kernels_);
   ts.write_to_file(txt_path.string());
 
   for (const auto &k : kernels_) {
-    const fs::path mtl_path = dir / fmt::format("{}.metal", k.kernel_name);
+    const fs::path mtl_path = dir / fmt::format("{}_{}.metal", filename, k.kernel_name);
     std::ofstream fs{mtl_path.string()};
     fs << k.source_code;
     fs.close();

--- a/taichi/backends/metal/aot_module_builder_impl.cpp
+++ b/taichi/backends/metal/aot_module_builder_impl.cpp
@@ -14,7 +14,8 @@ AotModuleBuilderImpl::AotModuleBuilderImpl(
     : compiled_structs_(compiled_structs) {
 }
 
-void AotModuleBuilderImpl::dump(const std::string &output_dir, const std::string &filename) const {
+void AotModuleBuilderImpl::dump(const std::string &output_dir,
+                                const std::string &filename) const {
   namespace fs = std::filesystem;
   const fs::path dir{output_dir};
   const fs::path bin_path = dir / fmt::format("{}_metadata.tcb", filename);
@@ -26,7 +27,8 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir, const std::string
   ts.write_to_file(txt_path.string());
 
   for (const auto &k : kernels_) {
-    const fs::path mtl_path = dir / fmt::format("{}_{}.metal", filename, k.kernel_name);
+    const fs::path mtl_path =
+        dir / fmt::format("{}_{}.metal", filename, k.kernel_name);
     std::ofstream fs{mtl_path.string()};
     fs << k.source_code;
     fs.close();

--- a/taichi/backends/metal/aot_module_builder_impl.h
+++ b/taichi/backends/metal/aot_module_builder_impl.h
@@ -15,7 +15,8 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
  public:
   explicit AotModuleBuilderImpl(const CompiledStructs *compiled_structs);
 
-  void dump(const std::string &output_dir, const std::string &filename) const override;
+  void dump(const std::string &output_dir,
+            const std::string &filename) const override;
 
  protected:
   void add_per_backend(const std::string &identifier, Kernel *kernel) override;

--- a/taichi/backends/metal/aot_module_builder_impl.h
+++ b/taichi/backends/metal/aot_module_builder_impl.h
@@ -15,7 +15,7 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
  public:
   explicit AotModuleBuilderImpl(const CompiledStructs *compiled_structs);
 
-  void dump(const std::string &output_dir) const override;
+  void dump(const std::string &output_dir, const std::string &filename) const override;
 
  protected:
   void add_per_backend(const std::string &identifier, Kernel *kernel) override;

--- a/taichi/program/aot_module_builder.h
+++ b/taichi/program/aot_module_builder.h
@@ -13,7 +13,7 @@ class AotModuleBuilder {
 
   void add(const std::string &identifier, Kernel *kernel);
 
-  virtual void dump(const std::string &output_dir) const = 0;
+  virtual void dump(const std::string &output_dir, const std::string &filename) const = 0;
 
  protected:
   /**

--- a/taichi/program/aot_module_builder.h
+++ b/taichi/program/aot_module_builder.h
@@ -13,7 +13,8 @@ class AotModuleBuilder {
 
   void add(const std::string &identifier, Kernel *kernel);
 
-  virtual void dump(const std::string &output_dir, const std::string &filename) const = 0;
+  virtual void dump(const std::string &output_dir,
+                    const std::string &filename) const = 0;
 
  protected:
   /**


### PR DESCRIPTION
Related issue = #
Make file names dumped from aot configurable

<!--
Thanks for your PR!
If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. E.g.:
    [Lang] Add ti.sin
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

[[Click here for the format server]](http://kun.csail.mit.edu:31415/)

----
