### PR TITLE
[javascript] Avoid using C++ inline asm when TI_EMSCRIPTENED (JS 6/n)

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -56,7 +56,7 @@ Program::Program(Arch desired_arch)
   // backends (including CPUs).
 #if defined(TI_ARCH_x64)
   _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
-#else
+#elif !defined(TI_EMSCRIPTENED)
   // Enforce flush to zero on arm64 CPUs
   // https://developer.arm.com/documentation/100403/0201/register-descriptions/advanced-simd-and-floating-point-registers/aarch64-register-descriptions/fpcr--floating-point-control-register?lang=en
   std::uint64_t fpcr;


### PR DESCRIPTION
Related issue = #3781