### PR TITLE
[Doc] Enable deploy preview if changes are detected in docs.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "git clone https://github.com/taichi-dev/docs.taichi.graphics.git; rm -rf docs.taichi.graphics/website/docs/lang; cp -rf docs/lang docs.taichi.graphics/website/docs/lang; cd docs.taichi.graphics/website; npm install --global yarn@1.22; yarn install; yarn build"
+
+  publish = "docs.taichi.graphics/website/build"
+
+  # Cancel the build if there're no changes detected in docs/ folder.
+  ignore = "git remote add upstream https://github.com/taichi-dev/taichi.git; git fetch upstream master; git diff --quiet $COMMIT_REF upstream/master -- docs/"
+


### PR DESCRIPTION
Worked with @rexwangcc together to set this up.
If files under docs are changed, this will build and preview the doc
site. Otherwiise it'll ignore the build.

Note this only covers the articles for now (not the api doc).

