### PR TITLE
[bug] Fix linux detection macro

### DIFF
--- a/taichi/backends/metal/aot_module_builder_impl.cpp
+++ b/taichi/backends/metal/aot_module_builder_impl.cpp
@@ -4,10 +4,8 @@
 
 #include "taichi/backends/metal/codegen_metal.h"
 
-#if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ < 8)
+#if defined(__linux__) && defined(__GNUC__) && (__GNUC__ < 8)
 // https://stackoverflow.com/a/45867491
-// !defined(__clang__) to make sure this is not clang
-// https://stackoverflow.com/questions/38499462/how-to-tell-clang-to-stop-pretending-to-be-other-compilers
 #include <experimental/filesystem>
 namespace fs = ::std::experimental::filesystem;
 #else

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -109,10 +109,10 @@ class KernelCodegenImpl : public IRVisitor {
         kernel_(kernel),
         compiled_structs_(compiled_structs),
         needs_root_buffer_(compiled_structs_->root_size > 0),
-        ctx_attribs_(*kernel_),
         print_strtab_(print_strtab),
         cgen_config_(config),
-        offloaded_(offloaded) {
+        offloaded_(offloaded),
+        ctx_attribs_(*kernel_) {
     ti_kernel_attribs_.name = taichi_kernel_name;
     ti_kernel_attribs_.is_jit_evaluator = kernel->is_evaluator;
     // allow_undefined_visitor = true;


### PR DESCRIPTION
Related issue = #2439

This should allow us to use the default GCC-7

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
