### PR TITLE
[IR] Add type_check for RangeAssumption/LoopUnique/ExternalTensorShapeAlongAxisExpression

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -441,12 +441,15 @@ void TensorElementExpression::flatten(FlattenContext *ctx) {
 void RangeAssumptionExpression::type_check() {
   // TODO: assert no unknowns after type_check for all expressions are
   // implemented
-  if (input->ret_type == PrimitiveType::unknown || base->ret_type == PrimitiveType::unknown)
+  if (input->ret_type == PrimitiveType::unknown ||
+      base->ret_type == PrimitiveType::unknown)
     return;
-  if (!input->ret_type->is<PrimitiveType>() || !base->ret_type->is<PrimitiveType>() || input->ret_type != base->ret_type)
-    throw std::runtime_error(fmt::format(
-        "TypeError: unsupported operand type(s) for 'range_assumption': '{}' and '{}'",
-        input->ret_type->to_string(), base->ret_type->to_string()));
+  if (!input->ret_type->is<PrimitiveType>() ||
+      !base->ret_type->is<PrimitiveType>() || input->ret_type != base->ret_type)
+    throw std::runtime_error(
+        fmt::format("TypeError: unsupported operand type(s) for "
+                    "'range_assumption': '{}' and '{}'",
+                    input->ret_type->to_string(), base->ret_type->to_string()));
   ret_type = input->ret_type;
 }
 
@@ -635,7 +638,8 @@ void ConstExpression::flatten(FlattenContext *ctx) {
 
 void ExternalTensorShapeAlongAxisExpression::type_check() {
   TI_ASSERT_INFO(ptr.is<ExternalTensorExpression>(),
-      "Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression", ptr.serialize());
+                 "Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
+                 ptr.serialize());
   ret_type = PrimitiveType::i32;
 }
 

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -587,6 +587,8 @@ class RangeAssumptionExpression : public Expression {
       : input(input), base(base), low(low), high(high) {
   }
 
+  void type_check() override;
+
   void serialize(std::ostream &ss) override {
     ss << "assume_in_range({";
     base.serialize(ss);
@@ -609,6 +611,8 @@ class LoopUniqueExpression : public Expression {
   LoopUniqueExpression(const Expr &input, const std::vector<SNode *> &covers)
       : input(input), covers(covers) {
   }
+
+  void type_check() override;
 
   void serialize(std::ostream &ss) override;
 
@@ -749,6 +753,8 @@ class ExternalTensorShapeAlongAxisExpression : public Expression {
   ExternalTensorShapeAlongAxisExpression(const Expr &ptr, int axis)
       : ptr(ptr), axis(axis) {
   }
+
+  void type_check() override;
 
   void flatten(FlattenContext *ctx) override;
 };

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -136,7 +136,7 @@ TEST(FrontendTypeInference, RangeAssumption) {
   auto const_f64 = Expr::make<ConstExpression, float64>(5.0);
   const_f64->type_check();
   auto invalid = Expr::make<RangeAssumptionExpression>(const_f32_a, const_f64, 0, 1);
-  EXPECT_THROW(  invalid->type_check();, std::runtime_error);
+  EXPECT_THROW(invalid->type_check(), std::runtime_error);
 }
 
 TEST(FrontendTypeInference, LoopUnique) {
@@ -144,7 +144,7 @@ TEST(FrontendTypeInference, LoopUnique) {
   const_i64->type_check();
   auto loop_unique = Expr::make<LoopUniqueExpression>(const_i64, std::vector<SNode *>{});
   loop_unique->type_check();
-  EXPECT_EQ(  loop_unique->ret_type, PrimitiveType::i64);
+  EXPECT_EQ(loop_unique->ret_type, PrimitiveType::i64);
 }
 
 }  // namespace lang

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -120,7 +120,8 @@ TEST(FrontendTypeInference, TensorElement) {
 TEST(FrontendTypeInference, ExternalTensorShapeAlongAxis) {
   auto external_tensor =
       Expr::make<ExternalTensorExpression>(PrimitiveType::u64, 1, 0, 0);
-  auto shape = Expr::make<ExternalTensorShapeAlongAxisExpression>(external_tensor, 0);
+  auto shape =
+      Expr::make<ExternalTensorShapeAlongAxisExpression>(external_tensor, 0);
   shape->type_check();
   EXPECT_EQ(shape->ret_type, PrimitiveType::i32);
 }
@@ -130,19 +131,22 @@ TEST(FrontendTypeInference, RangeAssumption) {
   const_f32_a->type_check();
   auto const_f32_b = Expr::make<ConstExpression, float32>(5.0);
   const_f32_b->type_check();
-  auto valid = Expr::make<RangeAssumptionExpression>(const_f32_a, const_f32_b, 0, 1);
+  auto valid =
+      Expr::make<RangeAssumptionExpression>(const_f32_a, const_f32_b, 0, 1);
   valid->type_check();
   EXPECT_EQ(valid->ret_type, PrimitiveType::f32);
   auto const_f64 = Expr::make<ConstExpression, float64>(5.0);
   const_f64->type_check();
-  auto invalid = Expr::make<RangeAssumptionExpression>(const_f32_a, const_f64, 0, 1);
+  auto invalid =
+      Expr::make<RangeAssumptionExpression>(const_f32_a, const_f64, 0, 1);
   EXPECT_THROW(invalid->type_check(), std::runtime_error);
 }
 
 TEST(FrontendTypeInference, LoopUnique) {
   auto const_i64 = Expr::make<ConstExpression, int64>(5);
   const_i64->type_check();
-  auto loop_unique = Expr::make<LoopUniqueExpression>(const_i64, std::vector<SNode *>{});
+  auto loop_unique =
+      Expr::make<LoopUniqueExpression>(const_i64, std::vector<SNode *>{});
   loop_unique->type_check();
   EXPECT_EQ(loop_unique->ret_type, PrimitiveType::i64);
 }

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -117,5 +117,35 @@ TEST(FrontendTypeInference, TensorElement) {
   EXPECT_EQ(load_tensor_element->ret_type, PrimitiveType::u32);
 }
 
+TEST(FrontendTypeInference, ExternalTensorShapeAlongAxis) {
+  auto external_tensor =
+      Expr::make<ExternalTensorExpression>(PrimitiveType::u64, 1, 0, 0);
+  auto shape = Expr::make<ExternalTensorShapeAlongAxisExpression>(external_tensor, 0);
+  shape->type_check();
+  EXPECT_EQ(shape->ret_type, PrimitiveType::i32);
+}
+
+TEST(FrontendTypeInference, RangeAssumption) {
+  auto const_f32_a = Expr::make<ConstExpression, float32>(5.0);
+  const_f32_a->type_check();
+  auto const_f32_b = Expr::make<ConstExpression, float32>(5.0);
+  const_f32_b->type_check();
+  auto valid = Expr::make<RangeAssumptionExpression>(const_f32_a, const_f32_b, 0, 1);
+  valid->type_check();
+  EXPECT_EQ(valid->ret_type, PrimitiveType::f32);
+  auto const_f64 = Expr::make<ConstExpression, float64>(5.0);
+  const_f64->type_check();
+  auto invalid = Expr::make<RangeAssumptionExpression>(const_f32_a, const_f64, 0, 1);
+  EXPECT_THROW(  invalid->type_check();, std::runtime_error);
+}
+
+TEST(FrontendTypeInference, LoopUnique) {
+  auto const_i64 = Expr::make<ConstExpression, int64>(5);
+  const_i64->type_check();
+  auto loop_unique = Expr::make<LoopUniqueExpression>(const_i64, std::vector<SNode *>{});
+  loop_unique->type_check();
+  EXPECT_EQ(  loop_unique->ret_type, PrimitiveType::i64);
+}
+
 }  // namespace lang
 }  // namespace taichi

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -196,7 +196,7 @@ def bls_particle_grid(N,
             u0 = ti.assume_in_range(u_[0], Im[0], 0, 1)
             u1 = ti.assume_in_range(u_[1], Im[1], 0, 1)
 
-            u = ti.Vector([u0, u1], dt=ti.i32)
+            u = ti.Vector([u0, u1])
 
             for offset in ti.static(ti.grouped(ti.ndrange(extend, extend))):
                 m[u + offset] += scatter_weight
@@ -229,7 +229,7 @@ def bls_particle_grid(N,
             u0 = ti.assume_in_range(u_[0], Im[0], 0, 1)
             u1 = ti.assume_in_range(u_[1], Im[1], 0, 1)
 
-            u = ti.Vector([u0, u1], dt=ti.i32)
+            u = ti.Vector([u0, u1])
 
             tot = 0.0
 

--- a/tests/python/test_custom_float_time_integration.py
+++ b/tests/python/test_custom_float_time_integration.py
@@ -35,7 +35,7 @@ def test_custom_float_time_integration(use_cft, use_exponent, use_shared_exp):
 
     @ti.func
     def v_at(p):
-        return ti.Vector([-p[1], p[0]], ti.f32)
+        return ti.Vector([-p[1], p[0]])
 
     @ti.kernel
     def advance(dt: ti.f32):


### PR DESCRIPTION
Related issue = #3301

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
