### PR TITLE
[ci] Fix ti testing with no supported arch.

### DIFF
--- a/python/taichi/testing.py
+++ b/python/taichi/testing.py
@@ -107,12 +107,14 @@ def test(arch=None, exclude=None, require=None, **options):
         arch = supported_archs
     else:
         arch = list(filter(lambda x: x in supported_archs, arch))
-    if len(arch) == 0:
-        return lambda x: print('No supported arch found. Skipping')
 
     def decorator(foo):
         @functools.wraps(foo)
         def wrapped(*args, **kwargs):
+            if len(arch) == 0:
+                print('No supported arch found. Skipping.')
+                return
+
             arch_params_sets = [arch, *_test_features.values()]
             arch_params_combinations = list(
                 itertools.product(*arch_params_sets))


### PR DESCRIPTION
`ti test -vr2 -a vulkan` fails with `TypeError: 'NoneType' object is not
callable` and this PR fixes it.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
