### PR TITLE
[refactor] Rename is_external_array -> is_array and arr_bufs_ -> ext_arr_bufs_

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -62,7 +62,7 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       Kernel::LaunchContextBuilder ctx_builder(kernel, &context);
       bool transferred = false;
       for (int i = 0; i < (int)args.size(); i++) {
-        if (args[i].is_external_array) {
+        if (args[i].is_array) {
           if (args[i].size == 0)
             continue;
           arg_buffers[i] = context.get_arg<void *>(i);

--- a/taichi/backends/metal/kernel_utils.cpp
+++ b/taichi/backends/metal/kernel_utils.cpp
@@ -87,7 +87,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
       TI_ERROR("Metal kernel only supports <= 32-bit data, got {}",
                metal_data_type_name(ma.dt));
     }
-    ma.is_array = ka.is_external_array;
+    ma.is_array = ka.is_array;
     ma.stride = ma.is_array ? ka.size : dt_bytes;
     ma.index = arg_attribs_vec_.size();
     arg_attribs_vec_.push_back(ma);

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -125,7 +125,7 @@ class DeviceCompiledTaichiKernel {
   // Only saves numpy/torch cpu based external array since they don't have
   // DeviceAllocation.
   // Taichi |Ndarray| manages their own DeviceAllocation so it's not saved here.
-  mutable DeviceAllocation arr_bufs_[taichi_max_num_args]{
+  mutable DeviceAllocation ext_arr_bufs_[taichi_max_num_args]{
       kDeviceNullAllocation};
 };
 

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -2260,7 +2260,7 @@ FunctionType CodeGenLLVM::compile_module_to_executable() {
     // For taichi ndarrays, context.args saves pointer to its
     // |DeviceAllocation|, CPU backend actually want to use the raw ptr here.
     for (int i = 0; i < (int)args.size(); i++) {
-      if (args[i].is_external_array && context.is_device_allocation[i] &&
+      if (args[i].is_array && context.is_device_allocation[i] &&
           args[i].size > 0) {
         DeviceAllocation *ptr =
             static_cast<DeviceAllocation *>(context.get_arg<void *>(i));

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -58,7 +58,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
       TI_ERROR("SPIRV kernel only supports less than 32-bit arguments, got {}",
                data_type_name(aa.dt));
     }
-    aa.is_array = ka.is_external_array;
+    aa.is_array = ka.is_array;
     // For array, |ka.size| is #elements * elements_size
     aa.stride = aa.is_array ? ka.size : dt_bytes;
     aa.index = arg_attribs_vec_.size();

--- a/taichi/program/callable.cpp
+++ b/taichi/program/callable.cpp
@@ -4,8 +4,8 @@
 namespace taichi {
 namespace lang {
 
-int Callable::insert_arg(const DataType &dt, bool is_external_array) {
-  args.emplace_back(dt->get_compute_type(), is_external_array);
+int Callable::insert_arg(const DataType &dt, bool is_array) {
+  args.emplace_back(dt->get_compute_type(), is_array);
   return (int)args.size() - 1;
 }
 

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -17,19 +17,19 @@ class Callable {
 
   struct Arg {
     DataType dt;
-    // For arr args
-    bool is_external_array{false};
+    bool is_array{
+        false};  // This is true for both ndarray and external array args.
     std::size_t size{0};  // TODO: size is runtime information, maybe remove?
     std::size_t total_dim{0};             // total dim of array
     std::vector<int> element_shape = {};  // shape of each element
 
     explicit Arg(const DataType &dt = PrimitiveType::unknown,
-                 bool is_external_array = false,
+                 bool is_array = false,
                  std::size_t size = 0,
                  int total_dim = 0,
                  std::vector<int> element_shape = {})
         : dt(dt),
-          is_external_array(is_external_array),
+          is_array(is_array),
           size(size),
           total_dim(total_dim),
           element_shape(std::move(element_shape)) {
@@ -48,7 +48,7 @@ class Callable {
 
   virtual ~Callable() = default;
 
-  int insert_arg(const DataType &dt, bool is_external_array);
+  int insert_arg(const DataType &dt, bool is_array);
 
   int insert_arr_arg(const DataType &dt,
                      int total_dim,

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -171,7 +171,7 @@ Kernel::LaunchContextBuilder::LaunchContextBuilder(Kernel *kernel)
 }
 
 void Kernel::LaunchContextBuilder::set_arg_float(int arg_id, float64 d) {
-  TI_ASSERT_INFO(!kernel_->args[arg_id].is_external_array,
+  TI_ASSERT_INFO(!kernel_->args[arg_id].is_array,
                  "Assigning scalar value to external (numpy) array argument is "
                  "not allowed.");
 
@@ -210,7 +210,7 @@ void Kernel::LaunchContextBuilder::set_arg_float(int arg_id, float64 d) {
 }
 
 void Kernel::LaunchContextBuilder::set_arg_int(int arg_id, int64 d) {
-  TI_ASSERT_INFO(!kernel_->args[arg_id].is_external_array,
+  TI_ASSERT_INFO(!kernel_->args[arg_id].is_array,
                  "Assigning scalar value to external (numpy) array argument is "
                  "not allowed.");
 
@@ -252,7 +252,7 @@ void Kernel::LaunchContextBuilder::set_arg_external_array(
     uint64 size,
     bool is_device_allocation) {
   TI_ASSERT_INFO(
-      kernel_->args[arg_id].is_external_array,
+      kernel_->args[arg_id].is_array,
       "Assigning external (numpy) array to scalar argument is not allowed.");
 
   ActionRecorder::get_instance().record(
@@ -267,7 +267,7 @@ void Kernel::LaunchContextBuilder::set_arg_external_array(
 }
 
 void Kernel::LaunchContextBuilder::set_arg_raw(int arg_id, uint64 d) {
-  TI_ASSERT_INFO(!kernel_->args[arg_id].is_external_array,
+  TI_ASSERT_INFO(!kernel_->args[arg_id].is_array,
                  "Assigning scalar value to external (numpy) array argument is "
                  "not allowed.");
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -923,9 +923,8 @@ void export_lang(py::module &m) {
               std::make_unique<FrontendPrintStmt>(contents));
         });
 
-  m.def("decl_arg", [&](const DataType &dt, bool is_external_array) {
-    return get_current_program().current_callable->insert_arg(
-        dt, is_external_array);
+  m.def("decl_arg", [&](const DataType &dt, bool is_array) {
+    return get_current_program().current_callable->insert_arg(dt, is_array);
   });
 
   m.def("decl_arr_arg",

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -108,7 +108,7 @@ TEST(IRBuilder, ExternalPtr) {
   builder.create_global_store(a2ptr, a0plusa2);  // a[2] = a[0] + a[2]
   auto block = builder.extract_ir();
   auto ker = std::make_unique<Kernel>(*test_prog.prog(), std::move(block));
-  ker->insert_arg(get_data_type<int>(), /*is_external_array=*/true);
+  ker->insert_arg(get_data_type<int>(), /*is_array=*/true);
   auto launch_ctx = ker->make_launch_context();
   launch_ctx.set_arg_external_array(/*arg_id=*/0, (uint64)array.get(), size,
                                     /*is_device_allocation=*/false);

--- a/tests/cpp/transforms/inlining_test.cpp
+++ b/tests/cpp/transforms/inlining_test.cpp
@@ -34,7 +34,7 @@ TEST_F(InliningTest, ArgLoadOfArgLoad) {
 
   auto *func = prog_->create_function(
       FunctionKey("test_func", /*func_id=*/0, /*instance_id=*/0));
-  func->insert_arg(get_data_type<int>(), /*is_external_array=*/false);
+  func->insert_arg(get_data_type<int>(), /*is_array=*/false);
   func->insert_ret(get_data_type<int>());
   func->set_function_body(std::move(func_body));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3835
* #3834
* __->__ #3833
* #3832

This PR is a simple massive rename PR which serves as the first step to
separate internal ndarray and external array implementation.