### PR TITLE
[opt] Add conservative alias analysis for ExternalPtrStmt

### DIFF
--- a/taichi/analysis/alias_analysis.cpp
+++ b/taichi/analysis/alias_analysis.cpp
@@ -82,6 +82,12 @@ AliasResult alias_analysis(Stmt *var1, Stmt *var2) {
                : AliasResult::uncertain;
   }
 
+  if (var1->is<ExternalPtrStmt>() || var2->is<ExternalPtrStmt>()) {
+    if (!var1->is<ExternalPtrStmt>() || !var2->is<ExternalPtrStmt>())
+      return AliasResult::different;
+    return AliasResult::uncertain;
+  }
+
   // If both statements are GlobalPtrStmts or GetChStmts, we can check by
   // SNode::id.
   TI_ASSERT(var1->width() == 1);

--- a/tests/python/test_reduction.py
+++ b/tests/python/test_reduction.py
@@ -127,3 +127,17 @@ def test_reduction_different_scale():
     # 1024 and 100000 since OpenGL max threads per group ~= 1792
     for n in [1, 10, 60, 1024, 100000]:
         assert n == func(n)
+
+
+@ti.test()
+def test_reduction_any_arr():
+    @ti.kernel
+    def reduce(a: ti.any_arr()) -> ti.i32:
+        s = 0
+        for i in a:
+            ti.atomic_add(s, a[i])
+        return s
+
+    n = 1024
+    x = np.ones(n, dtype=np.int32)
+    assert reduce(x) == n


### PR DESCRIPTION
Related issue = #2487, #2951

This PR adds conservative alias analysis for `ExternalPtrStmt`, which will unblock potential optimization opportunity such as #2487 for `ti.any_arr` arguments.

Let's try an example illustrating the optimization of #2487:
```python
import taichi as ti

ti.init(ti.cuda, kernel_profiler=True)
n = 1024 * 1024 * 32
x = ti.ndarray(ti.i32, n)
s = ti.field(ti.i32, ())

@ti.kernel
def reduce(a: ti.any_arr()):
    for i in range(n):
        ti.atomic_add(s[None], a[i])

reduce(x)
ti.clear_kernel_profile_info()
for i in range(100):
    reduce(x)
ti.print_kernel_profile_info()
```

Profiling result before this PR:
```
CUDA Profiler
=========================================================================
[      %     total   count |      min       avg       max   ] Kernel name
[100.00%   3.777 s   5150x |    0.729     0.733     0.737 ms] reduce_c4_0_kernel_0_range_for
-------------------------------------------------------------------------
[100.00%] Total kernel execution time:   3.777 s   number of records: 1
=========================================================================
```

Profiling result after this PR:
```
CUDA Profiler
=========================================================================
[      %     total   count |      min       avg       max   ] Kernel name
[100.00%   0.831 s   5150x |    0.160     0.161     0.188 ms] reduce_c4_0_kernel_0_range_for
-------------------------------------------------------------------------
[100.00%] Total kernel execution time:   0.831 s   number of records: 1
=========================================================================
```

We can see ~4.5x speedup.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
