### PR TITLE
[ci] Disable fail-fast matrix on release jobs.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
     needs: matrix_prep
     strategy:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
+    fail-fast: false
     runs-on: [self-hosted, cuda, vulkan, cn, release]
     steps:
       - uses: actions/checkout@v2
@@ -108,6 +109,7 @@ jobs:
     needs: matrix_prep
     strategy:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
+    fail-fast: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -173,6 +175,7 @@ jobs:
     needs: matrix_prep
     strategy:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix_osx) }}
+    fail-fast: false
     runs-on: [self-hosted, m1]
     defaults:
       run:
@@ -229,6 +232,7 @@ jobs:
     needs: matrix_prep
     strategy:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
+    fail-fast: false
     runs-on: windows-latest
     steps:
       - name: Install 7Zip PowerShell


### PR DESCRIPTION
This fits release jobs better than presubmit jobs. (in the sense that we
want release builds to finish as many as possible but in presubmit jobs
we want to save minutes.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
