### PR TITLE
[javascript] Find and use emscripten cmake toolchain in CMakeLists.txt (JS 2/n)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-if((DEFINED TI_EMSCRIPTENED) AND TI_EMSCRIPTENED)
+option(TI_EMSCRIPTENED "Build using emscripten" OFF)
+
+if(TI_EMSCRIPTENED)
   if(DEFINED ENV{EMSCRIPTEN_DIR})
       set(EMSCRIPTEN_DIR $ENV{EMSCRIPTEN_DIR})
       # Tool chain file must be specified before the `project()`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,17 @@
 
 cmake_minimum_required(VERSION 3.12)
 
+if((DEFINED TI_EMSCRIPTENED) AND TI_EMSCRIPTENED)
+  if(DEFINED ENV{EMSCRIPTEN_DIR})
+      set(EMSCRIPTEN_DIR $ENV{EMSCRIPTEN_DIR})
+      # Tool chain file must be specified before the `project()`
+      set(CMAKE_TOOLCHAIN_FILE "${EMSCRIPTEN_DIR}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake")
+      set(CMAKE_CROSSCOMPILING_EMULATOR "${EMSCRIPTEN_DIR}/node/14.15.5_64bit/bin/node.exe")
+  else()
+      message(FATAL_ERROR "To build taichi with emscripten, Please set EMSCRIPTEN_DIR environment variable.")
+  endif()
+endif()
+
 project(taichi)
 
 if (NOT DEFINED TI_VERSION_MAJOR)

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -7,7 +7,6 @@ option(TI_WITH_OPENGL "Build with the OpenGL backend" ON)
 option(TI_WITH_CC "Build with the C backend" ON)
 option(TI_WITH_VULKAN "Build with the Vulkan backend" OFF)
 option(TI_WITH_DX11 "Build with the DX11 backend" OFF)
-option(TI_EMSCRIPTENED "Build using emscripten" OFF)
 
 if(TI_EMSCRIPTENED)
     set(TI_WITH_LLVM OFF)


### PR DESCRIPTION
Related issue = #3781

Assuming that the path to the emscripten is stored in the `EMSCRIPTEN_DIR` environment variable, this PR finds the cmake toolchain files needed to build taichi with emscripten.

