### PR TITLE
[bug] Temporarily remove runtime_ usage in aot_module_builder.

### DIFF
--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -100,7 +100,6 @@ void AotModuleBuilderImpl::load(const std::string &output_dir) {
     VkRuntime::RegisterParams params;
     params.kernel_attribs = ti_aot_data_.kernels[i];
     params.task_spirv_source_codes = spirv_sources_codes;
-    runtime_->register_taichi_kernel(params);
   }
 }
 


### PR DESCRIPTION
This might be a better fix than reverting in #3744 since it keeps most
of @ghuau-innopeak's loading logic.
@ghuau-innopeak you might only need to properly register it else where
to make it fully functional again. (Since we don't have test coverage
for the load() function, I'll temporarily break it and unblock master.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
