### PR TITLE
[metal] Pull out the Runtime MSL code into its own module

### DIFF
--- a/taichi/backends/metal/aot_module_builder_impl.cpp
+++ b/taichi/backends/metal/aot_module_builder_impl.cpp
@@ -10,9 +10,12 @@ namespace lang {
 namespace metal {
 
 AotModuleBuilderImpl::AotModuleBuilderImpl(
+    const CompiledRuntimeModule *compiled_runtime_module,
     const CompiledStructs *compiled_structs,
     const BufferMetaData &buffer_meta_data)
-    : compiled_structs_(compiled_structs), buffer_meta_data_(buffer_meta_data) {
+    : compiled_runtime_module_(compiled_runtime_module),
+      compiled_structs_(compiled_structs),
+      buffer_meta_data_(buffer_meta_data) {
   ti_aot_data_.metadata = buffer_meta_data;
 }
 
@@ -50,8 +53,8 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
 
 void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
                                            Kernel *kernel) {
-  auto compiled =
-      run_codegen(compiled_structs_, kernel, &strtab_, /*offloaded=*/nullptr);
+  auto compiled = run_codegen(compiled_runtime_module_, compiled_structs_,
+                              kernel, &strtab_, /*offloaded=*/nullptr);
   compiled.kernel_name = identifier;
   ti_aot_data_.kernels.push_back(std::move(compiled));
 }
@@ -76,8 +79,8 @@ void AotModuleBuilderImpl::add_per_backend_field(const std::string &identifier,
 void AotModuleBuilderImpl::add_per_backend_tmpl(const std::string &identifier,
                                                 const std::string &key,
                                                 Kernel *kernel) {
-  auto compiled =
-      run_codegen(compiled_structs_, kernel, &strtab_, /*offloaded=*/nullptr);
+  auto compiled = run_codegen(compiled_runtime_module_, compiled_structs_,
+                              kernel, &strtab_, /*offloaded=*/nullptr);
   for (auto &k : ti_aot_data_.tmpl_kernels) {
     if (k.kernel_bundle_name == identifier) {
       k.kernel_tmpl_map.insert(std::make_pair(key, compiled));

--- a/taichi/backends/metal/aot_module_builder_impl.h
+++ b/taichi/backends/metal/aot_module_builder_impl.h
@@ -14,8 +14,11 @@ namespace metal {
 
 class AotModuleBuilderImpl : public AotModuleBuilder {
  public:
-  explicit AotModuleBuilderImpl(const CompiledStructs *compiled_structs,
-                                const BufferMetaData &buffer_meta_data);
+  explicit AotModuleBuilderImpl(
+      const CompiledRuntimeModule *compiled_runtime_module,
+      const CompiledStructs *compiled_structs,
+      const BufferMetaData &buffer_meta_data);
+
   void dump(const std::string &output_dir,
             const std::string &filename) const override;
 
@@ -32,10 +35,12 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
                             Kernel *kernel) override;
 
  private:
+  const CompiledRuntimeModule *compiled_runtime_module_;
   const CompiledStructs *compiled_structs_;
   BufferMetaData buffer_meta_data_;
   PrintStringTable strtab_;
   TaichiAotData ti_aot_data_;
+
   void metalgen(const stdfs::path &dir,
                 const std::string &filename,
                 const CompiledKernelData &k) const;

--- a/taichi/backends/metal/codegen_metal.h
+++ b/taichi/backends/metal/codegen_metal.h
@@ -17,10 +17,12 @@ namespace taichi {
 namespace lang {
 namespace metal {
 
-CompiledKernelData run_codegen(const CompiledStructs *compiled_structs,
-                               Kernel *kernel,
-                               PrintStringTable *print_strtab,
-                               OffloadedStmt *offloaded);
+CompiledKernelData run_codegen(
+    const CompiledRuntimeModule *compiled_runtime_module,
+    const CompiledStructs *compiled_structs,
+    Kernel *kernel,
+    PrintStringTable *print_strtab,
+    OffloadedStmt *offloaded);
 
 // If |offloaded| is nullptr, this compiles the AST in |kernel|. Otherwise it
 // compiles just |offloaded|. These ASTs must have already been lowered at the
@@ -28,6 +30,7 @@ CompiledKernelData run_codegen(const CompiledStructs *compiled_structs,
 FunctionType compile_to_metal_executable(
     Kernel *kernel,
     KernelManager *kernel_mgr,
+    const CompiledRuntimeModule *compiled_runtime_module,
     const CompiledStructs *compiled_structs,
     OffloadedStmt *offloaded = nullptr);
 

--- a/taichi/backends/metal/constants.h
+++ b/taichi/backends/metal/constants.h
@@ -2,14 +2,17 @@
 
 #include <string>
 
-#include "taichi/lang_util.h"
+#include "taichi/inc/constants.h"
 
-TLANG_NAMESPACE_BEGIN
+namespace taichi {
+namespace lang {
 namespace metal {
 
 inline constexpr int kMaxNumThreadsGridStrideLoop = 64 * 1024;
 inline constexpr int kNumRandSeeds = 64 * 1024;  // 256 KB is nothing
 inline constexpr int kMslVersionNone = 0;
+inline constexpr int kMaxNumSNodes = taichi_max_num_snodes;
 
 }  // namespace metal
-TLANG_NAMESPACE_END
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/backends/metal/kernel_manager.cpp
+++ b/taichi/backends/metal/kernel_manager.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstring>
 #include <limits>
+#include <optional>
 #include <random>
 #include <string_view>
 
@@ -568,6 +569,7 @@ class KernelManager::Impl {
  public:
   explicit Impl(Params params)
       : config_(params.config),
+        compiled_runtime_module_(params.compiled_runtime_module),
         compiled_structs_(params.compiled_structs),
         mem_pool_(params.mem_pool),
         host_result_buffer_(params.host_result_buffer),
@@ -605,24 +607,24 @@ class KernelManager::Impl {
         device_.get(), global_tmps_mem_->ptr(), global_tmps_mem_->size());
     TI_ASSERT(global_tmps_buffer_ != nullptr);
 
-    TI_ASSERT(compiled_structs_.runtime_size > 0);
+    TI_ASSERT(compiled_runtime_module_.runtime_size > 0);
     const size_t mem_pool_bytes =
         (config_->device_memory_GB * 1024 * 1024 * 1024ULL);
     runtime_mem_ = std::make_unique<BufferMemoryView>(
-        compiled_structs_.runtime_size + mem_pool_bytes, mem_pool_);
+        compiled_runtime_module_.runtime_size + mem_pool_bytes, mem_pool_);
     runtime_buffer_ = new_mtl_buffer_no_copy(device_.get(), runtime_mem_->ptr(),
                                              runtime_mem_->size());
-    buffer_meta_data_.runtime_buffer_size = compiled_structs_.runtime_size;
+    buffer_meta_data_.runtime_buffer_size = compiled_runtime_module_.runtime_size;
     TI_DEBUG(
         "Metal runtime buffer size: {} bytes (sizeof(Runtime)={} "
         "memory_pool={})",
-        runtime_mem_->size(), compiled_structs_.runtime_size, mem_pool_bytes);
+        runtime_mem_->size(), compiled_runtime_module_.runtime_size, mem_pool_bytes);
 
     ActionRecorder::get_instance().record(
         "allocate_runtime_buffer",
         {ActionArg("runtime_buffer_size_in_bytes", (int64)runtime_mem_->size()),
          ActionArg("runtime_struct_size_in_bytes",
-                   (int64)compiled_structs_.runtime_size),
+                   (int64)compiled_runtime_module_.runtime_size),
          ActionArg("memory_pool_size", (int64)mem_pool_bytes)});
 
     TI_ASSERT_INFO(
@@ -794,7 +796,7 @@ class KernelManager::Impl {
           i, snode_type_name(sn_meta.snode->type), rtm_meta->element_stride,
           rtm_meta->num_slots, rtm_meta->mem_offset_in_parent);
     }
-    size_t addr_offset = sizeof(SNodeMeta) * max_snodes;
+    size_t addr_offset = sizeof(SNodeMeta) * kMaxNumSNodes;
     addr += addr_offset;
     TI_DEBUG("Initialized SNodeMeta, size={} accumulated={}", addr_offset,
              (addr - addr_begin));
@@ -819,7 +821,7 @@ class KernelManager::Impl {
       }
       TI_DEBUG("");
     }
-    addr_offset = sizeof(SNodeExtractors) * max_snodes;
+    addr_offset = sizeof(SNodeExtractors) * kMaxNumSNodes;
     addr += addr_offset;
     TI_DEBUG("Initialized SNodeExtractors, size={} accumulated={}", addr_offset,
              (addr - addr_begin));
@@ -843,7 +845,7 @@ class KernelManager::Impl {
       TI_DEBUG("ListManagerData\n  id={}\n  num_elems_per_chunk={}\n", i,
                num_elems_per_chunk);
     }
-    addr_offset = sizeof(ListManagerData) * max_snodes;
+    addr_offset = sizeof(ListManagerData) * kMaxNumSNodes;
     addr += addr_offset;
     TI_DEBUG("Initialized ListManagerData, size={} accumulated={}", addr_offset,
              (addr - addr_begin));
@@ -892,7 +894,7 @@ class KernelManager::Impl {
       init_node_mgr(sn_desc, nm_data);
       snode_id_to_nodemgrs.push_back(std::make_pair(i, nm_data));
     }
-    addr_offset = sizeof(NodeManagerData) * max_snodes;
+    addr_offset = sizeof(NodeManagerData) * kMaxNumSNodes;
     addr += addr_offset;
     TI_DEBUG("Initialized NodeManagerData, size={} accumulated={}", addr_offset,
              (addr - addr_begin));
@@ -901,7 +903,7 @@ class KernelManager::Impl {
     auto *const ambient_indices_begin =
         reinterpret_cast<NodeManagerData::ElemIndex *>(addr);
     dev_runtime_mirror_.ambient_indices = ambient_indices_begin;
-    addr_offset = sizeof(NodeManagerData::ElemIndex) * max_snodes;
+    addr_offset = sizeof(NodeManagerData::ElemIndex) * kMaxNumSNodes;
     addr += addr_offset;
     TI_DEBUG(
         "Delayed the initialization of SNode ambient elements, size={} "
@@ -959,7 +961,6 @@ class KernelManager::Impl {
       TI_DEBUG("AmbientIndex\n  id={}\n  mem_alloc->next={}\n", snode_id,
                mem_alloc->next);
     }
-
     did_modify_range(runtime_buffer_.get(), /*location=*/0,
                      runtime_mem_->size());
   }
@@ -1129,6 +1130,7 @@ class KernelManager::Impl {
   }
 
   CompileConfig *const config_;
+  const CompiledRuntimeModule compiled_runtime_module_;
   const CompiledStructs compiled_structs_;
   BufferMetaData buffer_meta_data_;
   MemoryPool *const mem_pool_;
@@ -1172,6 +1174,10 @@ class KernelManager::Impl {
     TI_ERROR("Metal not supported on the current OS");
   }
 
+  void add_compiled_snode_tree(const CompiledStructs &) {
+    TI_ERROR("Metal not supported on the current OS");
+  }
+
   void register_taichi_kernel(const std::string &taichi_kernel_name,
                               const std::string &mtl_kernel_source_code,
                               const TaichiKernelAttributes &ti_kernel_attribs,
@@ -1210,6 +1216,10 @@ KernelManager::KernelManager(Params params)
 }
 
 KernelManager::~KernelManager() {
+}
+
+void KernelManager::add_compiled_snode_tree(const CompiledStructs &snode_tree) {
+  impl_->add_compiled_snode_tree(snode_tree);
 }
 
 void KernelManager::register_taichi_kernel(

--- a/taichi/backends/metal/kernel_manager.h
+++ b/taichi/backends/metal/kernel_manager.h
@@ -26,6 +26,7 @@ namespace metal {
 class KernelManager {
  public:
   struct Params {
+    CompiledRuntimeModule compiled_runtime_module;
     CompiledStructs compiled_structs;
     CompileConfig *config;
     MemoryPool *mem_pool;
@@ -38,6 +39,7 @@ class KernelManager {
   // To make Pimpl + std::unique_ptr work
   ~KernelManager();
 
+  void add_compiled_snode_tree(const CompiledStructs &snode_tree);
   // Register a Taichi kernel to the Metal runtime.
   // * |mtl_kernel_source_code| is the complete source code compiled from a
   // Taichi kernel. It may include one or more Metal compute kernels. Each

--- a/taichi/backends/metal/metal_program.cpp
+++ b/taichi/backends/metal/metal_program.cpp
@@ -13,9 +13,9 @@ FunctionType MetalProgramImpl::compile(Kernel *kernel,
   if (!kernel->lowered()) {
     kernel->lower();
   }
-  return metal::compile_to_metal_executable(kernel, metal_kernel_mgr_.get(),
-                                            &metal_compiled_structs_.value(),
-                                            offloaded);
+  return metal::compile_to_metal_executable(
+      kernel, metal_kernel_mgr_.get(), &(compiled_runtime_module_.value()),
+      &(metal_compiled_structs_.value()), offloaded);
 }
 
 std::size_t MetalProgramImpl::get_snode_num_dynamically_allocated(SNode *snode,
@@ -33,6 +33,7 @@ void MetalProgramImpl::materialize_runtime(MemoryPool *memory_pool,
       sizeof(uint64) * taichi_result_buffer_entries, 8);
   params_.mem_pool = memory_pool;
   params_.profiler = profiler;
+  compiled_runtime_module_ = metal::compile_runtime_module();
 }
 
 void MetalProgramImpl::materialize_snode_tree(
@@ -48,12 +49,20 @@ void MetalProgramImpl::materialize_snode_tree(
   metal_compiled_structs_ = metal::compile_structs(*root);
   if (metal_kernel_mgr_ == nullptr) {
     params_.compiled_structs = metal_compiled_structs_.value();
+    params_.compiled_runtime_module = compiled_runtime_module_.value();
     params_.config = config;
     params_.host_result_buffer = result_buffer;
     params_.root_id = root->id;
     metal_kernel_mgr_ =
         std::make_unique<metal::KernelManager>(std::move(params_));
   }
+  metal_kernel_mgr_->add_compiled_snode_tree(metal_compiled_structs_.value());
+}
+
+std::unique_ptr<AotModuleBuilder> MetalProgramImpl::make_aot_module_builder() {
+  return std::make_unique<metal::AotModuleBuilderImpl>(
+      &(compiled_runtime_module_.value()), &(metal_compiled_structs_.value()),
+      metal_kernel_mgr_->get_buffer_meta_data());
 }
 
 }  // namespace lang

--- a/taichi/backends/metal/metal_program.h
+++ b/taichi/backends/metal/metal_program.h
@@ -12,9 +12,11 @@
 
 namespace taichi {
 namespace lang {
+
 class MetalProgramImpl : public ProgramImpl {
  public:
   MetalProgramImpl(CompileConfig &config);
+
   FunctionType compile(Kernel *kernel, OffloadedStmt *offloaded) override;
 
   std::size_t get_snode_num_dynamically_allocated(
@@ -35,21 +37,19 @@ class MetalProgramImpl : public ProgramImpl {
     metal_kernel_mgr_->synchronize();
   }
 
-  virtual void destroy_snode_tree(SNodeTree *snode_tree) override{
-      TI_NOT_IMPLEMENTED}
+  void destroy_snode_tree(SNodeTree *snode_tree) override {
+    TI_NOT_IMPLEMENTED;
+  }
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override {
-    return std::make_unique<metal::AotModuleBuilderImpl>(
-        &(metal_compiled_structs_.value()),
-        metal_kernel_mgr_->get_buffer_meta_data());
-  }
-  ~MetalProgramImpl() {
-  }
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
 
  private:
-  std::optional<metal::CompiledStructs> metal_compiled_structs_;
-  std::unique_ptr<metal::KernelManager> metal_kernel_mgr_;
+  std::optional<metal::CompiledRuntimeModule> compiled_runtime_module_{
+      std::nullopt};
+  std::optional<metal::CompiledStructs> metal_compiled_structs_{std::nullopt};
+  std::unique_ptr<metal::KernelManager> metal_kernel_mgr_{nullptr};
   metal::KernelManager::Params params_;
 };
+
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/metal/struct_metal.cpp
+++ b/taichi/backends/metal/struct_metal.cpp
@@ -13,7 +13,8 @@
 #include "taichi/math/arithmetic.h"
 #include "taichi/util/line_appender.h"
 
-TLANG_NAMESPACE_BEGIN
+namespace taichi {
+namespace lang {
 namespace metal {
 namespace {
 namespace shaders {
@@ -51,9 +52,6 @@ class StructCompiler {
   CompiledStructs run(SNode &root) {
     TI_ASSERT(root.type == SNodeType::root);
     collect_snodes(root);
-    // The host side has run this!
-    // infer_snode_properties(node);
-
     auto snodes_rev = snodes_;
     std::reverse(snodes_rev.begin(), snodes_rev.end());
     {
@@ -82,17 +80,15 @@ class StructCompiler {
     CompiledStructs result;
     result.root_snode_type_name = root.node_type_name;
     result.root_size = compute_snode_size(&root);
-    emit_runtime_structs();
-    line_appender_.dump(&result.runtime_utils_source_code);
-    result.runtime_size = compute_runtime_size();
     for (auto &n : snodes_rev) {
       generate_types(*n);
     }
     line_appender_.dump(&result.snode_structs_source_code);
+    result.root_id = root.id;
     result.max_snodes = max_snodes_;
     result.snode_descriptors = std::move(snode_descriptors_);
-    TI_DEBUG("Metal: root_size={} runtime_size={}", result.root_size,
-             result.runtime_size);
+    TI_DEBUG("Metal: root_id={} root_size={}", result.root_id,
+             result.root_size);
     return result;
   }
 
@@ -340,15 +336,39 @@ class StructCompiler {
     return sn_desc.stride;
   }
 
+  template <typename... Args>
+  void emit(std::string f, Args &&... args) {
+    line_appender_.append(std::move(f), std::move(args)...);
+  }
+
+  std::vector<SNode *> snodes_;
+  int max_snodes_{0};
+  LineAppender line_appender_;
+  std::unordered_map<int, SNodeDescriptor> snode_descriptors_;
+  bool has_sparse_snode_{false};
+};
+
+class RuntimeModuleCompiler {
+ public:
+  CompiledRuntimeModule run() {
+    CompiledRuntimeModule res;
+    emit_runtime_structs();
+    line_appender_.dump(&res.runtime_utils_source_code);
+    res.rand_seeds_size = compute_rand_seeds_size();
+    res.runtime_size = compute_snodes_runtime_size() + res.rand_seeds_size;
+    return res;
+  }
+
+ private:
   void emit_runtime_structs() {
     line_appender_.append_raw(shaders::kMetalRuntimeStructsSourceCode);
     emit("");
     emit("struct Runtime {{");
-    emit("  SNodeMeta snode_metas[{}];", max_snodes_);
-    emit("  SNodeExtractors snode_extractors[{}];", max_snodes_);
-    emit("  ListManagerData snode_lists[{}];", max_snodes_);
-    emit("  NodeManagerData snode_allocators[{}];", max_snodes_);
-    emit("  NodeManagerData::ElemIndex ambient_indices[{}];", max_snodes_);
+    emit("  SNodeMeta snode_metas[{}];", kMaxNumSNodes);
+    emit("  SNodeExtractors snode_extractors[{}];", kMaxNumSNodes);
+    emit("  ListManagerData snode_lists[{}];", kMaxNumSNodes);
+    emit("  NodeManagerData snode_allocators[{}];", kMaxNumSNodes);
+    emit("  NodeManagerData::ElemIndex ambient_indices[{}];", kMaxNumSNodes);
     emit("  uint32_t rand_seeds[{}];", kNumRandSeeds);
     emit("}};");
     emit("");
@@ -358,12 +378,14 @@ class StructCompiler {
     emit("");
   }
 
-  size_t compute_runtime_size() {
-    size_t result = max_snodes_ * (kSNodeMetaSize + kSNodeExtractorsSize +
-                                   kListManagerDataSize + kNodeManagerDataSize +
-                                   kNodeManagerElemIndexSize);
-    result += sizeof(uint32_t) * kNumRandSeeds;
-    return result;
+  size_t compute_snodes_runtime_size() {
+    return kMaxNumSNodes *
+           (kSNodeMetaSize + kSNodeExtractorsSize + kListManagerDataSize +
+            kNodeManagerDataSize + kNodeManagerElemIndexSize);
+  }
+
+  size_t compute_rand_seeds_size() {
+    return sizeof(uint32_t) * kNumRandSeeds;
   }
 
   template <typename... Args>
@@ -371,11 +393,7 @@ class StructCompiler {
     line_appender_.append(std::move(f), std::move(args)...);
   }
 
-  std::vector<SNode *> snodes_;
-  int max_snodes_;
   LineAppender line_appender_;
-  std::unordered_map<int, SNodeDescriptor> snode_descriptors_;
-  bool has_sparse_snode_;
 };
 
 }  // namespace
@@ -397,5 +415,11 @@ int total_num_self_from_root(const SNodeDescriptorsMap &m, int snode_id) {
 CompiledStructs compile_structs(SNode &root) {
   return StructCompiler().run(root);
 }
+
+CompiledRuntimeModule compile_runtime_module() {
+  return RuntimeModuleCompiler{}.run();
+}
+
 }  // namespace metal
-TLANG_NAMESPACE_END
+}  // namespace lang
+}  // namespace taichi


### PR DESCRIPTION
Related issue = #3018

Decoupling the runtime part from the root/SNodes, so that it is easier for us to support multiple SNode roots.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
