### PR TITLE
[Example] Fix an oversight on the variance computation

### DIFF
--- a/examples/rendering/cornell_box.py
+++ b/examples/rendering/cornell_box.py
@@ -485,7 +485,7 @@ def render():
 
 
 @ti.kernel
-def tonemap(accumulated : ti.f32) -> ti.f32:
+def tonemap(accumulated: ti.f32) -> ti.f32:
     sum = 0.0
     sum_sq = 0.0
     for i, j in color_buffer:


### PR DESCRIPTION
I computed the variance of the accumulation buffer without dividing by the number of frames, causing variance to only grow over time. (This is a very dumb commit, I'm sorry that the last one has this oversight)

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
