### PR TITLE
[ir] Move infer_snode_properties out from StructCompiler

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -402,10 +402,11 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
 }
 
 void Program::materialize_layout() {
-  // always use host_arch() this is for host accessors
+  infer_snode_properties(*snode_root);
+  // always use host_arch() for host accessors
   std::unique_ptr<StructCompiler> scomp =
       StructCompiler::make(this, host_arch());
-  scomp->run(*snode_root, true);
+  scomp->run(*snode_root);
   materialize_snode_expr_attributes();
 
   for (auto snode : scomp->snodes) {
@@ -421,7 +422,7 @@ void Program::materialize_layout() {
     initialize_device_llvm_context();
     std::unique_ptr<StructCompiler> scomp_gpu =
         StructCompiler::make(this, Arch::cuda);
-    scomp_gpu->run(*snode_root, false);
+    scomp_gpu->run(*snode_root);
     initialize_runtime_system(scomp_gpu.get());
   } else if (config.arch == Arch::metal) {
     TI_ASSERT_INFO(config.use_llvm,

--- a/taichi/struct/struct.cpp
+++ b/taichi/struct/struct.cpp
@@ -6,17 +6,10 @@
 #include "taichi/program/program.h"
 #include "struct.h"
 
-TLANG_NAMESPACE_BEGIN
+namespace taichi {
+namespace lang {
 
-void StructCompiler::collect_snodes(SNode &snode) {
-  snodes.push_back(&snode);
-  for (int ch_id = 0; ch_id < (int)snode.ch.size(); ch_id++) {
-    auto &ch = snode.ch[ch_id];
-    collect_snodes(*ch);
-  }
-}
-
-void StructCompiler::infer_snode_properties(SNode &snode) {
+void infer_snode_properties(SNode &snode) {
   for (int ch_id = 0; ch_id < (int)snode.ch.size(); ch_id++) {
     auto &ch = snode.ch[ch_id];
     ch->parent = &snode;
@@ -86,10 +79,6 @@ void StructCompiler::infer_snode_properties(SNode &snode) {
       "your requested shape is too large.",
       snode.id, snode.total_num_bits, kMaxTotalNumBits);
 
-  if (snode.has_null()) {
-    ambient_snodes.push_back(&snode);
-  }
-
   if (snode.ch.empty()) {
     if (snode.type != SNodeType::place && snode.type != SNodeType::root) {
       TI_ERROR("{} node must have at least one child.",
@@ -99,6 +88,14 @@ void StructCompiler::infer_snode_properties(SNode &snode) {
 
   if (!snode.index_offsets.empty()) {
     TI_ASSERT(snode.index_offsets.size() == snode.num_active_indices);
+  }
+}
+
+void StructCompiler::collect_snodes(SNode &snode) {
+  snodes.push_back(&snode);
+  for (int ch_id = 0; ch_id < (int)snode.ch.size(); ch_id++) {
+    auto &ch = snode.ch[ch_id];
+    collect_snodes(*ch);
   }
 }
 
@@ -141,4 +138,5 @@ void StructCompiler::compute_trailing_bits(SNode &snode) {
   top_down(snode);
 }
 
-TLANG_NAMESPACE_END
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/struct/struct.h
+++ b/taichi/struct/struct.h
@@ -4,21 +4,25 @@
 #include "taichi/ir/snode.h"
 #include "taichi/program/program.h"
 
-TLANG_NAMESPACE_BEGIN
+namespace taichi {
+namespace lang {
+
+/**
+ * Computes the IndexExtractor from the SNode rooted in @param snode.
+ *
+ * @param snode The root SNode to compute.
+ */
+void infer_snode_properties(SNode &snode);
 
 class StructCompiler {
  public:
   std::vector<SNode *> stack;
   std::vector<SNode *> snodes;
-  std::vector<SNode *> ambient_snodes;
   std::size_t root_size{0};
 
   virtual ~StructCompiler() = default;
 
   void collect_snodes(SNode &snode);
-
-  // propagate root-to-leaf for a well-formed data structure
-  void infer_snode_properties(SNode &snode);
 
   void compute_trailing_bits(SNode &snode);
 
@@ -27,9 +31,10 @@ class StructCompiler {
 
   virtual void generate_child_accessors(SNode &snode) = 0;
 
-  virtual void run(SNode &node, bool host) = 0;
+  virtual void run(SNode &node) = 0;
 
   static std::unique_ptr<StructCompiler> make(Program *prog, Arch arch);
 };
 
-TLANG_NAMESPACE_END
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -260,15 +260,10 @@ std::string StructCompilerLLVM::type_stub_name(SNode *snode) {
   return snode->node_type_name + "_type_stubs";
 }
 
-void StructCompilerLLVM::run(SNode &root, bool host) {
+void StructCompilerLLVM::run(SNode &root) {
   TI_AUTO_PROF;
   // bottom to top
   collect_snodes(root);
-
-  if (host) {
-    infer_snode_properties(root);
-    // compute_trailing_bits(root);
-  }
 
   auto snodes_rev = snodes;
   std::reverse(snodes_rev.begin(), snodes_rev.end());

--- a/taichi/struct/struct_llvm.h
+++ b/taichi/struct/struct_llvm.h
@@ -18,7 +18,7 @@ class StructCompilerLLVM : public StructCompiler, public LLVMModuleBuilder {
 
   void generate_child_accessors(SNode &snode) override;
 
-  void run(SNode &node, bool host) override;
+  void run(SNode &node) override;
 
   void generate_refine_coordinates(SNode *snode);
 

--- a/tests/cpp/codegen/refine_coordinates_test.cpp
+++ b/tests/cpp/codegen/refine_coordinates_test.cpp
@@ -116,7 +116,7 @@ class RefineCoordinatesTest : public ::testing::Test {
     leaf_snode.dt = PrimitiveType::f32;
 
     auto sc = std::make_unique<StructCompilerLLVM>(arch_, &config_, tlctx_);
-    sc->run(*root_snode_, /*host=*/true);
+    sc->run(*root_snode_);
   }
 
   Arch arch_;

--- a/tests/cpp/struct/fake_struct_compiler.h
+++ b/tests/cpp/struct/fake_struct_compiler.h
@@ -11,15 +11,8 @@ class FakeStructCompiler : public StructCompiler {
   void generate_child_accessors(SNode &) override {
   }
 
-  void run(SNode &root, bool) override {
+  void run(SNode &root) override {
     infer_snode_properties(root);
-    // TODO(#2327): Stop calling this
-    compute_trailing_bits(root);
-  }
-
-  void run(SNode &root) {
-    // Just a wrapper around the virtual interface
-    run(root, /*(unused)*/ false);
   }
 };
 


### PR DESCRIPTION
Related issue = #2418

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
