### PR TITLE
[Bug] [ir] Visit RangeForStmt in IdentifyValuesUsedInOtherOffloads

### DIFF
--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -323,6 +323,13 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     TI_ASSERT(current_offloaded);
   }
 
+  void visit(RangeForStmt *stmt) override {
+    test_and_allocate(stmt->begin);
+    test_and_allocate(stmt->end);
+    if (stmt->body)
+      stmt->body->accept(this);
+  }
+
   void test_and_allocate(Stmt *stmt) {
     if (stmt == nullptr)
       return;

--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -108,3 +108,15 @@ def test_offload_with_cross_block_globals():
     ker()
 
     assert ret[None] == 46
+
+
+@ti.test()
+def test_offload_with_cross_nested_for():
+    @ti.kernel
+    def run(a: ti.i32):
+        b = a + 1
+        for x in range(1):
+            for i in range(b):
+                print('OK')
+
+    run(2)


### PR DESCRIPTION
Related issue = fixes #3463

See #3467 for more details.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
