### PR TITLE
[Misc] Keep debug symbols/line numbers in taichi_core.so by setting DEBUG=1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,10 @@
+# Optional environment variables supported by setup.py:
+#   DEBUG
+#     build the C++ taichi_core extension with debug symbols.
+#
+#   TAICHI_CMAKE_ARGS
+#     extra cmake args for C++ taichi_core extension.
+
 import glob
 import multiprocessing
 import os
@@ -121,6 +128,7 @@ class CMakeBuild(build_ext):
             f'-DTI_VERSION_PATCH={TI_VERSION_PATCH}',
         ]
 
+        self.debug = os.getenv('DEBUG', '0') in ('1', 'ON')
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
 


### PR DESCRIPTION
Our default build of taichi_core.so only has symbol information but not lineno. 

With DEBUG=1 taichi_core.so will keep both debug symbols and line numbers. Now that when we gdb, we can set breakpoints to filename:lineno which is much more convenient. 

Example backtrace: 
```
Thread 1 "python" hit Breakpoint 1, taichi::lang::irpass::compile_to_offloads (ir=0x55555a74bc10, config=..., kernel=0x55555a7a8d70,
    verbose=true, vectorize=false, grad=false, ad_use_stack=true, start_from_ast=true)
    at /home/ailing/github/taichi/taichi/transforms/compile_to_offloads.cpp:42
42        auto print = make_pass_printer(verbose, kernel->get_name(), ir);
(gdb) bt
#0  taichi::lang::irpass::compile_to_offloads (ir=0x55555a74bc10, config=..., kernel=0x55555a7a8d70, verbose=true, vectorize=false,
    grad=false, ad_use_stack=true, start_from_ast=true) at /home/ailing/github/taichi/taichi/transforms/compile_to_offloads.cpp:42
#1  0x00007fff7bb8d995 in taichi::lang::irpass::compile_to_executable (ir=0x55555a74bc10, config=..., kernel=0x55555a7a8d70,
    vectorize=false, grad=false, ad_use_stack=true, verbose=true, lower_global_access=true, make_thread_local=true,
    make_block_local=true, start_from_ast=true) at /home/ailing/github/taichi/taichi/transforms/compile_to_offloads.cpp:256
#2  0x00007fff7ba9df5e in taichi::lang::Kernel::lower (this=0x55555a7a8d70, to_executable=true)
    at /home/ailing/github/taichi/taichi/program/kernel.cpp:103
#3  0x00007fff7bad8d97 in taichi::lang::Program::compile (this=0x555558b99000, kernel=...)
    at /home/ailing/github/taichi/taichi/program/program.cpp:257
#4  0x00007fff7ba9d748 in taichi::lang::Kernel::compile (this=0x55555a7a8d70)
    at /home/ailing/github/taichi/taichi/program/kernel.cpp:87
```