### PR TITLE
[ci] Widen the GPU test timeout

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -245,7 +245,7 @@ jobs:
     needs: [check_code_format, check_files]
     runs-on: [self-hosted, cuda, vulkan, cn]
     if: needs.check_files.outputs.run_job == 'true'
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Related issue = #

Sample failures due to the early cancellation:

* https://github.com/taichi-dev/taichi/runs/4318329900?check_suite_focus=true
* https://github.com/taichi-dev/taichi/runs/4318962108?check_suite_focus=true

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
