### PR TITLE
[refactor] [opengl] For each taichi kernel, save a {kernel_name, CompiledProgram} pair instead of a vector.

### DIFF
--- a/taichi/backends/opengl/aot_data.h
+++ b/taichi/backends/opengl/aot_data.h
@@ -9,20 +9,6 @@ namespace taichi {
 namespace lang {
 namespace opengl {
 
-struct AotCompiledKernel {
-  CompiledProgram program;
-  std::string identifier;
-
-  TI_IO_DEF(program, identifier);
-};
-
-struct AotCompiledKernelTmpl {
-  std::unordered_map<std::string, CompiledProgram> program;
-  std::string identifier;
-
-  TI_IO_DEF(program, identifier);
-};
-
 struct CompiledFieldData {
   std::string field_name;
   uint32_t dtype;
@@ -44,8 +30,8 @@ struct CompiledFieldData {
 };
 
 struct AotData {
-  std::vector<AotCompiledKernel> kernels;
-  std::vector<AotCompiledKernelTmpl> kernel_tmpls;
+  std::unordered_map<std::string, CompiledProgram> kernels;
+  std::unordered_map<std::string, CompiledProgram> kernel_tmpls;
   std::vector<CompiledFieldData> fields;
 
   size_t root_buffer_size;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3692
* __->__ #3691
* #3690
* #3689
* #3688
* #3687

Nested data structures are confusing... Let's just use an unordered_map with taichi kernel_name as
keys.