### PR TITLE
[ci] Reduce Docker image size to 1/2 by removing build cache (Ubuntu 18.04 -> Ubuntu 20.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Taichi Dockerfile for development
-FROM nvidia/cuda:10.0-devel-ubuntu18.04
+FROM nvidia/cuda:11.0-devel-ubuntu20.04 as builder
 
 LABEL maintainer="https://github.com/taichi-dev"
 
@@ -7,10 +7,11 @@ LABEL maintainer="https://github.com/taichi-dev"
 # docker image is upgraded to Ubuntu 20.04 this will
 # install Python 3.8 by default
 RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" \
     apt-get install -y software-properties-common \
                        python3-pip \
                        libtinfo-dev \
-                       clang-8 \
+                       clang-10 \
                        wget \
                        git \
                        libx11-dev \
@@ -23,34 +24,27 @@ RUN apt-get update && \
                        mesa-common-dev \
                        libtinfo5 \
                        build-essential \
-                       libssl-dev
+                       libssl-dev \
+                       cmake \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Taichi's Python dependencies
 RUN python3 -m pip install --user setuptools astor pybind11 pylint sourceinspect
 RUN python3 -m pip install --user pytest pytest-rerunfailures pytest-xdist yapf
 RUN python3 -m pip install --user numpy GitPython coverage colorama autograd
 
-# Install the latest version of CMAKE v3.20.2 from source
-RUN apt purge --auto-remove cmake
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2.tar.gz
-RUN tar -zxvf cmake-3.20.2.tar.gz
-RUN cd cmake-3.20.2
-WORKDIR /cmake-3.20.2
-RUN ./bootstrap
-RUN make -j 8
-RUN make install
-
 # Intall LLVM 10
 WORKDIR /
-ENV CC=/usr/bin/clang-8
-ENV CXX=/usr/bin/clang++-8
+ENV CC=/usr/bin/clang-10
+ENV CXX=/usr/bin/clang++-10
 RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz
 RUN tar xvJf llvm-10.0.0.src.tar.xz
 RUN cd llvm-10.0.0.src && mkdir build
 WORKDIR /llvm-10.0.0.src/build
-RUN cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON
+RUN cmake .. -DLLVM_ENABLE_RTTI:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_INSTALL_PREFIX=/tmp/llvm-install
 RUN make -j 8
 RUN make install
+RUN cp -r /tmp/llvm-install/* /usr/local/
 
 # Install Taichi from source
 WORKDIR /taichi-dev
@@ -61,6 +55,39 @@ RUN cd taichi && \
 WORKDIR /taichi-dev/taichi/build
 RUN cmake .. -DPYTHON_EXECUTABLE=python3 -DTI_WITH_CUDA:BOOL=True -DTI_WITH_CC:BOOL=ON
 RUN make -j 8
+
+WORKDIR /taichi-dev/taichi
+RUN python3 setup.py develop --user
+RUN rm -rf build
+
+# Release the development environment without build cache
+FROM nvidia/cuda:11.0-devel-ubuntu20.04
+
+COPY --from=builder /tmp/llvm-install/ /usr/local/
+COPY --from=builder /taichi-dev/taichi /taichi-dev/taichi
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" \
+    apt-get install -y python3-pip \
+                       libtinfo5 \
+                       clang-10 \
+                       git \
+                       libx11-dev \
+                       libxrandr-dev \
+                       libxinerama-dev \
+                       libxcursor-dev \
+                       libxi-dev \
+                       libglu1-mesa-dev \
+                       freeglut3-dev \
+                       mesa-common-dev \
+                       libz3-4 \
+                       cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Taichi's Python dependencies
+RUN python3 -m pip install --user setuptools astor pybind11 pylint sourceinspect
+RUN python3 -m pip install --user pytest pytest-rerunfailures pytest-xdist yapf
+RUN python3 -m pip install --user numpy GitPython coverage colorama autograd
 
 # Link Taichi source repo to Python Path
 ENV PATH="/taichi-dev/taichi/bin:$PATH"


### PR DESCRIPTION
Related issue =  close #3016

Hi, I find the Dockerfile is a little outdated, and the following improvements drastically reduce the docker image size:

* Use Docker multi-stage builds to exclude temporary build files from the final image

* Upgrade base image from Ubuntu 18.04 to Ubuntu 20.04

~~* Install LLVM-10 via apt rather than build from source~~

* Install CMake via apt rather than build from source

The original docker image is around 6GB which is a little intimidating for a new user, now the final released docker image is here (~200MB extra layer and ~600MB in total):

https://hub.docker.com/r/wuhanstudio/taichi/tags?page=1&ordering=last_updated

Hope you find it helpful,
Han

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
