### PR TITLE
[Lang] Enable local tensors as writeback binary operation results

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -15,9 +15,8 @@ from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.ops import cast
 from taichi.lang.types import CompoundType
-from taichi.lang.util import (cook_dtype, in_python_scope, is_taichi_class,
-                              python_scope, taichi_scope, to_numpy_type,
-                              to_pytorch_type)
+from taichi.lang.util import (cook_dtype, in_python_scope, python_scope,
+                              taichi_scope, to_numpy_type, to_pytorch_type)
 from taichi.misc.util import deprecated, warning
 
 import taichi as ti

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -54,11 +54,15 @@ class Matrix(TaichiOperations):
             elif not isinstance(n[0], Iterable):  # now init a Vector
                 if in_python_scope() or keep_raw:
                     mat = [[x] for x in n]
-                elif disable_local_tensor or not ti.current_cfg().dynamic_index:
+                elif disable_local_tensor or not ti.current_cfg(
+                ).dynamic_index:
                     mat = [[impl.expr_init(x)] for x in n]
                 else:
-                    if not ti.is_extension_supported(ti.current_cfg().arch, ti.extension.dynamic_index):
-                        raise Exception(f"Backend {ti.current_cfg().arch} doesn't support dynamic index")
+                    if not ti.is_extension_supported(
+                            ti.current_cfg().arch, ti.extension.dynamic_index):
+                        raise Exception(
+                            f"Backend {ti.current_cfg().arch} doesn't support dynamic index"
+                        )
                     if dt is None:
                         if isinstance(n[0], (int, np.integer)):
                             dt = impl.get_runtime().default_ip
@@ -76,8 +80,7 @@ class Matrix(TaichiOperations):
                             )
                     self.local_tensor_proxy = impl.expr_init_local_tensor(
                         [len(n)], dt,
-                        expr.make_expr_group([expr.Expr(x)
-                                              for x in n]))
+                        expr.make_expr_group([expr.Expr(x) for x in n]))
                     mat = []
                     for i in range(len(n)):
                         mat.append(
@@ -90,11 +93,15 @@ class Matrix(TaichiOperations):
             else:  # now init a Matrix
                 if in_python_scope() or keep_raw:
                     mat = [list(row) for row in n]
-                elif disable_local_tensor or not ti.current_cfg().dynamic_index:
+                elif disable_local_tensor or not ti.current_cfg(
+                ).dynamic_index:
                     mat = [[impl.expr_init(x) for x in row] for row in n]
                 else:
-                    if not ti.is_extension_supported(ti.current_cfg().arch, ti.extension.dynamic_index):
-                        raise Exception(f"Backend {ti.current_cfg().arch} doesn't support dynamic index")
+                    if not ti.is_extension_supported(
+                            ti.current_cfg().arch, ti.extension.dynamic_index):
+                        raise Exception(
+                            f"Backend {ti.current_cfg().arch} doesn't support dynamic index"
+                        )
                     if dt is None:
                         if isinstance(n[0][0], (int, np.integer)):
                             dt = impl.get_runtime().default_ip
@@ -177,13 +184,15 @@ class Matrix(TaichiOperations):
         ] for i in range(self.n)])
 
     def element_wise_writeback_binary(self, foo, other):
-        if foo.__name__ == 'assign' and not isinstance(other, (list, tuple, Matrix)):
+        if foo.__name__ == 'assign' and not isinstance(other,
+                                                       (list, tuple, Matrix)):
             raise TaichiSyntaxError(
                 'cannot assign scalar expr to '
                 f'taichi class {type(self)}, maybe you want to use `a.fill(b)` instead?'
             )
         other = self.broadcast_copy(other)
-        entries = [[foo(self(i, j), other(i, j)) for j in range(self.m)] for i in range(self.n)]
+        entries = [[foo(self(i, j), other(i, j)) for j in range(self.m)]
+                   for i in range(self.n)]
         return self if foo.__name__ == 'assign' else Matrix(entries)
 
     def element_wise_unary(self, foo):


### PR DESCRIPTION
Related issue = #2590, #2880, #2637

This PR rewrites `element_wise_writeback_binary` to enable local tensor results. To make it work, `Matrix.__init__` is refactored a little bit to clean the logic and cover missing cases.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
