### PR TITLE
[mesh] Demote from-end element attribute atomic op

### DIFF
--- a/taichi/analysis/gather_uniquely_accessed_pointers.cpp
+++ b/taichi/analysis/gather_uniquely_accessed_pointers.cpp
@@ -118,6 +118,7 @@ class UniquelyAccessedSNodeSearcher : public BasicStmtVisitor {
   // one GlobalPtrStmt (or by definitely-same-address GlobalPtrStmts),
   // and that GlobalPtrStmt's address is loop-unique.
   std::unordered_map<const SNode *, GlobalPtrStmt *> accessed_pointer_;
+  std::unordered_map<const SNode *, GlobalPtrStmt *> rel_access_pointer_;
 
  public:
   using BasicStmtVisitor::visit;
@@ -128,6 +129,29 @@ class UniquelyAccessedSNodeSearcher : public BasicStmtVisitor {
   }
 
   void visit(GlobalPtrStmt *stmt) override {
+    // mesh-for loop unique
+    if (stmt->indices.size() == 1 && stmt->indices[0]->is<MeshIndexConversionStmt>()) {
+      auto idx = stmt->indices[0]->as<MeshIndexConversionStmt>()->idx;
+      while (idx->is<MeshIndexConversionStmt>()) {  // special case: l2g +
+                                                    // g2r
+        idx = idx->as<MeshIndexConversionStmt>()->idx;
+      }
+      if (idx->is<LoopIndexStmt>() &&
+          idx->as<LoopIndexStmt>()->is_mesh_index()) { // from-end access
+          for (auto &snode : stmt->snodes.data) {
+            if (rel_access_pointer_.find(snode) == rel_access_pointer_.end()) { // not accessed by neibhours yet
+              accessed_pointer_[snode] = stmt;
+            } else { // accessed by neibhours, so it's not unique
+              accessed_pointer_[snode] = nullptr;
+            }
+          }
+      } else { // to-end access
+        for (auto &snode : stmt->snodes.data) {
+            rel_access_pointer_[snode] = stmt;
+            accessed_pointer_[snode] = nullptr; // from-end access should not be unique
+          }
+      }
+    }
     for (auto &snode : stmt->snodes.data) {
       auto accessed_ptr = accessed_pointer_.find(snode);
       if (accessed_ptr == accessed_pointer_.end()) {
@@ -189,6 +213,11 @@ class UniquelyAccessedBitStructGatherer : public BasicStmtVisitor {
       for (auto &it : loop_unique_ptr) {
         auto *snode = it.first;
         auto *ptr1 = it.second;
+        if (ptr1 != nullptr && 
+            ptr1->indices.size() > 0 && 
+            ptr1->indices[0]->is<MeshIndexConversionStmt>()) {
+          continue;
+        }
         if (snode->is_bit_level) {
           // Find the nearest non-bit-level ancestor
           while (snode->is_bit_level) {

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -72,7 +72,8 @@ class DemoteAtomics : public BasicStmtVisitor {
             }
             if (idx->is<LoopIndexStmt>() &&
                 idx->as<LoopIndexStmt>()->is_mesh_index() &&
-                loop_unique_ptr_[stmt->dest->as<GlobalPtrStmt>()->snodes.data[0]] != nullptr) {
+                loop_unique_ptr_[stmt->dest->as<GlobalPtrStmt>()
+                                     ->snodes.data[0]] != nullptr) {
               demote = true;
             }
           }

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -71,10 +71,9 @@ class DemoteAtomics : public BasicStmtVisitor {
               idx = idx->as<MeshIndexConversionStmt>()->idx;
             }
             if (idx->is<LoopIndexStmt>() &&
-                idx->as<LoopIndexStmt>()->is_mesh_index()) {
+                idx->as<LoopIndexStmt>()->is_mesh_index() &&
+                loop_unique_ptr_[stmt->dest->as<GlobalPtrStmt>()->snodes.data[0]] != nullptr) {
               demote = true;
-              int x = loop_unique_ptr_[stmt->dest->as<GlobalPtrStmt>()->snodes.data[0]] != nullptr;
-              TI_INFO("not empty: {}", x);
             }
           }
         }

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -73,6 +73,8 @@ class DemoteAtomics : public BasicStmtVisitor {
             if (idx->is<LoopIndexStmt>() &&
                 idx->as<LoopIndexStmt>()->is_mesh_index()) {
               demote = true;
+              int x = loop_unique_ptr_[stmt->dest->as<GlobalPtrStmt>()->snodes.data[0]] != nullptr;
+              TI_INFO("not empty: {}", x);
             }
           }
         }


### PR DESCRIPTION
Related issue = #3608 

It is worth noting that in a mesh-for loop, the attribute of the from-end element should only be accessed in one loop, like the following case:
``` Python
for c in model.cells:
    for i in c.cells.size:
        c.a += c.cells[i].b
```
The variable `c.a` is a unique address in the whole loop scope so the atomic operation `+=` should be demoted.
Note that we ignore the following case since it's not reasonable for a parallel program.
 ``` Python
for c in model.cells:
    for i in c.cells.size:
        c.a += c.cells[i].a
```
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
