### PR TITLE
[ci] Fix clang-format version to 10

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -37,7 +37,7 @@ jobs:
           git checkout -b _fake_squash
           git remote add upstream https://github.com/taichi-dev/taichi.git
           git fetch upstream master
-          sudo apt-get install clang-format
+          sudo apt install clang-format-10
           python3 -m pip install --user yapf==0.31.0 gitpython colorama isort
           python3 python/taichi/code_format.py
           git checkout -b _enforced_format

--- a/docs/lang/articles/contribution/contributor_guide.md
+++ b/docs/lang/articles/contribution/contributor_guide.md
@@ -162,7 +162,7 @@ This design is terrible.
 ## Enforcing code style
 
 - Locally, you can run `ti format` in the command line to re-format
-  code style. Note that you have to install `clang-format-6.0` and
+  code style. Note that you have to install `clang-format-10` and
   `yapf v0.31.0` locally before you use `ti format`.
 
 - If you don't have these formatting tools locally, feel free to

--- a/python/taichi/code_format.py
+++ b/python/taichi/code_format.py
@@ -48,7 +48,7 @@ def find_clang_format_bin():
     except AttributeError:
         pass
 
-    candidates = ['clang-format-6.0', 'clang-format']
+    candidates = ['clang-format-10', 'clang-format']
     result = None
 
     for c in candidates:


### PR DESCRIPTION
We were using system default which is clang-format-10 before. Let's still fix it to 6.0. 