### PR TITLE
[lang] [refactor] Add a ExtArray class for external arrays

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -36,36 +36,8 @@ class Expr(TaichiOperations):
         if self.tb:
             self.ptr.set_tb(self.tb)
 
-    def loop_range(self):
-        return self
-
-    def is_global(self):
-        """Check whether the class itself represents GlobalVariableExpression (field) or ExternalTensorExpression internally.
-
-        Returns:
-            True or False depending on whether the class itself represents GlobalVariableExpression (field) or ExternalTensorExpression internally.
-        """
-        return self.ptr.is_global_var() or self.ptr.is_external_var()
-
     def __hash__(self):
         return self.ptr.get_raw_address()
-
-    @property
-    def shape(self):
-        """A list containing sizes for each dimension when the class itself represents GlobalVariableExpression (field) or ExternalTensorExpression internally.
-
-        Returns:
-            The list containing sizes for each dimension when the class itself represents GlobalVariableExpression (field) or ExternalTensorExpression internally.
-        """
-        if self.ptr.is_external_var():
-            dim = impl.get_external_tensor_dim(self.ptr)
-            ret = [
-                Expr(impl.get_external_tensor_shape_along_axis(self.ptr, i))
-                for i in range(dim)
-            ]
-            return ret
-        from taichi.lang.snode import SNode
-        return SNode(self.ptr.snode()).shape
 
     def __str__(self):
         return '<ti.Expr>'

--- a/python/taichi/lang/ext_array.py
+++ b/python/taichi/lang/ext_array.py
@@ -1,0 +1,38 @@
+from taichi.core.util import ti_core as _ti_core
+from taichi.lang.expr import Expr
+from taichi.lang.util import taichi_scope
+
+
+class ExtArray:
+    """Class for external arrays. Constructed by a C++ Expr wrapping a C++ ExternalTensorExpression.
+
+    Args:
+        ptr: The C++ Expr mentioned above.
+    """
+    def __init__(self, ptr):
+        assert ptr.is_external_var()
+        self.ptr = ptr
+
+    @property
+    @taichi_scope
+    def shape(self):
+        """A list containing sizes for each dimension.
+
+        Returns:
+            List[Int]: The result list.
+        """
+        dim = _ti_core.get_external_tensor_dim(self.ptr)
+        ret = [
+            Expr(_ti_core.get_external_tensor_shape_along_axis(self.ptr, i))
+            for i in range(dim)
+        ]
+        return ret
+
+    @taichi_scope
+    def loop_range(self):
+        """Gets the corresponding C++ Expr to serve as loop range.
+
+        Returns:
+            C++ Expr: See above.
+        """
+        return self.ptr

--- a/python/taichi/lang/ext_array.py
+++ b/python/taichi/lang/ext_array.py
@@ -32,6 +32,8 @@ class ExtArray:
     def loop_range(self):
         """Gets the corresponding taichi_core.Expr to serve as loop range.
 
+        This is not in use now because struct fors on ExtArrays are not supported yet.
+
         Returns:
             taichi_core.Expr: See above.
         """

--- a/python/taichi/lang/ext_array.py
+++ b/python/taichi/lang/ext_array.py
@@ -4,10 +4,10 @@ from taichi.lang.util import taichi_scope
 
 
 class ExtArray:
-    """Class for external arrays. Constructed by a C++ Expr wrapping a C++ ExternalTensorExpression.
+    """Class for external arrays. Constructed by a taichi_core.Expr wrapping a taichi_core.ExternalTensorExpression.
 
     Args:
-        ptr: The C++ Expr mentioned above.
+        ptr (taichi_core.Expr): See above.
     """
     def __init__(self, ptr):
         assert ptr.is_external_var()
@@ -30,9 +30,9 @@ class ExtArray:
 
     @taichi_scope
     def loop_range(self):
-        """Gets the corresponding C++ Expr to serve as loop range.
+        """Gets the corresponding taichi_core.Expr to serve as loop range.
 
         Returns:
-            C++ Expr: See above.
+            taichi_core.Expr: See above.
         """
         return self.ptr

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -81,7 +81,7 @@ class Field:
         """Gets representative field member for loop range info.
 
         Returns:
-            C++ Expr: Representative (first) field member.
+            taichi_core.Expr: Representative (first) field member.
         """
         return self.vars[0].ptr
 

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -81,9 +81,9 @@ class Field:
         """Gets representative field member for loop range info.
 
         Returns:
-            Expr: Representative (first) field member.
+            C++ Expr: Representative (first) field member.
         """
-        return self.vars[0]
+        return self.vars[0].ptr
 
     def set_grad(self, grad):
         """Sets corresponding gradient field.

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -74,7 +74,8 @@ def expr_init_func(
 
 def begin_frontend_struct_for(group, loop_range):
     if not isinstance(loop_range, (ExtArray, Field, SNode, _Root)):
-        raise TypeError('Can only iterate through Taichi fields or external arrays')
+        raise TypeError(
+            'Can only iterate through Taichi fields or external arrays')
     if group.size() != len(loop_range.shape):
         raise IndexError(
             'Number of struct-for indices does not match loop variable dimensionality '

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -73,9 +73,9 @@ def expr_init_func(
 
 
 def begin_frontend_struct_for(group, loop_range):
-    if not isinstance(loop_range, (ExtArray, Field, SNode, _Root)):
+    if not isinstance(loop_range, (Field, SNode, _Root)):
         raise TypeError(
-            'Can only iterate through Taichi fields or external arrays')
+            'Can only iterate through Taichi fields')
     if group.size() != len(loop_range.shape):
         raise IndexError(
             'Number of struct-for indices does not match loop variable dimensionality '

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -74,8 +74,7 @@ def expr_init_func(
 
 def begin_frontend_struct_for(group, loop_range):
     if not isinstance(loop_range, (Field, SNode, _Root)):
-        raise TypeError(
-            'Can only iterate through Taichi fields')
+        raise TypeError('Can only iterate through Taichi fields')
     if group.size() != len(loop_range.shape):
         raise IndexError(
             'Number of struct-for indices does not match loop variable dimensionality '

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -1,5 +1,6 @@
 from taichi.core.util import ti_core as _ti_core
 from taichi.lang.expr import Expr
+from taichi.lang.ext_array import ExtArray
 from taichi.lang.snode import SNode
 from taichi.lang.util import cook_dtype, to_taichi_type
 
@@ -74,7 +75,7 @@ def decl_scalar_arg(dtype):
 def decl_ext_arr_arg(dtype, dim):
     dtype = cook_dtype(dtype)
     arg_id = _ti_core.decl_arg(dtype, True)
-    return Expr(_ti_core.make_external_tensor_expr(dtype, dim, arg_id))
+    return ExtArray(_ti_core.make_external_tensor_expr(dtype, dim, arg_id))
 
 
 def decl_scalar_ret(dtype):

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -247,10 +247,10 @@ class SNode:
         return self.shape[i]
 
     def loop_range(self):
-        """Gets the C++ Expr wrapping the C++ GlobalVariableExpression corresponding to `self` to serve as loop range.
+        """Gets the taichi_core.Expr wrapping the taichi_core.GlobalVariableExpression corresponding to `self` to serve as loop range.
 
         Returns:
-            C++ Expr: See above.
+            taichi_core.Expr: See above.
         """
         return _ti_core.global_var_expr_from_snode(self.ptr)
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -247,12 +247,12 @@ class SNode:
         return self.shape[i]
 
     def loop_range(self):
-        """Wraps `self` into an :class:`~taichi.lang.Expr` to serve as loop range.
+        """Gets the C++ Expr wrapping the C++ GlobalVariableExpression corresponding to `self` to serve as loop range.
 
         Returns:
-            Expr: The wrapped result.
+            C++ Expr: See above.
         """
-        return Expr(_ti_core.global_var_expr_from_snode(self.ptr))
+        return _ti_core.global_var_expr_from_snode(self.ptr)
 
     @property
     def name(self):

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -432,9 +432,9 @@ if ti.static(1):
             template = '''
 if 1:
     ___loop_var = 0
-    {} = ti.lang.expr.make_var_vector(size=len(___loop_var.loop_range().shape))
+    {} = ti.lang.expr.make_var_vector(size=len(___loop_var.shape))
     ___expr_group = ti.lang.expr.make_expr_group({})
-    ti.begin_frontend_struct_for(___expr_group, ___loop_var.loop_range())
+    ti.begin_frontend_struct_for(___expr_group, ___loop_var)
     ti.core.end_frontend_range_for()
             '''.format(vars, vars)
             t = ast.parse(template).body[0]
@@ -447,7 +447,7 @@ if 1:
 {}
     ___loop_var = 0
     ___expr_group = ti.lang.expr.make_expr_group({})
-    ti.begin_frontend_struct_for(___expr_group, ___loop_var.loop_range())
+    ti.begin_frontend_struct_for(___expr_group, ___loop_var)
     ti.core.end_frontend_range_for()
             '''.format(var_decl, vars)
             t = ast.parse(template).body[0]


### PR DESCRIPTION
Related issue = #

Previously, things around external arrays are implemented under `Expr` class, which is not intuitive because `Expr` class should represent a scalar supporting `TaichiOperations`. This PR mostly involves slight code migration and internal API changes. After this PR, `Expr` class will become (hopefully) clean.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
