### PR TITLE
[refactor] Turn off empty root buffer warning for finalize_for_aot.

### DIFF
--- a/python/taichi/snode/fields_builder.py
+++ b/python/taichi/snode/fields_builder.py
@@ -152,7 +152,7 @@ class FieldsBuilder:
 
     def _finalize_for_aot(self):
         """Constructs the SNodeTree and compiles the type for AOT purpose."""
-        return self._finalize(raise_warning=True, compile_only=True)
+        return self._finalize(raise_warning=False, compile_only=True)
 
     def _finalize(self, raise_warning, compile_only):
         self._check_not_finalized()


### PR DESCRIPTION
This is a duplicate of #3674.

Now that we support ndarrays for AOT, it's possible/valid to have all
ndarray inputs and no field input as shown in test_mpm88_ndarray. So
let's turn off the warning here to avoid confusion.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
