### PR TITLE
[Lang] Make the kernel return a matrix

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -472,15 +472,18 @@ class ASTTransformer(Builder):
                 print(ctx.func.return_type)
                 if id(ctx.func.return_type) in primitive_types.type_ids:
                     _ti_core.create_kernel_exprgroup_return(
-                        expr.make_expr_group(ti_ops.cast(expr.Expr(node.value.ptr),
-                                    ctx.func.return_type).ptr))
+                        expr.make_expr_group(
+                            ti_ops.cast(expr.Expr(node.value.ptr),
+                                        ctx.func.return_type).ptr))
                 else:
                     _ti_core.create_kernel_exprgroup_return(
                         expr.make_expr_group([
                             ti_ops.cast(
                                 exp, ctx.func.return_type.dtype if isinstance(
                                     ctx.func.return_type, MatrixType) else
-                                ctx.func.return_type) for exp in list(itertools.chain.from_iterable(node.value.ptr.to_list()))
+                                ctx.func.return_type) for exp in list(
+                                    itertools.chain.from_iterable(
+                                        node.value.ptr.to_list()))
                         ]))
 
                 # For args[0], it is an ast.Attribute, because it loads the

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -12,8 +12,8 @@ from taichi.lang.exception import InvalidOperationError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
-from taichi.lang.matrix import (Matrix, MatrixField, MatrixType,
-                                _IntermediateMatrix, _MatrixFieldElement)
+from taichi.lang.matrix import (Matrix, MatrixField, _IntermediateMatrix,
+                                _MatrixFieldElement)
 from taichi.lang.mesh import (ConvType, MeshElementFieldProxy, MeshInstance,
                               MeshRelationAccessProxy,
                               MeshReorderedMatrixFieldProxy,

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -12,6 +12,7 @@ from taichi.lang.exception import InvalidOperationError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
+from taichi.lang.matrix import MatrixType  # pylint: disable=W0611
 from taichi.lang.matrix import (Matrix, MatrixField, _IntermediateMatrix,
                                 _MatrixFieldElement)
 from taichi.lang.mesh import (ConvType, MeshElementFieldProxy, MeshInstance,

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -12,8 +12,8 @@ from taichi.lang.exception import InvalidOperationError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
-from taichi.lang.matrix import (Matrix, MatrixField, _IntermediateMatrix,
-                                _MatrixFieldElement)
+from taichi.lang.matrix import (Matrix, MatrixField, MatrixType,
+                                _IntermediateMatrix, _MatrixFieldElement)
 from taichi.lang.mesh import (ConvType, MeshElementFieldProxy, MeshInstance,
                               MeshRelationAccessProxy,
                               MeshReorderedMatrixFieldProxy,

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -3,7 +3,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang.any_array import AnyArray
 from taichi.lang.enums import Layout
 from taichi.lang.expr import Expr
-from taichi.lang.matrix import Matrix, MatrixType
+from taichi.lang.matrix import Matrix
 from taichi.lang.util import cook_dtype
 from taichi.types.primitive_types import u64
 

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -3,7 +3,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang.any_array import AnyArray
 from taichi.lang.enums import Layout
 from taichi.lang.expr import Expr
-from taichi.lang.matrix import Matrix
+from taichi.lang.matrix import Matrix, MatrixType
 from taichi.lang.util import cook_dtype
 from taichi.types.primitive_types import u64
 
@@ -65,6 +65,6 @@ def decl_any_arr_arg(dtype, dim, element_shape, layout):
         element_shape, layout)
 
 
-def decl_scalar_ret(dtype):
+def decl_ret(dtype):
     dtype = cook_dtype(dtype)
     return _ti_core.decl_ret(dtype)

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -619,13 +619,12 @@ class Kernel:
                     ret = t_kernel.get_ret_float(0)
                 elif id(ret_dt.dtype) in primitive_types.integer_type_ids:
                     it = iter(t_kernel.get_ret_matrix_int(0))
-                    ret = Matrix([[next(it) for _ in range(ret_dt.n)]
-                                  for _ in range(ret_dt.m)])
+                    ret = Matrix([[next(it) for _ in range(ret_dt.m)]
+                                  for _ in range(ret_dt.n)])
                 else:
                     it = iter(t_kernel.get_ret_matrix_float(0))
-                    ret = Matrix([[next(it) for _ in range(ret_dt.n)]
-                                  for _ in range(ret_dt.m)])
-
+                    ret = Matrix([[next(it) for _ in range(ret_dt.m)]
+                                  for _ in range(ret_dt.n)])
             if callbacks:
                 for c in callbacks:
                     c()

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -235,7 +235,7 @@ class Func:
             else:
                 if not id(annotation
                           ) in primitive_types.type_ids and not isinstance(
-                    annotation, template):
+                              annotation, template):
                     raise KernelDefError(
                         f'Invalid type annotation (argument {i}) of Taichi function: {annotation}'
                     )
@@ -272,10 +272,10 @@ class TaichiCallableTemplateMapper:
                 return arg.dtype, len(arg.shape), (), Layout.AOS
             if isinstance(arg, taichi.lang.matrix.VectorNdarray):
                 anno.check_element_dim(arg, 1)
-                anno.check_element_shape((arg.n,))
+                anno.check_element_shape((arg.n, ))
                 anno.check_field_dim(len(arg.shape))
                 anno.check_layout(arg)
-                return arg.dtype, len(arg.shape) + 1, (arg.n,), arg.layout
+                return arg.dtype, len(arg.shape) + 1, (arg.n, ), arg.layout
             if isinstance(arg, taichi.lang.matrix.MatrixNdarray):
                 anno.check_element_dim(arg, 2)
                 anno.check_element_shape((arg.n, arg.m))
@@ -294,7 +294,7 @@ class TaichiCallableTemplateMapper:
             element_shape = (
             ) if element_dim == 0 else shape[:
                                              element_dim] if layout == Layout.SOA else shape[
-                                                                                       -element_dim:]
+                                                 -element_dim:]
             return to_taichi_type(arg.dtype), len(shape), element_shape, layout
         return type(arg).__name__,
 
@@ -619,10 +619,12 @@ class Kernel:
                     ret = t_kernel.get_ret_float(0)
                 elif id(ret_dt.dtype) in primitive_types.integer_type_ids:
                     it = iter(t_kernel.get_ret_matrix_int(0))
-                    ret = Matrix([[next(it) for _ in range(ret_dt.n)] for _ in range(ret_dt.m)])
+                    ret = Matrix([[next(it) for _ in range(ret_dt.n)]
+                                  for _ in range(ret_dt.m)])
                 else:
                     it = iter(t_kernel.get_ret_matrix_float(0))
-                    ret = Matrix([[next(it) for _ in range(ret_dt.n)]for _ in range(ret_dt.m)])
+                    ret = Matrix([[next(it) for _ in range(ret_dt.n)]
+                                  for _ in range(ret_dt.m)])
 
             if callbacks:
                 for c in callbacks:
@@ -824,7 +826,6 @@ def data_oriented(cls):
     Returns:
         The decorated class.
     """
-
     def _getattr(self, item):
         method = cls.__dict__.get(item, None)
         is_property = method.__class__ == property

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -14,7 +14,7 @@ from taichi.lang.ast import (ASTTransformerContext, KernelSimplicityASTChecker,
 from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiCompilationError, TaichiSyntaxError
 from taichi.lang.expr import Expr
-from taichi.lang.matrix import MatrixType
+from taichi.lang.matrix import Matrix, MatrixType
 from taichi.lang.shell import _shell_pop_print, oinspect
 from taichi.lang.util import to_taichi_type
 from taichi.linalg.sparse_matrix import sparse_matrix_builder
@@ -235,7 +235,7 @@ class Func:
             else:
                 if not id(annotation
                           ) in primitive_types.type_ids and not isinstance(
-                              annotation, template):
+                    annotation, template):
                     raise KernelDefError(
                         f'Invalid type annotation (argument {i}) of Taichi function: {annotation}'
                     )
@@ -272,10 +272,10 @@ class TaichiCallableTemplateMapper:
                 return arg.dtype, len(arg.shape), (), Layout.AOS
             if isinstance(arg, taichi.lang.matrix.VectorNdarray):
                 anno.check_element_dim(arg, 1)
-                anno.check_element_shape((arg.n, ))
+                anno.check_element_shape((arg.n,))
                 anno.check_field_dim(len(arg.shape))
                 anno.check_layout(arg)
-                return arg.dtype, len(arg.shape) + 1, (arg.n, ), arg.layout
+                return arg.dtype, len(arg.shape) + 1, (arg.n,), arg.layout
             if isinstance(arg, taichi.lang.matrix.MatrixNdarray):
                 anno.check_element_dim(arg, 2)
                 anno.check_element_shape((arg.n, arg.m))
@@ -294,7 +294,7 @@ class TaichiCallableTemplateMapper:
             element_shape = (
             ) if element_dim == 0 else shape[:
                                              element_dim] if layout == Layout.SOA else shape[
-                                                 -element_dim:]
+                                                                                       -element_dim:]
             return to_taichi_type(arg.dtype), len(shape), element_shape, layout
         return type(arg).__name__,
 
@@ -615,8 +615,14 @@ class Kernel:
             if has_ret:
                 if id(ret_dt) in primitive_types.integer_type_ids:
                     ret = t_kernel.get_ret_int(0)
-                else:
+                elif id(ret_dt) in primitive_types.real_type_ids:
                     ret = t_kernel.get_ret_float(0)
+                elif id(ret_dt.dtype) in primitive_types.integer_type_ids:
+                    it = iter(t_kernel.get_ret_matrix_int(0))
+                    ret = Matrix([[next(it) for _ in range(ret_dt.n)] for _ in range(ret_dt.m)])
+                else:
+                    it = iter(t_kernel.get_ret_matrix_float(0))
+                    ret = Matrix([[next(it) for _ in range(ret_dt.n)]for _ in range(ret_dt.m)])
 
             if callbacks:
                 for c in callbacks:
@@ -818,6 +824,7 @@ def data_oriented(cls):
     Returns:
         The decorated class.
     """
+
     def _getattr(self, item):
         method = cls.__dict__.get(item, None)
         is_property = method.__class__ == property

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -129,6 +129,13 @@ def cast(obj, dtype):
     return expr.Expr(_ti_core.value_cast(expr.Expr(obj).ptr, dtype))
 
 
+def group_cast(group, dtype):
+    dtype = cook_dtype(dtype)
+    if is_taichi_class(group):
+        return group.cast(dtype)
+    return _ti_core.ExprGroup()
+
+
 def bit_cast(obj, dtype):
     dtype = cook_dtype(dtype)
     if is_taichi_class(obj):

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -191,6 +191,8 @@ def cook_dtype(dtype):
         return dtype
     if isinstance(dtype, _ti_core.Type):
         return _ti_core.DataType(dtype)
+    if isinstance(dtype, impl.MatrixType):
+        return _ti_core.decl_tensor_type([dtype.n, dtype.m], dtype.dtype)
     if dtype is float:
         return impl.get_runtime().default_fp
     if dtype is int:

--- a/taichi/backends/cc/cc_program.cpp
+++ b/taichi/backends/cc/cc_program.cpp
@@ -189,7 +189,7 @@ CCContext *CCProgramImpl::update_context(RuntimeContext *ctx) {
 void CCProgramImpl::context_to_result_buffer() {
   TI_ASSERT(result_buffer_);
   std::memcpy(result_buffer_, context_->args,
-              sizeof(uint64));  // XXX: assumed 1 return
+              taichi_max_num_ret_values * sizeof(uint64));
   context_->earg = nullptr;
 }
 

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -188,7 +188,7 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(ReturnStmt *stmt) override {
-    emit("ti_ctx->args[0].val_{} = {};", data_types_name(stmt->element_types()),
+    emit("ti_ctx->args[0].val_{} = {};", data_type_name(stmt->element_types()[0]),
          stmt->values_raw_names());
   }
 

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -188,8 +188,8 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(ReturnStmt *stmt) override {
-    emit("ti_ctx->args[0].val_{} = {};", data_type_name(stmt->element_type()),
-         stmt->value->raw_name());
+    emit("ti_ctx->args[0].val_{} = {};", data_types_name(stmt->element_types()),
+         stmt->values_raw_names());
   }
 
   void visit(ConstStmt *stmt) override {

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -188,8 +188,11 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(ReturnStmt *stmt) override {
-    emit("ti_ctx->args[0].val_{} = {};",
-         data_type_name(stmt->element_types()[0]), stmt->values_raw_names());
+    int idx{0};
+    for (auto &value : stmt->values) {
+      emit("ti_ctx->args[0].val_{}[{}] = {};",
+           data_type_name(stmt->element_types()[0]), idx++, value->raw_name());
+    }
   }
 
   void visit(ConstStmt *stmt) override {

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -188,8 +188,8 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(ReturnStmt *stmt) override {
-    emit("ti_ctx->args[0].val_{} = {};", data_type_name(stmt->element_types()[0]),
-         stmt->values_raw_names());
+    emit("ti_ctx->args[0].val_{} = {};",
+         data_type_name(stmt->element_types()[0]), stmt->values_raw_names());
   }
 
   void visit(ConstStmt *stmt) override {

--- a/taichi/backends/cc/codegen_cc.cpp
+++ b/taichi/backends/cc/codegen_cc.cpp
@@ -190,9 +190,11 @@ class CCTransformer : public IRVisitor {
   void visit(ReturnStmt *stmt) override {
     int idx{0};
     for (auto &value : stmt->values) {
-      emit("ti_ctx->args[0].val_{}[{}] = {};",
-           data_type_name(stmt->element_types()[0]), idx++, value->raw_name());
+      emit("ti_ctx->args[{}].val_{} = {};", idx++,
+           data_type_name(value->element_type()), value->raw_name());
     }
+    // CC backend use arg buffer to access result values, so It doesn't support
+    // paas-by-ref now.
   }
 
   void visit(ConstStmt *stmt) override {

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -393,7 +393,10 @@ class KernelCodegenImpl : public IRVisitor {
 
   void visit(ReturnStmt *stmt) override {
     // TODO: use stmt->ret_id instead of 0 as index
-    emit("*{}.ret0() = {};", kContextVarName, stmt->values_raw_names());
+    int idx{0};
+    for (auto &value : stmt->values) {
+      emit("*{}.ret0()[{}] = {};", kContextVarName, idx++, value->raw_name());
+    }
   }
 
   void visit(ExternalPtrStmt *stmt) override {

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -393,7 +393,7 @@ class KernelCodegenImpl : public IRVisitor {
 
   void visit(ReturnStmt *stmt) override {
     // TODO: use stmt->ret_id instead of 0 as index
-    emit("*{}.ret0() = {};", kContextVarName, stmt->value->raw_name());
+    emit("*{}.ret0() = {};", kContextVarName, stmt->values_raw_names());
   }
 
   void visit(ExternalPtrStmt *stmt) override {

--- a/taichi/backends/metal/kernel_utils.cpp
+++ b/taichi/backends/metal/kernel_utils.cpp
@@ -94,15 +94,29 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
   }
   for (const auto &kr : kernel.rets) {
     RetAttributes mr;
-    mr.dt = to_metal_type(kr.dt);
-    const size_t dt_bytes = metal_data_type_bytes(mr.dt);
-    if (dt_bytes > 4) {
-      // Metal doesn't support 64bit data buffers.
-      TI_ERROR("Metal kernel only supports <= 32-bit data, got {}",
-               metal_data_type_name(mr.dt));
+    if (auto tensor_type = kr.dt->cast<TensorType>()) {
+      mr.dt = to_metal_type(tensor_type->get_element_type());
+      const size_t dt_bytes = metal_data_type_bytes(mr.dt);
+      mr.is_array = true;
+      if (dt_bytes > 4) {
+        // Metal doesn't support 64bit data buffers.
+        TI_ERROR(
+            "Metal kernel only supports <= 32-bit data, got {} which is "
+            "Tensor's element type",
+            metal_data_type_name(mr.dt));
+      }
+      mr.stride = tensor_type->get_num_elements() * dt_bytes;
+    } else {
+      mr.dt = to_metal_type(kr.dt);
+      const size_t dt_bytes = metal_data_type_bytes(mr.dt);
+      mr.is_array = false;
+      if (dt_bytes > 4) {
+        // Metal doesn't support 64bit data buffers.
+        TI_ERROR("Metal kernel only supports <= 32-bit data, got {}",
+                 metal_data_type_name(mr.dt));
+      }
+      mr.stride = dt_bytes;
     }
-    mr.is_array = false;  // TODO(#909): this is a temporary limitation
-    mr.stride = dt_bytes;
     mr.index = ret_attribs_vec_.size();
     ret_attribs_vec_.push_back(mr);
   }

--- a/taichi/backends/metal/kernel_utils.h
+++ b/taichi/backends/metal/kernel_utils.h
@@ -105,7 +105,7 @@ struct BufferDescriptor {
 struct KernelAttributes {
   std::string name;
   // Total number of threads to launch (i.e. threads per grid). Note that this
-  // is only advisory, because eventually this numb er is also determined by the
+  // is only advisory, because eventually this number is also determined by the
   // runtime config. This works because grid strided loop is supported.
   int advisory_total_num_threads;
   // Block size in CUDA's terminology. On Metal, it is called a threadgroup.

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -841,11 +841,13 @@ class KernelGen : public IRVisitor {
     // TODO: use stmt->ret_id instead of 0 as index
     int idx{0};
     for (auto &value : stmt->values) {
-      emit("_args_{}_[{} >> {} + {}] = {};",
-           opengl_data_type_short_name(stmt->element_types()[0]),
-           taichi_opengl_ret_base, idx++,
-           opengl_data_address_shifter(stmt->element_types()[0]),
-           stmt->values_short_names());
+      emit("_args_{}_[({} >> {}) + {}] = {};",
+           opengl_data_type_short_name(value->element_type()),
+           taichi_opengl_ret_base,
+           opengl_data_address_shifter(value->element_type()),
+           idx,
+           value->short_name());
+      idx+=2;
     }
   }
 

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -840,9 +840,9 @@ class KernelGen : public IRVisitor {
     used.buf_args = true;
     // TODO: use stmt->ret_id instead of 0 as index
     emit("_args_{}_[{} >> {} + 0] = {};",
-         opengl_data_type_short_name(stmt->element_type()),
+         opengl_data_type_short_name(stmt->element_types()[0]),
          taichi_opengl_ret_base,
-         opengl_data_address_shifter(stmt->element_type()),
+         opengl_data_address_shifter(stmt->element_types()[0]),
          stmt->values_short_names());
   }
 

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -843,7 +843,7 @@ class KernelGen : public IRVisitor {
          opengl_data_type_short_name(stmt->element_type()),
          taichi_opengl_ret_base,
          opengl_data_address_shifter(stmt->element_type()),
-         stmt->value->short_name());
+         stmt->values_short_names());
   }
 
   void visit(ArgLoadStmt *stmt) override {

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -839,11 +839,14 @@ class KernelGen : public IRVisitor {
   void visit(ReturnStmt *stmt) override {
     used.buf_args = true;
     // TODO: use stmt->ret_id instead of 0 as index
-    emit("_args_{}_[{} >> {} + 0] = {};",
-         opengl_data_type_short_name(stmt->element_types()[0]),
-         taichi_opengl_ret_base,
-         opengl_data_address_shifter(stmt->element_types()[0]),
-         stmt->values_short_names());
+    int idx{0};
+    for (auto &value : stmt->values) {
+      emit("_args_{}_[{} >> {} + {}] = {};",
+           opengl_data_type_short_name(stmt->element_types()[0]),
+           taichi_opengl_ret_base, idx++,
+           opengl_data_address_shifter(stmt->element_types()[0]),
+           stmt->values_short_names());
+    }
   }
 
   void visit(ArgLoadStmt *stmt) override {

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -844,10 +844,9 @@ class KernelGen : public IRVisitor {
       emit("_args_{}_[({} >> {}) + {}] = {};",
            opengl_data_type_short_name(value->element_type()),
            taichi_opengl_ret_base,
-           opengl_data_address_shifter(value->element_type()),
-           idx,
+           opengl_data_address_shifter(value->element_type()), idx,
            value->short_name());
-      idx+=2;
+      idx += 2;
     }
   }
 

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -223,7 +223,7 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
 void CompiledTaichiKernel::init_args(Kernel *kernel) {
   arg_count = kernel->args.size();
   ret_count = 0;
-  for(auto &ret:kernel->rets){
+  for (auto &ret : kernel->rets) {
     if (auto tensor_type = ret.dt->cast<TensorType>())
       ret_count += tensor_type->get_num_elements();
     else

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -222,7 +222,13 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
 
 void CompiledTaichiKernel::init_args(Kernel *kernel) {
   arg_count = kernel->args.size();
-  ret_count = kernel->rets.size();
+  ret_count = 0;
+  for(auto &ret:kernel->rets){
+    if (auto tensor_type = ret.dt->cast<TensorType>())
+      ret_count += tensor_type->get_num_elements();
+    else
+      ret_count += 1;
+  }
   for (int i = 0; i < arg_count; i++) {
     const auto dtype_name = kernel->args[i].dt.to_string();
     if (kernel->args[i].is_array) {

--- a/taichi/backends/opengl/opengl_kernel_util.h
+++ b/taichi/backends/opengl/opengl_kernel_util.h
@@ -19,7 +19,7 @@ constexpr int taichi_opengl_ret_base =
     taichi_opengl_extra_args_base +
     taichi_max_num_args * taichi_max_num_indices * sizeof(int);
 constexpr int taichi_opengl_external_arr_base =
-    taichi_opengl_ret_base + sizeof(uint64_t);
+    taichi_opengl_ret_base + taichi_max_num_ret_values * sizeof(uint64_t);
 
 struct UsedFeature {
   // types:

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -68,7 +68,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
     RetAttributes ra;
     ra.dt = kr.dt;
     size_t dt_bytes{0};
-    if (auto tensor_type = ra.dt->as<TensorType>()) {
+    if (auto tensor_type = ra.dt->cast<TensorType>()) {
       dt_bytes = data_type_size(ra.dt);
       ra.is_array = true;
       ra.stride = tensor_type->get_num_elements() * dt_bytes;

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -67,19 +67,19 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
   for (const auto &kr : kernel.rets) {
     RetAttributes ra;
     ra.dt = kr.dt;
-    size_t dt_bytes {0};
-    if (auto tensor_type = ra.dt->as<TensorType>()){
+    size_t dt_bytes{0};
+    if (auto tensor_type = ra.dt->as<TensorType>()) {
       dt_bytes = data_type_size(ra.dt);
       ra.is_array = true;
       ra.stride = tensor_type->get_num_elements() * dt_bytes;
       if (dt_bytes > 4) {
         // Metal doesn't support 64bit data buffers.
         TI_ERROR(
-            "SPIRV kernel only supports less than 32-bit return value, got {} which is Tensor's element type",
+            "SPIRV kernel only supports less than 32-bit return value, got {} "
+            "which is Tensor's element type",
             data_type_name(tensor_type->get_element_type()));
       }
-    }
-    else {
+    } else {
       dt_bytes = data_type_size(ra.dt);
       ra.is_array = false;
       ra.stride = dt_bytes;

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -523,17 +523,16 @@ class TaskCodegen : public IRVisitor {
     // TODO: use stmt->ret_id instead of 0 as index
     const auto &ret_attribs = ctx_attribs_->rets()[0];
     const int index_in_buffer = ret_attribs.offset_in_mem / sizeof(int32_t);
-    spirv::Value idx_val =
-        ir_->int_immediate_number(ir_->i32_type(), index_in_buffer);
-    spirv::Value buffer_val = ir_->struct_array_access(
-        ir_->i32_type(),
-        get_buffer_value(BufferType::Context, PrimitiveType::i32), idx_val);
-    if (stmt->values.size() == 1) {
-      spirv::Value val = ir_->query_value(stmt->values.back()->raw_name());
+    int idx{0};
+    for (auto &x : stmt->values) {
+      spirv::Value idx_val =
+          ir_->int_immediate_number(ir_->i32_type(), index_in_buffer + idx);
+      spirv::Value buffer_val = ir_->struct_array_access(
+          ir_->i32_type(),
+          get_buffer_value(BufferType::Context, PrimitiveType::i32), idx_val);
+      spirv::Value val = ir_->query_value(x->raw_name());
       ir_->store_variable(
           buffer_val, ir_->make_value(spv::OpBitcast, ir_->i32_type(), val));
-    } else {
-      TI_NOT_IMPLEMENTED;
     }
   }
 

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -528,9 +528,13 @@ class TaskCodegen : public IRVisitor {
     spirv::Value buffer_val = ir_->struct_array_access(
         ir_->i32_type(),
         get_buffer_value(BufferType::Context, PrimitiveType::i32), idx_val);
-    spirv::Value val = ir_->query_value(stmt->value->raw_name());
-    ir_->store_variable(buffer_val,
-                        ir_->make_value(spv::OpBitcast, ir_->i32_type(), val));
+    if (stmt->values.size() == 1) {
+      spirv::Value val = ir_->query_value(stmt->values.back()->raw_name());
+      ir_->store_variable(
+          buffer_val, ir_->make_value(spv::OpBitcast, ir_->i32_type(), val));
+    } else {
+      TI_NOT_IMPLEMENTED;
+    }
   }
 
   void visit(GlobalTemporaryStmt *stmt) override {

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -526,7 +526,7 @@ class TaskCodegen : public IRVisitor {
     int idx{0};
     for (auto &x : stmt->values) {
       spirv::Value idx_val =
-          ir_->int_immediate_number(ir_->i32_type(), index_in_buffer + idx);
+          ir_->int_immediate_number(ir_->i32_type(), index_in_buffer + (idx++));
       spirv::Value buffer_val = ir_->struct_array_access(
           ir_->i32_type(),
           get_buffer_value(BufferType::Context, PrimitiveType::i32), idx_val);

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -21,8 +21,8 @@ constexpr std::size_t taichi_result_buffer_entries = 32;
 // slot for kernel return value
 constexpr std::size_t taichi_result_buffer_ret_value_id = 0;
 // slot for error code and error message char *
-constexpr std::size_t taichi_result_buffer_error_id = 1;
-constexpr std::size_t taichi_result_buffer_runtime_query_id = 2;
+constexpr std::size_t taichi_result_buffer_error_id = 30;
+constexpr std::size_t taichi_result_buffer_runtime_query_id = 31;
 
 constexpr int taichi_listgen_max_element_size = 1024;
 

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -18,6 +18,7 @@ constexpr std::size_t taichi_page_size = 4096;
 constexpr std::size_t taichi_error_message_max_length = 2048;
 constexpr std::size_t taichi_error_message_max_num_arguments = 32;
 constexpr std::size_t taichi_result_buffer_entries = 32;
+constexpr std::size_t taichi_max_num_ret_values = 30;
 // slot for kernel return value
 constexpr std::size_t taichi_result_buffer_ret_value_id = 0;
 // slot for error code and error message char *

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -215,9 +215,9 @@ class FrontendWhileStmt : public Stmt {
 
 class FrontendReturnStmt : public Stmt {
  public:
-  Expr value;
+  ExprGroup values;
 
-  FrontendReturnStmt(const Expr &value) : value(value) {
+  FrontendReturnStmt(const ExprGroup &group) : values(group) {
   }
 
   bool is_container_statement() const override {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -120,19 +120,6 @@ class FrontendPrintStmt : public Stmt {
   TI_DEFINE_ACCEPT
 };
 
-// This statement evaluates the expression.
-// The expression should have side effects otherwise the expression will do
-// nothing.
-class FrontendEvalStmt : public Stmt {
- public:
-  Expr expr;
-
-  FrontendEvalStmt(const Expr &expr) : expr(load_if_ptr(expr)) {
-  }
-
-  TI_DEFINE_ACCEPT
-};
-
 class FrontendForStmt : public Stmt {
  public:
   Expr begin, end;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -895,24 +895,22 @@ class ReturnStmt : public Stmt {
     return names;
   }
   std::string values_raw_names() {
-    std::string names = "[";
+    std::string names  ;
     for (auto &x : values) {
       names += x->raw_name() + ", ";
     }
     names.pop_back();
     names.pop_back();
-    names += "]";
     return names;
   }
 
   std::string values_short_names() {
-    std::string names = "[";
+    std::string names ;
     for (auto &x : values) {
       names += x->short_name() + ", ";
     }
     names.pop_back();
     names.pop_back();
-    names += "]";
     return names;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -884,30 +884,11 @@ class ReturnStmt : public Stmt {
     }
     return ele_types;
   }
-  std::string values_names() {
-    std::string names = "[";
-    for (auto &x : values) {
-      names += x->name() + ", ";
-    }
-    names.pop_back();
-    names.pop_back();
-    names += "]";
-    return names;
-  }
+
   std::string values_raw_names() {
     std::string names;
     for (auto &x : values) {
       names += x->raw_name() + ", ";
-    }
-    names.pop_back();
-    names.pop_back();
-    return names;
-  }
-
-  std::string values_short_names() {
-    std::string names;
-    for (auto &x : values) {
-      names += x->short_name() + ", ";
     }
     names.pop_back();
     names.pop_back();

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -868,13 +868,55 @@ class FuncCallStmt : public Stmt {
  */
 class ReturnStmt : public Stmt {
  public:
-  Stmt *value;
+  std::vector<Stmt *> values;
 
-  explicit ReturnStmt(Stmt *value) : value(value) {
+  explicit ReturnStmt(const std::vector<Stmt *> &values) : values(values) {
+    TI_STMT_REG_FIELDS;
+  }
+  explicit ReturnStmt(Stmt *value) : values({value}) {
     TI_STMT_REG_FIELDS;
   }
 
-  TI_STMT_DEF_FIELDS(value);
+  std::vector<DataType> element_types() {
+    std::vector<DataType> ele_types;
+    for (auto &x : values) {
+      ele_types.push_back(x->element_type());
+    }
+    return ele_types;
+  }
+  std::string values_names() {
+    std::string names = "[";
+    for (auto &x : values) {
+      names += x->name() + ", ";
+    }
+    names.pop_back();
+    names.pop_back();
+    names += "]";
+    return names;
+  }
+  std::string values_raw_names() {
+    std::string names = "[";
+    for (auto &x : values) {
+      names += x->raw_name() + ", ";
+    }
+    names.pop_back();
+    names.pop_back();
+    names += "]";
+    return names;
+  }
+
+  std::string values_short_names() {
+    std::string names = "[";
+    for (auto &x : values) {
+      names += x->short_name() + ", ";
+    }
+    names.pop_back();
+    names.pop_back();
+    names += "]";
+    return names;
+  }
+
+  TI_STMT_DEF_FIELDS(values);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -196,6 +196,9 @@ class TensorType : public Type {
   std::vector<int> get_shape() const {
     return shape_;
   }
+  Type *get_compute_type() override {
+    return this;
+  }
 
   std::string to_string() const override;
 

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -19,16 +19,6 @@ std::string data_type_name(DataType t) {
     TI_NOT_IMPLEMENTED
 }
 
-std::string data_types_name(std::vector<DataType> types) {
-  std::string names;
-  for (auto &x : types) {
-    names += data_type_name(x) + ", ";
-  }
-  names.pop_back();
-  names.pop_back();
-  return names;
-}
-
 std::string data_type_format(DataType dt) {
   if (dt->is_primitive(PrimitiveTypeID::i16)) {
     return "%hd";

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -67,7 +67,7 @@ int data_type_size(DataType t) {
   //  2. Support pointer types here.
   t.set_is_pointer(false);
   // If DataType is a TensorType, returns its element type size
-  if (auto tensor_type = t->as<TensorType>()) {
+  if (auto tensor_type = t->cast<TensorType>()) {
     return data_type_size(tensor_type->get_element_type());
   }
 

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -66,6 +66,11 @@ int data_type_size(DataType t) {
   //  setting a loud failure on pointers);
   //  2. Support pointer types here.
   t.set_is_pointer(false);
+  // If DataType is a TensorType, returns its element type size
+  if(auto tensor_type = t->as<TensorType>()){
+    return data_type_size(tensor_type->get_element_type());
+  }
+
   if (false) {
   } else if (t->is_primitive(PrimitiveTypeID::f16))
     return 2;

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -19,6 +19,16 @@ std::string data_type_name(DataType t) {
     TI_NOT_IMPLEMENTED
 }
 
+std::string data_types_name(std::vector<DataType> types) {
+  std::string names;
+  for (auto &x : types) {
+    names += data_type_name(x) + ", ";
+  }
+  names.pop_back();
+  names.pop_back();
+  return names;
+}
+
 std::string data_type_format(DataType dt) {
   if (dt->is_primitive(PrimitiveTypeID::i16)) {
     return "%hd";

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -67,7 +67,7 @@ int data_type_size(DataType t) {
   //  2. Support pointer types here.
   t.set_is_pointer(false);
   // If DataType is a TensorType, returns its element type size
-  if(auto tensor_type = t->as<TensorType>()){
+  if (auto tensor_type = t->as<TensorType>()) {
     return data_type_size(tensor_type->get_element_type());
   }
 

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -7,8 +7,6 @@ namespace lang {
 
 std::string data_type_name(DataType t);
 
-std::string data_types_name(std::vector<DataType> types);
-
 std::string data_type_format(DataType dt);
 
 int data_type_size(DataType t);

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -7,6 +7,8 @@ namespace lang {
 
 std::string data_type_name(DataType t);
 
+std::string data_types_name(std::vector<DataType> types);
+
 std::string data_type_format(DataType dt);
 
 int data_type_size(DataType t);

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -314,7 +314,6 @@ RuntimeContext &Kernel::LaunchContextBuilder::get_context() {
   return *ctx_;
 }
 
-
 float64 Kernel::get_ret_float(int i) {
   auto dt = rets[i].dt->get_compute_type();
   if (dt->is_primitive(PrimitiveTypeID::f32)) {
@@ -345,7 +344,6 @@ float64 Kernel::get_ret_float(int i) {
   }
 }
 
-
 int64 Kernel::get_ret_int(int i) {
   auto dt = rets[i].dt->get_compute_type();
   if (dt->is_primitive(PrimitiveTypeID::i32)) {
@@ -375,11 +373,11 @@ int64 Kernel::get_ret_int(int i) {
 
 std::vector<int64> Kernel::get_ret_matrix_int(int i) {
   int size = rets[i].dt->as<TensorType>()->get_num_elements();
-  auto dt= rets[i].dt->as<TensorType>()->get_element_type();
+  auto dt = rets[i].dt->as<TensorType>()->get_element_type();
   std::vector<int64> res;
-  for (int j =0; j <size; j++){
+  for (int j = 0; j < size; j++) {
     if (dt->is_primitive(PrimitiveTypeID::i32)) {
-       res.emplace_back((int64)program->fetch_result<int32>(j));
+      res.emplace_back((int64)program->fetch_result<int32>(j));
     } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
       res.emplace_back((int64)program->fetch_result<int64>(j));
     } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
@@ -407,9 +405,9 @@ std::vector<int64> Kernel::get_ret_matrix_int(int i) {
 
 std::vector<float64> Kernel::get_ret_matrix_float(int i) {
   int size = rets[i].dt->as<TensorType>()->get_num_elements();
-  auto dt= rets[i].dt->as<TensorType>()->get_element_type();
+  auto dt = rets[i].dt->as<TensorType>()->get_element_type();
   std::vector<float64> res;
-  for (int j =0; j <size; j++){
+  for (int j = 0; j < size; j++) {
     if (dt->is_primitive(PrimitiveTypeID::i32)) {
       res.emplace_back((float64)program->fetch_result<int32>(j));
     } else if (dt->is_primitive(PrimitiveTypeID::i64)) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -314,6 +314,7 @@ RuntimeContext &Kernel::LaunchContextBuilder::get_context() {
   return *ctx_;
 }
 
+
 float64 Kernel::get_ret_float(int i) {
   auto dt = rets[i].dt->get_compute_type();
   if (dt->is_primitive(PrimitiveTypeID::f32)) {
@@ -344,6 +345,7 @@ float64 Kernel::get_ret_float(int i) {
   }
 }
 
+
 int64 Kernel::get_ret_int(int i) {
   auto dt = rets[i].dt->get_compute_type();
   if (dt->is_primitive(PrimitiveTypeID::i32)) {
@@ -369,6 +371,70 @@ int64 Kernel::get_ret_int(int i) {
   } else {
     TI_NOT_IMPLEMENTED
   }
+}
+
+std::vector<int64> Kernel::get_ret_matrix_int(int i) {
+  int size = rets[i].dt->as<TensorType>()->get_num_elements();
+  auto dt= rets[i].dt->as<TensorType>()->get_element_type();
+  std::vector<int64> res;
+  for (int j =0; j <size; j++){
+    if (dt->is_primitive(PrimitiveTypeID::i32)) {
+       res.emplace_back((int64)program->fetch_result<int32>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
+      res.emplace_back((int64)program->fetch_result<int64>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
+      res.emplace_back((int64)program->fetch_result<int8>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
+      res.emplace_back((int64)program->fetch_result<int16>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
+      res.emplace_back((int64)program->fetch_result<uint8>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
+      res.emplace_back((int64)program->fetch_result<uint16>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
+      res.emplace_back((int64)program->fetch_result<uint32>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
+      res.emplace_back((int64)program->fetch_result<uint64>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
+      res.emplace_back((int64)program->fetch_result<float32>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
+      res.emplace_back((int64)program->fetch_result<float64>(j));
+    } else {
+      TI_NOT_IMPLEMENTED
+    }
+  }
+  return res;
+}
+
+std::vector<float64> Kernel::get_ret_matrix_float(int i) {
+  int size = rets[i].dt->as<TensorType>()->get_num_elements();
+  auto dt= rets[i].dt->as<TensorType>()->get_element_type();
+  std::vector<float64> res;
+  for (int j =0; j <size; j++){
+    if (dt->is_primitive(PrimitiveTypeID::i32)) {
+      res.emplace_back((float64)program->fetch_result<int32>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
+      res.emplace_back((float64)program->fetch_result<int64>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
+      res.emplace_back((float64)program->fetch_result<int8>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
+      res.emplace_back((float64)program->fetch_result<int16>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
+      res.emplace_back((float64)program->fetch_result<uint8>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
+      res.emplace_back((float64)program->fetch_result<uint16>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
+      res.emplace_back((float64)program->fetch_result<uint32>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
+      res.emplace_back((float64)program->fetch_result<uint64>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
+      res.emplace_back((float64)program->fetch_result<float32>(j));
+    } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
+      res.emplace_back((float64)program->fetch_result<float64>(j));
+    } else {
+      TI_NOT_IMPLEMENTED
+    }
+  }
+  return res;
 }
 
 void Kernel::set_arch(Arch arch) {

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -97,6 +97,10 @@ class Kernel : public Callable {
 
   int64 get_ret_int(int i);
 
+  std::vector<int64> get_ret_matrix_int(int i);
+
+  std::vector<float64> get_ret_matrix_float(int i);
+
   void set_arch(Arch arch);
 
   void account_for_offloaded(OffloadedStmt *stmt);

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -360,8 +360,8 @@ Kernel &Program::get_snode_reader(SNode *snode) {
     for (int i = 0; i < snode->num_active_indices; i++) {
       indices.push_back(Expr::make<ArgLoadExpression>(i, PrimitiveType::i32));
     }
-    auto ret = Stmt::make<FrontendReturnStmt>(
-        load_if_ptr(Expr(snode_to_glb_var_exprs_.at(snode))[indices]));
+    auto ret = Stmt::make<FrontendReturnStmt>(ExprGroup(
+        load_if_ptr(Expr(snode_to_glb_var_exprs_.at(snode))[indices])));
     current_ast_builder().insert(std::move(ret));
   });
   ker.set_arch(get_accessor_arch());
@@ -403,9 +403,9 @@ Kernel &Program::get_ndarray_reader(Ndarray *ndarray) {
       indices.push_back(Expr::make<ArgLoadExpression>(i, PrimitiveType::i32));
     }
     auto ret = Stmt::make<FrontendReturnStmt>(
-        load_if_ptr(Expr(Expr::make<ExternalTensorExpression>(
+        ExprGroup(load_if_ptr(Expr(Expr::make<ExternalTensorExpression>(
             keys.dtype, keys.num_active_indices, keys.num_active_indices,
-            0))[indices]));
+            0))[indices])));
     current_ast_builder().insert(std::move(ret));
   });
   ker.set_arch(get_accessor_arch());

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -554,7 +554,7 @@ void export_lang(py::module &m) {
               (void *)func_addr, source, filename, funcname, args.exprs,
               outputs.exprs);
 
-          current_ast_builder().insert(Stmt::make<FrontendEvalStmt>(expr));
+          current_ast_builder().insert(Stmt::make<FrontendExprStmt>(expr));
         });
 
   m.def("insert_is_active", [](SNode *snode, const ExprGroup &indices) {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -455,6 +455,8 @@ void export_lang(py::module &m) {
   py::class_<Kernel>(m, "Kernel")
       .def("get_ret_int", &Kernel::get_ret_int)
       .def("get_ret_float", &Kernel::get_ret_float)
+      .def("get_ret_matrix_int", &Kernel::get_ret_matrix_int)
+      .def("get_ret_matrix_float", &Kernel::get_ret_matrix_float)
       .def("make_launch_context", &Kernel::make_launch_context)
       .def("__call__",
            [](Kernel *kernel, Kernel::LaunchContextBuilder &launch_ctx) {
@@ -633,8 +635,8 @@ void export_lang(py::module &m) {
     current_ast_builder().insert(Stmt::make<FrontendBreakStmt>());
   });
 
-  m.def("create_kernel_return", [&](const Expr &value) {
-    current_ast_builder().insert(Stmt::make<FrontendReturnStmt>(value));
+  m.def("create_kernel_exprgroup_return", [&](const ExprGroup &group) {
+    current_ast_builder().insert(Stmt::make<FrontendReturnStmt>(group));
   });
 
   m.def("insert_continue_stmt", [&]() {
@@ -925,6 +927,10 @@ void export_lang(py::module &m) {
           return get_current_program().current_callable->insert_arr_arg(
               dt, total_dim, shape);
         });
+
+  m.def("decl_tensor_type", [&](std::vector<int> shape, DataType element) {
+    return TypeFactory::create_tensor_type(shape, element);
+  });
 
   m.def("decl_ret", [&](const DataType &dt) {
     return get_current_program().current_callable->insert_ret(dt);

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -696,8 +696,8 @@ struct NodeManager {
 
 extern "C" {
 
-void LLVMRuntime_store_result(LLVMRuntime *runtime, u64 ret) {
-  runtime->set_result(taichi_result_buffer_ret_value_id, ret);
+void LLVMRuntime_store_result(LLVMRuntime *runtime, u64 ret, u32 idx) {
+  runtime->set_result(taichi_result_buffer_ret_value_id + idx, ret);
 }
 
 void LLVMRuntime_profiler_start(LLVMRuntime *runtime, Ptr kernel_name) {

--- a/taichi/transforms/inlining.cpp
+++ b/taichi/transforms/inlining.cpp
@@ -50,8 +50,9 @@ class Inliner : public BasicStmtVisitor {
           /*filter=*/[&](Stmt *s) { return s->is<ReturnStmt>(); },
           /*generator=*/
           [&](Stmt *s) {
+            TI_ASSERT(s->as<ReturnStmt>()->values.size() == 1);
             return Stmt::make<LocalStoreStmt>(return_address,
-                                              s->as<ReturnStmt>()->value);
+                                              s->as<ReturnStmt>()->values[0]);
           });
       modifier_.insert_before(stmt,
                               std::move(inlined_ir->as<Block>()->statements));

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -407,13 +407,13 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(FrontendReturnStmt *stmt) override {
-    print("{}{} : return {}", stmt->type_hint(), stmt->name(),
-          stmt->value.serialize());
+    print("{}{} : return [{}]", stmt->type_hint(), stmt->name(),
+          stmt->values.serialize());
   }
 
   void visit(ReturnStmt *stmt) override {
     print("{}{} : return {}", stmt->type_hint(), stmt->name(),
-          stmt->value->name());
+          stmt->values_raw_names());
   }
 
   void visit(LocalLoadStmt *stmt) override {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -240,10 +240,6 @@ class IRPrinter : public IRVisitor {
     print("}}");
   }
 
-  void visit(FrontendEvalStmt *stmt) override {
-    print("{} = eval {}", stmt->name(), stmt->expr.serialize());
-  }
-
   void visit(FrontendPrintStmt *print_stmt) override {
     std::vector<std::string> contents;
     for (auto const &c : print_stmt->contents) {

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -394,14 +394,6 @@ class LowerAST : public IRVisitor {
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
   }
 
-  void visit(FrontendEvalStmt *stmt) override {
-    // expand rhs
-    auto expr = stmt->expr;
-    auto fctx = make_flatten_ctx();
-    expr->flatten(&fctx);
-    stmt->parent->replace_with(stmt, std::move(fctx.stmts));
-  }
-
   void visit(FrontendAssignStmt *assign) override {
     // expand rhs
     auto expr = assign->rhs;

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -387,10 +387,14 @@ class LowerAST : public IRVisitor {
   }
 
   void visit(FrontendReturnStmt *stmt) override {
-    auto expr = stmt->value;
+    auto expr_group = stmt->values;
     auto fctx = make_flatten_ctx();
-    expr->flatten(&fctx);
-    fctx.push_back<ReturnStmt>(fctx.back_stmt());
+    std::vector<Stmt *> return_ele;
+    for (auto &x : expr_group.exprs) {
+      x->flatten(&fctx);
+      return_ele.push_back(fctx.back_stmt());
+    }
+    fctx.push_back<ReturnStmt>(return_ele);
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
   }
 

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -432,12 +432,15 @@ class TypeCheck : public IRVisitor {
 
   void visit(ReturnStmt *stmt) override {
     // TODO: Support stmt->ret_id?
-    TI_ASSERT(stmt->get_kernel()->rets.size() == 1);
-    if (auto ret_tensor = stmt->get_kernel()->rets[0].dt->cast<TensorType>()) {
-      TI_ASSERT(ret_tensor->get_num_elements() == stmt->values.size());
-    } else {
-      TI_ASSERT(stmt->values.size() == 1);
-      TI_ASSERT(stmt->values[0]->ret_type->vector_width() == 1);
+    if (stmt->get_kernel() != nullptr) {
+      TI_ASSERT(stmt->get_kernel()->rets.size() == 1);
+      if (auto ret_tensor =
+              stmt->get_kernel()->rets[0].dt->cast<TensorType>()) {
+        TI_ASSERT(ret_tensor->get_num_elements() == stmt->values.size());
+      } else {
+        TI_ASSERT(stmt->values.size() == 1);
+        TI_ASSERT(stmt->values[0]->ret_type->vector_width() == 1);
+      }
     }
   }
 

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -432,8 +432,13 @@ class TypeCheck : public IRVisitor {
 
   void visit(ReturnStmt *stmt) override {
     // TODO: Support stmt->ret_id?
-    stmt->ret_type = stmt->value->ret_type;
-    TI_ASSERT(stmt->ret_type->vector_width() == 1);
+    TI_ASSERT(stmt->get_kernel()->rets.size() == 1);
+    if (auto ret_tensor = stmt->get_kernel()->rets[0].dt->cast<TensorType>()) {
+      TI_ASSERT(ret_tensor->get_num_elements() == stmt->values.size());
+    } else {
+      TI_ASSERT(stmt->values.size() == 1);
+      TI_ASSERT(stmt->values[0]->ret_type->vector_width() == 1);
+    }
   }
 
   void visit(ExternalPtrStmt *stmt) override {

--- a/tests/cpp/transforms/binary_op_simplify_test.cpp
+++ b/tests/cpp/transforms/binary_op_simplify_test.cpp
@@ -50,7 +50,7 @@ TEST_F(BinaryOpSimplifyTest, MultiplyPOT) {
   EXPECT_EQ(bin_op->op_type, BinaryOpType::bit_shl);
   EXPECT_EQ(bin_op->rhs, const_stmt);
   EXPECT_TRUE(ir_block->statements[3]->is<ReturnStmt>());
-  EXPECT_EQ(ir_block->statements[3]->as<ReturnStmt>()->value, bin_op);
+  EXPECT_EQ(ir_block->statements[3]->as<ReturnStmt>()->values[0], bin_op);
 }
 
 TEST_F(BinaryOpSimplifyTest, ModPOT) {
@@ -98,7 +98,7 @@ TEST_F(BinaryOpSimplifyTest, ModPOT) {
   EXPECT_EQ(bin_op->op_type, BinaryOpType::bit_and);
   EXPECT_EQ(bin_op->rhs, const_stmt);
   EXPECT_TRUE(ir_block->statements[3]->is<ReturnStmt>());
-  EXPECT_EQ(ir_block->statements[3]->as<ReturnStmt>()->value, bin_op);
+  EXPECT_EQ(ir_block->statements[3]->as<ReturnStmt>()->values[0], bin_op);
 }
 
 }  // namespace lang

--- a/tests/python/test_matrix_return.py
+++ b/tests/python/test_matrix_return.py
@@ -6,67 +6,65 @@ import taichi as ti
 
 ### `ti.test`
 
+
 @ti.test(arch=ti.cpu)
 def test_arch_cpu():
-    
     @ti.kernel
-    def func()->ti.types.matrix(2,3,ti.i32):
-        return ti.Matrix([[1,2,3],[4,5,6]])
-    assert func()[1,2] == 6
+    def func() -> ti.types.matrix(2, 3, ti.i32):
+        return ti.Matrix([[1, 2, 3], [4, 5, 6]])
+
+    assert func()[1, 2] == 6
 
 
 @ti.test(arch=ti.gpu)
 def test_arch_gpu():
-
     @ti.kernel
-    def func()->ti.types.matrix(2,3,ti.i32):
-        return ti.Matrix([[1,2,3],[4,5,6]])
+    def func() -> ti.types.matrix(2, 3, ti.i32):
+        return ti.Matrix([[1, 2, 3], [4, 5, 6]])
 
-    assert func()[1,2] == 6
+    assert func()[1, 2] == 6
 
 
 @ti.test(arch=ti.cuda)
 def test_arch_cuda():
-
     @ti.kernel
-    def func()->ti.types.matrix(2,3,ti.i32):
-        return ti.Matrix([[1,2,3],[4,5,6]])
+    def func() -> ti.types.matrix(2, 3, ti.i32):
+        return ti.Matrix([[1, 2, 3], [4, 5, 6]])
 
-    assert func()[1,2] == 6
+    assert func()[1, 2] == 6
+
 
 @ti.test(arch=ti.vulkan)
 def test_arch_vulkan():
-
     @ti.kernel
-    def func()->ti.types.matrix(2,3,ti.i32):
-        return ti.Matrix([[1,2,3],[4,5,6]])
+    def func() -> ti.types.matrix(2, 3, ti.i32):
+        return ti.Matrix([[1, 2, 3], [4, 5, 6]])
 
-    assert func()[1,2] == 6
+    assert func()[1, 2] == 6
+
 
 @ti.test(arch=ti.cc)
 def test_arch_cc():
-
     @ti.kernel
-    def func()->ti.types.matrix(2,3,ti.i32):
-        return ti.Matrix([[1,2,3],[4,5,6]])
+    def func() -> ti.types.matrix(2, 3, ti.i32):
+        return ti.Matrix([[1, 2, 3], [4, 5, 6]])
 
-    assert func()[1,2] == 6
+    assert func()[1, 2] == 6
+
 
 @ti.test(arch=ti.metal)
 def test_arch_metal():
-
     @ti.kernel
-    def func()->ti.types.matrix(2,3,ti.i32):
-        return ti.Matrix([[1,2,3],[4,5,6]])
+    def func() -> ti.types.matrix(2, 3, ti.i32):
+        return ti.Matrix([[1, 2, 3], [4, 5, 6]])
 
-    assert func()[1,2] == 6
+    assert func()[1, 2] == 6
+
 
 @ti.test(arch=ti.opengl)
 def test_arch_opengl():
-
     @ti.kernel
-    def func()->ti.types.matrix(2,3,ti.i32):
-        return ti.Matrix([[1,2,3],[4,5,6]])
+    def func() -> ti.types.matrix(2, 3, ti.i32):
+        return ti.Matrix([[1, 2, 3], [4, 5, 6]])
 
-    assert func()[1,2] == 6
-
+    assert func()[1, 2] == 6

--- a/tests/python/test_matrix_return.py
+++ b/tests/python/test_matrix_return.py
@@ -1,0 +1,72 @@
+import os
+
+import pytest
+
+import taichi as ti
+
+### `ti.test`
+
+@ti.test(arch=ti.cpu)
+def test_arch_cpu():
+    
+    @ti.kernel
+    def func()->ti.types.matrix(2,3,ti.i32):
+        return ti.Matrix([[1,2,3],[4,5,6]])
+    assert func()[1,2] == 6
+
+
+@ti.test(arch=ti.gpu)
+def test_arch_gpu():
+
+    @ti.kernel
+    def func()->ti.types.matrix(2,3,ti.i32):
+        return ti.Matrix([[1,2,3],[4,5,6]])
+
+    assert func()[1,2] == 6
+
+
+@ti.test(arch=ti.cuda)
+def test_arch_cuda():
+
+    @ti.kernel
+    def func()->ti.types.matrix(2,3,ti.i32):
+        return ti.Matrix([[1,2,3],[4,5,6]])
+
+    assert func()[1,2] == 6
+
+@ti.test(arch=ti.vulkan)
+def test_arch_vulkan():
+
+    @ti.kernel
+    def func()->ti.types.matrix(2,3,ti.i32):
+        return ti.Matrix([[1,2,3],[4,5,6]])
+
+    assert func()[1,2] == 6
+
+@ti.test(arch=ti.cc)
+def test_arch_cc():
+
+    @ti.kernel
+    def func()->ti.types.matrix(2,3,ti.i32):
+        return ti.Matrix([[1,2,3],[4,5,6]])
+
+    assert func()[1,2] == 6
+
+@ti.test(arch=ti.metal)
+def test_arch_metal():
+
+    @ti.kernel
+    def func()->ti.types.matrix(2,3,ti.i32):
+        return ti.Matrix([[1,2,3],[4,5,6]])
+
+    assert func()[1,2] == 6
+
+@ti.test(arch=ti.opengl)
+def test_arch_opengl():
+
+    @ti.kernel
+    def func()->ti.types.matrix(2,3,ti.i32):
+        return ti.Matrix([[1,2,3],[4,5,6]])
+
+    assert func()[1,2] == 6
+


### PR DESCRIPTION
Related issue = #909
`@ti.kernel` cannot return a matrix or vector in the current version. I try to add this support in this PR. 
But there are still some problems here. Due to the current designs of the backend, the result buffer needs to be changed to pass more data.
I have done something about the result buffer in the llvm-backend, and it works fine on my computer. 

- [x] llvm IR
- [x] spirV IR
- [x] codegen_metal
- [x] codegen_cc
- [x] codegen_opengl
- [x] vulkan