### PR TITLE
[Refactor] Reduce reference count introduced by object closure

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -28,16 +28,9 @@ class Ndarray:
             if impl.current_cfg().arch == _ti_core.Arch.cuda:
                 self.arr = self.arr.cuda()
 
-            def ndarray_fill(val, fill_func):
-                self.arr.fill_(val)
         else:
             self.arr = _ti_core.Ndarray(impl.get_runtime().prog,
                                         cook_dtype(dtype), shape)
-
-            def ndarray_fill(val, fill_func):
-                fill_func(self, val)
-
-        self.ndarray_fill = ndarray_fill
 
     @property
     def shape(self):
@@ -96,6 +89,28 @@ class Ndarray:
             element type: Value retrieved.
         """
         raise NotImplementedError()
+
+    def ndarray_fill(self, val):
+        """Fills ndarray with a specific scalar value.
+
+        Args:
+            val (Union[int, float]): Value to fill.
+        """
+        if impl.current_cfg().ndarray_use_torch:
+            self.arr.fill_(val)
+        else:
+            taichi.lang.meta.fill_ndarray(self, val)
+
+    def ndarray_matrix_fill(self, val):
+        """Fills ndarray with a specific scalar value.
+
+        Args:
+            val (Union[int, float]): Value to fill.
+        """
+        if impl.current_cfg().ndarray_use_torch:
+            self.arr.fill_(val)
+        else:
+            taichi.lang.meta.fill_ndarray_matrix(self, val)
 
     def ndarray_to_numpy(self):
         """Converts ndarray to a numpy array.
@@ -258,7 +273,7 @@ class ScalarNdarray(Ndarray):
 
     @python_scope
     def fill(self, val):
-        self.ndarray_fill(val, taichi.lang.meta.fill_ndarray)
+        self.ndarray_fill(val)
 
     @python_scope
     def to_numpy(self):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1380,7 +1380,7 @@ class MatrixNdarray(Ndarray):
 
     @python_scope
     def fill(self, val):
-        self.ndarray_fill(val, taichi.lang.meta.fill_ndarray_matrix)
+        self.ndarray_matrix_fill(val)
 
     @python_scope
     def to_numpy(self):
@@ -1444,7 +1444,7 @@ class VectorNdarray(Ndarray):
 
     @python_scope
     def fill(self, val):
-        self.ndarray_fill(val, taichi.lang.meta.fill_ndarray_matrix)
+        self.ndarray_matrix_fill(val)
 
     @python_scope
     def to_numpy(self):


### PR DESCRIPTION
Before the change, any `Ndarray` obj will have an extra ref count due to the introduced `obj.__closure___`. This can be checked by `import gc 
  gc.get_referrers`. The problem is that the destructor will not be called until the program finish, due to this extra count. This prevents optimizations such as memory recycling.

After the change, the extra ref count is eliminated and object can be properly recycled when out of scope. 