### PR TITLE
[Refactor] Move print_memory_profiler_info to LlvmProgramImpl.

### DIFF
--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -53,6 +53,10 @@ class LlvmProgramImpl {
   }
 
   void print_list_manager_info(void *list_manager, uint64 *result_buffer);
+  void print_memory_profiler_info(
+      std::vector<std::unique_ptr<SNodeTree>> &snode_trees_,
+      uint64 *result_buffer);
+
   void device_synchronize();
 
  private:

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -823,73 +823,7 @@ int Program::default_block_dim(const CompileConfig &config) {
 
 void Program::print_memory_profiler_info() {
   TI_ASSERT(arch_uses_llvm(config.arch));
-
-  fmt::print("\n[Memory Profiler]\n");
-
-  std::locale::global(std::locale("en_US.UTF-8"));
-  // So that thousand separators are added to "{:n}" slots in fmtlib.
-  // E.g., 10000 is printed as "10,000".
-  // TODO: is there a way to set locale only locally in this function?
-
-  std::function<void(SNode *, int)> visit = [&](SNode *snode, int depth) {
-    auto element_list = llvm_program_->runtime_query<void *>(
-        "LLVMRuntime_get_element_lists", result_buffer,
-        llvm_program_->llvm_runtime, snode->id);
-
-    if (snode->type != SNodeType::place) {
-      fmt::print("SNode {:10}\n", snode->get_node_type_name_hinted());
-
-      if (element_list) {
-        fmt::print("  active element list:");
-        llvm_program_->print_list_manager_info(element_list, result_buffer);
-
-        auto node_allocator = llvm_program_->runtime_query<void *>(
-            "LLVMRuntime_get_node_allocators", result_buffer,
-            llvm_program_->llvm_runtime, snode->id);
-
-        if (node_allocator) {
-          auto free_list = llvm_program_->runtime_query<void *>(
-              "NodeManager_get_free_list", result_buffer, node_allocator);
-          auto recycled_list = llvm_program_->runtime_query<void *>(
-              "NodeManager_get_recycled_list", result_buffer, node_allocator);
-
-          auto free_list_len = llvm_program_->runtime_query<int32>(
-              "ListManager_get_num_elements", result_buffer, free_list);
-
-          auto recycled_list_len = llvm_program_->runtime_query<int32>(
-              "ListManager_get_num_elements", result_buffer, recycled_list);
-
-          auto free_list_used = llvm_program_->runtime_query<int32>(
-              "NodeManager_get_free_list_used", result_buffer, node_allocator);
-
-          auto data_list = llvm_program_->runtime_query<void *>(
-              "NodeManager_get_data_list", result_buffer, node_allocator);
-          fmt::print("  data list:          ");
-          llvm_program_->print_list_manager_info(data_list, result_buffer);
-
-          fmt::print(
-              "  Allocated elements={:n}; free list length={:n}; recycled list "
-              "length={:n}\n",
-              free_list_used, free_list_len, recycled_list_len);
-        }
-      }
-    }
-    for (const auto &ch : snode->ch) {
-      visit(ch.get(), depth + 1);
-    }
-  };
-
-  for (auto &a : snode_trees_) {
-    visit(a->root(), /*depth=*/0);
-  }
-
-  auto total_requested_memory = llvm_program_->runtime_query<std::size_t>(
-      "LLVMRuntime_get_total_requested_memory", result_buffer,
-      llvm_program_->llvm_runtime);
-
-  fmt::print(
-      "Total requested dynamic memory (excluding alignment padding): {:n} B\n",
-      total_requested_memory);
+  llvm_program_->print_memory_profiler_info(snode_trees_, result_buffer);
 }
 
 std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -280,6 +280,8 @@ class Program {
 
   static int default_block_dim(const CompileConfig &config);
 
+  // Note this method is specific to LlvmProgramImpl, but we keep it here since
+  // it's exposed to python.
   void print_memory_profiler_info();
 
   // Returns zero if the SNode is statically allocated


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #2759
* #2758
* #2757
* #2756
* #2755
* #2754
* #2753
* __->__ #2752
* #2751
* #2750
* #2749
* #2748
* #2747
* #2746
* #2745
* #2744
* #2743
* #2742

