### PR TITLE
[CUDA] [bug] Fix CUDA error "allocate_global (DataType type) misaligned address"

### DIFF
--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -294,7 +294,7 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
                        data_type_size(tensor_type->get_element_type());
     } else {
       std::size_t type_size = data_type_size(type);
-      //align global_offset to a multiple of type_size
+      // align global_offset to a multiple of type_size
       global_offset = ((global_offset + type_size - 1) / type_size) * type_size;
       ret = global_offset;
       global_offset += type_size;

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -288,13 +288,16 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   std::size_t allocate_global(DataType type) {
     TI_ASSERT(type->vector_width() == 1 || type->is<TensorType>());
     auto ret = global_offset;
+    std::size_t size = 0;
     if (type->is<TensorType>()) {
       auto tensor_type = type->cast<TensorType>();
-      global_offset += tensor_type->get_num_elements() *
-                       data_type_size(tensor_type->get_element_type());
+      size = tensor_type->get_num_elements() *
+             data_type_size(tensor_type->get_element_type());
     } else {
-      global_offset += data_type_size(type);
+      size = data_type_size(type);
     }
+    auto aligned_size = [](std::size_t size, const std::size_t alignment){return ((size+alignment-1)/alignment)*alignment;};
+    global_offset += aligned_size(size, sizeof(double));
     TI_ASSERT(global_offset < taichi_global_tmp_buffer_size);
     return ret;
   }

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -288,18 +288,17 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   std::size_t allocate_global(DataType type) {
     TI_ASSERT(type->vector_width() == 1 || type->is<TensorType>());
     auto ret = global_offset;
-    std::size_t size = 0;
     if (type->is<TensorType>()) {
       auto tensor_type = type->cast<TensorType>();
-      size = tensor_type->get_num_elements() *
-             data_type_size(tensor_type->get_element_type());
+      global_offset += tensor_type->get_num_elements() *
+                       data_type_size(tensor_type->get_element_type());
     } else {
-      size = data_type_size(type);
+      std::size_t type_size = data_type_size(type);
+      //align global_offset to a multiple of type_size
+      global_offset = ((global_offset + type_size - 1) / type_size) * type_size;
+      ret = global_offset;
+      global_offset += type_size;
     }
-    auto aligned_size = [](std::size_t size, const std::size_t alignment) {
-      return ((size + alignment - 1) / alignment) * alignment;
-    };
-    global_offset += aligned_size(size, sizeof(double));
     TI_ASSERT(global_offset < taichi_global_tmp_buffer_size);
     return ret;
   }

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -296,7 +296,9 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     } else {
       size = data_type_size(type);
     }
-    auto aligned_size = [](std::size_t size, const std::size_t alignment){return ((size+alignment-1)/alignment)*alignment;};
+    auto aligned_size = [](std::size_t size, const std::size_t alignment) {
+      return ((size + alignment - 1) / alignment) * alignment;
+    };
     global_offset += aligned_size(size, sizeof(double));
     TI_ASSERT(global_offset < taichi_global_tmp_buffer_size);
     return ret;

--- a/tests/python/test_global_buffer_misalined.py
+++ b/tests/python/test_global_buffer_misalined.py
@@ -1,12 +1,12 @@
 import taichi as ti
 
+
 @ti.test(require=ti.extension.data64)
 def test_global_buffer_misalignment():
-
     @ti.kernel
-    def test(x:ti.f32):
+    def test(x: ti.f32):
         a = x
-        b = ti.cast(0.12,ti.f64)
+        b = ti.cast(0.12, ti.f64)
         for i in range(8):
             b += a
 

--- a/tests/python/test_global_buffer_misalined.py
+++ b/tests/python/test_global_buffer_misalined.py
@@ -1,0 +1,14 @@
+import taichi as ti
+
+@ti.test(require=ti.extension.data64)
+def test_global_buffer_misalignment():
+
+    @ti.kernel
+    def test(x:ti.f32):
+        a = x
+        b = ti.cast(0.12,ti.f64)
+        for i in range(8):
+            b += a
+
+    for i in range(8):
+        test(0.1)


### PR DESCRIPTION
Related repo = [karman_taichi](https://github.com/houkensjtu/karman_taichi)

When trying to run this repo with cuda backend, we encountered
`CUDA Error CUDA_ERROR_MISALIGNED_ADDRESS: misaligned address while calling stream_synchronize (cuStreamSynchronize)`

---

Taichi stores some temporary variables into a global buffer ( memory ),
and the problem is caused by the access address is not aligned.

For example,  we have a 16-byte buffer with 3 elements : `[i32,f64,f32]` = `[4B,8B,4B]` ,  
Although the buffer size is 8-byte aligned , the `address offset of f64` = `sizeof(i32) = 4` is not a multiple of 8.
In this case，the above error is encountered.

If the 16-byte buffer is : `[i32,f32,f64]` = `[4B,4B,8B]` ,
the `address offset of f64` = `sizeof(i32) + sizeof(f32) = 4 + 4 = 8` is a multiple of 8 ,
then everything is fine.  

---

This commit aligns `global_offset` to a multiple of `type_size` to avoid this problem. 
`[i32,f64,f32]` will take `[8B,8B,4B] = 20 bytes` mem space ( aligned the address offset of `f64` from 4 to 8 )
`[i32,f32,f64]` will take `[4B,4B,8B] = 16 bytes` mem space ( nothing changed ) 

---

minimal test case to trigger this problem : 
```
import taichi as ti

ti.init(arch=ti.cuda)

def test_global_buffer_misalignment():

    @ti.kernel
    def test(x:ti.f32):
        a = x
        b = ti.cast(0.12,ti.f64)
        for i in range(8):
            b += a

    test(0.1)

test_global_buffer_misalignment()
```
---

I'm now writing test case  ... 