### PR TITLE
[metal] Fix upperbound for list-gen and struct-for

### DIFF
--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -1181,7 +1181,8 @@ class KernelCodegenImpl : public IRVisitor {
     emit("const int child_num_slots = parent_meta.num_slots;");
     // Grid-stride loops:
     // Each thread begins at thread_index, and incremets by grid_size
-    emit("for (int ii = {};; ii += {}) {{", kKernelThreadIdName, kKernelGridSizeName);
+    emit("for (int ii = {};; ii += {}) {{", kKernelThreadIdName,
+         kKernelGridSizeName);
     {
       ScopedIndent s2(current_appender());
       emit("const int parent_idx_ = (ii / child_num_slots);");

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -1181,8 +1181,7 @@ class KernelCodegenImpl : public IRVisitor {
     emit("const int child_num_slots = parent_meta.num_slots;");
     // Grid-stride loops:
     // Each thread begins at thread_index, and incremets by grid_size
-    emit("for (int ii = {}; ii < {}; ii += {}) {{", kKernelThreadIdName,
-         total_num_elems_from_root, kKernelGridSizeName);
+    emit("for (int ii = {};; ii += {}) {{", kKernelThreadIdName, kKernelGridSizeName);
     {
       ScopedIndent s2(current_appender());
       emit("const int parent_idx_ = (ii / child_num_slots);");

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -268,11 +268,10 @@ class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
   };
 
   explicit ListgenOpMtlKernel(Params &params)
-      : SparseRuntimeMtlKernelBase(params, /*args_size=*/sizeof(int32_t) * 3) {
-    // For such Metal kernels, it always takes in an args buffer of 3 int32's:
+      : SparseRuntimeMtlKernelBase(params, /*args_size=*/sizeof(int32_t) * 2) {
+    // For such Metal kernels, it always takes in an args buffer of 2 int32's:
     // args[0] = parent_snode_id
     // args[1] = child_snode_id
-    // args[2] = child_snode.total_num_self_from_root
     // Note that this args buffer has nothing to do with the one passed to
     // Taichi kernel. See taichi/backends/metal/shaders/runtime_kernels.metal.h
     const int parent_snode_id = params.snode()->parent->id;
@@ -281,14 +280,12 @@ class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
     mem[0] = parent_snode_id;
     mem[1] = child_snode_id;
     const auto &sn_descs = *params.snode_descriptors;
-    mem[2] = total_num_self_from_root(sn_descs, child_snode_id);
     TI_DEBUG(
         "Registered ListgenOpMtlKernel: name={} num_threads={} "
         "parent_snode={} "
-        "child_snode={} max_num_elems={} ",
+        "child_snode={}",
         params.kernel_attribs->name,
-        params.kernel_attribs->advisory_total_num_threads, mem[0], mem[1],
-        mem[2]);
+        params.kernel_attribs->advisory_total_num_threads, mem[0], mem[1]);
     did_modify_range(args_buffer_.get(), /*location=*/0, args_mem_->size());
   }
 };
@@ -994,11 +991,18 @@ class KernelManager::Impl {
     wait_until_completed(cur_command_buffer_.get());
     create_new_command_buffer();
     profiler_->stop();
+
+    // print_runtime_debug();
   }
 
   void print_runtime_debug() {
     // If debugging is necessary, make sure this is called after
     // blit_buffers_and_sync().
+    int *root_base = reinterpret_cast<int *>(root_mem_->ptr());
+    for (int i = 0; i < 10; ++i) {
+      TI_INFO("root[{}]={}", i, root_base[i]);
+    }
+
     const auto &sn_descs = compiled_structs_.snode_descriptors;
     for (int i = 0; i < compiled_structs_.max_snodes; ++i) {
       auto iter = sn_descs.find(i);

--- a/taichi/backends/metal/shaders/runtime_kernels.metal.h
+++ b/taichi/backends/metal/shaders/runtime_kernels.metal.h
@@ -55,10 +55,10 @@ STR(
       const int child_stride = parent_meta.element_stride;
       const int num_slots = parent_meta.num_slots;
       const SNodeMeta child_meta = runtime->snode_metas[child_snode_id];
-      // |max_num_elems| is NOT padded to power-of-two, while |num_slots| is.
-      // So we need to cap the loop precisely at child's |max_num_elems|.
-      const int max_num_elems = args[2];
-      for (int ii = utid_; ii < max_num_elems; ii += grid_size) {
+      // No need to put an upperbound here (same for listgen and struct-for).
+      // Say the number of valid elements per child container is 5, which then
+      // gets padded to 8 (POT). is_active() knows how to properly skip those.
+      for (int ii = utid_;; ii += grid_size) {
         const int parent_idx = (ii / num_slots);
         if (parent_idx >= parent_list.num_active()) {
           // Since |parent_idx| increases monotonically, we can return directly

--- a/tests/python/test_bitmasked.py
+++ b/tests/python/test_bitmasked.py
@@ -271,7 +271,6 @@ def test_bitmasked_2d_power_of_two():
     def init():
         num_active[None] = 0
         for x, y in ti.ndrange(width, height):
-            ti.activate(ptr, [x, y])
             some_val[x, y] = 5
             num_active[None] += 1
 

--- a/tests/python/test_bitmasked.py
+++ b/tests/python/test_bitmasked.py
@@ -260,28 +260,28 @@ def test_bitmasked_offset_child():
 
 @ti.test(require=ti.extension.sparse)
 def test_bitmasked_2d_power_of_two():
-  some_val = ti.field(dtype=float)
-  width, height = 10, 10
-  total = width * height
-  ptr = ti.root.bitmasked(ti.ij, (width, height))
-  ptr.place(some_val)
-  num_active = ti.field(dtype=int, shape=())
+    some_val = ti.field(dtype=float)
+    width, height = 10, 10
+    total = width * height
+    ptr = ti.root.bitmasked(ti.ij, (width, height))
+    ptr.place(some_val)
+    num_active = ti.field(dtype=int, shape=())
 
-  @ti.kernel
-  def init():
-      num_active[None] = 0
-      for x, y in ti.ndrange(width, height):
-          ti.activate(ptr, [x, y])
-          some_val[x, y] = 5
-          num_active[None] += 1
+    @ti.kernel
+    def init():
+        num_active[None] = 0
+        for x, y in ti.ndrange(width, height):
+            ti.activate(ptr, [x, y])
+            some_val[x, y] = 5
+            num_active[None] += 1
 
-  @ti.kernel
-  def run():
-      num_active[None] = 0
-      for x, y in some_val:
-          num_active[None] += 1
+    @ti.kernel
+    def run():
+        num_active[None] = 0
+        for x, y in some_val:
+            num_active[None] += 1
 
-  init()
-  assert num_active[None] == total
-  run()
-  assert num_active[None] == total
+    init()
+    assert num_active[None] == total
+    run()
+    assert num_active[None] == total

--- a/tests/python/test_bitmasked.py
+++ b/tests/python/test_bitmasked.py
@@ -256,3 +256,32 @@ def test_bitmasked_offset_child():
 
     func()
     assert s[None] == 7
+
+
+@ti.test(require=ti.extension.sparse)
+def test_bitmasked_2d_power_of_two():
+  some_val = ti.field(dtype=float)
+  width, height = 10, 10
+  total = width * height
+  ptr = ti.root.bitmasked(ti.ij, (width, height))
+  ptr.place(some_val)
+  num_active = ti.field(dtype=int, shape=())
+
+  @ti.kernel
+  def init():
+      num_active[None] = 0
+      for x, y in ti.ndrange(width, height):
+          ti.activate(ptr, [x, y])
+          some_val[x, y] = 5
+          num_active[None] += 1
+
+  @ti.kernel
+  def run():
+      num_active[None] = 0
+      for x, y in some_val:
+          num_active[None] += 1
+
+  init()
+  assert num_active[None] == total
+  run()
+  assert num_active[None] == total

--- a/tests/python/test_struct_for_intermediate.py
+++ b/tests/python/test_struct_for_intermediate.py
@@ -22,7 +22,6 @@ def _test_nested():
 
 # TODO: remove excluding of ti.metal.
 @ti.test(require=ti.extension.sparse,
-         exclude=[ti.metal],
          demote_dense_struct_fors=False,
          packed=False)
 def test_nested():

--- a/tests/python/test_struct_for_intermediate.py
+++ b/tests/python/test_struct_for_intermediate.py
@@ -20,7 +20,6 @@ def _test_nested():
             assert x[i * n, j * m] == 1, (i, j)
 
 
-# TODO: remove excluding of ti.metal.
 @ti.test(require=ti.extension.sparse,
          demote_dense_struct_fors=False,
          packed=False)


### PR DESCRIPTION
Related issue = #2804 

## Repro

I will use a smaller example compared to #2804 , so that the entire runtime information can be analyzed easily.

```py
import taichi as ti

ti.init(arch=ti.metal, print_ir=True)

some_val = ti.field(dtype=int)
width, height = 2, 3
ptr = ti.root.bitmasked(ti.ij, (width, height))
ptr.place(some_val)
num_active = ti.field(dtype=int, shape=())

@ti.kernel
def init():
    num_active[None] = 0
    for x, y in ti.ndrange(width, height):
        # ti.activate(ptr, [x, y])
        some_val[x, y] = x * 3 + y
        num_active[None] += 1

@ti.kernel
def run():
    num_active[None] = 0
    for x, y in some_val:
        print('x=', x, 'y=', y)
        num_active[None] += 1
        

init()
print('num activated', num_active[None])
run()
print("active = ", num_active[None])
```

1. `init() `
`init()` iterates over a 2D range of `(width, height)`. Internally, this gets converted into a linearized 1D range of `width x height = 6`.

Here's the corresponding Metal source code Taichi has generated (with simplication):

```cpp
void mtl_k0001_init_c4_0_1_func(const int linear_loop_idx_) {
  std::cout << "linear_loop_idx_=" << linear_loop_idx_ << '\n';
  const int tmp5 = linear_loop_idx_;
  constexpr int32_t tmp6 = 3;
  const int32_t tmp111 = (tmp5 / tmp6);
  constexpr int32_t tmp112 = 0;
  const int32_t tmp113 = -(tmp5 < tmp112);
  const int32_t tmp115 = (tmp111 * tmp6);
  const int32_t tmp116 = -(tmp113 != tmp112);
  const int32_t tmp117 = -(tmp5 != tmp112);
  const int32_t tmp118 = -(tmp115 != tmp5);
  const int32_t tmp119 = (tmp116 & tmp117);
  const int32_t tmp120 = (tmp119 & tmp118);
  const int32_t tmp121 = (tmp111 + tmp120);
  const int32_t tmp8 = (tmp121 * tmp6);
  const int32_t tmp9 = (tmp5 - tmp8);
  const int32_t tmp10 = (tmp8 + tmp9);
  // S0 tmp93(root_addr);
  // S0_ch tmp95 = tmp93.children(tmp112);
  // S1 tmp96 = tmp95.get0(runtime_, mem_alloc_);
  // std::cout << "  S0.children tmp112=" << tmp112 << std::endl;
  constexpr int32_t tmp124 = 1;
  const int32_t tmp125 = (tmp121 & tmp124);
  const int32_t tmp129 = (tmp9 & tmp6);
  constexpr int32_t tmp149 = 2;
  const int32_t tmp150 = (tmp125 << tmp149);
  const int32_t tmp146 = (tmp129 + tmp150);
  // tmp96.activate(tmp146);
  std::cout << "  activate tmp146=" << tmp146 << std::endl;
  // S1_ch tmp100 = tmp96.children(tmp146);
  // device int32_t *tmp101 = tmp100.get0(runtime_, mem_alloc_).val;
  // *tmp101 = tmp10;
  // const auto tmp80 = *tmp75;
  // const int32_t tmp81 = (tmp80 + tmp124);
  // *tmp75 = tmp81;
}
```

Ignoring the quirk math details, `linear_loop_idx_` iterates over `[0, 6)`, whereas `tmp146` is the linearized index of `[x, y]`.

Running the above code in any language, there is a discrepancy between these two indices.

| `linear_loop_idx_` | 0 | 1 | 2 | 3 | 4 | 5 |
|--------------------|---|---|---|---|---|---|
| `tmp146`           | 0 | 1 | 2 | 4 | 5 | 6 |

Note that there are "holes" in `tmp146`.

The reason behind this is that `some_val`'s internal shape is not `(2, 3)`. Rather, it is padded to the power-of-two, `(2, 4)`. This ensures that each axis takes a known number of bits. When accessing an element via a 2-D coordinate, each component is bit-shifted and bit-or'ed together to form the linearized index. In this example:

- `some_val` : externally it is a 2-D field of shape `(2, 3)`. Internally it is `(2, 4)`, so the first axis takes 1 bit, and the second 2 bits.
- 2-D coordinate: Taking `(1, 2)` as an example. The x-component 1 is left shifted by 2 bits, which is then bit-or'ed with the y-component 2. Therefore the linearized coordinate is `(1 << 2) | 2 = 6`. If not padded, this should have been `1 * 3 + 2 = 5`.

| 0: [0, 0] | 1: [0, 1] | 2: [0, 2] | 3: INVALID |
|-----------|-----------|-----------|------------|
| 4: [1, 0] | 5: [1, 1] | 6: [1, 2] | 7: INVALID |

2. `run()`
`run()` iterates over the field `some_val` itself. This is called a *struct-for*. Because `some_val` is a sparse field, Taichi will need to iterate over all the activated coordinates of the 2x3 region.

Here's a snippet of the generated Metal source code:

```cpp
  for (int ii = utid_; ii < 6; ii += ugrid_size_) {  // Note the 6
    const int parent_idx_ = (ii / child_num_slots);
    if (parent_idx_ >= parent_list.num_active()) break;
    const int child_idx_ = (ii % child_num_slots);
    const auto parent_elem_ = parent_list.get<ListgenElement>(parent_idx_);
    device auto *parent_addr_ =
        mtl_lgen_snode_addr(parent_elem_, root_addr, runtime_, mem_alloc_);
    if (!is_active(parent_addr_, parent_meta, child_idx_)) continue;
    ElementCoords elem_coords_;
    refine_coordinates(parent_elem_.coords, runtime_->snode_extractors[1],
                       child_idx_, &elem_coords_);
    mtl_k0003_run_c6_0_2_func(root_addr, global_tmps_addr, runtime_addr,
                              print_assert_addr, elem_coords_, tls_buffer_, ii);
  }
```

Unfortunately, this upperbound `6` is not correct. According to the above table, this only iterates over [0, 0], [0, 1], [0, 2], INVALID, [1, 0] and [1, 1]. The correct upperbound is `8` in this case, and `is_active()` knows to skip the INVALID holes as well as the inactivated coordinates.

We can make it even simpler, by not putting an upperbound limit at all. It works because `parent_idx_ >= parent_list.num_active()` serves as a natural upperbound check.

This upperbound was once necessary (see the discussion in https://github.com/taichi-dev/taichi/pull/986#discussion_r427712872). How it worked back then was beyond my memory.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
