### PR TITLE
[gui] GGUI 12/n: Window and Canvas

### DIFF
--- a/taichi/ui/backends/vulkan/canvas.cpp
+++ b/taichi/ui/backends/vulkan/canvas.cpp
@@ -1,0 +1,46 @@
+#include "canvas.h"
+#include "taichi/ui/utils/utils.h"
+
+#include "taichi/ui/backends/vulkan/vulkan_cuda_interop.h"
+#include "taichi/ui/backends/vulkan/vulkan_cuda_interop.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+using namespace taichi::lang;
+
+Canvas::Canvas(Renderer *renderer) : renderer_(renderer) {
+}
+
+void Canvas::set_background_color(const glm::vec3 &color) {
+  renderer_->set_background_color(color);
+}
+
+void Canvas::set_image(const SetImageInfo &info) {
+  renderer_->set_image(info);
+}
+
+void Canvas::triangles(const TrianglesInfo &info) {
+  renderer_->triangles(info);
+}
+
+void Canvas::lines(const LinesInfo &info) {
+  renderer_->lines(info);
+}
+
+void Canvas::circles(const CirclesInfo &info) {
+  renderer_->circles(info);
+}
+
+void Canvas::scene(SceneBase *scene_base) {
+  if (Scene *scene = dynamic_cast<Scene *>(scene_base)) {
+    renderer_->scene(scene);
+  } else {
+    throw std::runtime_error("Scene is not vulkan scene");
+  }
+}
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/canvas.h
+++ b/taichi/ui/backends/vulkan/canvas.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <stdexcept>
+#include <algorithm>
+#include <chrono>
+#include <vector>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include <array>
+#include <optional>
+#include <set>
+#include <memory>
+
+#include "taichi/ui/utils/utils.h"
+#include "taichi/ui/backends/vulkan/vertex.h"
+#include "taichi/ui/backends/vulkan/app_context.h"
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+#include "taichi/ui/backends/vulkan/renderable.h"
+#include "taichi/ui/common/canvas_base.h"
+
+#include "taichi/ui/backends/vulkan/gui.h"
+#include "taichi/ui/backends/vulkan/renderer.h"
+
+#include "taichi/ui/backends/vulkan/renderables/set_image.h"
+#include "taichi/ui/backends/vulkan/renderables/triangles.h"
+#include "taichi/ui/backends/vulkan/renderables/mesh.h"
+#include "taichi/ui/backends/vulkan/renderables/particles.h"
+#include "taichi/ui/backends/vulkan/renderables/circles.h"
+#include "taichi/ui/backends/vulkan/renderables/lines.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+class Canvas final : public CanvasBase {
+ public:
+  Canvas(Renderer *renderer);
+
+  virtual void set_background_color(const glm::vec3 &color) override;
+
+  virtual void set_image(const SetImageInfo &info) override;
+
+  virtual void triangles(const TrianglesInfo &info) override;
+
+  virtual void circles(const CirclesInfo &info) override;
+
+  virtual void lines(const LinesInfo &info) override;
+
+  virtual void scene(SceneBase *scene_base) override;
+
+ private:
+  Renderer *renderer_;
+};
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/vulkan_cuda_interop.cpp
+++ b/taichi/ui/backends/vulkan/vulkan_cuda_interop.cpp
@@ -310,7 +310,7 @@ inline unsigned char get_color_value<unsigned char>(unsigned char x) {
 
 template <>
 inline unsigned char get_color_value<float>(float x) {
-  x = max(0.f, min(1.f, x));
+  x = fmaxf(0.f, fminf(1.f, x));
   return (unsigned char)(x * 255);
 }
 

--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -1,0 +1,85 @@
+#include "taichi/ui/backends/vulkan/window.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+Window::Window(const AppConfig &config) : WindowBase(config) {
+  init(config);
+}
+
+void Window::init(const AppConfig &config) {
+  init_window();
+  init_vulkan(config);
+  gui_ = std::make_unique<Gui>(&renderer_->app_context(), glfw_window_);
+  prepare_for_next_frame();
+}
+
+void Window::show() {
+  draw_frame();
+  present_frame();
+  WindowBase::show();
+  prepare_for_next_frame();
+}
+
+void Window::prepare_for_next_frame() {
+  renderer_->prepare_for_next_frame();
+  gui_->prepare_for_next_frame();
+}
+
+CanvasBase *Window::get_canvas() {
+  return canvas_.get();
+}
+
+GuiBase *Window::GUI() {
+  return gui_.get();
+}
+
+void Window::init_window() {
+  glfwSetFramebufferSizeCallback(glfw_window_, framebuffer_resize_callback);
+}
+
+void Window::framebuffer_resize_callback(GLFWwindow *glfw_window_,
+                                         int width,
+                                         int height) {
+  auto window =
+      reinterpret_cast<Window *>(glfwGetWindowUserPointer(glfw_window_));
+  window->resize();
+}
+
+void Window::init_vulkan(const AppConfig &config) {
+  renderer_ = std::make_unique<Renderer>();
+  renderer_->init(glfw_window_, config);
+  canvas_ = std::make_unique<Canvas>(renderer_.get());
+}
+
+void Window::resize() {
+  int width = 0, height = 0;
+  glfwGetFramebufferSize(glfw_window_, &width, &height);
+  while (width == 0 || height == 0) {
+    glfwGetFramebufferSize(glfw_window_, &width, &height);
+    glfwWaitEvents();
+  }
+  renderer_->app_context().config.width = width;
+  renderer_->app_context().config.height = height;
+
+  renderer_->swap_chain().resize(width, height);
+}
+
+void Window::draw_frame() {
+  renderer_->draw_frame(gui_.get());
+}
+
+void Window::present_frame() {
+  renderer_->swap_chain().surface().present_image();
+}
+
+Window::~Window() {
+  gui_->cleanup();
+  renderer_->cleanup();
+  glfwTerminate();
+}
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END

--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -9,9 +9,13 @@ Window::Window(const AppConfig &config) : WindowBase(config) {
 }
 
 void Window::init(const AppConfig &config) {
-  init_window();
-  init_vulkan(config);
+  glfwSetFramebufferSizeCallback(glfw_window_, framebuffer_resize_callback);
+
+  renderer_ = std::make_unique<Renderer>();
+  renderer_->init(glfw_window_, config);
+  canvas_ = std::make_unique<Canvas>(renderer_.get());
   gui_ = std::make_unique<Gui>(&renderer_->app_context(), glfw_window_);
+
   prepare_for_next_frame();
 }
 
@@ -35,22 +39,12 @@ GuiBase *Window::GUI() {
   return gui_.get();
 }
 
-void Window::init_window() {
-  glfwSetFramebufferSizeCallback(glfw_window_, framebuffer_resize_callback);
-}
-
 void Window::framebuffer_resize_callback(GLFWwindow *glfw_window_,
                                          int width,
                                          int height) {
   auto window =
       reinterpret_cast<Window *>(glfwGetWindowUserPointer(glfw_window_));
   window->resize();
-}
-
-void Window::init_vulkan(const AppConfig &config) {
-  renderer_ = std::make_unique<Renderer>();
-  renderer_->init(glfw_window_, config);
-  canvas_ = std::make_unique<Canvas>(renderer_.get());
 }
 
 void Window::resize() {

--- a/taichi/ui/backends/vulkan/window.h
+++ b/taichi/ui/backends/vulkan/window.h
@@ -44,17 +44,11 @@ class Window final : public WindowBase {
  private:
   void init(const AppConfig &config);
 
-  void init_vulkan(const AppConfig &config);
-
-  void init_window();
-
   void prepare_for_next_frame();
 
   void draw_frame();
 
   void present_frame();
-
-  void update_image_index();
 
   void resize();
 

--- a/taichi/ui/backends/vulkan/window.h
+++ b/taichi/ui/backends/vulkan/window.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <stdexcept>
+#include <algorithm>
+#include <chrono>
+#include <vector>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include <array>
+#include <optional>
+#include <set>
+#include "taichi/ui/utils/utils.h"
+#include <memory>
+
+#include "taichi/ui/backends/vulkan/swap_chain.h"
+#include "taichi/ui/backends/vulkan/app_context.h"
+#include "taichi/ui/backends/vulkan/canvas.h"
+#include "taichi/ui/backends/vulkan/renderer.h"
+#include "taichi/ui/common/window_base.h"
+#include "taichi/ui/backends/vulkan/gui.h"
+
+TI_UI_NAMESPACE_BEGIN
+
+namespace vulkan {
+
+class Window final : public WindowBase {
+ public:
+  Window(const AppConfig &config);
+
+  virtual void show() override;
+  virtual CanvasBase *get_canvas() override;
+  virtual GuiBase *GUI() override;
+
+  ~Window();
+
+ private:
+  std::unique_ptr<Canvas> canvas_;
+  std::unique_ptr<Gui> gui_;
+  std::unique_ptr<Renderer> renderer_;
+
+ private:
+  void init(const AppConfig &config);
+
+  void init_vulkan(const AppConfig &config);
+
+  void init_window();
+
+  void prepare_for_next_frame();
+
+  void draw_frame();
+
+  void present_frame();
+
+  void update_image_index();
+
+  void resize();
+
+  static void framebuffer_resize_callback(GLFWwindow *glfw_window_,
+                                          int width,
+                                          int height);
+};
+
+}  // namespace vulkan
+
+TI_UI_NAMESPACE_END


### PR DESCRIPTION
Related issue = #2646 

This is the 12th of a series of PRs that adds a GPU-based GUI to taichi.

This PR adds a `Window` class which implements the `WindowBase` interface. It owns a renderer, a canvas, and a GUI.

The PR also adds a `Canvas` class which implements `CanvasBase`. The `Canvas` simply forwards calls to `Renderer`.

The PR also includes a small fix for a bug introduced in a previous PR..