### PR TITLE
[aot] Use element_shape instead of row_num & column_num for CompiledFieldData.

### DIFF
--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -17,8 +17,7 @@ struct CompiledFieldData {
   size_t mem_offset_in_parent{0};
   std::vector<int> shape;
   bool is_scalar{false};
-  int row_num{0};
-  int column_num{0};
+  std::vector<int> element_shape;
 
   TI_IO_DEF(field_name,
             dtype,
@@ -26,8 +25,7 @@ struct CompiledFieldData {
             mem_offset_in_parent,
             shape,
             is_scalar,
-            row_num,
-            column_num);
+            element_shape);
 };
 
 struct CompiledOffloadedTask {

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -159,9 +159,13 @@ void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
   // matter too much for now.
   TI_ERROR_IF(!all_fields_are_dense_in_container(rep_snode->parent),
               "AOT: only supports dense field");
+  std::vector<int> element_shape;
+  if (!is_scalar) {
+    element_shape = {row_num, column_num};
+  }
   aot_data_.fields.push_back({identifier, gl_dtype_enum, dt.to_string(),
                               get_snode_base_address(rep_snode), shape,
-                              is_scalar, row_num, column_num});
+                              is_scalar, element_shape});
 }
 
 void AotModuleBuilderImpl::add_per_backend_tmpl(const std::string &identifier,

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -184,8 +184,9 @@ void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
   field_data.dtype_name = dt.to_string();
   field_data.shape = shape;
   field_data.mem_offset_in_parent = dense_desc.mem_offset_in_parent_cell;
-  field_data.row_num = row_num;
-  field_data.column_num = column_num;
+  if (!is_scalar) {
+    field_data.element_shape = {row_num, column_num};
+  }
   ti_aot_data_.fields.push_back(field_data);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #4012
* #4039

related #3334

This PR mainly replaces row_num & column_num with `element_shape` so
that it aligns with ndarrays.