### PR TITLE
[Error] Shorten the length of traceback of exceptions thrown by ASTTransformer

### DIFF
--- a/python/taichi/lang/ast/ast_transformer_utils.py
+++ b/python/taichi/lang/ast/ast_transformer_utils.py
@@ -1,4 +1,5 @@
 import ast
+import traceback
 from enum import Enum
 from sys import version_info
 from textwrap import TextWrapper
@@ -23,13 +24,13 @@ class Builder:
             return method(ctx, node)
         except Exception as e:
             if ctx.raised or not isinstance(node, (ast.stmt, ast.expr)):
-                raise e
-            msg = str(e)
-            if not isinstance(e, TaichiCompilationError):
-                msg = f"{e.__class__.__name__}: " + msg
-            msg = ctx.get_pos_info(node) + msg
+                raise e.with_traceback(None)
             ctx.raised = True
-            raise TaichiCompilationError(msg)
+            if not isinstance(e, TaichiCompilationError):
+                msg = ctx.get_pos_info(node) + traceback.format_exc()
+                raise TaichiCompilationError(msg) from None
+            msg = ctx.get_pos_info(node) + str(e)
+            raise type(e)(msg) from None
 
 
 class VariableScopeGuard:

--- a/python/taichi/lang/exception.py
+++ b/python/taichi/lang/exception.py
@@ -1,10 +1,10 @@
-class TaichiSyntaxError(Exception):
+class TaichiCompilationError(Exception):
+    pass
+
+
+class TaichiSyntaxError(TaichiCompilationError):
     pass
 
 
 class InvalidOperationError(Exception):
-    pass
-
-
-class TaichiCompilationError(Exception):
     pass

--- a/tests/python/test_exception.py
+++ b/tests/python/test_exception.py
@@ -23,8 +23,7 @@ def test_exception_multiline():
     if version_info < (3, 8):
         msg = f"""\
 On line {frameinfo.lineno + 5} of file "{frameinfo.filename}":
-            aaaa(111,
-TypeError: 'NoneType' object is not callable"""
+            aaaa(111,"""
     else:
         msg = f"""\
 On line {frameinfo.lineno + 5} of file "{frameinfo.filename}":
@@ -35,10 +34,9 @@ On line {frameinfo.lineno + 5} of file "{frameinfo.filename}":
 
 
                  23)
-                 ^^^
-TypeError: 'NoneType' object is not callable"""
+                 ^^^"""
     print(e.value.args[0])
-    assert e.value.args[0] == msg
+    assert e.value.args[0][:len(msg)] == msg
 
 
 @ti.test()
@@ -68,8 +66,7 @@ On line {lineno + 13} of file "{file}":
 On line {lineno + 9} of file "{file}":
             baz()
 On line {lineno + 5} of file "{file}":
-            t()
-TypeError: 'NoneType' object is not callable"""
+            t()"""
     else:
         msg = f"""\
 On line {lineno + 13} of file "{file}":
@@ -80,10 +77,9 @@ On line {lineno + 9} of file "{file}":
             ^^^^^
 On line {lineno + 5} of file "{file}":
             t()
-            ^^^
-TypeError: 'NoneType' object is not callable"""
+            ^^^"""
     print(e.value.args[0])
-    assert e.value.args[0] == msg
+    assert e.value.args[0][:len(msg)] == msg
 
 
 @ti.test()
@@ -101,16 +97,14 @@ def test_tab():
     if version_info < (3, 8):
         msg = f"""\
 On line {lineno + 5} of file "{file}":
-            a(11,   22, 3)
-TypeError: 'NoneType' object is not callable"""
+            a(11,   22, 3)"""
     else:
         msg = f"""\
 On line {lineno + 5} of file "{file}":
             a(11,   22, 3)
-            ^^^^^^^^^^^^^^
-TypeError: 'NoneType' object is not callable"""
+            ^^^^^^^^^^^^^^"""
     print(e.value.args[0])
-    assert e.value.args[0] == msg
+    assert e.value.args[0][:len(msg)] == msg
 
 
 @ti.test()
@@ -129,7 +123,7 @@ def test_super_long_line():
         msg = f"""\
 On line {lineno + 5} of file "{file}":
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
-TypeError: 'NoneType' object is not callable"""
+"""
     else:
         msg = f"""\
 On line {lineno + 5} of file "{file}":
@@ -138,7 +132,6 @@ On line {lineno + 5} of file "{file}":
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 bbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-TypeError: 'NoneType' object is not callable"""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"""
     print(e.value.args[0])
-    assert e.value.args[0] == msg
+    assert e.value.args[0][:len(msg)] == msg


### PR DESCRIPTION
Related issue = fixes #3785 
Error message of the program in the issue after this PR:
```
Traceback (most recent call last):
  File "/home/lin/tmp/./test.py", line 15, in <module>
    foo()
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 715, in wrapped
    return primal(*args, **kwargs)
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 643, in __call__
    key = self.ensure_compiled(*args)
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 629, in ensure_compiled
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 475, in materialize
    taichi_kernel = _ti_core.create_kernel(taichi_ast_generator,
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 465, in taichi_ast_generator
    transform_tree(tree, ctx)
  File "/home/lin/taichi2/python/taichi/lang/ast/transform.py", line 8, in transform_tree
    ASTTransformer()(ctx, tree)
  File "/home/lin/taichi2/python/taichi/lang/ast/ast_transformer_utils.py", line 27, in __call__
    raise e.with_traceback(None)
taichi.lang.exception.TaichiCompilationError: On line 13 of file "/home/lin/tmp/./test.py":
    bar()
    ^^^^^
On line 9 of file "/home/lin/tmp/./test.py":
    baz()
    ^^^^^
Traceback (most recent call last):
  File "/home/lin/taichi2/python/taichi/lang/ast/ast_transformer_utils.py", line 24, in __call__
    return method(ctx, node)
  File "/home/lin/taichi2/python/taichi/lang/ast/ast_transformer.py", line 360, in build_Call
    node.ptr = node.func.ptr(*args, **keywords)
  File "/home/lin/tmp/./test.py", line 5, in baz
    raise RuntimeError("an error")
RuntimeError: an error
```
If a `TaichiSyntaxError` is thrown, which means the error is thrown by the transformer, the exception type will remain `TaichiSyntaxError`, and the original traceback at the bottom will not appear because it is not necessary. 
For the following program,
```python
import taichi as ti
ti.init()

@ti.kernel
def foo():
    1 in 2

foo()
```
The traceback looks like this.
```
Traceback (most recent call last):
  File "/home/lin/tmp/./test.py", line 8, in <module>
    foo()
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 715, in wrapped
    return primal(*args, **kwargs)
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 643, in __call__
    key = self.ensure_compiled(*args)
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 629, in ensure_compiled
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 475, in materialize
    taichi_kernel = _ti_core.create_kernel(taichi_ast_generator,
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 465, in taichi_ast_generator
    transform_tree(tree, ctx)
  File "/home/lin/taichi2/python/taichi/lang/ast/transform.py", line 8, in transform_tree
    ASTTransformer()(ctx, tree)
  File "/home/lin/taichi2/python/taichi/lang/ast/ast_transformer_utils.py", line 27, in __call__
    raise e.with_traceback(None)
taichi.lang.exception.TaichiSyntaxError: On line 6 of file "/home/lin/tmp/./test.py":
    1 in 2
    ^^^^^^
"In" is only supported inside `ti.static`.
```