### PR TITLE
[Bug] [opengl] Modify the implementation of norm_sqr()

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -628,7 +628,7 @@ class Matrix(TaichiOperations):
     @kern_mod.pyfunc
     def norm_sqr(self):
         """Return the sum of the absolute squares of its elements."""
-        return (self**2).sum()
+        return (self * self).sum()
 
     @kern_mod.pyfunc
     def max(self):

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -42,7 +42,7 @@ def test_basic_utils():
 
     @ti.kernel
     def init():
-        a[None] = ti.Vector([1.0, 2.0, 3.0])
+        a[None] = ti.Vector([1.0, 2.0, -3.0])
         b[None] = ti.Vector([4.0, 5.0])
         abT[None] = a[None].outer_product(b[None])
 
@@ -65,7 +65,7 @@ def test_basic_utils():
     assert normA[None] == approx(sqrt14)
     assert aNormalized[None][0] == approx(1.0 * invSqrt14)
     assert aNormalized[None][1] == approx(2.0 * invSqrt14)
-    assert aNormalized[None][2] == approx(3.0 * invSqrt14)
+    assert aNormalized[None][2] == approx(-3.0 * invSqrt14)
 
 
 @ti.test()


### PR DESCRIPTION
Related issue = fixes #3796

The phenomenon in #3796 appears after #3517. However, #3517 is not the root cause - after #3517, since the initial IR of that example changes, the optimization of `pow` in CHI IR goes into a different path and lets the OpenGL backend to calculate the result, which exposes a bug which already exists.

Let's look at a code snippet:
```py
import taichi as ti

ti.init(ti.opengl)

@ti.kernel
def test(a: ti.f32, b: ti.f32) -> ti.f32:
    return a ** b

print(test(-1.0, 2.0))
```
It will give `nan` as the result because in OpenGL `pow(x, y)` has undefined behavior when `x < 0` (https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/pow.xhtml). Therefore, we should avoid doing such calculation.

In that example, `pow()` comes from `norm_sqr()` of the `Matrix` class. To fix the problem, I replace `pow(x, 2)` with `x * x` in this PR.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
