### PR TITLE
[refactor] [ir] Use InternalFuncCall for retrieving thread index

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -2008,10 +2008,6 @@ void CodeGenLLVM::visit(LoopIndexStmt *stmt) {
   }
 }
 
-void CodeGenLLVM::visit(GlobalThreadIndexStmt *stmt) {
-  llvm_val[stmt] = create_call("linear_thread_idx", {get_context()});
-}
-
 void CodeGenLLVM::visit(LoopLinearIndexStmt *stmt) {
   if (stmt->loop->is<OffloadedStmt>() &&
       (stmt->loop->as<OffloadedStmt>()->task_type ==

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -322,8 +322,6 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(LoopLinearIndexStmt *stmt) override;
 
-  void visit(GlobalThreadIndexStmt *stmt) override;
-
   void visit(BlockCornerIndexStmt *stmt) override;
 
   void visit(GlobalTemporaryStmt *stmt) override;

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -151,16 +151,6 @@ void RandExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void GlobalThreadIndexExpression::flatten(FlattenContext *ctx) {
-  auto tid_stmt = std::make_unique<GlobalThreadIndexStmt>();
-  ctx->push_back(std::move(tid_stmt));
-  stmt = ctx->back_stmt();
-}
-
-void GlobalThreadIndexExpression::type_check() {
-  ret_type = PrimitiveType::i32;
-}
-
 void UnaryOpExpression::serialize(std::ostream &ss) {
   ss << '(';
   if (is_cast()) {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -558,20 +558,6 @@ class TensorElementExpression : public Expression {
   }
 };
 
-class GlobalThreadIndexExpression : public Expression {
- public:
-  GlobalThreadIndexExpression() {
-  }
-
-  void type_check() override;
-
-  void serialize(std::ostream &ss) override {
-    ss << fmt::format("global_thread_idx()");
-  }
-
-  void flatten(FlattenContext *ctx) override;
-};
-
 class RangeAssumptionExpression : public Expression {
  public:
   Expr input, base;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1066,7 +1066,8 @@ void export_lang(py::module &m) {
     }
     TI_ERROR_IF(!(loop && loop->is<FrontendForStmt>()),
                 "ti.thread_idx() is only valid within loops.");
-    return Expr::make<GlobalThreadIndexExpression>();
+    return Expr::make<InternalFuncCallExpression>("linear_thread_idx",
+                                                  std::vector<Expr>{});
   });
 
   m.def("insert_patch_idx_expr", [&]() {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -620,10 +620,6 @@ class IRPrinter : public IRVisitor {
           stmt->loop->name());
   }
 
-  void visit(GlobalThreadIndexStmt *stmt) override {
-    print("{}{} = global thread index", stmt->type_hint(), stmt->name());
-  }
-
   void visit(BlockCornerIndexStmt *stmt) override {
     print("{}{} = loop {} block corner index {}", stmt->type_hint(),
           stmt->name(), stmt->loop->name(), stmt->index);

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -432,11 +432,6 @@ class TypeCheck : public IRVisitor {
         TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
   }
 
-  void visit(GlobalThreadIndexStmt *stmt) override {
-    stmt->ret_type =
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
-  }
-
   void visit(BlockCornerIndexStmt *stmt) override {
     stmt->ret_type =
         TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);


### PR DESCRIPTION
Related issue = #4035

`global_thread_idx` is the only expr that can be refactored into a funccall without mass refactoring for now.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
