### PR TITLE
[vulkan] [aot] Throw error for templated kernels in vulkan aot.

### DIFF
--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -117,6 +117,7 @@ void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
 void AotModuleBuilderImpl::add_per_backend_tmpl(const std::string &identifier,
                                                 const std::string &key,
                                                 Kernel *kernel) {
+  TI_ERROR("Templated kernels are not yet supported on vulkan aot.");
 }
 
 }  // namespace vulkan

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -65,6 +65,20 @@ def test_save():
         for i, j in density:
             density[i, j] = 1
 
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # note ti.aot.Module(ti.opengl) is no-op according to its docstring.
+        m = ti.aot.Module(ti.cfg.arch)
+        m.add_field('density', density)
+        m.add_kernel(init)
+        m.save(tmpdir, '')
+        with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
+            json.load(json_file)
+
+
+@ti.test(arch=ti.opengl)
+def test_save_template_kernel():
+    density = ti.field(float, shape=(4, 4))
+
     @ti.kernel
     def foo(n: ti.template()):
         for i in range(n):
@@ -74,7 +88,6 @@ def test_save():
         # note ti.aot.Module(ti.opengl) is no-op according to its docstring.
         m = ti.aot.Module(ti.cfg.arch)
         m.add_field('density', density)
-        m.add_kernel(init)
         with m.add_kernel_template(foo) as kt:
             kt.instantiate(n=6)
             kt.instantiate(n=8)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #4012
* #4011
* __->__ #4010

related: #3334
I made a mistake in #4000 that vulkan aot doesn't support templated
kernel yet. This PR made it an explicit error and split the tests.