### PR TITLE
[lang] Calculate dynamic indexing strides of matrix field elements

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -352,6 +352,10 @@ class PyTaichi:
                     f'{shapes}:\n{self._get_tb(_field.get_field_members()[0])}'
                 )
 
+    def _calc_matrix_field_dynamic_index_stride(self):
+        for _field in self.matrix_fields:
+            _field.calc_dynamic_index_stride()
+
     def materialize(self):
         self.materialize_root_fb(not self.materialized)
 
@@ -362,6 +366,7 @@ class PyTaichi:
 
         self._check_field_not_placed()
         self._check_matrix_field_member_shape()
+        self._calc_matrix_field_dynamic_index_stride()
 
         for callback in self.materialize_callbacks:
             callback()

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1114,6 +1114,7 @@ class MatrixField(Field):
         super().__init__(_vars)
         self.n = n
         self.m = m
+        self.dynamic_index_stride = None
 
     def get_scalar_field(self, *indices):
         """Creates a ScalarField using a specific field member. Only used for quant.
@@ -1128,6 +1129,35 @@ class MatrixField(Field):
         i = indices[0]
         j = 0 if len(indices) == 1 else indices[1]
         return ScalarField(self.vars[i * self.m + j])
+
+    def calc_dynamic_index_stride(self):
+        # Algorithm: https://github.com/taichi-dev/taichi/issues/3810
+        paths = [ScalarField(var).snode.path_from_root() for var in self.vars]
+        num_members = len(paths)
+        if num_members == 1:
+            self.dynamic_index_stride = 0
+            return
+        length = len(paths[0])
+        if any(len(path) != length for path in paths):
+            return
+        for i in range(length):
+            if any(path[i] != paths[0][i] for path in paths):
+                depth_below_lca = i
+                break
+        for i in range(depth_below_lca, length - 1):
+            if any(path[i].ptr.type != ti_core.SNodeType.dense or
+                   path[i].cell_size_bytes != paths[0][i].cell_size_bytes or
+                   path[i + 1].offset_bytes_in_parent_cell !=
+                   paths[0][i + 1].offset_bytes_in_parent_cell
+                   for path in paths):
+                return
+        stride = paths[1][depth_below_lca].offset_bytes_in_parent_cell - \
+                 paths[0][depth_below_lca].offset_bytes_in_parent_cell
+        for i in range(2, num_members):
+            if stride != paths[i][depth_below_lca].offset_bytes_in_parent_cell \
+                    - paths[i - 1][depth_below_lca].offset_bytes_in_parent_cell:
+                return
+        self.dynamic_index_stride = stride
 
     @python_scope
     def fill(self, val):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1145,11 +1145,10 @@ class MatrixField(Field):
                 depth_below_lca = i
                 break
         for i in range(depth_below_lca, length - 1):
-            if any(path[i].ptr.type != ti_core.SNodeType.dense or
-                   path[i].cell_size_bytes != paths[0][i].cell_size_bytes or
-                   path[i + 1].offset_bytes_in_parent_cell !=
-                   paths[0][i + 1].offset_bytes_in_parent_cell
-                   for path in paths):
+            if any(path[i].ptr.type != ti_core.SNodeType.dense
+                   or path[i].cell_size_bytes != paths[0][i].cell_size_bytes
+                   or path[i + 1].offset_bytes_in_parent_cell != paths[0][
+                       i + 1].offset_bytes_in_parent_cell for path in paths):
                 return
         stride = paths[1][depth_below_lca].offset_bytes_in_parent_cell - \
                  paths[0][depth_below_lca].offset_bytes_in_parent_cell

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -191,6 +191,20 @@ class SNode:
             return impl.root
         return SNode(p)
 
+    def path_from_root(self):
+        """Gets the path from root to `self` in the SNode tree.
+
+        Returns:
+            List[Union[_Root, SNode]]: The list of SNodes on the path from root to `self`.
+        """
+        p = self
+        res = [p]
+        while p != impl.root:
+            p = p.parent()
+            res.append(p)
+        res.reverse()
+        return res
+
     @property
     def dtype(self):
         """Gets the data type of `self`.

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -397,8 +397,10 @@ def test_matrix_field_dynamic_index_stride():
     @ti.kernel
     def check_stride():
         for i in range(128):
-            assert ti.get_addr(y, i) - ti.get_addr(x, i) == v.dynamic_index_stride
-            assert ti.get_addr(z, i) - ti.get_addr(y, i) == v.dynamic_index_stride
+            assert ti.get_addr(y, i) - ti.get_addr(x,
+                                                   i) == v.dynamic_index_stride
+            assert ti.get_addr(z, i) - ti.get_addr(y,
+                                                   i) == v.dynamic_index_stride
 
     check_stride()
 

--- a/tests/python/test_tensor_reflection.py
+++ b/tests/python/test_tensor_reflection.py
@@ -88,6 +88,7 @@ def test_unordered_matrix():
     assert val.snode.parent(2) == blk2
     assert val.snode.parent(3) == blk1
     assert val.snode.parent(4) == ti.root
+    assert val.snode.path_from_root() == [ti.root, blk1, blk2, blk3, val.snode]
 
 
 @ti.test()


### PR DESCRIPTION
Related issue = close #3810

This PR implements the algorithm in #3810, and the result stride is stored in `dynamic_index_stride` of `MatrixField` instances. The tests cover both valid (the example in #3810) and invalid cases. `path_from_root()` is added to the `SNode` class by the way.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
