### PR TITLE
[gui] GGUI 5/n: swap chain and app context

### DIFF
--- a/taichi/ui/backends/vulkan/app_context.cpp
+++ b/taichi/ui/backends/vulkan/app_context.cpp
@@ -1,0 +1,134 @@
+#include "taichi/ui/utils/utils.h"
+#include "taichi/ui/backends/vulkan/vulkan_utils.h"
+#include "taichi/ui/backends/vulkan/app_context.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+using namespace taichi::lang::vulkan;
+
+// EmbeddedVulkanDevice will check that these are supported
+const std::vector<std::string> device_extensions = {
+    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+#ifdef _WIN64
+    VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
+#else
+    VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+#endif
+};
+
+std::vector<std::string> get_required_instance_extensions() {
+  uint32_t glfw_ext_count = 0;
+  const char **glfw_extensions;
+  glfw_extensions = glfwGetRequiredInstanceExtensions(&glfw_ext_count);
+
+  std::vector<std::string> extensions;
+
+  for (int i = 0; i < glfw_ext_count; ++i) {
+    extensions.push_back(glfw_extensions[i]);
+  }
+
+  // EmbeddedVulkanDevice will check that these are supported
+  extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+  extensions.push_back(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+  extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
+  extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+  return extensions;
+}
+
+void AppContext::init() {
+  EmbeddedVulkanDevice::Params evd_params;
+  evd_params.additional_instance_extensions =
+      get_required_instance_extensions();
+  evd_params.additional_device_extensions = device_extensions;
+  evd_params.is_for_ui = true;
+  evd_params.surface_creator = [&](VkInstance instance) -> VkSurfaceKHR {
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    if (glfwCreateWindowSurface(instance, glfw_window, nullptr, &surface) !=
+        VK_SUCCESS) {
+      throw std::runtime_error("failed to create window surface!");
+    }
+    return surface;
+  };
+  vulkan_device_ = std::make_unique<EmbeddedVulkanDevice>(evd_params);
+
+  swap_chain.app_context = this;
+  swap_chain.surface = vulkan_device_->surface();
+
+  swap_chain.create_swap_chain();
+  swap_chain.create_image_views();
+  swap_chain.create_depth_resources();
+  swap_chain.create_sync_objects();
+
+  create_render_passes();
+
+  swap_chain.create_framebuffers();
+}
+
+void AppContext::create_render_passes() {
+  create_render_pass(render_pass_, swap_chain.swap_chain_image_format,
+                     VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, device(),
+                     physical_device());
+}
+
+void AppContext::cleanup_swap_chain() {
+  vkDestroyRenderPass(device(), render_pass_, nullptr);
+  swap_chain.cleanup_swap_chain();
+}
+
+void AppContext::cleanup() {
+  swap_chain.cleanup();
+  vulkan_device_.reset();
+}
+
+void AppContext::recreate_swap_chain() {
+  create_render_passes();
+  swap_chain.recreate_swap_chain();
+}
+
+int AppContext::get_swap_chain_size() {
+  return swap_chain.swap_chain_images.size();
+}
+
+VkInstance AppContext::instance() const {
+  return vulkan_device_->instance();
+}
+
+VkDevice AppContext::device() const {
+  return vulkan_device_->device()->device();
+}
+
+VkPhysicalDevice AppContext::physical_device() const {
+  return vulkan_device_->physical_device();
+}
+
+VulkanQueueFamilyIndices AppContext::queue_family_indices() const {
+  return vulkan_device_->queue_family_indices();
+}
+
+VkQueue AppContext::graphics_queue() const {
+  return vulkan_device_->device()->graphics_queue();
+}
+
+VkQueue AppContext::present_queue() const {
+  return vulkan_device_->device()->present_queue();
+}
+
+VkCommandPool AppContext::command_pool() const {
+  return vulkan_device_->device()->command_pool();
+}
+
+VkRenderPass AppContext::render_pass() const {
+  return render_pass_;
+}
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/app_context.h
+++ b/taichi/ui/backends/vulkan/app_context.h
@@ -12,7 +12,7 @@ namespace vulkan {
 
 class AppContext {
  public:
-  void init();
+  void init(GLFWwindow *glfw_window);
 
   void cleanup_swap_chain();
   void cleanup();
@@ -28,18 +28,23 @@ class AppContext {
   VkQueue present_queue() const;
   VkCommandPool command_pool() const;
   VkRenderPass render_pass() const;
+  SwapChain &swap_chain();
+  const SwapChain &swap_chain() const;
+  GLFWwindow *glfw_window() const;
 
   AppConfig config;
-  SwapChain swap_chain;
-
-  GLFWwindow *glfw_window;
 
  private:
-  std::unique_ptr<taichi::lang::vulkan::EmbeddedVulkanDevice> vulkan_device_;
+  std::unique_ptr<taichi::lang::vulkan::EmbeddedVulkanDevice> vulkan_device_{
+      nullptr};
 
-  VkRenderPass render_pass_;
+  VkRenderPass render_pass_{VK_NULL_HANDLE};
 
   void create_render_passes();
+
+  SwapChain swap_chain_;
+
+  GLFWwindow *glfw_window_{nullptr};
 };
 
 }  // namespace vulkan

--- a/taichi/ui/backends/vulkan/app_context.h
+++ b/taichi/ui/backends/vulkan/app_context.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "taichi/ui/backends/vulkan/vulkan_utils.h"
+#include "taichi/ui/common/app_config.h"
+#include <memory>
+#include "taichi/backends/vulkan/vulkan_api.h"
+#include "taichi/backends/vulkan/loader.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+class AppContext {
+ public:
+  void init();
+
+  void cleanup_swap_chain();
+  void cleanup();
+  void recreate_swap_chain();
+
+  int get_swap_chain_size();
+
+  VkInstance instance() const;
+  VkDevice device() const;
+  VkPhysicalDevice physical_device() const;
+  taichi::lang::vulkan::VulkanQueueFamilyIndices queue_family_indices() const;
+  VkQueue graphics_queue() const;
+  VkQueue present_queue() const;
+  VkCommandPool command_pool() const;
+  VkRenderPass render_pass() const;
+
+  AppConfig config;
+  SwapChain swap_chain;
+
+  GLFWwindow *glfw_window;
+
+ private:
+  std::unique_ptr<taichi::lang::vulkan::EmbeddedVulkanDevice> vulkan_device_;
+
+  VkRenderPass render_pass_;
+
+  void create_render_passes();
+};
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/swap_chain.cpp
+++ b/taichi/ui/backends/vulkan/swap_chain.cpp
@@ -1,0 +1,296 @@
+#include "taichi/ui/utils/utils.h"
+#include "taichi/ui/backends/vulkan/vulkan_utils.h"
+#include "taichi/ui/backends/vulkan/app_context.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+using namespace taichi::lang::vulkan;
+
+void SwapChain::update_image_index() {
+  curr_image_index = get_image_index();
+}
+
+void SwapChain::cleanup_swap_chain() {
+  vkDestroyImageView(app_context->device(), depth_image_view, nullptr);
+  vkDestroyImage(app_context->device(), depth_image, nullptr);
+  vkFreeMemory(app_context->device(), depth_image_memory, nullptr);
+
+  for (auto framebuffer : swap_chain_framebuffers) {
+    vkDestroyFramebuffer(app_context->device(), framebuffer, nullptr);
+  }
+
+  for (auto image_view : swap_chain_image_views) {
+    vkDestroyImageView(app_context->device(), image_view, nullptr);
+  }
+
+  vkDestroySwapchainKHR(app_context->device(), swap_chain, nullptr);
+}
+
+void SwapChain::cleanup() {
+  for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
+    vkDestroySemaphore(app_context->device(), render_finished_semaphores[i],
+                       nullptr);
+    vkDestroySemaphore(app_context->device(), image_available_semaphores[i],
+                       nullptr);
+    vkDestroyFence(app_context->device(), in_flight_scenes[i], nullptr);
+  }
+
+  vkDestroySurfaceKHR(app_context->instance(), surface, nullptr);
+}
+
+void SwapChain::recreate_swap_chain() {
+  create_swap_chain();
+  create_image_views();
+
+  create_depth_resources();
+  create_framebuffers();
+
+  images_in_flight.resize(swap_chain_images.size(), VK_NULL_HANDLE);
+  requires_recreate = false;
+}
+
+void SwapChain::create_swap_chain() {
+  SwapChainSupportDetails swap_chain_support =
+      query_swap_chain_support(app_context->physical_device(), surface);
+
+  VkSurfaceFormatKHR surface_format =
+      choose_swap_surface_format(swap_chain_support.formats);
+  VkPresentModeKHR present_mode =
+      choose_swap_present_mode(swap_chain_support.present_modes);
+  VkExtent2D extent = choose_swap_extent(swap_chain_support.capabilities);
+
+  uint32_t image_count = swap_chain_support.capabilities.minImageCount + 1;
+  if (swap_chain_support.capabilities.maxImageCount > 0 &&
+      image_count > swap_chain_support.capabilities.maxImageCount) {
+    image_count = swap_chain_support.capabilities.maxImageCount;
+  }
+
+  VkSwapchainCreateInfoKHR create_info{};
+  create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+  create_info.surface = surface;
+
+  create_info.minImageCount = image_count;
+  create_info.imageFormat = surface_format.format;
+  create_info.imageColorSpace = surface_format.colorSpace;
+  create_info.imageExtent = extent;
+  create_info.imageArrayLayers = 1;
+  create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+  VulkanQueueFamilyIndices indices = app_context->queue_family_indices();
+  uint32_t queue_family_indices[] = {indices.graphics_family.value(),
+                                     indices.present_family.value()};
+
+  if (indices.graphics_family != indices.present_family) {
+    create_info.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
+    create_info.queueFamilyIndexCount = 2;
+    create_info.pQueueFamilyIndices = queue_family_indices;
+  } else {
+    create_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  }
+
+  create_info.preTransform = swap_chain_support.capabilities.currentTransform;
+  create_info.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+  create_info.presentMode = present_mode;
+  create_info.clipped = VK_TRUE;
+
+  if (vkCreateSwapchainKHR(app_context->device(), &create_info, nullptr,
+                           &swap_chain) != VK_SUCCESS) {
+    throw std::runtime_error("failed to create swap chain!");
+  }
+
+  vkGetSwapchainImagesKHR(app_context->device(), swap_chain, &image_count,
+                          nullptr);
+  swap_chain_images.resize(image_count);
+  vkGetSwapchainImagesKHR(app_context->device(), swap_chain, &image_count,
+                          swap_chain_images.data());
+
+  swap_chain_image_format = surface_format.format;
+  swap_chain_extent = extent;
+}
+
+void SwapChain::create_image_views() {
+  swap_chain_image_views.resize(swap_chain_images.size());
+
+  for (uint32_t i = 0; i < swap_chain_images.size(); i++) {
+    swap_chain_image_views[i] =
+        create_image_view(2, swap_chain_images[i], swap_chain_image_format,
+                          VK_IMAGE_ASPECT_COLOR_BIT, app_context->device());
+  }
+}
+
+void SwapChain::create_framebuffers() {
+  swap_chain_framebuffers.resize(swap_chain_image_views.size());
+
+  for (size_t i = 0; i < swap_chain_image_views.size(); i++) {
+    std::array<VkImageView, 2> attachments = {swap_chain_image_views[i],
+                                              depth_image_view};
+
+    VkFramebufferCreateInfo framebuffer_info{};
+    framebuffer_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    framebuffer_info.renderPass = app_context->render_pass();
+    framebuffer_info.attachmentCount =
+        static_cast<uint32_t>(attachments.size());
+    framebuffer_info.pAttachments = attachments.data();
+    framebuffer_info.width = swap_chain_extent.width;
+    framebuffer_info.height = swap_chain_extent.height;
+    framebuffer_info.layers = 1;
+
+    if (vkCreateFramebuffer(app_context->device(), &framebuffer_info, nullptr,
+                            &swap_chain_framebuffers[i]) != VK_SUCCESS) {
+      throw std::runtime_error("failed to create framebuffer!");
+    }
+  }
+}
+
+void SwapChain::create_depth_resources() {
+  VkFormat depth_format = find_depth_format(app_context->physical_device());
+
+  create_image(
+      2, swap_chain_extent.width, swap_chain_extent.height, 1, depth_format,
+      VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, depth_image, depth_image_memory,
+      app_context->device(), app_context->physical_device());
+  depth_image_view =
+      create_image_view(2, depth_image, depth_format, VK_IMAGE_ASPECT_DEPTH_BIT,
+                        app_context->device());
+}
+
+void SwapChain::create_sync_objects() {
+  image_available_semaphores.resize(MAX_FRAMES_IN_FLIGHT);
+  render_finished_semaphores.resize(MAX_FRAMES_IN_FLIGHT);
+  in_flight_scenes.resize(MAX_FRAMES_IN_FLIGHT);
+  images_in_flight.resize(swap_chain_images.size(), VK_NULL_HANDLE);
+
+  VkSemaphoreCreateInfo semaphore_info{};
+  semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+  VkFenceCreateInfo fenceInfo{};
+  fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+  fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+
+  for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
+    if (vkCreateSemaphore(app_context->device(), &semaphore_info, nullptr,
+                          &image_available_semaphores[i]) != VK_SUCCESS ||
+        vkCreateSemaphore(app_context->device(), &semaphore_info, nullptr,
+                          &render_finished_semaphores[i]) != VK_SUCCESS ||
+        vkCreateFence(app_context->device(), &fenceInfo, nullptr,
+                      &in_flight_scenes[i]) != VK_SUCCESS) {
+      throw std::runtime_error(
+          "failed to create synchronization objects for a frame!");
+    }
+  }
+}
+
+uint32_t SwapChain::get_image_index() {
+  vkWaitForFences(app_context->device(), 1, &in_flight_scenes[current_frame],
+                  VK_TRUE, UINT64_MAX);
+  uint32_t image_index;
+  vkAcquireNextImageKHR(app_context->device(), swap_chain, UINT64_MAX,
+                        image_available_semaphores[current_frame],
+                        VK_NULL_HANDLE, &image_index);
+  return image_index;
+}
+
+void SwapChain::present_frame() {
+  uint32_t image_index = curr_image_index;
+
+  VkSubmitInfo submit_info{};
+  VkSemaphore signal_semaphores[] = {render_finished_semaphores[current_frame]};
+  submit_info.signalSemaphoreCount = 1;
+  submit_info.pSignalSemaphores = signal_semaphores;
+
+  VkPresentInfoKHR present_info{};
+  present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+
+  present_info.waitSemaphoreCount = 1;
+  present_info.pWaitSemaphores = signal_semaphores;
+
+  VkSwapchainKHR swap_chains[] = {swap_chain};
+  present_info.swapchainCount = 1;
+  present_info.pSwapchains = swap_chains;
+
+  present_info.pImageIndices = &image_index;
+
+  VkResult result =
+      vkQueuePresentKHR(app_context->present_queue(), &present_info);
+
+  if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
+    requires_recreate = true;
+  } else if (result != VK_SUCCESS) {
+    throw std::runtime_error("failed to present swap chain image!");
+  }
+
+  current_frame = (current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
+
+  vkDeviceWaitIdle(app_context->device());
+}
+
+VkSurfaceFormatKHR SwapChain::choose_swap_surface_format(
+    const std::vector<VkSurfaceFormatKHR> &available_formats) {
+  for (const auto &available_format : available_formats) {
+    if (available_format.format == VK_FORMAT_B8G8R8A8_UNORM &&
+        available_format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+      return available_format;
+    }
+  }
+
+  return available_formats[0];
+}
+
+VkPresentModeKHR SwapChain::choose_swap_present_mode(
+    const std::vector<VkPresentModeKHR> &available_present_modes) {
+  if (app_context->config.vsync) {
+    for (const auto &available_present_mode : available_present_modes) {
+      if (available_present_mode == VK_PRESENT_MODE_FIFO_KHR) {
+        return available_present_mode;
+      }
+    }
+  } else {
+    for (const auto &available_present_mode : available_present_modes) {
+      if (available_present_mode == VK_PRESENT_MODE_MAILBOX_KHR) {
+        return available_present_mode;
+      }
+    }
+    for (const auto &available_present_mode : available_present_modes) {
+      if (available_present_mode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
+        return available_present_mode;
+      }
+    }
+  }
+
+  if (available_present_modes.size() == 0) {
+    throw std::runtime_error("no avialble present modes");
+  }
+
+  return available_present_modes[0];
+}
+
+VkExtent2D SwapChain::choose_swap_extent(
+    const VkSurfaceCapabilitiesKHR &capabilities) {
+  if (capabilities.currentExtent.width != UINT32_MAX) {
+    VkExtent2D result = capabilities.currentExtent;
+    // printf("using currentExtent: %d %d\n",result .width,result .height);
+    return result;
+  } else {
+    VkExtent2D actualExtent = {
+        static_cast<uint32_t>(app_context->config.width),
+        static_cast<uint32_t>(app_context->config.height)};
+
+    actualExtent.width =
+        std::clamp(actualExtent.width, capabilities.minImageExtent.width,
+                   capabilities.maxImageExtent.width);
+    actualExtent.height =
+        std::clamp(actualExtent.height, capabilities.minImageExtent.height,
+                   capabilities.maxImageExtent.height);
+
+    // printf("%d %d\n",app_context->config.width,app_context->config.height);
+
+    return actualExtent;
+  }
+}
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/swap_chain.cpp
+++ b/taichi/ui/backends/vulkan/swap_chain.cpp
@@ -9,36 +9,55 @@ namespace vulkan {
 
 using namespace taichi::lang::vulkan;
 
+void SwapChain::init(class AppContext *app_context, VkSurfaceKHR surface) {
+  app_context_ = app_context;
+  surface_ = surface;
+  create_swap_chain();
+  create_image_views();
+  create_depth_resources();
+  create_sync_objects();
+}
+
 void SwapChain::update_image_index() {
-  curr_image_index = get_image_index();
+  vkWaitForFences(app_context_->device(), 1, &in_flight_scenes_[current_frame_],
+                  VK_TRUE, UINT64_MAX);
+  uint32_t image_index;
+  vkAcquireNextImageKHR(app_context_->device(), swap_chain_, UINT64_MAX,
+                        image_available_semaphores_[current_frame_],
+                        VK_NULL_HANDLE, &image_index);
+  curr_image_index_ = image_index;
+}
+
+uint32_t SwapChain::curr_image_index() {
+  return curr_image_index_;
 }
 
 void SwapChain::cleanup_swap_chain() {
-  vkDestroyImageView(app_context->device(), depth_image_view, nullptr);
-  vkDestroyImage(app_context->device(), depth_image, nullptr);
-  vkFreeMemory(app_context->device(), depth_image_memory, nullptr);
+  vkDestroyImageView(app_context_->device(), depth_image_view_, nullptr);
+  vkDestroyImage(app_context_->device(), depth_image_, nullptr);
+  vkFreeMemory(app_context_->device(), depth_image_memory_, nullptr);
 
-  for (auto framebuffer : swap_chain_framebuffers) {
-    vkDestroyFramebuffer(app_context->device(), framebuffer, nullptr);
+  for (auto framebuffer : swap_chain_framebuffers_) {
+    vkDestroyFramebuffer(app_context_->device(), framebuffer, nullptr);
   }
 
-  for (auto image_view : swap_chain_image_views) {
-    vkDestroyImageView(app_context->device(), image_view, nullptr);
+  for (auto image_view : swap_chain_image_views_) {
+    vkDestroyImageView(app_context_->device(), image_view, nullptr);
   }
 
-  vkDestroySwapchainKHR(app_context->device(), swap_chain, nullptr);
+  vkDestroySwapchainKHR(app_context_->device(), swap_chain_, nullptr);
 }
 
 void SwapChain::cleanup() {
   for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-    vkDestroySemaphore(app_context->device(), render_finished_semaphores[i],
+    vkDestroySemaphore(app_context_->device(), render_finished_semaphores_[i],
                        nullptr);
-    vkDestroySemaphore(app_context->device(), image_available_semaphores[i],
+    vkDestroySemaphore(app_context_->device(), image_available_semaphores_[i],
                        nullptr);
-    vkDestroyFence(app_context->device(), in_flight_scenes[i], nullptr);
+    vkDestroyFence(app_context_->device(), in_flight_scenes_[i], nullptr);
   }
 
-  vkDestroySurfaceKHR(app_context->instance(), surface, nullptr);
+  vkDestroySurfaceKHR(app_context_->instance(), surface_, nullptr);
 }
 
 void SwapChain::recreate_swap_chain() {
@@ -48,13 +67,13 @@ void SwapChain::recreate_swap_chain() {
   create_depth_resources();
   create_framebuffers();
 
-  images_in_flight.resize(swap_chain_images.size(), VK_NULL_HANDLE);
-  requires_recreate = false;
+  images_in_flight_.resize(swap_chain_images_.size(), VK_NULL_HANDLE);
+  requires_recreate_ = false;
 }
 
 void SwapChain::create_swap_chain() {
   SwapChainSupportDetails swap_chain_support =
-      query_swap_chain_support(app_context->physical_device(), surface);
+      query_swap_chain_support(app_context_->physical_device(), surface_);
 
   VkSurfaceFormatKHR surface_format =
       choose_swap_surface_format(swap_chain_support.formats);
@@ -70,7 +89,7 @@ void SwapChain::create_swap_chain() {
 
   VkSwapchainCreateInfoKHR create_info{};
   create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-  create_info.surface = surface;
+  create_info.surface = surface_;
 
   create_info.minImageCount = image_count;
   create_info.imageFormat = surface_format.format;
@@ -79,7 +98,7 @@ void SwapChain::create_swap_chain() {
   create_info.imageArrayLayers = 1;
   create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-  VulkanQueueFamilyIndices indices = app_context->queue_family_indices();
+  VulkanQueueFamilyIndices indices = app_context_->queue_family_indices();
   uint32_t queue_family_indices[] = {indices.graphics_family.value(),
                                      indices.present_family.value()};
 
@@ -96,73 +115,73 @@ void SwapChain::create_swap_chain() {
   create_info.presentMode = present_mode;
   create_info.clipped = VK_TRUE;
 
-  if (vkCreateSwapchainKHR(app_context->device(), &create_info, nullptr,
-                           &swap_chain) != VK_SUCCESS) {
+  if (vkCreateSwapchainKHR(app_context_->device(), &create_info, nullptr,
+                           &swap_chain_) != VK_SUCCESS) {
     throw std::runtime_error("failed to create swap chain!");
   }
 
-  vkGetSwapchainImagesKHR(app_context->device(), swap_chain, &image_count,
+  vkGetSwapchainImagesKHR(app_context_->device(), swap_chain_, &image_count,
                           nullptr);
-  swap_chain_images.resize(image_count);
-  vkGetSwapchainImagesKHR(app_context->device(), swap_chain, &image_count,
-                          swap_chain_images.data());
+  swap_chain_images_.resize(image_count);
+  vkGetSwapchainImagesKHR(app_context_->device(), swap_chain_, &image_count,
+                          swap_chain_images_.data());
 
-  swap_chain_image_format = surface_format.format;
-  swap_chain_extent = extent;
+  swap_chain_image_format_ = surface_format.format;
+  swap_chain_extent_ = extent;
 }
 
 void SwapChain::create_image_views() {
-  swap_chain_image_views.resize(swap_chain_images.size());
+  swap_chain_image_views_.resize(swap_chain_images_.size());
 
-  for (uint32_t i = 0; i < swap_chain_images.size(); i++) {
-    swap_chain_image_views[i] =
-        create_image_view(2, swap_chain_images[i], swap_chain_image_format,
-                          VK_IMAGE_ASPECT_COLOR_BIT, app_context->device());
+  for (uint32_t i = 0; i < swap_chain_images_.size(); i++) {
+    swap_chain_image_views_[i] =
+        create_image_view(2, swap_chain_images_[i], swap_chain_image_format_,
+                          VK_IMAGE_ASPECT_COLOR_BIT, app_context_->device());
   }
 }
 
 void SwapChain::create_framebuffers() {
-  swap_chain_framebuffers.resize(swap_chain_image_views.size());
+  swap_chain_framebuffers_.resize(swap_chain_image_views_.size());
 
-  for (size_t i = 0; i < swap_chain_image_views.size(); i++) {
-    std::array<VkImageView, 2> attachments = {swap_chain_image_views[i],
-                                              depth_image_view};
+  for (size_t i = 0; i < swap_chain_image_views_.size(); i++) {
+    std::array<VkImageView, 2> attachments = {swap_chain_image_views_[i],
+                                              depth_image_view_};
 
     VkFramebufferCreateInfo framebuffer_info{};
     framebuffer_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-    framebuffer_info.renderPass = app_context->render_pass();
+    framebuffer_info.renderPass = app_context_->render_pass();
     framebuffer_info.attachmentCount =
         static_cast<uint32_t>(attachments.size());
     framebuffer_info.pAttachments = attachments.data();
-    framebuffer_info.width = swap_chain_extent.width;
-    framebuffer_info.height = swap_chain_extent.height;
+    framebuffer_info.width = swap_chain_extent_.width;
+    framebuffer_info.height = swap_chain_extent_.height;
     framebuffer_info.layers = 1;
 
-    if (vkCreateFramebuffer(app_context->device(), &framebuffer_info, nullptr,
-                            &swap_chain_framebuffers[i]) != VK_SUCCESS) {
+    if (vkCreateFramebuffer(app_context_->device(), &framebuffer_info, nullptr,
+                            &swap_chain_framebuffers_[i]) != VK_SUCCESS) {
       throw std::runtime_error("failed to create framebuffer!");
     }
   }
 }
 
 void SwapChain::create_depth_resources() {
-  VkFormat depth_format = find_depth_format(app_context->physical_device());
+  VkFormat depth_format = find_depth_format(app_context_->physical_device());
 
   create_image(
-      2, swap_chain_extent.width, swap_chain_extent.height, 1, depth_format,
+      2, swap_chain_extent_.width, swap_chain_extent_.height, 1, depth_format,
       VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
-      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, depth_image, depth_image_memory,
-      app_context->device(), app_context->physical_device());
-  depth_image_view =
-      create_image_view(2, depth_image, depth_format, VK_IMAGE_ASPECT_DEPTH_BIT,
-                        app_context->device());
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, depth_image_, depth_image_memory_,
+      app_context_->device(), app_context_->physical_device());
+  depth_image_view_ =
+      create_image_view(2, depth_image_, depth_format,
+                        VK_IMAGE_ASPECT_DEPTH_BIT, app_context_->device());
 }
 
 void SwapChain::create_sync_objects() {
-  image_available_semaphores.resize(MAX_FRAMES_IN_FLIGHT);
-  render_finished_semaphores.resize(MAX_FRAMES_IN_FLIGHT);
-  in_flight_scenes.resize(MAX_FRAMES_IN_FLIGHT);
-  images_in_flight.resize(swap_chain_images.size(), VK_NULL_HANDLE);
+  image_available_semaphores_.resize(MAX_FRAMES_IN_FLIGHT);
+  render_finished_semaphores_.resize(MAX_FRAMES_IN_FLIGHT);
+  in_flight_scenes_.resize(MAX_FRAMES_IN_FLIGHT);
+  images_in_flight_.resize(swap_chain_images_.size(), VK_NULL_HANDLE);
 
   VkSemaphoreCreateInfo semaphore_info{};
   semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
@@ -172,33 +191,24 @@ void SwapChain::create_sync_objects() {
   fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
   for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-    if (vkCreateSemaphore(app_context->device(), &semaphore_info, nullptr,
-                          &image_available_semaphores[i]) != VK_SUCCESS ||
-        vkCreateSemaphore(app_context->device(), &semaphore_info, nullptr,
-                          &render_finished_semaphores[i]) != VK_SUCCESS ||
-        vkCreateFence(app_context->device(), &fenceInfo, nullptr,
-                      &in_flight_scenes[i]) != VK_SUCCESS) {
+    if (vkCreateSemaphore(app_context_->device(), &semaphore_info, nullptr,
+                          &image_available_semaphores_[i]) != VK_SUCCESS ||
+        vkCreateSemaphore(app_context_->device(), &semaphore_info, nullptr,
+                          &render_finished_semaphores_[i]) != VK_SUCCESS ||
+        vkCreateFence(app_context_->device(), &fenceInfo, nullptr,
+                      &in_flight_scenes_[i]) != VK_SUCCESS) {
       throw std::runtime_error(
           "failed to create synchronization objects for a frame!");
     }
   }
 }
 
-uint32_t SwapChain::get_image_index() {
-  vkWaitForFences(app_context->device(), 1, &in_flight_scenes[current_frame],
-                  VK_TRUE, UINT64_MAX);
-  uint32_t image_index;
-  vkAcquireNextImageKHR(app_context->device(), swap_chain, UINT64_MAX,
-                        image_available_semaphores[current_frame],
-                        VK_NULL_HANDLE, &image_index);
-  return image_index;
-}
-
 void SwapChain::present_frame() {
-  uint32_t image_index = curr_image_index;
+  uint32_t image_index = curr_image_index_;
 
   VkSubmitInfo submit_info{};
-  VkSemaphore signal_semaphores[] = {render_finished_semaphores[current_frame]};
+  VkSemaphore signal_semaphores[] = {
+      render_finished_semaphores_[current_frame_]};
   submit_info.signalSemaphoreCount = 1;
   submit_info.pSignalSemaphores = signal_semaphores;
 
@@ -208,24 +218,24 @@ void SwapChain::present_frame() {
   present_info.waitSemaphoreCount = 1;
   present_info.pWaitSemaphores = signal_semaphores;
 
-  VkSwapchainKHR swap_chains[] = {swap_chain};
+  VkSwapchainKHR swap_chain_s[] = {swap_chain_};
   present_info.swapchainCount = 1;
-  present_info.pSwapchains = swap_chains;
+  present_info.pSwapchains = swap_chain_s;
 
   present_info.pImageIndices = &image_index;
 
   VkResult result =
-      vkQueuePresentKHR(app_context->present_queue(), &present_info);
+      vkQueuePresentKHR(app_context_->present_queue(), &present_info);
 
   if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
-    requires_recreate = true;
+    requires_recreate_ = true;
   } else if (result != VK_SUCCESS) {
     throw std::runtime_error("failed to present swap chain image!");
   }
 
-  current_frame = (current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
+  current_frame_ = (current_frame_ + 1) % MAX_FRAMES_IN_FLIGHT;
 
-  vkDeviceWaitIdle(app_context->device());
+  vkDeviceWaitIdle(app_context_->device());
 }
 
 VkSurfaceFormatKHR SwapChain::choose_swap_surface_format(
@@ -242,7 +252,7 @@ VkSurfaceFormatKHR SwapChain::choose_swap_surface_format(
 
 VkPresentModeKHR SwapChain::choose_swap_present_mode(
     const std::vector<VkPresentModeKHR> &available_present_modes) {
-  if (app_context->config.vsync) {
+  if (app_context_->config.vsync) {
     for (const auto &available_present_mode : available_present_modes) {
       if (available_present_mode == VK_PRESENT_MODE_FIFO_KHR) {
         return available_present_mode;
@@ -276,8 +286,8 @@ VkExtent2D SwapChain::choose_swap_extent(
     return result;
   } else {
     VkExtent2D actualExtent = {
-        static_cast<uint32_t>(app_context->config.width),
-        static_cast<uint32_t>(app_context->config.height)};
+        static_cast<uint32_t>(app_context_->config.width),
+        static_cast<uint32_t>(app_context_->config.height)};
 
     actualExtent.width =
         std::clamp(actualExtent.width, capabilities.minImageExtent.width,
@@ -286,11 +296,49 @@ VkExtent2D SwapChain::choose_swap_extent(
         std::clamp(actualExtent.height, capabilities.minImageExtent.height,
                    capabilities.maxImageExtent.height);
 
-    // printf("%d %d\n",app_context->config.width,app_context->config.height);
+    // printf("%d %d\n",app_context_->config.width,app_context_->config.height);
 
     return actualExtent;
   }
 }
+
+bool SwapChain::requires_recreate() const {
+  return requires_recreate_;
+}
+
+std::vector<VkFence> &SwapChain::in_flight_scenes() {
+  return in_flight_scenes_;
+}
+VkExtent2D SwapChain::swap_chain_extent() const {
+  return swap_chain_extent_;
+}
+std::vector<VkFence> &SwapChain::images_in_flight() {
+  return images_in_flight_;
+}
+
+uint32_t SwapChain::current_frame() const {
+  return current_frame_;
+}
+
+size_t SwapChain::chain_size() const {
+  return swap_chain_images_.size();
+}
+
+const std::vector<VkSemaphore> &SwapChain::image_available_semaphores() const {
+  return image_available_semaphores_;
+}
+
+const std::vector<VkSemaphore> &SwapChain::render_finished_semaphores() const {
+  return render_finished_semaphores_;
+}
+
+VkFormat SwapChain::swap_chain_image_format() const {
+  return swap_chain_image_format_;
+}
+const std::vector<VkFramebuffer> &SwapChain::swap_chain_framebuffers() const {
+  return swap_chain_framebuffers_;
+}
+
 }  // namespace vulkan
 
 TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/swap_chain.h
+++ b/taichi/ui/backends/vulkan/swap_chain.h
@@ -1,0 +1,63 @@
+#pragma once
+TI_UI_NAMESPACE_BEGIN
+namespace vulkan {
+
+struct SwapChain {
+  static const int MAX_FRAMES_IN_FLIGHT = 4;
+
+  uint32_t curr_image_index;
+
+  VkSurfaceKHR surface;
+
+  VkSwapchainKHR swap_chain;
+  std::vector<VkImage> swap_chain_images;
+  VkFormat swap_chain_image_format;
+  VkExtent2D swap_chain_extent;
+  std::vector<VkImageView> swap_chain_image_views;
+  std::vector<VkFramebuffer> swap_chain_framebuffers;
+
+  VkImage depth_image;
+  VkDeviceMemory depth_image_memory;
+  VkImageView depth_image_view;
+
+  std::vector<VkSemaphore> image_available_semaphores;
+  std::vector<VkSemaphore> render_finished_semaphores;
+  std::vector<VkFence> in_flight_scenes;
+  std::vector<VkFence> images_in_flight;
+  size_t current_frame = 0;
+
+  bool requires_recreate = false;
+
+  class AppContext *app_context;
+
+  void update_image_index();
+
+  void cleanup_swap_chain();
+  void cleanup();
+
+  void recreate_swap_chain();
+
+  void create_swap_chain();
+
+  void create_image_views();
+
+  void create_framebuffers();
+
+  void create_depth_resources();
+
+  void create_sync_objects();
+
+  uint32_t get_image_index();
+
+  void present_frame();
+
+  VkSurfaceFormatKHR choose_swap_surface_format(
+      const std::vector<VkSurfaceFormatKHR> &available_formats);
+  VkPresentModeKHR choose_swap_present_mode(
+      const std::vector<VkPresentModeKHR> &available_present_modes);
+  VkExtent2D choose_swap_extent(const VkSurfaceCapabilitiesKHR &capabilities);
+};
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/swap_chain.h
+++ b/taichi/ui/backends/vulkan/swap_chain.h
@@ -2,39 +2,12 @@
 TI_UI_NAMESPACE_BEGIN
 namespace vulkan {
 
-struct SwapChain {
-  static const int MAX_FRAMES_IN_FLIGHT = 4;
-
-  uint32_t curr_image_index;
-
-  VkSurfaceKHR surface;
-
-  VkSwapchainKHR swap_chain;
-  std::vector<VkImage> swap_chain_images;
-  VkFormat swap_chain_image_format;
-  VkExtent2D swap_chain_extent;
-  std::vector<VkImageView> swap_chain_image_views;
-  std::vector<VkFramebuffer> swap_chain_framebuffers;
-
-  VkImage depth_image;
-  VkDeviceMemory depth_image_memory;
-  VkImageView depth_image_view;
-
-  std::vector<VkSemaphore> image_available_semaphores;
-  std::vector<VkSemaphore> render_finished_semaphores;
-  std::vector<VkFence> in_flight_scenes;
-  std::vector<VkFence> images_in_flight;
-  size_t current_frame = 0;
-
-  bool requires_recreate = false;
-
-  class AppContext *app_context;
-
+class SwapChain {
+ public:
+  void init(class AppContext *app_context, VkSurfaceKHR surface);
   void update_image_index();
-
   void cleanup_swap_chain();
   void cleanup();
-
   void recreate_swap_chain();
 
   void create_swap_chain();
@@ -47,15 +20,56 @@ struct SwapChain {
 
   void create_sync_objects();
 
-  uint32_t get_image_index();
-
   void present_frame();
+
+  bool requires_recreate() const;
+  uint32_t curr_image_index();
+
+  uint32_t current_frame() const;
+
+  size_t chain_size() const;
+
+  std::vector<VkFence> &in_flight_scenes();
+  std::vector<VkFence> &images_in_flight();
+  const std::vector<VkSemaphore> &image_available_semaphores() const;
+  const std::vector<VkSemaphore> &render_finished_semaphores() const;
+
+  VkExtent2D swap_chain_extent() const;
+  VkFormat swap_chain_image_format() const;
+  const std::vector<VkFramebuffer> &swap_chain_framebuffers() const;
 
   VkSurfaceFormatKHR choose_swap_surface_format(
       const std::vector<VkSurfaceFormatKHR> &available_formats);
   VkPresentModeKHR choose_swap_present_mode(
       const std::vector<VkPresentModeKHR> &available_present_modes);
   VkExtent2D choose_swap_extent(const VkSurfaceCapabilitiesKHR &capabilities);
+
+  static const int MAX_FRAMES_IN_FLIGHT = 4;
+
+ private:
+  uint32_t curr_image_index_;
+  VkSurfaceKHR surface_;
+  VkSwapchainKHR swap_chain_;
+
+  std::vector<VkImage> swap_chain_images_;
+  VkFormat swap_chain_image_format_;
+  VkExtent2D swap_chain_extent_;
+  std::vector<VkImageView> swap_chain_image_views_;
+  std::vector<VkFramebuffer> swap_chain_framebuffers_;
+
+  VkImage depth_image_;
+  VkDeviceMemory depth_image_memory_;
+  VkImageView depth_image_view_;
+
+  std::vector<VkSemaphore> image_available_semaphores_;
+  std::vector<VkSemaphore> render_finished_semaphores_;
+  std::vector<VkFence> in_flight_scenes_;
+  std::vector<VkFence> images_in_flight_;
+  uint32_t current_frame_ = 0;
+
+  bool requires_recreate_{false};
+
+  class AppContext *app_context_;
 };
 
 }  // namespace vulkan


### PR DESCRIPTION
Related issue = #2646 

This is the 5th of a series of PRs that adds a GPU-based GUI to taichi. This PR adds two classes:
* SwapChain: which manages the vulkan swap chain.
* AppContext: which owns all the vulkan related resources needed by the GUI. This includes a `SwapChain`, an `EmbeddedVulkanDevice`, and for now a render pass.