### PR TITLE
[ir] Improve ExternalTensorShapeAlongAxisStmt IR print result

### DIFF
--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -649,8 +649,8 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(ExternalTensorShapeAlongAxisStmt *stmt) override {
-    print("external_tensor_shape_along_axis {}, arg_id {}", stmt->axis,
-          stmt->arg_id);
+    print("{}{} = external_tensor_shape_along_axis {}, arg_id {}", stmt->type_hint(), 
+          stmt->name(), stmt->axis, stmt->arg_id);
   }
 
   void visit(BitStructStoreStmt *stmt) override {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -649,8 +649,8 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(ExternalTensorShapeAlongAxisStmt *stmt) override {
-    print("{}{} = external_tensor_shape_along_axis {}, arg_id {}", stmt->type_hint(), 
-          stmt->name(), stmt->axis, stmt->arg_id);
+    print("{}{} = external_tensor_shape_along_axis {}, arg_id {}",
+          stmt->type_hint(), stmt->name(), stmt->axis, stmt->arg_id);
   }
 
   void visit(BitStructStoreStmt *stmt) override {


### PR DESCRIPTION
`ExternalTensorShapeAlongAxisStmt` has explicit return value but has not be shown by IR print yet, which would confuse developers. This PR fixed this.
The previous IR print result:
```
external_tensor_shape_along_axis 0, arg_id 0
```
Now:
```
<i32> $1 = external_tensor_shape_along_axis 0, arg_id 0
```