### PR TITLE
[CUDA] Save an extra host to device copy if arg_buffer is already on device.

### DIFF
--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -35,6 +35,10 @@ constexpr uint32 CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75;
 constexpr uint32 CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76;
 constexpr uint32 CUDA_ERROR_ASSERT = 710;
 constexpr uint32 CU_JIT_MAX_REGISTERS = 0;
+constexpr uint32 CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2;
+constexpr uint32 CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING = 41;
+constexpr uint32 CUDA_SUCCESS = 0;
+constexpr uint32 CU_MEMORYTYPE_DEVICE = 2;
 
 std::string get_cuda_error_message(uint32 err);
 

--- a/taichi/backends/cuda/cuda_driver_functions.inc.h
+++ b/taichi/backends/cuda/cuda_driver_functions.inc.h
@@ -30,6 +30,7 @@ PER_CUDA_FUNCTION(memset, cuMemsetD8_v2, void *, uint8, std::size_t);
 PER_CUDA_FUNCTION(mem_free, cuMemFree_v2, void *);
 PER_CUDA_FUNCTION(mem_advise, cuMemAdvise, void *, std::size_t, uint32, uint32);
 PER_CUDA_FUNCTION(mem_get_info, cuMemGetInfo_v2, std::size_t *, std::size_t *);
+PER_CUDA_FUNCTION(mem_get_attribute, cuPointerGetAttribute, void *, uint32, void *);
 
 // Module and kernels
 PER_CUDA_FUNCTION(module_get_function, cuModuleGetFunction, void **, void *, const char *);

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -235,25 +235,3 @@ def test_torch_zero():
     test_torch(torch.zeros((0), dtype=torch.int32))
     test_torch(torch.zeros((0, 5), dtype=torch.int32))
     test_torch(torch.zeros((5, 0, 5), dtype=torch.int32))
-
-
-@ti.torch_test
-def test_torch_on_arch_cuda():
-    if not torch.cuda.is_available():
-        print('Skipping torch cuda test due to cuda not available')
-        return
-    ti.init(arch=ti.cuda)
-    n = 16
-
-    @ti.kernel
-    def update(x: ti.ext_arr(), y: ti.ext_arr()):
-        for i in range(n):
-            x[i] = y[i] + 1
-
-    x = torch.from_numpy(np.random.randn(n).astype(np.float32)).to('cpu')
-    y = torch.from_numpy(np.random.randn(n).astype(np.float32)).to('cpu')
-
-    update(x, y)
-
-    for i in range(n):
-        assert x[i] == y[i] + 1

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -235,3 +235,25 @@ def test_torch_zero():
     test_torch(torch.zeros((0), dtype=torch.int32))
     test_torch(torch.zeros((0, 5), dtype=torch.int32))
     test_torch(torch.zeros((5, 0, 5), dtype=torch.int32))
+
+
+@ti.torch_test
+def test_torch_on_arch_cuda():
+    if not torch.cuda.is_available():
+        print('Skipping torch cuda test due to cuda not available')
+        return
+    ti.init(arch=ti.cuda)
+    n = 16
+
+    @ti.kernel
+    def update(x: ti.ext_arr(), y: ti.ext_arr()):
+        for i in range(n):
+            x[i] = y[i] + 1
+
+    x = torch.from_numpy(np.random.randn(n).astype(np.float32)).to('cpu')
+    y = torch.from_numpy(np.random.randn(n).astype(np.float32)).to('cpu')
+
+    update(x, y)
+
+    for i in range(n):
+        assert x[i] == y[i] + 1


### PR DESCRIPTION
This PR is pretty self contained and came from a discussion with @k-ye. 

I added a new test in test_torch_io.py since we only test cpu arch there, so I want to make sure cuda arch is tested. 

Note to self: I had indeterministic crash when I first tested this PR and crash also happened on master branch. After some time I was no longer able to reproduce the crash so I guess it was due to my GPU in a weird state but not related to this PR. 

Leaving a note here just in case if happens again in the future. 