### PR TITLE
[opt] Add more strict alias analysis for ExternalPtrStmt

### DIFF
--- a/taichi/analysis/alias_analysis.cpp
+++ b/taichi/analysis/alias_analysis.cpp
@@ -99,8 +99,12 @@ AliasResult alias_analysis(Stmt *var1, Stmt *var2) {
       return AliasResult::different;
     auto ptr1 = var1->as<ExternalPtrStmt>();
     auto ptr2 = var2->as<ExternalPtrStmt>();
-    if (ptr1->base_ptrs[0] != ptr2->base_ptrs[0])
-      return AliasResult::uncertain;
+    if (ptr1->base_ptrs[0] != ptr2->base_ptrs[0]) {
+      auto base1 = ptr1->base_ptrs[0]->as<ArgLoadStmt>();
+      auto base2 = ptr2->base_ptrs[0]->as<ArgLoadStmt>();
+      return base1->arg_id != base2->arg_id ? AliasResult::different
+                                            : AliasResult::uncertain;
+    }
     TI_ASSERT(ptr1->indices.size() == ptr2->indices.size());
     bool uncertain = false;
     for (int i = 0; i < (int)ptr1->indices.size(); i++) {

--- a/tests/cpp/analysis/alias_analysis_test.cpp
+++ b/tests/cpp/analysis/alias_analysis_test.cpp
@@ -143,7 +143,7 @@ TEST(AliasAnalysis, ExternalPtr_DiffPtr) {
   auto *eptr2 = builder.create_external_ptr(arg2, indices);
 
   const auto aa = alias_analysis(eptr1, eptr2);
-  EXPECT_EQ(aa, AliasResult::uncertain);
+  EXPECT_EQ(aa, AliasResult::different);
 }
 
 }  // namespace analysis


### PR DESCRIPTION
This is not likely not 100% safe, how about banning "passing the same ndarray as
different arguments to a taichi kernel"?

It helps eliminating identical `GlobalLoadStmt`s (whose source are`ExternalPtrStmt`s) in mpm88 aot example. 

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
