### PR TITLE
[lang] Make dynamic indexing compatible with BLS

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -559,14 +559,7 @@ def block_local(*args):
 
     Args:
         *args (List[Field]): A list of sparse Taichi fields.
-
-    Raises:
-        InvalidOperationError: If the ``dynamic_index`` feature (experimental)
-            is enabled.
     """
-    if ti.current_cfg().dynamic_index:
-        raise InvalidOperationError(
-            'dynamic_index is not allowed when block_local is turned on.')
     for a in args:
         for v in a.get_field_members():
             _ti_core.insert_snode_access_flag(

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -197,7 +197,7 @@ def bls_particle_grid(N,
             u0 = ti.assume_in_range(u_[0], Im[0], 0, 1)
             u1 = ti.assume_in_range(u_[1], Im[1], 0, 1)
 
-            u = ti.Vector([u0, u1])
+            u = ti.Vector([u0, u1], dt=ti.i32)
 
             for offset in ti.static(ti.grouped(ti.ndrange(extend, extend))):
                 m[u + offset] += scatter_weight
@@ -230,7 +230,7 @@ def bls_particle_grid(N,
             u0 = ti.assume_in_range(u_[0], Im[0], 0, 1)
             u1 = ti.assume_in_range(u_[1], Im[1], 0, 1)
 
-            u = ti.Vector([u0, u1])
+            u = ti.Vector([u0, u1], dt=ti.i32)
 
             tot = 0.0
 

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -357,7 +357,7 @@ def test_complex_body():
         assert a.grad[i] == g[i]
 
 
-@ti.test(require=[ti.extension.adstack, ti.extension.bls], dynamic_index=False)
+@ti.test(require=[ti.extension.adstack, ti.extension.bls])
 def test_triple_for_loops_bls():
     N = 8
     M = 3

--- a/tests/python/test_bls.py
+++ b/tests/python/test_bls.py
@@ -1,32 +1,7 @@
-import pytest
-
 import taichi as ti
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=True)
-def test_bls_with_dynamic_index():
-    x, y = ti.field(ti.f32), ti.field(ti.f32)
-
-    N = 64
-    bs = 16
-
-    ti.root.pointer(ti.i, N // bs).dense(ti.i, bs).place(x, y)
-
-    @ti.kernel
-    def populate():
-        for i in range(N):
-            x[i] = i
-
-    @ti.kernel
-    def call_block_local():
-        ti.block_local(x)
-
-    populate()
-    with pytest.raises(ti.InvalidOperationError):
-        call_block_local()
-
-
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_simple_1d():
     x, y = ti.field(ti.f32), ti.field(ti.f32)
 
@@ -53,7 +28,7 @@ def test_simple_1d():
         assert y[i] == i
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_simple_2d():
     x, y = ti.field(ti.f32), ti.field(ti.f32)
 
@@ -86,43 +61,43 @@ def _test_bls_stencil(*args, **kwargs):
     bls_test_template(*args, **kwargs)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_gather_1d_trivial():
     # y[i] = x[i]
     _test_bls_stencil(1, 128, bs=32, stencil=((0, ), ))
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_gather_1d():
     # y[i] = x[i - 1] + x[i]
     _test_bls_stencil(1, 128, bs=32, stencil=((-1, ), (0, )))
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_gather_2d():
     stencil = [(0, 0), (0, -1), (0, 1), (1, 0)]
     _test_bls_stencil(2, 128, bs=16, stencil=stencil)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_gather_2d_nonsquare():
     stencil = [(0, 0), (0, -1), (0, 1), (1, 0)]
     _test_bls_stencil(2, 128, bs=(4, 16), stencil=stencil)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_gather_3d():
     stencil = [(-1, -1, -1), (2, 0, 1)]
     _test_bls_stencil(3, 64, bs=(4, 8, 16), stencil=stencil)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_scatter_1d_trivial():
     # y[i] = x[i]
     _test_bls_stencil(1, 128, bs=32, stencil=((0, ), ), scatter=True)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_scatter_1d():
     _test_bls_stencil(1, 128, bs=32, stencil=(
         (1, ),
@@ -130,13 +105,13 @@ def test_scatter_1d():
     ), scatter=True)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_scatter_2d():
     stencil = [(0, 0), (0, -1), (0, 1), (1, 0)]
     _test_bls_stencil(2, 128, bs=16, stencil=stencil, scatter=True)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_multiple_inputs():
     x, y, z, w, w2 = ti.field(ti.i32), ti.field(ti.i32), ti.field(
         ti.i32), ti.field(ti.i32), ti.field(ti.i32)
@@ -171,7 +146,7 @@ def test_multiple_inputs():
             assert w[i, j] == w2[i, j]
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_bls_large_block():
     n = 2**10
     block_size = 32

--- a/tests/python/test_bls_assume_in_range.py
+++ b/tests/python/test_bls_assume_in_range.py
@@ -31,7 +31,7 @@ def _test_scattering_two_pointer_levels():
                       use_offset=False)
 
 
-@ti.test(require=ti.extension.bls, dynamic_index=False)
+@ti.test(require=ti.extension.bls)
 def test_gathering():
     bls_particle_grid(N=128,
                       ppc=10,


### PR DESCRIPTION
Related issue = #2590, #2637

Yet another remaining issue in #2637. #3237 enables CFG optimization for local tensors, so constant members can be known at compile time, which enables BLS analysis just as before (`dynamic_index=False`). What this PR does is to remove the parts which prevent users from using BLS with `dynamic_index=True`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
