### PR TITLE
[refactor] [CUDA] Add traced_records_ for KernelProfilerBase, refactoring KernelProfilerCUDA::sync()

### DIFF
--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -81,7 +81,7 @@ void KernelProfilerCUDA::sync() {
     CUDADriver::get_instance().event_destroy(record.start_event);
     CUDADriver::get_instance().event_destroy(record.stop_event);
 
-    //copy to traced_records_ then clear event_records_
+    // copy to traced_records_ then clear event_records_
     KernelProfileTracedRecord traced_record;
     traced_record.name = record.name;
     traced_record.kernel_elapsed_time_in_ms = record.kernel_elapsed_time_in_ms;
@@ -108,12 +108,12 @@ void KernelProfilerCUDA::sync() {
   if (Timelines::get_instance().get_enabled()) {
     auto &timeline = Timeline::get_this_thread_instance();
     for (auto &record : traced_records_) {
-      //param of insert_event() : 
-      //struct TimelineEvent @ taichi/taichi/system/timeline.h 
-      timeline.insert_event({record.name, /*param_name=begin*/true,
+      // param of insert_event() :
+      // struct TimelineEvent @ taichi/taichi/system/timeline.h
+      timeline.insert_event({record.name, /*param_name=begin*/ true,
                              base_time_ + record.time_since_base * 1e-3,
                              "cuda"});
-      timeline.insert_event({record.name, /*param_name=begin*/false,
+      timeline.insert_event({record.name, /*param_name=begin*/ false,
                              base_time_ + (record.time_since_base +
                                            record.kernel_elapsed_time_in_ms) *
                                               1e-3,

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -13,11 +13,14 @@ std::string KernelProfilerCUDA::title() const {
 
 KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(
     const std::string &kernel_name) {
-  void *start, *stop;
-  CUDADriver::get_instance().event_create(&start, CU_EVENT_DEFAULT);
-  CUDADriver::get_instance().event_create(&stop, CU_EVENT_DEFAULT);
-  CUDADriver::get_instance().event_record(start, 0);
-  outstanding_events_[kernel_name].push_back(std::make_pair(start, stop));
+  
+  CUDAEventRecord record;
+  record.name = kernel_name;
+  
+  CUDADriver::get_instance().event_create(&(record.start_event), CU_EVENT_DEFAULT);
+  CUDADriver::get_instance().event_create(&(record.stop_event), CU_EVENT_DEFAULT);
+  CUDADriver::get_instance().event_record((record.start_event), 0);
+  event_records_.push_back(record);
 
   if (!base_event_) {
     // Note that CUDA driver API only allows querying relative time difference
@@ -47,7 +50,7 @@ KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(
     }
   }
 
-  return stop;
+  return record.stop_event;
 }
 
 void KernelProfilerCUDA::stop(KernelProfilerBase::TaskHandle handle) {
@@ -60,44 +63,55 @@ void KernelProfilerCUDA::record(KernelProfilerBase::TaskHandle &task_handle,
 }
 
 void KernelProfilerCUDA::sync() {
+  
+  //sync
   CUDADriver::get_instance().stream_synchronize(nullptr);
-  auto &timeline = Timeline::get_this_thread_instance();
-  for (auto &map_elem : outstanding_events_) {
-    auto &list = map_elem.second;
-    for (auto &item : list) {
-      auto start = item.first, stop = item.second;
-      float kernel_time;
-      CUDADriver::get_instance().event_elapsed_time(&kernel_time, start, stop);
+  
+  //cuEvent : get traced kernel_elapsed_time
+  for (auto &record : event_records_) {
+    CUDADriver::get_instance().event_elapsed_time(&record.kernel_elapsed_time_in_ms, 
+                                                  record.start_event, record.stop_event); 
+    CUDADriver::get_instance().event_elapsed_time(&record.time_since_base, 
+                                                  base_event_, record.start_event);
+    
+    // TODO: the following two lines seem to increases profiler overhead a
+    // little bit. Is there a way to avoid the overhead while not creating
+    // too many events?
+    CUDADriver::get_instance().event_destroy(record.start_event);
+    CUDADriver::get_instance().event_destroy(record.stop_event);
 
-      if (Timelines::get_instance().get_enabled()) {
-        float time_since_base;
-        CUDADriver::get_instance().event_elapsed_time(&time_since_base,
-                                                      base_event_, start);
-        timeline.insert_event({map_elem.first, true,
-                               base_time_ + time_since_base * 1e-3, "cuda"});
-        timeline.insert_event(
-            {map_elem.first, false,
-             base_time_ + (time_since_base + kernel_time) * 1e-3, "cuda"});
-      }
+    KernelProfileTracedRecord traced_record;
+    traced_record.name = record.name;
+    traced_record.kernel_elapsed_time_in_ms = record.kernel_elapsed_time_in_ms;
+    traced_record.time_since_base = record.time_since_base;
+    traced_records_.push_back(traced_record);
+  }
 
-      auto it = std::find_if(
-          records.begin(), records.end(),
-          [&](KernelProfileRecord &r) { return r.name == map_elem.first; });
-      if (it == records.end()) {
-        records.emplace_back(map_elem.first);
-        it = std::prev(records.end());
-      }
-      it->insert_sample(kernel_time);
-      total_time_ms += kernel_time;
+  //statistics on traced_records_
+  for (auto &record : traced_records_){
+    auto it = std::find_if(
+        statistical_results_.begin(), statistical_results_.end(),
+        [&](KernelProfileStatisticalResult &result) {return result.name == record.name;});
+    if (it == statistical_results_.end()) {
+      statistical_results_.emplace_back(record.name);
+      it = std::prev(statistical_results_.end());
+    }
+    it->insert_record(record.kernel_elapsed_time_in_ms);
+    total_time_ms_ += record.kernel_elapsed_time_in_ms;
+  }
 
-      // TODO: the following two lines seem to increases profiler overhead a
-      // little bit. Is there a way to avoid the overhead while not creating
-      // too many events?
-      CUDADriver::get_instance().event_destroy(start);
-      CUDADriver::get_instance().event_destroy(stop);
+  //timeline
+  if (Timelines::get_instance().get_enabled()) {
+    auto &timeline = Timeline::get_this_thread_instance();
+    for (auto &record : traced_records_){
+      timeline.insert_event({record.name, true,
+                              base_time_ + record.time_since_base * 1e-3, "cuda"});
+      timeline.insert_event({record.name, false,
+                             base_time_ + (record.time_since_base + record.kernel_elapsed_time_in_ms) * 1e-3, "cuda"});
     }
   }
-  outstanding_events_.clear();
+
+  event_records_.clear();
 }
 
 void KernelProfilerCUDA::print() {
@@ -109,9 +123,9 @@ void KernelProfilerCUDA::print() {
   fmt::print(
       "[      %     total   count |      min       avg       max   ] Kernel "
       "name\n");
-  std::sort(records.begin(), records.end());
-  for (auto &rec : records) {
-    auto fraction = rec.total / total_time_ms * 100.0f;
+  std::sort(statistical_results_.begin(), statistical_results_.end());
+  for (auto &rec : statistical_results_) {
+    auto fraction = rec.total / total_time_ms_ * 100.0f;
     fmt::print("[{:6.2f}% {:7.3f} s {:6d}x |{:9.3f} {:9.3f} {:9.3f} ms] {}\n",
                fraction, rec.total / 1000.0f, rec.counter, rec.min,
                rec.total / rec.counter, rec.max, rec.name);
@@ -122,7 +136,7 @@ void KernelProfilerCUDA::print() {
   fmt::print(
       "[100.00%] Total kernel execution time: {:7.3f} s   number of records: "
       "{}\n",
-      get_total_time(), records.size());
+      get_total_time(), statistical_results_.size());
 
   fmt::print(
       "========================================================================"
@@ -131,8 +145,9 @@ void KernelProfilerCUDA::print() {
 
 void KernelProfilerCUDA::clear() {
   sync();
-  total_time_ms = 0;
-  records.clear();
+  total_time_ms_ = 0;
+  traced_records_.clear();
+  statistical_results_.clear();
 }
 
 #else

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -9,6 +9,14 @@
 
 TLANG_NAMESPACE_BEGIN
 
+struct CUDAEventRecord {
+  std::string name;
+  float kernel_elapsed_time_in_ms{0.0};
+  float time_since_base{0.0};
+  void *start_event{nullptr};
+  void *stop_event{nullptr};
+};
+
 // A CUDA kernel profiler that uses CUDA timing events
 class KernelProfilerCUDA : public KernelProfilerBase {
  public:
@@ -25,8 +33,8 @@ class KernelProfilerCUDA : public KernelProfilerBase {
  private:
   void *base_event_{nullptr};
   float64 base_time_{0.0};
-  std::map<std::string, std::vector<std::pair<void *, void *>>>
-      outstanding_events_;
+  //for cuEvent profiling, clear after sync()
+  std::vector<CUDAEventRecord> event_records_; 
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -33,8 +33,8 @@ class KernelProfilerCUDA : public KernelProfilerBase {
  private:
   void *base_event_{nullptr};
   float64 base_time_{0.0};
-  //for cuEvent profiling, clear after sync()
-  std::vector<CUDAEventRecord> event_records_; 
+  // for cuEvent profiling, clear after sync()
+  std::vector<CUDAEventRecord> event_records_;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -18,7 +18,8 @@ void KernelProfileStatisticalResult::insert_record(double t) {
   total += t;
 }
 
-bool KernelProfileStatisticalResult::operator<(const KernelProfileStatisticalResult &o) const {
+bool KernelProfileStatisticalResult::operator<(
+    const KernelProfileStatisticalResult &o) const {
   return total > o.total;
 }
 
@@ -122,9 +123,11 @@ class DefaultProfiler : public KernelProfilerBase {
   void stop() override {
     auto t = Time::get_time() - start_t_;
     auto ms = t * 1000.0;
-    auto it = std::find_if(
-        statistical_results_.begin(), statistical_results_.end(),
-        [&](KernelProfileStatisticalResult &r) { return r.name == event_name_; });
+    auto it =
+        std::find_if(statistical_results_.begin(), statistical_results_.end(),
+                     [&](KernelProfileStatisticalResult &r) {
+                       return r.name == event_name_;
+                     });
     if (it == statistical_results_.end()) {
       statistical_results_.emplace_back(event_name_);
       it = std::prev(statistical_results_.end());

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -7,7 +7,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
-void KernelProfileRecord::insert_sample(double t) {
+void KernelProfileStatisticalResult::insert_record(double t) {
   if (counter == 0) {
     min = t;
     max = t;
@@ -18,7 +18,7 @@ void KernelProfileRecord::insert_sample(double t) {
   total += t;
 }
 
-bool KernelProfileRecord::operator<(const KernelProfileRecord &o) const {
+bool KernelProfileStatisticalResult::operator<(const KernelProfileStatisticalResult &o) const {
   return total > o.total;
 }
 
@@ -42,9 +42,9 @@ void KernelProfilerBase::print() {
   fmt::print(
       "[      %     total   count |      min       avg       max   ] Kernel "
       "name\n");
-  std::sort(records.begin(), records.end());
-  for (auto &rec : records) {
-    auto fraction = rec.total / total_time_ms * 100.0f;
+  std::sort(statistical_results_.begin(), statistical_results_.end());
+  for (auto &rec : statistical_results_) {
+    auto fraction = rec.total / total_time_ms_ * 100.0f;
     fmt::print("[{:6.2f}% {:7.3f} s {:6d}x |{:9.3f} {:9.3f} {:9.3f} ms] {}\n",
                fraction, rec.total / 1000.0f, rec.counter, rec.min,
                rec.total / rec.counter, rec.max, rec.name);
@@ -55,7 +55,7 @@ void KernelProfilerBase::print() {
   fmt::print(
       "[100.00%] Total kernel execution time: {:7.3f} s   number of records: "
       "{}\n",
-      get_total_time(), records.size());
+      get_total_time(), statistical_results_.size());
 
   fmt::print(
       "========================================================================"
@@ -69,7 +69,7 @@ void KernelProfilerBase::query(const std::string &kernel_name,
                                double &avg) {
   sync();
   std::regex name_regex(kernel_name + "(.*)");
-  for (auto &rec : records) {
+  for (auto &rec : statistical_results_) {
     if (std::regex_match(rec.name, name_regex)) {
       if (counter == 0) {
         counter = rec.counter;
@@ -89,7 +89,7 @@ void KernelProfilerBase::query(const std::string &kernel_name,
 }
 
 double KernelProfilerBase::get_total_time() const {
-  return total_time_ms / 1000.0;
+  return total_time_ms_ / 1000.0;
 }
 
 namespace {
@@ -105,8 +105,9 @@ class DefaultProfiler : public KernelProfilerBase {
 
   void clear() override {
     sync();
-    total_time_ms = 0;
-    records.clear();
+    total_time_ms_ = 0;
+    traced_records_.clear();
+    statistical_results_.clear();
   }
 
   std::string title() const override {
@@ -122,14 +123,14 @@ class DefaultProfiler : public KernelProfilerBase {
     auto t = Time::get_time() - start_t_;
     auto ms = t * 1000.0;
     auto it = std::find_if(
-        records.begin(), records.end(),
-        [&](KernelProfileRecord &r) { return r.name == event_name_; });
-    if (it == records.end()) {
-      records.emplace_back(event_name_);
-      it = std::prev(records.end());
+        statistical_results_.begin(), statistical_results_.end(),
+        [&](KernelProfileStatisticalResult &r) { return r.name == event_name_; });
+    if (it == statistical_results_.end()) {
+      statistical_results_.emplace_back(event_name_);
+      it = std::prev(statistical_results_.end());
     }
-    it->insert_sample(ms);
-    total_time_ms += ms;
+    it->insert_record(ms);
+    total_time_ms_ += ms;
   }
 
  private:

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -15,7 +15,7 @@ TLANG_NAMESPACE_BEGIN
 struct KernelProfileTracedRecord {
   std::string name;
   float kernel_elapsed_time_in_ms{0.0};
-  float time_since_base{0.0}; //for Timeline
+  float time_since_base{0.0};  // for Timeline
 };
 
 struct KernelProfileStatisticalResult {
@@ -29,7 +29,8 @@ struct KernelProfileStatisticalResult {
       : name(name), counter(0), min(0), max(0), total(0) {
   }
 
-  void insert_record(double t); //TODO replace `double time` with `KernelProfileTracedRecord record`
+  void insert_record(double t);  // TODO replace `double time` with
+                                 // `KernelProfileTracedRecord record`
 
   bool operator<(const KernelProfileStatisticalResult &o) const;
 };

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -12,26 +12,33 @@
 
 TLANG_NAMESPACE_BEGIN
 
-struct KernelProfileRecord {
+struct KernelProfileTracedRecord {
+  std::string name;
+  float kernel_elapsed_time_in_ms{0.0};
+  float time_since_base{0.0}; //for Timeline
+};
+
+struct KernelProfileStatisticalResult {
   std::string name;
   int counter;
   double min;
   double max;
   double total;
 
-  KernelProfileRecord(const std::string &name)
+  KernelProfileStatisticalResult(const std::string &name)
       : name(name), counter(0), min(0), max(0), total(0) {
   }
 
-  void insert_sample(double t);
+  void insert_record(double t); //TODO replace `double time` with `KernelProfileTracedRecord record`
 
-  bool operator<(const KernelProfileRecord &o) const;
+  bool operator<(const KernelProfileStatisticalResult &o) const;
 };
 
 class KernelProfilerBase {
  protected:
-  std::vector<KernelProfileRecord> records;
-  double total_time_ms;
+  std::vector<KernelProfileTracedRecord> traced_records_;
+  std::vector<KernelProfileStatisticalResult> statistical_results_;
+  double total_time_ms_;
 
  public:
   // Needed for the CUDA backend since we need to know which task to "stop"

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -39,7 +39,7 @@ class KernelProfilerBase {
  protected:
   std::vector<KernelProfileTracedRecord> traced_records_;
   std::vector<KernelProfileStatisticalResult> statistical_results_;
-  double total_time_ms_;
+  double total_time_ms_{0};
 
  public:
   // Needed for the CUDA backend since we need to know which task to "stop"


### PR DESCRIPTION
Related issue = #2902

**Concisely describe the proposed feature**

Taichi counts profiling records and stores the results in `KernelProfileRecord` directly (StatisticalResult).
But didn't allocate space to store raw data (TracedRecord).

Code in `KernelProfilerCUDA::sync()` is somewhat complicated


**Describe the solution you'd like**

Add a new structure, `KernelProfileTracedRecord` to store traced records.
Rename the old structure from `KernelProfileRecord `to `KernelProfileStatisticalResult`

Decouple the code in `KernelProfilerCUDA::sync()` into 5 parts:
-  sync
-  get&store traced kernel_elapsed_time ( new feature )
-  statistics on traced_records_
-  code for Timelines
-  clear temporary records
