### PR TITLE
[ci] Pin yapf version to 0.31.0.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -38,7 +38,7 @@ jobs:
           git remote add upstream https://github.com/taichi-dev/taichi.git
           git fetch upstream master
           sudo apt-get install clang-format
-          python3 -m pip install --user yapf gitpython colorama isort
+          python3 -m pip install --user yapf==0.31.0 gitpython colorama isort
           python3 python/taichi/code_format.py
           git checkout -b _enforced_format
           git commit -am "enforce code format" || true

--- a/docs/lang/articles/contribution/contributor_guide.md
+++ b/docs/lang/articles/contribution/contributor_guide.md
@@ -163,7 +163,7 @@ This design is terrible.
 
 - Locally, you can run `ti format` in the command line to re-format
   code style. Note that you have to install `clang-format-6.0` and
-  `yapf v0.29.0` locally before you use `ti format`.
+  `yapf v0.31.0` locally before you use `ti format`.
 
 - If you don't have these formatting tools locally, feel free to
   leverage GitHub actions: simply comment `/format` in a PR

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pytest-rerunfailures
 pytest-xdist
 setuptools
 sourceinspect
-yapf
+yapf==0.31.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ numpy
 Pillow
 pybind11
 GitPython
-yapf
+yapf==0.31.0
 distro
 autograd
 astor


### PR DESCRIPTION
Recently noticed that `yapf` in the code format server no longer pins to 0.29. Changing yapf version is pretty annoying to dev workflow so let's pin it to the current version in the code format server (which is 0.31.0). 
Nit: I'm not sure if yapf should be a dependency for taichi user, maybe we can remove it from requirements.txt. 