### PR TITLE
[bug] Fix assertion failure when there is a redundant cast

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -322,8 +322,9 @@ void CodeGenLLVM::visit(UnaryOpStmt *stmt) {
     llvm::CastInst::CastOps cast_op;
     auto from = stmt->operand->ret_type;
     auto to = stmt->cast_type;
-    TI_ASSERT(from != to);
-    if (is_real(from) != is_real(to)) {
+    if (from == to) {
+      llvm_val[stmt] = llvm_val[stmt->operand];
+    } else if (is_real(from) != is_real(to)) {
       if (is_real(from) && is_integral(to)) {
         cast_op = llvm::Instruction::CastOps::FPToSI;
       } else if (is_integral(from) && is_real(to)) {


### PR DESCRIPTION
Related issue = fix #2446 

The code in the LLVM backend (including CPU and GPU) asserts there are no redundant casts (e.g., casting int32 to int32), but we should allow it when optimizations are not enabled. Other backends do not assert it.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
