### PR TITLE
[LLVM] Rename runtime memory allocation function

### DIFF
--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -840,7 +840,7 @@ Ptr LLVMRuntime::request_allocate_aligned(std::size_t size,
   }
 }
 
-void runtime_snode_tree_allocate_aligned(LLVMRuntime *runtime,
+void runtime_memory_allocate_aligned(LLVMRuntime *runtime,
                                          std::size_t size,
                                          std::size_t alignment) {
   runtime->set_result(taichi_result_buffer_runtime_query_id,

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -841,8 +841,8 @@ Ptr LLVMRuntime::request_allocate_aligned(std::size_t size,
 }
 
 void runtime_memory_allocate_aligned(LLVMRuntime *runtime,
-                                         std::size_t size,
-                                         std::size_t alignment) {
+                                     std::size_t size,
+                                     std::size_t alignment) {
   runtime->set_result(taichi_result_buffer_runtime_query_id,
                       runtime->allocate_aligned(size, alignment));
 }

--- a/taichi/system/snode_tree_buffer_manager.cpp
+++ b/taichi/system/snode_tree_buffer_manager.cpp
@@ -41,7 +41,7 @@ Ptr SNodeTreeBufferManager::allocate(JITModule *runtime_jit,
   auto set_it = size_set_.lower_bound(std::make_pair(size, nullptr));
   if (set_it == size_set_.end()) {
     runtime_jit->call<void *, std::size_t, std::size_t>(
-        "runtime_snode_tree_allocate_aligned", runtime, size, alignment);
+        "runtime_memory_allocate_aligned", runtime, size, alignment);
     auto ptr = prog_->fetch_result<Ptr>(taichi_result_buffer_runtime_query_id,
                                         result_buffer);
     roots_[snode_tree_id] = ptr;


### PR DESCRIPTION
Give the runtime memory allocation function a more generic name.
