### PR TITLE
[gui] GGUI 16/n: examples

### DIFF
--- a/examples/ggui_examples/fem128_ggui.py
+++ b/examples/ggui_examples/fem128_ggui.py
@@ -1,0 +1,169 @@
+import taichi as ti
+ 
+ti.init(arch=ti.gpu)
+
+N = 12
+dt = 5e-5
+dx = 1 / N
+rho = 4e1
+NF = 2 * N**2  # number of faces
+NV = (N + 1)**2  # number of vertices
+E, nu = 4e4, 0.2  # Young's modulus and Poisson's ratio
+mu, lam = E / 2 / (1 + nu), E * nu / (1 + nu) / (1 - 2 * nu)  # Lame parameters
+ball_pos, ball_radius = ti.Vector([0.5, 0.0]), 0.31
+damping = 14.5
+
+pos = ti.Vector.field(2, float, NV, needs_grad=True)
+vel = ti.Vector.field(2, float, NV)
+f2v = ti.Vector.field(3, int, NF)  # ids of three vertices of each face
+B = ti.Matrix.field(2, 2, float, NF)
+F = ti.Matrix.field(2, 2, float, NF, needs_grad=True)
+V = ti.field(float, NF)
+phi = ti.field(float, NF)  # potential energy of each face (Neo-Hookean)
+U = ti.field(float, (), needs_grad=True)  # total potential energy
+
+gravity = ti.Vector.field(2, float, ())
+attractor_pos = ti.Vector.field(2, float, ())
+attractor_strength = ti.field(float, ())
+
+
+@ti.kernel
+def update_U():
+    for i in range(NF):
+        ia, ib, ic = f2v[i]
+        a, b, c = pos[ia], pos[ib], pos[ic]
+        V[i] = abs((a - c).cross(b - c))
+        D_i = ti.Matrix.cols([a - c, b - c])
+        F[i] = D_i @ B[i]
+    for i in range(NF):
+        F_i = F[i]
+        log_J_i = ti.log(F_i.determinant())
+        phi_i = mu / 2 * ((F_i.transpose() @ F_i).trace() - 2)
+        phi_i -= mu * log_J_i
+        phi_i += lam / 2 * log_J_i**2
+        phi[i] = phi_i
+        U[None] += V[i] * phi_i
+
+
+@ti.kernel
+def advance():
+    for i in range(NV):
+        acc = -pos.grad[i] / (rho * dx**2)
+        g = gravity[None] * 0.8 + attractor_strength[None] * (
+            attractor_pos[None] - pos[i]).normalized(1e-5)
+        vel[i] += dt * (acc + g * 40)
+        vel[i] *= ti.exp(-dt * damping)
+    for i in range(NV):
+        # ball boundary condition:
+        disp = pos[i] - ball_pos
+        disp2 = disp.norm_sqr()
+        if disp2 <= ball_radius**2:
+            NoV = vel[i].dot(disp)
+            if NoV < 0: vel[i] -= NoV * disp / disp2
+        cond = pos[i] < 0 and vel[i] < 0 or pos[i] > 1 and vel[i] > 0
+        # rect boundary condition:
+        for j in ti.static(range(pos.n)):
+            if cond[j]: vel[i][j] = 0
+        pos[i] += dt * vel[i]
+
+
+@ti.kernel
+def init_pos():
+    for i, j in ti.ndrange(N + 1, N + 1):
+        k = i * (N + 1) + j
+        pos[k] = ti.Vector([i, j]) / N * 0.25 + ti.Vector([0.45, 0.45])
+        vel[k] = ti.Vector([0, 0])
+    for i in range(NF):
+        ia, ib, ic = f2v[i]
+        a, b, c = pos[ia], pos[ib], pos[ic]
+        B_i_inv = ti.Matrix.cols([a - c, b - c])
+        B[i] = B_i_inv.inverse()
+
+
+@ti.kernel
+def init_mesh():
+    for i, j in ti.ndrange(N, N):
+        k = (i * N + j) * 2
+        a = i * (N + 1) + j
+        b = a + 1
+        c = a + N + 2
+        d = a + N + 1
+        f2v[k + 0] = [a, b, c]
+        f2v[k + 1] = [c, d, a]
+
+window = ti.ui.Window('FEM128',(512,512))
+canvas = window.get_canvas()
+
+# rendering related fields
+vertexColors = ti.Vector.field(3, float, NV)
+vertexPositions = ti.Vector.field(2, float,NV)
+triangleIndices = ti.field(int, NF*3)
+mouse_circle = ti.Vector.field(2,dtype=float,shape = (1,))
+ball_circle = ti.Vector.field(2,dtype=float,shape = (1,))
+
+@ti.kernel
+def paint_triangles():
+    for i in range(NF):
+        k = phi[i] * (10 / E)
+        gb = (1 - k) * 0.5
+        color = ti.Vector([k + gb, gb, gb])
+
+        ia, ib, ic = f2v[i]
+        vertexColors[ia] = color
+        vertexColors[ib] = color
+        vertexColors[ic] = color
+        vertexPositions[ia] = pos[ia]
+        vertexPositions[ib] = pos[ib]
+        vertexPositions[ic] = pos[ic]
+        triangleIndices[i*3+0] = ia
+        triangleIndices[i*3+1] = ib
+        triangleIndices[i*3+2] = ic
+
+
+def paint_mouse_ball():
+    mouse = window.get_cursor_pos()
+    mouse_circle[0] = ti.Vector([mouse[0], mouse[1]])
+    ball_circle[0] = ball_pos
+
+def render():
+    paint_triangles()
+    paint_mouse_ball()
+
+    canvas.circles(mouse_circle, color=(0.2,0.4,0.6), radius=0.02)
+    canvas.circles(ball_circle, color=(0.4,0.4,0.4), radius=ball_radius)
+     
+    canvas.triangles(vertexPositions,indices = triangleIndices,per_vertex_color = vertexColors)
+    canvas.circles(vertexPositions, radius=0.003, color=(1,0.6,0.2))
+
+init_mesh()
+init_pos()
+gravity[None] = [0, -1]
+
+
+print(
+    "[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse bottons to attract/repel. Press R to reset."
+)
+while window.running:
+    for e in window.get_events(ti.ui.PRESS):
+        if e.key == ti.ui.ESCAPE:
+            window.running = False
+        elif e.key == 'r':
+            init_pos()
+        elif e.key in ('a', ti.ui.LEFT):
+            gravity[None] = [-1, 0]
+        elif e.key in ('d', ti.ui.RIGHT):
+            gravity[None] = [+1, 0]
+        elif e.key in ('s', ti.ui.DOWN):
+            gravity[None] = [0, -1]
+        elif e.key in ('w', ti.ui.UP):
+            gravity[None] = [0, +1]
+
+    mouse_pos = window.get_cursor_pos()
+    attractor_pos[None] = mouse_pos
+    attractor_strength[None] = window.is_pressed(ti.ui.LMB) - window.is_pressed(ti.ui.RMB)
+    for i in range(50):
+        with ti.Tape(loss=U):
+            update_U()
+        advance()
+    render()
+    window.show()

--- a/examples/ggui_examples/fem128_ggui.py
+++ b/examples/ggui_examples/fem128_ggui.py
@@ -1,5 +1,5 @@
 import taichi as ti
- 
+
 ti.init(arch=ti.gpu)
 
 N = 12
@@ -91,15 +91,17 @@ def init_mesh():
         f2v[k + 0] = [a, b, c]
         f2v[k + 1] = [c, d, a]
 
-window = ti.ui.Window('FEM128',(512,512))
+
+window = ti.ui.Window('FEM128', (512, 512))
 canvas = window.get_canvas()
 
 # rendering related fields
 vertexColors = ti.Vector.field(3, float, NV)
-vertexPositions = ti.Vector.field(2, float,NV)
-triangleIndices = ti.field(int, NF*3)
-mouse_circle = ti.Vector.field(2,dtype=float,shape = (1,))
-ball_circle = ti.Vector.field(2,dtype=float,shape = (1,))
+vertexPositions = ti.Vector.field(2, float, NV)
+triangleIndices = ti.field(int, NF * 3)
+mouse_circle = ti.Vector.field(2, dtype=float, shape=(1, ))
+ball_circle = ti.Vector.field(2, dtype=float, shape=(1, ))
+
 
 @ti.kernel
 def paint_triangles():
@@ -115,9 +117,9 @@ def paint_triangles():
         vertexPositions[ia] = pos[ia]
         vertexPositions[ib] = pos[ib]
         vertexPositions[ic] = pos[ic]
-        triangleIndices[i*3+0] = ia
-        triangleIndices[i*3+1] = ib
-        triangleIndices[i*3+2] = ic
+        triangleIndices[i * 3 + 0] = ia
+        triangleIndices[i * 3 + 1] = ib
+        triangleIndices[i * 3 + 2] = ic
 
 
 def paint_mouse_ball():
@@ -125,20 +127,23 @@ def paint_mouse_ball():
     mouse_circle[0] = ti.Vector([mouse[0], mouse[1]])
     ball_circle[0] = ball_pos
 
+
 def render():
     paint_triangles()
     paint_mouse_ball()
 
-    canvas.circles(mouse_circle, color=(0.2,0.4,0.6), radius=0.02)
-    canvas.circles(ball_circle, color=(0.4,0.4,0.4), radius=ball_radius)
-     
-    canvas.triangles(vertexPositions,indices = triangleIndices,per_vertex_color = vertexColors)
-    canvas.circles(vertexPositions, radius=0.003, color=(1,0.6,0.2))
+    canvas.circles(mouse_circle, color=(0.2, 0.4, 0.6), radius=0.02)
+    canvas.circles(ball_circle, color=(0.4, 0.4, 0.4), radius=ball_radius)
+
+    canvas.triangles(vertexPositions,
+                     indices=triangleIndices,
+                     per_vertex_color=vertexColors)
+    canvas.circles(vertexPositions, radius=0.003, color=(1, 0.6, 0.2))
+
 
 init_mesh()
 init_pos()
 gravity[None] = [0, -1]
-
 
 print(
     "[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse bottons to attract/repel. Press R to reset."
@@ -160,7 +165,8 @@ while window.running:
 
     mouse_pos = window.get_cursor_pos()
     attractor_pos[None] = mouse_pos
-    attractor_strength[None] = window.is_pressed(ti.ui.LMB) - window.is_pressed(ti.ui.RMB)
+    attractor_strength[None] = window.is_pressed(
+        ti.ui.LMB) - window.is_pressed(ti.ui.RMB)
     for i in range(50):
         with ti.Tape(loss=U):
             update_U()

--- a/examples/ggui_examples/mass_spring_3d_ggui.py
+++ b/examples/ggui_examples/mass_spring_3d_ggui.py
@@ -1,0 +1,113 @@
+import sys
+
+import numpy as np
+
+import taichi as ti
+
+ti.init(arch=ti.cuda)
+
+### Parameters
+
+N = 128
+W = 1
+L = W / N
+gravity = 0.5
+stiffness = 1600
+damping = 2
+steps = 30
+dt = 5e-4
+
+
+num_balls = 1
+ball_radius = 0.3
+ball_centers = ti.Vector.field(3,float,num_balls)
+
+
+x = ti.Vector.field(3, float, (N,N))
+v = ti.Vector.field(3, float, (N,N))
+
+num_triangles = (N-1)*(N-1)*2
+indices = ti.field(int,num_triangles*3)
+vertices =  ti.Vector.field(3, float, N*N)
+
+@ti.kernel
+def init():
+    for i, j in ti.ndrange(N,N):
+        x[i,j] = ti.Vector([(i + 0.5) * L - 0.5, (j + 0.5) * L / ti.sqrt(2) , (N-j)*L / ti.sqrt(2)])
+
+        if i < N-1 and j < N-1:
+            tri_id = ((i * (N-1)) + j) * 2
+            indices[tri_id * 3] = i * N + j
+            indices[tri_id * 3+1] = (i+1) * N + j
+            indices[tri_id * 3+2] = i * N + (j+1)
+
+            tri_id += 1
+            indices[tri_id * 3] = (i+1) * N + j+1
+            indices[tri_id * 3+1] = i * N + (j+1)
+            indices[tri_id * 3+2] = (i+1) * N + j
+    ball_centers[0] = ti.Vector([0.0, -0.5, -0.0])
+
+
+links = [(-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (1, -1), (-1, 1), (1, 1)]
+links = [ti.Vector([*v]) for v in links]
+
+@ti.func
+def reflect(v,normal):
+    return v.dot(normal)*2 - v
+
+@ti.func
+def ballBoundReflect(pos, vel, center, radius, bounce_magnitude = 0.1):
+    ret = vel
+    distance = (pos-center).norm()
+    if distance <= radius:
+        normal = (pos - radius).normalized()
+        ret = -1 * bounce_magnitude * reflect(vel,normal)
+    return ret
+
+
+@ti.kernel
+def substep():
+    for i in ti.grouped(x):
+        acc = x[i] * 0
+        for d in ti.static(links):
+            disp = x[min(max(i + d, 0), ti.Vector([N-1,N-1]))] - x[i]
+            length = L * float(d).norm()
+            acc += disp * (disp.norm() - length) / length**2
+        v[i] += stiffness * acc * dt
+    for i in ti.grouped(x):
+        v[i].y -= gravity * dt
+        for b in range(num_balls):
+            v[i] = ballBoundReflect(x[i],v[i],ball_centers[b],ball_radius*1.2)
+    for i in ti.grouped(x):
+        v[i] *= ti.exp(-damping * dt)
+        x[i] += dt * v[i]
+
+@ti.kernel
+def update_verts():
+    for i, j in ti.ndrange(N,N):
+        vertices[i*N+j] = x[i,j]
+
+init()
+
+
+window = ti.ui.Window("Cloth",(800,800),vsync = True)
+canvas = window.get_canvas()
+scene = ti.ui.Scene()
+camera = ti.ui.make_camera()
+
+while window.running:
+    update_verts()
+
+    for i in range(steps):
+        substep()
+
+    camera.position(0,0,3)
+    camera.lookat(0,0,0)
+    camera.up(0,1,0)
+    scene.set_camera(camera)
+
+    scene.point_light(pos=(0.5,1,2),color=(1,1,1))
+    scene.mesh(vertices,indices = indices,color = (0.5,0.5,0.5))
+    scene.particles(ball_centers,radius = ball_radius,color = (0.5,0,0))
+    canvas.scene(scene)
+    window.show()

--- a/examples/ggui_examples/mass_spring_3d_ggui.py
+++ b/examples/ggui_examples/mass_spring_3d_ggui.py
@@ -17,51 +17,53 @@ damping = 2
 steps = 30
 dt = 5e-4
 
-
 num_balls = 1
 ball_radius = 0.3
-ball_centers = ti.Vector.field(3,float,num_balls)
+ball_centers = ti.Vector.field(3, float, num_balls)
 
+x = ti.Vector.field(3, float, (N, N))
+v = ti.Vector.field(3, float, (N, N))
 
-x = ti.Vector.field(3, float, (N,N))
-v = ti.Vector.field(3, float, (N,N))
+num_triangles = (N - 1) * (N - 1) * 2
+indices = ti.field(int, num_triangles * 3)
+vertices = ti.Vector.field(3, float, N * N)
 
-num_triangles = (N-1)*(N-1)*2
-indices = ti.field(int,num_triangles*3)
-vertices =  ti.Vector.field(3, float, N*N)
 
 @ti.kernel
 def init():
-    for i, j in ti.ndrange(N,N):
-        x[i,j] = ti.Vector([(i + 0.5) * L - 0.5, (j + 0.5) * L / ti.sqrt(2) , (N-j)*L / ti.sqrt(2)])
+    for i, j in ti.ndrange(N, N):
+        x[i, j] = ti.Vector([(i + 0.5) * L - 0.5, (j + 0.5) * L / ti.sqrt(2),
+                             (N - j) * L / ti.sqrt(2)])
 
-        if i < N-1 and j < N-1:
-            tri_id = ((i * (N-1)) + j) * 2
+        if i < N - 1 and j < N - 1:
+            tri_id = ((i * (N - 1)) + j) * 2
             indices[tri_id * 3] = i * N + j
-            indices[tri_id * 3+1] = (i+1) * N + j
-            indices[tri_id * 3+2] = i * N + (j+1)
+            indices[tri_id * 3 + 1] = (i + 1) * N + j
+            indices[tri_id * 3 + 2] = i * N + (j + 1)
 
             tri_id += 1
-            indices[tri_id * 3] = (i+1) * N + j+1
-            indices[tri_id * 3+1] = i * N + (j+1)
-            indices[tri_id * 3+2] = (i+1) * N + j
+            indices[tri_id * 3] = (i + 1) * N + j + 1
+            indices[tri_id * 3 + 1] = i * N + (j + 1)
+            indices[tri_id * 3 + 2] = (i + 1) * N + j
     ball_centers[0] = ti.Vector([0.0, -0.5, -0.0])
 
 
 links = [(-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (1, -1), (-1, 1), (1, 1)]
 links = [ti.Vector([*v]) for v in links]
 
-@ti.func
-def reflect(v,normal):
-    return v.dot(normal)*2 - v
 
 @ti.func
-def ballBoundReflect(pos, vel, center, radius, bounce_magnitude = 0.1):
+def reflect(v, normal):
+    return v.dot(normal) * 2 - v
+
+
+@ti.func
+def ballBoundReflect(pos, vel, center, radius, bounce_magnitude=0.1):
     ret = vel
-    distance = (pos-center).norm()
+    distance = (pos - center).norm()
     if distance <= radius:
         normal = (pos - radius).normalized()
-        ret = -1 * bounce_magnitude * reflect(vel,normal)
+        ret = -1 * bounce_magnitude * reflect(vel, normal)
     return ret
 
 
@@ -70,27 +72,29 @@ def substep():
     for i in ti.grouped(x):
         acc = x[i] * 0
         for d in ti.static(links):
-            disp = x[min(max(i + d, 0), ti.Vector([N-1,N-1]))] - x[i]
+            disp = x[min(max(i + d, 0), ti.Vector([N - 1, N - 1]))] - x[i]
             length = L * float(d).norm()
             acc += disp * (disp.norm() - length) / length**2
         v[i] += stiffness * acc * dt
     for i in ti.grouped(x):
         v[i].y -= gravity * dt
         for b in range(num_balls):
-            v[i] = ballBoundReflect(x[i],v[i],ball_centers[b],ball_radius*1.2)
+            v[i] = ballBoundReflect(x[i], v[i], ball_centers[b],
+                                    ball_radius * 1.2)
     for i in ti.grouped(x):
         v[i] *= ti.exp(-damping * dt)
         x[i] += dt * v[i]
 
+
 @ti.kernel
 def update_verts():
-    for i, j in ti.ndrange(N,N):
-        vertices[i*N+j] = x[i,j]
+    for i, j in ti.ndrange(N, N):
+        vertices[i * N + j] = x[i, j]
+
 
 init()
 
-
-window = ti.ui.Window("Cloth",(800,800),vsync = True)
+window = ti.ui.Window("Cloth", (800, 800), vsync=True)
 canvas = window.get_canvas()
 scene = ti.ui.Scene()
 camera = ti.ui.make_camera()
@@ -101,13 +105,13 @@ while window.running:
     for i in range(steps):
         substep()
 
-    camera.position(0,0,3)
-    camera.lookat(0,0,0)
-    camera.up(0,1,0)
+    camera.position(0, 0, 3)
+    camera.lookat(0, 0, 0)
+    camera.up(0, 1, 0)
     scene.set_camera(camera)
 
-    scene.point_light(pos=(0.5,1,2),color=(1,1,1))
-    scene.mesh(vertices,indices = indices,color = (0.5,0.5,0.5))
-    scene.particles(ball_centers,radius = ball_radius,color = (0.5,0,0))
+    scene.point_light(pos=(0.5, 1, 2), color=(1, 1, 1))
+    scene.mesh(vertices, indices=indices, color=(0.5, 0.5, 0.5))
+    scene.particles(ball_centers, radius=ball_radius, color=(0.5, 0, 0))
     canvas.scene(scene)
     window.show()

--- a/examples/ggui_examples/mass_spring_game_ggui.py
+++ b/examples/ggui_examples/mass_spring_game_ggui.py
@@ -18,8 +18,9 @@ v = ti.Vector.field(2, dtype=ti.f32, shape=max_num_particles)
 f = ti.Vector.field(2, dtype=ti.f32, shape=max_num_particles)
 fixed = ti.field(dtype=ti.i32, shape=max_num_particles)
 
-indices = ti.field(dtype=ti.i32, shape=max_num_particles* max_num_particles * 2)
-per_vertex_color = ti.Vector.field(3,ti.f32,shape = max_num_particles)
+indices = ti.field(dtype=ti.i32,
+                   shape=max_num_particles * max_num_particles * 2)
+per_vertex_color = ti.Vector.field(3, ti.f32, shape=max_num_particles)
 
 # rest_length[i, j] == 0 means i and j are NOT connected
 rest_length = ti.field(dtype=ti.f32,
@@ -102,23 +103,24 @@ def render():
     for i in indices:
         indices[i] = max_num_particles - 1
     n = num_particles[None]
-    for i in range(n+1,max_num_particles):
-        x[i] = ti.Vector([-1,-1]) # hide them
+    for i in range(n + 1, max_num_particles):
+        x[i] = ti.Vector([-1, -1])  # hide them
     for i in range(n):
         if fixed[i]:
-            per_vertex_color[i] = ti.Vector([1,0,0]) 
+            per_vertex_color[i] = ti.Vector([1, 0, 0])
         else:
-            per_vertex_color[i] = ti.Vector([0,0,0]) 
+            per_vertex_color[i] = ti.Vector([0, 0, 0])
     for i in range(n):
-        for j in range(i+1,n):
-            line_id = i*max_num_particles + j 
+        for j in range(i + 1, n):
+            line_id = i * max_num_particles + j
             if rest_length[i, j] != 0:
-                indices[line_id*2 ] = i
-                indices[line_id*2 + 1] = j
+                indices[line_id * 2] = i
+                indices[line_id * 2 + 1] = j
 
 
 def main():
-    window = ti.ui.Window('Explicit Mass Spring System',(1024,1024),vsync = True)
+    window = ti.ui.Window('Explicit Mass Spring System', (1024, 1024),
+                          vsync=True)
     canvas = window.get_canvas()
 
     spring_Y[None] = 1000
@@ -152,16 +154,22 @@ def main():
                 substep()
 
         render()
-        canvas.set_background_color((1,1,1))
-        canvas.lines(x,indices = indices,color = (0,0,0),width = 0.01)
-        canvas.circles(x,per_vertex_color = per_vertex_color,radius = 0.02)
-        
-        window.GUI.begin("mass spring",0.05,0.05,0.9,0.2)
-        window.GUI.text("Left click: add mass point (with shift to fix); Right click: attract")
+        canvas.set_background_color((1, 1, 1))
+        canvas.lines(x, indices=indices, color=(0, 0, 0), width=0.01)
+        canvas.circles(x, per_vertex_color=per_vertex_color, radius=0.02)
+
+        window.GUI.begin("mass spring", 0.05, 0.05, 0.9, 0.2)
+        window.GUI.text(
+            "Left click: add mass point (with shift to fix); Right click: attract"
+        )
         window.GUI.text("C: clear all; Space: pause")
-        spring_Y[None] = window.GUI.slider_float("Spring Young's modulus",spring_Y[None],100,10000)
-        drag_damping[None] = window.GUI.slider_float("Drag damping",drag_damping[None],0.0,10)
-        dashpot_damping[None] = window.GUI.slider_float("Dashpot damping",dashpot_damping[None],10,1000)
+        spring_Y[None] = window.GUI.slider_float("Spring Young's modulus",
+                                                 spring_Y[None], 100, 10000)
+        drag_damping[None] = window.GUI.slider_float("Drag damping",
+                                                     drag_damping[None], 0.0,
+                                                     10)
+        dashpot_damping[None] = window.GUI.slider_float(
+            "Dashpot damping", dashpot_damping[None], 10, 1000)
         window.GUI.end()
 
         window.show()

--- a/examples/ggui_examples/mass_spring_game_ggui.py
+++ b/examples/ggui_examples/mass_spring_game_ggui.py
@@ -1,0 +1,171 @@
+import taichi as ti
+
+ti.init(arch=ti.cuda)
+
+spring_Y = ti.field(dtype=ti.f32, shape=())  # Young's modulus
+paused = ti.field(dtype=ti.i32, shape=())
+drag_damping = ti.field(dtype=ti.f32, shape=())
+dashpot_damping = ti.field(dtype=ti.f32, shape=())
+
+max_num_particles = 1024
+particle_mass = 1.0
+dt = 1e-3
+substeps = 10
+
+num_particles = ti.field(dtype=ti.i32, shape=())
+x = ti.Vector.field(2, dtype=ti.f32, shape=max_num_particles)
+v = ti.Vector.field(2, dtype=ti.f32, shape=max_num_particles)
+f = ti.Vector.field(2, dtype=ti.f32, shape=max_num_particles)
+fixed = ti.field(dtype=ti.i32, shape=max_num_particles)
+
+indices = ti.field(dtype=ti.i32, shape=max_num_particles* max_num_particles * 2)
+per_vertex_color = ti.Vector.field(3,ti.f32,shape = max_num_particles)
+
+# rest_length[i, j] == 0 means i and j are NOT connected
+rest_length = ti.field(dtype=ti.f32,
+                       shape=(max_num_particles, max_num_particles))
+
+
+@ti.kernel
+def substep():
+    n = num_particles[None]
+
+    # Compute force
+    for i in range(n):
+        # Gravity
+        f[i] = ti.Vector([0, -9.8]) * particle_mass
+        for j in range(n):
+            if rest_length[i, j] != 0:
+                x_ij = x[i] - x[j]
+                d = x_ij.normalized()
+
+                # Spring force
+                f[i] += -spring_Y[None] * (x_ij.norm() / rest_length[i, j] -
+                                           1) * d
+
+                # Dashpot damping
+                v_rel = (v[i] - v[j]).dot(d)
+                f[i] += -dashpot_damping[None] * v_rel * d
+
+    # We use a semi-implicit Euler (aka symplectic Euler) time integrator
+    for i in range(n):
+        if not fixed[i]:
+            v[i] += dt * f[i] / particle_mass
+            v[i] *= ti.exp(-dt * drag_damping[None])  # Drag damping
+
+            x[i] += v[i] * dt
+        else:
+            v[i] = ti.Vector([0, 0])
+
+        # Collide with four walls
+        for d in ti.static(range(2)):
+            # d = 0: treating X (horizontal) component
+            # d = 1: treating Y (vertical) component
+
+            if x[i][d] < 0:  # Bottom and left
+                x[i][d] = 0  # move particle inside
+                v[i][d] = 0  # stop it from moving further
+
+            if x[i][d] > 1:  # Top and right
+                x[i][d] = 1  # move particle inside
+                v[i][d] = 0  # stop it from moving further
+
+
+@ti.kernel
+def new_particle(pos_x: ti.f32, pos_y: ti.f32, fixed_: ti.i32):
+    # Taichi doesn't support using vectors as kernel arguments yet, so we pass scalars
+    new_particle_id = num_particles[None]
+    x[new_particle_id] = [pos_x, pos_y]
+    v[new_particle_id] = [0, 0]
+    fixed[new_particle_id] = fixed_
+    num_particles[None] += 1
+
+    # Connect with existing particles
+    for i in range(new_particle_id):
+        dist = (x[new_particle_id] - x[i]).norm()
+        connection_radius = 0.15
+        if dist < connection_radius:
+            # Connect the new particle with particle i
+            rest_length[i, new_particle_id] = 0.1
+            rest_length[new_particle_id, i] = 0.1
+
+
+@ti.kernel
+def attract(pos_x: ti.f32, pos_y: ti.f32):
+    for i in range(num_particles[None]):
+        p = ti.Vector([pos_x, pos_y])
+        v[i] += -dt * substeps * (x[i] - p) * 100
+
+
+@ti.kernel
+def render():
+    for i in indices:
+        indices[i] = max_num_particles - 1
+    n = num_particles[None]
+    for i in range(n+1,max_num_particles):
+        x[i] = ti.Vector([-1,-1]) # hide them
+    for i in range(n):
+        if fixed[i]:
+            per_vertex_color[i] = ti.Vector([1,0,0]) 
+        else:
+            per_vertex_color[i] = ti.Vector([0,0,0]) 
+    for i in range(n):
+        for j in range(i+1,n):
+            line_id = i*max_num_particles + j 
+            if rest_length[i, j] != 0:
+                indices[line_id*2 ] = i
+                indices[line_id*2 + 1] = j
+
+
+def main():
+    window = ti.ui.Window('Explicit Mass Spring System',(1024,1024),vsync = True)
+    canvas = window.get_canvas()
+
+    spring_Y[None] = 1000
+    drag_damping[None] = 1
+    dashpot_damping[None] = 100
+
+    new_particle(0.3, 0.3, False)
+    new_particle(0.3, 0.4, False)
+    new_particle(0.4, 0.4, False)
+
+    while window.running:
+        for e in window.get_events(ti.ui.PRESS):
+            if e.key in [ti.ui.ESCAPE]:
+                exit()
+            elif e.key == ti.ui.SPACE:
+                paused[None] = not paused[None]
+            elif e.key == ti.ui.LMB:
+                pos = window.get_cursor_pos()
+                new_particle(pos[0], pos[1],
+                             int(window.is_pressed(ti.ui.SHIFT)))
+            elif e.key == 'c':
+                num_particles[None] = 0
+                rest_length.fill(0)
+
+        if window.is_pressed(ti.ui.RMB):
+            cursor_pos = window.get_cursor_pos()
+            attract(cursor_pos[0], cursor_pos[1])
+
+        if not paused[None]:
+            for step in range(substeps):
+                substep()
+
+        render()
+        canvas.set_background_color((1,1,1))
+        canvas.lines(x,indices = indices,color = (0,0,0),width = 0.01)
+        canvas.circles(x,per_vertex_color = per_vertex_color,radius = 0.02)
+        
+        window.GUI.begin("mass spring",0.05,0.05,0.9,0.2)
+        window.GUI.text("Left click: add mass point (with shift to fix); Right click: attract")
+        window.GUI.text("C: clear all; Space: pause")
+        spring_Y[None] = window.GUI.slider_float("Spring Young's modulus",spring_Y[None],100,10000)
+        drag_damping[None] = window.GUI.slider_float("Drag damping",drag_damping[None],0.0,10)
+        dashpot_damping[None] = window.GUI.slider_float("Dashpot damping",dashpot_damping[None],10,1000)
+        window.GUI.end()
+
+        window.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ggui_examples/mpm128_ggui.py
+++ b/examples/ggui_examples/mpm128_ggui.py
@@ -1,0 +1,178 @@
+import numpy as np
+
+import taichi as ti
+
+
+ti.init(arch=ti.gpu)  # Try to run on GPU
+
+quality = 1  # Use a larger value for higher-res simulations
+n_particles, n_grid = 9000 * quality**2, 128 * quality
+dx, inv_dx = 1 / n_grid, float(n_grid)
+dt = 1e-4 / quality
+p_vol, p_rho = (dx * 0.5)**2, 1
+p_mass = p_vol * p_rho
+E, nu = 5e3, 0.2  # Young's modulus and Poisson's ratio
+mu_0, lambda_0 = E / (2 * (1 + nu)), E * nu / (
+    (1 + nu) * (1 - 2 * nu))  # Lame parameters
+
+x = ti.Vector.field(2, dtype=float, shape=n_particles)  # position
+v = ti.Vector.field(2, dtype=float, shape=n_particles)  # velocity
+C = ti.Matrix.field(2, 2, dtype=float,
+                    shape=n_particles)  # affine velocity field
+F = ti.Matrix.field(2, 2, dtype=float,
+                    shape=n_particles)  # deformation gradient
+material = ti.field(dtype=int, shape=n_particles)  # material id
+Jp = ti.field(dtype=float, shape=n_particles)  # plastic deformation
+grid_v = ti.Vector.field(2, dtype=float,
+                         shape=(n_grid, n_grid))  # grid node momentum/velocity
+grid_m = ti.field(dtype=float, shape=(n_grid, n_grid))  # grid node mass
+gravity = ti.Vector.field(2, dtype=float, shape=())
+attractor_strength = ti.field(dtype=float, shape=())
+attractor_pos = ti.Vector.field(2, dtype=float, shape=())
+
+group_size = n_particles // 3
+water = ti.Vector.field(2, dtype=float, shape= group_size)  # position
+jelly = ti.Vector.field(2, dtype=float, shape= group_size)  # position
+snow = ti.Vector.field(2, dtype=float, shape= group_size)  # position
+mouse_circle = ti.Vector.field(2,dtype=float,shape = (1,))
+
+
+
+@ti.kernel
+def substep():
+    for i, j in grid_m:
+        grid_v[i, j] = [0, 0]
+        grid_m[i, j] = 0
+    for p in x:  # Particle state update and scatter to grid (P2G)
+        base = (x[p] * inv_dx - 0.5).cast(int)
+        fx = x[p] * inv_dx - base.cast(float)
+        # Quadratic kernels  [http://mpm.graphics   Eqn. 123, with x=fx, fx-1,fx-2]
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+        F[p] = (ti.Matrix.identity(float, 2) +
+                dt * C[p]) @ F[p]  # deformation gradient update
+        h = max(0.1, min(5, ti.exp(10 * (1.0 - Jp[p])))
+                )  # Hardening coefficient: snow gets harder when compressed
+        if material[p] == 1:  # jelly, make it softer
+            h = 0.3
+        mu, la = mu_0 * h, lambda_0 * h
+        if material[p] == 0:  # liquid
+            mu = 0.0
+        U, sig, V = ti.svd(F[p])
+        J = 1.0
+        for d in ti.static(range(2)):
+            new_sig = sig[d, d]
+            if material[p] == 2:  # Snow
+                new_sig = min(max(sig[d, d], 1 - 2.5e-2),
+                              1 + 4.5e-3)  # Plasticity
+            Jp[p] *= sig[d, d] / new_sig
+            sig[d, d] = new_sig
+            J *= new_sig
+        if material[
+                p] == 0:  # Reset deformation gradient to avoid numerical instability
+            F[p] = ti.Matrix.identity(float, 2) * ti.sqrt(J)
+        elif material[p] == 2:
+            F[p] = U @ sig @ V.transpose(
+            )  # Reconstruct elastic deformation gradient after plasticity
+        stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose(
+        ) + ti.Matrix.identity(float, 2) * la * J * (J - 1)
+        stress = (-dt * p_vol * 4 * inv_dx * inv_dx) * stress
+        affine = stress + p_mass * C[p]
+        for i, j in ti.static(ti.ndrange(
+                3, 3)):  # Loop over 3x3 grid node neighborhood
+            offset = ti.Vector([i, j])
+            dpos = (offset.cast(float) - fx) * dx
+            weight = w[i][0] * w[j][1]
+            grid_v[base + offset] += weight * (p_mass * v[p] + affine @ dpos)
+            grid_m[base + offset] += weight * p_mass
+    for i, j in grid_m:
+        if grid_m[i, j] > 0:  # No need for epsilon here
+            grid_v[i,
+                   j] = (1 / grid_m[i, j]) * grid_v[i,
+                                                    j]  # Momentum to velocity
+            grid_v[i, j] += dt * gravity[None] * 30  # gravity
+            dist = attractor_pos[None] - dx * ti.Vector([i, j])
+            grid_v[i, j] += dist / (
+                0.01 + dist.norm()) * attractor_strength[None] * dt * 100
+            if i < 3 and grid_v[i, j][0] < 0:
+                grid_v[i, j][0] = 0  # Boundary conditions
+            if i > n_grid - 3 and grid_v[i, j][0] > 0: grid_v[i, j][0] = 0
+            if j < 3 and grid_v[i, j][1] < 0: grid_v[i, j][1] = 0
+            if j > n_grid - 3 and grid_v[i, j][1] > 0: grid_v[i, j][1] = 0
+    for p in x:  # grid to particle (G2P)
+        base = (x[p] * inv_dx - 0.5).cast(int)
+        fx = x[p] * inv_dx - base.cast(float)
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1.0)**2, 0.5 * (fx - 0.5)**2]
+        new_v = ti.Vector.zero(float, 2)
+        new_C = ti.Matrix.zero(float, 2, 2)
+        for i, j in ti.static(ti.ndrange(
+                3, 3)):  # loop over 3x3 grid node neighborhood
+            dpos = ti.Vector([i, j]).cast(float) - fx
+            g_v = grid_v[base + ti.Vector([i, j])]
+            weight = w[i][0] * w[j][1]
+            new_v += weight * g_v
+            new_C += 4 * inv_dx * weight * g_v.outer_product(dpos)
+        v[p], C[p] = new_v, new_C
+        x[p] += dt * v[p]  # advection
+
+
+@ti.kernel
+def reset():
+    for i in range(n_particles):
+        x[i] = [
+            ti.random() * 0.2 + 0.3 + 0.10 * (i // group_size),
+            ti.random() * 0.2 + 0.05 + 0.32 * (i // group_size)
+        ]
+        material[i] = i // group_size  # 0: fluid 1: jelly 2: snow
+        v[i] = [0, 0]
+        F[i] = ti.Matrix([[1, 0], [0, 1]])
+        Jp[i] = 1
+        C[i] = ti.Matrix.zero(float, 2, 2)
+
+@ti.kernel
+def render():
+    for i in range(group_size):
+        water[i] = x[i]
+        jelly[i] = x[i+group_size]
+        snow [i] = x[i+2*group_size]
+
+
+
+print(
+    "[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse bottons to attract/repel. Press R to reset."
+)
+
+res = (512,512)
+window = ti.ui.Window("Taichi MLS-MPM-128", res=res,vsync = True)
+canvas = window.get_canvas()
+radius = 0.003
+
+reset()
+gravity[None] = [0, -1]
+
+while window.running:
+    if window.get_event(ti.ui.PRESS):
+        if window.event.key == 'r': reset()
+        elif window.event.key in [ti.ui.ESCAPE]: break
+    if window.event is not None: gravity[None] = [0, 0]  # if had any event
+    if window.is_pressed(ti.ui.LEFT, 'a'): gravity[None][0] = -1
+    if window.is_pressed(ti.ui.RIGHT, 'd'): gravity[None][0] = 1
+    if window.is_pressed(ti.ui.UP, 'w'): gravity[None][1] = 1
+    if window.is_pressed(ti.ui.DOWN, 's'): gravity[None][1] = -1
+    mouse = window.get_cursor_pos()
+    mouse_circle[0] = ti.Vector([mouse[0], mouse[1]])
+    canvas.circles(mouse_circle, color=(0.2,0.4,0.6), radius=0.05)
+    attractor_pos[None] = [mouse[0], mouse[1]]
+    attractor_strength[None] = 0
+    if window.is_pressed(ti.ui.LMB):
+        attractor_strength[None] = 1
+    if window.is_pressed(ti.ui.RMB):
+        attractor_strength[None] = -1
+        
+    for s in range(int(2e-3 // dt)):
+        substep()
+    render()
+    canvas.set_background_color((0.067,0.184,0.255))
+    canvas.circles(water, radius=radius, color=(0,0.5,0.5))
+    canvas.circles(jelly, radius=radius, color=(0.93,0.33,0.23))
+    canvas.circles(snow, radius=radius, color=(1,1,1))
+    window.show()

--- a/examples/ggui_examples/mpm128_ggui.py
+++ b/examples/ggui_examples/mpm128_ggui.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import taichi as ti
 
-
 ti.init(arch=ti.gpu)  # Try to run on GPU
 
 quality = 1  # Use a larger value for higher-res simulations
@@ -31,11 +30,10 @@ attractor_strength = ti.field(dtype=float, shape=())
 attractor_pos = ti.Vector.field(2, dtype=float, shape=())
 
 group_size = n_particles // 3
-water = ti.Vector.field(2, dtype=float, shape= group_size)  # position
-jelly = ti.Vector.field(2, dtype=float, shape= group_size)  # position
-snow = ti.Vector.field(2, dtype=float, shape= group_size)  # position
-mouse_circle = ti.Vector.field(2,dtype=float,shape = (1,))
-
+water = ti.Vector.field(2, dtype=float, shape=group_size)  # position
+jelly = ti.Vector.field(2, dtype=float, shape=group_size)  # position
+snow = ti.Vector.field(2, dtype=float, shape=group_size)  # position
+mouse_circle = ti.Vector.field(2, dtype=float, shape=(1, ))
 
 
 @ti.kernel
@@ -128,21 +126,21 @@ def reset():
         Jp[i] = 1
         C[i] = ti.Matrix.zero(float, 2, 2)
 
+
 @ti.kernel
 def render():
     for i in range(group_size):
         water[i] = x[i]
-        jelly[i] = x[i+group_size]
-        snow [i] = x[i+2*group_size]
-
+        jelly[i] = x[i + group_size]
+        snow[i] = x[i + 2 * group_size]
 
 
 print(
     "[Hint] Use WSAD/arrow keys to control gravity. Use left/right mouse bottons to attract/repel. Press R to reset."
 )
 
-res = (512,512)
-window = ti.ui.Window("Taichi MLS-MPM-128", res=res,vsync = True)
+res = (512, 512)
+window = ti.ui.Window("Taichi MLS-MPM-128", res=res, vsync=True)
 canvas = window.get_canvas()
 radius = 0.003
 
@@ -160,19 +158,19 @@ while window.running:
     if window.is_pressed(ti.ui.DOWN, 's'): gravity[None][1] = -1
     mouse = window.get_cursor_pos()
     mouse_circle[0] = ti.Vector([mouse[0], mouse[1]])
-    canvas.circles(mouse_circle, color=(0.2,0.4,0.6), radius=0.05)
+    canvas.circles(mouse_circle, color=(0.2, 0.4, 0.6), radius=0.05)
     attractor_pos[None] = [mouse[0], mouse[1]]
     attractor_strength[None] = 0
     if window.is_pressed(ti.ui.LMB):
         attractor_strength[None] = 1
     if window.is_pressed(ti.ui.RMB):
         attractor_strength[None] = -1
-        
+
     for s in range(int(2e-3 // dt)):
         substep()
     render()
-    canvas.set_background_color((0.067,0.184,0.255))
-    canvas.circles(water, radius=radius, color=(0,0.5,0.5))
-    canvas.circles(jelly, radius=radius, color=(0.93,0.33,0.23))
-    canvas.circles(snow, radius=radius, color=(1,1,1))
+    canvas.set_background_color((0.067, 0.184, 0.255))
+    canvas.circles(water, radius=radius, color=(0, 0.5, 0.5))
+    canvas.circles(jelly, radius=radius, color=(0.93, 0.33, 0.23))
+    canvas.circles(snow, radius=radius, color=(1, 1, 1))
     window.show()

--- a/examples/ggui_examples/mpm3d_ggui.py
+++ b/examples/ggui_examples/mpm3d_ggui.py
@@ -23,15 +23,15 @@ g_x = 0
 g_y = -9.8
 g_z = 0
 bound = 3
-E = 1000 # Young's modulus
-nu =  0.2  #  Poisson's ratio
+E = 1000  # Young's modulus
+nu = 0.2  #  Poisson's ratio
 mu_0, lambda_0 = E / (2 * (1 + nu)), E * nu / (
     (1 + nu) * (1 - 2 * nu))  # Lame parameters
 
 x = ti.Vector.field(dim, float, n_particles)
 v = ti.Vector.field(dim, float, n_particles)
 C = ti.Matrix.field(dim, dim, float, n_particles)
-F = ti.Matrix.field(3,3, dtype=float,
+F = ti.Matrix.field(3, 3, dtype=float,
                     shape=n_particles)  # deformation gradient
 Jp = ti.field(float, n_particles)
 
@@ -40,7 +40,7 @@ colors_random = ti.Vector.field(3, float, n_particles)
 materials = ti.field(int, n_particles)
 grid_v = ti.Vector.field(dim, float, (n_grid, ) * dim)
 grid_m = ti.field(float, (n_grid, ) * dim)
-used = ti.field(int,n_particles)
+used = ti.field(int, n_particles)
 
 neighbour = (3, ) * dim
 
@@ -48,8 +48,9 @@ WATER = 0
 JELLY = 1
 SNOW = 2
 
+
 @ti.kernel
-def substep(g_x:float,g_y:float,g_z:float):
+def substep(g_x: float, g_y: float, g_z: float):
     for I in ti.grouped(grid_m):
         grid_v[I] = ti.zero(grid_v[I])
         grid_m[I] = 0
@@ -62,15 +63,19 @@ def substep(g_x:float,g_y:float,g_z:float):
         fx = Xp - base
         w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
 
-        F[p] = (ti.Matrix.identity(float, 3) + dt * C[p]) @ F[p]  # deformation gradient update
+        F[p] = (ti.Matrix.identity(float, 3) +
+                dt * C[p]) @ F[p]  # deformation gradient update
 
-        h = ti.exp( 10 * (1.0 -  Jp[p]))  # Hardening coefficient: snow gets harder when compressed
+        h = ti.exp(
+            10 *
+            (1.0 -
+             Jp[p]))  # Hardening coefficient: snow gets harder when compressed
         if materials[p] == JELLY:  # jelly, make it softer
             h = 0.3
         mu, la = mu_0 * h, lambda_0 * h
         if materials[p] == WATER:  # liquid
             mu = 0.0
-         
+
         U, sig, V = ti.svd(F[p])
         J = 1.0
         for d in ti.static(range(3)):
@@ -81,16 +86,18 @@ def substep(g_x:float,g_y:float,g_z:float):
             Jp[p] *= sig[d, d] / new_sig
             sig[d, d] = new_sig
             J *= new_sig
-        if materials[ p] == WATER:  # Reset deformation gradient to avoid numerical instability
+        if materials[
+                p] == WATER:  # Reset deformation gradient to avoid numerical instability
             new_F = ti.Matrix.identity(float, 3)
-            new_F[0,0] = J
+            new_F[0, 0] = J
             F[p] = new_F
         elif materials[p] == SNOW:
-            F[p] = U @ sig @ V.transpose( )  # Reconstruct elastic deformation gradient after plasticity
-        stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose() + ti.Matrix.identity(float, 3) * la * J * (J - 1)
-        stress = (-dt * p_vol * 4 ) * stress / dx**2
+            F[p] = U @ sig @ V.transpose(
+            )  # Reconstruct elastic deformation gradient after plasticity
+        stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose(
+        ) + ti.Matrix.identity(float, 3) * la * J * (J - 1)
+        stress = (-dt * p_vol * 4) * stress / dx**2
         affine = stress + p_mass * C[p]
- 
 
         for offset in ti.static(ti.grouped(ti.ndrange(*neighbour))):
             dpos = (offset - fx) * dx
@@ -102,7 +109,7 @@ def substep(g_x:float,g_y:float,g_z:float):
     for I in ti.grouped(grid_m):
         if grid_m[I] > 0:
             grid_v[I] /= grid_m[I]
-        grid_v[I] += dt * ti.Vector([g_x,g_y,g_z])
+        grid_v[I] += dt * ti.Vector([g_x, g_y, g_z])
         cond = I < bound and grid_v[I] < 0 or I > n_grid - bound and grid_v[
             I] > 0
         grid_v[I] = 0 if cond else grid_v[I]
@@ -128,20 +135,25 @@ def substep(g_x:float,g_y:float,g_z:float):
         x[p] += dt * v[p]
         C[p] = new_C
 
+
 class CubeVolume:
-    def __init__(self,minimum,size,material):
-        self.minimum=minimum
+    def __init__(self, minimum, size, material):
+        self.minimum = minimum
         self.size = size
-        self.volume = self.size.x * self.size.y *self.size.z
+        self.volume = self.size.x * self.size.y * self.size.z
         self.material = material
 
+
 @ti.kernel
-def init_cube_vol(first_par:int,last_par:int, x_begin:float,y_begin:float,z_begin:float,x_size:float,y_size:float,z_size:float,material:int ):
-    for i in range(first_par,last_par):
-        x[i] = ti.Vector([ti.random() for i in range(dim)]) * ti.Vector([x_size,y_size,z_size]) + ti.Vector([x_begin,y_begin,z_begin]) 
+def init_cube_vol(first_par: int, last_par: int, x_begin: float,
+                  y_begin: float, z_begin: float, x_size: float, y_size: float,
+                  z_size: float, material: int):
+    for i in range(first_par, last_par):
+        x[i] = ti.Vector([ti.random() for i in range(dim)]) * ti.Vector(
+            [x_size, y_size, z_size]) + ti.Vector([x_begin, y_begin, z_begin])
         Jp[i] = 1
-        F[i] = ti.Matrix([[1, 0,0], [0, 1,0],[0,0,1]])
-        v[i] = ti.Vector([0.0,0.0,0.0])
+        F[i] = ti.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        v[i] = ti.Vector([0.0, 0.0, 0.0])
         materials[i] = material
         colors_random[i] = ti.Vector([ti.random(), ti.random(), ti.random()])
         used[i] = 1
@@ -152,11 +164,11 @@ def set_all_unused():
     for p in used:
         used[p] = 0
         # basically throw them away so they aren't rendered
-        x[p] = ti.Vector([533799.0,533799.0,533799.0])
+        x[p] = ti.Vector([533799.0, 533799.0, 533799.0])
         Jp[p] = 1
-        F[p] = ti.Matrix([[1, 0,0], [0, 1,0],[0,0,1]])
-        C[p] = ti.Matrix([[0, 0,0], [0, 0,0],[0,0,0]])
-        v[p] = ti.Vector([0.0,0.0,0.0])
+        F[p] = ti.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        C[p] = ti.Matrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        v[p] = ti.Vector([0.0, 0.0, 0.0])
 
 
 def init_vols(vols):
@@ -164,42 +176,53 @@ def init_vols(vols):
     total_vol = 0
     for v in vols:
         total_vol += v.volume
-    
+
     next_p = 0
     for i in range(len(vols)):
         v = vols[i]
-        if isinstance(v,CubeVolume):
+        if isinstance(v, CubeVolume):
             par_count = int(v.volume / total_vol * n_particles)
-            if i == len(vols) -1: # this is the last volume, so use all remaining particles
+            if i == len(
+                    vols
+            ) - 1:  # this is the last volume, so use all remaining particles
                 par_count = n_particles - next_p
-            init_cube_vol(next_p,next_p+par_count,*v.minimum,*v.size,v.material)
+            init_cube_vol(next_p, next_p + par_count, *v.minimum, *v.size,
+                          v.material)
             next_p += par_count
         else:
             raise Exception("???")
 
 
 @ti.kernel
-def set_color_by_material(material_colors:ti.ext_arr()):
+def set_color_by_material(material_colors: ti.ext_arr()):
     for i in range(n_particles):
         mat = materials[i]
-        colors[i] = ti.Vector([material_colors[mat,0],material_colors[mat,1],material_colors[mat,2]])
- 
+        colors[i] = ti.Vector([
+            material_colors[mat, 0], material_colors[mat, 1],
+            material_colors[mat, 2]
+        ])
+
+
 print("Loading presets...this might take a minute")
 
-presets = [
-    [
-        CubeVolume(ti.Vector([0.55,0.05,0.55]),ti.Vector([0.4,0.4,0.4]),WATER), 
-    ],
-    [
-        CubeVolume(ti.Vector([0.05,0.05,0.05]),ti.Vector([0.3,0.4,0.3]),WATER), 
-        CubeVolume(ti.Vector([0.65,0.05,0.65]),ti.Vector([0.3,0.4,0.3]),WATER), 
-    ],
-    [
-        CubeVolume(ti.Vector([0.6,0.05,0.6]),ti.Vector([0.25,0.25,0.25]),WATER), 
-        CubeVolume(ti.Vector([0.35,0.35,0.35]),ti.Vector([0.25,0.25,0.25]),SNOW), 
-        CubeVolume(ti.Vector([0.05,0.6,0.05]),ti.Vector([0.25,0.25,0.25]),JELLY), 
-    ]
-]
+presets = [[
+    CubeVolume(ti.Vector([0.55, 0.05, 0.55]), ti.Vector([0.4, 0.4, 0.4]),
+               WATER),
+],
+           [
+               CubeVolume(ti.Vector([0.05, 0.05, 0.05]),
+                          ti.Vector([0.3, 0.4, 0.3]), WATER),
+               CubeVolume(ti.Vector([0.65, 0.05, 0.65]),
+                          ti.Vector([0.3, 0.4, 0.3]), WATER),
+           ],
+           [
+               CubeVolume(ti.Vector([0.6, 0.05, 0.6]),
+                          ti.Vector([0.25, 0.25, 0.25]), WATER),
+               CubeVolume(ti.Vector([0.35, 0.35, 0.35]),
+                          ti.Vector([0.25, 0.25, 0.25]), SNOW),
+               CubeVolume(ti.Vector([0.05, 0.6, 0.05]),
+                          ti.Vector([0.25, 0.25, 0.25]), JELLY),
+           ]]
 preset_names = [
     "Single Dam Break",
     "Double Dam Break",
@@ -208,25 +231,20 @@ preset_names = [
 
 curr_preset_id = 0
 
-
 paused = False
-
 
 use_random_colors = False
 particles_radius = 0.02
 
-material_colors = [
-    (0.1,0.6,0.9),
-    (0.93,0.33,0.23),
-    (1.0,1.0,1.0)
-]
+material_colors = [(0.1, 0.6, 0.9), (0.93, 0.33, 0.23), (1.0, 1.0, 1.0)]
+
 
 def init():
     global paused
     init_vols(presets[curr_preset_id])
 
-init()
 
+init()
 
 res = (1920, 1080)
 window = ti.ui.Window("Real MPM 3D", res, vsync=True)
@@ -235,18 +253,19 @@ frame_id = 0
 canvas = window.get_canvas()
 scene = ti.ui.Scene()
 camera = ti.ui.make_camera()
-camera.position(0.5,1.0,1.95)
-camera.lookat(0.5,0.3,0.5)
+camera.position(0.5, 1.0, 1.95)
+camera.lookat(0.5, 0.3, 0.5)
 camera.fov(55)
+
 
 def show_options():
     global use_random_colors
     global paused
     global particles_radius
     global curr_preset_id
-    global g_x,g_y,g_z
+    global g_x, g_y, g_z
 
-    window.GUI.begin("Presets",0.05, 0.1, 0.2, 0.15)
+    window.GUI.begin("Presets", 0.05, 0.1, 0.2, 0.15)
     old_preset = curr_preset_id
     for i in range(len(presets)):
         if window.GUI.checkbox(preset_names[i], curr_preset_id == i):
@@ -256,20 +275,23 @@ def show_options():
         paused = True
     window.GUI.end()
 
-    window.GUI.begin("Gravity",0.05, 0.3, 0.2, 0.1)
-    g_x = window.GUI.slider_float("x",g_x, -10, 10)
-    g_y = window.GUI.slider_float("y",g_y, -10, 10)
-    g_z = window.GUI.slider_float("z",g_z, -10, 10)
+    window.GUI.begin("Gravity", 0.05, 0.3, 0.2, 0.1)
+    g_x = window.GUI.slider_float("x", g_x, -10, 10)
+    g_y = window.GUI.slider_float("y", g_y, -10, 10)
+    g_z = window.GUI.slider_float("z", g_z, -10, 10)
     window.GUI.end()
 
-
     window.GUI.begin("Options", 0.05, 0.45, 0.2, 0.4)
-      
-    use_random_colors = window.GUI.checkbox("use_random_colors", use_random_colors)
+
+    use_random_colors = window.GUI.checkbox("use_random_colors",
+                                            use_random_colors)
     if not use_random_colors:
-        material_colors[WATER] = window.GUI.color_edit_3("water color",material_colors[WATER])
-        material_colors[SNOW] = window.GUI.color_edit_3("snow color",material_colors[SNOW])
-        material_colors[JELLY] = window.GUI.color_edit_3("jelly color",material_colors[JELLY])
+        material_colors[WATER] = window.GUI.color_edit_3(
+            "water color", material_colors[WATER])
+        material_colors[SNOW] = window.GUI.color_edit_3(
+            "snow color", material_colors[SNOW])
+        material_colors[JELLY] = window.GUI.color_edit_3(
+            "jelly color", material_colors[JELLY])
         set_color_by_material(np.array(material_colors))
     particles_radius = window.GUI.slider_float("particles radius ",
                                                particles_radius, 0, 0.1)
@@ -285,16 +307,16 @@ def show_options():
 
 
 def render():
-    camera.track_user_inputs(window,movement_speed = 0.03,hold_key = ti.ui.RMB)
+    camera.track_user_inputs(window, movement_speed=0.03, hold_key=ti.ui.RMB)
     scene.set_camera(camera)
 
     scene.ambient_light((0, 0, 0))
 
     colors_used = colors_random if use_random_colors else colors
-    scene.particles(x,per_vertex_color=colors_used, radius=particles_radius) 
+    scene.particles(x, per_vertex_color=colors_used, radius=particles_radius)
 
-    scene.point_light(pos=(0.5,1.5,0.5), color=(0.5, 0.5, 0.5))
-    scene.point_light(pos=(0.5,1.5,1.5), color=(0.5, 0.5, 0.5))
+    scene.point_light(pos=(0.5, 1.5, 0.5), color=(0.5, 0.5, 0.5))
+    scene.point_light(pos=(0.5, 1.5, 1.5), color=(0.5, 0.5, 0.5))
 
     canvas.scene(scene)
 
@@ -306,7 +328,7 @@ while window.running:
 
     if not paused:
         for s in range(steps):
-            substep(g_x,g_y,g_z)
+            substep(g_x, g_y, g_z)
 
     render()
 

--- a/examples/ggui_examples/mpm3d_ggui.py
+++ b/examples/ggui_examples/mpm3d_ggui.py
@@ -1,0 +1,315 @@
+import numpy as np
+
+import taichi as ti
+
+ti.init(ti.cuda)
+
+#dim, n_grid, steps, dt = 2, 128, 20, 2e-4
+#dim, n_grid, steps, dt = 2, 256, 32, 1e-4
+#dim, n_grid, steps, dt = 3, 32, 25, 4e-4
+dim, n_grid, steps, dt = 3, 64, 25, 2e-4
+#dim, n_grid, steps, dt = 3, 128, 5, 1e-4
+
+n_particles = n_grid**dim // 2**(dim - 1)
+
+print(n_particles)
+
+dx = 1 / n_grid
+
+p_rho = 1
+p_vol = (dx * 0.5)**2
+p_mass = p_vol * p_rho
+g_x = 0
+g_y = -9.8
+g_z = 0
+bound = 3
+E = 1000 # Young's modulus
+nu =  0.2  #  Poisson's ratio
+mu_0, lambda_0 = E / (2 * (1 + nu)), E * nu / (
+    (1 + nu) * (1 - 2 * nu))  # Lame parameters
+
+x = ti.Vector.field(dim, float, n_particles)
+v = ti.Vector.field(dim, float, n_particles)
+C = ti.Matrix.field(dim, dim, float, n_particles)
+F = ti.Matrix.field(3,3, dtype=float,
+                    shape=n_particles)  # deformation gradient
+Jp = ti.field(float, n_particles)
+
+colors = ti.Vector.field(3, float, n_particles)
+colors_random = ti.Vector.field(3, float, n_particles)
+materials = ti.field(int, n_particles)
+grid_v = ti.Vector.field(dim, float, (n_grid, ) * dim)
+grid_m = ti.field(float, (n_grid, ) * dim)
+used = ti.field(int,n_particles)
+
+neighbour = (3, ) * dim
+
+WATER = 0
+JELLY = 1
+SNOW = 2
+
+@ti.kernel
+def substep(g_x:float,g_y:float,g_z:float):
+    for I in ti.grouped(grid_m):
+        grid_v[I] = ti.zero(grid_v[I])
+        grid_m[I] = 0
+    ti.block_dim(n_grid)
+    for p in x:
+        if used[p] == 0:
+            continue
+        Xp = x[p] / dx
+        base = int(Xp - 0.5)
+        fx = Xp - base
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+
+        F[p] = (ti.Matrix.identity(float, 3) + dt * C[p]) @ F[p]  # deformation gradient update
+
+        h = ti.exp( 10 * (1.0 -  Jp[p]))  # Hardening coefficient: snow gets harder when compressed
+        if materials[p] == JELLY:  # jelly, make it softer
+            h = 0.3
+        mu, la = mu_0 * h, lambda_0 * h
+        if materials[p] == WATER:  # liquid
+            mu = 0.0
+         
+        U, sig, V = ti.svd(F[p])
+        J = 1.0
+        for d in ti.static(range(3)):
+            new_sig = sig[d, d]
+            if materials[p] == SNOW:  # Snow
+                new_sig = min(max(sig[d, d], 1 - 2.5e-2),
+                              1 + 4.5e-3)  # Plasticity
+            Jp[p] *= sig[d, d] / new_sig
+            sig[d, d] = new_sig
+            J *= new_sig
+        if materials[ p] == WATER:  # Reset deformation gradient to avoid numerical instability
+            new_F = ti.Matrix.identity(float, 3)
+            new_F[0,0] = J
+            F[p] = new_F
+        elif materials[p] == SNOW:
+            F[p] = U @ sig @ V.transpose( )  # Reconstruct elastic deformation gradient after plasticity
+        stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose() + ti.Matrix.identity(float, 3) * la * J * (J - 1)
+        stress = (-dt * p_vol * 4 ) * stress / dx**2
+        affine = stress + p_mass * C[p]
+ 
+
+        for offset in ti.static(ti.grouped(ti.ndrange(*neighbour))):
+            dpos = (offset - fx) * dx
+            weight = 1.0
+            for i in ti.static(range(dim)):
+                weight *= w[offset[i]][i]
+            grid_v[base + offset] += weight * (p_mass * v[p] + affine @ dpos)
+            grid_m[base + offset] += weight * p_mass
+    for I in ti.grouped(grid_m):
+        if grid_m[I] > 0:
+            grid_v[I] /= grid_m[I]
+        grid_v[I] += dt * ti.Vector([g_x,g_y,g_z])
+        cond = I < bound and grid_v[I] < 0 or I > n_grid - bound and grid_v[
+            I] > 0
+        grid_v[I] = 0 if cond else grid_v[I]
+    ti.block_dim(n_grid)
+    for p in x:
+        if used[p] == 0:
+            continue
+        Xp = x[p] / dx
+        base = int(Xp - 0.5)
+        fx = Xp - base
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+        new_v = ti.zero(v[p])
+        new_C = ti.zero(C[p])
+        for offset in ti.static(ti.grouped(ti.ndrange(*neighbour))):
+            dpos = (offset - fx) * dx
+            weight = 1.0
+            for i in ti.static(range(dim)):
+                weight *= w[offset[i]][i]
+            g_v = grid_v[base + offset]
+            new_v += weight * g_v
+            new_C += 4 * weight * g_v.outer_product(dpos) / dx**2
+        v[p] = new_v
+        x[p] += dt * v[p]
+        C[p] = new_C
+
+class CubeVolume:
+    def __init__(self,minimum,size,material):
+        self.minimum=minimum
+        self.size = size
+        self.volume = self.size.x * self.size.y *self.size.z
+        self.material = material
+
+@ti.kernel
+def init_cube_vol(first_par:int,last_par:int, x_begin:float,y_begin:float,z_begin:float,x_size:float,y_size:float,z_size:float,material:int ):
+    for i in range(first_par,last_par):
+        x[i] = ti.Vector([ti.random() for i in range(dim)]) * ti.Vector([x_size,y_size,z_size]) + ti.Vector([x_begin,y_begin,z_begin]) 
+        Jp[i] = 1
+        F[i] = ti.Matrix([[1, 0,0], [0, 1,0],[0,0,1]])
+        v[i] = ti.Vector([0.0,0.0,0.0])
+        materials[i] = material
+        colors_random[i] = ti.Vector([ti.random(), ti.random(), ti.random()])
+        used[i] = 1
+
+
+@ti.kernel
+def set_all_unused():
+    for p in used:
+        used[p] = 0
+        # basically throw them away so they aren't rendered
+        x[p] = ti.Vector([533799.0,533799.0,533799.0])
+        Jp[p] = 1
+        F[p] = ti.Matrix([[1, 0,0], [0, 1,0],[0,0,1]])
+        C[p] = ti.Matrix([[0, 0,0], [0, 0,0],[0,0,0]])
+        v[p] = ti.Vector([0.0,0.0,0.0])
+
+
+def init_vols(vols):
+    set_all_unused()
+    total_vol = 0
+    for v in vols:
+        total_vol += v.volume
+    
+    next_p = 0
+    for i in range(len(vols)):
+        v = vols[i]
+        if isinstance(v,CubeVolume):
+            par_count = int(v.volume / total_vol * n_particles)
+            if i == len(vols) -1: # this is the last volume, so use all remaining particles
+                par_count = n_particles - next_p
+            init_cube_vol(next_p,next_p+par_count,*v.minimum,*v.size,v.material)
+            next_p += par_count
+        else:
+            raise Exception("???")
+
+
+@ti.kernel
+def set_color_by_material(material_colors:ti.ext_arr()):
+    for i in range(n_particles):
+        mat = materials[i]
+        colors[i] = ti.Vector([material_colors[mat,0],material_colors[mat,1],material_colors[mat,2]])
+ 
+print("Loading presets...this might take a minute")
+
+presets = [
+    [
+        CubeVolume(ti.Vector([0.55,0.05,0.55]),ti.Vector([0.4,0.4,0.4]),WATER), 
+    ],
+    [
+        CubeVolume(ti.Vector([0.05,0.05,0.05]),ti.Vector([0.3,0.4,0.3]),WATER), 
+        CubeVolume(ti.Vector([0.65,0.05,0.65]),ti.Vector([0.3,0.4,0.3]),WATER), 
+    ],
+    [
+        CubeVolume(ti.Vector([0.6,0.05,0.6]),ti.Vector([0.25,0.25,0.25]),WATER), 
+        CubeVolume(ti.Vector([0.35,0.35,0.35]),ti.Vector([0.25,0.25,0.25]),SNOW), 
+        CubeVolume(ti.Vector([0.05,0.6,0.05]),ti.Vector([0.25,0.25,0.25]),JELLY), 
+    ]
+]
+preset_names = [
+    "Single Dam Break",
+    "Double Dam Break",
+    "Water Snow Jelly",
+]
+
+curr_preset_id = 0
+
+
+paused = False
+
+
+use_random_colors = False
+particles_radius = 0.02
+
+material_colors = [
+    (0.1,0.6,0.9),
+    (0.93,0.33,0.23),
+    (1.0,1.0,1.0)
+]
+
+def init():
+    global paused
+    init_vols(presets[curr_preset_id])
+
+init()
+
+
+res = (1920, 1080)
+window = ti.ui.Window("Real MPM 3D", res, vsync=True)
+
+frame_id = 0
+canvas = window.get_canvas()
+scene = ti.ui.Scene()
+camera = ti.ui.make_camera()
+camera.position(0.5,1.0,1.95)
+camera.lookat(0.5,0.3,0.5)
+camera.fov(55)
+
+def show_options():
+    global use_random_colors
+    global paused
+    global particles_radius
+    global curr_preset_id
+    global g_x,g_y,g_z
+
+    window.GUI.begin("Presets",0.05, 0.1, 0.2, 0.15)
+    old_preset = curr_preset_id
+    for i in range(len(presets)):
+        if window.GUI.checkbox(preset_names[i], curr_preset_id == i):
+            curr_preset_id = i
+    if curr_preset_id != old_preset:
+        init()
+        paused = True
+    window.GUI.end()
+
+    window.GUI.begin("Gravity",0.05, 0.3, 0.2, 0.1)
+    g_x = window.GUI.slider_float("x",g_x, -10, 10)
+    g_y = window.GUI.slider_float("y",g_y, -10, 10)
+    g_z = window.GUI.slider_float("z",g_z, -10, 10)
+    window.GUI.end()
+
+
+    window.GUI.begin("Options", 0.05, 0.45, 0.2, 0.4)
+      
+    use_random_colors = window.GUI.checkbox("use_random_colors", use_random_colors)
+    if not use_random_colors:
+        material_colors[WATER] = window.GUI.color_edit_3("water color",material_colors[WATER])
+        material_colors[SNOW] = window.GUI.color_edit_3("snow color",material_colors[SNOW])
+        material_colors[JELLY] = window.GUI.color_edit_3("jelly color",material_colors[JELLY])
+        set_color_by_material(np.array(material_colors))
+    particles_radius = window.GUI.slider_float("particles radius ",
+                                               particles_radius, 0, 0.1)
+    if window.GUI.button("restart"):
+        init()
+    if paused:
+        if window.GUI.button("Continue"):
+            paused = False
+    else:
+        if window.GUI.button("Pause"):
+            paused = True
+    window.GUI.end()
+
+
+def render():
+    camera.track_user_inputs(window,movement_speed = 0.03,hold_key = ti.ui.RMB)
+    scene.set_camera(camera)
+
+    scene.ambient_light((0, 0, 0))
+
+    colors_used = colors_random if use_random_colors else colors
+    scene.particles(x,per_vertex_color=colors_used, radius=particles_radius) 
+
+    scene.point_light(pos=(0.5,1.5,0.5), color=(0.5, 0.5, 0.5))
+    scene.point_light(pos=(0.5,1.5,1.5), color=(0.5, 0.5, 0.5))
+
+    canvas.scene(scene)
+
+
+while window.running:
+    #print("heyyy ",frame_id)
+    frame_id += 1
+    frame_id = frame_id % 256
+
+    if not paused:
+        for s in range(steps):
+            substep(g_x,g_y,g_z)
+
+    render()
+
+    show_options()
+
+    window.show()

--- a/examples/ggui_examples/stable_fluid_ggui.py
+++ b/examples/ggui_examples/stable_fluid_ggui.py
@@ -1,0 +1,280 @@
+# References:
+# http://developer.download.nvidia.com/books/HTML/gpugems/gpugems_ch38.html
+# https://github.com/PavelDoGreat/WebGL-Fluid-Simulation
+# https://www.bilibili.com/video/BV1ZK411H7Hc?p=4
+# https://github.com/ShaneFX/GAMES201/tree/master/HW01
+
+import numpy as np
+
+import taichi as ti
+
+res = 512
+dt = 0.03
+p_jacobi_iters = 500  # 40 for a quicker but less accurate result
+f_strength = 10000.0
+curl_strength = 0
+time_c = 2
+maxfps = 60
+dye_decay = 1 - 1 / (maxfps * time_c)
+force_radius = res / 2.0
+gravity = True
+debug = False
+paused = False
+
+ti.init(arch=ti.cuda)
+
+_velocities = ti.Vector.field(2, float, shape=(res, res))
+_new_velocities = ti.Vector.field(2, float, shape=(res, res))
+velocity_divs = ti.field(float, shape=(res, res))
+velocity_curls = ti.field(float, shape=(res, res))
+_pressures = ti.field(float, shape=(res, res))
+_new_pressures = ti.field(float, shape=(res, res))
+_dye_buffer = ti.Vector.field(3, float, shape=(res, res))
+_new_dye_buffer = ti.Vector.field(3, float, shape=(res, res))
+
+
+class TexPair:
+    def __init__(self, cur, nxt):
+        self.cur = cur
+        self.nxt = nxt
+
+    def swap(self):
+        self.cur, self.nxt = self.nxt, self.cur
+
+
+velocities_pair = TexPair(_velocities, _new_velocities)
+pressures_pair = TexPair(_pressures, _new_pressures)
+dyes_pair = TexPair(_dye_buffer, _new_dye_buffer)
+
+
+@ti.func
+def sample(qf, u, v):
+    I = ti.Vector([int(u), int(v)])
+    I = max(0, min(res - 1, I))
+    return qf[I]
+
+
+@ti.func
+def lerp(vl, vr, frac):
+    # frac: [0.0, 1.0]
+    return vl + frac * (vr - vl)
+
+
+@ti.func
+def bilerp(vf, p):
+    u, v = p
+    s, t = u - 0.5, v - 0.5
+    # floor
+    iu, iv = ti.floor(s), ti.floor(t)
+    # fract
+    fu, fv = s - iu, t - iv
+    a = sample(vf, iu, iv)
+    b = sample(vf, iu + 1, iv)
+    c = sample(vf, iu, iv + 1)
+    d = sample(vf, iu + 1, iv + 1)
+    return lerp(lerp(a, b, fu), lerp(c, d, fu), fv)
+
+
+# 3rd order Runge-Kutta
+@ti.func
+def backtrace(vf: ti.template(), p, dt: ti.template()):
+    v1 = bilerp(vf, p)
+    p1 = p - 0.5 * dt * v1
+    v2 = bilerp(vf, p1)
+    p2 = p - 0.75 * dt * v2
+    v3 = bilerp(vf, p2)
+    p -= dt * ((2 / 9) * v1 + (1 / 3) * v2 + (4 / 9) * v3)
+    return p
+
+
+@ti.kernel
+def advect(vf: ti.template(), qf: ti.template(), new_qf: ti.template()):
+    for i, j in vf:
+        p = ti.Vector([i, j]) + 0.5
+        p = backtrace(vf, p, dt)
+        new_qf[i, j] = bilerp(qf, p) * dye_decay
+
+
+@ti.kernel
+def apply_impulse(vf: ti.template(), dyef: ti.template(),
+                  imp_data: ti.ext_arr()):
+    g_dir = -ti.Vector([0, 9.8]) * 300
+    for i, j in vf:
+        omx, omy = imp_data[2], imp_data[3]
+        mdir = ti.Vector([imp_data[0], imp_data[1]])
+        dx, dy = (i + 0.5 - omx), (j + 0.5 - omy)
+        d2 = dx * dx + dy * dy
+        # dv = F * dt
+        factor = ti.exp(-d2 / force_radius)
+
+        dc = dyef[i, j]
+        a = dc.norm()
+
+        momentum = (mdir * f_strength * factor + g_dir * a / (1 + a)) * dt
+
+        v = vf[i, j]
+        vf[i, j] = v + momentum
+        # add dye
+        if mdir.norm() > 0.5:
+            dc += ti.exp(-d2 * (4 / (res / 15)**2)) * ti.Vector(
+                [imp_data[4], imp_data[5], imp_data[6]])
+
+        dyef[i, j] = dc
+
+
+@ti.kernel
+def divergence(vf: ti.template()):
+    for i, j in vf:
+        vl = sample(vf, i - 1, j)
+        vr = sample(vf, i + 1, j)
+        vb = sample(vf, i, j - 1)
+        vt = sample(vf, i, j + 1)
+        vc = sample(vf, i, j)
+        if i == 0:
+            vl.x = -vc.x
+        if i == res - 1:
+            vr.x = -vc.x
+        if j == 0:
+            vb.y = -vc.y
+        if j == res - 1:
+            vt.y = -vc.y
+        velocity_divs[i, j] = (vr.x - vl.x + vt.y - vb.y) * 0.5
+
+
+@ti.kernel
+def vorticity(vf: ti.template()):
+    for i, j in vf:
+        vl = sample(vf, i - 1, j)
+        vr = sample(vf, i + 1, j)
+        vb = sample(vf, i, j - 1)
+        vt = sample(vf, i, j + 1)
+        velocity_curls[i, j] = (vr.y - vl.y - vt.x + vb.x) * 0.5
+
+
+@ti.kernel
+def pressure_jacobi(pf: ti.template(), new_pf: ti.template()):
+    for i, j in pf:
+        pl = sample(pf, i - 1, j)
+        pr = sample(pf, i + 1, j)
+        pb = sample(pf, i, j - 1)
+        pt = sample(pf, i, j + 1)
+        div = velocity_divs[i, j]
+        new_pf[i, j] = (pl + pr + pb + pt - div) * 0.25
+
+
+@ti.kernel
+def subtract_gradient(vf: ti.template(), pf: ti.template()):
+    for i, j in vf:
+        pl = sample(pf, i - 1, j)
+        pr = sample(pf, i + 1, j)
+        pb = sample(pf, i, j - 1)
+        pt = sample(pf, i, j + 1)
+        vf[i, j] -= 0.5 * ti.Vector([pr - pl, pt - pb])
+
+
+@ti.kernel
+def enhance_vorticity(vf: ti.template(), cf: ti.template()):
+    # anti-physics visual enhancement...
+    for i, j in vf:
+        cl = sample(cf, i - 1, j)
+        cr = sample(cf, i + 1, j)
+        cb = sample(cf, i, j - 1)
+        ct = sample(cf, i, j + 1)
+        cc = sample(cf, i, j)
+        force = ti.Vector([abs(ct) - abs(cb),
+                           abs(cl) - abs(cr)]).normalized(1e-3)
+        force *= curl_strength * cc
+        vf[i, j] = min(max(vf[i, j] + force * dt, -1e3), 1e3)
+
+
+def step(mouse_data):
+    advect(velocities_pair.cur, velocities_pair.cur, velocities_pair.nxt)
+    advect(velocities_pair.cur, dyes_pair.cur, dyes_pair.nxt)
+    velocities_pair.swap()
+    dyes_pair.swap()
+
+    apply_impulse(velocities_pair.cur, dyes_pair.cur, mouse_data)
+
+    divergence(velocities_pair.cur)
+
+    if curl_strength:
+        vorticity(velocities_pair.cur)
+        enhance_vorticity(velocities_pair.cur, velocity_curls)
+
+    for _ in range(p_jacobi_iters):
+        pressure_jacobi(pressures_pair.cur, pressures_pair.nxt)
+        pressures_pair.swap()
+
+    subtract_gradient(velocities_pair.cur, pressures_pair.cur)
+
+    if debug:
+        divergence(velocities_pair.cur)
+        div_s = np.sum(velocity_divs.to_numpy())
+        print(f'divergence={div_s}')
+
+
+class MouseDataGen(object):
+    def __init__(self):
+        self.prev_mouse = None
+        self.prev_color = None
+
+    def __call__(self, window):
+        # [0:2]: normalized delta direction
+        # [2:4]: current mouse xy
+        # [4:7]: color
+        mouse_data = np.zeros(8, dtype=np.float32)
+        if window.is_pressed(ti.ui.LMB):
+            mxy = np.array(window.get_cursor_pos(), dtype=np.float32) * res
+            if self.prev_mouse is None:
+                self.prev_mouse = mxy
+                # Set lower bound to 0.3 to prevent too dark colors
+                self.prev_color = (np.random.rand(3) * 0.7) + 0.3
+            else:
+                mdir = mxy - self.prev_mouse
+                mdir = mdir / (np.linalg.norm(mdir) + 1e-5)
+                mouse_data[0], mouse_data[1] = mdir[0], mdir[1]
+                mouse_data[2], mouse_data[3] = mxy[0], mxy[1]
+                mouse_data[4:7] = self.prev_color
+                self.prev_mouse = mxy
+        else:
+            self.prev_mouse = None
+            self.prev_color = None
+        return mouse_data
+
+
+def reset():
+    velocities_pair.cur.fill(0)
+    pressures_pair.cur.fill(0)
+    dyes_pair.cur.fill(0)
+
+
+window = ti.ui.Window('Stable Fluid', (res, res),vsync = True)
+canvas = window.get_canvas()
+md_gen = MouseDataGen()
+
+while window.running:
+    if window.get_event(ti.ui.PRESS):
+        e = window.event
+        if e.key == ti.ui.ESCAPE:
+            break
+        elif e.key == 'r':
+            paused = False
+            reset()
+        elif e.key == 's':
+            if curl_strength:
+                curl_strength = 0
+            else:
+                curl_strength = 7
+        elif e.key == 'p':
+            paused = not paused
+        elif e.key == 'd':
+            debug = not debug
+
+    # Debug divergence:
+    # print(max((abs(velocity_divs.to_numpy().reshape(-1)))))
+
+    if not paused:
+        mouse_data = md_gen(window)
+        step(mouse_data)
+    canvas.set_image(dyes_pair.cur)
+    window.show()

--- a/examples/ggui_examples/stable_fluid_ggui.py
+++ b/examples/ggui_examples/stable_fluid_ggui.py
@@ -248,7 +248,7 @@ def reset():
     dyes_pair.cur.fill(0)
 
 
-window = ti.ui.Window('Stable Fluid', (res, res),vsync = True)
+window = ti.ui.Window('Stable Fluid', (res, res), vsync=True)
 canvas = window.get_canvas()
 md_gen = MouseDataGen()
 


### PR DESCRIPTION
Related issue = #2646 

This is the 16th of a series of PRs that adds a GPU-based GUI to taichi.

This PR adds 6 example applications that uses ggui. 

* `mpm128`, `fem128`, `stable_fluid`, `mass_spring_game`:  These examples demonstrate how existing `ti.gui` 2D apps can be re-written in ggui.
* `mass_spring_3d` demonstrates how to draw 3d meshes using ggui (the existing version of `mass_spring_3d` in taichi uses taichi-THREE for that)
* `mpm3d` demonstrates how to draw 3d particles and how to use IMGUI components.