### PR TITLE
[IR] Add type_check for UnaryOpExpression

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -112,6 +112,12 @@ class Matrix(TaichiOperations):
                             dt = impl.get_runtime().default_ip
                         elif isinstance(n[0][0], float):
                             dt = impl.get_runtime().default_fp
+                        elif isinstance(n[0][0], expr.Expr):
+                            dt = n[0][0].ptr.get_ret_type()
+                            if dt == ti_core.DataType_unknown:
+                                raise TypeError(
+                                    'Element type of the matrix cannot be inferred. Please set dt instead for now.'
+                                )
                         else:
                             raise Exception(
                                 'dt required when using dynamic_index for local tensor'

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -51,16 +51,11 @@ Expr operator~(const Expr &expr) {
 }
 
 Expr cast(const Expr &input, DataType dt) {
-  auto ret =
-      std::make_shared<UnaryOpExpression>(UnaryOpType::cast_value, input);
-  ret->cast_type = dt;
-  return Expr(ret);
+  return Expr::make<UnaryOpExpression>(UnaryOpType::cast_value, input, dt);
 }
 
 Expr bit_cast(const Expr &input, DataType dt) {
-  auto ret = std::make_shared<UnaryOpExpression>(UnaryOpType::cast_bits, input);
-  ret->cast_type = dt;
-  return Expr(ret);
+  return Expr::make<UnaryOpExpression>(UnaryOpType::cast_bits, input, dt);
 }
 
 Expr Expr::operator[](const ExprGroup &indices) const {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -131,7 +131,8 @@ void UnaryOpExpression::type_check() {
   if (operand->ret_type == PrimitiveType::unknown)
     return;
   if ((type == UnaryOpType::floor || type == UnaryOpType::ceil ||
-       is_trigonometric(type)) && !is_real(operand->ret_type))
+       is_trigonometric(type)) &&
+      !is_real(operand->ret_type))
     throw std::runtime_error(fmt::format(
         "TypeError: '{}' takes real inputs only, however '{}' is provided",
         unary_op_type_name(type), operand->ret_type->to_string()));

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -125,6 +125,19 @@ void UnaryOpExpression::serialize(std::ostream &ss) {
   ss << ')';
 }
 
+void UnaryOpExpression::type_check() {
+  // TODO: assert no unknowns after type_check for all expressions are
+  // implemented
+  if (operand->ret_type == PrimitiveType::unknown)
+    return;
+  if ((type == UnaryOpType::floor || type == UnaryOpType::ceil ||
+       is_trigonometric(type)) && !is_real(operand->ret_type))
+    throw std::runtime_error(fmt::format(
+        "TypeError: '{}' takes real inputs only, however '{}' is provided",
+        unary_op_type_name(type), operand->ret_type->to_string()));
+  ret_type = is_cast() ? cast_type : operand->ret_type;
+}
+
 bool UnaryOpExpression::is_cast() const {
   return unary_op_is_cast(type);
 }
@@ -149,7 +162,7 @@ void BinaryOpExpression::type_check() {
     return;
   auto error = [&]() {
     throw std::runtime_error(fmt::format(
-        "TypeError: unsupported operand type(s) for {}: '{}' and '{}'",
+        "TypeError: unsupported operand type(s) for '{}': '{}' and '{}'",
         binary_op_type_symbol(type), lhs->ret_type->to_string(),
         rhs->ret_type->to_string()));
   };

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -278,6 +278,12 @@ class UnaryOpExpression : public Expression {
     cast_type = PrimitiveType::unknown;
   }
 
+  UnaryOpExpression(UnaryOpType type, const Expr &operand, DataType cast_type)
+      : type(type), operand(load_if_ptr(operand)), cast_type(cast_type) {
+  }
+
+  void type_check() override;
+
   bool is_cast() const;
 
   void serialize(std::ostream &ss) override;

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -47,5 +47,17 @@ TEST(FrontendTypeInference, BinaryOp) {
   EXPECT_EQ(truediv_f64->ret_type, PrimitiveType::f64);
 }
 
+TEST(FrontendTypeInference, UnaryOp) {
+  auto const_i16 = Expr::make<ConstExpression, int16>(-(1 << 10));
+  const_i16->type_check();
+  EXPECT_EQ(const_i16->ret_type, PrimitiveType::i16);
+  auto cast_i8 = cast(const_i16, PrimitiveType::i8);
+  cast_i8->type_check();
+  EXPECT_EQ(cast_i8->ret_type, PrimitiveType::i8);
+  auto bit_not_i16 = ~const_i16;
+  bit_not_i16->type_check();
+  EXPECT_EQ(bit_not_i16->ret_type, PrimitiveType::i16);
+}
+
 }  // namespace lang
 }  // namespace taichi

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -44,7 +44,8 @@ def test_custom_matrix_rotation():
     def rotate_18_degrees():
         angle = math.pi / 10
         x[None] = x[None] @ ti.Matrix(
-            [[ti.cos(angle), ti.sin(angle)], [-ti.sin(angle), ti.cos(angle)]])
+            [[ti.cos(angle), ti.sin(angle)], [-ti.sin(angle),
+                                              ti.cos(angle)]])
 
     for i in range(5):
         rotate_18_degrees()

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -44,9 +44,7 @@ def test_custom_matrix_rotation():
     def rotate_18_degrees():
         angle = math.pi / 10
         x[None] = x[None] @ ti.Matrix(
-            [[ti.cos(angle), ti.sin(angle)], [-ti.sin(angle),
-                                              ti.cos(angle)]],
-            dt=impl.get_runtime().default_fp)
+            [[ti.cos(angle), ti.sin(angle)], [-ti.sin(angle), ti.cos(angle)]])
 
     for i in range(5):
         rotate_18_degrees()

--- a/tests/python/test_ssa.py
+++ b/tests/python/test_ssa.py
@@ -65,7 +65,7 @@ def test_func_argument_dup_eval():
 def test_func_random_argument_dup_eval():
     @ti.func
     def func(a):
-        return ti.Vector([ti.cos(a), ti.sin(a)], dt=ti.f32)
+        return ti.Vector([ti.cos(a), ti.sin(a)])
 
     @ti.kernel
     def kern() -> ti.f32:

--- a/tests/python/test_type_check.py
+++ b/tests/python/test_type_check.py
@@ -4,6 +4,17 @@ import taichi as ti
 
 
 @ti.test(arch=ti.cpu)
+def test_unary_op():
+    @ti.kernel
+    def floor():
+        a = 1
+        b = ti.floor(a)
+
+    with pytest.raises(SystemExit):
+        floor()
+
+
+@ti.test(arch=ti.cpu)
 def test_binary_op():
     @ti.kernel
     def bitwise_float():


### PR DESCRIPTION
Related issue = #3301

Now for
```python
import taichi as ti

ti.init()

@ti.kernel
def func():
    a = 1
    b = ti.ceil(a)

func()
```

The error message is:
```
[Taichi] version 0.8.4, llvm 10.0.0, commit d577b876, linux, python 3.8.10
[Taichi] Starting on arch=x64
[Taichi] Compilation failed
  File "type_test.py", line 8, in func
    b = ti.ceil(a)
TaichiTypeError: 'ceil' takes real inputs only, however 'i32' is provided
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
