### PR TITLE
[gui] Allowing recreating GGUI windows after ti.reset().

### DIFF
--- a/taichi/backends/interop/vulkan_cuda_interop.cpp
+++ b/taichi/backends/interop/vulkan_cuda_interop.cpp
@@ -149,7 +149,13 @@ void memcpy_cuda_to_vulkan(DevicePtr dst, DevicePtr src, uint64_t size) {
   DeviceAllocation dst_alloc(dst);
   DeviceAllocation src_alloc(src);
 
-  static std::unordered_map<int, unsigned char *> alloc_base_ptrs;
+  static std::unordered_map<
+      VulkanDevice *,
+      std::unordered_map<CudaDevice *,
+                         std::unordered_map<int, unsigned char *>>>
+      alloc_base_ptrs_all;
+  std::unordered_map<int, unsigned char *> &alloc_base_ptrs =
+      alloc_base_ptrs_all[vk_dev][cuda_dev];
 
   if (alloc_base_ptrs.find(dst_alloc.alloc_id) == alloc_base_ptrs.end()) {
     auto [base_mem, alloc_offset, alloc_size] =


### PR DESCRIPTION
I have been trying to write tests for GGUI, and one problem I encountered was that I couldn't run GGUI multiple times separated by ti.reset() calls. There were two reasons for this:

1. ti.reset() doesn't release the resources for the GGUI window. This PR adds an explicit destory() method that works around this. (i.e. after each test, I will call destroy() manually)

2. The vulkan_cuda interop function did not consider the fact that the VulkanDevice and CudaDevice could change. This is fixed in this PR.