### PR TITLE
[refactor] Decoupling KernelProfilerBase::sync() from Program::synchronize()

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -109,6 +109,29 @@ type_factory_ = _ti_core.get_type_factory_instance()
 
 
 def set_kernel_profiler_mode(mode: bool):
+    """Temporarily turn ON or OFF kernel profiler.
+
+    Args:
+        mode (bool): Temporarily turn ON or OFF.
+
+    Example::
+
+        >>> import taichi as ti
+
+        >>> ti.init(ti.cpu, kernel_profiler=True)
+        >>> ti.set_kernel_profiler_mode(False)
+        >>> var = ti.field(ti.f32, shape=1)
+
+        >>> @ti.kernel
+        >>> def compute():
+        >>>     var[0] = 1.0
+
+        >>> compute() # The first call has JIT compilation overhead.
+        >>> ti.set_kernel_profiler_mode(True)
+        >>> for i in range(128):
+        >>>     compute()
+        >>> ti.print_kernel_profile_info()
+    """
     get_default_kernel_profiler().set_kernel_profiler_mode(mode)
 
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -108,6 +108,10 @@ timeline_save = lambda fn: impl.get_runtime().prog.timeline_save(fn)
 type_factory_ = _ti_core.get_type_factory_instance()
 
 
+def set_kernel_profiler_mode(mode: bool):
+    get_default_kernel_profiler().set_kernel_profiler_mode(mode)
+
+
 @deprecated('kernel_profiler_print()', 'print_kernel_profile_info()')
 def kernel_profiler_print():
     return print_kernel_profile_info()

--- a/python/taichi/profiler/kernelprofiler.py
+++ b/python/taichi/profiler/kernelprofiler.py
@@ -63,6 +63,9 @@ class KernelProfiler:
         """Turn on or off :class:`~taichi.profiler.kernelprofiler.KernelProfiler`."""
         if type(mode) is bool:
             self._profiling_mode = mode
+            #passing `mode` to backend
+            if impl.get_runtime().prog is not None:
+                impl.get_runtime().prog.set_kernel_profiler_mode(mode)
         else:
             raise TypeError(
                 f'Arg `mode` must be of type boolean. Type {type(mode)} is not supported.'
@@ -93,7 +96,7 @@ class KernelProfiler:
         if self._check_not_turned_on_with_warning_message():
             return None
         #sync first
-        impl.get_runtime().sync()
+        self._sync_backend()
         #then clear backend & frontend info
         impl.get_runtime().prog.clear_kernel_profile_info()
         self._clear_frontend()
@@ -167,6 +170,9 @@ class KernelProfiler:
         else:
             return False
 
+    def _sync_backend(self):
+        impl.get_runtime().prog.sync_kernel_profiler()
+
     def _clear_frontend(self):
         """Clear member variables in :class:`~taichi.profiler.kernelprofiler.KernelProfiler`.
 
@@ -179,7 +185,7 @@ class KernelProfiler:
 
     def _update_records(self):
         """Acquires kernel records from a backend."""
-        impl.get_runtime().sync()
+        self._sync_backend()
         self._clear_frontend()
         self._traced_records = impl.get_runtime(
         ).prog.get_kernel_profiler_records()

--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -84,7 +84,7 @@ void CUDAContext::launch(void *func,
 
   KernelProfilerBase::TaskHandle task_handle;
   // Kernel launch
-  if (profiler_) {
+  if (profiler_ && profiler_->is_enabled()) {
     KernelProfilerCUDA *profiler_cuda =
         dynamic_cast<KernelProfilerCUDA *>(profiler_);
     profiler_cuda->trace(task_handle, task_name, func, grid_dim, block_dim, 0);
@@ -111,7 +111,7 @@ void CUDAContext::launch(void *func,
                           dynamic_shared_mem_bytes, nullptr,
                           arg_pointers.data(), nullptr);
   }
-  if (profiler_)
+  if (profiler_ && profiler_->is_enabled())
     profiler_->stop(task_handle);
 
   if (debug_) {

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -9,7 +9,8 @@ TLANG_NAMESPACE_BEGIN
 
 // The init logic here is temporarily set up for test CUPTI
 // will not affect default toolkit (cuEvent)
-KernelProfilerCUDA::KernelProfilerCUDA(bool enabled): KernelProfilerBase(enabled) {
+KernelProfilerCUDA::KernelProfilerCUDA(bool enabled)
+    : KernelProfilerBase(enabled) {
   metric_list_.clear();
   if (enabled) {
     tool_ = ProfilingToolkit::event;
@@ -31,6 +32,21 @@ KernelProfilerCUDA::KernelProfilerCUDA(bool enabled): KernelProfilerBase(enabled
 
 std::string KernelProfilerCUDA::get_device_name() {
   return CUDAContext::get_instance().get_device_name();
+}
+
+void KernelProfilerCUDA::set_kernel_profiler_mode(bool enabled) {
+  enabled_ = enabled;
+  if (tool_ == ProfilingToolkit::cupti) {
+    if (enabled_) {
+      // to reuse reinit_with_metrics(), init() first
+      cupti_toolkit_->init_cupti();
+      cupti_toolkit_->begin_profiling();
+      reinit_with_metrics(metric_list_);
+    } else {
+      cupti_toolkit_->end_profiling();
+      cupti_toolkit_->deinit_cupti();
+    }
+  }
 }
 
 bool KernelProfilerCUDA::reinit_with_metrics(

--- a/taichi/backends/cuda/cuda_profiler.cpp
+++ b/taichi/backends/cuda/cuda_profiler.cpp
@@ -9,9 +9,9 @@ TLANG_NAMESPACE_BEGIN
 
 // The init logic here is temporarily set up for test CUPTI
 // will not affect default toolkit (cuEvent)
-KernelProfilerCUDA::KernelProfilerCUDA(bool enable) {
+KernelProfilerCUDA::KernelProfilerCUDA(bool enabled): KernelProfilerBase(enabled) {
   metric_list_.clear();
-  if (enable) {
+  if (enabled) {
     tool_ = ProfilingToolkit::event;
 #if defined(TI_WITH_CUDA_TOOLKIT)
     // if Taichi was compiled with CUDA toolit, then use CUPTI

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -26,6 +26,7 @@ class KernelProfilerCUDA : public KernelProfilerBase {
 
   std::string get_device_name() override;
 
+  void set_kernel_profiler_mode(bool enabled) override;
   bool reinit_with_metrics(const std::vector<std::string> metrics) override;
   void trace(KernelProfilerBase::TaskHandle &task_handle,
              const std::string &kernel_name,

--- a/taichi/backends/cuda/cuda_profiler.h
+++ b/taichi/backends/cuda/cuda_profiler.h
@@ -22,7 +22,7 @@ class EventToolkit;
 // A CUDA kernel profiler
 class KernelProfilerCUDA : public KernelProfilerBase {
  public:
-  KernelProfilerCUDA(bool enable);
+  KernelProfilerCUDA(bool enabled);
 
   std::string get_device_name() override;
 

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -72,10 +72,11 @@ class DefaultProfiler : public KernelProfilerBase {
   void sync() override {
   }
 
-  DefaultProfiler(bool enabled) : KernelProfilerBase(enabled) {}
+  DefaultProfiler(bool enabled) : KernelProfilerBase(enabled) {
+  }
 
   void clear() override {
-    //trigger sync(); from the foront end
+    // trigger sync(); from the foront end
     total_time_ms_ = 0;
     traced_records_.clear();
     statistical_results_.clear();

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -72,8 +72,10 @@ class DefaultProfiler : public KernelProfilerBase {
   void sync() override {
   }
 
+  DefaultProfiler(bool enabled) : KernelProfilerBase(enabled) {}
+
   void clear() override {
-    // sync(); //decoupled: trigger from the foront end
+    //trigger sync(); from the foront end
     total_time_ms_ = 0;
     traced_records_.clear();
     statistical_results_.clear();
@@ -114,6 +116,9 @@ class DefaultProfiler : public KernelProfilerBase {
 }  // namespace
 
 std::unique_ptr<KernelProfilerBase> make_profiler(Arch arch, bool enable) {
+  if (!enable)
+    return nullptr;
+
   if (arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
     return std::make_unique<KernelProfilerCUDA>(enable);
@@ -121,7 +126,7 @@ std::unique_ptr<KernelProfilerBase> make_profiler(Arch arch, bool enable) {
     TI_NOT_IMPLEMENTED;
 #endif
   } else {
-    return std::make_unique<DefaultProfiler>();
+    return std::make_unique<DefaultProfiler>(enable);
   }
 }
 

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -83,11 +83,15 @@ class DefaultProfiler : public KernelProfilerBase {
   }
 
   void start(const std::string &kernel_name) override {
+    if (!enabled_)
+      return;
     start_t_ = Time::get_time();
     event_name_ = kernel_name;
   }
 
   void stop() override {
+    if (!enabled_)
+      return;
     auto t = Time::get_time() - start_t_;
     auto ms = t * 1000.0;
     // trace record

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -58,7 +58,7 @@ class KernelProfilerBase {
     enabled_ = enabled;
   }
 
-  void set_kernel_profiler_mode(bool enabled) {
+  virtual void set_kernel_profiler_mode(bool enabled) {
     enabled_ = enabled;
   }
 

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -48,10 +48,23 @@ class KernelProfilerBase {
   std::vector<KernelProfileTracedRecord> traced_records_;
   std::vector<KernelProfileStatisticalResult> statistical_results_;
   double total_time_ms_{0};
+  bool enabled_{false};
 
  public:
   // Needed for the CUDA backend since we need to know which task to "stop"
   using TaskHandle = void *;
+
+  KernelProfilerBase(bool enabled) {
+    enabled_ = enabled;
+  }
+
+  void set_kernel_profiler_mode(bool enabled) {
+    enabled_ = enabled;
+  }
+
+  bool is_enabled() {
+    return enabled_;
+  }
 
   virtual bool reinit_with_metrics(const std::vector<std::string> metrics) {
     return false;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -224,9 +224,6 @@ void Program::synchronize() {
     if (config.async_mode) {
       async_engine->synchronize();
     }
-    if (profiler) {
-      profiler->sync();
-    }
     if (arch_uses_llvm(config.arch) || config.arch == Arch::metal ||
         config.arch == Arch::vulkan) {
       program_impl_->synchronize();

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -141,6 +141,10 @@ class Program {
     return query_result;
   }
 
+  // void set_kernel_profiler_mode(bool enabled) {
+  //   profiler->set_kernel_profiler_mode(enabled);
+  // }
+
   void clear_kernel_profile_info() {
     profiler->clear();
   }

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -141,10 +141,6 @@ class Program {
     return query_result;
   }
 
-  // void set_kernel_profiler_mode(bool enabled) {
-  //   profiler->set_kernel_profiler_mode(enabled);
-  // }
-
   void clear_kernel_profile_info() {
     profiler->clear();
   }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -244,6 +244,12 @@ void export_lang(py::module &m) {
   py::class_<Program>(m, "Program")
       .def(py::init<>())
       .def_readonly("config", &Program::config)
+      .def("set_kernel_profiler_mode",
+           [](Program *program, const bool enabled) {
+             program->profiler->set_kernel_profiler_mode(enabled);
+           })
+      .def("sync_kernel_profiler",
+           [](Program *program) { program->profiler->sync(); })
       .def("query_kernel_profile_info",
            [](Program *program, const std::string &name) {
              return program->query_kernel_profile_info(name);


### PR DESCRIPTION
Related issue = #2922

And `set_kernel_profiler_mode()` for temporarily turn `ON` or `OFF` kernel profiler.