### PR TITLE
[refactor] Ignore filename prefix in opengl aot files.

### DIFF
--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -54,10 +54,8 @@ def test_save():
         with m.add_kernel_template(foo) as kt:
             kt.instantiate(n=6)
             kt.instantiate(n=8)
-        filename = 'taichi_aot_example'
-        m.save(tmpdir, filename)
-        with open(os.path.join(tmpdir,
-                               f'{filename}_metadata.json')) as json_file:
+        m.save(tmpdir, '')
+        with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
             json.load(json_file)
 
 
@@ -165,10 +163,8 @@ def test_mpm88_aot():
         m.add_field("grid_m", grid_m)
         m.add_kernel(substep)
         m.add_kernel(init)
-        filename = 'taichi_aot_example'
-        m.save(tmpdir, filename)
-        with open(os.path.join(tmpdir,
-                               f'{filename}_metadata.json')) as json_file:
+        m.save(tmpdir, '')
+        with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
             json.load(json_file)
 
 
@@ -320,8 +316,6 @@ def test_mpm88_ndarray():
         m.add_ndarray("grid_m", grid_m)
         m.add_kernel(substep, (x, v, C, J, grid_v, grid_m))
 
-        filename = 'taichi_aot_example'
-        m.save(tmpdir, filename)
-        with open(os.path.join(tmpdir,
-                               f'{filename}_metadata.json')) as json_file:
+        m.save(tmpdir, '')
+        with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
             json.load(json_file)


### PR DESCRIPTION
It seems good enough to use folders here so let's keep the filenames
simple and match kernel names.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
