### PR TITLE
[Lang] Enforce members of a matrix field to have same shape

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -354,14 +354,14 @@ class PyTaichi:
         _root_fb._finalize_for_aot()
 
     @staticmethod
-    def _get_tb_of_global_var(_var):
+    def _get_tb(_var):
         return getattr(_var, 'declaration_tb', str(_var.ptr))
 
     def _check_field_not_placed(self):
         not_placed = []
         for _var in self.global_vars:
             if _var.ptr.snode() is None:
-                not_placed.append(self._get_tb_of_global_var(_var))
+                not_placed.append(self._get_tb(_var))
 
         if len(not_placed):
             bar = '=' * 44 + '\n'
@@ -372,14 +372,13 @@ class PyTaichi:
                 '\n\n  x = ti.field(float, shape=(2, 3))')
 
     def _check_matrix_field_member_shape(self):
-        for matrix_field in self.matrix_fields:
-            shapes = [
-                matrix_field.get_scalar_field(i, j).shape
-                for i in range(matrix_field.n) for j in range(matrix_field.m)
-            ]
+        for _field in self.matrix_fields:
+            shapes = [_field.get_scalar_field(i, j).shape
+                      for i in range(_field.n) for j in range(_field.m)]
             if any(shape != shapes[0] for shape in shapes):
                 raise RuntimeError(
-                    f'Members of the following field have different shapes {shapes}:\n{self._get_tb_of_global_var(matrix_field.get_field_members()[0])}'
+                    'Members of the following field have different shapes ' +
+                    f'{shapes}:\n{self._get_tb(_field.get_field_members()[0])}'
                 )
 
     def materialize(self):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -373,8 +373,10 @@ class PyTaichi:
 
     def _check_matrix_field_member_shape(self):
         for _field in self.matrix_fields:
-            shapes = [_field.get_scalar_field(i, j).shape
-                      for i in range(_field.n) for j in range(_field.m)]
+            shapes = [
+                _field.get_scalar_field(i, j).shape for i in range(_field.n)
+                for j in range(_field.m)
+            ]
             if any(shape != shapes[0] for shape in shapes):
                 raise RuntimeError(
                     'Members of the following field have different shapes ' +

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -373,9 +373,14 @@ class PyTaichi:
 
     def _check_matrix_field_member_shape(self):
         for matrix_field in self.matrix_fields:
-            shapes = [matrix_field.get_scalar_field(i, j).shape for i in range(matrix_field.n) for j in range(matrix_field.m)]
+            shapes = [
+                matrix_field.get_scalar_field(i, j).shape
+                for i in range(matrix_field.n) for j in range(matrix_field.m)
+            ]
             if any(shape != shapes[0] for shape in shapes):
-                raise RuntimeError(f'Members of the following field have different shapes {shapes}:\n{self._get_tb_of_global_var(matrix_field.get_field_members()[0])}')
+                raise RuntimeError(
+                    f'Members of the following field have different shapes {shapes}:\n{self._get_tb_of_global_var(matrix_field.get_field_members()[0])}'
+                )
 
     def materialize(self):
         self.materialize_root_fb(not self.materialized)

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -304,6 +304,7 @@ class PyTaichi:
         self.inside_kernel = False
         self.current_kernel = None
         self.global_vars = []
+        self.matrix_fields = []
         self.print_preprocessed = False
         self.experimental_real_function = False
         self.default_fp = f32
@@ -352,18 +353,15 @@ class PyTaichi:
                 'AOT: can only finalize the root FieldsBuilder once')
         _root_fb._finalize_for_aot()
 
-    def materialize(self):
-        self.materialize_root_fb(not self.materialized)
+    @staticmethod
+    def _get_tb_of_global_var(_var):
+        return getattr(_var, 'declaration_tb', str(_var.ptr))
 
-        if self.materialized:
-            return
-
-        self.materialized = True
+    def _check_field_not_placed(self):
         not_placed = []
         for _var in self.global_vars:
             if _var.ptr.snode() is None:
-                tb = getattr(_var, 'declaration_tb', str(_var.ptr))
-                not_placed.append(tb)
+                not_placed.append(self._get_tb_of_global_var(_var))
 
         if len(not_placed):
             bar = '=' * 44 + '\n'
@@ -372,6 +370,23 @@ class PyTaichi:
                 f'{bar}'.join(not_placed) +
                 f'{bar}Please consider specifying a shape for them. E.g.,' +
                 '\n\n  x = ti.field(float, shape=(2, 3))')
+
+    def _check_matrix_field_member_shape(self):
+        for matrix_field in self.matrix_fields:
+            shapes = [matrix_field.get_scalar_field(i, j).shape for i in range(matrix_field.n) for j in range(matrix_field.m)]
+            if any(shape != shapes[0] for shape in shapes):
+                raise RuntimeError(f'Members of the following field have different shapes {shapes}:\n{self._get_tb_of_global_var(matrix_field.get_field_members()[0])}')
+
+    def materialize(self):
+        self.materialize_root_fb(not self.materialized)
+
+        if self.materialized:
+            return
+
+        self.materialized = True
+
+        self._check_field_not_placed()
+        self._check_matrix_field_member_shape()
 
         for callback in self.materialize_callbacks:
             callback()
@@ -576,7 +591,7 @@ def create_field_member(dtype, name):
 
     # primal
     x = Expr(_ti_core.make_id_expr(""))
-    x.declaration_tb = get_traceback(stacklevel=2)
+    x.declaration_tb = get_traceback(stacklevel=4)
     x.ptr = _ti_core.global_new(x.ptr, dtype)
     x.ptr.set_name(name)
     x.ptr.set_is_primal(True)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -858,6 +858,7 @@ class Matrix(TaichiOperations):
         entries, entries_grad = MatrixField(entries, n, m), MatrixField(
             entries_grad, n, m)
         entries.set_grad(entries_grad)
+        impl.get_runtime().matrix_fields.append(entries)
 
         if shape is None:
             assert offset is None, "shape cannot be None when offset is being set"
@@ -1117,7 +1118,6 @@ class MatrixField(Field):
         super().__init__(_vars)
         self.n = n
         self.m = m
-        impl.get_runtime().matrix_fields.append(self)
 
     def get_scalar_field(self, *indices):
         """Creates a ScalarField using a specific field member. Only used for quant.

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1117,6 +1117,7 @@ class MatrixField(Field):
         super().__init__(_vars)
         self.n = n
         self.m = m
+        impl.get_runtime().matrix_fields.append(self)
 
     def get_scalar_field(self, *indices):
         """Creates a ScalarField using a specific field member. Only used for quant.

--- a/tests/python/test_materialize_check.py
+++ b/tests/python/test_materialize_check.py
@@ -30,7 +30,5 @@ def test_check_matrix_field_member_shape():
 
     with pytest.raises(
             RuntimeError,
-            match=
-            r"Members of the following field have different shapes \[\(10,\), \(11,\), \(10,\), \(11,\)\].*"
-    ):
+            match=r"Members of the following field have different shapes.*"):
         foo()

--- a/tests/python/test_materialize_check.py
+++ b/tests/python/test_materialize_check.py
@@ -1,0 +1,30 @@
+import pytest
+import taichi as ti
+
+
+@ti.test()
+def test_check_field_not_placed():
+    a = ti.field(ti.i32)
+
+    @ti.kernel
+    def foo():
+        pass
+
+    with pytest.raises(RuntimeError, match=r"These field\(s\) are not placed.*"):
+        foo()
+
+
+@ti.test()
+def test_check_matrix_field_member_shape():
+    a = ti.Matrix.field(2, 2, ti.i32)
+    ti.root.dense(ti.i, 10).place(a.get_scalar_field(0, 0))
+    ti.root.dense(ti.i, 11).place(a.get_scalar_field(0, 1))
+    ti.root.dense(ti.i, 10).place(a.get_scalar_field(1, 0))
+    ti.root.dense(ti.i, 11).place(a.get_scalar_field(1, 1))
+
+    @ti.kernel
+    def foo():
+        pass
+
+    with pytest.raises(RuntimeError, match=r"Members of the following field have different shapes \[\(10,\), \(11,\), \(10,\), \(11,\)\].*"):
+        foo()

--- a/tests/python/test_materialize_check.py
+++ b/tests/python/test_materialize_check.py
@@ -1,4 +1,5 @@
 import pytest
+
 import taichi as ti
 
 
@@ -10,7 +11,8 @@ def test_check_field_not_placed():
     def foo():
         pass
 
-    with pytest.raises(RuntimeError, match=r"These field\(s\) are not placed.*"):
+    with pytest.raises(RuntimeError,
+                       match=r"These field\(s\) are not placed.*"):
         foo()
 
 
@@ -26,5 +28,9 @@ def test_check_matrix_field_member_shape():
     def foo():
         pass
 
-    with pytest.raises(RuntimeError, match=r"Members of the following field have different shapes \[\(10,\), \(11,\), \(10,\), \(11,\)\].*"):
+    with pytest.raises(
+            RuntimeError,
+            match=
+            r"Members of the following field have different shapes \[\(10,\), \(11,\), \(10,\), \(11,\)\].*"
+    ):
         foo()


### PR DESCRIPTION
Related issue = #2590

After this PR, the following code snippet:
```py
import taichi as ti

ti.init()
a = ti.Matrix.field(2, 2, ti.i32)
ti.root.dense(ti.i, 10).place(a.get_scalar_field(0, 0))
ti.root.dense(ti.i, 11).place(a.get_scalar_field(0, 1))
ti.root.dense(ti.i, 10).place(a.get_scalar_field(1, 0))
ti.root.dense(ti.i, 11).place(a.get_scalar_field(1, 1))

@ti.kernel
def func():
    pass

func()
```
will give the following error:
```
RuntimeError: Members of the following field have different shapes [(10,), (11,), (10,), (11,)]:
  File "test_matrix_field_member_shape.py", line 4, in <module>
    a = ti.Matrix.field(2, 2, ti.i32)

```
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
