### PR TITLE
[doc] Add using clang++ for submodules in dev install instructions

### DIFF
--- a/docs/lang/articles/contribution/dev_install.md
+++ b/docs/lang/articles/contribution/dev_install.md
@@ -120,7 +120,7 @@ After Vulkan is successfully installed. You can build Taichi with Vulkan by addi
   git clone --recursive https://github.com/taichi-dev/taichi
   cd taichi
   python3 -m pip install --user -r requirements_dev.txt
-  # export CXX=/path/to/clang++  # Uncomment if clang++ is not system default compiler, some submodules may require clang++ to complie rather than clang
+  # export CXX=/path/to/clang++  # Uncomment if clang++ is not system default compiler. Note that clang is not acceptable due to requirements of some submodules.
   python3 setup.py develop --user  # Optionally add DEBUG=1 to keep debug information.
   ```
 


### PR DESCRIPTION
Related issue = #
Some sub-modules (such as `SPIRV-Cross`) may require `clang++` to compile. 
Updated the dev install instructions for this. 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
