### PR TITLE
[vulkan] Vulkan and ggui for mac

### DIFF
--- a/examples/ggui_examples/mpm3d_ggui.py
+++ b/examples/ggui_examples/mpm3d_ggui.py
@@ -292,7 +292,7 @@ def show_options():
             "snow color", material_colors[SNOW])
         material_colors[JELLY] = window.GUI.color_edit_3(
             "jelly color", material_colors[JELLY])
-        set_color_by_material(np.array(material_colors))
+        set_color_by_material(np.array(material_colors, dtype="float32"))
     particles_radius = window.GUI.slider_float("particles radius ",
                                                particles_radius, 0, 0.1)
     if window.GUI.button("restart"):

--- a/taichi/backends/vulkan/embedded_device.cpp
+++ b/taichi/backends/vulkan/embedded_device.cpp
@@ -162,7 +162,7 @@ bool is_device_suitable(VkPhysicalDevice device, VkSurfaceKHR surface) {
     // this means we need ui
     VkPhysicalDeviceFeatures features{};
     vkGetPhysicalDeviceFeatures(device, &features);
-    return indices.is_complete_for_ui() && features.wideLines == VK_TRUE;
+    return indices.is_complete_for_ui();
   } else {
     return indices.is_complete();
   }

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -1148,12 +1148,20 @@ DeviceAllocation VulkanDevice::allocate_memory(const AllocParams &params) {
   if (params.export_sharing) {
     buffer_info.pNext = &external_mem_buffer_create_info;
   }
-
+#ifdef __APPLE__
+  // weird behavior on apple: these flags are needed even if either read or write is required
+  if (params.host_read || params.host_write) {
+#else
   if (params.host_read && params.host_write) {
+#endif //__APPLE__
     // This should be the unified memory on integrated GPUs
     alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
     alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
                                 VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+#ifdef __APPLE__
+  // weird behavior on apple: if coherent bit is not set, then the memory writes between map() and unmap() cannot be seen by gpu
+    alloc_info.preferredFlags |= VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+#endif //__APPLE__
   } else if (params.host_read) {
     alloc_info.usage = VMA_MEMORY_USAGE_GPU_TO_CPU;
   } else if (params.host_write) {


### PR DESCRIPTION
This PR enables vulkan and ggui on macOS.

I had to mess around with the memory alloc params in order to get them to work on mac. These are probably caused by some very implicit moltenVK issue.

Also, `device_is_suitable` no longer returns false when wide lines isn't supported. We're already printing a warning message for this.

I also fixed an accidental usage of f64 in the mpm3d example, which makes it crash for vulkan compute backend.

There're still a few bugs with ggui on macos and ggui on vulkan in general. Including:
1. set_image doesn't work (likely a ti.u8 issue)
2. on macos, changing particle size sometimes doesn't work.
3. In mpm3d example, sometimes the fluid goes missing.
I will try to gradually fix them. 