### PR TITLE
[perf] Avoid using property for simple attributes to reduce python overhead.

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -17,29 +17,21 @@ class Ndarray:
         dtype (DataType): Data type of each value.
         shape (Tuple[int]): Shape of the torch tensor.
     """
-    def __init__(self, dtype, shape):
+    def __init__(self, dtype, arr_shape):
         self.host_accessor = None
+        self.dtype = cook_dtype(dtype)
         if impl.current_cfg().ndarray_use_torch:
             assert has_pytorch(
             ), "PyTorch must be available if you want to create a Taichi ndarray with PyTorch as its underlying storage."
             # pylint: disable=E1101
-            self.arr = torch.zeros(shape,
+            self.arr = torch.zeros(arr_shape,
                                    dtype=to_pytorch_type(cook_dtype(dtype)))
             if impl.current_cfg().arch == _ti_core.Arch.cuda:
                 self.arr = self.arr.cuda()
 
         else:
             self.arr = _ti_core.Ndarray(impl.get_runtime().prog,
-                                        cook_dtype(dtype), shape)
-
-    @property
-    def shape(self):
-        """Gets ndarray shape.
-
-        Returns:
-            Tuple[Int]: Ndarray shape.
-        """
-        raise NotImplementedError()
+                                        cook_dtype(dtype), arr_shape)
 
     @property
     def element_shape(self):
@@ -49,15 +41,6 @@ class Ndarray:
             Tuple[Int]: Ndarray element shape.
         """
         raise NotImplementedError()
-
-    @property
-    def dtype(self):
-        """Gets data type of each individual value.
-
-        Returns:
-            DataType: Data type of each individual value.
-        """
-        return to_taichi_type(self.arr.dtype)
 
     @property
     def data_handle(self):
@@ -248,9 +231,9 @@ class ScalarNdarray(Ndarray):
         dtype (DataType): Data type of each value.
         shape (Tuple[int]): Shape of the ndarray.
     """
-    @property
-    def shape(self):
-        return tuple(self.arr.shape)
+    def __init__(self, dtype, arr_shape):
+        super().__init__(dtype, arr_shape)
+        self.shape = tuple(self.arr.shape)
 
     @property
     def element_shape(self):

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -4,7 +4,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.enums import Layout
 from taichi.lang.util import (cook_dtype, has_pytorch, python_scope,
-                              to_numpy_type, to_pytorch_type, to_taichi_type)
+                              to_numpy_type, to_pytorch_type)
 
 if has_pytorch():
     import torch

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -231,9 +231,9 @@ class ScalarNdarray(Ndarray):
         dtype (DataType): Data type of each value.
         shape (Tuple[int]): Shape of the ndarray.
     """
-    def __init__(self, dtype, arr_shape):
-        super().__init__(dtype, arr_shape)
-        self.shape = tuple(self.arr.shape)
+    def __init__(self, dtype, shape):
+        super().__init__(dtype, shape)
+        self.shape = shape
 
     @property
     def element_shape(self):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1319,21 +1319,11 @@ class MatrixNdarray(Ndarray):
     """
     def __init__(self, n, m, dtype, shape, layout):
         self.layout = layout
+        self.shape = shape
+        self.n = n
+        self.m = m
         arr_shape = (n, m) + shape if layout == Layout.SOA else shape + (n, m)
         super().__init__(dtype, arr_shape)
-
-    @property
-    def n(self):
-        return self.arr.shape[0 if self.layout == Layout.SOA else -2]
-
-    @property
-    def m(self):
-        return self.arr.shape[1 if self.layout == Layout.SOA else -1]
-
-    @property
-    def shape(self):
-        arr_shape = tuple(self.arr.shape)
-        return arr_shape[2:] if self.layout == Layout.SOA else arr_shape[:-2]
 
     @property
     def element_shape(self):
@@ -1391,17 +1381,10 @@ class VectorNdarray(Ndarray):
     """
     def __init__(self, n, dtype, shape, layout):
         self.layout = layout
+        self.shape = shape
+        self.n = n
         arr_shape = (n, ) + shape if layout == Layout.SOA else shape + (n, )
         super().__init__(dtype, arr_shape)
-
-    @property
-    def n(self):
-        return self.arr.shape[0 if self.layout == Layout.SOA else -1]
-
-    @property
-    def shape(self):
-        arr_shape = tuple(self.arr.shape)
-        return arr_shape[1:] if self.layout == Layout.SOA else arr_shape[:-1]
 
     @property
     def element_shape(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #3910
* #3909

This is a part of cprofile result when I profile python launch
overhead for ndarray kernels.  Note how `dtype/n/m/shape` queries takes up a
lot of time in extract_args. These are indeed caused by `property` which
is super slow.  We should just make them normal attributes to speed
things up.

This PR reduces the time we spent at `extract_args` from 1.6s to 1.01s
in my profiled use case.

Reference:
https://stackoverflow.com/questions/21174590/property-speed-overhead-in-python

Note that I didn't get rid of all properties here, there're still some
low hanging fruit like `element_shape`.

```
/home/ailing/github/taichi/python/taichi/lang/kernel_impl.py:252(extract_arg)                                        ->  600000    0.344    0.451  /home/ailing/github/taichi/python/taichi/lang/_ndarray.py:53(dtype)
                                                                                                                         400000    0.150    0.150  /home/ailing/github/taichi/python/taichi/lang/_ndarray.py:251(shape)
                                                                                                                         200000    0.102    0.102  /home/ailing/github/taichi/python/taichi/lang/matrix.py:1325(n)
                                                                                                                         200000    0.086    0.086  /home/ailing/github/taichi/python/taichi/lang/matrix.py:1329(m)
                                                                                                                         200000    0.104    0.104  /home/ailing/github/taichi/python/taichi/lang/matrix.py:1333(shape)
                                                                                                                         600000    0.351    0.351  /home/ailing/github/taichi/python/taichi/lang/matrix.py:1397(n)
                                                                                                                         600000    0.335    0.335  /home/ailing/github/taichi/python/taichi/lang/matrix.py:1401(shape)
                                                                                                                         600000    0.088    0.088  /home/ailing/github/taichi/python/taichi/types/annotations.py:33(check_element_dim)
                                                                                                                         400000    0.034    0.034  /home/ailing/github/taichi/python/taichi/types/annotations.py:39(check_layout)
                                                                                                                         600000    0.064    0.064  /home/ailing/github/taichi/python/taichi/types/annotations.py:45(check_element_shape)
                                                                                                                         600000    0.061    0.061  /home/ailing/github/taichi/python/taichi/types/annotations.py:51(check_field_dim)
                                                                                                                        2300000    0.153    0.153  {built-in method builtins.isinstance}
                                                                                                                        1200000    0.076    0.076  {built-in method builtins.len}
/home/ailing/github/taichi/python/taichi/lang/kernel_impl.py:300(extract)                                            ->  600000    1.655    3.709  /home/ailing/github/taichi/python/taichi/lang/kernel_impl.py:252(extract_arg)
                                                                                                                         600000    0.053    0.053  {method 'append' of 'list' objects}

```