### PR TITLE
[bug] Fix missing ti.template() in rand_vector(n) in examples

### DIFF
--- a/examples/simulation/math_utils.py
+++ b/examples/simulation/math_utils.py
@@ -4,7 +4,7 @@ import taichi as ti
 
 
 @ti.func
-def rand_vector(n):
+def rand_vector(n: ti.template()):
     '''
     Samples a n-dimensional random uniform vector.
     '''


### PR DESCRIPTION
Related issue = fix #2617

I think we should also update the docs about the restrictions on list comprehensions and dictionary comprehensions but I don't know which page to put them...

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
