### PR TITLE
[Lang] Add option short_circuit_operators for short-circuiting boolean ops

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -421,6 +421,7 @@ class _SpecialConfig:
         self.gdb_trigger = False
         self.excepthook = False
         self.experimental_real_function = False
+        self.short_circuit_operators = False
 
 
 def prepare_sandbox():
@@ -591,6 +592,7 @@ def init(arch=None,
     env_spec.add('gdb_trigger')
     env_spec.add('excepthook')
     env_spec.add('experimental_real_function')
+    env_spec.add('short_circuit_operators')
 
     # compiler configurations (ti.cfg):
     for key in dir(ti.cfg):
@@ -620,6 +622,8 @@ def init(arch=None,
         impl.get_runtime().print_preprocessed = spec_cfg.print_preprocessed
         impl.get_runtime().experimental_real_function = \
             spec_cfg.experimental_real_function
+        impl.get_runtime().short_circuit_operators = \
+            spec_cfg.short_circuit_operators
         ti.set_logging_level(spec_cfg.log_level.lower())
         if spec_cfg.excepthook:
             # TODO(#1405): add a way to restore old excepthook

--- a/tests/python/test_short_circuit.py
+++ b/tests/python/test_short_circuit.py
@@ -1,0 +1,49 @@
+import taichi as ti
+
+
+@ti.test(debug=True, short_circuit_operators=True)
+def test_and_shorted():
+    a = ti.field(ti.i32, shape=10)
+
+    @ti.func
+    def explode() -> ti.i32:
+        return a[-1]
+
+    @ti.kernel
+    def func() -> ti.i32:
+        return False and explode()
+
+    assert func() == 0
+
+
+@ti.test(debug=True, short_circuit_operators=True)
+def test_and_not_shorted():
+    @ti.kernel
+    def func() -> ti.i32:
+        return True and False
+
+    assert func() == 0
+
+
+@ti.test(debug=True, short_circuit_operators=True)
+def test_or_shorted():
+    a = ti.field(ti.i32, shape=10)
+
+    @ti.func
+    def explode() -> ti.i32:
+        return a[-1]
+
+    @ti.kernel
+    def func() -> ti.i32:
+        return True or explode()
+
+    assert func() == 1
+
+
+@ti.test(debug=True, short_circuit_operators=True)
+def test_or_not_shorted():
+    @ti.kernel
+    def func() -> ti.i32:
+        return False or True
+
+    assert func() == 1


### PR DESCRIPTION
Related issue = Fixes #3572

cc @strongoier 

```python
ti.init(short_circuit_operators=True)
```