### PR TITLE
[misc] Use ccache & prefer Ninja over Make as cmake generator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,11 @@ endif ()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 include(cmake/PythonNumpyPybind11.cmake)
 include(cmake/TaichiCXXFlags.cmake)
 include(cmake/TaichiCore.cmake)

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,9 @@ class CMakeBuild(build_ext):
             f'-DTI_VERSION_PATCH={TI_VERSION_PATCH}',
         ]
 
+        if shutil.which('ninja'):
+            cmake_args += ['-GNinja']
+
         self.debug = os.getenv('DEBUG', '0') in ('1', 'ON')
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]


### PR DESCRIPTION
This PR makes it more automatic using ccache + ninja. 
Ninja is very fast (i.e., instant) for incremental builds so it fits development need where we need to rebuild for small changes. Here we use it only when it's available to avoid breaking people's workflow. 