### PR TITLE
[Refactor] Rename tools.util to tools.async_utils and hide functions inside

### DIFF
--- a/python/taichi/tools/__init__.py
+++ b/python/taichi/tools/__init__.py
@@ -1,6 +1,6 @@
+from .async_utils import *
 from .image import imdisplay, imread, imresize, imshow, imwrite
 from .np2ply import PLYWriter
-from .async_utils import *
 # Don't import taichi_logo here which will cause circular import.
 # If you need it, just import from taichi.tools.patterns
 from .video import VideoManager

--- a/python/taichi/tools/__init__.py
+++ b/python/taichi/tools/__init__.py
@@ -1,6 +1,6 @@
 from .image import imdisplay, imread, imresize, imshow, imwrite
 from .np2ply import PLYWriter
-from .util import *
+from .async_utils import *
 # Don't import taichi_logo here which will cause circular import.
 # If you need it, just import from taichi.tools.patterns
 from .video import VideoManager
@@ -13,7 +13,4 @@ __all__ = [
     'imresize',
     'imshow',
     'imwrite',
-    'dump_dot',
-    'dot_to_pdf',
-    'get_kernel_stats',
 ]

--- a/python/taichi/tools/async_utils.py
+++ b/python/taichi/tools/async_utils.py
@@ -23,3 +23,6 @@ def dot_to_pdf(dot, filepath):
 
 def get_kernel_stats():
     return _ti_core.get_kernel_stats()
+
+
+__all__ = []

--- a/tests/python/test_async.py
+++ b/tests/python/test_async.py
@@ -52,4 +52,4 @@ def test_listgen_opt_with_offsets():
         inc()
 
     ti.sync()
-    assert ti.get_kernel_stats().get_counters()['launched_tasks_list_gen'] <= 2
+    assert ti.tools.async_utils.get_kernel_stats().get_counters()['launched_tasks_list_gen'] <= 2

--- a/tests/python/test_async.py
+++ b/tests/python/test_async.py
@@ -52,4 +52,5 @@ def test_listgen_opt_with_offsets():
         inc()
 
     ti.sync()
-    assert ti.tools.async_utils.get_kernel_stats().get_counters()['launched_tasks_list_gen'] <= 2
+    assert ti.tools.async_utils.get_kernel_stats().get_counters(
+    )['launched_tasks_list_gen'] <= 2

--- a/tests/python/test_sfg.py
+++ b/tests/python/test_sfg.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import taichi as ti
 
@@ -26,7 +25,7 @@ def test_remove_clear_list_from_fused_serial():
     init_xy()
     ti.sync()
 
-    stats = ti.get_kernel_stats()
+    stats = ti.tools.async_utils.get_kernel_stats()
     stats.clear()
 
     @ti.kernel
@@ -86,7 +85,7 @@ def test_sfg_dead_store_elimination():
     x.from_numpy(xnp)
     ti.sync()
 
-    stats = ti.get_kernel_stats()
+    stats = ti.tools.async_utils.get_kernel_stats()
     stats.clear()
 
     for _ in range(5):


### PR DESCRIPTION
Related issue = #3782

Now all functions in `tools.util` are async-related and need to be hidden.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
