### PR TITLE
[Bug] [lang] Fix copying a Matrix/Struct in Taichi scope

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -37,13 +37,9 @@ def expr_init(rhs):
     if rhs is None:
         return Expr(_ti_core.expr_alloca())
     if isinstance(rhs, Matrix):
-        if rhs.in_python_scope or isinstance(rhs, _IntermediateMatrix):
-            return Matrix(rhs.to_list())
-        return rhs
+        return Matrix(rhs.to_list())
     if isinstance(rhs, Struct):
-        if rhs.in_python_scope or isinstance(rhs, _IntermediateStruct):
-            return Struct(rhs.to_dict())
-        return rhs
+        return Struct(rhs.to_dict())
     if isinstance(rhs, list):
         return [expr_init(e) for e in rhs]
     if isinstance(rhs, tuple):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -34,7 +34,6 @@ class Matrix(TaichiOperations):
         self.local_tensor_proxy = None
         self.any_array_access = None
         self.grad = None
-        self.in_python_scope = in_python_scope()
 
         if isinstance(n, (list, tuple, np.ndarray)):
             if len(n) == 0:
@@ -1100,7 +1099,6 @@ class _IntermediateMatrix(Matrix):
         self.local_tensor_proxy = None
         self.any_array_access = None
         self.grad = None
-        self.in_python_scope = in_python_scope()
 
 
 class MatrixField(Field):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -38,7 +38,6 @@ class Struct(TaichiOperations):
                 v = Struct(v)
             self.entries[k] = v if in_python_scope() else impl.expr_init(v)
         self.register_members()
-        self.in_python_scope = in_python_scope()
 
     @property
     def keys(self):
@@ -288,7 +287,6 @@ class _IntermediateStruct(Struct):
         assert isinstance(entries, dict)
         self.entries = entries
         self.register_members()
-        self.in_python_scope = in_python_scope()
 
 
 class StructField(Field):

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -336,3 +336,21 @@ def test_copy_struct_field_element_to_taichi_scope():
         assert a[None].b == 3
 
     test()
+
+
+@ti.test(debug=True)
+def test_copy_struct_in_taichi_scope():
+    @ti.kernel
+    def test():
+        a = ti.Struct({'a': 2, 'b': 3})
+        b = a
+        assert b.a == 2
+        assert b.b == 3
+        b.a = 5
+        b.b = 9
+        assert b.a == 5
+        assert b.b == 9
+        assert a.a == 2
+        assert a.b == 3
+
+    test()

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -340,3 +340,25 @@ def test_copy_matrix_field_element_to_taichi_scope():
         assert a[None][2] == 3
 
     test()
+
+
+@ti.test(debug=True)
+def test_copy_matrix_in_taichi_scope():
+    @ti.kernel
+    def test():
+        a = ti.Vector([1, 2, 3])
+        b = a
+        assert b[0] == 1
+        assert b[1] == 2
+        assert b[2] == 3
+        b[0] = 5
+        b[1] = 9
+        b[2] = 7
+        assert b[0] == 5
+        assert b[1] == 9
+        assert b[2] == 7
+        assert a[0] == 1
+        assert a[1] == 2
+        assert a[2] == 3
+
+    test()


### PR DESCRIPTION
Related issue = fixes #3826

Previously we attempt to not enforce evaluating and storing compound type values in `expr_init()` whenever possible to avoid duplicate initialization, which turns out to be buggy because there are cases (#3826) where we cannot automatically make the decision. To fix it, I cancel the checks and stick to the non-optimized version of `expr_init()` in this PR.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
