### PR TITLE
[refactor] Make ti.ext_arr a special case of ti.any_arr

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -129,7 +129,8 @@ class Module:
         for i in range(len(kernel.argument_annotations)):
             anno = kernel.argument_annotations[i]
             if isinstance(anno, kernel_arguments.ArgAnyArray):
-                raise RuntimeError('Arg type `ext_arr`/`any_arr` not supported yet')
+                raise RuntimeError(
+                    'Arg type `ext_arr`/`any_arr` not supported yet')
             else:
                 # For primitive types, we can just inject a dummy value.
                 injected_args.append(0)

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -128,8 +128,8 @@ class Module:
         injected_args = []
         for i in range(len(kernel.argument_annotations)):
             anno = kernel.argument_annotations[i]
-            if isinstance(anno, kernel_arguments.ArgExtArray):
-                raise RuntimeError('Arg type `ext_arr` not supported yet')
+            if isinstance(anno, kernel_arguments.ArgAnyArray):
+                raise RuntimeError('Arg type `ext_arr`/`any_arr` not supported yet')
             else:
                 # For primitive types, we can just inject a dummy value.
                 injected_args.append(0)

--- a/python/taichi/lang/any_array.py
+++ b/python/taichi/lang/any_array.py
@@ -4,43 +4,6 @@ from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.util import taichi_scope
 
 
-class ExtArray:
-    """Class for external arrays. Constructed by a taichi_core.Expr wrapping a taichi_core.ExternalTensorExpression.
-
-    Args:
-        ptr (taichi_core.Expr): See above.
-    """
-    def __init__(self, ptr):
-        assert ptr.is_external_var()
-        self.ptr = ptr
-
-    @property
-    @taichi_scope
-    def shape(self):
-        """A list containing sizes for each dimension.
-
-        Returns:
-            List[Int]: The result list.
-        """
-        dim = _ti_core.get_external_tensor_dim(self.ptr)
-        ret = [
-            Expr(_ti_core.get_external_tensor_shape_along_axis(self.ptr, i))
-            for i in range(dim)
-        ]
-        return ret
-
-    @taichi_scope
-    def loop_range(self):
-        """Gets the corresponding taichi_core.Expr to serve as loop range.
-
-        This is not in use now because struct fors on ExtArrays are not supported yet.
-
-        Returns:
-            taichi_core.Expr: See above.
-        """
-        return self.ptr
-
-
 class AnyArray:
     """Class for arbitrary arrays in Python AST.
 
@@ -75,6 +38,17 @@ class AnyArray:
             return ret[
                 element_dim:] if self.layout == Layout.SOA else ret[:
                                                                     -element_dim]
+
+    @taichi_scope
+    def loop_range(self):
+        """Gets the corresponding taichi_core.Expr to serve as loop range.
+
+        This is not in use now because struct fors on AnyArrays are not supported yet.
+
+        Returns:
+            taichi_core.Expr: See above.
+        """
+        return self.ptr
 
 
 class AnyArrayAccess:

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -6,7 +6,7 @@ import numpy as np
 from taichi.core.util import ti_core as _ti_core
 from taichi.lang.exception import InvalidOperationError, TaichiSyntaxError
 from taichi.lang.expr import Expr, make_expr_group
-from taichi.lang.ext_array import AnyArray, AnyArrayAccess, ExtArray
+from taichi.lang.any_array import AnyArray, AnyArrayAccess
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.matrix import MatrixField
 from taichi.lang.ndarray import ScalarNdarray
@@ -182,12 +182,9 @@ def subscript(value, *indices):
         ])
         ret.any_array_access = any_array_access
         return ret
-    elif isinstance(value, (ExtArray, SNode)):
-        if isinstance(value, ExtArray):
-            field_dim = int(value.ptr.get_attribute("dim"))
-        else:
-            # When reading bit structure we only support the 0-D case for now.
-            field_dim = 0
+    elif isinstance(value, SNode):
+        # When reading bit structure we only support the 0-D case for now.
+        field_dim = 0
         if field_dim != index_dim:
             raise IndexError(
                 f'Field with dim {field_dim} accessed with indices of dim {index_dim}'
@@ -822,7 +819,7 @@ def static(x, *xs):
                   (bool, int, float, range, list, tuple, enumerate, ti.ndrange,
                    ti.GroupedNDRange, zip, filter, map)) or x is None:
         return x
-    elif isinstance(x, ExtArray):
+    elif isinstance(x, AnyArray):
         return x
     elif isinstance(x, Field):
         return x

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -4,9 +4,9 @@ from types import FunctionType, MethodType
 
 import numpy as np
 from taichi.core.util import ti_core as _ti_core
+from taichi.lang.any_array import AnyArray, AnyArrayAccess
 from taichi.lang.exception import InvalidOperationError, TaichiSyntaxError
 from taichi.lang.expr import Expr, make_expr_group
-from taichi.lang.any_array import AnyArray, AnyArrayAccess
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.matrix import MatrixField
 from taichi.lang.ndarray import ScalarNdarray

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -2,41 +2,29 @@ from taichi.core.primitive_types import u64
 from taichi.core.util import ti_core as _ti_core
 from taichi.lang.enums import Layout
 from taichi.lang.expr import Expr
-from taichi.lang.ext_array import AnyArray, ExtArray
+from taichi.lang.any_array import AnyArray
 from taichi.lang.snode import SNode
 from taichi.lang.sparse_matrix import SparseMatrixBuilder
 from taichi.lang.util import cook_dtype, to_taichi_type
 
 
-class ArgExtArray:
+def ext_arr():
     """Type annotation for external arrays.
 
-    External array is formally defined as the data from other Python frameworks.
+    External arrays are formally defined as the data from other Python frameworks.
     For now, Taichi supports numpy and pytorch.
 
-    Args:
-        dim (int, optional): must be 1.
+    Example::
+
+        >>> @ti.kernel
+        >>> def to_numpy(arr: ti.ext_arr()):
+        >>>     for i in x:
+        >>>         arr[i] = x[i]
+        >>>
+        >>> arr = numpy.zeros(...)
+        >>> to_numpy(arr)  # `arr` will be filled with `x`'s data.
     """
-    def __init__(self, dim=1):
-        assert dim == 1
-
-    def extract(self, x):
-        return to_taichi_type(x.dtype), len(x.shape)
-
-
-ext_arr = ArgExtArray
-"""Alias for :class:`~taichi.lang.kernel_arguments.ArgExtArray`.
-
-Example::
-
-    >>> @ti.kernel
-    >>> def to_numpy(arr: ti.ext_arr()):
-    >>>     for i in x:
-    >>>         arr[i] = x[i]
-    >>>
-    >>> arr = numpy.zeros(...)
-    >>> to_numpy(arr)  # `arr` will be filled with `x`'s data.
-"""
+    return ArgAnyArray()
 
 
 class ArgAnyArray:
@@ -174,12 +162,6 @@ def decl_scalar_arg(dtype):
     dtype = cook_dtype(dtype)
     arg_id = _ti_core.decl_arg(dtype, False)
     return Expr(_ti_core.make_arg_load_expr(arg_id, dtype))
-
-
-def decl_ext_arr_arg(dtype, dim):
-    dtype = cook_dtype(dtype)
-    arg_id = _ti_core.decl_arg(dtype, True)
-    return ExtArray(_ti_core.make_external_tensor_expr(dtype, dim, arg_id))
 
 
 def decl_sparse_matrix():

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -1,8 +1,8 @@
 from taichi.core.primitive_types import u64
 from taichi.core.util import ti_core as _ti_core
+from taichi.lang.any_array import AnyArray
 from taichi.lang.enums import Layout
 from taichi.lang.expr import Expr
-from taichi.lang.any_array import AnyArray
 from taichi.lang.snode import SNode
 from taichi.lang.sparse_matrix import SparseMatrixBuilder
 from taichi.lang.util import cook_dtype, to_taichi_type

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -10,7 +10,8 @@ from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl, util
 from taichi.lang.ast_checker import KernelSimplicityASTChecker
 from taichi.lang.exception import TaichiSyntaxError
-from taichi.lang.kernel_arguments import (any_arr, sparse_matrix_builder, template)
+from taichi.lang.kernel_arguments import (any_arr, sparse_matrix_builder,
+                                          template)
 from taichi.lang.ndarray import Ndarray
 from taichi.lang.shell import _shell_pop_print, oinspect
 from taichi.lang.transformer import ASTTransformerTotal
@@ -488,7 +489,8 @@ class Kernel:
                 elif isinstance(needed, sparse_matrix_builder):
                     # Pass only the base pointer of the ti.sparse_matrix_builder() argument
                     launch_ctx.set_arg_int(actual_argument_slot, v.get_addr())
-                elif isinstance(needed, any_arr) and (self.match_ext_arr(v) or isinstance(v, Ndarray)):
+                elif isinstance(needed, any_arr) and (self.match_ext_arr(v) or
+                                                      isinstance(v, Ndarray)):
                     if isinstance(v, Ndarray):
                         v = v.arr
                     has_external_arrays = True

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -10,8 +10,7 @@ from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl, util
 from taichi.lang.ast_checker import KernelSimplicityASTChecker
 from taichi.lang.exception import TaichiSyntaxError
-from taichi.lang.kernel_arguments import (any_arr, ext_arr,
-                                          sparse_matrix_builder, template)
+from taichi.lang.kernel_arguments import (any_arr, sparse_matrix_builder, template)
 from taichi.lang.ndarray import Ndarray
 from taichi.lang.shell import _shell_pop_print, oinspect
 from taichi.lang.transformer import ASTTransformerTotal
@@ -365,7 +364,7 @@ class Kernel:
                     raise KernelDefError(
                         'Taichi kernels parameters must be type annotated')
             else:
-                if isinstance(annotation, (template, ext_arr, any_arr)):
+                if isinstance(annotation, (template, any_arr)):
                     pass
                 elif id(annotation) in primitive_types.type_ids:
                     pass
@@ -489,8 +488,7 @@ class Kernel:
                 elif isinstance(needed, sparse_matrix_builder):
                     # Pass only the base pointer of the ti.sparse_matrix_builder() argument
                     launch_ctx.set_arg_int(actual_argument_slot, v.get_addr())
-                elif (isinstance(needed, (any_arr, ext_arr)) and self.match_ext_arr(v)) or \
-                     (isinstance(needed, any_arr) and isinstance(v, Ndarray)):
+                elif isinstance(needed, any_arr) and (self.match_ext_arr(v) or isinstance(v, Ndarray)):
                     if isinstance(v, Ndarray):
                         v = v.arr
                     has_external_arrays = True

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -544,7 +544,7 @@ if 1:
                 if isinstance(ctx.func.argument_annotations[i], ti.template):
                     continue
                 if isinstance(ctx.func.argument_annotations[i],
-                                ti.sparse_matrix_builder):
+                              ti.sparse_matrix_builder):
                     arg_init = parse_stmt(
                         'x = ti.lang.kernel_arguments.decl_sparse_matrix()')
                     arg_init.targets[0].id = arg.arg

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -543,20 +543,7 @@ if 1:
                 # such as class instances ("self"), fields, SNodes, etc.
                 if isinstance(ctx.func.argument_annotations[i], ti.template):
                     continue
-                if isinstance(ctx.func.argument_annotations[i], ti.ext_arr):
-                    arg_init = parse_stmt(
-                        'x = ti.lang.kernel_arguments.decl_ext_arr_arg(0, 0)')
-                    arg_init.targets[0].id = arg.arg
-                    ctx.create_variable(arg.arg)
-                    array_dt = ctx.arg_features[i][0]
-                    array_dim = ctx.arg_features[i][1]
-                    array_dt = to_taichi_type(array_dt)
-                    dt_expr = 'ti.' + ti.core.data_type_name(array_dt)
-                    dt = parse_expr(dt_expr)
-                    arg_init.value.args[0] = dt
-                    arg_init.value.args[1] = parse_expr("{}".format(array_dim))
-                    arg_decls.append(arg_init)
-                elif isinstance(ctx.func.argument_annotations[i],
+                if isinstance(ctx.func.argument_annotations[i],
                                 ti.sparse_matrix_builder):
                     arg_init = parse_stmt(
                         'x = ti.lang.kernel_arguments.decl_sparse_matrix()')


### PR DESCRIPTION
Related issue = #2772

Now `ti.any_arr` annotation is added, and `ti.ext_arr` is for backward compatibility and indeed a special case of `ti.any_arr` with no support for element shape. In this PR, I would like to remove all the duplicated code and directly turn a `ti.ext_arr` into a `ti.any_arr` with only default arguments. This aims for better code maintainability.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
