### PR TITLE
[refactor] Get rid of the indirection between KernelCodeGen::compile and KernelCodeGen::codegen.

### DIFF
--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -28,11 +28,6 @@ KernelCodeGen::KernelCodeGen(Kernel *kernel, IRNode *ir)
   stat.add("codegen_statements", num_stmts);
 }
 
-FunctionType KernelCodeGen::compile() {
-  TI_AUTO_PROF;
-  return codegen();
-}
-
 std::unique_ptr<KernelCodeGen> KernelCodeGen::create(Arch arch,
                                                      Kernel *kernel,
                                                      Stmt *stmt) {

--- a/taichi/codegen/codegen.h
+++ b/taichi/codegen/codegen.h
@@ -21,8 +21,6 @@ class KernelCodeGen {
                                                Kernel *kernel,
                                                Stmt *stmt = nullptr);
 
-  virtual FunctionType compile();
-
   virtual FunctionType codegen() = 0;
 };
 

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -122,7 +122,7 @@ FunctionType LlvmProgramImpl::compile(Kernel *kernel,
     kernel->lower();
   }
   auto codegen = KernelCodeGen::create(kernel->arch, kernel, offloaded);
-  return codegen->compile();
+  return codegen->codegen();
 }
 
 void LlvmProgramImpl::synchronize() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #3143
* #3142
* #3141

