### PR TITLE
[cpu] Cpu device 1/n: memory allocation

### DIFF
--- a/taichi/backends/cpu/cpu_device.h
+++ b/taichi/backends/cpu/cpu_device.h
@@ -1,0 +1,119 @@
+#pragma once
+#include <vector>
+#include <set>
+
+#include "taichi/common/core.h"
+#include "taichi/backends/device.h"
+#include "taichi/system/virtual_memory.h"
+
+namespace taichi {
+namespace lang {
+namespace cpu {
+
+class CpuResourceBinder : public ResourceBinder {
+ public:
+  ~CpuResourceBinder() override {
+  }
+
+  std::unique_ptr<Bindings> materialize() override{TI_NOT_IMPLEMENTED};
+
+  void rw_buffer(uint32_t set,
+                 uint32_t binding,
+                 DevicePtr ptr,
+                 size_t size) override{TI_NOT_IMPLEMENTED};
+  void rw_buffer(uint32_t set,
+                 uint32_t binding,
+                 DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
+
+  void buffer(uint32_t set,
+              uint32_t binding,
+              DevicePtr ptr,
+              size_t size) override{TI_NOT_IMPLEMENTED};
+  void buffer(uint32_t set, uint32_t binding, DeviceAllocation alloc) override{
+      TI_NOT_IMPLEMENTED};
+};
+
+class CpuPipeline : public Pipeline {
+ public:
+  ~CpuPipeline() override {
+  }
+
+  ResourceBinder *resource_binder() override{TI_NOT_IMPLEMENTED};
+};
+
+class CpuCommandList : public CommandList {
+ public:
+  ~CpuCommandList() override {
+  }
+
+  void bind_pipeline(Pipeline *p) override{TI_NOT_IMPLEMENTED};
+  void bind_resources(ResourceBinder *binder) override{TI_NOT_IMPLEMENTED};
+  void bind_resources(ResourceBinder *binder,
+                      ResourceBinder::Bindings *bindings) override{
+      TI_NOT_IMPLEMENTED};
+  void buffer_barrier(DevicePtr ptr, size_t size) override{TI_NOT_IMPLEMENTED};
+  void buffer_barrier(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
+  void memory_barrier() override{TI_NOT_IMPLEMENTED};
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override{
+      TI_NOT_IMPLEMENTED};
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override{
+      TI_NOT_IMPLEMENTED};
+  void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override{
+      TI_NOT_IMPLEMENTED};
+};
+
+class CpuStream : public Stream {
+ public:
+  ~CpuStream() override{};
+
+  std::unique_ptr<CommandList> new_command_list() override{TI_NOT_IMPLEMENTED};
+  void submit(CommandList *cmdlist) override{TI_NOT_IMPLEMENTED};
+  void submit_synced(CommandList *cmdlist) override{TI_NOT_IMPLEMENTED};
+
+  void command_sync() override{TI_NOT_IMPLEMENTED};
+};
+
+class CpuDevice : public Device {
+ public:
+  struct AllocInfo {
+    void *ptr{nullptr};
+    size_t size{0};
+  };
+
+  AllocInfo get_alloc_info(DeviceAllocation handle);
+
+  ~CpuDevice() override{};
+
+  DeviceAllocation allocate_memory(const AllocParams &params);
+  void dealloc_memory(DeviceAllocation handle);
+
+  std::unique_ptr<Pipeline> create_pipeline(
+      const PipelineSourceDesc &src,
+      std::string name = "Pipeline") override{TI_NOT_IMPLEMENTED};
+
+  void *map_range(DevicePtr ptr, uint64_t size) override{TI_NOT_IMPLEMENTED};
+  void *map(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
+
+  void unmap(DevicePtr ptr) override{TI_NOT_IMPLEMENTED};
+  void unmap(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
+
+  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override{
+      TI_NOT_IMPLEMENTED};
+
+  Stream *get_compute_stream() override{TI_NOT_IMPLEMENTED};
+
+ private:
+  std::vector<AllocInfo> allocations_;
+  std::vector<std::unique_ptr<VirtualMemoryAllocator>> virtual_memories_;
+  void validate_device_alloc(DeviceAllocation alloc) {
+    if (allocations_.size() <= alloc.alloc_id) {
+      TI_ERROR("invalid DeviceAllocation");
+    }
+  }
+};
+
+}  // namespace cpu
+
+}  // namespace lang
+
+}  // namespace taichi

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -8,6 +8,8 @@
 #include "taichi/util/str.h"
 #include "taichi/codegen/codegen.h"
 #include "taichi/ir/statements.h"
+#include "taichi/backends/cpu/cpu_device.h"
+
 #if defined(TI_WITH_CUDA)
 #include "taichi/backends/cuda/cuda_driver.h"
 #include "taichi/backends/cuda/codegen_cuda.h"
@@ -79,7 +81,7 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
 
   if (arch_is_cpu(config->arch)) {
     config_.max_block_dim = 1024;
-    device_ = std::make_unique<cuda::CudaDevice>();
+    device_ = std::make_unique<cpu::CpuDevice>();
   }
 
   if (config->kernel_profiler && runtime_mem_info) {

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -79,6 +79,7 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
 
   if (arch_is_cpu(config->arch)) {
     config_.max_block_dim = 1024;
+    device_ = std::make_unique<cuda::CudaDevice>();
   }
 
   if (config->kernel_profiler && runtime_mem_info) {

--- a/taichi/system/unified_allocator.cpp
+++ b/taichi/system/unified_allocator.cpp
@@ -67,7 +67,7 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch, Device *device)
   }
   // This is an intermediate state.
   // We will use memory pools to implement `Device::allocate_memory` soon.
-  else if (arch_ == Arch::x64 && false) {
+  else if (arch_ == Arch::x64) {
     Device::AllocParams alloc_params;
     alloc_params.size = size;
     alloc_params.host_read = true;
@@ -101,7 +101,7 @@ taichi::lang::UnifiedAllocator::~UnifiedAllocator() {
 #else
     TI_ERROR("No CUDA support");
 #endif
-  } else if (arch_ == Arch::x64 && false) {
+  } else if (arch_ == Arch::x64) {
     cpu::CpuDevice *cpu_device = static_cast<cpu::CpuDevice *>(device_);
     cpu_device->dealloc_memory(alloc);
   }

--- a/taichi/system/unified_allocator.cpp
+++ b/taichi/system/unified_allocator.cpp
@@ -64,7 +64,9 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch, Device *device)
 #else
     TI_NOT_IMPLEMENTED
 #endif
-  } 
+  }
+  // This is an intermediate state.
+  // We will use memory pools to implement `Device::allocate_memory` soon.
   else if (arch_ == Arch::x64 && false) {
     Device::AllocParams alloc_params;
     alloc_params.size = size;
@@ -73,9 +75,8 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch, Device *device)
 
     cpu::CpuDevice *cpu_device = static_cast<cpu::CpuDevice *>(device);
     alloc = cpu_device->allocate_memory(alloc_params);
-    data = (uint8*)cpu_device->get_alloc_info(alloc).ptr;
-  }
-  else {
+    data = (uint8 *)cpu_device->get_alloc_info(alloc).ptr;
+  } else {
     TI_TRACE("Allocating virtual address space of size {} MB",
              size / 1024 / 1024);
     cpu_vm = std::make_unique<VirtualMemoryAllocator>(size);
@@ -100,8 +101,7 @@ taichi::lang::UnifiedAllocator::~UnifiedAllocator() {
 #else
     TI_ERROR("No CUDA support");
 #endif
-  }
-  else if (arch_ == Arch::x64 && false) {
+  } else if (arch_ == Arch::x64 && false) {
     cpu::CpuDevice *cpu_device = static_cast<cpu::CpuDevice *>(device_);
     cpu_device->dealloc_memory(alloc);
   }

--- a/taichi/system/unified_allocator.cpp
+++ b/taichi/system/unified_allocator.cpp
@@ -10,6 +10,7 @@
 #include "taichi/system/unified_allocator.h"
 #include "taichi/system/virtual_memory.h"
 #include "taichi/system/timer.h"
+#include "taichi/backends/cpu/cpu_device.h"
 #include <string>
 
 TLANG_NAMESPACE_BEGIN
@@ -63,7 +64,18 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch, Device *device)
 #else
     TI_NOT_IMPLEMENTED
 #endif
-  } else {
+  } 
+  else if (arch_ == Arch::x64 && false) {
+    Device::AllocParams alloc_params;
+    alloc_params.size = size;
+    alloc_params.host_read = true;
+    alloc_params.host_write = true;
+
+    cpu::CpuDevice *cpu_device = static_cast<cpu::CpuDevice *>(device);
+    alloc = cpu_device->allocate_memory(alloc_params);
+    data = (uint8*)cpu_device->get_alloc_info(alloc).ptr;
+  }
+  else {
     TI_TRACE("Allocating virtual address space of size {} MB",
              size / 1024 / 1024);
     cpu_vm = std::make_unique<VirtualMemoryAllocator>(size);
@@ -88,6 +100,10 @@ taichi::lang::UnifiedAllocator::~UnifiedAllocator() {
 #else
     TI_ERROR("No CUDA support");
 #endif
+  }
+  else if (arch_ == Arch::x64 && false) {
+    cpu::CpuDevice *cpu_device = static_cast<cpu::CpuDevice *>(device_);
+    cpu_device->dealloc_memory(alloc);
   }
 }
 

--- a/taichi/system/unified_allocator.h
+++ b/taichi/system/unified_allocator.h
@@ -25,6 +25,7 @@ class UnifiedAllocator {
   // put these two on the unified memory so that GPU can have access
  public:
   uint8 *data;
+  DeviceAllocation alloc{kDeviceNullAllocation};
   uint8 *head;
   uint8 *tail;
   std::mutex lock;


### PR DESCRIPTION
related issue = #2736 

This PR starts the work on `CpuDevice`. 

`allocate_memory` and `dealloc_memory` are implemented, and these are used in unified allocator.

The next PR will start moving the memory pool inside `CudeDevice` and `CpuDevice` ([discussion](https://github.com/taichi-dev/taichi/pull/2963#discussion_r713908020))