### PR TITLE
[vulkan] Fix ti.sync() for vulkan

### DIFF
--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -389,6 +389,10 @@ void VkRuntime::launch_kernel(KernelHandle handle, Context *host_ctx) {
 }
 
 void VkRuntime::synchronize() {
+  if (current_cmdlist_) {
+    device_->get_compute_stream()->submit(current_cmdlist_.get());
+    current_cmdlist_ = nullptr;
+  }
   device_->get_compute_stream()->command_sync();
 }
 


### PR DESCRIPTION
Our vk backend doesn't submit a cmd list until an operation that requires syncing is performed.
Thus, during `synchronize()`, we should also check if there's a pending cmd list, and submit it if so.