### PR TITLE
[refactor] Avoid passing device strings into torch

### DIFF
--- a/python/taichi/lang/ndarray.py
+++ b/python/taichi/lang/ndarray.py
@@ -16,13 +16,10 @@ class Ndarray:
         assert has_pytorch(
         ), "PyTorch must be available if you want to create a Taichi ndarray."
         import torch
-        if impl.current_cfg().arch == _ti_core.Arch.cuda:
-            device = 'cuda:0'
-        else:
-            device = 'cpu'
         self.arr = torch.zeros(shape,
-                               dtype=to_pytorch_type(cook_dtype(dtype)),
-                               device=device)
+                               dtype=to_pytorch_type(cook_dtype(dtype)))
+        if impl.current_cfg().arch == _ti_core.Arch.cuda:
+            self.arr = self.arr.cuda()
 
     @property
     def shape(self):

--- a/python/taichi/lang/ndarray.py
+++ b/python/taichi/lang/ndarray.py
@@ -16,8 +16,7 @@ class Ndarray:
         assert has_pytorch(
         ), "PyTorch must be available if you want to create a Taichi ndarray."
         import torch
-        self.arr = torch.zeros(shape,
-                               dtype=to_pytorch_type(cook_dtype(dtype)))
+        self.arr = torch.zeros(shape, dtype=to_pytorch_type(cook_dtype(dtype)))
         if impl.current_cfg().arch == _ti_core.Arch.cuda:
             self.arr = self.arr.cuda()
 


### PR DESCRIPTION
For now (prototyping stage) we are using `torch.Tensor` as storage for Taichi ndarrays. When constructing ndarrays, we will pass device strings `cpu` or `cuda:0` into `torch.zeros`. However, there are some known issues like https://github.com/pytorch/pytorch/issues/50779, https://discuss.pytorch.org/t/std-regex-replace-not-work-with-libtorch-1-7-0/102253, which may prevent users from using Taichi as a part of their software. Therefore I'm getting rid of these device strings in this PR.


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
