### PR TITLE
[Lang] Fix pylint rule C0321 (multiple-statements) and C0325 (superfluous-parens).

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -21,7 +21,7 @@ class KernelTemplate:
             key_p += '=' + str(v) + ','
             return key_p
         for ky, val in fields:
-            if (val is v):
+            if val is v:
                 key_p += '=' + ky + ','
                 return key_p
         raise RuntimeError('Arg type must be of type int/float/boolean' +

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -413,7 +413,7 @@ def _clamp_unsigned_to_range(npty, val):
     if iif.min <= val <= iif.max:
         return val
     cap = (1 << iif.bits)
-    if not (0 <= val < cap):
+    if not 0 <= val < cap:
         # We let pybind11 fail intentionally, because this isn't the case we want
         # to deal with: |val| does't fall into the valid range of either
         # the signed or the unsigned type.

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -523,7 +523,7 @@ class MeshRelationAccessProxy:
                                        self.to_element_type))
 
     def subscript(self, *indices):
-        assert (len(indices) == 1)
+        assert len(indices) == 1
         entry_expr = _ti_core.get_relation_access(self.mesh.mesh_ptr,
                                                   self.from_index.ptr,
                                                   self.to_element_type,

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -233,7 +233,8 @@ class MeshElement:
                             size).place(*tuple(field_dict.values()))
             grads = []
             for key, field in field_dict.items():
-                if self.attr_dict[key].needs_grad: grads.append(field.grad)
+                if self.attr_dict[key].needs_grad:
+                    grads.append(field.grad)
             if len(grads) > 0:
                 impl.root.dense(impl.axes(0), size).place(*grads)
 

--- a/python/taichi/main.py
+++ b/python/taichi/main.py
@@ -180,7 +180,8 @@ class TaichiMain:
         sys.path.append(str((examples_dir / choices[args.name]).resolve()))
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
 
         if args.save:
             print(f"Saving example {args.name} to current directory...")
@@ -255,7 +256,8 @@ class TaichiMain:
         ti.info(f"Converting {args.input_file} to {args.output_file}")
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
         video.mp4_to_gif(args.input_file, args.output_file, args.framerate)
 
         return None
@@ -287,7 +289,8 @@ class TaichiMain:
             ))
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
         video.accelerate_video(args.input_file, args.output_file, args.speed)
 
         return None
@@ -331,7 +334,8 @@ class TaichiMain:
             ))
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
         video.crop_video(args.input_file, args.output_file, args.x_begin,
                          args.x_end, args.y_begin, args.y_end)
 
@@ -374,7 +378,8 @@ class TaichiMain:
             ))
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
         video.scale_video(args.input_file, args.output_file, args.ratio_width,
                           args.ratio_height)
 
@@ -420,7 +425,8 @@ class TaichiMain:
         ti.info(f'frame_rate = {args.framerate}')
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
         video.make_video(args.inputs,
                          output_path=str(args.output_file),
                          crf=args.crf,
@@ -515,13 +521,16 @@ class TaichiMain:
                 else:
                     res = b / a
                 scatter[key].append(res)
-                if res == 1: continue
+                if res == 1:
+                    continue
                 if not single_line:
                     ret += f'{key:<30}'
                 res -= 1
                 color = Fore.RESET
-                if res > 0: color = Fore.RED
-                elif res < 0: color = Fore.GREEN
+                if res > 0:
+                    color = Fore.RED
+                elif res < 0:
+                    color = Fore.GREEN
                 if isinstance(a, float):
                     a = f'{a:>7.2}'
                 else:
@@ -567,7 +576,8 @@ class TaichiMain:
         args = parser.parse_args(arguments)
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
 
         baseline_dir = TaichiMain._get_benchmark_baseline_dir()
         output_dir = TaichiMain._get_benchmark_output_dir()
@@ -584,7 +594,8 @@ class TaichiMain:
         args = parser.parse_args(arguments)
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
 
         baseline_dir = TaichiMain._get_benchmark_baseline_dir()
         output_dir = TaichiMain._get_benchmark_output_dir()
@@ -628,7 +639,8 @@ class TaichiMain:
         args = parser.parse_args(arguments)
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
 
         commit_hash = _ti_core.get_commit_hash()
         with os.popen('git rev-parse HEAD') as f:
@@ -669,7 +681,8 @@ class TaichiMain:
         args = parser.parse_args(arguments)
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
 
         runpy.run_path(args.filename)
 
@@ -687,7 +700,8 @@ class TaichiMain:
         args = parser.parse_args(arguments)
 
         # Short circuit for testing
-        if self.test_mode: return args
+        if self.test_mode:
+            return args
 
         _ti_core.set_core_trigger_gdb_when_crash(True)
         os.environ['TI_DEBUG'] = '1'

--- a/python/taichi/tools/np2ply.py
+++ b/python/taichi/tools/np2ply.py
@@ -213,7 +213,7 @@ class PLYWriter:
             for i in range(self.num_vertex_channels):
                 f.write("property " + self.vertex_data_type[i] + " " +
                         self.vertex_channels[i] + "\n")
-            if (self.num_faces != 0):
+            if self.num_faces != 0:
                 f.write("element face " + str(self.num_faces) + "\n")
                 f.write("property list uchar int vertex_indices\n")
                 for i in range(self.num_face_channels):

--- a/python/taichi/ui/utils.py
+++ b/python/taichi/ui/utils.py
@@ -56,7 +56,7 @@ def vec_to_euler(v):
         yaw = 0
     else:
         yaw = acos(cos_yaw)
-        if (sin_yaw < 0):
+        if sin_yaw < 0:
             yaw = -yaw
 
     return yaw, pitch

--- a/scripts/generate_pylint_tags.py
+++ b/scripts/generate_pylint_tags.py
@@ -22,6 +22,7 @@ TAGS = {
     'R1703': True,
     'W0108': True,
     'W1309': True,
+    'C0321': True,
 }
 
 if __name__ == '__main__':

--- a/scripts/generate_pylint_tags.py
+++ b/scripts/generate_pylint_tags.py
@@ -23,6 +23,7 @@ TAGS = {
     'W0108': True,
     'W1309': True,
     'C0321': True,
+    'C0325': True,
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related issue = #3151 

C0321: More than one statement on a single line (multiple-statements)
C0325: Unnecessary parens after 'if' keyword (superfluous-parens)
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
