### PR TITLE
[refactor] Remove dependency on lang::current_ast_builder() in lang::ConstantFold

### DIFF
--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -33,7 +33,7 @@ class ConstantFold : public BasicStmtVisitor {
       return it->second.get();
 
     auto kernel_name = fmt::format("jit_evaluator_{}", cache.size());
-    auto func = [&id]() {
+    auto func = [&id, this]() {
       auto lhstmt =
           Stmt::make<ArgLoadStmt>(/*arg_id=*/0, id.lhs, /*is_ptr=*/false);
       auto rhstmt =
@@ -49,11 +49,11 @@ class ConstantFold : public BasicStmtVisitor {
         }
       }
       auto ret = Stmt::make<ReturnStmt>(oper.get());
-      current_ast_builder().insert(std::move(lhstmt));
+      program->current_ast_builder()->insert(std::move(lhstmt));
       if (id.is_binary)
-        current_ast_builder().insert(std::move(rhstmt));
-      current_ast_builder().insert(std::move(oper));
-      current_ast_builder().insert(std::move(ret));
+        program->current_ast_builder()->insert(std::move(rhstmt));
+      program->current_ast_builder()->insert(std::move(oper));
+      program->current_ast_builder()->insert(std::move(ret));
     };
 
     auto ker = std::make_unique<Kernel>(*program, func, kernel_name);


### PR DESCRIPTION
Related issue = #3955 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
