### PR TITLE
[mesh] [opt] Support nested mesh-for

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -885,6 +885,36 @@ class ASTTransformer(Builder):
             ctx.mesh = None
             _ti_core.end_frontend_range_for()
         return None
+    
+    @staticmethod
+    def build_nested_mesh_for(ctx, node):
+        targets = ASTTransformer.get_for_loop_targets(node)
+        if len(targets) != 1:
+            raise TaichiSyntaxError(
+                "Nested-mesh for should have 1 loop target, found {len(targets)}")
+        target = targets[0]
+        
+        with ctx.variable_scope_guard():
+            ctx.mesh = node.iter.ptr.mesh
+            assert isinstance(ctx.mesh, impl.MeshInstance)
+            loop_name = node.target.id + '_index__'
+            loop_var = expr.Expr(_ti_core.make_id_expr(''))
+            ctx.create_variable(loop_name, loop_var)
+            begin = expr.Expr(0)
+            end = node.iter.ptr.size
+            _ti_core.begin_frontend_range_for(loop_var.ptr, begin.ptr, end.ptr)
+            entry_expr = _ti_core.get_relation_access(ctx.mesh.mesh_ptr,
+                                                  node.iter.ptr.from_index.ptr,
+                                                  node.iter.ptr.to_element_type,
+                                                  loop_var.ptr)
+            entry_expr.type_check()
+            mesh_idx = mesh.MeshElementFieldProxy(ctx.mesh,
+                                                  node.iter.ptr.to_element_type, entry_expr)
+            ctx.create_variable(target, mesh_idx)
+            build_stmts(ctx, node.body)
+            _ti_core.end_frontend_range_for()
+
+        return None
 
     @staticmethod
     def build_For(ctx, node):
@@ -933,6 +963,8 @@ class ASTTransformer(Builder):
                             'Backend ' + str(impl.default_cfg().arch) +
                             ' doesn\'t support MeshTaichi extension')
                     return ASTTransformer.build_mesh_for(ctx, node)
+                elif isinstance(node.iter.ptr, mesh.MeshRelationAccessProxy):
+                    return ASTTransformer.build_nested_mesh_for(ctx, node)
                 # Struct for
                 return ASTTransformer.build_struct_for(ctx,
                                                        node,

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -885,15 +885,16 @@ class ASTTransformer(Builder):
             ctx.mesh = None
             _ti_core.end_frontend_range_for()
         return None
-    
+
     @staticmethod
     def build_nested_mesh_for(ctx, node):
         targets = ASTTransformer.get_for_loop_targets(node)
         if len(targets) != 1:
             raise TaichiSyntaxError(
-                "Nested-mesh for should have 1 loop target, found {len(targets)}")
+                "Nested-mesh for should have 1 loop target, found {len(targets)}"
+            )
         target = targets[0]
-        
+
         with ctx.variable_scope_guard():
             ctx.mesh = node.iter.ptr.mesh
             assert isinstance(ctx.mesh, impl.MeshInstance)
@@ -903,13 +904,12 @@ class ASTTransformer(Builder):
             begin = expr.Expr(0)
             end = node.iter.ptr.size
             _ti_core.begin_frontend_range_for(loop_var.ptr, begin.ptr, end.ptr)
-            entry_expr = _ti_core.get_relation_access(ctx.mesh.mesh_ptr,
-                                                  node.iter.ptr.from_index.ptr,
-                                                  node.iter.ptr.to_element_type,
-                                                  loop_var.ptr)
+            entry_expr = _ti_core.get_relation_access(
+                ctx.mesh.mesh_ptr, node.iter.ptr.from_index.ptr,
+                node.iter.ptr.to_element_type, loop_var.ptr)
             entry_expr.type_check()
-            mesh_idx = mesh.MeshElementFieldProxy(ctx.mesh,
-                                                  node.iter.ptr.to_element_type, entry_expr)
+            mesh_idx = mesh.MeshElementFieldProxy(
+                ctx.mesh, node.iter.ptr.to_element_type, entry_expr)
             ctx.create_variable(target, mesh_idx)
             build_stmts(ctx, node.body)
             _ti_core.end_frontend_range_for()

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -963,7 +963,7 @@ class ASTTransformer(Builder):
                             'Backend ' + str(impl.default_cfg().arch) +
                             ' doesn\'t support MeshTaichi extension')
                     return ASTTransformer.build_mesh_for(ctx, node)
-                elif isinstance(node.iter.ptr, mesh.MeshRelationAccessProxy):
+                if isinstance(node.iter.ptr, mesh.MeshRelationAccessProxy):
                     return ASTTransformer.build_nested_mesh_for(ctx, node)
                 # Struct for
                 return ASTTransformer.build_struct_for(ctx,

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -229,7 +229,7 @@ def test_mesh_local():
 @ti.test(require=ti.extension.mesh)
 def test_nested_mesh_for():
     mesh_builder = ti.Mesh.Tet()
-    mesh_builder.faces.place({'a': ti.i32, 'b' : ti.i32})
+    mesh_builder.faces.place({'a': ti.i32, 'b': ti.i32})
     mesh_builder.faces.link(mesh_builder.verts)
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
 

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -224,3 +224,23 @@ def test_mesh_local():
         assert res1[i] == res2[i]
         assert res1[i] == res3[i]
         assert res1[i] == res4[i]
+
+
+@ti.test(require=ti.extension.mesh)
+def test_nested_mesh_for():
+    mesh_builder = ti.Mesh.Tet()
+    mesh_builder.faces.place({'a': ti.i32, 'b' : ti.i32})
+    mesh_builder.faces.link(mesh_builder.verts)
+    model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
+
+    @ti.kernel
+    def foo():
+        for f in model.faces:
+            for i in range(f.verts.size):
+                f.a += f.verts[i].id
+            for v in f.verts:
+                f.b += v.id
+
+    a = model.faces.a.to_numpy()
+    b = model.faces.b.to_numpy()
+    assert (a == b).all() == 1


### PR DESCRIPTION
Related issue = #3608 

Before this PR, do the neighbor query loop in mesh-for must resort to nested range-for, like:
``` Python
for u in model.verts:
  for i in u.verts.size:
    u.x += u.verts[i].y
```
This PR implemented the nested mesh-for loop, the code above could be rewritten as:
``` Python
for u in model.verts:
  for v in u.verts:
    u.x += v.y
```
**Note that the nested mesh-for loop would not be un-looped.**