### PR TITLE
[opengl] Save opengl aot data in json format.

### DIFF
--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -17,16 +17,43 @@ AotModuleBuilderImpl::AotModuleBuilderImpl(
   aot_data_.root_buffer_size = compiled_structs_.root_size;
 }
 
+namespace {
+void write_glsl_file(const std::string &output_dir,
+                     const std::string &filename,
+                     CompiledKernel &k) {
+  const std::string glsl_path =
+      fmt::format("{}/{}_{}.glsl", output_dir, filename, k.kernel_name);
+  std::ofstream fs{glsl_path};
+  fs << k.kernel_src;
+  k.kernel_src = glsl_path;
+  fs.close();
+}
+}  // namespace
+
 void AotModuleBuilderImpl::dump(const std::string &output_dir,
                                 const std::string &filename) const {
   const std::string bin_path =
       fmt::format("{}/{}_metadata.tcb", output_dir, filename);
   write_to_binary_file(aot_data_, bin_path);
-  // The txt file is mostly for debugging purpose.
+  // Json format doesn't support multiple line strings.
+  AotData new_aot_data = aot_data_;
+  for (auto &k : new_aot_data.kernels) {
+    for (auto &ki : k.program.kernels) {
+      write_glsl_file(output_dir, filename, ki);
+    }
+  }
+  for (auto &k : new_aot_data.kernel_tmpls) {
+    for (auto &ki : k.program) {
+      for (auto &kij : ki.second.kernels) {
+        write_glsl_file(output_dir, filename, kij);
+      }
+    }
+  }
+
   const std::string txt_path =
-      fmt::format("{}/{}_metadata.txt", output_dir, filename);
+      fmt::format("{}/{}_metadata.json", output_dir, filename);
   TextSerializer ts;
-  ts("taichi aot data", aot_data_);
+  ts.serialize_to_json("aot_data", new_aot_data);
   ts.write_to_file(txt_path);
 }
 

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 
@@ -49,4 +50,8 @@ def test_save():
         with m.add_kernel_template(foo) as kt:
             kt.instantiate(n=6)
             kt.instantiate(n=8)
-        m.save(tmpdir, 'taichi_aot_example.tcb')
+        filename = 'taichi_aot_example'
+        m.save(tmpdir, filename)
+        with open(os.path.join(tmpdir,
+                               f'{filename}_metadata.json')) as json_file:
+            json.load(json_file)


### PR DESCRIPTION
This PR does two things:
1. It converts `TextSerializer` to output json format instead of a customized format. I tried to not introduce any extra dependency like jsoncpp but just make our output json compliant. (two regex tricks are used :P) 
2. Since Json doesn't support multiple line string, it saves each glsl kernel source code in a `.glsl` file and only saves the filename in json. 

Example generated aot json file: https://gist.github.com/ailzhang/48b6126cabae2e9f2d35da02b210a719 

Currently I only changed opengl backend to json, will change metal later together with enabling its tests. 