### PR TITLE
[opengl] [aot] Convert opengl aot to dump ModuleData.

### DIFF
--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -91,6 +91,12 @@ struct ModuleData {
 
   size_t root_buffer_size;
 
+  void dump_json(std::string path) {
+    TextSerializer ts;
+    ts.serialize_to_json("aot_data", *this);
+    ts.write_to_file(path);
+  }
+
   TI_IO_DEF(kernels, kernel_tmpls, fields, root_buffer_size);
 };
 

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -106,7 +106,6 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
                                 const std::string &filename) const {
   TI_WARN_IF(!filename.empty(),
              "Filename prefix is ignored on opengl backend.");
-  // TODO(#3334): Convert |aot_data_| with AotDataConverter
   const std::string bin_path = fmt::format("{}/metadata.tcb", output_dir);
   write_to_binary_file(aot_data_, bin_path);
   // Json format doesn't support multiple line strings.
@@ -121,11 +120,9 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
       write_glsl_file(output_dir, t);
     }
   }
-
-  const std::string txt_path = fmt::format("{}/metadata.json", output_dir);
-  TextSerializer ts;
-  ts.serialize_to_json("aot_data", aot_data_copy);
-  ts.write_to_file(txt_path);
+  auto aot_module_data = AotDataConverter::convert(aot_data_copy);
+  const std::string json_path = fmt::format("{}/metadata.json", output_dir);
+  aot_module_data.dump_json(json_path);
 }
 
 void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -50,7 +50,7 @@ def test_opengl_max_block_dim():
         with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
             res = json.load(json_file)
             gl_file_path = res['aot_data']['kernels']['init']['tasks'][0][
-                'src']
+                'source_path']
             with open(gl_file_path) as gl_file:
                 s = 'layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;\n'
                 assert s in gl_file.readlines()


### PR DESCRIPTION
This PR switch opengl backend to dump `ModuleData` instead of its own structure. 

Followup: need to update the deserializer accordingly for bind_index. 