### PR TITLE
[aot] [opengl] Provide range_hint for range_for offloaded tasks in

### DIFF
--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -30,12 +30,13 @@ struct CompiledFieldData {
 
 struct CompiledOffloadedTask {
   std::string type;
+  std::string range_hint;
   std::string name;
   // Do we need to inline the source code?
   std::string source_path;
   int gpu_block_size{0};
 
-  TI_IO_DEF(type, name, source_path, gpu_block_size);
+  TI_IO_DEF(type, range_hint, name, source_path, gpu_block_size);
 };
 
 struct ScalarArg {

--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -63,6 +63,7 @@ class AotDataConverter {
     res.type = offloaded_task_type_name(in.type);
     res.name = in.name;
     res.source_path = in.src;
+    res.range_hint = in.range_hint;
     res.gpu_block_size = in.workgroup_size;
     return res;
   }

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -198,7 +198,8 @@ class KernelGen : public IRVisitor {
     return res;
   }
 
-  void generate_task_bottom(OffloadedTaskType task_type) {
+  void generate_task_bottom(OffloadedTaskType task_type,
+                            std::string range_hint) {
     emit("void main()");
     emit("{{");
     if (used.random)
@@ -300,8 +301,8 @@ class KernelGen : public IRVisitor {
                           ? std::min(workgroup_size_, prescribed_block_dim)
                           : workgroup_size_;
     compiled_program_.add(std::move(glsl_kernel_name_), kernel_src_code,
-                          task_type, num_workgroups_, workgroup_size_,
-                          &this->extptr_access_);
+                          task_type, range_hint, num_workgroups_,
+                          workgroup_size_, &this->extptr_access_);
     if (config.print_kernel_llvm_ir) {
       static FileSequenceWriter writer("shader{:04d}.comp",
                                        "OpenGL compute shader");
@@ -1031,6 +1032,8 @@ class KernelGen : public IRVisitor {
       num_workgroups_ = stmt->grid_dim;
       ScopedGridStrideLoop _gsl(this, end_value - begin_value);
       emit("int _itv = {} + _sid;", begin_value);
+      // range_hint is known after compilation, e.g. range of field
+      stmt->range_hint = std::to_string(end_value - begin_value);
       stmt->body->accept(this);
     } else {
       ScopedIndent _s(line_appender_);
@@ -1171,7 +1174,7 @@ class KernelGen : public IRVisitor {
                stmt->task_name());
     }
     is_top_level_ = true;
-    generate_task_bottom(task_type);
+    generate_task_bottom(task_type, stmt->range_hint);
     loaded_args_.clear();
   }
 

--- a/taichi/backends/opengl/opengl_api.cpp
+++ b/taichi/backends/opengl/opengl_api.cpp
@@ -254,6 +254,7 @@ void CompiledTaichiKernel::add(
     const std::string &name,
     const std::string &source_code,
     OffloadedTaskType type,
+    const std::string &range_hint,
     int num_workgroups,
     int workgroup_size,
     std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access) {
@@ -272,7 +273,8 @@ void CompiledTaichiKernel::add(
 
   TI_DEBUG("[glsl]\ncompiling kernel {}<<<{}, {}>>>:\n{}", name, num_workgroups,
            workgroup_size, source);
-  tasks.push_back({name, source, type, workgroup_size, num_workgroups});
+  tasks.push_back(
+      {name, source, type, range_hint, workgroup_size, num_workgroups});
 
   if (ext_ptr_access) {
     for (auto pair : *ext_ptr_access) {

--- a/taichi/backends/opengl/opengl_api.h
+++ b/taichi/backends/opengl/opengl_api.h
@@ -45,6 +45,7 @@ struct CompiledOffloadedTask {
   std::string name;
   std::string src;
   OffloadedTaskType type;
+  std::string range_hint;
   int workgroup_size;
   int num_groups;
 
@@ -78,6 +79,7 @@ struct CompiledTaichiKernel {
   void add(const std::string &name,
            const std::string &source_code,
            OffloadedTaskType type,
+           const std::string &range_hint,
            int num_workgrous,
            int workgroup_size,
            std::unordered_map<int, irpass::ExternalPtrAccess> *ext_ptr_access =

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -240,7 +240,8 @@ RangeForStmt::RangeForStmt(Stmt *begin,
                            int bit_vectorize,
                            int num_cpu_threads,
                            int block_dim,
-                           bool strictly_serialized)
+                           bool strictly_serialized,
+                           std::string range_hint)
     : begin(begin),
       end(end),
       body(std::move(body)),
@@ -248,7 +249,8 @@ RangeForStmt::RangeForStmt(Stmt *begin,
       bit_vectorize(bit_vectorize),
       num_cpu_threads(num_cpu_threads),
       block_dim(block_dim),
-      strictly_serialized(strictly_serialized) {
+      strictly_serialized(strictly_serialized),
+      range_hint(range_hint) {
   reversed = false;
   this->body->parent_stmt = this;
   TI_STMT_REG_FIELDS;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -733,6 +733,7 @@ class RangeForStmt : public Stmt {
   int num_cpu_threads;
   int block_dim;
   bool strictly_serialized;
+  std::string range_hint;
 
   RangeForStmt(Stmt *begin,
                Stmt *end,
@@ -741,7 +742,8 @@ class RangeForStmt : public Stmt {
                int bit_vectorize,
                int num_cpu_threads,
                int block_dim,
-               bool strictly_serialized);
+               bool strictly_serialized,
+               std::string range_hint = "");
 
   bool is_container_statement() const override {
     return true;
@@ -1094,6 +1096,7 @@ class OffloadedStmt : public Stmt {
   bool reversed{false};
   int num_cpu_threads{1};
   Stmt *end_stmt{nullptr};
+  std::string range_hint = "";
 
   mesh::Mesh *mesh{nullptr};
   mesh::MeshElementType major_from_type;

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -345,7 +345,8 @@ class LowerAST : public IRVisitor {
       auto &&new_for = std::make_unique<RangeForStmt>(
           begin, end, std::move(stmt->body), stmt->vectorize,
           stmt->bit_vectorize, stmt->num_cpu_threads, stmt->block_dim,
-          stmt->strictly_serialized);
+          stmt->strictly_serialized,
+          /*range_hint=*/fmt::format("arg {}", tensor->arg_id));
       VecStatement new_statements;
       Stmt *loop_index =
           new_statements.push_back<LoopIndexStmt>(new_for.get(), 0);

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -129,6 +129,7 @@ class Offloader {
         for (int j = 0; j < (int)s->body->statements.size(); j++) {
           offloaded->body->insert(std::move(s->body->statements[j]));
         }
+        offloaded->range_hint = s->range_hint;
         root_block->insert(std::move(offloaded));
       } else if (auto st = stmt->cast<StructForStmt>()) {
         assemble_serial_statements();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #4071
* __->__ #4070

opengl backend.

For range_for offloaded tasks, we try our best to provide some hints
about the range.

- If the range is known at compile time, it shows as

```
"type": "range_for",
"range_hint": "8192",
```

- If the range is range of a ndarray, it shows as

```
"type": "range_for",
"range_hint": "arg <X>",  # X is ndarray's arg_id
```

For other ranges that's only known at runtime, we currently don't handle
them.

note to self: I actually hacked a version to print out the IR of the
end_stmt of OffloadStmt. Although more accurate, it's not easy to parse
so I just abandoned it. prototype at
https://github.com/taichi-dev/taichi/compare/master...ailzhang:range_hint_aot?expand=1