### PR TITLE
[Refactor] Rename and move scoped profiler info under ti.profiler

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -18,7 +18,12 @@ from taichi.ui import GUI, hex_to_rgb, rgb_to_hex, ui
 from taichi import aot  # isort:skip
 from taichi._testing import *  # isort:skip
 
-__deprecated_names__ = {'SOA': 'Layout.SOA', 'AOS': 'Layout.AOS'}
+__deprecated_names__ = {
+    'SOA': 'Layout.SOA',
+    'AOS': 'Layout.AOS',
+    'print_profile_info': 'profiler.print_scoped_profiler_info',
+    'clear_profile_info': 'profiler.clear_scoped_profiler_info'
+}
 
 if sys.version_info.minor < 7:
     for name, alter in __deprecated_names__.items():

--- a/python/taichi/profiler/__init__.py
+++ b/python/taichi/profiler/__init__.py
@@ -1,3 +1,4 @@
 from taichi.profiler.kernelprofiler import \
     KernelProfiler  # import for docstring-gen
 from taichi.profiler.kernelprofiler import get_default_kernel_profiler
+from taichi.profiler.scoped_profiler import *

--- a/python/taichi/profiler/scoped_profiler.py
+++ b/python/taichi/profiler/scoped_profiler.py
@@ -1,0 +1,37 @@
+from taichi._lib import core as _ti_core
+
+
+def print_scoped_profiler_info():
+    """Print time elapsed on the host tasks in a hierarchical format.
+
+    This profiler is automatically on.
+
+    Call function imports from C++ : _ti_core.print_profile_info()
+
+    Example::
+
+            >>> import taichi as ti
+            >>> ti.init(arch=ti.cpu)
+            >>> var = ti.field(ti.f32, shape=1)
+            >>> @ti.kernel
+            >>> def compute():
+            >>>     var[0] = 1.0
+            >>>     print("Setting var[0] =", var[0])
+            >>> compute()
+            >>> ti.profiler.print_scoped_profiler_info()
+    """
+    _ti_core.print_profile_info()
+
+
+def clear_scoped_profiler_info():
+    """Clear profiler's records about time elapsed on the host tasks.
+
+    Call function imports from C++ : _ti_core.clear_profile_info()
+    """
+    _ti_core.clear_profile_info()
+
+
+__all__ = [
+    'print_scoped_profiler_info',
+    'clear_scoped_profiler_info'
+]

--- a/python/taichi/profiler/scoped_profiler.py
+++ b/python/taichi/profiler/scoped_profiler.py
@@ -31,7 +31,4 @@ def clear_scoped_profiler_info():
     _ti_core.clear_profile_info()
 
 
-__all__ = [
-    'print_scoped_profiler_info',
-    'clear_scoped_profiler_info'
-]
+__all__ = ['print_scoped_profiler_info', 'clear_scoped_profiler_info']

--- a/python/taichi/tools/__init__.py
+++ b/python/taichi/tools/__init__.py
@@ -21,6 +21,4 @@ __all__ = [
     'get_kernel_stats',
     'get_traceback',
     'set_gdb_trigger',
-    'print_profile_info',
-    'clear_profile_info',
 ]

--- a/python/taichi/tools/util.py
+++ b/python/taichi/tools/util.py
@@ -129,36 +129,6 @@ def set_gdb_trigger(on=True):
     _ti_core.set_core_trigger_gdb_when_crash(on)
 
 
-def print_profile_info():
-    """Print time elapsed on the host tasks in a hierarchical format.
-
-    This profiler is automatically on.
-
-    Call function imports from C++ : _ti_core.print_profile_info()
-
-    Example::
-
-            >>> import taichi as ti
-            >>> ti.init(arch=ti.cpu)
-            >>> var = ti.field(ti.f32, shape=1)
-            >>> @ti.kernel
-            >>> def compute():
-            >>>     var[0] = 1.0
-            >>>     print("Setting var[0] =", var[0])
-            >>> compute()
-            >>> ti.print_profile_info()
-    """
-    _ti_core.print_profile_info()
-
-
-def clear_profile_info():
-    """Clear profiler's records about time elapsed on the host tasks.
-
-    Call function imports from C++ : _ti_core.clear_profile_info()
-    """
-    _ti_core.clear_profile_info()
-
-
 def dump_dot(filepath=None, rankdir=None, embed_states_threshold=0):
     d = _ti_core.dump_dot(rankdir, embed_states_threshold)
     if filepath is not None:


### PR DESCRIPTION
Related issue = #3782

`ti.print_profile_info` -> `ti.profiler.print_scoped_profiler_info`
`ti.clear_profile_info` -> `ti.profiler.clear_scoped_profiler_info`

The old APIs are marked as deprecated for now. The docs will be updated after the next release.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
