### PR TITLE
[mesh] Make ti.Mesh compatible with dynamic index

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -591,9 +591,6 @@ def block_local(*args):
 
 
 def mesh_local(*args):
-    if ti.current_cfg().dynamic_index:
-        raise InvalidOperationError(
-            'dynamic_index is not allowed when mesh_local is turned on.')
     for a in args:
         for v in a.get_field_members():
             _ti_core.insert_snode_access_flag(

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -872,7 +872,10 @@ class MeshIndexConversionExpression : public Expression {
                                 mesh::MeshElementType idx_type,
                                 const Expr idx,
                                 mesh::ConvType conv_type)
-      : mesh(mesh), idx_type(idx_type), idx(load_if_ptr(idx)), conv_type(conv_type) {
+      : mesh(mesh),
+        idx_type(idx_type),
+        idx(load_if_ptr(idx)),
+        conv_type(conv_type) {
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -836,7 +836,7 @@ class MeshRelationAccessExpression : public Expression {
   MeshRelationAccessExpression(mesh::Mesh *mesh,
                                const Expr mesh_idx,
                                mesh::MeshElementType to_type)
-      : mesh(mesh), mesh_idx(mesh_idx), to_type(to_type) {
+      : mesh(mesh), mesh_idx(load_if_ptr(mesh_idx)), to_type(to_type) {
   }
 
   MeshRelationAccessExpression(mesh::Mesh *mesh,
@@ -844,9 +844,9 @@ class MeshRelationAccessExpression : public Expression {
                                mesh::MeshElementType to_type,
                                const Expr neighbor_idx)
       : mesh(mesh),
-        mesh_idx(mesh_idx),
+        mesh_idx(load_if_ptr(mesh_idx)),
         to_type(to_type),
-        neighbor_idx(neighbor_idx) {
+        neighbor_idx(load_if_ptr(neighbor_idx)) {
   }
 
   void flatten(FlattenContext *ctx) override;
@@ -872,7 +872,7 @@ class MeshIndexConversionExpression : public Expression {
                                 mesh::MeshElementType idx_type,
                                 const Expr idx,
                                 mesh::ConvType conv_type)
-      : mesh(mesh), idx_type(idx_type), idx(idx), conv_type(conv_type) {
+      : mesh(mesh), idx_type(idx_type), idx(load_if_ptr(idx)), conv_type(conv_type) {
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -8,7 +8,7 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 model_file_path = os.path.join(this_dir, 'ell.json')
 
 
-@ti.test(require=ti.extension.mesh, dynamic_index=False)
+@ti.test(require=ti.extension.mesh)
 def test_mesh_patch_idx():
     mesh_builder = ti.Mesh.Tet()
     mesh_builder.verts.place({'idx': ti.i32})
@@ -83,21 +83,19 @@ def _test_mesh_for(cell_reorder=False, vert_reorder=False, extra_tests=True):
     assert total == 1144
 
 
-@ti.test(require=ti.extension.mesh, dynamic_index=False)
+@ti.test(require=ti.extension.mesh)
 def test_mesh_for():
     _test_mesh_for(False, False)
     _test_mesh_for(False, True)
 
 
 @ti.test(require=ti.extension.mesh,
-         dynamic_index=False,
          optimize_mesh_reordered_mapping=False)
 def test_mesh_reordered_opt():
     _test_mesh_for(True, True, False)
 
 
 @ti.test(require=ti.extension.mesh,
-         dynamic_index=False,
          mesh_localize_to_end_mapping=False)
 def test_mesh_localize_mapping0():
     _test_mesh_for(False, False, False)
@@ -105,14 +103,13 @@ def test_mesh_localize_mapping0():
 
 
 @ti.test(require=ti.extension.mesh,
-         dynamic_index=False,
          mesh_localize_from_end_mapping=True)
 def test_mesh_localize_mapping1():
     _test_mesh_for(False, False, False)
     _test_mesh_for(True, True, False)
 
 
-@ti.test(require=ti.extension.mesh, dynamic_index=False)
+@ti.test(require=ti.extension.mesh)
 def test_mesh_reorder():
     vec3i = ti.types.vector(3, ti.i32)
     mesh_builder = ti.Mesh.Tet()
@@ -150,7 +147,7 @@ def test_mesh_reorder():
         assert id234[i][2] == i**4
 
 
-@ti.test(require=ti.extension.mesh, dynamic_index=False)
+@ti.test(require=ti.extension.mesh)
 def test_mesh_minor_relations():
     mesh_builder = ti.Mesh.Tet()
     mesh_builder.verts.place({'y': ti.i32})
@@ -175,7 +172,6 @@ def test_mesh_minor_relations():
 
 
 @ti.test(require=ti.extension.mesh,
-         dynamic_index=False,
          demote_no_access_mesh_fors=True)
 def test_multiple_meshes():
     mesh_builder = ti.Mesh.Tet()
@@ -198,7 +194,7 @@ def test_multiple_meshes():
         assert out[i] == i**2
 
 
-@ti.test(require=ti.extension.mesh, dynamic_index=False)
+@ti.test(require=ti.extension.mesh)
 def test_mesh_local():
     mesh_builder = ti.Mesh.Tet()
     mesh_builder.verts.place({'a': ti.i32})

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -89,21 +89,18 @@ def test_mesh_for():
     _test_mesh_for(False, True)
 
 
-@ti.test(require=ti.extension.mesh,
-         optimize_mesh_reordered_mapping=False)
+@ti.test(require=ti.extension.mesh, optimize_mesh_reordered_mapping=False)
 def test_mesh_reordered_opt():
     _test_mesh_for(True, True, False)
 
 
-@ti.test(require=ti.extension.mesh,
-         mesh_localize_to_end_mapping=False)
+@ti.test(require=ti.extension.mesh, mesh_localize_to_end_mapping=False)
 def test_mesh_localize_mapping0():
     _test_mesh_for(False, False, False)
     _test_mesh_for(True, True, False)
 
 
-@ti.test(require=ti.extension.mesh,
-         mesh_localize_from_end_mapping=True)
+@ti.test(require=ti.extension.mesh, mesh_localize_from_end_mapping=True)
 def test_mesh_localize_mapping1():
     _test_mesh_for(False, False, False)
     _test_mesh_for(True, True, False)
@@ -171,8 +168,7 @@ def test_mesh_minor_relations():
     assert total == 576
 
 
-@ti.test(require=ti.extension.mesh,
-         demote_no_access_mesh_fors=True)
+@ti.test(require=ti.extension.mesh, demote_no_access_mesh_fors=True)
 def test_multiple_meshes():
     mesh_builder = ti.Mesh.Tet()
     mesh_builder.verts.place({'y': ti.i32})


### PR DESCRIPTION
Related issue = #3567

Just remember to use `load_if_ptr` for any `Expr` when constructing Taichi frontend IR.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
