### PR TITLE
[Doc] Put back content from old docs/lang/api/atomic.md

### DIFF
--- a/docs/lang/articles/basic/type.md
+++ b/docs/lang/articles/basic/type.md
@@ -185,6 +185,74 @@ pow(x, y)  # Same as `x ** y`.
 ti.random(dtype=float)
 ```
 
+### Supported atomic operations
+
+In Taichi, augmented assignments (e.g., `x[i] += 1`) are automatically
+[atomic](https://en.wikipedia.org/wiki/Fetch-and-add).
+
+:::caution
+
+When modifying global variables in parallel, make sure you use atomic
+operations. For example, to sum up all the elements in `x`, :
+
+    @ti.kernel
+    def sum():
+        for i in x:
+            # Approach 1: OK
+            total[None] += x[i]
+
+            # Approach 2: OK
+            ti.atomic_add(total[None], x[i])
+
+            # Approach 3: Wrong result since the operation is not atomic.
+            total[None] = total[None] + x[i]
+
+:::
+
+:::note
+
+When atomic operations are applied to local values, the Taichi compiler
+will try to demote these operations into their non-atomic counterparts.
+:::
+
+Apart from the augmented assignments, explicit atomic operations, such
+as `ti.atomic_add`, also do read-modify-write atomically. These
+operations additionally return the **old value** of the first argument.
+For example,
+
+```python
+x[i] = 3
+y[i] = 4
+z[i] = ti.atomic_add(x[i], y[i])
+# now x[i] = 7, y[i] = 4, z[i] = 3
+```
+
+Below is a list of all explicit atomic operations:
+
+| Operation             | Behavior                                                                                             |
+| --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `ti.atomic_add(x, y)` | atomically compute `x + y`, store the result in `x`, and return the old value of `x`                 |
+| `ti.atomic_sub(x, y)` | atomically compute `x - y`, store the result in `x`, and return the old value of `x`                 |
+| `ti.atomic_and(x, y)` | atomically compute `x & y`, store the result in `x`, and return the old value of `x`                 |
+| `ti.atomic_or(x, y)`  | atomically compute <code>x &#124; y</code>, store the result in `x`, and return the old value of `x` |
+| `ti.atomic_xor(x, y)` | atomically compute `x ^ y`, store the result in `x`, and return the old value of `x`                 |
+| `ti.atomic_max(x, y)` | atomically compute `max(x, y)`, store the result in `x`, and return the old value of `x`             |
+| `ti.atomic_min(x, y)` | atomically compute `min(x, y)`, store the result in `x`, and return the old value of `x`             |
+
+:::note
+
+Supported atomic operations on each backend:
+
+| type | CPU/CUDA | OpenGL | Metal | C source |
+| ---- | -------- | ------ | ----- | -------- |
+| i32  | > OK     | > OK   | > OK  | > OK     |
+| f32  | > OK     | > OK   | > OK  | > OK     |
+| i64  | > OK     | > EXT  | > N/A | > OK     |
+| f64  | > OK     | > EXT  | > N/A | > OK     |
+
+(OK: supported; EXT: require extension; N/A: not available)
+:::
+
 ### Type promotion
 
 Binary operations on different types will give you a promoted type,

--- a/docs/lang/articles/basic/type.md
+++ b/docs/lang/articles/basic/type.md
@@ -193,20 +193,21 @@ In Taichi, augmented assignments (e.g., `x[i] += 1`) are automatically
 :::caution
 
 When modifying global variables in parallel, make sure you use atomic
-operations. For example, to sum up all the elements in `x`, :
+operations. For example, to sum up all the elements in `x`,
 
-    @ti.kernel
-    def sum():
-        for i in x:
-            # Approach 1: OK
-            total[None] += x[i]
+```python
+@ti.kernel
+def sum():
+    for i in x:
+        # Approach 1: OK
+        total[None] += x[i]
 
-            # Approach 2: OK
-            ti.atomic_add(total[None], x[i])
+        # Approach 2: OK
+        ti.atomic_add(total[None], x[i])
 
-            # Approach 3: Wrong result since the operation is not atomic.
-            total[None] = total[None] + x[i]
-
+        # Approach 3: Wrong result since the operation is not atomic.
+        total[None] = total[None] + x[i]
+```
 :::
 
 :::note


### PR DESCRIPTION
Related issue = #3318

This PR puts back content from old `docs/lang/api/atomic.md` into our current type system section. The format and content organization are refined to fit current doc better. `ti.atomic_max/min` is also added into the doc.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
