### PR TITLE
[refactor] Add TI_DLL_EXPORT to control symbol visibility

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -418,6 +418,7 @@ if(NOT TI_EMSCRIPTENED)
     endif ()
 
     set_target_properties(${CORE_WITH_PYBIND_LIBRARY_NAME} PROPERTIES CXX_VISIBILITY_PRESET ${_TI_SYMBOL_VISIBILITY})
+    # Remove symbols from static libs: https://stackoverflow.com/a/14863432/12003165
     if (LINUX)
         target_link_options(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
     endif()

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -226,7 +226,6 @@ endif()
 set(CORE_LIBRARY_NAME taichi_isolated_core)
 add_library(${CORE_LIBRARY_NAME} OBJECT ${TAICHI_CORE_SOURCE})
 set_target_properties(${CORE_LIBRARY_NAME} PROPERTIES CXX_VISIBILITY_PRESET ${_TI_SYMBOL_VISIBILITY})
-target_link_options(${CORE_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
 
 if (APPLE)
     # Ask OS X to minic Linux dynamic linking behavior
@@ -419,7 +418,9 @@ if(NOT TI_EMSCRIPTENED)
     endif ()
 
     set_target_properties(${CORE_WITH_PYBIND_LIBRARY_NAME} PROPERTIES CXX_VISIBILITY_PRESET ${_TI_SYMBOL_VISIBILITY})
-    target_link_options(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
+    if (LINUX)
+        target_link_options(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
+    endif()
     # It is actually possible to link with an OBJECT library
     # https://cmake.org/cmake/help/v3.13/command/target_link_libraries.html?highlight=target_link_libraries#linking-object-libraries
     target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC ${CORE_LIBRARY_NAME})

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -8,6 +8,7 @@ option(TI_WITH_CC "Build with the C backend" ON)
 option(TI_WITH_VULKAN "Build with the Vulkan backend" OFF)
 option(TI_WITH_DX11 "Build with the DX11 backend" OFF)
 option(TI_EMSCRIPTENED "Build using emscripten" OFF)
+set(_TI_SYMBOL_VISIBILITY default)
 
 if(TI_EMSCRIPTENED)
     set(TI_WITH_LLVM OFF)
@@ -224,6 +225,8 @@ endif()
 # everywhere in python.
 set(CORE_LIBRARY_NAME taichi_isolated_core)
 add_library(${CORE_LIBRARY_NAME} OBJECT ${TAICHI_CORE_SOURCE})
+set_target_properties(${CORE_LIBRARY_NAME} PROPERTIES CXX_VISIBILITY_PRESET ${_TI_SYMBOL_VISIBILITY})
+target_link_options(${CORE_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
 
 if (APPLE)
     # Ask OS X to minic Linux dynamic linking behavior
@@ -414,6 +417,9 @@ if(NOT TI_EMSCRIPTENED)
     else()
         add_library(${CORE_WITH_PYBIND_LIBRARY_NAME} SHARED)
     endif ()
+
+    set_target_properties(${CORE_WITH_PYBIND_LIBRARY_NAME} PROPERTIES CXX_VISIBILITY_PRESET ${_TI_SYMBOL_VISIBILITY})
+    target_link_options(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
     # It is actually possible to link with an OBJECT library
     # https://cmake.org/cmake/help/v3.13/command/target_link_libraries.html?highlight=target_link_libraries#linking-object-libraries
     target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC ${CORE_LIBRARY_NAME})

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -388,10 +388,12 @@ if (NOT WIN32)
         # Linux
         target_link_libraries(${CORE_LIBRARY_NAME} stdc++fs X11)
         target_link_libraries(${CORE_LIBRARY_NAME} -static-libgcc -static-libstdc++)
-        if (NOT TI_EXPORT_CORE) # expose api for CHI IR Builder
+        if ((NOT TI_EXPORT_CORE) AND (NOT ${_TI_SYMBOL_VISIBILITY} STREQUAL hidden)) # expose api for CHI IR Builder
+            message(WARNING "Using linker.map to hide symbols!")
             target_link_libraries(${CORE_LIBRARY_NAME} -Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/misc/linker.map)
         endif ()
-        target_link_libraries(${CORE_LIBRARY_NAME} -Wl,--wrap=log2f) # Avoid glibc dependencies
+        # Avoid glibc dependencies
+        target_link_libraries(${CORE_LIBRARY_NAME} -Wl,--wrap=log2f)
     endif()
 else()
     # windows

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -90,10 +90,18 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
 #include "taichi/platform/windows/windows.h"
 #pragma warning(pop)
 #include <intrin.h>
-#define TI_EXPORT __declspec(dllexport)
+#endif  // _WIN64
+
+// https://gcc.gnu.org/wiki/Visibility
+#if defined _WIN32 || defined _WIN64 || defined __CYGWIN__
+#ifdef __GNUC__
+#define TI_DLL_EXPORT __attribute__((dllexport))
 #else
-#define TI_EXPORT
-#endif
+#define TI_DLL_EXPORT __declspec(dllexport)
+#endif  //  __GNUC__
+#else
+#define TI_DLL_EXPORT __attribute__((visibility("default")))
+#endif  // defined _WIN32 || defined _WIN64 || defined __CYGWIN__
 
 #ifndef _WIN64
 #define sscanf_s sscanf
@@ -125,7 +133,7 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
   }                         \
   }
 
-TI_EXPORT void taichi_raise_assertion_failure_in_python(const char *msg);
+void taichi_raise_assertion_failure_in_python(const char *msg);
 
 TI_NAMESPACE_BEGIN
 
@@ -219,8 +227,6 @@ float64 constexpr operator"" _fd(long double v) {
 float64 constexpr operator"" _fd(unsigned long long v) {
   return float64(v);
 }
-
-TI_EXPORT void print_traceback();
 
 TI_NAMESPACE_END
 //******************************************************************************

--- a/taichi/common/interface.h
+++ b/taichi/common/interface.h
@@ -17,40 +17,38 @@
 TI_NAMESPACE_BEGIN
 
 template <typename T>
-TI_EXPORT std::shared_ptr<T> create_instance(const std::string &alias);
+std::shared_ptr<T> create_instance(const std::string &alias);
 
 template <typename T>
-TI_EXPORT std::shared_ptr<T> create_instance(const std::string &alias,
-                                             const Config &config);
+std::shared_ptr<T> create_instance(const std::string &alias,
+                                   const Config &config);
 
 template <typename T>
-TI_EXPORT std::unique_ptr<T> create_instance_unique(const std::string &alias);
+std::unique_ptr<T> create_instance_unique(const std::string &alias);
 
 template <typename T>
-TI_EXPORT std::unique_ptr<T> create_instance_unique(const std::string &alias,
-                                                    const Config &config);
+std::unique_ptr<T> create_instance_unique(const std::string &alias,
+                                          const Config &config);
 template <typename T>
-TI_EXPORT std::unique_ptr<T> create_instance_unique_ctor(
-    const std::string &alias,
-    const Config &config);
+std::unique_ptr<T> create_instance_unique_ctor(const std::string &alias,
+                                               const Config &config);
 
 template <typename T>
-TI_EXPORT T *create_instance_raw(const std::string &alias);
+T *create_instance_raw(const std::string &alias);
 
 template <typename T>
-TI_EXPORT T *create_instance_raw(const std::string &alias,
-                                 const Config &config);
+T *create_instance_raw(const std::string &alias, const Config &config);
 
 template <typename T>
-TI_EXPORT T *create_instance_placement(const std::string &alias, void *place);
+T *create_instance_placement(const std::string &alias, void *place);
 
 template <typename T>
-TI_EXPORT T *create_instance_placement(const std::string &alias,
-                                       void *place,
-                                       const Config &config);
+T *create_instance_placement(const std::string &alias,
+                             void *place,
+                             const Config &config);
 
 template <typename T>
-TI_EXPORT std::vector<std::string> get_implementation_names();
+std::vector<std::string> get_implementation_names();
 
 class Unit {
  public:
@@ -237,77 +235,76 @@ class InterfaceHolder {
   };                                                                         \
   extern TI_IMPLEMENTATION_HOLDER_NAME(T) * TI_IMPLEMENTATION_HOLDER_PTR(T);
 
-#define TI_INTERFACE_DEF(class_name, base_alias)                              \
-  template <>                                                                 \
-  TI_EXPORT std::shared_ptr<class_name> create_instance(                      \
-      const std::string &alias) {                                             \
-    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()->create( \
-        alias);                                                               \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT std::shared_ptr<class_name> create_instance(                      \
-      const std::string &alias, const Config &config) {                       \
-    auto instance = create_instance<class_name>(alias);                       \
-    instance->initialize(config);                                             \
-    return instance;                                                          \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT std::unique_ptr<class_name> create_instance_unique(               \
-      const std::string &alias) {                                             \
-    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()          \
-        ->create_unique(alias);                                               \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT std::unique_ptr<class_name> create_instance_unique(               \
-      const std::string &alias, const Config &config) {                       \
-    auto instance = create_instance_unique<class_name>(alias);                \
-    instance->initialize(config);                                             \
-    return instance;                                                          \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT std::unique_ptr<class_name> create_instance_unique_ctor(          \
-      const std::string &alias, const Dict &config) {                         \
-    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()          \
-        ->create_unique_ctor(alias, config);                                  \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT class_name *create_instance_raw(const std::string &alias) {       \
-    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()          \
-        ->create_raw(alias);                                                  \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT class_name *create_instance_placement(const std::string &alias,   \
-                                                  void *place) {              \
-    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()          \
-        ->create_placement(alias, place);                                     \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT class_name *create_instance_placement(                            \
-      const std::string &alias, void *place, const Config &config) {          \
-    auto instance = create_instance_placement<class_name>(alias, place);      \
-    instance->initialize(config);                                             \
-    return instance;                                                          \
-  }                                                                           \
-  template <>                                                                 \
-  TI_EXPORT class_name *create_instance_raw(const std::string &alias,         \
-                                            const Config &config) {           \
-    auto instance = create_instance_raw<class_name>(alias);                   \
-    instance->initialize(config);                                             \
-    return instance;                                                          \
-  }                                                                           \
-  template <>                                                                 \
-  std::vector<std::string> get_implementation_names<class_name>() {           \
-    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()          \
-        ->get_implementation_names();                                         \
-  }                                                                           \
-  TI_IMPLEMENTATION_HOLDER_NAME(class_name) *                                 \
-      TI_IMPLEMENTATION_HOLDER_PTR(class_name) = nullptr;                     \
-  void *get_implementation_holder_instance_##class_name() {                   \
-    if (!TI_IMPLEMENTATION_HOLDER_PTR(class_name)) {                          \
-      TI_IMPLEMENTATION_HOLDER_PTR(class_name) =                              \
-          new TI_IMPLEMENTATION_HOLDER_NAME(class_name)(base_alias);          \
-    }                                                                         \
-    return TI_IMPLEMENTATION_HOLDER_PTR(class_name);                          \
+#define TI_INTERFACE_DEF(class_name, base_alias)                               \
+  template <>                                                                  \
+  std::shared_ptr<class_name> create_instance(const std::string &alias) {      \
+    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()->create(  \
+        alias);                                                                \
+  }                                                                            \
+  template <>                                                                  \
+  std::shared_ptr<class_name> create_instance(const std::string &alias,        \
+                                              const Config &config) {          \
+    auto instance = create_instance<class_name>(alias);                        \
+    instance->initialize(config);                                              \
+    return instance;                                                           \
+  }                                                                            \
+  template <>                                                                  \
+  std::unique_ptr<class_name> create_instance_unique(                          \
+      const std::string &alias) {                                              \
+    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()           \
+        ->create_unique(alias);                                                \
+  }                                                                            \
+  template <>                                                                  \
+  std::unique_ptr<class_name> create_instance_unique(const std::string &alias, \
+                                                     const Config &config) {   \
+    auto instance = create_instance_unique<class_name>(alias);                 \
+    instance->initialize(config);                                              \
+    return instance;                                                           \
+  }                                                                            \
+  template <>                                                                  \
+  std::unique_ptr<class_name> create_instance_unique_ctor(                     \
+      const std::string &alias, const Dict &config) {                          \
+    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()           \
+        ->create_unique_ctor(alias, config);                                   \
+  }                                                                            \
+  template <>                                                                  \
+  class_name *create_instance_raw(const std::string &alias) {                  \
+    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()           \
+        ->create_raw(alias);                                                   \
+  }                                                                            \
+  template <>                                                                  \
+  class_name *create_instance_placement(const std::string &alias,              \
+                                        void *place) {                         \
+    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()           \
+        ->create_placement(alias, place);                                      \
+  }                                                                            \
+  template <>                                                                  \
+  class_name *create_instance_placement(const std::string &alias, void *place, \
+                                        const Config &config) {                \
+    auto instance = create_instance_placement<class_name>(alias, place);       \
+    instance->initialize(config);                                              \
+    return instance;                                                           \
+  }                                                                            \
+  template <>                                                                  \
+  class_name *create_instance_raw(const std::string &alias,                    \
+                                  const Config &config) {                      \
+    auto instance = create_instance_raw<class_name>(alias);                    \
+    instance->initialize(config);                                              \
+    return instance;                                                           \
+  }                                                                            \
+  template <>                                                                  \
+  std::vector<std::string> get_implementation_names<class_name>() {            \
+    return TI_IMPLEMENTATION_HOLDER_NAME(class_name)::get_instance()           \
+        ->get_implementation_names();                                          \
+  }                                                                            \
+  TI_IMPLEMENTATION_HOLDER_NAME(class_name) *                                  \
+      TI_IMPLEMENTATION_HOLDER_PTR(class_name) = nullptr;                      \
+  void *get_implementation_holder_instance_##class_name() {                    \
+    if (!TI_IMPLEMENTATION_HOLDER_PTR(class_name)) {                           \
+      TI_IMPLEMENTATION_HOLDER_PTR(class_name) =                               \
+          new TI_IMPLEMENTATION_HOLDER_NAME(class_name)(base_alias);           \
+    }                                                                          \
+    return TI_IMPLEMENTATION_HOLDER_PTR(class_name);                           \
   }
 
 #define TI_IMPLEMENTATION(base_class_name, class_name, alias)        \

--- a/taichi/common/serialization.h
+++ b/taichi/common/serialization.h
@@ -24,14 +24,13 @@ TI_NAMESPACE_BEGIN
 #else
 #define TI_NAMESPACE_BEGIN
 #define TI_NAMESPACE_END
-#define TI_EXPORT
 #define TI_TRACE
 #define TI_CRITICAL
 #define TI_ASSERT assert
 #endif
 
 template <typename T>
-TI_EXPORT std::unique_ptr<T> create_instance_unique(const std::string &alias);
+std::unique_ptr<T> create_instance_unique(const std::string &alias);
 
 ////////////////////////////////////////////////////////////////////////////////
 //                   A Minimalist Serializer for Taichi                       //

--- a/taichi/program/callable.cpp
+++ b/taichi/program/callable.cpp
@@ -4,6 +4,10 @@
 namespace taichi {
 namespace lang {
 
+Callable::Callable() = default;
+
+Callable::~Callable() = default;
+
 int Callable::insert_arg(const DataType &dt, bool is_array) {
   args.emplace_back(dt->get_compute_type(), is_array);
   return (int)args.size() - 1;

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -9,7 +9,7 @@ class Program;
 class IRNode;
 class FrontendContext;
 
-class Callable {
+class TI_DLL_EXPORT Callable {
  public:
   Program *program{nullptr};
   std::unique_ptr<IRNode> ir{nullptr};
@@ -46,7 +46,8 @@ class Callable {
   std::vector<Arg> args;
   std::vector<Ret> rets;
 
-  virtual ~Callable() = default;
+  Callable();
+  virtual ~Callable();
 
   int insert_arg(const DataType &dt, bool is_array);
 

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -9,11 +9,11 @@ class Program;
 class IRNode;
 class FrontendContext;
 
-class TI_DLL_EXPORT Callable {
+class Callable {
  public:
-  Program *program;
-  std::unique_ptr<IRNode> ir;
-  std::unique_ptr<FrontendContext> context;
+  Program *program{nullptr};
+  std::unique_ptr<IRNode> ir{nullptr};
+  std::unique_ptr<FrontendContext> context{nullptr};
 
   struct Arg {
     DataType dt;

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -9,7 +9,7 @@ class Program;
 class IRNode;
 class FrontendContext;
 
-class Callable {
+class TI_DLL_EXPORT Callable {
  public:
   Program *program;
   std::unique_ptr<IRNode> ir;

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -11,7 +11,7 @@ TLANG_NAMESPACE_BEGIN
 
 class Program;
 
-class Kernel : public Callable {
+class TI_DLL_EXPORT Kernel : public Callable {
  public:
   std::string name;
   std::vector<SNode *> no_activate;

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -98,7 +98,7 @@ class AsyncEngine;
  * LlvmProgramImpl, MetalProgramImpl..
  */
 
-class Program {
+class TI_DLL_EXPORT Program {
  public:
   using Kernel = taichi::lang::Kernel;
   Callable *current_callable{nullptr};

--- a/taichi/python/exception.cpp
+++ b/taichi/python/exception.cpp
@@ -13,6 +13,6 @@ void raise_assertion_failure_in_python(const std::string &msg) {
 
 TI_NAMESPACE_END
 
-TI_EXPORT void taichi_raise_assertion_failure_in_python(const char *msg) {
+void taichi_raise_assertion_failure_in_python(const char *msg) {
   taichi::raise_assertion_failure_in_python(std::string(msg));
 }

--- a/taichi/system/traceback.cpp
+++ b/taichi/system/traceback.cpp
@@ -197,7 +197,7 @@ inline std::vector<StackFrame> stack_trace() {
 
 TI_NAMESPACE_BEGIN
 
-TI_EXPORT void print_traceback() {
+void print_traceback() {
 #ifdef __APPLE__
   static std::mutex traceback_printer_mutex;
   // Modified based on

--- a/taichi/system/traceback.h
+++ b/taichi/system/traceback.h
@@ -2,6 +2,6 @@
 
 namespace taichi {
 
-TI_EXPORT void print_traceback();
+void print_traceback();
 
 }  // namespace taichi


### PR DESCRIPTION
Related issue = #4097

* Renaming `TI_EXPORT` to `TI_DLL_EXPORT` to make its semantics more obvious.
* Changed cmake files so that it is configurable to use `default` or `hidden` symbol visibility.
* Exported `Program`, `Kernel` and `Callable` as a start.

@ghuau-innopeak @xwang186: Note that this PR still uses the `default` visibility. Once this is merged, could you folks help flip to `hidden`, and see if it still works on Android :-)?

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
