### PR TITLE
[misc] Speed-up builds by removing LLVM includes from llvm_program.h

### DIFF
--- a/taichi/backends/cpu/jit_cpu.cpp
+++ b/taichi/backends/cpu/jit_cpu.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/LLVMContext.h"

--- a/taichi/backends/cuda/jit_cuda.h
+++ b/taichi/backends/cuda/jit_cuda.h
@@ -4,6 +4,7 @@
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -5,6 +5,7 @@
 #include "taichi/struct/struct_llvm.h"
 #include "taichi/util/file_sequence_writer.h"
 
+#include "llvm/IR/Module.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Linker/Linker.h"
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -12,6 +12,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/IntrinsicsNVPTX.h"
 #include "llvm/IR/LLVMContext.h"

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -1,4 +1,5 @@
 #include "llvm_program.h"
+#include "llvm/IR/Module.h"
 
 #include "taichi/backends/cuda/cuda_driver.h"
 #include "taichi/program/arch.h"

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -18,7 +18,7 @@
 #include <memory>
 
 namespace llvm {
-  class Module;
+class Module;
 }
 
 namespace taichi {

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -6,7 +6,6 @@
 #include "taichi/llvm/llvm_context.h"
 #include "taichi/runtime/runtime.h"
 #include "taichi/system/threading.h"
-#include "llvm/IR/Module.h"
 #include "taichi/struct/struct.h"
 #include "taichi/struct/struct_llvm.h"
 #include "taichi/program/snode_expr_utils.h"
@@ -17,6 +16,10 @@
 #undef TI_RUNTIME_HOST
 
 #include <memory>
+
+namespace llvm {
+  class Module;
+}
 
 namespace taichi {
 namespace lang {


### PR DESCRIPTION
This also reduces the warnings coming out from the LLVM headers, especially on windows, thus improving caching hit rates.