### PR TITLE
[test] Make arch the part of test name

### DIFF
--- a/python/taichi/_testing.py
+++ b/python/taichi/_testing.py
@@ -42,7 +42,6 @@ def approx(expected, **kwargs):
 
     kwargs['rel'] = max(kwargs.get('rel', 1e-6), get_rel_eps())
 
-    import pytest  # pylint: disable=C0415
     return pytest.approx(expected, **kwargs)
 
 


### PR DESCRIPTION
Close #3128

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out †n.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
cc @ailzhang 

After this patch:
```
$ cat tests/python/test_foo.py
import taichi as ti


@ti.test(arch=ti.gpu)
def test_foo():
    assert True

$ pytest tests/python/test_foo.py -v
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/knight/github/taichi
collected 3 items

tests/python/test_foo.py::test_foo[Arch.cuda-1] PASSED                                                                                                                                                                          [ 33%]
tests/python/test_foo.py::test_foo[Arch.cuda-2] PASSED                                                                                                                                                                          [ 66%]
tests/python/test_foo.py::test_foo[Arch.opengl-3] PASSED                                                                                                                                                                        [100%]

========================================================================================================== 3 passed in 0.97s ==========================================================================================================
```