### PR TITLE
[WASM] Add set_root() for each WASM module

### DIFF
--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -141,11 +141,11 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     // TI_INFO("Kernel function verified.");
   }
 
-  std::string create_taichi_get_root_function() {
+  std::string create_taichi_get_root_address_function() {
     auto task_function_type =
         llvm::FunctionType::get(llvm::Type::getInt32Ty(*llvm_context),
                                 {llvm::PointerType::get(context_ty, 0)}, false);
-    auto task_kernel_name = fmt::format("get_root");
+    auto task_kernel_name = fmt::format("get_root_address");
     auto func = llvm::Function::Create(task_function_type,
                                        llvm::Function::ExternalLinkage,
                                        task_kernel_name, module.get());
@@ -177,6 +177,45 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     return task_kernel_name;
   }
 
+  std::string create_taichi_set_root_function() {
+    auto task_function_type =
+        llvm::FunctionType::get(llvm::Type::getVoidTy(*llvm_context),
+                                {llvm::PointerType::get(context_ty, 0),
+                                 llvm::Type::getInt32Ty(*llvm_context)}, false);
+    auto task_kernel_name = fmt::format("set_root");
+    auto func = llvm::Function::Create(task_function_type,
+                                       llvm::Function::ExternalLinkage,
+                                       task_kernel_name, module.get());
+
+    std::vector<llvm::Value *> kernel_args;
+    for (auto &arg : func->args()) {
+      kernel_args.push_back(&arg);
+    }
+    kernel_args[0]->setName("context");
+    kernel_args[1]->setName("root");
+
+    auto entry_block = llvm::BasicBlock::Create(*llvm_context, "entry", func);
+    auto func_body_bb = llvm::BasicBlock::Create(*llvm_context, "body", func);
+    builder->SetInsertPoint(func_body_bb);
+
+    // memory reserved for Context object shouldn't be polluted
+    llvm::Value *runtime_ptr = create_call("Context_get_runtime", {kernel_args[0]});
+    llvm::Value *runtime = builder->CreateBitCast(
+        runtime_ptr, llvm::PointerType::get(get_runtime_type("LLVMRuntime"), 0));
+
+    llvm::Value *root_ptr = builder->CreateIntToPtr(
+        kernel_args[1], llvm::Type::getInt8PtrTy(*llvm_context));
+    llvm::Value *ret_ptr = create_call("LLVMRuntime_set_root", {runtime, root_ptr});
+    builder->CreateRetVoid();
+
+    builder->SetInsertPoint(entry_block);
+    builder->CreateBr(func_body_bb);
+
+    TI_ASSERT(!llvm::verifyFunction(*func, &llvm::errs()));
+    // TI_INFO("Kernel function verified.");
+    return task_kernel_name;
+  }
+
   FunctionType gen() override {
     TI_AUTO_PROF
     // emit_to_module
@@ -185,13 +224,15 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     ir->accept(this);
     finalize_taichi_kernel_function();
 
-    auto get_root_name = create_taichi_get_root_function();
+    auto get_root_address_name = create_taichi_get_root_address_function();
+    auto set_root_name = create_taichi_set_root_function();
 
     // compile_module_to_executable
     // only keep the current func
     TaichiLLVMContext::eliminate_unused_functions(
       module.get(), [&](std::string func_name) {
-        return offloaded_task_name == func_name || get_root_name == func_name;
+        return offloaded_task_name == func_name || get_root_address_name == func_name
+              || set_root_name == func_name;
       });
     tlctx->add_module(std::move(module));
     auto kernel_symbol = tlctx->lookup_function_pointer(offloaded_task_name);

--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -98,7 +98,13 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     current_offload = nullptr;
   }
 
-  std::string eliminate_underline_suffix(std::string kernel_name) {
+  /**
+   * Extracts the original function name decorated by @ti.kernel
+   * 
+   * @param kernel_name The format is defined in
+   * https://github.com/taichi-dev/taichi/blob/734da3f8f4439ce7f6a5337df7c54fb6dc34def8/python/taichi/lang/kernel_impl.py#L360-L362
+   */
+  std::string extract_original_kernel_name(const std::string& kernel_name) {
     if (kernel->is_evaluator)
       return kernel_name;
     int pos = kernel_name.length() - 1;
@@ -122,7 +128,7 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
                                 {llvm::PointerType::get(context_ty, 0)}, false);
 
     auto task_kernel_name =
-        fmt::format("{}_body", eliminate_underline_suffix(kernel_name));
+        fmt::format("{}_body", extract_original_kernel_name(kernel_name));
     func = llvm::Function::Create(task_function_type,
                                   llvm::Function::ExternalLinkage,
                                   task_kernel_name, module.get());

--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -203,7 +203,7 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
                                 {llvm::PointerType::get(context_ty, 0),
                                  llvm::Type::getInt32Ty(*llvm_context)},
                                 false);
-    auto task_kernel_name = fmt::format("set_root");
+    const std::string task_kernel_name = "set_root";
     auto func = llvm::Function::Create(task_function_type,
                                        llvm::Function::ExternalLinkage,
                                        task_kernel_name, module.get());

--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -202,7 +202,7 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
   }
 
   //  Context's address is pass by kernel_args[0] which is supposed to be 0 in default.
-  //  Runtime's address will be set to zero after set_root() call.
+  //  Runtime's address will be set to kernel_args[0] after set_root() call.
   //  The objects of Context and Runtime are overlapped with each other.
   //
   //     Context          Runtime            Root Buffer

--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -98,7 +98,9 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     current_offload = nullptr;
   }
 
-  static std::string eliminate_underline_suffix(std::string kernel_name) {
+  std::string eliminate_underline_suffix(std::string kernel_name) {
+    if (kernel->is_evaluator)
+      return kernel_name;
     int pos = kernel_name.length() - 1;
     int underline_count = 0;
     int redundant_count = 3;

--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -110,7 +110,6 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     int pos = kernel_name.length() - 1;
     int underline_count = 0;
     int redundant_count = 3;
-    // see https://github.com/taichi-dev/taichi/blob/734da3f8f4439ce7f6a5337df7c54fb6dc34def8/python/taichi/lang/kernel_impl.py#L360
     for (; pos >= 0; --pos) {
       if (kernel_name.at(pos) == '_') {
         underline_count += 1;

--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -100,11 +100,11 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
 
   /**
    * Extracts the original function name decorated by @ti.kernel
-   * 
+   *
    * @param kernel_name The format is defined in
    * https://github.com/taichi-dev/taichi/blob/734da3f8f4439ce7f6a5337df7c54fb6dc34def8/python/taichi/lang/kernel_impl.py#L360-L362
    */
-  std::string extract_original_kernel_name(const std::string& kernel_name) {
+  std::string extract_original_kernel_name(const std::string &kernel_name) {
     if (kernel->is_evaluator)
       return kernel_name;
     int pos = kernel_name.length() - 1;
@@ -200,9 +200,9 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     return task_kernel_name;
   }
 
-  //  Context's address is pass by kernel_args[0] which is supposed to be 0 in default.
-  //  Runtime's address will be set to kernel_args[0] after set_root() call.
-  //  The objects of Context and Runtime are overlapped with each other.
+  //  Context's address is pass by kernel_args[0] which is supposed to be 0 in
+  //  default. Runtime's address will be set to kernel_args[0] after set_root()
+  //  call. The objects of Context and Runtime are overlapped with each other.
   //
   //     Context          Runtime            Root Buffer
   //     +-----------+    +-------------+    +-------------+
@@ -240,7 +240,7 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     llvm::Value *runtime_address_val_ptr = builder->CreatePointerCast(
         runtime_address_ptr, llvm::Type::getInt32PtrTy(*llvm_context));
     llvm::Value *runtime_address_val = builder->CreatePtrToInt(
-      kernel_args[0], llvm::Type::getInt32Ty(*llvm_context));
+        kernel_args[0], llvm::Type::getInt32Ty(*llvm_context));
     builder->CreateStore(runtime_address_val, runtime_address_val_ptr);
 
     llvm::Value *runtime_ptr =
@@ -251,7 +251,7 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
 
     llvm::Value *root_base_ptr = builder->CreatePointerCast(
         kernel_args[0], llvm::Type::getInt32PtrTy(*llvm_context));
-    llvm::Value* root_base_val = builder->CreateLoad(root_base_ptr);
+    llvm::Value *root_base_val = builder->CreateLoad(root_base_ptr);
     llvm::Value *root_val = builder->CreateAdd(root_base_val, kernel_args[1]);
     llvm::Value *root_ptr = builder->CreateIntToPtr(
         root_val, llvm::Type::getInt8PtrTy(*llvm_context));

--- a/taichi/backends/wasm/codegen_wasm.cpp
+++ b/taichi/backends/wasm/codegen_wasm.cpp
@@ -141,6 +141,42 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     // TI_INFO("Kernel function verified.");
   }
 
+  std::string create_taichi_get_root_function() {
+    auto task_function_type =
+        llvm::FunctionType::get(llvm::Type::getInt32Ty(*llvm_context),
+                                {llvm::PointerType::get(context_ty, 0)}, false);
+    auto task_kernel_name = fmt::format("get_root");
+    auto func = llvm::Function::Create(task_function_type,
+                                       llvm::Function::ExternalLinkage,
+                                       task_kernel_name, module.get());
+
+    std::vector<llvm::Value *> kernel_args;
+    for (auto &arg : func->args()) {
+      kernel_args.push_back(&arg);
+    }
+    kernel_args[0]->setName("context");
+
+    auto entry_block = llvm::BasicBlock::Create(*llvm_context, "entry", func);
+    auto func_body_bb = llvm::BasicBlock::Create(*llvm_context, "body", func);
+    builder->SetInsertPoint(func_body_bb);
+
+    // memory reserved for Context object shouldn't be polluted
+    llvm::Value *runtime_ptr = create_call("Context_get_runtime", {kernel_args[0]});
+    llvm::Value *runtime = builder->CreateBitCast(
+        runtime_ptr, llvm::PointerType::get(get_runtime_type("LLVMRuntime"), 0));
+    llvm::Value *root_ptr = create_call("LLVMRuntime_get_ptr_root", {runtime});
+    llvm::Value *root_address = builder->CreatePtrToInt(
+        root_ptr, llvm::Type::getInt32Ty(*llvm_context));
+    builder->CreateRet(root_address);
+
+    builder->SetInsertPoint(entry_block);
+    builder->CreateBr(func_body_bb);
+
+    TI_ASSERT(!llvm::verifyFunction(*func, &llvm::errs()));
+    // TI_INFO("Kernel function verified.");
+    return task_kernel_name;
+  }
+
   FunctionType gen() override {
     TI_AUTO_PROF
     // emit_to_module
@@ -149,11 +185,13 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
     ir->accept(this);
     finalize_taichi_kernel_function();
 
+    auto get_root_name = create_taichi_get_root_function();
+
     // compile_module_to_executable
     // only keep the current func
     TaichiLLVMContext::eliminate_unused_functions(
       module.get(), [&](std::string func_name) {
-        return offloaded_task_name == func_name;
+        return offloaded_task_name == func_name || get_root_name == func_name;
       });
     tlctx->add_module(std::move(module));
     auto kernel_symbol = tlctx->lookup_function_pointer(offloaded_task_name);


### PR DESCRIPTION
Related issue = LAN-42

The generated WASM module now ships with a `set_root()` function. This function sets WASM's linear memory so that `LLVMRuntime` and root buffer are placed at the right place.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
