### PR TITLE
[mesh] Support multiple major relations in one mesh-for loop

### DIFF
--- a/taichi/analysis/gather_meshfor_relation_types.cpp
+++ b/taichi/analysis/gather_meshfor_relation_types.cpp
@@ -29,9 +29,6 @@ class GatherMeshforRelationTypes : public BasicStmtVisitor {
     TI_ASSERT(stmt->minor_relation_types.size() == 0);
     mesh_for = stmt;
     stmt->body->accept(this);
-    TI_ASSERT_INFO(
-        stmt->major_to_types.size() <= 1,
-        "Now ti.Mesh only allows single type first-order relation accesss");
     mesh_for = nullptr;
   }
 
@@ -46,7 +43,7 @@ class GatherMeshforRelationTypes : public BasicStmtVisitor {
       TI_ASSERT(!from_stmt->is_size());
       auto from_order = mesh::element_order(from_stmt->to_type);
       auto to_order = mesh::element_order(stmt->to_type);
-      TI_ASSERT_INFO(from_order > to_order,
+      TI_ASSERT_INFO(from_order >= to_order,
                      "Cannot access an indeterminate relation (E.g, Vert-Vert) "
                      "in a nested neighbor access");
       mesh_for->minor_relation_types.insert(

--- a/taichi/analysis/gather_meshfor_relation_types.cpp
+++ b/taichi/analysis/gather_meshfor_relation_types.cpp
@@ -43,7 +43,7 @@ class GatherMeshforRelationTypes : public BasicStmtVisitor {
       TI_ASSERT(!from_stmt->is_size());
       auto from_order = mesh::element_order(from_stmt->to_type);
       auto to_order = mesh::element_order(stmt->to_type);
-      TI_ASSERT_INFO(from_order >= to_order,
+      TI_ASSERT_INFO(from_order > to_order,
                      "Cannot access an indeterminate relation (E.g, Vert-Vert) "
                      "in a nested neighbor access");
       mesh_for->minor_relation_types.insert(

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -7,6 +7,7 @@ import taichi as ti
 this_dir = os.path.dirname(os.path.abspath(__file__))
 model_file_path = os.path.join(this_dir, 'ell.json')
 
+
 @ti.test(require=ti.extension.mesh)
 def test_mesh_patch_idx():
     mesh_builder = ti.Mesh.Tet()
@@ -248,9 +249,16 @@ def test_nested_mesh_for():
 @ti.test(require=ti.extension.mesh)
 def test_multiple_mesh_major_relations():
     mesh = ti.TetMesh()
-    mesh.verts.place({'s' : ti.i32, 's_' : ti.i32, 's1' : ti.i32, 'a' : ti.i32, 'b' : ti.i32, 'c' : ti.i32})
-    mesh.edges.place({'s2' : ti.i32})
-    mesh.cells.place({'s3' : ti.i32})
+    mesh.verts.place({
+        's': ti.i32,
+        's_': ti.i32,
+        's1': ti.i32,
+        'a': ti.i32,
+        'b': ti.i32,
+        'c': ti.i32
+    })
+    mesh.edges.place({'s2': ti.i32})
+    mesh.cells.place({'s3': ti.i32})
     mesh.verts.link(mesh.verts)
     mesh.verts.link(mesh.edges)
     mesh.verts.link(mesh.cells)
@@ -259,9 +267,12 @@ def test_multiple_mesh_major_relations():
 
     @ti.kernel
     def foo():
-        for u in model.verts: u.s1 = u.id
-        for e in model.edges: e.s2 = e.id
-        for c in model.cells: c.s3 = c.id
+        for u in model.verts:
+            u.s1 = u.id
+        for e in model.edges:
+            e.s2 = e.id
+        for c in model.cells:
+            c.s3 = c.id
 
         ti.mesh_local(model.verts.s1, model.edges.s2, model.cells.s3)
         for u in model.verts:
@@ -283,7 +294,8 @@ def test_multiple_mesh_major_relations():
         for u in model.verts:
             for i in range(u.cells.size):
                 u.c += u.cells[i].s3
-        for u in model.verts: u.s_ = u.a * u.b * u.c
+        for u in model.verts:
+            u.s_ = u.a * u.b * u.c
 
     foo()
 

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -7,7 +7,6 @@ import taichi as ti
 this_dir = os.path.dirname(os.path.abspath(__file__))
 model_file_path = os.path.join(this_dir, 'ell.json')
 
-
 @ti.test(require=ti.extension.mesh)
 def test_mesh_patch_idx():
     mesh_builder = ti.Mesh.Tet()
@@ -244,3 +243,50 @@ def test_nested_mesh_for():
     a = model.faces.a.to_numpy()
     b = model.faces.b.to_numpy()
     assert (a == b).all() == 1
+
+
+@ti.test(require=ti.extension.mesh)
+def test_multiple_mesh_major_relations():
+    mesh = ti.TetMesh()
+    mesh.verts.place({'s' : ti.i32, 's_' : ti.i32, 's1' : ti.i32, 'a' : ti.i32, 'b' : ti.i32, 'c' : ti.i32})
+    mesh.edges.place({'s2' : ti.i32})
+    mesh.cells.place({'s3' : ti.i32})
+    mesh.verts.link(mesh.verts)
+    mesh.verts.link(mesh.edges)
+    mesh.verts.link(mesh.cells)
+
+    model = mesh.build(ti.Mesh.load_meta(model_file_path))
+
+    @ti.kernel
+    def foo():
+        for u in model.verts: u.s1 = u.id
+        for e in model.edges: e.s2 = e.id
+        for c in model.cells: c.s3 = c.id
+
+        ti.mesh_local(model.verts.s1, model.edges.s2, model.cells.s3)
+        for u in model.verts:
+            a, b, c = 0, 0, 0
+            for i in range(u.verts.size):
+                a += u.verts[i].s1
+            for i in range(u.edges.size):
+                b += u.edges[i].s2
+            for i in range(u.cells.size):
+                c += u.cells[i].s3
+            u.s = a * b * c
+
+        for u in model.verts:
+            for i in range(u.verts.size):
+                u.a += u.verts[i].s1
+        for u in model.verts:
+            for i in range(u.edges.size):
+                u.b += u.edges[i].s2
+        for u in model.verts:
+            for i in range(u.cells.size):
+                u.c += u.cells[i].s3
+        for u in model.verts: u.s_ = u.a * u.b * u.c
+
+    foo()
+
+    sum1 = model.verts.s.to_numpy().sum()
+    sum2 = model.verts.s_.to_numpy().sum()
+    assert sum1 == sum2


### PR DESCRIPTION
Related issue = #3608
In the previous design principle, we restrict one mesh-for should only have one major relation, like the following case:
``` Python
for v in model.verts:
  for i in range(v.verts.size):
    # do something ...
  for i in range(v.cells.size): # it's not allowed before this PR because the major relation is Verts-Verts
    # do other things ...
```
But we found that supporting multiple major relations in one mesh-for loop is necessary for some scenarios. Otherwise, we must define some extra variables, like this:
``` Python
for v in model.verts:
  a, b = 0, 0
  for i in range(v.verts.size):
    a += v.verts[i].id
  for i in range(v.cells.size):
    b += v.cells[i].id
  v.res = a * b
```
Note that defining `a` and `b` as local variables is far optimized than placing them in the global memory. So we deprecate the single-major-relation restriction rule in this PR and add related test.