### PR TITLE
[ci] Conditional build matrix on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
       - id: set-matrix
         run: |
           # For nightly release, we only run on python 3.8
-          [ -z "${{ github.event.action }}" ] && matrix="[{\"with_cc\":\"OFF\",\"python\":\"3.8\"}]"
+          [ -z "${{ github.event.action }}" ] && matrix="[{\"release_type\":\"night\",\"python\":\"3.8\"}]"
           # For production release, we run on four python versions.
-          [ -z "${{ github.event.action }}" ] || matrix="[{\"with_cc\":\"OFF\",\"python\":\"3.6\"},{\"with_cc\":\"OFF\",\"python\":\"3.7\"},{\"with_cc\":\"OFF\",\"python\":\"3.8\"},{\"with_cc\":\"OFF\",\"python\":\"3.9\"}]"
+          [ -z "${{ github.event.action }}" ] || matrix="[{\"release_type\":\"prod\",\"python\":\"3.6\"},{\"release_type\":\"prod\",\"python\":\"3.7\"},{\"release_type\":\"prod\",\"python\":\"3.8\"},{\"release_type\":\"prod\",\"python\":\"3.9\"}]"
           echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
 
   build_and_upload_mac:
@@ -62,7 +62,8 @@ jobs:
           if [ $NUM_WHL -ne 1 ]; then echo 'ERROR: created more than 1 whl.' && exit 1; fi
           pip install dist/*.whl
         env:
-          CI_SETUP_CMAKE_ARGS: -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=${{ matrix.with_cc }} -DTI_BUILD_TESTS:BOOL=${{ matrix.with_cpp_tests }}
+          CI_SETUP_CMAKE_ARGS: -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=OFF -DTI_BUILD_TESTS:BOOL=${{ matrix.with_cpp_tests }}
+          RELEASE_TYPE: ${{ matrix.release_type }}
 
       - name: Test
         run: |
@@ -81,6 +82,8 @@ jobs:
           [ -z "${{ github.event.action }}" ] && python build.py upload --skip_build --testpypi --project_name taichi-nightly
           [ -z "${{ github.event.action }}" ] || export PYPI_PWD="$PROD_PWD"
           [ -z "${{ github.event.action }}" ] || python build.py upload --skip_build
+        env:
+          RELEASE_TYPE: ${{ matrix.release_type }}
 
   build_and_upload_windows:
     name: Build and Upload (Windows only)
@@ -129,6 +132,7 @@ jobs:
           python -m pip install $env:WHL
         env:
           CI_SETUP_CMAKE_ARGS: -G "Visual Studio 16 2019" -A x64 -DLLVM_DIR=C:\taichi_llvm\lib\cmake\llvm
+          RELEASE_TYPE: ${{ matrix.release_type }}
 
       - name: Test
         shell: powershell
@@ -152,3 +156,5 @@ jobs:
           if ([string]::IsNullOrEmpty("${{ github.event.action }}")) {python build.py upload --skip_build --testpypi --project_name taichi-nightly}
           if ( -not [string]::IsNullOrEmpty("${{ github.event.action }}")) {$env:PYPI_PWD = "$env:PROD_PWD"}
           if ( -not [string]::IsNullOrEmpty("${{ github.event.action }}")) {python build.py upload --skip_build}
+        env:
+          RELEASE_TYPE: ${{ matrix.release_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
       - id: set-matrix
         run: |
           # For nightly release, we only run on python 3.8
-          [ -z "${{ github.event.action }}" ] && matrix="[{\"release_type\":\"night\",\"python\":\"3.8\"}]"
+          [ -z "${{ github.event.action }}" ] && matrix="[{\"name\":\"taichi-nightly\",\"python\":\"3.8\"}]"
           # For production release, we run on four python versions.
-          [ -z "${{ github.event.action }}" ] || matrix="[{\"release_type\":\"prod\",\"python\":\"3.6\"},{\"release_type\":\"prod\",\"python\":\"3.7\"},{\"release_type\":\"prod\",\"python\":\"3.8\"},{\"release_type\":\"prod\",\"python\":\"3.9\"}]"
+          [ -z "${{ github.event.action }}" ] || matrix="[{\"name\":\"taichi\",\"python\":\"3.6\"},{\"name\":\"taichi\",\"python\":\"3.7\"},{\"name\":\"taichi\",\"python\":\"3.8\"},{\"name\":\"taichi\",\"python\":\"3.9\"}]"
           echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
 
   build_and_upload_mac:
@@ -55,15 +55,14 @@ jobs:
           git fetch origin master
           export TAICHI_CMAKE_ARGS=$CI_SETUP_CMAKE_ARGS
           export COMMIT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          if [ $RELEASE_TYPE == "night" ]; then python build.py build --project_name taichi-nightly
-          elif [ $RELEASE_TYPE == "prod" ]; then python build.py build; fi
+          python build.py build --project_name $PROJECT_NAME
           cd ..
           NUM_WHL=`ls dist/*.whl | wc -l`
           if [ $NUM_WHL -ne 1 ]; then echo 'ERROR: created more than 1 whl.' && exit 1; fi
           pip install dist/*.whl
         env:
           CI_SETUP_CMAKE_ARGS: -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=OFF -DTI_BUILD_TESTS:BOOL=${{ matrix.with_cpp_tests }}
-          RELEASE_TYPE: ${{ matrix.release_type }}
+          PROJECT_NAME: ${{ matrix.name }}
 
       - name: Test
         run: |
@@ -78,10 +77,10 @@ jobs:
           NIGHT_PWD: ${{ secrets.PYPI_PWD_NIGHTLY }}
         run: |
           cd python
-          if [ $RELEASE_TYPE == "night" ]; then export PYPI_PWD="$NIGHT_PWD" && python build.py upload --skip_build --testpypi --project_name taichi-nightly
-          elif [ $RELEASE_TYPE == "prod" ]; then export PYPI_PWD="$PROD_PWD" && python build.py upload --skip_build; fi
+          if [ $PROJECT_NAME == "taichi-nightly" ]; then export PYPI_PWD="$NIGHT_PWD" && python build.py upload --skip_build --testpypi --project_name $PROJECT_NAME
+          elif [ $PROJECT_NAME == "taichi" ]; then export PYPI_PWD="$PROD_PWD" && python build.py upload --skip_build; fi
         env:
-          RELEASE_TYPE: ${{ matrix.release_type }}
+          PROJECT_NAME: ${{ matrix.name }}
 
   build_and_upload_windows:
     name: Build and Upload (Windows only)
@@ -123,14 +122,13 @@ jobs:
           git fetch origin master
           $env:TAICHI_CMAKE_ARGS = $env:CI_SETUP_CMAKE_ARGS
           $env:COMMIT_SHA = $(git rev-parse --short $env:GITHUB_SHA)
-          if ( $env:RELEASE_TYPE -eq "night" ) {python build.py build --project_name taichi-nightly}
-          if ( $env:RELEASE_TYPE -eq "prod" ) {python build.py build}
+          python build.py build --project_name $env:PROJECT_NAME
           cd ..\dist
           $env:WHL = $(dir *.whl)
           python -m pip install $env:WHL
         env:
           CI_SETUP_CMAKE_ARGS: -G "Visual Studio 16 2019" -A x64 -DLLVM_DIR=C:\taichi_llvm\lib\cmake\llvm
-          RELEASE_TYPE: ${{ matrix.release_type }}
+          PROJECT_NAME: ${{ matrix.name }}
 
       - name: Test
         shell: powershell
@@ -150,9 +148,9 @@ jobs:
           NIGHT_PWD: ${{ secrets.PYPI_PWD_NIGHTLY }}
         run: |
           cd python
-          if ( $env:RELEASE_TYPE -eq "night" ) {$env:PYPI_PWD = "$env:NIGHT_PWD"}
-          if ( $env:RELEASE_TYPE -eq "night" ) {python build.py upload --skip_build --testpypi --project_name taichi-nightly}
-          if ( $env:RELEASE_TYPE -eq "prod" ) {$env:PYPI_PWD = "$env:PROD_PWD"}
-          if ( $env:RELEASE_TYPE -eq "prod" ) {python build.py upload --skip_build}
+          if ( $env:PROJECT_NAME -eq "taichi-nightly" ) {$env:PYPI_PWD = "$env:NIGHT_PWD"}
+          if ( $env:PROJECT_NAME -eq "taichi-nightly" ) {python build.py upload --skip_build --testpypi --project_name $env:PROJECT_NAME}
+          if ( $env:PROJECT_NAME -eq "taichi" ) {$env:PYPI_PWD = "$env:PROD_PWD"}
+          if ( $env:PROJECT_NAME -eq "taichi" ) {python build.py upload --skip_build}
         env:
-          RELEASE_TYPE: ${{ matrix.release_type }}
+          PROJECT_NAME: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,26 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
+  # This job set environment matrix with respect to production release and nightly release.
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          # For nightly release, we only run on python 3.8
+          [ -z "${{ github.event.action }}" ] && matrix="[{\"with_cc\":\"OFF\",\"python\":\"3.8\"}]"
+          # For production release, we run on four python versions.
+          [ -z "${{ github.event.action }}" ] || matrix="[{\"with_cc\":\"OFF\",\"python\":\"3.6\"},{\"with_cc\":\"OFF\",\"python\":\"3.7\"},{\"with_cc\":\"OFF\",\"python\":\"3.8\"},{\"with_cc\":\"OFF\",\"python\":\"3.9\"}]"
+          echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+
   build_and_upload_mac:
     name: Build and Upload (macOS only)
+    needs: matrix_prep
     strategy:
-      matrix:
-        include:
-          # We use only one python version because it would consume a large
-          # amount of github action minutes.
-          - os: macos-latest
-            python: 3.8
-            with_cc: OFF
-    runs-on: ${{ matrix.os }}
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -75,15 +84,10 @@ jobs:
 
   build_and_upload_windows:
     name: Build and Upload (Windows only)
+    needs: matrix_prep
     strategy:
-      matrix:
-        include:
-          # We use only one python version because it would consume a large
-          # amount of github action minutes.
-          - os: windows-latest
-            python: 3.8
-            with_cc: OFF
-    runs-on: ${{ matrix.os }}
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
+    runs-on: windows-latest
     steps:
       - name: Install 7Zip PowerShell
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
           git fetch origin master
           export TAICHI_CMAKE_ARGS=$CI_SETUP_CMAKE_ARGS
           export COMMIT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          [ -z "${{ github.event.action }}" ] && python build.py build --project_name taichi-nightly
-          [ -z "${{ github.event.action }}" ] || python build.py build
+          if [ $RELEASE_TYPE == "night" ]; then python build.py build --project_name taichi-nightly
+          elif [ $RELEASE_TYPE == "prod" ]; then python build.py build; fi
           cd ..
           NUM_WHL=`ls dist/*.whl | wc -l`
           if [ $NUM_WHL -ne 1 ]; then echo 'ERROR: created more than 1 whl.' && exit 1; fi
@@ -78,10 +78,8 @@ jobs:
           NIGHT_PWD: ${{ secrets.PYPI_PWD_NIGHTLY }}
         run: |
           cd python
-          [ -z "${{ github.event.action }}" ] && export PYPI_PWD="$NIGHT_PWD"
-          [ -z "${{ github.event.action }}" ] && python build.py upload --skip_build --testpypi --project_name taichi-nightly
-          [ -z "${{ github.event.action }}" ] || export PYPI_PWD="$PROD_PWD"
-          [ -z "${{ github.event.action }}" ] || python build.py upload --skip_build
+          if [ $RELEASE_TYPE == "night" ]; then export PYPI_PWD="$NIGHT_PWD" && python build.py upload --skip_build --testpypi --project_name taichi-nightly
+          elif [ $RELEASE_TYPE == "prod" ]; then export PYPI_PWD="$PROD_PWD" && python build.py upload --skip_build; fi
         env:
           RELEASE_TYPE: ${{ matrix.release_type }}
 
@@ -125,8 +123,8 @@ jobs:
           git fetch origin master
           $env:TAICHI_CMAKE_ARGS = $env:CI_SETUP_CMAKE_ARGS
           $env:COMMIT_SHA = $(git rev-parse --short $env:GITHUB_SHA)
-          if ([string]::IsNullOrEmpty("${{ github.event.action }}")) {python build.py build --project_name taichi-nightly}
-          if ( -not [string]::IsNullOrEmpty("${{ github.event.action }}")) {python build.py build}
+          if ( $env:RELEASE_TYPE -eq "night" ) {python build.py build --project_name taichi-nightly}
+          if ( $env:RELEASE_TYPE -eq "prod" ) {python build.py build}
           cd ..\dist
           $env:WHL = $(dir *.whl)
           python -m pip install $env:WHL
@@ -152,9 +150,9 @@ jobs:
           NIGHT_PWD: ${{ secrets.PYPI_PWD_NIGHTLY }}
         run: |
           cd python
-          if ([string]::IsNullOrEmpty("${{ github.event.action }}")) {$env:PYPI_PWD = "$env:NIGHT_PWD"}
-          if ([string]::IsNullOrEmpty("${{ github.event.action }}")) {python build.py upload --skip_build --testpypi --project_name taichi-nightly}
-          if ( -not [string]::IsNullOrEmpty("${{ github.event.action }}")) {$env:PYPI_PWD = "$env:PROD_PWD"}
-          if ( -not [string]::IsNullOrEmpty("${{ github.event.action }}")) {python build.py upload --skip_build}
+          if ( $env:RELEASE_TYPE -eq "night" ) {$env:PYPI_PWD = "$env:NIGHT_PWD"}
+          if ( $env:RELEASE_TYPE -eq "night" ) {python build.py upload --skip_build --testpypi --project_name taichi-nightly}
+          if ( $env:RELEASE_TYPE -eq "prod" ) {$env:PYPI_PWD = "$env:PROD_PWD"}
+          if ( $env:RELEASE_TYPE -eq "prod" ) {python build.py upload --skip_build}
         env:
           RELEASE_TYPE: ${{ matrix.release_type }}


### PR DESCRIPTION
I used conditional matrix setup to solve this issue.
Another workaround would be cancel workflow when python version is not equal to 3.8. However, this would show up as action failed. Therefore, I choose to use setup matrix with respect to release type.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
