### PR TITLE
[opengl] Unify windows path to posix format in python.

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -1,6 +1,7 @@
 import shutil
 import warnings
 from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
 
 from taichi.core import ti_core as _ti_core
 from taichi.lang import impl, kernel_impl
@@ -193,4 +194,5 @@ class Module:
           filepath (str): path to a folder to store aot files.
           filename (str): filename prefix for stored aot files.
         """
+        filepath = str(PurePosixPath(Path(filepath).resolve()))
         self._aot_builder.dump(filepath, filename)

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -21,15 +21,8 @@ namespace {
 void write_glsl_file(const std::string &output_dir,
                      const std::string &filename,
                      CompiledKernel &k) {
-// Hack to assemble readable windows/unix path.
-// Ideally we could use std::filesystem but it's not available on MacOS 10.14.
-#if defined(TI_PLATFORM_WINDOWS)
-  const std::string path_delim = "\\";
-#else
-  const std::string path_delim = "/";
-#endif
-  const std::string glsl_path = fmt::format(
-      "{}{}{}_{}.glsl", output_dir, path_delim, filename, k.kernel_name);
+  const std::string glsl_path =
+      fmt::format("{}/{}_{}.glsl", output_dir, filename, k.kernel_name);
   std::ofstream fs{glsl_path};
   fs << k.kernel_src;
   k.kernel_src = glsl_path;

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -8,11 +8,6 @@ import pytest
 import taichi as ti
 
 
-def _escape_path_for_win(json_str):
-    return json_str.replace(os.sep,
-                            r'\\') if ti.get_os_name() == 'win' else json_str
-
-
 @ti.test(arch=ti.cc)
 def test_record():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -62,9 +57,7 @@ def test_save():
         m.save(tmpdir, filename)
         with open(os.path.join(tmpdir,
                                f'{filename}_metadata.json')) as json_file:
-            json_str = ''.join(json_file.readlines())
-            json_str = _escape_path_for_win(json_str)
-            json.loads(json_str)
+            json.load(json_file)
 
 
 @ti.test(arch=ti.opengl)
@@ -175,6 +168,4 @@ def test_mpm88_aot():
         m.save(tmpdir, filename)
         with open(os.path.join(tmpdir,
                                f'{filename}_metadata.json')) as json_file:
-            json_str = ''.join(json_file.readlines())
-            json_str = _escape_path_for_win(json_str)
-            json.loads(json_str)
+            json.load(json_file)


### PR DESCRIPTION
Tested on the windows opengl backend manually.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
