### PR TITLE
[doc] Add the step of setting "TI_WITH_VULKAN" for linux

### DIFF
--- a/docs/lang/articles/contribution/dev_install.md
+++ b/docs/lang/articles/contribution/dev_install.md
@@ -373,7 +373,7 @@ You must install the Vulkan SDK in order to debug Taichi's Vulkan backend. To pr
 5. If the SDK is properly installed, add an environment variable `TAICHI_CMAKE_ARGS` with the value `-DTI_WITH_VULKAN:BOOL=ON` to enable the Vulkan backend: (Otherwise Vulkan backend is disabled by default when compiling from source.)
 
   ```shell
-  export TAICHI_CMAKE_ARGS=$TAICHI_CMAKE_ARGS:" -DTI_WITH_VULKAN:BOOL=ON"
+  export TAICHI_CMAKE_ARGS="$TAICHI_CMAKE_ARGS -DTI_WITH_VULKAN:BOOL=ON"
   ```
 
 </TabItem>

--- a/docs/lang/articles/contribution/dev_install.md
+++ b/docs/lang/articles/contribution/dev_install.md
@@ -370,7 +370,7 @@ You must install the Vulkan SDK in order to debug Taichi's Vulkan backend. To pr
 
 4. Check if the SDK is properly installed: `vulkaninfo`.
 
-5. If the SDK is properly installed, add an environment variable `TAICHI_CMAKE_ARGS` with the value `-DTI_WITH_VULKAN:BOOL=ON` to enable the Vulkan backend: (Otherwise Vulkan backend is disbaled by default when compling from source.)
+5. If the SDK is properly installed, add an environment variable `TAICHI_CMAKE_ARGS` with the value `-DTI_WITH_VULKAN:BOOL=ON` to enable the Vulkan backend: (Otherwise Vulkan backend is disabled by default when compiling from source.)
 
   ```shell
   export TAICHI_CMAKE_ARGS=$TAICHI_CMAKE_ARGS:" -DTI_WITH_VULKAN:BOOL=ON"

--- a/docs/lang/articles/contribution/dev_install.md
+++ b/docs/lang/articles/contribution/dev_install.md
@@ -369,6 +369,12 @@ You must install the Vulkan SDK in order to debug Taichi's Vulkan backend. To pr
   > On Ubuntu, check if a JSON file with a name corresponding to your GPU vendor is in: `/etc/vulkan/icd.d/` or `/usr/share/vulkan/icd.d/`.
 
 4. Check if the SDK is properly installed: `vulkaninfo`.
+  
+5. If the SDK is properly installed, add an environment variable `TAICHI_CMAKE_ARGS` with the value `-DTI_WITH_VULKAN:BOOL=ON` to enable the Vulkan backend: (Otherwise Vulkan backend is disbaled by default when compling from source.)
+
+  ```shell
+  export TAICHI_CMAKE_ARGS=$TAICHI_CMAKE_ARGS:" -DTI_WITH_VULKAN:BOOL=ON"
+  ```
 
 </TabItem>
 

--- a/docs/lang/articles/contribution/dev_install.md
+++ b/docs/lang/articles/contribution/dev_install.md
@@ -369,7 +369,7 @@ You must install the Vulkan SDK in order to debug Taichi's Vulkan backend. To pr
   > On Ubuntu, check if a JSON file with a name corresponding to your GPU vendor is in: `/etc/vulkan/icd.d/` or `/usr/share/vulkan/icd.d/`.
 
 4. Check if the SDK is properly installed: `vulkaninfo`.
-  
+
 5. If the SDK is properly installed, add an environment variable `TAICHI_CMAKE_ARGS` with the value `-DTI_WITH_VULKAN:BOOL=ON` to enable the Vulkan backend: (Otherwise Vulkan backend is disbaled by default when compling from source.)
 
   ```shell


### PR DESCRIPTION
It seems currently when building from source, by default, taichi will not enable Vulkan backend. Only when the cmake flag "TI_WITH_VULKAN" set to `on` will it be enabled. See  https://github.com/taichi-dev/taichi/blob/00183bbe9b966727c2a28fdfadb17286ba90eb17/cmake/TaichiCore.cmake#L8 . 
As a result, I was unable to use Vulkan backend for my custom build of taichi, and finding out this took me a long time. For some strange reasons, the step of setting this cmake flag is shown in the Windows section, but not in the Linux section. This commit adds the missing step of setting cmake flags back to the Linux section.

It seems to be caused by https://github.com/taichi-dev/taichi/commit/31a1f72e72f3e8fdb44e350d29a737085f2ff02a#diff-60d6ef959481bb49f8acf52a43314bd4dbfadedb2341043488620077b32bae93 . Perhaps the wording makes it unclear that the cmake flag need to be set for both Windows and Linux.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
