### PR TITLE
[cuda] Re-Re-enable sfg test on CUDA

### DIFF
--- a/tests/python/test_sfg.py
+++ b/tests/python/test_sfg.py
@@ -5,7 +5,6 @@ import taichi as ti
 
 
 @ti.test(require=[ti.extension.async_mode, ti.extension.sparse],
-         exclude=[ti.cuda],
          async_mode=True)
 def test_remove_clear_list_from_fused_serial():
     x = ti.field(ti.i32)


### PR DESCRIPTION
The story of this test (so far): 

it was enabled on CUDA when it was born, then disabled (#2847 ) because we observed that it was flaky. We then re-enabled it (#2874 ) because it stop being flaky anymore, but at (#3067  ) it started to fail because of an ancient alignment bug (probably the root cause of its previous flakiness), so it was re-disabled. Finally, the alignment bug was fixed at #3096 , so I'm re-re-enabling it here.

Phew.