### PR TITLE
[Refactor] Move print_list_manager_info to LlvmProgramImpl.

### DIFF
--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -68,5 +68,27 @@ uint64 LlvmProgramImpl::fetch_result_uint64(int i, uint64 *result_buffer) {
   return ret;
 }
 
+void LlvmProgramImpl::print_list_manager_info(void *list_manager,
+                                              uint64 *result_buffer) {
+  auto list_manager_len = runtime_query<int32>("ListManager_get_num_elements",
+                                               result_buffer, list_manager);
+
+  auto element_size = runtime_query<int32>("ListManager_get_element_size",
+                                           result_buffer, list_manager);
+
+  auto elements_per_chunk =
+      runtime_query<int32>("ListManager_get_max_num_elements_per_chunk",
+                           result_buffer, list_manager);
+
+  auto num_active_chunks = runtime_query<int32>(
+      "ListManager_get_num_active_chunks", result_buffer, list_manager);
+
+  auto size_MB = 1e-6f * num_active_chunks * elements_per_chunk * element_size;
+
+  fmt::print(
+      " length={:n}     {:n} chunks x [{:n} x {:n} B]  total={:.4f} MB\n",
+      list_manager_len, num_active_chunks, elements_per_chunk, element_size,
+      size_MB);
+}
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -51,6 +51,8 @@ class LlvmProgramImpl {
     return taichi_union_cast_with_different_sizes<T>(fetch_result_uint64(
         taichi_result_buffer_runtime_query_id, result_buffer));
   }
+
+  void print_list_manager_info(void *list_manager, uint64 *result_buffer);
   void device_synchronize();
 
  private:

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -280,8 +280,6 @@ class Program {
 
   static int default_block_dim(const CompileConfig &config);
 
-  void print_list_manager_info(void *list_manager);
-
   void print_memory_profiler_info();
 
   // Returns zero if the SNode is statically allocated


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #2759
* #2758
* #2757
* #2756
* #2755
* #2754
* #2753
* #2752
* __->__ #2751
* #2750
* #2749
* #2748
* #2747
* #2746
* #2745
* #2744
* #2743
* #2742

