### PR TITLE
[Refactor] Move cc backend to use runtime_lib_dir() and remove runtime_tmp_dir.

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -48,8 +48,6 @@ def import_ti_core(tmp_dir=None):
         sys.setdlopenflags(old_flags)
     lib_dir = os.path.join(package_root(), 'lib')
     core.set_lib_dir(locale_encode(lib_dir))
-    if tmp_dir is not None:
-        core.set_tmp_dir(locale_encode(tmp_dir))
 
 
 def locale_encode(path):
@@ -158,11 +156,6 @@ if settings.get_os_name() != 'win':
     if not os.path.exists(link_dst):
         os.symlink(link_src, link_dst)
 import_ti_core()
-if settings.get_os_name() != 'win':
-    dll = ctypes.CDLL(get_core_shared_object(), mode=ctypes.RTLD_LOCAL)
-    # The C backend needs a temporary directory for the generated .c and compiled .so files:
-    ti_core.set_tmp_dir(locale_encode(prepare_sandbox())
-                        )  # TODO: always allocate a tmp_dir for all situations
 
 ti_core.set_python_package_dir(package_root())
 os.makedirs(ti_core.get_repo_dir(), exist_ok=True)

--- a/taichi/backends/cc/cc_program.cpp
+++ b/taichi/backends/cc/cc_program.cpp
@@ -22,8 +22,8 @@ void CCKernel::compile() {
                               ActionArg("kernel_source", source),
                           });
 
-  obj_path = fmt::format("{}/{}.o", runtime_tmp_dir, name);
-  src_path = fmt::format("{}/{}.c", runtime_tmp_dir, name);
+  obj_path = fmt::format("{}/{}.o", runtime_lib_dir(), name);
+  src_path = fmt::format("{}/{}.c", runtime_lib_dir(), name);
 
   std::ofstream(src_path) << program->get_runtime()->header << "\n"
                           << program->get_layout()->source << "\n"
@@ -55,9 +55,9 @@ size_t CCLayout::compile() {
                                             ActionArg("layout_source", source),
                                         });
 
-  obj_path = fmt::format("{}/_rti_root.o", runtime_tmp_dir);
-  src_path = fmt::format("{}/_rti_root.c", runtime_tmp_dir);
-  auto dll_path = fmt::format("{}/libti_roottest.so", runtime_tmp_dir);
+  obj_path = fmt::format("{}/_rti_root.o", runtime_lib_dir());
+  src_path = fmt::format("{}/_rti_root.c", runtime_lib_dir());
+  auto dll_path = fmt::format("{}/libti_roottest.so", runtime_lib_dir());
 
   std::ofstream(src_path) << program->get_runtime()->header << "\n"
                           << source << "\n"
@@ -90,8 +90,8 @@ void CCRuntime::compile() {
                                             ActionArg("runtime_source", source),
                                         });
 
-  obj_path = fmt::format("{}/_rti_runtime.o", runtime_tmp_dir);
-  src_path = fmt::format("{}/_rti_runtime.c", runtime_tmp_dir);
+  obj_path = fmt::format("{}/_rti_runtime.o", runtime_lib_dir());
+  src_path = fmt::format("{}/_rti_runtime.c", runtime_lib_dir());
 
   std::ofstream(src_path) << header << "\n" << source;
   TI_DEBUG("[cc] compiling runtime -> [{}]:\n{}\n", obj_path, source);
@@ -102,7 +102,7 @@ void CCProgram::relink() {
   if (!need_relink)
     return;
 
-  dll_path = fmt::format("{}/libti_program.so", runtime_tmp_dir);
+  dll_path = fmt::format("{}/libti_program.so", runtime_lib_dir());
 
   std::vector<std::string> objects;
   objects.push_back(runtime->get_object());

--- a/taichi/lang_util.cpp
+++ b/taichi/lang_util.cpp
@@ -14,7 +14,6 @@ namespace lang {
 
 CompileConfig default_compile_config;
 std::string compiled_lib_dir;
-std::string runtime_tmp_dir;
 
 std::string runtime_lib_dir() {
   std::string folder;

--- a/taichi/lang_util.h
+++ b/taichi/lang_util.h
@@ -60,7 +60,6 @@ std::string make_list(const std::vector<T> &data,
 }
 
 extern std::string compiled_lib_dir;
-extern std::string runtime_tmp_dir;
 std::string runtime_lib_dir();
 
 bool command_exist(const std::string &command);

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -146,13 +146,6 @@ std::string get_runtime_src_dir() {
   return get_repo_dir() + "/taichi/runtime/llvm/";
 }
 
-std::string get_runtime_dir() {
-  if (runtime_tmp_dir.size() == 0)
-    return get_runtime_src_dir();
-  else
-    return runtime_tmp_dir + "/runtime/";
-}
-
 std::string libdevice_path() {
   std::string folder;
   folder = runtime_lib_dir();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -56,7 +56,6 @@ void expr_assign(const Expr &lhs_, const Expr &rhs, std::string tb) {
 std::vector<std::unique_ptr<ASTBuilder::ScopeGuard>> scope_stack;
 
 std::string libdevice_path();
-std::string get_runtime_dir();
 
 SNodeRwAccessorsBank::Accessors get_snode_rw_accessors(SNode *snode) {
   return get_current_program().get_snode_rw_accessors_bank().get(snode);
@@ -826,8 +825,6 @@ void export_lang(py::module &m) {
   m.def("host_arch", host_arch);
 
   m.def("set_lib_dir", [&](const std::string &dir) { compiled_lib_dir = dir; });
-  m.def("set_tmp_dir", [&](const std::string &dir) { runtime_tmp_dir = dir; });
-  m.def("get_runtime_dir", get_runtime_dir);
 
   m.def("get_commit_hash", get_commit_hash);
   m.def("get_version_string", get_version_string);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #2770
* __->__ #2769

