### PR TITLE
[misc] Add memcpy to micro-benchmarks

### DIFF
--- a/benchmarks/microbenchmarks/__init__.py
+++ b/benchmarks/microbenchmarks/__init__.py
@@ -1,5 +1,6 @@
 from .atomic_ops import AtomicOpsPlan
 from .fill import FillPlan
 from .math_opts_throughput import MathOpsThroughputPlan
+from .memcpy import MemcpyPlan
 
-benchmark_plan_list = [FillPlan, AtomicOpsPlan, MathOpsThroughputPlan]
+benchmark_plan_list = [FillPlan, AtomicOpsPlan, MathOpsThroughputPlan, MemcpyPlan]

--- a/benchmarks/microbenchmarks/__init__.py
+++ b/benchmarks/microbenchmarks/__init__.py
@@ -3,4 +3,6 @@ from .fill import FillPlan
 from .math_opts_throughput import MathOpsThroughputPlan
 from .memcpy import MemcpyPlan
 
-benchmark_plan_list = [FillPlan, AtomicOpsPlan, MathOpsThroughputPlan, MemcpyPlan]
+benchmark_plan_list = [
+    FillPlan, AtomicOpsPlan, MathOpsThroughputPlan, MemcpyPlan
+]

--- a/benchmarks/microbenchmarks/memcpy.py
+++ b/benchmarks/microbenchmarks/memcpy.py
@@ -24,7 +24,7 @@ def memcpy_default(arch, repeat, container, dtype, dsize, get_metric):
     y = container(dtype, num_elements)
 
     func = memcpy_field if container == ti.field else memcpy_array
-
+    fill_random(x, dtype, container)
     return get_metric(repeat, func, y, x)
 
 

--- a/benchmarks/microbenchmarks/memcpy.py
+++ b/benchmarks/microbenchmarks/memcpy.py
@@ -5,6 +5,7 @@ from microbenchmarks._utils import dtype_size, scaled_repeat_times
 
 import taichi as ti
 
+
 def memcpy_default(arch, repeat, container, dtype, dsize, get_metric):
     @ti.kernel
     def memcpy_field(dst: ti.template(), src: ti.template()):

--- a/benchmarks/microbenchmarks/memcpy.py
+++ b/benchmarks/microbenchmarks/memcpy.py
@@ -1,7 +1,7 @@
 from microbenchmarks._items import BenchmarkItem, Container, DataSize, DataType
 from microbenchmarks._metric import MetricType
 from microbenchmarks._plan import BenchmarkPlan
-from microbenchmarks._utils import dtype_size, scaled_repeat_times
+from microbenchmarks._utils import dtype_size, fill_random, scaled_repeat_times
 
 import taichi as ti
 

--- a/benchmarks/microbenchmarks/memcpy.py
+++ b/benchmarks/microbenchmarks/memcpy.py
@@ -1,0 +1,35 @@
+from microbenchmarks._items import BenchmarkItem, Container, DataSize, DataType
+from microbenchmarks._metric import MetricType
+from microbenchmarks._plan import BenchmarkPlan
+from microbenchmarks._utils import dtype_size, scaled_repeat_times
+
+import taichi as ti
+
+def memcpy_default(arch, repeat, container, dtype, dsize, get_metric):
+    @ti.kernel
+    def memcpy_field(dst: ti.template(), src: ti.template()):
+        for I in ti.grouped(dst):
+            dst[I] = src[I]
+
+    @ti.kernel
+    def memcpy_array(dst: ti.any_arr(), src: ti.any_arr()):
+        for I in ti.grouped(dst):
+            dst[I] = src[I]
+
+    repeat = scaled_repeat_times(arch, dsize, repeat)
+    num_elements = dsize // dtype_size(dtype)
+
+    x = container(dtype, num_elements)
+    y = container(dtype, num_elements)
+
+    func = memcpy_field if container == ti.field else memcpy_array
+
+    return get_metric(repeat, func, y, x)
+
+
+class MemcpyPlan(BenchmarkPlan):
+    def __init__(self, arch: str):
+        super().__init__('memcpy', arch, basic_repeat_times=10)
+        self.create_plan(Container(), DataType(), DataSize(), MetricType())
+        self.add_func(['field'], memcpy_default)
+        self.add_func(['ndarray'], memcpy_default)


### PR DESCRIPTION
This PR adds a `memcpy` case to the micro-benchmark suites.