### PR TITLE
[ir] [bug] Make control-flow graph take function call into account

### DIFF
--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -1,5 +1,3 @@
-import pytest
-
 import taichi as ti
 
 

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -150,8 +150,8 @@ def test_python_function():
     assert x[None] == 0
 
 
-@pytest.mark.skip(reason='https://github.com/taichi-dev/taichi/issues/2442')
-@ti.test(experimental_real_function=True, debug=True)
+@ti.test(experimental_real_function=True, debug=True,
+         exclude=[ti.opengl, ti.cc])
 def test_templates():
     x = ti.field(ti.i32, shape=())
     y = ti.field(ti.i32, shape=())

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -150,14 +150,11 @@ def test_python_function():
     assert x[None] == 0
 
 
-# TODO(#2447): Remove these exclusions when we support assertions in these
-#  backends
-@ti.test(experimental_real_function=True,
-         debug=True,
-         exclude=[ti.opengl, ti.cc])
+@ti.test(experimental_real_function=True)
 def test_templates():
     x = ti.field(ti.i32, shape=())
     y = ti.field(ti.i32, shape=())
+    answer = ti.field(ti.i32, shape=8)
 
     @ti.kernel
     def kernel_inc(x: ti.template()):
@@ -182,11 +179,18 @@ def test_templates():
         x[None] = 10
         y[None] = 20
         inc(x)
-        assert x[None] == 11
-        assert y[None] == 20
+        answer[0] = x[None]
+        answer[1] = y[None]
         inc(y)
-        assert x[None] == 11
-        assert y[None] == 21
+        answer[2] = x[None]
+        answer[3] = y[None]
+
+    def verify():
+        assert answer[0] == 11
+        assert answer[1] == 20
+        assert answer[2] == 11
+        assert answer[3] == 21
 
     run_kernel()
     run_func()
+    verify()

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -150,6 +150,8 @@ def test_python_function():
     assert x[None] == 0
 
 
+# TODO(#2447): Remove these exclusions when we support assertions in these
+#  backends
 @ti.test(experimental_real_function=True,
          debug=True,
          exclude=[ti.opengl, ti.cc])

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -150,7 +150,8 @@ def test_python_function():
     assert x[None] == 0
 
 
-@ti.test(experimental_real_function=True, debug=True,
+@ti.test(experimental_real_function=True,
+         debug=True,
          exclude=[ti.opengl, ti.cc])
 def test_templates():
     x = ti.field(ti.i32, shape=())


### PR DESCRIPTION
Related issue = #2193; fix #2442

This PR mainly adds `void visit(FuncCallStmt *stmt) override` to `CFGBuilder`. It also adds `struct CFGFuncKey`: note that the behavior of an inlined function is different when it's parallel executed or not (if not, a top-level range-for in the function will be parallel; otherwise it will be serial).

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
