### PR TITLE
[Vulkan] Add relaxed FIFO presentation mode

### DIFF
--- a/taichi/backends/device.h
+++ b/taichi/backends/device.h
@@ -417,7 +417,12 @@ struct VertexInputAttribute {
 };
 
 struct SurfaceConfig {
+  // VSync:
+  // - true: will attempt to wait for V-Blank
+  // - when adaptive is true: when supported, if a V-Blank is missed, instead of
+  //   waiting, a tearing may appear, reduces overall latency
   bool vsync{false};
+  bool adaptive{true};
   void *window_handle{nullptr};
 };
 

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -1888,8 +1888,15 @@ void VulkanDevice::create_vma_allocator() {
 
 VkPresentModeKHR choose_swap_present_mode(
     const std::vector<VkPresentModeKHR> &available_present_modes,
-    bool vsync) {
+    bool vsync, bool adaptive) {
   if (vsync) {
+    if (adaptive) {
+      for (const auto &available_present_mode : available_present_modes) {
+        if (available_present_mode == VK_PRESENT_MODE_FIFO_RELAXED_KHR) {
+          return available_present_mode;
+        }
+      }
+    }
     for (const auto &available_present_mode : available_present_modes) {
       if (available_present_mode == VK_PRESENT_MODE_FIFO_KHR) {
         return available_present_mode;
@@ -1983,7 +1990,7 @@ void VulkanSurface::create_swap_chain() {
                                               present_modes.data());
   }
   VkPresentModeKHR present_mode =
-      choose_swap_present_mode(present_modes, config_.vsync);
+      choose_swap_present_mode(present_modes, config_.vsync, config_.adaptive);
 
   int width, height;
   glfwGetFramebufferSize(window_, &width, &height);

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -1888,7 +1888,8 @@ void VulkanDevice::create_vma_allocator() {
 
 VkPresentModeKHR choose_swap_present_mode(
     const std::vector<VkPresentModeKHR> &available_present_modes,
-    bool vsync, bool adaptive) {
+    bool vsync,
+    bool adaptive) {
   if (vsync) {
     if (adaptive) {
       for (const auto &available_present_mode : available_present_modes) {


### PR DESCRIPTION
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentModeKHR.html

```VK_PRESENT_MODE_FIFO_RELAXED_KHR specifies that the presentation engine generally waits for the next vertical blanking period to update the current image. If a vertical blanking period has already passed since the last update of the current image then the presentation engine does not wait for another vertical blanking period for the update, meaning this mode may result in visible tearing in this case. This mode is useful for reducing visual stutter with an application that will mostly present a new image before the next vertical blanking period, but may occasionally be late, and present a new image just after the next vertical blanking period. An internal queue is used to hold pending presentation requests. New requests are appended to the end of the queue, and one request is removed from the beginning of the queue and processed during or after each vertical blanking period in which the queue is non-empty.```

When this is detected and vsync is requested, relaxed FIFO will be preferred as it reduces latency & "choppyness" when a frame is a little too long to hit the correct V-Blank timing, by allowing a tearing to appear in such scenerio (e.g. 59FPS & almost hitting 60)