### PR TITLE
[llvm] Add a TI_WITH_LLVM option

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -1,4 +1,5 @@
 option(USE_STDCPP "Use -stdlib=libc++" OFF)
+option(TI_WITH_LLVM "Build with LLVM backends" OFF)
 option(TI_WITH_CUDA "Build with the CUDA backend" ON)
 option(TI_WITH_CUDA_TOOLKIT "Build with the CUDA toolkit" OFF)
 option(TI_WITH_OPENGL "Build with the OpenGL backend" ON)
@@ -42,6 +43,10 @@ endif()
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/glad/src/gl.c")
     set(TI_WITH_OPENGL OFF)
     message(WARNING "external/glad submodule not detected. Settings TI_WITH_OPENGL to OFF.")
+endif()
+
+if(NOT TI_WITH_LLVM)
+    set(TI_WITH_CUDA OFF)
 endif()
 
 
@@ -98,8 +103,15 @@ file(GLOB TAICHI_VULKAN_REQUIRED_SOURCE
 
 list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_BACKEND_SOURCE})
 
-list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CPU_SOURCE})
-list(APPEND TAICHI_CORE_SOURCE ${TAICHI_WASM_SOURCE})
+if(TI_WITH_LLVM)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_LLVM")
+    list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CPU_SOURCE})
+    list(APPEND TAICHI_CORE_SOURCE ${TAICHI_WASM_SOURCE})
+else()
+    file(GLOB TAICHI_LLVM_SOURCE "taichi/llvm/*.cpp" "taichi/llvm/*.h")
+    list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_LLVM_SOURCE})
+endif()
+
 list(APPEND TAICHI_CORE_SOURCE ${TAICHI_INTEROP_SOURCE})
 
 

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -47,6 +47,7 @@ endif()
 
 if(NOT TI_WITH_LLVM)
     set(TI_WITH_CUDA OFF)
+    set(TI_WITH_CUDA_TOOLKIT OFF)
 endif()
 
 

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -1,5 +1,5 @@
 option(USE_STDCPP "Use -stdlib=libc++" OFF)
-option(TI_WITH_LLVM "Build with LLVM backends" OFF)
+option(TI_WITH_LLVM "Build with LLVM backends" ON)
 option(TI_WITH_CUDA "Build with the CUDA backend" ON)
 option(TI_WITH_CUDA_TOOLKIT "Build with the CUDA toolkit" OFF)
 option(TI_WITH_OPENGL "Build with the OpenGL backend" ON)

--- a/taichi/backends/interop/vulkan_cpu_interop.cpp
+++ b/taichi/backends/interop/vulkan_cpu_interop.cpp
@@ -10,7 +10,7 @@
 namespace taichi {
 namespace lang {
 
-#if TI_WITH_VULKAN
+#if TI_WITH_VULKAN && defined(TI_WITH_LLVM)
 
 using namespace taichi::lang::vulkan;
 using namespace taichi::lang::cpu;

--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<KernelCodeGen> KernelCodeGen::create(Arch arch,
     TI_NOT_IMPLEMENTED
   }
 #else
-  TI_NOT_IMPLEMENTED
+  TI_ERROR("Llvm disabled");
 #endif
 }
 

--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -3,8 +3,10 @@
 #include "codegen.h"
 
 #include "taichi/util/statistics.h"
+#if defined(TI_WITH_LLVM)
 #include "taichi/backends/cpu/codegen_cpu.h"
 #include "taichi/backends/wasm/codegen_wasm.h"
+#endif
 #if defined(TI_WITH_CUDA)
 #include "taichi/backends/cuda/codegen_cuda.h"
 #endif
@@ -31,6 +33,7 @@ KernelCodeGen::KernelCodeGen(Kernel *kernel, IRNode *ir)
 std::unique_ptr<KernelCodeGen> KernelCodeGen::create(Arch arch,
                                                      Kernel *kernel,
                                                      Stmt *stmt) {
+#ifdef TI_WITH_LLVM
   if (arch_is_cpu(arch) && arch != Arch::wasm) {
     return std::make_unique<CodeGenCPU>(kernel, stmt);
   } else if (arch == Arch::wasm) {
@@ -44,6 +47,9 @@ std::unique_ptr<KernelCodeGen> KernelCodeGen::create(Arch arch,
   } else {
     TI_NOT_IMPLEMENTED
   }
+#else
+  TI_NOT_IMPLEMENTED
+#endif
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1,3 +1,4 @@
+#ifdef TI_WITH_LLVM
 #include "taichi/codegen/codegen_llvm.h"
 
 #include "taichi/ir/statements.h"
@@ -2317,3 +2318,5 @@ llvm::Value *CodeGenLLVM::create_xlogue(std::unique_ptr<Block> &block) {
 }
 
 TLANG_NAMESPACE_END
+
+#endif  // #ifdef TI_WITH_LLVM

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -1,5 +1,6 @@
 // The LLVM backend for CPUs/NVPTX/AMDGPU
 #pragma once
+#ifdef TI_WITH_LLVM
 
 #include <set>
 #include <unordered_map>
@@ -371,3 +372,5 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 };
 
 TLANG_NAMESPACE_END
+
+#endif  // #ifdef TI_WITH_LLVM

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -1,3 +1,4 @@
+#ifdef TI_WITH_LLVM
 #include "taichi/codegen/codegen_llvm.h"
 
 #include "taichi/ir/statements.h"
@@ -669,3 +670,5 @@ llvm::Value *CodeGenLLVM::load_custom_float(Stmt *ptr_stmt) {
 }
 
 TLANG_NAMESPACE_END
+
+#endif  // #ifdef TI_WITH_LLVM

--- a/taichi/jit/jit_session.cpp
+++ b/taichi/jit/jit_session.cpp
@@ -8,6 +8,7 @@ std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch);
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(Arch arch);
 
 std::unique_ptr<JITSession> JITSession::create(Arch arch) {
+#ifdef TI_WITH_LLVM
   if (arch_is_cpu(arch)) {
     return create_llvm_jit_session_cpu(arch);
   } else if (arch == Arch::cuda) {
@@ -16,8 +17,10 @@ std::unique_ptr<JITSession> JITSession::create(Arch arch) {
 #else
     TI_NOT_IMPLEMENTED
 #endif
-  } else
-    TI_NOT_IMPLEMENTED
+  }
+#else
+  TI_NOT_IMPLEMENTED
+#endif
 }
 
 std::size_t JITSession::get_type_size(llvm::Type *type) {

--- a/taichi/jit/jit_session.cpp
+++ b/taichi/jit/jit_session.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<JITSession> JITSession::create(Arch arch) {
 #endif
   }
 #else
-  TI_NOT_IMPLEMENTED
+  TI_ERROR("Llvm disabled");
 #endif
 }
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -10,7 +10,10 @@
 #include "taichi/program/program.h"
 #include "taichi/util/action_recorder.h"
 #include "taichi/util/statistics.h"
+
+#ifdef TI_WITH_LLVM
 #include "taichi/llvm/llvm_program.h"
+#endif
 
 TLANG_NAMESPACE_BEGIN
 
@@ -22,9 +25,11 @@ Kernel::Kernel(Program &program,
                bool grad)
     : grad(grad), lowered_(false) {
   this->program = &program;
+#ifdef TI_WITH_LLVM
   if (auto *llvm_program_impl = program.get_llvm_program_impl()) {
     llvm_program_impl->maybe_initialize_cuda_llvm_context();
   }
+#endif
   is_accessor = false;
   is_evaluator = false;
   compiled_ = nullptr;
@@ -272,9 +277,11 @@ void Kernel::LaunchContextBuilder::set_arg_raw(int arg_id, uint64 d) {
 }
 
 Context &Kernel::LaunchContextBuilder::get_context() {
+#ifdef TI_WITH_LLVM
   if (auto *llvm_program_impl = kernel_->program->get_llvm_program_impl()) {
     ctx_->runtime = llvm_program_impl->get_llvm_runtime();
   }
+#endif
   return *ctx_;
 }
 

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -23,7 +23,7 @@ Ndarray::Ndarray(Program *prog,
 
   data_ptr_ = prog_impl->get_ndarray_alloc_info_ptr(ndarray_alloc_);
 #else
-  TI_NOT_IMPLEMENTED
+  TI_ERROR("Llvm disabled");
 #endif
 }
 

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -16,11 +16,15 @@ Ndarray::Ndarray(Program *prog,
                                 1,
                                 std::multiplies<>())),
       element_size_(data_type_size(dtype)) {
+#ifdef TI_WITH_LLVM
   LlvmProgramImpl *prog_impl = prog->get_llvm_program_impl();
   ndarray_alloc_ = prog_impl->allocate_memory_ndarray(nelement_ * element_size_,
                                                       prog->result_buffer);
 
   data_ptr_ = prog_impl->get_ndarray_alloc_info_ptr(ndarray_alloc_);
+#else
+  TI_NOT_IMPLEMENTED
+#endif
 }
 
 intptr_t Ndarray::get_data_ptr_as_int() const {

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -5,8 +5,12 @@
 
 #include "taichi/inc/constants.h"
 #include "taichi/ir/type_utils.h"
+#include "taichi/backends/device.h"
+
+#ifdef TI_WITH_LLVM
 #include "taichi/llvm/llvm_context.h"
 #include "taichi/llvm/llvm_program.h"
+#endif
 
 namespace taichi {
 namespace lang {

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -70,8 +70,11 @@ Program::Program(Arch desired_arch)
 
   profiler = make_profiler(config.arch, config.kernel_profiler);
   if (arch_uses_llvm(config.arch)) {
+#ifdef TI_WITH_LLVM
     program_impl_ = std::make_unique<LlvmProgramImpl>(config, profiler.get());
-
+#else
+    TI_NOT_IMPLEMENTED
+#endif
   } else if (config.arch == Arch::metal) {
     if (!metal::is_metal_api_available()) {
       TI_WARN("No Metal API detected.");
@@ -126,7 +129,11 @@ Program::Program(Arch desired_arch)
   TI_ASSERT(current_program == nullptr);
   current_program = this;
   if (arch_uses_llvm(config.arch)) {
+#if TI_WITH_LLVM
     static_cast<LlvmProgramImpl *>(program_impl_.get())->initialize_host();
+#else
+    TI_NOT_IMPLEMENTED
+#endif
   }
 
   result_buffer = nullptr;
@@ -214,9 +221,13 @@ SNode *Program::get_snode_root(int tree_id) {
 }
 
 void Program::check_runtime_error() {
+#ifdef TI_WITH_LLVM
   TI_ASSERT(arch_uses_llvm(config.arch));
   static_cast<LlvmProgramImpl *>(program_impl_.get())
       ->check_runtime_error(result_buffer);
+#else
+  TI_NOT_IMPLEMENTED
+#endif
 }
 
 void Program::synchronize() {
@@ -436,8 +447,12 @@ Kernel &Program::get_ndarray_writer(Ndarray *ndarray) {
 
 uint64 Program::fetch_result_uint64(int i) {
   if (arch_uses_llvm(config.arch)) {
+#ifdef TI_WITH_LLVM
     return static_cast<LlvmProgramImpl *>(program_impl_.get())
         ->fetch_result<uint64>(i, result_buffer);
+#else
+    TI_NOT_IMPLEMENTED
+#endif
   }
   return result_buffer[i];
 }
@@ -487,7 +502,11 @@ void Program::finalize() {
   memory_pool_->terminate();
 
   if (arch_uses_llvm(config.arch)) {
+#if TI_WITH_LLVM
     static_cast<LlvmProgramImpl *>(program_impl_.get())->finalize();
+#else
+    TI_NOT_IMPLEMENTED
+#endif
   }
 
   finalized_ = true;
@@ -504,9 +523,13 @@ int Program::default_block_dim(const CompileConfig &config) {
 }
 
 void Program::print_memory_profiler_info() {
+#ifdef TI_WITH_LLVM
   TI_ASSERT(arch_uses_llvm(config.arch));
   static_cast<LlvmProgramImpl *>(program_impl_.get())
       ->print_memory_profiler_info(snode_trees_, result_buffer);
+#else
+  TI_NOT_IMPLEMENTED
+#endif
 }
 
 std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
@@ -527,7 +550,11 @@ std::unique_ptr<AotModuleBuilder> Program::make_aot_module_builder(Arch arch) {
   // platform. Consider decoupling this part
   if (arch == Arch::wasm) {
     // Have to check WASM first, or it dispatches to the LlvmProgramImpl.
+#ifdef TI_WITH_LLVM
     return std::make_unique<wasm::AotModuleBuilderImpl>();
+#else
+    TI_NOT_IMPLEMENTED
+#endif
   }
   if (arch_uses_llvm(config.arch) || config.arch == Arch::metal ||
       config.arch == Arch::vulkan || config.arch == Arch::opengl) {
@@ -537,7 +564,11 @@ std::unique_ptr<AotModuleBuilder> Program::make_aot_module_builder(Arch arch) {
 }
 
 LlvmProgramImpl *Program::get_llvm_program_impl() {
+#ifdef TI_WITH_LLVM
   return static_cast<LlvmProgramImpl *>(program_impl_.get());
+#else
+  TI_NOT_IMPLEMENTED
+#endif
 }
 
 }  // namespace lang

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -226,7 +226,7 @@ void Program::check_runtime_error() {
   static_cast<LlvmProgramImpl *>(program_impl_.get())
       ->check_runtime_error(result_buffer);
 #else
-  TI_NOT_IMPLEMENTED
+  TI_ERROR("Llvm disabled");
 #endif
 }
 
@@ -528,7 +528,7 @@ void Program::print_memory_profiler_info() {
   static_cast<LlvmProgramImpl *>(program_impl_.get())
       ->print_memory_profiler_info(snode_trees_, result_buffer);
 #else
-  TI_NOT_IMPLEMENTED
+  TI_ERROR("Llvm disabled");
 #endif
 }
 
@@ -567,7 +567,7 @@ LlvmProgramImpl *Program::get_llvm_program_impl() {
 #ifdef TI_WITH_LLVM
   return static_cast<LlvmProgramImpl *>(program_impl_.get());
 #else
-  TI_NOT_IMPLEMENTED
+  TI_ERROR("Llvm disabled");
 #endif
 }
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -900,7 +900,9 @@ void export_lang(py::module &m) {
   m.def("test_throw", [] { throw IRModified(); });
   m.def("needs_grad", needs_grad);
 
+#if TI_WITH_LLVM
   m.def("libdevice_path", libdevice_path);
+#endif
 
   m.def("host_arch", host_arch);
 

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -1,3 +1,4 @@
+#ifdef TI_WITH_LLVM
 #include "taichi/struct/struct_llvm.h"
 
 #include "llvm/IR/Verifier.h"
@@ -347,3 +348,5 @@ llvm::Type *StructCompilerLLVM::get_llvm_element_type(llvm::Module *module,
 
 }  // namespace lang
 }  // namespace taichi
+
+#endif  //#ifdef TI_WITH_LLVM

--- a/taichi/struct/struct_llvm.h
+++ b/taichi/struct/struct_llvm.h
@@ -7,6 +7,8 @@
 
 namespace taichi {
 namespace lang {
+
+class LlvmProgramImpl;
 class StructCompilerLLVM : public StructCompiler, public LLVMModuleBuilder {
  public:
   StructCompilerLLVM(Arch arch,

--- a/taichi/struct/struct_llvm.h
+++ b/taichi/struct/struct_llvm.h
@@ -1,4 +1,5 @@
 #pragma once
+#ifdef TI_WITH_LLVM
 // Codegen for the hierarchical data structure (LLVM)
 #include "taichi/llvm/llvm_program.h"
 #include "taichi/llvm/llvm_codegen_utils.h"
@@ -46,3 +47,5 @@ class StructCompilerLLVM : public StructCompiler, public LLVMModuleBuilder {
 
 }  // namespace lang
 }  // namespace taichi
+
+#endif  //#ifdef TI_WITH_LLVM

--- a/taichi/system/snode_tree_buffer_manager.cpp
+++ b/taichi/system/snode_tree_buffer_manager.cpp
@@ -69,7 +69,7 @@ Ptr SNodeTreeBufferManager::allocate(JITModule *runtime_jit,
     return x.second;
   }
 #else
-  TI_NOT_IMPLEMENTED
+  TI_ERROR("Llvm disabled");
 #endif
 }
 

--- a/taichi/system/snode_tree_buffer_manager.cpp
+++ b/taichi/system/snode_tree_buffer_manager.cpp
@@ -1,10 +1,12 @@
 #include "snode_tree_buffer_manager.h"
 #include "taichi/program/program.h"
+#ifdef TI_WITH_LLVM
 #include "taichi/llvm/llvm_program.h"
+#endif
 
 TLANG_NAMESPACE_BEGIN
 
-SNodeTreeBufferManager::SNodeTreeBufferManager(LlvmProgramImpl *prog)
+SNodeTreeBufferManager::SNodeTreeBufferManager(ProgramImpl *prog)
     : prog_(prog) {
   TI_TRACE("SNode tree buffer manager created.");
 }
@@ -38,6 +40,7 @@ Ptr SNodeTreeBufferManager::allocate(JITModule *runtime_jit,
                                      std::size_t alignment,
                                      const int snode_tree_id,
                                      uint64 *result_buffer) {
+#ifdef TI_WITH_LLVM
   TI_TRACE("allocating memory for SNode Tree {}", snode_tree_id);
   TI_ASSERT_INFO(snode_tree_id < kMaxNumSnodeTreesLlvm,
                  "LLVM backend supports up to {} snode trees",
@@ -46,8 +49,9 @@ Ptr SNodeTreeBufferManager::allocate(JITModule *runtime_jit,
   if (set_it == size_set_.end()) {
     runtime_jit->call<void *, std::size_t, std::size_t>(
         "runtime_memory_allocate_aligned", runtime, size, alignment);
-    auto ptr = prog_->fetch_result<Ptr>(taichi_result_buffer_runtime_query_id,
-                                        result_buffer);
+    LlvmProgramImpl *llvm_prog = static_cast<LlvmProgramImpl *>(prog_);
+    auto ptr = llvm_prog->fetch_result<Ptr>(
+        taichi_result_buffer_runtime_query_id, result_buffer);
     roots_[snode_tree_id] = ptr;
     sizes_[snode_tree_id] = size;
     return ptr;
@@ -64,6 +68,9 @@ Ptr SNodeTreeBufferManager::allocate(JITModule *runtime_jit,
     sizes_[snode_tree_id] = size;
     return x.second;
   }
+#else
+  TI_NOT_IMPLEMENTED
+#endif
 }
 
 void SNodeTreeBufferManager::destroy(SNodeTree *snode_tree) {

--- a/taichi/system/snode_tree_buffer_manager.h
+++ b/taichi/system/snode_tree_buffer_manager.h
@@ -10,11 +10,11 @@ using Ptr = uint8_t *;
 
 TLANG_NAMESPACE_BEGIN
 
-class LlvmProgramImpl;
+class ProgramImpl;
 
 class SNodeTreeBufferManager {
  public:
-  SNodeTreeBufferManager(LlvmProgramImpl *prog);
+  SNodeTreeBufferManager(ProgramImpl *prog);
 
   void merge_and_insert(Ptr ptr, std::size_t size);
 
@@ -30,7 +30,7 @@ class SNodeTreeBufferManager {
  private:
   std::set<std::pair<std::size_t, Ptr>> size_set_;
   std::map<Ptr, std::size_t> ptr_map_;
-  LlvmProgramImpl *prog_;
+  ProgramImpl *prog_;
   Ptr roots_[kMaxNumSnodeTreesLlvm];
   std::size_t sizes_[kMaxNumSnodeTreesLlvm];
 };

--- a/taichi/system/unified_allocator.cpp
+++ b/taichi/system/unified_allocator.cpp
@@ -19,6 +19,7 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch, Device *device)
     : size(size), arch_(arch), device_(device) {
   auto t = Time::get_time();
   if (arch_ == Arch::x64) {
+#ifdef TI_WITH_LLVM
     Device::AllocParams alloc_params;
     alloc_params.size = size;
     alloc_params.host_read = true;
@@ -27,6 +28,9 @@ UnifiedAllocator::UnifiedAllocator(std::size_t size, Arch arch, Device *device)
     cpu::CpuDevice *cpu_device = static_cast<cpu::CpuDevice *>(device);
     alloc = cpu_device->allocate_memory(alloc_params);
     data = (uint8 *)cpu_device->get_alloc_info(alloc).ptr;
+#else
+    TI_NOT_IMPLEMENTED
+#endif
   } else {
     TI_TRACE("Allocating virtual address space of size {} MB",
              size / 1024 / 1024);


### PR DESCRIPTION
This PR adds a TI_WITH_LLVM option, so that one can optionally disable compiling with LLVM. (For example, I'm trying to emscripten the entire taichi project, and LLVM doesn't like that).

TI_WITH_LLVM is defaulted to ON, so this PR won't affect any of our existing CI/CD/build tools.