### PR TITLE
[Bug] Fix the always-in-cpu from_numpy in ti.ndarray

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -125,6 +125,8 @@ class Ndarray:
             )
         if impl.current_cfg().ndarray_use_torch:
             self.arr = torch.from_numpy(arr).to(self.arr.dtype)
+            if impl.current_cfg().arch == _ti_core.Arch.cuda:
+                self.arr = self.arr.cuda()
         else:
             if hasattr(arr, 'contiguous'):
                 arr = arr.contiguous()


### PR DESCRIPTION
Related issue = fixes #3238

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
