### PR TITLE
[vulkan] Further decouple SPIRV codegen from Vulkan runtime

### DIFF
--- a/cpp_examples/main.cpp
+++ b/cpp_examples/main.cpp
@@ -336,7 +336,7 @@ void aot_save() {
 
   int n = 10;
 
-  program.materialize_runtime();
+  // program.materialize_runtime();
   auto *root = new SNode(0, SNodeType::root);
   auto *pointer = &root->dense(Axis(0), n, false);
   auto *place = &pointer->insert_children(SNodeType::place);

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -25,29 +25,33 @@ class AotTargetDevice : public Device {
   }
 
   DeviceAllocation allocate_memory(const AllocParams &params) override {
-    TI_NOT_IMPLEMENTED
+    TI_NOT_IMPLEMENTED;
   }
-  void dealloc_memory(DeviceAllocation handle)
-      override{TI_NOT_IMPLEMENTED} std::unique_ptr<Pipeline> create_pipeline(
-          const PipelineSourceDesc &src,
-          std::string name = "Pipeline") override {
-    TI_NOT_IMPLEMENTED
+  void dealloc_memory(DeviceAllocation handle) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  std::unique_ptr<Pipeline> create_pipeline(
+      const PipelineSourceDesc &src,
+      std::string name = "Pipeline") override {
+    TI_NOT_IMPLEMENTED;
   }
   void *map_range(DevicePtr ptr, uint64_t size) override {
-    TI_NOT_IMPLEMENTED
+    TI_NOT_IMPLEMENTED;
   }
   void *map(DeviceAllocation alloc) override {
-    TI_NOT_IMPLEMENTED
+    TI_NOT_IMPLEMENTED;
   }
   void unmap(DevicePtr ptr) override {
-    TI_NOT_IMPLEMENTED
+    TI_NOT_IMPLEMENTED;
   }
   void unmap(DeviceAllocation alloc) override {
-    TI_NOT_IMPLEMENTED
+    TI_NOT_IMPLEMENTED;
   }
-  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override{
-      TI_NOT_IMPLEMENTED} Stream *get_compute_stream() override {
-    TI_NOT_IMPLEMENTED
+  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  Stream *get_compute_stream() override {
+    TI_NOT_IMPLEMENTED;
   }
 };
 

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -9,53 +9,10 @@ namespace taichi {
 namespace lang {
 namespace vulkan {
 
-// Only responsible for reporting device capabilities
-class AotTargetDevice : public Device {
- public:
-  AotTargetDevice() {
-    // TODO: make this configurable
-    set_default_caps();
-  }
-
-  void set_default_caps() {
-    set_cap(DeviceCapability::spirv_version, 0x10300);
-  }
-
-  DeviceAllocation allocate_memory(const AllocParams &params) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void dealloc_memory(DeviceAllocation handle) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  std::unique_ptr<Pipeline> create_pipeline(
-      const PipelineSourceDesc &src,
-      std::string name = "Pipeline") override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void *map_range(DevicePtr ptr, uint64_t size) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void *map(DeviceAllocation alloc) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void unmap(DevicePtr ptr) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void unmap(DeviceAllocation alloc) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  Stream *get_compute_stream() override {
-    TI_NOT_IMPLEMENTED;
-  }
-};
-
 AotModuleBuilderImpl::AotModuleBuilderImpl(
     const std::vector<CompiledSNodeStructs> &compiled_structs)
     : compiled_structs_(compiled_structs) {
-  aot_target_device_ = std::make_unique<AotTargetDevice>();
+  aot_target_device_ = std::make_unique<AotTargetDevice>(Arch::vulkan);
 }
 
 void AotModuleBuilderImpl::write_spv_file(

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -19,9 +19,6 @@ class AotTargetDevice : public Device {
 
   void set_default_caps() {
     set_cap(DeviceCapability::spirv_version, 0x10300);
-    set_cap(DeviceCapability::spirv_has_variable_ptr, true);
-    set_cap(DeviceCapability::spirv_has_atomic_float_add, true);
-    set_cap(DeviceCapability::spirv_has_atomic_float, true);
   }
 
   DeviceAllocation allocate_memory(const AllocParams &params) override {

--- a/taichi/backends/vulkan/aot_module_builder_impl.h
+++ b/taichi/backends/vulkan/aot_module_builder_impl.h
@@ -14,7 +14,6 @@ namespace taichi {
 namespace lang {
 namespace vulkan {
 
-class AotTargetDevice;
 class AotModuleBuilderImpl : public AotModuleBuilder {
  public:
   explicit AotModuleBuilderImpl(

--- a/taichi/backends/vulkan/aot_module_builder_impl.h
+++ b/taichi/backends/vulkan/aot_module_builder_impl.h
@@ -14,10 +14,10 @@ namespace taichi {
 namespace lang {
 namespace vulkan {
 
+class AotTargetDevice;
 class AotModuleBuilderImpl : public AotModuleBuilder {
  public:
   explicit AotModuleBuilderImpl(
-      VkRuntime *runtime,
       const std::vector<CompiledSNodeStructs> &compiled_structs);
 
   void dump(const std::string &output_dir,
@@ -43,8 +43,8 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
                       const std::vector<uint32_t> &source_code) const;
 
   const std::vector<CompiledSNodeStructs> &compiled_structs_;
-  VkRuntime *runtime_;
   TaichiAotData ti_aot_data_;
+  std::unique_ptr<AotTargetDevice> aot_target_device_;
 };
 
 }  // namespace vulkan

--- a/taichi/backends/vulkan/aot_module_builder_impl.h
+++ b/taichi/backends/vulkan/aot_module_builder_impl.h
@@ -44,7 +44,7 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
 
   const std::vector<CompiledSNodeStructs> &compiled_structs_;
   TaichiAotData ti_aot_data_;
-  std::unique_ptr<AotTargetDevice> aot_target_device_;
+  std::unique_ptr<Device> aot_target_device_;
 };
 
 }  // namespace vulkan

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -478,15 +478,18 @@ DevicePtr VkRuntime::get_snode_tree_device_ptr(int tree_id) {
   return root_buffers_[tree_id]->get_ptr();
 }
 
-VkRuntime::RegisterParams run_codegen(Kernel *kernel, VkRuntime *runtime) {
+VkRuntime::RegisterParams run_codegen(
+    Kernel *kernel,
+    Device *device,
+    const std::vector<CompiledSNodeStructs> &compiled_structs) {
   const auto id = Program::get_kernel_id();
   const auto taichi_kernel_name(fmt::format("{}_k{:04d}_vk", kernel->name, id));
   TI_TRACE("VK codegen for Taichi kernel={}", taichi_kernel_name);
   spirv::KernelCodegen::Params params;
   params.ti_kernel_name = taichi_kernel_name;
   params.kernel = kernel;
-  params.compiled_structs = runtime->get_compiled_structs();
-  params.device = runtime->get_ti_device();
+  params.compiled_structs = compiled_structs;
+  params.device = device;
   params.enable_spv_opt =
       kernel->program->config.external_optimization_level > 0;
   spirv::KernelCodegen codegen(params);

--- a/taichi/backends/vulkan/runtime.h
+++ b/taichi/backends/vulkan/runtime.h
@@ -123,7 +123,10 @@ class VkRuntime {
   std::vector<CompiledSNodeStructs> compiled_snode_structs_;
 };
 
-VkRuntime::RegisterParams run_codegen(Kernel *kernel, VkRuntime *runtime);
+VkRuntime::RegisterParams run_codegen(
+    Kernel *kernel,
+    Device *device,
+    const std::vector<CompiledSNodeStructs> &compiled_structs);
 
 }  // namespace vulkan
 }  // namespace lang

--- a/taichi/backends/vulkan/vulkan_program.h
+++ b/taichi/backends/vulkan/vulkan_program.h
@@ -82,6 +82,7 @@ class VulkanProgramImpl : public ProgramImpl {
  private:
   std::unique_ptr<vulkan::VulkanDeviceCreator> embedded_device_{nullptr};
   std::unique_ptr<vulkan::VkRuntime> vulkan_runtime_;
+  std::vector<spirv::CompiledSNodeStructs> aot_compiled_snode_structs_;
 };
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -95,7 +95,7 @@ class TaskCodegen : public IRVisitor {
 
   Result run() {
     ir_->init_header();
-    kernel_function_ = ir_->new_function();
+    kernel_function_ = ir_->new_function();  // void main();
     ir_->debug(spv::OpName, kernel_function_, "main");
 
     if (task_ir_->task_type == OffloadedTaskType::serial) {

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -95,7 +95,7 @@ class TaskCodegen : public IRVisitor {
 
   Result run() {
     ir_->init_header();
-    kernel_function_ = ir_->new_function();  // void main();
+    kernel_function_ = ir_->new_function();
     ir_->debug(spv::OpName, kernel_function_, "main");
 
     if (task_ir_->task_type == OffloadedTaskType::serial) {

--- a/taichi/program/aot_module_builder.h
+++ b/taichi/program/aot_module_builder.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "taichi/ir/snode.h"
-
+#include "taichi/backends/device.h"
 namespace taichi {
 namespace lang {
 
@@ -61,6 +61,51 @@ class AotModuleBuilder {
   static bool all_fields_are_dense_in_container(const SNode *container);
 
   static int find_children_id(const SNode *snode);
+};
+
+// Only responsible for reporting device capabilities
+class AotTargetDevice : public Device {
+ public:
+  AotTargetDevice(Arch arch) {
+    // TODO: make this configurable
+    set_default_caps(arch);
+  }
+
+  void set_default_caps(Arch arch) {
+    if (arch == Arch::vulkan) {
+      set_cap(DeviceCapability::spirv_version, 0x10300);
+    }
+  }
+
+  DeviceAllocation allocate_memory(const AllocParams &params) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  void dealloc_memory(DeviceAllocation handle) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  std::unique_ptr<Pipeline> create_pipeline(
+      const PipelineSourceDesc &src,
+      std::string name = "Pipeline") override {
+    TI_NOT_IMPLEMENTED;
+  }
+  void *map_range(DevicePtr ptr, uint64_t size) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  void *map(DeviceAllocation alloc) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  void unmap(DevicePtr ptr) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  void unmap(DeviceAllocation alloc) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
+    TI_NOT_IMPLEMENTED;
+  }
+  Stream *get_compute_stream() override {
+    TI_NOT_IMPLEMENTED;
+  }
 };
 
 }  // namespace lang


### PR DESCRIPTION
fixes #3708 

Previously, the SPIRV codegen requires an instance of `VkRuntime`. The runtime is in fact only used to provide a `Device*` and the compiled SNode structs. Moreover, the `Device*` is only used to query device capabilities.

This PR removes the `VkRuntime*` from the codegen. When there isn't a runtime, the `VulkanProgram` will own the compiled structs, and feed them to the codegen. The PR also adds a `AotTargetDevice`, which is used to report device capabilities to the codegen.

The result of this PR is that #3708 is fixed. In other words, we can run Vulkan AOT to generate SPIRV without ever creating a `VulkanDevice` or a `VkRuntime`.