### PR TITLE
[vulkan] Fix SPIRV types

### DIFF
--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -464,7 +464,7 @@ class TaskCodegen : public IRVisitor {
   void visit(GlobalStoreStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
     const auto dt = stmt->val->element_type();
-    const auto &primitive_buffer_type = ir_->get_primitive_buffer_type(dt);
+    const auto &primitive_buffer_type = ir_->get_primitive_type(dt);
 
     spirv::Value buffer_ptr = at_buffer(stmt->dest, dt);
     spirv::Value val = ir_->query_value(stmt->val->raw_name());
@@ -480,7 +480,7 @@ class TaskCodegen : public IRVisitor {
   void visit(GlobalLoadStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
     auto dt = stmt->element_type();
-    const auto &primitive_buffer_type = ir_->get_primitive_buffer_type(dt);
+    const auto &primitive_buffer_type = ir_->get_primitive_type(dt);
 
     spirv::Value buffer_ptr = at_buffer(stmt->src, dt);
     spirv::Value buffer_typed_value =
@@ -983,7 +983,7 @@ class TaskCodegen : public IRVisitor {
       }
       */
 
-      auto ptr_elem_type = ir_->get_primitive_buffer_type(dt);
+      auto ptr_elem_type = ir_->get_primitive_type(dt);
       val = ir_->make_value(op, ptr_elem_type, addr_ptr,
                             /*scope=*/ir_->const_i32_one_,
                             /*semantics=*/ir_->const_i32_zero_, data);
@@ -1567,8 +1567,8 @@ class TaskCodegen : public IRVisitor {
     spirv::Value idx_val =
         ir_->make_value(spv::OpShiftRightArithmetic, ptr_val.stype, ptr_val,
                         make_pointer(size_t(std::log2(width))));
-    spirv::Value ret = ir_->struct_array_access(
-        ir_->get_primitive_buffer_type(dt), buffer, idx_val);
+    spirv::Value ret =
+        ir_->struct_array_access(ir_->get_primitive_type(dt), buffer, idx_val);
     return ret;
   }
 
@@ -1579,13 +1579,13 @@ class TaskCodegen : public IRVisitor {
     spirv::Value idx_val =
         ir_->make_value(spv::OpShiftRightArithmetic, ptr_val.stype, ptr_val,
                         make_pointer(size_t(std::log2(width))));
-    spirv::Value ret = ir_->struct_array_access(
-        ir_->get_primitive_buffer_type(dt), buffer, idx_val);
+    spirv::Value ret =
+        ir_->struct_array_access(ir_->get_primitive_type(dt), buffer, idx_val);
     return ret;
   }
 
   spirv::Value get_buffer_value(BufferInfo buffer, DataType dt) {
-    auto type = ir_->get_primitive_buffer_type(dt);
+    auto type = ir_->get_primitive_type(dt);
     auto key = std::make_pair(buffer, type.id);
 
     const auto it = buffer_value_map_.find(key);

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -254,19 +254,6 @@ SType IRBuilder::get_primitive_type(const DataType &dt) const {
   }
 }
 
-SType IRBuilder::get_primitive_buffer_type(const DataType &dt) const {
-  size_t width = get_primitive_type_size(dt);
-  if (width == 8) {
-    return t_int64_;
-  } else if (width == 4) {
-    return t_int32_;
-  } else if (width == 2) {
-    return t_int16_;
-  } else {
-    return t_int8_;
-  }
-}
-
 size_t IRBuilder::get_primitive_type_size(const DataType &dt) const {
   if (dt == PrimitiveType::i64 || dt == PrimitiveType::u64 ||
       dt == PrimitiveType::f64) {

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -309,8 +309,6 @@ class IRBuilder {
   SType get_null_type();
   // Get the spirv type for a given Taichi data type
   SType get_primitive_type(const DataType &dt) const;
-  // Get the spirv type for the buffer for a given Taichi data type
-  SType get_primitive_buffer_type(const DataType &dt) const;
   // Get the size in bytes of a given Taichi data type
   size_t get_primitive_type_size(const DataType &dt) const;
   // Get the pointer type that points to value_type


### PR DESCRIPTION
We always use integral types for buffer type. This leads to SPIRV with invalid type errors.
For example, looking at the AOTed SPIRV of mpm 99, one can find things like:
```
        %575 = OpAccessChain %_ptr_StorageBuffer_int %root_buffer_0 %int_0 %574
     %tmp402 = OpAtomicFAddEXT %float %575 %int_1 %int_0 %tmp400
```
This is not valid, because we're treating a int pointer as a float pointer. Tools like `spirv-val` complains about this.

btw, I don't understand why `get_primitive_buffer_type` was introduced in the first place hmm.  