### PR TITLE
[ci] Restrict slash-command-dispatch to PR only

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -13,6 +13,7 @@ jobs:
           token: ${{ secrets.GARDENER_PAT }}
           reaction-token: ${{ secrets.GARDENER_PAT }}
           repository: taichi-dev/ci_workflows
+          issue-type: pull-request
           permission: triage
           commands: |
             format

--- a/taichi/program/arch.h
+++ b/taichi/program/arch.h
@@ -4,8 +4,7 @@
 #include "taichi/common/core.h"
 
 namespace taichi {
-  namespace lang {
-    
+namespace lang {
 
 enum class Arch : int {
 #define PER_ARCH(x) x,
@@ -30,6 +29,5 @@ bool arch_use_host_memory(Arch arch);
 
 int default_simd_width(Arch arch);
 
-
-  }
-}
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/program/arch.h
+++ b/taichi/program/arch.h
@@ -3,7 +3,9 @@
 #include <string>
 #include "taichi/common/core.h"
 
-TLANG_NAMESPACE_BEGIN
+namespace taichi {
+  namespace lang {
+    
 
 enum class Arch : int {
 #define PER_ARCH(x) x,
@@ -28,4 +30,6 @@ bool arch_use_host_memory(Arch arch);
 
 int default_simd_width(Arch arch);
 
-TLANG_NAMESPACE_END
+
+  }
+}


### PR DESCRIPTION
Related issue = #2369

Intentionally mess up the format of `arch.h` to make sure this still works.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guideline:
  https://taichi.graphics/contribution/

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://taichi.graphics/contribution/contributor_guide.html#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
