### PR TITLE
[Refactor] [cuda] Cleanup CUDA AtomicOpStmt codegen

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -246,9 +246,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     if (!stmt->is_reduction) {
       return nullptr;
     }
-    if (!stmt->val->ret_type->is<PrimitiveType>()) {
-      return nullptr;
-    }
+    TI_ASSERT(stmt->val->ret_type->is<PrimitiveType>());
     PrimitiveTypeID prim_type =
         stmt->val->ret_type->cast<PrimitiveType>()->type;
 
@@ -274,12 +272,75 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     if (fast_reductions.find(prim_type) == fast_reductions.end()) {
       return nullptr;
     }
-    if (fast_reductions.at(prim_type).find(op) ==
-        fast_reductions.at(prim_type).end()) {
-      return nullptr;
-    }
+    TI_ASSERT(fast_reductions.at(prim_type).find(op) !=
+              fast_reductions.at(prim_type).end());
     return create_call(fast_reductions.at(prim_type).at(op),
                        {llvm_val[stmt->dest], llvm_val[stmt->val]});
+  }
+
+  llvm::Value *custom_type_atomic(AtomicOpStmt *stmt) {
+    if (stmt->op_type == AtomicOpType::add) {
+      auto dst_type =
+          stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
+      if (auto cit = dst_type->cast<CustomIntType>()) {
+        return atomic_add_custom_int(stmt, cit);
+      } else if (auto cft = dst_type->cast<CustomFloatType>()) {
+        return atomic_add_custom_float(stmt, cft);
+      }
+    }
+    return nullptr;
+  }
+
+  llvm::Value *integral_type_atomic(AtomicOpStmt *stmt) {
+    if (is_integral(stmt->val->ret_type)) {
+      std::unordered_map<AtomicOpType, llvm::AtomicRMWInst::BinOp> bin_op;
+      bin_op[AtomicOpType::add] = llvm::AtomicRMWInst::BinOp::Add;
+      bin_op[AtomicOpType::min] = llvm::AtomicRMWInst::BinOp::Min;
+      bin_op[AtomicOpType::max] = llvm::AtomicRMWInst::BinOp::Max;
+
+      bin_op[AtomicOpType::bit_and] = llvm::AtomicRMWInst::BinOp::And;
+      bin_op[AtomicOpType::bit_or] = llvm::AtomicRMWInst::BinOp::Or;
+      bin_op[AtomicOpType::bit_xor] = llvm::AtomicRMWInst::BinOp::Xor;
+      TI_ASSERT(bin_op.find(stmt->op_type) != bin_op.end());
+      return builder->CreateAtomicRMW(
+          bin_op.at(stmt->op_type), llvm_val[stmt->dest], llvm_val[stmt->val],
+          llvm::AtomicOrdering::SequentiallyConsistent);
+    }
+    return nullptr;
+  }
+
+  llvm::Value *real_type_atomic(AtomicOpStmt *stmt) {
+    if (!stmt->val->ret_type->is<PrimitiveType>()) {
+      return nullptr;
+    }
+    AtomicOpType op = stmt->op_type;
+    if (is_real(stmt->val->ret_type) && op == AtomicOpType::add) {
+      return builder->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd,
+                                      llvm_val[stmt->dest], llvm_val[stmt->val],
+                                      AtomicOrdering::SequentiallyConsistent);
+    } else {
+      PrimitiveTypeID prim_type =
+          stmt->val->ret_type->cast<PrimitiveType>()->type;
+
+      std::unordered_map<PrimitiveTypeID,
+                         std::unordered_map<AtomicOpType, std::string>>
+          atomics;
+
+      atomics[PrimitiveTypeID::f32][AtomicOpType::min] = "atomic_min_f32";
+      atomics[PrimitiveTypeID::f64][AtomicOpType::min] = "atomic_min_f64";
+      atomics[PrimitiveTypeID::f32][AtomicOpType::max] = "atomic_max_f32";
+      atomics[PrimitiveTypeID::f64][AtomicOpType::max] = "atomic_max_f64";
+
+      if (atomics.find(prim_type) == atomics.end()) {
+        return nullptr;
+      }
+      TI_ASSERT(atomics.at(prim_type).find(op) != atomics.at(prim_type).end());
+
+      return builder->CreateCall(
+          get_runtime_function(atomics.at(prim_type).at(op)),
+          {llvm_val[stmt->dest], llvm_val[stmt->val]});
+    }
+    return nullptr;
   }
 
   void visit(AtomicOpStmt *stmt) override {
@@ -291,89 +352,15 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     TI_ASSERT(stmt->width() == 1);
     for (int l = 0; l < stmt->width(); l++) {
       llvm::Value *old_value;
-      auto dst_type =
-          stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
+
       if (llvm::Value *result = optimized_reduction(stmt)) {
         old_value = result;
-      } else if (stmt->op_type == AtomicOpType::add) {
-        if (dst_type->is<PrimitiveType>() && is_integral(stmt->val->ret_type)) {
-          old_value = builder->CreateAtomicRMW(
-              llvm::AtomicRMWInst::BinOp::Add, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              llvm::AtomicOrdering::SequentiallyConsistent);
-        } else if (!dst_type->is<CustomFloatType>() &&
-                   is_real(stmt->val->ret_type)) {
-          old_value = builder->CreateAtomicRMW(
-              llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest],
-              llvm_val[stmt->val], AtomicOrdering::SequentiallyConsistent);
-        } else if (auto cit = dst_type->cast<CustomIntType>()) {
-          old_value = atomic_add_custom_int(stmt, cit);
-        } else if (auto cft = dst_type->cast<CustomFloatType>()) {
-          old_value = atomic_add_custom_float(stmt, cft);
-        } else {
-          TI_NOT_IMPLEMENTED
-        }
-      } else if (stmt->op_type == AtomicOpType::min) {
-        if (is_integral(stmt->val->ret_type)) {
-          old_value = builder->CreateAtomicRMW(
-              llvm::AtomicRMWInst::BinOp::Min, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              llvm::AtomicOrdering::SequentiallyConsistent);
-        } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
-          old_value =
-              builder->CreateCall(get_runtime_function("atomic_min_f32"),
-                                  {llvm_val[stmt->dest], llvm_val[stmt->val]});
-        } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
-          old_value =
-              builder->CreateCall(get_runtime_function("atomic_min_f64"),
-                                  {llvm_val[stmt->dest], llvm_val[stmt->val]});
-        } else {
-          TI_NOT_IMPLEMENTED
-        }
-      } else if (stmt->op_type == AtomicOpType::max) {
-        if (is_integral(stmt->val->ret_type)) {
-          old_value = builder->CreateAtomicRMW(
-              llvm::AtomicRMWInst::BinOp::Max, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              llvm::AtomicOrdering::SequentiallyConsistent);
-        } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
-          old_value =
-              builder->CreateCall(get_runtime_function("atomic_max_f32"),
-                                  {llvm_val[stmt->dest], llvm_val[stmt->val]});
-        } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f64)) {
-          old_value =
-              builder->CreateCall(get_runtime_function("atomic_max_f64"),
-                                  {llvm_val[stmt->dest], llvm_val[stmt->val]});
-        } else {
-          TI_NOT_IMPLEMENTED
-        }
-      } else if (stmt->op_type == AtomicOpType::bit_and) {
-        if (is_integral(stmt->val->ret_type)) {
-          old_value = builder->CreateAtomicRMW(
-              llvm::AtomicRMWInst::BinOp::And, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              llvm::AtomicOrdering::SequentiallyConsistent);
-        } else {
-          TI_NOT_IMPLEMENTED
-        }
-      } else if (stmt->op_type == AtomicOpType::bit_or) {
-        if (is_integral(stmt->val->ret_type)) {
-          old_value = builder->CreateAtomicRMW(
-              llvm::AtomicRMWInst::BinOp::Or, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              llvm::AtomicOrdering::SequentiallyConsistent);
-        } else {
-          TI_NOT_IMPLEMENTED
-        }
-      } else if (stmt->op_type == AtomicOpType::bit_xor) {
-        if (is_integral(stmt->val->ret_type)) {
-          old_value = builder->CreateAtomicRMW(
-              llvm::AtomicRMWInst::BinOp::Xor, llvm_val[stmt->dest],
-              llvm_val[stmt->val],
-              llvm::AtomicOrdering::SequentiallyConsistent);
-        } else {
-          TI_NOT_IMPLEMENTED
-        }
+      } else if (llvm::Value *result = custom_type_atomic(stmt)) {
+        old_value = result;
+      } else if (llvm::Value *result = integral_type_atomic(stmt)) {
+        old_value = result;
+      } else if (llvm::Value *result = real_type_atomic(stmt)) {
+        old_value = result;
       } else {
         TI_NOT_IMPLEMENTED
       }


### PR DESCRIPTION
Avoid redundant if-elses in `visit(AtomicOpStmt *stmt)` using a look-up table.