### PR TITLE
[llvm] Support atomic operations of f16

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -447,7 +447,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       return nullptr;
     }
     AtomicOpType op = stmt->op_type;
-    if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f16) && op == AtomicOpType::add) {
+    if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f16)) {
       switch (op) {
         case AtomicOpType::add:
           return cas(llvm_val[stmt->dest], llvm_val[stmt->val], [&](auto v1, auto v2) { return builder->CreateFAdd(v1, v2); });

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -331,114 +331,139 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
         llvm::AtomicOrdering::SequentiallyConsistent);
   }
 
-  llvm::Value* cas(llvm::Value* output_address, llvm::Value* val, std::function<llvm::Value*(llvm::Value*, llvm::Value*)> op) {
-    llvm::PointerType* output_address_type =
-    llvm::dyn_cast<llvm::PointerType>(output_address->getType());
+  llvm::Value *cas(
+      llvm::Value *output_address,
+      llvm::Value *val,
+      std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op) {
+    llvm::PointerType *output_address_type =
+        llvm::dyn_cast<llvm::PointerType>(output_address->getType());
     TI_ASSERT(output_address_type != nullptr);
 
     // element_type is the data type for the binary operation.
-    llvm::Type* element_type = output_address_type->getPointerElementType();
+    llvm::Type *element_type = output_address_type->getPointerElementType();
     int element_size = 16;
-    llvm::Type* element_address_type = element_type->getPointerTo();
+    llvm::Type *element_address_type = element_type->getPointerTo();
 
     int atomic_size = 32;
-    llvm::Type* atomic_type = builder->getIntNTy(atomic_size);
-    llvm::Type* atomic_address_type =
-        atomic_type->getPointerTo(output_address_type->getPointerAddressSpace());
+    llvm::Type *atomic_type = builder->getIntNTy(atomic_size);
+    llvm::Type *atomic_address_type = atomic_type->getPointerTo(
+        output_address_type->getPointerAddressSpace());
 
     // cas_old_output_address and cas_new_output_address point to the scratch
     // memory where we store the old and new values for the repeated atomicCAS
     // operations.
-    llvm::Value* cas_old_output_address = builder->CreateAlloca(atomic_type, nullptr);
-    llvm::Value* cas_new_output_address = builder->CreateAlloca(atomic_type, nullptr);
+    llvm::Value *cas_old_output_address =
+        builder->CreateAlloca(atomic_type, nullptr);
+    llvm::Value *cas_new_output_address =
+        builder->CreateAlloca(atomic_type, nullptr);
 
-
-    llvm::Value* atomic_memory_address;
+    llvm::Value *atomic_memory_address;
     // binop_output_address points to the scratch memory that stores the
     // result of the binary operation.
-    llvm::Value* binop_output_address;
+    llvm::Value *binop_output_address;
     if (element_size < 32) {
-        // Assume the element size is an integer number of bytes.
-        llvm::Type* address_int_type =
-            module->getDataLayout().getIntPtrType(output_address_type);
-        atomic_memory_address = builder->CreatePtrToInt(output_address, address_int_type);
-        llvm::Value* mask = llvm::ConstantInt::get(address_int_type, 3);
-        llvm::Value* offset = builder->CreateAnd(atomic_memory_address, mask);
-        mask = llvm::ConstantInt::get(address_int_type, -4);
-        atomic_memory_address = builder->CreateAnd(atomic_memory_address, mask);
-        atomic_memory_address =
-            builder->CreateIntToPtr(atomic_memory_address, atomic_address_type);
-        binop_output_address =
-            builder->CreateAdd(builder->CreatePtrToInt(cas_new_output_address, address_int_type), offset);
-        binop_output_address = builder->CreateIntToPtr(binop_output_address, element_address_type);
-      } else {
-        atomic_memory_address = builder->CreateBitCast(output_address, atomic_address_type);
-        binop_output_address =
-            builder->CreateBitCast(cas_new_output_address, element_address_type);
-      }
+      // Assume the element size is an integer number of bytes.
+      llvm::Type *address_int_type =
+          module->getDataLayout().getIntPtrType(output_address_type);
+      atomic_memory_address =
+          builder->CreatePtrToInt(output_address, address_int_type);
+      llvm::Value *mask = llvm::ConstantInt::get(address_int_type, 3);
+      llvm::Value *offset = builder->CreateAnd(atomic_memory_address, mask);
+      mask = llvm::ConstantInt::get(address_int_type, -4);
+      atomic_memory_address = builder->CreateAnd(atomic_memory_address, mask);
+      atomic_memory_address =
+          builder->CreateIntToPtr(atomic_memory_address, atomic_address_type);
+      binop_output_address = builder->CreateAdd(
+          builder->CreatePtrToInt(cas_new_output_address, address_int_type),
+          offset);
+      binop_output_address =
+          builder->CreateIntToPtr(binop_output_address, element_address_type);
+    } else {
+      atomic_memory_address =
+          builder->CreateBitCast(output_address, atomic_address_type);
+      binop_output_address =
+          builder->CreateBitCast(cas_new_output_address, element_address_type);
+    }
 
-      // Use the value from the memory that atomicCAS operates on to initialize
-      // cas_old_output.
-      llvm::Value* cas_old_output = builder->CreateLoad(atomic_memory_address, "cas_old_output");
-      builder->CreateStore(cas_old_output, cas_old_output_address);
+    // Use the value from the memory that atomicCAS operates on to initialize
+    // cas_old_output.
+    llvm::Value *cas_old_output =
+        builder->CreateLoad(atomic_memory_address, "cas_old_output");
+    builder->CreateStore(cas_old_output, cas_old_output_address);
 
-      llvm::BasicBlock* loop_body_bb = BasicBlock::Create(*llvm_context, "atomic_op_loop_body", func);
-      llvm::BasicBlock* loop_exit_bb = BasicBlock::Create(*llvm_context, "loop_exit_bb", func);
-      builder->CreateBr(loop_body_bb);
-      builder->SetInsertPoint(loop_body_bb);
+    llvm::BasicBlock *loop_body_bb =
+        BasicBlock::Create(*llvm_context, "atomic_op_loop_body", func);
+    llvm::BasicBlock *loop_exit_bb =
+        BasicBlock::Create(*llvm_context, "loop_exit_bb", func);
+    builder->CreateBr(loop_body_bb);
+    builder->SetInsertPoint(loop_body_bb);
 
-      // Emit the body of the loop that repeatedly invokes atomicCAS.
-      //
-      // Use cas_old_output to initialize cas_new_output.
-      cas_old_output = builder->CreateLoad(cas_old_output_address, "cas_old_output");
-      builder->CreateStore(cas_old_output, cas_new_output_address);
-      // Emits code to calculate new_output = operation(old_output, source);
+    // Emit the body of the loop that repeatedly invokes atomicCAS.
+    //
+    // Use cas_old_output to initialize cas_new_output.
+    cas_old_output =
+        builder->CreateLoad(cas_old_output_address, "cas_old_output");
+    builder->CreateStore(cas_old_output, cas_new_output_address);
+    // Emits code to calculate new_output = operation(old_output, source);
 
-      auto binop_output = op(builder->CreateLoad(binop_output_address), val);
-      builder->CreateStore(binop_output, binop_output_address);
+    auto binop_output = op(builder->CreateLoad(binop_output_address), val);
+    builder->CreateStore(binop_output, binop_output_address);
 
-      llvm::Value* cas_new_output = builder->CreateLoad(cas_new_output_address, "cas_new_output");
+    llvm::Value *cas_new_output =
+        builder->CreateLoad(cas_new_output_address, "cas_new_output");
 
-      // Emit code to perform the atomicCAS operation
-      // (cas_old_output, success) = atomicCAS(memory_address, cas_old_output,
-      //                                       cas_new_output);
-      llvm::Value* ret_value =
-          builder->CreateAtomicCmpXchg(atomic_memory_address, cas_old_output, cas_new_output,
-                        llvm::AtomicOrdering::SequentiallyConsistent,
-                        llvm::AtomicOrdering::SequentiallyConsistent);
+    // Emit code to perform the atomicCAS operation
+    // (cas_old_output, success) = atomicCAS(memory_address, cas_old_output,
+    //                                       cas_new_output);
+    llvm::Value *ret_value = builder->CreateAtomicCmpXchg(
+        atomic_memory_address, cas_old_output, cas_new_output,
+        llvm::AtomicOrdering::SequentiallyConsistent,
+        llvm::AtomicOrdering::SequentiallyConsistent);
 
-      // Extract the memory value returned from atomicCAS and store it as
-      // cas_old_output.
-      builder->CreateStore(builder->CreateExtractValue(ret_value, 0, "cas_old_output"), cas_old_output_address);
-      // Extract the success bit returned from atomicCAS and generate a
-      // conditional branch on the success bit.
-      builder->CreateCondBr(builder->CreateExtractValue(ret_value, 1, "success"), loop_exit_bb, loop_body_bb);
+    // Extract the memory value returned from atomicCAS and store it as
+    // cas_old_output.
+    builder->CreateStore(
+        builder->CreateExtractValue(ret_value, 0, "cas_old_output"),
+        cas_old_output_address);
+    // Extract the success bit returned from atomicCAS and generate a
+    // conditional branch on the success bit.
+    builder->CreateCondBr(builder->CreateExtractValue(ret_value, 1, "success"),
+                          loop_exit_bb, loop_body_bb);
 
-      builder->SetInsertPoint(loop_exit_bb);
+    builder->SetInsertPoint(loop_exit_bb);
 
-      return output_address;
+    return output_address;
 
-    // BasicBlock *body = BasicBlock::Create(*llvm_context, "while_loop_body", func);
-    // BasicBlock *after_loop =BasicBlock::Create(*llvm_context, "after_while", func);
-    // 
+    // BasicBlock *body = BasicBlock::Create(*llvm_context, "while_loop_body",
+    // func); BasicBlock *after_loop =BasicBlock::Create(*llvm_context,
+    // "after_while", func);
+    //
     // builder->CreateBr(body);
     // builder->SetInsertPoint(body);
-    // 
+    //
     // {
     //   auto old_val = builder->CreateLoad(dest);
-    //   auto int_new_val = builder->CreateBitCast(op(old_val, val), llvm::Type::getInt32Ty(*llvm_context));
-    //   auto int_old_val = builder->CreateBitCast(old_val, llvm::Type::getInt32Ty(*llvm_context));
-    //   dest = builder->CreateBitCast(dest, llvm::Type::getInt32PtrTy(*llvm_context));
-    //   auto tmp = builder->CreateIntrinsic(Intrinsic::nvvm_atomic_cas_gen_i_sys, {int_new_val->getType(), dest->getType()}, {dest, int_new_val, int_old_val});
-    //   builder->CreatePtrToInt();
-    //   // auto atomicCmpXchg = builder->CreateAtomicCmpXchg(dest, builder->CreateBitCast(old_val, llvm::Type::getInt16Ty(*llvm_context)), builder->CreateBitCast(new_val, llvm::Type::getInt16Ty(*llvm_context)), AtomicOrdering::SequentiallyConsistent, AtomicOrdering::SequentiallyConsistent);
+    //   auto int_new_val = builder->CreateBitCast(op(old_val, val),
+    //   llvm::Type::getInt32Ty(*llvm_context)); auto int_old_val =
+    //   builder->CreateBitCast(old_val, llvm::Type::getInt32Ty(*llvm_context));
+    //   dest = builder->CreateBitCast(dest,
+    //   llvm::Type::getInt32PtrTy(*llvm_context)); auto tmp =
+    //   builder->CreateIntrinsic(Intrinsic::nvvm_atomic_cas_gen_i_sys,
+    //   {int_new_val->getType(), dest->getType()}, {dest, int_new_val,
+    //   int_old_val}); builder->CreatePtrToInt();
+    //   // auto atomicCmpXchg = builder->CreateAtomicCmpXchg(dest,
+    //   builder->CreateBitCast(old_val, llvm::Type::getInt16Ty(*llvm_context)),
+    //   builder->CreateBitCast(new_val, llvm::Type::getInt16Ty(*llvm_context)),
+    //   AtomicOrdering::SequentiallyConsistent,
+    //   AtomicOrdering::SequentiallyConsistent);
     //   // Check whether CAS was succussfukkkl
     //   // auto ok = builder->CreateExtractValue(atomicCmpXchg, 1);
-    //   builder->CreateCondBr(builder->CreateICmpNE(tmp, int_new_val), body, after_loop);
+    //   builder->CreateCondBr(builder->CreateICmpNE(tmp, int_new_val), body,
+    //   after_loop);
     // }
-    // 
+    //
     // builder->SetInsertPoint(after_loop);
-    // 
+    //
     // return dest;
   }
 
@@ -450,11 +475,17 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f16)) {
       switch (op) {
         case AtomicOpType::add:
-          return cas(llvm_val[stmt->dest], llvm_val[stmt->val], [&](auto v1, auto v2) { return builder->CreateFAdd(v1, v2); });
+          return cas(
+              llvm_val[stmt->dest], llvm_val[stmt->val],
+              [&](auto v1, auto v2) { return builder->CreateFAdd(v1, v2); });
         case AtomicOpType::max:
-          return cas(llvm_val[stmt->dest], llvm_val[stmt->val], [&](auto v1, auto v2) { return builder->CreateMaxNum(v1, v2); });
+          return cas(
+              llvm_val[stmt->dest], llvm_val[stmt->val],
+              [&](auto v1, auto v2) { return builder->CreateMaxNum(v1, v2); });
         case AtomicOpType::min:
-          return cas(llvm_val[stmt->dest], llvm_val[stmt->val], [&](auto v1, auto v2) { return builder->CreateMinNum(v1, v2); });
+          return cas(
+              llvm_val[stmt->dest], llvm_val[stmt->val],
+              [&](auto v1, auto v2) { return builder->CreateMinNum(v1, v2); });
         default:
           break;
       }

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -451,8 +451,9 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           cas_old_output_address);
       // Extract the success bit returned from atomicCAS and generate a
       // conditional branch on the success bit.
-      builder->CreateCondBr(builder->CreateExtractValue(ret_value, 1, "success"),
-                            loop_exit_bb, loop_body_bb);
+      builder->CreateCondBr(
+          builder->CreateExtractValue(ret_value, 1, "success"), loop_exit_bb,
+          loop_body_bb);
     }
 
     builder->SetInsertPoint(loop_exit_bb);

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -332,12 +332,14 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
   }
 
   // A huge hack for supporting f16 atomic add/max/min!
-  // The reason is that LLVM10 does not support generating atomicCAS for f16 on NVPTX backend.
+  // The reason is that LLVM10 does not support generating atomicCAS for f16 on
+  // NVPTX backend.
   //
-  // int32 is used for the atomicCAS operation. So atomicCAS reads and writes 32 bit values from
-  // the memory, which is larger than the memory size required by the original
-  // atomic binary operation. We mask off the last two bits of the output_address
-  // and use the result as an address to read the 32 bit values from the memory.
+  // int32 is used for the atomicCAS operation. So atomicCAS reads and writes 32
+  // bit values from the memory, which is larger than the memory size required
+  // by the original atomic binary operation. We mask off the last two bits of
+  // the output_address and use the result as an address to read the 32 bit
+  // values from the memory.
   //
   // This can avoid out of bound memory accesses, based on the assumption:
   // All buffers are 4 byte aligned and have a size of 4N.
@@ -358,8 +360,9 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
   //       *cas_new_output_address);
   //   } while (!success);
   //
-  // TODO(sjwsl): Try to rewrite this after upgrading LLVM or supporting raw NVPTX
-  
+  // TODO(sjwsl): Try to rewrite this after upgrading LLVM or supporting raw
+  // NVPTX
+
   llvm::Value *cas(
       llvm::Value *output_address,
       llvm::Value *val,

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -344,12 +344,12 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
   //     operation and stores the result in new_output.
   //   3. Calls atomicCAS which implements compare-and-swap as an atomic
   //     operation. In particular, atomicCAS reads the value from the memory
-  //     pointed to by output_address, and compares the value with old_output. If
-  //     the two values equal, new_output is written to the same memory location
-  //     and true is returned to indicate that the atomic operation succeeds.
-  //     Otherwise, the new value read from the memory is returned. In this case,
-  //     the new value is copied to old_output, and steps 2. and 3. are repeated
-  //     until atomicCAS succeeds.
+  //     pointed to by output_address, and compares the value with old_output.
+  //     If the two values equal, new_output is written to the same memory
+  //     location and true is returned to indicate that the atomic operation
+  //     succeeds. Otherwise, the new value read from the memory is returned. In
+  //     this case, the new value is copied to old_output, and steps 2. and 3.
+  //     are repeated until atomicCAS succeeds.
   //
   // int32 is used for the atomicCAS operation. So atomicCAS reads and writes 32
   // bit values from the memory, which is larger than the memory size required

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1174,7 +1174,7 @@ void CodeGenLLVM::visit(SNodeOpStmt *stmt) {
   }
 }
 
-void CodeGenLLVM::cas(
+void CodeGenLLVM::atomic_op_using_cas(
     llvm::Value *dest,
     llvm::Value *val,
     std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op) {
@@ -1216,15 +1216,15 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
       // Use CAS for f16 atomic add/max/min
       switch (stmt->op_type) {
         case AtomicOpType::add:
-          cas(llvm_val[stmt->dest], llvm_val[stmt->val],
+          atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateFAdd(v1, v2); });
           return;
         case AtomicOpType::max:
-          cas(llvm_val[stmt->dest], llvm_val[stmt->val],
+          atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateMaxNum(v1, v2); });
           return;
         case AtomicOpType::min:
-          cas(llvm_val[stmt->dest], llvm_val[stmt->val],
+          atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateMinNum(v1, v2); });
           return;
         default:

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1174,7 +1174,7 @@ void CodeGenLLVM::visit(SNodeOpStmt *stmt) {
   }
 }
 
-llvm::Value* CodeGenLLVM::atomic_op_using_cas(
+llvm::Value *CodeGenLLVM::atomic_op_using_cas(
     llvm::Value *dest,
     llvm::Value *val,
     std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op) {
@@ -1186,7 +1186,7 @@ llvm::Value* CodeGenLLVM::atomic_op_using_cas(
   builder->CreateBr(body);
   builder->SetInsertPoint(body);
 
-  llvm::Value* old_val;
+  llvm::Value *old_val;
 
   {
     old_val = builder->CreateLoad(dest);
@@ -1241,7 +1241,9 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
             llvm::AtomicRMWInst::BinOp::Min, llvm_val[stmt->dest],
             llvm_val[stmt->val], llvm::AtomicOrdering::SequentiallyConsistent);
       } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f16)) {
-        old_value = atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val], [&](auto v1, auto v2){ return builder->CreateMinNum(v1, v2); });
+        old_value = atomic_op_using_cas(
+            llvm_val[stmt->dest], llvm_val[stmt->val],
+            [&](auto v1, auto v2) { return builder->CreateMinNum(v1, v2); });
       } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
         old_value = create_call("atomic_min_f32",
                                 {llvm_val[stmt->dest], llvm_val[stmt->val]});
@@ -1257,7 +1259,9 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
             llvm::AtomicRMWInst::BinOp::Max, llvm_val[stmt->dest],
             llvm_val[stmt->val], llvm::AtomicOrdering::SequentiallyConsistent);
       } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f16)) {
-        old_value = atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val], [&](auto v1, auto v2){ return builder->CreateMaxNum(v1, v2); });
+        old_value = atomic_op_using_cas(
+            llvm_val[stmt->dest], llvm_val[stmt->val],
+            [&](auto v1, auto v2) { return builder->CreateMaxNum(v1, v2); });
       } else if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f32)) {
         old_value = create_call("atomic_max_f32",
                                 {llvm_val[stmt->dest], llvm_val[stmt->val]});

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1213,6 +1213,7 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
   for (int l = 0; l < stmt->width(); l++) {
     llvm::Value *old_value;
     if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f16)) {
+      // Use CAS for f16 atomic add/max/min
       switch (stmt->op_type) {
         case AtomicOpType::add:
           cas(llvm_val[stmt->dest], llvm_val[stmt->val],

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1216,15 +1216,18 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
       // Use CAS for f16 atomic add/max/min
       switch (stmt->op_type) {
         case AtomicOpType::add:
-          atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val],
+          atomic_op_using_cas(
+              llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateFAdd(v1, v2); });
           return;
         case AtomicOpType::max:
-          atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val],
+          atomic_op_using_cas(
+              llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateMaxNum(v1, v2); });
           return;
         case AtomicOpType::min:
-          atomic_op_using_cas(llvm_val[stmt->dest], llvm_val[stmt->val],
+          atomic_op_using_cas(
+              llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateMinNum(v1, v2); });
           return;
         default:

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1217,12 +1217,15 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
         case AtomicOpType::add:
           cas(llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateFAdd(v1, v2); });
+          return;
         case AtomicOpType::max:
           cas(llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateMaxNum(v1, v2); });
+          return;
         case AtomicOpType::min:
           cas(llvm_val[stmt->dest], llvm_val[stmt->val],
               [&](auto v1, auto v2) { return builder->CreateMinNum(v1, v2); });
+          return;
         default:
           break;
       }

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -362,6 +362,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 
+  llvm::Value *cas(llvm::Value* dest, llvm::Value* val, std::function<llvm::Value*(llvm::Value*, llvm::Value*)> op);
+
   ~CodeGenLLVM() = default;
 };
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -362,7 +362,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 
-  void atomic_op_using_cas(
+  llvm::Value *atomic_op_using_cas(
       llvm::Value *dest,
       llvm::Value *val,
       std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -362,9 +362,10 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 
-  void atomic_op_using_cas(llvm::Value *dest,
-           llvm::Value *val,
-           std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);
+  void atomic_op_using_cas(
+      llvm::Value *dest,
+      llvm::Value *val,
+      std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);
 
   ~CodeGenLLVM() = default;
 };

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -362,10 +362,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 
-  llvm::Value *cas(
-      llvm::Value *dest,
-      llvm::Value *val,
-      std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);
+  void cas(llvm::Value* dest, llvm::Value* val, std::function<llvm::Value*(llvm::Value*, llvm::Value*)> op);
 
   ~CodeGenLLVM() = default;
 };

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -362,7 +362,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 
-  void cas(llvm::Value* dest, llvm::Value* val, std::function<llvm::Value*(llvm::Value*, llvm::Value*)> op);
+  void cas(llvm::Value *dest,
+           llvm::Value *val,
+           std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);
 
   ~CodeGenLLVM() = default;
 };

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -362,7 +362,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 
-  void cas(llvm::Value *dest,
+  void atomic_op_using_cas(llvm::Value *dest,
            llvm::Value *val,
            std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -362,7 +362,10 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 
-  llvm::Value *cas(llvm::Value* dest, llvm::Value* val, std::function<llvm::Value*(llvm::Value*, llvm::Value*)> op);
+  llvm::Value *cas(
+      llvm::Value *dest,
+      llvm::Value *val,
+      std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);
 
   ~CodeGenLLVM() = default;
 };

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -218,3 +218,51 @@ def test_fractal_f16():
             pixels[i, j] = 1 - iterations * 0.02
 
     paint(0.03)
+
+@ti.test(arch=archs_support_f16)
+def test_atomic_add_f16():
+    f = ti.field(dtype=ti.f16, shape=(2))
+
+    @ti.kernel
+    def foo():
+        for i in range(1000):
+            f[0] += 1.12
+
+        if True:
+            for i in range(1000):
+                f[1] += 1.12
+
+    foo()
+    assert(f[0] == f[1])
+
+@ti.test(arch=archs_support_f16)
+def test_atomic_max_f16():
+    f = ti.field(dtype=ti.f16, shape=(2))
+
+    @ti.kernel
+    def foo():
+        for i in range(1000):
+            f[0] = ti.atomic_max(1.12 * i, f[0])
+
+        if True:
+            for i in range(1000):
+                f[1] = ti.max(1.12 * i, f[1])
+
+    foo()
+    assert(f[0] == f[1])
+
+@ti.test(arch=archs_support_f16)
+def test_atomic_min_f16():
+    f = ti.field(dtype=ti.f16, shape=(2))
+
+    @ti.kernel
+    def foo():
+        for i in range(1000):
+            f[0] = ti.atomic_max(-3.13 * i, f[0])
+
+        if True:
+            for i in range(1000):
+                f[1] = ti.max(-3.13 * i, f[1])
+
+    foo()
+    assert(f[0] == f[1])

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -226,12 +226,14 @@ def test_atomic_add_f16():
 
     @ti.kernel
     def foo():
+        # Parallel sum
         for i in range(1000):
             f[0] += 1.12
 
-        if True:
-            for i in range(1000):
-                f[1] += 1.12
+        # Serial sum
+        for _ in range(1):
+                for i in range(1000):
+                    f[1] = f[1] + 1.12
 
     foo()
     assert (f[0] == f[1])
@@ -243,10 +245,12 @@ def test_atomic_max_f16():
 
     @ti.kernel
     def foo():
+        # Parallel max
         for i in range(1000):
-            f[0] = ti.atomic_max(1.12 * i, f[0])
+            ti.atomic_max(f[0], 1.12 * i)
 
-        if True:
+        # Serial max
+        for _ in range(1):
             for i in range(1000):
                 f[1] = ti.max(1.12 * i, f[1])
 
@@ -260,12 +264,14 @@ def test_atomic_min_f16():
 
     @ti.kernel
     def foo():
+        # Parallel min
         for i in range(1000):
-            f[0] = ti.atomic_max(-3.13 * i, f[0])
+            ti.atomic_min(f[0], -3.13 * i)
 
-        if True:
+        # Serial min
+        for _ in range(1):
             for i in range(1000):
-                f[1] = ti.max(-3.13 * i, f[1])
+                f[1] = ti.min(-3.13 * i, f[1])
 
     foo()
     assert (f[0] == f[1])

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -237,7 +237,7 @@ def test_atomic_add_f16():
                 f[1] = f[1] + 1.12
 
     foo()
-    assert (f[0] == f[1])
+    assert (f[0] == approx(f[1], rel=1e-3))
 
 
 # TODO(): Vulkan support
@@ -257,7 +257,7 @@ def test_atomic_max_f16():
                 f[1] = ti.max(1.12 * i, f[1])
 
     foo()
-    assert (f[0] == f[1])
+    assert (f[0] == approx(f[1], rel=1e-3))
 
 # TODO(): Vulkan support
 @ti.test(arch=[ti.cpu, ti.cuda])
@@ -276,4 +276,4 @@ def test_atomic_min_f16():
                 f[1] = ti.min(-3.13 * i, f[1])
 
     foo()
-    assert (f[0] == f[1])
+    assert (f[0] == approx(f[1], rel=1e-3))

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -232,8 +232,8 @@ def test_atomic_add_f16():
 
         # Serial sum
         for _ in range(1):
-                for i in range(1000):
-                    f[1] = f[1] + 1.12
+            for i in range(1000):
+                f[1] = f[1] + 1.12
 
     foo()
     assert (f[0] == f[1])

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -259,6 +259,7 @@ def test_atomic_max_f16():
     foo()
     assert (f[0] == approx(f[1], rel=1e-3))
 
+
 # TODO(): Vulkan support
 @ti.test(arch=[ti.cpu, ti.cuda])
 def test_atomic_min_f16():

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -220,7 +220,8 @@ def test_fractal_f16():
     paint(0.03)
 
 
-@ti.test(arch=archs_support_f16)
+# TODO(): Vulkan support
+@ti.test(arch=[ti.cpu, ti.cuda])
 def test_atomic_add_f16():
     f = ti.field(dtype=ti.f16, shape=(2))
 
@@ -239,7 +240,8 @@ def test_atomic_add_f16():
     assert (f[0] == f[1])
 
 
-@ti.test(arch=archs_support_f16)
+# TODO(): Vulkan support
+@ti.test(arch=[ti.cpu, ti.cuda])
 def test_atomic_max_f16():
     f = ti.field(dtype=ti.f16, shape=(2))
 
@@ -257,8 +259,8 @@ def test_atomic_max_f16():
     foo()
     assert (f[0] == f[1])
 
-
-@ti.test(arch=archs_support_f16)
+# TODO(): Vulkan support
+@ti.test(arch=[ti.cpu, ti.cuda])
 def test_atomic_min_f16():
     f = ti.field(dtype=ti.f16, shape=(2))
 

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -219,6 +219,7 @@ def test_fractal_f16():
 
     paint(0.03)
 
+
 @ti.test(arch=archs_support_f16)
 def test_atomic_add_f16():
     f = ti.field(dtype=ti.f16, shape=(2))
@@ -233,7 +234,8 @@ def test_atomic_add_f16():
                 f[1] += 1.12
 
     foo()
-    assert(f[0] == f[1])
+    assert (f[0] == f[1])
+
 
 @ti.test(arch=archs_support_f16)
 def test_atomic_max_f16():
@@ -249,7 +251,8 @@ def test_atomic_max_f16():
                 f[1] = ti.max(1.12 * i, f[1])
 
     foo()
-    assert(f[0] == f[1])
+    assert (f[0] == f[1])
+
 
 @ti.test(arch=archs_support_f16)
 def test_atomic_min_f16():
@@ -265,4 +268,4 @@ def test_atomic_min_f16():
                 f[1] = ti.max(-3.13 * i, f[1])
 
     foo()
-    assert(f[0] == f[1])
+    assert (f[0] == f[1])


### PR DESCRIPTION
Support atomic add/max/min of `f16` by CAS (`CreateAtomicCmpXchg`) on CPU and CUDA backends. 
CPU: Cast to `i16` pointer.
CUDA: Extend to `i32` pointer in a hacky way because CAS for 16-bit values is not supported. The correctness depends on the memory arrangement.