### PR TITLE
[CUDA] [bug] Fix unified memory allocator when running on non-main th…

### DIFF
--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -51,7 +51,7 @@ CUDADriver::CUDADriver() {
   }
 }
 
-// This is for initializing the CUDA context itself
+// This is for initializing the CUDA driver itself
 CUDADriver &CUDADriver::get_instance_without_context() {
   // Thread safety guaranteed by C++ compiler
   // Note this is never deleted until the process finishes

--- a/taichi/common/logging.cpp
+++ b/taichi/common/logging.cpp
@@ -54,7 +54,7 @@ int Logger::level_enum_from_string(const std::string &level_name) {
 Logger::Logger() {
   console = spdlog::stdout_color_mt("console");
   console->flush_on(spdlog::level::trace);
-  TI_LOG_SET_PATTERN("%^[%L %D %X.%e] %v%$");
+  TI_LOG_SET_PATTERN("%^[%L %D %X.%e %t] %v%$");
 
   set_level_default();
 }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -862,9 +862,6 @@ void runtime_initialize(
     runtime = (LLVMRuntime *)vm_allocator(program, sizeof(LLVMRuntime), 128);
   }
 
-  runtime->root_mem_size =
-      taichi::iroundup((size_t)root_size, taichi_page_size);
-
   runtime->preallocated = preallocated_size > 0;
   runtime->preallocated_head = preallocated_buffer;
   runtime->preallocated_tail = preallocated_tail;

--- a/taichi/system/unified_allocator.h
+++ b/taichi/system/unified_allocator.h
@@ -36,6 +36,8 @@ class UnifiedAllocator {
     std::lock_guard<std::mutex> _(lock);
     auto ret =
         head + alignment - 1 - ((std::size_t)head + alignment - 1) % alignment;
+    TI_TRACE("UM [data={}] allocate() request={} remain={}", (intptr_t)data,
+             size, (tail - head));
     head = ret + size;
     if (head > tail) {
       // allocation failed

--- a/tests/python/test_memory.py
+++ b/tests/python/test_memory.py
@@ -1,0 +1,11 @@
+import taichi as ti
+
+
+@ti.test(arch=ti.cuda, use_unified_memory=True)
+def test_unified_memory_allocate():
+    HUGE_SIZE = 1024**3
+    x = ti.field(ti.i32, shape=(HUGE_SIZE, ))
+    for i in range(10):
+        x[i] = i
+    # There is no checking for this. If UM is not implemented correctly, this
+    # test would crash.


### PR DESCRIPTION
…read

Related issue = #2424

Discovered this while working on #2424 . The problem lies in that, when `MemoryPool` has to create a new `UnifiedAllocator` on the *daemon* thread, because there is no CUDA context installed, the program just crashes with 

`[cuda_driver.h:operator()@81] CUDA Error CUDA_ERROR_INVALID_CONTEXT: invalid device context while calling malloc_managed (cuMemAllocManaged)`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
