### PR TITLE
[gui] Fix canvas.lines on macOS

### DIFF
--- a/taichi/backends/device.cpp
+++ b/taichi/backends/device.cpp
@@ -120,6 +120,7 @@ void Device::print_all_cap() const {
       {DeviceCapability::spirv_has_atomic_float64_minmax,
        "spirv_has_atomic_float64_minmax"},
       {DeviceCapability::spirv_has_variable_ptr, "spirv_has_variable_ptr"},
+      {DeviceCapability::wide_lines, "wide_lines"},
   };
   for (auto &pair : caps_) {
     TI_TRACE("DeviceCapability::{} ({}) = {}", names.at(pair.first),

--- a/taichi/backends/device.h
+++ b/taichi/backends/device.h
@@ -37,6 +37,8 @@ enum class DeviceCapability : uint32_t {
   spirv_has_atomic_float64_add,
   spirv_has_atomic_float64_minmax,
   spirv_has_variable_ptr,
+  // Graphics Caps,
+  wide_lines
 };
 
 class Device;

--- a/taichi/backends/vulkan/embedded_device.cpp
+++ b/taichi/backends/vulkan/embedded_device.cpp
@@ -459,6 +459,7 @@ void EmbeddedVulkanDevice::create_logical_device() {
   }
   if (device_supported_features.wideLines) {
     device_features.wideLines = true;
+    ti_device_->set_cap(DeviceCapability::wide_lines, true);
   } else if (params_.is_for_ui) {
     TI_WARN_IF(!device_features.wideLines,
                "Taichi GPU GUI requires wide lines support");

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -1101,7 +1101,9 @@ void VulkanCommandList::blit_image(DeviceAllocation dst_img,
 }
 
 void VulkanCommandList::set_line_width(float width) {
-  vkCmdSetLineWidth(buffer_->buffer, width);
+  if (ti_device_->get_cap(DeviceCapability::wide_lines)) {
+    vkCmdSetLineWidth(buffer_->buffer, width);
+  }
 }
 
 vkapi::IVkRenderPass VulkanCommandList::current_renderpass() {


### PR DESCRIPTION
Related issue = #3416 

This is a temporary work around. The right thing to do would be to generate triangles that simulate lines. This is tracked by issue #3431.