### PR TITLE
[Test] Allow printing to console when running ti test -v.

### DIFF
--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -694,7 +694,8 @@ class TaichiMain:
             # run all the tests
             pytest_args = [test_dir]
         if args.verbose:
-            pytest_args += ['-v']
+            # -rP forwards python prints to console as well
+            pytest_args += ['-v', '-rP']
         if args.rerun:
             pytest_args += ['--reruns', args.rerun]
         try:


### PR DESCRIPTION
This PR makes debugging with pytest easier. Before pytest automatically
suppress the printing to console.
Example output (note the hello line)

```
 λ ~/github/taichi pytest_print ti test abs -t1 -v
[Taichi] version 0.7.30, llvm 10.0.0, commit e145b1f0, osx, python
3.8.10

*******************************************
**      Taichi Programming Language      **
*******************************************

Docs:   https://taichi.rtfd.io/en/stable
GitHub: https://github.com/taichi-dev/taichi
Forum:  https://forum.taichi.graphics

Running Python tests...

Starting 1 testing thread(s)...
=============================================== test session starts
===============================================
platform darwin -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
-- /Users/ailzhang/miniforge3/envs/dev/bin/python
cachedir: .pytest_cache
rootdir: /Users/ailzhang
plugins: cov-2.12.1, xdist-2.2.1, forked-1.3.0, rerunfailures-10.0
collected 1 item

../../miniforge3/envs/dev/lib/python3.8/site-packages/taichi-0.7.30-py3.8-macosx-11.0-arm64.egg/taichi/tests/test_abs.py::test_abs
PASSED [100%]

===================================================== PASSES
======================================================
____________________________________________________ test_abs
_____________________________________________________
---------------------------------------------- Captured stdout call
-----------------------------------------------
[Taichi] Starting on arch=arm64
hello
[Taichi] Starting on arch=arm64
hello
[Taichi] Starting on arch=metal
hello
================================================ 1 passed in 0.77s
================================================
```

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
