### PR TITLE
[Error] Do not show body in exceptions in nodes with body

### DIFF
--- a/python/taichi/lang/ast/ast_transformer_utils.py
+++ b/python/taichi/lang/ast/ast_transformer_utils.py
@@ -201,7 +201,14 @@ class ASTTransformerContext:
             hint = ' ' * col_offset + '^' * (end_col_offset - col_offset)
             msg += gen_line(self.src[node.lineno - 1], hint)
         else:
-            for i in range(node.lineno - 1, node.end_lineno):
+            node_type = node.__class__.__name__
+
+            if node_type in ["For", "While", "FunctionDef", "If"]:
+                end_lineno = max(node.body[0].lineno - 1, node.lineno)
+            else:
+                end_lineno = node.end_lineno
+
+            for i in range(node.lineno - 1, end_lineno):
                 last = len(self.src[i])
                 while last > 0 and (self.src[i][last - 1].isspace() or
                                     not self.src[i][last - 1].isprintable()):

--- a/tests/python/test_exception.py
+++ b/tests/python/test_exception.py
@@ -135,3 +135,29 @@ bbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"""
     print(e.value.args[0])
     assert e.value.args[0][:len(msg)] == msg
+
+
+@pytest.mark.skipif(version_info < (3, 8), reason="This is a feature for python>=3.8")
+@ti.test()
+def test_exception_in_node_with_body():
+    frameinfo = getframeinfo(currentframe())
+    @ti.kernel
+    def foo():
+        for i in range(1, 2, 3):
+            a = 1
+            b = 1
+            c = 1
+            d = 1
+
+    with pytest.raises(ti.TaichiCompilationError) as e:
+        foo()
+    lineno = frameinfo.lineno
+    file = frameinfo.filename
+    msg = f"""\
+On line {lineno + 3} of file "{file}":
+        for i in range(1, 2, 3):
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+Range should have 1 or 2 arguments, found 3"""
+    print(e.value.args[0])
+    assert e.value.args[0] == msg
+


### PR DESCRIPTION
Related issue = fixes #3784 
`max(node.body[0].lineno - 1, node.lineno)` is to deal with circumstances when `node.body[0]` starts on the same line as `node` and ends on another line. It makes sure at least one line can be printed. For example:
```python
for i in range(1, 2, 3):print(
i)
```
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
