### PR TITLE
[opt] Support atomic min/max in warp reduction optimization

### DIFF
--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -124,5 +124,57 @@ inline bool needs_grad(DataType dt) {
   return is_real(dt);
 }
 
+inline TypedConstant get_max_value(DataType dt) {
+  if (dt->is_primitive(PrimitiveTypeID::i8)) {
+    return {dt, std::numeric_limits<int8>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
+    return {dt, std::numeric_limits<int16>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
+    return {dt, std::numeric_limits<int32>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
+    return {dt, std::numeric_limits<int64>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
+    return {dt, std::numeric_limits<uint8>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
+    return {dt, std::numeric_limits<uint16>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
+    return {dt, std::numeric_limits<uint32>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
+    return {dt, std::numeric_limits<uint64>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
+    return {dt, std::numeric_limits<float32>::max()};
+  } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
+    return {dt, std::numeric_limits<float64>::max()};
+  } else {
+    TI_NOT_IMPLEMENTED;
+  }
+}
+
+inline TypedConstant get_min_value(DataType dt) {
+  if (dt->is_primitive(PrimitiveTypeID::i8)) {
+    return {dt, std::numeric_limits<int8>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
+    return {dt, std::numeric_limits<int16>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
+    return {dt, std::numeric_limits<int32>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
+    return {dt, std::numeric_limits<int64>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
+    return {dt, std::numeric_limits<uint8>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
+    return {dt, std::numeric_limits<uint16>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
+    return {dt, std::numeric_limits<uint32>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
+    return {dt, std::numeric_limits<uint64>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
+    return {dt, std::numeric_limits<float32>::min()};
+  } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
+    return {dt, std::numeric_limits<float64>::min()};
+  } else {
+    TI_NOT_IMPLEMENTED;
+  }
+}
+
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -135,7 +135,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
           TypeFactory::create_vector_or_scalar_type(1, data_type, true));
 
       auto zero = offload->tls_prologue->insert(
-          std::make_unique<ConstStmt>(TypedConstant(data_type, 0)), -1);
+          std::make_unique<ConstStmt>(dest.second == AtomicOpType::max ? get_min_value(data_type) : dest.second == AtomicOpType::min ? get_max_value(data_type) : TypedConstant(data_type, 0)), -1);
       // Zero-fill
       // TODO: do not use GlobalStore for TLS ptr.
       offload->tls_prologue->push_back<GlobalStoreStmt>(tls_ptr, zero);

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -15,7 +15,8 @@ TLANG_NAMESPACE_BEGIN
 namespace {
 
 bool is_atomic_op_supported(AtomicOpType op_type) {
-  return op_type == AtomicOpType::add || op_type == AtomicOpType::sub || op_type == AtomicOpType::max || op_type == AtomicOpType::min;
+  return op_type == AtomicOpType::add || op_type == AtomicOpType::sub ||
+         op_type == AtomicOpType::max || op_type == AtomicOpType::min;
 }
 
 AtomicOpType atomic_op_genre(AtomicOpType op_type) {
@@ -23,7 +24,8 @@ AtomicOpType atomic_op_genre(AtomicOpType op_type) {
 }
 
 bool does_atomic_op_belong_to_genre(AtomicOpType op_type, AtomicOpType genre) {
-  return op_type == AtomicOpType::sub && genre == AtomicOpType::add || op_type == genre;
+  return op_type == AtomicOpType::sub && genre == AtomicOpType::add ||
+         op_type == genre;
 }
 
 // Find the destinations of global atomic reductions that can be demoted into
@@ -68,15 +70,18 @@ std::vector<std::pair<T *, AtomicOpType>> find_global_reduction_destinations(
               return true;
             }
           } else if (auto atomic = stmt->cast<AtomicOpStmt>()) {
-            if (irpass::analysis::maybe_same_address(atomic->dest, dest.first)) {
-              return !does_atomic_op_belong_to_genre(atomic->op_type, dest.second);
+            if (irpass::analysis::maybe_same_address(atomic->dest,
+                                                     dest.first)) {
+              return !does_atomic_op_belong_to_genre(atomic->op_type,
+                                                     dest.second);
             }
           }
           for (auto &op : stmt->get_operands()) {
             // Make sure the values of related atomic add operation are not
             // used.
             if (auto atomic = op->cast<AtomicOpStmt>()) {
-              if (irpass::analysis::maybe_same_address(atomic->dest, dest.first)) {
+              if (irpass::analysis::maybe_same_address(atomic->dest,
+                                                       dest.first)) {
                 return true;
               }
             }
@@ -174,8 +179,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
               (Stmt *)irpass::analysis::clone(dest.first).release()),
           -1);
       offload->tls_epilogue->insert(
-          AtomicOpStmt::make_for_reduction(dest.second, global_ptr,
-                                           tls_load),
+          AtomicOpStmt::make_for_reduction(dest.second, global_ptr, tls_load),
           -1);
     }
 

--- a/tests/python/test_reduction.py
+++ b/tests/python/test_reduction.py
@@ -62,13 +62,13 @@ def _test_reduction_single(dtype, criterion, op):
 
     @ti.kernel
     def reduce_tmp() -> dtype:
-        s = ti.zero(tot[None]) if op == OP_ADD else a[0]
+        s = ti.zero(tot[None]) if op == OP_ADD or op == OP_XOR else a[0]
         for i in a:
             ti_op(s, a[i])
         return s
 
     fill()
-    tot[None] = 0 if op == OP_ADD else a[0]
+    tot[None] = 0 if op in [OP_ADD, OP_XOR] else a[0]
     reduce()
     tot2 = reduce_tmp()
 


### PR DESCRIPTION
Related issue = #2487, #2951, #2952

Previously, only atomic add/sub are supported in warp reduction optimization. This PR aims at also supporting atomic min/max.

Thanks @yolo2themoon for providing the following example:
```python
import taichi as ti

ti.init(kernel_profiler=True, arch=ti.cuda)

n = 2048 * 2048 * 2

a1 = ti.ndarray(ti.f32, n)
a2 = ti.ndarray(ti.f32, n)
f1 = ti.field(ti.f32, n)
f2 = ti.field(ti.f32, n)

temp_add = ti.field(ti.f32, ())
temp_max = ti.field(ti.f32, ())

@ti.kernel
def atomicadd_field():
    for P in range(n):
        ti.atomic_add(temp_add[None], f1[P])

@ti.kernel
def atomicadd_array(field_in: ti.any_arr()):
    for P in range(n):
        ti.atomic_add(temp_add[None], field_in[P])

@ti.kernel
def atomicmax_field():
    for P in range(n):
        ti.atomic_max(temp_max[None], f2[P])

@ti.kernel
def atomicmax_array(field_in: ti.any_arr()):
    for P in range(n):
        ti.atomic_max(temp_max[None], field_in[P])

@ti.kernel
def init():
    temp_add[None] = 0.
    temp_max[None] = 0.

init()
atomicadd_field()
atomicadd_array(a1)
atomicmax_field()
atomicmax_array(a2)
ti.clear_kernel_profile_info()
for i in range(100):
    init()
    atomicadd_field()
    atomicadd_array(a1)
    atomicmax_field()
    atomicmax_array(a2)
ti.print_kernel_profile_info()
```

Profiling results before this PR:
```
CUDA Profiler
=========================================================================
[      %     total   count |      min       avg       max   ] Kernel name
[ 49.77%  52.260 s  10100x |    5.015     5.174     5.767 ms] atomicmax_array_c10_0_kernel_4_range_for
[ 49.29%  51.757 s  10100x |    4.945     5.124     5.699 ms] atomicmax_field_c8_0_kernel_3_range_for
[  0.46%   0.480 s  10200x |    0.045     0.047     0.050 ms] atomicadd_array_c6_0_kernel_2_range_for
[  0.45%   0.476 s  10200x |    0.045     0.047     0.049 ms] atomicadd_field_c4_0_kernel_1_range_for
[  0.03%   0.035 s  10200x |    0.003     0.003     0.007 ms] init_c12_0_kernel_0_serial
-------------------------------------------------------------------------
[100.00%] Total kernel execution time: 105.009 s   number of records: 5
=========================================================================
```

Profiling results after this PR:
```
CUDA Profiler
=========================================================================
[      %     total   count |      min       avg       max   ] Kernel name
[ 26.41%   0.575 s  10100x |    0.056     0.057     0.059 ms] atomicmax_field_c8_0_kernel_3_range_for
[ 26.37%   0.574 s  10100x |    0.055     0.057     0.058 ms] atomicmax_array_c10_0_kernel_4_range_for
[ 22.95%   0.500 s  10200x |    0.048     0.049     0.050 ms] atomicadd_array_c6_0_kernel_2_range_for
[ 22.59%   0.492 s  10200x |    0.047     0.048     0.049 ms] atomicadd_field_c4_0_kernel_1_range_for
[  1.67%   0.036 s  10200x |    0.003     0.004     0.005 ms] init_c12_0_kernel_0_serial
-------------------------------------------------------------------------
[100.00%] Total kernel execution time:   2.178 s   number of records: 5
=========================================================================
```

We can see ~100x speedup for atomic max.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
