### PR TITLE
[refactor] Add _MatrixFieldElement class

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -10,7 +10,8 @@ from taichi.lang.exception import InvalidOperationError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
-from taichi.lang.matrix import Matrix, MatrixField, _IntermediateMatrix, _MatrixFieldElement
+from taichi.lang.matrix import (Matrix, MatrixField, _IntermediateMatrix,
+                                _MatrixFieldElement)
 from taichi.lang.mesh import (ConvType, MeshElementFieldProxy, MeshInstance,
                               MeshRelationAccessProxy,
                               MeshReorderedMatrixFieldProxy,

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -10,7 +10,7 @@ from taichi.lang.exception import InvalidOperationError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
-from taichi.lang.matrix import Matrix, MatrixField, _IntermediateMatrix
+from taichi.lang.matrix import Matrix, MatrixField, _IntermediateMatrix, _MatrixFieldElement
 from taichi.lang.mesh import (ConvType, MeshElementFieldProxy, MeshInstance,
                               MeshRelationAccessProxy,
                               MeshReorderedMatrixFieldProxy,
@@ -179,10 +179,7 @@ def subscript(value, *_indices, skip_reordered=False):
                 f'Field with dim {field_dim} accessed with indices of dim {index_dim}'
             )
         if isinstance(value, MatrixField):
-            return _IntermediateMatrix(value.n, value.m, [
-                Expr(_ti_core.subscript(e.ptr, indices_expr_group))
-                for e in value.get_field_members()
-            ])
+            return _MatrixFieldElement(value, indices_expr_group)
         if isinstance(value, StructField):
             return _IntermediateStruct(
                 {k: subscript(v, *_indices)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1094,8 +1094,10 @@ class _MatrixFieldElement(_IntermediateMatrix):
         indices (taichi_core.ExprGroup): Indices of the element.
     """
     def __init__(self, field, indices):
-        super().__init__(field.n, field.m, [expr.Expr(ti_core.subscript(
-            e.ptr, indices)) for e in field.get_field_members()])
+        super().__init__(field.n, field.m, [
+            expr.Expr(ti_core.subscript(e.ptr, indices))
+            for e in field.get_field_members()
+        ])
         self.dynamic_index_stride = field.dynamic_index_stride
 
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1093,10 +1093,10 @@ class _MatrixFieldElement(_IntermediateMatrix):
         _field (MatrixField): The matrix field.
         indices: Indices of the element.
     """
-    def __init__(self, _field, indices):
-        super().__init__(_field.n, _field.m, [expr.Expr(ti_core.subscript(
-            e.ptr, indices)) for e in _field.get_field_members()])
-        self.dynamic_index_stride = _field.dynamic_index_stride
+    def __init__(self, field, indices):
+        super().__init__(field.n, field.m, [expr.Expr(ti_core.subscript(
+            e.ptr, indices)) for e in field.get_field_members()])
+        self.dynamic_index_stride = field.dynamic_index_stride
 
 
 class MatrixField(Field):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1086,6 +1086,19 @@ class _IntermediateMatrix(Matrix):
         self.grad = None
 
 
+class _MatrixFieldElement(_IntermediateMatrix):
+    """Matrix field element class for compiler internal use only.
+
+    Args:
+        _field (MatrixField): The matrix field.
+        indices: Indices of the element.
+    """
+    def __init__(self, _field, indices):
+        super().__init__(_field.n, _field.m, [expr.Expr(ti_core.subscript(
+            e.ptr, indices)) for e in _field.get_field_members()])
+        self.dynamic_index_stride = _field.dynamic_index_stride
+
+
 class MatrixField(Field):
     """Taichi matrix field with SNode implementation.
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1090,7 +1090,7 @@ class _MatrixFieldElement(_IntermediateMatrix):
     """Matrix field element class for compiler internal use only.
 
     Args:
-        _field (MatrixField): The matrix field.
+        field (MatrixField): The matrix field.
         indices: Indices of the element.
     """
     def __init__(self, field, indices):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1091,7 +1091,7 @@ class _MatrixFieldElement(_IntermediateMatrix):
 
     Args:
         field (MatrixField): The matrix field.
-        indices: Indices of the element.
+        indices (taichi_core.ExprGroup): Indices of the element.
     """
     def __init__(self, field, indices):
         super().__init__(field.n, field.m, [expr.Expr(ti_core.subscript(

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -6,7 +6,7 @@ from taichi.lang import impl
 from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.field import Field, ScalarField
-from taichi.lang.matrix import MatrixField, _IntermediateMatrix
+from taichi.lang.matrix import MatrixField, _IntermediateMatrix, _MatrixFieldElement
 from taichi.lang.struct import StructField
 from taichi.lang.util import python_scope
 from taichi.types import CompoundType
@@ -65,6 +65,7 @@ class MeshReorderedMatrixFieldProxy(MatrixField):
         self.grad = field.grad
         self.n = field.n
         self.m = field.m
+        self.dynamic_index_stride = field.dynamic_index_stride
 
         self.mesh_ptr = mesh_ptr
         self.element_type = element_type
@@ -476,13 +477,8 @@ class MeshElementFieldProxy:
             global_entry_expr_group = impl.make_expr_group(
                 *tuple([global_entry_expr]))
             if isinstance(attr, MatrixField):
-                setattr(
-                    self, key,
-                    _IntermediateMatrix(attr.n, attr.m, [
-                        impl.Expr(
-                            _ti_core.subscript(e.ptr, global_entry_expr_group))
-                        for e in attr.get_field_members()
-                    ]))
+                setattr(self, key,
+                        _MatrixFieldElement(attr, global_entry_expr_group))
             elif isinstance(attr, StructField):
                 raise RuntimeError('ti.Mesh has not support StructField yet')
             else:  # isinstance(attr, Field)

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -6,7 +6,8 @@ from taichi.lang import impl
 from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.field import Field, ScalarField
-from taichi.lang.matrix import MatrixField, _IntermediateMatrix, _MatrixFieldElement
+from taichi.lang.matrix import (MatrixField, _IntermediateMatrix,
+                                _MatrixFieldElement)
 from taichi.lang.struct import StructField
 from taichi.lang.util import python_scope
 from taichi.types import CompoundType


### PR DESCRIPTION
Related issue = #2590, #2880

This PR makes one use case of `_IntermediateMatrix` class, an element of a matrix field, more explicit. It can unblock the implementation of enabling dynamic indexing of matrix field elements.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
