### PR TITLE
[Test] Allow ti test to work with specified cpu/gpu arch.

### DIFF
--- a/python/taichi/testing.py
+++ b/python/taichi/testing.py
@@ -106,6 +106,8 @@ def test(arch=None, exclude=None, require=None, **options):
         arch = supported_archs
     else:
         arch = list(filter(lambda x: x in supported_archs, arch))
+    if len(arch) == 0:
+        return lambda x: print('No supported arch found. Skipping')
 
     def decorator(foo):
         import functools

--- a/tests/python/test_customized_grad.py
+++ b/tests/python/test_customized_grad.py
@@ -168,8 +168,8 @@ def test_customized_kernels_oop2():
     assert a.x.grad[0] == 4
 
 
-@ti.must_throw(RuntimeError)
 @ti.test()
+@ti.must_throw(RuntimeError)
 def test_decorated_primal_is_taichi_kernel():
     x = ti.field(ti.f32)
     total = ti.field(ti.f32)
@@ -193,8 +193,8 @@ def test_decorated_primal_is_taichi_kernel():
         func(4)
 
 
-@ti.must_throw(RuntimeError)
 @ti.test()
+@ti.must_throw(RuntimeError)
 def test_decorated_primal_missing_decorator():
     x = ti.field(ti.f32)
     total = ti.field(ti.f32)


### PR DESCRIPTION
Issue: when running `ti test -vr2 -t4 -a cpu` two tests (asserting
must_throw) failed. But if I ran with `ti test -vr2 -t4` everything
passed.

It turned out that our `ti test -a` doesn't accept `cpu/cuda` as
arguments thus it ran on an empty arch list. When we assert must_throw
tests failed.

This PR fixes two things:
1. Add support for `cpu/cuda` and simplify `supported_arch`.
2. When there's no valid archs, explicitly print out a message and
return instead of running "empty" tests and reporting success.

```
# on a machine without metal
 λ ~/github/taichi fix_test_arch ti test test_customized_grad -vr2 -t4 -a metal -s
[Taichi] version 0.8.1, llvm 10.0.0, commit 502d12b3, linux, python 3.8.11

*******************************************
**      Taichi Programming Language      **
*******************************************

Docs:   https://taichi.rtfd.io/en/stable
GitHub: https://github.com/taichi-dev/taichi
Forum:  https://forum.taichi.graphics

Running on Arch=metal

Running Python tests...

Starting 4 testing thread(s)...
Due to how pytest-xdist is implemented, the -s option does not work with multiple thread...
========================================================= test session starts =========================================================
platform linux -- Python 3.8.11, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/ailing/miniconda3/envs/dev/bin/python
cachedir: .pytest_cache
rootdir: /home/ailing/github/taichi
plugins: xdist-2.3.0, rerunfailures-10.1, forked-1.3.0
collecting ... No supported arch found. Skipping
No supported arch found. Skipping
No supported arch found. Skipping
No supported arch found. Skipping
No supported arch found. Skipping
No supported arch found. Skipping
No supported arch found. Skipping
collected 0 items

======================================================== no tests ran in 0.01s ========================================================
>>> Running time: 0.09s

# running on cpu and cuda
 λ ~/github/taichi fix_test_arch ti test test_customized_grad -vr2 -t4 -a cpu,cuda -s
[Taichi] version 0.8.1, llvm 10.0.0, commit 502d12b3, linux, python 3.8.11

*******************************************
**      Taichi Programming Language      **
*******************************************

Docs:   https://taichi.rtfd.io/en/stable
GitHub: https://github.com/taichi-dev/taichi
Forum:  https://forum.taichi.graphics

Running on Arch=cpu,cuda

Running Python tests...

Starting 4 testing thread(s)...
Due to how pytest-xdist is implemented, the -s option does not work with multiple thread...
========================================================= test session starts =========================================================
platform linux -- Python 3.8.11, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/ailing/miniconda3/envs/dev/bin/python
cachedir: .pytest_cache
rootdir: /home/ailing/github/taichi
plugins: xdist-2.3.0, rerunfailures-10.1, forked-1.3.0
collected 7 items

python/taichi/tests/test_customized_grad.py::test_decorated_primal_is_taichi_kernel [Taichi] Starting on arch=x64
[Taichi] Starting on arch=x64
[Taichi] Starting on arch=cuda
[Taichi] Starting on arch=cuda
PASSED
python/taichi/tests/test_customized_grad.py::test_decorated_primal_missing_decorator [Taichi] Starting on arch=x64
[Taichi] Starting on arch=x64
[Taichi] Starting on arch=cuda
[Taichi] Starting on arch=cuda
PASSED
python/taichi/tests/test_customized_grad.py::test_customized_kernels_tape [Taichi] Starting on arch=x64
[Taichi] Starting on arch=x64
[Taichi] Starting on arch=cuda
[Taichi] Starting on arch=cuda
PASSED
python/taichi/tests/test_customized_grad.py::test_customized_kernels_grad [Taichi] Starting on arch=x64
[Taichi] Starting on arch=x64
[Taichi] Starting on arch=cuda
[Taichi] Starting on arch=cuda
PASSED
python/taichi/tests/test_customized_grad.py::test_customized_kernels_indirect [Taichi] Starting on arch=x64
[Taichi] Starting on arch=x64
[Taichi] Starting on arch=cuda
[Taichi] Starting on arch=cuda
PASSED
python/taichi/tests/test_customized_grad.py::test_customized_kernels_oop [Taichi] Starting on arch=x64
[Taichi] Starting on arch=x64
[Taichi] Starting on arch=cuda
[Taichi] Starting on arch=cuda
PASSED
python/taichi/tests/test_customized_grad.py::test_customized_kernels_oop2 [Taichi] Starting on arch=x64
[Taichi] Starting on arch=x64
[Taichi] Starting on arch=cuda
[Taichi] Starting on arch=cuda
PASSED

========================================================= 7 passed in 18.38s ==========================================================
>>> Running time: 18.47s
```