### PR TITLE
Revert "[Bug] Fix argument shadowed when there is a local variable with the same name"

### DIFF
--- a/python/taichi/lang/ast_builder_utils.py
+++ b/python/taichi/lang/ast_builder_utils.py
@@ -55,7 +55,6 @@ class BuilderContext:
         self.is_kernel = is_kernel
         self.arg_features = arg_features
         self.returns = None
-        self.args = []
 
     # e.g.: FunctionDef, Module, Global
     def variable_scope(self, *args):

--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -171,10 +171,6 @@ class StmtBuilder(Builder):
             value: A node representing the value.
         """
         is_local = isinstance(target, ast.Name)
-        if is_local and target.id in ctx.args:
-            raise TaichiSyntaxError(
-                f"Kernel argument \"{target.id}\" cannot be redefined in the kernel"
-            )
         if is_local and ctx.is_creation(target.id):
             var_name = target.id
             target.ctx = ast.Store()
@@ -552,7 +548,6 @@ if 1:
             for i, arg in enumerate(args.args):
                 # Directly pass in template arguments,
                 # such as class instances ("self"), fields, SNodes, etc.
-                ctx.args.append(arg.arg)
                 if isinstance(ctx.func.argument_annotations[i], ti.template):
                     continue
                 if isinstance(ctx.func.argument_annotations[i],
@@ -586,7 +581,6 @@ if 1:
                     arg_init = parse_stmt(
                         'x = ti.lang.kernel_arguments.decl_scalar_arg(0)')
                     arg_init.targets[0].id = arg.arg
-                    ctx.create_variable(arg.arg)
                     dt = arg.annotation
                     arg_init.value.args[0] = dt
                     arg_decls.append(arg_init)

--- a/tests/python/test_kernel_arg_errors.py
+++ b/tests/python/test_kernel_arg_errors.py
@@ -15,16 +15,3 @@ def test_pass_float_as_i32():
     assert e.type is ti.KernelArgError
     assert e.value.args[
         0] == "Argument 0 (type=<class 'float'>) cannot be converted into required type i32"
-
-
-@ti.test(arch=ti.cpu)
-def test_argument_redefinition():
-    @ti.kernel
-    def foo(a: ti.i32):
-        a = 1
-
-    with pytest.raises(ti.TaichiSyntaxError) as e:
-        foo(5)
-
-    assert e.value.args[
-        0] == "Kernel argument \"a\" cannot be redefined in the kernel"


### PR DESCRIPTION
Reverts taichi-dev/taichi#3105
related to #3144 