### PR TITLE
[vulkan] Disable validation layer with release builds

### DIFF
--- a/taichi/backends/vulkan/embedded_device.cpp
+++ b/taichi/backends/vulkan/embedded_device.cpp
@@ -17,7 +17,11 @@ namespace vulkan {
 
 namespace {
 
+#ifdef NDEBUG
+constexpr bool kEnableValidationLayers = false;
+#else
 constexpr bool kEnableValidationLayers = true;
+#endif
 const std::vector<const char *> kValidationLayers = {
     "VK_LAYER_KHRONOS_validation",
 };


### PR DESCRIPTION
Related issue = #3023

Hey, who doesn't like a +4/-0 PR

As for NDEBUG, ref: https://stackoverflow.com/questions/34302265/does-cmake-build-type-release-imply-dndebug

Unless we have our own flags