### PR TITLE
[Refactor] Only prepare sandbox for cc backend.

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -21,7 +21,7 @@ def in_docker():
         return True
 
 
-def import_ti_core(tmp_dir=None):
+def import_ti_core():
     global ti_core
     if settings.get_os_name() != 'win':
         old_flags = sys.getdlopenflags()
@@ -48,8 +48,6 @@ def import_ti_core(tmp_dir=None):
         sys.setdlopenflags(old_flags)
     lib_dir = os.path.join(package_root(), 'lib')
     core.set_lib_dir(locale_encode(lib_dir))
-    if tmp_dir is not None:
-        core.set_tmp_dir(locale_encode(tmp_dir))
 
 
 def locale_encode(path):
@@ -80,19 +78,10 @@ def get_core_shared_object():
     return os.path.join(directory, 'libtaichi_core.so')
 
 
-def get_repo():
-    from git import Repo
-    repo = Repo(settings.get_repo_directory())
-    return repo
-
-
 def print_red_bold(*args, **kwargs):
     print(Fore.RED + Style.BRIGHT, end='')
     print(*args, **kwargs)
     print(Style.RESET_ALL, end='')
-
-
-create_sand_box_on_windows = True
 
 
 def build():
@@ -127,21 +116,6 @@ def check_exists(src):
         )
 
 
-def prepare_sandbox():
-    '''
-    Returns a temporary directory, which will be automatically deleted on exit.
-    It may contain the taichi_core shared object or some misc. files.
-    '''
-    import atexit
-    import shutil
-    from tempfile import mkdtemp
-    tmp_dir = mkdtemp(prefix='taichi-')
-    atexit.register(shutil.rmtree, tmp_dir)
-    print(f'[Taichi] preparing sandbox at {tmp_dir}')
-    os.mkdir(os.path.join(tmp_dir, 'runtime/'))
-    return tmp_dir
-
-
 def get_unique_task_id():
     import datetime
     import random
@@ -149,7 +123,6 @@ def get_unique_task_id():
         '%05d' % random.randint(0, 10000))
 
 
-print("[Taichi] mode=release")
 sys.path.append(os.path.join(package_root(), 'lib'))
 if settings.get_os_name() != 'win':
     link_src = os.path.join(package_root(), 'lib', 'taichi_core.so')
@@ -158,11 +131,6 @@ if settings.get_os_name() != 'win':
     if not os.path.exists(link_dst):
         os.symlink(link_src, link_dst)
 import_ti_core()
-if settings.get_os_name() != 'win':
-    dll = ctypes.CDLL(get_core_shared_object(), mode=ctypes.RTLD_LOCAL)
-    # The C backend needs a temporary directory for the generated .c and compiled .so files:
-    ti_core.set_tmp_dir(locale_encode(prepare_sandbox())
-                        )  # TODO: always allocate a tmp_dir for all situations
 
 ti_core.set_python_package_dir(package_root())
 os.makedirs(ti_core.get_repo_dir(), exist_ok=True)

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -142,17 +142,6 @@ std::string get_runtime_fn(Arch arch) {
   return fmt::format("runtime_{}.bc", arch_name(arch));
 }
 
-std::string get_runtime_src_dir() {
-  return get_repo_dir() + "/taichi/runtime/llvm/";
-}
-
-std::string get_runtime_dir() {
-  if (runtime_tmp_dir.size() == 0)
-    return get_runtime_src_dir();
-  else
-    return runtime_tmp_dir + "/runtime/";
-}
-
 std::string libdevice_path() {
   std::string folder;
   folder = runtime_lib_dir();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -56,7 +56,6 @@ void expr_assign(const Expr &lhs_, const Expr &rhs, std::string tb) {
 std::vector<std::unique_ptr<ASTBuilder::ScopeGuard>> scope_stack;
 
 std::string libdevice_path();
-std::string get_runtime_dir();
 
 SNodeRwAccessorsBank::Accessors get_snode_rw_accessors(SNode *snode) {
   return get_current_program().get_snode_rw_accessors_bank().get(snode);
@@ -827,7 +826,6 @@ void export_lang(py::module &m) {
 
   m.def("set_lib_dir", [&](const std::string &dir) { compiled_lib_dir = dir; });
   m.def("set_tmp_dir", [&](const std::string &dir) { runtime_tmp_dir = dir; });
-  m.def("get_runtime_dir", get_runtime_dir);
 
   m.def("get_commit_hash", get_commit_hash);
   m.def("get_version_string", get_version_string);


### PR DESCRIPTION
Now when you import taichi, we'll only show:
```
>>> import taichi
[Taichi] version 0.7.29, llvm 10.0.0, commit e719c60a, linux, python 3.8.11
```

We'll prepare a sandbox when you initialize only on **cc backend**:
```
>>> ti.init(arch=ti.cc)
[Taichi] preparing sandbox at /tmp/taichi-osr4s9x5
[Taichi] Starting on arch=cc
```

fixes #2714. 