### PR TITLE
[Test] Fix uninitialized tests for ndarray

### DIFF
--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -303,7 +303,24 @@ def test_matrix_ndarray_taichi_scope_struct_for(layout):
     _test_matrix_ndarray_taichi_scope_struct_for(layout)
 
 
-def _test_vector_ndarray_python_scope(layout):
+@pytest.mark.parametrize('layout', layouts)
+@pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
+@ti.test(exclude=ti.opengl)
+def test_vector_ndarray_python_scope_torch(layout):
+    a = ti.Vector.ndarray(10, ti.i32, 5, layout=layout)
+    for i in range(5):
+        for j in range(4):
+            a[i][j * j] = j * j
+    assert a[0][6] == 0 # torch memory initialized to zero
+    assert a[1][0] == 0
+    assert a[2][1] == 1
+    assert a[3][4] == 4
+    assert a[4][9] == 9
+
+
+@pytest.mark.parametrize('layout', layouts)
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=False)
+def test_vector_ndarray_python_scope(layout):
     a = ti.Vector.ndarray(10, ti.i32, 5, layout=layout)
     for i in range(5):
         for j in range(4):
@@ -318,17 +335,25 @@ def _test_vector_ndarray_python_scope(layout):
 @pytest.mark.parametrize('layout', layouts)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
 @ti.test(exclude=ti.opengl)
-def test_vector_ndarray_python_scope_torch(layout):
-    _test_vector_ndarray_python_scope(layout)
+def test_vector_ndarray_taichi_scope_torch(layout):
+    @ti.kernel
+    def func(a: ti.any_arr()):
+        for i in range(5):
+            for j in range(4):
+                a[i][j * j] = j * j
+
+    v = ti.Vector.ndarray(10, ti.i32, 5, layout=layout)
+    func(v)
+    assert v[0][6] == 0 # torch memory initialized to zero
+    assert v[1][0] == 0
+    assert v[2][1] == 1
+    assert v[3][4] == 4
+    assert v[4][9] == 9
 
 
 @pytest.mark.parametrize('layout', layouts)
 @ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=False)
-def test_vector_ndarray_python_scope(layout):
-    _test_vector_ndarray_python_scope(layout)
-
-
-def _test_vector_ndarray_taichi_scope(layout):
+def test_vector_ndarray_taichi_scope(layout):
     @ti.kernel
     def func(a: ti.any_arr()):
         for i in range(5):
@@ -342,19 +367,6 @@ def _test_vector_ndarray_taichi_scope(layout):
     assert v[2][1] == 1
     assert v[3][4] == 4
     assert v[4][9] == 9
-
-
-@pytest.mark.parametrize('layout', layouts)
-@pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(exclude=ti.opengl)
-def test_vector_ndarray_taichi_scope_torch(layout):
-    _test_vector_ndarray_taichi_scope(layout)
-
-
-@pytest.mark.parametrize('layout', layouts)
-@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=False)
-def test_vector_ndarray_taichi_scope(layout):
-    _test_vector_ndarray_taichi_scope(layout)
 
 
 # number of compiled functions

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -311,7 +311,7 @@ def test_vector_ndarray_python_scope_torch(layout):
     for i in range(5):
         for j in range(4):
             a[i][j * j] = j * j
-    assert a[0][6] == 0 # torch memory initialized to zero
+    assert a[0][6] == 0  # torch memory initialized to zero
     assert a[1][0] == 0
     assert a[2][1] == 1
     assert a[3][4] == 4
@@ -344,7 +344,7 @@ def test_vector_ndarray_taichi_scope_torch(layout):
 
     v = ti.Vector.ndarray(10, ti.i32, 5, layout=layout)
     func(v)
-    assert v[0][6] == 0 # torch memory initialized to zero
+    assert v[0][6] == 0  # torch memory initialized to zero
     assert v[1][0] == 0
     assert v[2][1] == 1
     assert v[3][4] == 4

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -308,7 +308,7 @@ def _test_vector_ndarray_python_scope(layout):
     for i in range(5):
         for j in range(4):
             a[i][j * j] = j * j
-    assert a[0][6] == 0
+    assert a[0][9] == 9
     assert a[1][0] == 0
     assert a[2][1] == 1
     assert a[3][4] == 4
@@ -337,7 +337,7 @@ def _test_vector_ndarray_taichi_scope(layout):
 
     v = ti.Vector.ndarray(10, ti.i32, 5, layout=layout)
     func(v)
-    assert v[0][6] == 0
+    assert v[0][9] == 9
     assert v[1][0] == 0
     assert v[2][1] == 1
     assert v[3][4] == 4


### PR DESCRIPTION
Did not fail before because Torch memory is initialized to zero.