### PR TITLE
[Bug] Add GIL that was accidentally removed in PR #2939 back

### DIFF
--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -767,6 +767,7 @@ void export_lang(py::module &m) {
       "create_kernel",
       [&](const std::function<void()> &body, const std::string &name,
           bool grad) -> Kernel * {
+        py::gil_scoped_release release;
         return &get_current_program().kernel(body, name, grad);
       },
       py::return_value_policy::reference);


### PR DESCRIPTION
Related issue = fixes #2723

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
