### PR TITLE
[Lang] Add suppress_warning argument to ti.Matrix initialization

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -38,7 +38,8 @@ class Matrix(TaichiOperations):
                  m=1,
                  dt=None,
                  keep_raw=False,
-                 disable_local_tensor=False):
+                 disable_local_tensor=False,
+                 suppress_warning=False):
         self.local_tensor_proxy = None
         self.any_array_access = None
         self.grad = None
@@ -140,7 +141,7 @@ class Matrix(TaichiOperations):
                     "Declaring matrix fields using `ti.Matrix(n, m, dt, shape)` is no longer supported. Use `ti.Matrix.field(n, m, dtype, shape)` instead."
                 )
 
-        if self.n * self.m > 32:
+        if self.n * self.m > 32 and not suppress_warning:
             warning(
                 f'Taichi matrices/vectors with {self.n}x{self.m} > 32 entries are not suggested.'
                 ' Matrices/vectors will be automatically unrolled at compile-time for performance.'


### PR DESCRIPTION
Related issue = 

Cannot suppress ``Taichi matrices/vectors with {self.n}x{self.m} > 32 entries are not suggested`` warning. 

Fix this issue by adding ``suppress_warning`` argument to ti.Matrix initialization.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
