### PR TITLE
[refactor] [ir] Use FrontendExprStmt in place of FrontendEvalStmt

### DIFF
--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -120,19 +120,6 @@ class FrontendPrintStmt : public Stmt {
   TI_DEFINE_ACCEPT
 };
 
-// This statement evaluates the expression.
-// The expression should have side effects otherwise the expression will do
-// nothing.
-class FrontendEvalStmt : public Stmt {
- public:
-  Expr expr;
-
-  FrontendEvalStmt(const Expr &expr) : expr(load_if_ptr(expr)) {
-  }
-
-  TI_DEFINE_ACCEPT
-};
-
 class FrontendForStmt : public Stmt {
  public:
   Expr begin, end;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -554,7 +554,7 @@ void export_lang(py::module &m) {
               (void *)func_addr, source, filename, funcname, args.exprs,
               outputs.exprs);
 
-          current_ast_builder().insert(Stmt::make<FrontendEvalStmt>(expr));
+          current_ast_builder().insert(Stmt::make<FrontendExprStmt>(expr));
         });
 
   m.def("insert_is_active", [](SNode *snode, const ExprGroup &indices) {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -240,10 +240,6 @@ class IRPrinter : public IRVisitor {
     print("}}");
   }
 
-  void visit(FrontendEvalStmt *stmt) override {
-    print("{} = eval {}", stmt->name(), stmt->expr.serialize());
-  }
-
   void visit(FrontendPrintStmt *print_stmt) override {
     std::vector<std::string> contents;
     for (auto const &c : print_stmt->contents) {

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -394,14 +394,6 @@ class LowerAST : public IRVisitor {
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
   }
 
-  void visit(FrontendEvalStmt *stmt) override {
-    // expand rhs
-    auto expr = stmt->expr;
-    auto fctx = make_flatten_ctx();
-    expr->flatten(&fctx);
-    stmt->parent->replace_with(stmt, std::move(fctx.stmts));
-  }
-
   void visit(FrontendAssignStmt *assign) override {
     // expand rhs
     auto expr = assign->rhs;


### PR DESCRIPTION
Related issue = #3982

`FrontendExprStmt` and `FrontendEvalStmt` have identical functionalities.
