### PR TITLE
[refactor] Enable the new ast builder by default

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -396,7 +396,7 @@ class _SpecialConfig:
         self.gdb_trigger = False
         self.excepthook = False
         self.experimental_real_function = False
-        self.experimental_ast_refactor = False
+        self.experimental_ast_refactor = True
 
 
 def prepare_sandbox():

--- a/python/taichi/lang/ir_builder.py
+++ b/python/taichi/lang/ir_builder.py
@@ -910,7 +910,6 @@ class IRBuilder(Builder):
         raise node.exc.ptr
 
 
-
 build_stmt = IRBuilder()
 
 

--- a/python/taichi/lang/ir_builder.py
+++ b/python/taichi/lang/ir_builder.py
@@ -904,6 +904,12 @@ class IRBuilder(Builder):
     def build_Pass(ctx, node):
         return node
 
+    @staticmethod
+    def build_Raise(ctx, node):
+        node.exc = build_stmt(ctx, node.exc)
+        raise node.exc.ptr
+
+
 
 build_stmt = IRBuilder()
 

--- a/python/taichi/lang/linalg_impl.py
+++ b/python/taichi/lang/linalg_impl.py
@@ -228,12 +228,12 @@ def svd(A, dt):
     Returns:
         Decomposed nxn matrices `U`, 'S' and `V`.
     """
-    if ti.static(A.n == 2):
+    if ti.static(A.n == 2):  # pylint: disable=R1705
         ret = svd2d(A, dt)
         return ret
-    elif ti.static(A.n == 3):  # pylint: disable=R1705
+    elif ti.static(A.n == 3):
         return svd3d(A, dt)
-    else:  # pylint: disable=R1705
+    else:
         raise Exception("SVD only supports 2D and 3D matrices.")
 
 
@@ -252,11 +252,11 @@ def polar_decompose(A, dt):
     Returns:
         Decomposed nxn matrices `U` and `P`.
     """
-    if ti.static(A.n == 2):
+    if ti.static(A.n == 2):  # pylint: disable=R1705
         ret = polar_decompose2d(A, dt)
         return ret
-    elif ti.static(A.n == 3):  # pylint: disable=R1705
+    elif ti.static(A.n == 3):
         return polar_decompose3d(A, dt)
-    else:  # pylint: disable=R1705
+    else:
         raise Exception(
             "Polar decomposition only supports 2D and 3D matrices.")

--- a/python/taichi/lang/linalg_impl.py
+++ b/python/taichi/lang/linalg_impl.py
@@ -258,4 +258,5 @@ def polar_decompose(A, dt):
     elif ti.static(A.n == 3):  # pylint: disable=R1705
         return polar_decompose3d(A, dt)
     else:  # pylint: disable=R1705
-        raise Exception("Polar decomposition only supports 2D and 3D matrices.")
+        raise Exception(
+            "Polar decomposition only supports 2D and 3D matrices.")

--- a/python/taichi/lang/linalg_impl.py
+++ b/python/taichi/lang/linalg_impl.py
@@ -231,9 +231,10 @@ def svd(A, dt):
     if ti.static(A.n == 2):
         ret = svd2d(A, dt)
         return ret
-    if ti.static(A.n == 3):
+    elif ti.static(A.n == 3):  # pylint: disable=R1705
         return svd3d(A, dt)
-    raise Exception("SVD only supports 2D and 3D matrices.")
+    else:  # pylint: disable=R1705
+        raise Exception("SVD only supports 2D and 3D matrices.")
 
 
 @func
@@ -254,6 +255,7 @@ def polar_decompose(A, dt):
     if ti.static(A.n == 2):
         ret = polar_decompose2d(A, dt)
         return ret
-    if ti.static(A.n == 3):
+    elif ti.static(A.n == 3):  # pylint: disable=R1705
         return polar_decompose3d(A, dt)
-    raise Exception("Polar decomposition only supports 2D and 3D matrices.")
+    else:  # pylint: disable=R1705
+        raise Exception("Polar decomposition only supports 2D and 3D matrices.")

--- a/tests/python/test_ast_refactor.py
+++ b/tests/python/test_ast_refactor.py
@@ -968,6 +968,7 @@ def test_func_default_value_fail():
 
         foo()
 
+
 @ti.test(experimental_ast_refactor=True)
 def test_raise():
     dim = 1
@@ -975,9 +976,11 @@ def test_raise():
     ti.root.place(m)
 
     with pytest.raises(Exception) as e:
+
         @ti.kernel
         def foo():
             ti.polar_decompose(m, ti.f32)
-        foo()
-    assert e.value.args[0] == "Polar decomposition only supports 2D and 3D matrices."
 
+        foo()
+    assert e.value.args[
+        0] == "Polar decomposition only supports 2D and 3D matrices."

--- a/tests/python/test_ast_refactor.py
+++ b/tests/python/test_ast_refactor.py
@@ -967,3 +967,17 @@ def test_func_default_value_fail():
             return bar(1, 2, 3)
 
         foo()
+
+@ti.test(experimental_ast_refactor=True)
+def test_raise():
+    dim = 1
+    m = ti.Matrix.field(dim, dim, ti.f32)
+    ti.root.place(m)
+
+    with pytest.raises(Exception) as e:
+        @ti.kernel
+        def foo():
+            ti.polar_decompose(m, ti.f32)
+        foo()
+    assert e.value.args[0] == "Polar decomposition only supports 2D and 3D matrices."
+


### PR DESCRIPTION
issue = #3038

When fixing pylint R1705 no-else-return, some of the raise statements are moved outside the `else` scope of the static-if, resulting raising errors when traversing to the Raise node. For example:
```python
    if ti.static(A.n == 2): 
        ret = svd2d(A, dt)
        return ret
    elif ti.static(A.n == 3):
        return svd3d(A, dt)
    else:
        raise Exception("SVD only supports 2D and 3D matrices.")
```
was changed to 
```python
    if ti.static(A.n == 2):
        ret = svd2d(A, dt)
        return ret
    if ti.static(A.n == 3):
        return svd3d(A, dt)
    raise Exception("SVD only supports 2D and 3D matrices.")
```
and the AST builder will continue to visit the Raise node because it is not in the else branch of static-if.
Immediate termination of traversing when meeting return statement can be supported in the future.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
