### PR TITLE
[misc] Add instructions of installing libz3-dev

### DIFF
--- a/python/taichi/core/util.py
+++ b/python/taichi/core/util.py
@@ -41,7 +41,7 @@ def import_ti_core():
             if settings.get_os_name() == 'win':
                 e.msg += '\nConsider installing Microsoft Visual C++ Redistributable: https://aka.ms/vs/16/release/vc_redist.x64.exe'
             elif settings.get_os_name() == 'linux':
-                e.msg += '\nConsider installing libtinfo5: sudo apt-get install libtinfo5'
+                e.msg += '\nConsider installing libtinfo5 and libz3-dev: sudo apt-get install libtinfo5 libz3-dev'
         raise e from None
     ti_core = core
     if settings.get_os_name() != 'win':


### PR DESCRIPTION
Hi,

When I install taichi for the first time on Ubuntu 20.04, it gives the following error:

```
ImportError: libz3.so.4: cannot open shared object file: No such file or directory
Consider installing libtinfo5: sudo apt-get install libtinfo5
```
It tells me to install libtinfo5, but the actual missing library is libz3. Perhaps it's better provide instructions of installing`libz3-dev` as well. Here's the full  error:

```
Python 3.8.10 (default, Jun  2 2021, 10:49:15) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import taichi
Share object taichi_core import failed, check this page for possible solutions:
https://docs.taichi.graphics/docs/lang/articles/misc/install
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/wuhanstudio/.local/lib/python3.8/site-packages/taichi/__init__.py", line 3, in <module>
    from taichi.core import *
  File "/home/wuhanstudio/.local/lib/python3.8/site-packages/taichi/core/__init__.py", line 1, in <module>
    from taichi.core.logging import *
  File "/home/wuhanstudio/.local/lib/python3.8/site-packages/taichi/core/logging.py", line 4, in <module>
    from taichi.core import util
  File "/home/wuhanstudio/.local/lib/python3.8/site-packages/taichi/core/util.py", line 133, in <module>
    import_ti_core()
  File "/home/wuhanstudio/.local/lib/python3.8/site-packages/taichi/core/util.py", line 45, in import_ti_core
    raise e from None
  File "/home/wuhanstudio/.local/lib/python3.8/site-packages/taichi/core/util.py", line 33, in import_ti_core
    import taichi_core as core
ImportError: libz3.so.4: cannot open shared object file: No such file or directory
Consider installing libtinfo5: sudo apt-get install libtinfo5
```