### PR TITLE
[misc] Slient & non-blocking version check

### DIFF
--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -141,6 +141,7 @@ def require_version(major, minor=None, patch=None):
 
 at_startup()
 
+
 def compare_version(latest, current):
     latest_num = map(int, latest.split('.'))
     current_num = map(int, current.split('.'))
@@ -152,6 +153,7 @@ def compare_version(latest, current):
         else:
             continue
     return False
+
 
 def _print_taichi_header():
     header = '[Taichi] '

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -153,11 +153,11 @@ def _print_taichi_header():
     header += f'version {ti_core.get_version_string()}, '
 
     try:
-        version_path = os.path.join(ti_core.get_repo_dir(), 'latest_version')
-        if os.path.exists(version_path):
+        timestamp_path = os.path.join(ti_core.get_repo_dir(), 'timestamp')
+        if os.path.exists(timestamp_path):
             latest_version = ''
-            with open(version_path, 'r') as f:
-                latest_version = f.readlines()[0].rstrip()
+            with open(timestamp_path, 'r') as f:
+                latest_version = f.readlines()[1].rstrip()
             if compare_version(latest_version, ti_core.get_version_string()):
                 header += f'latest version {latest_version}, '
     except:

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -148,10 +148,9 @@ def compare_version(latest, current):
     for x, y in zip(latest_num, current_num):
         if x > y:
             return True
-        elif x < y:
+        if x < y:
             return False
-        else:
-            continue
+        continue
     return False
 
 

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -154,7 +154,7 @@ def _print_taichi_header():
                 latest_version = f.readlines()[0].rstrip()
             if latest_version > ti_core.get_version_string():
                 header += f'latest version {latest_version}, '
-    except Exception as error:
+    except Exception:
         pass
 
     llvm_version = ti_core.get_llvm_version_string()

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -141,6 +141,17 @@ def require_version(major, minor=None, patch=None):
 
 at_startup()
 
+def compare_version(latest, current):
+    latest_num = map(int, latest.split('.'))
+    current_num = map(int, current.split('.'))
+    for x, y in zip(latest_num, current_num):
+        if x > y:
+            return True
+        elif x < y:
+            return False
+        else:
+            continue
+    return False
 
 def _print_taichi_header():
     header = '[Taichi] '
@@ -152,7 +163,7 @@ def _print_taichi_header():
             latest_version = ''
             with open(version_path, 'r') as f:
                 latest_version = f.readlines()[0].rstrip()
-            if latest_version > ti_core.get_version_string():
+            if compare_version(latest_version, ti_core.get_version_string()):
                 header += f'latest version {latest_version}, '
     except Exception:
         pass

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -166,7 +166,7 @@ def _print_taichi_header():
                 latest_version = f.readlines()[0].rstrip()
             if compare_version(latest_version, ti_core.get_version_string()):
                 header += f'latest version {latest_version}, '
-    except Exception:
+    except:
         pass
 
     llvm_version = ti_core.get_llvm_version_string()

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -146,6 +146,17 @@ def _print_taichi_header():
     header = '[Taichi] '
     header += f'version {ti_core.get_version_string()}, '
 
+    try:
+        version_path = os.path.join(ti_core.get_repo_dir(), 'latest_version')
+        if os.path.exists(version_path):
+            latest_version = ''
+            with open(version_path, 'r') as f:
+                latest_version = f.readlines()[0].rstrip()
+            if latest_version > ti_core.get_version_string():
+                header += f'latest version {latest_version}, '
+    except Exception as error:
+        pass
+
     llvm_version = ti_core.get_llvm_version_string()
     header += f'llvm {llvm_version}, '
 

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -145,13 +145,7 @@ at_startup()
 def compare_version(latest, current):
     latest_num = map(int, latest.split('.'))
     current_num = map(int, current.split('.'))
-    for x, y in zip(latest_num, current_num):
-        if x > y:
-            return True
-        if x < y:
-            return False
-        continue
-    return False
+    return tuple(latest_num) > tuple(current_num)
 
 
 def _print_taichi_header():

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -460,7 +460,6 @@ def check_version():
                                             'latest_version')
                 with open(version_path, 'w') as f:
                     f.write(response['latest_version'])
-                    f.truncate()
     except Exception:
         pass
 
@@ -479,7 +478,6 @@ def try_check_version():
                 with open(timestamp_path, 'w') as f:
                     f.write((cur_date +
                              datetime.timedelta(days=7)).strftime('%Y-%m-%d'))
-                    f.truncate()
         else:
             check_version()
             with open(timestamp_path, 'w') as f:

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -460,7 +460,7 @@ def check_version():
                                             'latest_version')
                 with open(version_path, 'w') as f:
                     f.write(response['latest_version'])
-    except Exception:
+    except:
         pass
 
 
@@ -484,7 +484,7 @@ def try_check_version():
                 f.write((cur_date +
                          datetime.timedelta(days=7)).strftime('%Y-%m-%d'))
     # Wildcard exception to catch potential file writing errors.
-    except Exception:
+    except:
         pass
 
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -461,7 +461,7 @@ def check_version():
                 with open(version_path, 'w') as f:
                     f.write(response['latest_version'])
                     f.truncate()
-    except Exception as error:
+    except Exception:
         pass
 
 
@@ -486,7 +486,7 @@ def try_check_version():
                 f.write((cur_date +
                          datetime.timedelta(days=7)).strftime('%Y-%m-%d'))
     # Wildcard exception to catch potential file writing errors.
-    except Exception as error:
+    except Exception:
         pass
 
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -471,7 +471,7 @@ def try_check_version():
                 last_time = f.readlines()[0].rstrip()
             if cur_date.strftime('%Y-%m-%d') > last_time:
                 response = check_version()
-                if response == None:
+                if response is None:
                     return
                 with open(timestamp_path, 'w') as f:
                     f.write((cur_date +
@@ -483,7 +483,7 @@ def try_check_version():
                         f.write('0.0.0')
         else:
             response = check_version()
-            if response == None:
+            if response is None:
                 return
             with open(timestamp_path, 'w') as f:
                 f.write((cur_date +

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -6,8 +6,8 @@ import os
 import platform
 import shutil
 import tempfile
-import time
 import threading
+import time
 from contextlib import contextmanager
 from copy import deepcopy as _deepcopy
 from urllib import request
@@ -456,7 +456,8 @@ def check_version():
         with request.urlopen(req, data=payload, timeout=5) as response:
             response = json.loads(response.read().decode('utf-8'))
             if response['status'] == 1:
-                version_path = os.path.join(_ti_core.get_repo_dir(), 'latest_version')
+                version_path = os.path.join(_ti_core.get_repo_dir(),
+                                            'latest_version')
                 with open(version_path, 'w') as f:
                     f.write(response['latest_version'])
                     f.truncate()
@@ -519,7 +520,8 @@ def init(arch=None,
     skip = os.environ.get("TI_SKIP_VERSION_CHECK")
     if skip != 'ON':
         # We don't join this thread because we do not wish to block the user.
-        check_version_thread = threading.Thread(target=try_check_version, daemon=True)
+        check_version_thread = threading.Thread(target=try_check_version,
+                                                daemon=True)
         check_version_thread.start()
 
     # Make a deepcopy in case these args reference to items from ti.cfg, which are

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -437,13 +437,13 @@ def check_version():
             payload['platform'] = 'macosx_11_0_arm64'
 
     python_version = platform.python_version()
-    if python_version.startswith('3.6'):
+    if python_version.startswith('3.6.'):
         payload['python'] = 'cp36'
-    elif python_version.startswith('3.7'):
+    elif python_version.startswith('3.7.'):
         payload['python'] = 'cp37'
-    elif python_version.startswith('3.8'):
+    elif python_version.startswith('3.8.'):
         payload['python'] = 'cp38'
-    elif python_version.startswith('3.9'):
+    elif python_version.startswith('3.9.'):
         payload['python'] = 'cp39'
 
     # We do not want request exceptions break users' usage of Taichi.


### PR DESCRIPTION
Now version check runs silently per 7 days. Nothing will be printed in terminal.
If user's version is outdated, a latest_version file will be written to ~/.taichi and the latest version will be recorded.
After that, no more version check in 7 days. When user use Taichi again, if the current version is lower than the version recorded in the file, the latest version will be printed with the Taichi header. For example:
`[Taichi] version 0.8.7, latest version 0.9.0, llvm 10.0.0, commit abcdef, linux, python 3.8.10`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
