### PR TITLE
[IR] Remove EvalExpression

### DIFF
--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -68,7 +68,7 @@ Expr &Expr::operator=(const Expr &o) {
     // Inside a kernel or a function
     // Create an assignment in the IR
     if (expr == nullptr) {
-      set(o.eval());
+      set(o);
     } else if (expr->is_lvalue()) {
       current_ast_builder().insert(
           std::make_unique<FrontendAssignStmt>(*this, load_if_ptr(o)));
@@ -79,7 +79,6 @@ Expr &Expr::operator=(const Expr &o) {
                              ->rhs->ret_type;
       }
     } else {
-      // set(o.eval());
       TI_ERROR("Cannot assign to non-lvalue: {}", serialize());
     }
   } else {
@@ -131,20 +130,6 @@ Expr::Expr(float64 x) : Expr() {
 
 Expr::Expr(const Identifier &id) : Expr() {
   expr = std::make_shared<IdExpression>(id);
-}
-
-Expr Expr::eval() const {
-  TI_ASSERT(expr != nullptr);
-  if (is<EvalExpression>()) {
-    return *this;
-  }
-  auto eval_stmt = Stmt::make<FrontendEvalStmt>(*this);
-  auto eval_expr = Expr::make<EvalExpression>(eval_stmt.get());
-  eval_stmt->as<FrontendEvalStmt>()->eval_expr.set(eval_expr);
-  // needed in lower_ast to replace the statement itself with the
-  // lowered statement
-  current_ast_builder().insert(std::move(eval_stmt));
-  return eval_expr;
 }
 
 void Expr::operator+=(const Expr &o) {

--- a/taichi/ir/frontend.cpp
+++ b/taichi/ir/frontend.cpp
@@ -17,15 +17,6 @@ Expr global_new(DataType dt, std::string name) {
   return Expr::make<GlobalVariableExpression>(dt, id_expr->id);
 }
 
-Expr copy(const Expr &expr) {
-  auto e = expr.eval();
-  auto stmt = Stmt::make<ElementShuffleStmt>(
-      VectorElement(e.cast<EvalExpression>()->stmt_ptr, 0));
-  auto eval_expr = std::make_shared<EvalExpression>(stmt.get());
-  current_ast_builder().insert(std::move(stmt));
-  return Expr(eval_expr);
-}
-
 void insert_snode_access_flag(SNodeAccessFlag v, const Expr &field) {
   dec.mem_access_opt.add_flag(field.snode(), v);
 }

--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -34,13 +34,6 @@ Expr Rand() {
   return Expr::make<RandExpression>(get_data_type<T>());
 }
 
-template <typename T>
-T Eval(const T &t) {
-  return t.eval();
-}
-
-Expr copy(const Expr &expr);
-
 template <typename... AX>
 std::vector<Axis> Axes(AX... axes) {
   auto ax_vec = std::vector<int>({axes...});

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -125,7 +125,6 @@ class FrontendPrintStmt : public Stmt {
 class FrontendEvalStmt : public Stmt {
  public:
   Expr expr;
-  Expr eval_expr;
 
   FrontendEvalStmt(const Expr &expr) : expr(load_if_ptr(expr)) {
   }
@@ -555,23 +554,6 @@ class TensorElementExpression : public Expression {
 
   bool is_lvalue() const override {
     return true;
-  }
-};
-
-class EvalExpression : public Expression {
- public:
-  Stmt *stmt_ptr;
-  int stmt_id;
-  EvalExpression(Stmt *stmt) : stmt_ptr(stmt), stmt_id(stmt_ptr->id) {
-    // cache stmt->id since it may be released later
-  }
-
-  void serialize(std::ostream &ss) override {
-    ss << '%' << stmt_id;
-  }
-
-  void flatten(FlattenContext *ctx) override {
-    stmt = stmt_ptr;
   }
 };
 

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -380,9 +380,6 @@ class LowerAST : public IRVisitor {
     auto expr = stmt->expr;
     auto fctx = make_flatten_ctx();
     expr->flatten(&fctx);
-    if (stmt->eval_expr.expr && stmt->eval_expr.is<EvalExpression>()) {
-      stmt->eval_expr.cast<EvalExpression>()->stmt_ptr = stmt->expr->stmt;
-    }
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
     throw IRModified();
   }


### PR DESCRIPTION
Related issue = #3301 

`EvalExpression` and related functions look like legacy code and have no usage today. This PR aims at cleaning them up.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
