### PR TITLE
[javascript] Add Javascript PR tag (JS 0/n)

### DIFF
--- a/misc/prtags.json
+++ b/misc/prtags.json
@@ -1,4 +1,5 @@
 {
+  "javascript"      : "Taichi in javascript",
   "ci"              : "CI/CD workflow",
   "cpu"             : "CPU backends",
   "cuda"            : "CUDA backend",


### PR DESCRIPTION
Related issue = #3781

Having received positive results in my own [experimentations](https://github.com/AmesingFlank/ti.js/blob/master/src/examples/taichi4/main.ts), I'm confident of the feasibility of implementing a version of taichi in pure Javascript. I'd like to start merging PRs that prepare for this project. These PRs don't implement any real functionalities, instead, they only serve the following two purposes:
* Enable the existing Taichi code base to be built into a JS library, via [emscripten](https://emscripten.org/)
* Export the APIs necessary for the js frontend, via [embind](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html)

Once these PRs are merged, one will be able to build a `.js` library of taichi, simply by setting the `TI_EMSCRIPTENED` cmake option.

This is the 0th of a series of PRs. It adds a [javascript] PR tag