### PR TITLE
[perf] Accelerate _inside_class()

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -643,9 +643,8 @@ _KERNEL_CLASS_STACKFRAME_STMT_RES = [
 def _inside_class(level_of_class_stackframe):
     try:
         maybe_class_frame = inspect.currentframe()
-        while level_of_class_stackframe > 0:
+        for _ in range(level_of_class_stackframe):
             maybe_class_frame = maybe_class_frame.f_back
-            level_of_class_stackframe -= 1
         statement_list = inspect.getframeinfo(maybe_class_frame)[3]
         first_statment = statement_list[0].strip()
         for pat in _KERNEL_CLASS_STACKFRAME_STMT_RES:

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -642,9 +642,7 @@ _KERNEL_CLASS_STACKFRAME_STMT_RES = [
 
 def _inside_class(level_of_class_stackframe):
     try:
-        maybe_class_frame = inspect.currentframe()
-        for _ in range(level_of_class_stackframe):
-            maybe_class_frame = maybe_class_frame.f_back
+        maybe_class_frame = sys._getframe(level_of_class_stackframe)
         statement_list = inspect.getframeinfo(maybe_class_frame)[3]
         first_statment = statement_list[0].strip()
         for pat in _KERNEL_CLASS_STACKFRAME_STMT_RES:

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -641,10 +641,12 @@ _KERNEL_CLASS_STACKFRAME_STMT_RES = [
 
 
 def _inside_class(level_of_class_stackframe):
-    frames = oinspect.stack()
     try:
-        maybe_class_frame = frames[level_of_class_stackframe]
-        statement_list = maybe_class_frame[4]
+        maybe_class_frame = inspect.currentframe()
+        while level_of_class_stackframe > 0:
+            maybe_class_frame = maybe_class_frame.f_back
+            level_of_class_stackframe -= 1
+        statement_list = inspect.getframeinfo(maybe_class_frame)[3]
         first_statment = statement_list[0].strip()
         for pat in _KERNEL_CLASS_STACKFRAME_STMT_RES:
             if pat.match(first_statment):


### PR DESCRIPTION
When profiling my own application, I found that the `_inside_class()` function of taichi was the bottleneck: https://github.com/taichi-dev/taichi/blob/2166c8fe14e5444dc237d8b343a378a317962877/python/taichi/lang/kernel_impl.py#L649-L660

As we only needed the frame at `level_of_class_stackframe`, getting the whole stack was a waste of time. I accelerated this function by mimicking the implementation of `inspect.stack()`, but only fetching the target frame out.

This PR decreases the running time of my own application from 22.2s to 0.8s. It also decreases the running time of `import taichi as ti` from 1.7s to 0.5s on my machine.

References:
https://github.com/python/cpython/blob/9a5dec4e978f68ab956e979858ce3aa178436fa4/Lib/inspect.py#L1559-L1569
https://github.com/python/cpython/blob/9a5dec4e978f68ab956e979858ce3aa178436fa4/Lib/inspect.py#L1583-L1589

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
