### PR TITLE
[refactor] Remove dependency on current_ast_builder() in lang::For and cpp_tests

### DIFF
--- a/taichi/ir/frontend.cpp
+++ b/taichi/ir/frontend.cpp
@@ -25,38 +25,4 @@ void reset_snode_access_flag() {
   dec.reset();
 }
 
-// Begin: legacy frontend constructs
-
-For::For(const Expr &s, const Expr &e, const std::function<void(Expr)> &func) {
-  auto i = Expr(std::make_shared<IdExpression>());
-  auto stmt_unique = std::make_unique<FrontendForStmt>(i, s, e);
-  auto stmt = stmt_unique.get();
-  current_ast_builder().insert(std::move(stmt_unique));
-  auto _ = current_ast_builder().create_scope(stmt->body);
-  func(i);
-}
-
-For::For(const Expr &i,
-         const Expr &s,
-         const Expr &e,
-         const std::function<void()> &func) {
-  auto stmt_unique = std::make_unique<FrontendForStmt>(i, s, e);
-  auto stmt = stmt_unique.get();
-  current_ast_builder().insert(std::move(stmt_unique));
-  auto _ = current_ast_builder().create_scope(stmt->body);
-  func();
-}
-
-For::For(const ExprGroup &i,
-         const Expr &global,
-         const std::function<void()> &func) {
-  auto stmt_unique = std::make_unique<FrontendForStmt>(i, global);
-  auto stmt = stmt_unique.get();
-  current_ast_builder().insert(std::move(stmt_unique));
-  auto _ = current_ast_builder().create_scope(stmt->body);
-  func();
-}
-
-// End: legacy frontend constructs
-
 TLANG_NAMESPACE_END

--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -117,22 +117,4 @@ void insert_snode_access_flag(SNodeAccessFlag v, const Expr &field);
 
 void reset_snode_access_flag();
 
-// Begin: legacy frontend constructs
-
-class For {
- public:
-  For(const Expr &i,
-      const Expr &s,
-      const Expr &e,
-      const std::function<void()> &func);
-
-  For(const ExprGroup &i,
-      const Expr &global,
-      const std::function<void()> &func);
-
-  For(const Expr &s, const Expr &e, const std::function<void(Expr)> &func);
-};
-
-// End: legacy frontend constructs
-
 TLANG_NAMESPACE_END

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -710,6 +710,17 @@ Expr ASTBuilder::make_var(const Expr &x) {
   return var;
 }
 
+void ASTBuilder::insert_for(const Expr &s,
+                            const Expr &e,
+                            const std::function<void(Expr)> &func) {
+  auto i = Expr(std::make_shared<IdExpression>());
+  auto stmt_unique = std::make_unique<FrontendForStmt>(i, s, e);
+  auto stmt = stmt_unique.get();
+  this->insert(std::move(stmt_unique));
+  auto _ = this->create_scope(stmt->body);
+  func(i);
+}
+
 std::unique_ptr<ASTBuilder::ScopeGuard> ASTBuilder::create_scope(
     std::unique_ptr<Block> &list) {
   TI_ASSERT(list == nullptr);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -812,6 +812,9 @@ class ASTBuilder {
   void stop_gradient(SNode *);
   void insert_assignment(Expr &lhs, const Expr &rhs);
   Expr make_var(const Expr &x);
+  void insert_for(const Expr &s,
+                  const Expr &e,
+                  const std::function<void(Expr)> &func);
 };
 
 ASTBuilder &current_ast_builder();

--- a/taichi/math/svd.h
+++ b/taichi/math/svd.h
@@ -165,7 +165,7 @@ sifakis_svd_export(ASTBuilder *ast_builder,
   ast_builder->insert_assignment(Stmp1, Sa33 * Sa33);
   ast_builder->insert_assignment(Ss33, Stmp1 + Ss33);
   StrictlySerialize();
-  For(0, num_iters, [&](Expr sweep) {
+  ast_builder->insert_for(0, num_iters, [&](Expr sweep) {
     ast_builder->insert_assignment(Ssh, Ss21 * Sone_half);
     ast_builder->insert_assignment(Stmp5, Ss11 - Ss22);
     ast_builder->insert_assignment(Stmp2, Ssh * Ssh);

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -103,10 +103,10 @@ TEST(FrontendTypeInference, TensorElement) {
   Callable::CurrentCallableGuard _(kernel->program, kernel.get());
   const std::vector<int> shape{3};
   auto var = Expr(std::make_shared<IdExpression>());
-  current_ast_builder().insert(std::make_unique<FrontendAllocaStmt>(
+  prog->current_ast_builder()->insert(std::make_unique<FrontendAllocaStmt>(
       std::static_pointer_cast<IdExpression>(var.expr)->id, shape,
       PrimitiveType::u32));
-  var->ret_type = current_ast_builder().get_last_stmt()->ret_type;
+  var->ret_type = prog->current_ast_builder()->get_last_stmt()->ret_type;
   auto index = Expr::make<ConstExpression, int32>(2);
   index->type_check();
   auto tensor_element =


### PR DESCRIPTION
Related issue = #3955 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
