### PR TITLE
[misc] Fix typo in examples/simulation/fractal.py

### DIFF
--- a/docs/lang/articles/contribution/doc_writing.md
+++ b/docs/lang/articles/contribution/doc_writing.md
@@ -14,7 +14,7 @@ This site supports inserting code blocks with highlighted lines, for examples, t
 ```python {1-2,4,6} title=snippet.py
 @ti.kernel
 def paint(t: float):
-    for i, j in pixels:  # Parallized over all pixels
+    for i, j in pixels:  # Parallelized over all pixels
         c = ti.Vector([-0.8, ti.cos(t) * 0.2])
         z = ti.Vector([i / n - 1, j / n - 0.5]) * 2
         iterations = 0
@@ -30,7 +30,7 @@ will result in a code block like:
 ```python {1-2,4,6} title=snippet.py
 @ti.kernel
 def paint(t: float):
-    for i, j in pixels:  # Parallized over all pixels
+    for i, j in pixels:  # Parallelized over all pixels
         c = ti.Vector([-0.8, ti.cos(t) * 0.2])
         z = ti.Vector([i / n - 1, j / n - 0.5]) * 2
         iterations = 0

--- a/docs/lang/articles/get-started.md
+++ b/docs/lang/articles/get-started.md
@@ -82,7 +82,7 @@ def complex_sqr(z):
 
 @ti.kernel
 def paint(t: float):
-    for i, j in pixels:  # Parallized over all pixels
+    for i, j in pixels:  # Parallelized over all pixels
         c = ti.Vector([-0.8, ti.cos(t) * 0.2])
         z = ti.Vector([i / n - 1, j / n - 0.5]) * 2
         iterations = 0

--- a/examples/simulation/fractal.py
+++ b/examples/simulation/fractal.py
@@ -13,7 +13,7 @@ def complex_sqr(z):
 
 @ti.kernel
 def paint(t: float):
-    for i, j in pixels:  # Parallized over all pixels
+    for i, j in pixels:  # Parallelized over all pixels
         c = ti.Vector([-0.8, ti.cos(t) * 0.2])
         z = ti.Vector([i / n - 1, j / n - 0.5]) * 2
         iterations = 0


### PR DESCRIPTION
fix typo

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
