### PR TITLE
[Lang] Remove disable_local_tensor in most cases

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -482,8 +482,8 @@ class Matrix(TaichiOperations):
             return Matrix([1 / self(0, 0)])
         if self.n == 2:
             inv_determinant = impl.expr_init(1.0 / self.determinant())
-            return inv_determinant * Matrix([[self(1, 1), -self(0, 1)],
-                                             [-self(1, 0), self(0, 0)]])
+            return inv_determinant * Matrix([[self(
+                1, 1), -self(0, 1)], [-self(1, 0), self(0, 0)]])
         if self.n == 3:
             n = 3
             inv_determinant = impl.expr_init(1.0 / self.determinant())
@@ -508,16 +508,14 @@ class Matrix(TaichiOperations):
 
             for i in range(n):
                 for j in range(n):
-                    entries[j][i] = inv_determinant * (-1)**(i + j) * (
-                        (E(i + 1, j + 1) *
-                         (E(i + 2, j + 2) * E(i + 3, j + 3) -
-                          E(i + 3, j + 2) * E(i + 2, j + 3)) -
-                         E(i + 2, j + 1) *
-                         (E(i + 1, j + 2) * E(i + 3, j + 3) -
-                          E(i + 3, j + 2) * E(i + 1, j + 3)) +
-                         E(i + 3, j + 1) *
-                         (E(i + 1, j + 2) * E(i + 2, j + 3) -
-                          E(i + 2, j + 2) * E(i + 1, j + 3))))
+                    entries[j][i] = inv_determinant * (-1)**(i + j) * ((
+                        E(i + 1, j + 1) *
+                        (E(i + 2, j + 2) * E(i + 3, j + 3) -
+                         E(i + 3, j + 2) * E(i + 2, j + 3)) - E(i + 2, j + 1) *
+                        (E(i + 1, j + 2) * E(i + 3, j + 3) -
+                         E(i + 3, j + 2) * E(i + 1, j + 3)) + E(i + 3, j + 1) *
+                        (E(i + 1, j + 2) * E(i + 2, j + 3) -
+                         E(i + 2, j + 2) * E(i + 1, j + 3))))
             return Matrix(entries)
         raise Exception(
             "Inversions of matrices with sizes >= 5 are not supported")
@@ -564,7 +562,8 @@ class Matrix(TaichiOperations):
             Get the transpose of a matrix.
 
         """
-        return Matrix([[self[i, j] for i in range(self.n)] for j in range(self.m)])
+        return Matrix([[self[i, j] for i in range(self.n)]
+                       for j in range(self.m)])
 
     @taichi_scope
     def determinant(a):
@@ -837,7 +836,8 @@ class Matrix(TaichiOperations):
             :class:`~taichi.lang.matrix.Matrix`: A n x n identity :class:`~taichi.lang.matrix.Matrix` instance.
 
         """
-        return Matrix([[ti.cast(int(i == j), dt) for j in range(n)] for i in range(n)])
+        return Matrix([[ti.cast(int(i == j), dt) for j in range(n)]
+                       for i in range(n)])
 
     @staticmethod
     def rotation2d(alpha):
@@ -1140,7 +1140,8 @@ class Matrix(TaichiOperations):
         impl.static(
             impl.static_assert(other.m == 1,
                                "rhs for outer_product is not a vector"))
-        return Matrix([[self[i] * other[j] for j in range(other.n)] for i in range(self.n)])
+        return Matrix([[self[i] * other[j] for j in range(other.n)]
+                       for i in range(self.n)])
 
 
 def Vector(n, dt=None, **kwargs):


### PR DESCRIPTION
Related issue = #2590, #2880, #2637

After this PR, `disable_local_tensor` only appears in `ti.Matrix.empty`. Removing that requires significant refactoring, which will be done in a future PR.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
