### PR TITLE
[Refactor] Fix compiler warnings

### DIFF
--- a/taichi/analysis/gather_statements.cpp
+++ b/taichi/analysis/gather_statements.cpp
@@ -17,7 +17,7 @@ class StmtSearcher : public BasicStmtVisitor {
     invoke_default_visitor = true;
   }
 
-  void visit(Stmt *stmt) {
+  void visit(Stmt *stmt) override {
     if (test(stmt))
       results.push_back(stmt);
   }

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -487,7 +487,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
             data_ptr = builder->CreateBitCast(data_ptr, llvm_ptr_type(dtype));
             auto data = create_intrinsic_load(dtype, data_ptr);
             llvm_val[stmt] = extract_custom_int(data, bit_offset, int_in_mem);
-          } else if (auto cft = val_type->cast<CustomFloatType>()) {
+          } else if (val_type->cast<CustomFloatType>()) {
             // TODO: support __ldg
             llvm_val[stmt] = load_custom_float(stmt->src);
           } else {

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -54,6 +54,8 @@ bool KernelProfilerCUDA::reinit_with_metrics(
              metric_list_.size());
     return true;
   }
+
+  TI_NOT_IMPLEMENTED;
 }
 
 // deprecated, move to trace()

--- a/taichi/backends/cuda/cupti_toolkit.cpp
+++ b/taichi/backends/cuda/cupti_toolkit.cpp
@@ -22,7 +22,7 @@ enum class CuptiMetricsDefault : uint {
   CUPTI_METRIC_DEFAULT_TOTAL = 2
 };
 
-constexpr char *MetricListDeafult[] = {
+constexpr const char *MetricListDefault[] = {
     "smsp__cycles_elapsed.avg",  // CUPTI_METRIC_KERNEL_ELAPSED_CLK_NUMS
     "smsp__cycles_elapsed.avg.per_second",  // CUPTI_METRIC_CORE_FREQUENCY_HZS
 };
@@ -798,7 +798,7 @@ CuptiToolkit::CuptiToolkit() {
   uint metric_list_size =
       static_cast<uint>(CuptiMetricsDefault::CUPTI_METRIC_DEFAULT_TOTAL);
   for (uint idx = 0; idx < metric_list_size; idx++) {
-    cupti_config_.metric_list.push_back(MetricListDeafult[idx]);
+    cupti_config_.metric_list.push_back(MetricListDefault[idx]);
   }
 }
 
@@ -812,7 +812,7 @@ void CuptiToolkit::reset_metrics(const std::vector<std::string> &metrics) {
   uint metric_list_size =
       static_cast<uint>(CuptiMetricsDefault::CUPTI_METRIC_DEFAULT_TOTAL);
   for (uint idx = 0; idx < metric_list_size; idx++) {
-    cupti_config_.metric_list.push_back(MetricListDeafult[idx]);
+    cupti_config_.metric_list.push_back(MetricListDefault[idx]);
   }
   // user selected metrics
   for (auto metric : metrics)

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -106,6 +106,7 @@ class RootIdsExtractor : public BasicStmtVisitor {
   }
 
  private:
+  using BasicStmtVisitor::visit;
   std::unordered_set<int> roots_;
 };
 

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -59,6 +59,8 @@ void AotModuleBuilderImpl::add_per_backend_field(const std::string &identifier,
     gl_dtype_enum = GL_DOUBLE;
   } else if (dt == PrimitiveType::f32) {
     gl_dtype_enum = GL_FLOAT;
+  } else {
+    TI_NOT_IMPLEMENTED
   }
 
   aot_data_.fields.push_back({identifier, gl_dtype_enum, dt.to_string(), shape,

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -64,8 +64,8 @@ class KernelGen : public IRVisitor {
             const StructCompiledResult *struct_compiled,
             const std::string &kernel_name)
       : kernel_(kernel),
-        kernel_name_(kernel_name),
         struct_compiled_(struct_compiled),
+        kernel_name_(kernel_name),
         root_snode_type_name_(struct_compiled->root_snode_type_name),
         glsl_kernel_prefix_(kernel_name) {
     compiled_program_.init_args(kernel);

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -31,21 +31,6 @@ int opengl_max_grid_dim = 1024;
 
 #ifdef TI_WITH_OPENGL
 
-static std::string add_line_markers(std::string x) {
-  std::string marker;
-  size_t pos = 0, npos;
-  int line = 0;
-  while (1) {
-    npos = x.find_first_of('\n', pos);
-    marker = fmt::format("{:3d} ", ++line);
-    if (npos == std::string::npos)
-      break;
-    x.insert(pos, marker);
-    pos = npos + 1 + marker.size();
-  }
-  return x;
-}
-
 struct OpenGlRuntimeImpl {
   struct {
     DeviceAllocation runtime = kDeviceNullAllocation;
@@ -374,7 +359,7 @@ void DeviceCompiledProgram::launch(Context &ctx, OpenGlRuntime *runtime) const {
 
 DeviceCompiledProgram::DeviceCompiledProgram(CompiledProgram &&program,
                                              Device *device)
-    : program_(std::move(program)), device_(device) {
+    :  device_(device), program_(std::move(program)) {
   if (program_.args_buf_size || program_.total_ext_arr_size ||
       program_.ret_buf_size) {
     args_buf_ = device->allocate_memory(

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -359,7 +359,7 @@ void DeviceCompiledProgram::launch(Context &ctx, OpenGlRuntime *runtime) const {
 
 DeviceCompiledProgram::DeviceCompiledProgram(CompiledProgram &&program,
                                              Device *device)
-    :  device_(device), program_(std::move(program)) {
+    : device_(device), program_(std::move(program)) {
   if (program_.args_buf_size || program_.total_ext_arr_size ||
       program_.ret_buf_size) {
     args_buf_ = device->allocate_memory(

--- a/taichi/backends/opengl/opengl_device.h
+++ b/taichi/backends/opengl/opengl_device.h
@@ -127,6 +127,8 @@ class GLCommandList : public CommandList {
   struct Cmd {
     virtual void execute() {
     }
+    virtual ~Cmd() {
+    }
   };
 
   struct CmdBindPipeline : public Cmd {

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -48,10 +48,10 @@ class HostDeviceContextBlitter {
                            DeviceAllocation *host_shadow_buffer)
       : ctx_attribs_(ctx_attribs),
         host_ctx_(host_ctx),
-        device_(device),
         host_result_buffer_(host_result_buffer),
         device_buffer_(device_buffer),
-        host_shadow_buffer_(host_shadow_buffer) {
+        host_shadow_buffer_(host_shadow_buffer),
+        device_(device) {
   }
 
   void host_to_device() {
@@ -227,7 +227,6 @@ CompiledTaichiKernel::CompiledTaichiKernel(const Params &ti_params)
   }
   const auto ctx_sz = ti_kernel_attribs_.ctx_attribs.total_bytes();
   if (!ti_kernel_attribs_.ctx_attribs.empty()) {
-    Device::AllocParams params;
     ctx_buffer_ = ti_params.device->allocate_memory_unique(
         {size_t(ctx_sz),
          /*host_write=*/true, /*host_read=*/false,
@@ -298,7 +297,7 @@ void CompiledTaichiKernel::command_list(CommandList *cmdlist) const {
 }
 
 VkRuntime::VkRuntime(const Params &params)
-    : host_result_buffer_(params.host_result_buffer), device_(params.device) {
+    :  device_(params.device), host_result_buffer_(params.host_result_buffer) {
   TI_ASSERT(host_result_buffer_ != nullptr);
   init_buffers();
 }
@@ -349,9 +348,7 @@ VkRuntime::KernelHandle VkRuntime::register_taichi_kernel(
   params.global_tmps_buffer = global_tmps_buffer_.get();
 
   for (int i = 0; i < reg_params.task_spirv_source_codes.size(); ++i) {
-    const auto &attribs = reg_params.kernel_attribs.tasks_attribs[i];
     const auto &spirv_src = reg_params.task_spirv_source_codes[i];
-    const auto &task_name = attribs.name;
 
     // If we can reach here, we have succeeded. Otherwise
     // std::optional::value() would have killed us.

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -297,7 +297,7 @@ void CompiledTaichiKernel::command_list(CommandList *cmdlist) const {
 }
 
 VkRuntime::VkRuntime(const Params &params)
-    :  device_(params.device), host_result_buffer_(params.host_result_buffer) {
+    : device_(params.device), host_result_buffer_(params.host_result_buffer) {
   TI_ASSERT(host_result_buffer_ != nullptr);
   init_buffers();
 }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1225,7 +1225,7 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
     auto val_type = ptr_type->get_pointee_type();
     if (val_type->is<CustomIntType>()) {
       llvm_val[stmt] = load_as_custom_int(llvm_val[stmt->src], val_type);
-    } else if (auto cft = val_type->cast<CustomFloatType>()) {
+    } else if (val_type->cast<CustomFloatType>()) {
       TI_ASSERT(stmt->src->is<GetChStmt>());
       llvm_val[stmt] = load_custom_float(stmt->src);
     } else {

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -390,7 +390,7 @@ Kernel &Program::get_snode_writer(SNode *snode) {
 
 Kernel &Program::get_ndarray_reader(Ndarray *ndarray) {
   auto kernel_name = fmt::format("ndarray_reader");
-  auto &ker = kernel([ndarray, this] {
+  auto &ker = kernel([ndarray] {
     ExprGroup indices;
     for (int i = 0; i < ndarray->num_active_indices; i++) {
       indices.push_back(Expr::make<ArgLoadExpression>(i, PrimitiveType::i32));
@@ -413,7 +413,7 @@ Kernel &Program::get_ndarray_reader(Ndarray *ndarray) {
 
 Kernel &Program::get_ndarray_writer(Ndarray *ndarray) {
   auto kernel_name = fmt::format("ndarray_writer");
-  auto &ker = kernel([ndarray, this] {
+  auto &ker = kernel([ndarray] {
     ExprGroup indices;
     for (int i = 0; i < ndarray->num_active_indices; i++) {
       indices.push_back(Expr::make<ArgLoadExpression>(i, PrimitiveType::i32));

--- a/taichi/transforms/bit_loop_vectorize.cpp
+++ b/taichi/transforms/bit_loop_vectorize.cpp
@@ -40,7 +40,7 @@ class BitLoopVectorize : public IRVisitor {
   void visit(GlobalLoadStmt *stmt) override {
     auto ptr_type = stmt->src->ret_type->as<PointerType>();
     if (in_struct_for_loop && bit_vectorize != 1) {
-      if (auto cit = ptr_type->get_pointee_type()->cast<CustomIntType>()) {
+      if (ptr_type->get_pointee_type()->cast<CustomIntType>()) {
         // rewrite the previous GlobalPtrStmt's return type from *cit to
         // *phy_type
         auto ptr = stmt->src->cast<GlobalPtrStmt>();
@@ -127,7 +127,7 @@ class BitLoopVectorize : public IRVisitor {
   void visit(GlobalStoreStmt *stmt) override {
     auto ptr_type = stmt->dest->ret_type->as<PointerType>();
     if (in_struct_for_loop && bit_vectorize != 1) {
-      if (auto cit = ptr_type->get_pointee_type()->cast<CustomIntType>()) {
+      if (ptr_type->get_pointee_type()->cast<CustomIntType>()) {
         // rewrite the previous GlobalPtrStmt's return type from *cit to
         // *phy_type
         auto ptr = stmt->dest->cast<GlobalPtrStmt>();


### PR DESCRIPTION
Related issue = #3287

Fix some of the compiler warnings in the C++ codebase.
- Explicitly override
- Explicitly hide methods from the base class
- Use virtual destructors for base classes
- Remove unused variables, functions and lambda captures
- Avoid conversion from string literals to char*
- Avoid reordering constructions of class members
- All code paths return a value in non-void functions