### PR TITLE
[ci] Reduce the artifacts retention duration to 20 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-py${{ matrix.python }}-linux.whl
           path: dist/*.whl
+          retention-days: 20
 
       - name: Test
         run: |
@@ -148,6 +149,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-py${{ matrix.python }}-macos.whl
           path: dist/*.whl
+          retention-days: 20
 
       - name: Test
         run: |
@@ -209,6 +211,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-py${{ matrix.python }}-macos-m1.whl
           path: dist/*.whl
+          retention-days: 20
 
       - name: Upload PyPI
         env:
@@ -265,6 +268,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-py${{ matrix.python }}-macos-1014.whl
           path: dist/*.whl
+          retention-days: 20
 
       - name: Test
         run: |
@@ -349,6 +353,7 @@ jobs:
         with:
           name: ${{ matrix.name }}-py${{ matrix.python }}-windows.whl
           path: dist/*.whl
+          retention-days: 20
 
       - name: Test
         shell: powershell


### PR DESCRIPTION
The default is 90 days ([doc](https://github.blog/changelog/2020-10-08-github-actions-ability-to-change-retention-days-for-artifacts-and-logs/)). This seems to burn money.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
