### PR TITLE
[Bug] [metal] Fix data type alignment for arguments and return values

### DIFF
--- a/taichi/backends/metal/kernel_utils.cpp
+++ b/taichi/backends/metal/kernel_utils.cpp
@@ -121,6 +121,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
     for (int i : scalar_indices) {
       auto &attribs = (*vec)[i];
       const size_t dt_bytes = metal_data_type_bytes(attribs.dt);
+      // Align bytes to the nearest multiple of dt_bytes
       bytes = (bytes + dt_bytes - 1) / dt_bytes * dt_bytes;
       attribs.offset_in_mem = bytes;
       bytes += attribs.stride;

--- a/taichi/backends/metal/kernel_utils.cpp
+++ b/taichi/backends/metal/kernel_utils.cpp
@@ -120,12 +120,16 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
     // Put scalar args in the memory first
     for (int i : scalar_indices) {
       auto &attribs = (*vec)[i];
+      const size_t dt_bytes = metal_data_type_bytes(attribs.dt);
+      bytes = (bytes + dt_bytes - 1) / dt_bytes * dt_bytes;
       attribs.offset_in_mem = bytes;
       bytes += attribs.stride;
     }
     // Then the array args
     for (int i : array_indices) {
       auto &attribs = (*vec)[i];
+      const size_t dt_bytes = metal_data_type_bytes(attribs.dt);
+      bytes = (bytes + dt_bytes - 1) / dt_bytes * dt_bytes;
       attribs.offset_in_mem = bytes;
       bytes += attribs.stride;
     }

--- a/tests/python/test_arg_alignment.py
+++ b/tests/python/test_arg_alignment.py
@@ -1,0 +1,22 @@
+import taichi as ti
+
+
+@ti.test(exclude=[ti.opengl, ti.vulkan])
+def test_ret_write():
+    @ti.kernel
+    def func(a: ti.i16) -> ti.f32:
+        return 3.0
+
+    assert func(255) == 3.0
+
+
+@ti.test(exclude=[ti.opengl, ti.vulkan])
+def test_arg_read():
+    x = ti.field(ti.i32, shape=())
+
+    @ti.kernel
+    def func(a: ti.i8, b: ti.i32):
+        x[None] = b
+
+    func(255, 2)
+    assert x[None] == 2


### PR DESCRIPTION
This PR fixes #3563.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
