### PR TITLE
[opengl] Provide an option to disable NV extensions during codegen

### DIFF
--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -4,6 +4,9 @@
 namespace taichi {
 namespace lang {
 namespace opengl {
+namespace {
+constexpr bool kAllowsNvShaderExt = false;
+}  // namespace
 
 AotModuleBuilderImpl::AotModuleBuilderImpl(
     StructCompiledResult &compiled_structs)
@@ -26,7 +29,8 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
 
 void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
                                            Kernel *kernel) {
-  opengl::OpenglCodeGen codegen(kernel->name, &compiled_structs_);
+  opengl::OpenglCodeGen codegen(kernel->name, &compiled_structs_,
+                                kAllowsNvShaderExt);
   auto compiled = codegen.compile(*kernel);
   aot_data_.kernels.push_back({compiled, identifier});
 }
@@ -70,7 +74,8 @@ void AotModuleBuilderImpl::add_per_backend_field(const std::string &identifier,
 void AotModuleBuilderImpl::add_per_backend_tmpl(const std::string &identifier,
                                                 const std::string &key,
                                                 Kernel *kernel) {
-  opengl::OpenglCodeGen codegen(kernel->name, &compiled_structs_);
+  opengl::OpenglCodeGen codegen(kernel->name, &compiled_structs_,
+                                kAllowsNvShaderExt);
   auto compiled = codegen.compile(*kernel);
 
   for (auto &k : aot_data_.kernel_tmpls) {

--- a/taichi/backends/opengl/codegen_opengl.h
+++ b/taichi/backends/opengl/codegen_opengl.h
@@ -17,8 +17,11 @@ namespace opengl {
 class OpenglCodeGen {
  public:
   OpenglCodeGen(const std::string &kernel_name,
-                const StructCompiledResult *struct_compiled)
-      : kernel_name_(kernel_name), struct_compiled_(struct_compiled) {
+                const StructCompiledResult *struct_compiled,
+                bool allows_nv_shader_ext)
+      : kernel_name_(kernel_name),
+        struct_compiled_(struct_compiled),
+        allows_nv_shader_ext_(allows_nv_shader_ext) {
   }
 
   CompiledProgram compile(Kernel &kernel);
@@ -31,6 +34,7 @@ class OpenglCodeGen {
   [[maybe_unused]] const StructCompiledResult *struct_compiled_;
 
   Kernel *kernel_;
+  const bool allows_nv_shader_ext_;
 };
 
 }  // namespace opengl

--- a/taichi/backends/opengl/opengl_program.cpp
+++ b/taichi/backends/opengl/opengl_program.cpp
@@ -8,7 +8,9 @@ namespace lang {
 FunctionType OpenglProgramImpl::compile(Kernel *kernel,
                                         OffloadedStmt *offloaded) {
 #ifdef TI_WITH_OPENGL
-  opengl::OpenglCodeGen codegen(kernel->name, &opengl_struct_compiled_.value());
+  // TODO(#3298): Provide an option to enable/disable NV shader extensions.
+  opengl::OpenglCodeGen codegen(kernel->name, &opengl_struct_compiled_.value(),
+                                /*allows_nv_shader_ext=*/true);
   auto ptr = opengl_runtime_->keep(codegen.compile(*kernel));
 
   return [ptr, runtime = opengl_runtime_.get()](Context &ctx) {


### PR DESCRIPTION
Related issue = #3298

RIght now the users still don't have a way to disable the usage of extensions during JIT. After https://github.com/taichi-dev/taichi/pull/3329, hopefully we only need to disable this in the AOT module.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
