### PR TITLE
[Lang] Remove deprecated usage of ti.Matrix.__init__

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -30,17 +30,12 @@ class Matrix(TaichiOperations):
         dt (DataType): the elmement data type.
         shape ( Union[int, tuple of int], optional): the shape of a matrix field.
         offset (Union[int, tuple of int], optional): The coordinate offset of all elements in a field.
-        empty (Bool, deprecated): True if the matrix is empty, False otherwise.
         layout (Layout, optional): The filed layout (Layout.AOS or Layout.SOA).
         needs_grad (Bool, optional): True if used in auto diff, False otherwise.
         keep_raw (Bool, optional): Keep the contents in `n` as is.
-        rows (List, deprecated): construct matrix rows.
-        cols (List, deprecated): construct matrix columns.
     """
     is_taichi_class = True
 
-    # TODO(archibate): move the last two line to **kwargs,
-    # since they're not commonly used as positional args.
     def __init__(self,
                  n=1,
                  m=1,
@@ -50,30 +45,12 @@ class Matrix(TaichiOperations):
                  layout=Layout.AOS,
                  needs_grad=False,
                  keep_raw=False,
-                 disable_local_tensor=False,
-                 rows=None,
-                 cols=None):
+                 disable_local_tensor=False):
         self.local_tensor_proxy = None
         self.any_array_access = None
         self.grad = None
 
-        # construct from rows or cols (deprecated)
-        if rows is not None or cols is not None:
-            warning(
-                f"ti.Matrix(rows=[...]) or ti.Matrix(cols=[...]) is deprecated, use ti.Matrix.rows([...]) or ti.Matrix.cols([...]) instead.",
-                DeprecationWarning,
-                stacklevel=2)
-            if rows is not None and cols is not None:
-                raise Exception("cannot specify both rows and columns")
-            self.dt = dt
-            mat = Matrix.cols(cols) if cols is not None else Matrix.rows(rows)
-            self.n = mat.n
-            self.m = mat.m
-            self.entries = mat.entries
-            return
-
-
-        elif isinstance(n, (list, tuple, np.ndarray)):
+        if isinstance(n, (list, tuple, np.ndarray)):
             if len(n) == 0:
                 mat = []
             elif isinstance(n[0], Matrix):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -140,23 +140,7 @@ class Matrix(TaichiOperations):
                 self.n = n
                 self.m = m
             else:
-                # construct global matrix (deprecated)
-                warning(
-                    "Declaring global matrices using `ti.Matrix(n, m, dt, shape)` is deprecated, "
-                    "use `ti.Matrix.field(n, m, dtype, shape)` instead",
-                    DeprecationWarning,
-                    stacklevel=2)
-                mat = Matrix.field(n=n,
-                                   m=m,
-                                   dtype=dt,
-                                   shape=shape,
-                                   offset=offset,
-                                   needs_grad=needs_grad,
-                                   layout=layout)
-                self.n = mat.n
-                self.m = mat.m
-                self.entries = mat.entries
-                self.grad = mat.grad
+                raise ValueError("Declaring matrix fields using `ti.Matrix(n, m, dt, shape)` is no longer supported. Use `ti.Matrix.field(n, m, dtype, shape)` instead.")
 
         if self.n * self.m > 32:
             warning(

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -28,10 +28,6 @@ class Matrix(TaichiOperations):
         n (int): the first dimension of a matrix.
         m (int): the second dimension of a matrix.
         dt (DataType): the elmement data type.
-        shape ( Union[int, tuple of int], optional): the shape of a matrix field.
-        offset (Union[int, tuple of int], optional): The coordinate offset of all elements in a field.
-        layout (Layout, optional): The filed layout (Layout.AOS or Layout.SOA).
-        needs_grad (Bool, optional): True if used in auto diff, False otherwise.
         keep_raw (Bool, optional): Keep the contents in `n` as is.
     """
     is_taichi_class = True
@@ -1197,21 +1193,18 @@ class Matrix(TaichiOperations):
         return ret
 
 
-# TODO: deprecate ad-hoc use ti.Matrix() as global (#1500:2.2/2)
-def Vector(n, dt=None, shape=None, offset=None, **kwargs):
+def Vector(n, dt=None, **kwargs):
     """Construct a `Vector` instance i.e. 1-D Matrix.
 
     Args:
         n (int): The desired number of entries of the Vector.
         dt (DataType, optional): The desired data type of the Vector.
-        shape ( Union[int, tuple of int], optional): The shape of the Vector.
-        offset (Union[int, tuple of int], optional): The coordinate offset of all elements in a field.
 
     Returns:
         :class:`~taichi.lang.matrix.Matrix`: A Vector instance (1-D :class:`~taichi.lang.matrix.Matrix`).
 
     """
-    return Matrix(n, 1, dt=dt, shape=shape, offset=offset, **kwargs)
+    return Matrix(n, 1, dt=dt, **kwargs)
 
 
 Vector.var = Matrix._Vector_var

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -136,7 +136,9 @@ class Matrix(TaichiOperations):
                 self.n = n
                 self.m = m
             else:
-                raise ValueError("Declaring matrix fields using `ti.Matrix(n, m, dt, shape)` is no longer supported. Use `ti.Matrix.field(n, m, dtype, shape)` instead.")
+                raise ValueError(
+                    "Declaring matrix fields using `ti.Matrix(n, m, dt, shape)` is no longer supported. Use `ti.Matrix.field(n, m, dtype, shape)` instead."
+                )
 
         if self.n * self.m > 32:
             warning(

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -40,10 +40,6 @@ class Matrix(TaichiOperations):
                  n=1,
                  m=1,
                  dt=None,
-                 shape=None,
-                 offset=None,
-                 layout=Layout.AOS,
-                 needs_grad=False,
                  keep_raw=False,
                  disable_local_tensor=False):
         self.local_tensor_proxy = None

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -47,7 +47,6 @@ class Matrix(TaichiOperations):
                  dt=None,
                  shape=None,
                  offset=None,
-                 empty=False,
                  layout=Layout.AOS,
                  needs_grad=False,
                  keep_raw=False,
@@ -73,14 +72,6 @@ class Matrix(TaichiOperations):
             self.entries = mat.entries
             return
 
-        elif empty == True:
-            warning(
-                f"ti.Matrix(n, m, empty=True) is deprecated, use ti.Matrix.empty(n, m) instead",
-                DeprecationWarning,
-                stacklevel=2)
-            self.dt = dt
-            self.entries = [[None] * m for _ in range(n)]
-            return
 
         elif isinstance(n, (list, tuple, np.ndarray)):
             if len(n) == 0:

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -324,8 +324,10 @@ def test_init_matrix_from_vectors_deprecated():
             c = ti.Vector([3.0, 6.0, 9.0])
             m1[i] = ti.Matrix.rows([a, b, c])
             m2[i] = ti.Matrix.cols([a, b, c])
-            m3[i] = ti.Matrix.rows([[1.0, 4.0, 7.0], [2.0, 5.0, 8.0], [3.0, 6.0, 9.0]])
-            m4[i] = ti.Matrix.cols([[1.0, 4.0, 7.0], [2.0, 5.0, 8.0], [3.0, 6.0, 9.0]])
+            m3[i] = ti.Matrix.rows([[1.0, 4.0, 7.0], [2.0, 5.0, 8.0],
+                                    [3.0, 6.0, 9.0]])
+            m4[i] = ti.Matrix.cols([[1.0, 4.0, 7.0], [2.0, 5.0, 8.0],
+                                    [3.0, 6.0, 9.0]])
 
     fill()
 

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -322,12 +322,10 @@ def test_init_matrix_from_vectors_deprecated():
             a = ti.Vector([1.0, 4.0, 7.0])
             b = ti.Vector([2.0, 5.0, 8.0])
             c = ti.Vector([3.0, 6.0, 9.0])
-            m1[i] = ti.Matrix(rows=[a, b, c])
-            m2[i] = ti.Matrix(cols=[a, b, c])
-            m3[i] = ti.Matrix(
-                rows=[[1.0, 4.0, 7.0], [2.0, 5.0, 8.0], [3.0, 6.0, 9.0]])
-            m4[i] = ti.Matrix(
-                cols=[[1.0, 4.0, 7.0], [2.0, 5.0, 8.0], [3.0, 6.0, 9.0]])
+            m1[i] = ti.Matrix.rows([a, b, c])
+            m2[i] = ti.Matrix.cols([a, b, c])
+            m3[i] = ti.Matrix.rows([[1.0, 4.0, 7.0], [2.0, 5.0, 8.0], [3.0, 6.0, 9.0]])
+            m4[i] = ti.Matrix.cols([[1.0, 4.0, 7.0], [2.0, 5.0, 8.0], [3.0, 6.0, 9.0]])
 
     fill()
 


### PR DESCRIPTION
Related issue = #2880

`ti.Matrix.__init__` has many arguments which have been deprecated (and should have been obsolete) for a long time. This PR cleans them up.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
