### PR TITLE
[gui] GGUI 11/n: Renderer

### DIFF
--- a/taichi/ui/backends/vulkan/renderer.h
+++ b/taichi/ui/backends/vulkan/renderer.h
@@ -73,7 +73,6 @@ class Renderer {
   SwapChain swap_chain_;
   AppContext app_context_;
 
- private:
   template <typename T>
   T *get_renderable_of_type();
 };


### PR DESCRIPTION
Related issue = #2646 

This is the 11th of a series of PRs that adds a GPU-based GUI to taichi.

This PR adds a `renderer` class, which manages a list of `rendererable`s and renders them. The list is cached between frames and updated as needed.
