### PR TITLE
[opengl] Use element_size as alignment in root buffer.

### DIFF
--- a/taichi/backends/opengl/aot_module_builder_impl.cpp
+++ b/taichi/backends/opengl/aot_module_builder_impl.cpp
@@ -134,16 +134,6 @@ void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
   aot_data_.kernels.insert(std::make_pair(identifier, std::move(compiled)));
 }
 
-size_t AotModuleBuilderImpl::get_snode_base_address(const SNode *snode) {
-  if (snode->type == SNodeType::root)
-    return 0;
-  int chid = find_children_id(snode);
-  const auto &parent_meta =
-      compiled_structs_.snode_map.at(snode->parent->node_type_name);
-  auto choff = parent_meta.children_offsets[chid];
-  return choff + get_snode_base_address(snode->parent);
-}
-
 void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
                                                  const SNode *rep_snode,
                                                  bool is_scalar,
@@ -164,9 +154,11 @@ void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,
   if (!is_scalar) {
     element_shape = {row_num, column_num};
   }
-  aot_data_.fields.push_back({identifier, gl_dtype_enum, dt.to_string(),
-                              get_snode_base_address(rep_snode), shape,
-                              is_scalar, element_shape});
+  aot_data_.fields.push_back(
+      {identifier, gl_dtype_enum, dt.to_string(),
+       compiled_structs_.snode_map.at(rep_snode->node_type_name)
+           .mem_offset_in_root,
+       shape, is_scalar, element_shape});
 }
 
 void AotModuleBuilderImpl::add_per_backend_tmpl(const std::string &identifier,

--- a/taichi/backends/opengl/aot_module_builder_impl.h
+++ b/taichi/backends/opengl/aot_module_builder_impl.h
@@ -33,8 +33,6 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
                             Kernel *kernel) override;
 
  private:
-  size_t get_snode_base_address(const SNode *snode);
-
   StructCompiledResult &compiled_structs_;
   AotData aot_data_;
   bool allow_nv_shader_extension_ = false;

--- a/taichi/backends/opengl/opengl_kernel_launcher.h
+++ b/taichi/backends/opengl/opengl_kernel_launcher.h
@@ -37,6 +37,7 @@ struct SNodeInfo {
   size_t length;
   std::vector<size_t> children_offsets;
   size_t elem_stride;
+  size_t mem_offset_in_root{0};
 };
 
 struct StructCompiledResult {

--- a/taichi/program/aot_module.cpp
+++ b/taichi/program/aot_module.cpp
@@ -48,15 +48,6 @@ bool AotModuleBuilder::all_fields_are_dense_in_container(
   return true;
 }
 
-int AotModuleBuilder::find_children_id(const SNode *snode) {
-  auto parent = snode->parent;
-  for (int i = 0; i < parent->ch.size(); i++) {
-    if (parent->ch[i].get() == snode)
-      return i;
-  }
-  TI_ERROR("Child not found in parent!");
-}
-
 void AotModuleBuilder::load(const std::string &output_dir) {
   TI_ERROR("Aot loader not supported");
 }

--- a/taichi/program/aot_module.h
+++ b/taichi/program/aot_module.h
@@ -77,8 +77,6 @@ class AotModuleBuilder {
                                     Kernel *kernel) = 0;
 
   static bool all_fields_are_dense_in_container(const SNode *container);
-
-  static int find_children_id(const SNode *snode);
 };
 
 // Only responsible for reporting device capabilities

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -97,6 +97,24 @@ def test_aot_ndarray_range_hint():
             assert range_hint == 'arg 0'
 
 
+@ti.test(arch=ti.opengl)
+def test_element_size_alignment():
+    a = ti.field(ti.f32, shape=())
+    b = ti.Matrix.field(2, 3, ti.f32, shape=(2, 4))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        s = ti.aot.Module(ti.cfg.arch)
+        s.add_field('a', a)
+        s.add_field('b', b)
+        s.save(tmpdir, '')
+        with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
+            res = json.load(json_file)
+            offsets = (res['aot_data']['fields'][0]['mem_offset_in_parent'],
+                       res['aot_data']['fields'][1]['mem_offset_in_parent'])
+            assert 0 in offsets and 24 in offsets
+            assert res['aot_data']['root_buffer_size'] == 216
+
+
 @ti.test(arch=[ti.opengl, ti.vulkan])
 def test_save():
     density = ti.field(float, shape=(4, 4))


### PR DESCRIPTION
Fixes #4089

Also deduplicated the `get_snode_base_address` between compilation and
aot module builder. We can do it only once when calculating root buffer
size.



Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
