### PR TITLE
[refactor] Remove lang::current_ast_builder() and dependencies on it

### DIFF
--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -77,12 +77,16 @@ inline Expr Append(const Expr &expr,
   return Append(expr.snode(), indices, val);
 }
 
-inline void InsertAssert(const std::string &text, const Expr &cond) {
-  current_ast_builder().insert(Stmt::make<FrontendAssertStmt>(cond, text));
+inline void InsertAssert(ASTBuilder *ast_builder,
+                         const std::string &text,
+                         const Expr &cond) {
+  ast_builder->insert(Stmt::make<FrontendAssertStmt>(cond, text));
 }
 
-inline void Clear(SNode *snode, const ExprGroup &indices) {
-  current_ast_builder().insert(
+inline void Clear(ASTBuilder *ast_builder,
+                  SNode *snode,
+                  const ExprGroup &indices) {
+  ast_builder->insert(
       Stmt::make<FrontendSNodeOpStmt>(SNodeOpType::clear, snode, indices));
 }
 
@@ -90,8 +94,10 @@ inline Expr is_active(SNode *snode, const ExprGroup &indices) {
   return Expr::make<SNodeOpExpression>(snode, SNodeOpType::is_active, indices);
 }
 
-inline void Clear(const Expr &expr, const ExprGroup &indices) {
-  return Clear(expr.snode(), indices);
+inline void Clear(ASTBuilder *ast_builder,
+                  const Expr &expr,
+                  const ExprGroup &indices) {
+  return Clear(ast_builder, expr.snode(), indices);
 }
 
 inline Expr Length(SNode *snode, const ExprGroup &indices) {

--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -77,27 +77,8 @@ inline Expr Append(const Expr &expr,
   return Append(expr.snode(), indices, val);
 }
 
-inline void InsertAssert(ASTBuilder *ast_builder,
-                         const std::string &text,
-                         const Expr &cond) {
-  ast_builder->insert(Stmt::make<FrontendAssertStmt>(cond, text));
-}
-
-inline void Clear(ASTBuilder *ast_builder,
-                  SNode *snode,
-                  const ExprGroup &indices) {
-  ast_builder->insert(
-      Stmt::make<FrontendSNodeOpStmt>(SNodeOpType::clear, snode, indices));
-}
-
 inline Expr is_active(SNode *snode, const ExprGroup &indices) {
   return Expr::make<SNodeOpExpression>(snode, SNodeOpType::is_active, indices);
-}
-
-inline void Clear(ASTBuilder *ast_builder,
-                  const Expr &expr,
-                  const ExprGroup &indices) {
-  return Clear(ast_builder, expr.snode(), indices);
 }
 
 inline Expr Length(SNode *snode, const ExprGroup &indices) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -731,10 +731,6 @@ std::unique_ptr<ASTBuilder::ScopeGuard> ASTBuilder::create_scope(
   return std::make_unique<ScopeGuard>(this, list.get());
 }
 
-ASTBuilder &current_ast_builder() {
-  return get_current_program().current_callable->context->builder();
-}
-
 void flatten_lvalue(Expr expr, Expression::FlattenContext *ctx) {
   expr->flatten(ctx);
 }

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -828,8 +828,6 @@ class ASTBuilder {
                   const std::function<void(Expr)> &func);
 };
 
-ASTBuilder &current_ast_builder();
-
 class FrontendContext {
  private:
   std::unique_ptr<ASTBuilder> current_builder_;


### PR DESCRIPTION
Related issue = #3955 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
