### PR TITLE
[release] v0.7.27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ classifiers = [
 project_name = os.getenv('PROJECT_NAME', 'taichi')
 TI_VERSION_MAJOR = 0
 TI_VERSION_MINOR = 7
-TI_VERSION_PATCH = 26
+TI_VERSION_PATCH = 27
 version = f'{TI_VERSION_MAJOR}.{TI_VERSION_MINOR}.{TI_VERSION_PATCH}'
 
 data_files = glob.glob('python/lib/*')


### PR DESCRIPTION
Full changelog:
   - [Lang] Support very basic python string.format() now (#2552) (by **Jiasheng Zhang**)
   - [vulkan] Add a simple memory allocator (#2556) (by **Ye Kuang**)
   - [vulkan] Add Vulkan struct compiler and some helpers (#2550) (by **Ye Kuang**)
   - [autodiff] Raise no gradient instead of attribute dim not found (#2542) (by **Mingrui Zhang**)
   - [doc] Fix command typo in contributor guide (#2545) (by **Yi Xu**)
   - [bug] Fix python detection on windows (#2528) (by **Hoildkv**)
   - [Refactor] Use setup.py from root dir. (#2540) (by **Ailing**)
   - [test] [bug] Avoid accessing negative indices (#2538) (by **Yi Xu**)
   - [lang] Add a name parameter to fields (#2534) (by **ljss**)
   - [refactor] Move snode tree maintainance out of python (#2530) (by **Jiasheng Zhang**)
   - [Example] Fix an oversight on the variance computation (#2536) (by **Bob Cao**)
   - [Example] Use Taichi instead of numpy to perform tonemapping & significantly lower CPU's work (#2535) (by **Bob Cao**)
   - [doc] fix outdated links of examples in README.md (#2533) (by **Mingrui Zhang**)
   - [doc] Update links in the readme file. (#2523) (by **Chengchen(Rex) Wang**)
   - [windows] Use %lld as 64-bit integer output format on Windows (#2525) (by **xumingkuan**)
   - [bug] Set use_unified_memory=True for tests with pointer fields with 32-bit data types (#2521) (by **xumingkuan**)
   - [Refactor]Move llvm runtime build for archs to cmake from C++. (#2524) (by **Ailing**)
   - [Bug] Warp reduction bug fix (#2519) (by **Dunfan Lu**)
   - [misc] Output "taichi_cpp_tests.exe" to the "bin" folder on Windows (#2515) (by **xumingkuan**)
   - [misc] Import template and ext_arr and kernel in python code (#2514) (by **ljcc0930**)
   - [wasm] Add wasm_set_kernel_parameter_* into runtime.cpp (#2510) (by **squarefk**)