### PR TITLE
[autodiff] Refactor the IB identification and optimize the checker for global atomics and purely nested loops

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -8,40 +8,40 @@
 #include <typeinfo>
 
 TLANG_NAMESPACE_BEGIN
-class IndependentBlocksJudger : public BasicStmtVisitor{
-   public:
-    using BasicStmtVisitor::visit;
+class IndependentBlocksJudger : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
 
-    void visit(LocalLoadStmt *stmt) override{
-      for (auto &lane : stmt->src.data) {
-        touched_allocas.insert(lane.var->as<AllocaStmt>());
+  void visit(LocalLoadStmt *stmt) override {
+    for (auto &lane : stmt->src.data) {
+      touched_allocas.insert(lane.var->as<AllocaStmt>());
+    }
+  }
+
+  void visit(LocalStoreStmt *stmt) override {
+    touched_allocas.insert(stmt->dest->as<AllocaStmt>());
+  }
+
+  void visit(AtomicOpStmt *stmt) override {
+    if (is_inside_loop)
+      return;
+    TI_ASSERT(stmt->dest->is<GlobalPtrStmt>());
+    for (const auto &node : stmt->dest->cast<GlobalPtrStmt>()->snodes.data) {
+      if (node->has_grad()) {
+        qualified_atomics = false;
+        break;
       }
     }
+  }
 
-    void visit(LocalStoreStmt *stmt) override{
-      touched_allocas.insert(stmt->dest->as<AllocaStmt>());
-    }
+  void visit(RangeForStmt *stmt) override {
+    inner_most_loop = false;
+    is_inside_loop = true;
+    stmt->body->accept(this);
+    is_inside_loop = false;
+  }
 
-    void visit(AtomicOpStmt *stmt) override{
-      if(is_inside_loop) return;
-      TI_ASSERT(stmt->dest->is<GlobalPtrStmt>());
-      for (const auto &node :
-            stmt->dest->cast<GlobalPtrStmt>()->snodes.data) {
-        if (node->has_grad()) {
-          qualified_atomics = false;
-          break;
-        }
-      }
-    }
-
-    void visit(RangeForStmt *stmt) override {
-      inner_most_loop = false;
-      is_inside_loop = true;
-      stmt->body->accept(this);
-      is_inside_loop = false;
-    }
-
-    static bool run(IRNode *root) {
+  static bool run(IRNode *root) {
     IndependentBlocksJudger Judger;
     Block *block = root->as<Block>();
     root->accept(&Judger);
@@ -59,15 +59,16 @@ class IndependentBlocksJudger : public BasicStmtVisitor{
         break;
       }
     }
-    return Judger.qualified_local && (Judger.qualified_atomics || Judger.inner_most_loop);
-   }
+    return Judger.qualified_local &&
+           (Judger.qualified_atomics || Judger.inner_most_loop);
+  }
 
-   private:
-    std::set<AllocaStmt *> touched_allocas;
-    bool qualified_local = true;
-    bool qualified_atomics = true;
-    bool inner_most_loop = true;
-    bool is_inside_loop = false;
+ private:
+  std::set<AllocaStmt *> touched_allocas;
+  bool qualified_local = true;
+  bool qualified_atomics = true;
+  bool inner_most_loop = true;
+  bool is_inside_loop = false;
 };
 
 // Do automatic differentiation pass in the reverse order (reverse-mode AD)

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -8,40 +8,40 @@
 #include <typeinfo>
 
 TLANG_NAMESPACE_BEGIN
-class IndependentBlocksJudger : public BasicStmtVisitor{
-   public:
-    using BasicStmtVisitor::visit;
+class IndependentBlocksJudger : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
 
-    void visit(LocalLoadStmt *stmt) override{
-      for (auto &lane : stmt->src.data) {
-        touched_allocas.insert(lane.var->as<AllocaStmt>());
+  void visit(LocalLoadStmt *stmt) override {
+    for (auto &lane : stmt->src.data) {
+      touched_allocas.insert(lane.var->as<AllocaStmt>());
+    }
+  }
+
+  void visit(LocalStoreStmt *stmt) override {
+    touched_allocas.insert(stmt->dest->as<AllocaStmt>());
+  }
+
+  void visit(AtomicOpStmt *stmt) override {
+    if (is_inside_loop)
+      return;
+    TI_ASSERT(stmt->dest->is<GlobalPtrStmt>());
+    for (const auto &node : stmt->dest->cast<GlobalPtrStmt>()->snodes.data) {
+      if (node->has_grad()) {
+        qualified_atomics = false;
+        break;
       }
     }
+  }
 
-    void visit(LocalStoreStmt *stmt) override{
-      touched_allocas.insert(stmt->dest->as<AllocaStmt>());
-    }
+  void visit(RangeForStmt *stmt) override {
+    inner_most_loop = false;
+    is_inside_loop = true;
+    stmt->body->accept(this);
+    is_inside_loop = false;
+  }
 
-    void visit(AtomicOpStmt *stmt) override{
-      if(is_inside_loop) return;
-      TI_ASSERT(stmt->dest->is<GlobalPtrStmt>());
-      for (const auto &node :
-            stmt->dest->cast<GlobalPtrStmt>()->snodes.data) {
-        if (node->has_grad()) {
-          qualified_atomics = false;
-          break;
-        }
-      }
-    }
-
-    void visit(RangeForStmt *stmt) override {
-      inner_most_loop = false;
-      is_inside_loop = true;
-      stmt->body->accept(this);
-      is_inside_loop = false;
-    }
-
-    static bool run(IRNode *root) {
+  static bool run(IRNode *root) {
     IndependentBlocksJudger Judger;
     Block *block = root->as<Block>();
     root->accept(&Judger);
@@ -59,16 +59,18 @@ class IndependentBlocksJudger : public BasicStmtVisitor{
         break;
       }
     }
-    std::cout << Judger.qualified_local << Judger.qualified_atomics << Judger.inner_most_loop << std::endl;
-    return Judger.qualified_local && (Judger.qualified_atomics || Judger.inner_most_loop);
-   }
+    std::cout << Judger.qualified_local << Judger.qualified_atomics
+              << Judger.inner_most_loop << std::endl;
+    return Judger.qualified_local &&
+           (Judger.qualified_atomics || Judger.inner_most_loop);
+  }
 
-   private:
-    std::set<AllocaStmt *> touched_allocas;
-    bool qualified_local = true;
-    bool qualified_atomics = true;
-    bool inner_most_loop = true;
-    bool is_inside_loop = false;
+ private:
+  std::set<AllocaStmt *> touched_allocas;
+  bool qualified_local = true;
+  bool qualified_atomics = true;
+  bool inner_most_loop = true;
+  bool is_inside_loop = false;
 };
 
 // Do automatic differentiation pass in the reverse order (reverse-mode AD)
@@ -106,7 +108,7 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
     //  - Local atomics should have been demoted before this pass.
     //  - It is OK for an IB to have more than two for loops.
     //  - No atomics operations to the global variables which require gradient
-    
+
     return IndependentBlocksJudger::run(block);
   }
 

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -91,7 +91,6 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
       }
     }
     std::set<AllocaStmt *> touched_allocas;
-    std::set<AtomicOpStmt *> touched_global_atomics;
     // TODO: remove this abuse since it *gathers nothing* but only visit
     irpass::analysis::gather_statements(block, [&](Stmt *stmt) -> bool {
       if (auto local_load = stmt->cast<LocalLoadStmt>(); local_load) {

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -14,12 +14,12 @@ class IndependentBlocksJudger : public BasicStmtVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     for (auto &lane : stmt->src.data) {
-      touched_allocas.insert(lane.var->as<AllocaStmt>());
+      touched_allocas_.insert(lane.var->as<AllocaStmt>());
     }
   }
 
   void visit(LocalStoreStmt *stmt) override {
-    touched_allocas.insert(stmt->dest->as<AllocaStmt>());
+    touched_allocas_.insert(stmt->dest->as<AllocaStmt>());
   }
 
   void visit(AtomicOpStmt *stmt) override {
@@ -51,7 +51,7 @@ class IndependentBlocksJudger : public BasicStmtVisitor {
     IndependentBlocksJudger Judger;
     Block *block = root->as<Block>();
     root->accept(&Judger);
-    for (const auto &alloca : Judger.touched_allocas) {
+    for (const auto &alloca : Judger.touched_allocas_) {
       // Test if the alloca belongs to the current block
       bool belong_to_this_block = false;
       for (auto b = alloca->parent; b; b = b->parent_block()) {
@@ -76,7 +76,7 @@ class IndependentBlocksJudger : public BasicStmtVisitor {
   }
 
  private:
-  std::set<AllocaStmt *> touched_allocas;
+  std::set<AllocaStmt *> touched_allocas_;
   bool qualified_local_ = true;
   bool qualified_atomics_ = true;
   bool inner_most_loop_ = true;

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -62,8 +62,7 @@ class IndependentBlocksJudger : public BasicStmtVisitor {
       // Test if the alloca belongs to the current block
       if (outside_blocks.find(alloca->parent) != outside_blocks.end()) {
         // This block is not an IB since it loads/modifies outside variables
-        Judger.qualified_local_ = false;
-        break;
+        return false;
       }
     }
 
@@ -72,13 +71,11 @@ class IndependentBlocksJudger : public BasicStmtVisitor {
     // enforced
     // 2. If the #1 is satisfied, either an inner most loop or a block without
     // global atomics is an IB
-    return Judger.qualified_local_ &&
-           (Judger.qualified_atomics_ || Judger.inner_most_loop_);
+    return Judger.qualified_atomics_ || Judger.inner_most_loop_;
   }
 
  private:
   std::set<AllocaStmt *> touched_allocas_;
-  bool qualified_local_ = true;
   bool qualified_atomics_ = true;
   bool inner_most_loop_ = true;
   bool is_inside_loop_ = false;

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -47,10 +47,65 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
 
     bool qualified = true;
     bool qualified_atomics = true;
+    bool inner_most = true;
+    for (auto const &stmt : block->statements) {
+      std::cout << "do we has inner for " << stmt->type() << std::endl;
+      if (auto rangefor_stmt = stmt->cast<RangeForStmt>(); rangefor_stmt) {
+        inner_most = false;
+      }
+      // atomics here must be ones applied to global variables
+      else if (auto atomics = stmt->cast<AtomicOpStmt>(); atomics) {
+        TI_ASSERT(atomics->dest->is<GlobalPtrStmt>())
+        for (const auto &node :
+             atomics->dest->cast<GlobalPtrStmt>()->snodes.data) {
+          std::cout << "i am global ptr" << std::endl;
+          if (node->has_grad()) {
+            qualified_atomics = false;
+            break;
+          } else {
+            std::cout << " but i dont need grad " << std::endl;
+          }
+        }
+      } else if (auto if_stmt = stmt->cast<IfStmt>(); if_stmt) {
+        std::vector<Block *> if_condtions_blocks;
+        std::cout << "are we here ?" << std::endl;
+        if (if_stmt->true_statements.get())
+          if_condtions_blocks.push_back(if_stmt->true_statements.get());
+        if (if_stmt->false_statements.get())
+          if_condtions_blocks.push_back(if_stmt->false_statements.get());
+        std::cout << "are we here ???" << std::endl;
+        for (auto const &cond_block : if_condtions_blocks) {
+          irpass::analysis::gather_statements(
+              cond_block, [&](Stmt *stmt_to_check) -> bool {
+                if (auto atomics = stmt_to_check->cast<AtomicOpStmt>();
+                    atomics) {
+                  std::cout << "are we here ????" << std::endl;
+                  std::cout << "stmt " << atomics->type() << std::endl;
+                  std::cout << "stmt dest " << atomics->dest->type()
+                            << std::endl;
+                  TI_ASSERT(atomics->dest->is<GlobalPtrStmt>());
+                  std::cout << "are we here ?????" << std::endl;
+                  for (const auto &node :
+                       atomics->dest->cast<GlobalPtrStmt>()->snodes.data) {
+                    std::cout << "i am global ptr" << std::endl;
+                    if (node->has_grad()) {
+                      qualified_atomics = false;
+                      break;
+                    } else {
+                      std::cout << " but i dont need grad " << std::endl;
+                    }
+                  }
+                }
+                return false;
+              });
+        }
+      }
+    }
     std::set<AllocaStmt *> touched_allocas;
     std::set<AtomicOpStmt *> touched_global_atomics;
     // TODO: remove this abuse since it *gathers nothing* but only visit
     irpass::analysis::gather_statements(block, [&](Stmt *stmt) -> bool {
+      std::cout << "my type " << stmt->type() << std::endl;
       if (auto local_load = stmt->cast<LocalLoadStmt>(); local_load) {
         for (auto &lane : local_load->src.data) {
           touched_allocas.insert(lane.var->as<AllocaStmt>());
@@ -59,16 +114,16 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
         touched_allocas.insert(local_store->dest->as<AllocaStmt>());
       }
       // atomics here must be ones applied to global variables
-      else if (auto atomics = stmt->cast<AtomicOpStmt>(); atomics) {
-        TI_ASSERT(atomics->dest->is<GlobalPtrStmt>())
-        for (const auto &node :
-             atomics->dest->cast<GlobalPtrStmt>()->snodes.data) {
-          if (node->has_grad()) {
-            touched_global_atomics.insert(atomics);
-            break;
-          }
-        }
-      }
+      // else if (auto atomics = stmt->cast<AtomicOpStmt>(); atomics) {
+      //   TI_ASSERT(atomics->dest->is<GlobalPtrStmt>())
+      //   for (const auto &node :
+      //        atomics->dest->cast<GlobalPtrStmt>()->snodes.data) {
+      //     if (node->has_grad()) {
+      //       touched_global_atomics.insert(atomics);
+      //       break;
+      //     }
+      //   }
+      // }
       return false;
     });
 
@@ -87,24 +142,28 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
       }
     }
 
-    for (const auto &atomics : touched_global_atomics) {
-      // Test if the atomics belongs to the current block
-      bool belong_to_this_block = false;
-      for (auto b = atomics->parent; b; b = b->parent_block()) {
-        if (b == block) {
-          belong_to_this_block = true;
-          break;
-        }
-      }
-      if (belong_to_this_block) {
-        // This block is not an IB since it has atomics operation to global
-        // variables
-        qualified_atomics = false;
-        break;
-      }
-    }
+    // for (const auto &atomics : touched_global_atomics) {
+    //   // Test if the atomics belongs to the current block
+    //   bool belong_to_this_block = false;
+    //   for (auto b = atomics->parent; b; b = b->parent_block()) {
+    //     if (b == block) {
+    //       belong_to_this_block = true;
+    //       break;
+    //     }
+    //   }
+    //   if (belong_to_this_block) {
+    //     // This block is not an IB since it has atomics operation to global
+    //     // variables
+    //     qualified_atomics = false;
+    //     break;
+    //   }
+    // }
 
-    return qualified && qualified_atomics;
+    // return qualified && qualified_atomics;
+    std::cout << " condition "
+              << " local " << qualified << " atomics " << qualified_atomics
+              << " inner " << inner_most << std::endl;
+    return qualified && (qualified_atomics || inner_most);
   }
 
   void visit_loop_body(Block *block) {
@@ -113,6 +172,8 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
       block->accept(this);
     } else {
       // No need to dive further
+      std::cout << block << " issss not a IB, no need to dive further "
+                << std::endl;
     }
   }
 
@@ -128,6 +189,7 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
   }
 
   void visit(RangeForStmt *stmt) override {
+    std::cout << "I catched a rangfor stmt " << stmt << std::endl;
     if (depth_ == 0) {
       current_ib_ = stmt->body.get();
     }
@@ -137,6 +199,7 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
     if (depth_ == 0) {
       independent_blocks_.push_back(current_ib_);
     }
+    std::cout << "depth " << depth_ << std::endl;
   }
 
   static std::vector<Block *> run(IRNode *root) {


### PR DESCRIPTION
Related issue = #
Refactor the IB identification, remove the abused `gather_statements`.
Optimize the IB checker for global atomics and purely nested loops to avoid stack overflow of `ad_stack`.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
