### PR TITLE
[refactor] Do not expand to absolute path for saved shaders.

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -229,5 +229,5 @@ class Module:
           filepath (str): path to a folder to store aot files.
           filename (str): filename prefix for stored aot files.
         """
-        filepath = str(PurePosixPath(Path(filepath).resolve()))
+        filepath = str(PurePosixPath(Path(filepath)))
         self._aot_builder.dump(filepath, filename)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3623
* #3622
* __->__ #3621

Using absolute path confuses users so let's get rid of it.