### PR TITLE
[Bug] [ir] Fix the IdentifyValuesUsedInOtherOffloads pass

### DIFF
--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -120,3 +120,15 @@ def test_offload_with_cross_nested_for():
                 print('OK')
 
     run(2)
+
+
+@ti.test()
+def test_offload_with_cross_if_inside_for():
+    @ti.kernel
+    def run(a: ti.i32):
+        b = a > 2
+        for x in range(1):
+            if b:
+                print('OK')
+
+    run(2)


### PR DESCRIPTION
Related issue = #3463, #3467

#3467 didn't point out the accurate root cause of #3463. `RangeForStmt` was indeed visited with https://github.com/taichi-dev/taichi/blob/1ca4c408a69ba7475fd792aadd2e45cebf218615/taichi/ir/basic_stmt_visitor.cpp#L33-L36 instead of https://github.com/taichi-dev/taichi/blob/1ca4c408a69ba7475fd792aadd2e45cebf218615/taichi/transforms/offload.cpp#L374-L380

Having this, the most effective way to fix #3467 is to fill in the `preprocess_container_stmt()` member function common to all container statements, which is done in this PR.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
