### PR TITLE
[Lang] [ir] Add general operation abstraction and remove InternalFuncCallExpression

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -895,7 +895,14 @@ def default_cfg():
 
 def call_internal(name, *args):
     return expr_init(
-        _ti_core.insert_internal_func_call(name, make_expr_group(args)))
+        _ti_core.call_op(getattr(_ti_core.Operation, name),
+                         make_expr_group(args)))
+
+
+def call_test_internal(name, *args):
+    return expr_init(
+        _ti_core.call_op(getattr(_ti_core.TestOperation, name),
+                         make_expr_group(args)))
 
 
 @taichi_scope

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -2,6 +2,7 @@
 
 #include "taichi/ir/frontend_ir.h"
 #include "taichi/ir/ir.h"
+#include "taichi/ir/operation_impl.h"
 #include "taichi/program/program.h"
 
 TLANG_NAMESPACE_BEGIN
@@ -38,24 +39,23 @@ void Expr::type_check() {
 }
 
 Expr select(const Expr &cond, const Expr &true_val, const Expr &false_val) {
-  return Expr::make<TernaryOpExpression>(TernaryOpType::select, cond, true_val,
-                                         false_val);
+  return InternalOps::get().select->call(cond, true_val, false_val);
 }
 
 Expr operator-(const Expr &expr) {
-  return Expr::make<UnaryOpExpression>(UnaryOpType::neg, expr);
+  return InternalOps::get().neg->call(expr);
 }
 
 Expr operator~(const Expr &expr) {
-  return Expr::make<UnaryOpExpression>(UnaryOpType::bit_not, expr);
+  return InternalOps::get().bit_not->call(expr);
 }
 
 Expr cast(const Expr &input, DataType dt) {
-  return Expr::make<UnaryOpExpression>(UnaryOpType::cast_value, input, dt);
+  return Expr::make<CastExpression>(UnaryOpType::cast_value, input, dt);
 }
 
 Expr bit_cast(const Expr &input, DataType dt) {
-  return Expr::make<UnaryOpExpression>(UnaryOpType::cast_bits, input, dt);
+  return Expr::make<CastExpression>(UnaryOpType::cast_bits, input, dt);
 }
 
 Expr Expr::operator[](const ExprGroup &indices) const {
@@ -82,7 +82,7 @@ SNode *Expr::snode() const {
 }
 
 Expr Expr::operator!() {
-  return Expr::make<UnaryOpExpression>(UnaryOpType::logic_not, expr);
+  return InternalOps::get().logic_not->call(expr);
 }
 
 void Expr::declare(DataType dt) {

--- a/taichi/ir/expression_ops.cpp
+++ b/taichi/ir/expression_ops.cpp
@@ -1,7 +1,9 @@
-#include "taichi/ir/frontend.h"
+#include "taichi/ir/operation_impl.h"
+#include "taichi/ir/frontend_ir.h"
 
 namespace taichi {
 namespace lang {
+
 #define TI_EXPRESSION_IMPLEMENTATION
 #include "taichi/ir/expression_ops.h"
 

--- a/taichi/ir/expression_ops.h
+++ b/taichi/ir/expression_ops.h
@@ -2,77 +2,93 @@
 
 #if defined(TI_EXPRESSION_IMPLEMENTATION)
 
-#undef DEFINE_EXPRESSION_OP_BINARY
 #undef DEFINE_EXPRESSION_OP_UNARY
-#undef DEFINE_EXPRESSION_FUNC
+#undef DEFINE_EXPRESSION_OP_BINARY
+#undef DEFINE_EXPRESSION_FUNC_UNARY
+#undef DEFINE_EXPRESSION_FUNC_BINARY
+#undef DEFINE_EXPRESSION_FUNC_TERNARY
 
-#define DEFINE_EXPRESSION_OP_UNARY(opname)                           \
-  Expr opname(const Expr &expr) {                                    \
-    return Expr::make<UnaryOpExpression>(UnaryOpType::opname, expr); \
-  }                                                                  \
-  Expr expr_##opname(const Expr &expr) {                             \
-    return opname(expr);                                             \
+#define DEFINE_EXPRESSION_OP_UNARY(op, opname)                   \
+  Expr expr_##opname(const Expr &expr) {                         \
+    return Expr::make<CallExpression>(InternalOps::get().opname, \
+                                      std::vector<Expr>{expr});  \
+  }                                                              \
+  Expr operator op(const Expr &expr) {                           \
+    return expr_##opname(expr);                                  \
   }
 
-#define DEFINE_EXPRESSION_OP_BINARY(op, opname)                            \
-  Expr operator op(const Expr &lhs, const Expr &rhs) {                     \
-    return Expr::make<BinaryOpExpression>(BinaryOpType::opname, lhs, rhs); \
-  }                                                                        \
-  Expr expr_##opname(const Expr &lhs, const Expr &rhs) {                   \
-    return lhs op rhs;                                                     \
+#define DEFINE_EXPRESSION_FUNC_UNARY(opname)                     \
+  Expr expr_##opname(const Expr &expr) {                         \
+    return Expr::make<CallExpression>(InternalOps::get().opname, \
+                                      std::vector<Expr>{expr});  \
+  }                                                              \
+  Expr opname(const Expr &expr) {                                \
+    return expr_##opname(expr);                                  \
   }
 
-#define DEFINE_EXPRESSION_OP_TERNARY(opname)                                 \
-  Expr expr_##opname(const Expr &cond, const Expr &lhs, const Expr &rhs) {   \
-    return Expr::make<TernaryOpExpression>(TernaryOpType::opname, cond, lhs, \
-                                           rhs);                             \
+#define DEFINE_EXPRESSION_OP_BINARY(op, opname)                     \
+  Expr expr_##opname(const Expr &lhs, const Expr &rhs) {            \
+    return Expr::make<CallExpression>(InternalOps::get().opname,    \
+                                      std::vector<Expr>{lhs, rhs}); \
+  }                                                                 \
+  Expr operator op(const Expr &lhs, const Expr &rhs) {              \
+    return expr_##opname(lhs, rhs);                                 \
   }
 
-#define DEFINE_EXPRESSION_FUNC(opname)                                     \
-  Expr opname(const Expr &lhs, const Expr &rhs) {                          \
-    return Expr::make<BinaryOpExpression>(BinaryOpType::opname, lhs, rhs); \
-  }                                                                        \
-  Expr expr_##opname(const Expr &lhs, const Expr &rhs) {                   \
-    return opname(lhs, rhs);                                               \
+#define DEFINE_EXPRESSION_FUNC_TERNARY(opname)                             \
+  Expr expr_##opname(const Expr &cond, const Expr &lhs, const Expr &rhs) { \
+    return Expr::make<CallExpression>(InternalOps::get().opname,           \
+                                      std::vector<Expr>{cond, lhs, rhs});  \
+  }
+
+#define DEFINE_EXPRESSION_FUNC_BINARY(opname)                       \
+  Expr expr_##opname(const Expr &lhs, const Expr &rhs) {            \
+    return Expr::make<CallExpression>(InternalOps::get().opname,    \
+                                      std::vector<Expr>{lhs, rhs}); \
+  }                                                                 \
+  Expr opname(const Expr &lhs, const Expr &rhs) {                   \
+    return expr_##opname(lhs, rhs);                                 \
   }
 
 #else
+
+#define DEFINE_EXPRESSION_OP_UNARY(op, opname) \
+  Expr operator op(const Expr &expr);          \
+  Expr expr_##opname(const Expr &expr);
 
 #define DEFINE_EXPRESSION_OP_BINARY(op, opname)       \
   Expr operator op(const Expr &lhs, const Expr &rhs); \
   Expr expr_##opname(const Expr &lhs, const Expr &rhs);
 
-#define DEFINE_EXPRESSION_OP_TERNARY(opname) \
+#define DEFINE_EXPRESSION_FUNC_TERNARY(opname) \
   Expr expr_##opname(const Expr &cond, const Expr &lhs, const Expr &rhs);
 
-#define DEFINE_EXPRESSION_OP_UNARY(opname) \
-  Expr opname(const Expr &expr);           \
+#define DEFINE_EXPRESSION_FUNC_UNARY(opname) \
+  Expr opname(const Expr &expr);             \
   Expr expr_##opname(const Expr &expr);
 
-#define DEFINE_EXPRESSION_FUNC(opname)           \
+#define DEFINE_EXPRESSION_FUNC_BINARY(opname)    \
   Expr opname(const Expr &lhs, const Expr &rhs); \
   Expr expr_##opname(const Expr &lhs, const Expr &rhs);
 
 #endif
 
-DEFINE_EXPRESSION_OP_UNARY(sqrt)
-DEFINE_EXPRESSION_OP_UNARY(round)
-DEFINE_EXPRESSION_OP_UNARY(floor)
-DEFINE_EXPRESSION_OP_UNARY(ceil)
-DEFINE_EXPRESSION_OP_UNARY(abs)
-DEFINE_EXPRESSION_OP_UNARY(sin)
-DEFINE_EXPRESSION_OP_UNARY(asin)
-DEFINE_EXPRESSION_OP_UNARY(cos)
-DEFINE_EXPRESSION_OP_UNARY(acos)
-DEFINE_EXPRESSION_OP_UNARY(tan)
-DEFINE_EXPRESSION_OP_UNARY(tanh)
-DEFINE_EXPRESSION_OP_UNARY(inv)
-DEFINE_EXPRESSION_OP_UNARY(rcp)
-DEFINE_EXPRESSION_OP_UNARY(rsqrt)
-DEFINE_EXPRESSION_OP_UNARY(exp)
-DEFINE_EXPRESSION_OP_UNARY(log)
-DEFINE_EXPRESSION_OP_UNARY(bit_not)
-DEFINE_EXPRESSION_OP_UNARY(logic_not)
+DEFINE_EXPRESSION_FUNC_UNARY(sqrt)
+DEFINE_EXPRESSION_FUNC_UNARY(round)
+DEFINE_EXPRESSION_FUNC_UNARY(floor)
+DEFINE_EXPRESSION_FUNC_UNARY(ceil)
+DEFINE_EXPRESSION_FUNC_UNARY(abs)
+DEFINE_EXPRESSION_FUNC_UNARY(sin)
+DEFINE_EXPRESSION_FUNC_UNARY(asin)
+DEFINE_EXPRESSION_FUNC_UNARY(cos)
+DEFINE_EXPRESSION_FUNC_UNARY(acos)
+DEFINE_EXPRESSION_FUNC_UNARY(tan)
+DEFINE_EXPRESSION_FUNC_UNARY(tanh)
+DEFINE_EXPRESSION_FUNC_UNARY(rsqrt)
+DEFINE_EXPRESSION_FUNC_UNARY(exp)
+DEFINE_EXPRESSION_FUNC_UNARY(log)
+DEFINE_EXPRESSION_FUNC_UNARY(bit_not)
+DEFINE_EXPRESSION_FUNC_UNARY(logic_not)
 
 DEFINE_EXPRESSION_OP_BINARY(+, add)
 DEFINE_EXPRESSION_OP_BINARY(-, sub)
@@ -93,17 +109,17 @@ DEFINE_EXPRESSION_OP_BINARY(>=, cmp_ge)
 DEFINE_EXPRESSION_OP_BINARY(==, cmp_eq)
 DEFINE_EXPRESSION_OP_BINARY(!=, cmp_ne)
 
-DEFINE_EXPRESSION_OP_TERNARY(select)
+DEFINE_EXPRESSION_FUNC_TERNARY(select)
 
-DEFINE_EXPRESSION_FUNC(min);
-DEFINE_EXPRESSION_FUNC(max);
-DEFINE_EXPRESSION_FUNC(atan2);
-DEFINE_EXPRESSION_FUNC(pow);
-DEFINE_EXPRESSION_FUNC(truediv);
-DEFINE_EXPRESSION_FUNC(floordiv);
-DEFINE_EXPRESSION_FUNC(bit_shr)
+DEFINE_EXPRESSION_FUNC_BINARY(min)
+DEFINE_EXPRESSION_FUNC_BINARY(max)
+DEFINE_EXPRESSION_FUNC_BINARY(atan2)
+DEFINE_EXPRESSION_FUNC_BINARY(pow)
+DEFINE_EXPRESSION_FUNC_BINARY(truediv)
+DEFINE_EXPRESSION_FUNC_BINARY(floordiv)
+DEFINE_EXPRESSION_FUNC_BINARY(bit_shr)
 
-#undef DEFINE_EXPRESSION_OP_UNARY
+#undef DEFINE_EXPRESSION_FUNC_UNARY
 #undef DEFINE_EXPRESSION_OP_BINARY
-#undef DEFINE_EXPRESSION_OP_TERNARY
-#undef DEFINE_EXPRESSION_FUNC
+#undef DEFINE_EXPRESSION_FUNC_TERNARY
+#undef DEFINE_EXPRESSION_FUNC_BINARY

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -114,6 +114,14 @@ FrontendForStmt::FrontendForStmt(const Expr &loop_var,
   loop_var.expr->ret_type = PrimitiveType::i32;
 }
 
+void CallExpression::type_check() {
+  ret_type = operation->check(args);
+}
+
+void CallExpression::flatten(FlattenContext *ctx) {
+  stmt = operation->lower(ctx, args);
+}
+
 void ArgLoadExpression::type_check() {
   TI_ASSERT_INFO(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
                  "Invalid dt [{}] for ArgLoadExpression", dt->to_string());
@@ -250,25 +258,6 @@ void TernaryOpExpression::flatten(FlattenContext *ctx) {
   flatten_rvalue(op3, ctx);
   ctx->push_back(
       std::make_unique<TernaryOpStmt>(type, op1->stmt, op2->stmt, op3->stmt));
-  stmt = ctx->back_stmt();
-}
-
-void InternalFuncCallExpression::type_check() {
-  for (auto &arg : args) {
-    TI_ASSERT_TYPE_CHECKED(arg);
-    // no arg type compatibility check for now due to lack of specification
-  }
-  // internal func calls have default return type
-  ret_type = PrimitiveType::i32;
-}
-
-void InternalFuncCallExpression::flatten(FlattenContext *ctx) {
-  std::vector<Stmt *> args_stmts(args.size());
-  for (int i = 0; i < (int)args.size(); ++i) {
-    flatten_rvalue(args[i], ctx);
-    args_stmts[i] = args[i]->stmt;
-  }
-  ctx->push_back<InternalFuncStmt>(func_name, args_stmts);
   stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/operation.cpp
+++ b/taichi/ir/operation.cpp
@@ -1,0 +1,257 @@
+#include "taichi/ir/operation.h"
+
+namespace taichi {
+namespace lang {
+
+DataTypeExpression::DataTypeExpression(DataType ty) : type(ty) {
+}
+
+void DataTypeExpression::unify(Solutions &solutions, DataType ty) const {
+  TI_ASSERT(type == ty);
+}
+
+DataType DataTypeExpression::resolve(const Solutions &solutions) const {
+  return type;
+}
+
+std::string DataTypeExpression::to_string() const {
+  return type.to_string();
+}
+
+TyvarTypeExpression::TyvarTypeExpression(const Identifier &id) : id(id) {
+}
+
+void TyvarTypeExpression::unify(Solutions &solutions, DataType ty) const {
+  if (solutions.find(id) == solutions.end()) {
+    solutions[id] = ty;
+  } else {
+    DataTypeExpression(solutions[id]).unify(solutions, ty);
+  }
+}
+
+DataType TyvarTypeExpression::resolve(const Solutions &solutions) const {
+  if (solutions.find(id) == solutions.end()) {
+    TI_ERROR("Cannot determine type variable {}", id.name());
+  } else {
+    return solutions.at(id);
+  }
+}
+
+std::string TyvarTypeExpression::to_string() const {
+  return id.name();
+}
+
+CommonTypeExpression::CommonTypeExpression(TypeExpr lhs, TypeExpr rhs)
+    : lhs(lhs), rhs(rhs) {
+}
+
+void CommonTypeExpression::unify(Solutions &solutions, DataType ty) const {
+  TI_ASSERT(resolve(solutions) == ty);
+}
+
+DataType CommonTypeExpression::resolve(const Solutions &solutions) const {
+  DataType l = lhs->resolve(solutions), r = rhs->resolve(solutions);
+  return promoted_type(l->get_compute_type(), r->get_compute_type());
+}
+
+std::string CommonTypeExpression::to_string() const {
+  return fmt::format("{} | {}", lhs->to_string(), rhs->to_string());
+}
+
+std::shared_ptr<DataTypeExpression> TypeSpec::dt(DataType dt) {
+  std::cerr << (dt == DataType(nullptr));
+  return std::make_shared<DataTypeExpression>(dt);
+}
+
+Tyvar TypeSpec::var(const Identifier &id) {
+  return std::make_shared<TyvarTypeExpression>(id);
+}
+
+Tyvar TypeSpec::var(const std::string &name) {
+  return std::make_shared<TyvarTypeExpression>(Identifier(name));
+}
+
+std::shared_ptr<CommonTypeExpression> TypeSpec::lub(TypeExpr lhs,
+                                                    TypeExpr rhs) {
+  return std::make_shared<CommonTypeExpression>(lhs, rhs);
+}
+
+DynamicTrait::DynamicTrait(const std::string &description,
+                           const std::function<TraitPred> &func)
+    : description_(description), func_(func) {
+}
+
+std::string DynamicTrait::describe() const {
+  return description_;
+}
+
+bool DynamicTrait::has_type(DataType ty) const {
+  return func_(ty);
+}
+
+std::vector<Stmt *> get_all_stmts(const std::vector<Expr> &exprs) {
+  std::vector<Stmt *> stmts;
+  stmts.reserve(exprs.size());
+  for (auto &expr : exprs) {
+    stmts.push_back(expr->stmt);
+  }
+  return stmts;
+}
+
+Operation::Constraint::Constraint(Tyvar tyvar) : tyvar(tyvar) {
+}
+Operation::Constraint::Constraint(Tyvar tyvar, Trait *trait)
+    : tyvar(tyvar), traits{trait} {
+}
+Operation::Constraint::Constraint(Tyvar tyvar,
+                                  const std::vector<Trait *> &traits)
+    : tyvar(tyvar), traits(traits) {
+}
+
+Operation::Param::Param(TypeExpr ty) : type_expr(ty) {
+}
+Operation::Param::Param(ValueType vt, TypeExpr ty)
+    : value_type(vt), type_expr(ty) {
+}
+
+Operation::Operation(const std::string &name,
+                     const std::vector<Constraint> &constraints,
+                     const std::vector<Param> &params,
+                     TypeExpr result)
+    : name(name), constraints(constraints), params(params), result(result) {
+}
+
+Stmt *Operation::lower(Expression::FlattenContext *ctx,
+                       std::vector<Expr> &args) const {
+  for (int i = 0; i < args.size(); i++) {
+    if (params[i].value_type == LValue) {
+      flatten_lvalue(args[i], ctx);
+    } else if (params[i].value_type == RValue) {
+      flatten_rvalue(args[i], ctx);
+    }
+  }
+  return flatten(ctx, args);
+}
+
+DataType Operation::check(const std::vector<Expr> &args) const {
+  TypeExpression::Solutions solutions;
+  TI_ASSERT(args.size() == params.size());
+  for (int i = 0; i < args.size(); i++) {
+    params[i].type_expr->unify(solutions, args[i]->ret_type);
+  }
+  for (auto &constraint : constraints) {
+    if (solutions.find(constraint.tyvar->id) == solutions.end()) {
+      TI_ERROR("Type variable {} cannot be determined in operation {}",
+               constraint.tyvar->id.name(), name);
+    }
+    for (auto &trait : constraint.traits) {
+      if (!trait->has_type(solutions[constraint.tyvar->id])) {
+        TI_ERROR("{} is not {}, which is required by operation {}",
+                 constraint.tyvar->id.name(), trait->describe(), name);
+      }
+    }
+  }
+  return result->resolve(solutions);
+}
+
+Stmt *InternalCallOperation::flatten(Expression::FlattenContext *ctx,
+                                     std::vector<Expr> &args) const {
+  return ctx->push_back<InternalFuncStmt>(internal_call_name_,
+                                          get_all_stmts(args));
+}
+
+std::vector<Operation::Param> make_real_params_from_dt(
+    const std::vector<DataType> &params) {
+  std::vector<Operation::Param> real_params;
+  real_params.reserve(params.size());
+  for (auto dt : params) {
+    real_params.emplace_back(TypeSpec::dt(dt));
+  }
+  return real_params;
+}
+
+InternalCallOperation::InternalCallOperation(
+    const std::string &name,
+    const std::string &internal_name,
+    const std::vector<DataType> &params,
+    DataType result)
+    : Operation(name,
+                std::vector<Constraint>(),
+                make_real_params_from_dt(params),
+                TypeSpec::dt(result)),
+      internal_call_name_(internal_name) {
+}
+
+Stmt *DynamicOperation::flatten(Expression::FlattenContext *ctx,
+                                std::vector<Expr> &args) const {
+  return func_(ctx, args);
+}
+
+DynamicOperation::DynamicOperation(const std::string &name,
+                                   const std::vector<Constraint> &tyvars,
+                                   const std::vector<Param> &params,
+                                   TypeExpr result,
+                                   const std::function<DynOp> &func)
+    : Operation(name, tyvars, params, result), func_(func) {
+}
+
+StaticTraits::StaticTraits() {
+  primitive = new DynamicTrait(
+      "Primitive", [](DataType ty) { return ty->is<PrimitiveType>(); });
+
+  custom = new DynamicTrait("Custom", is_custom_type);
+
+  scalar = new DynamicTrait("Scalar", [this](DataType ty) {
+    return primitive->has_type(ty) || custom->has_type(ty);
+  });
+
+  real = new DynamicTrait("Real", is_real);
+
+  integral = new DynamicTrait("Integral", is_integral);
+}
+
+InternalOps::InternalOps() {
+  thread_index = new InternalCallOperation("thread_index", "linear_thread_idx",
+                                           {}, PrimitiveType::i32);
+
+  insert_triplet =
+      new InternalCallOperation("insert_triplet", "insert_triplet",
+                                {PrimitiveType::u64, PrimitiveType::i32,
+                                 PrimitiveType::i32, PrimitiveType::f32},
+                                PrimitiveType::i32);
+
+  do_nothing = new InternalCallOperation("do_nothing", "do_nothing", {},
+                                         PrimitiveType::i32);
+
+  refresh_counter = new InternalCallOperation(
+      "refresh_counter", "refresh_counter", {}, PrimitiveType::i32);
+}
+
+TestInternalOps::TestInternalOps() {
+  test_active_mask = new InternalCallOperation(
+      "test_active_mask", "test_active_mask", {}, PrimitiveType::i32);
+
+  test_shfl = new InternalCallOperation("test_shfl", "test_shfl", {},
+                                        PrimitiveType::i32);
+
+  test_stack = new InternalCallOperation("test_stack", "test_stack", {},
+                                         PrimitiveType::i32);
+
+  test_list_manager = new InternalCallOperation(
+      "test_list_manager", "test_list_manager", {}, PrimitiveType::i32);
+
+  test_node_allocator = new InternalCallOperation(
+      "test_node_allocator", "test_node_allocator", {}, PrimitiveType::i32);
+
+  test_node_allocator_gc_cpu = new InternalCallOperation(
+      "test_node_allocator_gc_cpu", "test_node_allocator_gc_cpu", {},
+      PrimitiveType::i32);
+
+  test_internal_func_args = new InternalCallOperation(
+      "test_internal_func_args", "test_internal_func_args",
+      {PrimitiveType::f32, PrimitiveType::f32, PrimitiveType::i32},
+      PrimitiveType::i32);
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/ir/operation.h
+++ b/taichi/ir/operation.h
@@ -1,0 +1,239 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "taichi/ir/type.h"
+#include "taichi/ir/expression.h"
+#include "taichi/ir/statements.h"
+
+namespace taichi {
+namespace lang {
+
+// a "type expression" that has type variables and type-level functions.
+class TypeExpression {
+ public:
+  // A Solution is a mapping of all tyvars in a type expression to concrete
+  // datatypes.
+  using Solutions = std::map<Identifier, DataType>;
+
+  // Equates the type expr and the given datatype, and solve the concrete type
+  // of tyvars along the way.
+  virtual void unify(Solutions &solutions, DataType ty) const = 0;
+
+  // Resolve a type expr to a concrete datatype with a set of solutions.
+  virtual DataType resolve(const Solutions &solutions) const = 0;
+
+  virtual std::string to_string() const = 0;
+};
+
+using TypeExpr = std::shared_ptr<TypeExpression>;
+
+// Any datatype is trivially a type expression.
+class DataTypeExpression : public TypeExpression {
+ public:
+  const DataType type;
+  DataTypeExpression(DataType ty);
+
+  void unify(Solutions &solutions, DataType ty) const override;
+  DataType resolve(const Solutions &solutions) const override;
+  std::string to_string() const override;
+};
+
+// The class of tyvars.
+class TyvarTypeExpression : public TypeExpression {
+ public:
+  const Identifier id;
+  TyvarTypeExpression(const Identifier &id);
+
+  void unify(Solutions &solutions, DataType ty) const override;
+  DataType resolve(const Solutions &solutions) const override;
+  std::string to_string() const override;
+};
+
+using Tyvar = std::shared_ptr<TyvarTypeExpression>;
+
+// A type-level function that returns the std::common_type of two primitive
+// datatypes.
+class CommonTypeExpression : public TypeExpression {
+ public:
+  const TypeExpr lhs;
+  const TypeExpr rhs;
+  CommonTypeExpression(TypeExpr lhs, TypeExpr rhs);
+
+  void unify(Solutions &solutions, DataType ty) const override;
+  DataType resolve(const Solutions &solutions) const override;
+  std::string to_string() const override;
+};
+
+// A convenient builder class for type expressions. Preferably use this instead
+// of std::make_shared for TypeExpressions.
+class TypeSpec {
+ public:
+  static std::shared_ptr<DataTypeExpression> dt(DataType dt);
+  static Tyvar var(const Identifier &id);
+  static Tyvar var(const std::string &name);
+  static std::shared_ptr<CommonTypeExpression> lub(TypeExpr lhs, TypeExpr rhs);
+};
+
+// A trait is a predicate on types.
+class Trait {
+ public:
+  virtual bool has_type(DataType ty) const = 0;
+  virtual std::string describe() const = 0;
+};
+
+class DynamicTrait : public Trait {
+ private:
+  using TraitPred = bool(DataType ty);
+
+  const std::string description_;
+  const std::function<TraitPred> func_;
+
+ public:
+  DynamicTrait(const std::string &description,
+               const std::function<TraitPred> &func);
+
+  std::string describe() const override;
+  bool has_type(DataType ty) const override;
+};
+
+void flatten_lvalue(Expr expr, Expression::FlattenContext *ctx);
+
+void flatten_rvalue(Expr expr, Expression::FlattenContext *ctx);
+
+std::vector<Stmt *> get_all_stmts(const std::vector<Expr> &exprs);
+
+class Operation {
+  virtual Stmt *flatten(Expression::FlattenContext *ctx,
+                        std::vector<Expr> &args) const = 0;
+
+ public:
+  // A Constraint describes one tyvar involved in the param and return types
+  // and also defines what traits should the tyvar satisfy.
+  class Constraint {
+   public:
+    const Tyvar tyvar;
+    const std::vector<Trait *> traits;
+
+    Constraint(Tyvar tyvar);
+    Constraint(Tyvar tyvar, Trait *trait);
+    Constraint(Tyvar tyvar, const std::vector<Trait *> &traits);
+  };
+
+  enum ValueType {
+    LValue,
+    RValue,
+  };
+
+  // A Param can be either an lvalue or an rvalue.
+  class Param {
+   public:
+    const ValueType value_type = RValue;
+    const TypeExpr type_expr;
+
+    Param(TypeExpr ty);
+    Param(ValueType vt, TypeExpr ty);
+  };
+
+  const std::string name;
+  const std::vector<Constraint> constraints;
+  const std::vector<Param> params;
+  const TypeExpr result;
+
+  Operation(const std::string &name,
+            const std::vector<Constraint> &constraints,
+            const std::vector<Param> &params,
+            TypeExpr result);
+
+  Stmt *lower(Expression::FlattenContext *ctx, std::vector<Expr> &args) const;
+  DataType check(const std::vector<Expr> &args) const;
+};
+
+// This class corresponds to InternalFuncStmt.
+class InternalCallOperation : public Operation {
+  const std::string internal_call_name_;
+
+  Stmt *flatten(Expression::FlattenContext *ctx,
+                std::vector<Expr> &args) const override;
+
+ public:
+  InternalCallOperation(const std::string &name,
+                        const std::string &internal_name,
+                        const std::vector<DataType> &params,
+                        DataType result);
+};
+
+class DynamicOperation : public Operation {
+  using DynOp = Stmt *(Expression::FlattenContext *ctx,
+                       const std::vector<Expr> &stmts);
+  const std::function<DynOp> func_;
+
+  Stmt *flatten(Expression::FlattenContext *ctx,
+                std::vector<Expr> &stmts) const override;
+
+ public:
+  DynamicOperation(const std::string &name,
+                   const std::vector<Constraint> &tyVars,
+                   const std::vector<Param> &params,
+                   TypeExpr result,
+                   const std::function<DynOp> &func);
+};
+
+class StaticTraits {
+  StaticTraits();
+  static inline std::unique_ptr<StaticTraits> instance_;
+
+ public:
+  Trait *primitive;
+  Trait *custom;
+  Trait *scalar;
+  Trait *real;
+  Trait *integral;
+
+  static const StaticTraits &get() {
+    if (!instance_)
+      instance_ = std::make_unique<StaticTraits>(StaticTraits());
+    return *instance_;
+  }
+};
+
+class InternalOps {
+  InternalOps();
+  static inline std::unique_ptr<InternalOps> instance_;
+
+ public:
+  Operation *thread_index;
+  Operation *insert_triplet;
+  Operation *do_nothing;
+  Operation *refresh_counter;
+
+  static const InternalOps &get() {
+    if (!instance_)
+      instance_ = std::make_unique<InternalOps>(InternalOps());
+    return *instance_;
+  }
+};
+
+class TestInternalOps {
+  TestInternalOps();
+  static inline std::unique_ptr<TestInternalOps> instance_;
+
+ public:
+  Operation *test_stack;
+  Operation *test_active_mask;
+  Operation *test_shfl;
+  Operation *test_list_manager;
+  Operation *test_node_allocator;
+  Operation *test_node_allocator_gc_cpu;
+  Operation *test_internal_func_args;
+
+  static const TestInternalOps &get() {
+    if (!instance_)
+      instance_ = std::make_unique<TestInternalOps>(TestInternalOps());
+    return *instance_;
+  }
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/ir/operation_impl.cpp
+++ b/taichi/ir/operation_impl.cpp
@@ -1,0 +1,340 @@
+#include "taichi/ir/operation_impl.h"
+#include "taichi/ir/frontend_ir.h"
+#include "taichi/ir/statements.h"
+
+namespace taichi {
+namespace lang {
+
+std::vector<TypeExpr> make_real_params_from_dt(
+    const std::vector<DataType> &params) {
+  std::vector<TypeExpr> real_params;
+  real_params.reserve(params.size());
+  for (auto dt : params) {
+    real_params.emplace_back(TypeSpec::dt(dt));
+  }
+  return real_params;
+}
+
+// This class corresponds to InternalFuncStmt.
+class InternalCallOperation : public Operation {
+  const std::string internal_call_name_;
+
+ public:
+  InternalCallOperation(const std::string &name,
+                        const std::string &internal_name,
+                        const std::vector<DataType> &params,
+                        DataType result)
+      : Operation(name,
+                  std::vector<Constraint>(),
+                  make_real_params_from_dt(params),
+                  TypeSpec::dt(result)),
+        internal_call_name_(internal_name) {
+  }
+
+  Stmt *flatten(Expression::FlattenContext *ctx,
+                std::vector<Expr> &args) const override {
+    return ctx->push_back<InternalFuncStmt>(internal_call_name_,
+                                            get_all_stmts(args, ctx));
+  }
+};
+
+class BinaryPrimOperation : public Operation {
+ protected:
+  const BinaryOpType op_type;
+
+ public:
+  static inline const Tyvar L = TypeSpec::var("LHS"), R = TypeSpec::var("RHS");
+  BinaryPrimOperation(const std::string &name,
+                      BinaryOpType op_type,
+                      const std::vector<Trait *> &common_traits,
+                      TypeExpr ret_type)
+      : Operation(name,
+                  {{L, common_traits}, {R, common_traits}},
+                  {L, R},
+                  ret_type),
+        op_type(op_type) {
+  }
+
+  Stmt *flatten(Expression::FlattenContext *ctx,
+                std::vector<Expr> &args) const override {
+    return ctx->push_back<BinaryOpStmt>(op_type, flatten_rvalue(args[0], ctx),
+                                        flatten_rvalue(args[1], ctx));
+  }
+
+  static Operation *arith(const std::string &name, BinaryOpType op_type) {
+    return new BinaryPrimOperation(
+        name, op_type, {StaticTraits::get().primitive}, TypeSpec::lub(L, R));
+  }
+
+  static Operation *bitwise(const std::string &name, BinaryOpType op_type) {
+    return new BinaryPrimOperation(
+        name, op_type, {StaticTraits::get().integral}, TypeSpec::lub(L, R));
+  }
+
+  static Operation *compare(const std::string &name, BinaryOpType op_type) {
+    return new BinaryPrimOperation(name, op_type,
+                                   {StaticTraits::get().primitive},
+                                   TypeSpec::dt(PrimitiveType::i32));
+  }
+};
+
+class UnaryPrimOperation : public Operation {
+ protected:
+  const UnaryOpType op_type;
+
+ public:
+  static inline const Tyvar T = TypeSpec::var("operandType");
+  UnaryPrimOperation(const std::string &name,
+                     UnaryOpType op_type,
+                     const std::vector<Trait *> &traits,
+                     TypeExpr ret_type)
+      : Operation(name, {{T, traits}}, {T}, ret_type), op_type(op_type) {
+  }
+
+  Stmt *flatten(Expression::FlattenContext *ctx,
+                std::vector<Expr> &args) const override {
+    return ctx->push_back<UnaryOpStmt>(op_type, flatten_rvalue(args[0], ctx));
+  }
+
+  static Operation *real(const std::string &name, UnaryOpType op_type) {
+    return new UnaryPrimOperation(name, op_type, {StaticTraits::get().real}, T);
+  }
+};
+
+class AtomicOperation : public Operation {
+ protected:
+  const AtomicOpType op_type;
+
+ public:
+  static inline const Tyvar Dest = TypeSpec::var("destType"),
+                            Val = TypeSpec::var("valType");
+  AtomicOperation(const std::string &name,
+                  AtomicOpType op_type,
+                  Trait *extra_trait)
+      : Operation(name,
+                  {{Dest, {StaticTraits::get().scalar, extra_trait}},
+                   {Val, {StaticTraits::get().primitive, extra_trait}}},
+                  {Dest, Val},
+                  TypeSpec::comp(Dest)),
+        op_type(op_type) {
+  }
+
+  AtomicOperation(const std::string &name, AtomicOpType op_type)
+      : Operation(name,
+                  {{Dest, StaticTraits::get().scalar},
+                   {Val, StaticTraits::get().primitive}},
+                  {Dest, Val},
+                  TypeSpec::comp(Dest)),
+        op_type(op_type) {
+  }
+
+  Stmt *flatten(Expression::FlattenContext *ctx,
+                std::vector<Expr> &args) const override = 0;
+};
+
+class AtomicPrimOperation : public AtomicOperation {
+ public:
+  AtomicPrimOperation(const std::string &name,
+                      AtomicOpType op_type,
+                      Trait *extra_trait)
+      : AtomicOperation(name, op_type, extra_trait) {
+  }
+
+  AtomicPrimOperation(const std::string &name, AtomicOpType op_type)
+      : AtomicOperation(name, op_type) {
+  }
+
+  Stmt *flatten(Expression::FlattenContext *ctx,
+                std::vector<Expr> &args) const override {
+    auto val = flatten_rvalue(args[1], ctx);
+    auto dest = args[0];
+    if (dest.is<IdExpression>()) {  // local variable
+      // emit local store stmt
+      auto alloca =
+          ctx->current_block->lookup_var(dest.cast<IdExpression>()->id);
+      return ctx->push_back<AtomicOpStmt>(op_type, alloca, val);
+    } else {
+      TI_ASSERT(dest.is<GlobalPtrExpression>() ||
+                dest.is<TensorElementExpression>());
+      return ctx->push_back<AtomicOpStmt>(op_type, flatten_lvalue(dest, ctx),
+                                          val);
+    }
+  }
+
+  static Operation *arith(const std::string &name, AtomicOpType op_type) {
+    return new AtomicPrimOperation(name, op_type);
+  }
+
+  static Operation *bitwise(const std::string &name, AtomicOpType op_type) {
+    return new AtomicPrimOperation(name, op_type, StaticTraits::get().integral);
+  }
+};
+
+void StaticTraits::init() {
+  primitive = new DynamicTrait(
+      "Primitive", [](DataType ty) { return ty->is<PrimitiveType>(); });
+
+  custom = new DynamicTrait("Custom", is_custom_type);
+
+  scalar = new DynamicTrait("Scalar", [this](DataType ty) {
+    return primitive->has_type(ty) || custom->has_type(ty);
+  });
+
+  real = new DynamicTrait("Real", is_real);
+
+  integral = new DynamicTrait("Integral", is_integral);
+}
+
+void InternalOps::init() {
+  thread_index = new InternalCallOperation("thread_index", "linear_thread_idx",
+                                           {}, PrimitiveType::i32);
+
+  insert_triplet =
+      new InternalCallOperation("insert_triplet", "insert_triplet",
+                                {PrimitiveType::u64, PrimitiveType::i32,
+                                 PrimitiveType::i32, PrimitiveType::f32},
+                                PrimitiveType::i32);
+
+  do_nothing = new InternalCallOperation("do_nothing", "do_nothing", {},
+                                         PrimitiveType::i32);
+
+  refresh_counter = new InternalCallOperation(
+      "refresh_counter", "refresh_counter", {}, PrimitiveType::i32);
+
+  max = BinaryPrimOperation::arith("max", BinaryOpType::max);
+  min = BinaryPrimOperation::arith("min", BinaryOpType::min);
+  add = BinaryPrimOperation::arith("operator +", BinaryOpType::add);
+  sub = BinaryPrimOperation::arith("operator -", BinaryOpType::sub);
+  mul = BinaryPrimOperation::arith("operator *", BinaryOpType::mul);
+  div = BinaryPrimOperation::arith("operator /", BinaryOpType::div);
+  truediv = BinaryPrimOperation::arith("truediv", BinaryOpType::truediv);
+  floordiv = BinaryPrimOperation::arith("operator //", BinaryOpType::floordiv);
+  pow = BinaryPrimOperation::arith("operator **", BinaryOpType::pow);
+
+  bit_and = BinaryPrimOperation::bitwise("operator &", BinaryOpType::bit_and);
+  bit_or = BinaryPrimOperation::bitwise("operator |", BinaryOpType::bit_or);
+  bit_xor = BinaryPrimOperation::bitwise("operator ^", BinaryOpType::bit_xor);
+  bit_shl = BinaryPrimOperation::bitwise("operator <<", BinaryOpType::bit_shl);
+  bit_shr = BinaryPrimOperation::bitwise("operator >>", BinaryOpType::bit_shr);
+  bit_sar = BinaryPrimOperation::bitwise("operator >>", BinaryOpType::bit_sar);
+
+  cmp_lt = BinaryPrimOperation::compare("operator <", BinaryOpType::cmp_lt);
+  cmp_le = BinaryPrimOperation::compare("operator <=", BinaryOpType::cmp_le);
+  cmp_gt = BinaryPrimOperation::compare("operator >", BinaryOpType::cmp_gt);
+  cmp_ge = BinaryPrimOperation::compare("operator >=", BinaryOpType::cmp_ge);
+  cmp_eq = BinaryPrimOperation::compare("operator ==", BinaryOpType::cmp_eq);
+  cmp_ne = BinaryPrimOperation::compare("operator !=", BinaryOpType::cmp_ne);
+
+  atan2 = new BinaryPrimOperation(
+      "atan2", BinaryOpType::atan2, {StaticTraits::get().real},
+      TypeSpec::lub(BinaryPrimOperation::L, BinaryPrimOperation::R));
+  mod = new BinaryPrimOperation(
+      "mod", BinaryOpType::mod, {StaticTraits::get().integral},
+      TypeSpec::lub(BinaryPrimOperation::L, BinaryPrimOperation::R));
+
+  floor = UnaryPrimOperation::real("floor", UnaryOpType::floor);
+  ceil = UnaryPrimOperation::real("ceil", UnaryOpType::ceil);
+  round = UnaryPrimOperation::real("round", UnaryOpType::round);
+
+  sin = UnaryPrimOperation::real("sin", UnaryOpType::sin);
+  asin = UnaryPrimOperation::real("asin", UnaryOpType::asin);
+  cos = UnaryPrimOperation::real("cos", UnaryOpType::cos);
+  acos = UnaryPrimOperation::real("acos", UnaryOpType::acos);
+  tan = UnaryPrimOperation::real("tan", UnaryOpType::tan);
+  tanh = UnaryPrimOperation::real("tanh", UnaryOpType::tanh);
+
+  exp = UnaryPrimOperation::real("exp", UnaryOpType::exp);
+  log = UnaryPrimOperation::real("log", UnaryOpType::log);
+  sqrt = UnaryPrimOperation::real("sqrt", UnaryOpType::sqrt);
+  rsqrt = UnaryPrimOperation::real("rsqrt", UnaryOpType::rsqrt);
+  sgn = UnaryPrimOperation::real("sgn", UnaryOpType::sgn);
+
+  neg = new UnaryPrimOperation("operator -", UnaryOpType::neg,
+                               {StaticTraits::get().primitive},
+                               UnaryPrimOperation::T);
+  abs = new UnaryPrimOperation("abs", UnaryOpType::abs,
+                               {StaticTraits::get().primitive},
+                               UnaryPrimOperation::T);
+
+  bit_not = new UnaryPrimOperation("operator ~", UnaryOpType::bit_not,
+                                   {StaticTraits::get().integral},
+                                   UnaryPrimOperation::T);
+  logic_not = new UnaryPrimOperation("operator not", UnaryOpType::logic_not,
+                                     {StaticTraits::get().integral},
+                                     UnaryPrimOperation::T);
+
+  atomic_add = AtomicPrimOperation::arith("operator +=", AtomicOpType::add);
+  atomic_max = AtomicPrimOperation::arith("atomic_max", AtomicOpType::max);
+  atomic_min = AtomicPrimOperation::arith("atomic_min", AtomicOpType::min);
+  atomic_sub = new DynamicOperation(
+      "operator -=", atomic_add,
+      [this](Expression::FlattenContext *ctx, std::vector<Expr> &args) {
+        args[1].set(
+            Expr::make<CallExpression>(neg, std::vector<Expr>{args[1]}));
+        args[1].type_check();
+        return atomic_add->flatten(ctx, args);
+      });
+
+  atomic_bit_and =
+      AtomicPrimOperation::bitwise("operator &=", AtomicOpType::bit_and);
+  atomic_bit_or =
+      AtomicPrimOperation::bitwise("operator |=", AtomicOpType::bit_or);
+  atomic_bit_xor =
+      AtomicPrimOperation::bitwise("operator ^=", AtomicOpType::bit_xor);
+
+  {
+    auto Res = TypeSpec::var("Res");
+    select = new DynamicOperation(
+        "select", {{Res, StaticTraits::get().primitive}},
+        {TypeSpec::dt(PrimitiveType::i32), Res, Res}, Res,
+        [](Expression::FlattenContext *ctx, std::vector<Expr> &args) {
+          return ctx->push_back(std::make_unique<TernaryOpStmt>(
+              TernaryOpType::select, flatten_rvalue(args[0], ctx),
+              flatten_rvalue(args[1], ctx), flatten_rvalue(args[2], ctx)));
+        });
+  }
+}
+
+void TestInternalOps::init() {
+  test_active_mask = new InternalCallOperation(
+      "test_active_mask", "test_active_mask", {}, PrimitiveType::i32);
+
+  test_shfl = new InternalCallOperation("test_shfl", "test_shfl", {},
+                                        PrimitiveType::i32);
+
+  test_stack = new InternalCallOperation("test_stack", "test_stack", {},
+                                         PrimitiveType::i32);
+
+  test_list_manager = new InternalCallOperation(
+      "test_list_manager", "test_list_manager", {}, PrimitiveType::i32);
+
+  test_node_allocator = new InternalCallOperation(
+      "test_node_allocator", "test_node_allocator", {}, PrimitiveType::i32);
+
+  test_node_allocator_gc_cpu = new InternalCallOperation(
+      "test_node_allocator_gc_cpu", "test_node_allocator_gc_cpu", {},
+      PrimitiveType::i32);
+
+  test_internal_func_args = new InternalCallOperation(
+      "test_internal_func_args", "test_internal_func_args",
+      {PrimitiveType::f32, PrimitiveType::f32, PrimitiveType::i32},
+      PrimitiveType::i32);
+}
+
+#define SINGLETON(cls)                          \
+  const cls &cls::get() {                       \
+    if (!instance_) {                           \
+      instance_ = std::make_unique<cls>(cls()); \
+      instance_->init();                        \
+    }                                           \
+    return *instance_;                          \
+  }
+
+SINGLETON(StaticTraits)
+SINGLETON(InternalOps)
+SINGLETON(TestInternalOps)
+
+#undef SINGLETON
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/ir/operation_impl.h
+++ b/taichi/ir/operation_impl.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "taichi/ir/operation.h"
+
+namespace taichi {
+namespace lang {
+
+class StaticTraits {
+  StaticTraits() = default;
+  void init();
+  static inline std::unique_ptr<StaticTraits> instance_;
+
+ public:
+  Trait *primitive;
+  Trait *custom;
+  Trait *scalar;
+  Trait *real;
+  Trait *integral;
+
+  static const StaticTraits &get();
+};
+
+class InternalOps {
+  InternalOps() = default;
+  void init();
+  static inline std::unique_ptr<InternalOps> instance_;
+
+ public:
+  Operation *thread_index;
+  Operation *insert_triplet;
+  Operation *do_nothing;
+  Operation *refresh_counter;
+
+  // binops
+
+  // arith - i/f
+  Operation *add;
+  Operation *sub;
+  Operation *mul;
+  Operation *div;
+  Operation *truediv;
+  Operation *floordiv;
+  Operation *pow;
+  Operation *max;
+  Operation *min;
+
+  // bitwise - i
+  Operation *bit_and;
+  Operation *bit_or;
+  Operation *bit_xor;
+  Operation *bit_shl;
+  Operation *bit_shr;
+  Operation *bit_sar;
+
+  // compare - i/f, ret i32
+  Operation *cmp_lt;
+  Operation *cmp_le;
+  Operation *cmp_gt;
+  Operation *cmp_ge;
+  Operation *cmp_eq;
+  Operation *cmp_ne;
+
+  // other binops
+  Operation *atan2;  // f
+  Operation *mod;    // i
+
+  // unops
+
+  // f
+  Operation *floor;
+  Operation *ceil;
+  Operation *round;
+  Operation *sin;
+  Operation *asin;
+  Operation *cos;
+  Operation *acos;
+  Operation *tan;
+  Operation *tanh;
+  Operation *exp;
+  Operation *log;
+  Operation *sqrt;
+  Operation *rsqrt;
+  Operation *sgn;
+
+  // i/f
+  Operation *neg;
+  Operation *abs;
+
+  // i
+  Operation *bit_not;
+  Operation *logic_not;
+
+  // atomics
+
+  // i/f
+  Operation *atomic_add;
+  Operation *atomic_sub;
+  Operation *atomic_max;
+  Operation *atomic_min;
+
+  // i
+  Operation *atomic_bit_and;
+  Operation *atomic_bit_or;
+  Operation *atomic_bit_xor;
+
+  // ternary
+
+  Operation *select;
+
+  static const InternalOps &get();
+};
+
+class TestInternalOps {
+  TestInternalOps() = default;
+  void init();
+  static inline std::unique_ptr<TestInternalOps> instance_;
+
+ public:
+  Operation *test_stack;
+  Operation *test_active_mask;
+  Operation *test_shfl;
+  Operation *test_list_manager;
+  Operation *test_node_allocator;
+  Operation *test_node_allocator_gc_cpu;
+  Operation *test_internal_func_args;
+
+  static const TestInternalOps &get();
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -172,8 +172,8 @@ TEST(FrontendTypeInference, LoopUnique) {
 }
 
 TEST(FrontendTypeInference, InternalFuncCall) {
-  auto internal_func_call =
-      Expr::make<InternalFuncCallExpression>("do_nothing", std::vector<Expr>{});
+  auto internal_func_call = Expr::make<CallExpression>(
+      InternalOps::get().do_nothing, std::vector<Expr>{});
   internal_func_call->type_check();
   EXPECT_EQ(internal_func_call->ret_type, PrimitiveType::i32);
 }

--- a/tests/python/test_ad_if.py
+++ b/tests/python/test_ad_if.py
@@ -238,6 +238,6 @@ def test_ad_if_parallel_complex_f64():
 def test_stack():
     @ti.kernel
     def func():
-        impl.call_internal("test_stack")
+        impl.call_test_internal("test_stack")
 
     func()

--- a/tests/python/test_binding.py
+++ b/tests/python/test_binding.py
@@ -4,10 +4,11 @@ import taichi as ti
 def test_binding():
     ti.init()
     taichi_lang = ti._lib.core
-    print(taichi_lang.BinaryOpType.mul)
     one = taichi_lang.make_const_expr_i32(1)
     two = taichi_lang.make_const_expr_i32(2)
-    expr = taichi_lang.make_binary_op_expr(taichi_lang.BinaryOpType.add, one,
-                                           two)
+    grp = taichi_lang.ExprGroup()
+    grp.push_back(one)
+    grp.push_back(two)
+    expr = taichi_lang.call_op(taichi_lang.Operation.add, grp)
     print(expr.serialize())
     print(taichi_lang.make_global_store_stmt(None, None))

--- a/tests/python/test_cuda_internals.py
+++ b/tests/python/test_cuda_internals.py
@@ -21,7 +21,7 @@ def test_active_mask():
     def test():
         for i in range(48):
             if i % 2 == 0:
-                impl.call_internal("test_active_mask")
+                impl.call_test_internal("test_active_mask")
 
     test()
 
@@ -31,6 +31,6 @@ def test_shfl_down():
     @ti.kernel
     def test():
         for i in range(32):
-            impl.call_internal("test_shfl")
+            impl.call_test_internal("test_shfl")
 
     test()

--- a/tests/python/test_internal_func.py
+++ b/tests/python/test_internal_func.py
@@ -33,7 +33,7 @@ def test_host_polling():
 def test_list_manager():
     @ti.kernel
     def test():
-        impl.call_internal("test_list_manager")
+        impl.call_test_internal("test_list_manager")
 
     test()
     test()
@@ -43,7 +43,7 @@ def test_list_manager():
 def test_node_manager():
     @ti.kernel
     def test():
-        impl.call_internal("test_node_allocator")
+        impl.call_test_internal("test_node_allocator")
 
     test()
     test()
@@ -53,7 +53,7 @@ def test_node_manager():
 def test_node_manager_gc():
     @ti.kernel
     def test_cpu():
-        impl.call_internal("test_node_allocator_gc_cpu")
+        impl.call_test_internal("test_node_allocator_gc_cpu")
 
     test_cpu()
 
@@ -62,7 +62,7 @@ def test_node_manager_gc():
 def test_return():
     @ti.kernel
     def test_cpu():
-        ret = impl.call_internal("test_internal_func_args", 1.0, 2.0, 3)
+        ret = impl.call_test_internal("test_internal_func_args", 1.0, 2.0, 3)
         assert ret == 9
 
     test_cpu()

--- a/tests/python/test_type_check.py
+++ b/tests/python/test_type_check.py
@@ -12,8 +12,9 @@ def test_unary_op():
         a = 1
         b = ti.floor(a)
 
-    with pytest.raises(ti.TaichiTypeError,
-                       match="'floor' takes real inputs only"):
+    with pytest.raises(
+            ti.TaichiTypeError,
+            match="`@operandType` needs to be Real, but i32 is not"):
         floor()
 
 
@@ -26,7 +27,7 @@ def test_binary_op():
         c = a & b
 
     with pytest.raises(ti.TaichiTypeError,
-                       match=r"unsupported operand type\(s\) for '&'"):
+                       match=r"`@RHS` needs to be Integral, but f32 is not"):
         bitwise_float()
 
 


### PR DESCRIPTION
Related issue = #3982, #4145, fixes #4035

`Operation` is an abstraction for language internal operations, with support of polymorphic type specifications and describing implicit casting behaviors. Each `Operation` can be thought of a generalized function, i.e. a type signature paired with a `flatten` implementation.

The type signature has these parts:

- `Constraint`s, that are type variables occurring in the signature together with `Trait`s they need to satisfy.
  - `Trait`s are predicates on `DataType`s, like `Primitive`, `Integral`, `Real`.
- parameter types and return type that are `TypeExpr`s, i.e. a type expression containing type variables and can be evaluated to a datatype.
  - To model implicit cast behaviors, a *type-level function* `CommonTypeExpression` is used to find the "least upper bound" of two types according to C++ implicit cast rules mentioned in #4145.

Other than internal funccalls, this construct can be used to reimplement Unary/BinaryOps in the (near?) future.