### PR TITLE
[Bug] Fix osx release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,31 +38,29 @@ jobs:
         env:
           CI_PLATFORM: ${{ matrix.os }}
 
-      - name: Build
+      - name: Create Python Wheel
         run: |
-          export TAICHI_REPO_DIR=`pwd`
+          TAICHI_REPO_DIR=`pwd`
           export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
           export CXX=clang++
+          # TODO: making changelog shouldn't depend on taichi.
+          # We currently install taichi to make changelog when building the wheel.
           python misc/ci_setup.py ci
+          cd python
+          python build.py build
+          # Uninstall taichi to make sure we test the wheel.
+          pip uninstall taichi -y
 
-      - name: Test
+      - name: Install Wheel and Test
         run: |
-          export TAICHI_REPO_DIR=`pwd`
-          export PATH=$TAICHI_REPO_DIR/bin:$PATH
+          TAICHI_REPO_DIR=`pwd`
           export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
-          export PYTHONPATH=$TAICHI_REPO_DIR/python
+          NUM_WHL=`ls dist/*.whl | wc -l`
+          if [ $NUM_WHL -ne 1 ]; then echo 'ERROR: created more than 1 whl.' && exit 1 ; fi
+          pip install dist/*.whl
           python examples/algorithm/laplace.py
           ti diagnose
           ti test -vr2 -t2
-
-      - name: Create Python Wheel
-        run: |
-          export TAICHI_REPO_DIR=`pwd`
-          export PATH=$TAICHI_REPO_DIR/bin:$PATH
-          export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
-          export PYTHONPATH=$TAICHI_REPO_DIR/python
-          cd python
-          python build.py build
 
       - name: Archive Wheel Artifacts
         # https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts#uploading-build-and-test-artifacts
@@ -71,16 +69,14 @@ jobs:
           # While ${{ github.ref }} does provide the release tag, it is of
           # format `refs/tags/<tag_name>`, which isn't a valid file path.
           name: taichi-py${{ matrix.python }}-${{ matrix.os }}.whl
-          path: python/dist/*.whl
+          path: dist/*.whl
 
       - name: Upload PyPI
         env:
           # https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow
           PYPI_PWD: ${{ secrets.PYPI_PWD }}
         run: |
-          export TAICHI_REPO_DIR=`pwd`
-          export PATH=$TAICHI_REPO_DIR/bin:$PATH
+          TAICHI_REPO_DIR=`pwd`
           export PATH=$TAICHI_REPO_DIR/taichi-llvm/bin/:$PATH
-          export PYTHONPATH=$TAICHI_REPO_DIR/python
           cd python
           python build.py try_upload --skip_build && bash <(curl -s https://codecov.io/bash)

--- a/python/build.py
+++ b/python/build.py
@@ -50,7 +50,7 @@ def build(project_name):
         os.remove('taichi/CHANGELOG.md')
     except FileNotFoundError:
         pass
-    shutil.rmtree('../build')
+    shutil.rmtree('../build', ignore_errors=True)
 
 
 def parse_args():

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ class EggInfo(egg_info):
     def run(self):
         taichi_dir = os.path.join(package_dir, 'taichi')
         remove_tmp(taichi_dir)
-        shutil.rmtree('build', ignore_errors=True)
 
         shutil.copytree('tests/python', os.path.join(taichi_dir, 'tests'))
         shutil.copytree('examples', os.path.join(taichi_dir, 'examples'))


### PR DESCRIPTION
This PR does 2 things: 
- Fix path issues in osx release workflow and stop using `TAICHI_REPO_DIR`
- Install from the wheel and run tests (instead of running tests in dev mode). 

There's a minor followup:
- Our changelog requires installing taichi but building taichi wheel requires making changelog. So currently we keep installing taichi using `python setup.py install` to first build the wheel and then uninstall it. Ideally this can be removed so that we just build a wheel -> install the wheel -> test taichi installed from wheel. 