### PR TITLE
[vulkan] Disable Vulkan validation layer

### DIFF
--- a/taichi/backends/vulkan/embedded_device.cpp
+++ b/taichi/backends/vulkan/embedded_device.cpp
@@ -17,11 +17,9 @@ namespace vulkan {
 
 namespace {
 
-#ifdef NDEBUG
+// FIXME: NDEBUG is broken, so just manually enable this if necessary.
 constexpr bool kEnableValidationLayers = false;
-#else
-constexpr bool kEnableValidationLayers = true;
-#endif
+
 const std::vector<const char *> kValidationLayers = {
     "VK_LAYER_KHRONOS_validation",
 };

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -79,6 +79,11 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
 #define TI_CPP14
 #endif
 
+// Do not disable assert...
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
 #ifdef _WIN64
 #pragma warning(push)
 #pragma warning(disable : 4005)

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -79,11 +79,6 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
 #define TI_CPP14
 #endif
 
-// Do not disable assert...
-#ifdef NDEBUG
-#undef NDEBUG
-#endif
-
 #ifdef _WIN64
 #pragma warning(push)
 #pragma warning(disable : 4005)
@@ -100,7 +95,6 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
 #define sprintf_s sprintf
 #endif
 
-#undef assert
 #ifdef _WIN64
 #ifndef TI_PASS_EXCEPTION_TO_PYTHON
 // For Visual Studio debugging...

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -95,6 +95,7 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
 #define sprintf_s sprintf
 #endif
 
+#undef assert
 #ifdef _WIN64
 #ifndef TI_PASS_EXCEPTION_TO_PYTHON
 // For Visual Studio debugging...


### PR DESCRIPTION
Related issue = #3028, #3031

Tested on Ubuntu 20.04:

* Removed `vulkan-sdk`, the vulkan backend still worked
* This line is **no longer** printed: `[W 09/29/21 19:18:13.253 54839] [embedded_device.cpp:vk_debug_callback@54] validation layer: loader_icd_scan: Can not find 'ICD' object in ICD JSON file /usr/share/vulkan/icd.d/nvidia_layers.json.  Skipping ICD JSON`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
