### PR TITLE
[opengl] Off-screen context using EGL & Support GLES

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -39,7 +39,7 @@ if(TI_WITH_VULKAN)
 endif()
 
 
-if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/glad/src/glad.c")
+if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/glad/src/gl.c")
     set(TI_WITH_OPENGL OFF)
     message(WARNING "external/glad submodule not detected. Settings TI_WITH_OPENGL to OFF.")
 endif()
@@ -119,7 +119,7 @@ if (TI_WITH_OPENGL)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_OPENGL")
   # Q: Why not external/glad/src/*.c?
   # A: To ensure glad submodule exists when TI_WITH_OPENGL is ON.
-  file(GLOB TAICHI_GLAD_SOURCE "external/glad/src/glad.c")
+  file(GLOB TAICHI_GLAD_SOURCE "external/glad/src/gl.c" "external/glad/src/egl.c")
   list(APPEND TAICHI_CORE_SOURCE ${TAICHI_GLAD_SOURCE})
   list(APPEND TAICHI_CORE_SOURCE ${TAICHI_OPENGL_SOURCE})
 endif()

--- a/cmake/external/SPIRV-Cross/gitversion.h
+++ b/cmake/external/SPIRV-Cross/gitversion.h
@@ -1,9 +1,0 @@
-// Copyright 2016-2021 The Khronos Group Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-#ifndef SPIRV_CROSS_GIT_VERSION_H_
-#define SPIRV_CROSS_GIT_VERSION_H_
-
-#define SPIRV_CROSS_GIT_REVISION "Git commit: 97a438d2 Timestamp: 2021-11-02T00:36:30"
-
-#endif

--- a/cmake/external/SPIRV-Cross/gitversion.h
+++ b/cmake/external/SPIRV-Cross/gitversion.h
@@ -1,0 +1,9 @@
+// Copyright 2016-2021 The Khronos Group Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SPIRV_CROSS_GIT_VERSION_H_
+#define SPIRV_CROSS_GIT_VERSION_H_
+
+#define SPIRV_CROSS_GIT_REVISION "Git commit: 97a438d2 Timestamp: 2021-11-02T00:36:30"
+
+#endif

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #endif
 
-#include "glad/glad.h"
+#include "glad/gl.h"
 
 namespace taichi {
 namespace lang {

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -59,17 +59,18 @@ std::string opengl_atomic_op_type_cap_name(AtomicOpType type) {
 }
 
 #if !defined(TI_PLATFORM_WINDOWS)
-#include<sys/wait.h>
+#include <sys/wait.h>
 #endif
 
 std::string preprocess_kernel(std::string src) {
-  if (!is_gles()) return src;
+  if (!is_gles())
+    return src;
 
 #if !defined(TI_PLATFORM_WINDOWS)
   int child_status;
   auto child_pid = fork();
-  if(child_pid == 0) {
-    char* const argv[] = {"glslc", "--version", nullptr};
+  if (child_pid == 0) {
+    char *const argv[] = {"glslc", "--version", nullptr};
     execvp("glslc", argv);
   } else {
     pid_t tpid = waitpid(child_pid, &child_status, 0);
@@ -77,7 +78,8 @@ std::string preprocess_kernel(std::string src) {
   if (!child_status) {
     // For debugging only
     // ker.kernel_src =
-    //   "#version 430 core\n#define DEFINE(NAME) add_##NAME##_f32\nDEFINE(TEST)";
+    //   "#version 430 core\n#define DEFINE(NAME)
+    //   add_##NAME##_f32\nDEFINE(TEST)";
     std::string command = "echo \"" + src + "\" | glslc -E /dev/stdin";
     char buffer[128];
     std::string result = "";
@@ -260,11 +262,12 @@ class KernelGen : public IRVisitor {
 #include "taichi/inc/opengl_extension.inc.h"
 #undef PER_OPENGL_EXTENSION
     auto kernel_src_code =
-        (is_gles() ? "#version 310 es\n" : "#version 430 core\n") + extensions + "precision highp float;\n" +
-        line_appender_header_.lines() + line_appender_.lines();
-    compiled_program_.add(std::move(glsl_kernel_name_), preprocess_kernel(kernel_src_code),
-                          num_workgroups_, workgroup_size_,
-                          &this->extptr_access);
+        (is_gles() ? "#version 310 es\n" : "#version 430 core\n") + extensions +
+        "precision highp float;\n" + line_appender_header_.lines() +
+        line_appender_.lines();
+    compiled_program_.add(std::move(glsl_kernel_name_),
+                          preprocess_kernel(kernel_src_code), num_workgroups_,
+                          workgroup_size_, &this->extptr_access);
     auto &config = kernel_->program->config;
     if (config.print_kernel_llvm_ir) {
       static FileSequenceWriter writer("shader{:04d}.comp",

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -63,6 +63,8 @@ std::string opengl_atomic_op_type_cap_name(AtomicOpType type) {
 #endif
 
 std::string preprocess_kernel(std::string src) {
+  if (!is_gles()) return src;
+
 #if !defined(TI_PLATFORM_WINDOWS)
   int child_status;
   auto child_pid = fork();

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -14,11 +14,6 @@
 #include "glad/egl.h"
 #include "GLFW/glfw3.h"
 #include "taichi/backends/opengl/opengl_device.h"
-
-//#include "glad/glad_egl.h"
-#include <dlfcn.h>
-#include <EGL/egl.h>
-
 #endif
 
 #include <list>

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -10,7 +10,8 @@
 #include "taichi/ir/transforms.h"
 
 #ifdef TI_WITH_OPENGL
-#include "glad/glad.h"
+#include "glad/gl.h"
+#include "glad/egl.h"
 #include "GLFW/glfw3.h"
 #include "taichi/backends/opengl/opengl_device.h"
 
@@ -33,6 +34,8 @@ namespace opengl {
 // value according to OpenGL spec in case glGetIntegerv didn't work properly
 int opengl_max_block_dim = 1024;
 int opengl_max_grid_dim = 1024;
+
+constexpr bool use_gles = false;
 
 #ifdef TI_WITH_OPENGL
 
@@ -65,128 +68,126 @@ bool initialize_opengl(bool error_tolerance) {
     }
   }
 
-  /*
-  glfwInit();
-  // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-  glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-  glfwWindowHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);
-  // GL context needs a window (There's no true headless GL)
-  GLFWwindow *window =
-      glfwCreateWindow(1, 1, "Make OpenGL Context", nullptr, nullptr);
-  if (!window) {
-    const char *desc = nullptr;
-    int status = glfwGetError(&desc);
-    if (!desc)
-      desc = "Unknown Error";
-    if (error_tolerance) {
-      // error tolerated, returning false
+  int opengl_version = 0;
+
+  if (glfwInit()) {
+    // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
+    if (use_gles) {
+      glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API) ;
+      glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+      glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    } else {
+      glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+      glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+      glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    }
+    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+    glfwWindowHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);
+    // GL context needs a window (when using GLFW)
+    GLFWwindow *window =
+        glfwCreateWindow(1, 1, "Make OpenGL Context", nullptr, nullptr);
+    if (!window) {
+      const char *desc = nullptr;
+      int status = glfwGetError(&desc);
+      if (!desc)
+        desc = "Unknown Error";
       TI_DEBUG("[glsl] cannot create GLFW window: error {}: {}", status, desc);
-      supported = std::make_optional<bool>(false);
-      return false;
+    } else {
+      glfwMakeContextCurrent(window);
+      if (use_gles) {
+        opengl_version = gladLoadGLES2(glfwGetProcAddress);
+      } else {
+        opengl_version = gladLoadGL(glfwGetProcAddress);
+      }
+      TI_DEBUG("OpenGL context loaded through GLFW");
     }
-    TI_ERROR("[glsl] cannot create GLFW window: error {}: {}", status, desc);
-  }
-  glfwMakeContextCurrent(window);
-   */
-
-  typedef EGLDisplay (*PfnEglGetDisplay)( 	NativeDisplayType);
-  typedef EGLBoolean (*PfnEglInitialize)(EGLDisplay,EGLint*,EGLint*);
-  typedef EGLBoolean (*PfnEglChooseConfig)(EGLDisplay,EGLint const *,
-                                           EGLConfig *,
-                                           EGLint,
-                                           EGLint *);
-  typedef EGLSurface (*PfnEglCreatePbufferSurface)(EGLDisplay,
-                                             EGLConfig,
-                                             EGLint const *);
-  typedef EGLBoolean (*PfnEglBindAPI)( 	EGLenum);
-  typedef EGLContext (*PfnEglCreateContext)( 	EGLDisplay,
-                                      EGLConfig,
-                                      EGLContext,
-                                      EGLint const *);
-  typedef EGLBoolean (*PfnEglMakeCurrent)( 	EGLDisplay,
-                                    EGLSurface,
-                                    EGLSurface,
-                                    EGLContext);
-
-  void *libegl = dlopen("libEGL.so", RTLD_NOW);
-
-  if (!libegl) {
-    TI_WARN("Failed to dlopen libEGL");
-    supported = std::make_optional<bool>(false);
-    return false;
   }
 
-  GLADloadproc loader = (GLADloadproc) dlsym(libegl, "eglGetProcAddress");
-  auto egl_get_display = (PfnEglGetDisplay) dlsym(libegl, "eglGetDisplay");
-  auto egl_initialize = (PfnEglInitialize) dlsym(libegl, "eglInitialize");
-  auto egl_choose_config = (PfnEglChooseConfig) dlsym(libegl, "eglChooseConfig");
-  auto egl_create_pbuffer_surface = (PfnEglCreatePbufferSurface) dlsym(libegl, "eglCreatePbufferSurface");
-  auto egl_bind_api = (PfnEglBindAPI) dlsym(libegl, "eglBindAPI");
-  auto egl_create_context = (PfnEglCreateContext) dlsym(libegl, "eglCreateContext");
-  auto egl_make_current = (PfnEglMakeCurrent) dlsym(libegl, "eglMakeCurrent");
+  if (!opengl_version) {
+    TI_TRACE("Attempting to load with EGL");
 
-  static const EGLint configAttribs[] = {
-      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
-      EGL_BLUE_SIZE, 8,
-      EGL_GREEN_SIZE, 8,
-      EGL_RED_SIZE, 8,
-      EGL_DEPTH_SIZE, 8,
-      EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
-      EGL_NONE
-  };
+    // Try EGL instead
+    int egl_version = gladLoaderLoadEGL(nullptr);
 
-  static const int pbufferWidth = 9;
-  static const int pbufferHeight = 9;
+    if (!egl_version) {
+      TI_DEBUG("Failed to load EGL");
+    } else {
+      static const EGLint configAttribs[] = {
+          EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+          EGL_BLUE_SIZE, 8,
+          EGL_GREEN_SIZE, 8,
+          EGL_RED_SIZE, 8,
+          EGL_DEPTH_SIZE, 8,
+          EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+          EGL_NONE
+      };
 
-  static const EGLint pbufferAttribs[] = {
-      EGL_WIDTH, pbufferWidth,
-      EGL_HEIGHT, pbufferHeight,
-      EGL_NONE,
-  };
+      // Initialize EGL
+      EGLDisplay egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 
-  // 1. Initialize EGL
-  EGLDisplay eglDpy = egl_get_display(EGL_DEFAULT_DISPLAY);
-  EGLint major, minor;
-  egl_initialize(eglDpy, &major, &minor);
+      EGLint major, minor;
+      eglInitialize(egl_display, &major, &minor);
 
-  // 2. Select an appropriate configuration
-  EGLint numConfigs;
-  EGLConfig eglCfg;
+      egl_version = gladLoaderLoadEGL(egl_display);
 
-  egl_choose_config(eglDpy, configAttribs, &eglCfg, 1, &numConfigs);
+      TI_DEBUG("Loaded EGL {}.{} on display {}", GLAD_VERSION_MAJOR(egl_version), GLAD_VERSION_MINOR(egl_version), egl_display);
 
-  // 3. Create a surface
-  EGLSurface eglSurf = egl_create_pbuffer_surface(eglDpy, eglCfg,
-                                               pbufferAttribs);
+      // Select an appropriate configuration
+      EGLint num_configs;
+      EGLConfig egl_config;
 
-  // 4. Bind the API
-  egl_bind_api(EGL_OPENGL_API);
+      eglChooseConfig(egl_display, configAttribs, &egl_config, 1, &num_configs);
 
-  // 5. Create a context and make it current
-  EGLContext eglCtx = egl_create_context(eglDpy, eglCfg, EGL_NO_CONTEXT,
-                                       NULL);
+      // Bind the API (EGL >= 1.2)
+      if (egl_version >= GLAD_MAKE_VERSION(1,2)) {
+        eglBindAPI(use_gles ? EGL_OPENGL_ES_API : EGL_OPENGL_API);
+      }
 
-  egl_make_current(eglDpy, eglSurf, eglSurf, eglCtx);
+      // Create a context and make it current
+      EGLContext egl_context = EGL_NO_CONTEXT;
+      if (use_gles) {
+        static const EGLint gl_attribs[] = {
+            EGL_CONTEXT_MAJOR_VERSION, 3,
+            EGL_CONTEXT_MINOR_VERSION, 1,
+            EGL_NONE,
+        };
 
-  // 6. Load OpenGL API
-  // if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
-  if (!gladLoadGLLoader(loader)) {
+        egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT,
+                                                  gl_attribs);
+      } else {
+        egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT,
+                                                  nullptr);
+      }
+
+      eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
+
+      if (use_gles) {
+        opengl_version = gladLoadGLES2(glad_eglGetProcAddress);
+      } else {
+        opengl_version = gladLoadGL(glad_eglGetProcAddress);
+      }
+    }
+  }
+
+  // Load OpenGL API
+  if (!opengl_version) {
     if (error_tolerance) {
-      TI_WARN("[glsl] cannot initialize GLAD");
+      TI_WARN("Can not create OpenGL context");
       supported = std::make_optional<bool>(false);
       return false;
     }
-    TI_ERROR("[glsl] cannot initialize GLAD");
+    TI_ERROR("Can not create OpenGL context");
   }
+
+  TI_DEBUG("{} version {}.{}", use_gles ? "GLES" : "OpenGL", GLAD_VERSION_MAJOR(opengl_version), GLAD_VERSION_MINOR(opengl_version));
+
 #define PER_OPENGL_EXTENSION(x)          \
   if ((opengl_extension_##x = GLAD_##x)) \
     TI_TRACE("[glsl] Found " #x);
 #include "taichi/inc/opengl_extension.inc.h"
 #undef PER_OPENGL_EXTENSION
-  if (!opengl_extension_GL_ARB_compute_shader) {
+
+  if (!use_gles && !opengl_extension_GL_ARB_compute_shader) {
     if (error_tolerance) {
       TI_INFO("Your OpenGL does not support GL_ARB_compute_shader extension");
       supported = std::make_optional<bool>(false);
@@ -539,6 +540,10 @@ bool initialize_opengl(bool error_tolerance) {
 }
 
 #endif  // TI_WITH_OPENGL
+
+bool is_gles() {
+  return use_gles;
+}
 
 }  // namespace opengl
 TLANG_NAMESPACE_END

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -68,7 +68,7 @@ bool initialize_opengl(bool error_tolerance) {
   if (glfwInit()) {
     // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
     if (use_gles) {
-      glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API) ;
+      glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
       glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
       glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
     } else {
@@ -107,15 +107,19 @@ bool initialize_opengl(bool error_tolerance) {
     if (!egl_version) {
       TI_DEBUG("Failed to load EGL");
     } else {
-      static const EGLint configAttribs[] = {
-          EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
-          EGL_BLUE_SIZE, 8,
-          EGL_GREEN_SIZE, 8,
-          EGL_RED_SIZE, 8,
-          EGL_DEPTH_SIZE, 8,
-          EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
-          EGL_NONE
-      };
+      static const EGLint configAttribs[] = {EGL_SURFACE_TYPE,
+                                             EGL_PBUFFER_BIT,
+                                             EGL_BLUE_SIZE,
+                                             8,
+                                             EGL_GREEN_SIZE,
+                                             8,
+                                             EGL_RED_SIZE,
+                                             8,
+                                             EGL_DEPTH_SIZE,
+                                             8,
+                                             EGL_RENDERABLE_TYPE,
+                                             EGL_OPENGL_BIT,
+                                             EGL_NONE};
 
       // Initialize EGL
       EGLDisplay egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
@@ -125,7 +129,9 @@ bool initialize_opengl(bool error_tolerance) {
 
       egl_version = gladLoaderLoadEGL(egl_display);
 
-      TI_DEBUG("Loaded EGL {}.{} on display {}", GLAD_VERSION_MAJOR(egl_version), GLAD_VERSION_MINOR(egl_version), egl_display);
+      TI_DEBUG("Loaded EGL {}.{} on display {}",
+               GLAD_VERSION_MAJOR(egl_version), GLAD_VERSION_MINOR(egl_version),
+               egl_display);
 
       // Select an appropriate configuration
       EGLint num_configs;
@@ -134,7 +140,7 @@ bool initialize_opengl(bool error_tolerance) {
       eglChooseConfig(egl_display, configAttribs, &egl_config, 1, &num_configs);
 
       // Bind the API (EGL >= 1.2)
-      if (egl_version >= GLAD_MAKE_VERSION(1,2)) {
+      if (egl_version >= GLAD_MAKE_VERSION(1, 2)) {
         eglBindAPI(use_gles ? EGL_OPENGL_ES_API : EGL_OPENGL_API);
       }
 
@@ -142,16 +148,18 @@ bool initialize_opengl(bool error_tolerance) {
       EGLContext egl_context = EGL_NO_CONTEXT;
       if (use_gles) {
         static const EGLint gl_attribs[] = {
-            EGL_CONTEXT_MAJOR_VERSION, 3,
-            EGL_CONTEXT_MINOR_VERSION, 1,
+            EGL_CONTEXT_MAJOR_VERSION,
+            3,
+            EGL_CONTEXT_MINOR_VERSION,
+            1,
             EGL_NONE,
         };
 
         egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT,
-                                                  gl_attribs);
+                                       gl_attribs);
       } else {
-        egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT,
-                                                  nullptr);
+        egl_context =
+            eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, nullptr);
       }
 
       eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
@@ -174,7 +182,9 @@ bool initialize_opengl(bool error_tolerance) {
     TI_ERROR("Can not create OpenGL context");
   }
 
-  TI_DEBUG("{} version {}.{}", use_gles ? "GLES" : "OpenGL", GLAD_VERSION_MAJOR(opengl_version), GLAD_VERSION_MINOR(opengl_version));
+  TI_DEBUG("{} version {}.{}", use_gles ? "GLES" : "OpenGL",
+           GLAD_VERSION_MAJOR(opengl_version),
+           GLAD_VERSION_MINOR(opengl_version));
 
 #define PER_OPENGL_EXTENSION(x)          \
   if ((opengl_extension_##x = GLAD_##x)) \

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -13,6 +13,11 @@
 #include "glad/glad.h"
 #include "GLFW/glfw3.h"
 #include "taichi/backends/opengl/opengl_device.h"
+
+#ifdef __linux__
+#include <EGL/egl.h>
+#endif
+
 #endif
 
 #include <list>
@@ -60,6 +65,7 @@ bool initialize_opengl(bool error_tolerance) {
     }
   }
 
+  /*
   glfwInit();
   // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
   glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
@@ -84,8 +90,53 @@ bool initialize_opengl(bool error_tolerance) {
     TI_ERROR("[glsl] cannot create GLFW window: error {}: {}", status, desc);
   }
   glfwMakeContextCurrent(window);
+   */
 
-  if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+  static const EGLint configAttribs[] = {
+      EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+      EGL_BLUE_SIZE, 8,
+      EGL_GREEN_SIZE, 8,
+      EGL_RED_SIZE, 8,
+      EGL_DEPTH_SIZE, 8,
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+      EGL_NONE
+  };
+
+  static const int pbufferWidth = 9;
+  static const int pbufferHeight = 9;
+
+  static const EGLint pbufferAttribs[] = {
+      EGL_WIDTH, pbufferWidth,
+      EGL_HEIGHT, pbufferHeight,
+      EGL_NONE,
+  };
+
+  // 1. Initialize EGL
+  EGLDisplay eglDpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  EGLint major, minor;
+  eglInitialize(eglDpy, &major, &minor);
+
+  // 2. Select an appropriate configuration
+  EGLint numConfigs;
+  EGLConfig eglCfg;
+
+  eglChooseConfig(eglDpy, configAttribs, &eglCfg, 1, &numConfigs);
+
+  // 3. Create a surface
+  EGLSurface eglSurf = eglCreatePbufferSurface(eglDpy, eglCfg,
+                                               pbufferAttribs);
+
+  // 4. Bind the API
+  eglBindAPI(EGL_OPENGL_API);
+
+  // 5. Create a context and make it current
+  EGLContext eglCtx = eglCreateContext(eglDpy, eglCfg, EGL_NO_CONTEXT,
+                                       NULL);
+
+  eglMakeCurrent(eglDpy, eglSurf, eglSurf, eglCtx);
+
+//  if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+  if (!gladLoadGLLoader((GLADloadproc)eglGetProcAddress)) {
     if (error_tolerance) {
       TI_WARN("[glsl] cannot initialize GLAD");
       supported = std::make_optional<bool>(false);

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -23,6 +23,7 @@ namespace opengl {
 
 bool initialize_opengl(bool error_tolerance = false);
 bool is_opengl_api_available();
+bool is_gles();
 
 #define PER_OPENGL_EXTENSION(x) extern bool opengl_extension_##x;
 #include "taichi/inc/opengl_extension.inc.h"

--- a/taichi/backends/opengl/opengl_device.cpp
+++ b/taichi/backends/opengl/opengl_device.cpp
@@ -1,4 +1,5 @@
 #include "opengl_device.h"
+#include "opengl_api.h"
 
 namespace taichi {
 namespace lang {
@@ -92,7 +93,8 @@ GLPipeline::GLPipeline(const PipelineSourceDesc &desc,
   shader_id = glCreateShader(GL_COMPUTE_SHADER);
 
   const GLchar *source_cstr = (const GLchar *)desc.data;
-  glShaderSource(shader_id, 1, &source_cstr, nullptr);
+  int length = desc.size;
+  glShaderSource(shader_id, 1, &source_cstr, &length);
 
   glCompileShader(shader_id);
   int status = GL_TRUE;
@@ -299,11 +301,11 @@ DeviceAllocation GLDevice::allocate_memory(const AllocParams &params) {
   alloc.alloc_id = buffer;
 
   if (params.host_read && params.host_write) {
-    buffer_to_access_[buffer] = GL_READ_WRITE;
+    buffer_to_access_[buffer] = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT;
   } else if (params.host_read) {
-    buffer_to_access_[buffer] = GL_READ_ONLY;
+    buffer_to_access_[buffer] = GL_MAP_READ_BIT;
   } else if (params.host_write) {
-    buffer_to_access_[buffer] = GL_WRITE_ONLY;
+    buffer_to_access_[buffer] = GL_MAP_WRITE_BIT;
   }
 
   return alloc;
@@ -333,6 +335,11 @@ void *GLDevice::map_range(DevicePtr ptr, uint64_t size) {
 }
 
 void *GLDevice::map(DeviceAllocation alloc) {
+  int size = 0;
+  glBindBuffer(GL_SHADER_STORAGE_BUFFER, alloc.alloc_id);
+  glGetBufferParameteriv(GL_SHADER_STORAGE_BUFFER, GL_BUFFER_SIZE, &size);
+  return map_range(alloc.get_ptr(0), size);
+  /*
   TI_ASSERT_INFO(
       buffer_to_access_.find(alloc.alloc_id) != buffer_to_access_.end(),
       "Buffer not created with host_read or write");
@@ -342,6 +349,7 @@ void *GLDevice::map(DeviceAllocation alloc) {
                              buffer_to_access_.at(alloc.alloc_id));
   check_opengl_error("glMapBuffer");
   return mapped;
+  */
 }
 
 void GLDevice::unmap(DevicePtr ptr) {
@@ -480,9 +488,17 @@ void GLCommandList::CmdBufferCopy::execute() {
 void GLCommandList::CmdBufferFill::execute() {
   glBindBuffer(GL_SHADER_STORAGE_BUFFER, buffer);
   check_opengl_error("glBindBuffer");
-  glClearBufferSubData(GL_SHADER_STORAGE_BUFFER, GL_R32F, offset, size, GL_RED,
-                       GL_FLOAT, &data);
-  check_opengl_error("glClearBufferSubData");
+  if (is_gles()) {
+    int buf_size = 0;
+    glGetBufferParameteriv(GL_SHADER_STORAGE_BUFFER,  GL_BUFFER_SIZE, &buf_size);
+    TI_ASSERT(offset == 0 && data == 0 && size == buf_size && "GLES only supports full clear");
+    glBufferData(GL_SHADER_STORAGE_BUFFER, buf_size, nullptr, GL_DYNAMIC_READ);
+    check_opengl_error("glBufferData");
+  } else {
+    glClearBufferSubData(GL_SHADER_STORAGE_BUFFER, GL_R32F, offset, size, GL_RED,
+                         GL_FLOAT, &data);
+    check_opengl_error("glClearBufferSubData");
+  }
 }
 
 void GLCommandList::CmdDispatch::execute() {

--- a/taichi/backends/opengl/opengl_device.cpp
+++ b/taichi/backends/opengl/opengl_device.cpp
@@ -490,13 +490,14 @@ void GLCommandList::CmdBufferFill::execute() {
   check_opengl_error("glBindBuffer");
   if (is_gles()) {
     int buf_size = 0;
-    glGetBufferParameteriv(GL_SHADER_STORAGE_BUFFER,  GL_BUFFER_SIZE, &buf_size);
-    TI_ASSERT(offset == 0 && data == 0 && size == buf_size && "GLES only supports full clear");
+    glGetBufferParameteriv(GL_SHADER_STORAGE_BUFFER, GL_BUFFER_SIZE, &buf_size);
+    TI_ASSERT(offset == 0 && data == 0 && size == buf_size &&
+              "GLES only supports full clear");
     glBufferData(GL_SHADER_STORAGE_BUFFER, buf_size, nullptr, GL_DYNAMIC_READ);
     check_opengl_error("glBufferData");
   } else {
-    glClearBufferSubData(GL_SHADER_STORAGE_BUFFER, GL_R32F, offset, size, GL_RED,
-                         GL_FLOAT, &data);
+    glClearBufferSubData(GL_SHADER_STORAGE_BUFFER, GL_R32F, offset, size,
+                         GL_RED, GL_FLOAT, &data);
     check_opengl_error("glClearBufferSubData");
   }
 }

--- a/taichi/backends/opengl/opengl_device.h
+++ b/taichi/backends/opengl/opengl_device.h
@@ -2,7 +2,7 @@
 
 #include "taichi/backends/device.h"
 
-#include "glad/glad.h"
+#include "glad/gl.h"
 #include "GLFW/glfw3.h"
 
 namespace taichi {


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/3364

GLES can be enabled by changing the flag in the `opengl_api.cpp`, and due to the need of GLSL preprocessing, it's only available on linux / BSD. (well other platforms don't really support GLES 3.1 anyways)

GLAD2 is introduced so that we can use its EGL loader to create our off-screen context. GLFW will be attempted first, if GLFW can not initialize a window, the code will try EGL. Therefore this does not introduce extra dependencies.