### PR TITLE
[llvm] Make taichi's Ndarray carry a ptr to its DeviceAllocation.

### DIFF
--- a/examples/chi_examples/main.cpp
+++ b/examples/chi_examples/main.cpp
@@ -306,9 +306,12 @@ void autograd() {
   auto ctx_backward = kernel_backward->make_launch_context();
   auto ctx_ext = kernel_ext->make_launch_context();
   std::vector<float> ext_a(n), ext_b(n), ext_c(n);
-  ctx_ext.set_arg_external_array(0, taichi::uint64(ext_a.data()), n);
-  ctx_ext.set_arg_external_array(1, taichi::uint64(ext_b.data()), n);
-  ctx_ext.set_arg_external_array(2, taichi::uint64(ext_c.data()), n);
+  ctx_ext.set_arg_external_array(0, taichi::uint64(ext_a.data()), n,
+                                 /*is_device_allocation=*/false);
+  ctx_ext.set_arg_external_array(1, taichi::uint64(ext_b.data()), n,
+                                 /*is_device_allocation=*/false);
+  ctx_ext.set_arg_external_array(2, taichi::uint64(ext_c.data()), n,
+                                 /*is_device_allocation=*/false);
 
   (*kernel_init)(ctx_init);
   (*kernel_forward)(ctx_forward);

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -518,13 +518,13 @@ class Kernel:
                         tmps.append(tmp)
                         launch_ctx.set_arg_external_array(
                             actual_argument_slot, int(tmp.ctypes.data),
-                            tmp.nbytes)
+                            tmp.nbytes, False)
                     elif is_ndarray and not ndarray_use_torch:
                         # Use ndarray's own memory allocator
                         tmp = v
                         launch_ctx.set_arg_external_array(
                             actual_argument_slot, int(tmp.data_ptr()),
-                            tmp.element_size() * tmp.nelement())
+                            tmp.element_size() * tmp.nelement(), True)
                     else:
 
                         def get_call_back(u, v):
@@ -561,7 +561,7 @@ class Kernel:
                                 callbacks.append(get_call_back(v, gpu_v))
                         launch_ctx.set_arg_external_array(
                             actual_argument_slot, int(tmp.data_ptr()),
-                            tmp.element_size() * tmp.nelement())
+                            tmp.element_size() * tmp.nelement(), False)
 
                     shape = v.shape
                     max_num_indices = _ti_core.get_max_num_indices()

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -62,31 +62,55 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       Kernel::LaunchContextBuilder ctx_builder(kernel, &context);
       bool transferred = false;
       for (int i = 0; i < (int)args.size(); i++) {
-        if (args[i].is_external_array && args[i].size > 0) {
-          // Note: both numpy and PyTorch support arrays/tensors with zeros
-          // in shapes, e.g., shape=(0) or shape=(100, 0, 200). This makes
-          // args[i].size = 0.
+        if (args[i].is_external_array) {
           arg_buffers[i] = context.get_arg<void *>(i);
-          unsigned int attr_val = 0;
-          uint32_t ret_code = CUDADriver::get_instance().mem_get_attribute.call(
-              &attr_val, CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
-              (void *)arg_buffers[i]);
-          if (ret_code != CUDA_SUCCESS || attr_val != CU_MEMORYTYPE_DEVICE) {
-            // Copy to device buffer if arg is on host
-            // - ret_code != CUDA_SUCCESS:
-            //   arg_buffers[i] is not on device
-            // - attr_val != CU_MEMORYTYPE_DEVICE:
-            //   Cuda driver is aware of arg_buffers[i] but it might be on host.
-            // See CUDA driver API `cuPointerGetAttribute` for more details.
-            transferred = true;
-            CUDADriver::get_instance().malloc(&device_buffers[i], args[i].size);
-            CUDADriver::get_instance().memcpy_host_to_device(
-                (void *)device_buffers[i], arg_buffers[i], args[i].size);
-          } else {
-            device_buffers[i] = arg_buffers[i];
+          if (context.sizes_in_bytes[i] > 0) {
+            // Note: both numpy and PyTorch support arrays/tensors with zeros
+            // in shapes, e.g., shape=(0) or shape=(100, 0, 200). This makes
+            // args[i].size = 0.
+            unsigned int attr_val = 0;
+            uint32_t ret_code =
+                CUDADriver::get_instance().mem_get_attribute.call(
+                    &attr_val, CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                    (void *)arg_buffers[i]);
+            if (ret_code != CUDA_SUCCESS || attr_val != CU_MEMORYTYPE_DEVICE) {
+              // Copy to device buffer if arg is on host
+              // - ret_code != CUDA_SUCCESS:
+              //   arg_buffers[i] is not on device
+              // - attr_val != CU_MEMORYTYPE_DEVICE:
+              //   Cuda driver is aware of arg_buffers[i] but it might be on
+              //   host.
+              // See CUDA driver API `cuPointerGetAttribute` for more details.
+              transferred = true;
+              CUDADriver::get_instance().malloc(&device_buffers[i],
+                                                args[i].size);
+              CUDADriver::get_instance().memcpy_host_to_device(
+                  (void *)device_buffers[i], arg_buffers[i], args[i].size);
+            } else {
+              device_buffers[i] = arg_buffers[i];
+            }
+            ctx_builder.set_arg_external_array(i, (uint64)device_buffers[i],
+                                               args[i].size,
+                                               /*is_device_allocation=*/false);
+
+          } else if (args[i].size > 0) {
+            // arg_buffers[i] is a DeviceAllocation*
+            // TODO: Unwraps DeviceAllocation* can be done at CodeGenLLVM since
+            // it's shared by cpu and cuda.
+            DeviceAllocation *ptr =
+                static_cast<DeviceAllocation *>(arg_buffers[i]);
+            device_buffers[i] = kernel->program->get_llvm_program_impl()
+                                    ->get_ndarray_alloc_info_ptr(*ptr);
+            // We compare arg_buffers[i] and device_buffers[i] later to check
+            // if transfer happened.
+            // TODO: this logic can be improved but I'll leave it to a followup
+            // PR.
+            arg_buffers[i] = device_buffers[i];
+
+            ctx_builder.set_arg_external_array(i, (uint64)device_buffers[i],
+                                               args[i].size,
+                                               /*is_device_allocation=*/false);
           }
-          ctx_builder.set_arg_external_array(i, (uint64)device_buffers[i],
-                                             args[i].size);
         }
       }
       if (transferred) {

--- a/taichi/program/context.h
+++ b/taichi/program/context.h
@@ -15,9 +15,20 @@ struct LLVMRuntime;
 // CPU).
 struct RuntimeContext {
   LLVMRuntime *runtime;
+  // args can contain:
+  // - primitive_types
+  // - raw ptrs: for external array, or torch-based ndarray
+  // - DeviceAllocation*: for taichi ndaray
   uint64 args[taichi_max_num_args_total];
   int32 extra_args[taichi_max_num_args_extra][taichi_max_num_indices];
   int32 cpu_thread_id;
+  // |sizes_in_byte| is necessary since when we do memcpy for raw ptrs,
+  // we need to know the total bytes. This is a common use case at runtime
+  // when we copy memory from host to device. But the shapes stored
+  // in |extra_args| above lost the sizeof(dtype) information already.
+  // Invariant:
+  //   sizes_in_byte[i] != 0 iff args[i] is a raw ptr
+  uint64 sizes_in_bytes[taichi_max_num_args_total]{0};
 
   static constexpr size_t extra_args_size = sizeof(extra_args);
 
@@ -34,6 +45,10 @@ struct RuntimeContext {
   template <typename T>
   void set_arg(int i, T v) {
     args[i] = taichi_union_cast_with_different_sizes<uint64>(v);
+  }
+
+  void set_raw_ptr_arg_size(int i, size_t size) {
+    sizes_in_bytes[i] = size;
   }
 #endif
 };

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -246,9 +246,11 @@ void Kernel::LaunchContextBuilder::set_extra_arg_int(int i, int j, int32 d) {
   ctx_->extra_args[i][j] = d;
 }
 
-void Kernel::LaunchContextBuilder::set_arg_external_array(int arg_id,
-                                                          uint64 ptr,
-                                                          uint64 size) {
+void Kernel::LaunchContextBuilder::set_arg_external_array(
+    int arg_id,
+    uint64 ptr,
+    uint64 size,
+    bool is_device_allocation) {
   TI_ASSERT_INFO(
       kernel_->args[arg_id].is_external_array,
       "Assigning external (numpy) array to scalar argument is not allowed.");
@@ -261,6 +263,10 @@ void Kernel::LaunchContextBuilder::set_arg_external_array(int arg_id,
 
   kernel_->args[arg_id].size = size;
   ctx_->set_arg(arg_id, ptr);
+  if (!is_device_allocation) {
+    // This is a raw ptr
+    ctx_->set_raw_ptr_arg_size(arg_id, size);
+  }
 }
 
 void Kernel::LaunchContextBuilder::set_arg_raw(int arg_id, uint64 d) {

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -36,7 +36,10 @@ class Kernel : public Callable {
 
     void set_extra_arg_int(int i, int j, int32 d);
 
-    void set_arg_external_array(int arg_id, uint64 ptr, uint64 size);
+    void set_arg_external_array(int arg_id,
+                                uint64 ptr,
+                                uint64 size,
+                                bool is_device_allocation);
 
     // Sets the |arg_id|-th arg in the context to the bits stored in |d|.
     // This ignores the underlying kernel's |arg_id|-th arg type.

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -21,7 +21,10 @@ Ndarray::Ndarray(Program *prog,
   ndarray_alloc_ = prog_impl->allocate_memory_ndarray(nelement_ * element_size_,
                                                       prog->result_buffer);
 
-  data_ptr_ = prog_impl->get_ndarray_alloc_info_ptr(ndarray_alloc_);
+  // taichi's own ndarray's ptr points to its |DeviceAllocation| on the
+  // specified device. Note that torch-based ndarray's ptr is a raw ptr but
+  // we'll get rid of it soon.
+  data_ptr_ = (uint64_t *)&ndarray_alloc_;
 #else
   TI_ERROR("Llvm disabled");
 #endif

--- a/taichi/program/ndarray_rw_accessors_bank.cpp
+++ b/taichi/program/ndarray_rw_accessors_bank.cpp
@@ -51,7 +51,8 @@ void NdarrayRwAccessorsBank::Accessors::write_float(const std::vector<int> &I,
   launch_ctx.set_arg_float(ndarray_->num_active_indices, val);
   launch_ctx.set_arg_external_array(
       ndarray_->num_active_indices + 1, ndarray_->get_data_ptr_as_int(),
-      ndarray_->get_nelement() * ndarray_->get_element_size());
+      ndarray_->get_nelement() * ndarray_->get_element_size(),
+      /*is_device_allocation=*/true);
   set_kernel_extra_args(ndarray_, ndarray_->num_active_indices + 1,
                         &launch_ctx);
   prog_->synchronize();
@@ -65,7 +66,8 @@ float64 NdarrayRwAccessorsBank::Accessors::read_float(
   set_kernel_args(I, ndarray_->num_active_indices, &launch_ctx);
   launch_ctx.set_arg_external_array(
       ndarray_->num_active_indices, ndarray_->get_data_ptr_as_int(),
-      ndarray_->get_nelement() * ndarray_->get_element_size());
+      ndarray_->get_nelement() * ndarray_->get_element_size(),
+      /*is_device_allocation=*/true);
   set_kernel_extra_args(ndarray_, ndarray_->num_active_indices, &launch_ctx);
   (*reader_)(launch_ctx);
   prog_->synchronize();
@@ -81,7 +83,8 @@ void NdarrayRwAccessorsBank::Accessors::write_int(const std::vector<int> &I,
   launch_ctx.set_arg_int(ndarray_->num_active_indices, val);
   launch_ctx.set_arg_external_array(
       ndarray_->num_active_indices + 1, ndarray_->get_data_ptr_as_int(),
-      ndarray_->get_nelement() * ndarray_->get_element_size());
+      ndarray_->get_nelement() * ndarray_->get_element_size(),
+      /*is_device_allocation=*/true);
   set_kernel_extra_args(ndarray_, ndarray_->num_active_indices + 1,
                         &launch_ctx);
   prog_->synchronize();
@@ -94,7 +97,8 @@ int64 NdarrayRwAccessorsBank::Accessors::read_int(const std::vector<int> &I) {
   set_kernel_args(I, ndarray_->num_active_indices, &launch_ctx);
   launch_ctx.set_arg_external_array(
       ndarray_->num_active_indices, ndarray_->get_data_ptr_as_int(),
-      ndarray_->get_nelement() * ndarray_->get_element_size());
+      ndarray_->get_nelement() * ndarray_->get_element_size(),
+      /*is_device_allocation=*/true);
   set_kernel_extra_args(ndarray_, ndarray_->num_active_indices, &launch_ctx);
   (*reader_)(launch_ctx);
   prog_->synchronize();

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -110,7 +110,8 @@ TEST(IRBuilder, ExternalPtr) {
   auto ker = std::make_unique<Kernel>(*test_prog.prog(), std::move(block));
   ker->insert_arg(get_data_type<int>(), /*is_external_array=*/true);
   auto launch_ctx = ker->make_launch_context();
-  launch_ctx.set_arg_external_array(/*arg_id=*/0, (uint64)array.get(), size);
+  launch_ctx.set_arg_external_array(/*arg_id=*/0, (uint64)array.get(), size,
+                                    /*is_device_allocation=*/false);
   (*ker)(launch_ctx);
   EXPECT_EQ(array[0], 2);
   EXPECT_EQ(array[1], 1);


### PR DESCRIPTION
Sorry I left a few todos in this PR since it enables some unification
between cpu/cuda backend, as well as some cleanups.
But they're not relevant to the goal of this PR so I'll send them
separately.

This PR mainly enforces an invariant that:
- Taichi ndarrays' ptr points to a DeviceAllocation instead of the raw
data like torch-based ndarray.

The invariant above makes it easier to unify our Ndarray implementation
between multiple backends. I'll add an opengl implementation of ndarray
on top of this.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
