### PR TITLE
[misc] Remove deprecated Python APIs

### DIFF
--- a/misc/demo_warning.py
+++ b/misc/demo_warning.py
@@ -1,14 +1,5 @@
 import taichi as ti
 
-x = ti.Vector([2, 3])
+x = ti.Vector([2, 2])
 
-x.transposed(x)
-
-
-@ti.kernel
-def func():
-    x = 0
-    x = 0.1
-
-
-func()
+ti.dot(x, x)

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -29,12 +29,12 @@ from taichi.lang.impl import (axes, begin_frontend_if,
                               chain_compare, current_cfg, expr_init,
                               expr_init_func, expr_init_list, field,
                               get_runtime, global_subscript_with_offset,
-                              grouped, indices, insert_expr_stmt_if_ti_func,
+                              grouped, insert_expr_stmt_if_ti_func,
                               local_subscript_with_offset,
                               materialize_callback, ndarray, one, root, static,
                               static_assert, static_print, stop_grad,
                               subscript, ti_assert, ti_float, ti_format,
-                              ti_int, ti_print, var, zero)
+                              ti_int, ti_print, zero)
 from taichi.lang.kernel_arguments import SparseMatrixProxy
 from taichi.lang.kernel_impl import (KernelArgError, KernelDefError,
                                      data_oriented, func, kernel, pyfunc)
@@ -717,9 +717,6 @@ bit_vectorize = _ti_core.bit_vectorize
 block_dim = _ti_core.block_dim
 global_thread_idx = _ti_core.insert_thread_idx_expr
 mesh_patch_idx = _ti_core.insert_patch_idx_expr
-
-inversed = deprecated('ti.inversed(a)', 'a.inverse()')(Matrix.inversed)
-transposed = deprecated('ti.transposed(a)', 'a.transpose()')(Matrix.transposed)
 
 
 def polar_decompose(A, dt=None):

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -133,11 +133,6 @@ timeline_save = lambda fn: impl.get_runtime().prog.timeline_save(fn)  # pylint: 
 type_factory_ = _ti_core.get_type_factory_instance()
 
 
-@deprecated('kernel_profiler_print()', 'print_kernel_profile_info()')
-def kernel_profiler_print():
-    return print_kernel_profile_info()
-
-
 def print_kernel_profile_info(mode='count'):
     """Print the profiling results of Taichi kernels.
 
@@ -218,11 +213,6 @@ def query_kernel_profile_info(name):
         backend due to its lack of support for `ti.sync()`.
     """
     return get_default_kernel_profiler().query_info(name)
-
-
-@deprecated('kernel_profiler_clear()', 'clear_kernel_profile_info()')
-def kernel_profiler_clear():
-    return clear_kernel_profile_info()
 
 
 def clear_kernel_profile_info():
@@ -332,11 +322,6 @@ def collect_kernel_profile_metrics(metric_list=default_cupti_metrics):
     get_default_kernel_profiler().set_metrics(metric_list)
     yield get_default_kernel_profiler()
     get_default_kernel_profiler().set_metrics()
-
-
-@deprecated('memory_profiler_print()', 'print_memory_profile_info()')
-def memory_profiler_print():
-    return print_memory_profile_info()
 
 
 def print_memory_profile_info():
@@ -701,11 +686,6 @@ def mesh_local(*args):
         for v in a.get_field_members():
             _ti_core.insert_snode_access_flag(
                 _ti_core.SNodeAccessFlag.mesh_local, v.ptr)
-
-
-@deprecated('ti.cache_shared', 'ti.block_local')
-def cache_shared(*args):
-    block_local(*args)
 
 
 def cache_read_only(*args):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -242,7 +242,7 @@ def global_subscript_with_offset(_var, _indices, shape, is_aos):
 def chain_compare(comparators, ops):
     _taichi_skip_traceback = 1
     assert len(comparators) == len(ops) + 1, \
-      f'Chain comparison invoked with {len(comparators)} comparators but {len(ops)} operators'
+        f'Chain comparison invoked with {len(comparators)} comparators but {len(ops)} operators'
     ret = True
     for i, op in enumerate(ops):
         lhs = comparators[i]
@@ -594,12 +594,6 @@ def create_field_member(dtype, name):
     return x, x_grad
 
 
-@deprecated('ti.var', 'ti.field')
-def var(dt, shape=None, offset=None, needs_grad=False):
-    _taichi_skip_traceback = 1
-    return field(dt, shape, offset, needs_grad)
-
-
 @python_scope
 def field(dtype, shape=None, name="", offset=None, needs_grad=False):
     """Defines a Taichi field
@@ -834,12 +828,6 @@ def axes(*x: Iterable[int]):
     Note that Taichi has already provided a set of commonly used axes. For example,
     `ti.ij` is just `axes(0, 1)` under the hood.
     """
-    return [_ti_core.Axis(i) for i in x]
-
-
-@deprecated("ti.indices", "ti.axes")
-def indices(*x):
-    """Same as :func:`~taichi.lang.impl.axes`."""
     return [_ti_core.Axis(i) for i in x]
 
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -21,7 +21,7 @@ from taichi.lang.tape import TapeImpl
 from taichi.lang.util import (cook_dtype, is_taichi_class, python_scope,
                               taichi_scope)
 from taichi.snode.fields_builder import FieldsBuilder
-from taichi.tools.util import deprecated, get_traceback, warning
+from taichi.tools.util import get_traceback, warning
 from taichi.types.primitive_types import f16, f32, f64, i32, i64, u32, u64
 
 import taichi as ti

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -831,8 +831,6 @@ def axes(*x: Iterable[int]):
     return [_ti_core.Axis(i) for i in x]
 
 
-index = indices
-
 Axis = _ti_core.Axis
 
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1073,7 +1073,6 @@ def Vector(n, dt=None, **kwargs):
     return Matrix(n, 1, dt=dt, **kwargs)
 
 
-Vector.var = Matrix._Vector_var
 Vector.field = Matrix._Vector_field
 Vector.ndarray = Matrix._Vector_ndarray
 Vector.zero = Matrix.zero

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -515,15 +515,6 @@ class Matrix(TaichiOperations):
         invlen = 1 / (self.norm() + eps)
         return invlen * self
 
-    @staticmethod
-    @deprecated('ti.Matrix.transposed(a)', 'a.transpose()')
-    def transposed(a):
-        return a.transpose()
-
-    @deprecated('a.T()', 'a.transpose()')
-    def T(self):
-        return self.transpose()
-
     @kern_mod.pyfunc
     def transpose(self):
         """Get the transpose of a matrix.
@@ -901,25 +892,10 @@ class Matrix(TaichiOperations):
         return entries
 
     @classmethod
-    @python_scope
-    @deprecated('ti.Matrix.var', 'ti.Matrix.field')
-    def var(cls, n, m, dt, *args, **kwargs):
-        """ti.Matrix.var"""
-        _taichi_skip_traceback = 1
-        return cls.field(n, m, dt, *args, **kwargs)
-
-    @classmethod
     def _Vector_field(cls, n, dtype, *args, **kwargs):
         """ti.Vector.field"""
         _taichi_skip_traceback = 1
         return cls.field(n, 1, dtype, *args, **kwargs)
-
-    @classmethod
-    @deprecated('ti.Vector.var', 'ti.Vector.field')
-    def _Vector_var(cls, n, dt, *args, **kwargs):
-        """ti.Vector.var"""
-        _taichi_skip_traceback = 1
-        return cls._Vector_field(n, dt, *args, **kwargs)
 
     @classmethod
     @python_scope
@@ -1142,10 +1118,6 @@ class MatrixField(Field):
         super().__init__(_vars)
         self.n = n
         self.m = m
-
-    @deprecated('x(i, j)', 'x.get_scalar_field(i, j)')
-    def __call__(self, *indices):
-        return self.get_scalar_field(*indices)
 
     def get_scalar_field(self, *indices):
         """Creates a ScalarField using a specific field member. Only used for quant.

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -102,10 +102,6 @@ class SNode:
             self.ptr.bitmasked(axes, dimensions,
                                impl.current_cfg().packed))
 
-    @deprecated('_bit_struct', 'bit_struct')
-    def _bit_struct(self, num_bits):
-        return self.bit_struct(num_bits)
-
     def bit_struct(self, num_bits: int):
         """Adds a bit_struct SNode as a child component of `self`.
 
@@ -116,10 +112,6 @@ class SNode:
             The added :class:`~taichi.lang.SNode` instance.
         """
         return SNode(self.ptr.bit_struct(num_bits, impl.current_cfg().packed))
-
-    @deprecated('_bit_array', 'bit_array')
-    def _bit_array(self, axes, dimensions, num_bits):
-        return self.bit_array(axes, dimensions, num_bits)
 
     def bit_array(self, axes, dimensions, num_bits):
         """Adds a bit_array SNode as a child component of `self`.
@@ -209,14 +201,6 @@ class SNode:
         """
         return self.ptr.data_type()
 
-    @deprecated('x.data_type()', 'x.dtype')
-    def data_type(self):
-        return self.dtype
-
-    @deprecated('x.dim()', 'len(x.shape)')
-    def dim(self):
-        return len(self.shape)
-
     @property
     def id(self):
         """Gets the id of `self`.
@@ -236,17 +220,7 @@ class SNode:
         dim = self.ptr.num_active_indices()
         ret = [self.ptr.get_shape_along_axis(i) for i in range(dim)]
 
-        class callable_tuple(tuple):
-            @deprecated('x.shape()', 'x.shape')
-            def __call__(self):
-                return self
-
-        ret = callable_tuple(ret)
         return ret
-
-    @deprecated('x.get_shape(i)', 'x.shape[i]')
-    def get_shape(self, i):
-        return self.shape[i]
 
     def loop_range(self):
         """Gets the taichi_core.Expr wrapping the taichi_core.GlobalVariableExpression corresponding to `self` to serve as loop range.

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -8,7 +8,6 @@ import taichi.lang
 from taichi.core.util import ti_core as _ti_core
 from taichi.lang import impl
 from taichi.lang.field import Field
-from taichi.tools.util import deprecated
 
 
 class SNode:

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -218,7 +218,7 @@ class SNode:
             Tuple[int]: The number of elements from root in each axis of `self`.
         """
         dim = self.ptr.num_active_indices()
-        ret = [self.ptr.get_shape_along_axis(i) for i in range(dim)]
+        ret = tuple(self.ptr.get_shape_along_axis(i) for i in range(dim))
 
         return ret
 

--- a/python/taichi/tools/util.py
+++ b/python/taichi/tools/util.py
@@ -161,16 +161,6 @@ def clear_profile_info():
     _ti_core.clear_profile_info()
 
 
-@deprecated('ti.vec(x, y)', 'ti.core_vec(x, y)')
-def vec(*args, **kwargs):
-    return core_vec(*args, **kwargs)
-
-
-@deprecated('ti.veci(x, y)', 'ti.core_veci(x, y)')
-def veci(*args, **kwargs):
-    return core_veci(*args, **kwargs)
-
-
 def dump_dot(filepath=None, rankdir=None, embed_states_threshold=0):
     d = _ti_core.dump_dot(rankdir, embed_states_threshold)
     if filepath is not None:

--- a/python/taichi/ui/gui.py
+++ b/python/taichi/ui/gui.py
@@ -6,7 +6,7 @@ import numpy as np
 import taichi.lang
 from taichi.core import ti_core as _ti_core
 from taichi.lang.field import Field, ScalarField
-from taichi.tools.util import core_veci, deprecated
+from taichi.tools.util import core_veci
 
 import taichi as ti
 

--- a/python/taichi/ui/gui.py
+++ b/python/taichi/ui/gui.py
@@ -112,7 +112,7 @@ class GUI:
     def close(self):
         self.core = None  # dereference to call GUI::~GUI()
 
-    ## Widget system
+    # Widget system
 
     class WidgetValue:
         def __init__(self, gui, wid):
@@ -185,7 +185,7 @@ class GUI:
         self.core.make_button(text, event_name)
         return event_name
 
-    ## Drawing system
+    # Drawing system
 
     def clear(self, color=None):
         """Clear the canvas with the color provided.
@@ -249,13 +249,13 @@ class GUI:
 
         if self.fast_gui:
             assert isinstance(img, taichi.lang.matrix.MatrixField), \
-                    "Only ti.Vector.field is supported in GUI.set_image when fast_gui=True"
+                "Only ti.Vector.field is supported in GUI.set_image when fast_gui=True"
             assert img.shape == self.res, \
-                    "Image resolution does not match GUI resolution"
+                "Image resolution does not match GUI resolution"
             assert img.n in [3, 4] and img.m == 1, \
-                    "Only RGB images are supported in GUI.set_image when fast_gui=True"
+                "Only RGB images are supported in GUI.set_image when fast_gui=True"
             assert img.dtype in [ti.f32, ti.f64, ti.u8], \
-                    "Only f32, f64, u8 are supported in GUI.set_image when fast_gui=True"
+                "Only f32, f64, u8 are supported in GUI.set_image when fast_gui=True"
 
             taichi.lang.meta.vector_to_fast_image(img, self.img)
             return
@@ -267,7 +267,7 @@ class GUI:
             else:
                 # Type matched! We can use an optimized copy kernel.
                 assert img.shape \
-                 == self.res, "Image resolution does not match GUI resolution"
+                    == self.res, "Image resolution does not match GUI resolution"
                 taichi.lang.meta.tensor_to_image(img, self.img)
                 ti.sync()
 
@@ -276,10 +276,10 @@ class GUI:
                 self.img = self.cook_image(img.to_numpy())
             else:
                 # Type matched! We can use an optimized copy kernel.
-                assert img.shape  == self.res, \
-                        "Image resolution does not match GUI resolution"
+                assert img.shape == self.res, \
+                    "Image resolution does not match GUI resolution"
                 assert img.n in [2, 3, 4] and img.m == 1, \
-                        "Only greyscale, RG, RGB or RGBA images are supported in GUI.set_image"
+                    "Only greyscale, RG, RGB or RGBA images are supported in GUI.set_image"
 
                 taichi.lang.meta.vector_to_image(img, self.img)
                 ti.sync()
@@ -665,7 +665,7 @@ class GUI:
         self.frame += 1
         self.clear()
 
-    ## Event system
+    # Event system
 
     class EventFilter:
         def __init__(self, *e_filter):
@@ -793,12 +793,6 @@ class GUI:
         pos = self.core.get_cursor_pos()
         return pos[0], pos[1]
 
-    @deprecated('gui.has_key_pressed()', 'gui.get_event()')
-    def has_key_pressed(self):
-        if self.has_key_event():
-            self.get_key_event()  # pop to update self.key_pressed
-        return len(self.key_pressed) != 0
-
     @property
     def running(self):
         """Get the property of whether the gui is running.
@@ -846,7 +840,9 @@ def rgb_to_hex(c):
         The hex representation of color.
 
     """
-    to255 = lambda x: np.clip(np.int32(x * 255), 0, 255)
+    def to255(x):
+        return np.clip(np.int32(x * 255), 0, 255)
+
     return (to255(c[0]) << 16) + (to255(c[1]) << 8) + to255(c[2])
 
 

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -15,7 +15,7 @@ def bls_test_template(dim,
                       dense=False):
     x, y, y2 = ti.field(ti.i32), ti.field(ti.i32), ti.field(ti.i32)
 
-    index = ti.indices(*range(dim))
+    index = ti.axes(*range(dim))
     mismatch = ti.field(ti.i32, shape=())
 
     if not isinstance(bs, (tuple, list)):

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -78,7 +78,7 @@ def run_mpm88_test():
             J[p] *= 1 + dt * new_C.trace()
             C[p] = new_C
 
-    # gui = ti.core.GUI("MPM88", ti.veci(512, 512))
+    # gui = ti.core.GUI("MPM88", ti.core_veci(512, 512))
     # canvas = gui.get_canvas()
 
     for i in range(n_particles):

--- a/tests/python/test_mpm_particle_list.py
+++ b/tests/python/test_mpm_particle_list.py
@@ -20,7 +20,7 @@ class MPMSolver:
         voxel = block.dense(indices, 8)
 
         voxel.place(self.grid_m)
-        block.dynamic(ti.indices(dim), 1024 * 1024,
+        block.dynamic(ti.axes(dim), 1024 * 1024,
                       chunk_size=4096).place(self.pid)
 
         ti.root.dynamic(ti.i, 2**25, 2**20).place(self.x)


### PR DESCRIPTION
This PR tries to remove all these deprecated Python APIs and it solves #3590. 

Before merging, we need to make sure all these APIs...

- `@deprecated('kernel_profiler_print()', 'print_kernel_profile_info()')`
- `@deprecated('kernel_profiler_clear()', 'clear_kernel_profile_info()')`
- `@deprecated('memory_profiler_print()', 'print_memory_profile_info()')`
- `@deprecated('ti.cache_shared', 'ti.block_local')`
- `@deprecated('ti.var', 'ti.field')`
- `@deprecated("ti.indices", "ti.axes")`
- `@deprecated('ti.Matrix.transposed(a)', 'a.transpose()')`
- `@deprecated('a.T()', 'a.transpose()')`
- `@deprecated('ti.Matrix.var', 'ti.Matrix.field')`
- `@deprecated('ti.Vector.var', 'ti.Vector.field')`
- `@deprecated('x(i, j)', 'x.get_scalar_field(i, j)')`
- `@deprecated('_bit_struct', 'bit_struct')`
- `@deprecated('_bit_array', 'bit_array')`
- `@deprecated('x.data_type()', 'x.dtype')`
- `@deprecated('x.dim()', 'len(x.shape)')`
- `@deprecated('x.shape()', 'x.shape')`
- `@deprecated('x.get_shape(i)', 'x.shape[i]')`
- `@deprecated('ti.vec(x, y)', 'ti.core_vec(x, y)')`
- `@deprecated('ti.veci(x, y)', 'ti.core_veci(x, y)')`
- `@deprecated('gui.has_key_pressed()', 'gui.get_event()')`

...can be safely deleted by checking other repos under Taichi including

- [x] [taichi-dev/difftaichi](https://github.com/taichi-dev/difftaichi) https://github.com/taichi-dev/difftaichi/pull/53
- [x] [taichi-dev/taichi_elements](https://github.com/taichi-dev/taichi_elements) https://github.com/taichi-dev/taichi_elements/pull/84
- [x] and more 🤔

This PR will follow such steps:

- [x] Remove these APIs from Taichi code
- [x] Make sure all Python tests pass
- [x] Fix other repos' dependence on these outdated APIs