### PR TITLE
[vulkan] Enable tests for Vulkan backend

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -812,7 +812,7 @@ def supported_archs():
     Returns:
         List[taichi_core.Arch]: All supported archs on the machine.
     """
-    archs = [cpu, cuda, metal, opengl, cc]
+    archs = [cpu, cuda, metal, opengl, vulkan, cc]
 
     wanted_archs = os.environ.get('TI_WANTED_ARCHS', '')
     want_exclude = wanted_archs.startswith('^')


### PR DESCRIPTION
Related issue = #2607

Right now quite a few tests would break if we enable `vulkan` here. Could you each help take a look at the reason? I guess the root causes aren't that many :-)

One example failure:

```bash
$ ti test -v
...
[W 08/09/21 17:07:15.950 196566] [vulkan_api.cpp:vk_debug_callback@49] validation layer: loader_icd_scan: Can not find 'ICD' object in ICD JSON file /usr/share/vulkan/icd.d/nvidia_layers.json.  Skipping ICD JSON
[W 08/09/21 17:07:15.958 196566] [vulkan_api.cpp:vk_debug_callback@49] validation layer: Validation Error: [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ] Object 0: VK_NULL_HANDLE, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x12537a2c | Missing extension required by the device extension VK_KHR_swapchain: VK_KHR_surface. The Vulkan spec states: All required extensions for each extension in the VkDeviceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://vulkan.lunarg.com/doc/view/1.2.182.0/linux/1.2-extensions/vkspec.html#VUID-vkCreateDevice-ppEnabledExtensionNames-01387)
[W 08/09/21 17:07:16.031 196566] [vulkan_api.cpp:vk_debug_callback@49] validation layer: Validation Error: [ VUID-vkCmdFillBuffer-dstBuffer-00029 ] Object 0: handle = 0xfa21a40000000003, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x636be4da | Invalid usage flag for VkBuffer 0xfa21a40000000003[] used by vkCmdFillBuffer(). In this case, VkBuffer should have VK_BUFFER_USAGE_TRANSFER_DST_BIT set during creation. The Vulkan spec states: dstBuffer must have been created with VK_BUFFER_USAGE_TRANSFER_DST_BIT usage flag (https://vulkan.lunarg.com/doc/view/1.2.182.0/linux/1.2-extensions/vkspec.html#VUID-vkCmdFillBuffer-dstBuffer-00029)
[W 08/09/21 17:07:16.031 196566] [vulkan_api.cpp:vk_debug_callback@49] validation layer: Validation Error: [ VUID-vkCmdFillBuffer-dstBuffer-00029 ] Object 0: handle = 0xe7f79a0000000005, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x636be4da | Invalid usage flag for VkBuffer 0xe7f79a0000000005[] used by vkCmdFillBuffer(). In this case, VkBuffer should have VK_BUFFER_USAGE_TRANSFER_DST_BIT set during creation. The Vulkan spec states: dstBuffer must have been created with VK_BUFFER_USAGE_TRANSFER_DST_BIT usage flag (https://vulkan.lunarg.com/doc/view/1.2.182.0/linux/1.2-extensions/vkspec.html#VUID-vkCmdFillBuffer-dstBuffer-00029)
[I 08/09/21 17:07:16.033 196566] [codegen_vulkan.cpp:compile_to_executable@1258] VK codegen for Taichi kernel=snode_writer_2_k0004_vk
[I 08/09/21 17:07:16.033 196566] [codegen_vulkan.cpp:get_buffer_value@1129] buffer name = context_buffer, value = 28
[I 08/09/21 17:07:16.033 196566] [codegen_vulkan.cpp:get_buffer_value@1129] buffer name = root_buffer, value = 43
[I 08/09/21 17:07:16.048 196566] [codegen_vulkan.cpp:compile_to_executable@1258] VK codegen for Taichi kernel=run_c46_0_k0005_vk
[I 08/09/21 17:07:16.048 196566] [codegen_vulkan.cpp:get_buffer_value@1129] buffer name = context_buffer, value = 43
[I 08/09/21 17:07:16.048 196566] [codegen_vulkan.cpp:get_buffer_value@1129] buffer name = root_buffer, value = 63
[I 08/09/21 17:07:16.051 196566] [codegen_vulkan.cpp:compile_to_executable@1258] VK codegen for Taichi kernel=snode_reader_2_k0006_vk
[I 08/09/21 17:07:16.051 196566] [codegen_vulkan.cpp:get_buffer_value@1129] buffer name = context_buffer, value = 28
[I 08/09/21 17:07:16.051 196566] [codegen_vulkan.cpp:get_buffer_value@1129] buffer name = root_buffer, value = 40
_____________________________________________ test_kernel_continue_in_nested_if_2 _____________________________________________
[gw1] linux -- Python 3.8.10 python

    @ti.all_archs
    def test_kernel_continue_in_nested_if_2():
        x = ti.field(ti.i32, shape=n)
    
        @ti.kernel
        def run(a: ti.i32):
            for i in range(1):
                if a:
                    if a:
                        continue
                if a:
                    continue
                x[i] = i
    
        x[0] = 1
        run(1)
        assert x[0] == 1
        run(0)
>       assert x[0] == 0
E       assert 1 == 0

tests/python/test_continue.py:127: AssertionError
---------------------------------------------------- Capt
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
