### PR TITLE
[benchmark] Add end-to-end benchmark suite

### DIFF
--- a/benchmarks/misc/end2end.py
+++ b/benchmarks/misc/end2end.py
@@ -1,0 +1,35 @@
+import os
+import time
+
+from end2end_cases import end2end_cases_list
+from utils import dump2json
+
+import taichi as ti
+
+
+class EndToEnd:
+    suite_name = 'end2end'
+    supported_archs = [ti.x64, ti.cuda]
+    test_cases = end2end_cases_list
+
+    def __init__(self, arch):
+        self._arch = arch
+        self._results = {}
+
+    def run(self):
+        for case in self.test_cases:
+            print(case.__name__)
+            case_result = case(self._arch)
+            self._results[case_result['case_name']] = case_result
+
+    def save_as_json(self, arch_dir='./'):
+        #folder of suite
+        suite_path = os.path.join(arch_dir, self.suite_name)
+        os.makedirs(suite_path)
+        #all cases in a json file
+        results_path = os.path.join(suite_path, f'{self.suite_name}.json')
+        with open(results_path, 'w') as f:
+            print(dump2json(self._results), file=f)
+
+    def save_as_markdown(self, arch_dir='./'):
+        return  #no need for this suite

--- a/benchmarks/misc/end2end_cases/__init__.py
+++ b/benchmarks/misc/end2end_cases/__init__.py
@@ -1,0 +1,5 @@
+from .cornell_box import e2e_cornellbox
+from .mpm99 import e2e_mpm99
+from .rasterizer import e2e_rasterizer
+
+end2end_cases_list = [e2e_mpm99, e2e_rasterizer, e2e_cornellbox]

--- a/benchmarks/misc/end2end_cases/cornell_box.py
+++ b/benchmarks/misc/end2end_cases/cornell_box.py
@@ -1,0 +1,496 @@
+import numpy as np
+
+import taichi as ti
+
+# copy from examples/rendering/cornell_box.py
+
+
+def e2e_cornellbox(test_arch):
+    ti.init(kernel_profiler=True, arch=test_arch)
+    basic_repeat_times = 100
+    arch_repeat_times = 100 if test_arch == ti.cuda else 1
+
+    res = (800, 800)
+    color_buffer = ti.Vector.field(3, dtype=ti.f32, shape=res)
+    count_var = ti.field(ti.i32, shape=(1, ))
+    tonemapped_buffer = ti.Vector.field(3, dtype=ti.f32, shape=res)
+
+    max_ray_depth = 10
+    eps = 1e-4
+    inf = 1e10
+    fov = 0.8
+
+    camera_pos = ti.Vector([0.0, 0.6, 3.0])
+
+    mat_none = 0
+    mat_lambertian = 1
+    mat_specular = 2
+    mat_glass = 3
+    mat_light = 4
+
+    light_y_pos = 2.0 - eps
+    light_x_min_pos = -0.25
+    light_x_range = 0.5
+    light_z_min_pos = 1.0
+    light_z_range = 0.12
+    light_area = light_x_range * light_z_range
+    light_min_pos = ti.Vector([light_x_min_pos, light_y_pos, light_z_min_pos])
+    light_max_pos = ti.Vector([
+        light_x_min_pos + light_x_range, light_y_pos,
+        light_z_min_pos + light_z_range
+    ])
+    light_color = ti.Vector(list(np.array([0.9, 0.85, 0.7])))
+    light_normal = ti.Vector([0.0, -1.0, 0.0])
+
+    # No absorbtion, integrates over a unit hemisphere
+    lambertian_brdf = 1.0 / np.pi
+    # diamond!
+    refr_idx = 2.4
+
+    # right sphere
+    sp1_center = ti.Vector([0.4, 0.225, 1.75])
+    sp1_radius = 0.22
+
+    def make_box_transform_matrices():
+        rad = np.pi / 8.0
+        c, s = np.cos(rad), np.sin(rad)
+        rot = np.array([[c, 0, s, 0], [0, 1, 0, 0], [-s, 0, c, 0],
+                        [0, 0, 0, 1]])
+        translate = np.array([
+            [1, 0, 0, -0.7],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0.7],
+            [0, 0, 0, 1],
+        ])
+        m = translate @ rot
+        m_inv = np.linalg.inv(m)
+        m_inv_t = np.transpose(m_inv)
+        return ti.Matrix(m_inv), ti.Matrix(m_inv_t)
+
+    # left box
+    box_min = ti.Vector([0.0, 0.0, 0.0])
+    box_max = ti.Vector([0.55, 1.1, 0.55])
+    box_m_inv, box_m_inv_t = make_box_transform_matrices()
+
+    @ti.func
+    def reflect(d, n):
+        # Assuming |d| and |n| are normalized
+        return d - 2.0 * d.dot(n) * n
+
+    @ti.func
+    def refract(d, n, ni_over_nt):
+        # Assuming |d| and |n| are normalized
+        has_r, rd = 0, d
+        dt = d.dot(n)
+        discr = 1.0 - ni_over_nt * ni_over_nt * (1.0 - dt * dt)
+        if discr > 0.0:
+            has_r = 1
+            rd = (ni_over_nt * (d - n * dt) - n * ti.sqrt(discr)).normalized()
+        else:
+            rd *= 0.0
+        return has_r, rd
+
+    @ti.func
+    def mat_mul_point(m, p):
+        hp = ti.Vector([p[0], p[1], p[2], 1.0])
+        hp = m @ hp
+        hp /= hp[3]
+        return ti.Vector([hp[0], hp[1], hp[2]])
+
+    @ti.func
+    def mat_mul_vec(m, v):
+        hv = ti.Vector([v[0], v[1], v[2], 0.0])
+        hv = m @ hv
+        return ti.Vector([hv[0], hv[1], hv[2]])
+
+    @ti.func
+    def intersect_sphere(pos, d, center, radius):
+        T = pos - center
+        A = 1.0
+        B = 2.0 * T.dot(d)
+        C = T.dot(T) - radius * radius
+        delta = B * B - 4.0 * A * C
+        dist = inf
+        hit_pos = ti.Vector([0.0, 0.0, 0.0])
+
+        if delta > -1e-4:
+            delta = ti.max(delta, 0)
+            sdelta = ti.sqrt(delta)
+            ratio = 0.5 / A
+            ret1 = ratio * (-B - sdelta)
+            dist = ret1
+            if dist < inf:
+                # refinement
+                old_dist = dist
+                new_pos = pos + d * dist
+                T = new_pos - center
+                A = 1.0
+                B = 2.0 * T.dot(d)
+                C = T.dot(T) - radius * radius
+                delta = B * B - 4 * A * C
+                if delta > 0:
+                    sdelta = ti.sqrt(delta)
+                    ratio = 0.5 / A
+                    ret1 = ratio * (-B - sdelta) + old_dist
+                    if ret1 > 0:
+                        dist = ret1
+                        hit_pos = new_pos + ratio * (-B - sdelta) * d
+                else:
+                    dist = inf
+
+        return dist, hit_pos
+
+    @ti.func
+    def intersect_plane(pos, d, pt_on_plane, norm):
+        dist = inf
+        hit_pos = ti.Vector([0.0, 0.0, 0.0])
+        denom = d.dot(norm)
+        if abs(denom) > eps:
+            dist = norm.dot(pt_on_plane - pos) / denom
+            hit_pos = pos + d * dist
+        return dist, hit_pos
+
+    @ti.func
+    def intersect_aabb(box_min, box_max, o, d):
+        intersect = 1
+
+        near_t = -inf
+        far_t = inf
+        near_face = 0
+        near_is_max = 0
+
+        for i in ti.static(range(3)):
+            if d[i] == 0:
+                if o[i] < box_min[i] or o[i] > box_max[i]:
+                    intersect = 0
+            else:
+                i1 = (box_min[i] - o[i]) / d[i]
+                i2 = (box_max[i] - o[i]) / d[i]
+
+                new_far_t = max(i1, i2)
+                new_near_t = min(i1, i2)
+                new_near_is_max = i2 < i1
+
+                far_t = min(new_far_t, far_t)
+                if new_near_t > near_t:
+                    near_t = new_near_t
+                    near_face = int(i)
+                    near_is_max = new_near_is_max
+
+        near_norm = ti.Vector([0.0, 0.0, 0.0])
+        if near_t > far_t:
+            intersect = 0
+        if intersect:
+            for i in ti.static(range(2)):
+                if near_face == i:
+                    near_norm[i] = -1 + near_is_max * 2
+        return intersect, near_t, far_t, near_norm
+
+    @ti.func
+    def intersect_aabb_transformed(box_min, box_max, o, d):
+        # Transform the ray to the box's local space
+        obj_o = mat_mul_point(box_m_inv, o)
+        obj_d = mat_mul_vec(box_m_inv, d)
+        intersect, near_t, _, near_norm = intersect_aabb(
+            box_min, box_max, obj_o, obj_d)
+        if intersect and 0 < near_t:
+            # Transform the normal in the box's local space to world space
+            near_norm = mat_mul_vec(box_m_inv_t, near_norm)
+        else:
+            intersect = 0
+        return intersect, near_t, near_norm
+
+    @ti.func
+    def intersect_light(pos, d, tmax):
+        hit, t, far_t, near_norm = intersect_aabb(light_min_pos, light_max_pos,
+                                                  pos, d)
+        if hit and 0 < t < tmax:
+            hit = 1
+        else:
+            hit = 0
+            t = inf
+        return hit, t
+
+    @ti.func
+    def intersect_scene(pos, ray_dir):
+        closest, normal = inf, ti.Vector.zero(ti.f32, 3)
+        c, mat = ti.Vector.zero(ti.f32, 3), mat_none
+
+        # right near sphere
+        cur_dist, hit_pos = intersect_sphere(pos, ray_dir, sp1_center,
+                                             sp1_radius)
+        if 0 < cur_dist < closest:
+            closest = cur_dist
+            normal = (hit_pos - sp1_center).normalized()
+            c, mat = ti.Vector([1.0, 1.0, 1.0]), mat_glass
+        # left box
+        hit, cur_dist, pnorm = intersect_aabb_transformed(
+            box_min, box_max, pos, ray_dir)
+        if hit and 0 < cur_dist < closest:
+            closest = cur_dist
+            normal = pnorm
+            c, mat = ti.Vector([0.8, 0.5, 0.4]), mat_specular
+
+        # left
+        pnorm = ti.Vector([1.0, 0.0, 0.0])
+        cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([-1.1, 0.0,
+                                                               0.0]), pnorm)
+        if 0 < cur_dist < closest:
+            closest = cur_dist
+            normal = pnorm
+            c, mat = ti.Vector([0.65, 0.05, 0.05]), mat_lambertian
+        # right
+        pnorm = ti.Vector([-1.0, 0.0, 0.0])
+        cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([1.1, 0.0, 0.0]),
+                                      pnorm)
+        if 0 < cur_dist < closest:
+            closest = cur_dist
+            normal = pnorm
+            c, mat = ti.Vector([0.12, 0.45, 0.15]), mat_lambertian
+        # bottom
+        gray = ti.Vector([0.93, 0.93, 0.93])
+        pnorm = ti.Vector([0.0, 1.0, 0.0])
+        cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([0.0, 0.0, 0.0]),
+                                      pnorm)
+        if 0 < cur_dist < closest:
+            closest = cur_dist
+            normal = pnorm
+            c, mat = gray, mat_lambertian
+        # top
+        pnorm = ti.Vector([0.0, -1.0, 0.0])
+        cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([0.0, 2.0, 0.0]),
+                                      pnorm)
+        if 0 < cur_dist < closest:
+            closest = cur_dist
+            normal = pnorm
+            c, mat = gray, mat_lambertian
+        # far
+        pnorm = ti.Vector([0.0, 0.0, 1.0])
+        cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([0.0, 0.0, 0.0]),
+                                      pnorm)
+        if 0 < cur_dist < closest:
+            closest = cur_dist
+            normal = pnorm
+            c, mat = gray, mat_lambertian
+        # light
+        hit_l, cur_dist = intersect_light(pos, ray_dir, closest)
+        if hit_l and 0 < cur_dist < closest:
+            # technically speaking, no need to check the second term
+            closest = cur_dist
+            normal = light_normal
+            c, mat = light_color, mat_light
+
+        return closest, normal, c, mat
+
+    @ti.func
+    def visible_to_light(pos, ray_dir):
+        # eps*ray_dir is easy way to prevent rounding error
+        # here is best way to check the float precision:
+        # http://www.pbr-book.org/3ed-2018/Shapes/Managing_Rounding_Error.html
+        a, b, c, mat = intersect_scene(pos + eps * ray_dir, ray_dir)
+        return mat == mat_light
+
+    @ti.func
+    def dot_or_zero(n, l):
+        return max(0.0, n.dot(l))
+
+    @ti.func
+    def mis_power_heuristic(pf, pg):
+        # Assume 1 sample for each distribution
+        f = pf**2
+        g = pg**2
+        return f / (f + g)
+
+    @ti.func
+    def compute_area_light_pdf(pos, ray_dir):
+        hit_l, t = intersect_light(pos, ray_dir, inf)
+        pdf = 0.0
+        if hit_l:
+            l_cos = light_normal.dot(-ray_dir)
+            if l_cos > eps:
+                tmp = ray_dir * t
+                dist_sqr = tmp.dot(tmp)
+                pdf = dist_sqr / (light_area * l_cos)
+        return pdf
+
+    @ti.func
+    def compute_brdf_pdf(normal, sample_dir):
+        return dot_or_zero(normal, sample_dir) / np.pi
+
+    @ti.func
+    def sample_area_light(hit_pos, pos_normal):
+        # sampling inside the light area
+        x = ti.random() * light_x_range + light_x_min_pos
+        z = ti.random() * light_z_range + light_z_min_pos
+        on_light_pos = ti.Vector([x, light_y_pos, z])
+        return (on_light_pos - hit_pos).normalized()
+
+    @ti.func
+    def sample_brdf(normal):
+        # cosine hemisphere sampling
+        # Uniformly sample on a disk using concentric sampling(r, theta)
+        # https://www.pbr-book.org/3ed-2018/Monte_Carlo_Integration/2D_Sampling_with_Multidimensional_Transformations#CosineSampleHemisphere
+        r, theta = 0.0, 0.0
+        sx = ti.random() * 2.0 - 1.0
+        sy = ti.random() * 2.0 - 1.0
+        if sx != 0 or sy != 0:
+            if abs(sx) > abs(sy):
+                r = sx
+                theta = np.pi / 4 * (sy / sx)
+            else:
+                r = sy
+                theta = np.pi / 4 * (2 - sx / sy)
+        # Apply Malley's method to project disk to hemisphere
+        u = ti.Vector([1.0, 0.0, 0.0])
+        if abs(normal[1]) < 1 - eps:
+            u = normal.cross(ti.Vector([0.0, 1.0, 0.0]))
+        v = normal.cross(u)
+        costt, sintt = ti.cos(theta), ti.sin(theta)
+        xy = (u * costt + v * sintt) * r
+        zlen = ti.sqrt(max(0.0, 1.0 - xy.dot(xy)))
+        return xy + zlen * normal
+
+    @ti.func
+    def sample_direct_light(hit_pos, hit_normal, hit_color):
+        direct_li = ti.Vector([0.0, 0.0, 0.0])
+        fl = lambertian_brdf * hit_color * light_color
+        light_pdf, brdf_pdf = 0.0, 0.0
+
+        # sample area light
+        to_light_dir = sample_area_light(hit_pos, hit_normal)
+        if to_light_dir.dot(hit_normal) > 0:
+            light_pdf = compute_area_light_pdf(hit_pos, to_light_dir)
+            brdf_pdf = compute_brdf_pdf(hit_normal, to_light_dir)
+            if light_pdf > 0 and brdf_pdf > 0:
+                l_visible = visible_to_light(hit_pos, to_light_dir)
+                if l_visible:
+                    w = mis_power_heuristic(light_pdf, brdf_pdf)
+                    nl = dot_or_zero(to_light_dir, hit_normal)
+                    direct_li += fl * w * nl / light_pdf
+
+        # sample brdf
+        brdf_dir = sample_brdf(hit_normal)
+        brdf_pdf = compute_brdf_pdf(hit_normal, brdf_dir)
+        if brdf_pdf > 0:
+            light_pdf = compute_area_light_pdf(hit_pos, brdf_dir)
+            if light_pdf > 0:
+                l_visible = visible_to_light(hit_pos, brdf_dir)
+                if l_visible:
+                    w = mis_power_heuristic(brdf_pdf, light_pdf)
+                    nl = dot_or_zero(brdf_dir, hit_normal)
+                    direct_li += fl * w * nl / brdf_pdf
+
+        return direct_li
+
+    @ti.func
+    def schlick(cos, eta):
+        r0 = (1.0 - eta) / (1.0 + eta)
+        r0 = r0 * r0
+        return r0 + (1 - r0) * ((1.0 - cos)**5)
+
+    @ti.func
+    def sample_ray_dir(indir, normal, hit_pos, mat):
+        u = ti.Vector([0.0, 0.0, 0.0])
+        pdf = 1.0
+        if mat == mat_lambertian:
+            u = sample_brdf(normal)
+            pdf = max(eps, compute_brdf_pdf(normal, u))
+        elif mat == mat_specular:
+            u = reflect(indir, normal)
+        elif mat == mat_glass:
+            cos = indir.dot(normal)
+            ni_over_nt = refr_idx
+            outn = normal
+            if cos > 0.0:
+                outn = -normal
+                cos = refr_idx * cos
+            else:
+                ni_over_nt = 1.0 / refr_idx
+                cos = -cos
+            has_refr, refr_dir = refract(indir, outn, ni_over_nt)
+            refl_prob = 1.0
+            if has_refr:
+                refl_prob = schlick(cos, refr_idx)
+            if ti.random() < refl_prob:
+                u = reflect(indir, normal)
+            else:
+                u = refr_dir
+        return u.normalized(), pdf
+
+    stratify_res = 5
+    inv_stratify = 1.0 / 5.0
+
+    @ti.kernel
+    def render():
+        for u, v in color_buffer:
+            aspect_ratio = res[0] / res[1]
+            pos = camera_pos
+            cur_iter = count_var[0]
+            str_x, str_y = (cur_iter / stratify_res), (cur_iter % stratify_res)
+            ray_dir = ti.Vector([
+                (2 * fov * (u +
+                            (str_x + ti.random()) * inv_stratify) / res[1] -
+                 fov * aspect_ratio - 1e-5),
+                (2 * fov * (v +
+                            (str_y + ti.random()) * inv_stratify) / res[1] -
+                 fov - 1e-5),
+                -1.0,
+            ])
+            ray_dir = ray_dir.normalized()
+
+            acc_color = ti.Vector([0.0, 0.0, 0.0])
+            throughput = ti.Vector([1.0, 1.0, 1.0])
+
+            depth = 0
+            while depth < max_ray_depth:
+                closest, hit_normal, hit_color, mat = intersect_scene(
+                    pos, ray_dir)
+                if mat == mat_none:
+                    break
+
+                hit_pos = pos + closest * ray_dir
+                hit_light = (mat == mat_light)
+                if hit_light:
+                    acc_color += throughput * light_color
+                    break
+                elif mat == mat_lambertian:
+                    acc_color += throughput * sample_direct_light(
+                        hit_pos, hit_normal, hit_color)
+
+                depth += 1
+                ray_dir, pdf = sample_ray_dir(ray_dir, hit_normal, hit_pos,
+                                              mat)
+                pos = hit_pos + 1e-4 * ray_dir
+                if mat == mat_lambertian:
+                    throughput *= lambertian_brdf * hit_color * dot_or_zero(
+                        hit_normal, ray_dir) / pdf
+                else:
+                    throughput *= hit_color
+            color_buffer[u, v] += acc_color
+        count_var[0] = (count_var[0] + 1) % (stratify_res * stratify_res)
+
+    @ti.kernel
+    def tonemap(accumulated: ti.f32):
+        for i, j in tonemapped_buffer:
+            tonemapped_buffer[i, j] = ti.sqrt(color_buffer[i, j] /
+                                              accumulated * 100.0)
+
+    print('    initializing ...')
+    for i in range(10 * arch_repeat_times):
+        render()
+
+    print('    profiling begin ...')
+    time_in_s = 0.0
+    for i in range(arch_repeat_times):
+        ti.clear_kernel_profile_info()
+        for j in range(basic_repeat_times):
+            render()
+        ti.sync()
+        time_in_s += ti.kernel_profiler_total_time()
+    print(f'    time_in_s = {time_in_s}')
+    ti.reset()
+    ret_dict = {}
+    ret_dict['case_name'] = 'cornellbox'
+    ret_dict['repeat_times'] = arch_repeat_times * basic_repeat_times
+    ret_dict['total_elapsed_time_ms'] = time_in_s * 1000
+    return ret_dict

--- a/benchmarks/misc/end2end_cases/mpm99.py
+++ b/benchmarks/misc/end2end_cases/mpm99.py
@@ -1,0 +1,145 @@
+import numpy as np
+
+import taichi as ti
+
+# copy from examples/simulation/mpm99.py
+
+
+def e2e_mpm99(test_arch):
+    ti.init(kernel_profiler=True, arch=test_arch)
+
+    quality = 1  # Use a larger value for higher-res simulations
+    n_particles, n_grid = 9000 * quality**2, 128 * quality
+    dx, inv_dx = 1 / n_grid, float(n_grid)
+    dt = 1e-4 / quality
+    p_vol, p_rho = (dx * 0.5)**2, 1
+    p_mass = p_vol * p_rho
+    E, nu = 0.1e4, 0.2  # Young's modulus and Poisson's ratio
+    mu_0, lambda_0 = E / (2 * (1 + nu)), E * nu / (
+        (1 + nu) * (1 - 2 * nu))  # Lame parameters
+    x = ti.Vector.field(2, dtype=float, shape=n_particles)  # position
+    v = ti.Vector.field(2, dtype=float, shape=n_particles)  # velocity
+    C = ti.Matrix.field(2, 2, dtype=float,
+                        shape=n_particles)  # affine velocity field
+    F = ti.Matrix.field(2, 2, dtype=float,
+                        shape=n_particles)  # deformation gradient
+    material = ti.field(dtype=int, shape=n_particles)  # material id
+    Jp = ti.field(dtype=float, shape=n_particles)  # plastic deformation
+    grid_v = ti.Vector.field(2, dtype=float,
+                             shape=(n_grid,
+                                    n_grid))  # grid node momentum/velocity
+    grid_m = ti.field(dtype=float, shape=(n_grid, n_grid))  # grid node mass
+
+    @ti.kernel
+    def substep():
+        for i, j in grid_m:
+            grid_v[i, j] = [0, 0]
+            grid_m[i, j] = 0
+        for p in x:  # Particle state update and scatter to grid (P2G)
+            base = (x[p] * inv_dx - 0.5).cast(int)
+            fx = x[p] * inv_dx - base.cast(float)
+            # Quadratic kernels  [http://mpm.graphics   Eqn. 123, with x=fx, fx-1,fx-2]
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+            F[p] = (ti.Matrix.identity(float, 2) +
+                    dt * C[p]) @ F[p]  # deformation gradient update
+            h = ti.exp(
+                10 * (1.0 - Jp[p])
+            )  # Hardening coefficient: snow gets harder when compressed
+            if material[p] == 1:  # jelly, make it softer
+                h = 0.3
+            mu, la = mu_0 * h, lambda_0 * h
+            if material[p] == 0:  # liquid
+                mu = 0.0
+            U, sig, V = ti.svd(F[p])
+            J = 1.0
+            for d in ti.static(range(2)):
+                new_sig = sig[d, d]
+                if material[p] == 2:  # Snow
+                    new_sig = min(max(sig[d, d], 1 - 2.5e-2),
+                                  1 + 4.5e-3)  # Plasticity
+                Jp[p] *= sig[d, d] / new_sig
+                sig[d, d] = new_sig
+                J *= new_sig
+            if material[
+                    p] == 0:  # Reset deformation gradient to avoid numerical instability
+                F[p] = ti.Matrix.identity(float, 2) * ti.sqrt(J)
+            elif material[p] == 2:
+                F[p] = U @ sig @ V.transpose(
+                )  # Reconstruct elastic deformation gradient after plasticity
+            stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose(
+            ) + ti.Matrix.identity(float, 2) * la * J * (J - 1)
+            stress = (-dt * p_vol * 4 * inv_dx * inv_dx) * stress
+            affine = stress + p_mass * C[p]
+            for i, j in ti.static(ti.ndrange(
+                    3, 3)):  # Loop over 3x3 grid node neighborhood
+                offset = ti.Vector([i, j])
+                dpos = (offset.cast(float) - fx) * dx
+                weight = w[i][0] * w[j][1]
+                grid_v[base +
+                       offset] += weight * (p_mass * v[p] + affine @ dpos)
+                grid_m[base + offset] += weight * p_mass
+        for i, j in grid_m:
+            if grid_m[i, j] > 0:  # No need for epsilon here
+                grid_v[i, j] = (
+                    1 / grid_m[i, j]) * grid_v[i, j]  # Momentum to velocity
+                grid_v[i, j][1] -= dt * 50  # gravity
+                if i < 3 and grid_v[i, j][0] < 0:
+                    grid_v[i, j][0] = 0  # Boundary conditions
+                if i > n_grid - 3 and grid_v[i, j][0] > 0: grid_v[i, j][0] = 0
+                if j < 3 and grid_v[i, j][1] < 0: grid_v[i, j][1] = 0
+                if j > n_grid - 3 and grid_v[i, j][1] > 0: grid_v[i, j][1] = 0
+        for p in x:  # grid to particle (G2P)
+            base = (x[p] * inv_dx - 0.5).cast(int)
+            fx = x[p] * inv_dx - base.cast(float)
+            w = [
+                0.5 * (1.5 - fx)**2, 0.75 - (fx - 1.0)**2, 0.5 * (fx - 0.5)**2
+            ]
+            new_v = ti.Vector.zero(float, 2)
+            new_C = ti.Matrix.zero(float, 2, 2)
+            for i, j in ti.static(ti.ndrange(
+                    3, 3)):  # loop over 3x3 grid node neighborhood
+                dpos = ti.Vector([i, j]).cast(float) - fx
+                g_v = grid_v[base + ti.Vector([i, j])]
+                weight = w[i][0] * w[j][1]
+                new_v += weight * g_v
+                new_C += 4 * inv_dx * weight * g_v.outer_product(dpos)
+            v[p], C[p] = new_v, new_C
+            x[p] += dt * v[p]  # advection
+
+    group_size = n_particles // 3
+
+    @ti.kernel
+    def initialize():
+        for i in range(n_particles):
+            x[i] = [
+                ti.random() * 0.2 + 0.3 + 0.10 * (i // group_size),
+                ti.random() * 0.2 + 0.05 + 0.32 * (i // group_size)
+            ]
+            material[i] = i // group_size  # 0: fluid 1: jelly 2: snow
+            v[i] = ti.Matrix([0, 0])
+            F[i] = ti.Matrix([[1, 0], [0, 1]])
+            Jp[i] = 1
+
+    print('    initializing ...')
+    innner_iter = int(2e-3 // dt)
+    outter_iter = 320
+    initialize()
+    for j in range(innner_iter):
+        substep()
+
+    print('    profiling begin ...')
+    time_in_s = 0.0
+    initialize()
+    ti.clear_kernel_profile_info()
+    for j in range(outter_iter):
+        for s in range(innner_iter):
+            substep()
+    ti.sync()
+    time_in_s += ti.kernel_profiler_total_time()
+    print(f'    time_in_s = {time_in_s}')
+    ti.reset()
+    ret_dict = {}
+    ret_dict['case_name'] = 'mpm99'
+    ret_dict['repeat_times'] = outter_iter * innner_iter
+    ret_dict['total_elapsed_time_ms'] = time_in_s * 1000
+    return ret_dict

--- a/benchmarks/misc/end2end_cases/rasterizer.py
+++ b/benchmarks/misc/end2end_cases/rasterizer.py
@@ -1,0 +1,159 @@
+import math
+
+import numpy as np
+
+import taichi as ti
+
+# copy from examples/rendering/rasterizer.py
+
+
+@ti.data_oriented
+class TriangleRasterizer:
+    def __init__(self, num_triangles, tile_size, width, height,
+                 num_samples_per_pixel, num_spp_sqrt):
+        self.num_triangles = num_triangles
+        self.tile_size = tile_size
+        self.num_samples_per_pixel = num_samples_per_pixel
+        self.num_spp_sqrt = num_spp_sqrt
+
+        self.samples = ti.Vector.field(3,
+                                       dtype=ti.f32,
+                                       shape=(width, height, num_spp_sqrt,
+                                              num_spp_sqrt))
+        self.pixels = ti.Vector.field(3, dtype=ti.f32, shape=(width, height))
+
+        self.A = ti.Vector.field(2, dtype=ti.f32)
+        self.B = ti.Vector.field(2, dtype=ti.f32)
+        self.C = ti.Vector.field(2, dtype=ti.f32)
+        self.c0 = ti.Vector.field(3, dtype=ti.f32)
+        self.c1 = ti.Vector.field(3, dtype=ti.f32)
+        self.c2 = ti.Vector.field(3, dtype=ti.f32)
+
+        self.vertices = ti.root.dense(ti.i, num_triangles).place(
+            self.A, self.B, self.C)
+        self.colors = ti.root.dense(ti.i, num_triangles).place(
+            self.c0, self.c1, self.c2)
+
+        # Tile-based culling
+        self.block_num_triangles = ti.field(dtype=ti.i32,
+                                            shape=(width // tile_size,
+                                                   height // tile_size))
+        self.block_indicies = ti.field(dtype=ti.i32,
+                                       shape=(width // tile_size,
+                                              height // tile_size,
+                                              num_triangles))
+
+    def set_triangle(self, i, v0, v1, v2, c0, c1, c2):
+        self.A[i] = v0
+        self.B[i] = v1
+        self.C[i] = v2
+        self.c0[i] = c0
+        self.c1[i] = c1
+        self.c2[i] = c2
+
+    @staticmethod
+    @ti.func
+    def point_in_triangle(P, A, B, C):
+        alpha = -(P.x - B.x) * (C.y - B.y) + (P.y - B.y) * (C.x - B.x)
+        alpha /= -(A.x - B.x) * (C.y - B.y) + (A.y - B.y) * (C.x - B.x)
+        beta = -(P.x - C.x) * (A.y - C.y) + (P.y - C.y) * (A.x - C.x)
+        beta /= -(B.x - C.x) * (A.y - C.y) + (B.y - C.y) * (A.x - C.x)
+        gamma = 1.0 - alpha - beta
+        result = alpha >= 0.0 and alpha <= 1.0 and beta >= 0.0 and beta <= 1.0 and gamma >= 0.0
+        return result, alpha, beta, gamma
+
+    @staticmethod
+    @ti.func
+    def bbox_intersect(A0, A1, B0, B1):
+        return (B0.x < A1.x and B0.y < A1.y and B1.x > A0.x and B1.y > A0.y)
+
+    @ti.kernel
+    def tile_culling(self):
+        for i, j in self.block_num_triangles:
+            idx = 0
+            tile_min = ti.Vector([i * self.tile_size, j * self.tile_size])
+            tile_max = ti.Vector([(i + 1) * self.tile_size,
+                                  (j + 1) * self.tile_size])
+            for t in range(self.num_triangles):
+                A, B, C = self.A[t], self.B[t], self.C[t]
+                tri_min = ti.min(A, ti.min(B, C))
+                tri_max = ti.max(A, ti.max(B, C))
+                if self.bbox_intersect(tile_min, tile_max, tri_min, tri_max):
+                    self.block_indicies[i, j, idx] = t
+                    idx = idx + 1
+            self.block_num_triangles[i, j] = idx
+
+    @ti.kernel
+    def rasterize(self):
+        for i, j in self.pixels:
+            for k in range(self.block_num_triangles[i // self.tile_size,
+                                                    j // self.tile_size]):
+                idx = self.block_indicies[i // self.tile_size,
+                                          j // self.tile_size, k]
+                A, B, C = self.A[idx], self.B[idx], self.C[idx]
+                c0, c1, c2 = self.c0[idx], self.c1[idx], self.c2[idx]
+
+                for subi, subj in ti.ndrange(self.num_spp_sqrt,
+                                             self.num_spp_sqrt):
+                    P = ti.Vector([
+                        i + (subi + 0.5) / self.num_spp_sqrt,
+                        j + (subj + 0.5) / self.num_spp_sqrt
+                    ])
+                    result, alpha, beta, gamma = self.point_in_triangle(
+                        P, A, B, C)
+
+                    if result:
+                        interpolated_color = c0 * alpha + c1 * beta + c2 * gamma
+                        self.samples[i, j, subi, subj] = interpolated_color
+
+            samples_sum = ti.Vector([0.0, 0.0, 0.0])
+            for subi, subj in ti.ndrange(self.num_spp_sqrt, self.num_spp_sqrt):
+                samples_sum += self.samples[i, j, subi, subj]
+            self.pixels[i, j] = samples_sum / self.num_samples_per_pixel
+
+
+def e2e_rasterizer(test_arch):
+    basic_repeat_times = 100
+    arch_repeat_times = 10 if test_arch == ti.cuda else 1
+
+    tile_size = 8  # Size of a tile
+    width, height = 800, 600  # Size of framebuffer
+    num_samples_per_pixel = 4  # Number of samples per pixel
+    num_spp_sqrt = int(math.sqrt(num_samples_per_pixel))
+    num_triangles = 256  # Number of random colored triangles to be generated
+
+    ti.init(kernel_profiler=True, arch=test_arch)
+
+    print('    initializing ...')
+    triangles = TriangleRasterizer(num_triangles, tile_size, width, height,
+                                   num_samples_per_pixel, num_spp_sqrt)
+    for i in range(num_triangles):
+        triangles.set_triangle(i % num_triangles,
+                               ti.Vector(np.random.rand(2) * [width, height]),
+                               ti.Vector(np.random.rand(2) * [width, height]),
+                               ti.Vector(np.random.rand(2) * [width, height]),
+                               ti.Vector(np.random.rand(3)),
+                               ti.Vector(np.random.rand(3)),
+                               ti.Vector(np.random.rand(3)))
+
+    triangles.samples.fill(ti.Vector([1.0, 1.0, 1.0]))
+    triangles.pixels.fill(ti.Vector([1.0, 1.0, 1.0]))
+    triangles.tile_culling()
+    triangles.rasterize()
+
+    print('    profiling begin ...')
+    time_in_s = 0.0
+    for i in range(arch_repeat_times):
+        ti.clear_kernel_profile_info()
+        for j in range(basic_repeat_times):
+            triangles.tile_culling()
+            triangles.rasterize()
+        ti.sync()
+        time_in_s += ti.kernel_profiler_total_time()
+    print(f'    time_in_s = {time_in_s}')
+    ti.reset()
+    ret_dict = {}
+    ret_dict['case_name'] = 'rasterizer'
+    ret_dict['repeat_times'] = arch_repeat_times * basic_repeat_times
+    ret_dict['total_elapsed_time_ms'] = time_in_s * 1000
+    return ret_dict

--- a/benchmarks/misc/run.py
+++ b/benchmarks/misc/run.py
@@ -1,12 +1,13 @@
 import os
 import warnings
 
+from end2end import EndToEnd
 from membound import MemoryBound
 from utils import arch_name, datatime_with_format, dump2json
 
 import taichi as ti
 
-benchmark_suites = [MemoryBound]
+benchmark_suites = [MemoryBound, EndToEnd]
 benchmark_archs = [ti.x64, ti.cuda]
 
 


### PR DESCRIPTION
Related issue = #2601

Use mpm99, cornell_box, and rasterizer from `examples/` to do end-to-end benchmark.
The time is not exactly end-to-end, still uses the elapsed time counted by kernel profiler.