### PR TITLE
[release] v0.7.30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ classifiers = [
 project_name = os.getenv('PROJECT_NAME', 'taichi')
 TI_VERSION_MAJOR = 0
 TI_VERSION_MINOR = 7
-TI_VERSION_PATCH = 29
+TI_VERSION_PATCH = 30
 version = f'{TI_VERSION_MAJOR}.{TI_VERSION_MINOR}.{TI_VERSION_PATCH}'
 
 data_files = glob.glob('python/lib/*')


### PR DESCRIPTION
Full changelog:
   - [gui] GGUI 7/n: Vertex class, and kernels for updating VBO/IBO/texture (#2797) (by **Dunfan Lu**)
   - [Refactor] Make Layout an Enum class and move it away from impl.py (#2774) (by **Yi Xu**)
   - app context and swap chain (#2794) (by **Dunfan Lu**)
   - [Refactor] Move snode_tree_buffer_manager and llvm_runtime to private. (by **Ailing Zhang**)
   - [Refactor] Move llvm_context_host/device to private. (by **Ailing Zhang**)
   - [Refactor] Further cleanup Program constructor. (by **Ailing Zhang**)
   - [Refactor] Move check_runtime_error to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Simplify synchronize and materialize_runtime in Program. (by **Ailing Zhang**)
   - [gui] GGUI 5/n: remove some stuff (#2793) (by **Dunfan Lu**)
   - [ci] Added gpu test timeout (#2791) (by **Jiasheng Zhang**)
   - [Vulkan] [test] Fix Vulkan CI test bug & Enable tests for Vulkan backend (#2776) (by **Yu Chang**)
   - [vulkan] Graphics Device API (#2789) (by **Dunfan Lu**)
   - [ci] Changed nightly tag from pre-release to post-release (#2786) (by **Jiasheng Zhang**)
   - [ci] Add Apple M1 buildbot (#2731) (by **ljcc0930**)
   - [Refactor] Move a few helpers in LlvmProgramImpl to private. (by **Ailing Zhang**)
   - [Refactor] Cleanup llvm specific apis in program.h (by **Ailing Zhang**)
   - [Ir] Clean up frontend ir for global tensor and local tensor (#2773) (by **squarefk**)
   - [Refactor] Only prepare sandbox for cc backend. (#2775) (by **Ailing**)
   - [gui] Remove DPI settings (#2767) (by **Ye Kuang**)
   - [Doc] Add instructions for how to use conda (#2764) (by **Ye Kuang**)
   - [Lang] Enable treating external arrays as Taichi vector/matrix fields (#2727) (by **Yi Xu**)
   - [Opt] [ir] Optimize offload (#2673) (by **squarefk**)
   - [Refactor] Add initialize_llvm_runtime_system to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Add materialize_snode_tree to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move initialize_llvm_runtime_snodes to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move clone_struct_compiler_initial_context to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move is_cuda_no_unified_memory to CompileConfig. (by **Ailing Zhang**)
   - [Refactor] Add maybe_initialize_cuda_llvm_context to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Add get_snode_num_dynamically_allocated to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move print_memory_profiler_info to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move print_list_manager_info to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move runtime_query to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move get_llvm_context to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move preallocated_device_buffer into LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move thread_pool into LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move runtime_mem_info into LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move llvm_runtime to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move llvm_context_device to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move llvm_context_host to LlvmProgramImpl. (by **Ailing Zhang**)
   - [Refactor] Move snode_tree_buffer_manager into LlvmProgramImpl. (by **Ailing Zhang**)
   - [Doc] Several dev install doc improvements. (#2741) (by **Ailing**)
   - [ci] Fix clang-format version to 10 (#2739) (by **Ailing**)
   - [Test] Unify tests decorators with @ti.test() (#2674) (by **squarefk**)
   - [Doc] Fix --user in dev install instruction. (#2732) (by **Ailing**)
   - [test] Fix potential memory error when DecoratorRecorder hasn't been reset correctly (#2735) (by **squarefk**)
   - [ci] Fix GPU buildbot paths and configs (#2728) (by **Yi Xu**)
   - [ci] Reduce the number of python wheels built nightly (#2726) (by **Jiasheng Zhang**)
   - [ir] Internal function call now supports arguments and i32 return value (#2722) (by **Yuanming Hu**)
   - [vulkan] Fix dumb memory error (#2721) (by **Bob Cao**)
   - [refactor] Remove unneccessary constructor argument (#2720) (by **saltyFamiliar**)
   - [Misc] Add submodule Eigen  (#2707) (by **FantasyVR**)
   - Pin yapf version to 0.31.0. (#2710) (by **Ailing**)
   - [vulkan] [test] Support full atomic operations on Vulkan backend (#2709) (by **Yu Chang**)
   - [Vulkan] Move vulkan to device API (#2695) (by **Bob Cao**)
   - [Doc] Update developer install doc to use setup.py. (#2706) (by **Ailing**)
   - [ci] Fixed pypi version (#2708) (by **Jiasheng Zhang**)
   - [Lang] Redesign Ndarray class and add ti.any_arr() annotation (#2703) (by **Yi Xu**)
   - [Bug] Close the kernel context when failing to compile AST (#2704) (by **Calvin Gu**)
   - [Doc] Add gdb debug instructions to dev utilities. (#2702) (by **Ailing**)
   - [vulkan] Better detect Vulkan availability (#2699) (by **Yu Chang**)
   - [benchmark] [refactor] Move fill() and reduction() into Membound suite, calculate the geometric mean of the time results (#2697) (by **rocket**)
   - [ci] Added taichi nightly auto release to github action (#2670) (by **Jiasheng Zhang**)
   - [Misc] Keep debug symbols/line numbers in taichi_core.so by setting DEBUG=1. (#2694) (by **Ailing**)
   - [vulkan] [test] Enable Vulkan backend on OS X (#2692) (by **Yu Chang**)
   - [Refactor] Remove is_release() in the codebase. (#2691) (by **Ailing**)
   - [doc] fix outdated links of examples in examples.md (#2693) (by **Yu Chang**)
   - [Refactor] Make is_release always True and delete runtime dep on TAICHI_REPO_DIR. (#2689) (by **Ailing**)
   - [CUDA] Save an extra host to device copy if arg_buffer is already on device. (#2688) (by **Ailing**)
   - [Refactor] Allow taichi_cpp_tests run in release mode as well. (#2686) (by **Ailing**)
   - [Refactor] Re-enable gdb attach on crash. (#2687) (by **Ailing**)
   - [Lang] Add a Ndarray class to serve as an alternative to dense scalar fields (#2676) (by **Yi Xu**)
   - [gui] GGUI 4/n: Vulkan GUI backend utils (#2672) (by **Dunfan Lu**)
   - [Test] Smarter enumerating features and raise exception when not supported (#2679) (by **squarefk**)
   - [vulkan] Querying features like a mad man (#2671) (by **Bob Cao**)
   - [IR] Support local tensor (#2637) (by **squarefk**)
   - [vulkan] Check that additional extensions are supported before adding them (#2667) (by **Dunfan Lu**)
   - [vulkan] [test] Fix bugs detected by tests & Skip unnecessary tests for Vulkan backend (#2664) (by **Yu Chang**)
