### PR TITLE
[ir] [llvm] Add offset_bytes_in_parent_cell to SNode

### DIFF
--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -279,6 +279,11 @@ class SNode:
         runtime.materialize()
         return self.ptr.cell_size_bytes
 
+    @property
+    def offset_bytes_in_parent_cell(self):
+        impl.get_runtime().materialize()
+        return self.ptr.offset_bytes_in_parent_cell
+
     def deactivate_all(self):
         """Recursively deactivate all children components of `self`."""
         ch = self.get_children()

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -123,6 +123,7 @@ class SNode {
   int total_bit_start{0};
   int chunk_size{0};
   std::size_t cell_size_bytes{0};
+  std::size_t offset_bytes_in_parent_cell{0};
   PrimitiveType *physical_type{nullptr};  // for bit_struct and bit_array only
   DataType dt;
   bool has_ambient{false};

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -521,7 +521,8 @@ std::size_t TaichiLLVMContext::get_type_size(llvm::Type *type) {
   return get_data_layout().getTypeAllocSize(type);
 }
 
-std::size_t TaichiLLVMContext::get_struct_element_offset(llvm::StructType *type, int idx) {
+std::size_t TaichiLLVMContext::get_struct_element_offset(llvm::StructType *type,
+                                                         int idx) {
   return get_data_layout().getStructLayout(type)->getElementOffset(idx);
 }
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -521,6 +521,10 @@ std::size_t TaichiLLVMContext::get_type_size(llvm::Type *type) {
   return get_data_layout().getTypeAllocSize(type);
 }
 
+std::size_t TaichiLLVMContext::get_struct_element_offset(llvm::StructType *type, int idx) {
+  return get_data_layout().getStructLayout(type)->getElementOffset(idx);
+}
+
 void TaichiLLVMContext::mark_inline(llvm::Function *f) {
   for (auto &B : *f)
     for (auto &I : B) {

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -104,6 +104,8 @@ class TaichiLLVMContext {
 
   std::size_t get_type_size(llvm::Type *type);
 
+  std::size_t get_struct_element_offset(llvm::StructType *type, int idx);
+
   template <typename T>
   llvm::Value *get_constant(T t);
 

--- a/taichi/llvm/llvm_fwd.h
+++ b/taichi/llvm/llvm_fwd.h
@@ -7,6 +7,7 @@ class Value;
 class Module;
 class Function;
 class DataLayout;
+class StructType;
 class JITSymbol;
 class ExitOnError;
 namespace orc {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -403,7 +403,8 @@ void export_lang(py::module &m) {
       .def("num_active_indices",
            [](SNode *snode) { return snode->num_active_indices; })
       .def_readonly("cell_size_bytes", &SNode::cell_size_bytes)
-      .def_readonly("offset_bytes_in_parent_cell", &SNode::offset_bytes_in_parent_cell)
+      .def_readonly("offset_bytes_in_parent_cell",
+                    &SNode::offset_bytes_in_parent_cell)
       .def("begin_shared_exp_placement", &SNode::begin_shared_exp_placement)
       .def("end_shared_exp_placement", &SNode::end_shared_exp_placement);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -403,6 +403,7 @@ void export_lang(py::module &m) {
       .def("num_active_indices",
            [](SNode *snode) { return snode->num_active_indices; })
       .def_readonly("cell_size_bytes", &SNode::cell_size_bytes)
+      .def_readonly("offset_bytes_in_parent_cell", &SNode::offset_bytes_in_parent_cell)
       .def("begin_shared_exp_placement", &SNode::begin_shared_exp_placement)
       .def("end_shared_exp_placement", &SNode::end_shared_exp_placement);
 

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -59,7 +59,8 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
 
   for (int i = 0; i < snode.ch.size(); i++) {
     if (!snode.ch[i]->is_bit_level) {
-      snode.ch[i]->offset_bytes_in_parent_cell = tlctx_->get_struct_element_offset(ch_type, i);
+      snode.ch[i]->offset_bytes_in_parent_cell =
+          tlctx_->get_struct_element_offset(ch_type, i);
     }
   }
 

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -57,6 +57,12 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
 
   snode.cell_size_bytes = tlctx_->get_type_size(ch_type);
 
+  for (int i = 0; i < snode.ch.size(); i++) {
+    if (!snode.ch[i]->is_bit_level) {
+      snode.ch[i]->offset_bytes_in_parent_cell = tlctx_->get_struct_element_offset(ch_type, i);
+    }
+  }
+
   llvm::Type *body_type = nullptr, *aux_type = nullptr;
   if (type == SNodeType::dense || type == SNodeType::bitmasked) {
     TI_ASSERT(snode._morton == false);

--- a/tests/python/test_snode_layout_inspection.py
+++ b/tests/python/test_snode_layout_inspection.py
@@ -21,8 +21,19 @@ def test_primitives():
     n3.place(p, q, r)
 
     assert n1.cell_size_bytes == 2
-    assert 12 <= n2.cell_size_bytes <= 16
+    assert n2.cell_size_bytes in [12, 16]
     assert n3.cell_size_bytes == 16
+
+    assert n1.offset_bytes_in_parent_cell == 0
+    assert n2.offset_bytes_in_parent_cell == 2 * 32
+    assert n3.offset_bytes_in_parent_cell in [2 * 32 + 12 * 32, 2 * 32 + 16 * 32]
+
+    assert x.snode.offset_bytes_in_parent_cell == 0
+    assert y.snode.offset_bytes_in_parent_cell == 0
+    assert z.snode.offset_bytes_in_parent_cell in [4, 8]
+    assert p.snode.offset_bytes_in_parent_cell == 0
+    assert q.snode.offset_bytes_in_parent_cell == 4
+    assert r.snode.offset_bytes_in_parent_cell == 8
 
 
 @ti.test(arch=ti.cpu)

--- a/tests/python/test_snode_layout_inspection.py
+++ b/tests/python/test_snode_layout_inspection.py
@@ -26,7 +26,9 @@ def test_primitives():
 
     assert n1.offset_bytes_in_parent_cell == 0
     assert n2.offset_bytes_in_parent_cell == 2 * 32
-    assert n3.offset_bytes_in_parent_cell in [2 * 32 + 12 * 32, 2 * 32 + 16 * 32]
+    assert n3.offset_bytes_in_parent_cell in [
+        2 * 32 + 12 * 32, 2 * 32 + 16 * 32
+    ]
 
     assert x.snode.offset_bytes_in_parent_cell == 0
     assert y.snode.offset_bytes_in_parent_cell == 0


### PR DESCRIPTION
Related issue = #2590

Exposing `offset_bytes_in_parent_cell` of a `SNode` is a prerequisite for analyzing memory layouts of different SNodes, which can further unblock the algorithm design of turning dynamic indexing of vector/matrix fields into the form of `pointer + offset`.

For now the functionality is only added in the LLVM backend.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
