### PR TITLE
[Doc] Fix an example in the documentation for Coordinate offsets

### DIFF
--- a/docs/lang/articles/advanced/offset.md
+++ b/docs/lang/articles/advanced/offset.md
@@ -18,10 +18,10 @@ a = ti.Matrix.field(2, 2, dtype=ti.f32, shape=(32, 64), offset=(-16, 8))
 In this way, the field's indices are from `(-16, 8)` to `(16, 72)` (exclusive).
 
 ```python
-a[-16, 32]  # lower left corner
-a[16, 32]   # lower right corner
-a[-16, 64]  # upper left corner
-a[16, 64]   # upper right corner
+a[-16, 8]  # lower left corner
+a[16, 8]   # lower right corner
+a[-16, 72]  # upper left corner
+a[16, 72]   # upper right corner
 ```
 
 :::note


### PR DESCRIPTION
Related issue = #
I think the original example given in the code is not right according to Ln 18. 
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/docs/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
