### PR TITLE
[ci] Fix sparse_solver for pylint.

### DIFF
--- a/python/taichi/linalg/sparse_solver.py
+++ b/python/taichi/linalg/sparse_solver.py
@@ -1,15 +1,15 @@
 import numpy as np
+import taichi.lang
 from taichi.core.util import ti_core as _ti_core
 from taichi.linalg import SparseMatrix
 
 
 class SparseSolver:
     def __init__(self, solver_type="LLT", ordering="AMD"):
-        from taichi.lang.impl import get_runtime
         solver_type_list = ["LLT", "LDLT", "LU"]
         solver_ordering = ['AMD', 'COLAMD']
         if solver_type in solver_type_list and ordering in solver_ordering:
-            taichi_arch = get_runtime().prog.config.arch
+            taichi_arch = taichi.lang.impl.get_runtime().prog.config.arch
             assert taichi_arch == _ti_core.Arch.x64 or taichi_arch == _ti_core.Arch.arm64, "SparseSolver only supports CPU for now."
             self.solver = _ti_core.make_sparse_solver(solver_type, ordering)
         else:
@@ -38,8 +38,7 @@ class SparseSolver:
             self.type_assert(sparse_matrix)
 
     def solve(self, b):
-        from taichi.lang import Field
-        if isinstance(b, Field):
+        if isinstance(b, taichi.lang.Field):
             return self.solver.solve(b.to_numpy())
         elif isinstance(b, np.ndarray):
             return self.solver.solve(b)


### PR DESCRIPTION
There was a race condition between me enabling pylint check and PR #3115 
merging. :P This PR fixes it to make sure master passes pylint check.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
