### PR TITLE
[Lang] Let rescale_index support SNode as input parameter

### DIFF
--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -9,6 +9,7 @@ from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl, matrix
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.expr import Expr, make_expr_group
+from taichi.lang.snode import SNode
 from taichi.lang.field import Field
 from taichi.lang.util import cook_dtype, is_taichi_class, taichi_scope
 
@@ -913,14 +914,14 @@ def length(l, indices):
 
 
 def rescale_index(a, b, I):
-    """Rescales the index 'I' of field 'a' the match the shape of field 'b'
+    """Rescales the index 'I' of field(snode) 'a' the match the shape of field(snode) 'b'
 
     Parameters
     ----------
     a: ti.field(), ti.Vector.field, ti.Matrix.field()
-        input taichi field
+        input taichi field or snode
     b: ti.field(), ti.Vector.field, ti.Matrix.field()
-        output taichi field
+        output taichi field or snode
     I: ti.Vector()
         grouped loop index
 
@@ -930,8 +931,8 @@ def rescale_index(a, b, I):
         rescaled grouped loop index
 
     """
-    assert isinstance(a, Field), f"first argument must be a field"
-    assert isinstance(b, Field), f"second argument must be a field"
+    assert isinstance(a, Field) or isinstance(a, SNode), f"first argument must be a field or an SNode"
+    assert isinstance(b, Field) or isinstance(b, SNode), f"second argument must be a field or an SNode"
     assert isinstance(I,
                       matrix.Matrix), f"third argument must be a grouped index"
     Ib = I.copy()

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -9,8 +9,8 @@ from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl, matrix
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.expr import Expr, make_expr_group
-from taichi.lang.snode import SNode
 from taichi.lang.field import Field
+from taichi.lang.snode import SNode
 from taichi.lang.util import cook_dtype, is_taichi_class, taichi_scope
 
 unary_ops = []
@@ -931,8 +931,10 @@ def rescale_index(a, b, I):
         rescaled grouped loop index
 
     """
-    assert isinstance(a, Field) or isinstance(a, SNode), f"first argument must be a field or an SNode"
-    assert isinstance(b, Field) or isinstance(b, SNode), f"second argument must be a field or an SNode"
+    assert isinstance(a, Field) or isinstance(
+        a, SNode), f"first argument must be a field or an SNode"
+    assert isinstance(b, Field) or isinstance(
+        b, SNode), f"second argument must be a field or an SNode"
     assert isinstance(I,
                       matrix.Matrix), f"third argument must be a grouped index"
     Ib = I.copy()


### PR DESCRIPTION
Related issue = 

this pr basically let `ti.rescale_index` support `SNode` as input parameter. The reason is that sometimes an `SNode` might not have '**placed**' a `Field` but we want to rescale the cell index based on the `SNode` anyway.

See the [example](https://github.com/Jack12xl/taichi_elements/blob/8c4a16cc0bfb45a667ec0d62e248c445bcea53e2/engine/mpm_solver.py#L321) from the **Taichi_elements**. We need to rescale the index from `pid(ti.root.pointer.pointer.dynamic)` to `block(ti.root.pointer.pointer)`. But `block` did not have a cell placed beneath (but we still need to rescale according to `block`). 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
