### PR TITLE
[Lang] Add get_element_size for ndarray

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -172,6 +172,24 @@ class Ndarray:
             impl.get_runtime().sync()
 
     @python_scope
+    def get_element_size(self):
+        """Returns the size of one element in bytes.
+
+        Returns:
+            Size in bytes.
+        """
+        return self.arr.element_size()
+
+    @python_scope
+    def get_nelement(self):
+        """Returns the total number of elements.
+
+        Returns:
+            Total number of elements.
+        """
+        return self.arr.nelement()
+
+    @python_scope
     def copy_from(self, other):
         """Copies all elements from another ndarray.
 

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -603,6 +603,27 @@ def test_arg_not_match():
     _test_arg_not_match()
 
 
+def _test_size_in_bytes():
+    a = ti.ndarray(ti.i32, 8)
+    assert a.get_element_size() == 4
+    assert a.get_nelement() == 8
+
+    b = ti.Vector.ndarray(10, ti.f64, 5)
+    assert b.get_element_size() == 8
+    assert b.get_nelement() == 50
+
+
+@pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
+@ti.test(arch=[ti.cpu, ti.cuda])
+def test_size_in_bytes_torch():
+    _test_size_in_bytes()
+
+
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=False)
+def test_size_in_bytes():
+    _test_size_in_bytes()
+
+
 @ti.test(arch=ti.opengl, ndarray_use_torch=True)
 def test_torch_based_ndarray_opengl():
     x = ti.ndarray(ti.f32, shape=(4, 2))


### PR DESCRIPTION
Add `get_element_size()` and `get_nelement()` for more convenient access of size in bytes.