### PR TITLE
[misc] Support clean command in setup.py.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README
+description_file = README

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ import platform
 import shutil
 import subprocess
 import sys
+from distutils.command.clean import clean
+from distutils.dir_util import remove_tree
 
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
@@ -45,6 +47,8 @@ print(packages)
 
 # Our python package root dir is python/
 package_dir = 'python'
+
+root_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 def get_python_executable():
@@ -113,7 +117,7 @@ class CMakeBuild(build_ext):
                 ", ".join(e.name for e in self.extensions))
 
         # CMakeLists.txt is in the same directory as this setup.py file
-        cmake_list_dir = os.path.abspath(os.path.dirname(__file__))
+        cmake_list_dir = root_dir
         self.build_temp = os.path.join(cmake_list_dir, 'build')
 
         build_directory = os.path.abspath(self.build_temp)
@@ -192,6 +196,30 @@ class CMakeBuild(build_ext):
                     shutil.copy(os.path.join(llvm_runtime_dir, f), target)
 
 
+class Clean(clean):
+    def run(self):
+        super().run()
+        self.build_temp = os.path.join(root_dir, 'build')
+        if os.path.exists(self.build_temp):
+            remove_tree(self.build_temp, dry_run=self.dry_run)
+        generated_folders = ('bin', 'dist', 'python/taichi/assets',
+                             'python/taichi/lib', 'python/taichi/examples',
+                             'python/taichi/tests', 'python/taichi.egg-info')
+        for d in generated_folders:
+            if os.path.exists(d):
+                remove_tree(d, dry_run=self.dry_run)
+        generated_files = [
+            'taichi/common/commit_hash.h', 'taichi/common/version.h'
+        ]
+        generated_files += glob.glob('taichi/runtime/llvm/runtime_*.bc')
+        generated_files += glob.glob('taichi/runtime/llvm/runtime_*.ll')
+        for f in generated_files:
+            if os.path.exists(f):
+                print(f'removing generated file {f}')
+                if not self.dry_run:
+                    os.remove(f)
+
+
 setup(name=project_name,
       packages=packages,
       package_dir={"": package_dir},
@@ -218,5 +246,8 @@ setup(name=project_name,
       },
       classifiers=classifiers,
       ext_modules=[CMakeExtension('taichi_core')],
-      cmdclass=dict(egg_info=EggInfo, build_py=BuildPy, build_ext=CMakeBuild),
+      cmdclass=dict(egg_info=EggInfo,
+                    build_py=BuildPy,
+                    build_ext=CMakeBuild,
+                    clean=Clean),
       has_ext_modules=lambda: True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#2962**
* #2961

```
$ python setup.py clean
running clean
removing '/Users/ailzhang/github/taichi/build' (and everything under it)
removing 'bin' (and everything under it)
removing 'python/taichi/assets' (and everything under it)
removing 'python/taichi/lib' (and everything under it)
removing 'python/taichi/examples' (and everything under it)
removing 'python/taichi/tests' (and everything under it)
removing 'python/taichi.egg-info' (and everything under it)
removing generated file taichi/common/commit_hash.h
removing generated file taichi/common/version.h
removing generated file taichi/runtime/llvm/runtime_arm64.bc
removing generated file taichi/runtime/llvm/runtime_arm64.ll

$ python setup.py clean --dry-run
```

Note this command only cleans up local information of your previous builds.
It mainly allows a fresh build without any cache from previous builds.
This is a different use case than `pip uninstall taichi` which uninstalls taichi package from your python environment.