### PR TITLE
[bug] [opengl] Avoid using new as variable name in generated glsl.

### DIFF
--- a/taichi/backends/opengl/shaders/atomics_macro_f32.glsl.h
+++ b/taichi/backends/opengl/shaders/atomics_macro_f32.glsl.h
@@ -6,35 +6,39 @@
 static_assert(false, "Do not include");
 #endif
 
-#define GENERATE_OPENGL_ATOMIC_F32(NAME)                                 \
-  constexpr auto kOpenGlAtomicF32Source_##NAME = STR(                    \
-      float atomicAdd_##NAME##_f32(int addr, float rhs) {                \
-        int old, new, ret;                                               \
-        do {                                                             \
-          old = _##NAME##_i32_[addr];                                    \
-          new = floatBitsToInt((intBitsToFloat(old) + rhs));             \
-        } while (old != atomicCompSwap(_##NAME##_i32_[addr], old, new)); \
-        return intBitsToFloat(old);                                      \
-      } float atomicSub_##NAME##_f32(int addr, float rhs) {              \
-        int old, new, ret;                                               \
-        do {                                                             \
-          old = _##NAME##_i32_[addr];                                    \
-          new = floatBitsToInt((intBitsToFloat(old) - rhs));             \
-        } while (old != atomicCompSwap(_##NAME##_i32_[addr], old, new)); \
-        return intBitsToFloat(old);                                      \
-      } float atomicMax_##NAME##_f32(int addr, float rhs) {              \
-        int old, new, ret;                                               \
-        do {                                                             \
-          old = _##NAME##_i32_[addr];                                    \
-          new = floatBitsToInt(max(intBitsToFloat(old), rhs));           \
-        } while (old != atomicCompSwap(_##NAME##_i32_[addr], old, new)); \
-        return intBitsToFloat(old);                                      \
-      } float atomicMin_##NAME##_f32(int addr, float rhs) {              \
-        int old, new, ret;                                               \
-        do {                                                             \
-          old = _##NAME##_i32_[addr];                                    \
-          new = floatBitsToInt(min(intBitsToFloat(old), rhs));           \
-        } while (old != atomicCompSwap(_##NAME##_i32_[addr], old, new)); \
-        return intBitsToFloat(old);                                      \
+#define GENERATE_OPENGL_ATOMIC_F32(NAME)                                  \
+  constexpr auto kOpenGlAtomicF32Source_##NAME = STR(                     \
+      float atomicAdd_##NAME##_f32(int addr, float rhs) {                 \
+        int old_val, new_val, ret;                                        \
+        do {                                                              \
+          old_val = _##NAME##_i32_[addr];                                 \
+          new_val = floatBitsToInt((intBitsToFloat(old_val) + rhs));      \
+        } while (old_val !=                                               \
+                 atomicCompSwap(_##NAME##_i32_[addr], old_val, new_val)); \
+        return intBitsToFloat(old_val);                                   \
+      } float atomicSub_##NAME##_f32(int addr, float rhs) {               \
+        int old_val, new_val, ret;                                        \
+        do {                                                              \
+          old_val = _##NAME##_i32_[addr];                                 \
+          new_val = floatBitsToInt((intBitsToFloat(old_val) - rhs));      \
+        } while (old_val !=                                               \
+                 atomicCompSwap(_##NAME##_i32_[addr], old_val, new_val)); \
+        return intBitsToFloat(old_val);                                   \
+      } float atomicMax_##NAME##_f32(int addr, float rhs) {               \
+        int old_val, new_val, ret;                                        \
+        do {                                                              \
+          old_val = _##NAME##_i32_[addr];                                 \
+          new_val = floatBitsToInt(max(intBitsToFloat(old_val), rhs));    \
+        } while (old_val !=                                               \
+                 atomicCompSwap(_##NAME##_i32_[addr], old_val, new_val)); \
+        return intBitsToFloat(old_val);                                   \
+      } float atomicMin_##NAME##_f32(int addr, float rhs) {               \
+        int old_val, new_val, ret;                                        \
+        do {                                                              \
+          old_val = _##NAME##_i32_[addr];                                 \
+          new_val = floatBitsToInt(min(intBitsToFloat(old_val), rhs));    \
+        } while (old_val !=                                               \
+                 atomicCompSwap(_##NAME##_i32_[addr], old_val, new_val)); \
+        return intBitsToFloat(old_val);                                   \
       });
 // NOLINTEND(*)

--- a/taichi/backends/opengl/shaders/atomics_macro_f64.glsl.h
+++ b/taichi/backends/opengl/shaders/atomics_macro_f64.glsl.h
@@ -16,36 +16,36 @@ OPENGL_BEGIN_ATOMIC_F64_DEF
 "#define DEFINE_ATOMIC_F64_FUNCTIONS(NAME) "
 STR(
 double atomicAdd_##NAME_f64(int addr, double rhs) {
-  int old, new, ret;
+  int old_val, new_val, ret;
   do {
-    old = _##NAME##_i64_[addr];
-    new = floatBitsToInt((intBitsToFloat(old) + rhs));
-  } while (old != atomicCompSwap(_##NAME##_i64_[addr], old, new));
-  return intBitsToFloat(old);
+    old_val = _##NAME##_i64_[addr];
+    new_val = floatBitsToInt((intBitsToFloat(old_val) + rhs));
+  } while (old_val != atomicCompSwap(_##NAME##_i64_[addr], old_val, new_val));
+  return intBitsToFloat(old_val);
 }
 double atomicSub_##NAME##_f64(int addr, double rhs) {
-  int old, new, ret;
+  int old_val, new_val, ret;
   do {
-    old = _##NAME##_i64_[addr];
-    new = floatBitsToInt((intBitsToFloat(old) - rhs));
-  } while (old != atomicCompSwap(_##NAME##_i64_[addr], old, new));
-  return intBitsToFloat(old);
+    old_val = _##NAME##_i64_[addr];
+    new_val = floatBitsToInt((intBitsToFloat(old_val) - rhs));
+  } while (old_val != atomicCompSwap(_##NAME##_i64_[addr], old_val, new_val));
+  return intBitsToFloat(old_val);
 }
 double atomicMax_##NAME##_f64(int addr, double rhs) {
-  int old, new, ret;
+  int old_val, new_val, ret;
   do {
-    old = _##NAME##_i64_[addr];
-    new = floatBitsToInt(max(intBitsToFloat(old), rhs));
-  } while (old != atomicCompSwap(_##NAME##_i64_[addr], old, new));
-  return intBitsToFloat(old);
+    old_val = _##NAME##_i64_[addr];
+    new_val = floatBitsToInt(max(intBitsToFloat(old_val), rhs));
+  } while (old_val != atomicCompSwap(_##NAME##_i64_[addr], old_val, new_val));
+  return intBitsToFloat(old_val);
 }
 double atomicMin_##NAME##_f64(int addr, double rhs) {
-  int old, new, ret;
+  int old_val, new_val, ret;
   do {
-    old = _##NAME##_i64_[addr];
-    new = floatBitsToInt(min(intBitsToFloat(old), rhs));
-  } while (old != atomicCompSwap(_##NAME##_i64_[addr], old, new));
-  return intBitsToFloat(old);
+    old_val = _##NAME##_i64_[addr];
+    new_val = floatBitsToInt(min(intBitsToFloat(old_val), rhs));
+  } while (old_val != atomicCompSwap(_##NAME##_i64_[addr], old_val, new_val));
+  return intBitsToFloat(old_val);
 }
 \n
 )


### PR DESCRIPTION
`new` is reserved in Metal shading language so let's avoid using these critical names in general. 