### PR TITLE
[vulkan] Fix vulkan rand

### DIFF
--- a/taichi/backends/vulkan/spirv_ir_builder.h
+++ b/taichi/backends/vulkan/spirv_ir_builder.h
@@ -203,7 +203,8 @@ class InstrBuilder {
 // Builder to build up a single SPIR-V module
 class IRBuilder {
  public:
-  IRBuilder(const VulkanCapabilities &vulkan_cap) : vulkan_cap_(vulkan_cap), init_rand_(false) {
+  IRBuilder(const VulkanCapabilities &vulkan_cap)
+      : vulkan_cap_(vulkan_cap), init_rand_(false) {
   }
 
   template <typename... Args>

--- a/taichi/backends/vulkan/spirv_ir_builder.h
+++ b/taichi/backends/vulkan/spirv_ir_builder.h
@@ -203,8 +203,7 @@ class InstrBuilder {
 // Builder to build up a single SPIR-V module
 class IRBuilder {
  public:
-  IRBuilder(const VulkanCapabilities &vulkan_cap)
-      : vulkan_cap_(vulkan_cap), init_rand_(false) {
+  IRBuilder(const VulkanCapabilities &vulkan_cap) : vulkan_cap_(vulkan_cap) {
   }
 
   template <typename... Args>
@@ -461,9 +460,24 @@ class IRBuilder {
   // glsl 450 extension
   Value ext_glsl450_;
   // Special cached types
-  bool support_int8_, support_int16_, support_int64_, support_fp64_;
-  SType t_bool_, t_int8_, t_int16_, t_int32_, t_int64_, t_uint8_, t_uint16_,
-      t_uint32_, t_uint64_, t_fp32_, t_fp64_, t_void_, t_void_func_;
+  bool support_int8_{false};
+  bool support_int16_{false};
+  bool support_int64_{false};
+  bool support_fp64_{false};
+  
+  SType t_bool_;
+  SType t_int8_;
+  SType t_int16_;
+  SType t_int32_;
+  SType t_int64_;
+  SType t_uint8_;
+  SType t_uint16_;
+  SType t_uint32_;
+  SType t_uint64_;
+  SType t_fp32_;
+  SType t_fp64_;
+  SType t_void_;
+  SType t_void_func_;
   // gl compute shader related type(s) and variables
   SType t_v3_uint_;
   Value gl_global_invocation_id;
@@ -473,8 +487,11 @@ class IRBuilder {
   // Float type atomic add function
   Value float_atomic_add_;
   // Random function and variables
-  bool init_rand_;
-  Value _rand_x_, _rand_y_, _rand_z_, _rand_w_;  // per-thread local variable
+  bool init_rand_{false};
+  Value _rand_x_;
+  Value _rand_y_;
+  Value _rand_z_;
+  Value _rand_w_;  // per-thread local variable
 
   // map from value to its pointer type
   std::map<std::pair<uint32_t, spv::StorageClass>, SType> pointer_type_tbl_;

--- a/taichi/backends/vulkan/spirv_ir_builder.h
+++ b/taichi/backends/vulkan/spirv_ir_builder.h
@@ -464,7 +464,7 @@ class IRBuilder {
   bool support_int16_{false};
   bool support_int64_{false};
   bool support_fp64_{false};
-  
+
   SType t_bool_;
   SType t_int8_;
   SType t_int16_;

--- a/taichi/backends/vulkan/spirv_ir_builder.h
+++ b/taichi/backends/vulkan/spirv_ir_builder.h
@@ -203,7 +203,7 @@ class InstrBuilder {
 // Builder to build up a single SPIR-V module
 class IRBuilder {
  public:
-  IRBuilder(const VulkanCapabilities &vulkan_cap) : vulkan_cap_(vulkan_cap) {
+  IRBuilder(const VulkanCapabilities &vulkan_cap) : vulkan_cap_(vulkan_cap), init_rand_(false) {
   }
 
   template <typename... Args>


### PR DESCRIPTION
Currently, the vulkan backend is failing sporadically on my Windows machine for all taichi programs that uses `ti.random()` (e.g. `mpm88`, `pbf2d`). This is because the variable `init_rand_` isn't explicitly initialised to be `false`, and thus `init_random_function` isn't always called.
