### PR TITLE
[refactor] [CUDA] Move KernelProfilerCUDA from program/kernel_profiler.cpp to backends/cuda/cuda_profiler.cpp

### DIFF
--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -75,8 +75,10 @@ void CUDAContext::launch(void *func,
 
   KernelProfilerBase::TaskHandle task_handle;
   // Kernel launch
-  if (profiler)
-    task_handle = profiler->start_with_handle(task_name);
+  if (profiler){
+    profiler->record(task_handle,task_name);
+  }
+    
   auto context_guard = CUDAContext::get_instance().get_guard();
 
   // TODO: remove usages of get_current_program here.

--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -75,10 +75,10 @@ void CUDAContext::launch(void *func,
 
   KernelProfilerBase::TaskHandle task_handle;
   // Kernel launch
-  if (profiler){
-    profiler->record(task_handle,task_name);
+  if (profiler) {
+    profiler->record(task_handle, task_name);
   }
-    
+
   auto context_guard = CUDAContext::get_instance().get_guard();
 
   // TODO: remove usages of get_current_program here.

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -1,0 +1,165 @@
+#include "taichi/backends/cuda/cuda_profiler.h"
+#include "taichi/backends/cuda/cuda_driver.h"
+#include "taichi/backends/cuda/cuda_context.h"
+#include "taichi/system/timeline.h"
+
+TLANG_NAMESPACE_BEGIN
+
+#if defined(TI_WITH_CUDA)
+
+std::string KernelProfilerCUDA::title() const {
+  return "CUDA Profiler";
+}
+
+KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(
+  const std::string &kernel_name) {
+  
+  void *start, *stop;
+  CUDADriver::get_instance().event_create(&start, CU_EVENT_DEFAULT);
+  CUDADriver::get_instance().event_create(&stop, CU_EVENT_DEFAULT);
+  CUDADriver::get_instance().event_record(start, 0);
+  outstanding_events_[kernel_name].push_back(std::make_pair(start, stop));
+
+  if (!base_event_) {
+    // Note that CUDA driver API only allows querying relative time difference
+    // between two events, therefore we need to manually build a mapping
+    // between GPU and CPU time.
+    // TODO: periodically reinitialize for more accuracy.
+    int n_iters = 100;
+    // Warm up CUDA driver, and use the final event as the base event.
+    for (int i = 0; i < n_iters; i++) {
+      void *e;
+      CUDADriver::get_instance().event_create(&e, CU_EVENT_DEFAULT);
+      CUDADriver::get_instance().event_record(e, 0);
+      CUDADriver::get_instance().event_synchronize(e);
+      auto final_t = Time::get_time();
+      if (i == n_iters - 1) {
+        base_event_ = e;
+        // TODO: figure out a better way to synchronize CPU and GPU time.
+        constexpr float64 cuda_time_offset = 3e-4;
+        // Since event recording and synchronization can take 5 us, it's hard
+        // to exactly measure the real event time. Also note there seems to be
+        // a systematic time offset on CUDA, so adjust for that using a 3e-4 s
+        // magic number.
+        base_time_ = final_t + cuda_time_offset;
+      } else {
+        CUDADriver::get_instance().event_destroy(e);
+      }
+    }
+  }
+
+  return stop;
+}
+
+void KernelProfilerCUDA::stop(KernelProfilerBase::TaskHandle handle) {
+  CUDADriver::get_instance().event_record(handle, 0);
+}
+
+void KernelProfilerCUDA::record(KernelProfilerBase::TaskHandle &task_handle,
+                                const std::string &task_name) {
+  task_handle = this->start_with_handle(task_name);
+}
+
+void KernelProfilerCUDA::sync() {
+  CUDADriver::get_instance().stream_synchronize(nullptr);
+  auto &timeline = Timeline::get_this_thread_instance();
+  for (auto &map_elem : outstanding_events_) {
+    auto &list = map_elem.second;
+    for (auto &item : list) {
+      auto start = item.first, stop = item.second;
+      float kernel_time;
+      CUDADriver::get_instance().event_elapsed_time(&kernel_time, start,
+                                                    stop);
+
+      if (Timelines::get_instance().get_enabled()) {
+        float time_since_base;
+        CUDADriver::get_instance().event_elapsed_time(&time_since_base,
+                                                      base_event_, start);
+        timeline.insert_event({map_elem.first, true,
+                                base_time_ + time_since_base * 1e-3, "cuda"});
+        timeline.insert_event(
+            {map_elem.first, false,
+              base_time_ + (time_since_base + kernel_time) * 1e-3, "cuda"});
+      }
+
+      auto it = std::find_if(
+          records.begin(), records.end(),
+          [&](KernelProfileRecord &r) { return r.name == map_elem.first; });
+      if (it == records.end()) {
+        records.emplace_back(map_elem.first);
+        it = std::prev(records.end());
+      }
+      it->insert_sample(kernel_time);
+      total_time_ms += kernel_time;
+
+      // TODO: the following two lines seem to increases profiler overhead a
+      // little bit. Is there a way to avoid the overhead while not creating
+      // too many events?
+      CUDADriver::get_instance().event_destroy(start);
+      CUDADriver::get_instance().event_destroy(stop);
+    }
+  }
+  outstanding_events_.clear();
+}
+
+
+void KernelProfilerCUDA::print() {
+  sync();
+  fmt::print("{}\n", title());
+  fmt::print(
+      "========================================================================"
+      "=\n");
+  fmt::print(
+      "[      %     total   count |      min       avg       max   ] Kernel "
+      "name\n");
+  std::sort(records.begin(), records.end());
+  for (auto &rec : records) {
+    auto fraction = rec.total / total_time_ms * 100.0f;
+    fmt::print("[{:6.2f}% {:7.3f} s {:6d}x |{:9.3f} {:9.3f} {:9.3f} ms] {}\n",
+               fraction, rec.total / 1000.0f, rec.counter, rec.min,
+               rec.total / rec.counter, rec.max, rec.name);
+  }
+  fmt::print(
+      "------------------------------------------------------------------------"
+      "-\n");
+  fmt::print(
+      "[100.00%] Total kernel execution time: {:7.3f} s   number of records: "
+      "{}\n",
+      get_total_time(), records.size());
+
+  fmt::print(
+      "========================================================================"
+      "=\n");
+}
+
+void KernelProfilerCUDA::clear(){
+  sync();
+  total_time_ms = 0;
+  records.clear();
+}
+
+#else
+
+std::string KernelProfilerCUDA::title() const {
+  TI_NOT_IMPLEMENTED;
+}
+KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(const std::string &kernel_name){
+  TI_NOT_IMPLEMENTED;
+}
+void KernelProfilerCUDA::record(KernelProfilerBase::TaskHandle &task_handle,
+            const std::string &task_name) {
+  TI_NOT_IMPLEMENTED;
+}
+void KernelProfilerCUDA::stop(KernelProfilerBase::TaskHandle handle) {
+  TI_NOT_IMPLEMENTED;
+}
+void KernelProfilerCUDA::sync(){
+  TI_NOT_IMPLEMENTED;
+}
+void KernelProfilerCUDA::clear(){
+  TI_NOT_IMPLEMENTED;
+}
+
+#endif
+  
+TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -12,8 +12,7 @@ std::string KernelProfilerCUDA::title() const {
 }
 
 KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(
-  const std::string &kernel_name) {
-  
+    const std::string &kernel_name) {
   void *start, *stop;
   CUDADriver::get_instance().event_create(&start, CU_EVENT_DEFAULT);
   CUDADriver::get_instance().event_create(&stop, CU_EVENT_DEFAULT);
@@ -68,18 +67,17 @@ void KernelProfilerCUDA::sync() {
     for (auto &item : list) {
       auto start = item.first, stop = item.second;
       float kernel_time;
-      CUDADriver::get_instance().event_elapsed_time(&kernel_time, start,
-                                                    stop);
+      CUDADriver::get_instance().event_elapsed_time(&kernel_time, start, stop);
 
       if (Timelines::get_instance().get_enabled()) {
         float time_since_base;
         CUDADriver::get_instance().event_elapsed_time(&time_since_base,
                                                       base_event_, start);
         timeline.insert_event({map_elem.first, true,
-                                base_time_ + time_since_base * 1e-3, "cuda"});
+                               base_time_ + time_since_base * 1e-3, "cuda"});
         timeline.insert_event(
             {map_elem.first, false,
-              base_time_ + (time_since_base + kernel_time) * 1e-3, "cuda"});
+             base_time_ + (time_since_base + kernel_time) * 1e-3, "cuda"});
       }
 
       auto it = std::find_if(
@@ -101,7 +99,6 @@ void KernelProfilerCUDA::sync() {
   }
   outstanding_events_.clear();
 }
-
 
 void KernelProfilerCUDA::print() {
   sync();
@@ -132,7 +129,7 @@ void KernelProfilerCUDA::print() {
       "=\n");
 }
 
-void KernelProfilerCUDA::clear(){
+void KernelProfilerCUDA::clear() {
   sync();
   total_time_ms = 0;
   records.clear();
@@ -143,23 +140,24 @@ void KernelProfilerCUDA::clear(){
 std::string KernelProfilerCUDA::title() const {
   TI_NOT_IMPLEMENTED;
 }
-KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(const std::string &kernel_name){
+KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(
+    const std::string &kernel_name) {
   TI_NOT_IMPLEMENTED;
 }
 void KernelProfilerCUDA::record(KernelProfilerBase::TaskHandle &task_handle,
-            const std::string &task_name) {
+                                const std::string &task_name) {
   TI_NOT_IMPLEMENTED;
 }
 void KernelProfilerCUDA::stop(KernelProfilerBase::TaskHandle handle) {
   TI_NOT_IMPLEMENTED;
 }
-void KernelProfilerCUDA::sync(){
+void KernelProfilerCUDA::sync() {
   TI_NOT_IMPLEMENTED;
 }
-void KernelProfilerCUDA::clear(){
+void KernelProfilerCUDA::clear() {
   TI_NOT_IMPLEMENTED;
 }
 
 #endif
-  
+
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "taichi/program/kernel_profiler.h"
+#include "taichi/backends/cuda/cuda_driver.h"
+#include "taichi/backends/cuda/cuda_context.h"
+
+#include <string>
+#include <stdint.h>
+
+TLANG_NAMESPACE_BEGIN
+
+// A CUDA kernel profiler that uses CUDA timing events
+class KernelProfilerCUDA : public KernelProfilerBase {
+
+public:
+
+  std::string title() const override;
+  KernelProfilerBase::TaskHandle start_with_handle(const std::string &kernel_name) override;
+  void record(KernelProfilerBase::TaskHandle &task_handle,
+              const std::string &task_name) override;
+  void sync() override;
+  void print() override;
+  void clear() override;
+  void stop(KernelProfilerBase::TaskHandle handle) override;
+
+private:
+  void *base_event_{nullptr};
+  float64 base_time_{0.0};
+  std::map<std::string, std::vector<std::pair<void *, void *>>>
+      outstanding_events_;
+};
+
+TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -11,11 +11,10 @@ TLANG_NAMESPACE_BEGIN
 
 // A CUDA kernel profiler that uses CUDA timing events
 class KernelProfilerCUDA : public KernelProfilerBase {
-
-public:
-
+ public:
   std::string title() const override;
-  KernelProfilerBase::TaskHandle start_with_handle(const std::string &kernel_name) override;
+  KernelProfilerBase::TaskHandle start_with_handle(
+      const std::string &kernel_name) override;
   void record(KernelProfilerBase::TaskHandle &task_handle,
               const std::string &task_name) override;
   void sync() override;
@@ -23,7 +22,7 @@ public:
   void clear() override;
   void stop(KernelProfilerBase::TaskHandle handle) override;
 
-private:
+ private:
   void *base_event_{nullptr};
   float64 base_time_{0.0};
   std::map<std::string, std::vector<std::pair<void *, void *>>>

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -2,6 +2,7 @@
 
 #include "taichi/system/timer.h"
 #include "taichi/backends/cuda/cuda_driver.h"
+#include "taichi/backends/cuda/cuda_profiler.h"
 #include "taichi/system/timeline.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -102,6 +103,12 @@ class DefaultProfiler : public KernelProfilerBase {
   void sync() override {
   }
 
+  void clear() override{
+    sync();
+    total_time_ms = 0;
+    records.clear();
+  }
+
   std::string title() const override {
     return title_;
   }
@@ -131,129 +138,15 @@ class DefaultProfiler : public KernelProfilerBase {
   std::string title_;
 };
 
-// A CUDA kernel profiler that uses CUDA timing events
-class KernelProfilerCUDA : public KernelProfilerBase {
- public:
-#if defined(TI_WITH_CUDA)
-
-  std::map<std::string, std::vector<std::pair<void *, void *>>>
-      outstanding_events;
-#endif
-
-  TaskHandle start_with_handle(const std::string &kernel_name) override {
-#if defined(TI_WITH_CUDA)
-    void *start, *stop;
-    CUDADriver::get_instance().event_create(&start, CU_EVENT_DEFAULT);
-    CUDADriver::get_instance().event_create(&stop, CU_EVENT_DEFAULT);
-    CUDADriver::get_instance().event_record(start, 0);
-    outstanding_events[kernel_name].push_back(std::make_pair(start, stop));
-
-    if (!base_event_) {
-      // Note that CUDA driver API only allows querying relative time difference
-      // between two events, therefore we need to manually build a mapping
-      // between GPU and CPU time.
-      // TODO: periodically reinitialize for more accuracy.
-      int n_iters = 100;
-      // Warm up CUDA driver, and use the final event as the base event.
-      for (int i = 0; i < n_iters; i++) {
-        void *e;
-        CUDADriver::get_instance().event_create(&e, CU_EVENT_DEFAULT);
-        CUDADriver::get_instance().event_record(e, 0);
-        CUDADriver::get_instance().event_synchronize(e);
-        auto final_t = Time::get_time();
-        if (i == n_iters - 1) {
-          base_event_ = e;
-          // TODO: figure out a better way to synchronize CPU and GPU time.
-          constexpr float64 cuda_time_offset = 3e-4;
-          // Since event recording and synchronization can take 5 us, it's hard
-          // to exactly measure the real event time. Also note there seems to be
-          // a systematic time offset on CUDA, so adjust for that using a 3e-4 s
-          // magic number.
-          base_time_ = final_t + cuda_time_offset;
-        } else {
-          CUDADriver::get_instance().event_destroy(e);
-        }
-      }
-    }
-
-    return stop;
-#else
-    TI_NOT_IMPLEMENTED;
-#endif
-  }
-
-  virtual void stop(TaskHandle handle) override {
-#if defined(TI_WITH_CUDA)
-    CUDADriver::get_instance().event_record(handle, 0);
-#else
-    TI_NOT_IMPLEMENTED;
-#endif
-  }
-
-  std::string title() const override {
-    return "CUDA Profiler";
-  }
-
-  void sync() override {
-#if defined(TI_WITH_CUDA)
-    CUDADriver::get_instance().stream_synchronize(nullptr);
-    auto &timeline = Timeline::get_this_thread_instance();
-    for (auto &map_elem : outstanding_events) {
-      auto &list = map_elem.second;
-      for (auto &item : list) {
-        auto start = item.first, stop = item.second;
-        float kernel_time;
-        CUDADriver::get_instance().event_elapsed_time(&kernel_time, start,
-                                                      stop);
-
-        if (Timelines::get_instance().get_enabled()) {
-          float time_since_base;
-          CUDADriver::get_instance().event_elapsed_time(&time_since_base,
-                                                        base_event_, start);
-          timeline.insert_event({map_elem.first, true,
-                                 base_time_ + time_since_base * 1e-3, "cuda"});
-          timeline.insert_event(
-              {map_elem.first, false,
-               base_time_ + (time_since_base + kernel_time) * 1e-3, "cuda"});
-        }
-
-        auto it = std::find_if(
-            records.begin(), records.end(),
-            [&](KernelProfileRecord &r) { return r.name == map_elem.first; });
-        if (it == records.end()) {
-          records.emplace_back(map_elem.first);
-          it = std::prev(records.end());
-        }
-        it->insert_sample(kernel_time);
-        total_time_ms += kernel_time;
-
-        // TODO: the following two lines seem to increases profiler overhead a
-        // little bit. Is there a way to avoid the overhead while not creating
-        // too many events?
-        CUDADriver::get_instance().event_destroy(start);
-        CUDADriver::get_instance().event_destroy(stop);
-      }
-    }
-    outstanding_events.clear();
-#else
-    printf("CUDA Profiler not implemented;\n");
-#endif
-  }
-
-  static KernelProfilerCUDA &get_instance() {
-    static KernelProfilerCUDA profiler;
-    return profiler;
-  }
-
- private:
-  void *base_event_{nullptr};
-  float64 base_time_;
-};
 }  // namespace
 
 std::unique_ptr<KernelProfilerBase> make_profiler(Arch arch) {
   if (arch == Arch::cuda) {
+#if defined(TI_WITH_CUDA)
     return std::make_unique<KernelProfilerCUDA>();
+#else
+    TI_NOT_IMPLEMENTED;
+#endif
   } else {
     return std::make_unique<DefaultProfiler>(arch);
   }

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -103,7 +103,7 @@ class DefaultProfiler : public KernelProfilerBase {
   void sync() override {
   }
 
-  void clear() override{
+  void clear() override {
     sync();
     total_time_ms = 0;
     records.clear();

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -37,11 +37,7 @@ class KernelProfilerBase {
   // Needed for the CUDA backend since we need to know which task to "stop"
   using TaskHandle = void *;
 
-  void clear() {
-    sync();
-    total_time_ms = 0;
-    records.clear();
-  }
+  virtual void clear() = 0;
 
   virtual void sync() = 0;
 
@@ -62,7 +58,11 @@ class KernelProfilerBase {
 
   static void profiler_stop(KernelProfilerBase *profiler);
 
-  void print();
+  virtual void print();
+
+  virtual void record(KernelProfilerBase::TaskHandle &task_handle,
+              const std::string &task_name){
+                TI_NOT_IMPLEMENTED};
 
   void query(const std::string &kernel_name,
              int &counter,

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -61,8 +61,7 @@ class KernelProfilerBase {
   virtual void print();
 
   virtual void record(KernelProfilerBase::TaskHandle &task_handle,
-              const std::string &task_name){
-                TI_NOT_IMPLEMENTED};
+                      const std::string &task_name){TI_NOT_IMPLEMENTED};
 
   void query(const std::string &kernel_name,
              int &counter,


### PR DESCRIPTION
Related issue = #

Move the backend-related class `KernelProfilerCUDA` 
from `program/kernelprofiler.cpp` to `backends/cuda/cuda_profiler.cpp` .

Keep back-end features from being exposed to `program/` 
Provide better encapsulation