### PR TITLE
[misc] Update "get_largest_pot" in scalar.h + Bug Fix

### DIFF
--- a/taichi/math/scalar.h
+++ b/taichi/math/scalar.h
@@ -164,7 +164,7 @@ inline int64 get_largest_pot(int64 a) noexcept {
 
   /* This code was copied from https://stackoverflow.com/a/20207950 and edited
   It uses loop unrolling, which all compilers will do.*/
-  for (int64 i = 0; i < 64; i *= 2){
+  for (int64 i = 1; i < 64; i *= 2){
     x |= (x >> i);
   }
   return x - (x >> 1);  

--- a/taichi/math/scalar.h
+++ b/taichi/math/scalar.h
@@ -165,9 +165,9 @@ inline int64 get_largest_pot(int64 a) noexcept {
   /* This code was copied from https://stackoverflow.com/a/20207950 and edited
   It uses loop unrolling, which all compilers will do.*/
   for (int64 i = 1; i < 64; i *= 2){
-    x |= (x >> i);
+    a |= (a >> i);
   }
-  return x - (x >> 1);  
+  return a - (a >> 1);  
 }
 
 TI_NAMESPACE_END

--- a/taichi/math/scalar.h
+++ b/taichi/math/scalar.h
@@ -161,12 +161,13 @@ TI_FORCE_INLINE bool abnormal(T m) noexcept {
 inline int64 get_largest_pot(int64 a) noexcept {
   TI_ASSERT_INFO(a > 0,
                  "a should be positive, instead of " + std::to_string(a));
-  // TODO: optimize
-  int64 i = 1;
-  while (i <= a / 2) {
-    i *= 2;
+
+  /* This code was copied from https://stackoverflow.com/a/20207950 and edited
+  It uses loop unrolling, which all compilers will do.*/
+  for (int64 i = 0; i < 64; i *= 2){
+    x |= (x >> i);
   }
-  return i;
+  return x - (x >> 1);  
 }
 
 TI_NAMESPACE_END

--- a/taichi/math/scalar.h
+++ b/taichi/math/scalar.h
@@ -163,7 +163,7 @@ inline int64 get_largest_pot(int64 a) noexcept {
                  "a should be positive, instead of " + std::to_string(a));
 
   /* This code was copied from https://stackoverflow.com/a/20207950 and edited
-  It uses loop unrolling, which all compilers will do.*/
+  It uses loop unrolling, which all (modern) compilers will do. */
   for (int64 i = 1; i < 64; i *= 2) {
     a |= (a >> i);
   }

--- a/taichi/math/scalar.h
+++ b/taichi/math/scalar.h
@@ -164,10 +164,10 @@ inline int64 get_largest_pot(int64 a) noexcept {
 
   /* This code was copied from https://stackoverflow.com/a/20207950 and edited
   It uses loop unrolling, which all compilers will do.*/
-  for (int64 i = 1; i < 64; i *= 2){
+  for (int64 i = 1; i < 64; i *= 2) {
     a |= (a >> i);
   }
-  return a - (a >> 1);  
+  return a - (a >> 1);
 }
 
 TI_NAMESPACE_END


### PR DESCRIPTION
Find the largest potence faster.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
