### PR TITLE
[CI] Add pip cache

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: 3.8
           
-      - name: Check code format for git init 
+      - name: Setup git & clang-format
         run: |
           git config user.email "taichigardener@gmail.com"
           git config user.name "Taichi Gardener"
@@ -51,13 +51,16 @@ jobs:
         run: |
           python3 -m pip install --user -r requirements_lint.txt
       
-      - name: Check code format for run code_format and pylint
+      - name: Check code format
         run: |
           python3 python/taichi/code_format.py
           git checkout -b _enforced_format
           git commit -am "enforce code format" || true
           # exit with 1 if there were differences:
           git diff _fake_squash _enforced_format --exit-code
+
+      - name: Pylint
+        run: |
           # Make sure pylint doesn't regress
           pylint python/taichi/ --disable=all --enable=C0415
           if [ $? -eq 0 ]


### PR DESCRIPTION
Related issue = #3126 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
1.I’m not good at give the step a name,like `Check code format for git init` can be improved.
2.I'm not sure these places whether need to add pip cache,like line 234 `python -m pip install -r requirements_dev.txt`。if need to do it, I am willing to do it.:D
3.refer to @yihong0618,these is a step Set Variable.I think it's used for adapting diferent enviroment .In this case,we just choose the python3.8 and ubuntu,So I don't add this step.
My English isn’t that good,forgive me.