### PR TITLE
[javascript] [cuda] Only spawn memory allocator daemon when CUDA is enabled (JS 8/n)

### DIFF
--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -134,7 +134,7 @@ void MemoryPool::terminate() {
 }
 
 MemoryPool::~MemoryPool() {
-  if (killed) {
+  if (!killed) {
     terminate();
   }
 }

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -24,8 +24,8 @@ MemoryPool::MemoryPool(Arch arch, Device *device)
     CUDADriver::get_instance().stream_create(&cuda_stream,
                                              CU_STREAM_NON_BLOCKING);
   }
-#endif
   th = std::make_unique<std::thread>([this] { this->daemon(); });
+#endif
 }
 
 void MemoryPool::set_queue(MemRequestQueue *queue) {
@@ -131,7 +131,7 @@ void MemoryPool::terminate() {
 }
 
 MemoryPool::~MemoryPool() {
-  if (!killed) {
+  if (th && !killed) {
     terminate();
   }
 }

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -118,6 +118,9 @@ void MemoryPool::daemon() {
 }
 
 void MemoryPool::terminate() {
+  if (!th) {
+    return;
+  }
   {
     std::lock_guard<std::mutex> _(mut);
     terminating = true;
@@ -131,7 +134,7 @@ void MemoryPool::terminate() {
 }
 
 MemoryPool::~MemoryPool() {
-  if (th && !killed) {
+  if (killed) {
     terminate();
   }
 }


### PR DESCRIPTION
Related issue = #3781

The daemon is only used for allocation memory in CUDA. (Actually, do we even use that in CUDA anymore, we have switched completely to pre-allocation right?)