### PR TITLE
[Refactor] Split transformer.py into StmtBuilder and ExprBuilder (Stage 2)

### DIFF
--- a/python/taichi/lang/expr_builder.py
+++ b/python/taichi/lang/expr_builder.py
@@ -112,10 +112,12 @@ class ExprBuilder(Builder):
         _taichi_skip_traceback = 1
         ti_func = node.func
         if '_sitebuiltins' == getattr(ti_func, '__module__', '') and getattr(
-                getattr(ti_func, '__class__', ''), '__name__', '') == 'Quitter':
-            raise TaichiSyntaxError(f'exit or quit not supported in Taichi-scope')
-        if getattr(ti_func, '__module__',
-                   '') == '__main__' and not getattr(ti_func, '__wrapped__', ''):
+                getattr(ti_func, '__class__', ''), '__name__',
+                '') == 'Quitter':
+            raise TaichiSyntaxError(
+                f'exit or quit not supported in Taichi-scope')
+        if getattr(ti_func, '__module__', '') == '__main__' and not getattr(
+                ti_func, '__wrapped__', ''):
             warnings.warn(
                 f'Calling into non-Taichi function {ti_func.__name__}.'
                 ' This means that scope inside that function will not be processed'

--- a/python/taichi/lang/expr_builder.py
+++ b/python/taichi/lang/expr_builder.py
@@ -1,4 +1,5 @@
 import ast
+import warnings
 
 from taichi.lang.ast_builder_utils import *
 from taichi.lang.ast_resolver import ASTResolver
@@ -107,6 +108,22 @@ class ExprBuilder(Builder):
                 node.func = parse_expr('ti.ti_all')
             else:
                 pass
+
+        _taichi_skip_traceback = 1
+        ti_func = node.func
+        if '_sitebuiltins' == getattr(ti_func, '__module__', '') and getattr(
+                getattr(ti_func, '__class__', ''), '__name__', '') == 'Quitter':
+            raise TaichiSyntaxError(f'exit or quit not supported in Taichi-scope')
+        if getattr(ti_func, '__module__',
+                   '') == '__main__' and not getattr(ti_func, '__wrapped__', ''):
+            warnings.warn(
+                f'Calling into non-Taichi function {ti_func.__name__}.'
+                ' This means that scope inside that function will not be processed'
+                ' by the Taichi transformer. Proceed with caution! '
+                ' Maybe you want to decorate it with @ti.func?',
+                UserWarning,
+                stacklevel=2)
+
         return node
 
     @staticmethod

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -188,6 +188,32 @@ def chain_compare(comparators, ops):
     return ret
 
 
+@taichi_scope
+def insert_expr_stmt_if_ti_func(func, *args, **kwargs):
+    """
+    This method is used only for real functions. It inserts a FrontendExprStmt
+    to the C++ AST to hold the function call if |func| is a Taichi function.
+    :param func: The function to be called.
+    :param args: The arguments of the function call.
+    :param kwargs: The keyword arguments of the function call.
+    :return: The return value of the function call if it's a non-Taichi
+    function. Returns None if it's a Taichi function.
+    """
+    is_taichi_function = getattr(func, '_is_taichi_function', False)
+    # If is_taichi_function is true: call a decorated Taichi function
+    # in a Taichi kernel/function.
+
+    if is_taichi_function:
+        # Compiles the function here.
+        # Invokes Func.__call__.
+        func_call_result = func(*args, **kwargs)
+        # Insert FrontendExprStmt here.
+        return _ti_core.insert_expr_stmt(func_call_result.ptr)
+    else:
+        # Call the non-Taichi function directly.
+        return func(*args, **kwargs)
+
+
 class PyTaichi:
     def __init__(self, kernels=None):
         self.materialized = False

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -188,35 +188,6 @@ def chain_compare(comparators, ops):
     return ret
 
 
-@taichi_scope
-def maybe_transform_ti_func_call_to_stmt(ti_func, *args, **kwargs):
-    _taichi_skip_traceback = 1
-    if '_sitebuiltins' == getattr(ti_func, '__module__', '') and getattr(
-            getattr(ti_func, '__class__', ''), '__name__', '') == 'Quitter':
-        raise TaichiSyntaxError(f'exit or quit not supported in Taichi-scope')
-    if getattr(ti_func, '__module__',
-               '') == '__main__' and not getattr(ti_func, '__wrapped__', ''):
-        warnings.warn(
-            f'Calling into non-Taichi function {ti_func.__name__}.'
-            ' This means that scope inside that function will not be processed'
-            ' by the Taichi transformer. Proceed with caution! '
-            ' Maybe you want to decorate it with @ti.func?',
-            UserWarning,
-            stacklevel=2)
-
-    is_taichi_function = getattr(ti_func, '_is_taichi_function', False)
-    # If is_taichi_function is true: call a decorated Taichi function
-    # in a Taichi kernel/function.
-
-    if is_taichi_function and get_runtime().experimental_real_function:
-        # Compiles the function here.
-        # Invokes Func.__call__.
-        func_call_result = ti_func(*args, **kwargs)
-        return _ti_core.insert_expr_stmt(func_call_result.ptr)
-    else:
-        return ti_func(*args, **kwargs)
-
-
 class PyTaichi:
     def __init__(self, kernels=None):
         self.materialized = False

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -190,15 +190,18 @@ def chain_compare(comparators, ops):
 
 @taichi_scope
 def insert_expr_stmt_if_ti_func(func, *args, **kwargs):
-    """
-    This method is used only for real functions. It inserts a FrontendExprStmt
-    to the C++ AST to hold the function call if |func| is a Taichi function.
-    :param func: The function to be called.
-    :param args: The arguments of the function call.
-    :param kwargs: The keyword arguments of the function call.
-    :return: The return value of the function call if it's a non-Taichi
-    function. Returns None if it's a Taichi function.
-    """
+    """This method is used only for real functions. It inserts a
+    FrontendExprStmt to the C++ AST to hold the function call if `func` is a
+    Taichi function.
+
+    Args:
+        func: The function to be called.
+        args: The arguments of the function call.
+        kwargs: The keyword arguments of the function call.
+
+    Returns:
+        The return value of the function call if it's a non-Taichi function.
+        Returns None if it's a Taichi function."""
     is_taichi_function = getattr(func, '_is_taichi_function', False)
     # If is_taichi_function is true: call a decorated Taichi function
     # in a Taichi kernel/function.

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -12,7 +12,7 @@ from taichi.lang.ast_checker import KernelSimplicityASTChecker
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.kernel_arguments import ext_arr, template
 from taichi.lang.shell import _shell_pop_print, oinspect
-from taichi.lang.transformer import ASTTransformer
+from taichi.lang.transformer import ASTTransformerTotal
 from taichi.misc.util import obsolete
 
 import taichi as ti
@@ -169,7 +169,7 @@ class Func:
         func_body = tree.body[0]
         func_body.decorator_list = []
 
-        visitor = ASTTransformer(is_kernel=False, func=self)
+        visitor = ASTTransformerTotal(is_kernel=False, func=self)
         visitor.visit(tree)
 
         ast.increment_lineno(tree, oinspect.getsourcelines(self.func)[1] - 1)
@@ -410,7 +410,7 @@ class Kernel:
         if self.is_grad:
             KernelSimplicityASTChecker(self.func).visit(tree)
 
-        visitor = ASTTransformer(
+        visitor = ASTTransformerTotal(
             excluded_parameters=self.template_slot_locations,
             func=self,
             arg_features=arg_features)

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -652,17 +652,28 @@ if 1:
 
     @staticmethod
     def build_Expr(ctx, node):
-        if isinstance(node.value, ast.Call):
-            # A function call.
-            node.value = build_expr(ctx, node.value)
-            # note that we can only return an ast.Expr instead of an ast.Call.
+        if not isinstance(node.value, ast.Call):
+            # A statement with a single expression.
             return node
-        # A statement with a single expression.
-        # TODO(#2495): Deprecate maybe_transform_ti_func_call_to_stmt
+
+        # A function call.
+        node.value = build_expr(ctx, node.value)
+        # note that we can only return an ast.Expr instead of an ast.Call.
+
+        ti_func = node.value.func
+        is_taichi_function = getattr(ti_func, '_is_taichi_function', False)
+        # If is_taichi_function is true: call a decorated Taichi function
+        # in a Taichi kernel/function.
+        if is_taichi_function and impl.get_runtime().experimental_real_function:
+            # The function call itself compiles the function,
+            # invoking Func.__call__.
+            # We need a statement to hold the return value of the function.
+            func_return_value = node
+            node = ast.Expr(
+                value=ast.Call(func=parse_expr('ti.core.insert_expr_stmt'),
+                               args=func_return_value, keywords=[]))
+            node = ast.copy_location(node, func_return_value)
         return node
-        # result = parse_stmt('ti.core.insert_expr_stmt(expr)')
-        # result.value.args[0] = build_expr(ctx, node.value)
-        # return ast.copy_location(result, node)
 
     @staticmethod
     def build_Import(ctx, node):

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -664,14 +664,16 @@ if 1:
         is_taichi_function = getattr(ti_func, '_is_taichi_function', False)
         # If is_taichi_function is true: call a decorated Taichi function
         # in a Taichi kernel/function.
-        if is_taichi_function and impl.get_runtime().experimental_real_function:
+        if is_taichi_function and impl.get_runtime(
+        ).experimental_real_function:
             # The function call itself compiles the function,
             # invoking Func.__call__.
             # We need a statement to hold the return value of the function.
             func_return_value = node
             node = ast.Expr(
                 value=ast.Call(func=parse_expr('ti.core.insert_expr_stmt'),
-                               args=func_return_value, keywords=[]))
+                               args=func_return_value,
+                               keywords=[]))
             node = ast.copy_location(node, func_return_value)
         return node
 

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -49,8 +49,8 @@ class ASTTransformer(object):
         self.print_ast(tree, 'Preprocessed')
         self.pass_Checks.visit(tree)
         self.print_ast(tree, 'Checked')
-        self.pass_transform_function_call.visit(tree)
-        ast.fix_missing_locations(tree)
+        # self.pass_transform_function_call.visit(tree)
+        # ast.fix_missing_locations(tree)
         self.print_ast(tree, 'Final AST')
 
 

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -16,15 +16,12 @@ class ASTTransformer(object):
             func=None,
             excluded_parameters=(),
             is_kernel=True,
-            is_classfunc=False,  # unused
             arg_features=None):
         self.func = func
         self.excluded_parameters = excluded_parameters
         self.is_kernel = is_kernel
         self.arg_features = arg_features
         self.pass_Checks = ASTTransformerChecks(func=func)
-        self.pass_transform_function_call = TransformFunctionCallAsStmt(
-            func=func)
 
     @staticmethod
     def print_ast(tree, title=None):

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -8,9 +8,7 @@ import taichi as ti
 
 
 # Total transform
-# TODO: ASTTransformerBase -> ASTTransformer
-# TODO: ASTTransformer -> ASTTransformerTotal
-class ASTTransformer(object):
+class ASTTransformerTotal(object):
     def __init__(
             self,
             func=None,

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -9,12 +9,11 @@ import taichi as ti
 
 # Total transform
 class ASTTransformerTotal(object):
-    def __init__(
-            self,
-            func=None,
-            excluded_parameters=(),
-            is_kernel=True,
-            arg_features=None):
+    def __init__(self,
+                 func=None,
+                 excluded_parameters=(),
+                 is_kernel=True,
+                 arg_features=None):
         self.func = func
         self.excluded_parameters = excluded_parameters
         self.is_kernel = is_kernel

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -37,10 +37,11 @@ class ASTTransformerTotal(object):
                              excluded_parameters=self.excluded_parameters,
                              is_kernel=self.is_kernel,
                              arg_features=self.arg_features)
+        # Convert Python AST to Python code that generates Taichi C++ AST.
         tree = build_stmt(ctx, tree)
         ast.fix_missing_locations(tree)
         self.print_ast(tree, 'Preprocessed')
-        self.pass_Checks.visit(tree)  # should not modify AST
+        self.pass_Checks.visit(tree)  # does not modify the AST
 
 
 class ASTTransformerBase(ast.NodeTransformer):
@@ -62,7 +63,7 @@ class ASTTransformerBase(ast.NodeTransformer):
         return ''
 
 
-# Second-pass transform
+# Performs checks at the Python AST level. Does not modify the AST.
 class ASTTransformerChecks(ASTTransformerBase):
     def __init__(self, func):
         super().__init__(func)

--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -1,7 +1,6 @@
 import ast
 
 from taichi.lang import impl
-from taichi.lang.ast_builder_utils import parse_expr
 from taichi.lang.ast_resolver import ASTResolver
 from taichi.lang.exception import TaichiSyntaxError
 
@@ -47,11 +46,7 @@ class ASTTransformer(object):
         tree = build_stmt(ctx, tree)
         ast.fix_missing_locations(tree)
         self.print_ast(tree, 'Preprocessed')
-        self.pass_Checks.visit(tree)
-        self.print_ast(tree, 'Checked')
-        # self.pass_transform_function_call.visit(tree)
-        # ast.fix_missing_locations(tree)
-        self.print_ast(tree, 'Final AST')
+        self.pass_Checks.visit(tree)  # should not modify AST
 
 
 class ASTTransformerBase(ast.NodeTransformer):
@@ -105,15 +100,4 @@ class ASTTransformerChecks(ASTTransformerBase):
                 'Taichi functions/kernels cannot have multiple returns!'
                 ' Consider using a local variable to walk around.')
 
-        return node
-
-
-# Transform a standalone Taichi function call expression into a statement.
-class TransformFunctionCallAsStmt(ASTTransformerBase):
-    def __init__(self, func):
-        super().__init__(func)
-
-    def visit_Call(self, node):
-        node.args = [node.func] + node.args
-        node.func = parse_expr('ti.maybe_transform_ti_func_call_to_stmt')
         return node


### PR DESCRIPTION
Related issue = #2193

Changeset:
- Deprecate `maybe_transform_ti_func_call_to_stmt` and split its logic into StmtBuilder and ExprBuilder
- Remove the pass transforming function calls to `maybe_transform_ti_func_call_to_stmt`
- Add a method `insert_expr_stmt_if_ti_func` to check if a function is Taichi function at Python runtime (we cannot check it in StmtBuilder). This method is called only when `experimental_real_function=True` and the Python statement contains only one expression which is the function call. So there will be no redundant calls like `maybe_transform_ti_func_call_to_stmt` before this PR.
- Remove an unused field `is_classfunc`
- Rename `ASTTransformer` to `ASTTransformerTotal`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
