### PR TITLE
[Lang] Add check version function to taichi main

### DIFF
--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -127,8 +127,10 @@ class TaichiMain:
 
         # We do not want request exceptions break users' usage of Taichi.
         try:
-            response = requests.post('http://ec2-54-90-48-192.compute-1.amazonaws.com/check_version',
-                                     json=payload, timeout=5)
+            response = requests.post(
+                'http://ec2-54-90-48-192.compute-1.amazonaws.com/check_version',
+                json=payload,
+                timeout=5)
             response.raise_for_status()
         except requests.exceptions.ConnectionError as err:
             print('No internet:', err)
@@ -146,9 +148,9 @@ class TaichiMain:
         response = response.json()
         if response['status'] == 1:
             print(
-                f'Your Taichi version {version} is outdated. The latest version is {response["latest_version"]}, you can use\n'+
-                f'pip install taichi=={response["latest_version"]}\n'+'to upgrade to the latest Taichi!'
-            )
+                f'Your Taichi version {version} is outdated. The latest version is {response["latest_version"]}, you can use\n'
+                + f'pip install taichi=={response["latest_version"]}\n' +
+                'to upgrade to the latest Taichi!')
         elif response['status'] == 0:
             # Status 0 means that user already have the latest Taichi. The message here prompts this infomation to users.
             print(response['message'])

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import math
 import os
 import platform
@@ -7,13 +8,12 @@ import shutil
 import subprocess
 import sys
 import timeit
-import requests
-import json
 from collections import defaultdict
 from functools import wraps
 from pathlib import Path
 
 import numpy as np
+import requests
 import taichi.cc_compose
 import taichi.diagnose
 from colorama import Fore

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import math
 import os
 import platform
@@ -127,12 +126,11 @@ class TaichiMain:
             payload['python'] = 'cp39'
 
         response = requests.post('http://54.90.48.192/check_version',
-                                 json=payload)
-        response_json = json.loads(response.text)
-        if response_json['status'] == 1:
-            print(f'Your Taichi version {version} is outdated. The latest version is {response_json["latest_version"]}, you can use pip to upgrade to the latest Taichi!')
-        elif response_json['status'] == 0:
-            print(response_json['message'])
+                                 json=payload).json()
+        if response['status'] == 1:
+            print(f'Your Taichi version {version} is outdated. The latest version is {response["latest_version"]}, you can use pip to upgrade to the latest Taichi!')
+        elif response['status'] == 0:
+            print(response['message'])
 
     @staticmethod
     def _get_friend_links():

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -1,12 +1,12 @@
 import argparse
 import math
 import os
+import platform
 import runpy
 import shutil
 import subprocess
 import sys
 import timeit
-import platform
 from collections import defaultdict
 from functools import wraps
 from pathlib import Path
@@ -99,7 +99,7 @@ class TaichiMain:
         minor = _ti_core.get_version_minor()
         patch = _ti_core.get_version_patch()
         version = '{}.{}.{}'.format(major, minor, patch)
-        payload = {'version':version, 'platform':'', 'python':''}
+        payload = {'version': version, 'platform': '', 'python': ''}
 
         os = platform.system()
         if os == 'Linux':
@@ -125,11 +125,14 @@ class TaichiMain:
             payload['python'] = 'cp39'
 
         import requests
-        response = requests.post('http://54.90.48.192/check_version', json=payload)
+        response = requests.post('http://54.90.48.192/check_version',
+                                 json=payload)
         import json
         response_json = json.loads(response.text)
         if response_json['status'] == 1:
-            print('Your Taichi version {} is outdated. The latest version is {}, you can use pip to upgrade to the latest Taichi!'.format(version, response_json['latest_version']))
+            print(
+                'Your Taichi version {} is outdated. The latest version is {}, you can use pip to upgrade to the latest Taichi!'
+                .format(version, response_json['latest_version']))
         elif response_json['status'] == 0:
             print(response_json['message'])
 

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -7,6 +7,8 @@ import shutil
 import subprocess
 import sys
 import timeit
+import requests
+import json
 from collections import defaultdict
 from functools import wraps
 from pathlib import Path
@@ -98,15 +100,15 @@ class TaichiMain:
         major = _ti_core.get_version_major()
         minor = _ti_core.get_version_minor()
         patch = _ti_core.get_version_patch()
-        version = '{}.{}.{}'.format(major, minor, patch)
+        version = f'{major}.{minor}.{patch}'
         payload = {'version': version, 'platform': '', 'python': ''}
 
-        os = platform.system()
-        if os == 'Linux':
+        system = platform.system()
+        if system == 'Linux':
             payload['platform'] = 'manylinux1_x86_64'
-        elif os == 'Windows':
+        elif system == 'Windows':
             payload['platform'] = 'win_amd64'
-        elif os == 'Darwin':
+        elif system == 'Darwin':
             if platform.release() < '19.0.0':
                 payload['platform'] = 'macosx_10_14_x86_64'
             elif platform.machine() == 'x86_64':
@@ -124,10 +126,8 @@ class TaichiMain:
         elif python_version.startswith('3.9'):
             payload['python'] = 'cp39'
 
-        import requests
         response = requests.post('http://54.90.48.192/check_version',
                                  json=payload)
-        import json
         response_json = json.loads(response.text)
         if response_json['status'] == 1:
             print(

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -130,9 +130,7 @@ class TaichiMain:
                                  json=payload)
         response_json = json.loads(response.text)
         if response_json['status'] == 1:
-            print(
-                'Your Taichi version {} is outdated. The latest version is {}, you can use pip to upgrade to the latest Taichi!'
-                .format(version, response_json['latest_version']))
+            print(f'Your Taichi version {version} is outdated. The latest version is {response_json["latest_version"]}, you can use pip to upgrade to the latest Taichi!')
         elif response_json['status'] == 0:
             print(response_json['message'])
 

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -139,7 +139,9 @@ class TaichiMain:
             print('Checking latest version failed: Server error,', err)
             return
         except requests.exceptions.Timeout as err:
-            print('Checking latest version failed: Time out when connecting server,', err)
+            print(
+                'Checking latest version failed: Time out when connecting server,',
+                err)
             return
         except requests.exceptions.RequestException as err:
             print('Checking latest version failed:', err)

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -128,7 +128,9 @@ class TaichiMain:
         response = requests.post('http://54.90.48.192/check_version',
                                  json=payload).json()
         if response['status'] == 1:
-            print(f'Your Taichi version {version} is outdated. The latest version is {response["latest_version"]}, you can use pip to upgrade to the latest Taichi!')
+            print(
+                f'Your Taichi version {version} is outdated. The latest version is {response["latest_version"]}, you can use pip to upgrade to the latest Taichi!'
+            )
         elif response['status'] == 0:
             print(response['message'])
 

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -130,19 +130,19 @@ class TaichiMain:
             response = requests.post(
                 'http://ec2-54-90-48-192.compute-1.amazonaws.com/check_version',
                 json=payload,
-                timeout=5)
+                timeout=3)
             response.raise_for_status()
         except requests.exceptions.ConnectionError as err:
-            print('No internet:', err)
+            print('Checking latest version failed: No internet,', err)
             return
         except requests.exceptions.HTTPError as err:
-            print('Server error:', err)
+            print('Checking latest version failed: Server error,', err)
             return
         except requests.exceptions.Timeout as err:
-            print('Time out when connecting server:', err)
+            print('Checking latest version failed: Time out when connecting server,', err)
             return
         except requests.exceptions.RequestException as err:
-            print('Unknown errors:', err)
+            print('Checking latest version failed:', err)
             return
 
         response = response.json()

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ pytest-rerunfailures
 pytest-cov
 numpy
 autograd
+requests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ pytest-rerunfailures
 pytest-cov
 numpy
 autograd
-requests==2.22
+requests==2.26

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ pytest-rerunfailures
 pytest-cov
 numpy
 autograd
-requests
+requests==2.22


### PR DESCRIPTION
Initial version of checking version for users when using Taichi. The method of getting users' platforms might looks hacky. Welcome any suggestions on how to map users' platform.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
