### PR TITLE
[bug] Fix silent int overflow in indice calculation.

### DIFF
--- a/taichi/backends/metal/struct_metal.cpp
+++ b/taichi/backends/metal/struct_metal.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -257,7 +258,14 @@ class StructCompiler {
       emit("struct {} {{", node_name);
       const auto snty_name = snode_type_name(snty);
       emit("  // {}", snty_name);
-      const int n = snode.num_cells_per_container;
+      const int64 n = snode.num_cells_per_container;
+      // There's no assert in metal shading language yet so we have to warn
+      // outside.
+      if (n > std::numeric_limits<int>::max()) {
+        TI_WARN(
+            "Snode index might be out of int32 boundary but int64 is not "
+            "supported on metal backend.");
+      }
       emit("  constant static constexpr int n = {};", n);
       emit_snode_stride(snty, ch_name, n);
       emit_snode_constructor(snode);

--- a/taichi/backends/opengl/struct_opengl.cpp
+++ b/taichi/backends/opengl/struct_opengl.cpp
@@ -67,7 +67,7 @@ void OpenglStructCompiler::generate_types(const SNode &snode) {
   } else if (snode.type == SNodeType::dense ||
              snode.type == SNodeType::dynamic ||
              snode.type == SNodeType::root) {
-    int n = snode.num_cells_per_container;
+    int64 n = snode.num_cells_per_container;
     // the `length` field of a dynamic SNode is at it's end:
     // | x[0] | x[1] | x[2] | x[3] | ... | len |
     int extension = opengl_get_snode_meta_size(snode);

--- a/taichi/transforms/demote_dense_struct_fors.cpp
+++ b/taichi/transforms/demote_dense_struct_fors.cpp
@@ -29,7 +29,7 @@ void convert_to_range_for(OffloadedStmt *offloaded, bool packed) {
   TI_ASSERT(total_bits <= 30);
 
   // general shape calculation - no dependence on POT
-  int total_n = 1;
+  int64 total_n = 1;
   std::array<int, taichi_max_num_indices> total_shape;
   total_shape.fill(1);
   for (const auto *s : snodes) {

--- a/taichi/ui/common/field_info.cpp
+++ b/taichi/ui/common/field_info.cpp
@@ -26,7 +26,7 @@ DevicePtr get_device_ptr(taichi::lang::Program *program, SNode *snode) {
   int tree_id = root->get_snode_tree_id();
   DevicePtr root_ptr = program->get_snode_tree_device_ptr(tree_id);
 
-  size_t offset = 0;
+  int64 offset = 0;
 
   int child_id = root->child_id(dense_parent);
 


### PR DESCRIPTION
This only showed difference in release/debug mode build of taichi. Analysis is at: https://o9ixctz0o7.feishu.cn/wiki/wikcn1wtT771fQ15GHyrwuoB5lO 
TLDR; `acc_shape` should have been a `int64` instead of `int` (`snode.num_cells_per_container` is a `int64`) so when `acc_shape` was a int overflow might happen silently there. 

Btw I didn't fix all the implicit conversions from in64 to int32 (but tried to make the conversions more explicit). IIUC we don't support int64 indexing yet so it should be good enough to do the explicit conversion for now and revisit this later. 

