### PR TITLE
[perf] [CUDA] Add missed AtomicOpType::min&max of warp reduction

### DIFF
--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -14,6 +14,7 @@ TLANG_NAMESPACE_BEGIN
 
 namespace {
 
+// TODO : bit_and, bit_or, bit_xor
 bool is_atomic_op_linear(AtomicOpType op_type) {
   return op_type == AtomicOpType::add || op_type == AtomicOpType::sub ||
          op_type == AtomicOpType::min || op_type == AtomicOpType::max;

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -15,7 +15,8 @@ TLANG_NAMESPACE_BEGIN
 namespace {
 
 bool is_atomic_op_linear(AtomicOpType op_type) {
-  return op_type == AtomicOpType::add || op_type == AtomicOpType::sub;
+  return op_type == AtomicOpType::add || op_type == AtomicOpType::sub ||
+         op_type == AtomicOpType::min || op_type == AtomicOpType::max;
 }
 
 // Find the destinations of global atomic reductions that can be demoted into


### PR DESCRIPTION
Related issue = #2487

This commit solves the problem of AtomicOpType::min & max not being added to the optimization list when warp reduction is performed on `ti.field` data.

But the one on `ti.ndarray` still unfixed.