### PR TITLE
[opt] Add more accurate alias analysis for ExternalPtrStmt

### DIFF
--- a/taichi/analysis/alias_analysis.cpp
+++ b/taichi/analysis/alias_analysis.cpp
@@ -91,16 +91,31 @@ AliasResult alias_analysis(Stmt *var1, Stmt *var2) {
                : AliasResult::uncertain;
   }
 
+  TI_ASSERT(var1->width() == 1);
+  TI_ASSERT(var2->width() == 1);
+
   if (var1->is<ExternalPtrStmt>() || var2->is<ExternalPtrStmt>()) {
     if (!var1->is<ExternalPtrStmt>() || !var2->is<ExternalPtrStmt>())
       return AliasResult::different;
-    return AliasResult::uncertain;
+    auto ptr1 = var1->as<ExternalPtrStmt>();
+    auto ptr2 = var2->as<ExternalPtrStmt>();
+    if (ptr1->base_ptrs[0] != ptr2->base_ptrs[0])
+      return AliasResult::uncertain;
+    TI_ASSERT(ptr1->indices.size() == ptr2->indices.size());
+    bool uncertain = false;
+    for (int i = 0; i < (int)ptr1->indices.size(); i++) {
+      auto diff = value_diff_ptr_index(ptr1->indices[i], ptr2->indices[i]);
+      if (!diff.is_diff_certain) {
+        uncertain = true;
+      } else if (diff.diff_range != 0) {
+        return AliasResult::different;
+      }
+    }
+    return uncertain ? AliasResult::uncertain : AliasResult::same;
   }
 
   // If both statements are GlobalPtrStmts or GetChStmts, we can check by
   // SNode::id.
-  TI_ASSERT(var1->width() == 1);
-  TI_ASSERT(var2->width() == 1);
   auto get_snode_id = [](Stmt *s) {
     if (auto ptr = s->cast<GlobalPtrStmt>()) {
       return ptr->snodes[0]->id;

--- a/tests/cpp/analysis/alias_analysis_test.cpp
+++ b/tests/cpp/analysis/alias_analysis_test.cpp
@@ -94,6 +94,58 @@ TEST(AliasAnalysis, GlobalPtr_DiffSNodes) {
 
 // TODO(#2193): Add tests for other edge cases and other kinds of statements.
 
+TEST(AliasAnalysis, ExternalPtr_Same) {
+  IRBuilder builder;
+  auto *arg1 = builder.create_arg_load(1, PrimitiveType::i32, true);
+  auto *arg2 = builder.create_arg_load(2, PrimitiveType::i32, false);
+  const auto indices = std::vector<Stmt *>{arg2, arg2};
+  auto *eptr1 = builder.create_external_ptr(arg1, indices);
+  auto *eptr2 = builder.create_external_ptr(arg1, indices);
+
+  const auto aa = alias_analysis(eptr1, eptr2);
+  EXPECT_EQ(aa, AliasResult::same);
+}
+
+TEST(AliasAnalysis, ExternalPtr_Different) {
+  IRBuilder builder;
+  auto *arg1 = builder.create_arg_load(1, PrimitiveType::i32, true);
+  auto *arg2 = builder.create_arg_load(2, PrimitiveType::i32, false);
+  const auto indices1 = std::vector<Stmt *>{arg2, builder.get_int32(1)};
+  const auto indices2 = std::vector<Stmt *>{arg2, builder.get_int32(2)};
+  auto *eptr1 = builder.create_external_ptr(arg1, indices1);
+  auto *eptr2 = builder.create_external_ptr(arg1, indices2);
+
+  const auto aa = alias_analysis(eptr1, eptr2);
+  EXPECT_EQ(aa, AliasResult::different);
+}
+
+TEST(AliasAnalysis, ExternalPtr_Uncertain) {
+  IRBuilder builder;
+  auto *arg1 = builder.create_arg_load(1, PrimitiveType::i32, true);
+  auto *arg2 = builder.create_arg_load(2, PrimitiveType::i32, false);
+  auto *arg3 = builder.create_arg_load(3, PrimitiveType::i32, false);
+  const auto indices1 = std::vector<Stmt *>{arg2, arg2};
+  const auto indices2 = std::vector<Stmt *>{arg2, arg3};
+  auto *eptr1 = builder.create_external_ptr(arg1, indices1);
+  auto *eptr2 = builder.create_external_ptr(arg1, indices2);
+
+  const auto aa = alias_analysis(eptr1, eptr2);
+  EXPECT_EQ(aa, AliasResult::uncertain);
+}
+
+TEST(AliasAnalysis, ExternalPtr_DiffPtr) {
+  IRBuilder builder;
+  auto *arg1 = builder.create_arg_load(1, PrimitiveType::i32, true);
+  auto *arg2 = builder.create_arg_load(2, PrimitiveType::i32, true);
+  auto *arg3 = builder.create_arg_load(3, PrimitiveType::i32, false);
+  const auto indices = std::vector<Stmt *>{arg3, arg3};
+  auto *eptr1 = builder.create_external_ptr(arg1, indices);
+  auto *eptr2 = builder.create_external_ptr(arg2, indices);
+
+  const auto aa = alias_analysis(eptr1, eptr2);
+  EXPECT_EQ(aa, AliasResult::uncertain);
+}
+
 }  // namespace analysis
 }  // namespace irpass
 }  // namespace lang


### PR DESCRIPTION
This PR is a follow-up of #2952. Making alias analysis more accurate can unblock future optimizations on `ExternalPtrStmt` (many of current optimization passes only focus on `GlobalPtrStmt`).

That said, we can already observe some benefits of this PR. For example, regarding the following code snippet,
```py
@ti.kernel
def test(a: ti.any_arr(element_dim=1)):
    for i in range(10):
        a[i][0] = i
        a[i][1] = i * 2
        a[i][2] = a[i][0]

a = np.zeros((10, 3))
test(a)
```

Before this PR, the final CHI IR is,
```
kernel {
  $0 = offloaded range_for(0, 10) grid_dim=0 block_dim=32 
  body {
    <i32> $1 = loop $0 index 0
    <*f64> $2 = arg[0]
    <i32> $3 = const [0]
    <*f64> $4 = external_ptr <$2>, [$1, $3]
    <f64> $5 = cast_value<f64> $1
    $6 : global store [$4 <- $5]
    <i32> $7 = const [1]
    <i32> $8 = bit_shl $1 $7
    <*f64> $9 = external_ptr <$2>, [$1, $7]
    <f64> $10 = cast_value<f64> $8
    $11 : global store [$9 <- $10]
    <f64> $12 = global load $4
    <i32> $13 = const [2]
    <*f64> $14 = external_ptr <$2>, [$1, $13]
    $15 : global store [$14 <- $12]
  }
}
```

After this PR, the final CHI IR is,
```
kernel {
  $0 = offloaded range_for(0, 10) grid_dim=0 block_dim=32 
  body {
    <i32> $1 = loop $0 index 0
    <*f64> $2 = arg[0]
    <i32> $3 = const [0]
    <*f64> $4 = external_ptr <$2>, [$1, $3]
    <f64> $5 = cast_value<f64> $1
    $6 : global store [$4 <- $5]
    <i32> $7 = const [1]
    <i32> $8 = bit_shl $1 $7
    <*f64> $9 = external_ptr <$2>, [$1, $7]
    <f64> $10 = cast_value<f64> $8
    $11 : global store [$9 <- $10]
    <i32> $12 = const [2]
    <*f64> $13 = external_ptr <$2>, [$1, $12]
    $14 : global store [$13 <- $5]
  }
}
```

We can see that a redundant global load can now be eliminated.


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
