### PR TITLE
[opt] Get store_to_load_forwarding work with local tensors across basic blocks

### DIFF
--- a/taichi/analysis/data_source_analysis.cpp
+++ b/taichi/analysis/data_source_analysis.cpp
@@ -57,7 +57,7 @@ Stmt *get_store_data(Stmt *store_stmt) {
 
 std::vector<Stmt *> get_store_destination(Stmt *store_stmt) {
   // If store_stmt provides some data sources, return the pointers of the data.
-  if (store_stmt->is<AllocaStmt>()) {
+  if (store_stmt->is<AllocaStmt>() && !store_stmt->ret_type->is<TensorType>()) {
     // The statement itself provides a data source (const [0]).
     return std::vector<Stmt *>(1, store_stmt);
   } else if (auto local_store = store_stmt->cast<LocalStoreStmt>()) {

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -218,8 +218,11 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
   }
   if (!result) {
     // The UD-chain is empty.
-    TI_WARN("stmt {} loaded in stmt {} before storing.", var->id,
-            block->statements[position]->id);
+    if (!(var->is<PtrOffsetStmt>() && var->as<PtrOffsetStmt>()->is_local_ptr())) {
+      // Only exception: tensor alloca is not considered as a store.
+      TI_WARN("stmt {} loaded in stmt {} before storing.", var->id,
+              block->statements[position]->id);
+    }
     return nullptr;
   }
   if (!result_visible) {

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -218,7 +218,8 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
   }
   if (!result) {
     // The UD-chain is empty.
-    if (!(var->is<PtrOffsetStmt>() && var->as<PtrOffsetStmt>()->is_local_ptr())) {
+    if (!(var->is<PtrOffsetStmt>() &&
+          var->as<PtrOffsetStmt>()->is_local_ptr())) {
       // Only exception: tensor alloca is not considered as a store.
       TI_WARN("stmt {} loaded in stmt {} before storing.", var->id,
               block->statements[position]->id);

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -39,7 +39,7 @@ CompileConfig::CompileConfig() {
   verbose = true;
   fast_math = true;
   async_mode = false;
-  dynamic_index = false;
+  dynamic_index = true;
   flatten_if = false;
   make_thread_local = true;
   make_block_local = true;

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -39,7 +39,7 @@ CompileConfig::CompileConfig() {
   verbose = true;
   fast_math = true;
   async_mode = false;
-  dynamic_index = true;
+  dynamic_index = false;
   flatten_if = false;
   make_thread_local = true;
   make_block_local = true;


### PR DESCRIPTION
Related issue = #2590

Currently, running our `cornell_box` example with `dynamic_index=True` is 21.4x slower than with `dynamic_index=False`, which is intolerable. This PR serves as a first step towards aligning their performance, and makes it only 3.7x slower now.

Technically, this PR is a follow-up of #3237. In fact, #3237 only makes `store_to_load_forwarding` for local tensors work properly within a basic block. And for code snippets like this:
```py
import taichi as ti

ti.init(print_ir=True, dynamic_index=True)

@ti.kernel
def func(x: ti.i32):
    a = ti.Vector([0])
    b = 0
    if x > 0:
        b = 1
    print(a[0], b)

func(2)
```
It will generate the following IR:
```
kernel {
  $0 = offloaded  
  body {
    <i32> $1 = const [1]
    <i32> $2 = const [0]
    <[Tensor (1, 1) i32]> $3 = alloca
    <*i32> $4 = shift ptr [$3 + $2]
    <i32> $5 : local store [$4 <- $2]
    <i32> $6 = alloca
    <i32> $7 = arg[0]
    <i32> $8 = cmp_gt $7 $2
    <i32> $9 = bit_and $8 $1
    $10 : if $9 {
      <i32> $11 : local store [$6 <- $1]
    }
    <i32> $12 = local load [ [$4[0]]]
    <i32> $13 = local load [ [$6[0]]]
    print $12, " ", $13, "\n"
  }
}
```
which is not optimized.

This PR makes `store_to_load_forwarding` work with local tensors across basic blocks. For the above example it will generate the following IR:
```
kernel {
  $0 = offloaded  
  body {
    <i32> $1 = const [1]
    <i32> $2 = const [0]
    <i32> $3 = alloca
    <i32> $4 = arg[0]
    <i32> $5 = cmp_gt $4 $2
    <i32> $6 = bit_and $5 $1
    $7 : if $6 {
      <i32> $8 : local store [$3 <- $1]
    }
    <i32> $9 = local load [ [$3[0]]]
    print $2, " ", $9, "\n"
  }
}
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
