### PR TITLE
[Refactor] Remove exposure of internal functions in taichi.lang.ops

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -337,7 +337,7 @@ class ASTTransformer(Builder):
                 name = "min" if func is min else "max"
                 warnings.warn_explicit(
                     f'Calling builtin function "{name}" in Taichi scope is deprecated. '
-                    f'Please use "ti.{name}" instead.', UserWarning, ctx.file,
+                    f'Please use "ti.{name}" instead.', DeprecationWarning, ctx.file,
                     node.lineno + ctx.lineno_offset)
             return True
         return False

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1080,6 +1080,11 @@ class ASTTransformer(Builder):
                 node.body.ptr) or is_taichi_class(node.orelse.ptr):
             node.ptr = ti_ops.select(node.test.ptr, node.body.ptr,
                                      node.orelse.ptr)
+            warnings.warn_explicit(
+                f'Using conditional expression for element-wise select operation on '
+                f'Taichi vectors/matrices is deprecated. '
+                f'Please use "ti.select" instead.', DeprecationWarning,
+                ctx.file, node.lineno + ctx.lineno_offset)
             return node.ptr
 
         is_static_if = (ASTTransformer.get_decorator(ctx,

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -322,8 +322,8 @@ class ASTTransformer(Builder):
         func = node.func.ptr
         replace_func = {
             id(print): impl.ti_print,
-            id(min): ti_ops.ti_min,
-            id(max): ti_ops.ti_max,
+            id(min): ti_ops.min,
+            id(max): ti_ops.max,
             id(int): impl.ti_int,
             id(float): impl.ti_float,
             id(any): ti_ops.ti_any,

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -337,8 +337,8 @@ class ASTTransformer(Builder):
                 name = "min" if func is min else "max"
                 warnings.warn_explicit(
                     f'Calling builtin function "{name}" in Taichi scope is deprecated. '
-                    f'Please use "ti.{name}" instead.', DeprecationWarning, ctx.file,
-                    node.lineno + ctx.lineno_offset)
+                    f'Please use "ti.{name}" instead.', DeprecationWarning,
+                    ctx.file, node.lineno + ctx.lineno_offset)
             return True
         return False
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1081,9 +1081,9 @@ class ASTTransformer(Builder):
             node.ptr = ti_ops.select(node.test.ptr, node.body.ptr,
                                      node.orelse.ptr)
             warnings.warn_explicit(
-                f'Using conditional expression for element-wise select operation on '
-                f'Taichi vectors/matrices is deprecated. '
-                f'Please use "ti.select" instead.', DeprecationWarning,
+                'Using conditional expression for element-wise select operation on '
+                'Taichi vectors/matrices is deprecated. '
+                'Please use "ti.select" instead.', DeprecationWarning,
                 ctx.file, node.lineno + ctx.lineno_offset)
             return node.ptr
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -614,11 +614,11 @@ class Matrix(TaichiOperations):
 
     def max(self):
         """Return the maximum element value."""
-        return ops_mod.ti_max(*self.entries)
+        return ops_mod.max(*self.entries)
 
     def min(self):
         """Return the minimum element value."""
-        return ops_mod.ti_min(*self.entries)
+        return ops_mod.min(*self.entries)
 
     def any(self):
         """Test whether any element not equal zero.

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -865,5 +865,5 @@ __all__ = [
     "atomic_max", "atomic_sub", "atomic_min", "atomic_add", "bit_cast",
     "bit_shr", "cast", "ceil", "cos", "exp", "floor", "log", "random",
     "raw_mod", "raw_div", "round", "rsqrt", "sin", "sqrt", "tan", "tanh",
-    "max", "min"
+    "max", "min", "select"
 ]

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -504,7 +504,7 @@ def truediv(a, b):
 
 
 @binary
-def max_impl(a, b):  # pylint: disable=W0622
+def max_impl(a, b):
     """The maxnimum function.
 
     Args:
@@ -518,7 +518,7 @@ def max_impl(a, b):  # pylint: disable=W0622
 
 
 @binary
-def min_impl(a, b):  # pylint: disable=W0622
+def min_impl(a, b):
     """The minimum function.
 
     Args:
@@ -832,7 +832,7 @@ def assign(a, b):
     return a
 
 
-def max(*args):
+def max(*args):  # pylint: disable=W0622
     num_args = len(args)
     assert num_args >= 1
     if num_args == 1:
@@ -842,7 +842,7 @@ def max(*args):
     return max_impl(args[0], max(*args[1:]))
 
 
-def min(*args):
+def min(*args):  # pylint: disable=W0622
     num_args = len(args)
     assert num_args >= 1
     if num_args == 1:

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -858,3 +858,11 @@ def ti_any(a):
 
 def ti_all(a):
     return a.all()
+
+
+__all__ = [
+    "acos", "asin", "atan2", "atomic_and", "atomic_or", "atomic_xor",
+    "atomic_max", "atomic_sub", "atomic_min", "atomic_add", "bit_cast",
+    "bit_shr", "cast", "ceil", "cos", "exp", "floor", "log", "random",
+    "raw_mod", "raw_div", "round", "rsqrt", "sin", "sqrt", "tan", "tanh"
+]

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -504,7 +504,7 @@ def truediv(a, b):
 
 
 @binary
-def max(a, b):  # pylint: disable=W0622
+def max_impl(a, b):  # pylint: disable=W0622
     """The maxnimum function.
 
     Args:
@@ -518,7 +518,7 @@ def max(a, b):  # pylint: disable=W0622
 
 
 @binary
-def min(a, b):  # pylint: disable=W0622
+def min_impl(a, b):  # pylint: disable=W0622
     """The minimum function.
 
     Args:
@@ -832,24 +832,24 @@ def assign(a, b):
     return a
 
 
-def ti_max(*args):
+def max(*args):
     num_args = len(args)
     assert num_args >= 1
     if num_args == 1:
         return args[0]
     if num_args == 2:
-        return max(args[0], args[1])
-    return max(args[0], ti_max(*args[1:]))
+        return max_impl(args[0], args[1])
+    return max_impl(args[0], max(*args[1:]))
 
 
-def ti_min(*args):
+def min(*args):
     num_args = len(args)
     assert num_args >= 1
     if num_args == 1:
         return args[0]
     if num_args == 2:
-        return min(args[0], args[1])
-    return min(args[0], ti_min(*args[1:]))
+        return min_impl(args[0], args[1])
+    return min_impl(args[0], min(*args[1:]))
 
 
 def ti_any(a):
@@ -864,5 +864,5 @@ __all__ = [
     "acos", "asin", "atan2", "atomic_and", "atomic_or", "atomic_xor",
     "atomic_max", "atomic_sub", "atomic_min", "atomic_add", "bit_cast",
     "bit_shr", "cast", "ceil", "cos", "exp", "floor", "log", "random",
-    "raw_mod", "raw_div", "round", "rsqrt", "sin", "sqrt", "tan", "tanh"
+    "raw_mod", "raw_div", "round", "rsqrt", "sin", "sqrt", "tan", "tanh", "max", "min"
 ]

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -864,5 +864,6 @@ __all__ = [
     "acos", "asin", "atan2", "atomic_and", "atomic_or", "atomic_xor",
     "atomic_max", "atomic_sub", "atomic_min", "atomic_add", "bit_cast",
     "bit_shr", "cast", "ceil", "cos", "exp", "floor", "log", "random",
-    "raw_mod", "raw_div", "round", "rsqrt", "sin", "sqrt", "tan", "tanh", "max", "min"
+    "raw_mod", "raw_div", "round", "rsqrt", "sin", "sqrt", "tan", "tanh",
+    "max", "min"
 ]

--- a/tests/python/test_abs.py
+++ b/tests/python/test_abs.py
@@ -15,7 +15,7 @@ def test_abs():
     @ti.kernel
     def func():
         for i in range(N):
-            x[i] = ti.abs(y[i])
+            x[i] = abs(y[i])
 
     for i in range(N):
         y[i] = i - 10

--- a/tests/python/test_element_wise.py
+++ b/tests/python/test_element_wise.py
@@ -256,10 +256,10 @@ def test_unary():
     def func():
         xi[0] = -yi[None]
         xi[1] = ~yi[None]
-        xi[2] = ti.logical_not(yi[None])
-        xi[3] = ti.abs(yi[None])
+        xi[2] = not yi[None]
+        xi[3] = abs(yi[None])
         xf[0] = -yf[None]
-        xf[1] = ti.abs(yf[None])
+        xf[1] = abs(yf[None])
         xf[2] = ti.sqrt(yf[None])
         xf[3] = ti.sin(yf[None])
         xf[4] = ti.cos(yf[None])

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -141,7 +141,7 @@ def test_unary_op():
 
     @ti.kernel
     def foo():
-        x[None] = ti.neg(y[None])
+        x[None] = -y[None]
         x[None] = ti.floor(x[None])
         y[None] = ti.ceil(y[None])
 
@@ -159,7 +159,7 @@ def test_extra_unary_promote():
 
     @ti.kernel
     def foo():
-        x[None] = ti.abs(y[None])
+        x[None] = abs(y[None])
 
     y[None] = -0.3
     foo()

--- a/tests/python/test_loops.py
+++ b/tests/python/test_loops.py
@@ -18,7 +18,7 @@ def test_loops():
     @ti.kernel
     def func():
         for i in range(ti.static(N // 2 + 3), N):
-            x[i] = ti.abs(y[i])
+            x[i] = abs(y[i])
 
     func()
 
@@ -50,7 +50,7 @@ def test_numpy_loops():
     @ti.kernel
     def func():
         for i in range(begin, end):
-            x[i] = ti.abs(y[i])
+            x[i] = abs(y[i])
 
     func()
 

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -1,3 +1,4 @@
+import math
 import operator
 
 import numpy as np
@@ -73,7 +74,7 @@ def test_python_scope_matrix_field(ops):
 
 @ti.test(arch=ti.get_host_arch_list())
 def test_constant_matrices():
-    assert ti.cos(ti.math.pi / 3) == approx(0.5)
+    assert ti.cos(math.pi / 3) == approx(0.5)
     assert np.allclose((-ti.Vector([2, 3])).to_numpy(), np.array([-2, -3]))
     assert ti.cos(ti.Vector([2,
                              3])).to_numpy() == approx(np.cos(np.array([2,

--- a/tests/python/test_scalar_op.py
+++ b/tests/python/test_scalar_op.py
@@ -31,8 +31,8 @@ binary_func_table = [
 unary_func_table = [
     (ops.neg, ) * 2,
     (ops.invert, ) * 2,
-    (ti.logical_not, np.logical_not),
-    (ti.abs, np.abs),
+    (ti.lang.ops.logical_not, np.logical_not),
+    (ti.lang.ops.abs, np.abs),
     (ti.exp, np.exp),
     (ti.log, np.log),
     (ti.sin, np.sin),
@@ -64,10 +64,10 @@ def test_python_scope_vector_binary(ti_func, np_func):
 def test_python_scope_vector_unary(ti_func, np_func):
     ti.init()
     x = ti.Vector([2, 3] if ti_func in
-                  [ops.invert, ti.logical_not] else [0.2, 0.3])
+                  [ops.invert, ti.lang.ops.logical_not] else [0.2, 0.3])
 
     result = ti_func(x).to_numpy()
-    if ti_func in [ti.logical_not]:
+    if ti_func in [ti.lang.ops.logical_not]:
         result = result.astype(bool)
     expected = np_func(x.to_numpy())
     assert allclose(result, expected)


### PR DESCRIPTION
Related issue = #4087, #3782

Renamed `ti.ti_max` and `ti.ti_min` to `ti.max` and `ti.min`, and added deprecate warnings to builtin `max` and `min`.
Deprecated element-wise select operation in conditional expression.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
