### PR TITLE
[javascript] Support TI_EMSCRIPTENED option as an env var (JS 3/n)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,10 @@ class CMakeBuild(build_ext):
             f'-DTI_VERSION_PATCH={TI_VERSION_PATCH}',
         ]
 
+        emscriptened = os.getenv('TI_EMSCRIPTENED', '0') in ('1', 'ON')
+        if emscriptened:
+            cmake_args += ['-DTI_EMSCRIPTENED=ON']
+
         if shutil.which('ninja'):
             cmake_args += ['-GNinja']
 


### PR DESCRIPTION
Related issue = #3781 

This PR makes it more convenient to turn on TI_EMSCRIPTENED.

Now you can do `TI_EMSCRIPTENED=1 python setup.py develop --user`, so that you won't have to edit the `TAICHI_CMAKE_ARGS` variable.