### PR TITLE
[Lang] Use ndarray own memory allocator by default

### DIFF
--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -44,7 +44,7 @@ CompileConfig::CompileConfig() {
   make_thread_local = true;
   make_block_local = true;
   detect_read_only = true;
-  ndarray_use_torch = true;
+  ndarray_use_torch = false;
   ndarray_use_cached_allocator = true;
 
   saturating_grid_dim = 0;

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -36,7 +36,7 @@ def test_scalar_ndarray_torch(dtype, shape):
 
 @pytest.mark.parametrize('dtype', data_types)
 @pytest.mark.parametrize('shape', ndarray_shapes)
-@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=False)
+@ti.test(arch=ti.get_host_arch_list())
 def test_scalar_ndarray(dtype, shape):
     _test_scalar_ndarray(dtype, shape)
 
@@ -66,7 +66,7 @@ def test_vector_ndarray_torch(n, dtype, shape):
 @pytest.mark.parametrize('n', vector_dims)
 @pytest.mark.parametrize('dtype', data_types)
 @pytest.mark.parametrize('shape', ndarray_shapes)
-@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=False)
+@ti.test(arch=ti.get_host_arch_list())
 def test_vector_ndarray(n, dtype, shape):
     _test_vector_ndarray(n, dtype, shape)
 
@@ -97,7 +97,7 @@ def test_matrix_ndarray_torch(n, m, dtype, shape):
 @pytest.mark.parametrize('n,m', matrix_dims)
 @pytest.mark.parametrize('dtype', data_types)
 @pytest.mark.parametrize('shape', ndarray_shapes)
-@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=False)
+@ti.test(arch=ti.get_host_arch_list())
 def test_matrix_ndarray(n, m, dtype, shape):
     _test_matrix_ndarray(n, m, dtype, shape)
 
@@ -115,8 +115,7 @@ def test_default_fp_ndarray_torch(dtype):
 @pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
 def test_default_fp_ndarray(dtype):
     ti.init(arch=supported_archs_taichi_ndarray,
-            default_fp=dtype,
-            ndarray_use_torch=False)
+            default_fp=dtype)
 
     x = ti.Vector.ndarray(2, float, ())
 
@@ -136,8 +135,7 @@ def test_default_ip_ndarray_torch(dtype):
 @pytest.mark.parametrize('dtype', [ti.i32, ti.i64])
 def test_default_ip_ndarray(dtype):
     ti.init(arch=supported_archs_taichi_ndarray,
-            default_ip=dtype,
-            ndarray_use_torch=False)
+            default_ip=dtype)
 
     x = ti.Vector.ndarray(2, int, ())
 
@@ -149,7 +147,7 @@ def test_default_ip_ndarray(dtype):
 layouts = [ti.Layout.SOA, ti.Layout.AOS]
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_1d():
     n = 4
 
@@ -201,7 +199,7 @@ def test_ndarray_2d_torch():
     _test_ndarray_2d()
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_2d():
     _test_ndarray_2d()
 
@@ -251,7 +249,7 @@ def test_ndarray_copy_from_ndarray_torch():
     _test_ndarray_copy_from_ndarray()
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_copy_from_ndarray():
     _test_ndarray_copy_from_ndarray()
 
@@ -311,7 +309,6 @@ def _test_ndarray_deepcopy():
 
 def test_ndarray_cuda_caching_allocator():
     ti.init(arch=ti.cuda,
-            ndarray_use_torch=False,
             ndarray_use_cached_allocator=True)
     n = 8
     a = ti.ndarray(ti.i32, shape=(n))
@@ -321,7 +318,7 @@ def test_ndarray_cuda_caching_allocator():
     b.fill(2)
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_rw_cache():
     a = ti.Vector.ndarray(3, ti.f32, ())
     b = ti.Vector.ndarray(3, ti.f32, 12)
@@ -339,7 +336,7 @@ def test_ndarray_deepcopy_torch():
     _test_ndarray_deepcopy()
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_deepcopy():
     _test_ndarray_deepcopy()
 
@@ -377,7 +374,7 @@ def test_ndarray_numpy_io_torch():
     _test_ndarray_numpy_io()
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_numpy_io():
     _test_ndarray_numpy_io()
 
@@ -402,7 +399,7 @@ def test_matrix_ndarray_python_scope_torch(layout):
 
 
 @pytest.mark.parametrize('layout', layouts)
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_matrix_ndarray_python_scope(layout):
     _test_matrix_ndarray_python_scope(layout)
 
@@ -431,7 +428,7 @@ def test_matrix_ndarray_taichi_scope_torch(layout):
 
 
 @pytest.mark.parametrize('layout', layouts)
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_matrix_ndarray_taichi_scope(layout):
     _test_matrix_ndarray_taichi_scope(layout)
 
@@ -460,7 +457,7 @@ def test_matrix_ndarray_taichi_scope_struct_for_torch(layout):
 
 
 @pytest.mark.parametrize('layout', layouts)
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_matrix_ndarray_taichi_scope_struct_for(layout):
     _test_matrix_ndarray_taichi_scope_struct_for(layout)
 
@@ -481,7 +478,7 @@ def test_vector_ndarray_python_scope_torch(layout):
 
 
 @pytest.mark.parametrize('layout', layouts)
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_vector_ndarray_python_scope(layout):
     a = ti.Vector.ndarray(10, ti.i32, 5, layout=layout)
     for i in range(5):
@@ -514,7 +511,7 @@ def test_vector_ndarray_taichi_scope_torch(layout):
 
 
 @pytest.mark.parametrize('layout', layouts)
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_vector_ndarray_taichi_scope(layout):
     @ti.kernel
     def func(a: ti.any_arr()):
@@ -562,7 +559,7 @@ def test_compiled_functions_torch():
     _test_compiled_functions()
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_compiled_functions():
     _test_compiled_functions()
 
@@ -656,7 +653,7 @@ def test_arg_not_match_torch():
     _test_arg_not_match()
 
 
-@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=False)
+@ti.test(arch=ti.get_host_arch_list())
 def test_arg_not_match():
     _test_arg_not_match()
 
@@ -677,7 +674,7 @@ def test_size_in_bytes_torch():
     _test_size_in_bytes()
 
 
-@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=False)
+@ti.test(arch=[ti.cpu, ti.cuda])
 def test_size_in_bytes():
     _test_size_in_bytes()
 
@@ -699,7 +696,7 @@ def test_torch_based_ndarray_not_supported():
         init(x)
 
 
-@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=False)
+@ti.test(arch=supported_archs_taichi_ndarray)
 def test_different_shape():
     n1 = 4
     x = ti.ndarray(dtype=ti.f32, shape=(n1, n1))

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -114,8 +114,7 @@ def test_default_fp_ndarray_torch(dtype):
 
 @pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
 def test_default_fp_ndarray(dtype):
-    ti.init(arch=supported_archs_taichi_ndarray,
-            default_fp=dtype)
+    ti.init(arch=supported_archs_taichi_ndarray, default_fp=dtype)
 
     x = ti.Vector.ndarray(2, float, ())
 
@@ -134,8 +133,7 @@ def test_default_ip_ndarray_torch(dtype):
 
 @pytest.mark.parametrize('dtype', [ti.i32, ti.i64])
 def test_default_ip_ndarray(dtype):
-    ti.init(arch=supported_archs_taichi_ndarray,
-            default_ip=dtype)
+    ti.init(arch=supported_archs_taichi_ndarray, default_ip=dtype)
 
     x = ti.Vector.ndarray(2, int, ())
 
@@ -308,8 +306,7 @@ def _test_ndarray_deepcopy():
 
 
 def test_ndarray_cuda_caching_allocator():
-    ti.init(arch=ti.cuda,
-            ndarray_use_cached_allocator=True)
+    ti.init(arch=ti.cuda, ndarray_use_cached_allocator=True)
     n = 8
     a = ti.ndarray(ti.i32, shape=(n))
     a.fill(2)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -29,7 +29,7 @@ def _test_scalar_ndarray(dtype, shape):
 @pytest.mark.parametrize('dtype', data_types)
 @pytest.mark.parametrize('shape', ndarray_shapes)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=ti.get_host_arch_list())
+@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=True)
 def test_scalar_ndarray_torch(dtype, shape):
     _test_scalar_ndarray(dtype, shape)
 
@@ -58,7 +58,7 @@ def _test_vector_ndarray(n, dtype, shape):
 @pytest.mark.parametrize('dtype', data_types)
 @pytest.mark.parametrize('shape', ndarray_shapes)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=ti.get_host_arch_list())
+@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=True)
 def test_vector_ndarray_torch(n, dtype, shape):
     _test_vector_ndarray(n, dtype, shape)
 
@@ -89,7 +89,7 @@ def _test_matrix_ndarray(n, m, dtype, shape):
 @pytest.mark.parametrize('dtype', data_types)
 @pytest.mark.parametrize('shape', ndarray_shapes)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=ti.get_host_arch_list())
+@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=True)
 def test_matrix_ndarray_torch(n, m, dtype, shape):
     _test_matrix_ndarray(n, m, dtype, shape)
 
@@ -105,7 +105,7 @@ def test_matrix_ndarray(n, m, dtype, shape):
 @pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
 def test_default_fp_ndarray_torch(dtype):
-    ti.init(default_fp=dtype)
+    ti.init(default_fp=dtype, ndarray_use_torch=True)
 
     x = ti.Vector.ndarray(2, float, ())
 
@@ -126,7 +126,7 @@ def test_default_fp_ndarray(dtype):
 @pytest.mark.parametrize('dtype', [ti.i32, ti.i64])
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
 def test_default_ip_ndarray_torch(dtype):
-    ti.init(default_ip=dtype)
+    ti.init(default_ip=dtype, ndarray_use_torch=True)
 
     x = ti.Vector.ndarray(2, int, ())
 
@@ -196,7 +196,7 @@ def _test_ndarray_2d():
 
 
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_ndarray_2d_torch():
     _test_ndarray_2d()
 
@@ -246,7 +246,7 @@ def _test_ndarray_copy_from_ndarray():
 
 
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_ndarray_copy_from_ndarray_torch():
     _test_ndarray_copy_from_ndarray()
 
@@ -322,7 +322,7 @@ def test_ndarray_rw_cache():
 
 
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_ndarray_deepcopy_torch():
     _test_ndarray_deepcopy()
 
@@ -360,7 +360,7 @@ def _test_ndarray_numpy_io():
 
 
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=supported_archs_taichi_ndarray)
+@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=True)
 def test_ndarray_numpy_io_torch():
     _test_ndarray_numpy_io()
 
@@ -384,7 +384,7 @@ def _test_matrix_ndarray_python_scope(layout):
 
 @pytest.mark.parametrize('layout', layouts)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=supported_archs_taichi_ndarray)
+@ti.test(arch=supported_archs_taichi_ndarray, ndarray_use_torch=True)
 def test_matrix_ndarray_python_scope_torch(layout):
     _test_matrix_ndarray_python_scope(layout)
 
@@ -413,7 +413,7 @@ def _test_matrix_ndarray_taichi_scope(layout):
 
 @pytest.mark.parametrize('layout', layouts)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_matrix_ndarray_taichi_scope_torch(layout):
     _test_matrix_ndarray_taichi_scope(layout)
 
@@ -442,7 +442,7 @@ def _test_matrix_ndarray_taichi_scope_struct_for(layout):
 
 @pytest.mark.parametrize('layout', layouts)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_matrix_ndarray_taichi_scope_struct_for_torch(layout):
     _test_matrix_ndarray_taichi_scope_struct_for(layout)
 
@@ -455,7 +455,7 @@ def test_matrix_ndarray_taichi_scope_struct_for(layout):
 
 @pytest.mark.parametrize('layout', layouts)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_vector_ndarray_python_scope_torch(layout):
     a = ti.Vector.ndarray(10, ti.i32, 5, layout=layout)
     for i in range(5):
@@ -484,7 +484,7 @@ def test_vector_ndarray_python_scope(layout):
 
 @pytest.mark.parametrize('layout', layouts)
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_vector_ndarray_taichi_scope_torch(layout):
     @ti.kernel
     def func(a: ti.any_arr()):
@@ -545,7 +545,7 @@ def _test_compiled_functions():
 
 
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_compiled_functions_torch():
     _test_compiled_functions()
 
@@ -639,7 +639,7 @@ def _test_arg_not_match():
 
 
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=ti.get_host_arch_list())
+@ti.test(arch=ti.get_host_arch_list(), ndarray_use_torch=True)
 def test_arg_not_match_torch():
     _test_arg_not_match()
 
@@ -660,7 +660,7 @@ def _test_size_in_bytes():
 
 
 @pytest.mark.skipif(not ti.has_pytorch(), reason='Pytorch not installed.')
-@ti.test(arch=[ti.cpu, ti.cuda])
+@ti.test(arch=[ti.cpu, ti.cuda], ndarray_use_torch=True)
 def test_size_in_bytes_torch():
     _test_size_in_bytes()
 


### PR DESCRIPTION
This PR disables the usage of torch for ndarray by default, by switching to Taichi's own memory allocator.