### PR TITLE
[gui] GGUI 6/n: App context and swap chain

### DIFF
--- a/taichi/ui/backends/vulkan/app_context.cpp
+++ b/taichi/ui/backends/vulkan/app_context.cpp
@@ -1,0 +1,89 @@
+#include "taichi/ui/utils/utils.h"
+#include "taichi/ui/backends/vulkan/app_context.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+
+#include <string_view>
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+using namespace taichi::lang::vulkan;
+
+namespace {
+std::vector<std::string> get_required_instance_extensions() {
+  uint32_t glfw_ext_count = 0;
+  const char **glfw_extensions;
+  glfw_extensions = glfwGetRequiredInstanceExtensions(&glfw_ext_count);
+
+  std::vector<std::string> extensions;
+
+  for (int i = 0; i < glfw_ext_count; ++i) {
+    extensions.push_back(glfw_extensions[i]);
+  }
+
+  // EmbeddedVulkanDevice will check that these are supported
+  extensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+  extensions.push_back(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+  extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
+  extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+  return extensions;
+}
+
+std::vector<std::string> get_required_device_extensions() {
+  static std::vector<std::string> extensions{
+      VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+#ifdef _WIN64
+      VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
+#else
+      VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+#endif
+  };
+
+  return extensions;
+}
+}  // namespace
+
+void AppContext::init(GLFWwindow *glfw_window, const AppConfig &config) {
+  glfw_window_ = glfw_window;
+  this->config = config;
+  EmbeddedVulkanDevice::Params evd_params;
+  evd_params.additional_instance_extensions =
+      get_required_instance_extensions();
+  evd_params.additional_device_extensions = get_required_device_extensions();
+  evd_params.is_for_ui = true;
+  evd_params.surface_creator = [&](VkInstance instance) -> VkSurfaceKHR {
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    if (glfwCreateWindowSurface(instance, glfw_window, nullptr, &surface) !=
+        VK_SUCCESS) {
+      throw std::runtime_error("failed to create window surface!");
+    }
+    return surface;
+  };
+  vulkan_device_ = std::make_unique<EmbeddedVulkanDevice>(evd_params);
+}
+
+taichi::lang::vulkan::VulkanDevice &AppContext::device() {
+  return *(vulkan_device_->device());
+}
+
+const taichi::lang::vulkan::VulkanDevice &AppContext::device() const {
+  return *(vulkan_device_->device());
+}
+
+void AppContext::cleanup() {
+  vulkan_device_.reset();
+}
+
+GLFWwindow *AppContext::glfw_window() const {
+  return glfw_window_;
+}
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/app_context.h
+++ b/taichi/ui/backends/vulkan/app_context.h
@@ -1,0 +1,34 @@
+#pragma once
+#include "taichi/ui/common/app_config.h"
+#include <memory>
+#include "taichi/backends/vulkan/vulkan_api.h"
+#include "taichi/backends/vulkan/loader.h"
+#include "taichi/backends/vulkan/vulkan_device.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+class AppContext {
+ public:
+  void init(GLFWwindow *glfw_window, const AppConfig &config);
+  void cleanup();
+
+  GLFWwindow *glfw_window() const;
+
+  taichi::lang::vulkan::VulkanDevice &device();
+  const taichi::lang::vulkan::VulkanDevice &device() const;
+
+  AppConfig config;
+
+ private:
+  std::unique_ptr<taichi::lang::vulkan::EmbeddedVulkanDevice> vulkan_device_{
+      nullptr};
+
+  GLFWwindow *glfw_window_{nullptr};
+};
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/swap_chain.cpp
+++ b/taichi/ui/backends/vulkan/swap_chain.cpp
@@ -1,0 +1,67 @@
+#include "taichi/ui/utils/utils.h"
+#include "taichi/ui/backends/vulkan/app_context.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+using namespace taichi::lang::vulkan;
+using namespace taichi::lang;
+
+void SwapChain::init(class AppContext *app_context) {
+  app_context_ = app_context;
+  SurfaceConfig config;
+  config.vsync = app_context_->config.vsync;
+  config.window_handle = app_context_->glfw_window();
+
+  surface_ = app_context_->device().create_surface(config);
+  auto [w, h] = surface_->get_size();
+  curr_width_ = w;
+  curr_height_ = h;
+  create_depth_resources();
+}
+
+void SwapChain::create_depth_resources() {
+  ImageParams params;
+  params.dimension = ImageDimension::d2D;
+  params.format = BufferFormat::depth32f;
+  params.initial_layout = ImageLayout::undefined;
+  params.x = curr_width_;
+  params.y = curr_height_;
+  params.export_sharing = false;
+
+  depth_allocation_ = app_context_->device().create_image(params);
+}
+
+void SwapChain::resize(uint32_t width, uint32_t height) {
+  surface().resize(width, height);
+  app_context_->device().destroy_image(depth_allocation_);
+  auto [w, h] = surface_->get_size();
+  curr_width_ = w;
+  curr_height_ = h;
+  create_depth_resources();
+}
+
+void SwapChain::cleanup() {
+  app_context_->device().destroy_image(depth_allocation_);
+  surface_.reset();
+}
+
+DeviceAllocation SwapChain::depth_allocation() {
+  return depth_allocation_;
+}
+
+uint32_t SwapChain::width() {
+  return curr_width_;
+}
+uint32_t SwapChain::height() {
+  return curr_height_;
+}
+taichi::lang::Surface &SwapChain::surface() {
+  return *(surface_.get());
+}
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/swap_chain.h
+++ b/taichi/ui/backends/vulkan/swap_chain.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <taichi/backends/device.h>
+
+TI_UI_NAMESPACE_BEGIN
+namespace vulkan {
+
+class SwapChain {
+ public:
+  void init(class AppContext *app_context);
+  uint32_t width();
+  uint32_t height();
+
+  taichi::lang::Surface &surface();
+  taichi::lang::DeviceAllocation depth_allocation();
+
+  void resize(uint32_t width, uint32_t height);
+
+  void cleanup();
+
+ private:
+  void create_depth_resources();
+
+  taichi::lang::DeviceAllocation depth_allocation_;
+
+  std::unique_ptr<taichi::lang::Surface> surface_;
+
+  class AppContext *app_context_;
+
+  uint32_t curr_width_;
+  uint32_t curr_height_;
+};
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END


### PR DESCRIPTION
Related issue = #2646 

This is the 6th of a series of PRs that adds a GPU-based GUI to taichi.

This PR adds two classes, both of which are thin wrappers around classes in the device api:

1. Swap Chain, which owns a VulkanSurface object, as well as a DeviceAllocation, which is used as the depth buffer.
2. App Context, which keeps track of the app config, and owns an EmbeddedVulkanDevice object.

side note, look how much smaller this PR is compared to #2700 ! props to our device api