### PR TITLE
[Misc] Remove more deprecated APIs

### DIFF
--- a/misc/demo_warning.py
+++ b/misc/demo_warning.py
@@ -1,5 +1,0 @@
-import taichi as ti
-
-x = ti.Vector([2, 2])
-
-ti.dot(x, x)

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -38,11 +38,5 @@ else:
 
 __all__ = ['ad', 'core', 'misc', 'lang', 'tools', 'main', 'ui', 'profiler']
 
-complex_kernel = deprecated('ti.complex_kernel',
-                            'ti.ad.grad_replaced')(ad.grad_replaced)
-
-complex_kernel_grad = deprecated('ti.complex_kernel_grad',
-                                 'ti.ad.grad_for')(ad.grad_for)
-
 __version__ = (core.get_version_major(), core.get_version_minor(),
                core.get_version_patch())

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -56,7 +56,7 @@ from taichi.profiler import KernelProfiler, get_default_kernel_profiler
 from taichi.profiler.kernelmetrics import (CuptiMetric, default_cupti_metrics,
                                            get_predefined_cupti_metrics)
 from taichi.snode.fields_builder import FieldsBuilder
-from taichi.tools.util import deprecated, get_traceback
+from taichi.tools.util import get_traceback
 from taichi.types.annotations import any_arr, ext_arr, template
 from taichi.types.primitive_types import (f16, f32, f64, i32, i64,
                                           integer_types, u32, u64)
@@ -80,13 +80,6 @@ ijl = axes(0, 1, 3)
 ikl = axes(0, 2, 3)
 jkl = axes(1, 2, 3)
 ijkl = axes(0, 1, 2, 3)
-
-outer_product = deprecated('ti.outer_product(a, b)',
-                           'a.outer_product(b)')(Matrix.outer_product)
-cross = deprecated('ti.cross(a, b)', 'a.cross(b)')(Matrix.cross)
-dot = deprecated('ti.dot(a, b)', 'a.dot(b)')(Matrix.dot)
-normalized = deprecated('ti.normalized(a)',
-                        'a.normalized()')(Matrix.normalized)
 
 cfg = impl.default_cfg()
 x86_64 = _ti_core.x64
@@ -596,12 +589,6 @@ def init(arch=None,
 
     unexpected_keys = kwargs.keys()
 
-    if 'use_unified_memory' in unexpected_keys:
-        _ti_core.warn(
-            '"use_unified_memory" is a deprecated option, as taichi no longer have the option of using unified memory.'
-        )
-        del kwargs['use_unified_memory']
-
     if len(unexpected_keys):
         raise KeyError(
             f'Unrecognized keyword argument(s) for ti.init: {", ".join(unexpected_keys)}'
@@ -796,11 +783,6 @@ def sym_eig(A, dt=None):
     if A.n == 2:
         return taichi.lang.linalg_impl.sym_eig2x2(A, dt)
     raise Exception("Symmetric eigen solver only supports 2D matrices.")
-
-
-determinant = deprecated('ti.determinant(a)',
-                         'a.determinant()')(Matrix.determinant)
-tr = deprecated('ti.tr(a)', 'a.trace()')(Matrix.trace)
 
 
 def Tape(loss, clear_gradients=True):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -14,7 +14,7 @@ from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.util import (cook_dtype, in_python_scope, python_scope,
                               taichi_scope, to_numpy_type, to_pytorch_type)
-from taichi.tools.util import deprecated, warning
+from taichi.tools.util import warning
 from taichi.types import CompoundType
 
 import taichi as ti
@@ -489,8 +489,6 @@ class Matrix(TaichiOperations):
             return Matrix(entries)
         raise Exception(
             "Inversions of matrices with sizes >= 5 are not supported")
-
-    inversed = deprecated('a.inversed()', 'a.inverse()')(inverse)
 
     @kern_mod.pyfunc
     def normalized(self, eps=0):
@@ -1161,7 +1159,7 @@ class MatrixField(Field):
         taichi.lang.meta.fill_matrix(self, val)
 
     @python_scope
-    def to_numpy(self, keep_dims=False, as_vector=None, dtype=None):
+    def to_numpy(self, keep_dims=False, dtype=None):
         """Converts the field instance to a NumPy array.
 
         Args:
@@ -1169,20 +1167,11 @@ class MatrixField(Field):
                 When keep_dims=True, on an n-D matrix field, the numpy array always has n+2 dims, even for 1x1, 1xn, nx1 matrix fields.
                 When keep_dims=False, the resulting numpy array should skip the matrix dims with size 1.
                 For example, a 4x1 or 1x4 matrix field with 5x6x7 elements results in an array of shape 5x6x7x4.
-            as_vector (bool, deprecated): Whether to make the returned numpy array as a vector, i.e., with shape (n,) rather than (n, 1).
-                Note that this argument has been deprecated.
-                More discussion about `as_vector`: https://github.com/taichi-dev/taichi/pull/1046#issuecomment-633548858.
             dtype (DataType, optional): The desired data type of returned numpy array.
 
         Returns:
             numpy.ndarray: The result NumPy array.
         """
-        if as_vector is not None:
-            warning(
-                'v.to_numpy(as_vector=True) is deprecated, '
-                'please use v.to_numpy() directly instead',
-                DeprecationWarning,
-                stacklevel=3)
         if dtype is None:
             dtype = to_numpy_type(self.dtype)
         as_vector = self.m == 1 and not keep_dims

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -339,16 +339,6 @@ def test_init_matrix_from_vectors_deprecated():
             assert m4[0][j, i] == int(i + 3 * j + 1)
 
 
-@pytest.mark.filterwarnings('ignore')
-@ti.test(arch=ti.get_host_arch_list())
-def test_to_numpy_as_vector_deprecated():
-    v = ti.Vector.field(3, dtype=ti.f32, shape=(2))
-    u = np.array([[2, 3, 4], [5, 6, 7]])
-    v.from_numpy(u)
-    assert v.to_numpy(as_vector=True) == approx(u)
-    assert v.to_numpy() == approx(u)
-
-
 @ti.test()
 def test_any_all():
     a = ti.Matrix.field(2, 2, dtype=ti.i32, shape=())


### PR DESCRIPTION
Related issue = close #3590 

This PR further removes more deprecated APIs: 

- [x] `ti.complex_kernel`
- [x] `ti.complex_kernel_grad`
- [x] `ti.outer_product(a, b)`
- [x] `ti.cross(a, b`
- [x] `ti.dot(a, b)`
- [x] `ti.normalized(a)`
- [x] `use_unified_memory`
- [x] `ti.determinant(a)`
- [x] `ti.tr(a)`
- [x] `a.inversed()`
- [x] `to_numpy(as_vector)`

Also, for other related repos:

- [x] taichi_elements https://github.com/taichi-dev/taichi_elements/pull/85
- [x] difftaichi 


After this PR, there should be almost no deprecated APIs in the codebase:

```bash
❯ rg "deprecated" python
# This is for testing only, and it raises RuntimeError immediately to alert users, so it's okay to keep it.
python/taichi/main.py
658:            'ti test is deprecated. Please run `python tests/run_tests.py` instead.'

# This is a quite recent change, and according to its original code review comments, we need to keep it
# See https://github.com/taichi-dev/taichi/pull/2774/files#r693818926
python/taichi/__init__.py
22:deprecated_names = {'SOA': 'Layout.SOA', 'AOS': 'Layout.AOS'}
24:    for name, alter in deprecated_names.items():
29:        if attr in deprecated_names:
31:                f'ti.{attr} is deprecated. Please use ti.{deprecated_names[attr]} instead.',
34:            exec(f'{attr} = {deprecated_names[attr]}')

# This is nothing :)
python/taichi/tools/__init__.py
16:    'deprecated',

# This is `deprecated` function definition, maybe we will need it in the future
# to mark other functions as outdated
python/taichi/tools/util.py
81:def deprecated(old, new, warning_type=DeprecationWarning):
82:    """Mark an API as deprecated.
91:        >>> @deprecated('ti.sqr(x)', 'x**2')
102:            msg = f'{old} is deprecated. Please use {new} instead.'
```
