### PR TITLE
[test] Replace make_temp_file with tempfile

### DIFF
--- a/python/taichi/_testing.py
+++ b/python/taichi/_testing.py
@@ -2,6 +2,7 @@ import copy
 import functools
 import itertools
 import os
+from tempfile import mkstemp
 
 from taichi._lib import core as _ti_core
 from taichi.lang import (cc, cpu, cuda, gpu, is_arch_supported, metal, opengl,
@@ -47,6 +48,14 @@ def approx(expected, **kwargs):
 def allclose(x, y, **kwargs):
     '''Same as: x == approx(y, **kwargs)'''
     return x == approx(y, **kwargs)
+
+
+def make_temp_file(*args, **kwargs):
+    '''Create a temporary file'''
+
+    fd, name = mkstemp(*args, **kwargs)
+    os.close(fd)
+    return name
 
 
 class TestParam:

--- a/python/taichi/_testing.py
+++ b/python/taichi/_testing.py
@@ -50,14 +50,6 @@ def allclose(x, y, **kwargs):
     return x == approx(y, **kwargs)
 
 
-def make_temp_file(*args, **kwargs):
-    '''Create a temporary file'''
-
-    fd, name = mkstemp(*args, **kwargs)
-    os.close(fd)
-    return name
-
-
 class TestParam:
     def __init__(self, value, required_extensions):
         self._value = value
@@ -205,6 +197,5 @@ __all__ = [
     'get_rel_eps',
     'approx',
     'allclose',
-    'make_temp_file',
     'test',
 ]

--- a/python/taichi/_testing.py
+++ b/python/taichi/_testing.py
@@ -2,7 +2,6 @@ import copy
 import functools
 import itertools
 import os
-from tempfile import mkstemp
 
 from taichi._lib import core as _ti_core
 from taichi.lang import (cc, cpu, cuda, gpu, is_arch_supported, metal, opengl,

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -1,7 +1,6 @@
-import tempfile
-
 import numpy as np
 import pytest
+from taichi._testing import make_temp_file
 
 import taichi as ti
 
@@ -24,9 +23,9 @@ def test_save_image_without_window(dtype):
         else:
             paint(i * 1.0 / n)
         gui.set_image(pixels)
-        with tempfile.NamedTemporaryFile(suffix='.png') as image_path:
-            gui.show(image_path.name)
-            image = ti.imread(image_path.name)
-            delta = (image - i).sum()
-            assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(
-                delta)
+        image_path = make_temp_file(suffix='.png')
+        gui.show(image_path)
+        image = ti.imread(image_path)
+        delta = (image - i).sum()
+        assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(
+            delta)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -1,8 +1,9 @@
+import tempfile
+
 import numpy as np
 import pytest
 
 import taichi as ti
-from taichi import make_temp_file
 
 
 @pytest.mark.parametrize('dtype', [ti.u8, ti.f32])
@@ -23,9 +24,9 @@ def test_save_image_without_window(dtype):
         else:
             paint(i * 1.0 / n)
         gui.set_image(pixels)
-        image_path = make_temp_file(suffix='.png')
-        gui.show(image_path)
-        image = ti.imread(image_path)
-        delta = (image - i).sum()
-        assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(
-            delta)
+        with tempfile.NamedTemporaryFile(suffix='.png') as image_path:
+            gui.show(image_path.name)
+            image = ti.imread(image_path.name)
+            delta = (image - i).sum()
+            assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(
+                delta)

--- a/tests/python/test_image_io.py
+++ b/tests/python/test_image_io.py
@@ -1,10 +1,10 @@
 import os
+import tempfile
 
 import numpy as np
 import pytest
 
 import taichi as ti
-from taichi import make_temp_file
 
 
 # jpg is also supported but hard to test here since it's lossy:
@@ -24,17 +24,16 @@ def test_image_io(resx, resy, comp, ext, is_field, dt):
     pixel = np.random.randint(256, size=shape, dtype=ti.to_numpy_type(dt))
     if is_field:
         pixel_t.from_numpy(pixel)
-    fn = make_temp_file(suffix='.' + ext)
-    if is_field:
-        ti.imwrite(pixel_t, fn)
-    else:
-        ti.imwrite(pixel, fn)
-    pixel_r = ti.imread(fn)
-    if comp == 1:
-        # from (resx, resy, 1) to (resx, resy)
-        pixel_r = pixel_r.reshape((resx, resy))
-    assert (pixel_r == pixel).all()
-    os.remove(fn)
+    with tempfile.NamedTemporaryFile(suffix='.' + ext) as fn:
+        if is_field:
+            ti.imwrite(pixel_t, fn.name)
+        else:
+            ti.imwrite(pixel, fn.name)
+        pixel_r = ti.imread(fn.name)
+        if comp == 1:
+            # from (resx, resy, 1) to (resx, resy)
+            pixel_r = pixel_r.reshape((resx, resy))
+        assert (pixel_r == pixel).all()
 
 
 @pytest.mark.parametrize('comp,ext', [(3, 'png'), (4, 'png')])
@@ -46,11 +45,11 @@ def test_image_io_vector(resx, resy, comp, ext, dt):
     pixel = np.random.rand(*shape, comp).astype(ti.to_numpy_type(dt))
     pixel_t = ti.Vector.field(comp, dt, shape)
     pixel_t.from_numpy(pixel)
-    fn = make_temp_file(suffix='.' + ext)
-    ti.imwrite(pixel_t, fn)
-    pixel_r = (ti.imread(fn).astype(ti.to_numpy_type(dt)) + 0.5) / 256.0
-    assert np.allclose(pixel_r, pixel, atol=2e-2)
-    os.remove(fn)
+    with tempfile.NamedTemporaryFile(suffix='.' + ext) as fn:
+        ti.imwrite(pixel_t, fn.name)
+        pixel_r = (ti.imread(fn.name).astype(ti.to_numpy_type(dt)) +
+                   0.5) / 256.0
+        assert np.allclose(pixel_r, pixel, atol=2e-2)
 
 
 @pytest.mark.parametrize('comp,ext', [(3, 'png')])
@@ -66,11 +65,10 @@ def test_image_io_uint(resx, resy, comp, ext, dt):
     pixel = np.random.randint(256, size=(*shape, comp), dtype=np_type) * np_max
     pixel_t = ti.Vector.field(comp, dt, shape)
     pixel_t.from_numpy(pixel)
-    fn = make_temp_file(suffix='.' + ext)
-    ti.imwrite(pixel_t, fn)
-    pixel_r = ti.imread(fn).astype(np_type) * np_max
-    assert (pixel_r == pixel).all()
-    os.remove(fn)
+    with tempfile.NamedTemporaryFile(suffix='.' + ext) as fn:
+        ti.imwrite(pixel_t, fn.name)
+        pixel_r = ti.imread(fn.name).astype(np_type) * np_max
+        assert (pixel_r == pixel).all()
 
 
 @pytest.mark.parametrize('comp', [1, 3])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #4114
* #4113
* #4112
* __->__ #4111

Related: #3782

`make_temp_file` can be easily replaced by native python tempfile so
let's just use tempfile.