### PR TITLE
[bug] [opengl] Process child nodes to compute alignment

### DIFF
--- a/tests/python/examples/autodiff/test_minimization.py
+++ b/tests/python/examples/autodiff/test_minimization.py
@@ -17,4 +17,4 @@ def test_minimization():
         gradient_descent()
 
     for i in range(n):
-        assert x[i] == ti._testing.approx(y[i], rel=1e-3)
+        assert x[i] == ti._testing.approx(y[i], rel=1e-2)

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -101,17 +101,20 @@ def test_aot_ndarray_range_hint():
 def test_element_size_alignment():
     a = ti.field(ti.f32, shape=())
     b = ti.Matrix.field(2, 3, ti.f32, shape=(2, 4))
+    c = ti.field(ti.i32, shape=())
 
     with tempfile.TemporaryDirectory() as tmpdir:
         s = ti.aot.Module(ti.cfg.arch)
         s.add_field('a', a)
         s.add_field('b', b)
+        s.add_field('c', c)
         s.save(tmpdir, '')
         with open(os.path.join(tmpdir, 'metadata.json')) as json_file:
             res = json.load(json_file)
             offsets = (res['aot_data']['fields'][0]['mem_offset_in_parent'],
-                       res['aot_data']['fields'][1]['mem_offset_in_parent'])
-            assert 0 in offsets and 24 in offsets
+                       res['aot_data']['fields'][1]['mem_offset_in_parent'],
+                       res['aot_data']['fields'][2]['mem_offset_in_parent'])
+            assert 0 in offsets and 4 in offsets and 24 in offsets
             assert res['aot_data']['root_buffer_size'] == 216
 
 


### PR DESCRIPTION
We need to process `snode.ch` in the order of their
`mem_offset_in_parent` so that the computed alignment is correct.

Also noticed the minimization autodiff test had a too strict `rel` (fails randomly on master) so
relaxing it a bit.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
