### PR TITLE
[Refactor] Make Layout an Enum class and move it away from impl.py

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -9,6 +9,17 @@ from taichi.torch_io import from_torch, to_torch
 # Issue#2223: Do not reorder, or we're busted with partially initialized module
 from taichi import aot  # isort:skip
 
+deprecated_names = {'SOA': 'Layout.SOA', 'AOS': 'Layout.AOS'}
+
+
+def __getattr__(attr):
+    if attr in deprecated_names:
+        warning('ti.{} is deprecated. Please use ti.{} instead.'.format(attr, deprecated_names[attr]), DeprecationWarning, stacklevel=2)
+        exec(f'{attr} = {deprecated_names[attr]}')
+        return locals()[attr]
+    raise AttributeError(f"module '{__name__}' has no attribute '{attr}'")
+
+
 __all__ = ['core', 'misc', 'lang', 'tools', 'main', 'torch_io']
 
 __version__ = (core.get_version_major(), core.get_version_minor(),

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -9,18 +9,22 @@ from taichi.torch_io import from_torch, to_torch
 # Issue#2223: Do not reorder, or we're busted with partially initialized module
 from taichi import aot  # isort:skip
 
+import sys
+
 deprecated_names = {'SOA': 'Layout.SOA', 'AOS': 'Layout.AOS'}
-
-
-def __getattr__(attr):
-    if attr in deprecated_names:
-        warning('ti.{} is deprecated. Please use ti.{} instead.'.format(
-            attr, deprecated_names[attr]),
-                DeprecationWarning,
-                stacklevel=2)
-        exec(f'{attr} = {deprecated_names[attr]}')
-        return locals()[attr]
-    raise AttributeError(f"module '{__name__}' has no attribute '{attr}'")
+if sys.version_info.minor < 7:
+    for name, alter in deprecated_names.items():
+        exec(f'{name} = {alter}')
+else:
+    def __getattr__(attr):
+        if attr in deprecated_names:
+            warning('ti.{} is deprecated. Please use ti.{} instead.'.format(
+                attr, deprecated_names[attr]),
+                    DeprecationWarning,
+                    stacklevel=2)
+            exec(f'{attr} = {deprecated_names[attr]}')
+            return locals()[attr]
+        raise AttributeError(f"module '{__name__}' has no attribute '{attr}'")
 
 
 __all__ = ['core', 'misc', 'lang', 'tools', 'main', 'torch_io']

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -1,3 +1,5 @@
+import sys
+
 from taichi.core import *
 from taichi.lang import *  # TODO(archibate): It's `taichi.lang.core` overriding `taichi.core`
 from taichi.main import main
@@ -9,13 +11,13 @@ from taichi.torch_io import from_torch, to_torch
 # Issue#2223: Do not reorder, or we're busted with partially initialized module
 from taichi import aot  # isort:skip
 
-import sys
 
 deprecated_names = {'SOA': 'Layout.SOA', 'AOS': 'Layout.AOS'}
 if sys.version_info.minor < 7:
     for name, alter in deprecated_names.items():
         exec(f'{name} = {alter}')
 else:
+
     def __getattr__(attr):
         if attr in deprecated_names:
             warning('ti.{} is deprecated. Please use ti.{} instead.'.format(

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -14,7 +14,10 @@ deprecated_names = {'SOA': 'Layout.SOA', 'AOS': 'Layout.AOS'}
 
 def __getattr__(attr):
     if attr in deprecated_names:
-        warning('ti.{} is deprecated. Please use ti.{} instead.'.format(attr, deprecated_names[attr]), DeprecationWarning, stacklevel=2)
+        warning('ti.{} is deprecated. Please use ti.{} instead.'.format(
+            attr, deprecated_names[attr]),
+                DeprecationWarning,
+                stacklevel=2)
         exec(f'{attr} = {deprecated_names[attr]}')
         return locals()[attr]
     raise AttributeError(f"module '{__name__}' has no attribute '{attr}'")

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -11,7 +11,6 @@ from taichi.torch_io import from_torch, to_torch
 # Issue#2223: Do not reorder, or we're busted with partially initialized module
 from taichi import aot  # isort:skip
 
-
 deprecated_names = {'SOA': 'Layout.SOA', 'AOS': 'Layout.AOS'}
 if sys.version_info.minor < 7:
     for name, alter in deprecated_names.items():

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -4,7 +4,7 @@ from copy import deepcopy as _deepcopy
 
 from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl
-from taichi.lang.enums import *
+from taichi.lang.enums import Layout
 from taichi.lang.exception import InvalidOperationError
 from taichi.lang.impl import *
 from taichi.lang.kernel_arguments import any_arr, ext_arr, template

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -3,6 +3,7 @@ import os
 from copy import deepcopy as _deepcopy
 
 from taichi.core.util import ti_core as _ti_core
+from taichi.lang.enums import *
 from taichi.lang import impl
 from taichi.lang.exception import InvalidOperationError
 from taichi.lang.impl import *

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -3,8 +3,8 @@ import os
 from copy import deepcopy as _deepcopy
 
 from taichi.core.util import ti_core as _ti_core
-from taichi.lang.enums import *
 from taichi.lang import impl
+from taichi.lang.enums import *
 from taichi.lang.exception import InvalidOperationError
 from taichi.lang.impl import *
 from taichi.lang.kernel_arguments import any_arr, ext_arr, template

--- a/python/taichi/lang/enums.py
+++ b/python/taichi/lang/enums.py
@@ -1,0 +1,11 @@
+from enum import Enum, unique
+
+
+@unique
+class Layout(Enum):
+    """Layout of a Taichi field or ndarray.
+
+    Currently, AOS (array of structures) and SOA (structure of arrays) are supported.
+    """
+    AOS = 1
+    SOA = 2

--- a/python/taichi/lang/ext_array.py
+++ b/python/taichi/lang/ext_array.py
@@ -72,7 +72,9 @@ class AnyArray:
         if element_dim == 0:
             return ret
         else:
-            return ret[element_dim:] if self.layout == Layout.SOA else ret[:-element_dim]
+            return ret[
+                element_dim:] if self.layout == Layout.SOA else ret[:
+                                                                    -element_dim]
 
 
 class AnyArrayAccess:

--- a/python/taichi/lang/ext_array.py
+++ b/python/taichi/lang/ext_array.py
@@ -1,4 +1,5 @@
 from taichi.core.util import ti_core as _ti_core
+from taichi.lang.enums import Layout
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.util import taichi_scope
 
@@ -46,13 +47,13 @@ class AnyArray:
     Args:
         ptr (taichi_core.Expr): A taichi_core.Expr wrapping a taichi_core.ExternalTensorExpression.
         element_shape (Tuple[Int]): () if scalar elements (default), (n) if vector elements, and (n, m) if matrix elements.
-        is_soa (bool): Whether to change the layout from AOS (default) to SOA.
+        layout (Layout): Memory layout.
     """
-    def __init__(self, ptr, element_shape, is_soa):
+    def __init__(self, ptr, element_shape, layout):
         assert ptr.is_external_var()
         self.ptr = ptr
         self.element_shape = element_shape
-        self.is_soa = is_soa
+        self.layout = layout
 
     @property
     @taichi_scope
@@ -71,7 +72,7 @@ class AnyArray:
         if element_dim == 0:
             return ret
         else:
-            return ret[element_dim:] if self.is_soa else ret[:-element_dim]
+            return ret[element_dim:] if self.layout == Layout.SOA else ret[:-element_dim]
 
 
 class AnyArrayAccess:
@@ -88,7 +89,7 @@ class AnyArrayAccess:
     @taichi_scope
     def subscript(self, i, j):
         indices_second = (i, ) if len(self.arr.element_shape) == 1 else (i, j)
-        if self.arr.is_soa:
+        if self.arr.layout == Layout.SOA:
             indices = indices_second + self.indices_first
         else:
             indices = self.indices_first + indices_second

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -607,20 +607,6 @@ def ndarray(dtype, shape):
     return ScalarNdarray(dtype, shape)
 
 
-class Layout:
-    def __init__(self, soa=False):
-        self.soa = soa
-
-
-SOA = Layout(soa=True)
-AOS = Layout(soa=False)
-
-
-@python_scope
-def layout(func):
-    raise InvalidOperationError('layout(): Deprecated')
-
-
 @taichi_scope
 def ti_print(*vars, sep=' ', end='\n'):
     def entry2content(var):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -3,12 +3,12 @@ import numbers
 from collections.abc import Iterable
 
 import numpy as np
+from taichi.lang.enums import Layout
 from taichi.lang import expr, impl
 from taichi.lang import kernel_impl as kern_mod
 from taichi.lang import ops as ops_mod
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.exception import TaichiSyntaxError
-from taichi.lang.ext_array import AnyArrayAccess
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.util import (in_python_scope, is_taichi_class, python_scope,
                               taichi_scope, to_numpy_type, to_pytorch_type)
@@ -27,7 +27,7 @@ class Matrix(TaichiOperations):
         shape ( Union[int, tuple of int], optional): the shape of a matrix field.
         offset (Union[int, tuple of int], optional): The coordinate offset of all elements in a field.
         empty (Bool, deprecated): True if the matrix is empty, False otherwise.
-        layout (TypeVar, optional): The filed layout(AOS or SOA).
+        layout (TypeVar, optional): The filed layout (AOS or SOA).
         needs_grad (Bool, optional): True if used in auto diff, False otherwise.
         keep_raw (Bool, optional): Keep the contents in `n` as is.
         rows (List, deprecated): construct matrix rows.
@@ -44,7 +44,7 @@ class Matrix(TaichiOperations):
                  shape=None,
                  offset=None,
                  empty=False,
-                 layout=None,
+                 layout=Layout.AOS,
                  needs_grad=False,
                  keep_raw=False,
                  disable_local_tensor=False,
@@ -914,7 +914,7 @@ class Matrix(TaichiOperations):
               name="",
               offset=None,
               needs_grad=False,
-              layout=None):  # TODO(archibate): deprecate layout
+              layout=Layout.AOS):  # TODO(archibate): deprecate layout
         """Construct a data container to hold all elements of the Matrix.
 
         Args:
@@ -925,7 +925,7 @@ class Matrix(TaichiOperations):
             name (string, optional): The custom name of the field.
             offset (Union[int, tuple of int], optional): The coordinate offset of all elements in a field.
             needs_grad (bool, optional): Whether the Matrix need gradients.
-            layout (:class:`~taichi.lang.impl.Layout`, optional): The field layout, i.e., Array Of Structure(AOS) or Structure Of Array(SOA).
+            layout (Layout, optional): The field layout, i.e., Array Of Structure (AOS) or Structure Of Array (SOA).
 
         Returns:
             :class:`~taichi.lang.matrix.Matrix`: A :class:`~taichi.lang.matrix.Matrix` instance serves as the data container.
@@ -958,8 +958,6 @@ class Matrix(TaichiOperations):
             entries_grad, n, m)
         entries.set_grad(entries_grad)
 
-        if layout is not None:
-            assert shape is not None, 'layout is useless without shape'
         if shape is None:
             assert offset is None, "shape cannot be None when offset is being set"
 
@@ -974,11 +972,8 @@ class Matrix(TaichiOperations):
                     offset
                 ), f'The dimensionality of shape and offset must be the same  ({len(shape)} != {len(offset)})'
 
-            if layout is None:
-                layout = ti.AOS
-
             dim = len(shape)
-            if layout.soa:
+            if layout == Layout.SOA:
                 for e in entries.get_field_members():
                     ti.root.dense(impl.index_nd(dim),
                                   shape).place(ScalarField(e), offset=offset)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -3,11 +3,11 @@ import numbers
 from collections.abc import Iterable
 
 import numpy as np
-from taichi.lang.enums import Layout
 from taichi.lang import expr, impl
 from taichi.lang import kernel_impl as kern_mod
 from taichi.lang import ops as ops_mod
 from taichi.lang.common_ops import TaichiOperations
+from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.util import (in_python_scope, is_taichi_class, python_scope,

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -27,7 +27,7 @@ class Matrix(TaichiOperations):
         shape ( Union[int, tuple of int], optional): the shape of a matrix field.
         offset (Union[int, tuple of int], optional): The coordinate offset of all elements in a field.
         empty (Bool, deprecated): True if the matrix is empty, False otherwise.
-        layout (TypeVar, optional): The filed layout (AOS or SOA).
+        layout (Layout, optional): The filed layout (Layout.AOS or Layout.SOA).
         needs_grad (Bool, optional): True if used in auto diff, False otherwise.
         keep_raw (Bool, optional): Keep the contents in `n` as is.
         rows (List, deprecated): construct matrix rows.
@@ -914,7 +914,7 @@ class Matrix(TaichiOperations):
               name="",
               offset=None,
               needs_grad=False,
-              layout=Layout.AOS):  # TODO(archibate): deprecate layout
+              layout=Layout.AOS):
         """Construct a data container to hold all elements of the Matrix.
 
         Args:

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -564,7 +564,7 @@ if 1:
                     array_dt = ctx.arg_features[i][0]
                     array_dim = ctx.arg_features[i][1]
                     array_element_shape = ctx.arg_features[i][2]
-                    array_is_soa = ctx.arg_features[i][3]
+                    array_layout = ctx.arg_features[i][3]
                     array_dt = to_taichi_type(array_dt)
                     dt_expr = 'ti.' + ti.core.data_type_name(array_dt)
                     dt = parse_expr(dt_expr)
@@ -573,7 +573,7 @@ if 1:
                     arg_init.value.args[2] = parse_expr(
                         "{}".format(array_element_shape))
                     arg_init.value.args[3] = parse_expr(
-                        "{}".format(array_is_soa))
+                        "ti.{}".format(array_layout))
                     arg_decls.append(arg_init)
                 else:
                     arg_init = parse_stmt(

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -177,7 +177,7 @@ def test_matrix_non_constant_index_numpy():
     assert m[4][0, 1] == 1
 
     @ti.kernel
-    def func2(b: ti.any_arr(element_shape=(10, ), is_soa=True)):
+    def func2(b: ti.any_arr(element_shape=(10, ), layout=ti.Layout.SOA)):
         for i in range(5):
             for j in range(4):
                 b[i][j * j] = j * j

--- a/tests/python/test_new_allocator.py
+++ b/tests/python/test_new_allocator.py
@@ -50,7 +50,7 @@ def test_3d():
 def test_matrix():
     N = 16
 
-    x = ti.Matrix.field(2, 2, dtype=ti.f32, shape=(N, ), layout=ti.AOS)
+    x = ti.Matrix.field(2, 2, dtype=ti.f32, shape=(N, ), layout=ti.Layout.AOS)
 
     @ti.kernel
     def func():


### PR DESCRIPTION
Related issue = #2223
Discussed in #2727 Review

Reasons:
- Make `Layout` an `Enum` class: Using `Enum` is more clear and extensible than using a class with a bool inside.
- Move `Layout` away from `impl.py`: Avoid circular import when we want to set default parameter values to some layout (previously it was hacked with a `None` value); Avoid exposing everything directly under `ti`.

Effects:
- Now users need to use `ti.Layout.AOS/SOA`. `ti.AOS/SOA` is still available but marked as deprecated.

Side Effects:
- A new way to handle deprecated names is implemented. We only need to directly add the mapping to `deprecated_names` in `taichi/__init__.py`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
