### PR TITLE
[refactor] Remove top level __all__

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -56,4 +56,3 @@ __version__ = (_ti_core.get_version_major(), _ti_core.get_version_minor(),
 
 del sys
 del _ti_core
-__all__ = ['ad', 'lang', 'tools', 'ui', 'profiler']


### PR DESCRIPTION
Related issue = #3782

`__all__` in `taichi/__init__.py` needs to be cleaned to make our api-doc site show top-level APIs properly.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
