### PR TITLE
[spirv] Move external arrays into seperate buffers

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -322,6 +322,7 @@ else()
 endif()
 
 if (TI_WITH_OPENGL)
+    set(SPIRV_CROSS_CLI false)
     add_subdirectory(external/SPIRV-Cross)
     target_include_directories(${CORE_LIBRARY_NAME} PRIVATE external/SPIRV-Cross)
     target_link_libraries(${CORE_LIBRARY_NAME} spirv-cross-glsl spirv-cross-core)

--- a/taichi/backends/cuda/jit_cuda.cpp
+++ b/taichi/backends/cuda/jit_cuda.cpp
@@ -1,4 +1,5 @@
 #include "taichi/backends/cuda/jit_cuda.h"
+#include "taichi/llvm/llvm_program.h"
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/backends/device.h
+++ b/taichi/backends/device.h
@@ -37,6 +37,7 @@ enum class DeviceCapability : uint32_t {
   spirv_has_atomic_float64_add,
   spirv_has_atomic_float64_minmax,
   spirv_has_variable_ptr,
+  spirv_has_ptr_cast,
   // Graphics Caps,
   wide_lines
 };

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -81,7 +81,7 @@ class HostDeviceContextBlitter {
         if (arg.is_array) {
           DeviceAllocation buffer = ext_arrays.at(i);
           char *const device_arr_ptr =
-              reinterpret_cast<char *>(device_->map(buffer));          
+              reinterpret_cast<char *>(device_->map(buffer));
           const void *host_ptr = host_ctx_->get_arg<void *>(i);
           std::memcpy(device_arr_ptr, host_ptr, arg.stride);
           device_->unmap(buffer);
@@ -467,7 +467,8 @@ void VkRuntime::launch_kernel(KernelHandle handle, RuntimeContext *host_ctx) {
   }
 
   ti_kernel->generate_command_list(current_cmdlist_.get(),
-                                   ctx_buffer_host.get(), ctx_buffer.get(), ext_arrays);
+                                   ctx_buffer_host.get(), ctx_buffer.get(),
+                                   ext_arrays);
 
   if (ti_kernel->get_ctx_buffer_size()) {
     ctx_buffers_.push_back(std::move(ctx_buffer_host));

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -78,13 +78,16 @@ class HostDeviceContextBlitter {
       const auto dt = arg.dt;
       char *device_ptr = device_base + arg.offset_in_mem;
       do {
-        if (arg.is_array && arg.stride) {
-          DeviceAllocation buffer = ext_arrays.at(i);
-          char *const device_arr_ptr =
-              reinterpret_cast<char *>(device_->map(buffer));
-          const void *host_ptr = host_ctx_->get_arg<void *>(i);
-          std::memcpy(device_arr_ptr, host_ptr, arg.stride);
-          device_->unmap(buffer);
+        if (arg.is_array) {
+          if (arg.stride) {
+            DeviceAllocation buffer = ext_arrays.at(i);
+            char *const device_arr_ptr =
+                reinterpret_cast<char *>(device_->map(buffer));
+            const void *host_ptr = host_ctx_->get_arg<void *>(i);
+            std::memcpy(device_arr_ptr, host_ptr, arg.stride);
+            device_->unmap(buffer);
+          }
+          // We should not process the rest
           break;
         }
         if (device_->get_cap(DeviceCapability::spirv_has_int8)) {

--- a/taichi/backends/vulkan/runtime.cpp
+++ b/taichi/backends/vulkan/runtime.cpp
@@ -453,7 +453,7 @@ void VkRuntime::launch_kernel(KernelHandle handle, RuntimeContext *host_ctx) {
         if (arg.stride) {
           DeviceAllocation extarr_buf = device_->allocate_memory(
               {arg.stride, /*host_write=*/true, /*host_read=*/true,
-              /*export_sharing=*/false, AllocUsage::Storage});
+               /*export_sharing=*/false, AllocUsage::Storage});
           ext_arrays[i] = extarr_buf;
         } else {
           ext_arrays[i] = kDeviceNullAllocation;

--- a/taichi/backends/vulkan/runtime.h
+++ b/taichi/backends/vulkan/runtime.h
@@ -53,7 +53,8 @@ class CompiledTaichiKernel {
 
   void generate_command_list(CommandList *cmdlist,
                              DeviceAllocationGuard *ctx_buffer_host,
-                             DeviceAllocationGuard *ctx_buffer) const;
+                             DeviceAllocationGuard *ctx_buffer,
+                             const std::unordered_map<int, DeviceAllocation> &ext_arrs) const;
 
  private:
   TaichiKernelAttributes ti_kernel_attribs_;

--- a/taichi/backends/vulkan/runtime.h
+++ b/taichi/backends/vulkan/runtime.h
@@ -51,10 +51,11 @@ class CompiledTaichiKernel {
 
   size_t get_ctx_buffer_size() const;
 
-  void generate_command_list(CommandList *cmdlist,
-                             DeviceAllocationGuard *ctx_buffer_host,
-                             DeviceAllocationGuard *ctx_buffer,
-                             const std::unordered_map<int, DeviceAllocation> &ext_arrs) const;
+  void generate_command_list(
+      CommandList *cmdlist,
+      DeviceAllocationGuard *ctx_buffer_host,
+      DeviceAllocationGuard *ctx_buffer,
+      const std::unordered_map<int, DeviceAllocation> &ext_arrs) const;
 
  private:
   TaichiKernelAttributes ti_kernel_attribs_;

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -506,7 +506,8 @@ void VulkanResourceBinder::rw_buffer(uint32_t set,
                                      size_t size) {
   CHECK_SET_BINDINGS;
 
-  if (ptr == kDeviceNullPtr) return;
+  if (ptr == kDeviceNullPtr)
+    return;
 
   if (layout_locked_) {
     TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -530,7 +531,8 @@ void VulkanResourceBinder::buffer(uint32_t set,
                                   size_t size) {
   CHECK_SET_BINDINGS;
 
-  if (ptr == kDeviceNullPtr) return;
+  if (ptr == kDeviceNullPtr)
+    return;
 
   if (layout_locked_) {
     TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -506,9 +506,6 @@ void VulkanResourceBinder::rw_buffer(uint32_t set,
                                      size_t size) {
   CHECK_SET_BINDINGS;
 
-  if (ptr == kDeviceNullPtr)
-    return;
-
   if (layout_locked_) {
     TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
   } else {
@@ -530,9 +527,6 @@ void VulkanResourceBinder::buffer(uint32_t set,
                                   DevicePtr ptr,
                                   size_t size) {
   CHECK_SET_BINDINGS;
-
-  if (ptr == kDeviceNullPtr)
-    return;
 
   if (layout_locked_) {
     TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);

--- a/taichi/backends/vulkan/vulkan_device.cpp
+++ b/taichi/backends/vulkan/vulkan_device.cpp
@@ -506,6 +506,8 @@ void VulkanResourceBinder::rw_buffer(uint32_t set,
                                      size_t size) {
   CHECK_SET_BINDINGS;
 
+  if (ptr == kDeviceNullPtr) return;
+
   if (layout_locked_) {
     TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
   } else {
@@ -527,6 +529,8 @@ void VulkanResourceBinder::buffer(uint32_t set,
                                   DevicePtr ptr,
                                   size_t size) {
   CHECK_SET_BINDINGS;
+
+  if (ptr == kDeviceNullPtr) return;
 
   if (layout_locked_) {
     TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -105,12 +105,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel)
     // Then the array args
     for (int i : array_indices) {
       auto &attribs = (*vec)[i];
-      const size_t dt_bytes = data_type_size(attribs.dt);
-      bytes = (bytes + dt_bytes - 1) / dt_bytes * dt_bytes;
-      attribs.offset_in_mem = bytes;
-      bytes += attribs.stride;
-      TI_TRACE("  at={} array offset_in_mem={} stride={}", i,
-               attribs.offset_in_mem, attribs.stride);
+      TI_TRACE("  at={} array size={}", i, attribs.stride);
     }
     return bytes - offset;
   };

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -25,11 +25,12 @@ struct TaskAttributes {
     GlobalTmps,
     Context,
     ListGen,
+    ExtArr
   };
 
   struct BufferInfo {
     BufferType type;
-    int root_id{-1};  // only used if type==Root
+    int root_id{-1};  // only used if type==Root or type==ExtArr
 
     BufferInfo() = default;
 

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -20,13 +20,7 @@ namespace spirv {
  * Per offloaded task attributes.
  */
 struct TaskAttributes {
-  enum class BufferType {
-    Root,
-    GlobalTmps,
-    Context,
-    ListGen,
-    ExtArr
-  };
+  enum class BufferType { Root, GlobalTmps, Context, ListGen, ExtArr };
 
   struct BufferInfo {
     BufferType type;

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -26,6 +26,7 @@ constexpr char kRootBufferName[] = "root_buffer";
 constexpr char kGlobalTmpsBufferName[] = "global_tmps_buffer";
 constexpr char kContextBufferName[] = "context_buffer";
 constexpr char kListgenBufferName[] = "listgen_buffer";
+constexpr char kExtArrBufferName[] = "ext_arr_buffer";
 
 constexpr int kMaxNumThreadsGridStrideLoop = 65536;
 
@@ -45,6 +46,8 @@ std::string buffer_instance_name(BufferInfo b) {
       return kContextBufferName;
     case BufferType::ListGen:
       return kListgenBufferName;
+    case BufferType::ExtArr:
+      return kExtArrBufferName;
     default:
       TI_NOT_IMPLEMENTED;
       break;
@@ -567,9 +570,9 @@ class TaskCodegen : public IRVisitor {
     // device.
     TI_ASSERT(stmt->width() == 1);
     spirv::Value linear_offset = ir_->int_immediate_number(ir_->i32_type(), 0);
+    const auto *argload = stmt->base_ptrs[0]->as<ArgLoadStmt>();
+    const int arg_id = argload->arg_id;
     {
-      const auto *argload = stmt->base_ptrs[0]->as<ArgLoadStmt>();
-      const int arg_id = argload->arg_id;
       const int num_indices = stmt->indices.size();
       std::vector<std::string> size_var_names;
       const auto extra_args_mem_offset = ctx_attribs_->extra_args_mem_offset();
@@ -602,11 +605,14 @@ class TaskCodegen : public IRVisitor {
               ir_->i32_type(),
               ir_->get_primitive_type_size(argload->ret_type.ptr_removed())));
     }
-    spirv::Value val = ir_->add(
-        ir_->query_value(stmt->base_ptrs[0]->raw_name()), linear_offset);
-    ir_->register_value(stmt->raw_name(), val);
 
-    ptr_to_buffers_[stmt] = BufferType::Context;
+    ir_->register_value(stmt->raw_name(), linear_offset);
+
+    if (ctx_attribs_->args()[arg_id].is_array) {
+      ptr_to_buffers_[stmt] = {BufferType::ExtArr, arg_id}; 
+    } else {
+      ptr_to_buffers_[stmt] = BufferType::Context;
+    }
   }
 
   void visit(UnaryOpStmt *stmt) override {
@@ -1618,8 +1624,8 @@ class TaskCodegen : public IRVisitor {
     spirv::Value buffer_value = ir_->buffer_argument(
         type, 0, buffer_binding_map_[buffer], buffer_instance_name(buffer));
     buffer_value_map_[key] = buffer_value;
-    TI_TRACE("buffer name = {}, value = {}", buffer_instance_name(buffer),
-             buffer_value.id);
+    TI_TRACE("buffer name = {}, value = {}, binding = {}", buffer_instance_name(buffer), buffer_value.id,
+             buffer_binding_map_[buffer]);
 
     return buffer_value;
   }
@@ -1649,11 +1655,18 @@ class TaskCodegen : public IRVisitor {
 
     bind_buffer(BufferType::GlobalTmps);
 
+    bind_buffer(BufferType::ListGen);
+
     if (!ctx_attribs_->empty()) {
       bind_buffer(BufferType::Context);
+    
+      for (int i = 0; i < ctx_attribs_->args().size(); i++) {
+        const auto &arg = ctx_attribs_->args()[i];
+        if (arg.is_array) {
+          bind_buffer({BufferType::ExtArr, i});
+        }
+      }
     }
-
-    bind_buffer(BufferType::ListGen);
 
     return result;
   }

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -609,7 +609,7 @@ class TaskCodegen : public IRVisitor {
     ir_->register_value(stmt->raw_name(), linear_offset);
 
     if (ctx_attribs_->args()[arg_id].is_array) {
-      ptr_to_buffers_[stmt] = {BufferType::ExtArr, arg_id}; 
+      ptr_to_buffers_[stmt] = {BufferType::ExtArr, arg_id};
     } else {
       ptr_to_buffers_[stmt] = BufferType::Context;
     }
@@ -1624,7 +1624,8 @@ class TaskCodegen : public IRVisitor {
     spirv::Value buffer_value = ir_->buffer_argument(
         type, 0, buffer_binding_map_[buffer], buffer_instance_name(buffer));
     buffer_value_map_[key] = buffer_value;
-    TI_TRACE("buffer name = {}, value = {}, binding = {}", buffer_instance_name(buffer), buffer_value.id,
+    TI_TRACE("buffer name = {}, value = {}, binding = {}",
+             buffer_instance_name(buffer), buffer_value.id,
              buffer_binding_map_[buffer]);
 
     return buffer_value;
@@ -1659,7 +1660,7 @@ class TaskCodegen : public IRVisitor {
 
     if (!ctx_attribs_->empty()) {
       bind_buffer(BufferType::Context);
-    
+
       for (int i = 0; i < ctx_attribs_->args().size(); i++) {
         const auto &arg = ctx_attribs_->args()[i];
         if (arg.is_array) {

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -402,6 +402,7 @@ Value IRBuilder::struct_array_access(const SType &res_type,
   ib_.begin(spv::OpAccessChain)
       .add_seq(ptr_type, ret, buffer, const_i32_zero_, index)
       .commit(&function_);
+
   return ret;
 }
 

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -1,6 +1,12 @@
 #include <numeric>
+
 #include "taichi/program/ndarray.h"
 #include "taichi/program/program.h"
+
+#ifdef TI_WITH_LLVM
+#include "taichi/llvm/llvm_context.h"
+#include "taichi/llvm/llvm_program.h"
+#endif
 
 namespace taichi {
 namespace lang {

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -7,11 +7,6 @@
 #include "taichi/ir/type_utils.h"
 #include "taichi/backends/device.h"
 
-#ifdef TI_WITH_LLVM
-#include "taichi/llvm/llvm_context.h"
-#include "taichi/llvm/llvm_program.h"
-#endif
-
 namespace taichi {
 namespace lang {
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <optional>
 #include <atomic>
+#include <stack>
 
 #define TI_RUNTIME_HOST
 #include "taichi/ir/ir.h"


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/3642

First step towards ndarray on SPIRV backends.

Also fixed a few small things to speed up compilation a small bit.

cc: @xwang186