### PR TITLE
[Bug] [lang] Fix copying Matrix/StructField elements in Taichi scope

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -37,11 +37,11 @@ def expr_init(rhs):
     if rhs is None:
         return Expr(_ti_core.expr_alloca())
     if isinstance(rhs, Matrix):
-        if rhs.in_python_scope:
+        if rhs.in_python_scope or isinstance(rhs, _IntermediateMatrix):
             return Matrix(rhs.to_list())
         return rhs
     if isinstance(rhs, Struct):
-        if rhs.in_python_scope:
+        if rhs.in_python_scope or isinstance(rhs, _IntermediateStruct):
             return Struct(rhs.to_dict())
         return rhs
     if isinstance(rhs, list):

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -357,7 +357,7 @@ void GlobalPtrExpression::type_check() {
   if (snode != nullptr) {
     ret_type = snode->dt;
   } else if (var.is<GlobalVariableExpression>()) {
-    ret_type = var.cast<GlobalVariableExpression>()->snode->dt;
+    ret_type = var.cast<GlobalVariableExpression>()->snode->dt->get_compute_type();
   } else if (var.is<ExternalTensorExpression>()) {
     for (int i = 0; i < indices.exprs.size(); i++) {
       auto &expr = indices.exprs[i];

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -357,7 +357,8 @@ void GlobalPtrExpression::type_check() {
   if (snode != nullptr) {
     ret_type = snode->dt;
   } else if (var.is<GlobalVariableExpression>()) {
-    ret_type = var.cast<GlobalVariableExpression>()->snode->dt->get_compute_type();
+    ret_type =
+        var.cast<GlobalVariableExpression>()->snode->dt->get_compute_type();
   } else if (var.is<ExternalTensorExpression>()) {
     for (int i = 0; i < indices.exprs.size(); i++) {
       auto &expr = indices.exprs[i];

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -726,7 +726,7 @@ class GlobalLoadExpression : public Expression {
   Expr ptr;
   GlobalLoadExpression(const Expr &ptr) : ptr(ptr) {
     // Now it is only constructed by load_if_ptr. No type_check will be called.
-    ret_type = ptr->ret_type->get_compute_type();
+    ret_type = ptr->ret_type;
   }
 
   void type_check() override {

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -315,3 +315,24 @@ def test_copy_python_scope_struct_to_taichi_scope():
         assert b.b == 4
 
     test()
+
+
+@ti.test(debug=True)
+def test_copy_struct_field_element_to_taichi_scope():
+    a = ti.Struct.field({'a': ti.i32, 'b': ti.i32}, shape=())
+    a[None].a = 2
+    a[None].b = 3
+
+    @ti.kernel
+    def test():
+        b = a[None]
+        assert b.a == 2
+        assert b.b == 3
+        b.a = 5
+        b.b = 9
+        assert b.a == 5
+        assert b.b == 9
+        assert a[None].a == 2
+        assert a[None].b == 3
+
+    test()

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -316,3 +316,27 @@ def test_copy_python_scope_matrix_to_taichi_scope():
         assert b[2] == 6
 
     test()
+
+
+@ti.test(debug=True)
+def test_copy_matrix_field_element_to_taichi_scope():
+    a = ti.Vector.field(3, ti.i32, shape=())
+    a[None] = ti.Vector([1, 2, 3])
+
+    @ti.kernel
+    def test():
+        b = a[None]
+        assert b[0] == 1
+        assert b[1] == 2
+        assert b[2] == 3
+        b[0] = 5
+        b[1] = 9
+        b[2] = 7
+        assert b[0] == 5
+        assert b[1] == 9
+        assert b[2] == 7
+        assert a[None][0] == 1
+        assert a[None][1] == 2
+        assert a[None][2] == 3
+
+    test()


### PR DESCRIPTION
Related issue = #3625

Accidentally, assignments from Matrix/StructField elements to local variables are by reference:
```python
import taichi as ti

ti.init(debug=True)

a = ti.Vector.field(3, ti.i32, shape=())
a[None] = ti.Vector([1, 2, 3])

@ti.kernel
def test():
    b = a[None]
    b[0] = 5
    b[1] = 9
    b[2] = 7
    print(a[None][0])  # 5
    print(a[None][1])  # 9
    print(a[None][2])  # 7

test()
```

However, they are indented to be by value. The PR aims at fixing it. After this PR, https://github.com/taichiCourse01/taichi_ray_tracing/blob/master/4_0_path_tracing.py should work fine.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
