### PR TITLE
[refactor] Remove import taichi in common_ops.py

### DIFF
--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -44,7 +44,8 @@ from taichi.lang.ndrange import GroupedNDRange, ndrange
 from taichi.lang.ops import *  # pylint: disable=W0622
 from taichi.lang.quant_impl import quant
 from taichi.lang.runtime_ops import async_flush, sync
-from taichi.lang.snode import SNode
+from taichi.lang.snode import (SNode, activate, append, deactivate, get_addr,
+                               is_active, length, rescale_index)
 from taichi.lang.source_builder import SourceBuilder
 from taichi.lang.struct import Struct, StructField
 from taichi.lang.tape import TapeImpl

--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -1,4 +1,4 @@
-import taichi.lang.ops as ti_ops
+from taichi.lang import ops as ti_ops
 
 
 class TaichiOperations:

--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -1,135 +1,135 @@
-import taichi as ti
+import taichi.lang.ops as ti_ops
 
 
 class TaichiOperations:
     """The base class of taichi operations of expressions. Subclasses: :class:`~taichi.lang.expr.Expr`, :class:`~taichi.lang.matrix.Matrix`"""
     def __neg__(self):
         _taichi_skip_traceback = 1
-        return ti.neg(self)
+        return ti_ops.neg(self)
 
     def __abs__(self):
         _taichi_skip_traceback = 1
-        return ti.abs(self)
+        return ti_ops.abs(self)
 
     def __add__(self, other):
         _taichi_skip_traceback = 1
-        return ti.add(self, other)
+        return ti_ops.add(self, other)
 
     def __radd__(self, other):
         _taichi_skip_traceback = 1
-        return ti.add(other, self)
+        return ti_ops.add(other, self)
 
     def __sub__(self, other):
         _taichi_skip_traceback = 1
-        return ti.sub(self, other)
+        return ti_ops.sub(self, other)
 
     def __rsub__(self, other):
         _taichi_skip_traceback = 1
-        return ti.sub(other, self)
+        return ti_ops.sub(other, self)
 
     def __mul__(self, other):
         _taichi_skip_traceback = 1
-        return ti.mul(self, other)
+        return ti_ops.mul(self, other)
 
     def __rmul__(self, other):
         _taichi_skip_traceback = 1
-        return ti.mul(other, self)
+        return ti_ops.mul(other, self)
 
     def __truediv__(self, other):
         _taichi_skip_traceback = 1
-        return ti.truediv(self, other)
+        return ti_ops.truediv(self, other)
 
     def __rtruediv__(self, other):
         _taichi_skip_traceback = 1
-        return ti.truediv(other, self)
+        return ti_ops.truediv(other, self)
 
     def __floordiv__(self, other):
         _taichi_skip_traceback = 1
-        return ti.floordiv(self, other)
+        return ti_ops.floordiv(self, other)
 
     def __rfloordiv__(self, other):
         _taichi_skip_traceback = 1
-        return ti.floordiv(other, self)
+        return ti_ops.floordiv(other, self)
 
     def __mod__(self, other):
         _taichi_skip_traceback = 1
-        return ti.mod(self, other)
+        return ti_ops.mod(self, other)
 
     def __rmod__(self, other):
         _taichi_skip_traceback = 1
-        return ti.mod(other, self)
+        return ti_ops.mod(other, self)
 
     def __pow__(self, other, modulo=None):
         _taichi_skip_traceback = 1
-        return ti.pow(self, other)
+        return ti_ops.pow(self, other)
 
     def __rpow__(self, other, modulo=None):
         _taichi_skip_traceback = 1
-        return ti.pow(other, self)
+        return ti_ops.pow(other, self)
 
     def __le__(self, other):
         _taichi_skip_traceback = 1
-        return ti.cmp_le(self, other)
+        return ti_ops.cmp_le(self, other)
 
     def __lt__(self, other):
         _taichi_skip_traceback = 1
-        return ti.cmp_lt(self, other)
+        return ti_ops.cmp_lt(self, other)
 
     def __ge__(self, other):
         _taichi_skip_traceback = 1
-        return ti.cmp_ge(self, other)
+        return ti_ops.cmp_ge(self, other)
 
     def __gt__(self, other):
         _taichi_skip_traceback = 1
-        return ti.cmp_gt(self, other)
+        return ti_ops.cmp_gt(self, other)
 
     def __eq__(self, other):
         _taichi_skip_traceback = 1
-        return ti.cmp_eq(self, other)
+        return ti_ops.cmp_eq(self, other)
 
     def __ne__(self, other):
         _taichi_skip_traceback = 1
-        return ti.cmp_ne(self, other)
+        return ti_ops.cmp_ne(self, other)
 
     def __and__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_and(self, other)
+        return ti_ops.bit_and(self, other)
 
     def __rand__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_and(other, self)
+        return ti_ops.bit_and(other, self)
 
     def __or__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_or(self, other)
+        return ti_ops.bit_or(self, other)
 
     def __ror__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_or(other, self)
+        return ti_ops.bit_or(other, self)
 
     def __xor__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_xor(self, other)
+        return ti_ops.bit_xor(self, other)
 
     def __rxor__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_xor(other, self)
+        return ti_ops.bit_xor(other, self)
 
     def __lshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_shl(self, other)
+        return ti_ops.bit_shl(self, other)
 
     def __rlshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_shl(other, self)
+        return ti_ops.bit_shl(other, self)
 
     def __rshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_sar(self, other)
+        return ti_ops.bit_sar(self, other)
 
     def __rrshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti.bit_sar(other, self)
+        return ti_ops.bit_sar(other, self)
 
     def logical_and(self, other):
         """Return the new expression of computing logical and between self and a given operand.
@@ -140,7 +140,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of logical and."""
         _taichi_skip_traceback = 1
-        return ti.logical_and(self, other)
+        return ti_ops.logical_and(self, other)
 
     def logical_or(self, other):
         """Return the new expression of computing logical or between self and a given operand.
@@ -151,15 +151,15 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of logical or."""
         _taichi_skip_traceback = 1
-        return ti.logical_or(self, other)
+        return ti_ops.logical_or(self, other)
 
     def __invert__(self):  # ~a => a.__invert__()
         _taichi_skip_traceback = 1
-        return ti.bit_not(self)
+        return ti_ops.bit_not(self)
 
     def __not__(self):  # not a => a.__not__()
         _taichi_skip_traceback = 1
-        return ti.logical_not(self)
+        return ti_ops.logical_not(self)
 
     def atomic_add(self, other):
         """Return the new expression of computing atomic add between self and a given operand.
@@ -170,7 +170,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic add."""
         _taichi_skip_traceback = 1
-        return ti.atomic_add(self, other)
+        return ti_ops.atomic_add(self, other)
 
     def atomic_sub(self, other):
         """Return the new expression of computing atomic sub between self and a given operand.
@@ -181,7 +181,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic sub."""
         _taichi_skip_traceback = 1
-        return ti.atomic_sub(self, other)
+        return ti_ops.atomic_sub(self, other)
 
     def atomic_and(self, other):
         """Return the new expression of computing atomic and between self and a given operand.
@@ -192,7 +192,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic and."""
         _taichi_skip_traceback = 1
-        return ti.atomic_and(self, other)
+        return ti_ops.atomic_and(self, other)
 
     def atomic_xor(self, other):
         """Return the new expression of computing atomic xor between self and a given operand.
@@ -203,7 +203,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic xor."""
         _taichi_skip_traceback = 1
-        return ti.atomic_xor(self, other)
+        return ti_ops.atomic_xor(self, other)
 
     def atomic_or(self, other):
         """Return the new expression of computing atomic or between self and a given operand.
@@ -214,7 +214,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic or."""
         _taichi_skip_traceback = 1
-        return ti.atomic_or(self, other)
+        return ti_ops.atomic_or(self, other)
 
     def __iadd__(self, other):
         _taichi_skip_traceback = 1
@@ -244,37 +244,37 @@ class TaichiOperations:
     # we don't support atomic_mul/truediv/floordiv/mod yet:
     def __imul__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti.mul(self, other))
+        self.assign(ti_ops.mul(self, other))
         return self
 
     def __itruediv__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti.truediv(self, other))
+        self.assign(ti_ops.truediv(self, other))
         return self
 
     def __ifloordiv__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti.floordiv(self, other))
+        self.assign(ti_ops.floordiv(self, other))
         return self
 
     def __imod__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti.mod(self, other))
+        self.assign(ti_ops.mod(self, other))
         return self
 
     def __ilshift__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti.bit_shl(self, other))
+        self.assign(ti_ops.bit_shl(self, other))
         return self
 
     def __irshift__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti.bit_shr(self, other))
+        self.assign(ti_ops.bit_shr(self, other))
         return self
 
     def __ipow__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti.pow(self, other))
+        self.assign(ti_ops.pow(self, other))
         return self
 
     def assign(self, other):
@@ -286,7 +286,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The expression after assigning."""
         _taichi_skip_traceback = 1
-        return ti.assign(self, other)
+        return ti_ops.assign(self, other)
 
     # pylint: disable=R0201
     def augassign(self, x, op):
@@ -325,8 +325,8 @@ class TaichiOperations:
 
     def __ti_int__(self):
         _taichi_skip_traceback = 1
-        return ti.cast(self, int)
+        return ti_ops.cast(self, int)
 
     def __ti_float__(self):
         _taichi_skip_traceback = 1
-        return ti.cast(self, float)
+        return ti_ops.cast(self, float)

--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -1,135 +1,135 @@
-from taichi.lang import ops as ti_ops
+from taichi.lang import ops
 
 
 class TaichiOperations:
     """The base class of taichi operations of expressions. Subclasses: :class:`~taichi.lang.expr.Expr`, :class:`~taichi.lang.matrix.Matrix`"""
     def __neg__(self):
         _taichi_skip_traceback = 1
-        return ti_ops.neg(self)
+        return ops.neg(self)
 
     def __abs__(self):
         _taichi_skip_traceback = 1
-        return ti_ops.abs(self)
+        return ops.abs(self)
 
     def __add__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.add(self, other)
+        return ops.add(self, other)
 
     def __radd__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.add(other, self)
+        return ops.add(other, self)
 
     def __sub__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.sub(self, other)
+        return ops.sub(self, other)
 
     def __rsub__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.sub(other, self)
+        return ops.sub(other, self)
 
     def __mul__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.mul(self, other)
+        return ops.mul(self, other)
 
     def __rmul__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.mul(other, self)
+        return ops.mul(other, self)
 
     def __truediv__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.truediv(self, other)
+        return ops.truediv(self, other)
 
     def __rtruediv__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.truediv(other, self)
+        return ops.truediv(other, self)
 
     def __floordiv__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.floordiv(self, other)
+        return ops.floordiv(self, other)
 
     def __rfloordiv__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.floordiv(other, self)
+        return ops.floordiv(other, self)
 
     def __mod__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.mod(self, other)
+        return ops.mod(self, other)
 
     def __rmod__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.mod(other, self)
+        return ops.mod(other, self)
 
     def __pow__(self, other, modulo=None):
         _taichi_skip_traceback = 1
-        return ti_ops.pow(self, other)
+        return ops.pow(self, other)
 
     def __rpow__(self, other, modulo=None):
         _taichi_skip_traceback = 1
-        return ti_ops.pow(other, self)
+        return ops.pow(other, self)
 
     def __le__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.cmp_le(self, other)
+        return ops.cmp_le(self, other)
 
     def __lt__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.cmp_lt(self, other)
+        return ops.cmp_lt(self, other)
 
     def __ge__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.cmp_ge(self, other)
+        return ops.cmp_ge(self, other)
 
     def __gt__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.cmp_gt(self, other)
+        return ops.cmp_gt(self, other)
 
     def __eq__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.cmp_eq(self, other)
+        return ops.cmp_eq(self, other)
 
     def __ne__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.cmp_ne(self, other)
+        return ops.cmp_ne(self, other)
 
     def __and__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_and(self, other)
+        return ops.bit_and(self, other)
 
     def __rand__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_and(other, self)
+        return ops.bit_and(other, self)
 
     def __or__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_or(self, other)
+        return ops.bit_or(self, other)
 
     def __ror__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_or(other, self)
+        return ops.bit_or(other, self)
 
     def __xor__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_xor(self, other)
+        return ops.bit_xor(self, other)
 
     def __rxor__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_xor(other, self)
+        return ops.bit_xor(other, self)
 
     def __lshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_shl(self, other)
+        return ops.bit_shl(self, other)
 
     def __rlshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_shl(other, self)
+        return ops.bit_shl(other, self)
 
     def __rshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_sar(self, other)
+        return ops.bit_sar(self, other)
 
     def __rrshift__(self, other):
         _taichi_skip_traceback = 1
-        return ti_ops.bit_sar(other, self)
+        return ops.bit_sar(other, self)
 
     def logical_and(self, other):
         """Return the new expression of computing logical and between self and a given operand.
@@ -140,7 +140,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of logical and."""
         _taichi_skip_traceback = 1
-        return ti_ops.logical_and(self, other)
+        return ops.logical_and(self, other)
 
     def logical_or(self, other):
         """Return the new expression of computing logical or between self and a given operand.
@@ -151,15 +151,15 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of logical or."""
         _taichi_skip_traceback = 1
-        return ti_ops.logical_or(self, other)
+        return ops.logical_or(self, other)
 
     def __invert__(self):  # ~a => a.__invert__()
         _taichi_skip_traceback = 1
-        return ti_ops.bit_not(self)
+        return ops.bit_not(self)
 
     def __not__(self):  # not a => a.__not__()
         _taichi_skip_traceback = 1
-        return ti_ops.logical_not(self)
+        return ops.logical_not(self)
 
     def atomic_add(self, other):
         """Return the new expression of computing atomic add between self and a given operand.
@@ -170,7 +170,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic add."""
         _taichi_skip_traceback = 1
-        return ti_ops.atomic_add(self, other)
+        return ops.atomic_add(self, other)
 
     def atomic_sub(self, other):
         """Return the new expression of computing atomic sub between self and a given operand.
@@ -181,7 +181,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic sub."""
         _taichi_skip_traceback = 1
-        return ti_ops.atomic_sub(self, other)
+        return ops.atomic_sub(self, other)
 
     def atomic_and(self, other):
         """Return the new expression of computing atomic and between self and a given operand.
@@ -192,7 +192,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic and."""
         _taichi_skip_traceback = 1
-        return ti_ops.atomic_and(self, other)
+        return ops.atomic_and(self, other)
 
     def atomic_xor(self, other):
         """Return the new expression of computing atomic xor between self and a given operand.
@@ -203,7 +203,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic xor."""
         _taichi_skip_traceback = 1
-        return ti_ops.atomic_xor(self, other)
+        return ops.atomic_xor(self, other)
 
     def atomic_or(self, other):
         """Return the new expression of computing atomic or between self and a given operand.
@@ -214,7 +214,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic or."""
         _taichi_skip_traceback = 1
-        return ti_ops.atomic_or(self, other)
+        return ops.atomic_or(self, other)
 
     def __iadd__(self, other):
         _taichi_skip_traceback = 1
@@ -244,37 +244,37 @@ class TaichiOperations:
     # we don't support atomic_mul/truediv/floordiv/mod yet:
     def __imul__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti_ops.mul(self, other))
+        self.assign(ops.mul(self, other))
         return self
 
     def __itruediv__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti_ops.truediv(self, other))
+        self.assign(ops.truediv(self, other))
         return self
 
     def __ifloordiv__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti_ops.floordiv(self, other))
+        self.assign(ops.floordiv(self, other))
         return self
 
     def __imod__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti_ops.mod(self, other))
+        self.assign(ops.mod(self, other))
         return self
 
     def __ilshift__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti_ops.bit_shl(self, other))
+        self.assign(ops.bit_shl(self, other))
         return self
 
     def __irshift__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti_ops.bit_shr(self, other))
+        self.assign(ops.bit_shr(self, other))
         return self
 
     def __ipow__(self, other):
         _taichi_skip_traceback = 1
-        self.assign(ti_ops.pow(self, other))
+        self.assign(ops.pow(self, other))
         return self
 
     def assign(self, other):
@@ -286,7 +286,7 @@ class TaichiOperations:
         Returns:
             :class:`~taichi.lang.expr.Expr`: The expression after assigning."""
         _taichi_skip_traceback = 1
-        return ti_ops.assign(self, other)
+        return ops.assign(self, other)
 
     # pylint: disable=R0201
     def augassign(self, x, op):
@@ -325,8 +325,8 @@ class TaichiOperations:
 
     def __ti_int__(self):
         _taichi_skip_traceback = 1
-        return ti_ops.cast(self, int)
+        return ops.cast(self, int)
 
     def __ti_float__(self):
         _taichi_skip_traceback = 1
-        return ti_ops.cast(self, float)
+        return ops.cast(self, float)

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -732,13 +732,13 @@ def ti_format(*args, **kwargs):
     new_mixed_kwargs = {}
     args = []
     for x in mixed:
-        if isinstance(x, Expr):
+        if isinstance(x, ti.Expr):
             new_mixed.append('{}')
             args.append(x)
         else:
             new_mixed.append(x)
     for k, v in kwargs.items():
-        if isinstance(v, Expr):
+        if isinstance(v, ti.Expr):
             new_mixed_kwargs[k] = '{}'
             args.append(v)
         else:

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -732,13 +732,13 @@ def ti_format(*args, **kwargs):
     new_mixed_kwargs = {}
     args = []
     for x in mixed:
-        if isinstance(x, ti.Expr):
+        if isinstance(x, Expr):
             new_mixed.append('{}')
             args.append(x)
         else:
             new_mixed.append(x)
     for k, v in kwargs.items():
-        if isinstance(v, ti.Expr):
+        if isinstance(v, Expr):
             new_mixed_kwargs[k] = '{}'
             args.append(v)
         else:

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -5,14 +5,23 @@ import operator as _bt_ops_mod  # bt for builtin
 import traceback
 
 from taichi._lib import core as _ti_core
-from taichi.lang import impl, matrix
+from taichi.lang import impl
 from taichi.lang.exception import TaichiSyntaxError
-from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field
 from taichi.lang.snode import SNode
 from taichi.lang.util import cook_dtype, is_taichi_class, taichi_scope
 
 unary_ops = []
+
+
+def Expr(*args, **kw):
+    from taichi.lang.expr import Expr as ti_Expr  # pylint: disable=C0415
+    return ti_Expr(*args, **kw)
+
+
+def make_expr_group(*args):
+    from taichi.lang.expr import make_expr_group as ti_make_expr_group  # pylint: disable=C0415
+    return ti_make_expr_group(*args)
 
 
 def stack_info():
@@ -27,7 +36,8 @@ def stack_info():
 
 
 def is_taichi_expr(a):
-    return isinstance(a, Expr)
+    from taichi.lang.expr import Expr as ti_Expr  # pylint: disable=C0415
+    return isinstance(a, ti_Expr)
 
 
 def wrap_if_not_expr(a):
@@ -922,6 +932,7 @@ def rescale_index(a, b, I):
         rescaled grouped loop index
 
     """
+    import taichi.lang.matrix as matrix
     assert isinstance(
         a, (Field, SNode)), "The first argument must be a field or an SNode"
     assert isinstance(

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -933,7 +933,7 @@ def rescale_index(a, b, I):
         rescaled grouped loop index
 
     """
-    import taichi.lang.matrix as matrix
+    from taichi.lang import matrix  # pylint: disable=C0415
     assert isinstance(
         a, (Field, SNode)), "The first argument must be a field or an SNode"
     assert isinstance(

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -5,24 +5,11 @@ import operator as _bt_ops_mod  # bt for builtin
 import traceback
 
 from taichi._lib import core as _ti_core
-from taichi.lang import impl
+from taichi.lang import expr, impl
 from taichi.lang.exception import TaichiSyntaxError
-from taichi.lang.field import Field
-from taichi.lang.snode import SNode
 from taichi.lang.util import cook_dtype, is_taichi_class, taichi_scope
 
 unary_ops = []
-
-
-def Expr(*args, **kw):
-    from taichi.lang.expr import Expr as ti_Expr  # pylint: disable=C0415
-    return ti_Expr(*args, **kw)
-
-
-def make_expr_group(*args):
-    from taichi.lang.expr import \
-        make_expr_group as ti_make_expr_group  # pylint: disable=C0415
-    return ti_make_expr_group(*args)
 
 
 def stack_info():
@@ -37,13 +24,12 @@ def stack_info():
 
 
 def is_taichi_expr(a):
-    from taichi.lang.expr import Expr as ti_Expr  # pylint: disable=C0415
-    return isinstance(a, ti_Expr)
+    return isinstance(a, expr.Expr)
 
 
 def wrap_if_not_expr(a):
     _taichi_skip_traceback = 1
-    return Expr(a) if not is_taichi_expr(a) else a
+    return expr.Expr(a) if not is_taichi_expr(a) else a
 
 
 def unary(foo):
@@ -153,7 +139,7 @@ def cast(obj, dtype):
     if is_taichi_class(obj):
         # TODO: unify with element_wise_unary
         return obj.cast(dtype)
-    return Expr(_ti_core.value_cast(Expr(obj).ptr, dtype))
+    return expr.Expr(_ti_core.value_cast(expr.Expr(obj).ptr, dtype))
 
 
 def bit_cast(obj, dtype):
@@ -162,13 +148,13 @@ def bit_cast(obj, dtype):
     if is_taichi_class(obj):
         raise ValueError('Cannot apply bit_cast on Taichi classes')
     else:
-        return Expr(_ti_core.bits_cast(Expr(obj).ptr, dtype))
+        return expr.Expr(_ti_core.bits_cast(expr.Expr(obj).ptr, dtype))
 
 
 def _unary_operation(taichi_op, python_op, a):
     _taichi_skip_traceback = 1
     if is_taichi_expr(a):
-        return Expr(taichi_op(a.ptr), tb=stack_info())
+        return expr.Expr(taichi_op(a.ptr), tb=stack_info())
     return python_op(a)
 
 
@@ -176,7 +162,7 @@ def _binary_operation(taichi_op, python_op, a, b):
     _taichi_skip_traceback = 1
     if is_taichi_expr(a) or is_taichi_expr(b):
         a, b = wrap_if_not_expr(a), wrap_if_not_expr(b)
-        return Expr(taichi_op(a.ptr, b.ptr), tb=stack_info())
+        return expr.Expr(taichi_op(a.ptr, b.ptr), tb=stack_info())
     return python_op(a, b)
 
 
@@ -184,7 +170,7 @@ def _ternary_operation(taichi_op, python_op, a, b, c):
     _taichi_skip_traceback = 1
     if is_taichi_expr(a) or is_taichi_expr(b) or is_taichi_expr(c):
         a, b, c = wrap_if_not_expr(a), wrap_if_not_expr(b), wrap_if_not_expr(c)
-        return Expr(taichi_op(a.ptr, b.ptr, c.ptr), tb=stack_info())
+        return expr.Expr(taichi_op(a.ptr, b.ptr, c.ptr), tb=stack_info())
     return python_op(a, b, c)
 
 
@@ -422,7 +408,7 @@ def random(dtype=float):
         A random variable whose type is `dtype`.
     """
     dtype = cook_dtype(dtype)
-    x = Expr(_ti_core.make_rand_expr(dtype))
+    x = expr.Expr(_ti_core.make_rand_expr(dtype))
     return impl.expr_init(x)
 
 
@@ -484,8 +470,8 @@ def mod(a, b):
     """
     def expr_python_mod(a, b):
         # a % b = a - (a // b) * b
-        quotient = Expr(_ti_core.expr_floordiv(a, b))
-        multiply = Expr(_ti_core.expr_mul(b, quotient.ptr))
+        quotient = expr.Expr(_ti_core.expr_floordiv(a, b))
+        multiply = expr.Expr(_ti_core.expr_mul(b, quotient.ptr))
         return _ti_core.expr_sub(a, multiply.ptr)
 
     return _binary_operation(expr_python_mod, _bt_ops_mod.mod, a, b)
@@ -818,43 +804,43 @@ def select(cond, a, b):
 @writeback_binary
 def atomic_add(a, b):
     return impl.expr_init(
-        Expr(_ti_core.expr_atomic_add(a.ptr, b.ptr), tb=stack_info()))
+        expr.Expr(_ti_core.expr_atomic_add(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_sub(a, b):
     return impl.expr_init(
-        Expr(_ti_core.expr_atomic_sub(a.ptr, b.ptr), tb=stack_info()))
+        expr.Expr(_ti_core.expr_atomic_sub(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_min(a, b):
     return impl.expr_init(
-        Expr(_ti_core.expr_atomic_min(a.ptr, b.ptr), tb=stack_info()))
+        expr.Expr(_ti_core.expr_atomic_min(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_max(a, b):
     return impl.expr_init(
-        Expr(_ti_core.expr_atomic_max(a.ptr, b.ptr), tb=stack_info()))
+        expr.Expr(_ti_core.expr_atomic_max(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_and(a, b):
     return impl.expr_init(
-        Expr(_ti_core.expr_atomic_bit_and(a.ptr, b.ptr), tb=stack_info()))
+        expr.Expr(_ti_core.expr_atomic_bit_and(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_or(a, b):
     return impl.expr_init(
-        Expr(_ti_core.expr_atomic_bit_or(a.ptr, b.ptr), tb=stack_info()))
+        expr.Expr(_ti_core.expr_atomic_bit_or(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
 def atomic_xor(a, b):
     return impl.expr_init(
-        Expr(_ti_core.expr_atomic_bit_xor(a.ptr, b.ptr), tb=stack_info()))
+        expr.Expr(_ti_core.expr_atomic_bit_xor(a.ptr, b.ptr), tb=stack_info()))
 
 
 @writeback_binary
@@ -889,81 +875,3 @@ def ti_any(a):
 
 def ti_all(a):
     return a.all()
-
-
-def append(l, indices, val):
-    a = impl.expr_init(
-        _ti_core.insert_append(l.snode.ptr, make_expr_group(indices),
-                               Expr(val).ptr))
-    return a
-
-
-def is_active(l, indices):
-    return Expr(
-        _ti_core.insert_is_active(l.snode.ptr, make_expr_group(indices)))
-
-
-def activate(l, indices):
-    _ti_core.insert_activate(l.snode.ptr, make_expr_group(indices))
-
-
-def deactivate(l, indices):
-    _ti_core.insert_deactivate(l.snode.ptr, make_expr_group(indices))
-
-
-def length(l, indices):
-    return Expr(_ti_core.insert_len(l.snode.ptr, make_expr_group(indices)))
-
-
-def rescale_index(a, b, I):
-    """Rescales the index 'I' of field (or SNode) 'a' to match the shape of SNode 'b'
-
-    Parameters
-    ----------
-    a: ti.field(), ti.Vector.field, ti.Matrix.field()
-        input taichi field or snode
-    b: ti.field(), ti.Vector.field, ti.Matrix.field()
-        output taichi field or snode
-    I: ti.Vector()
-        grouped loop index
-
-    Returns
-    -------
-    Ib: ti.Vector()
-        rescaled grouped loop index
-
-    """
-    from taichi.lang import matrix  # pylint: disable=C0415
-    assert isinstance(
-        a, (Field, SNode)), "The first argument must be a field or an SNode"
-    assert isinstance(
-        b, (Field, SNode)), "The second argument must be a field or an SNode"
-    if isinstance(I, list):
-        I = matrix.Vector(I)
-    else:
-        assert isinstance(
-            I, matrix.Matrix
-        ), "The third argument must be an index (list or ti.Vector)"
-    entries = [I(i) for i in range(I.n)]
-    for n in range(min(I.n, min(len(a.shape), len(b.shape)))):
-        if a.shape[n] > b.shape[n]:
-            entries[n] = I(n) // (a.shape[n] // b.shape[n])
-        if a.shape[n] < b.shape[n]:
-            entries[n] = I(n) * (b.shape[n] // a.shape[n])
-    return matrix.Vector(entries)
-
-
-def get_addr(f, indices):
-    """Query the memory address (on CUDA/x64) of field `f` at index `indices`.
-
-    Currently, this function can only be called inside a taichi kernel.
-
-    Args:
-        f (Union[ti.field, ti.Vector.field, ti.Matrix.field]): Input taichi field for memory address query.
-        indices (Union[int, ti.Vector()]): The specified field indices of the query.
-
-    Returns:
-        ti.u64:  The memory address of `f[indices]`.
-
-    """
-    return Expr(_ti_core.expr_get_addr(f.snode.ptr, make_expr_group(indices)))

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -20,7 +20,8 @@ def Expr(*args, **kw):
 
 
 def make_expr_group(*args):
-    from taichi.lang.expr import make_expr_group as ti_make_expr_group  # pylint: disable=C0415
+    from taichi.lang.expr import \
+        make_expr_group as ti_make_expr_group  # pylint: disable=C0415
     return ti_make_expr_group(*args)
 
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -6,7 +6,7 @@ import numbers
 # access to it.
 import taichi.lang
 from taichi._lib import core as _ti_core
-from taichi.lang import impl
+from taichi.lang import expr, impl, matrix
 from taichi.lang.field import Field
 
 
@@ -325,3 +325,82 @@ class SNode:
             if physical != -1:
                 ret[virtual] = physical
         return ret
+
+
+def rescale_index(a, b, I):
+    """Rescales the index 'I' of field (or SNode) 'a' to match the shape of SNode 'b'
+
+    Parameters
+    ----------
+    a: ti.field(), ti.Vector.field, ti.Matrix.field()
+        input taichi field or snode
+    b: ti.field(), ti.Vector.field, ti.Matrix.field()
+        output taichi field or snode
+    I: ti.Vector()
+        grouped loop index
+
+    Returns
+    -------
+    Ib: ti.Vector()
+        rescaled grouped loop index
+
+    """
+    assert isinstance(
+        a, (Field, SNode)), "The first argument must be a field or an SNode"
+    assert isinstance(
+        b, (Field, SNode)), "The second argument must be a field or an SNode"
+    if isinstance(I, list):
+        I = matrix.Vector(I)
+    else:
+        assert isinstance(
+            I, matrix.Matrix
+        ), "The third argument must be an index (list or ti.Vector)"
+    entries = [I(i) for i in range(I.n)]
+    for n in range(min(I.n, min(len(a.shape), len(b.shape)))):
+        if a.shape[n] > b.shape[n]:
+            entries[n] = I(n) // (a.shape[n] // b.shape[n])
+        if a.shape[n] < b.shape[n]:
+            entries[n] = I(n) * (b.shape[n] // a.shape[n])
+    return matrix.Vector(entries)
+
+
+def append(l, indices, val):
+    a = impl.expr_init(
+        _ti_core.insert_append(l.snode.ptr, expr.make_expr_group(indices),
+                               expr.Expr(val).ptr))
+    return a
+
+
+def is_active(l, indices):
+    return expr.Expr(
+        _ti_core.insert_is_active(l.snode.ptr, expr.make_expr_group(indices)))
+
+
+def activate(l, indices):
+    _ti_core.insert_activate(l.snode.ptr, expr.make_expr_group(indices))
+
+
+def deactivate(l, indices):
+    _ti_core.insert_deactivate(l.snode.ptr, expr.make_expr_group(indices))
+
+
+def length(l, indices):
+    return expr.Expr(
+        _ti_core.insert_len(l.snode.ptr, expr.make_expr_group(indices)))
+
+
+def get_addr(f, indices):
+    """Query the memory address (on CUDA/x64) of field `f` at index `indices`.
+
+    Currently, this function can only be called inside a taichi kernel.
+
+    Args:
+        f (Union[ti.field, ti.Vector.field, ti.Matrix.field]): Input taichi field for memory address query.
+        indices (Union[int, ti.Vector()]): The specified field indices of the query.
+
+    Returns:
+        ti.u64:  The memory address of `f[indices]`.
+
+    """
+    return expr.Expr(
+        _ti_core.expr_get_addr(f.snode.ptr, expr.make_expr_group(indices)))


### PR DESCRIPTION
Related issue = #3782 

In `ops.py`, a snode-related function introduced the dependence of `Matrix` to the file, which caused circular import. So, I moved the snode-related functions to `snode.py`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
