### PR TITLE
[LLVM] Add missing pre-processor macro when LLVM is disabled

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -224,48 +224,50 @@ if(DEFINED ENV{LLVM_DIR})
     message("Getting LLVM_DIR=${LLVM_DIR} from the environment variable")
 endif()
 
-# http://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
-find_package(LLVM REQUIRED CONFIG)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-if(${LLVM_PACKAGE_VERSION} VERSION_LESS "10.0")
-    message(FATAL_ERROR "LLVM version < 10 is not supported")
-endif()
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-include_directories(${LLVM_INCLUDE_DIRS})
-message("LLVM include dirs ${LLVM_INCLUDE_DIRS}")
-message("LLVM library dirs ${LLVM_LIBRARY_DIRS}")
-add_definitions(${LLVM_DEFINITIONS})
+if(TI_WITH_LLVM)
+    # http://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
+    find_package(LLVM REQUIRED CONFIG)
+    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+    if(${LLVM_PACKAGE_VERSION} VERSION_LESS "10.0")
+        message(FATAL_ERROR "LLVM version < 10 is not supported")
+    endif()
+    message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+    include_directories(${LLVM_INCLUDE_DIRS})
+    message("LLVM include dirs ${LLVM_INCLUDE_DIRS}")
+    message("LLVM library dirs ${LLVM_LIBRARY_DIRS}")
+    add_definitions(${LLVM_DEFINITIONS})
 
-llvm_map_components_to_libnames(llvm_libs
-        Core
-        ExecutionEngine
-        InstCombine
-        OrcJIT
-        RuntimeDyld
-        TransformUtils
-        BitReader
-        BitWriter
-        Object
-        ScalarOpts
-        Support
-        native
-        Linker
-        Target
-        MC
-        Passes
-        ipo
-        Analysis
-        )
-target_link_libraries(${LIBRARY_NAME} ${llvm_libs})
+    llvm_map_components_to_libnames(llvm_libs
+            Core
+            ExecutionEngine
+            InstCombine
+            OrcJIT
+            RuntimeDyld
+            TransformUtils
+            BitReader
+            BitWriter
+            Object
+            ScalarOpts
+            Support
+            native
+            Linker
+            Target
+            MC
+            Passes
+            ipo
+            Analysis
+            )
+    target_link_libraries(${LIBRARY_NAME} ${llvm_libs})
 
-if (APPLE AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
-    llvm_map_components_to_libnames(llvm_aarch64_libs AArch64)
-    target_link_libraries(${LIBRARY_NAME} ${llvm_aarch64_libs})
-endif()
+    if (APPLE AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+        llvm_map_components_to_libnames(llvm_aarch64_libs AArch64)
+        target_link_libraries(${LIBRARY_NAME} ${llvm_aarch64_libs})
+    endif()
 
-if (TI_WITH_CUDA)
-    llvm_map_components_to_libnames(llvm_ptx_libs NVPTX)
-    target_link_libraries(${LIBRARY_NAME} ${llvm_ptx_libs})
+    if (TI_WITH_CUDA)
+        llvm_map_components_to_libnames(llvm_ptx_libs NVPTX)
+        target_link_libraries(${LIBRARY_NAME} ${llvm_ptx_libs})
+    endif()
 endif()
 
 if (TI_WITH_CUDA_TOOLKIT)

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -7,7 +7,9 @@
 #include "taichi/ir/transforms.h"
 #include "taichi/util/line_appender.h"
 #include "taichi/util/str.h"
+#ifdef TI_WITH_LLVM
 #include "taichi/llvm/llvm_program.h"
+#endif
 #include "cc_utils.h"
 
 #define C90_COMPAT 0

--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#ifdef TI_WITH_LLVM
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
@@ -32,6 +33,7 @@
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/IPO.h"
+#endif
 
 #include "taichi/lang_util.h"
 #include "taichi/program/program.h"
@@ -41,8 +43,10 @@
 
 TLANG_NAMESPACE_BEGIN
 
+#ifdef TI_WITH_LLVM
 using namespace llvm;
 using namespace llvm::orc;
+#endif
 
 std::pair<JITTargetMachineBuilder, llvm::DataLayout> get_host_target_info() {
 #if defined(TI_PLATFORM_OSX) and defined(TI_ARCH_ARM)

--- a/taichi/backends/device.cpp
+++ b/taichi/backends/device.cpp
@@ -1,9 +1,11 @@
 #include <taichi/backends/device.h>
-#include <taichi/backends/cpu/cpu_device.h>
 
 #if TI_WITH_VULKAN
 #include <taichi/backends/vulkan/vulkan_device.h>
 #include <taichi/backends/interop/vulkan_cpu_interop.h>
+#if TI_WITH_LLVM
+#include <taichi/backends/cpu/cpu_device.h>
+#endif
 #if TI_WITH_CUDA
 #include <taichi/backends/cuda/cuda_device.h>
 #include <taichi/backends/interop/vulkan_cuda_interop.h>
@@ -29,11 +31,13 @@ Device::MemcpyCapability Device::check_memcpy_capability(DevicePtr dst,
   }
 
 #if TI_WITH_VULKAN
+#if TI_WITH_LLVM
   if (dynamic_cast<vulkan::VulkanDevice *>(dst.device) &&
       dynamic_cast<cpu::CpuDevice *>(src.device)) {
     // TODO: support direct copy if dst itself supports host write.
     return Device::MemcpyCapability::RequiresStagingBuffer;
   }
+#endif
 #if TI_WITH_CUDA
   if (dynamic_cast<vulkan::VulkanDevice *>(dst.device) &&
       dynamic_cast<cuda::CudaDevice *>(src.device)) {
@@ -71,7 +75,7 @@ void Device::memcpy_via_staging(DevicePtr dst,
                                 DevicePtr src,
                                 uint64_t size) {
   // Inter-device copy
-#if TI_WITH_VULKAN
+#if defined(TI_WITH_VULKAN) && defined(TI_WITH_LLVM)
   if (dynamic_cast<vulkan::VulkanDevice *>(dst.device) &&
       dynamic_cast<cpu::CpuDevice *>(src.device)) {
     memcpy_cpu_to_vulkan_via_staging(dst, staging, src, size);

--- a/taichi/backends/wasm/codegen_wasm.h
+++ b/taichi/backends/wasm/codegen_wasm.h
@@ -4,11 +4,14 @@
 
 #include "taichi/codegen/codegen.h"
 
+#ifdef TI_WITH_LLVM
 #include "llvm/IR/Module.h"
+#endif
 
 namespace taichi {
 namespace lang {
 
+#ifdef TI_WITH_LLVM
 class ModuleGenValue {
  public:
   ModuleGenValue(std::unique_ptr<llvm::Module> module,
@@ -18,6 +21,7 @@ class ModuleGenValue {
   std::unique_ptr<llvm::Module> module;
   std::vector<std::string> name_list;
 };
+#endif
 
 class CodeGenWASM : public KernelCodeGen {
  public:
@@ -27,8 +31,10 @@ class CodeGenWASM : public KernelCodeGen {
 
   virtual FunctionType codegen() override;
 
+#ifdef TI_WITH_LLVM
   std::unique_ptr<ModuleGenValue> modulegen(
       std::unique_ptr<llvm::Module> &&module);  // AOT Module Gen
+#endif
 };
 
 }  // namespace lang

--- a/taichi/jit/jit_session.cpp
+++ b/taichi/jit/jit_session.cpp
@@ -1,11 +1,15 @@
 #include "taichi/jit/jit_session.h"
 
+#ifdef TI_WITH_LLVM
 #include "llvm/IR/DataLayout.h"
+#endif
 
 TLANG_NAMESPACE_BEGIN
 
+#ifdef TI_WITH_LLVM
 std::unique_ptr<JITSession> create_llvm_jit_session_cpu(Arch arch);
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(Arch arch);
+#endif
 
 std::unique_ptr<JITSession> JITSession::create(Arch arch) {
 #ifdef TI_WITH_LLVM
@@ -23,10 +27,14 @@ std::unique_ptr<JITSession> JITSession::create(Arch arch) {
 #endif
 }
 
+#ifdef TI_WITH_LLVM
 std::size_t JITSession::get_type_size(llvm::Type *type) {
   return get_data_layout().getTypeAllocSize(type);
 }
 
-llvm::DataLayout JITSession::get_data_layout(){TI_NOT_IMPLEMENTED}
+llvm::DataLayout JITSession::get_data_layout() {
+  TI_NOT_IMPLEMENTED
+}
+#endif
 
 TLANG_NAMESPACE_END

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -21,7 +21,9 @@
 #include "taichi/program/snode_expr_utils.h"
 #include "taichi/util/statistics.h"
 #include "taichi/math/arithmetic.h"
+#ifdef TI_WITH_LLVM
 #include "taichi/llvm/llvm_program.h"
+#endif
 
 #if defined(TI_WITH_CC)
 #include "taichi/backends/cc/cc_program.h"

--- a/taichi/program/state_flow_graph.h
+++ b/taichi/program/state_flow_graph.h
@@ -6,8 +6,13 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#ifdef TI_WITH_LLVM
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
+#else
+#include <vector>
+#include <set>
+#endif
 #include "taichi/ir/ir.h"
 #include "taichi/lang_util.h"
 #include "taichi/program/async_utils.h"
@@ -28,7 +33,11 @@ class StateFlowGraph {
    public:
     static constexpr unsigned kNumInlined = 8u;
     using Edge = std::pair<AsyncState, Node *>;
+#ifdef TI_WITH_LLVM
     using Container = llvm::SmallVector<Edge, kNumInlined>;
+#else
+    using Container = std::vector<Edge>;
+#endif
 
     StateToNodesMap() = default;
 
@@ -317,8 +326,13 @@ class StateFlowGraph {
   AsyncState get_async_state(Kernel *kernel);
 
   void populate_latest_state_owner(std::size_t id);
+#ifdef TI_WITH_LLVM
   using LatestStateReaders =
       llvm::SmallVector<std::pair<AsyncState, llvm::SmallSet<Node *, 8>>, 4>;
+#else
+  using LatestStateReaders =
+      std::vector<std::pair<AsyncState, std::set<Node *>>>;
+#endif
 
  private:
   std::vector<std::unique_ptr<Node>> nodes_;

--- a/taichi/util/file_sequence_writer.cpp
+++ b/taichi/util/file_sequence_writer.cpp
@@ -1,5 +1,7 @@
+#ifdef TI_WITH_LLVM
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
+#endif
 
 #include "taichi/util/file_sequence_writer.h"
 
@@ -10,12 +12,14 @@ FileSequenceWriter::FileSequenceWriter(std::string filename_template,
     : counter(0), filename_template(filename_template), file_type(file_type) {
 }
 
+#ifdef TI_WITH_LLVM
 std::string FileSequenceWriter::write(llvm::Module *module) {
   std::string str;
   llvm::raw_string_ostream ros(str);
   module->print(ros, nullptr);
   return write(str);
 }
+#endif
 
 std::string FileSequenceWriter::write(const std::string &str) {
   auto [ofs, fn] = create_new_file();

--- a/taichi/util/file_sequence_writer.h
+++ b/taichi/util/file_sequence_writer.h
@@ -2,7 +2,9 @@
 
 #include "taichi/lang_util.h"
 #include "taichi/ir/transforms.h"
+#ifdef TI_WITH_LLVM
 #include "taichi/llvm/llvm_fwd.h"
+#endif
 
 TLANG_NAMESPACE_BEGIN
 
@@ -10,8 +12,10 @@ class FileSequenceWriter {
  public:
   FileSequenceWriter(std::string filename_template, std::string file_type);
 
+#ifdef TI_WITH_LLVM
   // returns filename
   std::string write(llvm::Module *module);
+#endif
 
   std::string write(IRNode *irnode);
 


### PR DESCRIPTION
Some components were still referencing LLVM with TI_WITH_LLVM set to
false triggering a build failure.

Related issue = #3679