### PR TITLE
[Doc] Changed llvm-10 link and installation instruction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,8 @@ void build_taichi() {
     cmake .. -DLLVM_DIR=/opt/taichi-llvm-10.0.0/lib/cmake/llvm \
         -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE \
         -DCUDA_VERSION=$HACK_CUDA_VERSION \
-        -DTI_WITH_OPENGL=ON
+        -DTI_WITH_OPENGL=ON \
+        -DLLVM_ENABLE_TERMINFO=OFF
     make -j 8
     ldd libtaichi_core.so
     objdump -T libtaichi_core.so| grep GLIBC

--- a/docs/dev_install.rst
+++ b/docs/dev_install.rst
@@ -43,7 +43,7 @@ Installing Dependencies
 - Make sure you have LLVM 10.0.0. Note that Taichi uses a **customized LLVM** so the pre-built binaries from the LLVM official website or other sources probably won't work.
   Here we provide LLVM binaries customized for Taichi, which may or may not work depending on your system environment:
 
-  * `LLVM 10.0.0 for Linux <https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-linux.zip>`_
+  * `LLVM 10.0.0 for Linux <https://github.com/taichi-dev/taichi_assets/releases/download/llvm10_linux/taichi-llvm-10.0.0-linux.zip>`_
   * `LLVM 10.0.0 for Windows MSVC 2019 <https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip>`_
   * `LLVM 10.0.0 for OS X <https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-macos.zip>`_
 
@@ -65,7 +65,7 @@ Installing Dependencies
         cd llvm-10.0.0.src
         mkdir build
         cd build
-        cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
+        cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_TERMINFO=OFF
         # If you are building on NVIDIA Jetson TX2, use -DLLVM_TARGETS_TO_BUILD="AArch64;NVPTX"
         # If you are building on Apple M1, use -DLLVM_TARGETS_TO_BUILD="AArch64"
 


### PR DESCRIPTION
Related issue = #2417
The download link of llvm-10 in docs has changed to the version without libtinfo.
LLVM installation instruction also changed to disable libtinfo.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
