### PR TITLE
[Lang] Fix ti func with template and add corresponding tests

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -164,7 +164,6 @@ class Func:
             _ti_core.make_func_call_expr(
                 self.taichi_functions[key.instance_id], non_template_args))
 
-    # TODO: Rename this to show only compiling func not kernel
     def do_compile(self, key, args):
         src = _remove_indent(oinspect.getsource(self.func))
         tree = ast.parse(src)

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -164,6 +164,7 @@ class Func:
             _ti_core.make_func_call_expr(
                 self.taichi_functions[key.instance_id], non_template_args))
 
+    # TODO: Rename this to show only compiling func not kernel
     def do_compile(self, key, args):
         src = _remove_indent(oinspect.getsource(self.func))
         tree = ast.parse(src)

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -602,6 +602,7 @@ if 1:
                     # such as class instances ("self"), fields, SNodes, etc.
                     if isinstance(ctx.func.argument_annotations[i],
                                   ti.template):
+                        ctx.create_variable(ctx.func.argument_names[i])
                         continue
                     # Create a copy for non-template arguments,
                     # so that they are passed by value.

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -166,6 +166,24 @@ def test_default_templates():
     def func4(x):
         x += 1
 
+    @ti.func
+    def func1_field(x: ti.template()):
+        x[None] = 1
+
+    @ti.func
+    def func2_field(x: ti.template()):
+        x[None] += 1
+
+    @ti.func
+    def func3_field(x):
+        x[None] = 1
+
+    @ti.func
+    def func4_field(x):
+        x[None] += 1
+
+    v = ti.Vector.field(3, dtype=ti.i32, shape=())
+
     @ti.kernel
     def run_func():
         a = 0
@@ -180,6 +198,19 @@ def test_default_templates():
         d = 0
         func1(d)
         assert d == 0
+
+        v[None] = 0
+        func1_field(v)
+        assert v[None] == 1
+        v[None] = 0
+        func2_field(v)
+        assert v[None] == 1
+        v[None] = 0
+        func3_field(v)
+        assert v[None] == 1
+        v[None] = 0
+        func4_field(v)
+        assert v[None] == 1
 
 
 @ti.test(experimental_real_function=True)

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -148,7 +148,7 @@ def test_python_function():
     assert x[None] == 0
 
 
-@ti.test()
+@ti.test(arch=[ti.cpu, ti.cuda], debug=True)
 def test_default_templates():
     @ti.func
     def func1(x: ti.template()):
@@ -182,7 +182,7 @@ def test_default_templates():
     def func4_field(x):
         x[None] += 1
 
-    v = ti.Vector.field(3, dtype=ti.i32, shape=())
+    v = ti.field(dtype=ti.i32, shape=())
 
     @ti.kernel
     def run_func():
@@ -190,13 +190,13 @@ def test_default_templates():
         func1(a)
         assert a == 1
         b = 0
-        func1(b)
+        func2(b)
         assert b == 1
         c = 0
-        func1(c)
+        func3(c)
         assert c == 0
         d = 0
-        func1(d)
+        func4(d)
         assert d == 0
 
         v[None] = 0
@@ -211,6 +211,8 @@ def test_default_templates():
         v[None] = 0
         func4_field(v)
         assert v[None] == 1
+
+    run_func()
 
 
 @ti.test(experimental_real_function=True)

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -147,9 +147,37 @@ def test_python_function():
     assert a.dec(4) == 3
     assert x[None] == 0
 
+@ti.test()
+def test_default_templates():
+    @ti.func
+    def func1(x: ti.template()):
+        x = 1
+    @ti.func
+    def func2(x: ti.template()):
+        x += 1
+    @ti.func
+    def func3(x):
+        x = 1
+    @ti.func
+    def func4(x):
+        x += 1
+    @ti.kernel
+    def run_func():
+        a = 0
+        func1(a)
+        assert a == 1
+        b = 0
+        func1(b)
+        assert b == 1
+        c = 0
+        func1(c)
+        assert c == 0
+        d = 0
+        func1(d)
+        assert c == 0
 
 @ti.test(experimental_real_function=True)
-def test_templates():
+def test_experimental_templates():
     x = ti.field(ti.i32, shape=())
     y = ti.field(ti.i32, shape=())
     answer = ti.field(ti.i32, shape=8)

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -179,7 +179,7 @@ def test_default_templates():
         assert c == 0
         d = 0
         func1(d)
-        assert c == 0
+        assert d == 0
 
 
 @ti.test(experimental_real_function=True)

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -147,20 +147,25 @@ def test_python_function():
     assert a.dec(4) == 3
     assert x[None] == 0
 
+
 @ti.test()
 def test_default_templates():
     @ti.func
     def func1(x: ti.template()):
         x = 1
+
     @ti.func
     def func2(x: ti.template()):
         x += 1
+
     @ti.func
     def func3(x):
         x = 1
+
     @ti.func
     def func4(x):
         x += 1
+
     @ti.kernel
     def run_func():
         a = 0
@@ -175,6 +180,7 @@ def test_default_templates():
         d = 0
         func1(d)
         assert c == 0
+
 
 @ti.test(experimental_real_function=True)
 def test_experimental_templates():


### PR DESCRIPTION
Related issue = #

According to https://docs.taichi.graphics/docs/lang/articles/basic/syntax#advanced-arguments-1, we can use `ti.template()` as type-hint to force arguments to be passed by reference to `ti.func`. However, current implementation doesn't match this description. This PR aims at fixing this mismatch.

Example:
```python
@ti.func
def my_func(x: ti.template()):
    x = x + 1  # will change the original value of x


@ti.kernel
def my_kernel():
    x = 233
    my_func(x)
    print(x)  # 234
```
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
