### PR TITLE
Revert "[Vulkan] Add support of loading AOT modules and fields"

### DIFF
--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -15,32 +15,6 @@ AotModuleBuilderImpl::AotModuleBuilderImpl(
   aot_target_device_ = std::make_unique<AotTargetDevice>(Arch::vulkan);
 }
 
-uint32_t AotModuleBuilderImpl::to_vk_dtype_enum(DataType dt) {
-  if (dt == PrimitiveType::u64) {
-    return 0;
-  } else if (dt == PrimitiveType::i64) {
-    return 1;
-  } else if (dt == PrimitiveType::u32) {
-    return 2;
-  } else if (dt == PrimitiveType::i32) {
-    return 3;
-  } else if (dt == PrimitiveType::u16) {
-    return 4;
-  } else if (dt == PrimitiveType::i16) {
-    return 5;
-  } else if (dt == PrimitiveType::u8) {
-    return 6;
-  } else if (dt == PrimitiveType::i8) {
-    return 7;
-  } else if (dt == PrimitiveType::f64) {
-    return 8;
-  } else if (dt == PrimitiveType::f32) {
-    return 9;
-  } else {
-    TI_NOT_IMPLEMENTED
-  }
-}
-
 void AotModuleBuilderImpl::write_spv_file(
     const std::string &output_dir,
     const TaskAttributes &k,
@@ -49,20 +23,6 @@ void AotModuleBuilderImpl::write_spv_file(
   std::ofstream fs(spv_path, std::ios_base::binary | std::ios::trunc);
   fs.write((char *)source_code.data(), source_code.size() * sizeof(uint32_t));
   fs.close();
-}
-
-std::vector<uint32_t> AotModuleBuilderImpl::read_spv_file(
-    const std::string &output_dir,
-    const TaskAttributes &k) {
-  const std::string spv_path = fmt::format("{}/{}.spv", output_dir, k.name);
-  std::vector<uint32_t> source_code;
-  std::ifstream fs(spv_path, std::ios_base::binary | std::ios::ate);
-  size_t size = fs.tellg();
-  fs.seekg(0, std::ios::beg);
-  source_code.resize(size / sizeof(uint32_t));
-  fs.read((char *)source_code.data(), size);
-  fs.close();
-  return source_code;
 }
 
 void AotModuleBuilderImpl::dump(const std::string &output_dir,
@@ -86,24 +46,6 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
   ts.write_to_file(txt_path);
 }
 
-void AotModuleBuilderImpl::load(const std::string &output_dir) {
-  const std::string bin_path = fmt::format("{}/metadata.tcb", output_dir);
-  read_from_binary_file(ti_aot_data_, bin_path);
-  for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
-    auto k = ti_aot_data_.kernels[i];
-    std::vector<std::vector<uint32_t>> spirv_sources_codes;
-    for (int j = 0; j < k.tasks_attribs.size(); ++j) {
-      std::vector<uint32_t> res = read_spv_file(output_dir, k.tasks_attribs[j]);
-      spirv_sources_codes.push_back(res);
-    }
-
-    VkRuntime::RegisterParams params;
-    params.kernel_attribs = ti_aot_data_.kernels[i];
-    params.task_spirv_source_codes = spirv_sources_codes;
-    runtime_->register_taichi_kernel(params);
-  }
-}
-
 void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
                                            Kernel *kernel) {
   spirv::lower(kernel);
@@ -120,27 +62,6 @@ void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
                                                  std::vector<int> shape,
                                                  int row_num,
                                                  int column_num) {
-  // Note that currently we only support adding dense fields in AOT for all
-  // backends. In opengl backend we only error out when a non dense field is
-  // added to the aot module, but in metal backend we error out earlier when
-  // constructing aot module. Ideally we will unify this behavior but it doesn't
-  // matter too much for now.
-  TI_ERROR_IF(!all_fields_are_dense_in_container(rep_snode->parent),
-              "AOT: only supports dense field");
-
-  const auto &dense_desc =
-      compiled_structs_[0].snode_descriptors.at(rep_snode->parent->id);
-
-  CompiledFieldData field_data;
-  field_data.field_name = identifier;
-  field_data.is_scalar = is_scalar;
-  field_data.dtype = to_vk_dtype_enum(dt);
-  field_data.dtype_name = dt.to_string();
-  field_data.shape = shape;
-  field_data.mem_offset_in_parent = dense_desc.mem_offset_in_parent_cell;
-  field_data.row_num = row_num;
-  field_data.column_num = column_num;
-  ti_aot_data_.fields.push_back(field_data);
 }
 
 void AotModuleBuilderImpl::add_per_backend_tmpl(const std::string &identifier,

--- a/taichi/backends/vulkan/aot_module_builder_impl.h
+++ b/taichi/backends/vulkan/aot_module_builder_impl.h
@@ -22,8 +22,6 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
   void dump(const std::string &output_dir,
             const std::string &filename) const override;
 
-  void load(const std::string &output_dir) override;
-
  private:
   void add_per_backend(const std::string &identifier, Kernel *kernel) override;
 
@@ -42,11 +40,6 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
   void write_spv_file(const std::string &output_dir,
                       const TaskAttributes &k,
                       const std::vector<uint32_t> &source_code) const;
-
-  std::vector<uint32_t> read_spv_file(const std::string &output_dir,
-                                      const TaskAttributes &k);
-
-  uint32_t to_vk_dtype_enum(DataType dt);
 
   const std::vector<CompiledSNodeStructs> &compiled_structs_;
   TaichiAotData ti_aot_data_;

--- a/taichi/backends/vulkan/aot_utils.h
+++ b/taichi/backends/vulkan/aot_utils.h
@@ -15,9 +15,8 @@ struct TaichiAotData {
   //   BufferMetaData metadata;
   std::vector<std::vector<std::vector<uint32_t>>> spirv_codes;
   std::vector<spirv::TaichiKernelAttributes> kernels;
-  std::vector<spirv::CompiledFieldData> fields;
 
-  TI_IO_DEF(kernels, fields);
+  TI_IO_DEF(kernels);
 };
 
 }  // namespace vulkan

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -277,26 +277,6 @@ struct TaichiKernelAttributes {
   TI_IO_DEF(name, is_jit_evaluator, tasks_attribs, ctx_attribs);
 };
 
-struct CompiledFieldData {
-  std::string field_name;
-  uint32_t dtype;
-  std::string dtype_name;
-  std::vector<int> shape;
-  int mem_offset_in_parent{0};
-  bool is_scalar{false};
-  int row_num{0};
-  int column_num{0};
-
-  TI_IO_DEF(field_name,
-            dtype,
-            dtype_name,
-            shape,
-            mem_offset_in_parent,
-            is_scalar,
-            row_num,
-            column_num);
-};
-
 }  // namespace spirv
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/program/aot_module_builder.cpp
+++ b/taichi/program/aot_module_builder.cpp
@@ -57,9 +57,5 @@ int AotModuleBuilder::find_children_id(const SNode *snode) {
   TI_ERROR("Child not found in parent!");
 }
 
-void AotModuleBuilder::load(const std::string &output_dir) {
-  TI_ERROR("Aot loader not supported");
-}
-
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/program/aot_module_builder.h
+++ b/taichi/program/aot_module_builder.h
@@ -29,8 +29,6 @@ class AotModuleBuilder {
                            const std::string &key,
                            Kernel *kernel);
 
-  virtual void load(const std::string &output_dir);
-
   virtual void dump(const std::string &output_dir,
                     const std::string &filename) const = 0;
 


### PR DESCRIPTION
Reverts taichi-dev/taichi#3703

Unfortunately I have to revert this PR due to a conflict with https://github.com/taichi-dev/taichi/pull/3711/files which removes runtime_ out of aot module and master is currently broken. 
cc: @ghuau-innopeak Aot loader might need to separate the loading part and the registration part. ;) 