### PR TITLE
[javascript] Add TI_EMSCRIPTENED to cmake options (JS 1/n)

### DIFF
--- a/cmake/TaichiExamples.cmake
+++ b/cmake/TaichiExamples.cmake
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
+if(NOT TI_EMSCRIPTENED)
+
 set(EXAMPLES_NAME taichi_cpp_examples)
 
 file(GLOB_RECURSE TAICHI_EXAMPLES_SOURCE
@@ -24,3 +26,5 @@ if (WIN32)
     set_target_properties(${EXAMPLES_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${EXAMPLES_OUTPUT_DIR})
 endif()
 target_link_libraries(${EXAMPLES_NAME} taichi_isolated_core)
+
+endif()


### PR DESCRIPTION
Related issue = #3781

Having received positive results in my own [experimentations](https://github.com/AmesingFlank/ti.js/blob/master/src/examples/taichi4/main.ts), I'm confident of feasibility of implementing a version of taichi in pure Javascript. I'd like to start merging PRs that prepare for this project. These PRs doesn't implement any real functionalities, instead, they only serve the following two purposes:
* Enable the existing Taichi code base to be built into a JS library, via [emscripten](https://emscripten.org/)
* Export the APIs necessary for the js frontend, via [embind](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html)

Once these PRs are merged, one will be able to build a `.js` library of taichi, simply by setting the `TI_EMSCRIPTENED` cmake option.

This is the 1st of a series of PRs. It adds the `TI_EMSCRIPTENED` option and the cmake logic for it. 