### PR TITLE
[vulkan] Fix a few errors encountered when building for x86

### DIFF
--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -1987,7 +1987,7 @@ void VulkanSurface::create_swap_chain() {
   createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
   createInfo.presentMode = present_mode;
   createInfo.clipped = VK_TRUE;
-  createInfo.oldSwapchain = nullptr;
+  createInfo.oldSwapchain = VK_NULL_HANDLE;
 
   if (vkCreateSwapchainKHR(device_->vk_device(), &createInfo,
                            kNoVkAllocCallbacks, &swapchain_) != VK_SUCCESS) {

--- a/taichi/backends/vulkan/vulkan_device.h
+++ b/taichi/backends/vulkan/vulkan_device.h
@@ -96,7 +96,7 @@ class VulkanResourceBinder : public ResourceBinder {
   struct Binding {
     VkDescriptorType type;
     DevicePtr ptr;
-    size_t size;
+    VkDeviceSize size;
     VkSampler sampler{VK_NULL_HANDLE};  // used only for images
   };
 


### PR DESCRIPTION
Lessons learned:
* Always prefer `VK_NULL_HANDLE` to `nullptr`
* Always prefer `VkDeviceSize` to `size_t`