### PR TITLE
[cuda] Cuda Device API 1/n: memory allocation

### DIFF
--- a/taichi/backends/cuda/cuda_device.cpp
+++ b/taichi/backends/cuda/cuda_device.cpp
@@ -2,11 +2,9 @@
 
 TLANG_NAMESPACE_BEGIN
 
+namespace cuda {
 
-namespace cuda{
-
-
-CudaDevice::AllocInfo  CudaDevice::get_alloc_info(DeviceAllocation handle){
+CudaDevice::AllocInfo CudaDevice::get_alloc_info(DeviceAllocation handle) {
   validate_device_alloc(handle);
   return allocations_[handle.alloc_id];
 }
@@ -14,16 +12,15 @@ CudaDevice::AllocInfo  CudaDevice::get_alloc_info(DeviceAllocation handle){
 DeviceAllocation CudaDevice::allocate_memory(const AllocParams &params) {
   AllocInfo info;
 
-  if(params.host_read || params.host_write){
+  if (params.host_read || params.host_write) {
     CUDADriver::get_instance().malloc_managed(&info.ptr, params.size,
                                               CU_MEM_ATTACH_GLOBAL);
-  }
-  else{
+  } else {
     CUDADriver::get_instance().malloc(&info.ptr, params.size);
   }
-  
+
   info.size = params.size;
-  
+
   DeviceAllocation alloc;
   alloc.alloc_id = allocations_.size();
   alloc.device = this;
@@ -34,13 +31,13 @@ DeviceAllocation CudaDevice::allocate_memory(const AllocParams &params) {
 
 void CudaDevice::dealloc_memory(DeviceAllocation handle) {
   validate_device_alloc(handle);
-  AllocInfo& info = allocations_[handle.alloc_id];
-  if(info.ptr == nullptr){
+  AllocInfo &info = allocations_[handle.alloc_id];
+  if (info.ptr == nullptr) {
     TI_ERROR("the DeviceAllocation is already deallocated");
   }
   CUDADriver::get_instance().mem_free(info.ptr);
   info.ptr = nullptr;
 }
 
-}
+}  // namespace cuda
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_device.cpp
+++ b/taichi/backends/cuda/cuda_device.cpp
@@ -13,8 +13,15 @@ CudaDevice::AllocInfo  CudaDevice::get_alloc_info(DeviceAllocation handle){
 
 DeviceAllocation CudaDevice::allocate_memory(const AllocParams &params) {
   AllocInfo info;
-  //TODO: unified memory for host read/write? Need to query CUDA capabilities.
-  CUDADriver::get_instance().malloc(&info.ptr, params.size);
+
+  if(params.host_read || params.host_write){
+    CUDADriver::get_instance().malloc_managed(&info.ptr, params.size,
+                                              CU_MEM_ATTACH_GLOBAL);
+  }
+  else{
+    CUDADriver::get_instance().malloc(&info.ptr, params.size);
+  }
+  
   info.size = params.size;
   
   DeviceAllocation alloc;

--- a/taichi/backends/cuda/cuda_device.cpp
+++ b/taichi/backends/cuda/cuda_device.cpp
@@ -1,0 +1,39 @@
+#include "taichi/backends/cuda/cuda_device.h"
+
+TLANG_NAMESPACE_BEGIN
+
+
+namespace cuda{
+
+
+CudaDevice::AllocInfo  CudaDevice::get_alloc_info(DeviceAllocation handle){
+  validate_device_alloc(handle);
+  return allocations_[handle.alloc_id];
+}
+
+DeviceAllocation CudaDevice::allocate_memory(const AllocParams &params) {
+  AllocInfo info;
+  //TODO: unified memory for host read/write? Need to query CUDA capabilities.
+  CUDADriver::get_instance().malloc(&info.ptr, params.size);
+  info.size = params.size;
+  
+  DeviceAllocation alloc;
+  alloc.alloc_id = allocations_.size();
+  alloc.device = this;
+
+  allocations_.push_back(info);
+  return alloc;
+}
+
+void CudaDevice::dealloc_memory(DeviceAllocation handle) {
+  validate_device_alloc(handle);
+  AllocInfo& info = allocations_[handle.alloc_id];
+  if(info.ptr == nullptr){
+    TI_ERROR("the DeviceAllocation is already deallocated");
+  }
+  CUDADriver::get_instance().mem_free(info.ptr);
+  info.ptr = nullptr;
+}
+
+}
+TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_device.cpp
+++ b/taichi/backends/cuda/cuda_device.cpp
@@ -1,6 +1,7 @@
 #include "taichi/backends/cuda/cuda_device.h"
 
-TLANG_NAMESPACE_BEGIN
+namespace taichi {
+namespace lang {
 
 namespace cuda {
 
@@ -40,4 +41,6 @@ void CudaDevice::dealloc_memory(DeviceAllocation handle) {
 }
 
 }  // namespace cuda
-TLANG_NAMESPACE_END
+}  // namespace lang
+
+}  // namespace taichi

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -7,8 +7,8 @@
 #include "taichi/backends/cuda/cuda_context.h"
 #include "taichi/backends/device.h"
 
-TLANG_NAMESPACE_BEGIN
-
+namespace taichi {
+namespace lang {
 namespace cuda {
 
 class CudaResourceBinder : public ResourceBinder {
@@ -114,4 +114,6 @@ class CudaDevice : public Device {
 
 }  // namespace cuda
 
-TLANG_NAMESPACE_END
+}  // namespace lang
+
+}  // namespace taichi

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -14,32 +14,32 @@ namespace cuda{
 
 class CudaResourceBinder:public ResourceBinder {
  public:
-  virtual ~CudaResourceBinder() override {
+  ~CudaResourceBinder() override {
   }
 
-  virtual std::unique_ptr<Bindings> materialize() override {
+  std::unique_ptr<Bindings> materialize() override {
       TI_NOT_IMPLEMENTED
   };
 
-  virtual void rw_buffer(uint32_t set,
+  void rw_buffer(uint32_t set,
                          uint32_t binding,
                          DevicePtr ptr,
                          size_t size) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void rw_buffer(uint32_t set,
+  void rw_buffer(uint32_t set,
                          uint32_t binding,
                          DeviceAllocation alloc) override {
       TI_NOT_IMPLEMENTED
   };
 
-  virtual void buffer(uint32_t set,
+  void buffer(uint32_t set,
                       uint32_t binding,
                       DevicePtr ptr,
                       size_t size) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void buffer(uint32_t set,
+  void buffer(uint32_t set,
                       uint32_t binding,
                       DeviceAllocation alloc) override {
       TI_NOT_IMPLEMENTED
@@ -51,10 +51,10 @@ class CudaResourceBinder:public ResourceBinder {
 
 class CudaPipeline:public Pipeline {
  public:
-  virtual ~CudaPipeline() override {
+  ~CudaPipeline() override {
   }
 
-  virtual ResourceBinder *resource_binder() override {
+  ResourceBinder *resource_binder() override {
       TI_NOT_IMPLEMENTED
   };
 };
@@ -62,35 +62,35 @@ class CudaPipeline:public Pipeline {
 
 class CudaCommandList:public CommandList {
  public:
-  virtual ~CudaCommandList() override {
+  ~CudaCommandList() override {
   }
 
-  virtual void bind_pipeline(Pipeline *p) override {
+  void bind_pipeline(Pipeline *p) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void bind_resources(ResourceBinder *binder) override {
+  void bind_resources(ResourceBinder *binder) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void bind_resources(ResourceBinder *binder,
+  void bind_resources(ResourceBinder *binder,
                               ResourceBinder::Bindings *bindings) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void buffer_barrier(DevicePtr ptr, size_t size) override {
+  void buffer_barrier(DevicePtr ptr, size_t size) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void buffer_barrier(DeviceAllocation alloc) override {
+  void buffer_barrier(DeviceAllocation alloc) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void memory_barrier() override {
+  void memory_barrier() override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override {
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override {
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override {
+  void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override {
       TI_NOT_IMPLEMENTED
   };
 
@@ -99,19 +99,19 @@ class CudaCommandList:public CommandList {
 
 class CudaStream :public Stream{
  public:
-  virtual ~CudaStream() override{};
+  ~CudaStream() override{};
 
-  virtual std::unique_ptr<CommandList> new_command_list() override {
+  std::unique_ptr<CommandList> new_command_list() override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void submit(CommandList *cmdlist) override {
+  void submit(CommandList *cmdlist) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void submit_synced(CommandList *cmdlist) override {
+  void submit_synced(CommandList *cmdlist) override {
       TI_NOT_IMPLEMENTED
   };
 
-  virtual void command_sync() override {
+  void command_sync() override {
       TI_NOT_IMPLEMENTED
   };
 };
@@ -127,36 +127,36 @@ class CudaDevice :public Device{
   AllocInfo get_alloc_info(DeviceAllocation handle);
 
 
-  virtual ~CudaDevice() override {};
+  ~CudaDevice() override {};
 
-  virtual DeviceAllocation allocate_memory(const AllocParams &params) ;
-  virtual void dealloc_memory(DeviceAllocation handle) ;
+  DeviceAllocation allocate_memory(const AllocParams &params) ;
+  void dealloc_memory(DeviceAllocation handle) ;
 
-  virtual std::unique_ptr<Pipeline> create_pipeline(
+  std::unique_ptr<Pipeline> create_pipeline(
       const PipelineSourceDesc &src,
       std::string name = "Pipeline") override {
       TI_NOT_IMPLEMENTED
   };
 
-  virtual void *map_range(DevicePtr ptr, uint64_t size) override {
+  void *map_range(DevicePtr ptr, uint64_t size) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void *map(DeviceAllocation alloc) override {
+  void *map(DeviceAllocation alloc) override {
       TI_NOT_IMPLEMENTED
   };
 
-  virtual void unmap(DevicePtr ptr) override {
+  void unmap(DevicePtr ptr) override {
       TI_NOT_IMPLEMENTED
   };
-  virtual void unmap(DeviceAllocation alloc) override {
+  void unmap(DeviceAllocation alloc) override {
       TI_NOT_IMPLEMENTED
   };
   
-  virtual void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
+  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
       TI_NOT_IMPLEMENTED
   };
 
-  virtual Stream *get_compute_stream() override {
+  Stream *get_compute_stream() override {
       TI_NOT_IMPLEMENTED
   };
 private:

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -9,170 +9,109 @@
 
 TLANG_NAMESPACE_BEGIN
 
+namespace cuda {
 
-namespace cuda{
-
-class CudaResourceBinder:public ResourceBinder {
+class CudaResourceBinder : public ResourceBinder {
  public:
   ~CudaResourceBinder() override {
   }
 
-  std::unique_ptr<Bindings> materialize() override {
-      TI_NOT_IMPLEMENTED
-  };
+  std::unique_ptr<Bindings> materialize() override{TI_NOT_IMPLEMENTED};
 
   void rw_buffer(uint32_t set,
-                         uint32_t binding,
-                         DevicePtr ptr,
-                         size_t size) override {
-      TI_NOT_IMPLEMENTED
-  };
+                 uint32_t binding,
+                 DevicePtr ptr,
+                 size_t size) override{TI_NOT_IMPLEMENTED};
   void rw_buffer(uint32_t set,
-                         uint32_t binding,
-                         DeviceAllocation alloc) override {
-      TI_NOT_IMPLEMENTED
-  };
+                 uint32_t binding,
+                 DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
 
   void buffer(uint32_t set,
-                      uint32_t binding,
-                      DevicePtr ptr,
-                      size_t size) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void buffer(uint32_t set,
-                      uint32_t binding,
-                      DeviceAllocation alloc) override {
-      TI_NOT_IMPLEMENTED
-  };
-
+              uint32_t binding,
+              DevicePtr ptr,
+              size_t size) override{TI_NOT_IMPLEMENTED};
+  void buffer(uint32_t set, uint32_t binding, DeviceAllocation alloc) override{
+      TI_NOT_IMPLEMENTED};
 };
 
-
-
-class CudaPipeline:public Pipeline {
+class CudaPipeline : public Pipeline {
  public:
   ~CudaPipeline() override {
   }
 
-  ResourceBinder *resource_binder() override {
-      TI_NOT_IMPLEMENTED
-  };
+  ResourceBinder *resource_binder() override{TI_NOT_IMPLEMENTED};
 };
 
-
-class CudaCommandList:public CommandList {
+class CudaCommandList : public CommandList {
  public:
   ~CudaCommandList() override {
   }
 
-  void bind_pipeline(Pipeline *p) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void bind_resources(ResourceBinder *binder) override {
-      TI_NOT_IMPLEMENTED
-  };
+  void bind_pipeline(Pipeline *p) override{TI_NOT_IMPLEMENTED};
+  void bind_resources(ResourceBinder *binder) override{TI_NOT_IMPLEMENTED};
   void bind_resources(ResourceBinder *binder,
-                              ResourceBinder::Bindings *bindings) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void buffer_barrier(DevicePtr ptr, size_t size) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void buffer_barrier(DeviceAllocation alloc) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void memory_barrier() override {
-      TI_NOT_IMPLEMENTED
-  };
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override {
-      TI_NOT_IMPLEMENTED
-  };
-
+                      ResourceBinder::Bindings *bindings) override{
+      TI_NOT_IMPLEMENTED};
+  void buffer_barrier(DevicePtr ptr, size_t size) override{TI_NOT_IMPLEMENTED};
+  void buffer_barrier(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
+  void memory_barrier() override{TI_NOT_IMPLEMENTED};
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override{
+      TI_NOT_IMPLEMENTED};
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override{
+      TI_NOT_IMPLEMENTED};
+  void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override{
+      TI_NOT_IMPLEMENTED};
 };
 
-
-class CudaStream :public Stream{
+class CudaStream : public Stream {
  public:
   ~CudaStream() override{};
 
-  std::unique_ptr<CommandList> new_command_list() override {
-      TI_NOT_IMPLEMENTED
-  };
-  void submit(CommandList *cmdlist) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void submit_synced(CommandList *cmdlist) override {
-      TI_NOT_IMPLEMENTED
-  };
+  std::unique_ptr<CommandList> new_command_list() override{TI_NOT_IMPLEMENTED};
+  void submit(CommandList *cmdlist) override{TI_NOT_IMPLEMENTED};
+  void submit_synced(CommandList *cmdlist) override{TI_NOT_IMPLEMENTED};
 
-  void command_sync() override {
-      TI_NOT_IMPLEMENTED
-  };
+  void command_sync() override{TI_NOT_IMPLEMENTED};
 };
 
-class CudaDevice :public Device{
+class CudaDevice : public Device {
  public:
-
-  struct AllocInfo{
-    void* ptr{nullptr};
+  struct AllocInfo {
+    void *ptr{nullptr};
     size_t size{0};
   };
 
   AllocInfo get_alloc_info(DeviceAllocation handle);
 
+  ~CudaDevice() override{};
 
-  ~CudaDevice() override {};
-
-  DeviceAllocation allocate_memory(const AllocParams &params) ;
-  void dealloc_memory(DeviceAllocation handle) ;
+  DeviceAllocation allocate_memory(const AllocParams &params);
+  void dealloc_memory(DeviceAllocation handle);
 
   std::unique_ptr<Pipeline> create_pipeline(
       const PipelineSourceDesc &src,
-      std::string name = "Pipeline") override {
-      TI_NOT_IMPLEMENTED
-  };
+      std::string name = "Pipeline") override{TI_NOT_IMPLEMENTED};
 
-  void *map_range(DevicePtr ptr, uint64_t size) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void *map(DeviceAllocation alloc) override {
-      TI_NOT_IMPLEMENTED
-  };
+  void *map_range(DevicePtr ptr, uint64_t size) override{TI_NOT_IMPLEMENTED};
+  void *map(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
 
-  void unmap(DevicePtr ptr) override {
-      TI_NOT_IMPLEMENTED
-  };
-  void unmap(DeviceAllocation alloc) override {
-      TI_NOT_IMPLEMENTED
-  };
-  
-  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
-      TI_NOT_IMPLEMENTED
-  };
+  void unmap(DevicePtr ptr) override{TI_NOT_IMPLEMENTED};
+  void unmap(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
 
-  Stream *get_compute_stream() override {
-      TI_NOT_IMPLEMENTED
-  };
-private:
+  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override{
+      TI_NOT_IMPLEMENTED};
+
+  Stream *get_compute_stream() override{TI_NOT_IMPLEMENTED};
+
+ private:
   std::vector<AllocInfo> allocations_;
-  void validate_device_alloc(DeviceAllocation alloc){
-    if(allocations_.size() <= alloc.alloc_id){
+  void validate_device_alloc(DeviceAllocation alloc) {
+    if (allocations_.size() <= alloc.alloc_id) {
       TI_ERROR("invalid DeviceAllocation");
     }
   }
 };
 
-
-
-
-}
-
-
+}  // namespace cuda
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -1,0 +1,178 @@
+#pragma once
+#include <vector>
+#include <set>
+
+#include "taichi/common/core.h"
+#include "taichi/backends/cuda/cuda_driver.h"
+#include "taichi/backends/cuda/cuda_context.h"
+#include "taichi/backends/device.h"
+
+TLANG_NAMESPACE_BEGIN
+
+
+namespace cuda{
+
+class CudaResourceBinder:public ResourceBinder {
+ public:
+  virtual ~CudaResourceBinder() override {
+  }
+
+  virtual std::unique_ptr<Bindings> materialize() override {
+      TI_NOT_IMPLEMENTED
+  };
+
+  virtual void rw_buffer(uint32_t set,
+                         uint32_t binding,
+                         DevicePtr ptr,
+                         size_t size) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void rw_buffer(uint32_t set,
+                         uint32_t binding,
+                         DeviceAllocation alloc) override {
+      TI_NOT_IMPLEMENTED
+  };
+
+  virtual void buffer(uint32_t set,
+                      uint32_t binding,
+                      DevicePtr ptr,
+                      size_t size) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void buffer(uint32_t set,
+                      uint32_t binding,
+                      DeviceAllocation alloc) override {
+      TI_NOT_IMPLEMENTED
+  };
+
+};
+
+
+
+class CudaPipeline:public Pipeline {
+ public:
+  virtual ~CudaPipeline() override {
+  }
+
+  virtual ResourceBinder *resource_binder() override {
+      TI_NOT_IMPLEMENTED
+  };
+};
+
+
+class CudaCommandList:public CommandList {
+ public:
+  virtual ~CudaCommandList() override {
+  }
+
+  virtual void bind_pipeline(Pipeline *p) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void bind_resources(ResourceBinder *binder) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void bind_resources(ResourceBinder *binder,
+                              ResourceBinder::Bindings *bindings) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void buffer_barrier(DevicePtr ptr, size_t size) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void buffer_barrier(DeviceAllocation alloc) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void memory_barrier() override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override {
+      TI_NOT_IMPLEMENTED
+  };
+
+};
+
+
+class CudaStream :public Stream{
+ public:
+  virtual ~CudaStream() override{};
+
+  virtual std::unique_ptr<CommandList> new_command_list() override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void submit(CommandList *cmdlist) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void submit_synced(CommandList *cmdlist) override {
+      TI_NOT_IMPLEMENTED
+  };
+
+  virtual void command_sync() override {
+      TI_NOT_IMPLEMENTED
+  };
+};
+
+class CudaDevice :public Device{
+ public:
+
+  struct AllocInfo{
+    void* ptr{nullptr};
+    size_t size{0};
+  };
+
+  AllocInfo get_alloc_info(DeviceAllocation handle);
+
+
+  virtual ~CudaDevice() override {};
+
+  virtual DeviceAllocation allocate_memory(const AllocParams &params) ;
+  virtual void dealloc_memory(DeviceAllocation handle) ;
+
+  virtual std::unique_ptr<Pipeline> create_pipeline(
+      const PipelineSourceDesc &src,
+      std::string name = "Pipeline") override {
+      TI_NOT_IMPLEMENTED
+  };
+
+  virtual void *map_range(DevicePtr ptr, uint64_t size) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void *map(DeviceAllocation alloc) override {
+      TI_NOT_IMPLEMENTED
+  };
+
+  virtual void unmap(DevicePtr ptr) override {
+      TI_NOT_IMPLEMENTED
+  };
+  virtual void unmap(DeviceAllocation alloc) override {
+      TI_NOT_IMPLEMENTED
+  };
+  
+  virtual void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
+      TI_NOT_IMPLEMENTED
+  };
+
+  virtual Stream *get_compute_stream() override {
+      TI_NOT_IMPLEMENTED
+  };
+private:
+  std::vector<AllocInfo> allocations_;
+  void validate_device_alloc(DeviceAllocation alloc){
+    if(allocations_.size() <= alloc.alloc_id){
+      TI_ERROR("invalid DeviceAllocation");
+    }
+  }
+};
+
+
+
+
+}
+
+
+
+TLANG_NAMESPACE_END

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -306,11 +306,12 @@ void LlvmProgramImpl::materialize_runtime(MemoryPool *memory_pool,
     TI_TRACE("Allocating device memory {:.2f} GB",
              1.0 * prealloc_size / (1UL << 30));
 
-
     Device::AllocParams preallocated_device_buffer_alloc_params;
     preallocated_device_buffer_alloc_params.size = prealloc_size;
-    preallocated_device_buffer_alloc = cuda_device()->allocate_memory(preallocated_device_buffer_alloc_params);
-    cuda::CudaDevice::AllocInfo preallocated_device_buffer_alloc_info = cuda_device()->get_alloc_info(preallocated_device_buffer_alloc);
+    preallocated_device_buffer_alloc =
+        cuda_device()->allocate_memory(preallocated_device_buffer_alloc_params);
+    cuda::CudaDevice::AllocInfo preallocated_device_buffer_alloc_info =
+        cuda_device()->get_alloc_info(preallocated_device_buffer_alloc);
     preallocated_device_buffer = preallocated_device_buffer_alloc_info.ptr;
 
     CUDADriver::get_instance().memset(preallocated_device_buffer, 0,
@@ -440,7 +441,7 @@ void LlvmProgramImpl::finalize() {
   if (runtime_mem_info)
     runtime_mem_info->set_profiler(nullptr);
 #if defined(TI_WITH_CUDA)
-  if (preallocated_device_buffer != nullptr){
+  if (preallocated_device_buffer != nullptr) {
     cuda_device()->dealloc_memory(preallocated_device_buffer_alloc);
   }
 #endif

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -92,7 +92,7 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
       CUDAContext::get_instance().set_profiler(nullptr);
     }
     CUDAContext::get_instance().set_debug(config->debug);
-    device_ = std::unique_ptr<Device>(new cuda::CudaDevice());
+    device_ = std::make_unique<cuda::CudaDevice>();
   }
 #endif
 }

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -126,8 +126,8 @@ class LlvmProgramImpl : public ProgramImpl {
     TI_NOT_IMPLEMENTED;
   }
 
-  virtual Device* get_compute_device() override{
-      return device_.get();
+  virtual Device *get_compute_device() override {
+    return device_.get();
   }
 
  private:
@@ -142,13 +142,12 @@ class LlvmProgramImpl : public ProgramImpl {
   DeviceAllocation preallocated_device_buffer_alloc{kDeviceNullAllocation};
 
   std::unique_ptr<Device> device_;
-  cuda::CudaDevice* cuda_device(){
-    if(config->arch != Arch::cuda){
+  cuda::CudaDevice *cuda_device() {
+    if (config->arch != Arch::cuda) {
       TI_ERROR("arch is not cuda");
     }
-    return static_cast<cuda::CudaDevice*>(device_.get());
+    return static_cast<cuda::CudaDevice *>(device_.get());
   }
-
 };
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -16,6 +16,8 @@
 #include "taichi/program/context.h"
 #undef TI_RUNTIME_HOST
 
+#include "taichi/backends/cuda/cuda_device.h"
+
 #include <memory>
 
 namespace taichi {
@@ -132,6 +134,17 @@ class LlvmProgramImpl : public ProgramImpl {
   std::unique_ptr<SNodeTreeBufferManager> snode_tree_buffer_manager{nullptr};
   void *llvm_runtime{nullptr};
   void *preallocated_device_buffer{nullptr};  // TODO: move to memory allocator
+
+  DeviceAllocation preallocated_device_buffer_alloc{kDeviceNullAllocation};
+
+  std::unique_ptr<Device> device_;
+  cuda::CudaDevice* cuda_device(){
+    if(config->arch != Arch::cuda){
+      TI_ERROR("arch is not cuda");
+    }
+    return static_cast<cuda::CudaDevice*>(device_.get());
+  }
+
 };
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -126,6 +126,10 @@ class LlvmProgramImpl : public ProgramImpl {
     TI_NOT_IMPLEMENTED;
   }
 
+  virtual Device* get_compute_device() override{
+      return device_.get();
+  }
+
  private:
   std::unique_ptr<TaichiLLVMContext> llvm_context_host{nullptr};
   std::unique_ptr<TaichiLLVMContext> llvm_context_device{nullptr};

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -111,8 +111,12 @@ Program::Program(Arch desired_arch) : snode_rw_accessors_bank_(this) {
     TI_WARN("Falling back to {}", arch_name(config.arch));
   }
 
+  Device* compute_device = nullptr;
+  if(program_impl_.get()){
+    compute_device = program_impl_->get_compute_device();
+  }
   // Must have handled all the arch fallback logic by this point.
-  memory_pool = std::make_unique<MemoryPool>(config.arch);
+  memory_pool = std::make_unique<MemoryPool>(config.arch,compute_device);
   TI_ASSERT_INFO(num_instances_ == 0, "Only one instance at a time");
   total_compilation_time_ = 0;
   num_instances_ += 1;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -111,12 +111,12 @@ Program::Program(Arch desired_arch) : snode_rw_accessors_bank_(this) {
     TI_WARN("Falling back to {}", arch_name(config.arch));
   }
 
-  Device* compute_device = nullptr;
-  if(program_impl_.get()){
+  Device *compute_device = nullptr;
+  if (program_impl_.get()) {
     compute_device = program_impl_->get_compute_device();
   }
   // Must have handled all the arch fallback logic by this point.
-  memory_pool = std::make_unique<MemoryPool>(config.arch,compute_device);
+  memory_pool = std::make_unique<MemoryPool>(config.arch, compute_device);
   TI_ASSERT_INFO(num_instances_ == 0, "Only one instance at a time");
   total_compilation_time_ = 0;
   num_instances_ += 1;

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -103,7 +103,7 @@ class Program {
   Callable *current_callable{nullptr};
   CompileConfig config;
   bool sync{false};  // device/host synchronized?
-  std::unique_ptr<MemoryPool> memory_pool{nullptr};
+  
   uint64 *result_buffer{nullptr};  // Note result_buffer is used by all backends
 
   std::unordered_map<int, SNode *>
@@ -295,6 +295,8 @@ class Program {
   float64 total_compilation_time_{0.0};
   static std::atomic<int> num_instances_;
   bool finalized_{false};
+
+  std::unique_ptr<MemoryPool> memory_pool{nullptr};
 
  public:
 #ifdef TI_WITH_CC

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -103,7 +103,7 @@ class Program {
   Callable *current_callable{nullptr};
   CompileConfig config;
   bool sync{false};  // device/host synchronized?
-  
+
   uint64 *result_buffer{nullptr};  // Note result_buffer is used by all backends
 
   std::unordered_map<int, SNode *>

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -7,7 +7,6 @@
 #include "taichi/program/aot_module_builder.h"
 #include "taichi/backends/device.h"
 
-
 namespace taichi {
 namespace lang {
 class ProgramImpl {
@@ -57,12 +56,12 @@ class ProgramImpl {
    */
   virtual std::unique_ptr<AotModuleBuilder> make_aot_module_builder() = 0;
 
-  virtual Device* get_compute_device(){
-      return nullptr;
+  virtual Device *get_compute_device() {
+    return nullptr;
   }
 
-  virtual Device* get_graphics_device(){
-      return nullptr;
+  virtual Device *get_graphics_device() {
+    return nullptr;
   }
 
   virtual ~ProgramImpl() {

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -5,6 +5,8 @@
 #include "taichi/program/snode_expr_utils.h"
 #include "taichi/program/kernel_profiler.h"
 #include "taichi/program/aot_module_builder.h"
+#include "taichi/backends/device.h"
+
 
 namespace taichi {
 namespace lang {
@@ -54,6 +56,14 @@ class ProgramImpl {
    * Make a AotModulerBuilder, currently only supported by metal and wasm.
    */
   virtual std::unique_ptr<AotModuleBuilder> make_aot_module_builder() = 0;
+
+  virtual Device* get_compute_device(){
+      return nullptr;
+  }
+
+  virtual Device* get_graphics_device(){
+      return nullptr;
+  }
 
   virtual ~ProgramImpl() {
   }

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -1,6 +1,7 @@
 #include "memory_pool.h"
 #include "taichi/system/timer.h"
 #include "taichi/backends/cuda/cuda_driver.h"
+#include "taichi/backends/cuda/cuda_device.h"
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -4,7 +4,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
-MemoryPool::MemoryPool(Arch arch) : arch_(arch) {
+MemoryPool::MemoryPool(Arch arch,Device* device) : arch_(arch),device_(device) {
   TI_TRACE("Memory pool created. Default buffer size per allocator = {} MB",
            default_allocator_size / 1024 / 1024);
   terminating = false;
@@ -39,7 +39,7 @@ void *MemoryPool::allocate(std::size_t size, std::size_t alignment) {
     // allocation have failed
     auto new_buffer_size = std::max(size, default_allocator_size);
     allocators.emplace_back(
-        std::make_unique<UnifiedAllocator>(new_buffer_size, arch_));
+        std::make_unique<UnifiedAllocator>(new_buffer_size, arch_,device_));
     ret = allocators.back()->allocate(size, alignment);
   }
   TI_ASSERT(ret);

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -5,6 +5,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
+// In the future we wish to move the MemoryPool inside each Device
+// so that the memory allocated from each Device can be used as-is.
 MemoryPool::MemoryPool(Arch arch, Device *device)
     : arch_(arch), device_(device) {
   TI_TRACE("Memory pool created. Default buffer size per allocator = {} MB",

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -5,7 +5,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
-MemoryPool::MemoryPool(Arch arch,Device* device) : arch_(arch),device_(device) {
+MemoryPool::MemoryPool(Arch arch, Device *device)
+    : arch_(arch), device_(device) {
   TI_TRACE("Memory pool created. Default buffer size per allocator = {} MB",
            default_allocator_size / 1024 / 1024);
   terminating = false;
@@ -40,7 +41,7 @@ void *MemoryPool::allocate(std::size_t size, std::size_t alignment) {
     // allocation have failed
     auto new_buffer_size = std::max(size, default_allocator_size);
     allocators.emplace_back(
-        std::make_unique<UnifiedAllocator>(new_buffer_size, arch_,device_));
+        std::make_unique<UnifiedAllocator>(new_buffer_size, arch_, device_));
     ret = allocators.back()->allocate(size, alignment);
   }
   TI_ASSERT(ret);

--- a/taichi/system/memory_pool.h
+++ b/taichi/system/memory_pool.h
@@ -3,7 +3,7 @@
 #include "taichi/system/unified_allocator.h"
 #define TI_RUNTIME_HOST
 #include "taichi/runtime/llvm/mem_request.h"
-
+#include "taichi/backends/cuda/cuda_device.h"
 #include <mutex>
 #include <vector>
 #include <memory>
@@ -27,7 +27,7 @@ class MemoryPool {
   MemRequestQueue *queue;
   void *cuda_stream{nullptr};
 
-  MemoryPool(Arch arch);
+  MemoryPool(Arch arch, Device* device);
 
   template <typename T>
   T fetch(volatile void *ptr);
@@ -48,6 +48,7 @@ class MemoryPool {
  private:
   static constexpr bool use_cuda_stream = false;
   Arch arch_;
+  Device* device_;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/system/memory_pool.h
+++ b/taichi/system/memory_pool.h
@@ -3,7 +3,7 @@
 #include "taichi/system/unified_allocator.h"
 #define TI_RUNTIME_HOST
 #include "taichi/runtime/llvm/mem_request.h"
-#include "taichi/backends/cuda/cuda_device.h"
+#include "taichi/backends/device.h"
 #include <mutex>
 #include <vector>
 #include <memory>

--- a/taichi/system/memory_pool.h
+++ b/taichi/system/memory_pool.h
@@ -27,7 +27,7 @@ class MemoryPool {
   MemRequestQueue *queue;
   void *cuda_stream{nullptr};
 
-  MemoryPool(Arch arch, Device* device);
+  MemoryPool(Arch arch, Device *device);
 
   template <typename T>
   T fetch(volatile void *ptr);
@@ -48,7 +48,7 @@ class MemoryPool {
  private:
   static constexpr bool use_cuda_stream = false;
   Arch arch_;
-  Device* device_;
+  Device *device_;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/system/memory_pool.h
+++ b/taichi/system/memory_pool.h
@@ -27,6 +27,8 @@ class MemoryPool {
   MemRequestQueue *queue;
   void *cuda_stream{nullptr};
 
+  // In the future we wish to move the MemoryPool inside each Device
+  // so that the memory allocated from each Device can be used as-is.
   MemoryPool(Arch arch, Device *device);
 
   template <typename T>

--- a/taichi/system/unified_allocator.cpp
+++ b/taichi/system/unified_allocator.cpp
@@ -3,6 +3,8 @@
 #if defined(TI_WITH_CUDA)
 #include "taichi/backends/cuda/cuda_driver.h"
 #include "taichi/backends/cuda/cuda_context.h"
+#include "taichi/backends/cuda/cuda_device.h"
+
 #endif
 #include "taichi/lang_util.h"
 #include "taichi/system/unified_allocator.h"
@@ -12,8 +14,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
-UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch)
-    : size(size), arch_(arch) {
+UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch,Device* device)
+    : size(size), arch_(arch),device_(device) {
   auto t = Time::get_time();
   if (arch_ == Arch::cuda) {
     // CUDA gets stuck when
@@ -30,8 +32,16 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch)
     // This could be run on a host worker thread, so we have to set the context
     // before using any of the CUDA driver function call.
     auto _ = CUDAContext::get_instance().get_guard();
-    CUDADriver::get_instance().malloc_managed(&_cuda_data, size,
-                                              CU_MEM_ATTACH_GLOBAL);
+    
+    Device::AllocParams alloc_params;
+    alloc_params.size = size;
+    alloc_params.host_read = true;
+    alloc_params.host_write = true;
+
+    cuda::CudaDevice *cuda_device = static_cast<cuda::CudaDevice*>(device);
+    cuda_alloc = cuda_device->allocate_memory(alloc_params);
+    _cuda_data = cuda_device->get_alloc_info(cuda_alloc).ptr;
+    
     if (_cuda_data == nullptr) {
       TI_ERROR("CUDA memory allocation failed.");
     }
@@ -73,7 +83,8 @@ taichi::lang::UnifiedAllocator::~UnifiedAllocator() {
   }
   if (arch_ == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-    CUDADriver::get_instance().mem_free(_cuda_data);
+    cuda::CudaDevice *cuda_device = static_cast<cuda::CudaDevice*>(device_);
+    cuda_device->dealloc_memory(cuda_alloc);
 #else
     TI_ERROR("No CUDA support");
 #endif

--- a/taichi/system/unified_allocator.cpp
+++ b/taichi/system/unified_allocator.cpp
@@ -14,8 +14,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
-UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch,Device* device)
-    : size(size), arch_(arch),device_(device) {
+UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch, Device *device)
+    : size(size), arch_(arch), device_(device) {
   auto t = Time::get_time();
   if (arch_ == Arch::cuda) {
     // CUDA gets stuck when
@@ -32,16 +32,16 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch,Device* device)
     // This could be run on a host worker thread, so we have to set the context
     // before using any of the CUDA driver function call.
     auto _ = CUDAContext::get_instance().get_guard();
-    
+
     Device::AllocParams alloc_params;
     alloc_params.size = size;
     alloc_params.host_read = true;
     alloc_params.host_write = true;
 
-    cuda::CudaDevice *cuda_device = static_cast<cuda::CudaDevice*>(device);
+    cuda::CudaDevice *cuda_device = static_cast<cuda::CudaDevice *>(device);
     cuda_alloc = cuda_device->allocate_memory(alloc_params);
     _cuda_data = cuda_device->get_alloc_info(cuda_alloc).ptr;
-    
+
     if (_cuda_data == nullptr) {
       TI_ERROR("CUDA memory allocation failed.");
     }
@@ -83,7 +83,7 @@ taichi::lang::UnifiedAllocator::~UnifiedAllocator() {
   }
   if (arch_ == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-    cuda::CudaDevice *cuda_device = static_cast<cuda::CudaDevice*>(device_);
+    cuda::CudaDevice *cuda_device = static_cast<cuda::CudaDevice *>(device_);
     cuda_device->dealloc_memory(cuda_alloc);
 #else
     TI_ERROR("No CUDA support");

--- a/taichi/system/unified_allocator.h
+++ b/taichi/system/unified_allocator.h
@@ -30,7 +30,7 @@ class UnifiedAllocator {
   std::mutex lock;
 
  public:
-  UnifiedAllocator(std::size_t size, Arch arch, Device* device);
+  UnifiedAllocator(std::size_t size, Arch arch, Device *device);
 
   ~UnifiedAllocator();
 
@@ -59,8 +59,8 @@ class UnifiedAllocator {
 
   UnifiedAllocator operator=(const UnifiedAllocator &) = delete;
 
-  private:
-  Device* device_;
+ private:
+  Device *device_;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/system/unified_allocator.h
+++ b/taichi/system/unified_allocator.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "taichi/program/arch.h"
-#include "taichi/backends/cuda/cuda_device.h"
+#include "taichi/backends/device.h"
 
 namespace taichi {
 class VirtualMemoryAllocator;

--- a/taichi/system/unified_allocator.h
+++ b/taichi/system/unified_allocator.h
@@ -60,7 +60,7 @@ class UnifiedAllocator {
   UnifiedAllocator operator=(const UnifiedAllocator &) = delete;
 
  private:
-  Device *device_;
+  Device *device_{nullptr};
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/system/unified_allocator.h
+++ b/taichi/system/unified_allocator.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "taichi/program/arch.h"
+#include "taichi/backends/cuda/cuda_device.h"
 
 namespace taichi {
 class VirtualMemoryAllocator;
@@ -16,6 +17,7 @@ class UnifiedAllocator {
   std::unique_ptr<VirtualMemoryAllocator> cpu_vm;
 #if defined(TI_WITH_CUDA)
   void *_cuda_data;
+  DeviceAllocation cuda_alloc;
 #endif
   std::size_t size;
   Arch arch_;
@@ -28,7 +30,7 @@ class UnifiedAllocator {
   std::mutex lock;
 
  public:
-  UnifiedAllocator(std::size_t size, Arch arch);
+  UnifiedAllocator(std::size_t size, Arch arch, Device* device);
 
   ~UnifiedAllocator();
 
@@ -56,6 +58,9 @@ class UnifiedAllocator {
   }
 
   UnifiedAllocator operator=(const UnifiedAllocator &) = delete;
+
+  private:
+  Device* device_;
 };
 
 TLANG_NAMESPACE_END


### PR DESCRIPTION
This PR begins the work on CUDA deivce API.

The PR only implements memory allocation and deallocation, and makes use of those methods in LlvmProgram and MemoryPool.

This would be very useful for unifying the memcpy logic used in GGUI, which would facilitate implementing GGUI on other backends.

