### PR TITLE
[misc] Get changelogs via tags instead of commit messages

### DIFF
--- a/misc/make_changelog.py
+++ b/misc/make_changelog.py
@@ -19,6 +19,7 @@ def load_pr_tags():
 
 def main(ver='master', repo_dir='.'):
     g = Repo(repo_dir)
+    commits_with_tags = set([tag.commit for tag in g.tags])
     commits = list(g.iter_commits(ver, max_count=200))
     begin, end = -1, 0
 
@@ -32,7 +33,7 @@ def main(ver='master', repo_dir='.'):
 
     for i, c in enumerate(commits):
         s = format(c)
-        if s.startswith('[release]'):
+        if c in commits_with_tags:
             if i == 0:
                 continue
             else:


### PR DESCRIPTION
Related issue = #

Previously, `make_changelog.py` identifies the last commit with `[release]` message as the last version. After this PR, `make_changelog.py` identifies the last commit with a tag as the last version. This allows a more flexible releasing process.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
