### PR TITLE
[refactor] Minimize Python context

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -290,17 +290,8 @@ class KernelArgError(Exception):
 
 
 def _get_global_vars(func):
-    # Discussions: https://github.com/taichi-dev/taichi/issues/282
-    global_vars = copy.copy(func.__globals__)
-
-    freevar_names = func.__code__.co_freevars
-    closure = func.__closure__
-    if closure:
-        freevar_values = list(map(lambda x: x.cell_contents, closure))
-        for name, value in zip(freevar_names, freevar_values):
-            global_vars[name] = value
-
-    return global_vars
+    closure_vars = inspect.getclosurevars(func)
+    return {**closure_vars.globals, **closure_vars.nonlocals}
 
 
 class Kernel:

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -595,11 +595,12 @@ if 1:
             if impl.get_runtime().experimental_real_function:
                 transform_as_kernel()
             else:
-                # Transform as func (all parameters passed by value)
+                # Transform as force-inlined func
                 arg_decls = []
                 for i, arg in enumerate(args.args):
-                    # Directly pass in template arguments,
-                    # such as class instances ("self"), fields, SNodes, etc.
+                    # Remove annotations because they are not used.
+                    args.args[i].annotation = None
+                    # Template arguments are passed by reference.
                     if isinstance(ctx.func.argument_annotations[i],
                                   ti.template):
                         ctx.create_variable(ctx.func.argument_names[i])


### PR DESCRIPTION
Related issue = #282

### Background
The Taichi compiler first translates the AST of a kernel/function into another Python function, and runs that function to generate C++ AST. In order to run that function, the Python context (global vars and non-local vars) needs to be passed in.

### Problem
Previous way is to use `func.__globals__` for all global vars (not limited to what are used in that `func`) and ad-hoc manipulation for non-local vars. The former may make the Python context too large and the latter might be error-prone.

### Solution
Use `inspect.getclosurevars(func)` instead. This provides a minimum Python context, which only captures actually used global/non-local variables. This may also serve as a first step towards cleaning up the compilation process.

### Other details
After AST translation of force-inlined functions, the annotations of arguments should be removed (effects have been translated into function body) to avoid using `ti.template()` before importing `taichi`. Comments of force-inlined functions are also fixed by the way (which should be done in #2871).

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
