### PR TITLE
[Lang] Add a Ndarray class to serve as an alternative to dense scalar fields

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -971,7 +971,7 @@ def archs_support_sparse(test, **kwargs):
 def torch_test(func):
     if ti.has_pytorch():
         # OpenGL somehow crashes torch test without a reason, unforturnately
-        return ti.archs_excluding(ti.opengl)(func)
+        return ti.test(exclude=[opengl])(func)
     else:
         return lambda: None
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -9,10 +9,11 @@ from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.ext_array import ExtArray
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.matrix import MatrixField
+from taichi.lang.ndarray import Ndarray
 from taichi.lang.snode import SNode
 from taichi.lang.tape import TapeImpl
-from taichi.lang.util import (cook_dtype, is_taichi_class, python_scope,
-                              taichi_scope)
+from taichi.lang.util import (cook_dtype, has_pytorch, is_taichi_class, python_scope,
+                              taichi_scope, to_pytorch_type)
 from taichi.misc.util import deprecated, get_traceback, warning
 from taichi.snode.fields_builder import FieldsBuilder
 
@@ -554,6 +555,33 @@ def field(dtype, shape=None, name="", offset=None, needs_grad=False):
         if needs_grad:
             root.dense(index_nd(dim), shape).place(x_grad)
     return x
+
+
+@python_scope
+def ndarray(dtype, shape):
+    """Defines a default Taichi ndarray.
+
+    It is currently implemented with a torch tensor.
+
+    Args:
+        dtype (DataType): Data type of the ndarray.
+        shape (Union[int, tuple[int]]): Shape of the ndarray.
+
+    Example:
+        The code below shows how a Taichi field can be declared and defined::
+
+            >>> x = ti.ndarray(ti.f32, shape=(16, 8))
+    """
+    if isinstance(shape, numbers.Number):
+        shape = (shape, )
+    assert has_pytorch(), "PyTorch must be available if you want to create a default Taichi ndarray."
+    import torch
+    if current_cfg().arch == _ti_core.Arch.cuda:
+        device = 'cuda:0'
+    else:
+        device = 'cpu'
+    arr = torch.empty(shape, dtype=to_pytorch_type(dtype), device=device)
+    return Ndarray(arr)
 
 
 class Layout:

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -12,8 +12,8 @@ from taichi.lang.matrix import MatrixField
 from taichi.lang.ndarray import Ndarray
 from taichi.lang.snode import SNode
 from taichi.lang.tape import TapeImpl
-from taichi.lang.util import (cook_dtype, has_pytorch, is_taichi_class, python_scope,
-                              taichi_scope, to_pytorch_type)
+from taichi.lang.util import (cook_dtype, has_pytorch, is_taichi_class,
+                              python_scope, taichi_scope, to_pytorch_type)
 from taichi.misc.util import deprecated, get_traceback, warning
 from taichi.snode.fields_builder import FieldsBuilder
 
@@ -574,7 +574,8 @@ def ndarray(dtype, shape):
     """
     if isinstance(shape, numbers.Number):
         shape = (shape, )
-    assert has_pytorch(), "PyTorch must be available if you want to create a default Taichi ndarray."
+    assert has_pytorch(
+    ), "PyTorch must be available if you want to create a default Taichi ndarray."
     import torch
     if current_cfg().arch == _ti_core.Arch.cuda:
         device = 'cuda:0'

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -11,6 +11,7 @@ from taichi.lang import impl, util
 from taichi.lang.ast_checker import KernelSimplicityASTChecker
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.kernel_arguments import ext_arr, template
+from taichi.lang.ndarray import Ndarray
 from taichi.lang.shell import _shell_pop_print, oinspect
 from taichi.lang.transformer import ASTTransformerTotal
 from taichi.misc.util import obsolete
@@ -480,7 +481,9 @@ class Kernel:
                     if not isinstance(v, int):
                         raise KernelArgError(i, needed.to_string(), provided)
                     launch_ctx.set_arg_int(actual_argument_slot, int(v))
-                elif self.match_ext_arr(v, needed):
+                elif isinstance(needed, ext_arr) and (isinstance(v, Ndarray) or self.match_ext_arr(v)):
+                    if isinstance(v, Ndarray):
+                        v = v.arr
                     has_external_arrays = True
                     has_torch = util.has_pytorch()
                     is_numpy = isinstance(v, np.ndarray)
@@ -564,15 +567,12 @@ class Kernel:
 
         return func__
 
-    def match_ext_arr(self, v, needed):
-        needs_array = isinstance(
-            needed, np.ndarray) or needed == np.ndarray or isinstance(
-                needed, ext_arr)
+    def match_ext_arr(self, v):
         has_array = isinstance(v, np.ndarray)
         if not has_array and util.has_pytorch():
             import torch
             has_array = isinstance(v, torch.Tensor)
-        return has_array and needs_array
+        return has_array
 
     def ensure_compiled(self, *args):
         instance_id, arg_features = self.mapper.lookup(args)

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -481,7 +481,8 @@ class Kernel:
                     if not isinstance(v, int):
                         raise KernelArgError(i, needed.to_string(), provided)
                     launch_ctx.set_arg_int(actual_argument_slot, int(v))
-                elif isinstance(needed, ext_arr) and (isinstance(v, Ndarray) or self.match_ext_arr(v)):
+                elif isinstance(needed, ext_arr) and (isinstance(v, Ndarray) or
+                                                      self.match_ext_arr(v)):
                     if isinstance(v, Ndarray):
                         v = v.arr
                     has_external_arrays = True

--- a/python/taichi/lang/ndarray.py
+++ b/python/taichi/lang/ndarray.py
@@ -1,0 +1,45 @@
+from taichi.lang.util import has_pytorch, python_scope, to_taichi_type
+
+
+class Ndarray:
+    """Taichi ndarray class implemented with an external array.
+
+    Currently, a torch tensor or a numpy ndarray is supported.
+
+    Args:
+        arr: The external array.
+    """
+    def __init__(self, arr):
+        import numpy as np
+        valid = isinstance(arr, np.ndarray)
+        if not valid and has_pytorch():
+            import torch
+            valid = isinstance(arr, torch.Tensor)
+        assert valid, "Only a torch tensor or a numpy ndarray is supported as Taichi ndarray implementation now."
+        self.arr = arr
+
+    @property
+    def shape(self):
+        """Gets ndarray shape.
+
+        Returns:
+            Tuple[Int]: Ndarray shape.
+        """
+        return tuple(self.arr.shape)
+
+    @property
+    def dtype(self):
+        """Gets data type of each individual value.
+
+        Returns:
+            DataType: Data type of each individual value.
+        """
+        return to_taichi_type(self.arr.dtype)
+
+    @python_scope
+    def __getitem__(self, item):
+        return self.arr.__getitem__(item)
+
+    @python_scope
+    def __setitem__(self, key, value):
+        return self.arr.__setitem__(key, value)

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -53,3 +53,17 @@ def test_get_external_tensor_shape_access_torch(size):
         y_hat = func(x_hat, idx)
         assert y_ref == y_hat, "Size of axis {} should equal {} and not {}.".format(
             idx, y_ref, y_hat)
+
+
+@ti.torch_test
+@pytest.mark.parametrize('size', [[1, 2, 3, 4]])
+def test_get_external_tensor_shape_access_ndarray(size):
+    @ti.kernel
+    def func(x: ti.ext_arr(), index: ti.template()) -> ti.i32:
+        return x.shape[index]
+
+    x_hat = ti.ndarray(ti.i32, shape=size)
+    for idx, y_ref in enumerate(size):
+        y_hat = func(x_hat, idx)
+        assert y_ref == y_hat, "Size of axis {} should equal {} and not {}.".format(
+            idx, y_ref, y_hat)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -1,0 +1,47 @@
+import taichi as ti
+
+import numpy as np
+if ti.has_pytorch():
+    import torch
+
+
+def _test_ndarray_2d(n, m, a):
+    @ti.kernel
+    def run(arr: ti.ext_arr()):
+        for i in range(n):
+            for j in range(m):
+                arr[i, j] += i + j
+
+    for i in range(n):
+        for j in range(m):
+            a[i, j] = i * j
+
+    run(a)
+
+    for i in range(n):
+        for j in range(m):
+            assert a[i, j] == i * j + i + j
+
+
+@ti.test()
+def test_ndarray_numpy_2d():
+    n = 4
+    m = 7
+    a = ti.Ndarray(np.empty(shape=(n, m), dtype=np.int32))
+    _test_ndarray_2d(n, m, a)
+
+
+@ti.torch_test
+def test_ndarray_torch_2d():
+    n = 4
+    m = 7
+    a = ti.Ndarray(torch.empty((n, m), dtype=torch.int32))
+    _test_ndarray_2d(n, m, a)
+
+
+@ti.torch_test
+def test_ndarray_default_2d():
+    n = 4
+    m = 7
+    a = ti.ndarray(ti.i32, shape=(n, m))
+    _test_ndarray_2d(n, m, a)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 import taichi as ti
 
-import numpy as np
 if ti.has_pytorch():
     import torch
 


### PR DESCRIPTION
Related issue = #

Usage:
```
a = ti.ndarray(ti.i32, shape=(n, m)) // by default torch tensor is used
// arbitrary initialization using numpy arrays and torch tensors is also supported
b = ti.Ndarray(np.empty(shape=(n, m), dtype=np.int32))
c = ti.Ndarray(torch.empty((n, m), dtype=torch.int32))
```

When passing it to Taichi kernels, you need to annotate it as `ti.ext_arr()` for now.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
