### PR TITLE
[Refactor] Allow taichi_cpp_tests run in release mode as well.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -99,9 +99,9 @@ jobs:
           python examples/algorithm/laplace.py
           ti diagnose
           ti changelog
-          # TODO: make cpp tests work in both release & dev mode.
-          # Currently cpp tests only works in dev mode since it depends on the path set there.
-          TAICHI_REPO_DIR=$TAICHI_REPO_DIR ./build/taichi_cpp_tests
+          # taichi_cpp_tests requires passing in TI_LIB_DIR manually.
+          TI_LIB_DIR=`python -c "import taichi;print(taichi.__path__[0])" | tail -1`
+          TI_LIB_DIR=$TI_LIB_DIR ./build/taichi_cpp_tests
           ti test -vr2 -t2
 
   build_and_test_cpu:
@@ -171,9 +171,9 @@ jobs:
           python examples/algorithm/laplace.py
           ti diagnose
           ti changelog
-          # TODO: make cpp tests work in both release & dev mode.
-          # Currently cpp tests only works in dev mode since it depends on the path set there.
-          [ "$RUN_CPP_TESTS" = "ON" ] && TAICHI_REPO_DIR=$TAICHI_REPO_DIR ./build/taichi_cpp_tests
+          # taichi_cpp_tests requires passing in TI_LIB_DIR manually.
+          TI_LIB_DIR=`python -c "import taichi;print(taichi.__path__[0])" | tail -1`
+          [ "$RUN_CPP_TESTS" = "ON" ] && TI_LIB_DIR=$TI_LIB_DIR ./build/taichi_cpp_tests
           ti test -vr2 -t2
         env:
           RUN_CPP_TESTS: ${{ matrix.with_cpp_tests }}

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -101,7 +101,7 @@ jobs:
           ti changelog
           # taichi_cpp_tests requires passing in TI_LIB_DIR manually.
           TI_LIB_DIR=`python -c "import taichi;print(taichi.__path__[0])" | tail -1`
-          TI_LIB_DIR=$TI_LIB_DIR ./build/taichi_cpp_tests
+          TI_LIB_DIR="$TI_LIB_DIR/lib" ./build/taichi_cpp_tests
           ti test -vr2 -t2
 
   build_and_test_cpu:
@@ -173,7 +173,7 @@ jobs:
           ti changelog
           # taichi_cpp_tests requires passing in TI_LIB_DIR manually.
           TI_LIB_DIR=`python -c "import taichi;print(taichi.__path__[0])" | tail -1`
-          [ "$RUN_CPP_TESTS" = "ON" ] && TI_LIB_DIR=$TI_LIB_DIR ./build/taichi_cpp_tests
+          [ "$RUN_CPP_TESTS" = "ON" ] && TI_LIB_DIR="$TI_LIB_DIR/lib" ./build/taichi_cpp_tests
           ti test -vr2 -t2
         env:
           RUN_CPP_TESTS: ${{ matrix.with_cpp_tests }}

--- a/taichi/gui/gui.h
+++ b/taichi/gui/gui.h
@@ -410,7 +410,7 @@ class Canvas {
     position = transform(position);
     std::string folder;
     if (is_release()) {
-      folder = fmt::format("{}/../assets", lang::compiled_lib_dir);
+      folder = fmt::format("{}/../assets", lang::runtime_lib_dir());
     } else {
       folder = fmt::format("{}/external/assets", get_repo_dir());
     }

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -19,11 +19,14 @@ std::string runtime_tmp_dir;
 std::string runtime_lib_dir() {
   std::string folder;
   if (!compiled_lib_dir.empty()) {
-      folder = compiled_lib_dir;
+    folder = compiled_lib_dir;
   } else {
-      auto ti_lib_dir = getenv("TI_LIB_DIR");
-      TI_ERROR_IF(!ti_lib_dir, "If you are running the taichi_cpp_tests please set TI_LIB_DIR to $TAICHI_INSTALL_DIR/lib where TAICHI_INSTALL_DIR can be retrieved from taichi.__path__ in python");
-      folder = std::string(ti_lib_dir);
+    auto ti_lib_dir = getenv("TI_LIB_DIR");
+    TI_ERROR_IF(!ti_lib_dir,
+                "If you are running the taichi_cpp_tests please set TI_LIB_DIR "
+                "to $TAICHI_INSTALL_DIR/lib where TAICHI_INSTALL_DIR can be "
+                "retrieved from taichi.__path__ in python");
+    folder = std::string(ti_lib_dir);
   }
   return folder;
 }

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -16,6 +16,18 @@ CompileConfig default_compile_config;
 std::string compiled_lib_dir;
 std::string runtime_tmp_dir;
 
+std::string runtime_lib_dir() {
+  std::string folder;
+  if (!compiled_lib_dir.empty()) {
+      folder = compiled_lib_dir;
+  } else {
+      auto ti_lib_dir = getenv("TI_LIB_DIR");
+      TI_ERROR_IF(!ti_lib_dir, "If you are running the taichi_cpp_tests please set TI_LIB_DIR to $TAICHI_INSTALL_DIR/lib where TAICHI_INSTALL_DIR can be retrieved from taichi.__path__ in python");
+      folder = std::string(ti_lib_dir);
+  }
+  return folder;
+}
+
 real get_cpu_frequency() {
   static real cpu_frequency = 0;
   if (cpu_frequency == 0) {

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -61,6 +61,7 @@ std::string make_list(const std::vector<T> &data,
 
 extern std::string compiled_lib_dir;
 extern std::string runtime_tmp_dir;
+std::string runtime_lib_dir();
 
 bool command_exist(const std::string &command);
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -233,7 +233,7 @@ void compile_runtime_bitcode(Arch arch) {
 std::string libdevice_path() {
   std::string folder;
   if (is_release()) {
-    folder = compiled_lib_dir;
+    folder = runtime_lib_dir();
   } else {
     folder = fmt::format("{}/external/cuda_libdevice", get_repo_dir());
   }
@@ -359,7 +359,7 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_runtime_module() {
   if (!data->runtime_module) {
     if (is_release()) {
       data->runtime_module = module_from_bitcode_file(
-          fmt::format("{}/{}", compiled_lib_dir, get_runtime_fn(arch)), ctx);
+          fmt::format("{}/{}", runtime_lib_dir(), get_runtime_fn(arch)), ctx);
     } else {
       compile_runtime_bitcode(arch);
       data->runtime_module = module_from_bitcode_file(


### PR DESCRIPTION
taichi_cpp_tests used to depend on `TAICHI_REPO_DIR` and thus only runs
in dev mode. This PR decouples them, instead we explicitly ask users to
pass in `TI_LIB_DIR` if they want to run the cpp tests.

Note this PR will unblock `TAICHI_REPO_DIR` and is_release check removal in the codebase.

Also instead of a crash report, we'll properly throw an error
message to remind setting `TI_LIB_DIR` when running cpp tests.

```
[E 08/14/21 14:34:16.990 2077742] [lang_util.cpp:runtime_lib_dir@25]
If you are running the taichi_cpp_tests please set TI_LIB_DIR to
$TAICHI_INSTALL_DIR/lib where TAICHI_INSTALL_DIR can be retrieved from
taichi.__path__ in python
```
