### PR TITLE
[refactor] [CUDA] Wrap the default profiling tool as EventToolkit , add a new class for CUPTI toolkit

### DIFF
--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -76,7 +76,7 @@ void CUDAContext::launch(void *func,
   KernelProfilerBase::TaskHandle task_handle;
   // Kernel launch
   if (profiler) {
-    profiler->record(task_handle, task_name);
+    profiler->trace(task_handle, task_name);
   }
 
   auto context_guard = CUDAContext::get_instance().get_guard();

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -1,95 +1,62 @@
 #include "taichi/backends/cuda/cuda_profiler.h"
 #include "taichi/backends/cuda/cuda_driver.h"
 #include "taichi/backends/cuda/cuda_context.h"
-#include "taichi/system/timeline.h"
 
 TLANG_NAMESPACE_BEGIN
 
 #if defined(TI_WITH_CUDA)
 
-std::string KernelProfilerCUDA::title() const {
-  return "CUDA Profiler";
+bool check_device_capability(){
+  void *device;
+  int cc_major;
+  CUDADriver::get_instance().device_get(&device, 0);
+  CUDADriver::get_instance().device_get_attribute(
+      &cc_major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device);
+  if(cc_major<7){
+    TI_WARN("CUPTI profiler APIs unsupported on Device with compute capability < 7.0 , fallback to default kernel profiler");
+    return false;
+  }
+  return true;
 }
 
+KernelProfilerCUDA::KernelProfilerCUDA(){
+
+// if Taichi was compiled with CUDA toolit, then use CUPTI
+// TODO : add set_mode() to select toolkit by user
+#if defined(TI_WITH_CUDA_TOOLKIT)
+  if(check_device_capability())
+    tool_ = ProfilingToolkit::cupti;
+#endif
+
+  if(tool_ == ProfilingToolkit::event){
+    event_toolkit_ = std::make_unique<EventToolkit>();
+  }
+  else if(tool_ == ProfilingToolkit::cupti){
+    cupti_toolkit_ = std::make_unique<CuptiToolkit>();
+  }
+}
+
+//deprecated, move to trace()
 KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(
     const std::string &kernel_name) {
-  CUDAEventRecord record;
-  record.name = kernel_name;
+  TI_NOT_IMPLEMENTED;
+}
 
-  CUDADriver::get_instance().event_create(&(record.start_event),
-                                          CU_EVENT_DEFAULT);
-  CUDADriver::get_instance().event_create(&(record.stop_event),
-                                          CU_EVENT_DEFAULT);
-  CUDADriver::get_instance().event_record((record.start_event), 0);
-  event_records_.push_back(record);
-
-  if (!base_event_) {
-    // Note that CUDA driver API only allows querying relative time difference
-    // between two events, therefore we need to manually build a mapping
-    // between GPU and CPU time.
-    // TODO: periodically reinitialize for more accuracy.
-    int n_iters = 100;
-    // Warm up CUDA driver, and use the final event as the base event.
-    for (int i = 0; i < n_iters; i++) {
-      void *e;
-      CUDADriver::get_instance().event_create(&e, CU_EVENT_DEFAULT);
-      CUDADriver::get_instance().event_record(e, 0);
-      CUDADriver::get_instance().event_synchronize(e);
-      auto final_t = Time::get_time();
-      if (i == n_iters - 1) {
-        base_event_ = e;
-        // TODO: figure out a better way to synchronize CPU and GPU time.
-        constexpr float64 cuda_time_offset = 3e-4;
-        // Since event recording and synchronization can take 5 us, it's hard
-        // to exactly measure the real event time. Also note there seems to be
-        // a systematic time offset on CUDA, so adjust for that using a 3e-4 s
-        // magic number.
-        base_time_ = final_t + cuda_time_offset;
-      } else {
-        CUDADriver::get_instance().event_destroy(e);
-      }
-    }
+void KernelProfilerCUDA::trace(KernelProfilerBase::TaskHandle &task_handle,
+                                const std::string &task_name) {
+  if(tool_ == ProfilingToolkit::event)
+    task_handle = event_toolkit_->start_with_handle(task_name);
+  else if(tool_ == ProfilingToolkit::cupti){
+    TI_NOT_IMPLEMENTED;
   }
-
-  return record.stop_event;
 }
 
 void KernelProfilerCUDA::stop(KernelProfilerBase::TaskHandle handle) {
-  CUDADriver::get_instance().event_record(handle, 0);
+  if(tool_ == ProfilingToolkit::event)
+    CUDADriver::get_instance().event_record(handle, 0);
 }
 
-void KernelProfilerCUDA::record(KernelProfilerBase::TaskHandle &task_handle,
-                                const std::string &task_name) {
-  task_handle = this->start_with_handle(task_name);
-}
-
-void KernelProfilerCUDA::sync() {
-  // sync
-  CUDADriver::get_instance().stream_synchronize(nullptr);
-
-  // cuEvent : get kernel_elapsed_time
-  for (auto &record : event_records_) {
-    CUDADriver::get_instance().event_elapsed_time(
-        &record.kernel_elapsed_time_in_ms, record.start_event,
-        record.stop_event);
-    CUDADriver::get_instance().event_elapsed_time(
-        &record.time_since_base, base_event_, record.start_event);
-
-    // TODO: the following two lines seem to increases profiler overhead a
-    // little bit. Is there a way to avoid the overhead while not creating
-    // too many events?
-    CUDADriver::get_instance().event_destroy(record.start_event);
-    CUDADriver::get_instance().event_destroy(record.stop_event);
-
-    // copy to traced_records_ then clear event_records_
-    KernelProfileTracedRecord traced_record;
-    traced_record.name = record.name;
-    traced_record.kernel_elapsed_time_in_ms = record.kernel_elapsed_time_in_ms;
-    traced_record.time_since_base = record.time_since_base;
-    traced_records_.push_back(traced_record);
-  }
-
-  // statistics on traced_records_
+bool KernelProfilerCUDA::statistics_on_traced_records() {
   for (auto &record : traced_records_) {
     auto it =
         std::find_if(statistical_results_.begin(), statistical_results_.end(),
@@ -104,24 +71,28 @@ void KernelProfilerCUDA::sync() {
     total_time_ms_ += record.kernel_elapsed_time_in_ms;
   }
 
-  // timeline
-  if (Timelines::get_instance().get_enabled()) {
-    auto &timeline = Timeline::get_this_thread_instance();
-    for (auto &record : traced_records_) {
-      // param of insert_event() :
-      // struct TimelineEvent @ taichi/taichi/system/timeline.h
-      timeline.insert_event({record.name, /*param_name=begin*/ true,
-                             base_time_ + record.time_since_base * 1e-3,
-                             "cuda"});
-      timeline.insert_event({record.name, /*param_name=begin*/ false,
-                             base_time_ + (record.time_since_base +
-                                           record.kernel_elapsed_time_in_ms) *
-                                              1e-3,
-                             "cuda"});
-    }
-  }
+  return true;
+}
 
-  event_records_.clear();
+void KernelProfilerCUDA::sync() {
+  // sync
+  CUDADriver::get_instance().stream_synchronize(nullptr);
+
+  //update
+  if(tool_ == ProfilingToolkit::event){
+     event_toolkit_->update_record(traced_records_);
+     event_toolkit_->update_timeline(traced_records_);
+     statistics_on_traced_records();
+     event_toolkit_->clear();
+  }
+  else if(tool_ == ProfilingToolkit::cupti){
+    cupti_toolkit_->calculate_metric_values();
+    statistics_on_traced_records();
+    cupti_toolkit_->end_profiling();
+    cupti_toolkit_->deinit_cupti();//reinit is nessasary to get accurate  result
+    cupti_toolkit_->init_cupti();//data image will be cleared
+    cupti_toolkit_->begin_profiling();
+  }
 }
 
 void KernelProfilerCUDA::print() {
@@ -162,14 +133,14 @@ void KernelProfilerCUDA::clear() {
 
 #else
 
-std::string KernelProfilerCUDA::title() const {
+KernelProfilerCUDA::KernelProfilerCUDA(){
   TI_NOT_IMPLEMENTED;
 }
 KernelProfilerBase::TaskHandle KernelProfilerCUDA::start_with_handle(
     const std::string &kernel_name) {
   TI_NOT_IMPLEMENTED;
 }
-void KernelProfilerCUDA::record(KernelProfilerBase::TaskHandle &task_handle,
+void KernelProfilerCUDA::trace(KernelProfilerBase::TaskHandle &task_handle,
                                 const std::string &task_name) {
   TI_NOT_IMPLEMENTED;
 }
@@ -183,6 +154,107 @@ void KernelProfilerCUDA::clear() {
   TI_NOT_IMPLEMENTED;
 }
 
+#endif
+
+//default profiling toolkit : cuEvent
+//for now put it together with KernelProfilerCUDA
+#if defined(TI_WITH_CUDA)
+KernelProfilerBase::TaskHandle EventToolkit::start_with_handle(
+    const std::string &kernel_name) {
+  EventRecord record;
+  record.name = kernel_name;
+
+  CUDADriver::get_instance().event_create(&(record.start_event),
+                                          CU_EVENT_DEFAULT);
+  CUDADriver::get_instance().event_create(&(record.stop_event),
+                                          CU_EVENT_DEFAULT);
+  CUDADriver::get_instance().event_record((record.start_event), 0);
+  event_records_.push_back(record);
+
+  if (!base_event_) {
+    // Note that CUDA driver API only allows querying relative time difference
+    // between two events, therefore we need to manually build a mapping
+    // between GPU and CPU time.
+    // TODO: periodically reinitialize for more accuracy.
+    int n_iters = 100;
+    // Warm up CUDA driver, and use the final event as the base event.
+    for (int i = 0; i < n_iters; i++) {
+      void *e;
+      CUDADriver::get_instance().event_create(&e, CU_EVENT_DEFAULT);
+      CUDADriver::get_instance().event_record(e, 0);
+      CUDADriver::get_instance().event_synchronize(e);
+      auto final_t = Time::get_time();
+      if (i == n_iters - 1) {
+        base_event_ = e;
+        // TODO: figure out a better way to synchronize CPU and GPU time.
+        constexpr float64 cuda_time_offset = 3e-4;
+        // Since event recording and synchronization can take 5 us, it's hard
+        // to exactly measure the real event time. Also note there seems to be
+        // a systematic time offset on CUDA, so adjust for that using a 3e-4 s
+        // magic number.
+        base_time_ = final_t + cuda_time_offset;
+      } else {
+        CUDADriver::get_instance().event_destroy(e);
+      }
+    }
+  }
+
+  return record.stop_event;
+}
+
+void EventToolkit::update_record(std::vector<KernelProfileTracedRecord> &traced_records){
+  // cuEvent : get kernel_elapsed_time
+  for (auto &record : event_records_) {
+    CUDADriver::get_instance().event_elapsed_time(
+      &record.kernel_elapsed_time_in_ms, record.start_event,
+      record.stop_event);
+    CUDADriver::get_instance().event_elapsed_time(
+      &record.time_since_base, base_event_, record.start_event);
+
+    // TODO: the following two lines seem to increases profiler overhead a
+    // little bit. Is there a way to avoid the overhead while not creating
+    // too many events?
+    CUDADriver::get_instance().event_destroy(record.start_event);
+    CUDADriver::get_instance().event_destroy(record.stop_event);
+
+    // copy to traced_records_ then clear event_records_
+    KernelProfileTracedRecord traced_record;
+    traced_record.name = record.name;
+    traced_record.kernel_elapsed_time_in_ms = record.kernel_elapsed_time_in_ms;
+    traced_record.time_since_base = record.time_since_base;
+    traced_records.push_back(traced_record);
+  }
+}
+
+void EventToolkit::update_timeline(std::vector<KernelProfileTracedRecord> &traced_records){
+  if(Timelines::get_instance().get_enabled()){
+    auto &timeline = Timeline::get_this_thread_instance();
+    for (auto &record : traced_records) {
+      // param of insert_event() :
+      // struct TimelineEvent @ taichi/taichi/system/timeline.h
+      timeline.insert_event({record.name, /*param_name=begin*/ true,
+                            base_time_ + record.time_since_base * 1e-3,
+                            "cuda"});
+      timeline.insert_event({record.name, /*param_name=begin*/ false,
+                            base_time_ + (record.time_since_base +
+                                          record.kernel_elapsed_time_in_ms) *
+                                              1e-3,
+                            "cuda"});
+    }
+  }
+}
+
+#else
+KernelProfilerBase::TaskHandle EventToolkit::start_with_handle(
+    const std::string &kernel_name) {
+  TI_NOT_IMPLEMENTED;
+}
+void EventToolkit::update_record(std::vector<KernelProfileTracedRecord> &traced_records){
+  TI_NOT_IMPLEMENTED;
+}
+void EventToolkit::update_timeline(std::vector<KernelProfileTracedRecord> &traced_records){
+  TI_NOT_IMPLEMENTED;
+}
 #endif
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -88,7 +88,7 @@ void KernelProfilerCUDA::sync() {
     cupti_toolkit_->calculate_metric_values();
     statistics_on_traced_records();
     cupti_toolkit_->end_profiling();
-    cupti_toolkit_->deinit_cupti();  
+    cupti_toolkit_->deinit_cupti();
     // reinit is necessary to get accurate  result
     cupti_toolkit_->init_cupti();  // data image will be cleared
     cupti_toolkit_->begin_profiling();

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -21,6 +21,8 @@ bool check_device_capability() {
   return true;
 }
 
+//The init logic here is temporarily set up for test CUPTI
+//will not affect default toolkit (cuEvent)
 KernelProfilerCUDA::KernelProfilerCUDA() {
 // if Taichi was compiled with CUDA toolit, then use CUPTI
 // TODO : add set_mode() to select toolkit by user

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -88,8 +88,8 @@ void KernelProfilerCUDA::sync() {
     cupti_toolkit_->calculate_metric_values();
     statistics_on_traced_records();
     cupti_toolkit_->end_profiling();
-    cupti_toolkit_
-        ->deinit_cupti();  // reinit is nessasary to get accurate  result
+    cupti_toolkit_->deinit_cupti();  
+    // reinit is necessary to get accurate  result
     cupti_toolkit_->init_cupti();  // data image will be cleared
     cupti_toolkit_->begin_profiling();
   }

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -21,8 +21,8 @@ bool check_device_capability() {
   return true;
 }
 
-//The init logic here is temporarily set up for test CUPTI
-//will not affect default toolkit (cuEvent)
+// The init logic here is temporarily set up for test CUPTI
+// will not affect default toolkit (cuEvent)
 KernelProfilerCUDA::KernelProfilerCUDA() {
 // if Taichi was compiled with CUDA toolit, then use CUPTI
 // TODO : add set_mode() to select toolkit by user

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -1,40 +1,73 @@
 #pragma once
 
+#include "taichi/system/timeline.h"
 #include "taichi/program/kernel_profiler.h"
 #include "taichi/backends/cuda/cuda_driver.h"
 #include "taichi/backends/cuda/cuda_context.h"
+#include "taichi/backends/cuda/cupti_toolkit.h"
 
 #include <string>
 #include <stdint.h>
 
 TLANG_NAMESPACE_BEGIN
 
-struct CUDAEventRecord {
-  std::string name;
-  float kernel_elapsed_time_in_ms{0.0};
-  float time_since_base{0.0};
-  void *start_event{nullptr};
-  void *stop_event{nullptr};
+enum class ProfilingToolkit : int{
+    event,
+    cupti,
 };
 
-// A CUDA kernel profiler that uses CUDA timing events
+class EventToolkit;
+
+// A CUDA kernel profiler
 class KernelProfilerCUDA : public KernelProfilerBase {
  public:
-  std::string title() const override;
-  KernelProfilerBase::TaskHandle start_with_handle(
-      const std::string &kernel_name) override;
-  void record(KernelProfilerBase::TaskHandle &task_handle,
+  KernelProfilerCUDA();
+  std::string title() const override{
+    return "CUDA Profiler";
+  }
+  
+  void trace(KernelProfilerBase::TaskHandle &task_handle,
               const std::string &task_name) override;
   void sync() override;
   void print() override;
   void clear() override;
   void stop(KernelProfilerBase::TaskHandle handle) override;
 
+  bool statistics_on_traced_records();
+
+  KernelProfilerBase::TaskHandle start_with_handle(
+    const std::string &kernel_name) override;
+
  private:
-  void *base_event_{nullptr};
-  float64 base_time_{0.0};
-  // for cuEvent profiling, clear after sync()
-  std::vector<CUDAEventRecord> event_records_;
+  ProfilingToolkit tool_ = ProfilingToolkit::event;
+  std::unique_ptr<EventToolkit> event_toolkit_{nullptr};
+  std::unique_ptr<CuptiToolkit> cupti_toolkit_{nullptr};
 };
+
+
+//default profiling toolkit
+class EventToolkit{
+public:
+
+  void update_record(std::vector<KernelProfileTracedRecord> &traced_records);
+  KernelProfilerBase::TaskHandle start_with_handle(
+      const std::string &kernel_name);
+  void update_timeline(std::vector<KernelProfileTracedRecord> &traced_records);
+  void clear(){event_records_.clear();}
+
+private:
+  struct EventRecord {
+    std::string name;
+    float kernel_elapsed_time_in_ms{0.0};
+    float time_since_base{0.0};
+    void *start_event{nullptr};
+    void *stop_event{nullptr};
+  };
+  float64 base_time_{0.0};
+  void *base_event_{nullptr};
+  // for cuEvent profiling, clear after sync()
+  std::vector<EventRecord> event_records_;
+};
+
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -40,11 +40,11 @@ class KernelProfilerCUDA : public KernelProfilerBase {
 
  private:
   ProfilingToolkit tool_ = ProfilingToolkit::event;
-  std::unique_ptr<EventToolkit> event_toolkit_{nullptr}; 
-  //if(tool_ == ProfilingToolkit::cupti) event_toolkit_ = nullptr
-  std::unique_ptr<CuptiToolkit> cupti_toolkit_{nullptr}; 
-  //if(tool_ == ProfilingToolkit::event) cupti_toolkit_ = nullptr
-  //TODO : switch profiling toolkit at runtime
+  std::unique_ptr<EventToolkit> event_toolkit_{nullptr};
+  // if(tool_ == ProfilingToolkit::cupti) event_toolkit_ = nullptr
+  std::unique_ptr<CuptiToolkit> cupti_toolkit_{nullptr};
+  // if(tool_ == ProfilingToolkit::event) cupti_toolkit_ = nullptr
+  // TODO : switch profiling toolkit at runtime
 };
 
 // default profiling toolkit

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -40,8 +40,11 @@ class KernelProfilerCUDA : public KernelProfilerBase {
 
  private:
   ProfilingToolkit tool_ = ProfilingToolkit::event;
-  std::unique_ptr<EventToolkit> event_toolkit_{nullptr};
-  std::unique_ptr<CuptiToolkit> cupti_toolkit_{nullptr};
+  std::unique_ptr<EventToolkit> event_toolkit_{nullptr}; 
+  //if(tool_ == ProfilingToolkit::cupti) event_toolkit_ = nullptr
+  std::unique_ptr<CuptiToolkit> cupti_toolkit_{nullptr}; 
+  //if(tool_ == ProfilingToolkit::event) cupti_toolkit_ = nullptr
+  //TODO : switch profiling toolkit at runtime
 };
 
 // default profiling toolkit

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -11,9 +11,9 @@
 
 TLANG_NAMESPACE_BEGIN
 
-enum class ProfilingToolkit : int{
-    event,
-    cupti,
+enum class ProfilingToolkit : int {
+  event,
+  cupti,
 };
 
 class EventToolkit;
@@ -22,12 +22,12 @@ class EventToolkit;
 class KernelProfilerCUDA : public KernelProfilerBase {
  public:
   KernelProfilerCUDA();
-  std::string title() const override{
+  std::string title() const override {
     return "CUDA Profiler";
   }
-  
+
   void trace(KernelProfilerBase::TaskHandle &task_handle,
-              const std::string &task_name) override;
+             const std::string &task_name) override;
   void sync() override;
   void print() override;
   void clear() override;
@@ -36,7 +36,7 @@ class KernelProfilerCUDA : public KernelProfilerBase {
   bool statistics_on_traced_records();
 
   KernelProfilerBase::TaskHandle start_with_handle(
-    const std::string &kernel_name) override;
+      const std::string &kernel_name) override;
 
  private:
   ProfilingToolkit tool_ = ProfilingToolkit::event;
@@ -44,18 +44,18 @@ class KernelProfilerCUDA : public KernelProfilerBase {
   std::unique_ptr<CuptiToolkit> cupti_toolkit_{nullptr};
 };
 
-
-//default profiling toolkit
-class EventToolkit{
-public:
-
+// default profiling toolkit
+class EventToolkit {
+ public:
   void update_record(std::vector<KernelProfileTracedRecord> &traced_records);
   KernelProfilerBase::TaskHandle start_with_handle(
       const std::string &kernel_name);
   void update_timeline(std::vector<KernelProfileTracedRecord> &traced_records);
-  void clear(){event_records_.clear();}
+  void clear() {
+    event_records_.clear();
+  }
 
-private:
+ private:
   struct EventRecord {
     std::string name;
     float kernel_elapsed_time_in_ms{0.0};
@@ -68,6 +68,5 @@ private:
   // for cuEvent profiling, clear after sync()
   std::vector<EventRecord> event_records_;
 };
-
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cupti_toolkit.cpp
+++ b/taichi/backends/cuda/cupti_toolkit.cpp
@@ -15,7 +15,7 @@ CuptiToolkit::~CuptiToolkit() {
   deinit_cupti();
 }
 
-//TODO Next PR
+// TODO Next PR
 bool CuptiToolkit::init_cupti() {
   return false;
 }
@@ -31,6 +31,5 @@ bool CuptiToolkit::deinit_cupti() {
 bool CuptiToolkit::calculate_metric_values() {
   return false;
 }
-
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cupti_toolkit.cpp
+++ b/taichi/backends/cuda/cupti_toolkit.cpp
@@ -1,0 +1,36 @@
+#include "taichi/backends/cuda/cupti_toolkit.h"
+
+TLANG_NAMESPACE_BEGIN
+
+void CuptiToolkit::set_enbale() {
+  cupti_config_.enable = true;
+}
+
+CuptiToolkit::CuptiToolkit() {
+  TI_TRACE("CuptiToolkit::CuptiToolkit() ");
+}
+
+CuptiToolkit::~CuptiToolkit() {
+  end_profiling();
+  deinit_cupti();
+}
+
+//TODO Next PR
+bool CuptiToolkit::init_cupti() {
+  return false;
+}
+bool CuptiToolkit::begin_profiling() {
+  return false;
+}
+bool CuptiToolkit::end_profiling() {
+  return false;
+}
+bool CuptiToolkit::deinit_cupti() {
+  return false;
+}
+bool CuptiToolkit::calculate_metric_values() {
+  return false;
+}
+
+
+TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cupti_toolkit.cpp
+++ b/taichi/backends/cuda/cupti_toolkit.cpp
@@ -2,7 +2,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
-void CuptiToolkit::set_enbale() {
+void CuptiToolkit::set_enable() {
   cupti_config_.enable = true;
 }
 

--- a/taichi/backends/cuda/cupti_toolkit.h
+++ b/taichi/backends/cuda/cupti_toolkit.h
@@ -32,7 +32,7 @@ class CuptiToolkit {
   CuptiToolkit();
   ~CuptiToolkit();
 
-  void set_enbale();
+  void set_enable();
 
   bool init_cupti();
   bool deinit_cupti();

--- a/taichi/backends/cuda/cupti_toolkit.h
+++ b/taichi/backends/cuda/cupti_toolkit.h
@@ -9,7 +9,7 @@
 TLANG_NAMESPACE_BEGIN
 
 struct CuptiConfig {
-  bool enable;
+  bool enable = false;
 #if defined(TI_WITH_CUDA_TOOLKIT)
   uint32_t num_ranges = 16384;  // max number of kernels traced by CUPTI
   std::vector<std::string> metric_list;

--- a/taichi/backends/cuda/cupti_toolkit.h
+++ b/taichi/backends/cuda/cupti_toolkit.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// #include "taichi/backends/cuda/cuda_profiler.h"
+#include "taichi/common/core.h"
+
+#include <string>
+#include <stdint.h>
+
+TLANG_NAMESPACE_BEGIN
+
+struct CuptiConfig {
+  bool enable;
+#if defined(TI_WITH_CUDA_TOOLKIT)
+  uint32_t num_ranges = 16384;  // max number of kernels traced by CUPTI
+  std::vector<std::string> metric_list;
+  // CUpti_ProfilerRange profiler_range = CUPTI_AutoRange;
+  // CUpti_ProfilerReplayMode profiler_replay_mode = CUPTI_KernelReplay;
+#endif
+};
+
+struct CuptiImage {
+  std::string chip_name;
+  std::vector<uint8_t> config_image;
+  std::vector<uint8_t> counter_availability_image;
+  std::vector<uint8_t> counter_data_scratch_buffer;
+  std::vector<uint8_t> counter_data_image_prefix;
+  std::vector<uint8_t> counter_data_image;
+};
+
+class CuptiToolkit {
+ public:
+  CuptiToolkit();
+  ~CuptiToolkit();
+
+  void set_enbale();
+
+  bool init_cupti();
+  bool deinit_cupti();
+  bool begin_profiling();
+  bool end_profiling();
+  bool calculate_metric_values();
+
+ private:
+  CuptiConfig cupti_config_;
+  CuptiImage cupti_image_;
+};
+
+TLANG_NAMESPACE_END

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -68,7 +68,7 @@ class KernelProfilerBase {
 
   virtual void print();
 
-  virtual void record(KernelProfilerBase::TaskHandle &task_handle,
+  virtual void trace(KernelProfilerBase::TaskHandle &task_handle,
                       const std::string &task_name){TI_NOT_IMPLEMENTED};
 
   void query(const std::string &kernel_name,

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -69,7 +69,7 @@ class KernelProfilerBase {
   virtual void print();
 
   virtual void trace(KernelProfilerBase::TaskHandle &task_handle,
-                      const std::string &task_name){TI_NOT_IMPLEMENTED};
+                     const std::string &task_name){TI_NOT_IMPLEMENTED};
 
   void query(const std::string &kernel_name,
              int &counter,


### PR DESCRIPTION
Related issue = #2909 #2902

The implementation of CuptiToolkit will be added in the next PR.

The code in sync() is now more abstract:
```
void KernelProfilerCUDA::sync() {
  // sync
  CUDADriver::get_instance().stream_synchronize(nullptr);

  // update
  if (tool_ == ProfilingToolkit::event) {
    event_toolkit_->update_record(traced_records_);
    event_toolkit_->update_timeline(traced_records_);
    statistics_on_traced_records();
    event_toolkit_->clear();
  } else if (tool_ == ProfilingToolkit::cupti) {
    cupti_toolkit_->calculate_metric_values();
    statistics_on_traced_records();
    cupti_toolkit_->end_profiling();
    cupti_toolkit_->deinit_cupti();  
    // reinit is necessary to get accurate  result
    cupti_toolkit_->init_cupti();  // data image will be cleared
    cupti_toolkit_->begin_profiling();
  }
}
```
