### PR TITLE
[lang] [opt] Memory allocator for ti.ndarray

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -501,6 +501,7 @@ class Kernel:
                     if isinstance(v, Ndarray):
                         v = v.arr
                     has_external_arrays = True
+                    use_torch = self.runtime.prog.config.use_torch
                     has_torch = util.has_pytorch()
                     is_numpy = isinstance(v, np.ndarray)
                     if is_numpy:
@@ -510,8 +511,7 @@ class Kernel:
                         launch_ctx.set_arg_nparray(actual_argument_slot,
                                                    int(tmp.ctypes.data),
                                                    tmp.nbytes)
-                    else:
-
+                    elif use_torch:
                         def get_call_back(u, v):
                             def call_back():
                                 u.copy_(v)
@@ -540,6 +540,12 @@ class Kernel:
                         launch_ctx.set_arg_nparray(
                             actual_argument_slot, int(tmp.data_ptr()),
                             tmp.element_size() * tmp.nelement())
+                    else:
+                        tmp = v
+                        launch_ctx.set_arg_nparray(
+                            actual_argument_slot, int(tmp.data_ptr()),
+                            tmp.element_size() * tmp.nelement())
+
                     shape = v.shape
                     max_num_indices = _ti_core.get_max_num_indices()
                     assert len(

--- a/python/taichi/lang/ndarray.py
+++ b/python/taichi/lang/ndarray.py
@@ -13,16 +13,19 @@ class Ndarray:
         shape (Tuple[int]): Shape of the torch tensor.
     """
     def __init__(self, dtype, shape):
-        assert has_pytorch(
-        ), "PyTorch must be available if you want to create a Taichi ndarray."
-        import torch
-        if impl.current_cfg().arch == _ti_core.Arch.cuda:
-            device = 'cuda:0'
+        if impl.current_cfg().use_torch:
+            assert has_pytorch(
+            ), "PyTorch must be available if you want to create a Taichi ndarray."
+            import torch
+            if impl.current_cfg().arch == _ti_core.Arch.cuda:
+                device = 'cuda:0'
+            else:
+                device = 'cpu'
+                self.arr = torch.zeros(shape,
+                                   dtype=to_pytorch_type(cook_dtype(dtype)),
+                                   device=device)
         else:
-            device = 'cpu'
-        self.arr = torch.zeros(shape,
-                               dtype=to_pytorch_type(cook_dtype(dtype)),
-                               device=device)
+            self.arr = _ti_core.Ndarray(impl.get_runtime().prog, cook_dtype(dtype), shape)
 
     @property
     def shape(self):

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -41,6 +41,7 @@ CompileConfig::CompileConfig() {
   make_thread_local = true;
   make_block_local = true;
   detect_read_only = true;
+  use_torch = true;
 
   saturating_grid_dim = 0;
   max_block_dim = 0;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -38,6 +38,7 @@ struct CompileConfig {
   bool make_thread_local;
   bool make_block_local;
   bool detect_read_only;
+  bool use_torch;
   DataType default_fp;
   DataType default_ip;
   std::string extra_flags;

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -1,0 +1,63 @@
+#include <numeric> 
+#include "ndarray.h"
+
+namespace taichi {
+namespace lang {
+
+Ndarray::Ndarray(Program *prog, const DataType type, 
+                 const std::vector<int> &shape)
+    : program(prog), dtype(type), shape(shape), 
+      data_ptr(nullptr), nelement(1), element_size(1) {
+  LlvmProgramImpl *prog_ = program->get_llvm_program_impl();
+  TaichiLLVMContext *tlctx = prog_->get_llvm_context(program->config.arch);
+
+  nelement = std::accumulate(std::begin(shape), std::end(shape), 1,
+      std::multiplies<>());
+  element_size = data_type_size(dtype);
+  auto *const runtime_jit = tlctx->runtime_jit_module;
+  runtime_jit->call<void *, std::size_t, std::size_t>(
+      "runtime_snode_tree_allocate_aligned", 
+      prog_->get_llvm_runtime(), nelement*element_size, 1);
+
+  data_ptr = prog_->fetch_result<int *>(taichi_result_buffer_runtime_query_id,
+                                      program->result_buffer);
+}
+
+void Ndarray::set_item(std::vector<int> &key, int val) {
+  int pos = get_linear_index(key);
+  data_ptr[pos] = val;
+}
+
+int Ndarray::get_item(std::vector<int> &key) const {
+  int pos = get_linear_index(key);
+  return data_ptr[pos];
+}
+
+intptr_t Ndarray::get_data_ptr_as_int() const {
+  return reinterpret_cast<std::intptr_t>(data_ptr);
+}
+
+int Ndarray::get_element_size() const {
+  return element_size;
+}
+
+int Ndarray::get_nelement() const {
+  return nelement;
+}
+
+int Ndarray::get_linear_index(std::vector<int> &key) const {
+  assert(key.size() == shape.size());
+
+  // TODO, generalize this to ND?
+  int ret{0};
+  if (shape.size() == 1) {
+    ret = key[0];
+  } else if (shape.size() == 2) {
+    ret = key[0] * shape[1] + key[1]; 
+  } else {
+    assert(0);
+  }
+  return ret;
+}
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "taichi/program/program.h"
+#include "taichi/inc/constants.h"
+#include "taichi/ir/type_utils.h"
+#include "taichi/llvm/llvm_context.h"
+#include "taichi/llvm/llvm_program.h"
+
+namespace taichi {
+namespace lang {
+
+class Program;
+
+class Ndarray {
+ public:
+  explicit Ndarray(Program *prog, const DataType type, const std::vector<int> &shape);
+
+  DataType dtype;
+	std::vector<int> shape;
+
+  void set_item(std::vector<int> &key, int val);
+  int get_item(std::vector<int> &key) const;
+  intptr_t get_data_ptr_as_int() const;
+  int get_element_size() const;
+  int get_nelement() const;
+
+ private:
+  Program *program;
+  int *data_ptr;
+  int nelement;
+  int element_size;
+
+  int get_linear_index(std::vector<int> &key) const;
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -17,6 +17,7 @@
 #include "taichi/program/async_engine.h"
 #include "taichi/program/snode_expr_utils.h"
 #include "taichi/program/snode_rw_accessors_bank.h"
+#include "taichi/program/ndarray.h"
 #include "taichi/common/interface.h"
 #include "taichi/python/export.h"
 #include "taichi/gui/gui.h"
@@ -176,6 +177,7 @@ void export_lang(py::module &m) {
       .def_readwrite("make_thread_local", &CompileConfig::make_thread_local)
       .def_readwrite("make_block_local", &CompileConfig::make_block_local)
       .def_readwrite("detect_read_only", &CompileConfig::detect_read_only)
+      .def_readwrite("use_torch", &CompileConfig::use_torch)
       .def_readwrite("cc_compile_cmd", &CompileConfig::cc_compile_cmd)
       .def_readwrite("cc_link_cmd", &CompileConfig::cc_link_cmd)
       .def_readwrite("async_opt_passes", &CompileConfig::async_opt_passes)
@@ -352,6 +354,16 @@ void export_lang(py::module &m) {
       .def("destroy_snode_tree", [](SNodeTree *snode_tree, Program *program) {
         program->destroy_snode_tree(snode_tree);
       });
+
+  py::class_<Ndarray>(m, "Ndarray")
+      .def(py::init<Program *, const DataType &, const std::vector<int> &>())
+      .def("__setitem__", &Ndarray::set_item)
+      .def("__getitem__", &Ndarray::get_item)
+      .def("data_ptr", &Ndarray::get_data_ptr_as_int)
+      .def("element_size", &Ndarray::get_element_size)
+      .def("nelement", &Ndarray::get_nelement)
+      .def_readonly("dtype", &Ndarray::dtype)
+      .def_readonly("shape", &Ndarray::shape);
 
   py::class_<Kernel>(m, "Kernel")
       .def("get_ret_int", &Kernel::get_ret_int)


### PR DESCRIPTION
Related issue = #2771 

**Proposed feature**
Using Taichi's own memory allocator to move away from the dependency on Pytorch.

**Status**
supported targets
- [ ] x86
- [ ] CUDA

