### PR TITLE
[opengl] Move old runtime onto Device API

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -255,8 +255,8 @@ class KernelGen : public IRVisitor {
     }
     line_appender_header_.clear_all();
     line_appender_.clear_all();
-    num_workgroups = 0;
-    num_workgroups = 0;
+    num_workgroups = 1;
+    num_workgroups = 1;
   }
 
   void visit(Block *stmt) override {

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -100,7 +100,7 @@ class KernelGen : public IRVisitor {
   std::unordered_map<int, irpass::ExternalPtrAccess> extptr_access;
 
   template <typename... Args>
-  void emit(std::string f, Args &&...args) {
+  void emit(std::string f, Args &&... args) {
     line_appender_.append(std::move(f), std::move(args)...);
   }
 

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -248,7 +248,8 @@ struct CompiledProgram::Impl {
            int workgroup_size,
            std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access) {
     kernels.push_back(std::make_unique<CompiledKernel>(
-        kernel_name, kernel_source_code, device, workgroup_size, num_workgrpus));
+        kernel_name, kernel_source_code, device, workgroup_size,
+        num_workgrpus));
     if (ext_ptr_access) {
       for (auto pair : *ext_ptr_access) {
         if (ext_arr_access.find(pair.first) != ext_arr_access.end()) {
@@ -478,28 +479,17 @@ bool is_opengl_api_available() {
 struct GLProgram {};
 struct GLSLLauncherImpl {};
 
-struct CompiledKernel::Impl {
-  Impl(const std::string &kernel_name_,
-       const std::string &kernel_source_code,
-       std::unique_ptr<ParallelSize> ps_) {
-    TI_NOT_IMPLEMENTED;
-  }
-
-  void dispatch_compute(GLSLLauncher *launcher) const {
-    TI_NOT_IMPLEMENTED;
-  }
-};
-
 struct CompiledProgram::Impl {
   UsedFeature used;
 
-  Impl(Kernel *kernel) {
+  Impl(Kernel *kernel, Device *device) {
     TI_NOT_IMPLEMENTED;
   }
 
   void add(const std::string &kernel_name,
            const std::string &kernel_source_code,
-           std::unique_ptr<ParallelSize> ps,
+           int num_workgrpus,
+           int workgroup_size,
            std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access) {
     TI_NOT_IMPLEMENTED;
   }

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -47,293 +47,14 @@ static std::string add_line_markers(std::string x) {
   return x;
 }
 
-struct GLShader {
-  GLuint id_;
-
-  GLShader(GLuint type = GL_COMPUTE_SHADER) {
-    id_ = glCreateShader(type);
-  }
-
-  GLShader(const std::string &source, GLuint type = GL_COMPUTE_SHADER)
-      : GLShader(type) {
-    this->compile(source);
-  }
-
-  ~GLShader() {
-    glDeleteShader(id_);
-  }
-
-  void compile(const std::string &source) const {
-    const GLchar *source_cstr = source.c_str();
-    glShaderSource(id_, 1, &source_cstr, nullptr);
-
-    TI_TRACE("glCompileShader IN");
-    glCompileShader(id_);
-    TI_TRACE("glCompileShader OUT");
-    int status = GL_TRUE;
-    glGetShaderiv(id_, GL_COMPILE_STATUS, &status);
-    if (status != GL_TRUE) {
-      GLsizei logLength;
-      glGetShaderiv(id_, GL_INFO_LOG_LENGTH, &logLength);
-      auto log = std::vector<GLchar>(logLength + 1);
-      glGetShaderInfoLog(id_, logLength, &logLength, log.data());
-      log[logLength] = 0;
-      TI_ERROR("[glsl] error while compiling shader:\n{}\n{}",
-               add_line_markers(source), log.data());
-    }
-  }
-};
-
-struct GLProgram {
-  GLuint id_;
-
-  GLProgram() {
-    id_ = glCreateProgram();
-  }
-
-  explicit GLProgram(GLuint id) : id_(id) {
-  }
-
-  explicit GLProgram(const GLShader &shader) : GLProgram() {
-    this->attach(shader);
-  }
-
-  ~GLProgram() {
-    glDeleteProgram(id_);
-  }
-
-  void attach(const GLShader &shader) const {
-    glAttachShader(id_, shader.id_);
-  }
-
-  void link() const {
-    TI_TRACE("glLinkProgram IN");
-    glLinkProgram(id_);
-    TI_TRACE("glLinkProgram OUT");
-    int status = GL_TRUE;
-    glGetProgramiv(id_, GL_LINK_STATUS, &status);
-    if (status != GL_TRUE) {
-      GLsizei logLength;
-      glGetProgramiv(id_, GL_INFO_LOG_LENGTH, &logLength);
-      auto log = std::vector<GLchar>(logLength + 1);
-      glGetProgramInfoLog(id_, logLength, &logLength, log.data());
-      log[logLength] = 0;
-      TI_ERROR("[glsl] error while linking program:\n{}", log.data());
-    }
-  }
-
-  void use() const {
-    glUseProgram(id_);
-  }
-};
-
-// https://blog.csdn.net/ylbs110/article/details/52074826
-// https://www.khronos.org/opengl/wiki/Shader_Storage_Buffer_Object
-// This is Shader Storage Buffer, we use it to share data between CPU & GPU
-class GLBuffer {
- private:
-  GLuint id;
-  GLenum type;
-  size_t size;
-
- public:
-  GLuint gl_get_id() const {
-    return id;
-  }
-
-  GLuint gl_get_type() const {
-    return type;
-  }
-
-  size_t get_size() const {
-    return size;
-  }
-
-  GLBuffer(size_t size,
-           void *initial_data = nullptr,
-           GLenum type = GL_SHADER_STORAGE_BUFFER,
-           GLbitfield access = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT)
-      : type(type), size(size) {
-    glGenBuffers(1, &id);
-    check_opengl_error("glGenBuffers");
-    glBindBuffer(type, id);
-    check_opengl_error("glBindBuffer");
-
-    if (size) {
-      glBufferStorage(type, size, initial_data, access);
-      check_opengl_error("glBufferStorage");
-    }
-  }
-
-  void bind_to_index(GLuint location, size_t offset, size_t size) {
-    if (size) {
-      glBindBufferRange(type, location, id, GLintptr(offset), GLsizeiptr(size));
-      check_opengl_error("glBindBufferRange");
-    }
-  }
-
-  void bind_to_index(GLuint location) {
-    bind_to_index(location, /*offset=*/0, size);
-  }
-
-  void *map(GLenum access) {
-    return map_region(/*offset=*/0, size, access);
-  }
-
-  void *map_region(size_t offset, size_t size, GLenum access) {
-    glBindBuffer(type, id);
-    check_opengl_error("glBindBuffer");
-    void *mapped =
-        glMapBufferRange(type, GLintptr(offset), GLsizeiptr(size), access);
-    check_opengl_error("glMapBufferRange");
-    TI_ASSERT(mapped);
-    return mapped;
-  }
-
-  void unmap() {
-    glBindBuffer(type, id);
-    check_opengl_error("glBindBuffer");
-    glUnmapBuffer(type);
-    check_opengl_error("glUnmapBuffer");
-  }
-
-  void flush_mapped_region(size_t offset, size_t size) {
-    glBindBuffer(type, id);
-    check_opengl_error("glBindBuffer");
-    glFlushMappedBufferRange(type, offset, size);
-    check_opengl_error("glFlushMappedBufferRange");
-  }
-
-  void read_back(void *buffer, size_t offset, size_t size) {
-    glBindBuffer(type, id);
-    check_opengl_error("glBindBuffer");
-    glGetBufferSubData(type, offset, size, buffer);
-    check_opengl_error("glGetBufferSubData");
-  }
-
-  void read_back(void *buffer) {
-    read_back(buffer, /*offset=*/0, size);
-  }
-
-  void upload(void *buffer, size_t offset, size_t size) {
-    memcpy(map_region(offset, size, GL_MAP_WRITE_BIT), buffer, size);
-    unmap();
-  }
-
-  void upload(void *buffer) {
-    upload(buffer, /*offset=*/0, size);
-  }
-};
-
-struct GLBufferAllocator {
- private:
-  static constexpr size_t kMaxFreeResidentSize = 64 << 20;
-
-  struct BufferKey {
-    GLbitfield access{0};
-    size_t size{0};
-
-    struct Hash {
-      size_t operator()(const BufferKey &k) const {
-        return (size_t(k.access) << 48) ^ k.size;
-      }
-    };
-
-    bool operator==(const BufferKey &k) const {
-      return k.access == access && k.size == size;
-    }
-  };
-
-  std::list<std::unique_ptr<GLBuffer>> buffers_storage_;
-
-  std::unordered_multimap<BufferKey, GLBuffer *, BufferKey::Hash>
-      buffers_mapping_;
-  std::unordered_multimap<BufferKey, GLBuffer *, BufferKey::Hash> free_mapping_;
-
- public:
-  GLBufferAllocator() {
-  }
-
-  void new_frame() {
-    size_t free_resident_size = 0;
-    for (auto pair : free_mapping_) {
-      free_resident_size += pair.first.size;
-
-      if (free_resident_size > kMaxFreeResidentSize) {
-        GLBuffer *buf = pair.second;
-
-        // TI_INFO("Release {}", (void *)buf);
-
-        buffers_storage_.remove_if(
-            [buf](const auto &p) { return p.get() == buf; });
-
-        {
-          auto buffer_iter =
-              std::find_if(buffers_mapping_.begin(), buffers_mapping_.end(),
-                           [buf](const auto &mo) { return mo.second == buf; });
-          buffers_mapping_.erase(buffer_iter);
-        }
-
-        free_mapping_.erase(pair.first);
-      }
-    }
-  }
-
-  GLBuffer *alloc_buffer(size_t size,
-                         void *base,
-                         GLenum type = GL_SHADER_STORAGE_BUFFER,
-                         GLbitfield access = GL_MAP_READ_BIT |
-                                             GL_MAP_WRITE_BIT) {
-    GLBuffer *buffer;
-    auto buffer_iter = free_mapping_.find(BufferKey{access, size});
-    if (buffer_iter == free_mapping_.end()) {
-      // This buffer does not exist / can not be reused
-      buffers_storage_.push_back(
-          std::make_unique<GLBuffer>(size, base, type, access));
-      buffer = buffers_storage_.back().get();
-      buffers_mapping_.insert(std::pair(BufferKey{access, size}, buffer));
-
-      // TI_INFO("New buffer {}, {}", size, (void *)buffer);
-    } else {
-      // Reuse
-      buffer = buffer_iter->second;
-      free_mapping_.erase(buffer_iter);
-
-      if (base) {
-        memcpy(buffer->map(GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT),
-               base, size);
-        buffer->unmap();
-      } else {
-        glInvalidateBufferData(buffer->gl_get_id());
-      }
-
-      // TI_INFO("Reuse buffer {}, {}", size, (void *)buffer);
-    }
-
-    return buffer;
-  }
-
-  void dealloc_buffer(GLBuffer *buf) {
-    auto buffer_iter =
-        std::find_if(buffers_mapping_.begin(), buffers_mapping_.end(),
-                     [buf](const auto &mo) { return mo.second == buf; });
-    if (buffer_iter != buffers_mapping_.end()) {
-      // Insert back to free list
-      free_mapping_.insert(std::pair(buffer_iter->first, buf));
-
-      // TI_INFO("Dealloc {}", (void *)buf);
-    }
-  }
-};
-
 struct GLSLLauncherImpl {
-  GLBufferAllocator gl_allocator;
+  std::unique_ptr<Device> device;
 
   struct {
-    GLBuffer *runtime = nullptr;
-    GLBuffer *listman = nullptr;
-    GLBuffer *root = nullptr;
-    GLBuffer *gtmp = nullptr;
+    DeviceAllocation runtime = kDeviceNullAllocation;
+    DeviceAllocation listman = kDeviceNullAllocation;
+    DeviceAllocation root = kDeviceNullAllocation;
+    DeviceAllocation gtmp = kDeviceNullAllocation;
   } core_bufs;
 
   GLSLLauncherImpl() {
@@ -418,78 +139,68 @@ bool initialize_opengl(bool error_tolerance) {
   return true;
 }
 
-void show_kernel_info(std::string const &kernel_name,
-                      std::string const &kernel_source_code,
-                      ParallelSize *ps) {
-  bool is_accessor = taichi::starts_with(kernel_name, "snode_") ||
-                     taichi::starts_with(kernel_name, "tensor_to_") ||
-                     taichi::starts_with(kernel_name, "matrix_to_") ||
-                     taichi::starts_with(kernel_name, "ext_arr_to_") ||
-                     taichi::starts_with(kernel_name, "indirect_evaluator_") ||
-                     taichi::starts_with(kernel_name, "jit_evaluator_");
-  auto msg =
-      fmt::format("[glsl]\ncompiling kernel {}<<<{}, {}>>>:\n{}", kernel_name,
-                  ps->grid_dim, ps->block_dim, kernel_source_code);
-  if (!is_accessor)
-    TI_DEBUG("{}", msg);
-  else
-    TI_TRACE("{}", msg);
-}
-
-struct CompiledKernel::Impl {
+struct CompiledKernel {
   std::string kernel_name;
-  std::unique_ptr<GLProgram> glsl;
-  std::unique_ptr<ParallelSize> ps;
-  std::string source;
+  std::unique_ptr<Pipeline> pipeline;
+  int workgroup_size;
+  int num_groups;
 
-  Impl(const std::string &kernel_name_,
-       const std::string &kernel_source_code,
-       std::unique_ptr<ParallelSize> ps_)
-      : kernel_name(kernel_name_), ps(std::move(ps_)) {
-    if (ps->grid_dim > opengl_max_grid_dim)
-      ps->grid_dim = opengl_max_grid_dim;
-    if (ps->block_dim > opengl_max_block_dim)
-      ps->block_dim = opengl_max_block_dim;
+  CompiledKernel(const std::string &kernel_name_,
+                 const std::string &kernel_source_code,
+                 Device *device,
+                 int _workgroup_size,
+                 int _num_groups)
+      : kernel_name(kernel_name_) {
+    num_groups = std::min(_num_groups, opengl_max_grid_dim);
+    workgroup_size = std::min(_workgroup_size, opengl_max_block_dim);
 
     size_t layout_pos = kernel_source_code.find("precision highp float;\n");
     TI_ASSERT(layout_pos != std::string::npos);
-    source = kernel_source_code.substr(0, layout_pos) +
-             fmt::format(
-                 "layout(local_size_x = {}, local_size_y = 1, local_size_z = "
-                 "1) in;\n",
-                 ps->block_dim) +
-             kernel_source_code.substr(layout_pos);
-    show_kernel_info(kernel_name_, source, ps.get());
-    glsl = std::make_unique<GLProgram>(GLShader(source));
-    glsl->link();
-  }
+    std::string source =
+        kernel_source_code.substr(0, layout_pos) +
+        fmt::format(
+            "layout(local_size_x = {}, local_size_y = 1, local_size_z = "
+            "1) in;\n",
+            workgroup_size) +
+        kernel_source_code.substr(layout_pos);
 
-  void dispatch_compute(GLSLLauncher *launcher) const {
-    // https://www.khronos.org/opengl/wiki/Compute_Shader
-    // https://community.arm.com/developer/tools-software/graphics/b/blog/posts/get-started-with-compute-shaders
-    // https://www.khronos.org/assets/uploads/developers/library/2014-siggraph-bof/KITE-BOF_Aug14.pdf
-    //
-    // `glDispatchCompute(X, Y, Z)`   - the X*Y*Z  == `Blocks`   in CUDA
-    // `layout(local_size_x = X) in;` - the X      == `Threads`  in CUDA
-    //
-    glsl->use();
-    glDispatchCompute(ps->grid_dim, 1, 1);
-    check_opengl_error("glDispatchCompute");
+    bool is_accessor =
+        taichi::starts_with(kernel_name, "snode_") ||
+        taichi::starts_with(kernel_name, "tensor_to_") ||
+        taichi::starts_with(kernel_name, "matrix_to_") ||
+        taichi::starts_with(kernel_name, "ext_arr_to_") ||
+        taichi::starts_with(kernel_name, "indirect_evaluator_") ||
+        taichi::starts_with(kernel_name, "jit_evaluator_");
 
-    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
-    check_opengl_error("glMemoryBarrier");
+    TI_TRACE("[glsl]\ncompiling kernel {}<<<{}, {}>>>:\n{}", kernel_name,
+             num_groups, workgroup_size, kernel_source_code);
+
+    pipeline = device->create_pipeline(
+        {PipelineSourceType::glsl_src, source.data(), source.size()},
+        kernel_name);
   }
 };
 
 struct CompiledProgram::Impl {
   std::vector<std::unique_ptr<CompiledKernel>> kernels;
-  int arg_count, ret_count;
+
+  int arg_count{0};
+  int ret_count{0};
+  size_t args_buf_size{0};
+  size_t total_ext_arr_size{0};
+  size_t ret_buf_size{0};
+
   std::unordered_map<int, size_t> ext_arr_map;
   std::unordered_map<int, irpass::ExternalPtrAccess> ext_arr_access;
   std::vector<std::string> str_table;
   UsedFeature used;
+  Device *device;
 
-  Impl(Kernel *kernel) {
+  DeviceAllocation args_buf{kDeviceNullAllocation};
+  DeviceAllocation ext_arr_buf{kDeviceNullAllocation};
+  DeviceAllocation ret_buf{kDeviceNullAllocation};
+
+  Impl(Kernel *kernel, Device *device) : device(device) {
     arg_count = kernel->args.size();
     ret_count = kernel->rets.size();
     for (int i = 0; i < arg_count; i++) {
@@ -497,14 +208,47 @@ struct CompiledProgram::Impl {
         ext_arr_map[i] = kernel->args[i].size;
       }
     }
+
+    for (const auto &[i, size] : ext_arr_map) {
+      total_ext_arr_size += size;
+    }
+
+    args_buf_size = arg_count * sizeof(uint64_t);
+    if (ext_arr_map.size()) {
+      args_buf_size = taichi_opengl_earg_base +
+                      arg_count * taichi_max_num_indices * sizeof(int);
+    }
+
+    ret_buf_size = ret_count * sizeof(uint64_t);
+
+    if (args_buf_size) {
+      args_buf = device->allocate_memory({args_buf_size, /*host_write=*/true,
+                                          /*host_read=*/false,
+                                          /*export_sharing=*/false});
+    }
+
+    if (total_ext_arr_size) {
+      // Set both host write & host read for now
+      ext_arr_buf =
+          device->allocate_memory({total_ext_arr_size, /*host_write=*/true,
+                                   /*host_read=*/true,
+                                   /*export_sharing=*/false});
+    }
+
+    if (ret_buf_size) {
+      ret_buf = device->allocate_memory({ret_buf_size, /*host_write=*/false,
+                                         /*host_read=*/true,
+                                         /*export_sharing=*/false});
+    }
   }
 
   void add(const std::string &kernel_name,
            const std::string &kernel_source_code,
-           std::unique_ptr<ParallelSize> ps,
+           int num_workgrpus,
+           int workgroup_size,
            std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access) {
     kernels.push_back(std::make_unique<CompiledKernel>(
-        kernel_name, kernel_source_code, std::move(ps)));
+        kernel_name, kernel_source_code, device, workgroup_size, num_workgrpus));
     if (ext_ptr_access) {
       for (auto pair : *ext_ptr_access) {
         if (ext_arr_access.find(pair.first) != ext_arr_access.end()) {
@@ -529,7 +273,7 @@ struct CompiledProgram::Impl {
 
   void dump_message_buffer(GLSLLauncher *launcher) const {
     auto runtime = launcher->impl->core_bufs.runtime;
-    auto rt_buf = (GLSLRuntime *)runtime->map(GL_MAP_READ_BIT);
+    auto rt_buf = (GLSLRuntime *)device->map(launcher->impl->core_bufs.runtime);
 
     auto msg_count = rt_buf->msg_count;
     if (msg_count > MAX_MESSAGES) {
@@ -563,7 +307,7 @@ struct CompiledProgram::Impl {
       }
     }
     rt_buf->msg_count = 0;
-    runtime->unmap();
+    device->unmap(launcher->impl->core_bufs.runtime);
   }
 
   bool check_ext_arr_read(int i) const {
@@ -599,28 +343,13 @@ struct CompiledProgram::Impl {
   }
 
   void launch(Context &ctx, GLSLLauncher *launcher) const {
-    launcher->impl->gl_allocator.new_frame();
-
     std::array<void *, taichi_max_num_args> ext_arr_host_ptrs;
 
-    GLBuffer *extr_buf = nullptr;
-    GLBuffer *args_buf = nullptr;
-    GLBuffer *retr_buf = nullptr;
     uint8_t *args_buf_mapped = nullptr;
 
     // Prepare external array
-    if (ext_arr_map.size()) {
-      size_t total_ext_arr_size = 0;
-      GLbitfield access = get_ext_arr_access(total_ext_arr_size);
-
-      extr_buf = launcher->impl->gl_allocator.alloc_buffer(
-          total_ext_arr_size, nullptr, GL_SHADER_STORAGE_BUFFER, access);
-
-      void *baseptr = nullptr;
-      if (access & GL_MAP_WRITE_BIT) {
-        baseptr =
-            extr_buf->map(GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
-      }
+    if (total_ext_arr_size) {
+      void *baseptr = device->map(ext_arr_buf);
 
       size_t accum_size = 0;
       for (const auto &[i, size] : ext_arr_map) {
@@ -633,67 +362,57 @@ struct CompiledProgram::Impl {
         accum_size += size;
       }
 
-      if (baseptr)
-        extr_buf->unmap();
+      device->unmap(ext_arr_buf);
     }
 
     // Prepare argument buffer
-    {
-      size_t args_buf_size = arg_count * sizeof(uint64_t);
+    if (args_buf_size) {
+      args_buf_mapped = (uint8_t *)device->map(args_buf);
+      std::memcpy(args_buf_mapped, ctx.args, arg_count * sizeof(uint64_t));
       if (ext_arr_map.size()) {
-        args_buf_size = taichi_opengl_earg_base +
-                        arg_count * taichi_max_num_indices * sizeof(int);
+        std::memcpy(args_buf_mapped + size_t(taichi_opengl_earg_base),
+                    ctx.extra_args,
+                    size_t(arg_count * taichi_max_num_indices) * sizeof(int));
       }
-
-      if (args_buf_size > 0) {
-        args_buf = launcher->impl->gl_allocator.alloc_buffer(
-            args_buf_size, nullptr, GL_SHADER_STORAGE_BUFFER, GL_MAP_WRITE_BIT);
-
-        args_buf_mapped = (uint8_t *)args_buf->map(
-            GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
-        std::memcpy(args_buf_mapped, ctx.args, arg_count * sizeof(uint64_t));
-        if (ext_arr_map.size()) {
-          std::memcpy(args_buf_mapped + size_t(taichi_opengl_earg_base),
-                      ctx.extra_args,
-                      size_t(arg_count * taichi_max_num_indices) * sizeof(int));
-        }
-        args_buf->unmap();
-      }
-    }
-
-    // Prepare return buffer
-    if (ret_count > 0) {
-      retr_buf = launcher->impl->gl_allocator.alloc_buffer(
-          ret_count * sizeof(uint64_t), nullptr, GL_SHADER_STORAGE_BUFFER,
-          GL_MAP_READ_BIT);
+      device->unmap(args_buf);
     }
 
     // Prepare runtime
     if (used.print) {
       // TODO(archibate): use result_buffer for print results
       auto runtime_buf = launcher->impl->core_bufs.runtime;
-      auto mapped = (GLSLRuntime *)runtime_buf->map(GL_MAP_WRITE_BIT);
+      auto mapped = (GLSLRuntime *)device->map(args_buf);
       mapped->msg_count = 0;
-      runtime_buf->unmap();
+      device->unmap(args_buf);
     }
 
-    // Bind uniforms (descriptors in low level APIs)
-    auto &core_bufs = launcher->impl->core_bufs;
-    core_bufs.runtime->bind_to_index(GLuint(GLBufId::Runtime));
-    core_bufs.listman->bind_to_index(GLuint(GLBufId::Listman));
-    core_bufs.root->bind_to_index(GLuint(GLBufId::Root));
-    core_bufs.gtmp->bind_to_index(GLuint(GLBufId::Gtmp));
-
-    if (args_buf)
-      args_buf->bind_to_index(GLuint(GLBufId::Args));
-    if (retr_buf)
-      retr_buf->bind_to_index(GLuint(GLBufId::Retr));
-    if (extr_buf)
-      extr_buf->bind_to_index(GLuint(GLBufId::Extr));
+    auto cmdlist = device->get_compute_stream()->new_command_list();
 
     // Kernel dispatch
-    for (const auto &ker : kernels) {
-      ker->dispatch_compute(launcher);
+    for (const auto &kernel : kernels) {
+      auto binder = kernel->pipeline->resource_binder();
+      auto &core_bufs = launcher->impl->core_bufs;
+      binder->buffer(0, int(GLBufId::Runtime), core_bufs.runtime);
+      binder->buffer(0, int(GLBufId::Listman), core_bufs.listman);
+      binder->buffer(0, int(GLBufId::Root), core_bufs.root);
+      binder->buffer(0, int(GLBufId::Gtmp), core_bufs.gtmp);
+      if (args_buf_size)
+        binder->buffer(0, int(GLBufId::Args), args_buf);
+      if (ret_buf_size)
+        binder->buffer(0, int(GLBufId::Retr), ret_buf);
+      if (total_ext_arr_size)
+        binder->buffer(0, int(GLBufId::Extr), ext_arr_buf);
+
+      cmdlist->bind_pipeline(kernel->pipeline.get());
+      cmdlist->bind_resources(binder);
+      cmdlist->dispatch(kernel->num_groups, 1, 1);
+      cmdlist->memory_barrier();
+    }
+
+    if (used.print || total_ext_arr_size || ret_buf_size) {
+      device->get_compute_stream()->submit_synced(cmdlist.get());
+    } else {
+      device->get_compute_stream()->submit(cmdlist.get());
     }
 
     // Data read-back
@@ -701,45 +420,48 @@ struct CompiledProgram::Impl {
       dump_message_buffer(launcher);
     }
 
-    if (extr_buf) {
+    if (total_ext_arr_size) {
+      uint8_t *baseptr = (uint8_t *)device->map(ext_arr_buf);
       for (const auto &[i, size] : ext_arr_map) {
-        if (check_ext_arr_write(i)) {
-          extr_buf->read_back(ext_arr_host_ptrs[i], size_t(ctx.args[i]), size);
-        }
+        memcpy(ext_arr_host_ptrs[i], baseptr + size_t(ctx.args[i]), size);
       }
+      device->unmap(ext_arr_buf);
     }
 
-    if (ret_count > 0) {
-      retr_buf->read_back(launcher->result_buffer, 0,
-                          ret_count * sizeof(uint64_t));
+    if (ret_buf_size) {
+      memcpy(launcher->result_buffer, device->map(ret_buf), ret_buf_size);
+      device->unmap(ret_buf);
     }
-
-    if (args_buf)
-      launcher->impl->gl_allocator.dealloc_buffer(args_buf);
-    if (retr_buf)
-      launcher->impl->gl_allocator.dealloc_buffer(retr_buf);
-    if (extr_buf)
-      launcher->impl->gl_allocator.dealloc_buffer(extr_buf);
   }
 };
 
 GLSLLauncher::GLSLLauncher(size_t root_size) {
   initialize_opengl();
+
+  device = std::make_unique<GLDevice>();
+
   impl = std::make_unique<GLSLLauncherImpl>();
 
   impl->runtime = std::make_unique<GLSLRuntime>();
-  impl->core_bufs.runtime =
-      impl->gl_allocator.alloc_buffer(sizeof(GLSLRuntime), impl->runtime.get());
+  impl->core_bufs.runtime = device->allocate_memory({sizeof(GLSLRuntime)});
 
   impl->listman = std::make_unique<GLSLListman>();
-  impl->core_bufs.listman =
-      impl->gl_allocator.alloc_buffer(sizeof(GLSLListman), impl->listman.get());
+  impl->core_bufs.listman = device->allocate_memory({sizeof(GLSLListman)});
 
-  impl->core_bufs.root = impl->gl_allocator.alloc_buffer(
-      root_size, nullptr, GL_SHADER_STORAGE_BUFFER, 0);
+  impl->core_bufs.root = device->allocate_memory({root_size});
 
-  impl->core_bufs.gtmp = impl->gl_allocator.alloc_buffer(
-      taichi_global_tmp_buffer_size, nullptr, GL_SHADER_STORAGE_BUFFER, 0);
+  impl->core_bufs.gtmp =
+      device->allocate_memory({taichi_global_tmp_buffer_size});
+
+  auto cmdlist = device->get_compute_stream()->new_command_list();
+  cmdlist->buffer_fill(impl->core_bufs.runtime.get_ptr(0), sizeof(GLSLRuntime),
+                       0);
+  cmdlist->buffer_fill(impl->core_bufs.listman.get_ptr(0), sizeof(GLSLListman),
+                       0);
+  cmdlist->buffer_fill(impl->core_bufs.root.get_ptr(0), root_size, 0);
+  cmdlist->buffer_fill(impl->core_bufs.gtmp.get_ptr(0),
+                       taichi_global_tmp_buffer_size, 0);
+  device->get_compute_stream()->submit_synced(cmdlist.get());
 }
 
 void GLSLLauncher::keep(std::unique_ptr<CompiledProgram> program) {
@@ -809,8 +531,8 @@ bool initialize_opengl(bool error_tolerance) {
 
 #endif  // TI_WITH_OPENGL
 
-CompiledProgram::CompiledProgram(Kernel *kernel)
-    : impl(std::make_unique<Impl>(kernel)) {
+CompiledProgram::CompiledProgram(Kernel *kernel, Device *device)
+    : impl(std::make_unique<Impl>(kernel, device)) {
 }
 
 CompiledProgram::~CompiledProgram() = default;
@@ -818,9 +540,11 @@ CompiledProgram::~CompiledProgram() = default;
 void CompiledProgram::add(
     const std::string &kernel_name,
     const std::string &kernel_source_code,
-    std::unique_ptr<ParallelSize> ps,
+    int num_workgrous,
+    int workgroup_size,
     std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access) {
-  impl->add(kernel_name, kernel_source_code, std::move(ps), ext_ptr_access);
+  impl->add(kernel_name, kernel_source_code, num_workgrous, workgroup_size,
+            ext_ptr_access);
 }
 
 void CompiledProgram::set_used(const UsedFeature &used) {
@@ -834,20 +558,6 @@ int CompiledProgram::lookup_or_add_string(const std::string &str) {
 void CompiledProgram::launch(Context &ctx, GLSLLauncher *launcher) const {
   impl->launch(ctx, launcher);
 }
-
-CompiledKernel::CompiledKernel(const std::string &kernel_name_,
-                               const std::string &kernel_source_code,
-                               std::unique_ptr<ParallelSize> ps_)
-    : impl(std::make_unique<Impl>(kernel_name_,
-                                  kernel_source_code,
-                                  std::move(ps_))) {
-}
-
-void CompiledKernel::dispatch_compute(GLSLLauncher *launcher) const {
-  impl->dispatch_compute(launcher);
-}
-
-CompiledKernel::~CompiledKernel() = default;
 
 GLSLLauncher::~GLSLLauncher() = default;
 

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -128,11 +128,11 @@ bool initialize_opengl(bool error_tolerance) {
     TI_ERROR("Your OpenGL does not support GL_ARB_compute_shader extension");
   }
 
-  glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &opengl_max_block_dim);
-  check_opengl_error("glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS)");
-  TI_TRACE("GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS: {}", opengl_max_block_dim);
+  glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_COUNT, 0, &opengl_max_block_dim);
+  check_opengl_error("glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_COUNT)");
+  TI_TRACE("GL_MAX_COMPUTE_WORK_GROUP_COUNT: {}", opengl_max_block_dim);
   glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_SIZE, 0, &opengl_max_grid_dim);
-  check_opengl_error("glGetIntegerv(GL_MAX_COMPUTE_WORK_GROUP_SIZE)");
+  check_opengl_error("glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_SIZE)");
   TI_TRACE("GL_MAX_COMPUTE_WORK_GROUP_SIZE: {}", opengl_max_grid_dim);
 
   supported = std::make_optional<bool>(true);
@@ -382,9 +382,9 @@ struct CompiledProgram::Impl {
     if (used.print) {
       // TODO(archibate): use result_buffer for print results
       auto runtime_buf = launcher->impl->core_bufs.runtime;
-      auto mapped = (GLSLRuntime *)device->map(args_buf);
+      auto mapped = (GLSLRuntime *)device->map(runtime_buf);
       mapped->msg_count = 0;
-      device->unmap(args_buf);
+      device->unmap(runtime_buf);
     }
 
     auto cmdlist = device->get_compute_stream()->new_command_list();

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -164,14 +164,6 @@ struct CompiledKernel {
             workgroup_size) +
         kernel_source_code.substr(layout_pos);
 
-    bool is_accessor =
-        taichi::starts_with(kernel_name, "snode_") ||
-        taichi::starts_with(kernel_name, "tensor_to_") ||
-        taichi::starts_with(kernel_name, "matrix_to_") ||
-        taichi::starts_with(kernel_name, "ext_arr_to_") ||
-        taichi::starts_with(kernel_name, "indirect_evaluator_") ||
-        taichi::starts_with(kernel_name, "jit_evaluator_");
-
     TI_TRACE("[glsl]\ncompiling kernel {}<<<{}, {}>>>:\n{}", kernel_name,
              num_groups, workgroup_size, kernel_source_code);
 

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -444,7 +444,8 @@ GLSLLauncher::GLSLLauncher(size_t root_size) {
   impl = std::make_unique<GLSLLauncherImpl>();
 
   impl->runtime = std::make_unique<GLSLRuntime>();
-  impl->core_bufs.runtime = device->allocate_memory({sizeof(GLSLRuntime)});
+  impl->core_bufs.runtime = device->allocate_memory(
+      {sizeof(GLSLRuntime), /*host_write=*/false, /*host_read=*/true});
 
   impl->listman = std::make_unique<GLSLListman>();
   impl->core_bufs.listman = device->allocate_memory({sizeof(GLSLListman)});

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -40,32 +40,6 @@ extern int opengl_threads_per_block;
 
 struct CompiledKernel;
 
-class ParallelSize {
- public:
-  size_t block_dim;
-  size_t grid_dim;
-  ParallelSize(size_t block_dim = 1, size_t grid_dim = 1)
-      : block_dim(block_dim), grid_dim(grid_dim) {
-  }
-};
-
-struct CompiledKernel {
-  struct Impl;
-  std::unique_ptr<Impl> impl;
-
-  // disscussion:
-  // https://github.com/taichi-dev/taichi/pull/696#issuecomment-609332527
-  CompiledKernel(CompiledKernel &&) = default;
-  CompiledKernel &operator=(CompiledKernel &&) = default;
-
-  CompiledKernel(const std::string &kernel_name_,
-                 const std::string &kernel_source_code,
-                 std::unique_ptr<ParallelSize> ps_);
-  ~CompiledKernel();
-
-  void dispatch_compute(GLSLLauncher *launcher) const;
-};
-
 struct CompiledProgram {
   struct Impl;
   std::unique_ptr<Impl> impl;
@@ -75,12 +49,13 @@ struct CompiledProgram {
   CompiledProgram(CompiledProgram &&) = default;
   CompiledProgram &operator=(CompiledProgram &&) = default;
 
-  CompiledProgram(Kernel *kernel);
+  CompiledProgram(Kernel *kernel, Device *device);
   ~CompiledProgram();
 
   void add(const std::string &kernel_name,
            const std::string &kernel_source_code,
-           std::unique_ptr<ParallelSize> ps,
+           int num_workgrous,
+           int workgroup_size,
            std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access =
                nullptr);
   void set_used(const UsedFeature &used);

--- a/taichi/backends/opengl/opengl_kernel_launcher.h
+++ b/taichi/backends/opengl/opengl_kernel_launcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "taichi/lang_util.h"
+#include "taichi/backends/device.h"
 
 #include <vector>
 
@@ -15,6 +16,7 @@ class GLBuffer;
 
 struct GLSLLauncher {
   std::unique_ptr<GLSLLauncherImpl> impl;
+  std::unique_ptr<Device> device{nullptr};
   GLSLLauncher(size_t size);
   ~GLSLLauncher();
   void keep(std::unique_ptr<CompiledProgram> program);


### PR DESCRIPTION
Related issue = #2736

Move the old GL runtime (opengl_api.cpp) to Device API. This commit did not really change the runtime itself and therefore another PR is needed to decouple GLSL codegen with GL runtime