### PR TITLE
[ci] Fix windows ci

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -371,6 +371,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -371,7 +371,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
-          fetch-depth: 0
+          clean: false
 
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Fix the following persistent error in windows ci
```
Submodule path 'external/SPIRV-Reflect/third_party/googletest': checked out '3f0cf6b62ad1eb50d8736538363d3580dd640c3e'
  Error: fatal: Needed a single revision
  Error: fatal: Unable to find current revision in submodule path 'external/SPIRV-Tools'
  Error: The process 'C:\Program Files\Git\cmd\git.exe' failed with exit code 1
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
