### PR TITLE
[misc] [doc] Rename some profiler APIs and add docstring, mark old names as deprecated

### DIFF
--- a/benchmarks/misc/baseline_fill.py
+++ b/benchmarks/misc/baseline_fill.py
@@ -26,10 +26,10 @@ def fill(arch, dtype, dsize, repeat=10):
 
     # compile the kernel first
     fill_const(n)
-    ti.clear_kernel_profiler()
+    ti.clear_kernel_profile()
     for i in range(repeat):
         fill_const(n)
     kernelname = fill_const.__name__
     suffix = "_c"
-    quering_result = ti.query_kernel_profiler(kernelname + suffix)
+    quering_result = ti.query_kernel_profile(kernelname + suffix)
     return quering_result.min

--- a/benchmarks/misc/baseline_fill.py
+++ b/benchmarks/misc/baseline_fill.py
@@ -26,12 +26,9 @@ def fill(arch, dtype, dsize, repeat=10):
 
     # compile the kernel first
     fill_const(n)
-    ti.sync()
-    ti.kernel_profiler_clear()
-    ti.sync()
+    ti.clear_kernel_profiler()
     for i in range(repeat):
         fill_const(n)
-    ti.sync()
     kernelname = fill_const.__name__
     suffix = "_c"
     quering_result = ti.query_kernel_profiler(kernelname + suffix)

--- a/benchmarks/misc/baseline_fill.py
+++ b/benchmarks/misc/baseline_fill.py
@@ -26,10 +26,10 @@ def fill(arch, dtype, dsize, repeat=10):
 
     # compile the kernel first
     fill_const(n)
-    ti.clear_kernel_profile()
+    ti.clear_kernel_profile_info()
     for i in range(repeat):
         fill_const(n)
     kernelname = fill_const.__name__
     suffix = "_c"
-    quering_result = ti.query_kernel_profile(kernelname + suffix)
+    quering_result = ti.query_kernel_profile_info(kernelname + suffix)
     return quering_result.min

--- a/benchmarks/misc/baseline_reduction.py
+++ b/benchmarks/misc/baseline_reduction.py
@@ -41,10 +41,10 @@ def reduction(arch, dtype, dsize, repeat=10):
 
     # compile the kernel first
     reduction(n)
-    ti.clear_kernel_profiler()
+    ti.clear_kernel_profile()
     for i in range(repeat):
         reduction(n)
     kernelname = reduction.__name__
     suffix = "_c"
-    quering_result = ti.query_kernel_profiler(kernelname + suffix)
+    quering_result = ti.query_kernel_profile(kernelname + suffix)
     return quering_result.min

--- a/benchmarks/misc/baseline_reduction.py
+++ b/benchmarks/misc/baseline_reduction.py
@@ -41,12 +41,9 @@ def reduction(arch, dtype, dsize, repeat=10):
 
     # compile the kernel first
     reduction(n)
-    ti.sync()
-    ti.kernel_profiler_clear()
-    ti.sync()
+    ti.clear_kernel_profiler()
     for i in range(repeat):
         reduction(n)
-    ti.sync()
     kernelname = reduction.__name__
     suffix = "_c"
     quering_result = ti.query_kernel_profiler(kernelname + suffix)

--- a/benchmarks/misc/baseline_reduction.py
+++ b/benchmarks/misc/baseline_reduction.py
@@ -41,10 +41,10 @@ def reduction(arch, dtype, dsize, repeat=10):
 
     # compile the kernel first
     reduction(n)
-    ti.clear_kernel_profile()
+    ti.clear_kernel_profile_info()
     for i in range(repeat):
         reduction(n)
     kernelname = reduction.__name__
     suffix = "_c"
-    quering_result = ti.query_kernel_profile(kernelname + suffix)
+    quering_result = ti.query_kernel_profile_info(kernelname + suffix)
     return quering_result.min

--- a/docs/lang/articles/misc/profiler.md
+++ b/docs/lang/articles/misc/profiler.md
@@ -17,7 +17,7 @@ performance of the compiler itself.
 
 1.  `KernelProfiler` records the costs of Taichi kernels on devices. To
     enable this profiler, set `kernel_profiler=True` in `ti.init`.
-2.  Call `ti.kernel_profiler_print()` to show the kernel profiling
+2.  Call `ti.print_kernel_profiler()` to show the kernel profiling
     result. For example:
 
 ```python {3,13}
@@ -33,7 +33,7 @@ def compute():
 
 
 compute()
-ti.kernel_profiler_print()
+ti.print_kernel_profiler()
 ```
 
 The outputs would be:

--- a/docs/lang/articles/misc/profiler.md
+++ b/docs/lang/articles/misc/profiler.md
@@ -17,7 +17,7 @@ performance of the compiler itself.
 
 1.  `KernelProfiler` records the costs of Taichi kernels on devices. To
     enable this profiler, set `kernel_profiler=True` in `ti.init`.
-2.  Call `ti.print_kernel_profiler()` to show the kernel profiling
+2.  Call `ti.print_kernel_profile_info()` to show the kernel profiling
     result. For example:
 
 ```python {3,13}
@@ -33,7 +33,7 @@ def compute():
 
 
 compute()
-ti.print_kernel_profiler()
+ti.print_kernel_profile_info()
 ```
 
 The outputs would be:

--- a/examples/algorithm/mgpcg.py
+++ b/examples/algorithm/mgpcg.py
@@ -209,4 +209,4 @@ for i in range(400):
     gui.set_image(pixels)
     gui.show()
 
-ti.print_kernel_profiler()
+ti.print_kernel_profile_info()

--- a/examples/algorithm/mgpcg.py
+++ b/examples/algorithm/mgpcg.py
@@ -209,4 +209,4 @@ for i in range(400):
     gui.set_image(pixels)
     gui.show()
 
-ti.kernel_profiler_print()
+ti.print_kernel_profiler()

--- a/examples/algorithm/mgpcg_advanced.py
+++ b/examples/algorithm/mgpcg_advanced.py
@@ -277,7 +277,7 @@ class MGPCG_Example(MGPCG):
         self.solve(max_iters=400, verbose=verbose)
         self.paint()
         ti.imshow(self.pixels)
-        ti.print_kernel_profiler()
+        ti.print_kernel_profile_info()
 
 
 if __name__ == '__main__':

--- a/examples/algorithm/mgpcg_advanced.py
+++ b/examples/algorithm/mgpcg_advanced.py
@@ -277,7 +277,7 @@ class MGPCG_Example(MGPCG):
         self.solve(max_iters=400, verbose=verbose)
         self.paint()
         ti.imshow(self.pixels)
-        ti.kernel_profiler_print()
+        ti.print_kernel_profiler()
 
 
 if __name__ == '__main__':

--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -227,6 +227,6 @@ for _ in range(3):
         iterate()
     loud_sync()
 
-ti.print_kernel_profiler()
+ti.print_kernel_profile_info()
 ti.core.print_stat()
 ti.print_profile_info()

--- a/misc/async_mgpcg.py
+++ b/misc/async_mgpcg.py
@@ -227,6 +227,6 @@ for _ in range(3):
         iterate()
     loud_sync()
 
-ti.kernel_profiler_print()
+ti.print_kernel_profiler()
 ti.core.print_stat()
 ti.print_profile_info()

--- a/misc/benchmark_bit_struct_stores.py
+++ b/misc/benchmark_bit_struct_stores.py
@@ -30,4 +30,4 @@ def foo():
 for i in range(10):
     foo()
 
-ti.kernel_profiler_print()
+ti.print_kernel_profiler()

--- a/misc/benchmark_bit_struct_stores.py
+++ b/misc/benchmark_bit_struct_stores.py
@@ -30,4 +30,4 @@ def foo():
 for i in range(10):
     foo()
 
-ti.print_kernel_profiler()
+ti.print_kernel_profile_info()

--- a/misc/benchmark_parallel_compilation.py
+++ b/misc/benchmark_parallel_compilation.py
@@ -68,5 +68,5 @@ def substep():
 for i in range(32):
     substep()
 
-ti.print_kernel_profiler()
+ti.print_kernel_profile_info()
 ti.core.print_profile_info()

--- a/misc/benchmark_parallel_compilation.py
+++ b/misc/benchmark_parallel_compilation.py
@@ -68,5 +68,5 @@ def substep():
 for i in range(32):
     substep()
 
-ti.kernel_profiler_print()
+ti.print_kernel_profiler()
 ti.core.print_profile_info()

--- a/misc/benchmark_reduction.py
+++ b/misc/benchmark_reduction.py
@@ -32,4 +32,4 @@ for i in range(10):
 
 ground_truth = 10 * N * (N - 1) / 2 % 2**32
 assert tot[None] % 2**32 == ground_truth
-ti.kernel_profiler_print()
+ti.print_kernel_profiler()

--- a/misc/benchmark_reduction.py
+++ b/misc/benchmark_reduction.py
@@ -32,4 +32,4 @@ for i in range(10):
 
 ground_truth = 10 * N * (N - 1) / 2 % 2**32
 assert tot[None] % 2**32 == ground_truth
-ti.print_kernel_profiler()
+ti.print_kernel_profile_info()

--- a/misc/benchmark_scatter_bls.py
+++ b/misc/benchmark_scatter_bls.py
@@ -15,4 +15,4 @@ bls_particle_grid(N=512,
                   pointer_level=2,
                   use_offset=True)
 
-ti.kernel_profiler_print()
+ti.print_kernel_profiler()

--- a/misc/benchmark_scatter_bls.py
+++ b/misc/benchmark_scatter_bls.py
@@ -15,4 +15,4 @@ bls_particle_grid(N=512,
                   pointer_level=2,
                   use_offset=True)
 
-ti.print_kernel_profiler()
+ti.print_kernel_profile_info()

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -97,7 +97,7 @@ def print_kernel_profile_info():
     impl.get_runtime().prog.print_kernel_profile_info()
 
 
-def query_kernel_profile(name):
+def query_kernel_profile_info(name):
     """Query kernel elapsed time(min,avg,max) on devices using the kernel name.
     To enable this profiler, set `kernel_profiler=True` in `ti.init`.
 
@@ -121,35 +121,35 @@ def query_kernel_profile(name):
         >>>         var[i] = 0.1
 
         >>> fill()
-        >>> ti.clear_kernel_profile() #[1]
+        >>> ti.clear_kernel_profile_info() #[1]
         >>> for i in range(100):
         >>>     fill()
-        >>> query_result = ti.query_kernel_profile(fill.__name__) #[2]
+        >>> query_result = ti.query_kernel_profile_info(fill.__name__) #[2]
         >>> print("kernel excuted times =",query_result.counter)
         >>> print("kernel elapsed time(min_in_ms) =",query_result.min)
         >>> print("kernel elapsed time(max_in_ms) =",query_result.max)
         >>> print("kernel elapsed time(avg_in_ms) =",query_result.avg)
 
     Note:
-        [1] To get the correct result, query_kernel_profile() must be used in conjunction with
-        clear_kernel_profile().
+        [1] To get the correct result, query_kernel_profile_info() must be used in conjunction with
+        clear_kernel_profile_info().
 
         [2] Currently the result of `KernelProfiler` could be incorrect on OpenGL
         backend due to its lack of support for `ti.sync()`.
     """
-    return impl.get_runtime().prog.query_kernel_profile(name)
+    return impl.get_runtime().prog.query_kernel_profile_info(name)
 
 
-@deprecated('kernel_profiler_clear()', 'clear_kernel_profile()')
+@deprecated('kernel_profiler_clear()', 'clear_kernel_profile_info()')
 def kernel_profiler_clear():
-    return clear_kernel_profile()
+    return clear_kernel_profile_info()
 
 
-def clear_kernel_profile():
+def clear_kernel_profile_info():
     """
     Clear all KernelProfiler records.
     """
-    impl.get_runtime().prog.clear_kernel_profile()
+    impl.get_runtime().prog.clear_kernel_profile_info()
 
 
 def kernel_profiler_total_time():
@@ -603,7 +603,7 @@ def benchmark(func, repeat=300, args=()):
         for i in range(3):
             func(*args)
             ti.sync()
-        ti.clear_kernel_profile()
+        ti.clear_kernel_profile_info()
         t = time.time()
         for n in range(repeat):
             func(*args)

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -18,8 +18,8 @@ from taichi.lang.type_factory_impl import type_factory
 from taichi.lang.util import (has_pytorch, is_taichi_class, python_scope,
                               taichi_scope, to_numpy_type, to_pytorch_type,
                               to_taichi_type)
-from taichi.snode.fields_builder import FieldsBuilder
 from taichi.misc.util import deprecated
+from taichi.snode.fields_builder import FieldsBuilder
 
 import taichi as ti
 
@@ -66,12 +66,14 @@ timeline_save = lambda fn: impl.get_runtime().prog.timeline_save(fn)
 # Legacy API
 type_factory_ = _ti_core.get_type_factory_instance()
 
+
 @deprecated('kernel_profiler_print()', 'print_kernel_profiler()')
 def kernel_profiler_print():
     return print_kernel_profiler()
 
+
 def print_kernel_profiler():
-    """Print the elapsed time(min,max,avg) of Taichi kernels on devices. 
+    """Print the elapsed time(min,max,avg) of Taichi kernels on devices.
     To enable this profiler, set `kernel_profiler=True` in `ti.init`.
 
     Example::
@@ -87,7 +89,7 @@ def print_kernel_profiler():
 
         >>> compute()
         >>> ti.print_kernel_profiler() #[1]
-    
+
     Note:
         [1] Currently the result of `KernelProfiler` could be incorrect on OpenGL
         backend due to its lack of support for `ti.sync()`.
@@ -108,7 +110,7 @@ def query_kernel_profiler(name):
     Example::
 
         >>> import taichi as ti
- 
+
         >>> ti.init(ti.cpu, kernel_profiler=True)
         >>> n = 1024*1024
         >>> var = ti.field(ti.f32, shape=n)
@@ -127,25 +129,28 @@ def query_kernel_profiler(name):
         >>> print("kernel elapsed time(min_in_ms) =",query_result.min)
         >>> print("kernel elapsed time(max_in_ms) =",query_result.max)
         >>> print("kernel elapsed time(avg_in_ms) =",query_result.avg)
-    
+
     Note:
-        [1] To get the correct result, query_kernel_profiler() must be used in conjunction with 
+        [1] To get the correct result, query_kernel_profiler() must be used in conjunction with
         clear_kernel_profiler().
-        
+
         [2] Currently the result of `KernelProfiler` could be incorrect on OpenGL
         backend due to its lack of support for `ti.sync()`.
     """
     return impl.get_runtime().prog.query_kernel_profiler(name)
 
+
 @deprecated('kernel_profiler_clear()', 'clear_kernel_profiler()')
 def kernel_profiler_clear():
     return clear_kernel_profiler()
+
 
 def clear_kernel_profiler():
     """
     Clear all KernelProfiler records.
     """
     impl.get_runtime().prog.clear_kernel_profiler()
+
 
 def kernel_profiler_total_time():
     """
@@ -160,6 +165,7 @@ def kernel_profiler_total_time():
 @deprecated('memory_profiler_print()', 'print_memory_profiler()')
 def memory_profiler_print():
     return print_memory_profiler()
+
 
 def print_memory_profiler():
     """Memory profiling tool for LLVM backends with full sparse support.

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -67,12 +67,12 @@ timeline_save = lambda fn: impl.get_runtime().prog.timeline_save(fn)
 type_factory_ = _ti_core.get_type_factory_instance()
 
 
-@deprecated('kernel_profiler_print()', 'print_kernel_profiler()')
+@deprecated('kernel_profiler_print()', 'print_kernel_profile_info()')
 def kernel_profiler_print():
-    return print_kernel_profiler()
+    return print_kernel_profile_info()
 
 
-def print_kernel_profiler():
+def print_kernel_profile_info():
     """Print the elapsed time(min,max,avg) of Taichi kernels on devices.
     To enable this profiler, set `kernel_profiler=True` in `ti.init`.
 
@@ -88,16 +88,16 @@ def print_kernel_profiler():
         >>>     var[0] = 1.0
 
         >>> compute()
-        >>> ti.print_kernel_profiler() #[1]
+        >>> ti.print_kernel_profile_info() #[1]
 
     Note:
         [1] Currently the result of `KernelProfiler` could be incorrect on OpenGL
         backend due to its lack of support for `ti.sync()`.
     """
-    impl.get_runtime().prog.print_kernel_profiler()
+    impl.get_runtime().prog.print_kernel_profile_info()
 
 
-def query_kernel_profiler(name):
+def query_kernel_profile(name):
     """Query kernel elapsed time(min,avg,max) on devices using the kernel name.
     To enable this profiler, set `kernel_profiler=True` in `ti.init`.
 
@@ -121,35 +121,35 @@ def query_kernel_profiler(name):
         >>>         var[i] = 0.1
 
         >>> fill()
-        >>> ti.clear_kernel_profiler() #[1]
+        >>> ti.clear_kernel_profile() #[1]
         >>> for i in range(100):
         >>>     fill()
-        >>> query_result = ti.query_kernel_profiler(fill.__name__) #[2]
+        >>> query_result = ti.query_kernel_profile(fill.__name__) #[2]
         >>> print("kernel excuted times =",query_result.counter)
         >>> print("kernel elapsed time(min_in_ms) =",query_result.min)
         >>> print("kernel elapsed time(max_in_ms) =",query_result.max)
         >>> print("kernel elapsed time(avg_in_ms) =",query_result.avg)
 
     Note:
-        [1] To get the correct result, query_kernel_profiler() must be used in conjunction with
-        clear_kernel_profiler().
+        [1] To get the correct result, query_kernel_profile() must be used in conjunction with
+        clear_kernel_profile().
 
         [2] Currently the result of `KernelProfiler` could be incorrect on OpenGL
         backend due to its lack of support for `ti.sync()`.
     """
-    return impl.get_runtime().prog.query_kernel_profiler(name)
+    return impl.get_runtime().prog.query_kernel_profile(name)
 
 
-@deprecated('kernel_profiler_clear()', 'clear_kernel_profiler()')
+@deprecated('kernel_profiler_clear()', 'clear_kernel_profile()')
 def kernel_profiler_clear():
-    return clear_kernel_profiler()
+    return clear_kernel_profile()
 
 
-def clear_kernel_profiler():
+def clear_kernel_profile():
     """
     Clear all KernelProfiler records.
     """
-    impl.get_runtime().prog.clear_kernel_profiler()
+    impl.get_runtime().prog.clear_kernel_profile()
 
 
 def kernel_profiler_total_time():
@@ -162,12 +162,12 @@ def kernel_profiler_total_time():
     return impl.get_runtime().prog.kernel_profiler_total_time()
 
 
-@deprecated('memory_profiler_print()', 'print_memory_profiler()')
+@deprecated('memory_profiler_print()', 'print_memory_profile_info()')
 def memory_profiler_print():
-    return print_memory_profiler()
+    return print_memory_profile_info()
 
 
-def print_memory_profiler():
+def print_memory_profile_info():
     """Memory profiling tool for LLVM backends with full sparse support.
     This profiler is automatically on.
     """
@@ -603,7 +603,7 @@ def benchmark(func, repeat=300, args=()):
         for i in range(3):
             func(*args)
             ti.sync()
-        ti.clear_kernel_profiler()
+        ti.clear_kernel_profile()
         t = time.time()
         for n in range(repeat):
             func(*args)

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -176,7 +176,7 @@ def set_gdb_trigger(on=True):
 
 
 def print_profile_info():
-    """Print time elasped on the host tasks in a hierarchical format.
+    """Print time elapsed on the host tasks in a hierarchical format.
 
     This profiler is automatically on.
 
@@ -198,7 +198,7 @@ def print_profile_info():
 
 
 def clear_profile_info():
-    """Clear profiler's records about time elasped on the host tasks.
+    """Clear profiler's records about time elapsed on the host tasks.
 
     Call function imports from C++ : _ti_core.clear_profile_info()
     """
@@ -241,7 +241,7 @@ def get_kernel_stats():
 def print_async_stats(include_kernel_profiler=False):
     import taichi as ti
     if include_kernel_profiler:
-        ti.kernel_profiler_print()
+        ti.print_kernel_profiler()
         print()
     stat = ti.get_kernel_stats()
     counters = stat.get_counters()

--- a/python/taichi/misc/util.py
+++ b/python/taichi/misc/util.py
@@ -241,7 +241,7 @@ def get_kernel_stats():
 def print_async_stats(include_kernel_profiler=False):
     import taichi as ti
     if include_kernel_profiler:
-        ti.print_kernel_profiler()
+        ti.print_kernel_profile_info()
         print()
     stat = ti.get_kernel_stats()
     counters = stat.get_counters()

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -66,6 +66,7 @@ void KernelProfilerBase::query(const std::string &kernel_name,
                                double &min,
                                double &max,
                                double &avg) {
+  sync();
   std::regex name_regex(kernel_name + "(.*)");
   for (auto &rec : records) {
     if (std::regex_match(rec.name, name_regex)) {

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -38,6 +38,7 @@ class KernelProfilerBase {
   using TaskHandle = void *;
 
   void clear() {
+    sync();
     total_time_ms = 0;
     records.clear();
   }

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -143,14 +143,14 @@ class Program {
     double avg{0.0};
   };
 
-  KernelProfilerQueryResult query_kernel_profile(const std::string &name) {
+  KernelProfilerQueryResult query_kernel_profile_info(const std::string &name) {
     KernelProfilerQueryResult query_result;
     profiler->query(name, query_result.counter, query_result.min,
                     query_result.max, query_result.avg);
     return query_result;
   }
 
-  void clear_kernel_profile() {
+  void clear_kernel_profile_info() {
     profiler->clear();
   }
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -132,7 +132,7 @@ class Program {
 
   ~Program();
 
-  void print_kernel_profiler() {
+  void print_kernel_profile_info() {
     profiler->print();
   }
 
@@ -143,14 +143,14 @@ class Program {
     double avg{0.0};
   };
 
-  KernelProfilerQueryResult query_kernel_profiler(const std::string &name) {
+  KernelProfilerQueryResult query_kernel_profile(const std::string &name) {
     KernelProfilerQueryResult query_result;
     profiler->query(name, query_result.counter, query_result.min,
                     query_result.max, query_result.avg);
     return query_result;
   }
 
-  void clear_kernel_profiler() {
+  void clear_kernel_profile() {
     profiler->clear();
   }
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -132,7 +132,7 @@ class Program {
 
   ~Program();
 
-  void kernel_profiler_print() {
+  void print_kernel_profiler() {
     profiler->print();
   }
 
@@ -150,7 +150,7 @@ class Program {
     return query_result;
   }
 
-  void kernel_profiler_clear() {
+  void clear_kernel_profiler() {
     profiler->clear();
   }
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -214,13 +214,13 @@ void export_lang(py::module &m) {
       .def(py::init<>())
       .def_readonly("config", &Program::config)
       .def("print_kernel_profile_info", &Program::print_kernel_profile_info)
-      .def("query_kernel_profile",
+      .def("query_kernel_profile_info",
            [](Program *program, const std::string &name) {
-             return program->query_kernel_profile(name);
+             return program->query_kernel_profile_info(name);
            })
       .def("kernel_profiler_total_time",
            [](Program *program) { return program->profiler->get_total_time(); })
-      .def("clear_kernel_profile", &Program::clear_kernel_profile)
+      .def("clear_kernel_profile_info", &Program::clear_kernel_profile_info)
       .def("timeline_clear",
            [](Program *) { Timelines::get_instance().clear(); })
       .def("timeline_save",

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -213,14 +213,14 @@ void export_lang(py::module &m) {
   py::class_<Program>(m, "Program")
       .def(py::init<>())
       .def_readonly("config", &Program::config)
-      .def("kernel_profiler_print", &Program::kernel_profiler_print)
+      .def("print_kernel_profiler", &Program::print_kernel_profiler)
       .def("query_kernel_profiler",
            [](Program *program, const std::string &name) {
              return program->query_kernel_profiler(name);
            })
       .def("kernel_profiler_total_time",
            [](Program *program) { return program->profiler->get_total_time(); })
-      .def("kernel_profiler_clear", &Program::kernel_profiler_clear)
+      .def("clear_kernel_profiler", &Program::clear_kernel_profiler)
       .def("timeline_clear",
            [](Program *) { Timelines::get_instance().clear(); })
       .def("timeline_save",

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -213,14 +213,14 @@ void export_lang(py::module &m) {
   py::class_<Program>(m, "Program")
       .def(py::init<>())
       .def_readonly("config", &Program::config)
-      .def("print_kernel_profiler", &Program::print_kernel_profiler)
-      .def("query_kernel_profiler",
+      .def("print_kernel_profile_info", &Program::print_kernel_profile_info)
+      .def("query_kernel_profile",
            [](Program *program, const std::string &name) {
-             return program->query_kernel_profiler(name);
+             return program->query_kernel_profile(name);
            })
       .def("kernel_profiler_total_time",
            [](Program *program) { return program->profiler->get_total_time(); })
-      .def("clear_kernel_profiler", &Program::clear_kernel_profiler)
+      .def("clear_kernel_profile", &Program::clear_kernel_profile)
       .def("timeline_clear",
            [](Program *) { Timelines::get_instance().clear(); })
       .def("timeline_save",

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -98,7 +98,7 @@ def bls_test_template(dim,
 
     check()
 
-    ti.kernel_profiler_print()
+    ti.print_kernel_profiler()
 
     assert mismatch[None] == 0
 

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -98,7 +98,7 @@ def bls_test_template(dim,
 
     check()
 
-    ti.print_kernel_profiler()
+    ti.print_kernel_profile_info()
 
     assert mismatch[None] == 0
 


### PR DESCRIPTION
Related issue = #2579

Add docstring for:
```
    kernel_profiler_print() 
    kernel_profiler_clear()
    kernel_profiler_total_time()
    memory_profiler_print()
    query_kernel_profiler()
```

Rename:
```
    kernel_profiler_print() >>> print_kernel_profile_info()
    kernel_profiler_clear() >>> clear_kernel_profile_info()
    memory_profiler_print() >>> print_memory_profile_info()
    query_kernel_profiler() >>> query_kernel_profile_info()
```
(and mark old names as deprecated)

misc:
Execute sync() before clear() & query() in kernel_profiler APIs