### PR TITLE
[example] SPIR-V AOT example in C++

### DIFF
--- a/cpp_examples/main.cpp
+++ b/cpp_examples/main.cpp
@@ -342,7 +342,7 @@ void aot() {
   place->dt = PrimitiveType::i32;
   program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/false);
 
-  auto &aot_builder = program.make_aot_module_builder(Arch::vulkan);
+  auto aot_builder = program.make_aot_module_builder(Arch::vulkan);
 
   std::unique_ptr<Kernel> kernel_init, kernel_ret;
 

--- a/cpp_examples/main.cpp
+++ b/cpp_examples/main.cpp
@@ -327,8 +327,83 @@ void autograd() {
   std::cout << std::endl;
 }
 
+void aot() {
+  using namespace taichi;
+  using namespace lang;
+  auto program = Program(Arch::vulkan);
+
+  program.config.advanced_optimization = false;
+
+  int n = 10;
+  program.materialize_runtime();
+  auto *root = new SNode(0, SNodeType::root);
+  auto *pointer = &root->dense(Axis(0), n, false);
+  auto *place = &pointer->insert_children(SNodeType::place);
+  place->dt = PrimitiveType::i32;
+  program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/false);
+
+  auto &aot_builder = program.make_aot_module_builder(Arch::vulkan);
+
+  std::unique_ptr<Kernel> kernel_init, kernel_ret;
+
+  {
+    /*
+    @ti.kernel
+    def init():
+      for index in range(n):
+        place[index] = index
+    */
+    IRBuilder builder;
+    auto *zero = builder.get_int32(0);
+    auto *n_stmt = builder.get_int32(n);
+    auto *loop = builder.create_range_for(zero, n_stmt, 1, 0, 4);
+    {
+      auto _ = builder.get_loop_guard(loop);
+      auto *index = builder.get_loop_index(loop);
+      auto *ptr = builder.create_global_ptr(place, {index});
+      builder.create_global_store(ptr, index);
+    }
+
+    kernel_init =
+        std::make_unique<Kernel>(program, builder.extract_ir(), "init");
+  }
+
+  {
+    /*
+    @ti.kernel
+    def ret():
+      sum = 0
+      for index in place:
+        sum = sum + place[index];
+      return sum
+    */
+    IRBuilder builder;
+    auto *sum = builder.create_local_var(PrimitiveType::i32);
+    auto *loop = builder.create_struct_for(pointer, 1, 0, 4);
+    {
+      auto _ = builder.get_loop_guard(loop);
+      auto *index = builder.get_loop_index(loop);
+      auto *sum_old = builder.create_local_load(sum);
+      auto *place_index =
+          builder.create_global_load(builder.create_global_ptr(place, {index}));
+      builder.create_local_store(sum, builder.create_add(sum_old, place_index));
+    }
+    builder.create_return(builder.create_local_load(sum));
+
+    kernel_ret = std::make_unique<Kernel>(program, builder.extract_ir(), "ret");
+    kernel_ret->insert_ret(PrimitiveType::i32);
+  }
+
+  aot_builder->add_field("place", place, true, place->dt, {n}, 1, 1);
+  aot_builder->add("init", kernel_init.get());
+  aot_builder->add("ret", kernel_ret.get());
+  aot_builder->dump(".", "aot.tcb");
+  std::cout << "done" << std::endl;
+}
+
 int main() {
   run_snode();
   autograd();
+  aot();
   return 0;
 }

--- a/cpp_examples/main.cpp
+++ b/cpp_examples/main.cpp
@@ -335,12 +335,13 @@ void aot() {
   program.config.advanced_optimization = false;
 
   int n = 10;
-  program.materialize_runtime();
+  // not needed, but `compile_only` needs to be set to `true`
+  // program.materialize_runtime();
   auto *root = new SNode(0, SNodeType::root);
   auto *pointer = &root->dense(Axis(0), n, false);
   auto *place = &pointer->insert_children(SNodeType::place);
   place->dt = PrimitiveType::i32;
-  program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/false);
+  program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/true);
 
   auto aot_builder = program.make_aot_module_builder(Arch::vulkan);
 

--- a/cpp_examples/main.cpp
+++ b/cpp_examples/main.cpp
@@ -335,8 +335,8 @@ void aot_save() {
   program.config.advanced_optimization = false;
 
   int n = 10;
-  // not needed, but `compile_only` needs to be set to `true`
-  // program.materialize_runtime();
+
+  program.materialize_runtime();
   auto *root = new SNode(0, SNodeType::root);
   auto *pointer = &root->dense(Axis(0), n, false);
   auto *place = &pointer->insert_children(SNodeType::place);

--- a/cpp_examples/main.cpp
+++ b/cpp_examples/main.cpp
@@ -327,7 +327,7 @@ void autograd() {
   std::cout << std::endl;
 }
 
-void aot() {
+void aot_save() {
   using namespace taichi;
   using namespace lang;
   auto program = Program(Arch::vulkan);
@@ -405,6 +405,6 @@ void aot() {
 int main() {
   run_snode();
   autograd();
-  aot();
+  aot_save();
   return 0;
 }


### PR DESCRIPTION
This PR adds an example of using the C++ API to AOT compile a kernel to SPIRV.