### PR TITLE
[refactor] Exchange compiled_grad_functions and compiled_functions in kernel_impl.py

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -325,9 +325,9 @@ class Kernel:
     def reset(self):
         self.runtime = impl.get_runtime()
         if self.is_grad:
-            self.compiled_functions = self.runtime.compiled_functions
-        else:
             self.compiled_functions = self.runtime.compiled_grad_functions
+        else:
+            self.compiled_functions = self.runtime.compiled_functions
 
     def extract_arguments(self):
         sig = inspect.signature(self.func)


### PR DESCRIPTION
This PR doesn't change program behavior. Instead, it exchanges two variable names which are put in opposite positions which may make people confused while reading the code.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
