### PR TITLE
[vulkan] [aot] Enable aot tests for vulkan backend.

### DIFF
--- a/taichi/common/serialization.h
+++ b/taichi/common/serialization.h
@@ -818,6 +818,7 @@ class TextSerializer : public Serializer {
     add_key("has_value");
     process(val.has_value());
     if (val.has_value()) {
+      add_raw(",");
       add_key("value");
       process(val.value());
     }

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -56,7 +56,7 @@ def test_opengl_max_block_dim():
                 assert s in gl_file.readlines()
 
 
-@ti.test(arch=ti.opengl)
+@ti.test(arch=[ti.opengl, ti.vulkan])
 def test_save():
     density = ti.field(float, shape=(4, 4))
 
@@ -71,7 +71,8 @@ def test_save():
             density[0, 0] += 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        m = ti.aot.Module(ti.opengl)
+        # note ti.aot.Module(ti.opengl) is no-op according to its docstring.
+        m = ti.aot.Module(ti.cfg.arch)
         m.add_field('density', density)
         m.add_kernel(init)
         with m.add_kernel_template(foo) as kt:
@@ -82,7 +83,7 @@ def test_save():
             json.load(json_file)
 
 
-@ti.test(arch=ti.opengl)
+@ti.test(arch=[ti.opengl, ti.vulkan])
 def test_non_dense_snode():
     n = 8
     x = ti.field(dtype=ti.f32)
@@ -92,12 +93,12 @@ def test_non_dense_snode():
     blk.dense(ti.i, n).place(y)
 
     with pytest.raises(RuntimeError, match='AOT: only supports dense field'):
-        m = ti.aot.Module(ti.opengl)
+        m = ti.aot.Module(ti.cfg.arch)
         m.add_field('x', x)
         m.add_field('y', y)
 
 
-@ti.test(arch=ti.opengl)
+@ti.test(arch=[ti.opengl, ti.vulkan])
 def test_mpm88_aot():
     n_particles = 8192
     n_grid = 128
@@ -177,7 +178,7 @@ def test_mpm88_aot():
             J[i] = 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        m = ti.aot.Module(ti.opengl)
+        m = ti.aot.Module(ti.cfg.arch)
         m.add_field("x", x)
         m.add_field("v", v)
         m.add_field("C", C)
@@ -256,7 +257,7 @@ def test_opengl_exceed_max_ssbo():
              density7, density8)
 
 
-@ti.test(arch=ti.opengl)
+@ti.test(arch=[ti.opengl, ti.vulkan])
 def test_mpm99_aot():
     quality = 1  # Use a larger value for higher-res simulations
     n_particles, n_grid = 9000 * quality**2, 128 * quality
@@ -383,7 +384,7 @@ def test_mpm99_aot():
             Jp[i] = 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        m = ti.aot.Module(ti.opengl)
+        m = ti.aot.Module(ti.cfg.arch)
         m.add_field('x', x)
         m.add_field('v', v)
         m.add_field('C', C)


### PR DESCRIPTION
This PR fixes a typo in std::optional serialization and enabled field
based aot tests for vulkan backend.

Note our `arch` in `ti.aot.Module(arch)` API is ignored, this API is a bit
misleading so we made it clear in tests.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
