### PR TITLE
[vulkan] Use native struct types when supported & fix performance

### DIFF
--- a/taichi/backends/vulkan/codegen_vulkan.cpp
+++ b/taichi/backends/vulkan/codegen_vulkan.cpp
@@ -758,7 +758,7 @@ class TaskCodegen : public IRVisitor {
       } else {
         spirv::Value func = ir_->float_atomic_add();
         val = ir_->make_value(spv::OpFunctionCall, ir_->f32_type(), func,
-                              addr_ptr, data);      
+                              addr_ptr, data);
       }
     } else if (is_integral(dt)) {
       val = ir_->make_value(

--- a/taichi/backends/vulkan/codegen_vulkan.cpp
+++ b/taichi/backends/vulkan/codegen_vulkan.cpp
@@ -353,8 +353,7 @@ class TaskCodegen : public IRVisitor {
     }
 
     auto &primitive_buffer_type = ir_->get_primitive_buffer_type(dt);
-    if (primitive_buffer_type.element_type_id ==
-        ir_->get_primitive_type(dt).element_type_id) {
+    if (buffer_ptr.stype.element_type_id == val.stype.id) {
       // No bit cast
       ir_->store_variable(buffer_ptr, val);
     } else {
@@ -378,14 +377,10 @@ class TaskCodegen : public IRVisitor {
     }
 
     auto &primitive_buffer_type = ir_->get_primitive_buffer_type(dt);
-    if (primitive_buffer_type.element_type_id ==
-        ir_->get_primitive_type(dt).element_type_id) {
+    if (buffer_ptr.stype.element_type_id == val.stype.id) {
       // No bit cast
       val = ir_->load_variable(buffer_ptr, primitive_buffer_type);
     } else {
-      ir_->store_variable(
-          buffer_ptr,
-          ir_->make_value(spv::OpBitcast, primitive_buffer_type, val));
       val = ir_->make_value(
           spv::OpBitcast, ir_->get_primitive_type(dt),
           ir_->load_variable(buffer_ptr, primitive_buffer_type));

--- a/taichi/backends/vulkan/codegen_vulkan.cpp
+++ b/taichi/backends/vulkan/codegen_vulkan.cpp
@@ -219,10 +219,9 @@ class TaskCodegen : public IRVisitor {
       TI_ASSERT(ptr_to_buffers_.count(stmt) == 0);
       ptr_to_buffers_[stmt] = BuffersEnum::Root;
 
-      spirv::SType dt_ptr = ir_->get_pointer_type(
-          ir_->i32_type(),
-          spv::StorageClassStorageBuffer);  // TODO(changyu): use type-based
-                                            // pointer
+      spirv::SType dt_ptr =
+          ir_->get_pointer_type(ir_->get_primitive_buffer_type(out_snode->dt),
+                                spv::StorageClassStorageBuffer);
       val = ir_->make_value(spv::OpAccessChain, dt_ptr, input_ptr_val, offset);
     } else {
       spirv::SType snode_array =
@@ -352,8 +351,17 @@ class TaskCodegen : public IRVisitor {
     } else {
       buffer_ptr = at_buffer(stmt->dest, dt);
     }
-    ir_->store_variable(buffer_ptr,
-                        ir_->make_value(spv::OpBitcast, ir_->i32_type(), val));
+
+    auto &primitive_buffer_type = ir_->get_primitive_buffer_type(dt);
+    if (primitive_buffer_type.element_type_id ==
+        ir_->get_primitive_type(dt).element_type_id) {
+      // No bit cast
+      ir_->store_variable(buffer_ptr, val);
+    } else {
+      ir_->store_variable(
+          buffer_ptr,
+          ir_->make_value(spv::OpBitcast, primitive_buffer_type, val));
+    }
   }
 
   void visit(GlobalLoadStmt *stmt) override {
@@ -368,8 +376,21 @@ class TaskCodegen : public IRVisitor {
     } else {
       buffer_ptr = at_buffer(stmt->src, dt);
     }
-    val = ir_->make_value(spv::OpBitcast, ir_->get_primitive_type(dt),
-                          ir_->load_variable(buffer_ptr, ir_->i32_type()));
+
+    auto &primitive_buffer_type = ir_->get_primitive_buffer_type(dt);
+    if (primitive_buffer_type.element_type_id ==
+        ir_->get_primitive_type(dt).element_type_id) {
+      // No bit cast
+      val = ir_->load_variable(buffer_ptr, primitive_buffer_type);
+    } else {
+      ir_->store_variable(
+          buffer_ptr,
+          ir_->make_value(spv::OpBitcast, primitive_buffer_type, val));
+      val = ir_->make_value(
+          spv::OpBitcast, ir_->get_primitive_type(dt),
+          ir_->load_variable(buffer_ptr, primitive_buffer_type));
+    }
+
     ir_->register_value(stmt->raw_name(), val);
   }
 
@@ -734,9 +755,16 @@ class TaskCodegen : public IRVisitor {
     spirv::Value data = ir_->query_value(stmt->val->raw_name());
     spirv::Value val;
     if (dt->is_primitive(PrimitiveTypeID::f32)) {
-      spirv::Value func = ir_->float_atomic_add();
-      val = ir_->make_value(spv::OpFunctionCall, ir_->f32_type(), func,
-                            addr_ptr, data);
+      if (ir_->get_vulkan_cap().has_atomic_float) {
+        val = ir_->make_value(
+            spv::OpAtomicFAddEXT, ir_->get_primitive_type(dt), addr_ptr,
+            ir_->uint_immediate_number(ir_->u32_type(), 1),
+            ir_->uint_immediate_number(ir_->u32_type(), 0), data);
+      } else {
+        spirv::Value func = ir_->float_atomic_add();
+        val = ir_->make_value(spv::OpFunctionCall, ir_->f32_type(), func,
+                              addr_ptr, data);      
+      }
     } else if (is_integral(dt)) {
       val = ir_->make_value(
           spv::OpAtomicIAdd, ir_->get_primitive_type(dt), addr_ptr,
@@ -1079,8 +1107,8 @@ class TaskCodegen : public IRVisitor {
     spirv::Value idx_val =
         ir_->make_value(spv::OpShiftRightArithmetic, ir_->i32_type(), ptr_val,
                         ir_->int_immediate_number(ir_->i32_type(), 2));
-    spirv::Value ret =
-        ir_->struct_array_access(ir_->i32_type(), buffer, idx_val);
+    spirv::Value ret = ir_->struct_array_access(
+        ir_->get_primitive_buffer_type(dt), buffer, idx_val);
     return ret;
   }
 

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -436,8 +436,8 @@ class VkRuntime ::Impl {
     LinearVkMemoryPool::Params mp_params;
     mp_params.physical_device = managed_device_->physical_device();
     mp_params.device = managed_device_->device()->device();
-#pragma message("Vulkan memory pool size hardcoded to 64MB")
-    mp_params.pool_size = 64 * 1024 * 1024;
+#pragma message("Vulkan memory pool size hardcoded to 256MB")
+    mp_params.pool_size = 256 * 1024 * 1024;
     mp_params.required_properties = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     mp_params.compute_queue_family_index =
         managed_device_->queue_family_indices().compute_family.value();
@@ -459,6 +459,7 @@ class VkRuntime ::Impl {
 
     // On-device host visible memory (Utilie ReBAR / Smart Access Memory)
     // Otherwise GPU needs to go through PCI-E to visit this memory
+    mp_params.pool_size = 64 * 1024 * 1024;
     mp_params.required_properties = (VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
                                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     buf_creation_template.usage =
@@ -477,7 +478,7 @@ class VkRuntime ::Impl {
 
   void init_vk_buffers() {
 #pragma message("Vulkan buffers size hardcoded")
-    root_buffer_ = dev_local_memory_pool_->alloc_and_bind(16 * 1024 * 1024);
+    root_buffer_ = dev_local_memory_pool_->alloc_and_bind(64 * 1024 * 1024);
     global_tmps_buffer_ = dev_local_memory_pool_->alloc_and_bind(1024 * 1024);
 
     // Need to zero fill the buffers, otherwise there could be NaN.

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -383,7 +383,8 @@ class VkRuntime ::Impl {
       TI_TRACE("SPIRV-Tools-opt: binary size, before={}, after={}",
                spirv_src.size(), optimized_spv.size());
 
-#if 1
+      // Enable to dump SPIR-V assembly of kernels
+#if 0
       std::string spirv_asm;
       spirv_tools_->Disassemble(optimized_spv, &spirv_asm);
       TI_TRACE("SPIR-V Assembly dump:\n{}\n\n", spirv_asm);

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -66,11 +66,13 @@ class HostDeviceContextBlitter {
   HostDeviceContextBlitter(const KernelContextAttributes *ctx_attribs,
                            Context *host_ctx,
                            uint64_t *host_result_buffer,
-                           VkBufferWithMemory *device_buffer)
+                           VkBufferWithMemory *device_buffer,
+                           VkBufferWithMemory *host_shadow_buffer)
       : ctx_attribs_(ctx_attribs),
         host_ctx_(host_ctx),
         host_result_buffer_(host_result_buffer),
-        device_buffer_(device_buffer) {
+        device_buffer_(device_buffer),
+        host_shadow_buffer_(host_shadow_buffer) {
   }
 
   void host_to_device() {
@@ -85,6 +87,7 @@ class HostDeviceContextBlitter {
     auto d = host_ctx_->get_arg<type>(i);                   \
     std::memcpy(device_ptr, &d, sizeof(d));                 \
   }
+
     for (int i = 0; i < ctx_attribs_->args().size(); ++i) {
       const auto &arg = ctx_attribs_->args()[i];
       const auto dt = arg.dt;
@@ -110,14 +113,9 @@ class HostDeviceContextBlitter {
     if (ctx_attribs_->empty()) {
       return;
     }
-    auto mapped = device_buffer_->map_mem();
+    auto mapped = host_shadow_buffer_->map_mem();
     char *const device_base = reinterpret_cast<char *>(mapped.data());
-#define TO_HOST(short_type, type)                           \
-  else if (dt->is_primitive(PrimitiveTypeID::short_type)) { \
-    const type d = *reinterpret_cast<type *>(device_ptr);   \
-    host_result_buffer_[i] =                                \
-        taichi_union_cast_with_different_sizes<uint64>(d);  \
-  }
+
     for (int i = 0; i < ctx_attribs_->args().size(); ++i) {
       const auto &arg = ctx_attribs_->args()[i];
       char *device_ptr = device_base + arg.offset_in_mem;
@@ -126,6 +124,14 @@ class HostDeviceContextBlitter {
         std::memcpy(host_ptr, device_ptr, arg.stride);
       }
     }
+
+#define TO_HOST(short_type, type)                           \
+  else if (dt->is_primitive(PrimitiveTypeID::short_type)) { \
+    const type d = *reinterpret_cast<type *>(device_ptr);   \
+    host_result_buffer_[i] =                                \
+        taichi_union_cast_with_different_sizes<uint64>(d);  \
+  }
+
     for (int i = 0; i < ctx_attribs_->rets().size(); ++i) {
       // Note that we are copying the i-th return value on Metal to the i-th
       // *arg* on the host context.
@@ -152,12 +158,14 @@ class HostDeviceContextBlitter {
       const KernelContextAttributes *ctx_attribs,
       Context *host_ctx,
       uint64_t *host_result_buffer,
-      VkBufferWithMemory *device_buffer) {
+      VkBufferWithMemory *device_buffer,
+      VkBufferWithMemory *host_shadow_buffer) {
     if (ctx_attribs->empty()) {
       return nullptr;
     }
     return std::make_unique<HostDeviceContextBlitter>(
-        ctx_attribs, host_ctx, host_result_buffer, device_buffer);
+        ctx_attribs, host_ctx, host_result_buffer, device_buffer,
+        host_shadow_buffer);
   }
 
  private:
@@ -165,6 +173,7 @@ class HostDeviceContextBlitter {
   Context *const host_ctx_;
   uint64_t *const host_result_buffer_;
   VkBufferWithMemory *const device_buffer_;
+  VkBufferWithMemory *const host_shadow_buffer_;
 };
 
 // Info for launching a compiled Taichi kernel, which consists of a series of
@@ -180,6 +189,7 @@ class CompiledTaichiKernel {
     VkBufferWithMemory *root_buffer{nullptr};
     VkBufferWithMemory *global_tmps_buffer{nullptr};
     LinearVkMemoryPool *host_visible_mem_pool{nullptr};
+    LinearVkMemoryPool *host_mem_pool{nullptr};
   };
 
   CompiledTaichiKernel(const Params &ti_params)
@@ -188,9 +198,10 @@ class CompiledTaichiKernel {
         {BufferEnum::Root, ti_params.root_buffer},
         {BufferEnum::GlobalTmps, ti_params.global_tmps_buffer},
     };
+    const auto ctx_sz = ti_kernel_attribs_.ctx_attribs.total_bytes();
     if (!ti_kernel_attribs_.ctx_attribs.empty()) {
-      const auto ctx_sz = ti_kernel_attribs_.ctx_attribs.total_bytes();
       ctx_buffer_ = ti_params.host_visible_mem_pool->alloc_and_bind(ctx_sz);
+      ctx_buffer_host_ = ti_params.host_mem_pool->alloc_and_bind(ctx_sz);
       input_buffers[BufferEnum::Context] = ctx_buffer_.get();
     }
 
@@ -198,11 +209,12 @@ class CompiledTaichiKernel {
     const auto &spirv_bins = ti_params.spirv_bins;
     TI_ASSERT(task_attribs.size() == spirv_bins.size());
 
-    VulkanComputeCommandBuilder cmd_builder(ti_params.device);
+    VulkanCommandBuilder cmd_builder(ti_params.device);
     for (int i = 0; i < task_attribs.size(); ++i) {
       const auto &attribs = task_attribs[i];
       VulkanPipeline::Params vp_params;
       vp_params.device = ti_params.device;
+      vp_params.name = ti_kernel_attribs_.name;
       for (const auto &bb : task_attribs[i].buffer_binds) {
         vp_params.buffer_bindings.push_back(VulkanPipeline::BufferBinding{
             input_buffers.at(bb.type)->buffer(), (uint32_t)bb.binding});
@@ -211,9 +223,15 @@ class CompiledTaichiKernel {
       auto vp = std::make_unique<VulkanPipeline>(vp_params);
       const int group_x = attribs.advisory_total_num_threads /
                           attribs.advisory_num_threads_per_group;
-      cmd_builder.append(*vp, group_x);
+      cmd_builder.dispatch(*vp, group_x);
       vk_pipelines_.push_back(std::move(vp));
     }
+
+    if (!ti_kernel_attribs_.ctx_attribs.empty()) {
+      cmd_builder.copy(ctx_buffer_->buffer(), ctx_buffer_host_->buffer(),
+                       ctx_sz, VulkanCopyBufferDirection::D2H);
+    }
+
     command_buffer_ = cmd_builder.build();
   }
 
@@ -229,6 +247,10 @@ class CompiledTaichiKernel {
     return ctx_buffer_.get();
   }
 
+  VkBufferWithMemory *ctx_buffer_host() const {
+    return ctx_buffer_host_.get();
+  }
+
   VkCommandBuffer command_buffer() const {
     return command_buffer_;
   }
@@ -242,6 +264,7 @@ class CompiledTaichiKernel {
   // TODO: Provide an option to use staging buffer. This could be useful if the
   // kernel does lots of IO on the context buffer, e.g., copy a large np array.
   std::unique_ptr<VkBufferWithMemory> ctx_buffer_{nullptr};
+  std::unique_ptr<VkBufferWithMemory> ctx_buffer_host_{nullptr};
   std::vector<std::unique_ptr<VulkanPipeline>> vk_pipelines_;
 
   // VkCommandBuffers are destroyed when the underlying command pool is
@@ -342,6 +365,7 @@ class VkRuntime ::Impl {
     params.root_buffer = root_buffer_.get();
     params.global_tmps_buffer = global_tmps_buffer_.get();
     params.host_visible_mem_pool = host_visible_memory_pool_.get();
+    params.host_mem_pool = host_memory_pool_.get();
 
     for (int i = 0; i < reg_params.task_spirv_source_codes.size(); ++i) {
       const auto &attribs = reg_params.kernel_attribs.tasks_attribs[i];
@@ -379,7 +403,8 @@ class VkRuntime ::Impl {
     auto *ti_kernel = ti_kernels_[handle.id_].get();
     auto ctx_blitter = HostDeviceContextBlitter::maybe_make(
         &ti_kernel->ti_kernel_attribs().ctx_attribs, host_ctx,
-        host_result_buffer_, ti_kernel->ctx_buffer());
+        host_result_buffer_, ti_kernel->ctx_buffer(),
+        ti_kernel->ctx_buffer_host());
     if (ctx_blitter) {
       TI_ASSERT(ti_kernel->ctx_buffer() != nullptr);
       ctx_blitter->host_to_device();
@@ -432,13 +457,22 @@ class VkRuntime ::Impl {
     dev_local_memory_pool_ = LinearVkMemoryPool::try_make(mp_params);
     TI_ASSERT(dev_local_memory_pool_ != nullptr);
 
-    mp_params.required_properties = (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                     VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
-                                     VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
+    // On-device host visible memory (Utilie ReBAR / Smart Access Memory)
+    // Otherwise GPU needs to go through PCI-E to visit this memory
+    mp_params.required_properties = (VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     buf_creation_template.usage =
-        (VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+        (VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+         VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     host_visible_memory_pool_ = LinearVkMemoryPool::try_make(mp_params);
-    TI_ASSERT(host_visible_memory_pool_ != nullptr);
+
+    // Host side memory
+    mp_params.required_properties = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
+                                    VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+    buf_creation_template.usage =
+        (VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    host_memory_pool_ = LinearVkMemoryPool::try_make(mp_params);
   }
 
   void init_vk_buffers() {
@@ -464,6 +498,7 @@ class VkRuntime ::Impl {
   std::unique_ptr<VkBufferWithMemory> root_buffer_;
   std::unique_ptr<VkBufferWithMemory> global_tmps_buffer_;
   std::unique_ptr<LinearVkMemoryPool> host_visible_memory_pool_;
+  std::unique_ptr<LinearVkMemoryPool> host_memory_pool_;
 
   std::vector<std::unique_ptr<CompiledTaichiKernel>> ti_kernels_;
   int num_pending_kernels_{0};

--- a/taichi/backends/vulkan/spirv_ir_builder.h
+++ b/taichi/backends/vulkan/spirv_ir_builder.h
@@ -313,6 +313,8 @@ class IRBuilder {
   SType get_null_type();
   // Get the spirv type for a given Taichi data type
   SType get_primitive_type(const DataType &dt) const;
+  // Get the spirv type for the buffer for a given Taichi data type
+  SType get_primitive_buffer_type(const DataType &dt) const;
   // Get the pointer type that points to value_type
   SType get_pointer_type(const SType &value_type,
                          spv::StorageClass storage_class);
@@ -433,6 +435,10 @@ class IRBuilder {
   Value rand_u32(Value global_tmp_);
   Value rand_f32(Value global_tmp_);
   Value rand_i32(Value global_tmp_);
+
+  const VulkanCapabilities &get_vulkan_cap() const {
+    return vulkan_cap_;
+  }
 
  private:
   Value new_value(const SType &type, ValueKind flag) {

--- a/taichi/backends/vulkan/spirv_snode_compiler.cpp
+++ b/taichi/backends/vulkan/spirv_snode_compiler.cpp
@@ -26,9 +26,7 @@ class SpirvSNodeCompiler {
                             SNodeSTypeTbl *snode_id_array_stype_tbl_) {
     const auto &sn = sn_desc.snode;
     if (sn->is_place()) {
-      // return get_primitive_type(sn->dt); // TODO(changyu): use type-based
-      // pointer
-      return ir_->i32_type();
+      return ir_->get_primitive_buffer_type(sn->dt);
     } else {
       SType sn_type = ir_->get_null_type();
       sn_type.snode_desc = sn_desc;

--- a/taichi/backends/vulkan/vulkan_api.cpp
+++ b/taichi/backends/vulkan/vulkan_api.cpp
@@ -729,7 +729,7 @@ VulkanCommandBuilder::VulkanCommandBuilder(const VulkanDevice *device) {
       vkAllocateCommandBuffers(device->device(), &alloc_info, &command_buffer_),
       "failed to allocate command buffer");
 
-  this->device = device->device();
+  this->device_ = device->device();
 
   VkCommandBufferBeginInfo begin_info{};
   begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
@@ -760,10 +760,10 @@ void VulkanCommandBuilder::dispatch(const VulkanPipeline &pipeline,
   // Must call extension functions through a function pointer:
   PFN_vkCmdBeginDebugUtilsLabelEXT pfnCmdBeginDebugUtilsLabelEXT =
       (PFN_vkCmdBeginDebugUtilsLabelEXT)vkGetDeviceProcAddr(
-          device, "vkCmdBeginDebugUtilsLabelEXT");
+          device_, "vkCmdBeginDebugUtilsLabelEXT");
   PFN_vkCmdEndDebugUtilsLabelEXT pfnCmdEndDebugUtilsLabelEXT =
       (PFN_vkCmdEndDebugUtilsLabelEXT)vkGetDeviceProcAddr(
-          device, "vkCmdEndDebugUtilsLabelEXT");
+          device_, "vkCmdEndDebugUtilsLabelEXT");
 
   VkDebugUtilsLabelEXT marker;
   marker.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;

--- a/taichi/backends/vulkan/vulkan_api.cpp
+++ b/taichi/backends/vulkan/vulkan_api.cpp
@@ -171,15 +171,29 @@ ManagedVulkanDevice::ManagedVulkanDevice(const Params &params) {
   pick_physical_device();
   create_logical_device();
   create_command_pool();
+  create_debug_swapchain();
 
   VulkanDevice::Params dparams;
   dparams.device = device_;
   dparams.compute_queue = compute_queue_;
   dparams.command_pool = command_pool_;
   owned_device_ = std::make_unique<VulkanDevice>(dparams);
+  owned_device_->set_debug_struct(&debug_struct_);
 }
 
 ManagedVulkanDevice::~ManagedVulkanDevice() {
+#ifdef TI_VULKAN_DEBUG
+  if (capability_.has_presentation) {
+    vkDestroySemaphore(device_, debug_struct_.image_available,
+                       kNoVkAllocCallbacks);
+    vkDestroySwapchainKHR(device_, debug_struct_.swapchain,
+                          kNoVkAllocCallbacks);
+    vkDestroySurfaceKHR(instance_, debug_struct_.surface, kNoVkAllocCallbacks);
+    glfwDestroyWindow(debug_struct_.window);
+    glfwTerminate();
+  }
+#endif
+
   if constexpr (kEnableValidationLayers) {
     destroy_debug_utils_messenger_ext(instance_, debug_messenger_,
                                       kNoVkAllocCallbacks);
@@ -226,7 +240,18 @@ void ManagedVulkanDevice::create_instance(const Params &params) {
     create_info.enabledLayerCount = 0;
     create_info.pNext = nullptr;
   }
-  const auto extensions = get_required_extensions();
+
+  auto extensions = get_required_extensions();
+
+#ifdef TI_VULKAN_DEBUG
+  glfwInit();
+  uint32_t count;
+  const char **glfw_extensions = glfwGetRequiredInstanceExtensions(&count);
+  for (uint32_t i = 0; i < count; i++) {
+    extensions.push_back(glfw_extensions[i]);
+  }
+#endif
+
   create_info.enabledExtensionCount = (uint32_t)extensions.size();
   create_info.ppEnabledExtensionNames = extensions.data();
 
@@ -301,9 +326,7 @@ void ManagedVulkanDevice::create_logical_device() {
   capability_.api_version = physical_device_properties.apiVersion;
   capability_.spirv_version = 0x10000;
 
-  if (capability_.api_version >= VK_API_VERSION_1_2) {
-    capability_.spirv_version = 0x10500;
-  } else if (capability_.api_version >= VK_API_VERSION_1_1) {
+  if (capability_.api_version >= VK_API_VERSION_1_1) {
     capability_.spirv_version = 0x10300;
   }
 
@@ -332,8 +355,10 @@ void ManagedVulkanDevice::create_logical_device() {
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_SURFACE_EXTENSION_NAME) {
       has_surface = true;
+      enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_SWAPCHAIN_EXTENSION_NAME) {
       has_swapchain = true;
+      enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME) {
       capability_.has_atomic_float = true;
       enabled_extensions.push_back(ext.extensionName);
@@ -357,8 +382,6 @@ void ManagedVulkanDevice::create_logical_device() {
   }
 
   if (has_surface && has_swapchain) {
-    enabled_extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
-    enabled_extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     capability_.has_presentation = true;
   }
 
@@ -368,6 +391,9 @@ void ManagedVulkanDevice::create_logical_device() {
       "this extension is not supported on the device");
 
   VkPhysicalDeviceFeatures device_features{};
+  device_features.shaderInt64 = true;
+  device_features.shaderFloat64 = true;
+
   create_info.pEnabledFeatures = &device_features;
   create_info.enabledExtensionCount = enabled_extensions.size();
   create_info.ppEnabledExtensionNames = enabled_extensions.data();
@@ -433,6 +459,120 @@ void ManagedVulkanDevice::create_command_pool() {
       vkCreateCommandPool(device_, &pool_info, kNoVkAllocCallbacks,
                           &command_pool_),
       "failed to create command pool");
+}
+
+void VulkanDevice::debug_frame_marker() const {
+#ifdef TI_VULKAN_DEBUG
+  if (debug_struct_) {
+    uint32_t imageIndex;
+    vkAcquireNextImageKHR(rep_.device, debug_struct_->swapchain, UINT64_MAX,
+                          debug_struct_->image_available, VK_NULL_HANDLE,
+                          &imageIndex);
+
+    VkPresentInfoKHR presentInfo{};
+    presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    presentInfo.waitSemaphoreCount = 1;
+    presentInfo.pWaitSemaphores = &debug_struct_->image_available;
+    presentInfo.swapchainCount = 1;
+    presentInfo.pSwapchains = &debug_struct_->swapchain;
+    presentInfo.pImageIndices = &imageIndex;
+    presentInfo.pResults = nullptr;
+
+    vkQueuePresentKHR(rep_.compute_queue, &presentInfo);
+  }
+#endif
+}
+
+void ManagedVulkanDevice::create_debug_swapchain() {
+#ifdef TI_VULKAN_DEBUG
+  TI_TRACE("Creating debug swapchian");
+  if (capability_.has_presentation) {
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    debug_struct_.window =
+        glfwCreateWindow(640, 480, "Taichi Debug Swapchain", NULL, NULL);
+    VkResult err = glfwCreateWindowSurface(instance_, debug_struct_.window,
+                                           NULL, &debug_struct_.surface);
+    if (err) {
+      TI_ERROR("Failed to create debug window ({})", err);
+      return;
+    }
+
+    auto choose_surface_format =
+        [](const std::vector<VkSurfaceFormatKHR> &availableFormats) {
+          for (const auto &availableFormat : availableFormats) {
+            if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB &&
+                availableFormat.colorSpace ==
+                    VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+              return availableFormat;
+            }
+          }
+          return availableFormats[0];
+        };
+
+    VkSurfaceCapabilitiesKHR capabilities;
+    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        physical_device_, debug_struct_.surface, &capabilities);
+
+    VkBool32 supported = false;
+    vkGetPhysicalDeviceSurfaceSupportKHR(
+        physical_device_, queue_family_indices_.compute_family.value(),
+        debug_struct_.surface, &supported);
+
+    if (!supported) {
+      TI_ERROR("Selected queue does not support presenting", err);
+      return;
+    }
+
+    uint32_t formatCount;
+    vkGetPhysicalDeviceSurfaceFormatsKHR(
+        physical_device_, debug_struct_.surface, &formatCount, nullptr);
+    std::vector<VkSurfaceFormatKHR> surface_formats(formatCount);
+    vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device_,
+                                         debug_struct_.surface, &formatCount,
+                                         surface_formats.data());
+
+    VkSurfaceFormatKHR surface_format = choose_surface_format(surface_formats);
+
+    int width, height;
+    glfwGetFramebufferSize(debug_struct_.window, &width, &height);
+
+    VkExtent2D extent = {uint32_t(width), uint32_t(height)};
+
+    VkSwapchainCreateInfoKHR createInfo;
+    createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    createInfo.pNext = nullptr;
+    createInfo.flags = 0;
+    createInfo.surface = debug_struct_.surface;
+    createInfo.minImageCount = capabilities.minImageCount;
+    createInfo.imageFormat = surface_format.format;
+    createInfo.imageColorSpace = surface_format.colorSpace;
+    createInfo.imageExtent = extent;
+    createInfo.imageArrayLayers = 1;
+    createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    createInfo.queueFamilyIndexCount = 0;
+    createInfo.pQueueFamilyIndices = nullptr;
+    createInfo.preTransform = capabilities.currentTransform;
+    createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    createInfo.presentMode = VK_PRESENT_MODE_MAILBOX_KHR;
+    createInfo.clipped = VK_TRUE;
+    createInfo.oldSwapchain = nullptr;
+
+    if (vkCreateSwapchainKHR(device_, &createInfo, kNoVkAllocCallbacks,
+                             &debug_struct_.swapchain) != VK_SUCCESS) {
+      TI_ERROR("Failed to create debug swapchain");
+      return;
+    }
+
+    VkSemaphoreCreateInfo sema_create_info;
+    sema_create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    sema_create_info.pNext = nullptr;
+    sema_create_info.flags = 0;
+    vkCreateSemaphore(device_, &sema_create_info, kNoVkAllocCallbacks,
+                      &debug_struct_.image_available);
+    TI_TRACE("Creating debug swapchian3");
+  }
+#endif
 }
 
 VulkanPipeline::VulkanPipeline(const Params &params)
@@ -742,6 +882,8 @@ void VulkanStream::synchronize() {
     }
     in_flight_fences_.clear();
   }
+
+  device_->debug_frame_marker();
 }
 
 }  // namespace vulkan

--- a/taichi/backends/vulkan/vulkan_api.h
+++ b/taichi/backends/vulkan/vulkan_api.h
@@ -87,7 +87,7 @@ class VulkanDevice {
 
   void debug_frame_marker() const;
 
-private:
+ private:
   VulkanDeviceDebugStruct *debug_struct_{nullptr};
   Params rep_;
 };
@@ -236,9 +236,9 @@ class VulkanCommandBuilder {
   ~VulkanCommandBuilder();
 
   VkCommandBuffer build();
-  
+
   void dispatch(const VulkanPipeline &pipeline, int group_count_x);
-  
+
   void copy(VkBuffer src_buffer,
             VkBuffer dst_buffer,
             VkDeviceSize size,
@@ -249,7 +249,7 @@ class VulkanCommandBuilder {
   // destroyed.
   // https://vulkan-tutorial.com/Drawing_a_triangle/Drawing/Command_buffers#page_Command-buffer-allocation
   VkCommandBuffer command_buffer_{VK_NULL_HANDLE};
-  VkDevice device_; // do not own
+  VkDevice device_;  // do not own
 };
 
 VkCommandBuffer record_copy_buffer_command(const VulkanDevice *device,

--- a/taichi/backends/vulkan/vulkan_api.h
+++ b/taichi/backends/vulkan/vulkan_api.h
@@ -10,6 +10,12 @@
 #include <vector>
 #include <string>
 
+#define TI_VULKAN_DEBUG
+
+#ifdef TI_VULKAN_DEBUG
+#include <GLFW/glfw3.h>
+#endif
+
 namespace taichi {
 namespace lang {
 namespace vulkan {
@@ -35,6 +41,13 @@ struct VulkanQueueFamilyIndices {
   bool is_complete() const {
     return compute_family.has_value();
   }
+};
+
+struct VulkanDeviceDebugStruct {
+  GLFWwindow *window{nullptr};
+  VkSurfaceKHR surface;
+  VkSwapchainKHR swapchain;
+  VkSemaphore image_available;
 };
 
 // Many classes here are inspired by TVM's runtime
@@ -68,7 +81,14 @@ class VulkanDevice {
     return rep_.command_pool;
   }
 
- private:
+  void set_debug_struct(VulkanDeviceDebugStruct *s) {
+    this->debug_struct_ = s;
+  }
+
+  void debug_frame_marker() const;
+
+private:
+  VulkanDeviceDebugStruct *debug_struct_{nullptr};
   Params rep_;
 };
 
@@ -121,6 +141,9 @@ class ManagedVulkanDevice {
   void pick_physical_device();
   void create_logical_device();
   void create_command_pool();
+  void create_debug_swapchain();
+
+  VulkanDeviceDebugStruct debug_struct_;
 
   VkInstance instance_{VK_NULL_HANDLE};
   VkDebugUtilsMessengerEXT debug_messenger_{VK_NULL_HANDLE};

--- a/taichi/backends/vulkan/vulkan_api.h
+++ b/taichi/backends/vulkan/vulkan_api.h
@@ -10,7 +10,7 @@
 #include <vector>
 #include <string>
 
-#define TI_VULKAN_DEBUG
+// #define TI_VULKAN_DEBUG
 
 #ifdef TI_VULKAN_DEBUG
 #include <GLFW/glfw3.h>
@@ -249,7 +249,7 @@ class VulkanCommandBuilder {
   // destroyed.
   // https://vulkan-tutorial.com/Drawing_a_triangle/Drawing/Command_buffers#page_Command-buffer-allocation
   VkCommandBuffer command_buffer_{VK_NULL_HANDLE};
-  VkDevice device; // do not own
+  VkDevice device_; // do not own
 };
 
 VkCommandBuffer record_copy_buffer_command(const VulkanDevice *device,


### PR DESCRIPTION
The current performance issue is entirely from the host/device transfer.

Originally, the `host_visible` memory pool is allocated actually on host & is cached. This means this chunk of memory is very fast when mapping (since no mapping is really there, it's host memory), but GPU has a hard time read / write on it.

Now the arguments and the return buffer are now on the `host_visible` and at the same time `device_local` memory. This is a special memory heap for sending arguments where host can directly write to it (and pay a small cost), and GPU can directly read/write off it. However this memory type is very slow when reading from host since it is not cached. (This is essentially the PCI-E BAR, and recently improved as ReBAR or SAM). So when we read back the return value, the context buffer is transferred from the device memory to a host memory, then mapped & copied out.

In cornell_box, when changing the interval to 5000 (making it almost entirely compute dominated), the Vulkan backend massively out-performed both the OpenGL and CUDA backend. (The CUDA side performance is a bit of a mystery, the advantage to OpenGL is perhaps we are compiling SNodes directly to structs)

On my RTX3080 + Ryzen 3700X + ReBAR enabled, the performance on `cornell_box.py` is roughly
OpenGL: 1500 samples/s, Vulkan 1900 samples/s, CUDA 1000 samples/s

This PR is dependent on #2615 (It is branched off there), we should merge the other one first and rebase this one to master later.