### PR TITLE
[metal] Always initialize root SNode ListManager

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -827,21 +827,22 @@ class KernelManager::Impl {
         {
             ActionArg("rand_seeds_begin", (int64)rand_seeds_begin),
         });
-    if (compiled_structs_.need_snode_lists_data) {
-      auto *mem_alloc = reinterpret_cast<MemoryAllocator *>(addr);
-      // Make sure the retured memory address is always greater than 1.
-      mem_alloc->next = shaders::MemoryAllocator::kInitOffset;
-      // root list data are static
-      ListgenElement root_elem;
-      root_elem.mem_offset = 0;
-      for (int i = 0; i < taichi_max_num_indices; ++i) {
-        root_elem.coords.at[i] = 0;
-      }
-      ListManager root_lm;
-      root_lm.lm_data = rtm_list_begin + root_id;
-      root_lm.mem_alloc = mem_alloc;
-      root_lm.append(root_elem);
+
+    // Initialize the memory allocator
+    auto *mem_alloc = reinterpret_cast<MemoryAllocator *>(addr);
+    // Make sure the retured memory address is always greater than 1.
+    mem_alloc->next = shaders::MemoryAllocator::kInitOffset;
+
+    // Root list is static, so it can be initialized here once.
+    ListgenElement root_elem;
+    root_elem.mem_offset = 0;
+    for (int i = 0; i < taichi_max_num_indices; ++i) {
+      root_elem.coords.at[i] = 0;
     }
+    ListManager root_lm;
+    root_lm.lm_data = rtm_list_begin + root_id;
+    root_lm.mem_alloc = mem_alloc;
+    root_lm.append(root_elem);
 
     did_modify_range(runtime_buffer_.get(), /*location=*/0,
                      runtime_mem_->size());

--- a/taichi/backends/metal/struct_metal.cpp
+++ b/taichi/backends/metal/struct_metal.cpp
@@ -94,7 +94,6 @@ class StructCompiler {
       generate_types(*n);
     }
     line_appender_.dump(&result.snode_structs_source_code);
-    result.need_snode_lists_data = has_sparse_snode_;
     result.max_snodes = max_snodes_;
     result.snode_descriptors = std::move(snode_descriptors_);
     TI_DEBUG("Metal: root_size={} runtime_size={}", result.root_size,

--- a/taichi/backends/metal/struct_metal.h
+++ b/taichi/backends/metal/struct_metal.h
@@ -72,10 +72,6 @@ struct CompiledStructs {
   //
   // TODO(k-ye): See if Metal ArgumentBuffer can directly store the pointers.
   size_t runtime_size;
-  // In case there is no sparse SNode (e.g. bitmasked), we don't need to
-  // allocate the additional memory for |snode_lists|.
-  // TODO(k-ye): Rename to |needs_kernel_memory_allocator|.
-  bool need_snode_lists_data;
   // max(ID of Root or Dense Snode) + 1
   int max_snodes;
   // Map from SNode ID to its descriptor.


### PR DESCRIPTION
Related issue = #975, #1174

This kind of reverts #1028. Now that Metal has implemented a dynamic memory allocator, we no longer pre-allocate the runtime that can hold the maximum amount of list elements. Therefore `need_snode_lists_data` can be removed.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
