### PR TITLE
[ci] Fixed pypi version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ TI_VERSION_PATCH = 29
 version = f'{TI_VERSION_MAJOR}.{TI_VERSION_MINOR}.{TI_VERSION_PATCH}'
 if project_name == 'taichi-nightly':
     from datetime import date
-    today = date.today().strftime('%Y_%m_%d')
+    today = date.today().strftime('%Y%m%d')
     commit_sha = os.getenv('COMMIT_SHA')
-    version += f'.{today}.{commit_sha}'
+    version += f'.dev{today}'
 
 data_files = glob.glob('python/lib/*')
 print(data_files)

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,10 @@ version = f'{TI_VERSION_MAJOR}.{TI_VERSION_MINOR}.{TI_VERSION_PATCH}'
 if project_name == 'taichi-nightly':
     from datetime import date
     today = date.today().strftime('%Y%m%d')
+    # As required in PEP440, the commit hash cannot be used in version
+    # because it is not meaningful with respect to order. Therefore,
+    # we temperally do not use this commit_sha in our version.
+    # https://www.python.org/dev/peps/pep-0440
     commit_sha = os.getenv('COMMIT_SHA')
     version += f'.dev{today}'
 


### PR DESCRIPTION
The first nightly release has failed because the version does not meet the requirement of PyPi.
```
<title>400 '0.7.29.2021-08-17.899707f' is an invalid value for Version. Error: Start and end with a letter or numeral containing only ASCII numeric and '.', '_' and '-'. See https://packaging.python.org/specifications/core-metadata for more information.</title>
```
As PyPi requires versioning of projects meets the PEP440 standards, which does not allow commit hash in project version, I discard adding commit hash in nightly versions and made version meet PEP440 standards.
```
DVCS based version labels

Many build tools integrate with distributed version control systems like Git and Mercurial in order to add an identifying hash to the version identifier. As hashes cannot be ordered reliably such versions are not permitted in the public version field.

As with semantic versioning, the public .devN suffix may be used to uniquely identify such releases for publication, while the original DVCS based label can be stored in the project metadata.

Identifying hash information may also be included in local version labels.
```
For hash information of each nightly release, find it in github action workflows pages.