### PR TITLE
[gui] GGUI 8/n: Renderable class

### DIFF
--- a/taichi/ui/backends/vulkan/renderable.cpp
+++ b/taichi/ui/backends/vulkan/renderable.cpp
@@ -1,0 +1,301 @@
+#include "taichi/ui/backends/vulkan/renderable.h"
+#include "taichi/ui/utils/utils.h"
+
+#include "taichi/ui/backends/vulkan/vulkan_cuda_interop.h"
+#include "taichi/ui/backends/vulkan/renderables/kernels.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+using namespace taichi::lang;
+using namespace taichi::lang::vulkan;
+
+void Renderable::init(const RenderableConfig &config, AppContext *app_context) {
+  config_ = config;
+  app_context_ = app_context;
+}
+
+void Renderable::init_render_resources() {
+  create_graphics_pipeline();
+  init_buffers();
+}
+
+void Renderable::free_buffers() {
+  app_context_->device().dealloc_memory(vertex_buffer_);
+  app_context_->device().dealloc_memory(staging_vertex_buffer_);
+  app_context_->device().dealloc_memory(index_buffer_);
+  app_context_->device().dealloc_memory(staging_index_buffer_);
+
+  destroy_uniform_buffers();
+  destroy_storage_buffers();
+}
+
+void Renderable::init_buffers() {
+  create_vertex_buffer();
+  create_index_buffer();
+  create_uniform_buffers();
+  create_storage_buffers();
+
+  create_bindings();
+
+  if (app_context_->config.ti_arch == Arch::cuda) {
+    auto [vb_mem, vb_offset, vb_size] =
+        app_context_->device().get_vkmemory_offset_size(vertex_buffer_);
+
+    auto [ib_mem, ib_offset, ib_size] =
+        app_context_->device().get_vkmemory_offset_size(index_buffer_);
+
+    auto block_size = VulkanDevice::kMemoryBlockSize;
+
+    vertex_buffer_device_ptr_ =
+        (Vertex *)get_memory_pointer(vb_mem, block_size, vb_offset, vb_size,
+                                     app_context_->device().vk_device());
+    index_buffer_device_ptr_ =
+        (int *)get_memory_pointer(ib_mem, block_size, ib_offset, ib_size,
+                                  app_context_->device().vk_device());
+  }
+}
+
+void Renderable::update_data(const RenderableInfo &info) {
+  int num_vertices = info.vertices.shape[0];
+  int num_indices;
+  if (info.indices.valid) {
+    num_indices = info.indices.shape[0];
+    if (info.indices.dtype != PrimitiveType::i32 &&
+        info.indices.dtype != PrimitiveType::u32) {
+      throw std::runtime_error("dtype needs to be 32-bit ints for indices");
+    }
+  } else {
+    num_indices = num_vertices;
+  }
+  if (num_vertices > config_.vertices_count ||
+      num_indices > config_.indices_count) {
+    free_buffers();
+    config_.vertices_count = num_vertices;
+    config_.indices_count = num_indices;
+    init_buffers();
+  }
+
+  if (info.vertices.dtype != PrimitiveType::f32) {
+    throw std::runtime_error("dtype needs to be f32 for vertices");
+  }
+
+  int num_components = info.vertices.matrix_rows;
+
+  if (info.vertices.field_source == FieldSource::TaichiCuda) {
+    update_renderables_vertices_cuda(vertex_buffer_device_ptr_,
+                                     (float *)info.vertices.data, num_vertices,
+                                     num_components, offsetof(Vertex, pos));
+
+    if (info.per_vertex_color.valid) {
+      if (info.per_vertex_color.shape[0] != num_vertices) {
+        throw std::runtime_error(
+            "shape of per_vertex_color should be the same as vertices");
+      }
+      update_renderables_vertices_cuda(
+          vertex_buffer_device_ptr_, (float *)info.per_vertex_color.data,
+          num_vertices, 3, offsetof(Vertex, color));
+    }
+
+    if (info.normals.valid) {
+      if (info.normals.shape[0] != num_vertices) {
+        throw std::runtime_error(
+            "shape of normals should be the same as vertices");
+      }
+      update_renderables_vertices_cuda(vertex_buffer_device_ptr_,
+                                       (float *)info.normals.data, num_vertices,
+                                       3, offsetof(Vertex, normal));
+    }
+
+    if (info.indices.valid) {
+      indexed_ = true;
+      update_renderables_indices_cuda(index_buffer_device_ptr_,
+                                      (int *)info.indices.data, num_indices);
+    } else {
+      indexed_ = false;
+    }
+
+  } else if (info.vertices.field_source == FieldSource::TaichiX64) {
+    {
+      Vertex *mapped_vbo =
+          (Vertex *)app_context_->device().map(staging_vertex_buffer_);
+
+      update_renderables_vertices_x64(mapped_vbo, (float *)info.vertices.data,
+                                      num_vertices, num_components,
+                                      offsetof(Vertex, pos));
+      if (info.per_vertex_color.valid) {
+        if (info.per_vertex_color.shape[0] != num_vertices) {
+          throw std::runtime_error(
+              "shape of per_vertex_color should be the same as vertices");
+        }
+        update_renderables_vertices_x64(
+            mapped_vbo, (float *)info.per_vertex_color.data, num_vertices, 3,
+            offsetof(Vertex, color));
+      }
+      if (info.normals.valid) {
+        if (info.normals.shape[0] != num_vertices) {
+          throw std::runtime_error(
+              "shape of normals should be the same as vertices");
+        }
+        update_renderables_vertices_x64(mapped_vbo, (float *)info.normals.data,
+                                        num_vertices, 3,
+                                        offsetof(Vertex, normal));
+      }
+      app_context_->device().unmap(staging_vertex_buffer_);
+
+      int *mapped_ibo =
+          (int *)app_context_->device().map(staging_index_buffer_);
+      if (info.indices.valid) {
+        indexed_ = true;
+        update_renderables_indices_x64(mapped_ibo, (int *)info.indices.data,
+                                       num_indices);
+      } else {
+        indexed_ = false;
+      }
+      app_context_->device().unmap(staging_index_buffer_);
+    }
+    app_context_->device().memcpy(vertex_buffer_.get_ptr(0),
+                                  staging_vertex_buffer_.get_ptr(0),
+                                  config_.vertices_count * sizeof(Vertex));
+    app_context_->device().memcpy(index_buffer_.get_ptr(0),
+                                  staging_index_buffer_.get_ptr(0),
+                                  config_.indices_count * sizeof(int));
+  } else {
+    throw std::runtime_error("unsupported field source");
+  }
+}
+
+Pipeline &Renderable::pipeline() {
+  return *(pipeline_.get());
+}
+
+const Pipeline &Renderable::pipeline() const {
+  return *(pipeline_.get());
+}
+
+void Renderable::create_bindings() {
+  ResourceBinder *binder = pipeline_->resource_binder();
+  binder->vertex_buffer(vertex_buffer_.get_ptr(0), 0);
+  binder->index_buffer(index_buffer_.get_ptr(0), 32);
+}
+
+void Renderable::create_graphics_pipeline() {
+  if (pipeline_.get()) {
+    return;
+  }
+  auto vert_code = read_file(config_.vertex_shader_path);
+  auto frag_code = read_file(config_.fragment_shader_path);
+
+  std::vector<PipelineSourceDesc> source(2);
+  source[0] = {PipelineSourceType::spirv_binary, frag_code.data(),
+               frag_code.size(), PipelineStageType::fragment};
+  source[1] = {PipelineSourceType::spirv_binary, vert_code.data(),
+               vert_code.size(), PipelineStageType::vertex};
+
+  RasterParams raster_params;
+  raster_params.prim_topology = config_.topology_type;
+  raster_params.depth_test = true;
+  raster_params.depth_write = true;
+
+  std::vector<VertexInputBinding> vertex_inputs = {{0, sizeof(Vertex), false}};
+  std::vector<VertexInputAttribute> vertex_attribs = {
+      {0, 0, BufferFormat::rgb32f, offsetof(Vertex, pos)},
+      {1, 0, BufferFormat::rgb32f, offsetof(Vertex, normal)},
+      {2, 0, BufferFormat::rg32f, offsetof(Vertex, texCoord)},
+      {3, 0, BufferFormat::rgb32f, offsetof(Vertex, color)}};
+
+  pipeline_ = app_context_->device().create_raster_pipeline(
+      source, raster_params, vertex_inputs, vertex_attribs);
+}
+
+void Renderable::create_vertex_buffer() {
+  size_t buffer_size = sizeof(Vertex) * config_.vertices_count;
+
+  Device::AllocParams vb_params{buffer_size, false, false, true,
+                                AllocUsage::Vertex};
+  vertex_buffer_ = app_context_->device().allocate_memory(vb_params);
+
+  Device::AllocParams staging_vb_params{buffer_size, true, false, false,
+                                        AllocUsage::Vertex};
+  staging_vertex_buffer_ =
+      app_context_->device().allocate_memory(staging_vb_params);
+}
+
+void Renderable::create_index_buffer() {
+  size_t buffer_size = sizeof(int) * config_.indices_count;
+
+  Device::AllocParams ib_params{buffer_size, false, false, true,
+                                AllocUsage::Index};
+  index_buffer_ = app_context_->device().allocate_memory(ib_params);
+
+  Device::AllocParams staging_ib_params{buffer_size, true, false, false,
+                                        AllocUsage::Index};
+  staging_index_buffer_ =
+      app_context_->device().allocate_memory(staging_ib_params);
+}
+
+void Renderable::create_uniform_buffers() {
+  size_t buffer_size = config_.ubo_size;
+  if (buffer_size == 0) {
+    return;
+  }
+
+  Device::AllocParams ub_params{buffer_size, true, false, false,
+                                AllocUsage::Uniform};
+  uniform_buffer_ = app_context_->device().allocate_memory(ub_params);
+}
+
+void Renderable::create_storage_buffers() {
+  size_t buffer_size = config_.ssbo_size;
+  if (buffer_size == 0) {
+    return;
+  }
+
+  Device::AllocParams sb_params{buffer_size, true, false, false,
+                                AllocUsage::Storage};
+  storage_buffer_ = app_context_->device().allocate_memory(sb_params);
+}
+
+void Renderable::destroy_uniform_buffers() {
+  if (config_.ubo_size == 0) {
+    return;
+  }
+  app_context_->device().dealloc_memory(uniform_buffer_);
+}
+
+void Renderable::destroy_storage_buffers() {
+  if (config_.ssbo_size == 0) {
+    return;
+  }
+  app_context_->device().dealloc_memory(storage_buffer_);
+}
+
+void Renderable::cleanup() {
+  free_buffers();
+  pipeline_.reset();
+}
+
+void Renderable::record_this_frame_commands(CommandList *command_list) {
+  command_list->bind_pipeline(pipeline_.get());
+  command_list->bind_resources(pipeline_->resource_binder());
+
+  if (indexed_) {
+    command_list->draw_indexed(config_.indices_count, 0, 0);
+  } else {
+    command_list->draw(config_.vertices_count, 0);
+  }
+}
+
+void Renderable::resize_storage_buffers(int new_ssbo_size) {
+  if (new_ssbo_size == config_.ssbo_size) {
+    return;
+  }
+  destroy_storage_buffers();
+  config_.ssbo_size = new_ssbo_size;
+  create_storage_buffers();
+}
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/renderable.h
+++ b/taichi/ui/backends/vulkan/renderable.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <stdexcept>
+#include <algorithm>
+#include <chrono>
+#include <vector>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include <array>
+#include <optional>
+#include <set>
+#include "taichi/ui/utils/utils.h"
+#include "taichi/ui/backends/vulkan/vertex.h"
+#include "taichi/ui/backends/vulkan/app_context.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+#include "taichi/ui/common/renderable_info.h"
+#include "taichi/backends/vulkan/vulkan_device.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+struct RenderableConfig {
+  int vertices_count;
+  int indices_count;
+  size_t ubo_size;
+  size_t ssbo_size;
+  std::string vertex_shader_path;
+  std::string fragment_shader_path;
+  taichi::lang::TopologyType topology_type;
+};
+
+class Renderable {
+ public:
+  void update_data(const RenderableInfo &info);
+
+  virtual void record_this_frame_commands(
+      taichi::lang::CommandList *command_list);
+
+  virtual ~Renderable() = default;
+
+  taichi::lang::Pipeline &pipeline();
+  const taichi::lang::Pipeline &pipeline() const;
+
+  virtual void cleanup();
+
+ protected:
+  RenderableConfig config_;
+  AppContext *app_context_;
+
+  std::unique_ptr<taichi::lang::Pipeline> pipeline_{nullptr};
+
+  taichi::lang::DeviceAllocation vertex_buffer_;
+  taichi::lang::DeviceAllocation index_buffer_;
+
+  // these staging buffers are used to copy data into the actual buffers when
+  // `ti.cfg.arch==ti.cpu`
+  taichi::lang::DeviceAllocation staging_vertex_buffer_;
+  taichi::lang::DeviceAllocation staging_index_buffer_;
+
+  taichi::lang::DeviceAllocation uniform_buffer_;
+  taichi::lang::DeviceAllocation storage_buffer_;
+
+  Vertex *vertex_buffer_device_ptr_;
+  int *index_buffer_device_ptr_;
+
+  bool indexed_{false};
+
+ protected:
+  void init(const RenderableConfig &config_, AppContext *app_context);
+  void free_buffers();
+  void init_buffers();
+  void init_render_resources();
+
+  virtual void create_bindings();
+
+  void create_graphics_pipeline();
+
+  void create_vertex_buffer();
+
+  void create_index_buffer();
+
+  void create_uniform_buffers();
+
+  void create_storage_buffers();
+
+  void destroy_uniform_buffers();
+
+  void destroy_storage_buffers();
+
+  void resize_storage_buffers(int new_ssbo_size);
+};
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END


### PR DESCRIPTION
Related issue = #2646 

This is the 8th of a series of PRs that adds a GPU-based GUI to taichi.

This PR adds a `Renderable` class, which manages a graphics pipeline, a VBO, an IBO, and optionally an UBO and a SSBO. It also implements methods of updating the VBO and IBO using data from a taichi field (represented by a `FieldInfo`)

