### PR TITLE
[Llvm] Increase the number of arguments allowed in a kernel

### DIFF
--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -3,7 +3,12 @@
 #include <cstddef>
 
 constexpr int taichi_max_num_indices = 8;
+// legacy: only used in cc and opengl backends
 constexpr int taichi_max_num_args = 8;
+// used in llvm backend: only the first 16 arguments can be ext_arr/any_arr
+// TODO: refine argument passing
+constexpr int taichi_max_num_args_total = 64;
+constexpr int taichi_max_num_args_extra = 16;
 constexpr int taichi_max_num_snodes = 1024;
 constexpr int taichi_max_num_snode_trees = 32;
 constexpr int taichi_max_gpu_block_dim = 1024;

--- a/taichi/program/context.h
+++ b/taichi/program/context.h
@@ -14,8 +14,8 @@ struct LLVMRuntime;
 // to the LLVMRuntime struct, kernel arguments, and the thread id (if on CPU).
 struct Context {
   LLVMRuntime *runtime;
-  uint64 args[taichi_max_num_args];
-  int32 extra_args[taichi_max_num_args][taichi_max_num_indices];
+  uint64 args[taichi_max_num_args_total];
+  int32 extra_args[taichi_max_num_args_extra][taichi_max_num_indices];
   int32 cpu_thread_id;
 
   static constexpr size_t extra_args_size = sizeof(extra_args);


### PR DESCRIPTION
This PR aims at increasing the number of arguments allowed in a kernel in the LLVM backend (for user requirements). However, this is a temporary solution which may make the context a bit larger and not fully utilized. A better way for argument passing needs to be utilized in the future.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
