### PR TITLE
[refactor] [opengl] Use CompiledOffloadedTask instead of CompiledKernel.

### DIFF
--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -18,12 +18,11 @@ AotModuleBuilderImpl::AotModuleBuilderImpl(
 }
 
 namespace {
-void write_glsl_file(const std::string &output_dir, CompiledKernel &k) {
-  const std::string glsl_path =
-      fmt::format("{}/{}.glsl", output_dir, k.kernel_name);
+void write_glsl_file(const std::string &output_dir, CompiledOffloadedTask &t) {
+  const std::string glsl_path = fmt::format("{}/{}.glsl", output_dir, t.name);
   std::ofstream fs{glsl_path};
-  fs << k.kernel_src;
-  k.kernel_src = glsl_path;
+  fs << t.src;
+  t.src = glsl_path;
   fs.close();
 }
 
@@ -38,14 +37,14 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
   // Json format doesn't support multiple line strings.
   AotData new_aot_data = aot_data_;
   for (auto &k : new_aot_data.kernels) {
-    for (auto &ki : k.program.kernels) {
-      write_glsl_file(output_dir, ki);
+    for (auto &t : k.program.tasks) {
+      write_glsl_file(output_dir, t);
     }
   }
   for (auto &k : new_aot_data.kernel_tmpls) {
     for (auto &ki : k.program) {
-      for (auto &kij : ki.second.kernels) {
-        write_glsl_file(output_dir, kij);
+      for (auto &t : ki.second.tasks) {
+        write_glsl_file(output_dir, t);
       }
     }
   }

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -40,13 +40,13 @@ extern int opengl_threads_per_block;
     return false;                  \
   })()
 
-struct CompiledKernel {
-  std::string kernel_name;
-  std::string kernel_src;
+struct CompiledOffloadedTask {
+  std::string name;
+  std::string src;
   int workgroup_size;
   int num_groups;
 
-  TI_IO_DEF(kernel_name, kernel_src, workgroup_size, num_groups);
+  TI_IO_DEF(name, src, workgroup_size, num_groups);
 };
 
 struct CompiledArrayData {
@@ -66,8 +66,8 @@ struct CompiledArrayData {
 
 struct CompiledProgram {
   void init_args(Kernel *kernel);
-  void add(const std::string &kernel_name,
-           const std::string &kernel_source_code,
+  void add(const std::string &name,
+           const std::string &source_code,
            int num_workgrous,
            int workgroup_size,
            std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access =
@@ -78,7 +78,7 @@ struct CompiledProgram {
   bool check_ext_arr_read(int i) const;
   bool check_ext_arr_write(int i) const;
 
-  std::vector<CompiledKernel> kernels;
+  std::vector<CompiledOffloadedTask> tasks;
 
   int arg_count{0};
   int ret_count{0};
@@ -90,7 +90,7 @@ struct CompiledProgram {
   UsedFeature used;
   mutable std::unordered_map<int, CompiledArrayData> arr_args;
 
-  TI_IO_DEF(kernels,
+  TI_IO_DEF(tasks,
             arg_count,
             ret_count,
             args_buf_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3692
* #3691
* __->__ #3690
* #3689
* #3688
* #3687

`CompiledKernel` isn't an accurate name and it conflicts with what we
understand as "taichi kernel". A better name for it is indeed
`CompiledOffloadedTask`.