### PR TITLE
[llvm] Remove duplicated set dim attribute for GlobalVariableExpression in LLVM

### DIFF
--- a/taichi/backends/metal/metal_program.cpp
+++ b/taichi/backends/metal/metal_program.cpp
@@ -39,7 +39,6 @@ void MetalProgramImpl::materialize_snode_tree(
     SNodeTree *tree,
     std::vector<std::unique_ptr<SNodeTree>> &,
     std::unordered_map<int, SNode *> &,
-    SNodeGlobalVarExprMap &,
     uint64 *result_buffer) {
   // TODO: support materializing multiple snode trees
   TI_ASSERT_INFO(config->use_llvm,

--- a/taichi/backends/metal/metal_program.h
+++ b/taichi/backends/metal/metal_program.h
@@ -29,7 +29,6 @@ class MetalProgramImpl : public ProgramImpl {
       SNodeTree *tree,
       std::vector<std::unique_ptr<SNodeTree>> &snode_trees_,
       std::unordered_map<int, SNode *> &snodes,
-      SNodeGlobalVarExprMap &snode_to_glb_var_exprs_,
       uint64 *result_buffer) override;
 
   void synchronize() override {

--- a/taichi/backends/opengl/opengl_program.cpp
+++ b/taichi/backends/opengl/opengl_program.cpp
@@ -25,7 +25,6 @@ void OpenglProgramImpl::materialize_snode_tree(
     SNodeTree *tree,
     std::vector<std::unique_ptr<SNodeTree>> &,
     std::unordered_map<int, SNode *> &,
-    SNodeGlobalVarExprMap &,
     uint64 *result_buffer) {
   // TODO: support materializing multiple snode trees
   auto *const root = tree->root();

--- a/taichi/backends/opengl/opengl_program.h
+++ b/taichi/backends/opengl/opengl_program.h
@@ -36,7 +36,6 @@ class OpenglProgramImpl : public ProgramImpl {
       SNodeTree *tree,
       std::vector<std::unique_ptr<SNodeTree>> &snode_trees_,
       std::unordered_map<int, SNode *> &snodes,
-      SNodeGlobalVarExprMap &snode_to_glb_var_exprs_,
       uint64 *result_buffer) override;
 
   void synchronize() override {

--- a/taichi/backends/vulkan/vulkan_program.cpp
+++ b/taichi/backends/vulkan/vulkan_program.cpp
@@ -25,7 +25,6 @@ void VulkanProgramImpl::materialize_snode_tree(
     SNodeTree *tree,
     std::vector<std::unique_ptr<SNodeTree>> &,
     std::unordered_map<int, SNode *> &,
-    SNodeGlobalVarExprMap &,
     uint64 *result_buffer) {
   // TODO: support materializing multiple snode trees
   vulkan_runtime_->materialize_snode_tree(tree);

--- a/taichi/backends/vulkan/vulkan_program.h
+++ b/taichi/backends/vulkan/vulkan_program.h
@@ -31,7 +31,6 @@ class VulkanProgramImpl : public ProgramImpl {
   void materialize_snode_tree(SNodeTree *tree,
                               std::vector<std::unique_ptr<SNodeTree>> &,
                               std::unordered_map<int, SNode *> &,
-                              SNodeGlobalVarExprMap &,
                               uint64 *result_buffer) override;
 
   void synchronize() override {

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -193,7 +193,6 @@ void LlvmProgramImpl::materialize_snode_tree(
     SNodeTree *tree,
     std::vector<std::unique_ptr<SNodeTree>> &snode_trees_,
     std::unordered_map<int, SNode *> &snodes,
-    SNodeGlobalVarExprMap &snode_to_glb_var_exprs_,
     uint64 *result_buffer) {
   auto *const root = tree->root();
   auto host_module = clone_struct_compiler_initial_context(
@@ -201,7 +200,6 @@ void LlvmProgramImpl::materialize_snode_tree(
   std::unique_ptr<StructCompiler> scomp = std::make_unique<StructCompilerLLVM>(
       host_arch(), this, std::move(host_module));
   scomp->run(*root);
-  materialize_snode_expr_attributes(snode_to_glb_var_exprs_);
 
   for (auto snode : scomp->snodes) {
     snodes[snode->id] = snode;
@@ -221,12 +219,6 @@ void LlvmProgramImpl::materialize_snode_tree(
   }
 }
 
-void LlvmProgramImpl::materialize_snode_expr_attributes(
-    SNodeGlobalVarExprMap &snode_to_glb_var_exprs_) {
-  for (auto &[snode, glb_var] : snode_to_glb_var_exprs_) {
-    glb_var->set_attribute("dim", std::to_string(snode->num_active_indices));
-  }
-}
 uint64 LlvmProgramImpl::fetch_result_uint64(int i, uint64 *result_buffer) {
   // TODO: We are likely doing more synchronization than necessary. Simplify the
   // sync logic when we fetch the result.

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -53,7 +53,6 @@ class LlvmProgramImpl : public ProgramImpl {
       SNodeTree *tree,
       std::vector<std::unique_ptr<SNodeTree>> &snode_trees_,
       std::unordered_map<int, SNode *> &snodes,
-      SNodeGlobalVarExprMap &snode_to_glb_var_exprs_,
       uint64 *result_buffer) override;
 
   template <typename T>
@@ -98,12 +97,6 @@ class LlvmProgramImpl : public ProgramImpl {
   void initialize_llvm_runtime_snodes(const SNodeTree *tree,
                                       StructCompiler *scomp,
                                       uint64 *result_buffer);
-
-  /**
-   * Sets the attributes of the Exprs that are backed by SNodes.
-   */
-  void materialize_snode_expr_attributes(
-      SNodeGlobalVarExprMap &snode_to_glb_var_exprs_);
 
   uint64 fetch_result_uint64(int i, uint64 *result_buffer);
 

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -206,6 +206,7 @@ SNodeTree *Program::add_snode_tree(std::unique_ptr<SNode> root) {
   tree->root()->set_snode_tree_id(id);
   materialize_snode_tree(tree.get());
   snode_trees_.push_back(std::move(tree));
+
   return snode_trees_[id].get();
 }
 
@@ -218,8 +219,8 @@ void Program::materialize_snode_tree(SNodeTree *tree) {
   if (arch_is_cpu(config.arch) || config.arch == Arch::cuda ||
       config.arch == Arch::metal || config.arch == Arch::vulkan ||
       config.arch == Arch::opengl) {
-    program_impl_->materialize_snode_tree(
-        tree, snode_trees_, snodes, snode_to_glb_var_exprs_, result_buffer);
+    program_impl_->materialize_snode_tree(tree, snode_trees_, snodes,
+                                          result_buffer);
 #ifdef TI_WITH_CC
   } else if (config.arch == Arch::cc) {
     TI_ASSERT(result_buffer == nullptr);

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -37,7 +37,6 @@ class ProgramImpl {
       SNodeTree *tree,
       std::vector<std::unique_ptr<SNodeTree>> &snode_trees_,
       std::unordered_map<int, SNode *> &snodes,
-      SNodeGlobalVarExprMap &snode_to_glb_var_exprs_,
       uint64 *result_buffer_ptr) = 0;
 
   virtual void destroy_snode_tree(SNodeTree *snode_tree) = 0;


### PR DESCRIPTION
Looks like this is already done in
https://github.com/taichi-dev/taichi/blob/master/taichi/program/snode_expr_utils.cpp#L69
for all backends. So `materialize_snode_expr_attributes` seems
redundant.