### PR TITLE
[Bug] [lang] Ban redefinition of template and matrix arguments in Taichi kernel

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -427,9 +427,10 @@ class ASTTransformer(Builder):
                             ctx.arg_features[i][1], ctx.arg_features[i][2],
                             ctx.arg_features[i][3]))
                 elif isinstance(ctx.func.argument_annotations[i], MatrixType):
-                    ctx.global_vars[
-                        arg.arg] = kernel_arguments.decl_matrix_arg(
-                            ctx.func.argument_annotations[i])
+                    ctx.create_variable(
+                        arg.arg,
+                        kernel_arguments.decl_matrix_arg(
+                            ctx.func.argument_annotations[i]))
                 else:
                     ctx.global_vars[
                         arg.arg] = kernel_arguments.decl_scalar_arg(

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -144,7 +144,7 @@ class ASTTransformer(Builder):
                 var.assign(value)
             except AttributeError:
                 raise TaichiSyntaxError(
-                    f"Variable '{unparse(target)}' cannot be assigned. Maybe it is not a Taichi object?"
+                    f"Variable '{unparse(target).strip()}' cannot be assigned. Maybe it is not a Taichi object?"
                 )
         return var
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -140,7 +140,12 @@ class ASTTransformer(Builder):
             ctx.create_variable(target.id, var)
         else:
             var = build_stmt(ctx, target)
-            var.assign(value)
+            try:
+                var.assign(value)
+            except AttributeError:
+                raise TaichiSyntaxError(
+                    f"Variable '{unparse(target)}' cannot be assigned. Maybe it is not a Taichi object?"
+                )
         return var
 
     @staticmethod
@@ -408,7 +413,7 @@ class ASTTransformer(Builder):
             for i, arg in enumerate(args.args):
                 if isinstance(ctx.func.argument_annotations[i],
                               annotations.template):
-                    continue
+                    ctx.create_variable(arg.arg, ctx.global_vars[arg.arg])
                 elif isinstance(ctx.func.argument_annotations[i],
                                 linalg.sparse_matrix_builder):
                     ctx.create_variable(arg.arg,

--- a/tests/python/test_syntax_errors.py
+++ b/tests/python/test_syntax_errors.py
@@ -290,3 +290,17 @@ def test_func_def_inside_func():
     with pytest.raises(ti.TaichiCompilationError,
                        match='Function definition not allowed'):
         k()
+
+
+@ti.test()
+def test_redefining_template_args():
+    @ti.kernel
+    def foo(a: ti.template()):
+        a = 5
+
+    with pytest.raises(
+            ti.TaichiSyntaxError,
+            match=
+            "Variable 'a' cannot be assigned. Maybe it is not a Taichi object?"
+    ):
+        foo(1)


### PR DESCRIPTION
Related issue = close #4075 
The matrix type can be redefined as well, so I also fixed it in this PR.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
