### PR TITLE
[bug] [opt] Treat PtrOffsetStmt as random-initialized

### DIFF
--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -218,12 +218,8 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
   }
   if (!result) {
     // The UD-chain is empty.
-    if (!(var->is<PtrOffsetStmt>() &&
-          var->as<PtrOffsetStmt>()->is_local_ptr())) {
-      // Only exception: tensor alloca is not considered as a store.
-      TI_WARN("stmt {} loaded in stmt {} before storing.", var->id,
-              block->statements[position]->id);
-    }
+    TI_WARN("stmt {} loaded in stmt {} before storing.", var->id,
+            block->statements[position]->id);
     return nullptr;
   }
   if (!result_visible) {
@@ -631,11 +627,7 @@ void ControlFlowGraph::reaching_definition_analysis(bool after_lower_access) {
         auto stmt = nodes[i]->block->statements[j].get();
         if (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
             stmt->is<BlockLocalPtrStmt>() || stmt->is<ThreadLocalPtrStmt>() ||
-            stmt->is<GlobalTemporaryStmt>() ||
-            (stmt->is<PtrOffsetStmt>() &&
-             stmt->cast<PtrOffsetStmt>()->origin->is<GlobalTemporaryStmt>()) ||
-            (stmt->is<PtrOffsetStmt>() &&
-             stmt->cast<PtrOffsetStmt>()->is_unlowered_global_ptr())) {
+            stmt->is<GlobalTemporaryStmt>() || stmt->is<PtrOffsetStmt>()) {
           // TODO: unify them
           // A global pointer that may contain some data before this kernel.
           nodes[start_node]->reach_gen.insert(stmt);

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -624,10 +624,12 @@ void ControlFlowGraph::reaching_definition_analysis(bool after_lower_access) {
   for (int i = 0; i < num_nodes; i++) {
     for (int j = nodes[i]->begin_location; j < nodes[i]->end_location; j++) {
       auto stmt = nodes[i]->block->statements[j].get();
-      if ((stmt->is<PtrOffsetStmt>() && stmt->as<PtrOffsetStmt>()->origin->is<AllocaStmt>()) ||
-          (!after_lower_access && (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
-          stmt->is<BlockLocalPtrStmt>() || stmt->is<ThreadLocalPtrStmt>() ||
-          stmt->is<GlobalTemporaryStmt>() || stmt->is<PtrOffsetStmt>()))) {
+      if ((stmt->is<PtrOffsetStmt>() &&
+           stmt->as<PtrOffsetStmt>()->origin->is<AllocaStmt>()) ||
+          (!after_lower_access &&
+           (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
+            stmt->is<BlockLocalPtrStmt>() || stmt->is<ThreadLocalPtrStmt>() ||
+            stmt->is<GlobalTemporaryStmt>() || stmt->is<PtrOffsetStmt>()))) {
         // TODO: unify them
         // A global pointer that may contain some data before this kernel.
         nodes[start_node]->reach_gen.insert(stmt);

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -621,17 +621,16 @@ void ControlFlowGraph::reaching_definition_analysis(bool after_lower_access) {
   TI_ASSERT(nodes[start_node]->empty());
   nodes[start_node]->reach_gen.clear();
   nodes[start_node]->reach_kill.clear();
-  if (!after_lower_access) {
-    for (int i = 0; i < num_nodes; i++) {
-      for (int j = nodes[i]->begin_location; j < nodes[i]->end_location; j++) {
-        auto stmt = nodes[i]->block->statements[j].get();
-        if (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
-            stmt->is<BlockLocalPtrStmt>() || stmt->is<ThreadLocalPtrStmt>() ||
-            stmt->is<GlobalTemporaryStmt>() || stmt->is<PtrOffsetStmt>()) {
-          // TODO: unify them
-          // A global pointer that may contain some data before this kernel.
-          nodes[start_node]->reach_gen.insert(stmt);
-        }
+  for (int i = 0; i < num_nodes; i++) {
+    for (int j = nodes[i]->begin_location; j < nodes[i]->end_location; j++) {
+      auto stmt = nodes[i]->block->statements[j].get();
+      if ((stmt->is<PtrOffsetStmt>() && stmt->as<PtrOffsetStmt>()->origin->is<AllocaStmt>()) ||
+          (!after_lower_access && (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
+          stmt->is<BlockLocalPtrStmt>() || stmt->is<ThreadLocalPtrStmt>() ||
+          stmt->is<GlobalTemporaryStmt>() || stmt->is<PtrOffsetStmt>()))) {
+        // TODO: unify them
+        // A global pointer that may contain some data before this kernel.
+        nodes[start_node]->reach_gen.insert(stmt);
       }
     }
   }

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -508,3 +508,15 @@ def test_matrix_field_dynamic_index_multiple_materialize():
     for i in range(n):
         for j in range(3):
             assert a[i][j] == (i if j == i % 3 else 0)
+
+
+@ti.test(arch=[ti.cpu, ti.cuda], dynamic_index=True, debug=True)
+def test_local_vector_initialized_in_a_loop():
+    @ti.kernel
+    def foo():
+        for c in range(10):
+            p = ti.Vector([c, c * 2])
+            for i in range(2):
+                assert p[i] == c * (i + 1)
+
+    foo()


### PR DESCRIPTION
Related issue = fixes #3954

We should treat any `PtrOffsetStmt` (previously local tensors are excluded) as if it has already been stored with random values to prevent invalid optimization.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
