### PR TITLE
[refactor] Recover 'in' operator in vector_to_fast_image()

### DIFF
--- a/python/taichi/lang/meta.py
+++ b/python/taichi/lang/meta.py
@@ -58,8 +58,7 @@ def vector_to_fast_image(img: template(), out: ext_arr()):
     for i, j in ti.ndrange(*img.shape):
         r, g, b = 0, 0, 0
         color = img[i, img.shape[1] - 1 - j]
-        if ti.static(img.dtype == ti.f16 or img.dtype == ti.f32
-                     or img.dtype == ti.f64):
+        if ti.static(img.dtype in [ti.f16, ti.f32, ti.f64]):
             r, g, b = min(255, max(0, int(color * 255)))
         else:
             impl.static_assert(img.dtype == ti.u8)


### PR DESCRIPTION
In #3778, the use of `in` is temporarily removed due to lack of support. After #3792, `in` is supported again so we can add it back.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
