### PR TITLE
[vulkan] Querying features like a mad man

### DIFF
--- a/taichi/backends/device.h
+++ b/taichi/backends/device.h
@@ -1,0 +1,53 @@
+#pragma once
+#include "taichi/lang_util.h"
+
+#include "taichi/program/compile_config.h"
+
+namespace taichi {
+namespace lang {
+
+// For backend dependent code (e.g. codegen)
+// Or the backend runtime itself
+// Capabilities are per-device
+enum class DeviceCapability : uint32_t {
+  vk_api_version,
+  vk_spirv_version,
+  vk_has_physical_features2,
+  vk_has_int8,
+  vk_has_int16,
+  vk_has_int64,
+  vk_has_float16,
+  vk_has_float64,
+  vk_has_external_memory,
+  vk_has_atomic_i64,
+  vk_has_atomic_float, // load, store, exchange
+  vk_has_atomic_float_add,
+  vk_has_atomic_float_minmax,
+  vk_has_atomic_float64, // load, store, exchange
+  vk_has_atomic_float64_add,
+  vk_has_atomic_float64_minmax,
+  vk_has_surface,
+  vk_has_presentation,
+  vk_has_spv_variable_ptr,
+};
+
+class Device {
+ public:
+  virtual ~Device(){};
+
+  virtual uint32_t get_cap(DeviceCapability capability_id) const {
+    if (caps_.find(capability_id) == caps_.end())
+      return 0;
+    return caps_.at(capability_id);
+  }
+
+  virtual void set_cap(DeviceCapability capability_id, uint32_t val) {
+    caps_[capability_id] = val;
+  }
+
+ private:
+  std::unordered_map<DeviceCapability, uint32_t> caps_;
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -416,7 +416,8 @@ class VkRuntime ::Impl {
       const auto &spirv_src = reg_params.task_spirv_source_codes[i];
       const auto &task_name = attribs.name;
 
-      TI_WARN_IF(!spirv_tools_->Validate(spirv_src), "SPIRV validation failed");
+      // TI_WARN_IF(!spirv_tools_->Validate(spirv_src), "SPIRV validation
+      // failed");
 
       std::vector<uint32_t> optimized_spv;
 
@@ -472,8 +473,8 @@ class VkRuntime ::Impl {
     num_pending_kernels_ = 0;
   }
 
-  const VulkanCapabilities &get_capabilities() const {
-    return embedded_device_->get_capabilities();
+  Device *get_ti_device() const {
+    return embedded_device_->get_ti_device();
   }
 
  private:
@@ -519,7 +520,8 @@ class VkRuntime ::Impl {
                                   "vkGetPhysicalDeviceMemoryProperties2KHR"));
 
     VmaAllocatorCreateInfo allocatorInfo = {};
-    allocatorInfo.vulkanApiVersion = get_capabilities().api_version;
+    allocatorInfo.vulkanApiVersion = embedded_device_->get_ti_device()->get_cap(
+        DeviceCapability::vk_api_version);
     allocatorInfo.physicalDevice = embedded_device_->physical_device();
     allocatorInfo.device = embedded_device_->device()->device();
     allocatorInfo.instance = embedded_device_->instance();
@@ -604,11 +606,13 @@ void VkRuntime::synchronize() {
   impl_->synchronize();
 }
 
+Device *VkRuntime::get_ti_device() const {
 #ifdef TI_WITH_VULKAN
-const VulkanCapabilities &VkRuntime::get_capabilities() const {
-  return impl_->get_capabilities();
-}
+  return impl_->get_ti_device();
+#else
+  return nullptr;
 #endif
+}
 
 bool is_vulkan_api_available() {
 #ifdef TI_WITH_VULKAN

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -449,8 +449,8 @@ class VkRuntime ::Impl {
     auto *ti_kernel = ti_kernels_[handle.id_].get();
     auto ctx_blitter = HostDeviceContextBlitter::maybe_make(
         &ti_kernel->ti_kernel_attribs().ctx_attribs, host_ctx,
-        embedded_device_->get_ti_device(), host_result_buffer_, ti_kernel->ctx_buffer(),
-        ti_kernel->ctx_buffer_host());
+        embedded_device_->get_ti_device(), host_result_buffer_,
+        ti_kernel->ctx_buffer(), ti_kernel->ctx_buffer_host());
     if (ctx_blitter) {
       TI_ASSERT(ti_kernel->ctx_buffer() != nullptr);
       ctx_blitter->host_to_device();

--- a/taichi/backends/vulkan/runtime.h
+++ b/taichi/backends/vulkan/runtime.h
@@ -12,8 +12,6 @@ namespace taichi {
 namespace lang {
 namespace vulkan {
 
-struct VulkanCapabilities;
-
 class VkRuntime {
  private:
   class Impl;

--- a/taichi/backends/vulkan/runtime.h
+++ b/taichi/backends/vulkan/runtime.h
@@ -49,7 +49,7 @@ class VkRuntime {
 
   void synchronize();
 
-  Device *VkRuntime::get_ti_device() const;
+  Device *get_ti_device() const;
 
  private:
   std::unique_ptr<Impl> impl_;

--- a/taichi/backends/vulkan/runtime.h
+++ b/taichi/backends/vulkan/runtime.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 
+#include "taichi/backends/device.h"
 #include "taichi/backends/vulkan/snode_struct_compiler.h"
 #include "taichi/backends/vulkan/kernel_utils.h"
 #include "taichi/program/compile_config.h"
@@ -48,9 +49,7 @@ class VkRuntime {
 
   void synchronize();
 
-#ifdef TI_WITH_VULKAN
-  const VulkanCapabilities &get_capabilities() const;
-#endif
+  Device *VkRuntime::get_ti_device() const;
 
  private:
   std::unique_ptr<Impl> impl_;

--- a/taichi/backends/vulkan/spirv_ir_builder.cpp
+++ b/taichi/backends/vulkan/spirv_ir_builder.cpp
@@ -5,13 +5,16 @@ namespace lang {
 namespace vulkan {
 
 namespace spirv {
+
+using cap = DeviceCapability;
+
 void IRBuilder::init_header() {
   TI_ASSERT(header_.size() == 0U);
   header_.push_back(spv::MagicNumber);
 
-  header_.push_back(vulkan_cap_.spirv_version);
+  header_.push_back(device_->get_cap(cap::vk_spirv_version));
 
-  TI_TRACE("SPIR-V Version {}", vulkan_cap_.spirv_version);
+  TI_TRACE("SPIR-V Version {}", device_->get_cap(cap::vk_spirv_version));
 
   // generator: set to 0, unknown
   header_.push_back(0U);
@@ -23,56 +26,57 @@ void IRBuilder::init_header() {
   // capability
   ib_.begin(spv::OpCapability).add(spv::CapabilityShader).commit(&header_);
 
-  if (vulkan_cap_.has_atomic_float_add) {
-    if (vulkan_cap_.has_float64) {
-      ib_.begin(spv::OpCapability)
-          .add(spv::CapabilityAtomicFloat64AddEXT)
-          .commit(&header_);
-    }
+  if (device_->get_cap(cap::vk_has_atomic_float64_add)) {
+    ib_.begin(spv::OpCapability)
+        .add(spv::CapabilityAtomicFloat64AddEXT)
+        .commit(&header_);
+  }
+
+  if (device_->get_cap(cap::vk_has_atomic_float_add)) {
     ib_.begin(spv::OpCapability)
         .add(spv::CapabilityAtomicFloat32AddEXT)
         .commit(&header_);
   }
 
-  if (vulkan_cap_.has_atomic_float_minmax) {
-    if (vulkan_cap_.has_float64) {
-      ib_.begin(spv::OpCapability)
-          .add(spv::CapabilityAtomicFloat64MinMaxEXT)
-          .commit(&header_);
-    }
+  if (device_->get_cap(cap::vk_has_atomic_float_minmax)) {
     ib_.begin(spv::OpCapability)
         .add(spv::CapabilityAtomicFloat32MinMaxEXT)
         .commit(&header_);
   }
 
-  if (vulkan_cap_.has_int8) {
+  if (device_->get_cap(cap::vk_has_int8)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt8).commit(&header_);
   }
-  if (vulkan_cap_.has_int16) {
+  if (device_->get_cap(cap::vk_has_int16)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt16).commit(&header_);
   }
-  if (vulkan_cap_.has_int64) {
+  if (device_->get_cap(cap::vk_has_int64)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt64).commit(&header_);
   }
-  if (vulkan_cap_.has_float16) {
+  if (device_->get_cap(cap::vk_has_float16)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityFloat16).commit(&header_);
   }
-  if (vulkan_cap_.has_float64) {
+  if (device_->get_cap(cap::vk_has_float64)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityFloat64).commit(&header_);
   }
 
   ib_.begin(spv::OpExtension)
       .add("SPV_KHR_storage_buffer_storage_class")
       .commit(&header_);
-  ib_.begin(spv::OpExtension).add("SPV_KHR_variable_pointers").commit(&header_);
+  
+  if (device_->get_cap(cap::vk_has_spv_variable_ptr)) {
+    ib_.begin(spv::OpExtension)
+        .add("SPV_KHR_variable_pointers")
+        .commit(&header_);
+  }
 
-  if (vulkan_cap_.has_atomic_float_add) {
+  if (device_->get_cap(cap::vk_has_atomic_float_add)) {
     ib_.begin(spv::OpExtension)
         .add("SPV_EXT_shader_atomic_float_add")
         .commit(&header_);
   }
 
-  if (vulkan_cap_.has_atomic_float_minmax) {
+  if (device_->get_cap(cap::vk_has_atomic_float_minmax)) {
     ib_.begin(spv::OpExtension)
         .add("SPV_EXT_shader_atomic_float_min_max")
         .commit(&header_);
@@ -109,22 +113,22 @@ std::vector<uint32_t> IRBuilder::finalize() {
 void IRBuilder::init_pre_defs() {
   ext_glsl450_ = ext_inst_import("GLSL.std.450");
   t_bool_ = declare_primitive_type(get_data_type<bool>());
-  if (vulkan_cap_.has_int8) {
+  if (device_->get_cap(cap::vk_has_int8)) {
     t_int8_ = declare_primitive_type(get_data_type<int8>());
     t_uint8_ = declare_primitive_type(get_data_type<uint8>());
   }
-  if (vulkan_cap_.has_int16) {
+  if (device_->get_cap(cap::vk_has_int16)) {
     t_int16_ = declare_primitive_type(get_data_type<int16>());
     t_uint16_ = declare_primitive_type(get_data_type<uint16>());
   }
   t_int32_ = declare_primitive_type(get_data_type<int32>());
   t_uint32_ = declare_primitive_type(get_data_type<uint32>());
-  if (vulkan_cap_.has_int64) {
+  if (device_->get_cap(cap::vk_has_int64)) {
     t_int64_ = declare_primitive_type(get_data_type<int64>());
     t_uint64_ = declare_primitive_type(get_data_type<uint64>());
   }
   t_fp32_ = declare_primitive_type(get_data_type<float32>());
-  if (vulkan_cap_.has_float64) {
+  if (device_->get_cap(cap::vk_has_float64)) {
     t_fp64_ = declare_primitive_type(get_data_type<float64>());
   }
   // declare void, and void functions
@@ -201,35 +205,35 @@ SType IRBuilder::get_primitive_type(const DataType &dt) const {
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
     return t_fp32_;
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
-    if (!vulkan_cap_.has_float64)
+    if (!device_->get_cap(cap::vk_has_float64))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_fp64_;
   } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
-    if (!vulkan_cap_.has_int8)
+    if (!device_->get_cap(cap::vk_has_int8))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_int8_;
   } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
-    if (!vulkan_cap_.has_int16)
+    if (!device_->get_cap(cap::vk_has_int16))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_int16_;
   } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
     return t_int32_;
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
-    if (!vulkan_cap_.has_int64)
+    if (!device_->get_cap(cap::vk_has_int64))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_int64_;
   } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
-    if (!vulkan_cap_.has_int8)
+    if (!device_->get_cap(cap::vk_has_int8))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_uint8_;
   } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
-    if (!vulkan_cap_.has_int16)
+    if (!device_->get_cap(cap::vk_has_int16))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_uint16_;
   } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
     return t_uint32_;
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    if (!vulkan_cap_.has_int64)
+    if (!device_->get_cap(cap::vk_has_int64))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_uint64_;
   } else {
@@ -238,14 +242,14 @@ SType IRBuilder::get_primitive_type(const DataType &dt) const {
 }
 
 SType IRBuilder::get_primitive_buffer_type(const DataType &dt) const {
-  if (vulkan_cap_.has_atomic_float_add) {
-    if (dt->is_primitive(PrimitiveTypeID::f32)) {
-      return t_fp32_;
-    } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
-      return t_fp64_;
-    }
-  } else if (vulkan_cap_.has_atomic_i64 &&
-             dt->is_primitive(PrimitiveTypeID::i64)) {
+  if (dt->is_primitive(PrimitiveTypeID::f32) &&
+      device_->get_cap(cap::vk_has_atomic_float_add)) {
+    return t_fp32_;
+  } else if (dt->is_primitive(PrimitiveTypeID::f64) &&
+             device_->get_cap(cap::vk_has_atomic_float64_add)) {
+    return t_fp64_;
+  } else if (dt->is_primitive(PrimitiveTypeID::i64) &&
+             device_->get_cap(cap::vk_has_atomic_i64)) {
     return t_int64_;
   }
   return t_int32_;
@@ -312,7 +316,7 @@ SType IRBuilder::get_struct_array_type(const SType &value_type,
       .add_seq(struct_type, 0, spv::DecorationOffset, 0)
       .commit(&decorate_);
 
-  if (vulkan_cap_.spirv_version < 0x10300) {
+  if (device_->get_cap(cap::vk_spirv_version) < 0x10300) {
     // NOTE: BufferBlock was deprecated in SPIRV 1.3
     // use StorageClassStorageBuffer instead.
     // runtime array are always decorated as BufferBlock(shader storage buffer)
@@ -332,7 +336,7 @@ Value IRBuilder::buffer_argument(const SType &value_type,
   // NOTE: BufferBlock was deprecated in SPIRV 1.3
   // use StorageClassStorageBuffer instead.
   spv::StorageClass storage_class;
-  if (vulkan_cap_.spirv_version < 0x10300) {
+  if (device_->get_cap(cap::vk_spirv_version) < 0x10300) {
     storage_class = spv::StorageClassUniform;
   } else {
     storage_class = spv::StorageClassStorageBuffer;
@@ -358,7 +362,7 @@ Value IRBuilder::struct_array_access(const SType &res_type,
   TI_ASSERT(res_type.flag == TypeKind::kPrimitive);
 
   spv::StorageClass storage_class;
-  if (vulkan_cap_.spirv_version < 0x10300) {
+  if (device_->get_cap(cap::vk_spirv_version) < 0x10300) {
     storage_class = spv::StorageClassUniform;
   } else {
     storage_class = spv::StorageClassStorageBuffer;

--- a/taichi/backends/vulkan/spirv_ir_builder.h
+++ b/taichi/backends/vulkan/spirv_ir_builder.h
@@ -203,7 +203,7 @@ class InstrBuilder {
 // Builder to build up a single SPIR-V module
 class IRBuilder {
  public:
-  IRBuilder(const VulkanCapabilities &vulkan_cap) : vulkan_cap_(vulkan_cap) {
+  IRBuilder(const Device *device) : device_(device) {
   }
 
   template <typename... Args>
@@ -433,10 +433,6 @@ class IRBuilder {
   Value rand_f32(Value global_tmp_);
   Value rand_i32(Value global_tmp_);
 
-  const VulkanCapabilities &get_vulkan_cap() const {
-    return vulkan_cap_;
-  }
-
  private:
   Value new_value(const SType &type, ValueKind flag) {
     Value val;
@@ -451,7 +447,7 @@ class IRBuilder {
 
   void init_random_function(Value global_tmp_);
 
-  const VulkanCapabilities &vulkan_cap_;
+  const Device *device_;
 
   // internal instruction builder
   InstrBuilder ib_;

--- a/taichi/backends/vulkan/vulkan_api.h
+++ b/taichi/backends/vulkan/vulkan_api.h
@@ -5,6 +5,8 @@
 #include <vulkan/vulkan.h>
 #include <vulkan/vulkan_core.h>
 
+#include <taichi/backends/device.h>
+
 #include <memory>
 #include <optional>
 #include <vector>
@@ -119,24 +121,6 @@ class VulkanDevice {
   Params rep_;
 };
 
-struct VulkanCapabilities {
-  uint32_t api_version;
-  uint32_t spirv_version;
-
-  bool has_int8{false};
-  bool has_int16{false};
-  bool has_int64{false};
-  bool has_float16{false};
-  bool has_float64{false};
-
-  bool has_nvidia_interop{false};
-  bool has_atomic_i64{false};
-  bool has_atomic_float_add{false};
-  bool has_atomic_float_minmax{false};
-  bool has_presentation{false};
-  bool has_spv_variable_ptr{false};
-};
-
 /**
  * This class creates a VulkanDevice instance. The underlying Vk* resources are
  * embedded directly inside the class.
@@ -185,8 +169,8 @@ class EmbeddedVulkanDevice {
     return queue_family_indices_;
   }
 
-  const VulkanCapabilities &get_capabilities() const {
-    return capability_;
+  Device *get_ti_device() const {
+    return ti_device_.get();
   }
 
  private:
@@ -220,8 +204,7 @@ class EmbeddedVulkanDevice {
   // commands, respectively?
   VkCommandPool command_pool_{VK_NULL_HANDLE};
 
-  VulkanCapabilities capability_;
-
+  std::unique_ptr<Device> ti_device_{nullptr};
   std::unique_ptr<VulkanDevice> owned_device_{nullptr};
 
   Params params_;


### PR DESCRIPTION
- Added the very first initial piece of Device API and moving capability queries to that. (So now the codegen is decoupled from the runtime)
- Query & enable features properly (previously we don't query the feature support within an extension, e.g. a device may support f16 but not i8)