### PR TITLE
[refactor] Remove Matrix.new

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -240,13 +240,13 @@ class Matrix(TaichiOperations):
         assert isinstance(other, Matrix), "rhs of `@` is not a matrix / vector"
         assert self.m == other.n, f"Dimension mismatch between shapes ({self.n}, {self.m}), ({other.n}, {other.m})"
         del _taichi_skip_traceback
-        ret = Matrix.new(self.n, other.m)
+        ret = Matrix.empty(self.n, other.m)
         for i in range(self.n):
             for j in range(other.m):
                 acc = self(i, 0) * other(0, j)
                 for k in range(1, other.n):
                     acc = acc + self(i, k) * other(k, j)
-                ret.set_entry(i, j, acc)
+                ret.entries[i * other.m + j] = acc
         return ret
 
     def linearize_entry_id(self, *args):
@@ -1121,13 +1121,6 @@ class Matrix(TaichiOperations):
         mat = cls.empty(n, m)
         mat.entries = entries
         return mat
-
-    @classmethod
-    def new(cls, n, m):
-        if impl.inside_kernel():
-            return cls(n, m)
-        else:
-            return cls.empty(n, m)
 
     def __hash__(self):
         # TODO: refactor KernelTemplateMapper


### PR DESCRIPTION
Related issue = #2880

`Matrix.new` is an internal API which is used only once. This adds unnecessary complexity to the `Matrix` class.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
