### PR TITLE
[vulkan] Link to MoltenVK on macOS

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -188,6 +188,10 @@ if (TI_WITH_OPENGL OR TI_WITH_VULKAN)
   set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
   set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
   set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+  
+  if (APPLE)
+    set(GLFW_VULKAN_STATIC ON CACHE BOOL "" FORCE)
+  endif()
 
   message("Building with GLFW")
   add_subdirectory(external/glfw)
@@ -275,7 +279,11 @@ if (TI_WITH_VULKAN)
     target_link_libraries(${CORE_LIBRARY_NAME} SPIRV-Tools-opt ${SPIRV_TOOLS})
 
     include_directories(SYSTEM external/Vulkan-Headers/include)
-    include_directories(SYSTEM external/volk)
+    
+    if (NOT APPLE)
+        include_directories(SYSTEM external/volk)
+    endif()
+    
     target_include_directories(${CORE_LIBRARY_NAME} PRIVATE external/SPIRV-Headers/include)
     target_include_directories(${CORE_LIBRARY_NAME} PRIVATE external/SPIRV-Reflect)
     target_include_directories(${CORE_LIBRARY_NAME} PRIVATE external/VulkanMemoryAllocator/include)
@@ -285,6 +293,12 @@ if (TI_WITH_VULKAN)
         set(THREADS_PREFER_PTHREAD_FLAG ON)
         find_package(Threads REQUIRED)
         target_link_libraries(${CORE_LIBRARY_NAME} Threads::Threads)
+    endif()
+
+    if (APPLE)
+        find_library(MOLTEN_VK libMoltenVK.a /opt/homebrew/Cellar/molten-vk)
+        target_link_libraries(${CORE_LIBRARY_NAME} ${MOLTEN_VK})
+        message(STATUS "MoltenVK library ${MOLTEN_VK}")
     endif()
 endif ()
 

--- a/examples/rendering/cornell_box.py
+++ b/examples/rendering/cornell_box.py
@@ -485,20 +485,9 @@ def render():
 
 
 @ti.kernel
-def tonemap(accumulated: ti.f32) -> ti.f32:
-    sum = 0.0
-    sum_sq = 0.0
-    for i, j in color_buffer:
-        luma = color_buffer[i, j][0] * 0.2126 + color_buffer[
-            i, j][1] * 0.7152 + color_buffer[i, j][2] * 0.0722
-        sum += luma
-        sum_sq += ti.pow(luma / accumulated, 2.0)
-    mean = sum / (res[0] * res[1])
-    var = sum_sq / (res[0] * res[1]) - ti.pow(mean / accumulated, 2.0)
+def tonemap(accumulated: ti.f32):
     for i, j in tonemapped_buffer:
-        tonemapped_buffer[i, j] = ti.sqrt(color_buffer[i, j] / mean * 0.6)
-    return var
-
+        tonemapped_buffer[i, j] = ti.sqrt(color_buffer[i, j] / accumulated * 100.0)
 
 gui = ti.GUI('Cornell Box', res, fast_gui=True)
 gui.fps_limit = 300
@@ -508,9 +497,9 @@ while gui.running:
     render()
     interval = 10
     if i % interval == 0:
-        var = tonemap(i)
-        print("{:.2f} samples/s ({} iters, var={})".format(
-            interval / (time.time() - last_t), i, var))
+        tonemap(i)
+        print("{:.2f} samples/s ({} iters)".format(
+            interval / (time.time() - last_t), i))
         last_t = time.time()
         gui.set_image(tonemapped_buffer)
         gui.show()

--- a/taichi/backends/vulkan/embedded_device.cpp
+++ b/taichi/backends/vulkan/embedded_device.cpp
@@ -304,6 +304,7 @@ void EmbeddedVulkanDevice::create_instance() {
   if (res != VK_SUCCESS) {
     throw std::runtime_error("failed to create instance");
   }
+
   VulkanLoader::instance().load_instance(instance_);
 }
 

--- a/taichi/backends/vulkan/embedded_device.h
+++ b/taichi/backends/vulkan/embedded_device.h
@@ -4,10 +4,7 @@
 #define VK_USE_PLATFORM_WIN32_KHR 1
 #endif
 
-#include <volk.h>
-#define VK_NO_PROTOTYPES
-#include <vulkan/vulkan.h>
-#include <vulkan/vulkan_core.h>
+#include "taichi/backends/vulkan/vulkan_common.h"
 
 #include <taichi/backends/device.h>
 

--- a/taichi/backends/vulkan/loader.cpp
+++ b/taichi/backends/vulkan/loader.cpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#define VOLK_IMPLEMENTATION
-#include <volk.h>
+#include "taichi/backends/vulkan/vulkan_common.h"
 
 #include "taichi/backends/vulkan/loader.h"
 #include "taichi/common/logging.h"
@@ -18,19 +17,29 @@ bool VulkanLoader::init() {
     if (initialized) {
       return;
     }
+#ifdef __APPLE__
+    initialized = true;
+#else
     VkResult result = volkInitialize();
     initialized = result == VK_SUCCESS;
+#endif
   });
   return initialized;
 }
 
 void VulkanLoader::load_instance(VkInstance instance) {
   vulkan_instance_ = instance;
+#ifdef __APPLE__
+#else
   volkLoadInstance(instance);
+#endif
 }
 void VulkanLoader::load_device(VkDevice device) {
   vulkan_device_ = device;
+#ifdef __APPLE__
+#else
   volkLoadDevice(device);
+#endif
 }
 
 PFN_vkVoidFunction VulkanLoader::load_function(const char *name) {

--- a/taichi/backends/vulkan/loader.h
+++ b/taichi/backends/vulkan/loader.h
@@ -3,7 +3,7 @@
 #include <thread>
 #include <mutex>
 
-#include <volk.h>
+#include "taichi/backends/vulkan/vulkan_common.h"
 
 namespace taichi {
 namespace lang {
@@ -24,6 +24,9 @@ class VulkanLoader {
   void load_device(VkDevice device_);
   bool init();
   PFN_vkVoidFunction load_function(const char *name);
+  VkInstance get_instance() {
+    return vulkan_instance_;
+  }
 
  private:
   std::once_flag init_flag_;

--- a/taichi/backends/vulkan/vulkan_api.cpp
+++ b/taichi/backends/vulkan/vulkan_api.cpp
@@ -1,3 +1,5 @@
+#define VOLK_IMPLEMENTATION
+
 #include "taichi/backends/vulkan/vulkan_api.h"
 #include "taichi/backends/vulkan/loader.h"
 

--- a/taichi/backends/vulkan/vulkan_api.cpp
+++ b/taichi/backends/vulkan/vulkan_api.cpp
@@ -1,4 +1,5 @@
 #include "taichi/backends/vulkan/vulkan_api.h"
+#include "taichi/backends/vulkan/loader.h"
 
 namespace vkapi {
 
@@ -74,7 +75,10 @@ DeviceObjVkBufferView::~DeviceObjVkBufferView() {
 }
 
 DeviceObjVkAccelerationStructureKHR::~DeviceObjVkAccelerationStructureKHR() {
-  vkDestroyAccelerationStructureKHR(device, accel, nullptr);
+  PFN_vkDestroyAccelerationStructureKHR destroy_raytracing_pipeline_khr =
+  PFN_vkDestroyAccelerationStructureKHR(vkGetInstanceProcAddr(taichi::lang::vulkan::VulkanLoader::instance().get_instance(), "vkDestroyAccelerationStructureKHR"));
+
+  destroy_raytracing_pipeline_khr(device, accel, nullptr);
 }
 
 IDeviceObj create_device_obj(VkDevice device) {
@@ -341,7 +345,10 @@ IVkPipeline create_raytracing_pipeline(
     create_info->basePipelineIndex = 0;
   }
 
-  vkCreateRayTracingPipelinesKHR(device, deferredOperation,
+  PFN_vkCreateRayTracingPipelinesKHR create_raytracing_pipeline_khr =
+  PFN_vkCreateRayTracingPipelinesKHR(vkGetInstanceProcAddr(taichi::lang::vulkan::VulkanLoader::instance().get_instance(), "vkCreateRayTracingPipelinesKHR"));
+
+  create_raytracing_pipeline_khr(device, deferredOperation,
                                  cache ? cache->cache : VK_NULL_HANDLE, 1,
                                  create_info, nullptr, &obj->pipeline);
 
@@ -499,7 +506,10 @@ IVkAccelerationStructureKHR create_acceleration_structure(
   info.type = type;
   info.deviceAddress = 0;
 
-  vkCreateAccelerationStructureKHR(buffer->device, &info, nullptr, &obj->accel);
+  PFN_vkCreateAccelerationStructureKHR create_acceleration_structure_khr =
+  PFN_vkCreateAccelerationStructureKHR(vkGetInstanceProcAddr(taichi::lang::vulkan::VulkanLoader::instance().get_instance(), "vkCreateAccelerationStructureKHR"));
+  
+  create_acceleration_structure_khr(buffer->device, &info, nullptr, &obj->accel);
 
   return obj;
 }

--- a/taichi/backends/vulkan/vulkan_common.h
+++ b/taichi/backends/vulkan/vulkan_common.h
@@ -4,8 +4,11 @@
 #define VK_USE_PLATFORM_WIN32_KHR 1
 #endif
 
+#ifndef __APPLE__
 #include <volk.h>
 #define VK_NO_PROTOTYPES
+#endif
+
 #include <vulkan/vulkan.h>
 #include <vulkan/vulkan_core.h>
 

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -1748,6 +1748,14 @@ vkapi::IVkDescriptorSet VulkanDevice::alloc_desc_set(
 }
 
 void VulkanDevice::create_vma_allocator() {
+  VmaAllocatorCreateInfo allocatorInfo = {};
+  allocatorInfo.vulkanApiVersion =
+      this->get_cap(DeviceCapability::vk_api_version);
+  allocatorInfo.physicalDevice = physical_device_;
+  allocatorInfo.device = device_;
+  allocatorInfo.instance = instance_;
+
+#ifndef __APPLE__
   VolkDeviceTable table;
   VmaVulkanFunctions vk_vma_functions;
 
@@ -1786,13 +1794,8 @@ void VulkanDevice::create_vma_allocator() {
       PFN_vkGetPhysicalDeviceMemoryProperties2KHR(vkGetInstanceProcAddr(
           volkGetLoadedInstance(), "vkGetPhysicalDeviceMemoryProperties2KHR"));
 
-  VmaAllocatorCreateInfo allocatorInfo = {};
-  allocatorInfo.vulkanApiVersion =
-      this->get_cap(DeviceCapability::vk_api_version);
-  allocatorInfo.physicalDevice = physical_device_;
-  allocatorInfo.device = device_;
-  allocatorInfo.instance = instance_;
   allocatorInfo.pVulkanFunctions = &vk_vma_functions;
+#endif
 
   vmaCreateAllocator(&allocatorInfo, &allocator_);
 

--- a/taichi/backends/vulkan/vulkan_utils.h
+++ b/taichi/backends/vulkan/vulkan_utils.h
@@ -8,9 +8,7 @@
 #include <VersionHelpers.h>
 #endif
 
-#include <volk.h>
-#define VK_NO_PROTOTYPES
-#include <vulkan/vulkan.h>
+#include "taichi/backends/vulkan/vulkan_common.h"
 
 #include <functional>
 #include <optional>

--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -31,7 +31,8 @@
 #ifdef _WIN64
 #define VK_USE_PLATFORM_WIN32_KHR 1
 #endif
-#include <volk.h>
+
+#include "taichi/backends/vulkan/vulkan_common.h"
 #include <GLFW/glfw3.h>
 
 #include <stdarg.h>


### PR DESCRIPTION
Related issue = #3416 #2736

On macOS, volk is disabled and direct linking to MoltenVK is used instead so that we can ship Vulkan by default to users without having users to install the Vulkan SDK.

Also changed the cornell_box example to not use atomic reduction. A atomic reduction on a buffer with that size is just asking for trouble with devices that do not support FP atomics.