### PR TITLE
[ci] Use paths-ignore to skip CI when only docs change

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -2,6 +2,8 @@ name: Presubmit Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - docs/**
 
 jobs:
   title_format:
@@ -20,41 +22,10 @@ jobs:
           python misc/ci_check_pr_title.py "$PR_TITLE"
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-  check_files:
-    name: Check files
-    outputs:
-      run_job: ${{ steps.check_files.outputs.run_job }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-
-      - name: check modified files
-        id: check_files
-        run: |
-          echo "=============== list modified files ==============="
-          git diff --name-only @^
-          
-          echo "========== check paths of modified files =========="
-          git diff --name-only @^ > files.txt
-          while IFS= read -r file
-          do
-            echo $file
-            if [[ $file == docs/* ]]; then
-              echo "This modified file is not under the 'docs' folder."
-              echo "::set-output name=run_job::false"
-              break
-            else
-              echo "::set-output name=run_job::true"
-            fi
-          done < files.txt
 
   check_code_format:
     name: Check Code Format
     runs-on: ubuntu-latest
-    needs: check_files
     # This job will be required to pass before merging to master branch.
     steps:
       - uses: actions/checkout@v2
@@ -65,9 +36,6 @@ jobs:
 
       - name: Setup git & clang-format
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           git config user.email "taichigardener@gmail.com"
           git config user.name "Taichi Gardener"
           git checkout -b _fake_squash
@@ -83,16 +51,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           python3 -m pip install --user -r requirements_dev.txt
 
       - name: Check code format
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           python3 misc/code_format.py
           git checkout -b _enforced_format
           git commit -am "enforce code format" || true
@@ -101,9 +63,6 @@ jobs:
 
       - name: Pylint
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           # Make sure pylint doesn't regress
           pylint python/taichi/ --disable=all --enable=C0121,C0415
           if [ $? -eq 0 ]
@@ -118,16 +77,12 @@ jobs:
   check_clang_tidy:
     name: Check clang-tidy
     runs-on: ubuntu-latest
-    needs: check_files
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
       - name: Get docker images
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio
           echo $CR_PAT | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker pull ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0
@@ -135,9 +90,6 @@ jobs:
           CR_PAT: ${{ secrets.GITHUB_TOKEN }}
       - name: Run clang-tidy
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           docker run -id --user dev --name check_clang_tidy ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0 /bin/bash
           tar -cf - ../${{ github.event.repository.name }} --mode u=+rwx,g=+rwx,o=+rwx --owner dev --group dev | docker cp - check_clang_tidy:/home/dev/
           docker exec --user root check_clang_tidy apt install -y clang-tidy-10
@@ -148,7 +100,7 @@ jobs:
   build_and_test_cpu_required:
     # This job will be required to pass before merging to master branch.
     name: Required Build and Test (CPU)
-    needs: [check_code_format, check_files]
+    needs: check_code_format
     timeout-minutes: 60
     strategy:
       matrix:
@@ -166,9 +118,6 @@ jobs:
 
       - name: Get docker images
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio
           echo $CR_PAT | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker pull ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0
@@ -177,9 +126,6 @@ jobs:
 
       - name: Build
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           mkdir -m777 wheel
           docker create -v `pwd`/wheel:/wheel --user dev --name taichi_build ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0 /home/dev/taichi/.github/workflows/scripts/unix_docker_build.sh $PY $GPU_BUILD $PROJECT_NAME "$CI_SETUP_CMAKE_ARGS"
           # Docker cp preserves the ownership in the host machine. However, the user in the host machine won't be recognized
@@ -194,9 +140,6 @@ jobs:
 
       - name: Test
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           docker create --user dev --name taichi_test ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0 /home/dev/unix_docker_test.sh $PY $GPU_TEST
           docker cp .github/workflows/scripts/unix_docker_test.sh taichi_test:/home/dev/unix_docker_test.sh
           docker cp wheel/*.whl taichi_test:/home/dev/
@@ -208,7 +151,7 @@ jobs:
 
   build_and_test_cpu_linux:
     name: Build and Test linux (CPU)
-    needs: [build_and_test_cpu_required, check_files]
+    needs: build_and_test_cpu_required
     timeout-minutes: 60
     strategy:
       matrix:
@@ -230,9 +173,6 @@ jobs:
 
       - name: Get docker images
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio
           echo $CR_PAT | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker pull ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0
@@ -241,9 +181,6 @@ jobs:
 
       - name: Build
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           mkdir -m777 wheel
           docker create -v `pwd`/wheel:/wheel --user dev --name taichi_build ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0 /home/dev/taichi/.github/workflows/scripts/unix_docker_build.sh $PY $GPU_BUILD $PROJECT_NAME "$CI_SETUP_CMAKE_ARGS"
           tar -cf - ../${{ github.event.repository.name }} --mode u=+rwx,g=+rwx,o=+rwx --owner dev --group dev | docker cp - taichi_build:/home/dev/
@@ -256,9 +193,6 @@ jobs:
 
       - name: Test
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           docker create --user dev --name taichi_test ghcr.io/taichi-dev/taichidev-cpu-ubuntu18.04:v0.1.0 /home/dev/unix_docker_test.sh $PY $GPU_TEST
           docker cp .github/workflows/scripts/unix_docker_test.sh taichi_test:/home/dev/unix_docker_test.sh
           docker cp wheel/*.whl taichi_test:/home/dev/
@@ -270,7 +204,7 @@ jobs:
 
   build_and_test_cpu_mac:
     name: Build and Test macos (CPU)
-    needs: [build_and_test_cpu_required, check_files]
+    needs: build_and_test_cpu_required
     timeout-minutes: 60
     strategy:
       matrix:
@@ -291,18 +225,12 @@ jobs:
 
       - name: Download Pre-Built LLVM 10.0.0
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           python misc/ci_download.py
         env:
           CI_PLATFORM: ${{ matrix.os }}
 
       - name: Build & Install
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           .github/workflows/scripts/unix_build.sh
         env:
           CI_SETUP_CMAKE_ARGS: -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=${{ matrix.with_cc }} -DTI_WITH_VULKAN:BOOL=OFF -DTI_BUILD_TESTS:BOOL=${{ matrix.with_cpp_tests }}
@@ -315,16 +243,13 @@ jobs:
 
       - name: Test
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           .github/workflows/scripts/unix_test.sh
         env:
           RUN_CPP_TESTS: ${{ matrix.with_cpp_tests }}
 
   build_and_test_gpu_linux:
     name: Build and Test (GPU)
-    needs: [check_code_format, check_files]
+    needs: check_code_format
     runs-on: [self-hosted, cuda, vulkan, cn]
     timeout-minutes: 60
     steps:
@@ -334,9 +259,6 @@ jobs:
 
       - name: Build & Install
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           mkdir -m777 wheel
           docker create -v `pwd`/wheel:/wheel --user dev --name taichi_build --gpus all -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix registry.taichigraphics.com/taichidev-ubuntu18.04:v0.1.1 /home/dev/taichi/.github/workflows/scripts/unix_docker_build.sh $PY $GPU_BUILD $PROJECT_NAME "$CI_SETUP_CMAKE_ARGS"
           tar -cf - ../${{ github.event.repository.name }} --mode u=+rwx,g=+rwx,o=+rwx --owner dev --group dev | docker cp - taichi_build:/home/dev/
@@ -350,9 +272,6 @@ jobs:
 
       - name: Test
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           docker create --user dev --name taichi_test --gpus all -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix registry.taichigraphics.com/taichidev-ubuntu18.04:v0.1.1 /home/dev/unix_docker_test.sh $PY $GPU_TEST
           docker cp .github/workflows/scripts/unix_docker_test.sh taichi_test:/home/dev/unix_docker_test.sh
           docker cp wheel/*.whl taichi_test:/home/dev/
@@ -365,14 +284,11 @@ jobs:
       - name: clean docker container
         if: always()
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           docker rm taichi_build taichi_test -f
 
   build_and_test_windows:
     name: Build and Test (Windows)
-    needs: [check_code_format, check_files]
+    needs: check_code_format
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
@@ -394,9 +310,6 @@ jobs:
       - name: Download And Install Vulkan
         shell: powershell
         run: |
-          if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
-            exit 0
-          }
           Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.2.189.0/windows/VulkanSDK-1.2.189.0-Installer.exe" -OutFile VulkanSDK.exe
           $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
           $installer.WaitForExit();
@@ -404,9 +317,6 @@ jobs:
       - name: Build
         shell: powershell
         run: |
-          if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
-            exit 0
-          }
           $env:Path += ";C:/VulkanSDK/1.2.189.0/Bin"
           cd C:\
           Remove-item alias:curl
@@ -434,9 +344,6 @@ jobs:
       - name: Test
         shell: powershell
         run: |
-          if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
-            exit 0
-          }
           $env:PATH = ";C:\taichi_llvm\bin;C:\taichi_clang\bin;" + $env:PATH
           python -c "import taichi"
           python examples/algorithm/laplace.py
@@ -448,7 +355,7 @@ jobs:
 
   build_and_test_m1:
     name: Build and Test (Apple M1)
-    needs: [check_code_format, check_files]
+    needs: check_code_format
     timeout-minutes: 60
     strategy:
       matrix:
@@ -467,9 +374,6 @@ jobs:
 
       - name: Build
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           rm -rf $HOME/Library/Python/3.8/lib/python/site-packages/taichi
           .github/workflows/scripts/unix_build.sh
         env:
@@ -478,9 +382,6 @@ jobs:
 
       - name: Test
         run: |
-          if [[ ${{needs.check_files.outputs.run_job}} == false ]]; then
-            exit 0
-          fi
           export PATH=$PATH:$HOME/Library/Python/3.8/bin
           python3 -m pip install -r requirements_test.txt
           python3 examples/algorithm/laplace.py


### PR DESCRIPTION
Related issue = #3399 

This PR proposes a cleaner method to skip the CI run with `paths-ignore`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
