### PR TITLE
[mesh] [opt] Experimental automatic mesh_local

### DIFF
--- a/taichi/analysis/mesh_bls_analyzer.cpp
+++ b/taichi/analysis/mesh_bls_analyzer.cpp
@@ -6,8 +6,14 @@
 namespace taichi {
 namespace lang {
 
-MeshBLSAnalyzer::MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches, bool auto_mesh_local, const CompileConfig &config)
-    : for_stmt_(for_stmt), caches_(caches), auto_mesh_local_(auto_mesh_local), config_(config) {
+MeshBLSAnalyzer::MeshBLSAnalyzer(OffloadedStmt *for_stmt,
+                                 MeshBLSCaches *caches,
+                                 bool auto_mesh_local,
+                                 const CompileConfig &config)
+    : for_stmt_(for_stmt),
+      caches_(caches),
+      auto_mesh_local_(auto_mesh_local),
+      config_(config) {
   TI_AUTO_PROF;
   allow_undefined_visitor = true;
   invoke_default_visitor = false;
@@ -32,16 +38,19 @@ void MeshBLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
   for (int l = 0; l < stmt->width(); l++) {
     auto snode = ptr->snodes[l];
     if (!caches_->has(snode)) {
-      if (auto_mesh_local_ && 
-          (flag == AccessFlag::accumulate || (flag == AccessFlag::read && config_.arch == Arch::cuda)) &&
-          (!idx->is<LoopIndexStmt>() || !idx->as<LoopIndexStmt>()->is_mesh_index())) {
+      if (auto_mesh_local_ &&
+          (flag == AccessFlag::accumulate ||
+           (flag == AccessFlag::read && config_.arch == Arch::cuda)) &&
+          (!idx->is<LoopIndexStmt>() ||
+           !idx->as<LoopIndexStmt>()->is_mesh_index())) {
         caches_->insert(snode);
       } else {
         continue;
       }
     }
 
-    if (!caches_->access(snode, element_type, conv_type, flag, idx->as<MeshRelationAccessStmt>()->neighbor_idx)) {
+    if (!caches_->access(snode, element_type, conv_type, flag,
+                         idx->as<MeshRelationAccessStmt>()->neighbor_idx)) {
       analysis_ok_ = false;
       break;
     }
@@ -82,7 +91,9 @@ namespace irpass {
 namespace analysis {
 
 std::unique_ptr<MeshBLSCaches> initialize_mesh_local_attribute(
-    OffloadedStmt *offload, bool auto_mesh_local, const CompileConfig &config) {
+    OffloadedStmt *offload,
+    bool auto_mesh_local,
+    const CompileConfig &config) {
   TI_AUTO_PROF
   TI_ASSERT(offload->task_type == OffloadedTaskType::mesh_for);
   std::unique_ptr<MeshBLSCaches> caches;

--- a/taichi/analysis/mesh_bls_analyzer.cpp
+++ b/taichi/analysis/mesh_bls_analyzer.cpp
@@ -6,8 +6,8 @@
 namespace taichi {
 namespace lang {
 
-MeshBLSAnalyzer::MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches)
-    : for_stmt_(for_stmt), caches_(caches) {
+MeshBLSAnalyzer::MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches, bool auto_mesh_local)
+    : for_stmt_(for_stmt), caches_(caches), auto_mesh_local(auto_mesh_local) {
   TI_AUTO_PROF;
   allow_undefined_visitor = true;
   invoke_default_visitor = false;
@@ -26,15 +26,21 @@ void MeshBLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
   auto conv = ptr->indices[0]->as<MeshIndexConversionStmt>();
   auto element_type = conv->idx_type;
   auto conv_type = conv->conv_type;
+  auto idx = conv->idx;
   if (conv_type == mesh::ConvType::g2r)
     return;
   for (int l = 0; l < stmt->width(); l++) {
     auto snode = ptr->snodes[l];
     if (!caches_->has(snode)) {
-      continue;
+      if (auto_mesh_local && flag != AccessFlag::write && 
+          (!idx->is<LoopIndexStmt>() || !idx->as<LoopIndexStmt>()->is_mesh_index())) {
+        caches_->insert(snode);
+      } else {
+        continue;
+      }
     }
 
-    if (!caches_->access(snode, element_type, conv_type, flag)) {
+    if (!caches_->access(snode, element_type, conv_type, flag, idx->as<MeshRelationAccessStmt>()->neighbor_idx)) {
       analysis_ok_ = false;
       break;
     }
@@ -75,7 +81,7 @@ namespace irpass {
 namespace analysis {
 
 std::unique_ptr<MeshBLSCaches> initialize_mesh_local_attribute(
-    OffloadedStmt *offload) {
+    OffloadedStmt *offload, bool auto_mesh_local) {
   TI_AUTO_PROF
   TI_ASSERT(offload->task_type == OffloadedTaskType::mesh_for);
   std::unique_ptr<MeshBLSCaches> caches;
@@ -85,7 +91,7 @@ std::unique_ptr<MeshBLSCaches> initialize_mesh_local_attribute(
     caches->insert(snode);
   }
 
-  MeshBLSAnalyzer bls_analyzer(offload, caches.get());
+  MeshBLSAnalyzer bls_analyzer(offload, caches.get(), auto_mesh_local);
   bool analysis_ok = bls_analyzer.run();
   if (!analysis_ok) {
     TI_ERROR("Mesh BLS analysis failed !");

--- a/taichi/analysis/mesh_bls_analyzer.h
+++ b/taichi/analysis/mesh_bls_analyzer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "taichi/program/compile_config.h"
 #include "taichi/ir/visitors.h"
 #include "taichi/ir/statements.h"
 #include "taichi/ir/mesh.h"
@@ -123,7 +124,7 @@ class MeshBLSAnalyzer : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
 
  public:
-  MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches, bool auto_mesh_local);
+  MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches, bool auto_mesh_local, const CompileConfig &config);
 
   void visit(GlobalPtrStmt *stmt) override {
   }
@@ -145,7 +146,8 @@ class MeshBLSAnalyzer : public BasicStmtVisitor {
   OffloadedStmt *for_stmt_{nullptr};
   MeshBLSCaches *caches_{nullptr};
   bool analysis_ok_{true};
-  bool auto_mesh_local{false};
+  bool auto_mesh_local_{false};
+  CompileConfig config_;
 };
 
 }  // namespace lang

--- a/taichi/analysis/mesh_bls_analyzer.h
+++ b/taichi/analysis/mesh_bls_analyzer.h
@@ -21,6 +21,8 @@ class MeshBLSCache {
 
   bool initialized;
   bool finalized;
+  bool loop_index;
+  int unique_accessed;
   AccessFlag total_flags;
 
   MeshBLSCache() = default;
@@ -29,11 +31,14 @@ class MeshBLSCache {
     total_flags = AccessFlag(0);
     initialized = false;
     finalized = false;
+    loop_index = false;
+    unique_accessed = 0;
   }
 
   bool access(mesh::MeshElementType element_type,
               mesh::ConvType conv_type,
-              AccessFlag flags) {
+              AccessFlag flags,
+              Stmt *idx) {
     if (!initialized) {
       initialized = true;
       this->conv_type = conv_type;
@@ -43,6 +48,11 @@ class MeshBLSCache {
         return false;
     }
     this->total_flags |= flags;
+    if (idx->is<LoopIndexStmt>()) {
+      loop_index = true;
+    } else {
+      unique_accessed++;
+    }
     return true;
   }
 
@@ -83,10 +93,11 @@ class MeshBLSCaches {
   bool access(SNode *snode,
               mesh::MeshElementType element_type,
               mesh::ConvType conv_type,
-              AccessFlag flags) {
+              AccessFlag flags,
+              Stmt *idx) {
     if (caches.find(snode) == caches.end())
       return false;
-    return caches.find(snode)->second.access(element_type, conv_type, flags);
+    return caches.find(snode)->second.access(element_type, conv_type, flags, idx);
   }
 
   Rec finalize() {
@@ -112,7 +123,7 @@ class MeshBLSAnalyzer : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
 
  public:
-  MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches);
+  MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches, bool auto_mesh_local);
 
   void visit(GlobalPtrStmt *stmt) override {
   }
@@ -134,6 +145,7 @@ class MeshBLSAnalyzer : public BasicStmtVisitor {
   OffloadedStmt *for_stmt_{nullptr};
   MeshBLSCaches *caches_{nullptr};
   bool analysis_ok_{true};
+  bool auto_mesh_local{false};
 };
 
 }  // namespace lang

--- a/taichi/analysis/mesh_bls_analyzer.h
+++ b/taichi/analysis/mesh_bls_analyzer.h
@@ -98,7 +98,8 @@ class MeshBLSCaches {
               Stmt *idx) {
     if (caches.find(snode) == caches.end())
       return false;
-    return caches.find(snode)->second.access(element_type, conv_type, flags, idx);
+    return caches.find(snode)->second.access(element_type, conv_type, flags,
+                                             idx);
   }
 
   Rec finalize() {
@@ -124,7 +125,10 @@ class MeshBLSAnalyzer : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
 
  public:
-  MeshBLSAnalyzer(OffloadedStmt *for_stmt, MeshBLSCaches *caches, bool auto_mesh_local, const CompileConfig &config);
+  MeshBLSAnalyzer(OffloadedStmt *for_stmt,
+                  MeshBLSCaches *caches,
+                  bool auto_mesh_local,
+                  const CompileConfig &config);
 
   void visit(GlobalPtrStmt *stmt) override {
   }

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -26,6 +26,10 @@ constexpr std::size_t taichi_result_buffer_runtime_query_id = 2;
 
 constexpr int taichi_listgen_max_element_size = 1024;
 
+// use for auto mesh_local to determine shared-mem size per block (in bytes)
+// TODO: get this at runtime
+constexpr std::size_t default_shared_mem_size = 65536;
+
 template <typename T, typename G>
 T taichi_union_cast_with_different_sizes(G g) {
   union {

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -242,7 +242,9 @@ std::pair</* owned= */ std::unordered_set<mesh::MeshElementType>,
           /* total= */ std::unordered_set<mesh::MeshElementType>>
 gather_mesh_thread_local(OffloadedStmt *offload, const CompileConfig &config);
 std::unique_ptr<MeshBLSCaches> initialize_mesh_local_attribute(
-    OffloadedStmt *offload, bool auto_mesh_local, const CompileConfig &config);
+    OffloadedStmt *offload,
+    bool auto_mesh_local,
+    const CompileConfig &config);
 
 }  // namespace analysis
 }  // namespace irpass

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -242,7 +242,7 @@ std::pair</* owned= */ std::unordered_set<mesh::MeshElementType>,
           /* total= */ std::unordered_set<mesh::MeshElementType>>
 gather_mesh_thread_local(OffloadedStmt *offload, const CompileConfig &config);
 std::unique_ptr<MeshBLSCaches> initialize_mesh_local_attribute(
-    OffloadedStmt *offload, bool auto_mesh_local);
+    OffloadedStmt *offload, bool auto_mesh_local, const CompileConfig &config);
 
 }  // namespace analysis
 }  // namespace irpass

--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -242,7 +242,7 @@ std::pair</* owned= */ std::unordered_set<mesh::MeshElementType>,
           /* total= */ std::unordered_set<mesh::MeshElementType>>
 gather_mesh_thread_local(OffloadedStmt *offload, const CompileConfig &config);
 std::unique_ptr<MeshBLSCaches> initialize_mesh_local_attribute(
-    OffloadedStmt *offload);
+    OffloadedStmt *offload, bool auto_mesh_local);
 
 }  // namespace analysis
 }  // namespace irpass

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -101,6 +101,8 @@ struct CompileConfig {
   bool mesh_localize_from_end_mapping{false};
   bool mesh_localize_all_attr_mappings{false};
   bool demote_no_access_mesh_fors{true};
+  bool auto_mesh_local{false};
+  int auto_mesh_local_default_occupacy{4};
 
   CompileConfig();
 };

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -101,7 +101,7 @@ struct CompileConfig {
   bool mesh_localize_from_end_mapping{false};
   bool mesh_localize_all_attr_mappings{false};
   bool demote_no_access_mesh_fors{true};
-  bool auto_mesh_local{false};
+  bool experimental_auto_mesh_local{false};
   int auto_mesh_local_default_occupacy{4};
 
   CompileConfig();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -229,8 +229,8 @@ void export_lang(py::module &m) {
                      &CompileConfig::mesh_localize_all_attr_mappings)
       .def_readwrite("demote_no_access_mesh_fors",
                      &CompileConfig::demote_no_access_mesh_fors)
-      .def_readwrite("auto_mesh_local",
-                     &CompileConfig::auto_mesh_local)
+      .def_readwrite("experimental_auto_mesh_local",
+                     &CompileConfig::experimental_auto_mesh_local)
       .def_readwrite("auto_mesh_local_default_occupacy",
                      &CompileConfig::auto_mesh_local_default_occupacy);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -228,7 +228,11 @@ void export_lang(py::module &m) {
       .def_readwrite("mesh_localize_all_attr_mappings",
                      &CompileConfig::mesh_localize_all_attr_mappings)
       .def_readwrite("demote_no_access_mesh_fors",
-                     &CompileConfig::demote_no_access_mesh_fors);
+                     &CompileConfig::demote_no_access_mesh_fors)
+      .def_readwrite("auto_mesh_local",
+                     &CompileConfig::auto_mesh_local)
+      .def_readwrite("auto_mesh_local_default_occupacy",
+                     &CompileConfig::auto_mesh_local_default_occupacy);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -417,9 +417,9 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
         SNodeAccessFlag::mesh_local).size() > 0) { // disable when user determine which attributes to be cached manually
           auto_mesh_local = false;
   }
-  auto caches = irpass::analysis::initialize_mesh_local_attribute(offload, auto_mesh_local);
+  auto caches = irpass::analysis::initialize_mesh_local_attribute(offload, auto_mesh_local, config);
 
-  if (auto_mesh_local) {
+  if (auto_mesh_local && config.arch == Arch::cuda) {
     const auto to_type = *offload->major_to_types.begin();
     std::size_t shared_mem_size_per_block = default_shared_mem_size / config.auto_mesh_local_default_occupacy;
     int available_bytes = shared_mem_size_per_block / offload->mesh->patch_max_element_num.find(to_type)->second;

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -411,22 +411,31 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
   // Step 1: use Mesh BLS analyzer to gather which mesh attributes user declared
   // to cache
   bool auto_mesh_local = config.experimental_auto_mesh_local;
-  if (offload->major_to_types.size() != 1 || // not support multiple major relations yet
-      offload->minor_relation_types.size() > 0 || // not support minor relations yet
-      offload->mem_access_opt.get_snodes_with_flag(
-        SNodeAccessFlag::mesh_local).size() > 0) { // disable when user determine which attributes to be cached manually
-          auto_mesh_local = false;
+  if (offload->major_to_types.size() !=
+          1 ||  // not support multiple major relations yet
+      offload->minor_relation_types.size() >
+          0 ||  // not support minor relations yet
+      offload->mem_access_opt.get_snodes_with_flag(SNodeAccessFlag::mesh_local)
+              .size() > 0) {  // disable when user determine which attributes to
+                              // be cached manually
+    auto_mesh_local = false;
   }
-  auto caches = irpass::analysis::initialize_mesh_local_attribute(offload, auto_mesh_local, config);
+  auto caches = irpass::analysis::initialize_mesh_local_attribute(
+      offload, auto_mesh_local, config);
 
   if (auto_mesh_local && config.arch == Arch::cuda) {
     const auto to_type = *offload->major_to_types.begin();
-    std::size_t shared_mem_size_per_block = default_shared_mem_size / config.auto_mesh_local_default_occupacy;
-    int available_bytes = shared_mem_size_per_block / offload->mesh->patch_max_element_num.find(to_type)->second;
-    if (mappings_.find(std::make_pair(to_type, mesh::ConvType::l2g)) != mappings_.end()) {
+    std::size_t shared_mem_size_per_block =
+        default_shared_mem_size / config.auto_mesh_local_default_occupacy;
+    int available_bytes =
+        shared_mem_size_per_block /
+        offload->mesh->patch_max_element_num.find(to_type)->second;
+    if (mappings_.find(std::make_pair(to_type, mesh::ConvType::l2g)) !=
+        mappings_.end()) {
       available_bytes -= 4;
     }
-    if (mappings_.find(std::make_pair(to_type, mesh::ConvType::l2r)) != mappings_.end()) {
+    if (mappings_.find(std::make_pair(to_type, mesh::ConvType::l2r)) !=
+        mappings_.end()) {
       available_bytes -= 4;
     }
     TI_TRACE("available cache attributes bytes = {}", available_bytes);
@@ -435,18 +444,24 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
     for (const auto [snode, cache] : caches->caches) {
       priority_caches.push_back(cache);
     }
-    std::sort(priority_caches.begin(), priority_caches.end(), [](const MeshBLSCache &a, const MeshBLSCache &b) {
-      return a.total_flags > b.total_flags ||
-             (a.total_flags == b.total_flags && a.loop_index > b.loop_index) ||
-             (a.total_flags == b.total_flags && a.loop_index == b.loop_index && a.unique_accessed > b.unique_accessed);
-    });
+    std::sort(priority_caches.begin(), priority_caches.end(),
+              [](const MeshBLSCache &a, const MeshBLSCache &b) {
+                return a.total_flags > b.total_flags ||
+                       (a.total_flags == b.total_flags &&
+                        a.loop_index > b.loop_index) ||
+                       (a.total_flags == b.total_flags &&
+                        a.loop_index == b.loop_index &&
+                        a.unique_accessed > b.unique_accessed);
+              });
     caches->caches.clear();
     for (const auto &cache : priority_caches) {
       available_bytes -= data_type_size(cache.snode->dt);
       if (available_bytes < 0) {
-        break;    // not enough space to ensure occupacy
+        break;  // not enough space to ensure occupacy
       }
-      TI_TRACE("available = {}, x = {}, loop_index = {}, unique_access = {}", available_bytes, cache.total_flags, int(cache.loop_index), cache.unique_accessed);
+      TI_TRACE("available = {}, x = {}, loop_index = {}, unique_access = {}",
+               available_bytes, cache.total_flags, int(cache.loop_index),
+               cache.unique_accessed);
       caches->caches.insert(std::make_pair(cache.snode, cache));
     }
   }
@@ -454,7 +469,8 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
 
   // If a mesh attribute is in bls, the config makes its index mapping must also
   // be in bls
-  if (config.mesh_localize_all_attr_mappings && !config.experimental_auto_mesh_local) {
+  if (config.mesh_localize_all_attr_mappings &&
+      !config.experimental_auto_mesh_local) {
     for (auto [mapping, attr_set] : rec_) {
       if (mappings_.find(mapping) == mappings_.end()) {
         mappings_.insert(mapping);

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -404,17 +404,57 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
   // Step 0: simplify l2g + g2r -> l2r
   simplify_nested_conversion();
 
-  // Step 1: use Mesh BLS analyzer to gather which mesh attributes user declared
-  // to cache
-  auto caches = irpass::analysis::initialize_mesh_local_attribute(offload);
-  rec_ = caches->finalize();
-
-  // Step 2: A analyzer to determine which mapping should be localized
+  // Step 1: A analyzer to determine which mapping should be localized
   mappings_.clear();
   gather_candidate_mapping();
+
+  // Step 1: use Mesh BLS analyzer to gather which mesh attributes user declared
+  // to cache
+  bool auto_mesh_local = config.experimental_auto_mesh_local;
+  if (offload->major_to_types.size() != 1 || // not support multiple major relations yet
+      offload->minor_relation_types.size() > 0 || // not support minor relations yet
+      offload->mem_access_opt.get_snodes_with_flag(
+        SNodeAccessFlag::mesh_local).size() > 0) { // disable when user determine which attributes to be cached manually
+          auto_mesh_local = false;
+  }
+  auto caches = irpass::analysis::initialize_mesh_local_attribute(offload, auto_mesh_local);
+
+  if (auto_mesh_local) {
+    const auto to_type = *offload->major_to_types.begin();
+    std::size_t shared_mem_size_per_block = default_shared_mem_size / config.auto_mesh_local_default_occupacy;
+    int available_bytes = shared_mem_size_per_block / offload->mesh->patch_max_element_num.find(to_type)->second;
+    if (mappings_.find(std::make_pair(to_type, mesh::ConvType::l2g)) != mappings_.end()) {
+      available_bytes -= 4;
+    }
+    if (mappings_.find(std::make_pair(to_type, mesh::ConvType::l2r)) != mappings_.end()) {
+      available_bytes -= 4;
+    }
+    TI_INFO("available cache attributes bytes = {}", available_bytes);
+    TI_INFO("caches size = {}", caches->caches.size());
+    std::vector<MeshBLSCache> priority_caches;
+    for (const auto [snode, cache] : caches->caches) {
+      priority_caches.push_back(cache);
+    }
+    std::sort(priority_caches.begin(), priority_caches.end(), [](const MeshBLSCache &a, const MeshBLSCache &b) {
+      return a.total_flags > b.total_flags ||
+             (a.total_flags == b.total_flags && a.loop_index > b.loop_index) ||
+             (a.total_flags == b.total_flags && a.loop_index == b.loop_index && a.unique_accessed > b.unique_accessed);
+    });
+    caches->caches.clear();
+    for (const auto &cache : priority_caches) {
+      available_bytes -= data_type_size(cache.snode->dt);
+      if (available_bytes < 0) {
+        break;    // not enough space to ensure occupacy
+      }
+      TI_INFO("available = {}, x = {}, loop_index = {}, unique_access = {}", available_bytes, cache.total_flags, int(cache.loop_index), cache.unique_accessed);
+      caches->caches.insert(std::make_pair(cache.snode, cache));
+    }
+  }
+  rec_ = caches->finalize();
+
   // If a mesh attribute is in bls, the config makes its index mapping must also
   // be in bls
-  if (config.mesh_localize_all_attr_mappings) {
+  if (config.mesh_localize_all_attr_mappings && !config.experimental_auto_mesh_local) {
     for (auto [mapping, attr_set] : rec_) {
       if (mappings_.find(mapping) == mappings_.end()) {
         mappings_.insert(mapping);

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -429,8 +429,8 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
     if (mappings_.find(std::make_pair(to_type, mesh::ConvType::l2r)) != mappings_.end()) {
       available_bytes -= 4;
     }
-    TI_INFO("available cache attributes bytes = {}", available_bytes);
-    TI_INFO("caches size = {}", caches->caches.size());
+    TI_TRACE("available cache attributes bytes = {}", available_bytes);
+    TI_TRACE("caches size = {}", caches->caches.size());
     std::vector<MeshBLSCache> priority_caches;
     for (const auto [snode, cache] : caches->caches) {
       priority_caches.push_back(cache);
@@ -446,7 +446,7 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
       if (available_bytes < 0) {
         break;    // not enough space to ensure occupacy
       }
-      TI_INFO("available = {}, x = {}, loop_index = {}, unique_access = {}", available_bytes, cache.total_flags, int(cache.loop_index), cache.unique_accessed);
+      TI_TRACE("available = {}, x = {}, loop_index = {}, unique_access = {}", available_bytes, cache.total_flags, int(cache.loop_index), cache.unique_accessed);
       caches->caches.insert(std::make_pair(cache.snode, cache));
     }
   }

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -7,7 +7,7 @@ import taichi as ti
 this_dir = os.path.dirname(os.path.abspath(__file__))
 model_file_path = os.path.join(this_dir, 'ell.json')
 
-
+'''
 @ti.test(require=ti.extension.mesh)
 def test_mesh_patch_idx():
     mesh_builder = ti.Mesh.Tet()
@@ -210,6 +210,43 @@ def test_mesh_local():
             ext_a[f.verts[0].id] += m
             ext_a[f.verts[1].id] += m
             ext_a[f.verts[2].id] += m
+
+    foo(False)
+    res1 = model.verts.a.to_numpy()
+    res2 = ext_a.to_numpy()
+    model.verts.a.fill(0)
+    ext_a.fill(0)
+    foo(True)
+    res3 = model.verts.a.to_numpy()
+    res4 = ext_a.to_numpy()
+
+    for i in range(len(model.verts)):
+        assert res1[i] == res2[i]
+        assert res1[i] == res3[i]
+        assert res1[i] == res4[i]
+'''
+
+@ti.test(require=ti.extension.mesh, experimental_auto_mesh_local=True)
+def test_auto_mesh_local():
+    mesh_builder = ti.Mesh.Tet()
+    mesh_builder.verts.place({'a': ti.i32, 's' : ti.i32})
+    mesh_builder.faces.link(mesh_builder.verts)
+    model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
+    ext_a = ti.field(ti.i32, shape=len(model.verts))
+
+    @ti.kernel
+    def foo(cache: ti.template()):
+        for v in model.verts:
+            v.s = v.id
+        if ti.static(cache):
+            ti.mesh_local(ext_a, model.verts.a)
+        for f in model.faces:
+            m = f.verts[0].s + f.verts[1].s + f.verts[2].s
+            f.verts[0].a += m
+            f.verts[1].a += m
+            f.verts[2].a += m
+            for i in range(3):
+                ext_a[f.verts[i].id] += m
 
     foo(False)
     res1 = model.verts.a.to_numpy()

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -7,7 +7,7 @@ import taichi as ti
 this_dir = os.path.dirname(os.path.abspath(__file__))
 model_file_path = os.path.join(this_dir, 'ell.json')
 
-'''
+
 @ti.test(require=ti.extension.mesh)
 def test_mesh_patch_idx():
     mesh_builder = ti.Mesh.Tet()
@@ -224,12 +224,12 @@ def test_mesh_local():
         assert res1[i] == res2[i]
         assert res1[i] == res3[i]
         assert res1[i] == res4[i]
-'''
+
 
 @ti.test(require=ti.extension.mesh, experimental_auto_mesh_local=True)
 def test_auto_mesh_local():
     mesh_builder = ti.Mesh.Tet()
-    mesh_builder.verts.place({'a': ti.i32, 's' : ti.i32})
+    mesh_builder.verts.place({'a': ti.i32, 's': ti.i32})
     mesh_builder.faces.link(mesh_builder.verts)
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
     ext_a = ti.field(ti.i32, shape=len(model.verts))


### PR DESCRIPTION
Related issue = #3608 

This PR implemented the experimental automatic `ti.mesh_local`. The optimization pass will cache all the atomic-add attributes and ignore the read-only attributes in the CPU backend. In the CUDA backend, when the minimal default occupancy is guaranteed, the optimization pass will cache mesh attributes in specific priority order as much as it could.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
