### PR TITLE
[lang] Fix ndarray cuda dealloc when using preallocated memory

### DIFF
--- a/taichi/backends/cuda/cuda_device.cpp
+++ b/taichi/backends/cuda/cuda_device.cpp
@@ -23,6 +23,7 @@ DeviceAllocation CudaDevice::allocate_memory(const AllocParams &params) {
   info.size = params.size;
   info.is_imported = false;
   info.use_cached = false;
+  info.use_preallocated = false;
 
   DeviceAllocation alloc;
   alloc.alloc_id = allocations_.size();
@@ -48,6 +49,7 @@ DeviceAllocation CudaDevice::allocate_memory_runtime(
   info.size = taichi::iroundup(params.size, taichi_page_size);
   info.is_imported = false;
   info.use_cached = params.use_cached;
+  info.use_preallocated = true;
 
   DeviceAllocation alloc;
   alloc.alloc_id = allocations_.size();
@@ -69,7 +71,7 @@ void CudaDevice::dealloc_memory(DeviceAllocation handle) {
       TI_ERROR("the CudaCachingAllocator is not initialized");
     }
     caching_allocator_->release(info.size, (uint64_t *)info.ptr);
-  } else {
+  } else if (!info.use_preallocated) {
     CUDADriver::get_instance().mem_free(info.ptr);
     info.ptr = nullptr;
   }

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -82,13 +82,13 @@ class CudaDevice : public Device {
     size_t size{0};
     bool is_imported{false};
     /* Note: Memory allocation in CUDA device.
-     * CudaDevice can use either its own cuda malloc mechanism via 
-     * `allocate_memory` or the preallocated memory managed by Llvmprogramimpl 
-     * via `allocate_memory_runtime`. The `use_preallocated` is used to track 
-     * this option. For now, we keep both options and the preallocated method is 
-     * used by default for CUDA backend. The `use_cached` is to enable/disable 
-     * the caching behavior in `allocate_memory_runtime`. Later it should be 
-     * always enabled, for now we keep both options to allow a scenario when 
+     * CudaDevice can use either its own cuda malloc mechanism via
+     * `allocate_memory` or the preallocated memory managed by Llvmprogramimpl
+     * via `allocate_memory_runtime`. The `use_preallocated` is used to track
+     * this option. For now, we keep both options and the preallocated method is
+     * used by default for CUDA backend. The `use_cached` is to enable/disable
+     * the caching behavior in `allocate_memory_runtime`. Later it should be
+     * always enabled, for now we keep both options to allow a scenario when
      * using preallocated memory while disabling the caching behavior.
      * */
     bool use_preallocated{true};

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -82,6 +82,7 @@ class CudaDevice : public Device {
     size_t size{0};
     bool is_imported{false};
     bool use_cached{false};
+    bool use_preallocated{true};
   };
 
   AllocInfo get_alloc_info(DeviceAllocation handle);

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -81,8 +81,18 @@ class CudaDevice : public Device {
     void *ptr{nullptr};
     size_t size{0};
     bool is_imported{false};
-    bool use_cached{false};
+    /* Note: Memory allocation in CUDA device.
+     * CudaDevice can use either its own cuda malloc mechanism via 
+     * `allocate_memory` or the preallocated memory managed by Llvmprogramimpl 
+     * via `allocate_memory_runtime`. The `use_preallocated` is used to track 
+     * this option. For now, we keep both options and the preallocated method is 
+     * used by default for CUDA backend. The `use_cached` is to enable/disable 
+     * the caching behavior in `allocate_memory_runtime`. Later it should be 
+     * always enabled, for now we keep both options to allow a scenario when 
+     * using preallocated memory while disabling the caching behavior.
+     * */
     bool use_preallocated{true};
+    bool use_cached{false};
   };
 
   AllocInfo get_alloc_info(DeviceAllocation handle);

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -309,6 +309,16 @@ def _test_ndarray_deepcopy():
     assert y[4][1, 0] == 9
 
 
+def test_ndarray_cuda_caching_allocator():
+    ti.init(arch=ti.cuda, ndarray_use_torch=False, ndarray_use_cached_allocator=True)
+    n = 8
+    a = ti.ndarray(ti.i32, shape=(n))
+    a.fill(2)
+    a = 1
+    b = ti.ndarray(ti.i32, shape=(n))
+    b.fill(2)
+
+
 @ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
 def test_ndarray_rw_cache():
     a = ti.Vector.ndarray(3, ti.f32, ())

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -310,7 +310,9 @@ def _test_ndarray_deepcopy():
 
 
 def test_ndarray_cuda_caching_allocator():
-    ti.init(arch=ti.cuda, ndarray_use_torch=False, ndarray_use_cached_allocator=True)
+    ti.init(arch=ti.cuda,
+            ndarray_use_torch=False,
+            ndarray_use_cached_allocator=True)
     n = 8
     a = ti.ndarray(ti.i32, shape=(n))
     a.fill(2)


### PR DESCRIPTION
When using preallocated memory, deallocation is handled by LLVMProgramImpl [finalize](https://github.com/taichi-dev/taichi/blob/3818ba3142288752ebdd8c57bd47e92501aafcac/taichi/llvm/llvm_program.cpp#L479) instead of CUDA device.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
