### PR TITLE
[bug] Enable int32 atomic ops for opengl backend.

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -762,7 +762,7 @@ class KernelGen : public IRVisitor {
   bool maybe_generate_fatomics_using_nv_ext(AtomicOpStmt *stmt,
                                             DataType dt,
                                             const std::string &val_name) {
-    if (!allows_nv_shader_ext_) {
+    if (!allows_nv_shader_ext_ and !dt->is_primitive(PrimitiveTypeID::i32)) {
       return false;
     }
     const bool check_int =

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -232,6 +232,151 @@ def test_opengl_exceed_max_ssbo():
 
 
 @ti.test(arch=ti.opengl)
+def test_mpm99_aot():
+    quality = 1  # Use a larger value for higher-res simulations
+    n_particles, n_grid = 9000 * quality**2, 128 * quality
+    dx, inv_dx = 1 / n_grid, float(n_grid)
+    dt = 1e-4 / quality
+    p_vol, p_rho = (dx * 0.5)**2, 1
+    p_mass = p_vol * p_rho
+    E, nu = 0.1e4, 0.2  # Young's modulus and Poisson's ratio
+    mu_0, lambda_0 = E / (2 * (1 + nu)), E * nu / (
+        (1 + nu) * (1 - 2 * nu))  # Lame parameters
+    x = ti.Vector.field(2, dtype=float, shape=n_particles)  # position
+    v = ti.Vector.field(2, dtype=float, shape=n_particles)  # velocity
+    C = ti.Matrix.field(2, 2, dtype=float,
+                        shape=n_particles)  # affine velocity field
+    F = ti.Matrix.field(2, 2, dtype=float,
+                        shape=n_particles)  # deformation gradient
+    material = ti.field(dtype=int, shape=n_particles)  # material id
+    Jp = ti.field(dtype=float, shape=n_particles)  # plastic deformation
+    grid_v = ti.Vector.field(2, dtype=float,
+                             shape=(n_grid,
+                                    n_grid))  # grid node momentum/velocity
+    grid_m = ti.field(dtype=float, shape=(n_grid, n_grid))  # grid node mass
+    grid_v_int = ti.Vector.field(2, dtype=int,
+                                 shape=(n_grid,
+                                        n_grid))  # grid node momentum/velocity
+    grid_m_int = ti.field(dtype=int, shape=(n_grid, n_grid))  # grid node mass
+
+    v_exp = 24
+    m_exp = 40
+
+    @ti.kernel
+    def substep():
+        for i, j in grid_m:
+            grid_v[i, j] = [0, 0]
+            grid_m[i, j] = 0
+            grid_v_int[i, j] = [0, 0]
+            grid_m_int[i, j] = 0
+        for p in x:  # Particle state update and scatter to grid (P2G)
+            base = (x[p] * inv_dx - 0.5).cast(int)
+            fx = x[p] * inv_dx - base.cast(float)
+            # Quadratic kernels  [http://mpm.graphics   Eqn. 123, with x=fx, fx-1,fx-2]
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+            F[p] = (ti.Matrix.identity(float, 2) +
+                    dt * C[p]) @ F[p]  # deformation gradient update
+            h = ti.exp(
+                10 * (1.0 - Jp[p])
+            )  # Hardening coefficient: snow gets harder when compressed
+            if material[p] == 1:  # jelly, make it softer
+                h = 0.3
+            mu, la = mu_0 * h, lambda_0 * h
+            if material[p] == 0:  # liquid
+                mu = 0.0
+            U, sig, V = ti.svd(F[p])
+            J = 1.0
+            for d in ti.static(range(2)):
+                new_sig = sig[d, d]
+                if material[p] == 2:  # Snow
+                    new_sig = min(max(sig[d, d], 1 - 2.5e-2),
+                                  1 + 4.5e-3)  # Plasticity
+                Jp[p] *= sig[d, d] / new_sig
+                sig[d, d] = new_sig
+                J *= new_sig
+            if material[
+                    p] == 0:  # Reset deformation gradient to avoid numerical instability
+                F[p] = ti.Matrix.identity(float, 2) * ti.sqrt(J)
+            elif material[p] == 2:
+                F[p] = U @ sig @ V.transpose(
+                )  # Reconstruct elastic deformation gradient after plasticity
+            stress = 2 * mu * (F[p] - U @ V.transpose()) @ F[p].transpose(
+            ) + ti.Matrix.identity(float, 2) * la * J * (J - 1)
+            stress = (-dt * p_vol * 4 * inv_dx * inv_dx) * stress
+            affine = stress + p_mass * C[p]
+            for i, j in ti.static(ti.ndrange(
+                    3, 3)):  # Loop over 3x3 grid node neighborhood
+                offset = ti.Vector([i, j])
+                dpos = (offset.cast(float) - fx) * dx
+                weight = w[i][0] * w[j][1]
+                grid_v_int[base + offset] += int(
+                    ti.floor(0.5 + weight * (p_mass * v[p] + affine @ dpos) *
+                             (2.0**v_exp)))
+                grid_m_int[base + offset] += int(
+                    ti.floor(0.5 + weight * p_mass * (2.0**m_exp)))
+        for i, j in grid_m:
+            if grid_m_int[i, j] > 0:  # No need for epsilon here
+                # grid_v[i, j] = (1.0 / grid_m[i, j]) * grid_v[i, j] # Momentum to velocity
+                grid_v[i, j] = (2**(m_exp - v_exp) / grid_m_int[i, j]
+                                ) * grid_v_int[i, j]  # Momentum to velocity
+                grid_v[i, j][1] -= dt * 50  # gravity
+                if i < 3 and grid_v[i, j][0] < 0:
+                    grid_v[i, j][0] = 0  # Boundary conditions
+                if i > n_grid - 3 and grid_v[i, j][0] > 0: grid_v[i, j][0] = 0
+                if j < 3 and grid_v[i, j][1] < 0: grid_v[i, j][1] = 0
+                if j > n_grid - 3 and grid_v[i, j][1] > 0: grid_v[i, j][1] = 0
+        for p in x:  # grid to particle (G2P)
+            base = (x[p] * inv_dx - 0.5).cast(int)
+            fx = x[p] * inv_dx - base.cast(float)
+            w = [
+                0.5 * (1.5 - fx)**2, 0.75 - (fx - 1.0)**2, 0.5 * (fx - 0.5)**2
+            ]
+            new_v = ti.Vector.zero(float, 2)
+            new_C = ti.Matrix.zero(float, 2, 2)
+            for i, j in ti.static(ti.ndrange(
+                    3, 3)):  # loop over 3x3 grid node neighborhood
+                dpos = ti.Vector([i, j]).cast(float) - fx
+                g_v = grid_v[base + ti.Vector([i, j])]
+                weight = w[i][0] * w[j][1]
+                new_v += weight * g_v
+                new_C += 4 * inv_dx * weight * g_v.outer_product(dpos)
+            v[p], C[p] = new_v, new_C
+            x[p] += dt * v[p]  # advection
+
+    group_size = n_particles // 3
+
+    @ti.kernel
+    def initialize():
+        for i in range(n_particles):
+            x[i] = [
+                ti.random() * 0.2 + 0.3 + 0.10 * (i // group_size),
+                ti.random() * 0.2 + 0.05 + 0.32 * (i // group_size)
+            ]
+            material[i] = i // group_size  # 0: fluid 1: jelly 2: snow
+            v[i] = ti.Matrix([0, 0])
+            F[i] = ti.Matrix([[1, 0], [0, 1]])
+            Jp[i] = 1
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        m = ti.aot.Module(ti.opengl)
+        m.add_field('x', x)
+        m.add_field('v', v)
+        m.add_field('C', C)
+        m.add_field('J', Jp)
+        m.add_field('grid_v', grid_v)
+        m.add_field('grid_m', grid_m)
+        m.add_field('grid_v_int', grid_v_int)
+        m.add_field('grid_m_int', grid_m_int)
+        m.add_field('material', material)
+        m.add_kernel(initialize)
+        m.add_kernel(substep)
+
+        m.save(tmpdir, '')
+        with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
+            json.load(json_file)
+
+
+@ti.test(arch=ti.opengl)
 def test_mpm88_ndarray():
     dim = 2
     N = 64


### PR DESCRIPTION
Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
