### PR TITLE
[vulkan] Force u8 capability on Apple

### DIFF
--- a/taichi/backends/vulkan/embedded_device.cpp
+++ b/taichi/backends/vulkan/embedded_device.cpp
@@ -393,6 +393,8 @@ void EmbeddedVulkanDevice::create_logical_device() {
 
   bool has_surface = false, has_swapchain = false;
 
+  bool portability_subset_enabled = false;
+
   for (auto &ext : extension_properties) {
     TI_TRACE("Vulkan device extension {} ({})", ext.extensionName,
              ext.specVersion);
@@ -403,6 +405,7 @@ void EmbeddedVulkanDevice::create_logical_device() {
       TI_WARN(
           "Potential non-conformant Vulkan implementation, enabling "
           "VK_KHR_portability_subset");
+      portability_subset_enabled = true;
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_SWAPCHAIN_EXTENSION_NAME) {
       has_swapchain = true;
@@ -528,10 +531,10 @@ void EmbeddedVulkanDevice::create_logical_device() {
       } else if (shader_f16_i8_feature.shaderInt8) {
         ti_device_->set_cap(DeviceCapability::spirv_has_int8, true);
       }
-#ifdef __APPLE__
-      // TODO: investigate why MoltenVK isn't reporting int8 caps. See #3252
-      ti_device_->set_cap(DeviceCapability::spirv_has_int8, true);
-#endif
+      if (portability_subset_enabled) {
+        // TODO: investigate why MoltenVK isn't reporting int8 caps. See #3252
+        ti_device_->set_cap(DeviceCapability::spirv_has_int8, true);
+      }
       *pNextEnd = &shader_f16_i8_feature;
       pNextEnd = &shader_f16_i8_feature.pNext;
     }


### PR DESCRIPTION
On macOS, MoltenVK doesn't report that uint8 is supported. I'm inclined to believe that this is a bug with MoltenVK, for the following reasons:

* Metal has very good support of int8 on all GPUs, see [this table](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf)
* On my machine, enabling u8 this way straight-up works, for both compute and GGUI.
* Was reading the source code of MoltenVK, and [this](https://github.com/KhronosGroup/MoltenVK/blob/8132cec62ea1114f73c464ed0cdcc714a6e4e331/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm#L4109-L4115) looked a bit dodgy. This is done for float16 but not for int8. Might be an oversight.

Anyways, if we enable it this way, we will have `canvas.set_image()` working on macOS.