### PR TITLE
[util] fix ModuleNotFoundError in Windows

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -130,6 +130,27 @@ if settings.get_os_name() != 'win':
     # For llvm jit to find the runtime symbols
     if not os.path.exists(link_dst):
         os.symlink(link_src, link_dst)
+else:
+    bin_dir = os.path.join(settings.get_repo_directory(), 'runtimes')
+    possible_folders = ['Debug', 'RelWithDebInfo', 'Release']
+    detected_dlls = []
+    for folder in possible_folders:
+        dll_path = os.path.join(bin_dir, folder, 'taichi_core.dll')
+        if os.path.exists(dll_path):
+            detected_dlls.append(dll_path)
+    if len(detected_dlls) == 0:
+        raise FileNotFoundError(
+            f'Cannot find Taichi core dll under {bin_dir}/{possible_folders}'
+        )
+    elif len(detected_dlls) != 1:
+        print('Warning: multiple Taichi core dlls found: %s' %
+            ','.join(detected_dlls))
+        print(f'Using {detected_dlls[0]}')
+    dll_path = detected_dlls[0]
+    old_wd = os.getcwd()
+    os.chdir(bin_dir)
+    shutil.copy(dll_path, os.path.join(bin_dir, 'taichi_core.pyd'))
+    sys.path.append(bin_dir)
 import_ti_core()
 
 ti_core.set_python_package_dir(package_root())


### PR DESCRIPTION
Add back the code that copies taichi_core.pyd from VS build folder
to the binary directory (TAICHI_REPO_DIR/runtimes) and add the
binary directory to sys.path in order to fix the ModuleNotFoundError.

Tested: Built with cmake and VS in Windows 10, then ran Python as
follows:
```
C:\Users\USER_NAME\taichi_my>python
Python 3.7.0 (v3.7.0:1bf9cc5093, Jun 27 2018, 04:59:51) [MSC v.1914 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import taichi
[Taichi] version 0.0.0, llvm 10.0.0, commit 10c2cbb2, win, python 3.7.0
>>>
```

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
