### PR TITLE
[gui] Implemented per_vertex_radius for particles

### DIFF
--- a/python/taichi/shaders/Particles_vk.vert
+++ b/python/taichi/shaders/Particles_vk.vert
@@ -17,6 +17,7 @@ layout(binding = 0) uniform UBO {
   SceneUBO scene;
   vec3 color;
   int use_per_vertex_color;
+  int has_per_vertex_radius;
   float radius;
   float window_width;
   float window_height;
@@ -26,6 +27,7 @@ ubo;
 
 layout(location = 0) out vec4 pos_camera_space;
 layout(location = 1) out vec4 selected_color;
+layout(location = 2) out vec2 selected_radius;
 
 void main() {
   float distance = length(in_position - ubo.scene.camera_pos);
@@ -41,5 +43,11 @@ void main() {
     selected_color = vec4(ubo.color, 1.0);
   } else {
     selected_color = in_color;
+  }
+
+  if (ubo.has_per_vertex_radius == 0) {
+    selected_radius = vec2(ubo.radius, 0);
+  } else {
+    selected_radius = in_texcoord;
   }
 }

--- a/python/taichi/ui/scene.py
+++ b/python/taichi/ui/scene.py
@@ -7,7 +7,8 @@ from taichi.types.annotations import template
 from taichi.types.primitive_types import f32
 
 from .staging_buffer import (copy_colors_to_vbo, copy_normals_to_vbo,
-                             copy_vertices_to_vbo, get_vbo_field)
+                             copy_vertices_to_vbo, get_vbo_field,
+                             copy_texcoords_to_vbo)
 from .utils import get_field_info
 
 normals_field_cache = {}
@@ -113,7 +114,8 @@ class Scene(_ti_core.PyScene):
                   centers,
                   radius,
                   color=(0.5, 0.5, 0.5),
-                  per_vertex_color=None):
+                  per_vertex_color=None,
+                  per_vertex_radius=None):
         """Declare a set of particles within the scene.
 
         Args:
@@ -125,10 +127,13 @@ class Scene(_ti_core.PyScene):
         vbo = get_vbo_field(centers)
         copy_vertices_to_vbo(vbo, centers)
         has_per_vertex_color = per_vertex_color is not None
+        has_per_vertex_radius = per_vertex_radius is not None
         if has_per_vertex_color:
             copy_colors_to_vbo(vbo, per_vertex_color)
+        if has_per_vertex_radius:
+            copy_texcoords_to_vbo(vbo, per_vertex_radius)
         vbo_info = get_field_info(vbo)
-        super().particles(vbo_info, has_per_vertex_color, color, radius)
+        super().particles(vbo_info, has_per_vertex_color, has_per_vertex_radius, color, radius)
 
     def point_light(self, pos, color):  # pylint: disable=W0235
         super().point_light(pos, color)

--- a/taichi/ui/common/renderable_info.h
+++ b/taichi/ui/common/renderable_info.h
@@ -8,6 +8,7 @@ struct RenderableInfo {
   FieldInfo vbo;
   FieldInfo indices;
   bool has_per_vertex_color;
+  bool has_per_vertex_radius;
 };
 
 TI_UI_NAMESPACE_END


### PR DESCRIPTION
For Particles_vk.vert:
Added uniform input to check if has per vertex radius, added output selected_radius, if has per vertex radius, selected radius is in_texcoord

For renderable_info.h, added has per vertex radius condition

For scene.py, implemented per_vertex_radius into code

Related issue = #3888 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
