### PR TITLE
[aot] Add a generic set of AOT structs

### DIFF
--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -30,6 +30,70 @@ struct CompiledFieldData {
             column_num);
 };
 
+struct CompiledOffloadedTask {
+  std::string type;
+  std::string name;
+  // Do we need to inline the source code?
+  std::string source_path;
+  int gpu_block_size{0};
+
+  TI_IO_DEF(type, name, source_path, gpu_block_size);
+};
+
+struct ScalarArg {
+  std::string dtype_name;
+  // Unit: byte
+  size_t offset_in_args_buf{0};
+
+  TI_IO_DEF(dtype_name, offset_in_args_buf);
+};
+
+struct ArrayArg {
+  std::string dtype_name;
+  std::size_t field_dim{0};
+  // If |element_shape| is empty, it means this is a scalar
+  std::vector<int> element_shape;
+  // Unit: byte
+  std::size_t shape_offset_in_args_buf{0};
+  // For Vulkan/OpenGL/Metal, this is the binding index
+  int bind_index{0};
+
+  TI_IO_DEF(dtype_name,
+            field_dim,
+            element_shape,
+            shape_offset_in_args_buf,
+            bind_index);
+};
+
+struct CompiledTaichiKernel {
+  std::vector<CompiledOffloadedTask> tasks;
+  int arg_count{0};
+  int ret_count{0};
+  size_t args_buf_size{0};
+  size_t ret_buf_size{0};
+
+  std::unordered_map<int, ScalarArg> scalar_args;
+  std::unordered_map<int, ArrayArg> arr_args;
+
+  TI_IO_DEF(tasks,
+            arg_count,
+            ret_count,
+            args_buf_size,
+            ret_buf_size,
+            scalar_args,
+            arr_args);
+};
+
+struct ModuleData {
+  std::unordered_map<std::string, CompiledTaichiKernel> kernels;
+  std::unordered_map<std::string, CompiledTaichiKernel> kernel_tmpls;
+  std::vector<aot::CompiledFieldData> fields;
+
+  size_t root_buffer_size;
+
+  TI_IO_DEF(kernels, kernel_tmpls, fields, root_buffer_size);
+};
+
 }  // namespace aot
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -67,19 +67,19 @@ struct ArrayArg {
 
 struct CompiledTaichiKernel {
   std::vector<CompiledOffloadedTask> tasks;
-  int arg_count{0};
-  int ret_count{0};
-  size_t args_buf_size{0};
-  size_t ret_buf_size{0};
+  int args_count{0};
+  int rets_count{0};
+  size_t args_buffer_size{0};
+  size_t rets_buffer_size{0};
 
   std::unordered_map<int, ScalarArg> scalar_args;
   std::unordered_map<int, ArrayArg> arr_args;
 
   TI_IO_DEF(tasks,
-            arg_count,
-            ret_count,
-            args_buf_size,
-            ret_buf_size,
+            args_count,
+            rets_count,
+            args_buffer_size,
+            rets_buffer_size,
             scalar_args,
             arr_args);
 };

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -95,7 +95,8 @@ void write_glsl_file(const std::string &output_dir, CompiledOffloadedTask &t) {
 }  // namespace
 
 AotModuleBuilderImpl::AotModuleBuilderImpl(
-    StructCompiledResult &compiled_structs, bool allow_nv_shader_extension)
+    StructCompiledResult &compiled_structs,
+    bool allow_nv_shader_extension)
     : compiled_structs_(compiled_structs),
       allow_nv_shader_extension_(allow_nv_shader_extension) {
   aot_data_.root_buffer_size = compiled_structs_.root_size;
@@ -136,7 +137,8 @@ void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
 }
 
 size_t AotModuleBuilderImpl::get_snode_base_address(const SNode *snode) {
-  if (snode->type == SNodeType::root) return 0;
+  if (snode->type == SNodeType::root)
+    return 0;
   int chid = find_children_id(snode);
   const auto &parent_meta =
       compiled_structs_.snode_map.at(snode->parent->node_type_name);
@@ -146,9 +148,11 @@ size_t AotModuleBuilderImpl::get_snode_base_address(const SNode *snode) {
 
 void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
                                                  const SNode *rep_snode,
-                                                 bool is_scalar, DataType dt,
+                                                 bool is_scalar,
+                                                 DataType dt,
                                                  std::vector<int> shape,
-                                                 int row_num, int column_num) {
+                                                 int row_num,
+                                                 int column_num) {
   uint32_t gl_dtype_enum = to_gl_dtype_enum(dt);
 
   // Note that currently we only support adding dense fields in AOT for all

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -42,10 +42,10 @@ class AotDataConverter {
     for (const auto &t : in.tasks) {
       res.tasks.push_back(visit(t));
     }
-    res.arg_count = in.arg_count;
-    res.ret_count = in.ret_count;
-    res.args_buf_size = in.args_buf_size;
-    res.ret_buf_size = in.ret_buf_size;
+    res.args_count = in.arg_count;
+    res.rets_count = in.ret_count;
+    res.args_buffer_size = in.args_buf_size;
+    res.rets_buffer_size = in.ret_buf_size;
     for (const auto &[arg_id, val] : in.scalar_args) {
       res.scalar_args[arg_id] = visit(val);
     }

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -1,4 +1,6 @@
 #include "taichi/backends/opengl/aot_module_builder_impl.h"
+
+#include "taichi/aot/module_data.h"
 #include "taichi/backends/opengl/opengl_utils.h"
 
 #if !defined(TI_PLATFORM_WINDOWS)
@@ -8,16 +10,80 @@
 namespace taichi {
 namespace lang {
 namespace opengl {
-
-AotModuleBuilderImpl::AotModuleBuilderImpl(
-    StructCompiledResult &compiled_structs,
-    bool allow_nv_shader_extension)
-    : compiled_structs_(compiled_structs),
-      allow_nv_shader_extension_(allow_nv_shader_extension) {
-  aot_data_.root_buffer_size = compiled_structs_.root_size;
-}
-
 namespace {
+
+class AotDataConverter {
+ public:
+  static aot::ModuleData convert(const opengl::AotData &in) {
+    AotDataConverter c{};
+    return c.visit(in);
+  }
+
+ private:
+  explicit AotDataConverter() = default;
+
+  aot::ModuleData visit(const opengl::AotData &in) const {
+    aot::ModuleData res{};
+    for (const auto &[key, val] : in.kernels) {
+      res.kernels[key] = visit(val);
+    }
+    for (const auto &[key, val] : in.kernel_tmpls) {
+      res.kernel_tmpls[key] = visit(val);
+    }
+    res.fields = in.fields;
+    res.root_buffer_size = in.root_buffer_size;
+    return res;
+  }
+
+  aot::CompiledTaichiKernel visit(
+      const opengl::CompiledTaichiKernel &in) const {
+    aot::CompiledTaichiKernel res{};
+    res.tasks.reserve(in.tasks.size());
+    for (const auto &t : in.tasks) {
+      res.tasks.push_back(visit(t));
+    }
+    res.arg_count = in.arg_count;
+    res.ret_count = in.ret_count;
+    res.args_buf_size = in.args_buf_size;
+    res.ret_buf_size = in.ret_buf_size;
+    for (const auto &[arg_id, val] : in.scalar_args) {
+      res.scalar_args[arg_id] = visit(val);
+    }
+    for (const auto &[arg_id, val] : in.arr_args) {
+      aot::ArrayArg out_arr = visit(val);
+      out_arr.bind_index = in.used.arr_arg_to_bind_idx.at(arg_id);
+      res.arr_args[arg_id] = out_arr;
+    }
+    return res;
+  }
+
+  aot::CompiledOffloadedTask visit(
+      const opengl::CompiledOffloadedTask &in) const {
+    aot::CompiledOffloadedTask res{};
+    res.type = offloaded_task_type_name(in.type);
+    res.name = in.name;
+    res.source_path = in.src;
+    res.gpu_block_size = in.workgroup_size;
+    return res;
+  }
+
+  aot::ScalarArg visit(const opengl::ScalarArg &in) const {
+    aot::ScalarArg res{};
+    res.dtype_name = in.dtype_name;
+    res.offset_in_args_buf = in.offset_in_bytes_in_args_buf;
+    return res;
+  }
+
+  aot::ArrayArg visit(const opengl::CompiledArrayArg &in) const {
+    aot::ArrayArg res{};
+    res.dtype_name = in.dtype_name;
+    res.field_dim = in.field_dim;
+    res.element_shape = in.element_shape;
+    res.shape_offset_in_args_buf = in.shape_offset_in_bytes_in_args_buf;
+    return res;
+  }
+};
+
 void write_glsl_file(const std::string &output_dir, CompiledOffloadedTask &t) {
   const std::string glsl_path = fmt::format("{}/{}.glsl", output_dir, t.name);
   std::ofstream fs{glsl_path};
@@ -28,20 +94,28 @@ void write_glsl_file(const std::string &output_dir, CompiledOffloadedTask &t) {
 
 }  // namespace
 
+AotModuleBuilderImpl::AotModuleBuilderImpl(
+    StructCompiledResult &compiled_structs, bool allow_nv_shader_extension)
+    : compiled_structs_(compiled_structs),
+      allow_nv_shader_extension_(allow_nv_shader_extension) {
+  aot_data_.root_buffer_size = compiled_structs_.root_size;
+}
+
 void AotModuleBuilderImpl::dump(const std::string &output_dir,
                                 const std::string &filename) const {
   TI_WARN_IF(!filename.empty(),
              "Filename prefix is ignored on opengl backend.");
+  // TODO(#3334): Convert |aot_data_| with AotDataConverter
   const std::string bin_path = fmt::format("{}/metadata.tcb", output_dir);
   write_to_binary_file(aot_data_, bin_path);
   // Json format doesn't support multiple line strings.
-  AotData new_aot_data = aot_data_;
-  for (auto &k : new_aot_data.kernels) {
+  AotData aot_data_copy = aot_data_;
+  for (auto &k : aot_data_copy.kernels) {
     for (auto &t : k.second.tasks) {
       write_glsl_file(output_dir, t);
     }
   }
-  for (auto &k : new_aot_data.kernel_tmpls) {
+  for (auto &k : aot_data_copy.kernel_tmpls) {
     for (auto &t : k.second.tasks) {
       write_glsl_file(output_dir, t);
     }
@@ -49,7 +123,7 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
 
   const std::string txt_path = fmt::format("{}/metadata.json", output_dir);
   TextSerializer ts;
-  ts.serialize_to_json("aot_data", new_aot_data);
+  ts.serialize_to_json("aot_data", aot_data_copy);
   ts.write_to_file(txt_path);
 }
 
@@ -62,8 +136,7 @@ void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
 }
 
 size_t AotModuleBuilderImpl::get_snode_base_address(const SNode *snode) {
-  if (snode->type == SNodeType::root)
-    return 0;
+  if (snode->type == SNodeType::root) return 0;
   int chid = find_children_id(snode);
   const auto &parent_meta =
       compiled_structs_.snode_map.at(snode->parent->node_type_name);
@@ -73,11 +146,9 @@ size_t AotModuleBuilderImpl::get_snode_base_address(const SNode *snode) {
 
 void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
                                                  const SNode *rep_snode,
-                                                 bool is_scalar,
-                                                 DataType dt,
+                                                 bool is_scalar, DataType dt,
                                                  std::vector<int> shape,
-                                                 int row_num,
-                                                 int column_num) {
+                                                 int row_num, int column_num) {
   uint32_t gl_dtype_enum = to_gl_dtype_enum(dt);
 
   // Note that currently we only support adding dense fields in AOT for all

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -11,6 +11,8 @@
 #include "taichi/program/py_print_buffer.h"
 #include "taichi/util/environ_config.h"
 
+#define TI_WITH_OPENGL 1
+ 
 #ifdef TI_WITH_OPENGL
 #include "glad/gl.h"
 #include "glad/egl.h"

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -11,8 +11,6 @@
 #include "taichi/program/py_print_buffer.h"
 #include "taichi/util/environ_config.h"
 
-#define TI_WITH_OPENGL 1
-
 #ifdef TI_WITH_OPENGL
 #include "glad/gl.h"
 #include "glad/egl.h"

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -12,7 +12,7 @@
 #include "taichi/util/environ_config.h"
 
 #define TI_WITH_OPENGL 1
- 
+
 #ifdef TI_WITH_OPENGL
 #include "glad/gl.h"
 #include "glad/egl.h"

--- a/taichi/program/aot_module.h
+++ b/taichi/program/aot_module.h
@@ -6,6 +6,7 @@
 #include "taichi/aot/module_data.h"
 #include "taichi/backends/device.h"
 #include "taichi/ir/snode.h"
+#include "taichi/aot/module_data.h"
 
 namespace taichi {
 namespace lang {


### PR DESCRIPTION
Related issue = #3334

I haven't really switched OpenGL or Vulkan to use these new AOT structs yet, but the migration should be very simple, e.g.,

```cpp
auto ad = AotDataConverter::convert(aot_data_);
TextSerializer ts;
t2.serialize_to_json("aot_data", ad);
t2.print();
```

I've also added/removed/changed a few field names:

* `ScalarArg`
   * `offset_in_bytes_in_args_buf` --> `offset_in_args_buf`
* `ogl::CompiledArrayArg` --> `aot::ArrayArg`
   * `shape_offset_in_bytes_in_args_buf` --> `shape_offset_in_args_buf`
   * Added `bind_index`
* `CompiledTaichiKernel`
   * `arg_count` --> `args_count`
   * `ret_count` --> `rets_count`
   * `args_buf_size` --> `args_buffer_size`
   * `ret_buf_size` --> `rets_buffer_size`
   * Removed `used.arr_arg_to_bind_idx`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
