### PR TITLE
[refactor] Rename nparray to external_array in Python-side

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -540,9 +540,9 @@ class Kernel:
                         tmp = np.ascontiguousarray(v)
                         # Purpose: DO NOT GC |tmp|!
                         tmps.append(tmp)
-                        launch_ctx.set_arg_external_array(actual_argument_slot,
-                                                          int(tmp.ctypes.data),
-                                                          tmp.nbytes)
+                        launch_ctx.set_arg_external_array(
+                            actual_argument_slot, int(tmp.ctypes.data),
+                            tmp.nbytes)
                     else:
 
                         def get_call_back(u, v):

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -807,7 +807,8 @@ void export_lang(py::module &m) {
         });
 
   m.def("decl_arg", [&](const DataType &dt, bool is_external_array) {
-    return get_current_program().current_callable->insert_arg(dt, is_external_array);
+    return get_current_program().current_callable->insert_arg(
+        dt, is_external_array);
   });
 
   m.def("decl_ret", [&](const DataType &dt) {


### PR DESCRIPTION
Related issue = #2280

#2280 did the renaming in C++-side. This PR does the same thing in Python-side to keep things consistent.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
