### PR TITLE
[Lang] Enable local tensors as arithmetic operation results

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -169,20 +169,24 @@ class Matrix(TaichiOperations):
     def element_wise_binary(self, foo, other):
         _taichi_skip_traceback = 1
         other = self.broadcast_copy(other)
-        return Matrix([[foo(self(i, j), other(i, j)) for j in range(self.m)] for i in range(self.n)])
+        return Matrix([[foo(self(i, j), other(i, j)) for j in range(self.m)]
+                       for i in range(self.n)])
 
     def broadcast_copy(self, other):
         if isinstance(other, (list, tuple)):
             other = Matrix(other)
         if not isinstance(other, Matrix):
-            other = Matrix([[other for _ in range(self.m)] for _ in range(self.n)])
+            other = Matrix([[other for _ in range(self.m)]
+                            for _ in range(self.n)])
         assert self.m == other.m and self.n == other.n, f"Dimension mismatch between shapes ({self.n}, {self.m}), ({other.n}, {other.m})"
         return other
 
     def element_wise_ternary(self, foo, other, extra):
         other = self.broadcast_copy(other)
         extra = self.broadcast_copy(extra)
-        return Matrix([[foo(self(i, j), other(i, j), extra(i, j)) for j in range(self.m)] for i in range(self.n)])
+        return Matrix([[
+            foo(self(i, j), other(i, j), extra(i, j)) for j in range(self.m)
+        ] for i in range(self.n)])
 
     def element_wise_writeback_binary(self, foo, other):
         ret = self.empty_copy()
@@ -206,7 +210,8 @@ class Matrix(TaichiOperations):
 
     def element_wise_unary(self, foo):
         _taichi_skip_traceback = 1
-        return Matrix([[foo(self(i, j)) for j in range(self.m)] for i in range(self.n)])
+        return Matrix([[foo(self(i, j)) for j in range(self.m)]
+                       for i in range(self.n)])
 
     def __matmul__(self, other):
         """Matrix-matrix or matrix-vector multiply.

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -659,7 +659,10 @@ class SNodeOpExpression : public Expression {
                     SNodeOpType op_type,
                     const ExprGroup &indices,
                     const Expr &value)
-      : snode(snode), op_type(op_type), indices(indices.loaded()), value(value) {
+      : snode(snode),
+        op_type(op_type),
+        indices(indices.loaded()),
+        value(value) {
   }
 
   void type_check() override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -652,14 +652,14 @@ class SNodeOpExpression : public Expression {
   Expr value;
 
   SNodeOpExpression(SNode *snode, SNodeOpType op_type, const ExprGroup &indices)
-      : snode(snode), op_type(op_type), indices(indices) {
+      : snode(snode), op_type(op_type), indices(indices.loaded()) {
   }
 
   SNodeOpExpression(SNode *snode,
                     SNodeOpType op_type,
                     const ExprGroup &indices,
                     const Expr &value)
-      : snode(snode), op_type(op_type), indices(indices), value(value) {
+      : snode(snode), op_type(op_type), indices(indices.loaded()), value(value) {
   }
 
   void type_check() override;


### PR DESCRIPTION
Related issue = #2590, #2880, #2637

This PR rewrites arithmetic operations of matrices so as to simplify the implementation as well as to enable local tensors as arithmetic operation results (`empty_copy()` in the old implementation has `disable_local_tensor=True`).

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
