### PR TITLE
[opengl] Do not promote simple ExternalTensorShapeAlongAxisStmt into globals.

### DIFF
--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -240,8 +240,7 @@ RangeForStmt::RangeForStmt(Stmt *begin,
                            int bit_vectorize,
                            int num_cpu_threads,
                            int block_dim,
-                           bool strictly_serialized,
-                           bool end_is_array_axis)
+                           bool strictly_serialized)
     : begin(begin),
       end(end),
       body(std::move(body)),
@@ -249,8 +248,7 @@ RangeForStmt::RangeForStmt(Stmt *begin,
       bit_vectorize(bit_vectorize),
       num_cpu_threads(num_cpu_threads),
       block_dim(block_dim),
-      strictly_serialized(strictly_serialized),
-      end_is_array_axis(end_is_array_axis) {
+      strictly_serialized(strictly_serialized) {
   reversed = false;
   this->body->parent_stmt = this;
   TI_STMT_REG_FIELDS;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -733,7 +733,6 @@ class RangeForStmt : public Stmt {
   int num_cpu_threads;
   int block_dim;
   bool strictly_serialized;
-  bool end_is_array_axis{false};
 
   RangeForStmt(Stmt *begin,
                Stmt *end,
@@ -742,8 +741,7 @@ class RangeForStmt : public Stmt {
                int bit_vectorize,
                int num_cpu_threads,
                int block_dim,
-               bool strictly_serialized,
-               bool end_is_array_axis = false);
+               bool strictly_serialized);
 
   bool is_container_statement() const override {
     return true;
@@ -762,8 +760,7 @@ class RangeForStmt : public Stmt {
                      bit_vectorize,
                      num_cpu_threads,
                      block_dim,
-                     strictly_serialized,
-                     end_is_array_axis);
+                     strictly_serialized);
   TI_DEFINE_ACCEPT
 };
 

--- a/taichi/transforms/die.cpp
+++ b/taichi/transforms/die.cpp
@@ -100,6 +100,12 @@ class DIE : public IRVisitor {
   }
 
   void visit(OffloadedStmt *stmt) override {
+    // TODO: A hack to make sure end_stmt is registered.
+    // Ideally end_stmt should be its own Block instead.
+    if (stmt->end_stmt &&
+        used.find(stmt->end_stmt->instance_id) == used.end()) {
+      used.insert(stmt->end_stmt->instance_id);
+    }
     stmt->all_blocks_accept(this, true);
   }
 };

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -345,8 +345,7 @@ class LowerAST : public IRVisitor {
       auto &&new_for = std::make_unique<RangeForStmt>(
           begin, end, std::move(stmt->body), stmt->vectorize,
           stmt->bit_vectorize, stmt->num_cpu_threads, stmt->block_dim,
-          stmt->strictly_serialized,
-          /*end_is_array_axis=*/!end->is<ConstStmt>());
+          stmt->strictly_serialized);
       VecStatement new_statements;
       Stmt *loop_index =
           new_statements.push_back<LoopIndexStmt>(new_for.get(), 0);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #3980
* __->__ #3979

Previously we only make sure `for i in range(x)` (here `x` is ndarray)
don't get their end_range from gtmp on opengl. This PR expands the scope
to all simple calculations involving only ConstStmt and
ExternalTensorShapeAlongAxisStmt as leaves, and it's not limited to the
end_stmt in RangeForStmt as well. In most cases this should save an
additional serial offloaded task which only saves the simple
intermediates into gtmp.