### PR TITLE
[bug] Fix the mapping from virtual axes to physical axes again

### DIFF
--- a/taichi/transforms/scalar_pointer_lowerer.cpp
+++ b/taichi/transforms/scalar_pointer_lowerer.cpp
@@ -60,6 +60,7 @@ void ScalarPointerLowerer::run() {
   if (path_length_ == 0)
     return;
 
+  auto *leaf_snode = snodes_[path_length_ - 1];
   Stmt *last = lowered_->push_back<GetRootStmt>(snodes_[0]);
   for (int i = 0; i < path_length_; i++) {
     auto *snode = snodes_[i];
@@ -72,8 +73,8 @@ void ScalarPointerLowerer::run() {
     std::vector<int> strides;
     // extract lowered indices
     for (int k_ = 0; k_ < (int)indices_.size(); k_++) {
-      int k = snode->physical_index_position[k_];
-      if (k < 0)
+      int k = leaf_snode->physical_index_position[k_];
+      if (!snode->extractors[k].active)
         continue;
       Stmt *extracted;
       if (packed_) {  // no dependence on POT

--- a/tests/python/test_indices.py
+++ b/tests/python/test_indices.py
@@ -18,6 +18,21 @@ def test_indices():
     # Note that b is column-major:
     # the virtual first index exposed to the user comes second in memory layout.
 
+    @ti.kernel
+    def fill():
+        for i, j in b:
+            b[i, j] = i * 10 + j
+
+    @ti.kernel
+    def get_field_addr(i: ti.i32, j: ti.i32) -> ti.u64:
+        return ti.get_addr(b, [i, j])
+
+    fill()
+    for i in range(16):
+        for j in range(32):
+            assert b[i, j] == i * 10 + j
+    assert get_field_addr(0, 1) + 4 == get_field_addr(1, 1)
+
 
 @ti.test(arch=ti.get_host_arch_list())
 def test_float_as_index():


### PR DESCRIPTION
Related issue = #3154

In Taichi docs, there is a subsection introducing row-major vs column-major dense layouts:
https://github.com/taichi-dev/taichi/blob/801f7bd5e2fa196a6b6685b691f02dac82e39e64/docs/lang/articles/advanced/layout.md#L87

However, in Taichi v0.8.1,
```python
ti.root.dense(ti.j, 2).dense(ti.i, 3).place(x)
```
is equivalent to
```python
ti.root.dense(ti.i, 2).dense(ti.j, 3).place(x)
```
The reason is that virtual axes (user-view) are set according to the **appearance order in SNode definition** of physical axes (`ti.i`, `ti.j`, ... in the physical world). In the first example, the first axis in user-view is `ti.j`, and the second axis is `ti.i`, while in the second example,  the first axis is `ti.i`, and the second axis is `ti.j`. Now comes the tricky thing - as for the memory layouts, in the first example we split `ti.j` first, and in the second example we split `ti.i` first. That is, the major axes in layouts are the same as the first axes in user-view. So essentially there is no user-viable difference between these two examples, which breaks the docs.

This PR, together with #3159, fixes this issue by setting virtual axes according to the **alphabetical order** of physical axes. Now in both examples, the first axis in user-view is `ti.i`, and the second axis in user-view is `ti.j`. Then the column-major layout is finally created in the first example.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
