### PR TITLE
[misc] Enable flushing when printing preprocessed ast.

### DIFF
--- a/python/taichi/lang/ast/transformer.py
+++ b/python/taichi/lang/ast/transformer.py
@@ -29,7 +29,7 @@ class ASTTransformerTotal(object):
             return
         if title is not None:
             ti.info(f'{title}:')
-        print(astor.to_source(tree.body[0], indent_with='    '))
+        print(astor.to_source(tree.body[0], indent_with='    '), flush=True)
 
     def visit(self, tree):
         self.print_ast(tree, 'Initial AST')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3143
* __->__ #3142
* #3141

Sometimes these prints are buffered and doesn't show in the correct
order when mixed with e.g. prints from cpp. But when I enable `print_preprocessed=True`, I care more about
ordering than performance. ;)