### PR TITLE
[lang] Annotate constants with dtype without casting.

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -62,7 +62,10 @@ class ASTTransformer(Builder):
             raise TaichiSyntaxError(
                 "Static assign cannot be used on annotated assignment")
         if is_local and not ctx.is_var_declared(target.id):
-            var = ti_ops.cast(value, anno)
+            if isinstance(value, expr.Expr):
+                var = ti_ops.cast(value, anno)
+            else:
+                var = impl.make_constant_expr(value, anno)
             var = impl.expr_init(var)
             ctx.create_variable(target.id, var)
         else:

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -9,7 +9,7 @@ from taichi.lang.util import is_taichi_class
 # Scalar, basic data type
 class Expr(TaichiOperations):
     """A Python-side Expr wrapper, whose member variable `ptr` is an instance of C++ Expr class. A C++ Expr object contains member variable `expr` which holds an instance of C++ Expression class."""
-    def __init__(self, *args, tb=None):
+    def __init__(self, *args, tb=None, dtype=None):
         self.tb = tb
         if len(args) == 1:
             if isinstance(args[0], _ti_core.Expr):
@@ -29,11 +29,8 @@ class Expr(TaichiOperations):
                         raise TaichiTypeError(
                             "Only 0-dimensional numpy array can be used to initialize a scalar expression"
                         )
-                    try:
-                        arg = arg.dtype.type(arg)
-                    except:
-                        pass
-                self.ptr = impl.make_constant_expr(arg).ptr
+                    arg = arg.dtype.type(arg)
+                self.ptr = impl.make_constant_expr(arg, dtype).ptr
         else:
             assert False
         if self.tb:

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 import numpy as np
 from taichi._lib import core as _ti_core
-from taichi._logging import warn
+from taichi._logging import error
 from taichi._snode.fields_builder import FieldsBuilder
 from taichi.lang._ndarray import ScalarNdarray
 from taichi.lang._ndrange import GroupedNDRange, _Ndrange
@@ -23,8 +23,9 @@ from taichi.lang.snode import SNode
 from taichi.lang.struct import Struct, StructField, _IntermediateStruct
 from taichi.lang.tape import TapeImpl
 from taichi.lang.util import (cook_dtype, get_traceback, is_taichi_class,
-                              python_scope, taichi_scope, warning)
-from taichi.types.primitive_types import f16, f32, f64, i32, i64, u32, u64
+                              python_scope, taichi_scope, to_numpy_type,
+                              to_taichi_type, warning)
+from taichi.types.primitive_types import f16, f32, f64, i32, i64
 
 
 @taichi_scope
@@ -381,58 +382,45 @@ def get_runtime():
     return pytaichi
 
 
+def _check_in_range(npty, val):
+    iif = np.iinfo(npty)
+    if not iif.min <= val <= iif.max:
+        # This isn't the case we want to deal with: |val| does't fall into the valid range of either
+        # the signed or the unsigned type.
+        error(
+            f'Constant {val} has exceeded the range of {to_taichi_type(npty)}: [{iif.min}, {iif.max}]'
+        )
+
+
 def _clamp_unsigned_to_range(npty, val):
     # npty: np.int32 or np.int64
     iif = np.iinfo(npty)
     if iif.min <= val <= iif.max:
         return val
     cap = (1 << iif.bits)
-    if not 0 <= val < cap:
-        # We let pybind11 fail intentionally, because this isn't the case we want
-        # to deal with: |val| does't fall into the valid range of either
-        # the signed or the unsigned type.
-        return val
+    assert 0 <= val < cap
     new_val = val - cap
-    warn(
-        f'Constant {val} has exceeded the range of {iif.bits} int, clamped to {new_val}'
-    )
     return new_val
 
 
 @taichi_scope
 def make_constant_expr_i32(val):
     assert isinstance(val, (int, np.integer))
-    return Expr(
-        _ti_core.make_const_expr_i32(_clamp_unsigned_to_range(np.int32, val)))
+    return Expr(_ti_core.make_const_expr_int(i32, val))
 
 
 @taichi_scope
-def make_constant_expr(val):
+def make_constant_expr(val, dtype):
     if isinstance(val, (int, np.integer)):
-        if pytaichi.default_ip in {i32, u32}:
-            # It is not always correct to do such clamp without the type info on
-            # the LHS, but at least this makes assigning constant to unsigned
-            # int work. See https://github.com/taichi-dev/taichi/issues/2060
-            return Expr(
-                _ti_core.make_const_expr_i32(
-                    _clamp_unsigned_to_range(np.int32, val)))
-        if pytaichi.default_ip in {i64, u64}:
-            return Expr(
-                _ti_core.make_const_expr_i64(
-                    _clamp_unsigned_to_range(np.int64, val)))
-        assert False
-    elif isinstance(val, (float, np.floating, np.ndarray)):
-        if pytaichi.default_fp == f32:
-            return Expr(_ti_core.make_const_expr_f32(val))
-        if pytaichi.default_fp == f64:
-            return Expr(_ti_core.make_const_expr_f64(val))
-        if pytaichi.default_fp == f16:
-            # Use f32 to interact with python
-            return Expr(_ti_core.make_const_expr_f32(val))
-        assert False
-    else:
-        raise TaichiTypeError(
-            f'Invalid constant scalar data type: {type(val)}')
+        constant_dtype = pytaichi.default_ip if dtype is None else dtype
+        _check_in_range(to_numpy_type(constant_dtype), val)
+        return Expr(
+            _ti_core.make_const_expr_int(
+                constant_dtype, _clamp_unsigned_to_range(np.int64, val)))
+    if isinstance(val, (float, np.floating)):
+        constant_dtype = pytaichi.default_fp if dtype is None else dtype
+        return Expr(_ti_core.make_const_expr_fp(constant_dtype, val))
+    raise TaichiTypeError(f'Invalid constant scalar data type: {type(val)}')
 
 
 def reset():

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -94,19 +94,19 @@ void Expr::set_grad(const Expr &o) {
 }
 
 Expr::Expr(int32 x) : Expr() {
-  expr = std::make_shared<ConstExpression>(x);
+  expr = std::make_shared<ConstExpression>(PrimitiveType::i32, x);
 }
 
 Expr::Expr(int64 x) : Expr() {
-  expr = std::make_shared<ConstExpression>(x);
+  expr = std::make_shared<ConstExpression>(PrimitiveType::i64, x);
 }
 
 Expr::Expr(float32 x) : Expr() {
-  expr = std::make_shared<ConstExpression>(x);
+  expr = std::make_shared<ConstExpression>(PrimitiveType::f32, x);
 }
 
 Expr::Expr(float64 x) : Expr() {
-  expr = std::make_shared<ConstExpression>(x);
+  expr = std::make_shared<ConstExpression>(PrimitiveType::f64, x);
 }
 
 Expr::Expr(const Identifier &id) : Expr() {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -652,6 +652,10 @@ class ConstExpression : public Expression {
   ConstExpression(const T &x) : val(x) {
     ret_type = val.dt;
   }
+  template <typename T>
+  ConstExpression(const DataType &dt, const T &x) : val({dt, x}) {
+    ret_type = dt;
+  }
 
   void type_check() override;
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -332,8 +332,9 @@ void export_lang(py::module &m) {
                ExprGroup reversed_indices;
                int linearized_index = i;
                for (int d = (int)shape.size() - 1; d >= 0; --d) {
-                 reversed_indices.push_back(Expr::make<ConstExpression, int32>(
-                     linearized_index % shape[d]));
+                 reversed_indices.push_back(
+                     Expr::make<ConstExpression, const DataType &, int32>(
+                         PrimitiveType::i32, linearized_index % shape[d]));
                  linearized_index /= shape[d];
                }
                ExprGroup indices;
@@ -777,10 +778,11 @@ void export_lang(py::module &m) {
 
   m.def("make_rand_expr", Expr::make<RandExpression, const DataType &>);
 
-  m.def("make_const_expr_i32", Expr::make<ConstExpression, int32>);
-  m.def("make_const_expr_i64", Expr::make<ConstExpression, int64>);
-  m.def("make_const_expr_f32", Expr::make<ConstExpression, float32>);
-  m.def("make_const_expr_f64", Expr::make<ConstExpression, float64>);
+  m.def("make_const_expr_int",
+        Expr::make<ConstExpression, const DataType &, int64>);
+
+  m.def("make_const_expr_fp",
+        Expr::make<ConstExpression, const DataType &, float64>);
 
   m.def("make_global_ptr_expr",
         Expr::make<GlobalPtrExpression, const Expr &, const ExprGroup &>);

--- a/tests/python/test_binding.py
+++ b/tests/python/test_binding.py
@@ -5,8 +5,8 @@ def test_binding():
     ti.init()
     taichi_lang = ti._lib.core
     print(taichi_lang.BinaryOpType.mul)
-    one = taichi_lang.make_const_expr_i32(1)
-    two = taichi_lang.make_const_expr_i32(2)
+    one = taichi_lang.make_const_expr_int(ti.i32, 1)
+    two = taichi_lang.make_const_expr_int(ti.i32, 2)
     expr = taichi_lang.make_binary_op_expr(taichi_lang.BinaryOpType.add, one,
                                            two)
     print(expr.serialize())


### PR DESCRIPTION
Fixes #4210

This PR also simplifies the clamping logic by:
1. Make sure constant is valid in range of specified dtype.
2. Always use the widest int64/float64 to communicate between python and C++ and
converts it to the specified dtype in C++. This is just to avoid
handling each dtype on both python and C++ side.

We might consider further improve it by moving this logic from python to C++ in the future and this PR made it a step closer.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
