### PR TITLE
[Metal] Fix dumped runtime buffer size

### DIFF
--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -536,7 +536,6 @@ class KernelManager::Impl {
   explicit Impl(Params params)
       : config_(params.config),
         compiled_structs_(params.compiled_structs),
-        buffer_meta_data_(params.buffer_meta_data),
         mem_pool_(params.mem_pool),
         host_result_buffer_(params.host_result_buffer),
         profiler_(params.profiler),
@@ -580,7 +579,7 @@ class KernelManager::Impl {
         compiled_structs_.runtime_size + mem_pool_bytes, mem_pool_);
     runtime_buffer_ = new_mtl_buffer_no_copy(device_.get(), runtime_mem_->ptr(),
                                              runtime_mem_->size());
-    buffer_meta_data_.runtime_buffer_size = runtime_mem_->size();
+    buffer_meta_data_.runtime_buffer_size = compiled_structs_.runtime_size;
     TI_DEBUG(
         "Metal runtime buffer size: {} bytes (sizeof(Runtime)={} "
         "memory_pool={})",

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -30,7 +30,6 @@ class KernelManager {
     MemoryPool *mem_pool;
     uint64_t *host_result_buffer;
     KernelProfilerBase *profiler;
-    BufferMetaData buffer_meta_data;
     int root_id;
   };
 


### PR DESCRIPTION
Related issue = #

Fix dumped runtime buffer size. Eliminate memory pool size.
Code clean off in aot module. 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
