### PR TITLE
[perf] Clear global_vars/matrix_fields after materialize()

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -350,6 +350,8 @@ class PyTaichi:
         self._check_field_not_placed()
         self._check_matrix_field_member_shape()
         self._calc_matrix_field_dynamic_index_stride()
+        self.global_vars = []
+        self.matrix_fields = []
 
     def _register_signal_handlers(self):
         if self._signal_handler_registry is None:


### PR DESCRIPTION
Related issue = #3906

https://github.com/taichi-dev/taichi/runs/4664728269?check_suite_focus=true shows that #3906 causes performance regression. This PR aims at fixing it by clearing `global_vars`/`matrix_fields` after `materialize()` because they should not be handled in the next `materialize()`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
