### PR TITLE
[ci] Enforce using ninja on Windows in both release and normal testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,8 +317,18 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Add Visual Studio Shell to ENV
+        uses: egor-tensin/vs-shell@v2
+        with:
+          arch: x64
+
+      - name: Get sccache cache
+        uses: actions/cache@v2
+        with:
+          path: ccache_cache
+          key: ccache-win64-clang-${{ github.sha }}
+          restore-keys: |
+            ccache-win64-clang-
 
       - name: Build Python Wheel
         shell: powershell

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -371,9 +371,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-
-      #- name: Add msbuild to PATH
-      #  uses: microsoft/setup-msbuild@v1.0.2
         
       - name: Add Visual Studio Shell to ENV
         uses: egor-tensin/vs-shell@v2

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -388,13 +388,8 @@ if (MSVC)
 endif ()
 
 if (WIN32)
-    if (CMAKE_GENERATOR EQUAL "Ninja")
-        set_target_properties(${CORE_WITH_PYBIND_LIBRARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                "${CMAKE_CURRENT_SOURCE_DIR}/runtimes/Release")
-    else ()
-        set_target_properties(${CORE_WITH_PYBIND_LIBRARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
-                "${CMAKE_CURRENT_SOURCE_DIR}/runtimes")
-    endif ()
+    set_target_properties(${CORE_WITH_PYBIND_LIBRARY_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+            "${CMAKE_CURRENT_SOURCE_DIR}/runtimes")
 endif ()
 
 


### PR DESCRIPTION
This is a follow-up PR of #3735 to make the release work properly.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
