### PR TITLE
[misc] Remove unnecessary symlink step.

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -124,12 +124,6 @@ def get_unique_task_id():
 
 
 sys.path.append(os.path.join(package_root(), 'lib'))
-if settings.get_os_name() != 'win':
-    link_src = os.path.join(package_root(), 'lib', 'taichi_core.so')
-    link_dst = os.path.join(package_root(), 'lib', 'libtaichi_core.so')
-    # For llvm jit to find the runtime symbols
-    if not os.path.exists(link_dst):
-        os.symlink(link_src, link_dst)
 import_ti_core()
 
 ti_core.set_python_package_dir(package_root())


### PR DESCRIPTION
When I debugged the nightly release failure I realized that `pip uninstall taichi -y` won't fully delete the `taichi` folder in the python `site-packages`. This happens since we generates a symlinked
`libtaichi_core.so` at runtime that `pip` isn't aware of. So `pip`
leaves it in `site-packages/taichi/lib` during uninstall. This is **BAD** since it means even after
you uninstall taichi, you'll still be able to `import taichi`(altho empty!) due to the
`site-packages/taichi` folder.

Note this only happens when you install taichi from a wheel, `python
setup.py install/develop` works fine.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
