### PR TITLE
[error] Fix tab and long line in error messages

### DIFF
--- a/misc/code_format.py
+++ b/misc/code_format.py
@@ -130,6 +130,8 @@ def main(all=False, diff=None):
             continue
         if fn.find('docs/build/') != -1:
             continue
+        if fn.find(os.path.join('tests', 'python', 'test_exception.py')) != -1:
+            continue
         if re.match(r'.*examples\/[a-z_]+\d\d+\.py$', fn):
             print(f'Skipping example file "{fn}"...')
             continue

--- a/python/taichi/lang/ast/ast_transformer_utils.py
+++ b/python/taichi/lang/ast/ast_transformer_utils.py
@@ -1,6 +1,7 @@
 import ast
 from enum import Enum
 from sys import version_info
+from textwrap import TextWrapper
 
 import astor
 from taichi.lang import impl
@@ -96,8 +97,6 @@ class ASTTransformerContext:
                 self.indent += 1
             else:
                 break
-        if self.src[-1][-1] != '\n':
-            self.src[-1] += '\n'
         self.lineno_offset = start_lineno - 1
         self.raised = False
 
@@ -157,15 +156,24 @@ class ASTTransformerContext:
     def get_pos_info(self, node):
         msg = f'On line {node.lineno + self.lineno_offset} of file "{self.file}":\n'
         if version_info < (3, 8):
-            msg += self.src[node.lineno - 1]
+            msg += self.src[node.lineno - 1] + "\n"
             return msg
         col_offset = self.indent + node.col_offset
         end_col_offset = self.indent + node.end_col_offset
 
+        wrapper = TextWrapper(width=80)
+
+        def gen_line(code, hint):
+            hint += ' ' * (len(code) - len(hint))
+            code = wrapper.wrap(code)
+            hint = wrapper.wrap(hint)
+            if not len(code):
+                return "\n\n"
+            return "".join([c + '\n' + h + '\n' for c, h in zip(code, hint)])
+
         if node.lineno == node.end_lineno:
-            msg += self.src[node.lineno - 1]
-            msg += ' ' * col_offset + '^' * (end_col_offset -
-                                             col_offset) + '\n'
+            hint = ' ' * col_offset + '^' * (end_col_offset - col_offset)
+            msg += gen_line(self.src[node.lineno - 1], hint)
         else:
             for i in range(node.lineno - 1, node.end_lineno):
                 last = len(self.src[i])
@@ -177,15 +185,15 @@ class ASTTransformerContext:
                         self.src[i][first].isspace()
                         or not self.src[i][first].isprintable()):
                     first += 1
-                msg += self.src[i]
                 if i == node.lineno - 1:
-                    msg += ' ' * col_offset + '^' * (last - col_offset) + '\n'
+                    hint = ' ' * col_offset + '^' * (last - col_offset)
                 elif i == node.end_lineno - 1:
-                    msg += ' ' * first + '^' * (end_col_offset - first) + '\n'
+                    hint = ' ' * first + '^' * (end_col_offset - first)
                 elif first < last:
-                    msg += ' ' * first + '^' * (last - first) + '\n'
+                    hint = ' ' * first + '^' * (last - first)
                 else:
-                    msg += '\n'
+                    hint = ''
+                msg += gen_line(self.src[i], hint)
         return msg
 
 

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -93,11 +93,10 @@ def _get_tree_and_ctx(self,
                       is_kernel=True,
                       arg_features=None,
                       args=None):
-    src = textwrap.dedent(oinspect.getsource(self.func))
-    tree = ast.parse(src)
-    src, start_lineno = oinspect.getsourcelines(self.func)
-    src = [line.replace("\t", "    ") for line in src]
     file = oinspect.getsourcefile(self.func)
+    src, start_lineno = oinspect.getsourcelines(self.func)
+    src = [textwrap.fill(line, tabsize=4, width=9999) for line in src]
+    tree = ast.parse(textwrap.dedent("\n".join(src)))
 
     func_body = tree.body[0]
     func_body.decorator_list = []

--- a/tests/python/test_exception.py
+++ b/tests/python/test_exception.py
@@ -84,3 +84,61 @@ On line {lineno + 5} of file "{file}":
 TypeError: 'NoneType' object is not callable"""
     print(e.value.args[0])
     assert e.value.args[0] == msg
+
+
+@ti.test()
+def test_tab():
+    frameinfo = getframeinfo(currentframe())
+    with pytest.raises(ti.TaichiCompilationError) as e:
+        # yapf: disable
+        @ti.kernel
+        def foo():
+            a(11,	22,	3)
+        foo()
+        # yapf: enable
+    lineno = frameinfo.lineno
+    file = frameinfo.filename
+    if version_info < (3, 8):
+        msg = f"""\
+On line {lineno + 5} of file "{file}":
+            a(11,   22, 3)
+TypeError: 'NoneType' object is not callable"""
+    else:
+        msg = f"""\
+On line {lineno + 5} of file "{file}":
+            a(11,   22, 3)
+            ^^^^^^^^^^^^^^
+TypeError: 'NoneType' object is not callable"""
+    print(e.value.args[0])
+    assert e.value.args[0] == msg
+
+
+@ti.test()
+def test_super_long_line():
+    frameinfo = getframeinfo(currentframe())
+    with pytest.raises(ti.TaichiCompilationError) as e:
+        # yapf: disable
+        @ti.kernel
+        def foo():
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
+        foo()
+        # yapf: enable
+    lineno = frameinfo.lineno
+    file = frameinfo.filename
+    if version_info < (3, 8):
+        msg = f"""\
+On line {lineno + 5} of file "{file}":
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
+TypeError: 'NoneType' object is not callable"""
+    else:
+        msg = f"""\
+On line {lineno + 5} of file "{file}":
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaa
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+bbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+TypeError: 'NoneType' object is not callable"""
+    print(e.value.args[0])
+    assert e.value.args[0] == msg


### PR DESCRIPTION
Related issue = close #3666
I have to disable code format check on test_exception.py, otherwise it will always turn the tabs to spaces and I cannot disable it even if I disabled yapf.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
