### PR TITLE
[ci] Enable verbose on M1 CI to collect more info on hanging jobs.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -320,4 +320,4 @@ jobs:
           arch -arm64 python3 examples/algorithm/laplace.py
           TI_LIB_DIR=`arch -arm64 python3 -c "import taichi;print(taichi.__path__[0])" | tail -1`
           TI_LIB_DIR="$TI_LIB_DIR/lib" arch -arm64 ./build/taichi_cpp_tests
-          arch -arm64 ti test -t2 -x
+          arch -arm64 ti test -vr2 -t4 -x


### PR DESCRIPTION
I've occasionally seen M1 job hanging in some tests and finally timed out. Enabling verbose option here so that we can have more information about the hang. 