### PR TITLE
[opengl] Make sure ndarray arg bind indices are sorted.

### DIFF
--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -119,7 +119,6 @@ class KernelGen : public IRVisitor {
   bool is_top_level_{true};
   CompiledTaichiKernel compiled_program_;
   UsedFeature used;  // TODO: is this actually per-offload?
-  int arr_bind_idx_ = static_cast<int>(GLBufId::Arr);
 
   // per-offload variables:
   LineAppender line_appender_;
@@ -866,7 +865,8 @@ class KernelGen : public IRVisitor {
     const auto dt = opengl_data_type_name(stmt->element_type());
     if (stmt->is_ptr) {
       if (!used.arr_arg_to_bind_idx.count(stmt->arg_id)) {
-        used.arr_arg_to_bind_idx[stmt->arg_id] = arr_bind_idx_++;
+        used.arr_arg_to_bind_idx[stmt->arg_id] =
+            static_cast<int>(GLBufId::Arr) + stmt->arg_id;
       }
     } else {
       used.buf_args = true;


### PR DESCRIPTION
We have reserved bind idx 0~3 for root, gtmp, args and runtime,
so let's force generated bind_idx for array args to be `arg_id + 4`.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
