### PR TITLE
[GUI] Support text_colored in GGUI

### DIFF
--- a/examples/ggui_examples/mass_spring_game_ggui.py
+++ b/examples/ggui_examples/mass_spring_game_ggui.py
@@ -29,6 +29,7 @@ rest_length = ti.field(dtype=ti.f32,
 # gray color
 gray = (128, 128, 128, 255)
 
+
 @ti.kernel
 def substep():
     n = num_particles[None]
@@ -161,7 +162,8 @@ def main():
         canvas.circles(x, per_vertex_color=per_vertex_color, radius=0.02)
 
         window.GUI.begin("mass spring", 0.05, 0.05, 0.9, 0.2)
-        window.GUI.text_colored(gray,
+        window.GUI.text_colored(
+            gray,
             "Left click: add mass point (with shift to fix); Right click: attract"
         )
         window.GUI.text_colored(gray, "C: clear all; Space: pause")

--- a/examples/ggui_examples/mass_spring_game_ggui.py
+++ b/examples/ggui_examples/mass_spring_game_ggui.py
@@ -26,6 +26,8 @@ per_vertex_color = ti.Vector.field(3, ti.f32, shape=max_num_particles)
 rest_length = ti.field(dtype=ti.f32,
                        shape=(max_num_particles, max_num_particles))
 
+# gray color
+gray = (128, 128, 128, 255)
 
 @ti.kernel
 def substep():
@@ -159,10 +161,10 @@ def main():
         canvas.circles(x, per_vertex_color=per_vertex_color, radius=0.02)
 
         window.GUI.begin("mass spring", 0.05, 0.05, 0.9, 0.2)
-        window.GUI.text(
+        window.GUI.text_colored(gray,
             "Left click: add mass point (with shift to fix); Right click: attract"
         )
-        window.GUI.text("C: clear all; Space: pause")
+        window.GUI.text_colored(gray, "C: clear all; Space: pause")
         spring_Y[None] = window.GUI.slider_float("Spring Young's modulus",
                                                  spring_Y[None], 100, 10000)
         drag_damping[None] = window.GUI.slider_float("Drag damping",

--- a/python/taichi/ui/gui.py
+++ b/python/taichi/ui/gui.py
@@ -88,3 +88,11 @@ class Gui:
             text (str): a line of text to be shown next to the button
         """
         return self.gui.button(text)
+
+    def text_colored(self, color, text):
+        """Declares a line of colored text.
+
+        Args:
+            TODO
+        """
+        return self.gui.text_colored(color, text)

--- a/python/taichi/ui/gui.py
+++ b/python/taichi/ui/gui.py
@@ -49,6 +49,9 @@ class Gui:
 
     def text(self, text):
         """Declares a line of text.
+
+        Args:
+            text (str): a line of text to be shown.
         """
         self.gui.text(text)
 
@@ -93,6 +96,7 @@ class Gui:
         """Declares a line of colored text.
 
         Args:
-            TODO
+            color (Tuple[float]): the color of the text, this should be a tuple of floats in [0,1] that indicates RGB values.
+            text (str): a line of text to be shown.
         """
         return self.gui.text_colored(color, text)

--- a/taichi/python/export_ggui.cpp
+++ b/taichi/python/export_ggui.cpp
@@ -29,6 +29,10 @@ glm::vec3 tuple_to_vec3(pybind11::tuple t) {
   return glm::vec3(t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>());
 }
 
+glm::vec4 tuple_to_vec4(py::tuple t) {
+  return glm::vec4(t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>(), t[3].cast<float>());
+}
+
 pybind11::tuple vec3_to_tuple(glm::vec3 v) {
   return pybind11::make_tuple(v.x, v.y, v.z);
 }
@@ -60,6 +64,10 @@ struct PyGui {
   }
   bool button(std::string name) {
     return gui->button(name);
+  }
+  void text_colored(py::tuple color, std::string text) {
+    glm::vec4 glm_color = tuple_to_vec4(color);
+    gui->text_colored(glm_color, text);
   }
 };
 
@@ -341,7 +349,8 @@ void export_ggui(py::module &m) {
       .def("checkbox", &PyGui::checkbox)
       .def("slider_float", &PyGui::slider_float)
       .def("color_edit_3", &PyGui::color_edit_3)
-      .def("button", &PyGui::button);
+      .def("button", &PyGui::button)
+      .def("text_colored", &PyGui::text_colored);
 
   py::class_<PyScene>(m, "PyScene")
       .def(py::init<>())

--- a/taichi/python/export_ggui.cpp
+++ b/taichi/python/export_ggui.cpp
@@ -30,7 +30,8 @@ glm::vec3 tuple_to_vec3(pybind11::tuple t) {
 }
 
 glm::vec4 tuple_to_vec4(py::tuple t) {
-  return glm::vec4(t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>(), t[3].cast<float>());
+  return glm::vec4(t[0].cast<float>(), t[1].cast<float>(), t[2].cast<float>(),
+                   t[3].cast<float>());
 }
 
 pybind11::tuple vec3_to_tuple(glm::vec3 v) {

--- a/taichi/ui/backends/vulkan/gui.cpp
+++ b/taichi/ui/backends/vulkan/gui.cpp
@@ -177,7 +177,8 @@ void Gui::text_colored(glm::vec4 color, std::string text) {
   if (!initialized()) {
     return;
   }
-  ImGui::TextColored(ImVec4(color[0], color[1], color[2], color[3]), text.c_str());
+  ImGui::TextColored(ImVec4(color[0], color[1], color[2], color[3]),
+                     text.c_str());
 }
 
 void Gui::draw(taichi::lang::CommandList *cmd_list) {

--- a/taichi/ui/backends/vulkan/gui.cpp
+++ b/taichi/ui/backends/vulkan/gui.cpp
@@ -173,6 +173,12 @@ bool Gui::button(std::string text) {
   }
   return ImGui::Button(text.c_str());
 }
+void Gui::text_colored(glm::vec4 color, std::string text) {
+  if (!initialized()) {
+    return;
+  }
+  ImGui::TextColored(ImVec4(color[0], color[1], color[2], color[3]), text.c_str());
+}
 
 void Gui::draw(taichi::lang::CommandList *cmd_list) {
   // Rendering

--- a/taichi/ui/backends/vulkan/gui.h
+++ b/taichi/ui/backends/vulkan/gui.h
@@ -42,6 +42,8 @@ class Gui final : public GuiBase {
                                  glm::vec3 old_value) override;
   virtual bool button(std::string text) override;
 
+  virtual void text_colored(glm::vec4 color, std::string text) override;
+
   void draw(taichi::lang::CommandList *cmd_list);
 
   void prepare_for_next_frame();

--- a/taichi/ui/common/gui_base.h
+++ b/taichi/ui/common/gui_base.h
@@ -20,6 +20,7 @@ class GuiBase {
                              float maximum) = 0;
   virtual glm::vec3 color_edit_3(std::string name, glm::vec3 old_value) = 0;
   virtual bool button(std::string text) = 0;
+  virtual void text_colored(glm::vec4 color, std::string text) = 0;
   virtual ~GuiBase() = default;
 };
 


### PR DESCRIPTION
Signed-off-by: Ce Gao <ce.gao@outlook.com>

Related issue = #3013 

- [x] Implement the feature
- [x] Add docs and comments
- [x] Add examples

Feature preview ./examples/ggui_examples/mass_spring_game_ggui.py

```diff
-        window.GUI.text(
+        window.GUI.text_colored((0,112,112,112),
            "Left click: add mass point (with shift to fix); Right click: attract"
        )
```

![Screenshot from 2021-10-01 21-28-12](https://user-images.githubusercontent.com/5100735/135628101-da77389f-b6cd-4ed6-bcae-cb403d9c5806.png)


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
