### PR TITLE
[Lang] Refine semantics of ti.any_arr

### DIFF
--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -64,17 +64,26 @@ class ArgAnyArray:
         layout = Layout.AOS if self.layout is None else self.layout
         shape = tuple(x.shape)
         if len(shape) < element_dim:
-            raise ValueError(f"Invalid argument into ti.any_arr() - required element_dim={element_dim}, but the argument has only {len(shape)} dimensions")
-        element_shape = () if element_dim == 0 else shape[:element_dim] if layout == Layout.SOA else shape[-element_dim:]
+            raise ValueError(
+                f"Invalid argument into ti.any_arr() - required element_dim={element_dim}, but the argument has only {len(shape)} dimensions"
+            )
+        element_shape = (
+        ) if element_dim == 0 else shape[:
+                                         element_dim] if layout == Layout.SOA else shape[
+                                             -element_dim:]
         return to_taichi_type(x.dtype), len(shape), element_shape, layout
 
     def check_element_dim(self, arg, arg_dim):
         if self.element_dim is not None and self.element_dim != arg_dim:
-            raise ValueError(f"Invalid argument into ti.any_arr() - required element_dim={self.element_dim}, but {arg} is provided")
+            raise ValueError(
+                f"Invalid argument into ti.any_arr() - required element_dim={self.element_dim}, but {arg} is provided"
+            )
 
     def check_layout(self, arg):
         if self.layout is not None and self.layout != arg.layout:
-            raise ValueError(f"Invalid argument into ti.any_arr() - required layout={self.layout}, but {arg} is provided")
+            raise ValueError(
+                f"Invalid argument into ti.any_arr() - required layout={self.layout}, but {arg} is provided"
+            )
 
 
 any_arr = ArgAnyArray

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -49,29 +49,32 @@ class ArgAnyArray:
         from taichi.lang.matrix import MatrixNdarray, VectorNdarray
         from taichi.lang.ndarray import ScalarNdarray
         if isinstance(x, ScalarNdarray):
-            if self.element_dim is not None and self.element_dim != 0:
-                raise ValueError("Invalid argument passed to ti.any_arr()")
+            self.check_element_dim(x, 0)
             return x.dtype, len(x.shape), (), Layout.AOS
         if isinstance(x, VectorNdarray):
-            if self.element_dim is not None and self.element_dim != 1:
-                raise ValueError("Invalid argument passed to ti.any_arr()")
-            if self.layout is not None and self.layout != x.layout:
-                raise ValueError("Invalid argument passed to ti.any_arr()")
+            self.check_element_dim(x, 1)
+            self.check_layout(x)
             return x.dtype, len(x.shape) + 1, (x.n, ), x.layout
         if isinstance(x, MatrixNdarray):
-            if self.element_dim is not None and self.element_dim != 2:
-                raise ValueError("Invalid argument passed to ti.any_arr()")
-            if self.layout is not None and self.layout != x.layout:
-                raise ValueError("Invalid argument passed to ti.any_arr()")
+            self.check_element_dim(x, 2)
+            self.check_layout(x)
             return x.dtype, len(x.shape) + 2, (x.n, x.m), x.layout
         # external arrays
         element_dim = 0 if self.element_dim is None else self.element_dim
         layout = Layout.AOS if self.layout is None else self.layout
         shape = tuple(x.shape)
         if len(shape) < element_dim:
-            raise ValueError("Invalid argument passed to ti.any_arr()")
+            raise ValueError(f"Invalid argument into ti.any_arr() - required element_dim={element_dim}, but the argument has only {len(shape)} dimensions")
         element_shape = () if element_dim == 0 else shape[:element_dim] if layout == Layout.SOA else shape[-element_dim:]
         return to_taichi_type(x.dtype), len(shape), element_shape, layout
+
+    def check_element_dim(self, arg, arg_dim):
+        if self.element_dim is not None and self.element_dim != arg_dim:
+            raise ValueError(f"Invalid argument into ti.any_arr() - required element_dim={self.element_dim}, but {arg} is provided")
+
+    def check_layout(self, arg):
+        if self.layout is not None and self.layout != arg.layout:
+            raise ValueError(f"Invalid argument into ti.any_arr() - required layout={self.layout}, but {arg} is provided")
 
 
 any_arr = ArgAnyArray

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -30,52 +30,48 @@ def ext_arr():
 class ArgAnyArray:
     """Type annotation for arbitrary arrays, including external arrays and Taichi ndarrays.
 
-    For external arrays, we can treat it as a Taichi field with Vector or Matrix elements by specifying element shape and layout.
-    For Taichi vector/matrix ndarrays, we need to specify element shape and layout for type checking.
+    For external arrays, we can treat it as a Taichi field with Vector or Matrix elements by specifying element dim and layout.
+    For Taichi vector/matrix ndarrays, we will automatically identify element dim and layout. If they are explicitly specified, we will check compatibility between the actual arguments and the annotation.
 
     Args:
-        element_shape (Tuple[Int], optional): () if scalar elements (default), (n) if vector elements, and (n, m) if matrix elements.
-        layout (Layout, optional): Memory layout, AOS by default.
+        element_dim (Union[Int, NoneType], optional): None if not specified (will be treated as 0 for external arrays), 0 if scalar elements, 1 if vector elements, and 2 if matrix elements.
+        layout (Union[Layout, NoneType], optional): None if not specified (will be treated as Layout.AOS for external arrays), Layout.AOS or Layout.SOA.
     """
-    def __init__(self, element_shape=(), layout=Layout.AOS):
-        if len(element_shape) > 2:
+    def __init__(self, element_dim=None, layout=None):
+        if element_dim is not None and (element_dim < 0 or element_dim > 2):
             raise ValueError(
                 "Only scalars, vectors, and matrices are allowed as elements of ti.any_arr()"
             )
-        self.element_shape = element_shape
+        self.element_dim = element_dim
         self.layout = layout
 
     def extract(self, x):
         from taichi.lang.matrix import MatrixNdarray, VectorNdarray
-        from taichi.lang.ndarray import Ndarray, ScalarNdarray
-        element_dim = len(self.element_shape)
-        if isinstance(x, Ndarray):
-            if isinstance(x, ScalarNdarray) and element_dim != 0:
+        from taichi.lang.ndarray import ScalarNdarray
+        if isinstance(x, ScalarNdarray):
+            if self.element_dim is not None and self.element_dim != 0:
                 raise ValueError("Invalid argument passed to ti.any_arr()")
-            if isinstance(x, VectorNdarray) and (element_dim != 1 or
-                                                 self.element_shape[0] != x.n
-                                                 or self.layout != x.layout):
+            return x.dtype, len(x.shape), (), Layout.AOS
+        if isinstance(x, VectorNdarray):
+            if self.element_dim is not None and self.element_dim != 1:
                 raise ValueError("Invalid argument passed to ti.any_arr()")
-            if isinstance(x,
-                          MatrixNdarray) and (element_dim != 2
-                                              or self.element_shape[0] != x.n
-                                              or self.element_shape[1] != x.m
-                                              or self.layout != x.layout):
+            if self.layout is not None and self.layout != x.layout:
                 raise ValueError("Invalid argument passed to ti.any_arr()")
-            return x.dtype, len(
-                x.shape) + element_dim, self.element_shape, self.layout
+            return x.dtype, len(x.shape) + 1, (x.n, ), x.layout
+        if isinstance(x, MatrixNdarray):
+            if self.element_dim is not None and self.element_dim != 2:
+                raise ValueError("Invalid argument passed to ti.any_arr()")
+            if self.layout is not None and self.layout != x.layout:
+                raise ValueError("Invalid argument passed to ti.any_arr()")
+            return x.dtype, len(x.shape) + 2, (x.n, x.m), x.layout
+        # external arrays
+        element_dim = 0 if self.element_dim is None else self.element_dim
+        layout = Layout.AOS if self.layout is None else self.layout
         shape = tuple(x.shape)
         if len(shape) < element_dim:
             raise ValueError("Invalid argument passed to ti.any_arr()")
-        if element_dim > 0:
-            if self.layout == Layout.SOA:
-                if shape[:element_dim] != self.element_shape:
-                    raise ValueError("Invalid argument passed to ti.any_arr()")
-            else:
-                if shape[-element_dim:] != self.element_shape:
-                    raise ValueError("Invalid argument passed to ti.any_arr()")
-        return to_taichi_type(
-            x.dtype), len(shape), self.element_shape, self.layout
+        element_shape = () if element_dim == 0 else shape[:element_dim] if layout == Layout.SOA else shape[-element_dim:]
+        return to_taichi_type(x.dtype), len(shape), element_shape, layout
 
 
 any_arr = ArgAnyArray

--- a/python/taichi/lang/ndarray.py
+++ b/python/taichi/lang/ndarray.py
@@ -64,6 +64,41 @@ class Ndarray:
         """
         raise NotImplementedError()
 
+    @python_scope
+    def fill(self, val):
+        """Fills ndarray with a specific scalar value.
+
+        Args:
+            val (Union[int, float]): Value to fill.
+        """
+        self.arr.fill_(val)
+
+    @python_scope
+    def to_numpy(self):
+        """Converts ndarray to a numpy array.
+
+        Returns:
+            numpy.ndarray: The result numpy array.
+        """
+        return self.arr.cpu().numpy()
+
+    @python_scope
+    def from_numpy(self, arr):
+        """Loads all values from a numpy array.
+
+        Args:
+            arr (numpy.ndarray): The source numpy array.
+        """
+        import numpy as np
+        if not isinstance(arr, np.ndarray):
+            raise TypeError(f"{np.ndarray} expected, but {type(arr)} provided")
+        if tuple(self.arr.shape) != tuple(arr.shape):
+            raise ValueError(
+                f"Mismatch shape: {tuple(self.arr.shape)} expected, but {tuple(arr.shape)} provided"
+            )
+        import torch
+        self.arr = torch.from_numpy(arr).to(self.arr.dtype)
+
 
 class ScalarNdarray(Ndarray):
     """Taichi ndarray with scalar elements implemented with a torch tensor.

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -164,7 +164,7 @@ def test_taichi_scope_matrix_operations_with_global_matrices(ops):
 @ti.test()
 def test_matrix_non_constant_index_numpy():
     @ti.kernel
-    def func1(a: ti.any_arr(element_shape=(2, 2))):
+    def func1(a: ti.any_arr(element_dim=2)):
         for i in range(5):
             for j, k in ti.ndrange(2, 2):
                 a[i][j, k] = j * j + k * k
@@ -177,7 +177,7 @@ def test_matrix_non_constant_index_numpy():
     assert m[4][0, 1] == 1
 
     @ti.kernel
-    def func2(b: ti.any_arr(element_shape=(10, ), layout=ti.Layout.SOA)):
+    def func2(b: ti.any_arr(element_dim=1, layout=ti.Layout.SOA)):
         for i in range(5):
             for j in range(4):
                 b[i][j * j] = j * j

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -143,11 +143,9 @@ def test_mpm88_numpy_and_ndarray():
     E = 400
 
     @ti.kernel
-    def substep(x: ti.any_arr(element_shape=(dim, )),
-                v: ti.any_arr(element_shape=(dim, )),
-                C: ti.any_arr(element_shape=(dim, dim)), J: ti.any_arr(),
-                grid_v: ti.any_arr(element_shape=(dim, )),
-                grid_m: ti.any_arr()):
+    def substep(x: ti.any_arr(element_dim=1), v: ti.any_arr(element_dim=1),
+                C: ti.any_arr(element_dim=2), J: ti.any_arr(),
+                grid_v: ti.any_arr(element_dim=1), grid_m: ti.any_arr()):
         for p in x:
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -199,14 +199,7 @@ def test_mpm88_numpy_and_ndarray():
             J[p] *= 1 + dt * new_C.trace()
             C[p] = new_C
 
-    def test_numpy():
-        x = np.zeros((n_particles, dim), dtype=np.float32)
-        v = np.zeros((n_particles, dim), dtype=np.float32)
-        C = np.zeros((n_particles, dim, dim), dtype=np.float32)
-        J = np.zeros(n_particles, dtype=np.float32)
-        grid_v = np.zeros((n_grid, n_grid, dim), dtype=np.float32)
-        grid_m = np.zeros((n_grid, n_grid), dtype=np.float32)
-
+    def run_test(x, v, C, J, grid_v, grid_m):
         for i in range(n_particles):
             x[i] = [i % N / N * 0.4 + 0.2, i / N / N * 0.4 + 0.05]
             v[i] = [0, -3]
@@ -218,7 +211,7 @@ def test_mpm88_numpy_and_ndarray():
                 grid_m.fill(0)
                 substep(x, v, C, J, grid_v, grid_m)
 
-        pos = x
+        pos = x if isinstance(x, np.ndarray) else x.to_numpy()
         pos[:, 1] *= 2
         regression = [
             0.31722742,
@@ -229,35 +222,23 @@ def test_mpm88_numpy_and_ndarray():
         for i in range(4):
             assert (pos**(i + 1)).mean() == approx(regression[i], rel=1e-2)
 
+    def test_numpy():
+        x = np.zeros((n_particles, dim), dtype=np.float32)
+        v = np.zeros((n_particles, dim), dtype=np.float32)
+        C = np.zeros((n_particles, dim, dim), dtype=np.float32)
+        J = np.zeros(n_particles, dtype=np.float32)
+        grid_v = np.zeros((n_grid, n_grid, dim), dtype=np.float32)
+        grid_m = np.zeros((n_grid, n_grid), dtype=np.float32)
+        run_test(x, v, C, J, grid_v, grid_m)
+
     def test_ndarray():
         x = ti.Vector.ndarray(dim, ti.f32, n_particles)
         v = ti.Vector.ndarray(dim, ti.f32, n_particles)
         C = ti.Matrix.ndarray(dim, dim, ti.f32, n_particles)
         J = ti.ndarray(ti.f32, n_particles)
-
-        for i in range(n_particles):
-            x[i] = [i % N / N * 0.4 + 0.2, i / N / N * 0.4 + 0.05]
-            v[i] = [0, -3]
-            J[i] = 1
-
-        for frame in range(10):
-            for s in range(50):
-                grid_v = ti.Vector.ndarray(dim, ti.f32, (n_grid, n_grid))
-                grid_m = ti.ndarray(ti.f32, (n_grid, n_grid))
-                substep(x, v, C, J, grid_v, grid_m)
-
-        pos = np.zeros((n_particles, dim), dtype=np.float32)
-        for i in range(n_particles):
-            pos[i][0] = x[i][0]
-            pos[i][1] = x[i][1] * 2
-        regression = [
-            0.31722742,
-            0.15826741,
-            0.10224003,
-            0.07810827,
-        ]
-        for i in range(4):
-            assert (pos**(i + 1)).mean() == approx(regression[i], rel=1e-2)
+        grid_v = ti.Vector.ndarray(dim, ti.f32, (n_grid, n_grid))
+        grid_m = ti.ndarray(ti.f32, (n_grid, n_grid))
+        run_test(x, v, C, J, grid_v, grid_m)
 
     test_numpy()
     test_ndarray()

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -145,7 +145,7 @@ def test_matrix_ndarray_python_scope(layout):
 @ti.test(exclude=ti.opengl)
 def test_matrix_ndarray_taichi_scope(layout):
     @ti.kernel
-    def func(a: ti.any_arr(element_shape=(2, 2), layout=layout)):
+    def func(a: ti.any_arr()):
         for i in range(5):
             for j, k in ti.ndrange(2, 2):
                 a[i][j, k] = j * j + k * k
@@ -164,7 +164,7 @@ def test_matrix_ndarray_taichi_scope(layout):
 @ti.test(exclude=ti.opengl)
 def test_matrix_ndarray_taichi_scope_struct_for(layout):
     @ti.kernel
-    def func(a: ti.any_arr(element_shape=(2, 2), layout=layout)):
+    def func(a: ti.any_arr()):
         for i in a:
             for j, k in ti.ndrange(2, 2):
                 a[i][j, k] = j * j + k * k
@@ -198,7 +198,7 @@ def test_vector_ndarray_python_scope(layout):
 @ti.test(exclude=ti.opengl)
 def test_vector_ndarray_taichi_scope(layout):
     @ti.kernel
-    def func(a: ti.any_arr(element_shape=(10, ), layout=layout)):
+    def func(a: ti.any_arr()):
         for i in range(5):
             for j in range(4):
                 a[i][j * j] = j * j
@@ -219,7 +219,7 @@ def test_vector_ndarray_taichi_scope(layout):
 @ti.test(exclude=ti.opengl)
 def test_compiled_functions():
     @ti.kernel
-    def func(a: ti.any_arr(element_shape=(10, ))):
+    def func(a: ti.any_arr(element_dim=1)):
         for i in range(5):
             for j in range(4):
                 a[i][j * j] = j * j
@@ -231,6 +231,9 @@ def test_compiled_functions():
     func(v)
     assert ti.get_runtime().get_num_compiled_functions() == 1
     import torch
-    v = torch.zeros((7, 10), dtype=torch.int32)
+    v = torch.zeros((6, 11), dtype=torch.int32)
     func(v)
-    assert ti.get_runtime().get_num_compiled_functions() == 1
+    assert ti.get_runtime().get_num_compiled_functions() == 2
+    v = ti.Vector.ndarray(10, ti.i32, 5, layout=ti.Layout.SOA)
+    func(v)
+    assert ti.get_runtime().get_num_compiled_functions() == 3

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -113,6 +113,18 @@ def test_ndarray_2d():
             assert b[i, j] == i * j + (i + j + 1) * 2
 
 
+@pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
+@ti.test(exclude=ti.opengl)
+def test_ndarray_numpy_io():
+    n = 7
+    m = 4
+    a = ti.ndarray(ti.i32, shape=(n, m))
+    a.fill(2)
+    b = ti.ndarray(ti.i32, shape=(n, m))
+    b.from_numpy(np.ones((n, m), dtype=np.int32) * 2)
+    assert (a.to_numpy() == b.to_numpy()).all()
+
+
 @pytest.mark.parametrize('layout', layouts)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
 @ti.test(exclude=ti.opengl)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -241,6 +241,7 @@ def test_compiled_functions():
 
 # annotation compatibility
 
+
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
 @ti.test(arch=ti.get_host_arch_list())
 def test_arg_not_match():
@@ -249,8 +250,11 @@ def test_arg_not_match():
         pass
 
     x = ti.Matrix.ndarray(2, 3, ti.i32, shape=(4, 7))
-    with pytest.raises(ValueError,
-                       match=r'Invalid argument into ti\.any_arr\(\) - required element_dim=1, but .* is provided'):
+    with pytest.raises(
+            ValueError,
+            match=
+            r'Invalid argument into ti\.any_arr\(\) - required element_dim=1, but .* is provided'
+    ):
         func1(x)
 
     @ti.kernel
@@ -258,8 +262,11 @@ def test_arg_not_match():
         pass
 
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
-    with pytest.raises(ValueError,
-                       match=r'Invalid argument into ti\.any_arr\(\) - required element_dim=2, but .* is provided'):
+    with pytest.raises(
+            ValueError,
+            match=
+            r'Invalid argument into ti\.any_arr\(\) - required element_dim=2, but .* is provided'
+    ):
         func2(x)
 
     @ti.kernel
@@ -267,8 +274,11 @@ def test_arg_not_match():
         pass
 
     x = ti.Matrix.ndarray(2, 3, ti.i32, shape=(4, 7), layout=ti.Layout.SOA)
-    with pytest.raises(ValueError,
-                       match=r'Invalid argument into ti\.any_arr\(\) - required layout=Layout\.AOS, but .* is provided'):
+    with pytest.raises(
+            ValueError,
+            match=
+            r'Invalid argument into ti\.any_arr\(\) - required layout=Layout\.AOS, but .* is provided'
+    ):
         func3(x)
 
     @ti.kernel
@@ -276,6 +286,9 @@ def test_arg_not_match():
         pass
 
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
-    with pytest.raises(ValueError,
-                       match=r'Invalid argument into ti\.any_arr\(\) - required layout=Layout\.SOA, but .* is provided'):
+    with pytest.raises(
+            ValueError,
+            match=
+            r'Invalid argument into ti\.any_arr\(\) - required layout=Layout\.SOA, but .* is provided'
+    ):
         func4(x)


### PR DESCRIPTION
Related issue = #2772

Changes:
- For external arrays, we can treat it as a Taichi field with Vector or Matrix elements by specifying element **dim** (instead of **shape**) and layout.
- For Taichi vector/matrix ndarrays, we will **automatically** identify element dim and layout. If they are explicitly specified, we will check compatibility between the actual arguments and the annotation.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
