### PR TITLE
[bug] [opt] Disable putting pointers into global tmp buffer

### DIFF
--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -557,7 +557,7 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
     if (local_to_global_offset.find(op) == local_to_global_offset.end()) {
       TI_ASSERT_INFO(op->is<ConstStmt>() || op->is<PtrOffsetStmt>() ||
                          op->is<GlobalTemporaryStmt>() ||
-                         op->is<ArgLoadStmt>() || op->is<ExternalPtrStmt>(),
+                         op->is<ExternalPtrStmt>() || (op->is<ArgLoadStmt>() && op->as<ArgLoadStmt>()->is_ptr),
                      "{} is not allowed here.", op->type());
       // For cases like ConstStmt
       auto copy = op->clone();

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -333,7 +333,7 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
       return;
     auto top_level_ptr = SquashPtrOffset::run(stmt);
     // We don't support storing a pointer for now.
-    if (top_level_ptr->is<GlobalPtrStmt>())
+    if (top_level_ptr->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() || (stmt->is<ArgLoadStmt>() && stmt->as<ArgLoadStmt>()->is_ptr))
       return;
     // Not yet allocated
     if (local_to_global.find(top_level_ptr) == local_to_global.end()) {
@@ -555,7 +555,7 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
 
     if (local_to_global_offset.find(op) == local_to_global_offset.end()) {
       TI_ASSERT_INFO(op->is<ConstStmt>() || op->is<PtrOffsetStmt>() ||
-                         op->is<GlobalTemporaryStmt>(),
+                         op->is<GlobalTemporaryStmt>() || op->is<ArgLoadStmt>() || op->is<ExternalPtrStmt>(),
                      "{} is not allowed here.", op->type());
       // For cases like ConstStmt
       auto copy = op->clone();

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -333,7 +333,8 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
       return;
     auto top_level_ptr = SquashPtrOffset::run(stmt);
     // We don't support storing a pointer for now.
-    if (top_level_ptr->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() || (stmt->is<ArgLoadStmt>() && stmt->as<ArgLoadStmt>()->is_ptr))
+    if (top_level_ptr->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
+        (stmt->is<ArgLoadStmt>() && stmt->as<ArgLoadStmt>()->is_ptr))
       return;
     // Not yet allocated
     if (local_to_global.find(top_level_ptr) == local_to_global.end()) {
@@ -555,7 +556,8 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
 
     if (local_to_global_offset.find(op) == local_to_global_offset.end()) {
       TI_ASSERT_INFO(op->is<ConstStmt>() || op->is<PtrOffsetStmt>() ||
-                         op->is<GlobalTemporaryStmt>() || op->is<ArgLoadStmt>() || op->is<ExternalPtrStmt>(),
+                         op->is<GlobalTemporaryStmt>() ||
+                         op->is<ArgLoadStmt>() || op->is<ExternalPtrStmt>(),
                      "{} is not allowed here.", op->type());
       // For cases like ConstStmt
       auto copy = op->clone();

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -555,10 +555,11 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
     }
 
     if (local_to_global_offset.find(op) == local_to_global_offset.end()) {
-      TI_ASSERT_INFO(op->is<ConstStmt>() || op->is<PtrOffsetStmt>() ||
-                         op->is<GlobalTemporaryStmt>() ||
-                         op->is<ExternalPtrStmt>() || (op->is<ArgLoadStmt>() && op->as<ArgLoadStmt>()->is_ptr),
-                     "{} is not allowed here.", op->type());
+      TI_ASSERT_INFO(
+          op->is<ConstStmt>() || op->is<PtrOffsetStmt>() ||
+              op->is<GlobalTemporaryStmt>() || op->is<ExternalPtrStmt>() ||
+              (op->is<ArgLoadStmt>() && op->as<ArgLoadStmt>()->is_ptr),
+          "{} is not allowed here.", op->type());
       // For cases like ConstStmt
       auto copy = op->clone();
       stmt_to_offloaded[copy.get()] = offloaded;


### PR DESCRIPTION
Related issue = close #2884

Previously, `GlobalPtrStmt` is not put into global tmp buffer due to lack of support for pointers to pointers. Same thing should also happen to other pointers including `ExternalPtrStmt` and `ArgLoad` (if the arg is a pointer) so that bug #2884 can be resolved.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
