### PR TITLE
[ci] Get rid of requirements_lint.txt.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-          
+
       - name: Setup git & clang-format
         run: |
           git config user.email "taichigardener@gmail.com"
@@ -41,16 +41,16 @@ jobs:
           git fetch upstream master
           sudo apt install clang-format-10
 
-      - name: Cache PIP 
+      - name: Cache PIP
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_lint.txt') }}
+          key: ${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_dev.txt') }}
 
-      - name: Install requirements 
+      - name: Install requirements
         run: |
-          python3 -m pip install --user -r requirements_lint.txt
-      
+          python3 -m pip install --user -r requirements_dev.txt
+
       - name: Check code format
         run: |
           python3 python/taichi/code_format.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ pytest-xdist
 pytest-rerunfailures
 pytest-cov
 torch
+isort

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,5 +1,0 @@
-yapf==0.31.0
-gitpython
-colorama
-isort
-pylint


### PR DESCRIPTION
Now that we have pip cache, we can save one copy of requirements.txt and
reuse requirements_dev.txt.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
