### PR TITLE
[Lang] [bug] Fix support property decorator for data_oriented class

### DIFF
--- a/tests/python/test_oop.py
+++ b/tests/python/test_oop.py
@@ -222,3 +222,16 @@ def test_hook():
     for i in range(32):
         for j in range(32):
             assert (solver.val[i, j] == 1.0)
+
+
+@ti.test(arch=ti.get_host_arch_list())
+def test_oop_with_portery_decorator():
+    @ti.data_oriented
+    class Test:
+        @property
+        @ti.kernel
+        def test(self) -> ti.i32:
+            return 0
+
+    a = Test()
+    print(a.test)


### PR DESCRIPTION
Related issue =3019 #

Because the @portery decorator can not use __getattribute__ in this case it will mark as a `porterty class` with fset fset and somehing else.
I use a tricy to support it. 