### PR TITLE
[Refactor] Re-enable gdb attach on crash

### DIFF
--- a/taichi/common/core.cpp
+++ b/taichi/common/core.cpp
@@ -8,6 +8,13 @@
 #include "taichi/common/version.h"
 #include "taichi/common/commit_hash.h"
 
+#if defined(TI_PLATFORM_WINDOWS)
+#include "taichi/platform/windows/windows.h"
+#else
+// Mac and Linux
+#include <unistd.h>
+#endif
+
 TI_NAMESPACE_BEGIN
 
 extern "C" {
@@ -87,6 +94,23 @@ std::string get_commit_hash() {
 
 std::string get_cuda_version_string() {
   return TI_CUDAVERSION;
+}
+
+int PID::get_pid() {
+#if defined(TI_PLATFORM_WINDOWS)
+  return (int)GetCurrentProcessId();
+#else
+  return (int)getpid();
+#endif
+}
+
+int PID::get_parent_pid() {
+#if defined(TI_PLATFORM_WINDOWS)
+  TI_NOT_IMPLEMENTED
+  return -1;
+#else
+  return (int)getppid();
+#endif
 }
 
 TI_NAMESPACE_END

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -367,4 +367,10 @@ std::string get_commit_hash();
 
 std::string get_cuda_version_string();
 
+class PID {
+ public:
+  static int get_pid();
+  static int get_parent_pid();
+};
+
 TI_NAMESPACE_END

--- a/taichi/common/logging.cpp
+++ b/taichi/common/logging.cpp
@@ -85,13 +85,11 @@ void Logger::error(const std::string &s, bool raise_exception) {
   if (print_stacktrace_fn_) {
     print_stacktrace_fn_();
   }
-  // Disable this to decouple from taichi/system/threading
-  // Also I doubt if GDB still works...
-  //   if (taichi::CoreState::get_instance().trigger_gdb_when_crash) {
-  // #if defined(TI_PLATFORM_LINUX)
-  //     trash(system(fmt::format("sudo gdb -p {}", PID::get_pid()).c_str()));
-  // #endif
-  //   }
+  if (taichi::CoreState::get_instance().trigger_gdb_when_crash) {
+#if defined(TI_PLATFORM_LINUX)
+    trash(system(fmt::format("sudo gdb -p {}", PID::get_pid()).c_str()));
+#endif
+  }
   if (raise_exception)
     throw s;
 }

--- a/taichi/system/threading.cpp
+++ b/taichi/system/threading.cpp
@@ -5,14 +5,6 @@
 
 #include "taichi/system/threading.h"
 
-#if defined(TI_PLATFORM_WINDOWS)
-#include "taichi/platform/windows/windows.h"
-#else
-// Mac and Linux
-#include "threading.h"
-#include <unistd.h>
-#endif
-
 #include <algorithm>
 #include <condition_variable>
 #include <thread>
@@ -32,23 +24,6 @@ bool test_threading() {
     });
   }
   return true;
-}
-
-int PID::get_pid() {
-#if defined(TI_PLATFORM_WINDOWS)
-  return (int)GetCurrentProcessId();
-#else
-  return (int)getpid();
-#endif
-}
-
-int PID::get_parent_pid() {
-#if defined(TI_PLATFORM_WINDOWS)
-  TI_NOT_IMPLEMENTED
-  return -1;
-#else
-  return (int)getppid();
-#endif
 }
 
 ThreadPool::ThreadPool(int max_num_threads) : max_num_threads(max_num_threads) {

--- a/taichi/system/threading.h
+++ b/taichi/system/threading.h
@@ -17,12 +17,6 @@ TI_NAMESPACE_BEGIN
 using RangeForTaskFunc = void(void *, int thread_id, int i);
 using ParallelFor = void(int n, int num_threads, void *, RangeForTaskFunc func);
 
-class PID {
- public:
-  static int get_pid();
-  static int get_parent_pid();
-};
-
 class ThreadPool {
  public:
   std::vector<std::thread> threads;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #2681

PID struct seems pretty self-contained so let's move it to
core.h/core.cpp in taichi/common/. This ensures no dependency from
taichi/common to taichi/system. This PR also re-enables the developer
feature that automatically attaching when crash happens.