### PR TITLE
[opengl] [refactor] Expose use_gles in CompileConfig.

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -635,7 +635,7 @@ def init(arch=None,
     if env_arch is not None:
         ti.info(f'Following TI_ARCH setting up for arch={env_arch}')
         arch = _ti_core.arch_from_name(env_arch)
-    ti.cfg.arch = adaptive_arch_select(arch, enable_fallback)
+    ti.cfg.arch = adaptive_arch_select(arch, enable_fallback, ti.cfg.use_gles)
     if ti.cfg.arch == cc:
         _ti_core.set_tmp_dir(locale_encode(prepare_sandbox()))
     print(f'[Taichi] Starting on arch={_ti_core.arch_name(ti.cfg.arch)}')
@@ -1105,19 +1105,23 @@ def stat_write(key, value):
         yaml.dump(data, f, Dumper=yaml.SafeDumper)
 
 
-def is_arch_supported(arch):
+def is_arch_supported(arch, use_gles=False):
     """Checks whether an arch is supported on the machine.
 
     Args:
         arch (taichi_core.Arch): Specified arch.
+        use_gles (bool): If True, check is GLES is available otherwise
+          check if GLSL is available. Only effective when `arch` is `ti.opengl`.
+          Default is `False`.
 
     Returns:
         bool: Whether `arch` is supported on the machine.
     """
+
     arch_table = {
         cuda: _ti_core.with_cuda,
         metal: _ti_core.with_metal,
-        opengl: _ti_core.with_opengl,
+        opengl: functools.partial(_ti_core.with_opengl, use_gles),
         cc: _ti_core.with_cc,
         vulkan: _ti_core.with_vulkan,
         wasm: lambda: True,
@@ -1135,13 +1139,13 @@ def is_arch_supported(arch):
         return False
 
 
-def adaptive_arch_select(arch, enable_fallback):
+def adaptive_arch_select(arch, enable_fallback, use_gles):
     if arch is None:
         return cpu
     if not isinstance(arch, (list, tuple)):
         arch = [arch]
     for a in arch:
-        if is_arch_supported(a):
+        if is_arch_supported(a, use_gles):
             return a
     if not enable_fallback:
         raise RuntimeError(f'Arch={arch} is not supported')

--- a/python/taichi/testing.py
+++ b/python/taichi/testing.py
@@ -94,7 +94,9 @@ def expected_archs():
         List[taichi_core.Arch]: All expected archs on the machine.
     """
     archs = set([cpu, cuda, metal, vulkan, opengl, cc])
-    archs = set(filter(is_arch_supported, archs))
+    # TODO: now expected_archs is not called per test so we cannot test it
+    archs = set(
+        filter(functools.partial(is_arch_supported, use_gles=False), archs))
 
     wanted_archs = os.environ.get('TI_WANTED_ARCHS', '')
     want_exclude = wanted_archs.startswith('^')

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -30,7 +30,10 @@ namespace opengl {
 int opengl_max_block_dim = 1024;
 int opengl_max_grid_dim = 1024;
 
-constexpr bool use_gles = false;
+// kUseGles is set at most once in initialize_opengl below.
+// TODO: Properly support setting GLES/GLSL in opengl backend
+// without this global static boolean.
+static bool kUseGles = false;
 
 #ifdef TI_WITH_OPENGL
 
@@ -48,10 +51,12 @@ struct OpenGlRuntimeImpl {
   std::vector<std::unique_ptr<DeviceCompiledProgram>> programs;
 };
 
-bool initialize_opengl(bool error_tolerance) {
+// TODO: Move this into ProgramImpl class so that it naturally
+// gets access to config->use_gles.
+bool initialize_opengl(bool use_gles, bool error_tolerance) {
   static std::optional<bool> supported;  // std::nullopt
 
-  TI_TRACE("initialize_opengl({}) called", error_tolerance);
+  TI_TRACE("initialize_opengl({}, {}) called", use_gles, error_tolerance);
 
   if (supported.has_value()) {  // this function has been called before
     if (supported.value()) {    // detected to be true in last call
@@ -63,6 +68,7 @@ bool initialize_opengl(bool error_tolerance) {
     }
   }
 
+  // Code below is guaranteed to be called at most once.
   int opengl_version = 0;
 
   if (glfwInit()) {
@@ -209,6 +215,7 @@ bool initialize_opengl(bool error_tolerance) {
   TI_TRACE("GL_MAX_COMPUTE_WORK_GROUP_SIZE: {}", opengl_max_grid_dim);
 
   supported = std::make_optional<bool>(true);
+  kUseGles = use_gles;
   return true;
 }
 
@@ -527,10 +534,10 @@ void OpenGlRuntime::add_snode_tree(size_t size) {
   device->get_compute_stream()->submit_synced(cmdlist.get());
 }
 
-bool is_opengl_api_available() {
+bool is_opengl_api_available(bool use_gles) {
   if (get_environ_config("TI_ENABLE_OPENGL", 1) == 0)
     return false;
-  return initialize_opengl(true);
+  return initialize_opengl(use_gles, true);
 }
 
 #else
@@ -554,18 +561,18 @@ void OpenGlRuntime::add_snode_tree(size_t size) {
   TI_NOT_IMPLEMENTED;
 }
 
-bool is_opengl_api_available() {
+bool is_opengl_api_available(bool use_gles) {
   return false;
 }
 
-bool initialize_opengl(bool error_tolerance) {
+bool initialize_opengl(bool use_gles, bool error_tolerance) {
   TI_NOT_IMPLEMENTED;
 }
 
 #endif  // TI_WITH_OPENGL
 
 bool is_gles() {
-  return use_gles;
+  return kUseGles;
 }
 
 }  // namespace opengl

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -21,8 +21,8 @@ class OffloadedStmt;
 
 namespace opengl {
 
-bool initialize_opengl(bool error_tolerance = false);
-bool is_opengl_api_available();
+bool initialize_opengl(bool use_gles = false, bool error_tolerance = false);
+bool is_opengl_api_available(bool use_gles = false);
 bool is_gles();
 
 #define PER_OPENGL_EXTENSION(x) extern bool opengl_extension_##x;

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -65,9 +65,6 @@ CompileConfig::CompileConfig() {
   // C backend options:
   cc_compile_cmd = "gcc -Wc99-c11-compat -c -o '{}' '{}' -O3";
   cc_link_cmd = "gcc -shared -fPIC -o '{}' '{}'";
-
-  // Opengl backend options:
-  allow_nv_shader_extension = true;
 }
 
 TLANG_NAMESPACE_END

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -74,7 +74,8 @@ struct CompileConfig {
   std::string cc_link_cmd;
 
   // Opengl backend options:
-  bool allow_nv_shader_extension;
+  bool allow_nv_shader_extension{true};
+  bool use_gles{false};
 
   // Async options
   int async_opt_passes{3};

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -86,7 +86,7 @@ Program::Program(Arch desired_arch)
     TI_ERROR("This taichi is not compiled with Vulkan")
 #endif
   } else if (config.arch == Arch::opengl) {
-    TI_ASSERT(opengl::is_opengl_api_available());
+    TI_ASSERT(opengl::initialize_opengl(config.use_gles));
     program_impl_ = std::make_unique<OpenglProgramImpl>(config);
   } else if (config.arch == Arch::cc) {
 #ifdef TI_WITH_CC

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -214,6 +214,7 @@ void export_lang(py::module &m) {
                      &CompileConfig::quant_opt_atomic_demotion)
       .def_readwrite("allow_nv_shader_extension",
                      &CompileConfig::allow_nv_shader_extension)
+      .def_readwrite("use_gles", &CompileConfig::use_gles)
       .def_readwrite("make_mesh_block_local",
                      &CompileConfig::make_mesh_block_local)
       .def_readwrite("mesh_localize_to_end_mapping",

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -170,7 +170,8 @@ void export_misc(py::module &m) {
   m.def("toggle_python_print_buffer", [](bool opt) { py_cout.enabled = opt; });
   m.def("with_cuda", is_cuda_api_available);
   m.def("with_metal", taichi::lang::metal::is_metal_api_available);
-  m.def("with_opengl", taichi::lang::opengl::is_opengl_api_available);
+  m.def("with_opengl", taichi::lang::opengl::is_opengl_api_available,
+        py::arg("use_gles") = false);
 #ifdef TI_WITH_VULKAN
   m.def("with_vulkan", taichi::lang::vulkan::is_vulkan_api_available);
 #else


### PR DESCRIPTION
This PR converts use_gles from a constexpr to a static variable set in
`initialize_opengl` so that users can optionally turn it on/off using
`ti.init(use_gles=True)`.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
