### PR TITLE
[Misc] Fix the path in conda_env.yaml

### DIFF
--- a/conda/conda_env.yaml
+++ b/conda/conda_env.yaml
@@ -1,7 +1,7 @@
 # How to update the env:
 #
 # conda activate taichi-dev
-# conda env update --file conda-env.yaml --prune
+# conda env update --file conda_env.yaml --prune
 # https://stackoverflow.com/a/43873901/12003165
 
 name: taichi-dev


### PR DESCRIPTION
Related issue = null

When I follow the comment to create conda env, there's an error like this:

```
EnvironmentFileNotFound: 'taichi/conda/conda-env.yaml' file not found
```

This PR is to fix the typo in conda_env.yaml
