### PR TITLE
[refactor] [ci] Enable identifier naming in clang-tidy

### DIFF
--- a/.github/workflows/scripts/check_clang_tidy.sh
+++ b/.github/workflows/scripts/check_clang_tidy.sh
@@ -9,4 +9,4 @@ rm -rf build && mkdir build && cd build
 cmake $CI_SETUP_CMAKE_ARGS ..
 
 cd ..
-python3 ./scripts/run_clang_tidy.py $PWD/taichi -clang-tidy-binary clang-tidy-10 -checks=-*,performance-inefficient-string-concatenation -header-filter=$PWD/taichi -p $PWD/build -j2
+python3 ./scripts/run_clang_tidy.py $PWD/taichi -clang-tidy-binary clang-tidy-10 -checks=-*,performance-inefficient-string-concatenation,readability-identifier-naming -header-filter=$PWD/taichi -p $PWD/build -j2

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -119,7 +119,7 @@ class KernelGen : public IRVisitor {
   bool is_top_level_{true};
   CompiledTaichiKernel compiled_program_;
   UsedFeature used;  // TODO: is this actually per-offload?
-  int arr_bind_idx = static_cast<int>(GLBufId::Arr);
+  int arr_bind_idx_ = static_cast<int>(GLBufId::Arr);
 
   // per-offload variables:
   LineAppender line_appender_;
@@ -851,7 +851,7 @@ class KernelGen : public IRVisitor {
     const auto dt = opengl_data_type_name(stmt->element_type());
     if (stmt->is_ptr) {
       if (!used.arr_arg_to_bind_idx.count(stmt->arg_id)) {
-        used.arr_arg_to_bind_idx[stmt->arg_id] = arr_bind_idx++;
+        used.arr_arg_to_bind_idx[stmt->arg_id] = arr_bind_idx_++;
       }
     } else {
       used.buf_args = true;

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -795,8 +795,8 @@ Value IRBuilder::rand_i32(Value global_tmp_) {
 }
 
 Value IRBuilder::get_const(const SType &dtype,
-                            const uint64_t *pvalue,
-                            bool cache) {
+                           const uint64_t *pvalue,
+                           bool cache) {
   auto key = std::make_pair(dtype.id, pvalue[0]);
   if (cache) {
     auto it = const_tbl_.find(key);

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -178,25 +178,25 @@ PhiValue IRBuilder::make_phi(const SType &out_type, uint32_t num_incoming) {
 Value IRBuilder::int_immediate_number(const SType &dtype,
                                       int64_t value,
                                       bool cache) {
-  return get_const_(dtype, reinterpret_cast<uint64_t *>(&value), cache);
+  return get_const(dtype, reinterpret_cast<uint64_t *>(&value), cache);
 }
 
 Value IRBuilder::uint_immediate_number(const SType &dtype,
                                        uint64_t value,
                                        bool cache) {
-  return get_const_(dtype, &value, cache);
+  return get_const(dtype, &value, cache);
 }
 
 Value IRBuilder::float_immediate_number(const SType &dtype,
                                         double value,
                                         bool cache) {
   if (data_type_bits(dtype.dt) == 64) {
-    return get_const_(dtype, reinterpret_cast<uint64_t *>(&value), cache);
+    return get_const(dtype, reinterpret_cast<uint64_t *>(&value), cache);
   } else if (data_type_bits(dtype.dt) == 32) {
     float fvalue = static_cast<float>(value);
     uint32_t *ptr = reinterpret_cast<uint32_t *>(&fvalue);
     uint64_t data = ptr[0];
-    return get_const_(dtype, &data, cache);
+    return get_const(dtype, &data, cache);
   } else {
     TI_ERROR("Type {} not supported.", dtype.dt->to_string());
   }
@@ -406,46 +406,46 @@ void IRBuilder::set_work_group_size(const std::array<int, 3> group_size) {
   Value size_z =
       uint_immediate_number(t_uint32_, static_cast<uint64_t>(group_size[2]));
 
-  if (gl_work_group_size.id == 0) {
-    gl_work_group_size.id = id_counter_++;
+  if (gl_work_group_size_.id == 0) {
+    gl_work_group_size_.id = id_counter_++;
   }
   ib_.begin(spv::OpConstantComposite)
-      .add_seq(t_v3_uint_, gl_work_group_size, size_x, size_y, size_z)
+      .add_seq(t_v3_uint_, gl_work_group_size_, size_x, size_y, size_z)
       .commit(&global_);
-  this->decorate(spv::OpDecorate, gl_work_group_size, spv::DecorationBuiltIn,
+  this->decorate(spv::OpDecorate, gl_work_group_size_, spv::DecorationBuiltIn,
                  spv::BuiltInWorkgroupSize);
 }
 
 Value IRBuilder::get_num_work_groups(uint32_t dim_index) {
-  if (gl_num_work_groups.id == 0) {
+  if (gl_num_work_groups_.id == 0) {
     SType ptr_type = this->get_pointer_type(t_v3_uint_, spv::StorageClassInput);
-    gl_num_work_groups = new_value(ptr_type, ValueKind::kVectorPtr);
+    gl_num_work_groups_ = new_value(ptr_type, ValueKind::kVectorPtr);
     ib_.begin(spv::OpVariable)
-        .add_seq(ptr_type, gl_num_work_groups, spv::StorageClassInput)
+        .add_seq(ptr_type, gl_num_work_groups_, spv::StorageClassInput)
         .commit(&global_);
-    this->decorate(spv::OpDecorate, gl_num_work_groups, spv::DecorationBuiltIn,
+    this->decorate(spv::OpDecorate, gl_num_work_groups_, spv::DecorationBuiltIn,
                    spv::BuiltInNumWorkgroups);
   }
   SType pint_type = this->get_pointer_type(t_uint32_, spv::StorageClassInput);
   Value ptr = this->make_value(
-      spv::OpAccessChain, pint_type, gl_num_work_groups,
+      spv::OpAccessChain, pint_type, gl_num_work_groups_,
       uint_immediate_number(t_uint32_, static_cast<uint64_t>(dim_index)));
 
   return this->make_value(spv::OpLoad, t_uint32_, ptr);
 }
 Value IRBuilder::get_global_invocation_id(uint32_t dim_index) {
-  if (gl_global_invocation_id.id == 0) {
+  if (gl_global_invocation_id_.id == 0) {
     SType ptr_type = this->get_pointer_type(t_v3_uint_, spv::StorageClassInput);
-    gl_global_invocation_id = new_value(ptr_type, ValueKind::kVectorPtr);
+    gl_global_invocation_id_ = new_value(ptr_type, ValueKind::kVectorPtr);
     ib_.begin(spv::OpVariable)
-        .add_seq(ptr_type, gl_global_invocation_id, spv::StorageClassInput)
+        .add_seq(ptr_type, gl_global_invocation_id_, spv::StorageClassInput)
         .commit(&global_);
-    this->decorate(spv::OpDecorate, gl_global_invocation_id,
+    this->decorate(spv::OpDecorate, gl_global_invocation_id_,
                    spv::DecorationBuiltIn, spv::BuiltInGlobalInvocationId);
   }
   SType pint_type = this->get_pointer_type(t_uint32_, spv::StorageClassInput);
   Value ptr = this->make_value(
-      spv::OpAccessChain, pint_type, gl_global_invocation_id,
+      spv::OpAccessChain, pint_type, gl_global_invocation_id_,
       uint_immediate_number(t_uint32_, static_cast<uint64_t>(dim_index)));
 
   return this->make_value(spv::OpLoad, t_uint32_, ptr);
@@ -753,19 +753,19 @@ Value IRBuilder::rand_u32(Value global_tmp_) {
   Value _19u = uint_immediate_number(t_uint32_, 19u);
   Value _8u = uint_immediate_number(t_uint32_, 8u);
   Value _1000000007u = uint_immediate_number(t_uint32_, 1000000007u);
-  Value tmp0 = load_variable(_rand_x_, t_uint32_);
+  Value tmp0 = load_variable(rand_x_, t_uint32_);
   Value tmp1 = make_value(spv::OpShiftLeftLogical, t_uint32_, tmp0, _11u);
   Value tmp_t = make_value(spv::OpBitwiseXor, t_uint32_, tmp0, tmp1);  // t
-  store_variable(_rand_x_, load_variable(_rand_y_, t_uint32_));
-  store_variable(_rand_y_, load_variable(_rand_z_, t_uint32_));
-  Value tmp_w = load_variable(_rand_w_, t_uint32_);  // reuse w
-  store_variable(_rand_z_, tmp_w);
+  store_variable(rand_x_, load_variable(rand_y_, t_uint32_));
+  store_variable(rand_y_, load_variable(rand_z_, t_uint32_));
+  Value tmp_w = load_variable(rand_w_, t_uint32_);  // reuse w
+  store_variable(rand_z_, tmp_w);
   Value tmp2 = make_value(spv::OpShiftRightLogical, t_uint32_, tmp_w, _19u);
   Value tmp3 = make_value(spv::OpBitwiseXor, t_uint32_, tmp_w, tmp2);
   Value tmp4 = make_value(spv::OpShiftRightLogical, t_uint32_, tmp_t, _8u);
   Value tmp5 = make_value(spv::OpBitwiseXor, t_uint32_, tmp_t, tmp4);
   Value new_w = make_value(spv::OpBitwiseXor, t_uint32_, tmp3, tmp5);
-  store_variable(_rand_w_, new_w);
+  store_variable(rand_w_, new_w);
   Value val = make_value(spv::OpIMul, t_uint32_, new_w, _1000000007u);
 
   return val;
@@ -794,7 +794,7 @@ Value IRBuilder::rand_i32(Value global_tmp_) {
   return val;
 }
 
-Value IRBuilder::get_const_(const SType &dtype,
+Value IRBuilder::get_const(const SType &dtype,
                             const uint64_t *pvalue,
                             bool cache) {
   auto key = std::make_pair(dtype.id, pvalue[0]);
@@ -862,30 +862,30 @@ SType IRBuilder::declare_primitive_type(DataType dt) {
 void IRBuilder::init_random_function(Value global_tmp_) {
   // variables declare
   SType local_type = get_pointer_type(t_uint32_, spv::StorageClassPrivate);
-  _rand_x_ = new_value(local_type, ValueKind::kVariablePtr);
-  _rand_y_ = new_value(local_type, ValueKind::kVariablePtr);
-  _rand_z_ = new_value(local_type, ValueKind::kVariablePtr);
-  _rand_w_ = new_value(local_type, ValueKind::kVariablePtr);
-  global_values.push_back(_rand_x_);
-  global_values.push_back(_rand_y_);
-  global_values.push_back(_rand_z_);
-  global_values.push_back(_rand_w_);
+  rand_x_ = new_value(local_type, ValueKind::kVariablePtr);
+  rand_y_ = new_value(local_type, ValueKind::kVariablePtr);
+  rand_z_ = new_value(local_type, ValueKind::kVariablePtr);
+  rand_w_ = new_value(local_type, ValueKind::kVariablePtr);
+  global_values.push_back(rand_x_);
+  global_values.push_back(rand_y_);
+  global_values.push_back(rand_z_);
+  global_values.push_back(rand_w_);
   ib_.begin(spv::OpVariable)
-      .add_seq(local_type, _rand_x_, spv::StorageClassPrivate)
+      .add_seq(local_type, rand_x_, spv::StorageClassPrivate)
       .commit(&global_);
   ib_.begin(spv::OpVariable)
-      .add_seq(local_type, _rand_y_, spv::StorageClassPrivate)
+      .add_seq(local_type, rand_y_, spv::StorageClassPrivate)
       .commit(&global_);
   ib_.begin(spv::OpVariable)
-      .add_seq(local_type, _rand_z_, spv::StorageClassPrivate)
+      .add_seq(local_type, rand_z_, spv::StorageClassPrivate)
       .commit(&global_);
   ib_.begin(spv::OpVariable)
-      .add_seq(local_type, _rand_w_, spv::StorageClassPrivate)
+      .add_seq(local_type, rand_w_, spv::StorageClassPrivate)
       .commit(&global_);
-  debug(spv::OpName, _rand_x_, "_rand_x");
-  debug(spv::OpName, _rand_y_, "_rand_y");
-  debug(spv::OpName, _rand_z_, "_rand_z");
-  debug(spv::OpName, _rand_w_, "_rand_w");
+  debug(spv::OpName, rand_x_, "_rand_x");
+  debug(spv::OpName, rand_y_, "_rand_y");
+  debug(spv::OpName, rand_z_, "_rand_z");
+  debug(spv::OpName, rand_w_, "_rand_w");
   SType gtmp_type = get_pointer_type(t_int32_, spv::StorageClassStorageBuffer);
   Value rand_gtmp_ = new_value(gtmp_type, ValueKind::kVariablePtr);
   debug(spv::OpName, rand_gtmp_, "rand_gtmp");
@@ -928,7 +928,7 @@ void IRBuilder::init_random_function(Value global_tmp_) {
   SType pint_type = this->get_pointer_type(t_uint32_, spv::StorageClassInput);
   Value tmp0 = new_value(pint_type, ValueKind::kVariablePtr);
   ib_.begin(spv::OpAccessChain)
-      .add_seq(pint_type, tmp0, gl_global_invocation_id,
+      .add_seq(pint_type, tmp0, gl_global_invocation_id_,
                uint_immediate_number(t_uint32_, 0))
       .commit(&func_header_);
   Value tmp1 = load_var(tmp0, t_uint32_);
@@ -961,10 +961,10 @@ void IRBuilder::init_random_function(Value global_tmp_) {
   ib_.begin(spv::OpIMul)
       .add_seq(t_uint32_, tmp8, _1000000007u, tmp7)
       .commit(&func_header_);
-  store_var(_rand_x_, tmp8);
-  store_var(_rand_y_, _362436069u);
-  store_var(_rand_z_, _521288629u);
-  store_var(_rand_w_, _88675123u);
+  store_var(rand_x_, tmp8);
+  store_var(rand_y_, _362436069u);
+  store_var(rand_z_, _521288629u);
+  store_var(rand_w_, _88675123u);
   // Yes, this is not an atomic operation, but just fine since no matter
   // how RAND_STATE changes, `gl_GlobalInvocationID.x` can still help
   // us to set different seeds for different threads.

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -346,11 +346,11 @@ class IRBuilder {
         ib_.add(v);
       }
     }
-    if (gl_global_invocation_id.id != 0) {
-      ib_.add(gl_global_invocation_id);
+    if (gl_global_invocation_id_.id != 0) {
+      ib_.add(gl_global_invocation_id_);
     }
-    if (gl_num_work_groups.id != 0) {
-      ib_.add(gl_num_work_groups);
+    if (gl_num_work_groups_.id != 0) {
+      ib_.add(gl_num_work_groups_);
     }
     ib_.commit(&entry_);
     ib_.begin(spv::OpExecutionMode)
@@ -476,7 +476,7 @@ class IRBuilder {
     return val;
   }
 
-  Value get_const_(const SType &dtype, const uint64_t *pvalue, bool cache);
+  Value get_const(const SType &dtype, const uint64_t *pvalue, bool cache);
   SType declare_primitive_type(DataType dt);
 
   void init_random_function(Value global_tmp_);
@@ -509,16 +509,16 @@ class IRBuilder {
   SType t_void_func_;
   // gl compute shader related type(s) and variables
   SType t_v3_uint_;
-  Value gl_global_invocation_id;
-  Value gl_num_work_groups;
-  Value gl_work_group_size;
+  Value gl_global_invocation_id_;
+  Value gl_num_work_groups_;
+  Value gl_work_group_size_;
 
   // Random function and variables
   bool init_rand_{false};
-  Value _rand_x_;
-  Value _rand_y_;
-  Value _rand_z_;
-  Value _rand_w_;  // per-thread local variable
+  Value rand_x_;
+  Value rand_y_;
+  Value rand_z_;
+  Value rand_w_;  // per-thread local variable
 
   // map from value to its pointer type
   std::map<std::pair<uint32_t, spv::StorageClass>, SType> pointer_type_tbl_;

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -13,7 +13,7 @@ void MakeMeshBlockLocal::simplify_nested_conversion() {
   std::vector<MeshIndexConversionStmt *> stmts;
   std::vector<Stmt *> ori_indices;
 
-  irpass::analysis::gather_statements(offload->body.get(), [&](Stmt *stmt) {
+  irpass::analysis::gather_statements(offload_->body.get(), [&](Stmt *stmt) {
     if (auto conv1 = stmt->cast<MeshIndexConversionStmt>()) {
       if (auto conv2 = conv1->idx->cast<MeshIndexConversionStmt>()) {
         if (conv1->conv_type == mesh::ConvType::g2r &&
@@ -36,24 +36,24 @@ void MakeMeshBlockLocal::simplify_nested_conversion() {
 }
 
 void MakeMeshBlockLocal::gather_candidate_mapping() {
-  irpass::analysis::gather_statements(offload->body.get(), [&](Stmt *stmt) {
+  irpass::analysis::gather_statements(offload_->body.get(), [&](Stmt *stmt) {
     if (auto conv = stmt->cast<MeshIndexConversionStmt>()) {
       if (conv->conv_type != mesh::ConvType::g2r) {
-        bool is_from_end = (conv->idx_type == offload->major_from_type);
+        bool is_from_end = (conv->idx_type == offload_->major_from_type);
         bool is_to_end = false;
-        for (auto type : offload->major_to_types) {
+        for (auto type : offload_->major_to_types) {
           is_to_end |= (conv->idx_type == type);
         }
-        for (auto rel : offload->minor_relation_types) {
+        for (auto rel : offload_->minor_relation_types) {
           auto from_type =
               mesh::MeshElementType(mesh::from_end_element_order(rel));
           auto to_type = mesh::MeshElementType(mesh::to_end_element_order(rel));
           is_from_end |= (conv->idx_type == from_type);
           is_to_end |= (conv->idx_type == to_type);
         }
-        if ((is_to_end && config.mesh_localize_to_end_mapping) ||
-            (is_from_end && config.mesh_localize_from_end_mapping)) {
-          mappings.insert(std::make_pair(conv->idx_type, conv->conv_type));
+        if ((is_to_end && config_.mesh_localize_to_end_mapping) ||
+            (is_from_end && config_.mesh_localize_from_end_mapping)) {
+          mappings_.insert(std::make_pair(conv->idx_type, conv->conv_type));
         }
       }
     }
@@ -64,10 +64,10 @@ void MakeMeshBlockLocal::gather_candidate_mapping() {
 void MakeMeshBlockLocal::replace_conv_statements() {
   std::vector<MeshIndexConversionStmt *> idx_conv_stmts;
 
-  irpass::analysis::gather_statements(offload->body.get(), [&](Stmt *stmt) {
+  irpass::analysis::gather_statements(offload_->body.get(), [&](Stmt *stmt) {
     if (auto idx_conv = stmt->cast<MeshIndexConversionStmt>()) {
-      if (idx_conv->mesh == offload->mesh && idx_conv->conv_type == conv_type &&
-          idx_conv->idx_type == element_type) {
+      if (idx_conv->mesh == offload_->mesh && idx_conv->conv_type == conv_type_ &&
+          idx_conv->idx_type == element_type_) {
         idx_conv_stmts.push_back(idx_conv);
       }
     }
@@ -77,15 +77,15 @@ void MakeMeshBlockLocal::replace_conv_statements() {
   for (auto stmt : idx_conv_stmts) {
     VecStatement bls;
     Stmt *bls_element_offset_bytes = bls.push_back<ConstStmt>(
-        LaneAttribute<TypedConstant>{(int32)mapping_bls_offset_in_bytes});
+        LaneAttribute<TypedConstant>{(int32)mapping_bls_offset_in_bytes_});
     Stmt *idx_byte = bls.push_back<BinaryOpStmt>(
         BinaryOpType::mul, stmt->idx,
-        bls.push_back<ConstStmt>(TypedConstant(mapping_dtype_size)));
+        bls.push_back<ConstStmt>(TypedConstant(mapping_dtype_size_)));
     Stmt *offset = bls.push_back<BinaryOpStmt>(
         BinaryOpType::add, bls_element_offset_bytes, idx_byte);
     Stmt *bls_ptr = bls.push_back<BlockLocalPtrStmt>(
         offset,
-        TypeFactory::create_vector_or_scalar_type(1, mapping_data_type, true));
+        TypeFactory::create_vector_or_scalar_type(1, mapping_data_type_, true));
     [[maybe_unused]] Stmt *bls_load = bls.push_back<GlobalLoadStmt>(bls_ptr);
     stmt->replace_with(std::move(bls));
   }
@@ -94,10 +94,10 @@ void MakeMeshBlockLocal::replace_conv_statements() {
 void MakeMeshBlockLocal::replace_global_ptrs(SNode *snode) {
   auto data_type = snode->dt.ptr_removed();
   auto dtype_size = data_type_size(data_type);
-  auto offset_in_bytes = attr_bls_offset_in_bytes.find(snode)->second;
+  auto offset_in_bytes = attr_bls_offset_in_bytes_.find(snode)->second;
 
   std::vector<GlobalPtrStmt *> global_ptrs;
-  irpass::analysis::gather_statements(offload->body.get(), [&](Stmt *stmt) {
+  irpass::analysis::gather_statements(offload_->body.get(), [&](Stmt *stmt) {
     if (auto global_ptr = stmt->cast<GlobalPtrStmt>()) {
       TI_ASSERT(global_ptr->width() == 1);
       if (global_ptr->snodes[0] == snode &&
@@ -125,11 +125,11 @@ void MakeMeshBlockLocal::replace_global_ptrs(SNode *snode) {
   }
 
   // in the cpu backend, atomic op in body block could be demoted to non-atomic
-  if (config.arch != Arch::x64) {
+  if (config_.arch != Arch::x64) {
     return;
   }
   std::vector<AtomicOpStmt *> atomic_ops;
-  irpass::analysis::gather_statements(offload->body.get(), [&](Stmt *stmt) {
+  irpass::analysis::gather_statements(offload_->body.get(), [&](Stmt *stmt) {
     if (auto atomic_op = stmt->cast<AtomicOpStmt>()) {
       if (atomic_op->op_type == AtomicOpType::add &&
           atomic_op->dest->is<BlockLocalPtrStmt>()) {
@@ -159,15 +159,15 @@ Stmt *MakeMeshBlockLocal::create_xlogue(
     Stmt *start_val,
     Stmt *end_val,
     std::function<void(Block * /*block*/, Stmt * /*idx_val*/)> body_) {
-  Stmt *idx = block->push_back<AllocaStmt>(mapping_data_type);
+  Stmt *idx = block_->push_back<AllocaStmt>(mapping_data_type_);
   [[maybe_unused]] Stmt *init_val =
-      block->push_back<LocalStoreStmt>(idx, start_val);
+      block_->push_back<LocalStoreStmt>(idx, start_val);
   Stmt *block_dim_val;
-  if (config.arch == Arch::x64) {
-    block_dim_val = block->push_back<ConstStmt>(TypedConstant(1));
+  if (config_.arch == Arch::x64) {
+    block_dim_val = block_->push_back<ConstStmt>(TypedConstant(1));
   } else {
-    block_dim_val = block->push_back<ConstStmt>(
-        LaneAttribute<TypedConstant>{offload->block_dim});
+    block_dim_val = block_->push_back<ConstStmt>(
+        LaneAttribute<TypedConstant>{offload_->block_dim});
   }
 
   std::unique_ptr<Block> body = std::make_unique<Block>();
@@ -182,8 +182,8 @@ Stmt *MakeMeshBlockLocal::create_xlogue(
     [[maybe_unused]] Stmt *idx_store =
         body->push_back<LocalStoreStmt>(idx, idx_val_);
   }
-  block->push_back<WhileStmt>(std::move(body));
-  Stmt *idx_val = block->push_back<LocalLoadStmt>(LocalAddress{idx, 0});
+  block_->push_back<WhileStmt>(std::move(body));
+  Stmt *idx_val = block_->push_back<LocalLoadStmt>(LocalAddress{idx, 0});
   return idx_val;
 }
 
@@ -197,17 +197,17 @@ Stmt *MakeMeshBlockLocal::create_cache_mapping(
     Stmt *start_val,
     Stmt *end_val,
     std::function<Stmt *(Block * /*block*/, Stmt * /*idx_val*/)> global_val) {
-  Stmt *bls_element_offset_bytes = block->push_back<ConstStmt>(
-      LaneAttribute<TypedConstant>{(int32)mapping_bls_offset_in_bytes});
+  Stmt *bls_element_offset_bytes = block_->push_back<ConstStmt>(
+      LaneAttribute<TypedConstant>{(int32)mapping_bls_offset_in_bytes_});
   return create_xlogue(start_val, end_val, [&](Block *body, Stmt *idx_val) {
     Stmt *idx_val_byte = body->push_back<BinaryOpStmt>(
         BinaryOpType::mul, idx_val,
-        body->push_back<ConstStmt>(TypedConstant(mapping_dtype_size)));
+        body->push_back<ConstStmt>(TypedConstant(mapping_dtype_size_)));
     Stmt *offset = body->push_back<BinaryOpStmt>(
         BinaryOpType::add, bls_element_offset_bytes, idx_val_byte);
     Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
         offset,
-        TypeFactory::create_vector_or_scalar_type(1, mapping_data_type, true));
+        TypeFactory::create_vector_or_scalar_type(1, mapping_data_type_, true));
     [[maybe_unused]] Stmt *bls_store =
         body->push_back<GlobalStoreStmt>(bls_ptr, global_val(body, idx_val));
   });
@@ -216,8 +216,8 @@ Stmt *MakeMeshBlockLocal::create_cache_mapping(
 void MakeMeshBlockLocal::fetch_attr_to_bls(Block *body,
                                            Stmt *idx_val,
                                            Stmt *mapping_val) {
-  auto attrs = rec.find(std::make_pair(element_type, conv_type));
-  if (attrs == rec.end()) {
+  auto attrs = rec_.find(std::make_pair(element_type_, conv_type_));
+  if (attrs == rec_.end()) {
     return;
   }
   for (auto [snode, total_flags] : attrs->second) {
@@ -233,18 +233,18 @@ void MakeMeshBlockLocal::fetch_attr_to_bls(Block *body,
                    "BLS with both read and accumulation is not supported.");
 
     bool first_allocate = {false};
-    if (attr_bls_offset_in_bytes.find(snode) ==
-        attr_bls_offset_in_bytes.end()) {
+    if (attr_bls_offset_in_bytes_.find(snode) ==
+        attr_bls_offset_in_bytes_.end()) {
       first_allocate = {true};
-      bls_offset_in_bytes +=
-          (dtype_size - bls_offset_in_bytes % dtype_size) % dtype_size;
-      attr_bls_offset_in_bytes.insert(
-          std::make_pair(snode, bls_offset_in_bytes));
-      bls_offset_in_bytes +=
+      bls_offset_in_bytes_ +=
+          (dtype_size - bls_offset_in_bytes_ % dtype_size) % dtype_size;
+      attr_bls_offset_in_bytes_.insert(
+          std::make_pair(snode, bls_offset_in_bytes_));
+      bls_offset_in_bytes_ +=
           dtype_size *
-          offload->mesh->patch_max_element_num.find(element_type)->second;
+          offload_->mesh->patch_max_element_num.find(element_type_)->second;
     }
-    auto offset_in_bytes = attr_bls_offset_in_bytes.find(snode)->second;
+    auto offset_in_bytes = attr_bls_offset_in_bytes_.find(snode)->second;
 
     Stmt *value{nullptr};
     if (bls_has_read) {
@@ -282,8 +282,8 @@ void MakeMeshBlockLocal::fetch_attr_to_bls(Block *body,
 void MakeMeshBlockLocal::push_attr_to_global(Block *body,
                                              Stmt *idx_val,
                                              Stmt *mapping_val) {
-  auto attrs = rec.find(std::make_pair(element_type, conv_type));
-  if (attrs == rec.end()) {
+  auto attrs = rec_.find(std::make_pair(element_type_, conv_type_));
+  if (attrs == rec_.end()) {
     return;
   }
   for (auto [snode, total_flags] : attrs->second) {
@@ -293,7 +293,7 @@ void MakeMeshBlockLocal::push_attr_to_global(Block *body,
     }
     auto data_type = snode->dt.ptr_removed();
     auto dtype_size = data_type_size(data_type);
-    auto offset_in_bytes = attr_bls_offset_in_bytes.find(snode)->second;
+    auto offset_in_bytes = attr_bls_offset_in_bytes_.find(snode)->second;
 
     Stmt *offset =
         body->push_back<ConstStmt>(TypedConstant(int32(offset_in_bytes)));
@@ -321,18 +321,18 @@ void MakeMeshBlockLocal::fetch_mapping(
     std::function<void(Block *body, Stmt *idx_val, Stmt *mapping_val)>
         attr_callback_handler) {
   Stmt *thread_idx_stmt;
-  if (config.arch == Arch::x64) {
-    thread_idx_stmt = block->push_back<ConstStmt>(TypedConstant(0));
+  if (config_.arch == Arch::x64) {
+    thread_idx_stmt = block_->push_back<ConstStmt>(TypedConstant(0));
   } else {
-    thread_idx_stmt = block->push_back<LoopLinearIndexStmt>(
-        offload);  // Equivalent to CUDA threadIdx
+    thread_idx_stmt = block_->push_back<LoopLinearIndexStmt>(
+        offload_);  // Equivalent to CUDA threadIdx
   }
-  Stmt *total_element_num = offload->total_num_local.find(element_type)->second;
+  Stmt *total_element_num = offload_->total_num_local.find(element_type_)->second;
   Stmt *total_element_offset =
-      offload->total_offset_local.find(element_type)->second;
+      offload_->total_offset_local.find(element_type_)->second;
 
-  if (config.optimize_mesh_reordered_mapping &&
-      conv_type == mesh::ConvType::l2r) {
+  if (config_.optimize_mesh_reordered_mapping &&
+      conv_type_ == mesh::ConvType::l2r) {
     // int i = threadIdx.x;
     // while (i < owned_{}_num) {
     //  mapping_shared[i] = i + owned_{}_offset;
@@ -351,9 +351,9 @@ void MakeMeshBlockLocal::fetch_mapping(
     //  i += blockDim.x;
     // }
     Stmt *owned_element_num =
-        offload->owned_num_local.find(element_type)->second;
+        offload_->owned_num_local.find(element_type_)->second;
     Stmt *owned_element_offset =
-        offload->owned_offset_local.find(element_type)->second;
+        offload_->owned_offset_local.find(element_type_)->second;
     Stmt *pre_idx_val = mapping_callback_handler(
         thread_idx_stmt, owned_element_num, [&](Block *body, Stmt *idx_val) {
           Stmt *global_index = body->push_back<BinaryOpStmt>(
@@ -366,7 +366,7 @@ void MakeMeshBlockLocal::fetch_mapping(
           Stmt *global_offset = body->push_back<BinaryOpStmt>(
               BinaryOpType::add, total_element_offset, idx_val);
           Stmt *global_ptr = body->push_back<GlobalPtrStmt>(
-              LaneAttribute<SNode *>{mapping_snode},
+              LaneAttribute<SNode *>{mapping_snode_},
               std::vector<Stmt *>{global_offset});
           Stmt *global_load = body->push_back<GlobalLoadStmt>(global_ptr);
           attr_callback_handler(body, idx_val, global_load);
@@ -387,7 +387,7 @@ void MakeMeshBlockLocal::fetch_mapping(
           Stmt *global_offset = body->push_back<BinaryOpStmt>(
               BinaryOpType::add, total_element_offset, idx_val);
           Stmt *global_ptr = body->push_back<GlobalPtrStmt>(
-              LaneAttribute<SNode *>{mapping_snode},
+              LaneAttribute<SNode *>{mapping_snode_},
               std::vector<Stmt *>{global_offset});
           Stmt *global_load = body->push_back<GlobalLoadStmt>(global_ptr);
           attr_callback_handler(body, idx_val, global_load);
@@ -398,32 +398,32 @@ void MakeMeshBlockLocal::fetch_mapping(
 
 MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
                                        const CompileConfig &config)
-    : offload(offload), config(config) {
+    : offload_(offload), config_(config) {
   // Step 0: simplify l2g + g2r -> l2r
   simplify_nested_conversion();
 
   // Step 1: use Mesh BLS analyzer to gather which mesh attributes user declared
   // to cache
   auto caches = irpass::analysis::initialize_mesh_local_attribute(offload);
-  rec = caches->finalize();
+  rec_ = caches->finalize();
 
   // Step 2: A analyzer to determine which mapping should be localized
-  mappings.clear();
+  mappings_.clear();
   gather_candidate_mapping();
   // If a mesh attribute is in bls, the config makes its index mapping must also
   // be in bls
   if (config.mesh_localize_all_attr_mappings) {
-    for (auto [mapping, attr_set] : rec) {
-      if (mappings.find(mapping) == mappings.end()) {
-        mappings.insert(mapping);
+    for (auto [mapping, attr_set] : rec_) {
+      if (mappings_.find(mapping) == mappings_.end()) {
+        mappings_.insert(mapping);
       }
     }
   }
 
   auto has_acc = [&](mesh::MeshElementType element_type,
                      mesh::ConvType conv_type) {
-    auto ptr = rec.find(std::make_pair(element_type, conv_type));
-    if (ptr == rec.end()) {
+    auto ptr = rec_.find(std::make_pair(element_type, conv_type));
+    if (ptr == rec_.end()) {
       return false;
     }
     bool has_accumulate = {false};
@@ -434,7 +434,7 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
   };
 
   // Step 3: Cache the mappings and the attributes
-  bls_offset_in_bytes = offload->bls_size;
+  bls_offset_in_bytes_ = offload->bls_size;
   if (offload->bls_prologue == nullptr) {
     offload->bls_prologue = std::make_unique<Block>();
     offload->bls_prologue->parent_stmt = offload;
@@ -445,9 +445,9 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
   }
 
   // Cache both mappings and mesh attribute
-  for (auto [element_type, conv_type] : mappings) {
-    this->element_type = element_type;
-    this->conv_type = conv_type;
+  for (auto [element_type, conv_type] : mappings_) {
+    this->element_type_ = element_type;
+    this->conv_type_ = conv_type;
     TI_ASSERT(conv_type != mesh::ConvType::g2r);  // g2r will not be cached.
     // There is not corresponding mesh element attribute read/write,
     // It's useless to localize this mapping
@@ -456,20 +456,20 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
       continue;
     }
 
-    mapping_snode = (offload->mesh->index_mapping
+    mapping_snode_ = (offload->mesh->index_mapping
                          .find(std::make_pair(element_type, conv_type))
                          ->second);
-    mapping_data_type = mapping_snode->dt.ptr_removed();
-    mapping_dtype_size = data_type_size(mapping_data_type);
+    mapping_data_type_ = mapping_snode_->dt.ptr_removed();
+    mapping_dtype_size_ = data_type_size(mapping_data_type_);
 
     // Ensure BLS alignment
-    bls_offset_in_bytes +=
-        (mapping_dtype_size - bls_offset_in_bytes % mapping_dtype_size) %
-        mapping_dtype_size;
-    mapping_bls_offset_in_bytes = bls_offset_in_bytes;
+    bls_offset_in_bytes_ +=
+        (mapping_dtype_size_ - bls_offset_in_bytes_ % mapping_dtype_size_) %
+        mapping_dtype_size_;
+    mapping_bls_offset_in_bytes_ = bls_offset_in_bytes_;
     // allocate storage for the BLS variable
-    bls_offset_in_bytes +=
-        mapping_dtype_size *
+    bls_offset_in_bytes_ +=
+        mapping_dtype_size_ *
         offload->mesh->patch_max_element_num.find(element_type)->second;
 
     // Step 3-1:
@@ -477,7 +477,7 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
     // Step 3-2
     // Fetch mesh attributes to the BLS block at the same time
     // TODO(changyu): better way to use lambda
-    block = offload->bls_prologue.get();
+    block_ = offload->bls_prologue.get();
     fetch_mapping(
         [&](Stmt *start_val, Stmt *end_val,
             std::function<Stmt *(Block * /*block*/, Stmt * /*idx_val*/)>
@@ -497,9 +497,9 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
     if (!has_acc(element_type, conv_type)) {
       continue;
     }
-    block = offload->bls_epilogue.get();
+    block_ = offload->bls_epilogue.get();
     {
-      Stmt *thread_idx_stmt = block->push_back<LoopLinearIndexStmt>(
+      Stmt *thread_idx_stmt = block_->push_back<LoopLinearIndexStmt>(
           offload);  // Equivalent to CUDA threadIdx
       Stmt *total_element_num =
           offload->total_num_local.find(element_type)->second;
@@ -509,15 +509,15 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
           thread_idx_stmt, total_element_num, [&](Block *body, Stmt *idx_val) {
             Stmt *bls_element_offset_bytes =
                 body->push_back<ConstStmt>(LaneAttribute<TypedConstant>{
-                    (int32)mapping_bls_offset_in_bytes});
+                    (int32)mapping_bls_offset_in_bytes_});
             Stmt *idx_byte = body->push_back<BinaryOpStmt>(
                 BinaryOpType::mul, idx_val,
-                body->push_back<ConstStmt>(TypedConstant(mapping_dtype_size)));
+                body->push_back<ConstStmt>(TypedConstant(mapping_dtype_size_)));
             Stmt *offset = body->push_back<BinaryOpStmt>(
                 BinaryOpType::add, bls_element_offset_bytes, idx_byte);
             Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
                 offset, TypeFactory::create_vector_or_scalar_type(
-                            1, mapping_data_type, true));
+                            1, mapping_data_type_, true));
             Stmt *global_val = body->push_back<GlobalLoadStmt>(bls_ptr);
             this->push_attr_to_global(body, idx_val, global_val);
           });
@@ -525,25 +525,25 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
   }
 
   // Cache mesh attribute only
-  for (auto [mapping, attr_set] : rec) {
-    if (mappings.find(mapping) != mappings.end()) {
+  for (auto [mapping, attr_set] : rec_) {
+    if (mappings_.find(mapping) != mappings_.end()) {
       continue;
     }
 
-    this->element_type = mapping.first;
-    this->conv_type = mapping.second;
-    TI_ASSERT(conv_type != mesh::ConvType::g2r);  // g2r will not be cached.
+    this->element_type_ = mapping.first;
+    this->conv_type_ = mapping.second;
+    TI_ASSERT(conv_type_ != mesh::ConvType::g2r);  // g2r will not be cached.
 
-    mapping_snode = (offload->mesh->index_mapping
-                         .find(std::make_pair(element_type, conv_type))
+    mapping_snode_ = (offload->mesh->index_mapping
+                         .find(std::make_pair(element_type_, conv_type_))
                          ->second);
-    mapping_data_type = mapping_snode->dt.ptr_removed();
-    mapping_dtype_size = data_type_size(mapping_data_type);
+    mapping_data_type_ = mapping_snode_->dt.ptr_removed();
+    mapping_dtype_size_ = data_type_size(mapping_data_type_);
 
     // Step 3-1
     // Only fetch mesh attributes to the BLS block
     // TODO(changyu): better way to use lambda
-    block = offload->bls_prologue.get();
+    block_ = offload->bls_prologue.get();
     fetch_mapping(
         [&](Stmt *start_val, Stmt *end_val,
             std::function<Stmt *(Block * /*block*/, Stmt * /*idx_val*/)>
@@ -558,10 +558,10 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
 
     // Step 3-2
     // Atomic-add BLS contribution to its global version if necessary
-    if (!has_acc(element_type, conv_type)) {
+    if (!has_acc(element_type_, conv_type_)) {
       continue;
     }
-    block = offload->bls_epilogue.get();
+    block_ = offload->bls_epilogue.get();
     fetch_mapping(
         [&](Stmt *start_val, Stmt *end_val,
             std::function<Stmt *(Block * /*block*/, Stmt * /*idx_val*/)>
@@ -575,7 +575,7 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
         });
   }
 
-  offload->bls_size = std::max(std::size_t(1), bls_offset_in_bytes);
+  offload->bls_size = std::max(std::size_t(1), bls_offset_in_bytes_);
 }
 
 void MakeMeshBlockLocal::run(OffloadedStmt *offload,

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -66,7 +66,8 @@ void MakeMeshBlockLocal::replace_conv_statements() {
 
   irpass::analysis::gather_statements(offload_->body.get(), [&](Stmt *stmt) {
     if (auto idx_conv = stmt->cast<MeshIndexConversionStmt>()) {
-      if (idx_conv->mesh == offload_->mesh && idx_conv->conv_type == conv_type_ &&
+      if (idx_conv->mesh == offload_->mesh &&
+          idx_conv->conv_type == conv_type_ &&
           idx_conv->idx_type == element_type_) {
         idx_conv_stmts.push_back(idx_conv);
       }
@@ -327,7 +328,8 @@ void MakeMeshBlockLocal::fetch_mapping(
     thread_idx_stmt = block_->push_back<LoopLinearIndexStmt>(
         offload_);  // Equivalent to CUDA threadIdx
   }
-  Stmt *total_element_num = offload_->total_num_local.find(element_type_)->second;
+  Stmt *total_element_num =
+      offload_->total_num_local.find(element_type_)->second;
   Stmt *total_element_offset =
       offload_->total_offset_local.find(element_type_)->second;
 
@@ -457,8 +459,8 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
     }
 
     mapping_snode_ = (offload->mesh->index_mapping
-                         .find(std::make_pair(element_type, conv_type))
-                         ->second);
+                          .find(std::make_pair(element_type, conv_type))
+                          ->second);
     mapping_data_type_ = mapping_snode_->dt.ptr_removed();
     mapping_dtype_size_ = data_type_size(mapping_data_type_);
 
@@ -535,8 +537,8 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
     TI_ASSERT(conv_type_ != mesh::ConvType::g2r);  // g2r will not be cached.
 
     mapping_snode_ = (offload->mesh->index_mapping
-                         .find(std::make_pair(element_type_, conv_type_))
-                         ->second);
+                          .find(std::make_pair(element_type_, conv_type_))
+                          ->second);
     mapping_data_type_ = mapping_snode_->dt.ptr_removed();
     mapping_dtype_size_ = data_type_size(mapping_data_type_);
 

--- a/taichi/transforms/make_mesh_block_local.h
+++ b/taichi/transforms/make_mesh_block_local.h
@@ -52,22 +52,22 @@ class MakeMeshBlockLocal : public Pass {
                          Stmt * /*idx_val*/,
                          Stmt * /*mapping_val*/)> attr_callback_handler);
 
-  const CompileConfig &config;
-  OffloadedStmt *offload{nullptr};
-  std::set<std::pair<mesh::MeshElementType, mesh::ConvType>> mappings{};
-  MeshBLSCaches::Rec rec;
+  const CompileConfig &config_;
+  OffloadedStmt *offload_{nullptr};
+  std::set<std::pair<mesh::MeshElementType, mesh::ConvType>> mappings_{};
+  MeshBLSCaches::Rec rec_;
 
-  Block *block;
+  Block *block_;
 
-  std::size_t bls_offset_in_bytes{0};
-  std::size_t mapping_bls_offset_in_bytes{0};
-  std::unordered_map<SNode *, std::size_t> attr_bls_offset_in_bytes{};
+  std::size_t bls_offset_in_bytes_{0};
+  std::size_t mapping_bls_offset_in_bytes_{0};
+  std::unordered_map<SNode *, std::size_t> attr_bls_offset_in_bytes_{};
 
-  mesh::MeshElementType element_type;
-  mesh::ConvType conv_type;
-  SNode *mapping_snode{nullptr};
-  DataType mapping_data_type;
-  int mapping_dtype_size{0};
+  mesh::MeshElementType element_type_;
+  mesh::ConvType conv_type_;
+  SNode *mapping_snode_{nullptr};
+  DataType mapping_data_type_;
+  int mapping_dtype_size_{0};
 };
 
 }  // namespace lang


### PR DESCRIPTION
Let's enable the `readability-identifier-naming` check to make use of the rules defined in `.clang-tidy`. Currently, checks only enabled for the `taichi/` directory.

Local checks and fixes can be applied with `python scripts/run_clang_tidy.py $PWD/taichi -clang-tidy-binary clang-tidy-10 -clang-apply-replacements-binary clang-apply-replacements-10 -checks=-*,performance-inefficient-string-concatenation,readability-identifier-naming -header-filter=$PWD/taichi -p $PWD/build -j4 -fix`