### PR TITLE
[lang] Make dynamic indexing compatible with grouped loop indices of ndrange fors

### DIFF
--- a/python/taichi/lang/stmt_builder.py
+++ b/python/taichi/lang/stmt_builder.py
@@ -396,13 +396,13 @@ if ti.static(1):
         template = '''
 if ti.static(1):
     __ndrange = 0
-    {} = ti.expr_init(ti.Vector([0] * len(__ndrange.dimensions), disable_local_tensor=True))
     ___begin = ti.Expr(0)
     ___end = __ndrange.acc_dimensions[0]
     ___begin = ti.cast(___begin, ti.i32)
     ___end = ti.cast(___end, ti.i32)
     __ndrange_I = ti.Expr(ti.core.make_id_expr(''))
     ti.core.begin_frontend_range_for(__ndrange_I.ptr, ___begin.ptr, ___end.ptr)
+    {} = ti.expr_init(ti.Vector([0] * len(__ndrange.dimensions), dt=ti.i32))
     __I = __ndrange_I
     for __grouped_I in range(len(__ndrange.dimensions)):
         __grouped_I_tmp = 0


### PR DESCRIPTION
Related issue = #2590, #2637

Yet another remaining issue in #2637. Grouped loop indices of ndrange fors are exposed to users as `ti.Vector` and are set via assignments to individual loop variables. Dynamic indexing can naturally work here, and we just need to move the `ti.Vector` definition inside the loop to avoid unnecessary usage of the global temporary buffer.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
