### PR TITLE
[cuda] Fix memory alignment bug in pre-allocated memory allocator.

### DIFF
--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -789,7 +789,7 @@ Ptr LLVMRuntime::allocate_from_buffer(std::size_t size, std::size_t alignment) {
         ((std::size_t)preallocated_head + alignment - 1) % alignment;
     size += alignment_bytes;
     if (preallocated_head + size <= preallocated_tail) {
-      ret = preallocated_head;
+      ret = preallocated_head + alignment_bytes;
       preallocated_head += size;
       success = true;
     } else {


### PR DESCRIPTION
Related issue = #2847 

This will fix `test_sfg`.