### PR TITLE
[bug] Fix bug that building with TI_WITH_LLVM=OFF will fail

### DIFF
--- a/taichi/jit/jit_session.cpp
+++ b/taichi/jit/jit_session.cpp
@@ -35,10 +35,4 @@ std::unique_ptr<JITSession> JITSession::create(LlvmProgramImpl *llvm_prog,
 #endif
 }
 
-#ifdef TI_WITH_LLVM
-llvm::DataLayout JITSession::get_data_layout() {
-  TI_NOT_IMPLEMENTED
-}
-#endif
-
 TLANG_NAMESPACE_END

--- a/taichi/jit/jit_session.h
+++ b/taichi/jit/jit_session.h
@@ -32,7 +32,7 @@ class JITSession {
     TI_NOT_IMPLEMENTED
   }
 
-  virtual llvm::DataLayout get_data_layout();
+  virtual llvm::DataLayout get_data_layout() = 0;
 
   static std::unique_ptr<JITSession> create(LlvmProgramImpl *llvm_prog,
                                             Arch arch);

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -16,6 +16,7 @@ namespace taichi {
 namespace lang {
 
 class Program;
+class LlvmProgramImpl;
 
 class Ndarray {
  public:


### PR DESCRIPTION
Related issue = fix #3999

Taichi isn't at a state that can be built easily without LLVM at all. Currently, the `-DTI_WITH_LLVM=OFF` doesn't mean that Taichi will be built without using LLVM at all. Fixing this problem completely in the future version is that we should consider, which is difficult but necessary.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
