### PR TITLE
[IR] Enforce type check for all expressions

### DIFF
--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -72,12 +72,6 @@ Expr &Expr::operator=(const Expr &o) {
     } else if (expr->is_lvalue()) {
       current_ast_builder().insert(
           std::make_unique<FrontendAssignStmt>(*this, load_if_ptr(o)));
-      if (this->is<IdExpression>()) {
-        expr->ret_type = current_ast_builder()
-                             .get_last_stmt()
-                             ->cast<FrontendAssignStmt>()
-                             ->rhs->ret_type;
-      }
     } else {
       TI_ERROR("Cannot assign to non-lvalue: {}", serialize());
     }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -5,6 +5,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
+#define TI_ASSERT_TYPE_CHECKED(x) TI_ASSERT_INFO(x->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", x.serialize())
+
 FrontendSNodeOpStmt::FrontendSNodeOpStmt(SNodeOpType op_type,
                                          SNode *snode,
                                          const ExprGroup &indices,
@@ -131,8 +133,7 @@ void UnaryOpExpression::serialize(std::ostream &ss) {
 }
 
 void UnaryOpExpression::type_check() {
-  TI_ASSERT_INFO(operand->ret_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", operand.serialize());
+  TI_ASSERT_TYPE_CHECKED(operand);
   if (!operand->ret_type->is<PrimitiveType>())
     throw std::runtime_error(
         fmt::format("TypeError: unsupported operand type(s) for '{}': '{}'",
@@ -162,12 +163,10 @@ void UnaryOpExpression::flatten(FlattenContext *ctx) {
 }
 
 void BinaryOpExpression::type_check() {
+  TI_ASSERT_TYPE_CHECKED(lhs);
+  TI_ASSERT_TYPE_CHECKED(rhs);
   auto lhs_type = lhs->ret_type;
   auto rhs_type = rhs->ret_type;
-  TI_ASSERT_INFO(lhs_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", lhs.serialize());
-  TI_ASSERT_INFO(rhs_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", rhs.serialize());
   auto error = [&]() {
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for '{}': '{}' and '{}'",
@@ -206,15 +205,12 @@ void BinaryOpExpression::flatten(FlattenContext *ctx) {
 }
 
 void TernaryOpExpression::type_check() {
+  TI_ASSERT_TYPE_CHECKED(op1);
+  TI_ASSERT_TYPE_CHECKED(op2);
+  TI_ASSERT_TYPE_CHECKED(op3);
   auto op1_type = op1->ret_type;
   auto op2_type = op2->ret_type;
   auto op3_type = op3->ret_type;
-  TI_ASSERT_INFO(op1_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", op1.serialize());
-  TI_ASSERT_INFO(op2_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", op2.serialize());
-  TI_ASSERT_INFO(op3_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", op3.serialize());
   auto error = [&]() {
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for '{}': '{}', '{}' and '{}'",
@@ -240,8 +236,7 @@ void TernaryOpExpression::flatten(FlattenContext *ctx) {
 
 void InternalFuncCallExpression::type_check() {
   for (auto &arg : args) {
-    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown,
-                   "[{}] was not type-checked", arg.serialize());
+    TI_ASSERT_TYPE_CHECKED(arg);
     // no arg type compatibility check for now due to lack of specification
   }
   // internal func calls have default return type
@@ -260,13 +255,11 @@ void InternalFuncCallExpression::flatten(FlattenContext *ctx) {
 
 void ExternalFuncCallExpression::type_check() {
   for (auto &arg : args) {
-    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown,
-                   "[{}] was not type-checked", arg.serialize());
+    TI_ASSERT_TYPE_CHECKED(arg);
     // no arg type compatibility check for now due to lack of specification
   }
   for (auto &output : outputs) {
-    TI_ASSERT_INFO(output->ret_type != PrimitiveType::unknown,
-                   "[{}] was not type-checked", output.serialize());
+    TI_ASSERT_TYPE_CHECKED(output);
     // no output type compatibility check for now due to lack of specification
   }
   // external func calls have no return type for now
@@ -327,8 +320,7 @@ void GlobalPtrExpression::type_check() {
   } else if (var.is<ExternalTensorExpression>()) {
     for (int i = 0; i < indices.exprs.size(); i++) {
       auto &expr = indices.exprs[i];
-      TI_ASSERT_INFO(expr->ret_type != PrimitiveType::unknown,
-                     "[{}] was not type-checked", expr.serialize());
+      TI_ASSERT_TYPE_CHECKED(expr);
       if (!is_integral(expr->ret_type))
         throw std::runtime_error(
             fmt::format("TypeError: indices must be integers, however '{}' is "
@@ -471,10 +463,8 @@ void TensorElementExpression::flatten(FlattenContext *ctx) {
 }
 
 void RangeAssumptionExpression::type_check() {
-  TI_ASSERT_INFO(input->ret_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", input.serialize());
-  TI_ASSERT_INFO(base->ret_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", base.serialize());
+  TI_ASSERT_TYPE_CHECKED(input);
+  TI_ASSERT_TYPE_CHECKED(base);
   if (!input->ret_type->is<PrimitiveType>() ||
       !base->ret_type->is<PrimitiveType>() || input->ret_type != base->ret_type)
     throw std::runtime_error(
@@ -493,8 +483,7 @@ void RangeAssumptionExpression::flatten(FlattenContext *ctx) {
 }
 
 void LoopUniqueExpression::type_check() {
-  TI_ASSERT_INFO(input->ret_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", input.serialize());
+  TI_ASSERT_TYPE_CHECKED(input);
   if (!input->ret_type->is<PrimitiveType>())
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for 'loop_unique': '{}'",
@@ -543,10 +532,8 @@ void IdExpression::flatten(FlattenContext *ctx) {
 }
 
 void AtomicOpExpression::type_check() {
-  TI_ASSERT_INFO(dest->ret_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", dest.serialize());
-  TI_ASSERT_INFO(val->ret_type != PrimitiveType::unknown,
-                 "[{}] was not type-checked", val.serialize());
+  TI_ASSERT_TYPE_CHECKED(dest);
+  TI_ASSERT_TYPE_CHECKED(val);
   auto error = [&]() {
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
@@ -713,8 +700,7 @@ void ExternalTensorShapeAlongAxisExpression::flatten(FlattenContext *ctx) {
 
 void FuncCallExpression::type_check() {
   for (auto &arg : args.exprs) {
-    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown,
-                   "[{}] was not type-checked", arg.serialize());
+    TI_ASSERT_TYPE_CHECKED(arg);
     // no arg type compatibility check for now due to lack of specification
   }
   TI_ASSERT_INFO(func->rets.size() <= 1,

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -22,7 +22,7 @@ FrontendAssignStmt::FrontendAssignStmt(const Expr &lhs, const Expr &rhs)
     : lhs(lhs), rhs(rhs) {
   TI_ASSERT(lhs->is_lvalue());
   if (lhs.is<IdExpression>() && lhs->ret_type == PrimitiveType::unknown) {
-      lhs.expr->ret_type = rhs->ret_type;
+    lhs.expr->ret_type = rhs->ret_type;
   }
 }
 
@@ -131,11 +131,12 @@ void UnaryOpExpression::serialize(std::ostream &ss) {
 }
 
 void UnaryOpExpression::type_check() {
-  TI_ASSERT_INFO(operand->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", operand.serialize());
+  TI_ASSERT_INFO(operand->ret_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", operand.serialize());
   if (!operand->ret_type->is<PrimitiveType>())
-    throw std::runtime_error(fmt::format(
-        "TypeError: unsupported operand type(s) for '{}': '{}'",
-        unary_op_type_name(type), operand->ret_type->to_string()));
+    throw std::runtime_error(
+        fmt::format("TypeError: unsupported operand type(s) for '{}': '{}'",
+                    unary_op_type_name(type), operand->ret_type->to_string()));
   if ((type == UnaryOpType::floor || type == UnaryOpType::ceil ||
        is_trigonometric(type)) &&
       !is_real(operand->ret_type))
@@ -163,8 +164,10 @@ void UnaryOpExpression::flatten(FlattenContext *ctx) {
 void BinaryOpExpression::type_check() {
   auto lhs_type = lhs->ret_type;
   auto rhs_type = rhs->ret_type;
-  TI_ASSERT_INFO(lhs_type != PrimitiveType::unknown, "[{}] was not type-checked", lhs.serialize());
-  TI_ASSERT_INFO(rhs_type != PrimitiveType::unknown, "[{}] was not type-checked", rhs.serialize());
+  TI_ASSERT_INFO(lhs_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", lhs.serialize());
+  TI_ASSERT_INFO(rhs_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", rhs.serialize());
   auto error = [&]() {
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for '{}': '{}' and '{}'",
@@ -206,9 +209,12 @@ void TernaryOpExpression::type_check() {
   auto op1_type = op1->ret_type;
   auto op2_type = op2->ret_type;
   auto op3_type = op3->ret_type;
-  TI_ASSERT_INFO(op1_type != PrimitiveType::unknown, "[{}] was not type-checked", op1.serialize());
-  TI_ASSERT_INFO(op2_type != PrimitiveType::unknown, "[{}] was not type-checked", op2.serialize());
-  TI_ASSERT_INFO(op3_type != PrimitiveType::unknown, "[{}] was not type-checked", op3.serialize());
+  TI_ASSERT_INFO(op1_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", op1.serialize());
+  TI_ASSERT_INFO(op2_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", op2.serialize());
+  TI_ASSERT_INFO(op3_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", op3.serialize());
   auto error = [&]() {
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for '{}': '{}', '{}' and '{}'",
@@ -234,7 +240,8 @@ void TernaryOpExpression::flatten(FlattenContext *ctx) {
 
 void InternalFuncCallExpression::type_check() {
   for (auto &arg : args) {
-    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", arg.serialize());
+    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown,
+                   "[{}] was not type-checked", arg.serialize());
     // no arg type compatibility check for now due to lack of specification
   }
   // internal func calls have default return type
@@ -253,11 +260,13 @@ void InternalFuncCallExpression::flatten(FlattenContext *ctx) {
 
 void ExternalFuncCallExpression::type_check() {
   for (auto &arg : args) {
-    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", arg.serialize());
+    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown,
+                   "[{}] was not type-checked", arg.serialize());
     // no arg type compatibility check for now due to lack of specification
   }
   for (auto &output : outputs) {
-    TI_ASSERT_INFO(output->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", output.serialize());
+    TI_ASSERT_INFO(output->ret_type != PrimitiveType::unknown,
+                   "[{}] was not type-checked", output.serialize());
     // no output type compatibility check for now due to lack of specification
   }
   // external func calls have no return type for now
@@ -318,7 +327,8 @@ void GlobalPtrExpression::type_check() {
   } else if (var.is<ExternalTensorExpression>()) {
     for (int i = 0; i < indices.exprs.size(); i++) {
       auto &expr = indices.exprs[i];
-      TI_ASSERT_INFO(expr->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", expr.serialize());
+      TI_ASSERT_INFO(expr->ret_type != PrimitiveType::unknown,
+                     "[{}] was not type-checked", expr.serialize());
       if (!is_integral(expr->ret_type))
         throw std::runtime_error(
             fmt::format("TypeError: indices must be integers, however '{}' is "
@@ -461,8 +471,10 @@ void TensorElementExpression::flatten(FlattenContext *ctx) {
 }
 
 void RangeAssumptionExpression::type_check() {
-  TI_ASSERT_INFO(input->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", input.serialize());
-  TI_ASSERT_INFO(base->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", base.serialize());
+  TI_ASSERT_INFO(input->ret_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", input.serialize());
+  TI_ASSERT_INFO(base->ret_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", base.serialize());
   if (!input->ret_type->is<PrimitiveType>() ||
       !base->ret_type->is<PrimitiveType>() || input->ret_type != base->ret_type)
     throw std::runtime_error(
@@ -481,7 +493,8 @@ void RangeAssumptionExpression::flatten(FlattenContext *ctx) {
 }
 
 void LoopUniqueExpression::type_check() {
-  TI_ASSERT_INFO(input->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", input.serialize());
+  TI_ASSERT_INFO(input->ret_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", input.serialize());
   if (!input->ret_type->is<PrimitiveType>())
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for 'loop_unique': '{}'",
@@ -530,8 +543,10 @@ void IdExpression::flatten(FlattenContext *ctx) {
 }
 
 void AtomicOpExpression::type_check() {
-  TI_ASSERT_INFO(dest->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", dest.serialize());
-  TI_ASSERT_INFO(val->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", val.serialize());
+  TI_ASSERT_INFO(dest->ret_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", dest.serialize());
+  TI_ASSERT_INFO(val->ret_type != PrimitiveType::unknown,
+                 "[{}] was not type-checked", val.serialize());
   auto error = [&]() {
     throw std::runtime_error(fmt::format(
         "TypeError: unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
@@ -698,10 +713,12 @@ void ExternalTensorShapeAlongAxisExpression::flatten(FlattenContext *ctx) {
 
 void FuncCallExpression::type_check() {
   for (auto &arg : args.exprs) {
-    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", arg.serialize());
+    TI_ASSERT_INFO(arg->ret_type != PrimitiveType::unknown,
+                   "[{}] was not type-checked", arg.serialize());
     // no arg type compatibility check for now due to lack of specification
   }
-  TI_ASSERT_INFO(func->rets.size() <= 1, "Too many (> 1) return values for FuncCallExpression");
+  TI_ASSERT_INFO(func->rets.size() <= 1,
+                 "Too many (> 1) return values for FuncCallExpression");
   if (func->rets.size() == 1) {
     ret_type = func->rets[0].dt;
   }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -5,7 +5,9 @@
 
 TLANG_NAMESPACE_BEGIN
 
-#define TI_ASSERT_TYPE_CHECKED(x) TI_ASSERT_INFO(x->ret_type != PrimitiveType::unknown, "[{}] was not type-checked", x.serialize())
+#define TI_ASSERT_TYPE_CHECKED(x)                       \
+  TI_ASSERT_INFO(x->ret_type != PrimitiveType::unknown, \
+                 "[{}] was not type-checked", x.serialize())
 
 FrontendSNodeOpStmt::FrontendSNodeOpStmt(SNodeOpType op_type,
                                          SNode *snode,

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -230,6 +230,19 @@ void TernaryOpExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
+void InternalFuncCallExpression::type_check() {
+  for (auto &arg : args) {
+    // TODO: assert no unknowns after type_check for all expressions are
+    // implemented
+    if (arg->ret_type == PrimitiveType::unknown)
+      return;
+    // There are no specifications for internal func calls for now,
+    // so arg types are not checked.
+  }
+  // Internal func calls will have default i32 return type.
+  ret_type = PrimitiveType::i32;
+}
+
 void InternalFuncCallExpression::flatten(FlattenContext *ctx) {
   std::vector<Stmt *> args_stmts(args.size());
   for (int i = 0; i < (int)args.size(); ++i) {
@@ -238,6 +251,26 @@ void InternalFuncCallExpression::flatten(FlattenContext *ctx) {
   }
   ctx->push_back<InternalFuncStmt>(func_name, args_stmts);
   stmt = ctx->back_stmt();
+}
+
+void ExternalFuncCallExpression::type_check() {
+  for (auto &arg : args) {
+    // TODO: assert no unknowns after type_check for all expressions are
+    // implemented
+    if (arg->ret_type == PrimitiveType::unknown)
+      return;
+    // There are no specifications for external func calls for now,
+    // so arg types are not checked.
+  }
+  for (auto &output : outputs) {
+    // TODO: assert no unknowns after type_check for all expressions are
+    // implemented
+    if (output->ret_type == PrimitiveType::unknown)
+      return;
+    // There are no specifications for external func calls for now,
+    // so output types are not checked.
+  }
+  // External func calls have no return type.
 }
 
 void ExternalFuncCallExpression::flatten(FlattenContext *ctx) {
@@ -683,6 +716,20 @@ void ExternalTensorShapeAlongAxisExpression::flatten(FlattenContext *ctx) {
   TI_ASSERT(0 <= axis && axis < temp->dim);
   ctx->push_back<ExternalTensorShapeAlongAxisStmt>(axis, temp->arg_id);
   stmt = ctx->back_stmt();
+}
+
+void FuncCallExpression::type_check() {
+  for (auto &arg : args.exprs) {
+    // TODO: assert no unknowns after type_check for all expressions are
+    // implemented
+    if (arg->ret_type == PrimitiveType::unknown)
+      return;
+    // There are no specifications for external func calls for now,
+    // so arg types are not checked.
+  }
+  if (func->rets.size() == 1) {
+    ret_type = func->rets[0].dt;
+  }
 }
 
 void FuncCallExpression::flatten(FlattenContext *ctx) {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -357,6 +357,8 @@ class InternalFuncCallExpression : public Expression {
     }
   }
 
+  void type_check() override;
+
   void serialize(std::ostream &ss) override {
     ss << "internal call " << func_name << '(';
     std::string args_str;
@@ -394,6 +396,8 @@ class ExternalFuncCallExpression : public Expression {
         args(args),
         outputs(outputs) {
   }
+
+  void type_check() override;
 
   void serialize(std::ostream &ss) override {
     if (so_func != nullptr) {
@@ -749,6 +753,8 @@ class FuncCallExpression : public Expression {
  public:
   Function *func;
   ExprGroup args;
+
+  void type_check() override;
 
   void serialize(std::ostream &ss) override;
 

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -173,5 +173,11 @@ TEST(FrontendTypeInference, LoopUnique) {
   EXPECT_EQ(loop_unique->ret_type, PrimitiveType::i64);
 }
 
+TEST(FrontendTypeInference, InternalFuncCall) {
+  auto internal_func_call = Expr::make<InternalFuncCallExpression>("do_nothing", std::vector<Expr>{});
+  internal_func_call->type_check();
+  EXPECT_EQ(internal_func_call->ret_type, PrimitiveType::i32);
+}
+
 }  // namespace lang
 }  // namespace taichi

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -174,7 +174,8 @@ TEST(FrontendTypeInference, LoopUnique) {
 }
 
 TEST(FrontendTypeInference, InternalFuncCall) {
-  auto internal_func_call = Expr::make<InternalFuncCallExpression>("do_nothing", std::vector<Expr>{});
+  auto internal_func_call =
+      Expr::make<InternalFuncCallExpression>("do_nothing", std::vector<Expr>{});
   internal_func_call->type_check();
   EXPECT_EQ(internal_func_call->ret_type, PrimitiveType::i32);
 }


### PR DESCRIPTION
Related issue = #3301

This PR adds `type_check` for remaining expressions and removes all `TODO: assert no unknowns after type_check for all expressions are implemented`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
