### PR TITLE
[vulkan] Release vulkan on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           python examples/algorithm/laplace.py
           ti diagnose
-          ti test -vr2 -t2 -a cpu,meta
+          ti test -vr2 -t2 -a cpu,metal
 
       - name: Upload PyPI
         env:


### PR DESCRIPTION
Related issue = #3030 

Download and install vulkan before building the release wheel, and enable TI_WITH_VULKAN. 

Vulkan tests are disabled for now. Issue that tracks this: #3240 

These changes has been tested [in the test_actions repo](https://github.com/taichi-dev/test_actions/runs/4028275304?check_suite_focus=true). Build was successful for both python 3.7, 3.8, and 3.9. It failed for python 3.6 but I think that's an unrelated issue.

This PR doesn't try to release on 10.14 or on M1. Since we're using self-hosted bots for these, we shouldn't have to download and install vulkan everytime.

-------------------------------------------

Update:

With #3307 , no need to download the sdk anymore. So I'm simply turning on `TI_WITH_VULKAN` for all 3 macOS releases. These are tested [here](https://github.com/taichi-dev/test_actions/runs/4036964082?check_suite_focus=true).