### PR TITLE
[Doc] Update differentiable programming doc.

### DIFF
--- a/docs/lang/articles/advanced/differentiable_programming.md
+++ b/docs/lang/articles/advanced/differentiable_programming.md
@@ -4,13 +4,19 @@ sidebar_position: 4
 
 # Differentiable programming
 
-We suggest starting with the `ti.Tape()`, and then migrate to more
-advanced differentiable programming using the `kernel.grad()` syntax if
-necessary.
-
 ## Introduction
 
-For example, you have the following kernel:
+Differentiable programming has been proved to be useful in a wide variety of areas
+like scientific computing and artificial intelligence. For instance, using a
+differentiable simulator in controller optimization system can converge one to
+four magnitude faster than model-free reinforcement learning algorithms.[^1][^2]
+
+[^1]: [End-to-End Differentiable Physics for Learning and Control
+](https://papers.nips.cc/paper/2018/file/842424a1d0595b76ec4fa03c46e8d755-Paper.pdf)
+
+[^2]: [ChainQueen: A Real-Time Differentiable Physical Simulator for Soft Robotics](https://arxiv.org/pdf/1810.01054.pdf)
+
+Imagine that you have the following kernel:
 
 ```python
 x = ti.field(float, ())
@@ -21,10 +27,10 @@ def compute_y():
     y[None] = ti.sin(x[None])
 ```
 
-Now if you want to get the derivative of y corresponding to x, i.e.,
-dy/dx. You may want to implement the derivative kernel by yourself:
+Now if you want to get the derivative of `y` corresponding to `x`:
+`dy/dx`, it's straightforward to write out the gradient kernel manually:
 
-```python
+```python {4-6}
 x = ti.field(float, ())
 y = ti.field(float, ())
 dy_dx = ti.field(float, ())
@@ -34,23 +40,27 @@ def compute_dy_dx():
     dy_dx[None] = ti.cos(x[None])
 ```
 
-But wait, what if I changed the original `compute_y`? We will have to
-recalculate the derivative by hand and rewrite `compute_dy_dx` again,
-which is very error-prone and not convenient at all.
+However, as you make a change to `compute_y`, you will have to rework the gradient formula
+by hand and update `compute_dy_dx` accordingly. Apparently when
+the kernel becomes larger and gets frequently updated, this manual workflow is
+really error-prone and hard to maintain.
 
-If you run into this situation, don't worry! Taichi provides a handy autodiff system that can help you obtain the derivative of a kernel without any pain!
+If you run into this situation, Taichi's handy automatic differentiation (autodiff)
+system comes to rescue! Taichi supports obtaining the derivative through
+either `ti.Tape()` or the more flexible `kernel.grad()` syntax.
 
 ## Using `ti.Tape()`
 
-Let's still take the `compute_y` in above example for explaination.
-What's the most convienent way to obtain a kernel that computes x to
-$dy/dx$?
+Let's still take the `compute_y` above for explaination.
+Using `ti.Tape()` is the easiest way to obtain a kernel that computes `x` to `dy/dx`:
 
-1.  Use the `needs_grad=True` option when declaring fields involved in
+1.  Enable `needs_grad=True` option when declaring fields involved in
     the derivative chain.
-2.  Use `with ti.Tape(y):` to embrace the invocation into kernel(s) you
+2.  Use context manager `with ti.Tape(y):` to embrace the invocation into kernel(s) you
     want to compute derivative.
-3.  Now `x.grad[None]` is the dy/dx value at current x.
+3.  Now `dy/dx` value at current `x` is available at `x.grad[None]`.
+
+Here's the full code snippet elaborating the steps above:
 
 ```python
 x = ti.field(float, (), needs_grad=True)
@@ -63,40 +73,18 @@ def compute_y():
 with ti.Tape(y):
     compute_y()
 
-print('dy/dx =', x.grad[None])
-print('at x =', x[None])
+print('dy/dx =', x.grad[None], ' at x =', x[None])
 ```
+### Case study: gravity simulation
 
-It's equivalant to:
-
-```python
-x = ti.field(float, ())
-y = ti.field(float, ())
-dy_dx = ti.field(float, ())
-
-@ti.kernel
-def compute_dy_dx():
-    dy_dx[None] = ti.cos(x[None])
-
-compute_dy_dx()
-
-print('dy/dx =', dy_dx[None])
-print('at x =', x[None])
-```
-
-### Usage example
-
-For a physical simulation, sometimes it could be easy to compute the
-energy but hard to compute the force on each particles.
-
-But recall that we can differentiate (negative) potential energy to get
-forces. a.k.a.: $F_i = -dU / dx_i$. So once you've write a kernel that
-is able to compute the potential energy, you may use Taichi's autodiff
-system to obtain the derivative of it and then the force on each
-particles.
+A common problem in physical simulation is that it's usually easy to compute
+energy but hard to compute force on every particle. Recall that we can differentiate
+(negative) potential energy to get forces: `F_i = -dU / dx_i`. So once you've written
+a kernel that is able to compute the potential energy, you may use Taichi's autodiff
+system to obtain the derivative and then `F_i` on each particle.
 
 Take
-[examples/ad_gravity.py](https://github.com/taichi-dev/taichi/blob/master/examples/ad_gravity.py)
+[examples/simulation/ad_gravity.py](https://github.com/taichi-dev/taichi/blob/master/examples/simulation/ad_gravity.py)
 as an example:
 
 ```python
@@ -106,8 +94,8 @@ ti.init()
 N = 8
 dt = 1e-5
 
-x = ti.Vector.field(2, float, N, needs_grad=True)  # position of particles
-v = ti.Vector.field(2, float, N)  # velocity of particles
+x = ti.Vector.field(2, float, N, needs_grad=True)  # particle positions
+v = ti.Vector.field(2, float, N)  # particle velocities
 U = ti.field(float, (), needs_grad=True)  # potential energy
 
 
@@ -130,10 +118,10 @@ def advance():
 
 def substep():
     with ti.Tape(U):
-        # every kernel invocation within this indent scope
-        # will also be accounted into the partial derivate of U
-        # with corresponding input variables like x.
-        compute_U()  # will also computes dU/dx and save in x.grad
+        # Kernel invocations in this scope contribute to partial derivatives of
+        # U with respect to input variables such as x.
+        compute_U(
+        )  # The tape will automatically compute dU/dx and save the results in x.grad
     advance()
 
 
@@ -148,7 +136,6 @@ gui = ti.GUI('Autodiff gravity')
 while gui.running:
     for i in range(50):
         substep()
-    print('U = ', U[None])
     gui.circles(x.to_numpy(), radius=3)
     gui.show()
 ```
@@ -157,7 +144,7 @@ while gui.running:
 
 The argument `U` to `ti.Tape(U)` must be a 0D field.
 
-For using autodiff with multiple output variables, please see the
+To use autodiff with multiple output variables, please see the
 `kernel.grad()` usage below.
 :::
 
@@ -169,69 +156,214 @@ start up.
 
 :::tip
 See
-[examples/mpm_lagrangian_forces.py](https://github.com/taichi-dev/taichi/blob/master/examples/mpm_lagrangian_forces.py)
+[examples/simulation/mpm_lagrangian_forces.py](https://github.com/taichi-dev/taichi/blob/master/examples/simulation/mpm_lagrangian_forces.py)
 and
-[examples/fem99.py](https://github.com/taichi-dev/taichi/blob/master/examples/fem99.py)
+[examples/simulation/fem99.py](https://github.com/taichi-dev/taichi/blob/master/examples/simulation/fem99.py)
 for examples on using autodiff for MPM and FEM.
 :::
 
 ## Using `kernel.grad()`
 
-TODO: Documentation WIP.
+As mentioned above, `ti.Tape()` can only track a 0D field as output variable.
+If there're multiple output variables that you want to back-propagate
+gradients to inputs, `kernel.grad()` should be used instead of `ti.Tape()`.
 
-## Kernel Simplicity Rule
+```python {13-14}
+import taichi as ti
+ti.init()
+
+N = 16
+
+x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)
+loss = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
+loss2 = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
+
+@ti.kernel
+def func():
+    for i in x:
+       loss[None] += x[i] ** 2
+       loss2[None] += x[i]
+
+for i in range(N):
+    x[i] = i
+loss.grad[None] = 1
+loss2.grad[None] = 1
+
+func()
+func.grad()
+for i in range(N):
+    assert x.grad[i] == i * 2 + 1
+```
+
+:::tip
+It might be tedious to write out `need_grad=True` for every input in a complicated use case.
+Alternatively Taichi provides `ti.root.lazy_grad()` API that can automatically place the
+adjoint fields following the layout of their primal fields.
+:::
+
+:::caution
+When using `kernel.grad()`, it's recommended to always run forward kernel before backward, e.g. `kernel(); kernel.grad()`. If global fields used in the derivative calculation get mutated in the forward, skipping
+`kernel()` breaks global data access rule #1 below and might produce incorrect gradients.
+:::
+
+## Limitations of Taichi autodiff system
 
 Unlike tools such as TensorFlow where **immutable** output buffers are
 generated, the **imperative** programming paradigm adopted in Taichi
 allows programmers to freely modify global fields.
 
-To make automatic differentiation well-defined under this setting, we
-make the following assumption on Taichi programs for differentiable
-programming:
+To make automatic differentiation well-defined under this setting, the following
+rules are enforced when writing differentiable programs in Taichi:
 
-**Global Data Access Rules:**
+### Global Data Access Rules
 
-- If a global field element is written more than once, then starting
-  from the second write, the write **must** come in the form of an
-  atomic add ("accumulation\", using `ti.atomic_add` or simply
-  `+=`).
-- No read accesses happen to a global field element, until its
-  accumulation is done.
+Currently Taichi's autodiff implementation doesn't save intermediate results of global fields which might be used in the backward pass. Therefore mutation is forbidden once you've read from a global field.
 
-**Kernel Simplicity Rule:** Kernel body consists of multiple [simply
-nested]{.title-ref} for-loops. I.e., each for-loop can either contain
-exactly one (nested) for-loop (and no other statements), or a group of
-statements without loops.
+:::note Global Data Access Rule #1
+Once you read an element in global field, it cannot be mutated anymore.
+:::
+
+```python
+import taichi as ti
+ti.init()
+
+N = 16
+
+x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)
+loss = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
+b = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
+
+@ti.kernel
+def func_broke_rule_1():
+    # BAD: broke global data access rule #1, reading global field and before mutation is done.
+    loss[None] = x[1] * b[None]
+    b[None] += 100
+
+
+@ti.kernel
+def func_equivalent():
+    loss[None] = x[1] * 10
+
+for i in range(N):
+    x[i] = i
+b[None] = 10
+loss.grad[None] = 1
+
+with ti.Tape(loss):
+    func_broke_rule_1()
+# Call func_equivalent to see the correct result
+# with ti.Tape(loss):
+    # func_equivalent()
+
+assert x.grad[1] == 10.0
+```
+
+:::note Global Data Access Rule #2
+If a global field element is written more than once, then starting from the second write, the write **must** come in the form of an atomic add ("accumulation\", using `ti.atomic_add` or simply `+=`). Although `+=` violates rule #1 above, it's the only special case of "read before mutation" that Taichi allows in the autodiff system.
+:::
+
+```python
+import taichi as ti
+ti.init()
+
+N = 16
+
+x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)
+loss = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
+
+@ti.kernel
+def func_break_rule_2():
+    loss[None] += x[1] ** 2
+    # Bad: broke global data access rule #2, it's not an atomic_add.
+    loss[None] *= x[2]
+
+@ti.kernel
+def func_equivalent():
+    loss[None] = (2 + x[1] ** 2) * x[2]
+
+for i in range(N):
+    x[i] = i
+loss.grad[None] = 1
+loss[None] = 2
+
+func_break_rule_2()
+func_break_rule_2.grad()
+# Call func_equivalent to see the correct result
+# func_equivalent()
+# func_equivalent.grad()
+assert x.grad[1] == 4.0
+assert x.grad[2] == 3.0
+```
+### Kernel Simplicity Rule
+
+:::note Kernel Simplicity Rule
+Kernel body must consist of multiple simply nested for-loops. For example, each for-loop can either contain exactly one (nested) for-loop (and no other statements), or a group of statements without loops.
+:::
 
 Example:
 
 ```python
 @ti.kernel
-def differentiable_task():
+def differentiable_task1():
+    # Good: simple for loop
     for i in x:
         x[i] = y[i]
 
+@ti.kernel
+def differentiable_task2():
+    # Good: one nested for loop
     for i in range(10):
         for j in range(20):
             for k in range(300):
                 ... do whatever you want, as long as there are no loops
 
-    # Not allowed. The outer for loop contains two for loops
+@ti.kernel
+def differentiable_task3():
+    # Bad: the outer for loop contains two for loops.
     for i in range(10):
         for j in range(20):
             ...
         for j in range(20):
             ...
+
+@ti.kernel
+def differentiable_task4():
+    # Bad: mixed use of for-loop and statements without for-loops.
+    loss[None] += x[0]
+    for i in range(10):
+        ...
 ```
 
 Taichi programs that violate this rule will result in an error.
 
-:::note
+### Workaround kernel simplicity rule
+
+:::tip
 **static for-loops** (e.g. `for i in ti.static(range(4))`) will get
 unrolled by the Python frontend preprocessor and therefore does not
 count as a level of loop.
 :::
 
+For instance, we can rewrite `differentiable_task3` listed above using `ti.static`:
+
+``` python
+@ti.kernel
+def differentiable_task3():
+    # Good: ti.static unrolls the inner loops so that it now only has one simple for loop.
+    for i in range(10):
+        for j in ti.static(range(20)):
+            ...
+        for j in ti.static(range(20)):
+            ...
+```
+
+
+:::danger DANGER
+Violation of rules above might result in incorrect gradient result without a proper error.
+We're actively working on improving the error reporting mechanism for it. Please feel free
+to open a [github issue](https://github.com/taichi-dev/taichi/issues/new?assignees=&labels=potential+bug&template=bug_report.md&title=)
+if you see any silent wrong results.
+:::
 ## DiffTaichi
 
 The [DiffTaichi repo](https://github.com/yuanming-hu/difftaichi)
@@ -251,3 +383,4 @@ Check out [the DiffTaichi paper](https://arxiv.org/pdf/1910.00935.pdf)
 and [video](https://www.youtube.com/watch?v=Z1xvAZve9aE) to learn more
 about Taichi differentiable programming.
 :::
+7

--- a/docs/lang/articles/advanced/differentiable_programming.md
+++ b/docs/lang/articles/advanced/differentiable_programming.md
@@ -41,17 +41,17 @@ def compute_dy_dx():
 ```
 
 However, as you make a change to `compute_y`, you will have to rework the gradient formula
-by hand and update `compute_dy_dx` accordingly. Apparently when
+by hand and update `compute_dy_dx` accordingly. Apparently, when
 the kernel becomes larger and gets frequently updated, this manual workflow is
 really error-prone and hard to maintain.
 
 If you run into this situation, Taichi's handy automatic differentiation (autodiff)
-system comes to rescue! Taichi supports gradient evaluation through
+system comes to the rescue! Taichi supports gradient evaluation through
 either `ti.Tape()` or the more flexible `kernel.grad()` syntax.
 
 ## Using `ti.Tape()`
 
-Let's still take the `compute_y` kernel above for explanation.
+Let's still take the `compute_y` kernel above for an explanation.
 Using `ti.Tape()` is the easiest way to obtain a kernel that computes `dy/dx`:
 
 1.  Enable `needs_grad=True` option when declaring fields involved in
@@ -63,7 +63,7 @@ Here's the full code snippet elaborating the steps above:
 
 ```python
 x = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
-y = ti.field(float, (), needs_grad=True)
+y = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
 
 @ti.kernel
 def compute_y():
@@ -78,7 +78,7 @@ print('dy/dx =', x.grad[None], ' at x =', x[None])
 
 A common problem in physical simulation is that it's usually easy to compute
 energy but hard to compute force on every particle,
-e.g [Bond bending (and torsion) in molecular dynamics](https://github.com/victoriacity/taichimd/blob/5a44841cc8dfe5eb97de51f1d46f1bede1cc9936/taichimd/interaction.py#L190-L220).
+e.g [Bond bending (and torsion) in molecular dynamics](https://github.com/victoriacity/taichimd/blob/5a44841cc8dfe5eb97de51f1d46f1bede1cc9936/taichimd/interaction.py#L190-L220)
 and [FEM with hyperelastic energy functions](https://github.com/taichi-dev/taichi/blob/master/examples/simulation/fem128.py).
 Recall that we can differentiate
 (negative) potential energy to get forces: `F_i = -dU / dx_i`. So once you have coded
@@ -98,7 +98,7 @@ dt = 1e-5
 
 x = ti.Vector.field(2, dtype=ti.f32, shape=N, needs_grad=True)  # particle positions
 v = ti.Vector.field(2, dtype=ti.f32, shape=N)  # particle velocities
-U = ti.field(float, (), needs_grad=True)  # potential energy
+U = ti.field(dtype=ti.f32, shape=(), needs_grad=True)  # potential energy
 
 
 @ti.kernel
@@ -161,7 +161,7 @@ See
 [examples/simulation/mpm_lagrangian_forces.py](https://github.com/taichi-dev/taichi/blob/master/examples/simulation/mpm_lagrangian_forces.py)
 and
 [examples/simulation/fem99.py](https://github.com/taichi-dev/taichi/blob/master/examples/simulation/fem99.py)
-for examples on using autodiff for MPM and FEM.
+for examples on using autodiff-based force evaluation MPM and FEM.
 :::
 
 ## Using `kernel.grad()`
@@ -199,7 +199,7 @@ for i in range(N):
 
 :::tip
 It might be tedious to write out `need_grad=True` for every input in a complicated use case.
-Alternatively Taichi provides `ti.root.lazy_grad()` API that can automatically place the
+Alternatively, Taichi provides an API `ti.root.lazy_grad()` that automatically places the
 gradient fields following the layout of their primal fields.
 :::
 
@@ -261,7 +261,7 @@ assert x.grad[1] == 10.0
 ```
 
 :::note Global Data Access Rule #2
-If a global field element is written more than once, then starting from the second write, the write **must** come in the form of an atomic add ("accumulation\", using `ti.atomic_add` or simply `+=`). Although `+=` violates rule #1 above, it's the only special case of "read before mutation" that Taichi allows in the autodiff system.
+If a global field element is written more than once, then starting from the second write, the write **must** come in the form of an atomic add ("accumulation", using `ti.atomic_add` or simply `+=`). Although `+=` violates rule #1 above since it reads the old value before computing the sum, it is the only special case of "read before mutation" that Taichi allows in the autodiff system.
 :::
 
 ```python
@@ -330,7 +330,7 @@ def differentiable_task3():
 
 @ti.kernel
 def differentiable_task4():
-    # Bad: mixed use of for-loop and statements without for-loops.
+    # Bad: mixed usage of for-loop and a statement without looping. Please split them into two kernels.
     loss[None] += x[0]
     for i in range(10):
         ...

--- a/docs/lang/articles/advanced/differentiable_programming.md
+++ b/docs/lang/articles/advanced/differentiable_programming.md
@@ -27,7 +27,7 @@ def compute_y():
     y[None] = ti.sin(x[None])
 ```
 
-Now if you want to get the derivative of `y` corresponding to `x`:
+Now if you want to get the derivative of `y` with respect to `x`:
 `dy/dx`, it's straightforward to write out the gradient kernel manually:
 
 ```python {4-6}
@@ -78,7 +78,10 @@ print('dy/dx =', x.grad[None], ' at x =', x[None])
 ### Case study: gravity simulation
 
 A common problem in physical simulation is that it's usually easy to compute
-energy but hard to compute force on every particle. Recall that we can differentiate
+energy but hard to compute force on every particle,
+e.g [Bond bending (and torsion) in molecular dynamics](https://github.com/victoriacity/taichimd/blob/5a44841cc8dfe5eb97de51f1d46f1bede1cc9936/taichimd/interaction.py#L190-L220).
+and [FEM with Lagrangian forces](https://github.com/taichi-dev/taichi/blob/master/examples/simulation/fem128.py).
+Recall that we can differentiate
 (negative) potential energy to get forces: `F_i = -dU / dx_i`. So once you've written
 a kernel that is able to compute the potential energy, you may use Taichi's autodiff
 system to obtain the derivative and then `F_i` on each particle.
@@ -164,7 +167,7 @@ for examples on using autodiff for MPM and FEM.
 
 ## Using `kernel.grad()`
 
-As mentioned above, `ti.Tape()` can only track a 0D field as output variable.
+As mentioned above, `ti.Tape()` can only track a 0D field as the output variable.
 If there're multiple output variables that you want to back-propagate
 gradients to inputs, `kernel.grad()` should be used instead of `ti.Tape()`.
 
@@ -198,11 +201,11 @@ for i in range(N):
 :::tip
 It might be tedious to write out `need_grad=True` for every input in a complicated use case.
 Alternatively Taichi provides `ti.root.lazy_grad()` API that can automatically place the
-adjoint fields following the layout of their primal fields.
+gradient fields following the layout of their primal fields.
 :::
 
 :::caution
-When using `kernel.grad()`, it's recommended to always run forward kernel before backward, e.g. `kernel(); kernel.grad()`. If global fields used in the derivative calculation get mutated in the forward, skipping
+When using `kernel.grad()`, it's recommended to always run forward kernel before backward, e.g. `kernel(); kernel.grad()`. If global fields used in the derivative calculation get mutated in the forward run, skipping
 `kernel()` breaks global data access rule #1 below and might produce incorrect gradients.
 :::
 

--- a/examples/simulation/ad_gravity.py
+++ b/examples/simulation/ad_gravity.py
@@ -5,9 +5,10 @@ ti.init()
 N = 8
 dt = 1e-5
 
-x = ti.Vector.field(2, float, N, needs_grad=True)  # particle positions
-v = ti.Vector.field(2, float, N)  # particle velocities
-U = ti.field(float, (), needs_grad=True)  # potential energy
+x = ti.Vector.field(2, dtype=ti.f32, shape=N,
+                    needs_grad=True)  # particle positions
+v = ti.Vector.field(2, dtype=ti.f32, shape=N)  # particle velocities
+U = ti.field(dtype=ti.f32, shape=(), needs_grad=True)  # potential energy
 
 
 @ti.kernel
@@ -28,8 +29,8 @@ def advance():
 
 
 def substep():
-    with ti.Tape(U):
-        # Kernel invocations in this scope contribute to partial derivatives of
+    with ti.Tape(loss=U):
+        # Kernel invocations in this scope will later contribute to partial derivatives of
         # U with respect to input variables such as x.
         compute_U(
         )  # The tape will automatically compute dU/dx and save the results in x.grad


### PR DESCRIPTION
This PR mainly improves differentiable programming doc by clarifying global
data access rules and kernel simplicity rule by examples.

There're a few followups wip, e.g. renaming and adding docs for
`complex_kernel`, better error reporting when violating the autodiff
rules etc.