### PR TITLE
[Error] Shorten the length of traceback of TaichiCompilationError

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -12,7 +12,7 @@ from taichi.lang import impl, runtime_ops, util
 from taichi.lang.ast import (ASTTransformerContext, KernelSimplicityASTChecker,
                              transform_tree)
 from taichi.lang.enums import Layout
-from taichi.lang.exception import TaichiSyntaxError, TaichiCompilationError
+from taichi.lang.exception import TaichiCompilationError, TaichiSyntaxError
 from taichi.lang.expr import Expr
 from taichi.lang.matrix import MatrixType
 from taichi.lang.shell import _shell_pop_print, oinspect

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -12,7 +12,7 @@ from taichi.lang import impl, runtime_ops, util
 from taichi.lang.ast import (ASTTransformerContext, KernelSimplicityASTChecker,
                              transform_tree)
 from taichi.lang.enums import Layout
-from taichi.lang.exception import TaichiSyntaxError
+from taichi.lang.exception import TaichiSyntaxError, TaichiCompilationError
 from taichi.lang.expr import Expr
 from taichi.lang.matrix import MatrixType
 from taichi.lang.shell import _shell_pop_print, oinspect
@@ -718,7 +718,10 @@ def _kernel_impl(_func, level_of_class_stackframe, verbose=False):
 
         @functools.wraps(_func)
         def wrapped(*args, **kwargs):
-            return primal(*args, **kwargs)
+            try:
+                return primal(*args, **kwargs)
+            except TaichiCompilationError as e:
+                raise type(e)('\n' + str(e)) from None
 
         wrapped.grad = adjoint
 

--- a/tests/python/test_exception.py
+++ b/tests/python/test_exception.py
@@ -21,11 +21,11 @@ def test_exception_multiline():
         # yapf: enable
 
     if version_info < (3, 8):
-        msg = f"""\
+        msg = f"""
 On line {frameinfo.lineno + 5} of file "{frameinfo.filename}":
             aaaa(111,"""
     else:
-        msg = f"""\
+        msg = f"""
 On line {frameinfo.lineno + 5} of file "{frameinfo.filename}":
             aaaa(111,
             ^^^^^^^^^
@@ -60,7 +60,7 @@ def test_exception_from_func():
     lineno = frameinfo.lineno
     file = frameinfo.filename
     if version_info < (3, 8):
-        msg = f"""\
+        msg = f"""
 On line {lineno + 13} of file "{file}":
             bar()
 On line {lineno + 9} of file "{file}":
@@ -68,7 +68,7 @@ On line {lineno + 9} of file "{file}":
 On line {lineno + 5} of file "{file}":
             t()"""
     else:
-        msg = f"""\
+        msg = f"""
 On line {lineno + 13} of file "{file}":
             bar()
             ^^^^^
@@ -95,11 +95,11 @@ def test_tab():
     lineno = frameinfo.lineno
     file = frameinfo.filename
     if version_info < (3, 8):
-        msg = f"""\
+        msg = f"""
 On line {lineno + 5} of file "{file}":
             a(11,   22, 3)"""
     else:
-        msg = f"""\
+        msg = f"""
 On line {lineno + 5} of file "{file}":
             a(11,   22, 3)
             ^^^^^^^^^^^^^^"""
@@ -120,12 +120,12 @@ def test_super_long_line():
     lineno = frameinfo.lineno
     file = frameinfo.filename
     if version_info < (3, 8):
-        msg = f"""\
+        msg = f"""
 On line {lineno + 5} of file "{file}":
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
 """
     else:
-        msg = f"""\
+        msg = f"""
 On line {lineno + 5} of file "{file}":
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaa
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,7 +153,7 @@ def test_exception_in_node_with_body():
         foo()
     lineno = frameinfo.lineno
     file = frameinfo.filename
-    msg = f"""\
+    msg = f"""
 On line {lineno + 3} of file "{file}":
         for i in range(1, 2, 3):
         ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Related issue = #3785

For the following program:
```python
import taichi as ti
ti.init()

@ti.kernel
def foo():
    1 in 2

foo()
```
The traceback looks like this after this PR:
```
Traceback (most recent call last):
  File "/home/lin/tmp/./test.py", line 8, in <module>
    foo()
  File "/home/lin/taichi2/python/taichi/lang/kernel_impl.py", line 724, in wrapped
    raise type(e)('\n' + str(e)) from None
taichi.lang.exception.TaichiSyntaxError: 
On line 6 of file "/home/lin/tmp/./test.py":
    1 in 2
    ^^^^^^
"In" is only supported inside `ti.static`.
```
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
