### PR TITLE
[opengl] Only bind buffers per ti.kernel.

### DIFF
--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -452,7 +452,8 @@ void DeviceCompiledTaichiKernel::launch(RuntimeContext &ctx,
     }
 
     cmdlist->bind_pipeline(compiled_pipeline_[i].get());
-    cmdlist->bind_resources(binder);
+    if (i == 0)
+      cmdlist->bind_resources(binder);
     cmdlist->dispatch(task.num_groups, 1, 1);
     cmdlist->memory_barrier();
     i++;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3835
* #3834
* #3833
* __->__ #3832

Binding won't change among different offloaded tasks in the same
ti.kernel so we can save some time here.

For my ndarray based mpm88 benchmark, this improves from 12.50 fps to
13.01 fps.