### PR TITLE
[ci] Move pytest/pylint out of runtime dep.

### DIFF
--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -12,8 +12,6 @@ from functools import wraps
 from pathlib import Path
 
 import numpy as np
-import pylint.lint
-import pytest
 import taichi.cc_compose
 import taichi.code_format
 import taichi.diagnose
@@ -664,6 +662,7 @@ class TaichiMain:
         else:
             if int(threads) > 1:
                 pytest_args += ['-n', str(threads)]
+        import pytest  # pylint: disable=C0415
         return int(pytest.main(pytest_args))
 
     @staticmethod
@@ -997,6 +996,7 @@ class TaichiMain:
 
         # http://pylint.pycqa.org/en/latest/user_guide/run.html
         # TODO: support redirect output to lint.log
+        import pylint  # pylint: disable=C0415
         pylint.lint.Run(options)
 
 

--- a/python/taichi/testing.py
+++ b/python/taichi/testing.py
@@ -4,7 +4,6 @@ import itertools
 import os
 from tempfile import mkstemp
 
-import pytest
 from taichi.core import ti_core as _ti_core
 
 import taichi as ti
@@ -40,6 +39,7 @@ def approx(expected, **kwargs):
 
     kwargs['rel'] = max(kwargs.get('rel', 1e-6), get_rel_eps())
 
+    import pytest  # pylint: disable=C0415
     return pytest.approx(expected, **kwargs)
 
 


### PR DESCRIPTION
I prefer not to add more packages into `install_requires` inside
`setup.py` so giving this a try. It should work but I'm not sure if
there are other packages that are in requirements.txt but required in
runtime.
Details:
https://packaging.python.org/discussions/install-requires-vs-requirements/

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
