### PR TITLE
[Refactor] Remove redundant set_gdb_trigger

### DIFF
--- a/docs/lang/articles/contribution/utilities.md
+++ b/docs/lang/articles/contribution/utilities.md
@@ -150,7 +150,7 @@ when the program crashes.
 
 ```python
 # Python
-ti.set_gdb_trigger(True)
+ti.init(gdb_trigger=True)
 ```
 
 ```cpp

--- a/python/taichi/examples/autodiff/regression.py
+++ b/python/taichi/examples/autodiff/regression.py
@@ -4,11 +4,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import taichi as ti
-import taichi as tc
 
 ti.init(arch=ti.cpu)
-
-tc.set_gdb_trigger(True)
 
 number_coeffs = 4
 learning_rate = 1e-4

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -18,7 +18,6 @@ from taichi.lang.sort import parallel_sort
 from taichi.lang.source_builder import SourceBuilder
 from taichi.lang.struct import Struct, StructField
 from taichi.lang.type_factory_impl import type_factory
-from taichi.tools.util import set_gdb_trigger
 from taichi.types.annotations import any_arr, ext_arr, template
 from taichi.types.primitive_types import f16, f32, f64, i32, i64, u32, u64
 

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -15,7 +15,6 @@ from taichi.lang.runtime_ops import sync
 from taichi.lang.snode import SNode
 from taichi.lang.util import warning
 from taichi.profiler.kernel_profiler import get_default_kernel_profiler
-from taichi.tools.util import set_gdb_trigger
 from taichi.types.primitive_types import f32, f64, i32, i64
 
 from taichi import _logging, _snode, _version_check
@@ -281,7 +280,7 @@ def init(arch=None,
 
     # dispatch configurations that are not in ti.cfg:
     if not _test_mode:
-        set_gdb_trigger(spec_cfg.gdb_trigger)
+        _ti_core.set_core_trigger_gdb_when_crash(spec_cfg.gdb_trigger)
         impl.get_runtime().experimental_real_function = \
             spec_cfg.experimental_real_function
         impl.get_runtime().short_circuit_operators = \

--- a/python/taichi/tools/__init__.py
+++ b/python/taichi/tools/__init__.py
@@ -16,5 +16,4 @@ __all__ = [
     'dump_dot',
     'dot_to_pdf',
     'get_kernel_stats',
-    'set_gdb_trigger',
 ]

--- a/python/taichi/tools/util.py
+++ b/python/taichi/tools/util.py
@@ -3,10 +3,6 @@ import subprocess
 from taichi._lib import core as _ti_core
 
 
-def set_gdb_trigger(on=True):
-    _ti_core.set_core_trigger_gdb_when_crash(on)
-
-
 def dump_dot(filepath=None, rankdir=None, embed_states_threshold=0):
     d = _ti_core.dump_dot(rankdir, embed_states_threshold)
     if filepath is not None:

--- a/tests/python/test_assert.py
+++ b/tests/python/test_assert.py
@@ -6,8 +6,6 @@ import taichi as ti
 
 @ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_assert_minimal():
-    ti.set_gdb_trigger(False)
-
     @ti.kernel
     def func():
         assert 0

--- a/tests/python/test_debug.py
+++ b/tests/python/test_debug.py
@@ -12,47 +12,38 @@ def test_cpu_debug_snode_reader():
     assert x[None] == 10.0
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_cpu_debug_snode_writer_out_of_bound():
-    ti.set_gdb_trigger(False)
-
     x = ti.field(ti.f32, shape=3)
 
     with pytest.raises(RuntimeError):
         x[3] = 10.0
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_cpu_debug_snode_writer_out_of_bound_negative():
-    ti.set_gdb_trigger(False)
-
     x = ti.field(ti.f32, shape=3)
     with pytest.raises(RuntimeError):
         x[-1] = 10.0
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_cpu_debug_snode_reader_out_of_bound():
-    ti.set_gdb_trigger(False)
-
     x = ti.field(ti.f32, shape=3)
 
     with pytest.raises(RuntimeError):
         a = x[3]
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_cpu_debug_snode_reader_out_of_bound_negative():
-    ti.set_gdb_trigger(False)
-
     x = ti.field(ti.f32, shape=3)
     with pytest.raises(RuntimeError):
         a = x[-1]
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_out_of_bound():
-    ti.set_gdb_trigger(False)
     x = ti.field(ti.i32, shape=(8, 16))
 
     @ti.kernel
@@ -63,9 +54,8 @@ def test_out_of_bound():
         func()
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_not_out_of_bound():
-    ti.set_gdb_trigger(False)
     x = ti.field(ti.i32, shape=(8, 16))
 
     @ti.kernel
@@ -75,9 +65,8 @@ def test_not_out_of_bound():
     func()
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_out_of_bound_dynamic():
-    ti.set_gdb_trigger(False)
     x = ti.field(ti.i32)
 
     ti.root.dynamic(ti.i, 16, 4).place(x)
@@ -90,9 +79,8 @@ def test_out_of_bound_dynamic():
         func()
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_not_out_of_bound_dynamic():
-    ti.set_gdb_trigger(False)
     x = ti.field(ti.i32)
 
     ti.root.dynamic(ti.i, 16, 4).place(x)
@@ -104,10 +92,8 @@ def test_not_out_of_bound_dynamic():
     func()
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_out_of_bound_with_offset():
-    ti.init(debug=True)
-    ti.set_gdb_trigger(False)
     x = ti.field(ti.i32, shape=(8, 16), offset=(-8, -8))
 
     @ti.kernel
@@ -119,9 +105,8 @@ def test_out_of_bound_with_offset():
         func()
 
 
-@ti.test(require=ti.extension.assertion, debug=True)
+@ti.test(require=ti.extension.assertion, debug=True, gdb_trigger=False)
 def test_not_out_of_bound_with_offset():
-    ti.set_gdb_trigger(False)
     x = ti.field(ti.i32, shape=(8, 16), offset=(-4, -8))
 
     @ti.kernel


### PR DESCRIPTION
Related issue = #3782

`set_gdb_trigger` is a redundant API because `gdb_trigger` is already a configuration option in `ti.init`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
