### PR TITLE
[Bug] [lang] Fix copying a Matrix/Struct from Python scope to Taichi scope

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -10,13 +10,13 @@ from taichi.lang.exception import InvalidOperationError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
-from taichi.lang.matrix import MatrixField, _IntermediateMatrix
+from taichi.lang.matrix import Matrix, MatrixField, _IntermediateMatrix
 from taichi.lang.mesh import (ConvType, MeshElementFieldProxy, MeshInstance,
                               MeshRelationAccessProxy,
                               MeshReorderedMatrixFieldProxy,
                               MeshReorderedScalarFieldProxy, element_type_name)
 from taichi.lang.snode import SNode
-from taichi.lang.struct import StructField, _IntermediateStruct
+from taichi.lang.struct import Struct, StructField, _IntermediateStruct
 from taichi.lang.tape import TapeImpl
 from taichi.lang.util import (cook_dtype, is_taichi_class, python_scope,
                               taichi_scope)
@@ -36,7 +36,13 @@ def expr_init_local_tensor(shape, element_type, elements):
 def expr_init(rhs):
     if rhs is None:
         return Expr(_ti_core.expr_alloca())
-    if is_taichi_class(rhs):
+    if isinstance(rhs, Matrix):
+        if rhs.in_python_scope:
+            return Matrix(rhs.to_list())
+        return rhs
+    if isinstance(rhs, Struct):
+        if rhs.in_python_scope:
+            return Struct(rhs.to_dict())
         return rhs
     if isinstance(rhs, list):
         return [expr_init(e) for e in rhs]

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -34,6 +34,7 @@ class Matrix(TaichiOperations):
         self.local_tensor_proxy = None
         self.any_array_access = None
         self.grad = None
+        self.in_python_scope = in_python_scope()
 
         if isinstance(n, (list, tuple, np.ndarray)):
             if len(n) == 0:
@@ -345,8 +346,10 @@ class Matrix(TaichiOperations):
     @property
     @python_scope
     def value(self):
-        return Matrix([[self(i, j) for j in range(self.m)]
-                       for i in range(self.n)])
+        return Matrix(self.to_list())
+
+    def to_list(self):
+        return [[self(i, j) for j in range(self.m)] for i in range(self.n)]
 
     # host access & python scope operation
     @python_scope
@@ -1123,6 +1126,7 @@ class _IntermediateMatrix(Matrix):
         self.local_tensor_proxy = None
         self.any_array_access = None
         self.grad = None
+        self.in_python_scope = in_python_scope()
 
 
 class MatrixField(Field):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -212,7 +212,11 @@ class Struct(TaichiOperations):
         Returns:
             Dict: The result dictionary.
         """
-        return {k: v.to_dict() if isinstance(v, Struct) else v.to_list() if isinstance(v, Matrix) else v for k, v in self.entries.items()}
+        return {
+            k: v.to_dict() if isinstance(v, Struct) else
+            v.to_list() if isinstance(v, Matrix) else v
+            for k, v in self.entries.items()
+        }
 
     @classmethod
     @python_scope

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -38,6 +38,7 @@ class Struct(TaichiOperations):
                 v = Struct(v)
             self.entries[k] = v if in_python_scope() else impl.expr_init(v)
         self.register_members()
+        self.in_python_scope = in_python_scope()
 
     @property
     def keys(self):
@@ -203,7 +204,6 @@ class Struct(TaichiOperations):
     def __repr__(self):
         return str(self.to_dict())
 
-    @python_scope
     def to_dict(self):
         """Converts the Struct to a dictionary.
 
@@ -212,7 +212,7 @@ class Struct(TaichiOperations):
         Returns:
             Dict: The result dictionary.
         """
-        return self.entries
+        return {k: v.to_dict() if isinstance(v, Struct) else v.to_list() if isinstance(v, Matrix) else v for k, v in self.entries.items()}
 
     @classmethod
     @python_scope
@@ -284,6 +284,7 @@ class _IntermediateStruct(Struct):
         assert isinstance(entries, dict)
         self.entries = entries
         self.register_members()
+        self.in_python_scope = in_python_scope()
 
 
 class StructField(Field):

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -299,3 +299,19 @@ def test_local_struct_assign():
 
     run_taichi_scope()
     run_python_scope()
+
+
+@ti.test(debug=True)
+def test_copy_python_scope_struct_to_taichi_scope():
+    a = ti.Struct({'a': 2, 'b': 3})
+
+    @ti.kernel
+    def test():
+        b = a
+        assert b.a == 2
+        assert b.b == 3
+        b = ti.Struct({'a': 3, 'b': 4})
+        assert b.a == 3
+        assert b.b == 4
+
+    test()

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -298,3 +298,21 @@ def test_matrix_needs_grad():
             gr[i] = m1.grad[i] + m2.grad[i]
 
     func()
+
+
+@ti.test(debug=True)
+def test_copy_python_scope_matrix_to_taichi_scope():
+    a = ti.Vector([1, 2, 3])
+
+    @ti.kernel
+    def test():
+        b = a
+        assert b[0] == 1
+        assert b[1] == 2
+        assert b[2] == 3
+        b = ti.Vector([4, 5, 6])
+        assert b[0] == 4
+        assert b[1] == 5
+        assert b[2] == 6
+
+    test()


### PR DESCRIPTION
Related issue = #3625

A `Matrix/Struct` defined in Python scope is read-only in Taichi scope. To assign it to a local variable in Taichi scope, we have to do explicit copy. After this PR, https://github.com/taichiCourse01/taichi_ray_tracing/blob/master/3_2_whitted_style_ray_tracing.py should work fine.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
