### PR TITLE
[Opengl] [cc] Increase the number of arguments allowed in a kernel

### DIFF
--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -3,11 +3,9 @@
 #include <cstddef>
 
 constexpr int taichi_max_num_indices = 8;
-// legacy: only used in cc and opengl backends
-constexpr int taichi_max_num_args = 8;
-// used in llvm backend: only the first 16 arguments can be ext_arr/any_arr
 // TODO: refine argument passing
-constexpr int taichi_max_num_args_total = 64;
+constexpr int taichi_max_num_args = 64;
+// only the first 16 arguments can be ext_arr/any_arr
 constexpr int taichi_max_num_args_extra = 16;
 constexpr int taichi_max_num_snodes = 1024;
 constexpr int kMaxNumSnodeTreesLlvm = 512;

--- a/taichi/program/context.h
+++ b/taichi/program/context.h
@@ -19,11 +19,11 @@ struct RuntimeContext {
   // - primitive_types
   // - raw ptrs: for external array, or torch-based ndarray
   // - DeviceAllocation*: for taichi ndaray
-  uint64 args[taichi_max_num_args_total];
+  uint64 args[taichi_max_num_args];
   int32 extra_args[taichi_max_num_args_extra][taichi_max_num_indices];
   int32 cpu_thread_id;
   // |is_device_allocation| is true iff args[i] is a DeviceAllocation*.
-  bool is_device_allocation[taichi_max_num_args_total]{false};
+  bool is_device_allocation[taichi_max_num_args]{false};
 
   static constexpr size_t extra_args_size = sizeof(extra_args);
 


### PR DESCRIPTION
Related issue = close #4050

This PR is a follow-up of #2886, which increases the number of arguments allowed in a kernel for OpenGL and CC backends as well.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
