### PR TITLE
[Lang] [refactor] Separate runtime and root initialization

### DIFF
--- a/examples/chi_examples/main.cpp
+++ b/examples/chi_examples/main.cpp
@@ -51,7 +51,7 @@ void run_snode() {
   auto *place = &pointer->insert_children(SNodeType::place);
   place->dt = PrimitiveType::i32;
 
-  program.materialize_layout();
+  program.materialize_runtime();
 
   std::unique_ptr<Kernel> kernel_init, kernel_ret, kernel_ext;
 
@@ -219,7 +219,7 @@ void autograd() {
   };
   auto *a = get_snode_grad(), *b = get_snode_grad(), *c = get_snode_grad();
 
-  program.materialize_layout();
+  program.materialize_runtime();
 
   std::unique_ptr<Kernel> kernel_init, kernel_forward, kernel_backward,
       kernel_ext;

--- a/python/taichi/lang/exception.py
+++ b/python/taichi/lang/exception.py
@@ -1,3 +1,7 @@
 class TaichiSyntaxError(Exception):
     def __init__(self, *args):
         super().__init__(*args)
+
+
+class InvalidOperationError(Exception):
+    pass

--- a/taichi/backends/metal/aot_module_builder_impl.cpp
+++ b/taichi/backends/metal/aot_module_builder_impl.cpp
@@ -4,8 +4,10 @@
 
 #include "taichi/backends/metal/codegen_metal.h"
 
-#if defined(__GNUC__) && (__GNUC__ < 8)
+#if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ < 8)
 // https://stackoverflow.com/a/45867491
+// !defined(__clang__) to make sure this is not clang
+// https://stackoverflow.com/questions/38499462/how-to-tell-clang-to-stop-pretending-to-be-other-compilers
 #include <experimental/filesystem>
 namespace fs = ::std::experimental::filesystem;
 #else

--- a/taichi/ir/frontend.cpp
+++ b/taichi/ir/frontend.cpp
@@ -5,10 +5,6 @@
 
 TLANG_NAMESPACE_BEGIN
 
-void layout(const std::function<void()> &body) {
-  get_current_program().layout(body);
-}
-
 Expr global_new(Expr id_expr, DataType dt) {
   TI_ASSERT(id_expr.is<IdExpression>());
   auto ret = Expr(std::make_shared<GlobalVariableExpression>(

--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -25,8 +25,6 @@ inline int maximum(int a) {
 
 TLANG_NAMESPACE_BEGIN
 
-void layout(const std::function<void()> &body);
-
 inline Kernel &kernel(const std::function<void()> &body) {
   return get_current_program().kernel(body);
 }

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -132,7 +132,7 @@ class SNode {
   bool is_bit_level{false};
 
   // Whether the path from root to |this| contains only `dense` SNodes.
-  bool is_path_all_dense{false};
+  bool is_path_all_dense{true};
 
   SNode();
 

--- a/taichi/program/arch.cpp
+++ b/taichi/program/arch.cpp
@@ -44,12 +44,8 @@ bool arch_is_cpu(Arch arch) {
 }
 
 bool arch_uses_llvm(Arch arch) {
-  if (arch == Arch::x64 || arch == Arch::arm64 || arch == Arch::cuda ||
-      arch == Arch::wasm) {
-    return true;
-  } else {
-    return false;
-  }
+  return (arch == Arch::x64 || arch == Arch::arm64 || arch == Arch::cuda ||
+          arch == Arch::wasm);
 }
 
 bool arch_is_gpu(Arch arch) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -24,7 +24,7 @@ Kernel::Kernel(Program &program,
   // Do not corrupt the context calling this kernel here -- maybe unnecessary
   auto backup_context = std::move(taichi::lang::context);
 
-  program.initialize_device_llvm_context();
+  program.maybe_initialize_cuda_llvm_context();
   is_accessor = false;
   is_evaluator = false;
   compiled_ = nullptr;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -39,8 +39,8 @@
 #include <xmmintrin.h>
 #endif
 
-TLANG_NAMESPACE_BEGIN
-
+namespace taichi {
+namespace lang {
 namespace {
 
 void assert_failed_host(const char *msg) {
@@ -56,6 +56,10 @@ void *taichi_allocate_aligned(Program *prog,
 inline uint64 *allocate_result_buffer_default(Program *prog) {
   return (uint64 *)taichi_allocate_aligned(
       prog, sizeof(uint64) * taichi_result_buffer_entries, 8);
+}
+
+bool is_cuda_no_unified_memory(const CompileConfig &config) {
+  return (config.arch == Arch::cuda && !config.use_unified_memory);
 }
 
 }  // namespace
@@ -86,14 +90,14 @@ Program::Program(Arch desired_arch) : snode_rw_accessors_bank_(this) {
 
   auto arch = desired_arch;
   if (arch == Arch::cuda) {
-    runtime = Runtime::create(arch);
-    if (!runtime) {
+    runtime_mem_info = Runtime::create(arch);
+    if (!runtime_mem_info) {
       TI_WARN("Taichi is not compiled with CUDA.");
       arch = host_arch();
     } else if (!is_cuda_api_available()) {
       TI_WARN("No CUDA driver API detected.");
       arch = host_arch();
-    } else if (!runtime->detected()) {
+    } else if (!runtime_mem_info->detected()) {
       TI_WARN("No CUDA device detected.");
       arch = host_arch();
     } else {
@@ -134,7 +138,7 @@ Program::Program(Arch desired_arch) : snode_rw_accessors_bank_(this) {
   total_compilation_time = 0;
   num_instances += 1;
   SNode::counter = 0;
-  // llvm_context_device is initialized before kernel compilation
+  // |llvm_context_device| is initialized before kernel compilation
   TI_ASSERT(current_program == nullptr);
   current_program = this;
   config = default_compile_config;
@@ -143,12 +147,14 @@ Program::Program(Arch desired_arch) : snode_rw_accessors_bank_(this) {
   thread_pool = std::make_unique<ThreadPool>(config.cpu_max_num_threads);
 
   llvm_context_host = std::make_unique<TaichiLLVMContext>(host_arch());
+  llvm_context_host->init_runtime_jit_module();
+  // TODO: Can we initialize |llvm_context_device| here?
   profiler = make_profiler(arch);
 
   preallocated_device_buffer = nullptr;
 
-  if (config.kernel_profiler && runtime) {
-    runtime->set_profiler(profiler.get());
+  if (config.kernel_profiler && runtime_mem_info) {
+    runtime_mem_info->set_profiler(profiler.get());
   }
 #if defined(TI_WITH_CUDA)
   if (config.arch == Arch::cuda) {
@@ -166,7 +172,6 @@ Program::Program(Arch desired_arch) : snode_rw_accessors_bank_(this) {
   llvm_runtime = nullptr;
   finalized = false;
   snode_root = std::make_unique<SNode>(0, SNodeType::root);
-  snode_root->is_path_all_dense = true;
 
   if (config.async_mode) {
     TI_WARN("Running in async mode. This is experimental.");
@@ -273,18 +278,24 @@ FunctionType Program::compile_to_backend_executable(Kernel &kernel,
   return nullptr;
 }
 
+void Program::materialize_runtime() {
+  if (arch_uses_llvm(config.arch)) {
+    initialize_llvm_runtime_system();
+  }
+  materialize_root();
+}
+
 // For CPU and CUDA archs only
-void Program::initialize_runtime_system(StructCompiler *scomp) {
-  // auto tlctx = llvm_context_host.get();
-  TaichiLLVMContext *tlctx;
+void Program::initialize_llvm_runtime_system() {
+  maybe_initialize_cuda_llvm_context();
 
   std::size_t prealloc_size = 0;
-
-  if (config.arch == Arch::cuda && !config.use_unified_memory) {
+  TaichiLLVMContext *tlctx = nullptr;
+  if (is_cuda_no_unified_memory(config)) {
 #if defined(TI_WITH_CUDA)
     CUDADriver::get_instance().malloc(
         (void **)&result_buffer, sizeof(uint64) * taichi_result_buffer_entries);
-    auto total_mem = runtime->get_total_memory();
+    const auto total_mem = runtime_mem_info->get_total_memory();
     if (config.device_memory_fraction == 0) {
       TI_ASSERT(config.device_memory_GB > 0);
       prealloc_size = std::size_t(config.device_memory_GB * (1UL << 30));
@@ -308,12 +319,7 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
     result_buffer = allocate_result_buffer_default(this);
     tlctx = llvm_context_host.get();
   }
-  auto runtime = tlctx->runtime_jit_module;
-
-  // By the time this creator is called, "this" is already destroyed.
-  // Therefore it is necessary to capture members by values.
-  auto snodes = scomp->snodes;
-  int root_id = snode_root->id;
+  auto *const runtime_jit = tlctx->runtime_jit_module;
 
   // Starting random state for the program calculated using the random seed.
   // The seed is multiplied by 2^20 so that two programs with different seeds
@@ -335,30 +341,68 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
     num_rand_states = config.cpu_max_num_threads;
   }
 
-  TI_TRACE("Allocating data structure of size {} B", scomp->root_size);
   TI_TRACE("Allocating {} random states (used by CUDA only)", num_rand_states);
 
-  runtime->call<void *, void *, std::size_t, std::size_t, void *, int, int,
-                void *, void *, void *>(
-      "runtime_initialize", result_buffer, this, (std::size_t)scomp->root_size,
-      prealloc_size, preallocated_device_buffer, starting_rand_state,
-      num_rand_states, (void *)&taichi_allocate_aligned, (void *)std::printf,
+  runtime_jit->call<void *, void *, std::size_t, void *, int, int, void *,
+                    void *, void *>(
+      "runtime_initialize", result_buffer, this, prealloc_size,
+      preallocated_device_buffer, starting_rand_state, num_rand_states,
+      (void *)&taichi_allocate_aligned, (void *)std::printf,
       (void *)std::vsnprintf);
 
-  TI_TRACE("LLVMRuntime initialized");
+  TI_TRACE("LLVMRuntime initialized (excluding `root`)");
   llvm_runtime = fetch_result<void *>(taichi_result_buffer_ret_value_id);
   TI_TRACE("LLVMRuntime pointer fetched");
 
   if (arch_use_host_memory(config.arch) || config.use_unified_memory) {
-    runtime->call<void *>("runtime_get_mem_req_queue", llvm_runtime);
+    runtime_jit->call<void *>("runtime_get_mem_req_queue", llvm_runtime);
     auto mem_req_queue =
         fetch_result<void *>(taichi_result_buffer_ret_value_id);
     memory_pool->set_queue((MemRequestQueue *)mem_req_queue);
   }
 
-  runtime->call<void *, int, int>("runtime_initialize2", llvm_runtime, root_id,
-                                  (int)snodes.size());
+  if (arch_use_host_memory(config.arch)) {
+    runtime_jit->call<void *, void *, void *>(
+        "LLVMRuntime_initialize_thread_pool", llvm_runtime, thread_pool.get(),
+        (void *)ThreadPool::static_run);
 
+    runtime_jit->call<void *, void *>("LLVMRuntime_set_assert_failed",
+                                      llvm_runtime, (void *)assert_failed_host);
+  }
+  if (arch_is_cpu(config.arch)) {
+    // Profiler functions can only be called on CPU kernels
+    runtime_jit->call<void *, void *>("LLVMRuntime_set_profiler", llvm_runtime,
+                                      profiler.get());
+    runtime_jit->call<void *, void *>(
+        "LLVMRuntime_set_profiler_start", llvm_runtime,
+        (void *)&KernelProfilerBase::profiler_start);
+    runtime_jit->call<void *, void *>(
+        "LLVMRuntime_set_profiler_stop", llvm_runtime,
+        (void *)&KernelProfilerBase::profiler_stop);
+  }
+}
+
+void Program::initialize_llvm_runtime_snodes(StructCompiler *scomp) {
+  TaichiLLVMContext *tlctx = nullptr;
+  if (is_cuda_no_unified_memory(config)) {
+#if defined(TI_WITH_CUDA)
+    tlctx = llvm_context_device.get();
+#else
+    TI_NOT_IMPLEMENTED
+#endif
+  } else {
+    tlctx = llvm_context_host.get();
+  }
+  auto *const runtime_jit = tlctx->runtime_jit_module;
+  // By the time this creator is called, "this" is already destroyed.
+  // Therefore it is necessary to capture members by values.
+  const auto snodes = scomp->snodes;
+  const int root_id = snode_root->id;
+
+  TI_TRACE("Allocating data structure of size {} bytes", scomp->root_size);
+  runtime_jit->call<void *, std::size_t, int, int>(
+      "runtime_initialize_snodes", llvm_runtime, scomp->root_size, root_id,
+      (int)snodes.size());
   for (int i = 0; i < (int)snodes.size(); i++) {
     if (is_gc_able(snodes[i]->type)) {
       std::size_t node_size;
@@ -373,35 +417,17 @@ void Program::initialize_runtime_system(StructCompiler *scomp) {
       TI_TRACE("Initializing allocator for snode {} (node size {})",
                snodes[i]->id, node_size);
       auto rt = llvm_runtime;
-      runtime->call<void *, int, std::size_t>(
+      runtime_jit->call<void *, int, std::size_t>(
           "runtime_NodeAllocator_initialize", rt, snodes[i]->id, node_size);
       TI_TRACE("Allocating ambient element for snode {} (node size {})",
                snodes[i]->id, node_size);
-      runtime->call<void *, int>("runtime_allocate_ambient", rt, i, node_size);
+      runtime_jit->call<void *, int>("runtime_allocate_ambient", rt, i,
+                                     node_size);
     }
-  }
-
-  if (arch_use_host_memory(config.arch)) {
-    runtime->call<void *, void *, void *>("LLVMRuntime_initialize_thread_pool",
-                                          llvm_runtime, thread_pool.get(),
-                                          (void *)ThreadPool::static_run);
-
-    runtime->call<void *, void *>("LLVMRuntime_set_assert_failed", llvm_runtime,
-                                  (void *)assert_failed_host);
-  }
-  if (arch_is_cpu(config.arch)) {
-    // Profiler functions can only be called on CPU kernels
-    runtime->call<void *, void *>("LLVMRuntime_set_profiler", llvm_runtime,
-                                  profiler.get());
-    runtime->call<void *, void *>("LLVMRuntime_set_profiler_start",
-                                  llvm_runtime,
-                                  (void *)&KernelProfilerBase::profiler_start);
-    runtime->call<void *, void *>("LLVMRuntime_set_profiler_stop", llvm_runtime,
-                                  (void *)&KernelProfilerBase::profiler_stop);
   }
 }
 
-void Program::materialize_layout() {
+void Program::materialize_root() {
   infer_snode_properties(*snode_root);
   // always use host_arch() for host accessors
   std::unique_ptr<StructCompiler> scomp =
@@ -414,16 +440,12 @@ void Program::materialize_layout() {
   }
 
   if (arch_is_cpu(config.arch)) {
-    initialize_runtime_system(scomp.get());
-  }
-
-  TI_TRACE("materialize_layout called");
-  if (config.arch == Arch::cuda) {
-    initialize_device_llvm_context();
+    initialize_llvm_runtime_snodes(scomp.get());
+  } else if (config.arch == Arch::cuda) {
     std::unique_ptr<StructCompiler> scomp_gpu =
         StructCompiler::make(this, Arch::cuda);
     scomp_gpu->run(*snode_root);
-    initialize_runtime_system(scomp_gpu.get());
+    initialize_llvm_runtime_snodes(scomp_gpu.get());
   } else if (config.arch == Arch::metal) {
     TI_ASSERT_INFO(config.use_llvm,
                    "Metal arch requires that LLVM being enabled");
@@ -619,17 +641,17 @@ void Program::visualize_layout(const std::string &fn) {
   trash(system(fmt::format("pdflatex {}", fn).c_str()));
 }
 
-void Program::initialize_device_llvm_context() {
-  if (config.arch == Arch::cuda) {
-    if (llvm_context_device == nullptr)
-      llvm_context_device = std::make_unique<TaichiLLVMContext>(Arch::cuda);
+void Program::maybe_initialize_cuda_llvm_context() {
+  if ((config.arch == Arch::cuda) && (llvm_context_device == nullptr)) {
+    llvm_context_device = std::make_unique<TaichiLLVMContext>(Arch::cuda);
+    llvm_context_device->init_runtime_jit_module();
   }
 }
 
 Arch Program::get_snode_accessor_arch() {
   if (config.arch == Arch::opengl) {
     return Arch::opengl;
-  } else if (config.arch == Arch::cuda && !config.use_unified_memory) {
+  } else if (is_cuda_no_unified_memory(config)) {
     return Arch::cuda;
   } else if (config.arch == Arch::metal) {
     return Arch::metal;
@@ -745,8 +767,8 @@ void Program::finalize() {
       ofs << stat_string;
     }
   }
-  if (runtime)
-    runtime->set_profiler(nullptr);
+  if (runtime_mem_info)
+    runtime_mem_info->set_profiler(nullptr);
   synchronize();
   current_program = nullptr;
   memory_pool->terminate();
@@ -883,4 +905,5 @@ std::unique_ptr<AotModuleBuilder> Program::make_aot_module_builder(Arch arch) {
   return nullptr;
 }
 
-TLANG_NAMESPACE_END
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -235,6 +235,7 @@ void export_lang(py::module &m) {
            })
       .def("synchronize", &Program::synchronize)
       .def("async_flush", &Program::async_flush)
+      .def("materialize_runtime", &Program::materialize_runtime)
       .def("make_aot_module_builder", &Program::make_aot_module_builder);
 
   py::class_<AotModuleBuilder>(m, "AotModuleBuilder")
@@ -513,8 +514,6 @@ void export_lang(py::module &m) {
 
   m.def("make_func_call_expr",
         Expr::make<FuncCallExpression, Function *, const ExprGroup &>);
-
-  m.def("layout", layout);
 
   m.def("value_cast", static_cast<Expr (*)(const Expr &expr, DataType)>(cast));
   m.def("bits_cast",

--- a/taichi/util/testing.h
+++ b/taichi/util/testing.h
@@ -33,7 +33,7 @@ TI_NAMESPACE_BEGIN
 #define TI_CHECK(x) CHECK(x)
 #define TI_TEST_PROGRAM                     \
   auto prog_ = std::make_unique<Program>(); \
-  prog_->materialize_layout();
+  prog_->materialize_runtime();
 
 int run_tests(std::vector<std::string> argv);
 

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -86,7 +86,7 @@ TEST(IRBuilder, LoopGuard) {
 
 TEST(IRBuilder, ExternalPtr) {
   auto prog = Program(arch_from_name("x64"));
-  prog.materialize_layout();
+  prog.materialize_runtime();
   IRBuilder builder;
   const int size = 10;
   auto array = std::make_unique<int[]>(size);

--- a/tests/cpp/transforms/alg_simp_test.cpp
+++ b/tests/cpp/transforms/alg_simp_test.cpp
@@ -11,7 +11,7 @@ class AlgebraicSimplicationTest : public ::testing::Test {
  protected:
   void SetUp() override {
     prog_ = std::make_unique<Program>();
-    prog_->materialize_layout();
+    prog_->materialize_runtime();
   }
 
   std::unique_ptr<Program> prog_;

--- a/tests/cpp/transforms/binary_op_simplify_test.cpp
+++ b/tests/cpp/transforms/binary_op_simplify_test.cpp
@@ -11,7 +11,7 @@ class BinaryOpSimplifyTest : public ::testing::Test {
  protected:
   void SetUp() override {
     prog_ = std::make_unique<Program>();
-    prog_->materialize_layout();
+    prog_->materialize_runtime();
   }
 
   std::unique_ptr<Program> prog_;

--- a/tests/cpp/transforms/inlining_test.cpp
+++ b/tests/cpp/transforms/inlining_test.cpp
@@ -13,7 +13,7 @@ class InliningTest : public ::testing::Test {
  protected:
   void SetUp() override {
     prog_ = std::make_unique<Program>();
-    prog_->materialize_layout();
+    prog_->materialize_runtime();
   }
 
   std::unique_ptr<Program> prog_;

--- a/tests/cpp/transforms/simplify_test.cpp
+++ b/tests/cpp/transforms/simplify_test.cpp
@@ -10,7 +10,7 @@ namespace lang {
 
 TEST(Simplify, SimplifyLinearizedWithTrivialInputs) {
   auto prog_ = std::make_unique<Program>();
-  prog_->materialize_layout();
+  prog_->materialize_runtime();
 
   auto block = std::make_unique<Block>();
 


### PR DESCRIPTION
Related issue = #2418

This PR refactors `Program` so that the LLVM runtime and SNode related initialization are separated into two functions: `initialize_llvm_runtime_system()` and `initialize_llvm_runtime_snodes()`. In the future, we should only call `initialize_llvm_runtime_system()` once globally, but call `initialize_llvm_runtime_snodes()` for each new SNode tree.

Several notes:

* PTX `.entry` vs `.func`: CUDA kernels are marked as `.entry` + `__glb__` in the PTX module. If not properly marked, `cuModuleGetFunction` won't be able to find this kernel. This is done around https://github.com/taichi-dev/taichi/blob/de3b2262de944cbf04e41fe0679e7e18eb242099/taichi/llvm/llvm_context.cpp#L544-L559
* Unified memory: #2427 
 
Also fully deprecate `ti.layout()` (FYI @yuanming-hu ) .

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
