### PR TITLE
[vulkan] [aot] Switch vulkan aot to use taichi::aot::ModuleData.

### DIFF
--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -46,9 +46,6 @@ class AotDataConverter {
     for (const auto &arg : in.ctx_attribs.args()) {
       res.scalar_args[arg.index] = visit(arg);
     }
-    for (const auto &ret : in.ctx_attribs.rets()) {
-      res.arr_args[ret.index] = visit(ret);
-    }
     return res;
   }
 
@@ -67,13 +64,6 @@ class AotDataConverter {
     aot::ScalarArg res{};
     res.dtype_name = in.dt.to_string();
     res.offset_in_args_buf = in.offset_in_mem;
-    return res;
-  }
-
-  aot::ArrayArg visit(
-      const spirv::KernelContextAttributes::RetAttributes &in) const {
-    aot::ArrayArg res{};
-    TI_ERROR("Ndarray is not yet supported on vulkan backend");
     return res;
   }
 };

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -54,8 +54,7 @@ class AotDataConverter {
     res.type = offloaded_task_type_name(in.task_type);
     res.name = in.name;
     res.source_path = in.source_path;
-    res.gpu_block_size =
-        in.advisory_total_num_threads / in.advisory_num_threads_per_group;
+    res.gpu_block_size = in.advisory_num_threads_per_group;
     return res;
   }
 

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -3,12 +3,82 @@
 #include <fstream>
 #include <type_traits>
 
+#include "taichi/aot/module_data.h"
 #include "taichi/codegen/spirv/spirv_codegen.h"
 
 namespace taichi {
 namespace lang {
 namespace vulkan {
 
+namespace {
+class AotDataConverter {
+ public:
+  static aot::ModuleData convert(const TaichiAotData &in) {
+    AotDataConverter c{};
+    return c.visit(in);
+  }
+
+ private:
+  explicit AotDataConverter() = default;
+
+  aot::ModuleData visit(const TaichiAotData &in) const {
+    aot::ModuleData res{};
+    for (const auto &ker : in.kernels) {
+      auto val = visit(ker);
+      res.kernels[ker.name] = val;
+    }
+    res.fields = in.fields;
+    res.root_buffer_size = in.root_buffer_size;
+    return res;
+  }
+
+  aot::CompiledTaichiKernel visit(
+      const spirv::TaichiKernelAttributes &in) const {
+    aot::CompiledTaichiKernel res{};
+    res.tasks.reserve(in.tasks_attribs.size());
+    for (const auto &t : in.tasks_attribs) {
+      res.tasks.push_back(visit(t));
+    }
+    res.args_count = in.ctx_attribs.args().size();
+    res.rets_count = in.ctx_attribs.rets().size();
+    res.args_buffer_size = in.ctx_attribs.args_bytes();
+    res.rets_buffer_size = in.ctx_attribs.rets_bytes();
+    for (const auto &arg : in.ctx_attribs.args()) {
+      res.scalar_args[arg.index] = visit(arg);
+    }
+    for (const auto &ret : in.ctx_attribs.rets()) {
+      res.arr_args[ret.index] = visit(ret);
+    }
+    return res;
+  }
+
+  aot::CompiledOffloadedTask visit(const TaskAttributes &in) const {
+    aot::CompiledOffloadedTask res{};
+    res.type = offloaded_task_type_name(in.task_type);
+    res.name = in.name;
+    res.source_path = in.source_path;
+    res.gpu_block_size =
+        in.advisory_total_num_threads / in.advisory_num_threads_per_group;
+    return res;
+  }
+
+  aot::ScalarArg visit(
+      const spirv::KernelContextAttributes::ArgAttributes &in) const {
+    aot::ScalarArg res{};
+    res.dtype_name = in.dt.to_string();
+    res.offset_in_args_buf = in.offset_in_mem;
+    return res;
+  }
+
+  aot::ArrayArg visit(
+      const spirv::KernelContextAttributes::RetAttributes &in) const {
+    aot::ArrayArg res{};
+    TI_ERROR("Ndarray is not yet supported on vulkan backend");
+    return res;
+  }
+};
+
+}  // namespace
 AotModuleBuilderImpl::AotModuleBuilderImpl(
     const std::vector<CompiledSNodeStructs> &compiled_structs)
     : compiled_structs_(compiled_structs) {
@@ -46,9 +116,10 @@ uint32_t AotModuleBuilderImpl::to_vk_dtype_enum(DataType dt) {
 
 void AotModuleBuilderImpl::write_spv_file(
     const std::string &output_dir,
-    const TaskAttributes &k,
+    TaskAttributes &k,
     const std::vector<uint32_t> &source_code) const {
   const std::string spv_path = fmt::format("{}/{}.spv", output_dir, k.name);
+  k.source_path = spv_path;
   std::ofstream fs(spv_path, std::ios_base::binary | std::ios::trunc);
   fs.write((char *)source_code.data(), source_code.size() * sizeof(uint32_t));
   fs.close();
@@ -60,19 +131,22 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
              "Filename prefix is ignored on vulkan backend.");
   const std::string bin_path = fmt::format("{}/metadata.tcb", output_dir);
   write_to_binary_file(ti_aot_data_, bin_path);
-  // Json format doesn't support multiple line strings.
-  for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
-    auto k = ti_aot_data_.kernels[i];
+
+  // Copy to avoid messing up the original ti_aot_data_.
+  TaichiAotData ti_aot_data_copy = ti_aot_data_;
+  for (int i = 0; i < ti_aot_data_copy.kernels.size(); ++i) {
+    auto &k = ti_aot_data_copy.kernels[i];
     for (int j = 0; j < k.tasks_attribs.size(); ++j) {
       write_spv_file(output_dir, k.tasks_attribs[j],
                      ti_aot_data_.spirv_codes[i][j]);
     }
   }
 
-  const std::string txt_path = fmt::format("{}/metadata.json", output_dir);
+  auto converted = AotDataConverter::convert(ti_aot_data_copy);
+  const std::string json_path = fmt::format("{}/metadata.json", output_dir);
   TextSerializer ts;
-  ts.serialize_to_json("aot_data", ti_aot_data_);
-  ts.write_to_file(txt_path);
+  ts.serialize_to_json("aot_data", converted);
+  ts.write_to_file(json_path);
 }
 
 void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
@@ -80,6 +154,7 @@ void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
   spirv::lower(kernel);
   auto compiled =
       run_codegen(kernel, aot_target_device_.get(), compiled_structs_);
+  compiled.kernel_attribs.name = identifier;
   ti_aot_data_.kernels.push_back(compiled.kernel_attribs);
   ti_aot_data_.spirv_codes.push_back(compiled.task_spirv_source_codes);
 }

--- a/taichi/backends/vulkan/aot_module_builder_impl.h
+++ b/taichi/backends/vulkan/aot_module_builder_impl.h
@@ -38,7 +38,7 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
                             Kernel *kernel) override;
 
   void write_spv_file(const std::string &output_dir,
-                      const TaskAttributes &k,
+                      TaskAttributes &k,
                       const std::vector<uint32_t> &source_code) const;
 
   uint32_t to_vk_dtype_enum(DataType dt);

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -73,6 +73,7 @@ struct TaskAttributes {
   };
 
   std::string name;
+  std::string source_path;
   // Total number of threads to launch (i.e. threads per grid). Note that this
   // is only advisory, because eventually this number is also determined by the
   // runtime config. This works because grid strided loop is supported.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #4012
* __->__ #4011

related #3334

This PR implements a converter to convert vulkan aot data structure to
unified taichi::aot::ModuleData.