### PR TITLE
[LLVM] [bug] fix typo of PR #2781

### DIFF
--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -84,8 +84,8 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
     runtime_mem_info->set_profiler(profiler);
   }
 #if defined(TI_WITH_CUDA)
-  if (config.arch == Arch::cuda) {
-    if (config.kernel_profiler) {
+  if (config_.arch == Arch::cuda) {
+    if (config_.kernel_profiler) {
       CUDAContext::get_instance().set_profiler(profiler);
     } else {
       CUDAContext::get_instance().set_profiler(nullptr);


### PR DESCRIPTION
Related issue = #2781

>Previously, I encountered a segfault with a null pointer ( `profiler` ). I will move the code back and try to solve the problem

_Originally posted by @yolo2themoon in https://github.com/taichi-dev/taichi/pull/2848#discussion_r698975565_


run this example
```
import taichi as ti
ti.init(ti.cuda, kernel_profiler=True)
var = ti.field(ti.f32, shape=1)

@ti.kernel
def compute():
var[0] = 1.0

compute()
ti.print_kernel_profile_info()
```

before this commit
```
CUDA Profiler
=========================================================================
[ % total count | min avg max ] Kernel name
-------------------------------------------------------------------------
[100.00%] Total kernel execution time: 0.000 s number of records: 0
=========================================================================
```

after 
```
CUDA Profiler
=========================================================================
[ % total count | min avg max ] Kernel name
[ 84.51% 0.001 s 1x | 0.687 0.687 0.687 ms] jit_evaluator_0_kernel_0_serial
[ 9.45% 0.000 s 1x | 0.077 0.077 0.077 ms] compute_c4_0_kernel_2_serial
[ 6.05% 0.000 s 1x | 0.049 0.049 0.049 ms] jit_evaluator_1_kernel_1_serial
-------------------------------------------------------------------------
[100.00%] Total kernel execution time: 0.001 s number of records: 3
=========================================================================
```

