### PR TITLE
[Refactor] Move snode_tree_buffer_manager into LlvmProgramImpl.

### DIFF
--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -1,0 +1,47 @@
+#include "llvm_program.h"
+
+#include "taichi/backends/cuda/cuda_driver.h"
+#include "taichi/program/arch.h"
+
+namespace taichi {
+namespace lang {
+LlvmProgramImpl::LlvmProgramImpl(CompileConfig config) : config(config) {
+  snode_tree_buffer_manager = std::make_unique<SNodeTreeBufferManager>(this);
+}
+
+void LlvmProgramImpl::device_synchronize() {
+  if (config.arch == Arch::cuda) {
+#if defined(TI_WITH_CUDA)
+    CUDADriver::get_instance().stream_synchronize(nullptr);
+#else
+    TI_ERROR("No CUDA support");
+#endif
+  }
+}
+
+uint64 LlvmProgramImpl::fetch_result_uint64(int i, uint64 *result_buffer) {
+  // TODO: We are likely doing more synchronization than necessary. Simplify the
+  // sync logic when we fetch the result.
+  device_synchronize();
+  uint64 ret;
+  auto arch = config.arch;
+  if (arch == Arch::cuda) {
+#if defined(TI_WITH_CUDA)
+    if (config.use_unified_memory) {
+      // More efficient than a cudaMemcpy call in practice
+      ret = result_buffer[i];
+    } else {
+      CUDADriver::get_instance().memcpy_device_to_host(&ret, result_buffer + i,
+                                                       sizeof(uint64));
+    }
+#else
+    TI_NOT_IMPLEMENTED;
+#endif
+  } else {
+    ret = result_buffer[i];
+  }
+  return ret;
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "taichi/system/snode_tree_buffer_manager.h"
+#include "taichi/inc/constants.h"
+#include "taichi/program/compile_config.h"
+#include "taichi/common/logging.h"
+
+#include <memory>
+
+namespace taichi {
+namespace lang {
+class LlvmProgramImpl {
+ public:
+  std::unique_ptr<SNodeTreeBufferManager> snode_tree_buffer_manager{nullptr};
+
+  LlvmProgramImpl(CompileConfig config);
+
+  uint64 fetch_result_uint64(int i, uint64 *);
+
+  void device_synchronize();
+
+ private:
+  CompileConfig config;
+};
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -12,6 +12,7 @@
 #include "taichi/ir/snode.h"
 #include "taichi/lang_util.h"
 #include "taichi/llvm/llvm_context.h"
+#include "taichi/llvm/llvm_program.h"
 #include "taichi/backends/metal/kernel_manager.h"
 #include "taichi/backends/opengl/opengl_kernel_launcher.h"
 #include "taichi/backends/cc/cc_program.h"
@@ -29,7 +30,6 @@
 #include "taichi/struct/snode_tree.h"
 #include "taichi/backends/vulkan/snode_struct_compiler.h"
 #include "taichi/system/memory_pool.h"
-#include "taichi/system/snode_tree_buffer_manager.h"
 #include "taichi/system/threading.h"
 #include "taichi/system/unified_allocator.h"
 
@@ -102,8 +102,7 @@ class Program {
   static std::atomic<int> num_instances;
   std::unique_ptr<ThreadPool> thread_pool{nullptr};
   std::unique_ptr<MemoryPool> memory_pool{nullptr};
-  std::unique_ptr<SNodeTreeBufferManager> snode_tree_buffer_manager{nullptr};
-  uint64 *result_buffer{nullptr};  // TODO: move this
+  uint64 *result_buffer{nullptr};  // Note result_buffer is used by all backends
   void *preallocated_device_buffer{
       nullptr};  // TODO: move this to memory allocator
   std::unordered_map<int, SNode *> snodes;
@@ -387,6 +386,8 @@ class Program {
   std::unique_ptr<vulkan::VkRuntime> vulkan_runtime_;
 
   std::vector<std::unique_ptr<SNodeTree>> snode_trees_;
+
+  std::unique_ptr<LlvmProgramImpl> llvm_program_;
 
  public:
 #ifdef TI_WITH_CC

--- a/taichi/system/snode_tree_buffer_manager.cpp
+++ b/taichi/system/snode_tree_buffer_manager.cpp
@@ -3,7 +3,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
-SNodeTreeBufferManager::SNodeTreeBufferManager(Program *prog) : prog_(prog) {
+SNodeTreeBufferManager::SNodeTreeBufferManager(LlvmProgramImpl *prog)
+    : prog_(prog) {
   TI_TRACE("SNode tree buffer manager created.");
 }
 
@@ -34,13 +35,16 @@ Ptr SNodeTreeBufferManager::allocate(JITModule *runtime_jit,
                                      void *runtime,
                                      std::size_t size,
                                      std::size_t alignment,
-                                     const int snode_tree_id) {
+                                     const int snode_tree_id,
+                                     uint64 *result_buffer) {
   TI_TRACE("allocating memory for SNode Tree {}", snode_tree_id);
   auto set_it = size_set_.lower_bound(std::make_pair(size, nullptr));
   if (set_it == size_set_.end()) {
     runtime_jit->call<void *, std::size_t, std::size_t>(
         "runtime_snode_tree_allocate_aligned", runtime, size, alignment);
-    auto ptr = prog_->fetch_result<Ptr>(taichi_result_buffer_runtime_query_id);
+    auto ptr =
+        taichi_union_cast_with_different_sizes<Ptr>(prog_->fetch_result_uint64(
+            taichi_result_buffer_runtime_query_id, result_buffer));
     roots_[snode_tree_id] = ptr;
     sizes_[snode_tree_id] = size;
     return ptr;

--- a/taichi/system/snode_tree_buffer_manager.h
+++ b/taichi/system/snode_tree_buffer_manager.h
@@ -10,11 +10,11 @@ using Ptr = uint8_t *;
 
 TLANG_NAMESPACE_BEGIN
 
-class Program;
+class LlvmProgramImpl;
 
 class SNodeTreeBufferManager {
  public:
-  SNodeTreeBufferManager(Program *prog);
+  SNodeTreeBufferManager(LlvmProgramImpl *prog);
 
   void merge_and_insert(Ptr ptr, std::size_t size);
 
@@ -22,14 +22,15 @@ class SNodeTreeBufferManager {
                void *runtime,
                std::size_t size,
                std::size_t alignment,
-               const int snode_tree_id);
+               const int snode_tree_id,
+               uint64 *result_buffer);
 
   void destroy(SNodeTree *snode_tree);
 
  private:
   std::set<std::pair<std::size_t, Ptr>> size_set_;
   std::map<Ptr, std::size_t> ptr_map_;
-  Program *prog_;
+  LlvmProgramImpl *prog_;
   Ptr roots_[taichi_max_num_snode_trees];
   std::size_t sizes_[taichi_max_num_snode_trees];
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #2759
* #2758
* #2757
* #2756
* #2755
* #2754
* #2753
* #2752
* #2751
* #2750
* #2749
* #2748
* #2747
* #2746
* #2745
* #2744
* #2743
* __->__ #2742

snode_tree_buffer_manager is only used by LLVM backends so moving it to
LlvmProgramImpl first.