### PR TITLE
[refactor] Remove primitive_types module in top level package.

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -8,7 +8,9 @@ from taichi.main import main
 from taichi.misc import *
 from taichi.testing import *
 from taichi.tools import *
-from taichi.type import *
+from taichi.type.annotations import *
+# Provide a shortcut to types since they're commonly used.
+from taichi.type.primitive_types import *
 
 from taichi import ad
 from taichi.ui import ui


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3641
* #3640
* __->__ #3639

We only need provide shortcuts to types `u8, f32` etc but not the
`primitive_types` module.