### PR TITLE
[Perf] Reduce GL backend's overhead (driver overhead & copy overhead)

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -29,6 +29,8 @@ namespace shaders {
 #undef TI_INSIDE_OPENGL_CODEGEN
 }  // namespace shaders
 
+using irpass::ExternalPtrAccess;
+
 int find_children_id(const SNode *snode) {
   auto parent = snode->parent;
   for (int i = 0; i < parent->ch.size(); i++) {
@@ -94,7 +96,7 @@ class KernelGen : public IRVisitor {
   std::string glsl_kernel_name_;
   std::unique_ptr<ParallelSize> ps;
   bool used_tls;  // TODO: move into UsedFeature?
-  std::unordered_map<int, int> extptr_access;
+  std::unordered_map<int, irpass::ExternalPtrAccess> extptr_access;
 
   template <typename... Args>
   void emit(std::string f, Args &&... args) {
@@ -177,8 +179,8 @@ class KernelGen : public IRVisitor {
       bool read = false;
 
       for (auto pair : this->extptr_access) {
-        write |= (pair.second & int(irpass::ExternalPtrAccess::WRITE)) > 0;
-        read |= (pair.second & int(irpass::ExternalPtrAccess::WRITE)) > 0;
+        write |= (pair.second & irpass::ExternalPtrAccess::WRITE) != irpass::ExternalPtrAccess::NONE;
+        read |= (pair.second & irpass::ExternalPtrAccess::WRITE) != irpass::ExternalPtrAccess::NONE;
       }
 
       if (write && !read) {

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -672,11 +672,9 @@ struct CompiledProgram::Impl {
     }
     for (auto &[idx, buf] : launcher->impl->user_bufs.bufs) {
       if (buf->index == GLBufId::Args) {
-        if (ret_count > 0) {
-          // Copying of data between host and device cause implicit
-          // synchronization Should avoid any synchronization if not needed
-          buf->copy_back(launcher->result_buffer, ret_count * sizeof(uint64_t));
-        }
+        // Copying of data between host and device cause implicit
+        // synchronization Should avoid any synchronization if not needed
+        buf->copy_back(launcher->result_buffer, ret_count * sizeof(uint64_t));
       } else {
         // TODO: Use the analysis information built during codegen to figure out
         // whether a buffer is read-only or not If a buffer is read-only there

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -293,8 +293,8 @@ struct GLBufferAllocator {
 
   std::list<std::unique_ptr<GLBuffer>> buffers_storage_;
 
-  std::unordered_map<std::pair<GLBufId, size_t>, GLBuffer *> buffers_mapping;
-  std::unordered_map<std::pair<GLBufId, size_t>, GLBuffer *> free_mapping;
+  std::map<std::pair<GLBufId, size_t>, GLBuffer *> buffers_mapping;
+  std::map<std::pair<GLBufId, size_t>, GLBuffer *> free_mapping;
 
  public:
   GLBufferAllocator() {

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -79,7 +79,8 @@ struct CompiledProgram {
 
   void add(const std::string &kernel_name,
            const std::string &kernel_source_code,
-           std::unique_ptr<ParallelSize> ps);
+           std::unique_ptr<ParallelSize> ps,
+           std::unordered_map<int, int> *ext_ptr_access = nullptr);
   void set_used(const UsedFeature &used);
   int lookup_or_add_string(const std::string &str);
   void launch(Context &ctx, GLSLLauncher *launcher) const;

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "taichi/common/core.h"
+#include "taichi/ir/transforms.h"
 
 #include <string>
 #include <vector>
@@ -80,7 +81,8 @@ struct CompiledProgram {
   void add(const std::string &kernel_name,
            const std::string &kernel_source_code,
            std::unique_ptr<ParallelSize> ps,
-           std::unordered_map<int, int> *ext_ptr_access = nullptr);
+           std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access =
+               nullptr);
   void set_used(const UsedFeature &used);
   int lookup_or_add_string(const std::string &str);
   void launch(Context &ctx, GLSLLauncher *launcher) const;

--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -29,6 +29,7 @@ struct UsedFeature {
   bool buf_earg{false};
   bool buf_extr{false};
   bool buf_gtmp{false};
+  bool buf_retr{false};
 
   // utilties:
   bool fast_pow{false};
@@ -48,6 +49,7 @@ enum class GLBufId {
   Listman = 7,
   Gtmp = 1,
   Args = 2,
+  Retr = 3,
   Extr = 4,
 };
 

--- a/taichi/common/trait.h
+++ b/taichi/common/trait.h
@@ -12,4 +12,19 @@ struct always_false : std::false_type {};
 template <typename T>
 inline constexpr bool always_false_v = always_false<T>::value;
 
+#define ENUM_FLAG_OPERATOR(T, X)                                   \
+  inline T operator X(T lhs, T rhs) {                              \
+    return (T)(static_cast<std::underlying_type_t<T>>(lhs)         \
+                   X static_cast<std::underlying_type_t<T>>(rhs)); \
+  }
+#define ENUM_FLAGS(T)                                       \
+  enum class T;                                             \
+  inline T operator~(T t) {                                 \
+    return (T)(~static_cast<std::underlying_type_t<T>>(t)); \
+  }                                                         \
+  ENUM_FLAG_OPERATOR(T, |)                                  \
+  ENUM_FLAG_OPERATOR(T, ^)                                  \
+  ENUM_FLAG_OPERATOR(T, &)                                  \
+  enum class T
+
 }  // namespace taichi

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -14,6 +14,7 @@
 #include "taichi/transforms/lower_access.h"
 #include "taichi/transforms/make_block_local.h"
 #include "taichi/transforms/simplify.h"
+#include "taichi/common/trait.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -114,9 +115,18 @@ void optimize_bit_struct_stores(IRNode *root,
                                 const CompileConfig &config,
                                 AnalysisManager *amgr);
 
-enum class ExternalPtrAccess : int { NONE = 0, READ = 1, WRITE = 2 };
+ENUM_FLAGS(ExternalPtrAccess){NONE = 0, READ = 1, WRITE = 2};
 
-std::unordered_map<int, int> detect_external_ptr_access_in_task(
+/**
+ * Checks the access to external pointers in an offload.
+ *
+ * @param val1
+ *   The offloaded statement to check
+ *
+ * @return
+ *   The analyzed result.
+ */
+std::unordered_map<int, ExternalPtrAccess> detect_external_ptr_access_in_task(
     OffloadedStmt *offload);
 
 // compile_to_offloads does the basic compilation to create all the offloaded

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -114,6 +114,11 @@ void optimize_bit_struct_stores(IRNode *root,
                                 const CompileConfig &config,
                                 AnalysisManager *amgr);
 
+enum class ExternalPtrAccess : int { NONE = 0, READ = 1, WRITE = 2 };
+
+std::unordered_map<int, int> detect_external_ptr_access_in_task(
+    OffloadedStmt *offload);
+
 // compile_to_offloads does the basic compilation to create all the offloaded
 // tasks of a Taichi kernel. It's worth pointing out that this doesn't demote
 // dense struct fors. This is a necessary workaround to prevent the async

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -2,6 +2,7 @@
 #include "taichi/ir/statements.h"
 #include "taichi/ir/analysis.h"
 #include "taichi/ir/visitors.h"
+#include "taichi/ir/transforms.h"
 
 #include <algorithm>
 
@@ -21,6 +22,43 @@ void detect_read_only_in_task(OffloadedStmt *offload) {
   }
 }
 
+class ExternalPtrAccessVisitor : public BasicStmtVisitor {
+ private:
+  std::unordered_map<int, int> &map;
+
+ public:
+  using BasicStmtVisitor::visit;
+
+  ExternalPtrAccessVisitor(std::unordered_map<int, int> &map)
+      : map(map), BasicStmtVisitor() {
+  }
+
+  void visit(GlobalLoadStmt *stmt) {
+    if (stmt->src && stmt->src->is<ExternalPtrStmt>()) {
+      ExternalPtrStmt *src = stmt->src->cast<ExternalPtrStmt>();
+      ArgLoadStmt *arg = src->base_ptrs.data[0]->cast<ArgLoadStmt>();
+      if (map.find(arg->arg_id) != map.end()) {
+        map[arg->arg_id] = int(map[arg->arg_id]) | int(ExternalPtrAccess::READ);
+      } else {
+        map[arg->arg_id] = int(ExternalPtrAccess::READ);
+      }
+    }
+  }
+
+  void visit(GlobalStoreStmt *stmt) {
+    if (stmt->dest && stmt->dest->is<ExternalPtrStmt>()) {
+      ExternalPtrStmt *dst = stmt->dest->cast<ExternalPtrStmt>();
+      ArgLoadStmt *arg = dst->base_ptrs.data[0]->cast<ArgLoadStmt>();
+      if (map.find(arg->arg_id) != map.end()) {
+        map[arg->arg_id] =
+            int(map[arg->arg_id]) | int(ExternalPtrAccess::WRITE);
+      } else {
+        map[arg->arg_id] = int(ExternalPtrAccess::WRITE);
+      }
+    }
+  }
+};
+
 }  // namespace
 
 void detect_read_only(IRNode *root) {
@@ -31,6 +69,14 @@ void detect_read_only(IRNode *root) {
   } else {
     detect_read_only_in_task(root->as<OffloadedStmt>());
   }
+}
+
+std::unordered_map<int, int> detect_external_ptr_access_in_task(
+    OffloadedStmt *offload) {
+  std::unordered_map<int, int> map;
+  ExternalPtrAccessVisitor v(map);
+  offload->accept(&v);
+  return map;
 }
 
 }  // namespace irpass

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -24,37 +24,38 @@ void detect_read_only_in_task(OffloadedStmt *offload) {
 
 class ExternalPtrAccessVisitor : public BasicStmtVisitor {
  private:
-  std::unordered_map<int, int> &map;
+  std::unordered_map<int, ExternalPtrAccess> &map_;
 
  public:
   using BasicStmtVisitor::visit;
 
-  ExternalPtrAccessVisitor(std::unordered_map<int, int> &map)
-      : map(map), BasicStmtVisitor() {
+  ExternalPtrAccessVisitor(std::unordered_map<int, ExternalPtrAccess> &map)
+      : map_(map), BasicStmtVisitor() {
   }
 
   void visit(GlobalLoadStmt *stmt) {
-    if (stmt->src && stmt->src->is<ExternalPtrStmt>()) {
-      ExternalPtrStmt *src = stmt->src->cast<ExternalPtrStmt>();
-      ArgLoadStmt *arg = src->base_ptrs.data[0]->cast<ArgLoadStmt>();
-      if (map.find(arg->arg_id) != map.end()) {
-        map[arg->arg_id] = int(map[arg->arg_id]) | int(ExternalPtrAccess::READ);
-      } else {
-        map[arg->arg_id] = int(ExternalPtrAccess::READ);
-      }
+    if (!(stmt->src && stmt->src->is<ExternalPtrStmt>()))
+      return;
+
+    ExternalPtrStmt *src = stmt->src->cast<ExternalPtrStmt>();
+    ArgLoadStmt *arg = src->base_ptrs.data[0]->cast<ArgLoadStmt>();
+    if (map_.find(arg->arg_id) != map_.end()) {
+      map_[arg->arg_id] = map_[arg->arg_id] | ExternalPtrAccess::READ;
+    } else {
+      map_[arg->arg_id] = ExternalPtrAccess::READ;
     }
   }
 
   void visit(GlobalStoreStmt *stmt) {
-    if (stmt->dest && stmt->dest->is<ExternalPtrStmt>()) {
-      ExternalPtrStmt *dst = stmt->dest->cast<ExternalPtrStmt>();
-      ArgLoadStmt *arg = dst->base_ptrs.data[0]->cast<ArgLoadStmt>();
-      if (map.find(arg->arg_id) != map.end()) {
-        map[arg->arg_id] =
-            int(map[arg->arg_id]) | int(ExternalPtrAccess::WRITE);
-      } else {
-        map[arg->arg_id] = int(ExternalPtrAccess::WRITE);
-      }
+    if (!(stmt->dest && stmt->dest->is<ExternalPtrStmt>()))
+      return;
+
+    ExternalPtrStmt *dst = stmt->dest->cast<ExternalPtrStmt>();
+    ArgLoadStmt *arg = dst->base_ptrs.data[0]->cast<ArgLoadStmt>();
+    if (map_.find(arg->arg_id) != map_.end()) {
+      map_[arg->arg_id] = map_[arg->arg_id] | ExternalPtrAccess::WRITE;
+    } else {
+      map_[arg->arg_id] = ExternalPtrAccess::WRITE;
     }
   }
 };
@@ -71,9 +72,9 @@ void detect_read_only(IRNode *root) {
   }
 }
 
-std::unordered_map<int, int> detect_external_ptr_access_in_task(
+std::unordered_map<int, ExternalPtrAccess> detect_external_ptr_access_in_task(
     OffloadedStmt *offload) {
-  std::unordered_map<int, int> map;
+  std::unordered_map<int, ExternalPtrAccess> map;
   ExternalPtrAccessVisitor v(map);
   offload->accept(&v);
   return map;


### PR DESCRIPTION
This is a (sort of) WIP PR.

In the OpenGL backend there are quite some overhead on kernel launch. These overheads can be categorized into two types:
1. Driver overhead
2. Synchronization / copy overhead

For the driver overhead, the main problem is the (unpredictable) cost of GL functions. Currently every frame the code creates a series of buffers, and then populate them with the host side data we want to pass in. This process not only involves C++'s RAII and related allocation overhead, it also calls `glGenBuffers` and `glDeleteBuffers` which do not have a predictable cost. The driver will do a lot of things behind, and therefore it is better to not allocating and reallocating resources every frame. This process should be managed internally since we know the details of these buffers, the drivers do not, not until we request to upload data.

For the synchronization overhead, after a kernel's invocation all buffers are transferred back to host indiscriminately. This transfer should not be needed if say the kernel does not have a return argument, or it only performs read on a certain buffer. Currently this PR has not utilized the read write access insight from codegen yet, but simply avoiding a copy if there is no returns is already yielding performance improvements. (Also in GL a device to host copy causes an implicit synchronization which flushes the GPU pipeline, so the cost is higher than what we may expect.)

Currently I observed in `cornell_box.py` an increase in `270~280 samples` to `300~330 samples` per second.

For the future iterations of this PR (or maybe making a new PR) I'm aiming to revise the device resource management in the GL backend. Currently it is doing a few things that are not quite optimal, and some internal terms / APIs in the code are slightly confusing.

----

7.16.2021, commit `1be6fa4`
- Added a transform that detects the read write operations to external ptrs (perhaps this should be in analysis instead of transforms?)
- Use this knowledge to reduce host/device transfers. (If kernel does not read from extptr, we don't need to transfer the current content in.)
- Potential issue here: What if the kernel is expected to write to a few entries in the extptr but not the entire one, where old data should be preserved? Is this a valid case in taichi? If that is the case then this transfer becomes more or less unavoidable, unless we eliminate the use of this external buffer on the host side and let it stay in GPU.
- I propose we should add a unified device memory allocator / manager, and all backends or frontends use this allocator to create buffers. Hopefully with this we can use advanced features such as host-visible device memory and persistently mapped resources. This will also help later API interop work.