### PR TITLE
[Lang] Fix python AST print format issues in python/taichi/lang/transformer.py

### DIFF
--- a/python/taichi/lang/transformer.py
+++ b/python/taichi/lang/transformer.py
@@ -25,7 +25,7 @@ class ASTTransformerTotal(object):
         if not impl.get_runtime().print_preprocessed:
             return
         if title is not None:
-            print(f'{title}:')
+            ti.info(f'{title}:')
         import astor
         print(astor.to_source(tree.body[0], indent_with='    '))
 


### PR DESCRIPTION
Test case:

```python
ti.init(print_ir=True,print_preprocessed=True)
@ti.kernel
def func():
    (a, b) = (1, 2)
    print(a, b)
```

There are formatting inconsistencies between `print_ir` and `print_preprocess`. The output before the PR looks like:

```
[Taichi] version 0.8.1, llvm 10.0.0, commit cc2dd342, osx, python 3.7.9
[Taichi] Starting on arch=x64
Initial AST:
def func():
...
Preprocessed:
def func():
...
[I 09/30/21 16:42:14.133 16716489] [compile_to_offloads.cpp:operator()@22] [func_c4_0] Initial IR:
kernel {
...
[I 09/30/21 16:42:14.134 16716489] [compile_to_offloads.cpp:operator()@22] [func_c4_0] Lowered:
...
```

This PR is to make it consistent (with) logic here https://github.com/taichi-dev/taichi/blob/master/taichi/transforms/compile_to_offloads.cpp#L17:

```
[Taichi] version 0.8.1, llvm 10.0.0, commit cc2dd342, osx, python 3.7.9
[Taichi] Starting on arch=x64
[I 09/30/21 16:45:23.741 16718700] [transformer.py:print_ast@28] Initial AST:
def func():
...
[I 09/30/21 16:45:35.869 16719262] [transformer.py:print_ast@28] Preprocessed:
def func():
...
[I 09/30/21 16:42:14.133 16716489] [compile_to_offloads.cpp:operator()@22] [func_c4_0] Initial IR:
kernel {
...
[I 09/30/21 16:42:14.134 16716489] [compile_to_offloads.cpp:operator()@22] [func_c4_0] Lowered:
...
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
