### PR TITLE
[example] [test] Fix misuse of logical operators in examples and tests

### DIFF
--- a/python/taichi/examples/ggui_examples/mpm3d_ggui.py
+++ b/python/taichi/examples/ggui_examples/mpm3d_ggui.py
@@ -110,8 +110,8 @@ def substep(g_x: float, g_y: float, g_z: float):
         if grid_m[I] > 0:
             grid_v[I] /= grid_m[I]
         grid_v[I] += dt * ti.Vector([g_x, g_y, g_z])
-        cond = I < bound and grid_v[I] < 0 or I > n_grid - bound and grid_v[
-            I] > 0
+        cond = (I < bound) & (grid_v[I] < 0) | (I > n_grid - bound) & (grid_v[
+            I] > 0)
         grid_v[I] = 0 if cond else grid_v[I]
     ti.block_dim(n_grid)
     for p in x:

--- a/python/taichi/examples/ggui_examples/mpm3d_ggui.py
+++ b/python/taichi/examples/ggui_examples/mpm3d_ggui.py
@@ -110,8 +110,8 @@ def substep(g_x: float, g_y: float, g_z: float):
         if grid_m[I] > 0:
             grid_v[I] /= grid_m[I]
         grid_v[I] += dt * ti.Vector([g_x, g_y, g_z])
-        cond = (I < bound) & (grid_v[I] < 0) | (I > n_grid - bound) & (grid_v[
-            I] > 0)
+        cond = (I < bound) & (grid_v[I] < 0) | \
+               (I > n_grid - bound) & (grid_v[I] > 0)
         grid_v[I] = 0 if cond else grid_v[I]
     ti.block_dim(n_grid)
     for p in x:

--- a/python/taichi/examples/simulation/fem128.py
+++ b/python/taichi/examples/simulation/fem128.py
@@ -60,7 +60,7 @@ def advance():
         if disp2 <= ball_radius**2:
             NoV = vel[i].dot(disp)
             if NoV < 0: vel[i] -= NoV * disp / disp2
-        cond = pos[i] < 0 and vel[i] < 0 or pos[i] > 1 and vel[i] > 0
+        cond = (pos[i] < 0) & (vel[i] < 0) | (pos[i] > 1) & (vel[i] > 0)
         # rect boundary condition:
         for j in ti.static(range(pos.n)):
             if cond[j]: vel[i][j] = 0

--- a/python/taichi/examples/simulation/fem99.py
+++ b/python/taichi/examples/simulation/fem99.py
@@ -56,7 +56,7 @@ def advance():
             NoV = vel[i].dot(disp)
             if NoV < 0: vel[i] -= NoV * disp / disp2
         # rect boundary condition:
-        cond = pos[i] < 0 and vel[i] < 0 or pos[i] > 1 and vel[i] > 0
+        cond = (pos[i] < 0) & (vel[i] < 0) | (pos[i] > 1) & (vel[i] > 0)
         for j in ti.static(range(pos.n)):
             if cond[j]: vel[i][j] = 0
         pos[i] += dt * vel[i]

--- a/python/taichi/examples/simulation/mpm3d.py
+++ b/python/taichi/examples/simulation/mpm3d.py
@@ -57,8 +57,8 @@ def substep():
         if grid_m[I] > 0:
             grid_v[I] /= grid_m[I]
         grid_v[I][1] -= dt * gravity
-        cond = (I < bound) & (grid_v[I] < 0) | (I > n_grid - bound) & (grid_v[
-            I] > 0)
+        cond = (I < bound) & (grid_v[I] < 0) | \
+               (I > n_grid - bound) & (grid_v[I] > 0)
         grid_v[I] = 0 if cond else grid_v[I]
     ti.block_dim(n_grid)
     for p in x:

--- a/python/taichi/examples/simulation/mpm3d.py
+++ b/python/taichi/examples/simulation/mpm3d.py
@@ -57,8 +57,8 @@ def substep():
         if grid_m[I] > 0:
             grid_v[I] /= grid_m[I]
         grid_v[I][1] -= dt * gravity
-        cond = I < bound and grid_v[I] < 0 or I > n_grid - bound and grid_v[
-            I] > 0
+        cond = (I < bound) & (grid_v[I] < 0) | (I > n_grid - bound) & (grid_v[
+            I] > 0)
         grid_v[I] = 0 if cond else grid_v[I]
     ti.block_dim(n_grid)
     for p in x:

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -398,7 +398,7 @@ class _SpecialConfig:
         self.log_level = 'info'
         self.gdb_trigger = False
         self.experimental_real_function = False
-        self.short_circuit_operators = False
+        self.short_circuit_operators = True
         self.ndarray_use_torch = False
 
 

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -398,7 +398,7 @@ class _SpecialConfig:
         self.log_level = 'info'
         self.gdb_trigger = False
         self.experimental_real_function = False
-        self.short_circuit_operators = True
+        self.short_circuit_operators = False
         self.ndarray_use_torch = False
 
 

--- a/tests/python/test_bit_array_vectorization.py
+++ b/tests/python/test_bit_array_vectorization.py
@@ -145,8 +145,7 @@ def test_evolve():
             num_active_neighbors += ti.cast(x[i + 1, j - 1], ti.u32)
             num_active_neighbors += ti.cast(x[i + 1, j], ti.u32)
             num_active_neighbors += ti.cast(x[i + 1, j + 1], ti.u32)
-            y[i, j] = (num_active_neighbors == 3) or (num_active_neighbors == 2
-                                                      and x[i, j] == 1)
+            y[i, j] = (num_active_neighbors == 3) | ((num_active_neighbors == 2) & (x[i, j] == 1))
 
     @ti.kernel
     def evolve_naive(x: ti.template(), y: ti.template()):

--- a/tests/python/test_bit_array_vectorization.py
+++ b/tests/python/test_bit_array_vectorization.py
@@ -145,7 +145,8 @@ def test_evolve():
             num_active_neighbors += ti.cast(x[i + 1, j - 1], ti.u32)
             num_active_neighbors += ti.cast(x[i + 1, j], ti.u32)
             num_active_neighbors += ti.cast(x[i + 1, j + 1], ti.u32)
-            y[i, j] = (num_active_neighbors == 3) | ((num_active_neighbors == 2) & (x[i, j] == 1))
+            y[i, j] = (num_active_neighbors == 3) | \
+                      ((num_active_neighbors == 2) & (x[i, j] == 1))
 
     @ti.kernel
     def evolve_naive(x: ti.template(), y: ti.template()):


### PR DESCRIPTION
Related issue = #3635

In #3635, we determine that the logical operators in Taichi should behave the same as in Python. Therefore, we should no longer misuse logical operators as bitwise operators anymore. This PR aims at fixing these misuses in examples and tests.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
