### PR TITLE
[Refactor] Make is_release always True and delete runtime dep on TAICHI_REPO_DIR

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -76,7 +76,7 @@ def package_root():
 
 
 def is_release():
-    return os.environ.get('TAICHI_REPO_DIR', '') == ''
+    return True
 
 
 def get_core_shared_object():

--- a/python/taichi/diagnose.py
+++ b/python/taichi/diagnose.py
@@ -29,7 +29,6 @@ def main():
     else:
         print(f'{lsb_release.decode()}')
 
-    print(f'TAICHI_REPO_DIR={os.environ.get("TAICHI_REPO_DIR", "")}')
     for k, v in os.environ.items():
         if k.startswith('TI_'):
             print(f'{k}={v}')

--- a/taichi/common/core.cpp
+++ b/taichi/common/core.cpp
@@ -30,12 +30,7 @@ float __wrap_log2f(float x) {
 }
 
 bool is_release() {
-  auto dir = std::getenv("TAICHI_REPO_DIR");
-  if (dir == nullptr || std::string(dir) == "") {
-    return true;
-  } else {
-    return false;
-  }
+  return true;
 }
 
 std::string python_package_dir;
@@ -49,19 +44,14 @@ void set_python_package_dir(const std::string &dir) {
 }
 
 std::string get_repo_dir() {
-  auto dir = std::getenv("TAICHI_REPO_DIR");
-  if (is_release()) {
-    // release mode. Use ~/.taichi as root
+  // release mode. Use ~/.taichi as root
 #if defined(TI_PLATFORM_WINDOWS)
-    return "C:/taichi_cache/";
+  return "C:/taichi_cache/";
 #else
-    auto home = std::getenv("HOME");
-    TI_ASSERT(home != nullptr);
-    return std::string(home) + "/.taichi/";
+  auto home = std::getenv("HOME");
+  TI_ASSERT(home != nullptr);
+  return std::string(home) + "/.taichi/";
 #endif
-  } else {
-    return std::string(dir);
-  }
 }
 
 CoreState &CoreState::get_instance() {

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -335,24 +335,6 @@ inline std::string assets_dir() {
   return get_repo_dir() + "/assets/";
 }
 
-inline std::string absolute_path(std::string path) {
-  // If 'path' is actually relative to TAICHI_REPO_DIR, convert it to an
-  // absolute one. There are three types of paths:
-  //    A. Those who start with / or "C:/" are absolute paths
-  //    B. Those who start with "." are relative to cwd
-  //    C. Those who start with "$" are relative to assets_dir()
-  //    D. Others are relative to $ENV{TAICHI_REPO_DIR}
-
-  TI_ASSERT(!path.empty());
-  if (path[0] == '$') {
-    path = assets_dir() + path.substr(1, (int)path.size() - 1);
-  } else if (path[0] != '.' && path[0] != '/' &&
-             (path.size() >= 2 && path[1] != ':')) {
-    path = get_repo_dir() + "/" + path;
-  }
-  return path;
-}
-
 std::string cpp_demangle(const std::string &mangled_name);
 
 int get_version_major();

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -149,7 +149,6 @@ void export_misc(py::module &m) {
   m.def("clear_profile_info",
         [&]() { Profiling::get_instance().clear_profile_info(); });
   m.def("start_memory_monitoring", start_memory_monitoring);
-  m.def("absolute_path", absolute_path);
   m.def("get_repo_dir", get_repo_dir);
   m.def("get_python_package_dir", get_python_package_dir);
   m.def("set_python_package_dir", set_python_package_dir);


### PR DESCRIPTION
This PR removes runtime dependency on `TAICHI_REPO_DIR` in the codebase. 

Known followups:
- There's a use of `TAICHI_REPO_DIR` in `python/ti.cpp` which is used by
  windows. I'll skip it for now.
- Need to cleanup `TAICHI_REPO_DIR` in docs and examples.

