### PR TITLE
[cuda] [refactor] Use cuda graph in command list to defer executions 1/n

### DIFF
--- a/taichi/backends/cuda/cuda_device.cpp
+++ b/taichi/backends/cuda/cuda_device.cpp
@@ -112,18 +112,19 @@ uint64 CudaDevice::fetch_result_uint64(int i, uint64 *result_buffer) {
   return ret;
 }
 
-CudaCommandList::CudaCommandList(CudaDevice *ti_device, CudaStream *stream) 
-  : ti_device_(ti_device),
-    stream_(stream) {
+CudaCommandList::CudaCommandList(CudaDevice *ti_device, CudaStream *stream)
+    : ti_device_(ti_device), stream_(stream) {
   // enable cuda graph stream capture mode to defer command list's executions
   auto cu_stream = ti_device_->get_cu_stream();
-  CUDADriver::get_instance().stream_begin_capture(cu_stream, CU_STREAM_CAPTURE_MODE_GLOBAL);
+  CUDADriver::get_instance().stream_begin_capture(
+      cu_stream, CU_STREAM_CAPTURE_MODE_GLOBAL);
 }
 
 CUgraphExec CudaCommandList::finalize() {
   auto cu_stream = ti_device_->get_cu_stream();
   CUDADriver::get_instance().stream_end_capture(cu_stream, &graph_);
-  CUDADriver::get_instance().graph_instantiate(&graph_exec_, graph_, nullptr, nullptr, 0);
+  CUDADriver::get_instance().graph_instantiate(&graph_exec_, graph_, nullptr,
+                                               nullptr, 0);
   return graph_exec_;
 }
 
@@ -132,13 +133,14 @@ void CudaCommandList::buffer_fill(DevicePtr ptr, size_t size, uint32_t data) {
   if (buffer_ptr == nullptr) {
     TI_ERROR("the device ptr is null");
   }
-	
-  CUDADriver::get_instance().memsetd32async((void *)buffer_ptr, data, 
-    size, ti_device_->get_cu_stream());
+
+  CUDADriver::get_instance().memsetd32async((void *)buffer_ptr, data, size,
+                                            ti_device_->get_cu_stream());
 }
 
 CudaStream::CudaStream(CudaDevice &device, void *cu_stream)
-  : device_(device), cu_stream_(cu_stream) {}
+    : device_(device), cu_stream_(cu_stream) {
+}
 
 std::unique_ptr<CommandList> CudaStream::new_command_list() {
   return std::make_unique<CudaCommandList>(&device_, this);
@@ -150,7 +152,8 @@ void CudaStream::submit_synced(CommandList *cmdlist_) {
 
   // graph launch requires an explicit cuda stream
   CUstream stream_graph_launch{nullptr};
-  CUDADriver::get_instance().stream_create(&stream_graph_launch, CU_STREAM_NON_BLOCKING);
+  CUDADriver::get_instance().stream_create(&stream_graph_launch,
+                                           CU_STREAM_NON_BLOCKING);
   CUDADriver::get_instance().graph_launch(graph_exec, stream_graph_launch);
   CUDADriver::get_instance().stream_synchronize(stream_graph_launch);
 }

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -66,14 +66,19 @@ class CudaCommandList : public CommandList {
   void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override{
       TI_NOT_IMPLEMENTED};
 
+  // Cuda specific functions
+  CUgraphExec finalize();
+
  private:
   CudaDevice *ti_device_{nullptr};
   CudaStream *stream_{nullptr};
+  CUgraph graph_{nullptr};
+  CUgraphExec graph_exec_{nullptr};
 };
 
 class CudaStream : public Stream {
  public:
-   CudaStream(CudaDevice &device, void *cuda_stream);
+   CudaStream(CudaDevice &device, void *cu_stream);
   ~CudaStream() override{};
 
   std::unique_ptr<CommandList> new_command_list() override;
@@ -84,7 +89,7 @@ class CudaStream : public Stream {
 
  private:
   CudaDevice &device_;
-  void *cuda_stream_{nullptr};
+  CUstream cu_stream_{nullptr};
 };
 
 class CudaDevice : public Device {
@@ -140,7 +145,7 @@ class CudaDevice : public Device {
 
   Stream *get_compute_stream() override;
 
-  void *get_cu_stream() const { return cuda_stream_; }
+  void *get_cu_stream() const { return cu_stream_; }
 
  private:
   std::vector<AllocInfo> allocations_;
@@ -149,9 +154,8 @@ class CudaDevice : public Device {
       TI_ERROR("invalid DeviceAllocation");
     }
   }
-  void *cuda_stream_{nullptr};
+  void *cu_stream_{nullptr};
   std::unique_ptr<CudaStream> stream_{nullptr}; 
-bool has_stream{0};
   std::unique_ptr<CudaCachingAllocator> caching_allocator_{nullptr};
 };
 

--- a/taichi/backends/cuda/cuda_device.h
+++ b/taichi/backends/cuda/cuda_device.h
@@ -78,7 +78,7 @@ class CudaCommandList : public CommandList {
 
 class CudaStream : public Stream {
  public:
-   CudaStream(CudaDevice &device, void *cu_stream);
+  CudaStream(CudaDevice &device, void *cu_stream);
   ~CudaStream() override{};
 
   std::unique_ptr<CommandList> new_command_list() override;
@@ -145,7 +145,9 @@ class CudaDevice : public Device {
 
   Stream *get_compute_stream() override;
 
-  void *get_cu_stream() const { return cu_stream_; }
+  void *get_cu_stream() const {
+    return cu_stream_;
+  }
 
  private:
   std::vector<AllocInfo> allocations_;
@@ -155,7 +157,7 @@ class CudaDevice : public Device {
     }
   }
   void *cu_stream_{nullptr};
-  std::unique_ptr<CudaStream> stream_{nullptr}; 
+  std::unique_ptr<CudaStream> stream_{nullptr};
   std::unique_ptr<CudaCachingAllocator> caching_allocator_{nullptr};
 };
 

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -40,6 +40,7 @@ constexpr uint32 CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2;
 constexpr uint32 CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING = 41;
 constexpr uint32 CUDA_SUCCESS = 0;
 constexpr uint32 CU_MEMORYTYPE_DEVICE = 2;
+constexpr uint32 CU_STREAM_CAPTURE_MODE_GLOBAL = 0;
 
 std::string get_cuda_error_message(uint32 err);
 

--- a/taichi/backends/cuda/cuda_driver_functions.inc.h
+++ b/taichi/backends/cuda/cuda_driver_functions.inc.h
@@ -28,6 +28,7 @@ PER_CUDA_FUNCTION(malloc, cuMemAlloc_v2, void **, std::size_t);
 PER_CUDA_FUNCTION(malloc_managed, cuMemAllocManaged, void **, std::size_t, uint32);
 PER_CUDA_FUNCTION(memset, cuMemsetD8_v2, void *, uint8, std::size_t);
 PER_CUDA_FUNCTION(memsetd32, cuMemsetD32_v2, void *, uint32, std::size_t);
+PER_CUDA_FUNCTION(memsetd32async, cuMemsetD32Async, void *, uint32, std::size_t, CUstream);
 PER_CUDA_FUNCTION(mem_free, cuMemFree_v2, void *);
 PER_CUDA_FUNCTION(mem_advise, cuMemAdvise, void *, std::size_t, uint32, uint32);
 PER_CUDA_FUNCTION(mem_get_info, cuMemGetInfo_v2, std::size_t *, std::size_t *);

--- a/taichi/backends/cuda/cuda_driver_functions.inc.h
+++ b/taichi/backends/cuda/cuda_driver_functions.inc.h
@@ -9,7 +9,6 @@ PER_CUDA_FUNCTION(device_get, cuDeviceGet, void *, void *);
 PER_CUDA_FUNCTION(device_get_name, cuDeviceGetName, char *, int, void *);
 PER_CUDA_FUNCTION(device_get_attribute, cuDeviceGetAttribute, int *, uint32, void *);
 
-
 // Context management
 PER_CUDA_FUNCTION(context_create, cuCtxCreate_v2, void*, int, void *);
 PER_CUDA_FUNCTION(context_set_current, cuCtxSetCurrent, void *);
@@ -17,6 +16,13 @@ PER_CUDA_FUNCTION(context_get_current, cuCtxGetCurrent, void **);
 
 // Stream management
 PER_CUDA_FUNCTION(stream_create, cuStreamCreate, void **, uint32);
+
+// Graph management
+PER_CUDA_FUNCTION(stream_begin_capture, cuStreamBeginCapture, void *, uint32);
+PER_CUDA_FUNCTION(stream_end_capture, cuStreamEndCapture, void *, void **);
+PER_CUDA_FUNCTION(graph_instantiate, cuGraphInstantiate, void **, void *,
+                  void **, char*, size_t);
+PER_CUDA_FUNCTION(graph_launch, cuGraphLaunch, void *, void *);
 
 // Memory management
 PER_CUDA_FUNCTION(memcpy_host_to_device, cuMemcpyHtoD_v2, void *, void *, std::size_t);
@@ -28,7 +34,7 @@ PER_CUDA_FUNCTION(malloc, cuMemAlloc_v2, void **, std::size_t);
 PER_CUDA_FUNCTION(malloc_managed, cuMemAllocManaged, void **, std::size_t, uint32);
 PER_CUDA_FUNCTION(memset, cuMemsetD8_v2, void *, uint8, std::size_t);
 PER_CUDA_FUNCTION(memsetd32, cuMemsetD32_v2, void *, uint32, std::size_t);
-PER_CUDA_FUNCTION(memsetd32async, cuMemsetD32Async, void *, uint32, std::size_t, CUstream);
+PER_CUDA_FUNCTION(memsetd32async, cuMemsetD32Async, void *, uint32, std::size_t, void *);
 PER_CUDA_FUNCTION(mem_free, cuMemFree_v2, void *);
 PER_CUDA_FUNCTION(mem_advise, cuMemAdvise, void *, std::size_t, uint32, uint32);
 PER_CUDA_FUNCTION(mem_get_info, cuMemGetInfo_v2, std::size_t *, std::size_t *);

--- a/taichi/backends/cuda/cuda_types.h
+++ b/taichi/backends/cuda/cuda_types.h
@@ -13,6 +13,8 @@ using CUstream = void *;
 using CUdeviceptr = void *;
 using CUmipmappedArray = void *;
 using CUarray = void *;
+using CUgraph = void *;
+using CUgraphExec = void *;
 
 // copied from <cuda.h>
 

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -111,11 +111,12 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
     device_ = std::make_shared<cuda::CudaDevice>();
 
     void *cuda_stream{nullptr};
-    CUDADriver::get_instance().stream_create(&cuda_stream, CU_STREAM_NON_BLOCKING);
+    CUDADriver::get_instance().stream_create(&cuda_stream,
+                                             CU_STREAM_NON_BLOCKING);
 
     cuda::CudaDevice::Params params;
-	  params.stream = cuda_stream;
-		cuda_device()->init_cuda_structs(params);
+    params.stream = cuda_stream;
+    cuda_device()->init_cuda_structs(params);
   }
 #endif
 }
@@ -624,10 +625,10 @@ void LlvmProgramImpl::fill_ndarray(const DeviceAllocation &alloc,
                                    uint32_t data) {
   if (config->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-  Stream *stream = device_->get_compute_stream();
-  auto cmdlist = stream->new_command_list();
-  cmdlist->buffer_fill(alloc.get_ptr(), size, data);
-  stream->submit_synced(cmdlist.get());
+    Stream *stream = device_->get_compute_stream();
+    auto cmdlist = stream->new_command_list();
+    cmdlist->buffer_fill(alloc.get_ptr(), size, data);
+    stream->submit_synced(cmdlist.get());
 #else
     TI_NOT_IMPLEMENTED
 #endif

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -110,7 +110,6 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
     CUDAContext::get_instance().set_debug(config->debug);
     device_ = std::make_shared<cuda::CudaDevice>();
 
-
     void *cuda_stream{nullptr};
     CUDADriver::get_instance().stream_create(&cuda_stream, CU_STREAM_NON_BLOCKING);
 


### PR DESCRIPTION
This PR kicks off the process of moving cuda device operations into CommandList (Unified Device API). The goal is to reduce host-side overhead using a graph (analogous to CommandBuffer in Vulkan) to avoid unnecessary synchronizations. In this PR, we first simulate an immediate buffer fill operation using the submit_sync.

