### PR TITLE
[CUDA] Fix a misuse of std::move: address of stack memory associated with temporary object of type std::lock_guard<std::mutex> returned to caller

### DIFF
--- a/taichi/backends/cuda/cuda_context.h
+++ b/taichi/backends/cuda/cuda_context.h
@@ -95,8 +95,8 @@ class CUDAContext {
     return ContextGuard(this);
   }
 
-  std::lock_guard<std::mutex> get_lock_guard() {
-    return std::lock_guard<std::mutex>(lock_);
+  std::unique_lock<std::mutex> get_lock_guard() {
+    return std::unique_lock<std::mutex>(lock_);
   }
 
   static CUDAContext &get_instance();

--- a/taichi/backends/cuda/cuda_context.h
+++ b/taichi/backends/cuda/cuda_context.h
@@ -95,8 +95,8 @@ class CUDAContext {
     return ContextGuard(this);
   }
 
-  std::lock_guard<std::mutex> &&get_lock_guard() {
-    return std::move(std::lock_guard<std::mutex>(lock_));
+  std::lock_guard<std::mutex> get_lock_guard() {
+    return std::lock_guard<std::mutex>(lock_);
   }
 
   static CUDAContext &get_instance();

--- a/taichi/backends/cuda/jit_cuda.cpp
+++ b/taichi/backends/cuda/jit_cuda.cpp
@@ -20,8 +20,7 @@ JITModule *JITSessionCUDA ::add_module(std::unique_ptr<llvm::Module> M,
   TI_TRACE("PTX size: {:.2f}KB", ptx.size() / 1024.0);
   auto t = Time::get_time();
   TI_TRACE("Loading module...");
-  [[maybe_unused]] auto &&_ =
-      std::move(CUDAContext::get_instance().get_lock_guard());
+  [[maybe_unused]] auto _ = CUDAContext::get_instance().get_lock_guard();
 
   constexpr int max_num_options = 8;
   int num_options = 0;


### PR DESCRIPTION
Related issue = #

In the original code, the returned rvalue reference is obviously a dangling reference, and the scoped mutex has no effect (destructed immediately after construction).
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
