### PR TITLE
[opengl] Make windows path in saved aot json human readable.

### DIFF
--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -21,8 +21,15 @@ namespace {
 void write_glsl_file(const std::string &output_dir,
                      const std::string &filename,
                      CompiledKernel &k) {
-  const std::string glsl_path =
-      fmt::format("{}/{}_{}.glsl", output_dir, filename, k.kernel_name);
+// Hack to assemble readable windows/unix path.
+// Ideally we could use std::filesystem but it's not available on MacOS 10.14.
+#if defined(TI_PLATFORM_WINDOWS)
+  const std::string path_delim = "\\";
+#else
+  const std::string path_delim = "/";
+#endif
+  const std::string glsl_path = fmt::format(
+      "{}{}{}_{}.glsl", output_dir, path_delim, filename, k.kernel_name);
   std::ofstream fs{glsl_path};
   fs << k.kernel_src;
   k.kernel_src = glsl_path;

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -10,7 +10,7 @@ import taichi as ti
 
 def _escape_path_for_win(json_str):
     return json_str.replace(os.sep,
-                            '\\\\') if ti.get_os_name() == 'win' else json_str
+                            r'\\') if ti.get_os_name() == 'win' else json_str
 
 
 @ti.test(arch=ti.cc)

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -1,10 +1,16 @@
 import json
 import os
+import sys
 import tempfile
 
 import pytest
 
 import taichi as ti
+
+
+def _escape_path_for_win(json_str):
+    return json_str.replace(os.sep,
+                            '\\\\') if ti.get_os_name() == 'win' else json_str
 
 
 @ti.test(arch=ti.cc)
@@ -56,7 +62,9 @@ def test_save():
         m.save(tmpdir, filename)
         with open(os.path.join(tmpdir,
                                f'{filename}_metadata.json')) as json_file:
-            json.load(json_file)
+            json_str = ''.join(json_file.readlines())
+            json_str = _escape_path_for_win(json_str)
+            json.loads(json_str)
 
 
 @ti.test(arch=ti.opengl)
@@ -167,4 +175,6 @@ def test_mpm88_aot():
         m.save(tmpdir, filename)
         with open(os.path.join(tmpdir,
                                f'{filename}_metadata.json')) as json_file:
-            json.load(json_file)
+            json_str = ''.join(json_file.readlines())
+            json_str = _escape_path_for_win(json_str)
+            json.loads(json_str)


### PR DESCRIPTION
Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
