### PR TITLE
[ci] Add build script for win

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -194,10 +194,6 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
-      - name: Install 7Zip PowerShell
-        shell: powershell
-        run: Install-Module 7Zip4PowerShell -Force -Verbose
-
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
@@ -209,39 +205,10 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: Download And Install Vulkan
-        shell: powershell
-        run: |
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.2.189.0/windows/VulkanSDK-1.2.189.0-Installer.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
-          $installer.WaitForExit();
-
       - name: Build
         shell: powershell
         run: |
-          $env:Path += ";C:/VulkanSDK/1.2.189.0/Bin"
-          cd C:\
-          Remove-item alias:curl
-          curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip -LO
-          7z x taichi-llvm-10.0.0-msvc2019.zip -otaichi_llvm
-          curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/clang-10.0.0-win.zip -LO
-          7z x clang-10.0.0-win.zip -otaichi_clang
-          $env:PATH = ";C:\taichi_llvm\bin;C:\taichi_clang\bin;" + $env:PATH
-          clang --version
-          cd D:\a\taichi\taichi
-          python -m pip install -r requirements_dev.txt
-          python -m pip install -r requirements_test.txt
-          cd python
-          git fetch origin master
-          $env:TAICHI_CMAKE_ARGS = $env:CI_SETUP_CMAKE_ARGS
-          python build.py build
-          cd ..\dist
-          $env:WHL = $(dir *.whl)
-          python -m pip install $env:WHL
-        env:
-          PYTHON: C:\hostedtoolcache\windows\Python\3.7.9\x64\python.exe
-          CI_SETUP_CMAKE_ARGS: -G "Visual Studio 16 2019" -A x64 -DLLVM_DIR=C:\taichi_llvm\lib\cmake\llvm -DTI_WITH_VULKAN:BOOL=ON
-          VULKAN_SDK: C:/VulkanSDK/1.2.189.0
+          .\.github\workflows\scripts\win_build.ps1 -vulkan -build C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Build
         shell: powershell
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -vulkan -install -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -build C:\
 
       - name: Test
         shell: powershell
@@ -274,7 +274,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Build & Install
         run: |

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Build
         shell: powershell
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -libdir C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -libsDir C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Build
         shell: powershell
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -vulkan -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -vulkan -install -build C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -214,11 +214,12 @@ jobs:
         shell: powershell
         run: |
           $env:PATH = ";C:\taichi_llvm\bin;C:\taichi_clang\bin;" + $env:PATH
+          . venv\Scripts\activate.ps1
           python -c "import taichi"
           python examples/algorithm/laplace.py
-          python bin/taichi diagnose
-          python bin/taichi changelog
-          python bin/taichi test -vr2 -t2
+          ti diagnose
+          ti changelog
+          ti test -vr2 -t2
         env:
           PYTHON: C:\hostedtoolcache\windows\Python\3.7.9\x64\python.exe
 

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Build
         shell: powershell
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -libdir C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "=============== list modified files ==============="
           git diff --name-only @^
-          
+
           echo "========== check paths of modified files =========="
           git diff --name-only @^ > files.txt
           while IFS= read -r file
@@ -376,10 +376,6 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 90
     steps:
-      - name: Install 7Zip PowerShell
-        shell: powershell
-        run: Install-Module 7Zip4PowerShell -Force -Verbose
-
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
@@ -391,45 +387,13 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: Download And Install Vulkan
-        shell: powershell
-        run: |
-          if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
-            exit 0
-          }
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.2.189.0/windows/VulkanSDK-1.2.189.0-Installer.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
-          $installer.WaitForExit();
-
       - name: Build
         shell: powershell
         run: |
           if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
             exit 0
           }
-          $env:Path += ";C:/VulkanSDK/1.2.189.0/Bin"
-          cd C:\
-          Remove-item alias:curl
-          curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip -LO
-          7z x taichi-llvm-10.0.0-msvc2019.zip -otaichi_llvm
-          curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/clang-10.0.0-win.zip -LO
-          7z x clang-10.0.0-win.zip -otaichi_clang
-          $env:PATH = ";C:\taichi_llvm\bin;C:\taichi_clang\bin;" + $env:PATH
-          clang --version
-          cd D:\a\taichi\taichi
-          python -m pip install -r requirements_dev.txt
-          python -m pip install -r requirements_test.txt
-          cd python
-          git fetch origin master
-          $env:TAICHI_CMAKE_ARGS = $env:CI_SETUP_CMAKE_ARGS
-          python build.py build
-          cd ..\dist
-          $env:WHL = $(dir *.whl)
-          python -m pip install $env:WHL
-        env:
-          PYTHON: C:\hostedtoolcache\windows\Python\3.7.9\x64\python.exe
-          CI_SETUP_CMAKE_ARGS: -G "Visual Studio 16 2019" -A x64 -DLLVM_DIR=C:\taichi_llvm\lib\cmake\llvm -DTI_WITH_VULKAN:BOOL=ON
-          VULKAN_SDK: C:/VulkanSDK/1.2.189.0
+          .\.github\workflows\scripts\win_build.ps1 -vulkan -build C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -393,7 +393,7 @@ jobs:
           if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
             exit 0
           }
-          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -libdir C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -libsDir C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -393,7 +393,7 @@ jobs:
           if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
             exit 0
           }
-          .\.github\workflows\scripts\win_build.ps1 -vulkan -install -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -build C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -393,7 +393,7 @@ jobs:
           if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
             exit 0
           }
-          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -install -libdir C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -402,11 +402,12 @@ jobs:
             exit 0
           }
           $env:PATH = ";C:\taichi_llvm\bin;C:\taichi_clang\bin;" + $env:PATH
+          . venv\Scripts\activate.ps1
           python -c "import taichi"
           python examples/algorithm/laplace.py
-          python bin/taichi diagnose
-          python bin/taichi changelog
-          python bin/taichi test -vr2 -t2
+          ti diagnose
+          ti changelog
+          ti test -vr2 -t2
         env:
           PYTHON: C:\hostedtoolcache\windows\Python\3.7.9\x64\python.exe
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -393,7 +393,7 @@ jobs:
           if ( "${{needs.check_files.outputs.run_job}}" -eq "false" ) {
             exit 0
           }
-          .\.github\workflows\scripts\win_build.ps1 -vulkan -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -vulkan -install -build C:\
 
       - name: Test
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,6 @@ jobs:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     runs-on: windows-latest
     steps:
-
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
@@ -303,7 +302,7 @@ jobs:
       - name: Build Python Wheel
         shell: powershell
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -vulkan -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -build C:\
           venv\Scripts\python -m pip install $(dir dist\*.whl)
         env:
           PROJECT_NAME: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Build Python Wheel
         shell: powershell
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -installVulkan -libdir C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -libsDir C:\
           venv\Scripts\python -m pip install $(dir dist\*.whl)
         env:
           PROJECT_NAME: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Build Python Wheel
         shell: powershell
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -installVulkan -build C:\
+          .\.github\workflows\scripts\win_build.ps1 -installVulkan -libdir C:\
           venv\Scripts\python -m pip install $(dir dist\*.whl)
         env:
           PROJECT_NAME: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,9 +288,6 @@ jobs:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     runs-on: windows-latest
     steps:
-      - name: Install 7Zip PowerShell
-        shell: powershell
-        run: Install-Module 7Zip4PowerShell -Force -Verbose
 
       - uses: actions/checkout@v2
         with:
@@ -303,39 +300,13 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: Download And Install Vulkan
-        shell: powershell
-        run: |
-          Invoke-WebRequest -Uri "https://sdk.lunarg.com/sdk/download/1.2.189.0/windows/VulkanSDK-1.2.189.0-Installer.exe" -OutFile VulkanSDK.exe
-          $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
-          $installer.WaitForExit();
-
       - name: Build Python Wheel
         shell: powershell
         run: |
-          $env:Path += ";C:/VulkanSDK/1.2.189.0/Bin"
-          cd C:\
-          Remove-item alias:curl
-          curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip -LO
-          7z x taichi-llvm-10.0.0-msvc2019.zip -otaichi_llvm
-          curl --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/clang-10.0.0-win.zip -LO
-          7z x clang-10.0.0-win.zip -otaichi_clang
-          $env:PATH = ";C:\taichi_llvm\bin;C:\taichi_clang\bin;" + $env:PATH
-          clang --version
-          cd D:\a\taichi\taichi
-          python -m pip install -r requirements_dev.txt
-          python -m pip install -r requirements_test.txt
-          cd python
-          git fetch origin master
-          $env:TAICHI_CMAKE_ARGS = $env:CI_SETUP_CMAKE_ARGS
-          python build.py build --project_name $env:PROJECT_NAME
-          cd ..\dist
-          $env:WHL = $(dir *.whl)
-          python -m pip install $env:WHL
+          .\.github\workflows\scripts\win_build.ps1 -vulkan -build C:\
+          venv\Scripts\python -m pip install $(dir dist\*.whl)
         env:
-          CI_SETUP_CMAKE_ARGS: -G "Visual Studio 16 2019" -A x64 -DLLVM_DIR=C:\taichi_llvm\lib\cmake\llvm -DTI_WITH_VULKAN:BOOL=ON
           PROJECT_NAME: ${{ matrix.name }}
-          VULKAN_SDK: C:/VulkanSDK/1.2.189.0
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v2
@@ -348,10 +319,11 @@ jobs:
         shell: powershell
         run: |
           $env:PATH = ";C:\taichi_llvm\bin;C:\taichi_clang\bin;" + $env:PATH
+          . venv\Scripts\activate.ps1
           python -c "import taichi"
           python examples/algorithm/laplace.py
-          python bin/taichi diagnose
-          python bin/taichi test -vr2 -t2
+          ti diagnose
+          ti test -vr2 -t2
 
       - name: Upload PyPI
         shell: powershell

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -55,6 +55,7 @@ clang --version
 WriteInfo("Setting up Python environment")
 python -m venv venv
 . venv\Scripts\activate.ps1
+python -m pip install wheel
 python -m pip install -r requirements_dev.txt
 python -m pip install -r requirements_test.txt
 WriteInfo("Building Taichi")

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -2,7 +2,7 @@
 
 param (
     [switch]$clone = $false,
-    [switch]$vulkan = $false,
+    [switch]$installVulkan = $false,
     [switch]$develop = $false,
     [switch]$install = $false,
     [string]$build = "_build"
@@ -38,7 +38,7 @@ if (-not (Test-Path "taichi_clang")) {
 }
 $env:PATH = "$build\taichi_llvm\bin;$build\taichi_clang\bin;$env:PATH"
 $env:TAICHI_CMAKE_ARGS = "-G 'Visual Studio 16 2019' -A x64 -DLLVM_DIR=$build\taichi_llvm\lib\cmake\llvm"
-if ($vulkan) {
+if ($installVulkan) {
     WriteInfo("Download and install Vulkan")
     if (-not (Test-Path "VulkanSDK.exe")) {
         curl.exe --retry 10 --retry-delay 5 https://sdk.lunarg.com/sdk/download/1.2.189.0/windows/VulkanSDK-1.2.189.0-Installer.exe -Lo VulkanSDK.exe

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -21,7 +21,9 @@ if ($clone) {
     git clone --recurse-submodules $RepoURL
     Set-Location .\taichi
 }
-New-Item -ItemType Directory -Force -Path $build
+if (-not (Test-Path $build)) {
+    New-Item -ItemType Directory -Path $build
+}
 Push-Location $build
 WriteInfo("Download and extract LLVM")
 if (-not (Test-Path "taichi_llvm")) {

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -1,0 +1,66 @@
+# Build script for windows
+
+param (
+    [switch]$clone = $false,
+    [switch]$vulkan = $false,
+    [switch]$develop = $false,
+    [string]$build = "_build"
+)
+
+$RepoURL = 'https://github.com/taichi-dev/taichi'
+
+function WriteInfo($text) {
+    Write-Host -ForegroundColor Green "[BUILD] $text"
+}
+
+WriteInfo("Install 7Zip")
+Install-Module 7Zip4PowerShell -Force -Verbose -Scope CurrentUser
+
+if ($clone) {
+    WriteInfo("Clone the repository")
+    git clone --recurse-submodules $RepoURL
+    Set-Location .\taichi
+}
+New-Item -ItemType Directory -Force -Path $build
+Push-Location $build
+WriteInfo("Download and extract LLVM")
+if (-not (Test-Path "taichi_llvm")) {
+    curl.exe --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip -LO
+    7z x taichi-llvm-10.0.0-msvc2019.zip -otaichi_llvm
+}
+WriteInfo("Download and extract Clang")
+if (-not (Test-Path "taichi_clang")) {
+    curl.exe --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/clang-10.0.0-win.zip -LO
+    7z x clang-10.0.0-win.zip -otaichi_clang
+}
+$env:PATH = "$build\taichi_llvm\bin;$build\taichi_clang\bin;$env:PATH"
+$env:TAICHI_CMAKE_ARGS = "-G 'Visual Studio 16 2019' -A x64 -DLLVM_DIR=$build\taichi_llvm\lib\cmake\llvm"
+if ($vulkan) {
+    WriteInfo("Download and install Vulkan")
+    if (-not (Test-Path "VulkanSDK.exe")) {
+        curl.exe --retry 10 --retry-delay 5 https://sdk.lunarg.com/sdk/download/1.2.189.0/windows/VulkanSDK-1.2.189.0-Installer.exe -Lo VulkanSDK.exe
+    }
+    $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
+    $installer.WaitForExit();
+    $env:VULKAN_SDK = "$build\VulkanSDK\1.2.189.0"
+    $env:PATH += ";$env:VULKAN_SDK\Bin"
+    $env:TAICHI_CMAKE_ARGS += "_DTI_WITH_VULKAN:BOOL=ON"
+}
+
+Pop-Location
+clang --version
+
+WriteInfo("Setting up Python environment")
+python -m venv venv
+. venv\Scripts\activate.ps1
+python -m pip install -r requirements_dev.txt
+python -m pip install -r requirements_test.txt
+WriteInfo("Building Taichi")
+$env:CXX = "$build\taichi_clang\bin\clang++.exe"
+if ($develop) {
+    python -m pip install -e .
+}
+else {
+    python -m pip install .
+}
+WriteInfo("Build finished")

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -66,9 +66,9 @@ WriteInfo("Building Taichi")
 $env:CXX = "$libsDir\taichi_clang\bin\clang++.exe"
 if ($install) {
     if ($develop) {
-        python -m pip install -e .
+        python -m pip install -v -e .
     } else {
-        python -m pip install .
+        python -m pip install -v .
     }
     WriteInfo("Build and install finished")
 } else {

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -4,6 +4,7 @@ param (
     [switch]$clone = $false,
     [switch]$vulkan = $false,
     [switch]$develop = $false,
+    [switch]$install = $false,
     [string]$build = "_build"
 )
 
@@ -60,10 +61,14 @@ python -m pip install -r requirements_dev.txt
 python -m pip install -r requirements_test.txt
 WriteInfo("Building Taichi")
 $env:CXX = "$build\taichi_clang\bin\clang++.exe"
-if ($develop) {
-    python -m pip install -e .
+if ($install) {
+    if ($develop) {
+        python -m pip install -e .
+    } else {
+        python -m pip install .
+    }
+    WriteInfo("Build and install finished")
+} else {
+    python setup.py bdist_wheel
+    WriteInfo("Build finished")
 }
-else {
-    python -m pip install .
-}
-WriteInfo("Build finished")

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -46,7 +46,7 @@ if ($vulkan) {
     $installer.WaitForExit();
     $env:VULKAN_SDK = "$build\VulkanSDK\1.2.189.0"
     $env:PATH += ";$env:VULKAN_SDK\Bin"
-    $env:TAICHI_CMAKE_ARGS += "_DTI_WITH_VULKAN:BOOL=ON"
+    $env:TAICHI_CMAKE_ARGS += " -DTI_WITH_VULKAN:BOOL=ON"
 }
 
 Pop-Location

--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -5,7 +5,7 @@ param (
     [switch]$installVulkan = $false,
     [switch]$develop = $false,
     [switch]$install = $false,
-    [string]$build = "_build"
+    [string]$libdir = "_build"
 )
 
 $RepoURL = 'https://github.com/taichi-dev/taichi'
@@ -22,10 +22,10 @@ if ($clone) {
     git clone --recurse-submodules $RepoURL
     Set-Location .\taichi
 }
-if (-not (Test-Path $build)) {
-    New-Item -ItemType Directory -Path $build
+if (-not (Test-Path $libdir)) {
+    New-Item -ItemType Directory -Path $libdir
 }
-Push-Location $build
+Push-Location $libdir
 WriteInfo("Download and extract LLVM")
 if (-not (Test-Path "taichi_llvm")) {
     curl.exe --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/taichi-llvm-10.0.0-msvc2019.zip -LO
@@ -36,8 +36,8 @@ if (-not (Test-Path "taichi_clang")) {
     curl.exe --retry 10 --retry-delay 5 https://github.com/taichi-dev/taichi_assets/releases/download/llvm10/clang-10.0.0-win.zip -LO
     7z x clang-10.0.0-win.zip -otaichi_clang
 }
-$env:PATH = "$build\taichi_llvm\bin;$build\taichi_clang\bin;$env:PATH"
-$env:TAICHI_CMAKE_ARGS = "-G 'Visual Studio 16 2019' -A x64 -DLLVM_DIR=$build\taichi_llvm\lib\cmake\llvm"
+$env:PATH = "$libdir\taichi_llvm\bin;$libdir\taichi_clang\bin;$env:PATH"
+$env:TAICHI_CMAKE_ARGS = "-G 'Visual Studio 16 2019' -A x64 -DLLVM_DIR=$libdir\taichi_llvm\lib\cmake\llvm"
 if ($installVulkan) {
     WriteInfo("Download and install Vulkan")
     if (-not (Test-Path "VulkanSDK.exe")) {
@@ -45,7 +45,7 @@ if ($installVulkan) {
     }
     $installer = Start-Process -FilePath VulkanSDK.exe -Wait -PassThru -ArgumentList @("/S");
     $installer.WaitForExit();
-    $env:VULKAN_SDK = "$build\VulkanSDK\1.2.189.0"
+    $env:VULKAN_SDK = "$libdir\VulkanSDK\1.2.189.0"
     $env:PATH += ";$env:VULKAN_SDK\Bin"
     $env:TAICHI_CMAKE_ARGS += " -DTI_WITH_VULKAN:BOOL=ON"
 }
@@ -60,7 +60,7 @@ python -m pip install wheel
 python -m pip install -r requirements_dev.txt
 python -m pip install -r requirements_test.txt
 WriteInfo("Building Taichi")
-$env:CXX = "$build\taichi_clang\bin\clang++.exe"
+$env:CXX = "$libdir\taichi_clang\bin\clang++.exe"
 if ($install) {
     if ($develop) {
         python -m pip install -e .

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -51,10 +51,14 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
         sys.stdout.write(str(sys.version_info[1]))"
         OUTPUT_VARIABLE PYTHON_MINOR_VERSION)
 
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+        "import sys;sys.stdout.write(sys.base_prefix.replace('\\\\', '/'))"
+        OUTPUT_VARIABLE PYTHON_BASE_PREFIX)
+
 if (WIN32)
-  link_directories(${PYTHON_LIBRARY_DIR}/../../libs)
-  set(PYTHON_LIBRARIES ${PYTHON_LIBRARY_DIR}/../../libs/python3.lib)
-  set(PYTHON_LIBRARIES ${PYTHON_LIBRARY_DIR}/../../libs/python3${PYTHON_MINOR_VERSION}.lib)
+  link_directories(${PYTHON_BASE_PREFIX}/libs)
+  set(PYTHON_LIBRARIES ${PYTHON_BASE_PREFIX}/libs/python3.lib)
+  set(PYTHON_LIBRARIES ${PYTHON_BASE_PREFIX}/libs/python3${PYTHON_MINOR_VERSION}.lib)
 else()
   find_library(PYTHON_LIBRARY NAMES python${PYTHON_VERSION} python${PYTHON_VERSION}m PATHS ${PYTHON_LIBRARY_DIR}
           NO_DEFAULT_PATH NO_SYSTEM_ENVIRONMENT_PATH PATH_SUFFIXES x86_64-linux-gnu)

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -51,11 +51,11 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
         sys.stdout.write(str(sys.version_info[1]))"
         OUTPUT_VARIABLE PYTHON_MINOR_VERSION)
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-        "import sys;sys.stdout.write(sys.base_prefix.replace('\\\\', '/'))"
-        OUTPUT_VARIABLE PYTHON_BASE_PREFIX)
 
 if (WIN32)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+          "import sys;sys.stdout.write(sys.base_prefix.replace('\\\\', '/'))"
+          OUTPUT_VARIABLE PYTHON_BASE_PREFIX)
   link_directories(${PYTHON_BASE_PREFIX}/libs)
   set(PYTHON_LIBRARIES ${PYTHON_BASE_PREFIX}/libs/python3.lib)
   set(PYTHON_LIBRARIES ${PYTHON_BASE_PREFIX}/libs/python3${PYTHON_MINOR_VERSION}.lib)


### PR DESCRIPTION
Related issue = #3391 #2715 

1. Fix the cmake file to support in-venv build
2. Add a build script for windows as requested in #3391 that:
   a. Usage: `win_build.ps1 [[-libdir] <string>] [-clone] [-installVulkan] [-develop] [-install]`
   b. Support rerun, won't download again if already exists
   c. build and install python library in a virtual environment to avoid contaminating the system site-packages
   d. support install in develop mode(with `-develop` flag), like `python setup.py develop`
   e. CMake args and environments are populated automatically, users don't bother to set them.
3. Replace the building steps in postsubmit and presubmit CI jobs with the script.

I've tested on Windows 10, CPU build, both build and install are successful. If you have a Windows PC, please help to test the script.

## Other thoughts

Now setting up a taichi development environment on Windows is as easy as downloading a script from the internet and run it. We may also do the same for linux and mac. And development installation doc can be updated accordingly.
