### PR TITLE
[refactor] Remove redundant code in snode_rw_accessors_bank

### DIFF
--- a/taichi/program/snode_rw_accessors_bank.cpp
+++ b/taichi/program/snode_rw_accessors_bank.cpp
@@ -40,9 +40,6 @@ void SNodeRwAccessorsBank::Accessors::write_float(const std::vector<int> &I,
                                                   float64 val) {
   auto launch_ctx = writer_->make_launch_context();
   set_kernel_args(I, snode_->num_active_indices, &launch_ctx);
-  for (int i = 0; i < snode_->num_active_indices; i++) {
-    launch_ctx.set_arg_int(i, I[i]);
-  }
   launch_ctx.set_arg_float(snode_->num_active_indices, val);
   prog_->synchronize();
   (*writer_)(launch_ctx);


### PR DESCRIPTION
Related issue = #

L42, which expands to https://github.com/taichi-dev/taichi/blob/30b45f8c34d918f7e465d68f230c0690bc24eaff/taichi/program/snode_rw_accessors_bank.cpp#L9-L15, does exactly the same thing as the removed L43-45. Therefore L43-45 are redundant.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
