### PR TITLE
[build] Handle empty TAICHI_EMBIND_SOURCE

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -207,7 +207,9 @@ file(GLOB TAICHI_EMBIND_SOURCE
       "taichi/javascript/*.cpp"
       "taichi/javascript/*.h"
 )
-list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_EMBIND_SOURCE})
+if (TAICHI_EMBIND_SOURCE)
+  list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_EMBIND_SOURCE})
+endif()
 
 # TODO(#2196): Rename these CMAKE variables:
 # CORE_LIBRARY_NAME --> TAICHI_ISOLATED_CORE_LIB_NAME


### PR DESCRIPTION
Empty `TAICHI_EMBIND_SOURCE` works on cmake 3.22 but not 3.19 so let's
just condition on it.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
