### PR TITLE
[refactor] Correct a few indices->axes renamings

### DIFF
--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -86,12 +86,12 @@ T Eval(const T &t) {
 
 Expr copy(const Expr &expr);
 
-template <typename... axes>
-std::vector<Axis> Axes(axes... ind) {
-  auto ind_vec = std::vector<int>({ind...});
+template <typename... AX>
+std::vector<Axis> Axes(AX... axes) {
+  auto ax_vec = std::vector<int>({axes...});
   std::vector<Axis> ret;
-  for (auto in : ind_vec) {
-    ret.push_back(Axis(in));
+  for (auto ax : ax_vec) {
+    ret.push_back(Axis(ax));
   }
   return ret;
 }
@@ -103,7 +103,7 @@ inline Expr Atomic(Expr dest) {
   return dest;
 }
 
-// expr_group are axes
+// expr_group are indices
 inline void Activate(SNode *snode, const ExprGroup &expr_group) {
   current_ast_builder().insert(Stmt::make<FrontendSNodeOpStmt>(
       SNodeOpType::activate, snode, expr_group));
@@ -118,37 +118,40 @@ inline void Deactivate(SNode *snode, const ExprGroup &expr_group) {
       SNodeOpType::deactivate, snode, expr_group));
 }
 
-inline Expr Append(SNode *snode, const ExprGroup &axes, const Expr &val) {
-  return Expr::make<SNodeOpExpression>(snode, SNodeOpType::append, axes, val);
+inline Expr Append(SNode *snode, const ExprGroup &indices, const Expr &val) {
+  return Expr::make<SNodeOpExpression>(snode, SNodeOpType::append, indices,
+                                       val);
 }
 
-inline Expr Append(const Expr &expr, const ExprGroup &axes, const Expr &val) {
-  return Append(expr.snode(), axes, val);
+inline Expr Append(const Expr &expr,
+                   const ExprGroup &indices,
+                   const Expr &val) {
+  return Append(expr.snode(), indices, val);
 }
 
 inline void InsertAssert(const std::string &text, const Expr &cond) {
   current_ast_builder().insert(Stmt::make<FrontendAssertStmt>(cond, text));
 }
 
-inline void Clear(SNode *snode, const ExprGroup &axes) {
+inline void Clear(SNode *snode, const ExprGroup &indices) {
   current_ast_builder().insert(
-      Stmt::make<FrontendSNodeOpStmt>(SNodeOpType::clear, snode, axes));
+      Stmt::make<FrontendSNodeOpStmt>(SNodeOpType::clear, snode, indices));
 }
 
-inline Expr is_active(SNode *snode, const ExprGroup &axes) {
-  return Expr::make<SNodeOpExpression>(snode, SNodeOpType::is_active, axes);
+inline Expr is_active(SNode *snode, const ExprGroup &indices) {
+  return Expr::make<SNodeOpExpression>(snode, SNodeOpType::is_active, indices);
 }
 
-inline void Clear(const Expr &expr, const ExprGroup &axes) {
-  return Clear(expr.snode(), axes);
+inline void Clear(const Expr &expr, const ExprGroup &indices) {
+  return Clear(expr.snode(), indices);
 }
 
-inline Expr Length(SNode *snode, const ExprGroup &axes) {
-  return Expr::make<SNodeOpExpression>(snode, SNodeOpType::length, axes);
+inline Expr Length(SNode *snode, const ExprGroup &indices) {
+  return Expr::make<SNodeOpExpression>(snode, SNodeOpType::length, indices);
 }
 
-inline Expr Length(const Expr &expr, const ExprGroup &axes) {
-  return Length(expr.snode(), axes);
+inline Expr Length(const Expr &expr, const ExprGroup &indices) {
+  return Length(expr.snode(), indices);
 }
 
 inline Expr AssumeInRange(const Expr &expr,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -412,21 +412,21 @@ void export_lang(py::module &m) {
           },
           py::return_value_policy::reference);
 
-  m.def("insert_deactivate", [](SNode *snode, const ExprGroup &axes) {
-    return Deactivate(snode, axes);
+  m.def("insert_deactivate", [](SNode *snode, const ExprGroup &indices) {
+    return Deactivate(snode, indices);
   });
 
-  m.def("insert_activate", [](SNode *snode, const ExprGroup &axes) {
-    return Activate(snode, axes);
+  m.def("insert_activate", [](SNode *snode, const ExprGroup &indices) {
+    return Activate(snode, indices);
   });
 
-  m.def("expr_get_addr", [](SNode *snode, const ExprGroup &axes) {
-    return Expr::make<SNodeOpExpression>(snode, SNodeOpType::get_addr, axes);
+  m.def("expr_get_addr", [](SNode *snode, const ExprGroup &indices) {
+    return Expr::make<SNodeOpExpression>(snode, SNodeOpType::get_addr, indices);
   });
 
   m.def("insert_append",
-        [](SNode *snode, const ExprGroup &axes, const Expr &val) {
-          return Append(snode, axes, val);
+        [](SNode *snode, const ExprGroup &indices, const Expr &val) {
+          return Append(snode, indices, val);
         });
 
   m.def("insert_external_func_call",
@@ -438,12 +438,12 @@ void export_lang(py::module &m) {
           current_ast_builder().insert(Stmt::make<FrontendEvalStmt>(expr));
         });
 
-  m.def("insert_is_active", [](SNode *snode, const ExprGroup &axes) {
-    return is_active(snode, axes);
+  m.def("insert_is_active", [](SNode *snode, const ExprGroup &indices) {
+    return is_active(snode, indices);
   });
 
-  m.def("insert_len", [](SNode *snode, const ExprGroup &axes) {
-    return Length(snode, axes);
+  m.def("insert_len", [](SNode *snode, const ExprGroup &indices) {
+    return Length(snode, indices);
   });
 
   m.def("create_assert_stmt", [&](const Expr &cond, const std::string &msg,
@@ -471,13 +471,13 @@ void export_lang(py::module &m) {
           scope_stack.push_back(current_ast_builder().create_scope(stmt->body));
         });
 
-  m.def("begin_frontend_struct_for",
-        [&](const ExprGroup &axes, const Expr &global) {
-          auto stmt_unique = std::make_unique<FrontendForStmt>(axes, global);
-          auto stmt = stmt_unique.get();
-          current_ast_builder().insert(std::move(stmt_unique));
-          scope_stack.push_back(current_ast_builder().create_scope(stmt->body));
-        });
+  m.def("begin_frontend_struct_for", [&](const ExprGroup &loop_vars,
+                                         const Expr &global) {
+    auto stmt_unique = std::make_unique<FrontendForStmt>(loop_vars, global);
+    auto stmt = stmt_unique.get();
+    current_ast_builder().insert(std::move(stmt_unique));
+    scope_stack.push_back(current_ast_builder().create_scope(stmt->body));
+  });
 
   m.def("end_frontend_range_for", [&]() { scope_stack.pop_back(); });
   m.def("pop_scope", [&]() { scope_stack.pop_back(); });
@@ -690,8 +690,8 @@ void export_lang(py::module &m) {
     return expr[expr_group];
   });
 
-  m.def("subscript", [](SNode *snode, const ExprGroup &axes) {
-    return Expr::make<GlobalPtrExpression>(snode, axes.loaded());
+  m.def("subscript", [](SNode *snode, const ExprGroup &indices) {
+    return Expr::make<GlobalPtrExpression>(snode, indices.loaded());
   });
 
   m.def("get_external_tensor_dim", [](const Expr &expr) {


### PR DESCRIPTION
Related issue = #2560 

I took another pass and found a few places where we didn't need to rename. Note that `ExprGroup` is indeed a group of indices (aka a coordinate) 

FYI @cruedo 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
