### PR TITLE
[refactor] Add namespaces for cpp_examples.

### DIFF
--- a/cpp_examples/aot_save.cpp
+++ b/cpp_examples/aot_save.cpp
@@ -2,6 +2,8 @@
 #include "taichi/ir/statements.h"
 #include "taichi/program/program.h"
 
+namespace taichi {
+namespace example {
 void aot_save() {
   using namespace taichi;
   using namespace lang;
@@ -76,3 +78,5 @@ void aot_save() {
   aot_builder->dump(".", "aot.tcb");
   std::cout << "done" << std::endl;
 }
+}  // namespace example
+}  // namespace taichi

--- a/cpp_examples/autograd.cpp
+++ b/cpp_examples/autograd.cpp
@@ -2,6 +2,8 @@
 #include "taichi/ir/statements.h"
 #include "taichi/program/program.h"
 
+namespace taichi {
+namespace example {
 void autograd() {
   /*
   import taichi as ti, numpy as np
@@ -188,3 +190,5 @@ void autograd() {
     std::cout << ext_c[i] << " ";
   std::cout << std::endl;
 }
+}  // namespace example
+}  // namespace taichi

--- a/cpp_examples/main.cpp
+++ b/cpp_examples/main.cpp
@@ -2,6 +2,8 @@
 #include "taichi/ir/statements.h"
 #include "taichi/program/program.h"
 
+namespace taichi {
+namespace example {
 void run_snode();
 void autograd();
 void aot_save();
@@ -12,3 +14,5 @@ int main() {
   aot_save();
   return 0;
 }
+}  // namespace example
+}  // namespace taichi

--- a/cpp_examples/run_snode.cpp
+++ b/cpp_examples/run_snode.cpp
@@ -2,6 +2,8 @@
 #include "taichi/ir/statements.h"
 #include "taichi/program/program.h"
 
+namespace taichi {
+namespace example {
 void run_snode() {
   /*
   import taichi as ti, numpy as np
@@ -139,3 +141,5 @@ void run_snode() {
     std::cout << ext_arr[i] << " ";
   std::cout << std::endl;
 }
+}  // namespace example
+}  // namespace taichi


### PR DESCRIPTION
C++ build fails in my linux machine complaining about multiple
definition of `main`. Not sure why this only happened with `ninja`
but not `make`. But it's good to add namespaces anyway. :D

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
