### PR TITLE
[dx11] Add underlying DX11 device, memory allocation, and some tests

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -8,7 +8,6 @@ option(TI_WITH_CC "Build with the C backend" ON)
 option(TI_WITH_VULKAN "Build with the Vulkan backend" OFF)
 option(TI_WITH_DX11 "Build with the DX11 backend" OFF)
 
-
 if(UNIX AND NOT APPLE)
     # Handy helper for Linux
     # https://stackoverflow.com/a/32259072/12003165

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -13,6 +13,7 @@ endif()
 file(GLOB_RECURSE TAICHI_TESTS_SOURCE
         "tests/cpp/analysis/*.cpp"
         "tests/cpp/aot/*.cpp"
+        "tests/cpp/backends/*.cpp"
         "tests/cpp/codegen/*.cpp"
         "tests/cpp/common/*.cpp"
         "tests/cpp/ir/*.cpp"

--- a/misc/prtags.json
+++ b/misc/prtags.json
@@ -12,6 +12,8 @@
   "metal"           : "Metal backend",
   "opengl"          : "OpenGL backend",
   "vulkan"          : "Vulkan backend",
+  "dx11"            : "DirectX 11 backend",
+  "spirv"           : "SPIR-V common codegen",
   "wasm"            : "WebAssembly backend",
   "misc"            : "Miscellaneous",
   "std"             : "Standard library",

--- a/taichi/backends/dx/dx_api.h
+++ b/taichi/backends/dx/dx_api.h
@@ -1,6 +1,7 @@
 #pragma once
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "d3dcompiler.lib")
+#pragma comment(lib, "dxguid.lib")
 
 #include "taichi/common/core.h"
 

--- a/taichi/backends/dx/dx_device.cpp
+++ b/taichi/backends/dx/dx_device.cpp
@@ -4,18 +4,6 @@ namespace taichi {
 namespace lang {
 namespace directx11 {
 
-bool kD3d11DebugEnabled = false;  // D3D11 debugging is enabled. For testing.
-bool kD3d11ForceRef = false;      // Force REF device. May be used to
-                                  // force software rendering.
-
-void debug_enabled(bool enabled) {
-  kD3d11DebugEnabled = enabled;
-}
-
-void force_ref(bool force) {
-  kD3d11ForceRef = force;
-}
-
 void check_dx_error(HRESULT hr, const char *msg) {
   if (!SUCCEEDED(hr)) {
     TI_ERROR("Error in {}: {}", msg, hr);

--- a/taichi/backends/dx/dx_device.cpp
+++ b/taichi/backends/dx/dx_device.cpp
@@ -4,6 +4,16 @@ namespace taichi {
 namespace lang {
 namespace directx11 {
 
+bool kD3d11DebugEnabled = false;  // D3D11 debugging is enabled. For testing.
+bool kD3d11ForceRef = false;      // Force REF device. May be used to
+                                  // force software rendering.
+
+void check_dx_error(HRESULT hr, const char *msg) {
+  if (!SUCCEEDED(hr)) {
+    TI_ERROR("Error in {}: {}", msg, hr);
+  }
+}
+
 Dx11ResourceBinder::~Dx11ResourceBinder() {
 }
 
@@ -19,11 +29,107 @@ ResourceBinder *Dx11Pipeline::resource_binder() {
   return nullptr;
 }
 
+HRESULT create_compute_device(ID3D11Device **out_device,
+                              ID3D11DeviceContext **out_context,
+                              bool force_ref,
+                              bool debug_enabled) {
+  const D3D_FEATURE_LEVEL levels[] = {
+      D3D_FEATURE_LEVEL_11_1,
+      D3D_FEATURE_LEVEL_11_0,
+      D3D_FEATURE_LEVEL_10_1,
+      D3D_FEATURE_LEVEL_10_0,
+  };
+
+  UINT flags = 0;
+  if (debug_enabled)
+    flags |= D3D11_CREATE_DEVICE_DEBUG;
+
+  ID3D11Device *device = nullptr;
+  ID3D11DeviceContext *context = nullptr;
+  HRESULT hr;
+
+  D3D_DRIVER_TYPE driver_types[] = {
+      D3D_DRIVER_TYPE_HARDWARE, D3D_DRIVER_TYPE_SOFTWARE,
+      D3D_DRIVER_TYPE_REFERENCE, D3D_DRIVER_TYPE_WARP};
+  const char *driver_type_names[] = {
+      "D3D_DRIVER_TYPE_HARDWARE", "D3D_DRIVER_TYPE_SOFTWARE",
+      "D3D_DRIVER_TYPE_REFERENCE", "D3D_DRIVER_TYPE_WARP"};
+
+  const int num_types = sizeof(driver_types) / sizeof(driver_types[0]);
+
+  int attempt_idx = 0;
+  if (force_ref) {
+    attempt_idx = 2;
+  }
+
+  for (; attempt_idx < num_types; attempt_idx++) {
+    D3D_DRIVER_TYPE driver_type = driver_types[attempt_idx];
+    hr = D3D11CreateDevice(nullptr, driver_type, nullptr, flags, levels,
+                           _countof(levels), D3D11_SDK_VERSION, &device,
+                           nullptr, &context);
+
+    if (FAILED(hr) || device == nullptr) {
+      TI_WARN("Failed to create D3D11 device with type {}: {}\n", driver_type,
+              driver_type_names[attempt_idx]);
+      continue;
+    }
+
+    if (device->GetFeatureLevel() < D3D_FEATURE_LEVEL_11_0) {
+      D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS hwopts = {0};
+      device->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS,
+                                  &hwopts, sizeof(hwopts));
+      if (!hwopts.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x) {
+        device->Release();
+        TI_WARN(
+            "DirectCompute not supported via "
+            "ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4");
+      }
+      continue;
+    }
+
+    TI_INFO("Successfully created DX11 device with type {}",
+            driver_type_names[attempt_idx]);
+    *out_device = device;
+    *out_context = context;
+    break;
+  }
+
+  if (*out_device == nullptr || *out_context == nullptr) {
+    TI_ERROR("Failed to create DX11 device using all {} driver types",
+             num_types);
+  }
+
+  return hr;
+}
+
 Dx11Device::Dx11Device() {
+  create_dx11_device();
   set_cap(DeviceCapability::spirv_version, 0x10300);
 }
 
 Dx11Device::~Dx11Device() {
+  destroy_dx11_device();
+}
+
+void Dx11Device::create_dx11_device() {
+  if (device_ != nullptr && context_ != nullptr) {
+    TI_TRACE("D3D11 device has already been created.");
+    return;
+  }
+  TI_TRACE("Creating D3D11 device");
+  create_compute_device(&device_, &context_, kD3d11ForceRef,
+                        kD3d11DebugEnabled);
+}
+
+void Dx11Device::destroy_dx11_device() {
+  if (context_ != nullptr) {
+    context_->Release();
+    context_ = nullptr;
+  }
+  if (device_ != nullptr) {
+    device_->Release();
+    device_ = nullptr;
+  }
 }
 
 DeviceAllocation Dx11Device::allocate_memory(const AllocParams &params) {

--- a/taichi/backends/dx/dx_device.cpp
+++ b/taichi/backends/dx/dx_device.cpp
@@ -150,7 +150,6 @@ HRESULT create_buffer_uav(ID3D11Device *device,
   return device->CreateUnorderedAccessView(buffer, &uav_desc, out_uav);
 }
 
-
 }  // namespace
 
 Dx11Device::Dx11Device() {

--- a/taichi/backends/dx/dx_device.h
+++ b/taichi/backends/dx/dx_device.h
@@ -1,10 +1,18 @@
 #pragma once
 
 #include "taichi/backends/device.h"
+#include <d3d11.h>
 
 namespace taichi {
 namespace lang {
 namespace directx11 {
+
+void check_dx_error(HRESULT hr, const char *msg);
+
+HRESULT create_compute_device(ID3D11Device **out_device,
+                              ID3D11DeviceContext **out_context,
+                              bool force_ref,
+                              bool debug_enabled);
 
 class Dx11ResourceBinder : public ResourceBinder {
   ~Dx11ResourceBinder() override;
@@ -55,6 +63,12 @@ class Dx11Device : public GraphicsDevice {
                        DeviceAllocation src_img,
                        ImageLayout img_layout,
                        const BufferImageCopyParams &params) override;
+
+ private:
+  void create_dx11_device();
+  void destroy_dx11_device();
+  ID3D11Device *device_{};
+  ID3D11DeviceContext *context_{};
 };
 
 }  // namespace directx11

--- a/taichi/backends/dx/dx_device.h
+++ b/taichi/backends/dx/dx_device.h
@@ -1,13 +1,19 @@
 #pragma once
 
 #include "taichi/backends/device.h"
+#include "taichi/backends/dx/dx_info_queue.h"
 #include <d3d11.h>
 
 namespace taichi {
 namespace lang {
 namespace directx11 {
 
-void check_dx_error(HRESULT hr, const char *msg);
+void debug_enabled(bool);
+void force_ref(bool);
+
+namespace {
+  void check_dx_error(HRESULT hr, const char *msg);
+}
 
 HRESULT create_compute_device(ID3D11Device **out_device,
                               ID3D11DeviceContext **out_context,
@@ -64,11 +70,14 @@ class Dx11Device : public GraphicsDevice {
                        ImageLayout img_layout,
                        const BufferImageCopyParams &params) override;
 
+  int live_dx11_object_count();
+
  private:
   void create_dx11_device();
   void destroy_dx11_device();
   ID3D11Device *device_{};
   ID3D11DeviceContext *context_{};
+  std::unique_ptr<Dx11InfoQueue> info_queue_{};
 };
 
 }  // namespace directx11

--- a/taichi/backends/dx/dx_device.h
+++ b/taichi/backends/dx/dx_device.h
@@ -8,6 +8,11 @@ namespace taichi {
 namespace lang {
 namespace directx11 {
 
+// Only enable debug layer when the corresponding testing facility is enabled
+constexpr bool kD3d11DebugEnabled = true;
+constexpr bool kD3d11ForceRef = false;  // Force REF device. May be used to
+                                        // force software rendering.
+
 void debug_enabled(bool);
 void force_ref(bool);
 void check_dx_error(HRESULT hr, const char *msg);

--- a/taichi/backends/dx/dx_device.h
+++ b/taichi/backends/dx/dx_device.h
@@ -10,15 +10,7 @@ namespace directx11 {
 
 void debug_enabled(bool);
 void force_ref(bool);
-
-namespace {
-  void check_dx_error(HRESULT hr, const char *msg);
-}
-
-HRESULT create_compute_device(ID3D11Device **out_device,
-                              ID3D11DeviceContext **out_context,
-                              bool force_ref,
-                              bool debug_enabled);
+void check_dx_error(HRESULT hr, const char *msg);
 
 class Dx11ResourceBinder : public ResourceBinder {
   ~Dx11ResourceBinder() override;
@@ -75,9 +67,19 @@ class Dx11Device : public GraphicsDevice {
  private:
   void create_dx11_device();
   void destroy_dx11_device();
+  ID3D11Buffer *alloc_id_to_buffer(uint32_t alloc_id);
+  ID3D11Buffer *alloc_id_to_buffer_cpu_copy(uint32_t alloc_id);
+  ID3D11UnorderedAccessView *alloc_id_to_uav(uint32_t alloc_id);
   ID3D11Device *device_{};
   ID3D11DeviceContext *context_{};
   std::unique_ptr<Dx11InfoQueue> info_queue_{};
+  std::unordered_map<uint32_t, ID3D11Buffer *>
+      alloc_id_to_buffer_;  // binding ID to buffer
+  std::unordered_map<uint32_t, ID3D11Buffer *>
+      alloc_id_to_cpucopy_;  // binding ID to CPU copy of buffer
+  std::unordered_map<uint32_t, ID3D11UnorderedAccessView *>
+      alloc_id_to_uav_;  // binding ID to UAV
+  int alloc_serial_;
 };
 
 }  // namespace directx11

--- a/taichi/backends/dx/dx_info_queue.cpp
+++ b/taichi/backends/dx/dx_info_queue.cpp
@@ -1,0 +1,140 @@
+#include "taichi/backends/dx/dx_info_queue.h"
+
+namespace taichi {
+namespace lang {
+namespace directx11 {
+
+void check_dx_error(HRESULT hr, const char *msg);
+
+namespace {
+inline std::string trim_string(const std::string &s) {
+  int begin = 0, end = (int)s.size();
+  while (begin < end && std::isspace(s[begin])) {
+    begin++;
+  }
+  while (begin < end && std::isspace(s[end - 1])) {
+    end--;
+  }
+  return std::string(s.begin() + begin, s.begin() + end);
+}
+}  // namespace
+
+std::string munch_token(std::string &s) {
+  if (s.empty()) {
+    return "";
+  }
+  size_t idx = s.find(' ');
+  std::string ret;
+  ret = trim_string(s.substr(0, idx));
+  s = s.substr(idx + 1);
+  if (ret.empty() == false && ret.back() == ',')
+    ret.pop_back();
+  return ret;
+}
+
+std::vector<Dx11InfoQueue::Entry> Dx11InfoQueue::parse_reference_count(
+    const std::vector<std::string> messages) {
+  std::vector<Dx11InfoQueue::Entry> ret;
+  for (std::string line : messages) {
+    Dx11InfoQueue::Entry entry;
+    line = trim_string(line);
+    std::string x;
+    x = munch_token(line);
+
+    // Example 1: "Live ID3D11Query at 0x0000018F64E81DA0, Refcount: 0, IntRef:
+    // 1" Example 2: "Live ID3D11Buffer at 0x000001F8AF284370, Name: buffer
+    // alloc#0 size=1048576, Refcount: 1, IntRef: 1"
+
+    if (x != "Live")
+      continue;
+
+    x = munch_token(line);
+    entry.type = x;
+
+    x = munch_token(line);
+    if (x != "at")
+      continue;
+
+    x = munch_token(line);
+    if (x.empty())
+      continue;
+
+    entry.addr = reinterpret_cast<void *>(std::atoll(x.c_str()));
+
+    while (true) {
+      x = munch_token(line);
+      if (x == "Refcount:") {
+        x = munch_token(line);
+        entry.refcount = std::atoi(x.c_str());
+      } else if (x == "IntRef:") {
+        x = munch_token(line);
+        entry.intref = std::atoi(x.c_str());
+      } else
+        break;
+    }
+    ret.push_back(entry);
+  }
+  return ret;
+}
+
+Dx11InfoQueue::Dx11InfoQueue(ID3D11Device *device)
+    : device_(device), last_message_count_(0) {
+  init();
+}
+
+void Dx11InfoQueue::init() {
+  typedef HRESULT(WINAPI * DXGIGetDebugInterface)(REFIID, void **);
+
+  HRESULT hr;
+  hr = device_->QueryInterface(__uuidof(ID3D11InfoQueue),
+                               reinterpret_cast<void **>(&info_queue_));
+  check_dx_error(hr, "Query ID3D11InfoQueue interface from the DX11 device");
+  hr = device_->QueryInterface(__uuidof(ID3D11Debug),
+                               reinterpret_cast<void **>(&debug_));
+  check_dx_error(hr, "Query ID3D11Debug interface from the DX11 device");
+}
+
+std::vector<std::string> Dx11InfoQueue::get_updated_messages() {
+  std::vector<std::string> ret;
+  if (!info_queue_) {
+    return ret;
+  }
+  const int num_messages = info_queue_->GetNumStoredMessages();
+  const int n = num_messages - last_message_count_;
+  ret.resize(n);
+  for (int i = 0; i < n; i++) {
+    D3D11_MESSAGE *msg;
+    size_t len = 0;
+    HRESULT hr =
+        info_queue_->GetMessageW(i + last_message_count_, nullptr, &len);
+    check_dx_error(hr, "Check D3D11 info queue message length");
+    msg = (D3D11_MESSAGE *)malloc(len);
+    hr = info_queue_->GetMessageW(i + last_message_count_, msg, &len);
+    check_dx_error(hr, "Obtain D3D11 info queue message content");
+    ret[i] = std::string(msg->pDescription);
+    free(msg);
+  }
+  last_message_count_ = num_messages;
+  return ret;
+}
+
+bool Dx11InfoQueue::has_updated_messages() {
+  if (!info_queue_) {
+    return false;
+  }
+  const int n = info_queue_->GetNumStoredMessages();
+  return n > last_message_count_;
+}
+
+int Dx11InfoQueue::live_object_count() {
+  get_updated_messages();  // Drain message queue
+  debug_->ReportLiveDeviceObjects(D3D11_RLDO_DETAIL);
+  if (has_updated_messages()) {
+    live_objects_ = parse_reference_count(get_updated_messages());
+  }
+  return static_cast<int>(live_objects_.size());
+}
+
+}  // namespace directx11
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/backends/dx/dx_info_queue.h
+++ b/taichi/backends/dx/dx_info_queue.h
@@ -16,7 +16,7 @@ class Dx11InfoQueue {
     int intref;
   };
   static std::vector<Entry> parse_reference_count(
-      const std::vector<std::string>);
+      const std::vector<std::string>&);
   explicit Dx11InfoQueue(ID3D11Device *device);
   int live_object_count();
 

--- a/taichi/backends/dx/dx_info_queue.h
+++ b/taichi/backends/dx/dx_info_queue.h
@@ -16,7 +16,7 @@ class Dx11InfoQueue {
     int intref;
   };
   static std::vector<Entry> parse_reference_count(
-      const std::vector<std::string>&);
+      const std::vector<std::string> &);
   explicit Dx11InfoQueue(ID3D11Device *device);
   int live_object_count();
 

--- a/taichi/backends/dx/dx_info_queue.h
+++ b/taichi/backends/dx/dx_info_queue.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "taichi/backends/device.h"
+#include <d3d11.h>
+
+namespace taichi {
+namespace lang {
+namespace directx11 {
+
+class Dx11InfoQueue {
+ public:
+  struct Entry {
+    std::string type;
+    void *addr;
+    int refcount;
+    int intref;
+  };
+  static std::vector<Entry> parse_reference_count(
+      const std::vector<std::string>);
+  explicit Dx11InfoQueue(ID3D11Device *device);
+  int live_object_count();
+
+ private:
+  bool has_updated_messages();
+  std::vector<std::string> get_updated_messages();
+  std::vector<Entry> live_objects_;
+  void init();
+  ID3D11Device *device_{};
+  ID3D11Debug *debug_{};
+  ID3D11InfoQueue *info_queue_{};
+  int last_message_count_;
+};
+
+}  // namespace directx11
+}  // namespace lang
+}  // namespace taichi

--- a/tests/cpp/backends/dx11_device_test.cpp
+++ b/tests/cpp/backends/dx11_device_test.cpp
@@ -1,5 +1,7 @@
 #include "gtest/gtest.h"
 
+#ifdef TI_WITH_DX11
+
 #include "taichi/backends/dx/dx_device.h"
 #include "taichi/backends/dx/dx_info_queue.h"
 
@@ -81,3 +83,5 @@ TEST(Dx11InfoQueueTest, ParseReferenceCount) {
 
 }  // namespace lang
 }  // namespace taichi
+
+#endif

--- a/tests/cpp/backends/dx11_device_test.cpp
+++ b/tests/cpp/backends/dx11_device_test.cpp
@@ -7,11 +7,63 @@ namespace taichi {
 namespace lang {
 
 TEST(Dx11DeviceCreationTest, CreateDevice) {
+  // Enable debug layer
+  directx11::debug_enabled(true);
+
   std::unique_ptr<directx11::Dx11Device> device =
       std::make_unique<directx11::Dx11Device>();
 
   // Should not crash
   EXPECT_TRUE(device != nullptr);
+
+  // Should have one object of each of the following types:
+  // ID3D11Device
+  // ID3D11Context
+  // ID3DDeviceContextState
+  // ID3D11BlendState
+  // ID3D11DepthStencilState
+  // ID3D11RasterizerState
+  // ID3D11Sampler
+  // ID3D11Query
+  EXPECT_EQ(device->live_dx11_object_count(), 8);
+}
+
+TEST(Dx11InfoQueueTest, ParseReferenceCount) {
+  const std::vector<std::string> messages = {
+      "Create ID3D11Context: Name=\"unnamed\", Addr=0x0000018F6678E080, "
+      "ExtRef=1, IntRef=0",
+      "Create ID3DDeviceContextState: Name=\"unnamed\", "
+      "Addr=0x0000018F6686CE10, "
+      "ExtRef=1, IntRef=0",
+      "Create ID3D11BlendState: Name=\"unnamed\", Addr=0x0000018F667F6DB0, "
+      "ExtRef=1, IntRef=0",
+      "Create ID3D11DepthStencilState: Name=\"unnamed\", "
+      "Addr=0x0000018F667F6BC0, ExtRef=1, IntRef=0",
+      "Create ID3D11RasterizerState: Name=\"unnamed\", "
+      "Addr=0x0000018F64891420, "
+      "ExtRef=1, IntRef=0",
+      "Create ID3D11Sampler: Name=\"unnamed\", Addr=0x0000018F667F6FA0, "
+      "ExtRef=1, IntRef=0",
+      "Create ID3D11Query: Name=\"unnamed\", Addr=0x0000018F64E81DA0, "
+      "ExtRef=1, IntRef=0",
+      "Create ID3D11Fence: Name=\"unnamed\", Addr=0x0000018F64FF7380, "
+      "ExtRef=1, IntRef=0",
+      "Destroy ID3D11Fence: Name=\"unnamed\", Addr=0x0000018F64FF7380",
+      "Live ID3D11Device at 0x0000018F66782250, Refcount: 5",
+      "Live ID3D11Context at 0x0000018F6678E080, Refcount: 1, IntRef: 1",
+      "Live ID3DDeviceContextState at 0x0000018F6686CE10, Refcount: 0, IntRef: "
+      "1",
+      "Live ID3D11BlendState at 0x0000018F667F6DB0, Refcount: 0, "
+      "IntRef: 1",
+      "Live ID3D11DepthStencilState at 0x0000018F667F6BC0, Refcount: 0, "
+      "IntRef: 1",
+      "Live ID3D11RasterizerState at 0x0000018F64891420, Refcount: 0, "
+      "IntRef: 1",
+      "Live ID3D11Sampler at 0x0000018F667F6FA0, Refcount: 0, IntRef: 1",
+      "Live ID3D11Query at 0x0000018F64E81DA0, Refcount: 0, IntRef: 1"};
+  std::vector<directx11::Dx11InfoQueue::Entry> entries =
+      directx11::Dx11InfoQueue::parse_reference_count(messages);
+  EXPECT_EQ(entries.size(), 8);
 }
 
 }  // namespace lang

--- a/tests/cpp/backends/dx11_device_test.cpp
+++ b/tests/cpp/backends/dx11_device_test.cpp
@@ -1,0 +1,18 @@
+#include "gtest/gtest.h"
+
+#include "taichi/backends/dx/dx_device.h"
+#include "taichi/backends/dx/dx_info_queue.h"
+
+namespace taichi {
+namespace lang {
+
+TEST(Dx11DeviceCreationTest, CreateDevice) {
+  std::unique_ptr<directx11::Dx11Device> device =
+      std::make_unique<directx11::Dx11Device>();
+
+  // Should not crash
+  EXPECT_TRUE(device != nullptr);
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/tests/cpp/backends/dx11_device_test.cpp
+++ b/tests/cpp/backends/dx11_device_test.cpp
@@ -7,11 +7,9 @@
 
 namespace taichi {
 namespace lang {
+namespace directx11 {
 
 TEST(Dx11DeviceCreationTest, CreateDeviceAndAllocateMemory) {
-  // Enable debug layer
-  directx11::debug_enabled(true);
-
   std::unique_ptr<directx11::Dx11Device> device =
       std::make_unique<directx11::Dx11Device>();
 
@@ -27,20 +25,28 @@ TEST(Dx11DeviceCreationTest, CreateDeviceAndAllocateMemory) {
   // ID3D11RasterizerState
   // ID3D11Sampler
   // ID3D11Query
-  const int count0 = device->live_dx11_object_count();
-  EXPECT_EQ(count0, 8);
+  int count0, count1, count2;
+  if (kD3d11DebugEnabled) {
+    count0 = device->live_dx11_object_count();
+    EXPECT_EQ(count0, 8);
+  }
 
   taichi::lang::Device::AllocParams params;
   params.size = 1048576;
   const taichi::lang::DeviceAllocation device_alloc =
       device->allocate_memory(params);
-  const int count1 = device->live_dx11_object_count();
-  // Should have allocated an UAV and a Buffer, so 2 more objects.
-  EXPECT_EQ(count1 - count0, 2);
+  if (kD3d11DebugEnabled) {
+    count1 = device->live_dx11_object_count();
+    // Should have allocated an UAV and a Buffer, so 2 more objects.
+    EXPECT_EQ(count1 - count0, 2);
+  }
+
   // The 2 objects should have been released.
   device->dealloc_memory(device_alloc);
-  const int count2 = device->live_dx11_object_count();
-  EXPECT_EQ(count2 - count1, -2);
+  if (kD3d11DebugEnabled) {
+    count2 = device->live_dx11_object_count();
+    EXPECT_EQ(count2 - count1, -2);
+  }
 }
 
 TEST(Dx11InfoQueueTest, ParseReferenceCount) {
@@ -81,6 +87,7 @@ TEST(Dx11InfoQueueTest, ParseReferenceCount) {
   EXPECT_EQ(entries.size(), 8);
 }
 
+}  // namespace directx11
 }  // namespace lang
 }  // namespace taichi
 


### PR DESCRIPTION
Related issue = #992

This change adds an underlying DX11 device, memory allocation, and some tests.

The tests for the Device functionalities make it easier to confirm the functionalities are working without having to touch the rest of the code base (such as Program) or having to run a .py Taichi program.

I wonder if backend-specific tests are a good approach?
