### PR TITLE
[opengl] Work group reduction

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -671,6 +671,8 @@ class KernelGen : public IRVisitor {
            opengl_data_type_name(stmt->val->element_type()), val_name, op_name,
            opengl_data_type_name(stmt->val->element_type()),
            stmt->val->short_name());
+
+      emit("if (gl_LocalInvocationIndex == 0)");
     }
 
     if (dt->is_primitive(PrimitiveTypeID::i32) ||

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -26,6 +26,7 @@ namespace shaders {
 #include "taichi/backends/opengl/shaders/random.glsl.h"
 #include "taichi/backends/opengl/shaders/fast_pow.glsl.h"
 #include "taichi/backends/opengl/shaders/print.glsl.h"
+#include "taichi/backends/opengl/shaders/reduction.glsl.h"
 #undef TI_INSIDE_OPENGL_CODEGEN
 }  // namespace shaders
 
@@ -205,6 +206,20 @@ class KernelGen : public IRVisitor {
       if (used.buf_extr) {
         kernel_header += ("DEFINE_ATOMIC_F32_FUNCTIONS(extr);\n");
       }
+    }
+
+    if (used.reduction) {
+      line_appender_header_.append_raw(shaders::kOpenGLReductionCommon);
+      line_appender_header_.append_raw(shaders::kOpenGLReductionSourceCode);
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(add, float);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(max, float);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(min, float);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(add, int);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(max, int);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(min, int);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(add, uint);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(max, uint);\n");
+      kernel_header += ("DEFINE_REDUCTION_FUNCTIONS(min, uint);\n");
     }
 
     line_appender_header_.append_raw(kernel_header);
@@ -627,6 +642,37 @@ class KernelGen : public IRVisitor {
   void visit(AtomicOpStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
     auto dt = stmt->dest->element_type().ptr_removed();
+
+    auto val_name = stmt->val->short_name();
+
+    if (stmt->is_reduction &&
+        (dt->is_primitive(PrimitiveTypeID::f32) ||
+         dt->is_primitive(PrimitiveTypeID::i32) ||
+         dt->is_primitive(PrimitiveTypeID::u32)) &&
+        (stmt->op_type == AtomicOpType::add ||
+         stmt->op_type == AtomicOpType::sub ||
+         stmt->op_type == AtomicOpType::min ||
+         stmt->op_type == AtomicOpType::max)) {
+      used.reduction = true;
+      val_name += "_reduction";
+
+      auto op_name = "";
+
+      if (stmt->op_type == AtomicOpType::sub ||
+          stmt->op_type == AtomicOpType::add) {
+        op_name = "add";
+      } else if (stmt->op_type == AtomicOpType::max) {
+        op_name = "max";
+      } else if (stmt->op_type == AtomicOpType::min) {
+        op_name = "min";
+      }
+
+      emit("{} {} = reduction_workgroup_{}_{}({});",
+           opengl_data_type_name(stmt->val->element_type()), val_name, op_name,
+           opengl_data_type_name(stmt->val->element_type()),
+           stmt->val->short_name());
+    }
+
     if (dt->is_primitive(PrimitiveTypeID::i32) ||
         (TI_OPENGL_REQUIRE(used, GL_NV_shader_atomic_int64) &&
          dt->is_primitive(PrimitiveTypeID::i64)) ||
@@ -640,8 +686,7 @@ class KernelGen : public IRVisitor {
            opengl_data_type_name(stmt->val->element_type()), stmt->short_name(),
            opengl_atomic_op_type_cap_name(stmt->op_type),
            ptr_signats.at(stmt->dest->id), opengl_data_type_short_name(dt),
-           stmt->dest->short_name(), opengl_data_address_shifter(dt),
-           stmt->val->short_name());
+           stmt->dest->short_name(), opengl_data_address_shifter(dt), val_name);
     } else {
       if (dt != PrimitiveType::f32) {
         TI_ERROR(
@@ -656,8 +701,7 @@ class KernelGen : public IRVisitor {
            opengl_data_type_name(stmt->val->element_type()), stmt->short_name(),
            opengl_atomic_op_type_cap_name(stmt->op_type),
            ptr_signats.at(stmt->dest->id), opengl_data_type_short_name(dt),
-           stmt->dest->short_name(), opengl_data_address_shifter(dt),
-           stmt->val->short_name());
+           stmt->dest->short_name(), opengl_data_address_shifter(dt), val_name);
     }
   }
 

--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -36,6 +36,7 @@ struct UsedFeature {
   bool listman{false};
   bool random{false};
   bool print{false};
+  bool reduction{false};
 
   // extensions:
 #define PER_OPENGL_EXTENSION(x) bool extension_##x{false};

--- a/taichi/backends/opengl/shaders/reduction.glsl.h
+++ b/taichi/backends/opengl/shaders/reduction.glsl.h
@@ -1,0 +1,55 @@
+// vim: ft=glsl
+// clang-format off
+#include "taichi/util/macros.h"
+
+constexpr auto kOpenGLReductionCommon = STR(
+shared float _reduction_temp_float[gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z];
+shared int _reduction_temp_int[gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z];
+shared uint _reduction_temp_uint[gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z];
+float add(float a, float b) { return a + b; }
+int add(int a, int b) { return a + b; }
+uint add(uint a, uint b) { return a + b; }
+\n
+);
+
+#ifdef TI_INSIDE_OPENGL_CODEGEN
+#define OPENGL_BEGIN_REDUCTION_DEF constexpr auto kOpenGLReductionSourceCode =
+#define OPENGL_END_REDUCTION_DEF ;
+#else
+static_assert(false, "Do not include");
+#define OPENGL_BEGIN_REDUCTION_DEF
+#define OPENGL_END_REDUCTION_DEF
+#endif
+
+OPENGL_BEGIN_REDUCTION_DEF
+"#define DEFINE_REDUCTION_FUNCTIONS(OP, TYPE) "
+STR(
+TYPE reduction_workgroup_##OP##_##TYPE##(in TYPE r) {
+  _reduction_temp_##TYPE##[gl_LocalInvocationIndex] = r;
+  barrier();
+  memoryBarrierShared();
+  const int group_size = int(gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z);
+  const int depth = int(ceil(log2(float(group_size))));
+  for (int i = 0; i < depth; ++i) {
+    const int radix = 1 << (i + 1);
+    const int stride = 1 << i;
+    const int cmp_index = int(gl_LocalInvocationIndex) + stride;
+    if (gl_LocalInvocationIndex % radix == 1 && cmp_index < group_size) {
+      _reduction_temp_##TYPE##[gl_LocalInvocationIndex] = ##OP##(
+        _reduction_temp_##TYPE##[gl_LocalInvocationIndex],
+        _reduction_temp_##TYPE##[cmp_index]
+      );
+    }
+    barrier();
+    memoryBarrierShared();
+  }
+  const TYPE result = _reduction_temp_##TYPE##[0];
+  barrier();
+  return result;
+}
+\n
+)
+OPENGL_END_REDUCTION_DEF
+
+#undef OPENGL_BEGIN_REDUCTION_DEF
+#undef OPENGL_END_REDUCTION_DEF

--- a/taichi/backends/opengl/shaders/reduction.glsl.h
+++ b/taichi/backends/opengl/shaders/reduction.glsl.h
@@ -34,7 +34,7 @@ TYPE reduction_workgroup_##OP##_##TYPE##(in TYPE r) {
     const int radix = 1 << (i + 1);
     const int stride = 1 << i;
     const int cmp_index = int(gl_LocalInvocationIndex) + stride;
-    if (gl_LocalInvocationIndex % radix == 1 && cmp_index < group_size) {
+    if (gl_LocalInvocationIndex % radix == 0 && cmp_index < group_size) {
       _reduction_temp_##TYPE##[gl_LocalInvocationIndex] = ##OP##(
         _reduction_temp_##TYPE##[gl_LocalInvocationIndex],
         _reduction_temp_##TYPE##[cmp_index]


### PR DESCRIPTION
- Reduces traffic to L2
- (In theory) better performance
- Did not use vendor specific warp/subgroup extensions
- Did not use the subgroup ballot extension
- Used a shared memory implementation (which is in L1)