### PR TITLE
[gui] Fix bug where VBO/IBO cannot exceed 128 MB

### DIFF
--- a/taichi/backends/interop/vulkan_cuda_interop.cpp
+++ b/taichi/backends/interop/vulkan_cuda_interop.cpp
@@ -154,9 +154,11 @@ void memcpy_cuda_to_vulkan(DevicePtr dst, DevicePtr src, uint64_t size) {
   if (alloc_base_ptrs.find(dst_alloc.alloc_id) == alloc_base_ptrs.end()) {
     auto [base_mem, alloc_offset, alloc_size] =
         vk_dev->get_vkmemory_offset_size(dst_alloc);
-    auto block_size = VulkanDevice::kMemoryBlockSize;
+    // this might be smaller than the actual size of the VkDeviceMemory, but it
+    // is big enough to cover the region of this buffer, so it's fine.
+    size_t mem_size = alloc_offset + alloc_size;
     void *alloc_base_ptr = get_cuda_memory_pointer(
-        base_mem, /*mem_size=*/block_size, /*offset=*/alloc_offset,
+        base_mem, /*mem_size=*/mem_size, /*offset=*/alloc_offset,
         /*buffer_size=*/alloc_size, vk_dev->vk_device());
     alloc_base_ptrs[dst_alloc.alloc_id] = (unsigned char *)alloc_base_ptr;
   }

--- a/taichi/backends/vulkan/vulkan_device.h
+++ b/taichi/backends/vulkan/vulkan_device.h
@@ -513,8 +513,6 @@ class VulkanDevice : public GraphicsDevice {
       VulkanResourceBinder::Set &set);
   vkapi::IVkDescriptorSet alloc_desc_set(vkapi::IVkDescriptorSetLayout layout);
 
-  static constexpr size_t kMemoryBlockSize = 128ull * 1024 * 1024;
-
  private:
   void create_vma_allocator();
   void new_descriptor_pool();


### PR DESCRIPTION
GGUI used to have an 128 MB limit on VBO/IBO. This was removed a while ago, but I forgot to update the `vulkan_cuda_interop` procedure to accommodate this. 