### PR TITLE
[build] Please help in correcting CMake...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ if (NOT CLANG_EXECUTABLE)
 endif()
 
 find_program(LLVM_AS_EXECUTABLE NAMES llvm-as)
-if (NOT LLVM_AS_EXECUTABLE)
+if (NOT TARGET llvm-as)
     message(FATAL_ERROR "Cannot find llvm-as executable.")
 endif()
 

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -200,6 +200,10 @@ if(DEFINED ENV{LLVM_DIR})
     message("Getting LLVM_DIR=${LLVM_DIR} from the environment variable")
 endif()
 
+if(WIN)
+list(APPEND CMAKE_PREFIX_PATH "C:/Program Files(x86)/LLVM")
+endif()
+
 # http://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")


### PR DESCRIPTION
Is LLVM_AS_EXECUTABLE redudant?

Related issue = #3413 

I have got no idea. But it is an absolute pain in the ass to install llvm and use it with this build.
I also encountered that the variable LLVM_AS_EXECUTABLE is actually false, while LLVM_AS was installed (seemingly)
I think "NOT TARGET LLVM_AS" would be better.
Can CMAKE search in "ProgramFiles (x86)" for LLVM?