### PR TITLE
[refactor] Remove dependency on get_current_program() in lang::BinaryOpExpression

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -955,7 +955,7 @@ class ASTTransformer(Builder):
             entry_expr = _ti_core.get_relation_access(
                 ctx.mesh.mesh_ptr, node.iter.ptr.from_index.ptr,
                 node.iter.ptr.to_element_type, loop_var.ptr)
-            entry_expr.type_check()
+            entry_expr.type_check(impl.get_runtime().prog.config)
             mesh_idx = mesh.MeshElementFieldProxy(
                 ctx.mesh, node.iter.ptr.to_element_type, entry_expr)
             ctx.create_variable(target, mesh_idx)

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -35,7 +35,7 @@ class Expr(TaichiOperations):
             assert False
         if self.tb:
             self.ptr.set_tb(self.tb)
-        self.ptr.type_check()
+        self.ptr.type_check(impl.get_runtime().prog.config)
 
     def __hash__(self):
         return self.ptr.get_raw_address()

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -525,7 +525,7 @@ class MeshRelationAccessProxy:
                                                   self.from_index.ptr,
                                                   self.to_element_type,
                                                   impl.Expr(indices[0]).ptr)
-        entry_expr.type_check()
+        entry_expr.type_check(impl.get_runtime().prog.config)
         return MeshElementFieldProxy(self.mesh, self.to_element_type,
                                      entry_expr)
 

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -33,8 +33,8 @@ DataType Expr::get_ret_type() const {
   return expr->ret_type;
 }
 
-void Expr::type_check() {
-  expr->type_check();
+void Expr::type_check(CompileConfig *config) {
+  expr->type_check(config);
 }
 
 Expr select(const Expr &cond, const Expr &true_val, const Expr &false_val) {

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -5,6 +5,7 @@
 
 TLANG_NAMESPACE_BEGIN
 
+struct CompileConfig;
 class Expression;
 class Identifier;
 class ExprGroup;
@@ -109,7 +110,7 @@ class Expr {
 
   DataType get_ret_type() const;
 
-  void type_check();
+  void type_check(CompileConfig *config);
 };
 
 Expr select(const Expr &cond, const Expr &true_val, const Expr &false_val);

--- a/taichi/ir/expression.h
+++ b/taichi/ir/expression.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "taichi/program/compile_config.h"
 #include "taichi/util/str.h"
 #include "taichi/ir/ir.h"
 #include "taichi/ir/expr.h"
@@ -38,7 +39,7 @@ class Expression {
     stmt = nullptr;
   }
 
-  virtual void type_check() {
+  virtual void type_check(CompileConfig *config) {
     // TODO: make it pure virtual after type_check for all expressions are
     // implemented
   }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -114,7 +114,7 @@ FrontendForStmt::FrontendForStmt(const Expr &loop_var,
   loop_var.expr->ret_type = PrimitiveType::i32;
 }
 
-void ArgLoadExpression::type_check() {
+void ArgLoadExpression::type_check(CompileConfig *) {
   TI_ASSERT_INFO(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
                  "Invalid dt [{}] for ArgLoadExpression", dt->to_string());
   ret_type = dt;
@@ -126,7 +126,7 @@ void ArgLoadExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void RandExpression::type_check() {
+void RandExpression::type_check(CompileConfig *) {
   TI_ASSERT_INFO(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
                  "Invalid dt [{}] for RandExpression", dt->to_string());
   ret_type = dt;
@@ -151,7 +151,7 @@ void UnaryOpExpression::serialize(std::ostream &ss) {
   ss << ')';
 }
 
-void UnaryOpExpression::type_check() {
+void UnaryOpExpression::type_check(CompileConfig *) {
   TI_ASSERT_TYPE_CHECKED(operand);
   if (!operand->ret_type->is<PrimitiveType>())
     throw TaichiTypeError(
@@ -181,7 +181,7 @@ void UnaryOpExpression::flatten(FlattenContext *ctx) {
   ctx->push_back(std::move(unary));
 }
 
-void BinaryOpExpression::type_check() {
+void BinaryOpExpression::type_check(CompileConfig *config) {
   TI_ASSERT_TYPE_CHECKED(lhs);
   TI_ASSERT_TYPE_CHECKED(rhs);
   auto lhs_type = lhs->ret_type;
@@ -202,7 +202,7 @@ void BinaryOpExpression::type_check() {
     return;
   }
   if (type == BinaryOpType::truediv) {
-    auto default_fp = get_current_program().config.default_fp;
+    auto default_fp = config->default_fp;
     if (!is_real(lhs_type)) {
       lhs_type = default_fp;
     }
@@ -223,7 +223,7 @@ void BinaryOpExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void TernaryOpExpression::type_check() {
+void TernaryOpExpression::type_check(CompileConfig *) {
   TI_ASSERT_TYPE_CHECKED(op1);
   TI_ASSERT_TYPE_CHECKED(op2);
   TI_ASSERT_TYPE_CHECKED(op3);
@@ -253,7 +253,7 @@ void TernaryOpExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void InternalFuncCallExpression::type_check() {
+void InternalFuncCallExpression::type_check(CompileConfig *) {
   for (auto &arg : args) {
     TI_ASSERT_TYPE_CHECKED(arg);
     // no arg type compatibility check for now due to lack of specification
@@ -285,7 +285,7 @@ void GlobalVariableExpression::flatten(FlattenContext *ctx) {
   ctx->push_back(std::move(ptr));
 }
 
-void GlobalPtrExpression::type_check() {
+void GlobalPtrExpression::type_check(CompileConfig *) {
   // Currently, dimension compatibility check happens in Python
   if (snode != nullptr) {
     ret_type = snode->dt;
@@ -356,7 +356,7 @@ void GlobalPtrExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void TensorElementExpression::type_check() {
+void TensorElementExpression::type_check(CompileConfig *) {
   std::string invalid_msg{
       "Invalid TensorElementExpression: the source is neither a local tensor "
       "nor a global tensor field"};
@@ -401,7 +401,7 @@ void TensorElementExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->push_back<PtrOffsetStmt>(var->stmt, offset_stmt);
 }
 
-void RangeAssumptionExpression::type_check() {
+void RangeAssumptionExpression::type_check(CompileConfig *) {
   TI_ASSERT_TYPE_CHECKED(input);
   TI_ASSERT_TYPE_CHECKED(base);
   if (!input->ret_type->is<PrimitiveType>() ||
@@ -421,7 +421,7 @@ void RangeAssumptionExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void LoopUniqueExpression::type_check() {
+void LoopUniqueExpression::type_check(CompileConfig *) {
   TI_ASSERT_TYPE_CHECKED(input);
   if (!input->ret_type->is<PrimitiveType>())
     throw TaichiTypeError(
@@ -455,7 +455,7 @@ void IdExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->current_block->lookup_var(id);
 }
 
-void AtomicOpExpression::type_check() {
+void AtomicOpExpression::type_check(CompileConfig *) {
   TI_ASSERT_TYPE_CHECKED(dest);
   TI_ASSERT_TYPE_CHECKED(val);
   auto error = [&]() {
@@ -524,7 +524,7 @@ void AtomicOpExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void SNodeOpExpression::type_check() {
+void SNodeOpExpression::type_check(CompileConfig *) {
   if (op_type == SNodeOpType::get_addr) {
     ret_type = PrimitiveType::u64;
   } else {
@@ -575,7 +575,7 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void ConstExpression::type_check() {
+void ConstExpression::type_check(CompileConfig *) {
   TI_ASSERT_INFO(
       val.dt->is<PrimitiveType>() && val.dt != PrimitiveType::unknown,
       "Invalid dt [{}] for ConstExpression", val.dt->to_string());
@@ -587,7 +587,7 @@ void ConstExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void ExternalTensorShapeAlongAxisExpression::type_check() {
+void ExternalTensorShapeAlongAxisExpression::type_check(CompileConfig *) {
   TI_ASSERT_INFO(ptr.is<ExternalTensorExpression>(),
                  "Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
                  ptr.serialize());
@@ -601,7 +601,7 @@ void ExternalTensorShapeAlongAxisExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void FuncCallExpression::type_check() {
+void FuncCallExpression::type_check(CompileConfig *) {
   for (auto &arg : args.exprs) {
     TI_ASSERT_TYPE_CHECKED(arg);
     // no arg type compatibility check for now due to lack of specification
@@ -637,11 +637,11 @@ void MeshPatchIndexExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void MeshPatchIndexExpression::type_check() {
+void MeshPatchIndexExpression::type_check(CompileConfig *) {
   ret_type = PrimitiveType::i32;
 }
 
-void MeshRelationAccessExpression::type_check() {
+void MeshRelationAccessExpression::type_check(CompileConfig *) {
   ret_type = PrimitiveType::i32;
 }
 
@@ -657,7 +657,7 @@ void MeshRelationAccessExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
-void MeshIndexConversionExpression::type_check() {
+void MeshIndexConversionExpression::type_check(CompileConfig *) {
   ret_type = PrimitiveType::i32;
 }
 

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -266,7 +266,7 @@ class ArgLoadExpression : public Expression {
   ArgLoadExpression(int arg_id, DataType dt) : arg_id(arg_id), dt(dt) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << fmt::format("arg[{}] (dt={})", arg_id, data_type_name(dt));
@@ -282,7 +282,7 @@ class RandExpression : public Expression {
   RandExpression(DataType dt) : dt(dt) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << fmt::format("rand<{}>()", data_type_name(dt));
@@ -306,7 +306,7 @@ class UnaryOpExpression : public Expression {
       : type(type), operand(operand), cast_type(cast_type) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   bool is_cast() const;
 
@@ -324,7 +324,7 @@ class BinaryOpExpression : public Expression {
       : type(type), lhs(lhs), rhs(rhs) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << '(';
@@ -354,7 +354,7 @@ class TernaryOpExpression : public Expression {
     this->op3.set(op3);
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << ternary_type_name(type) << '(';
@@ -382,7 +382,7 @@ class InternalFuncCallExpression : public Expression {
     }
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << "internal call " << func_name << '(';
@@ -416,7 +416,7 @@ class ExternalTensorExpression : public Expression {
     set_attribute("dim", std::to_string(dim));
   }
 
-  void type_check() override {
+  void type_check(CompileConfig *config) override {
   }
 
   void serialize(std::ostream &ss) override {
@@ -451,7 +451,7 @@ class GlobalVariableExpression : public Expression {
     is_primal = true;
   }
 
-  void type_check() override {
+  void type_check(CompileConfig *config) override {
   }
 
   void set_snode(SNode *snode) {
@@ -480,7 +480,7 @@ class GlobalPtrExpression : public Expression {
       : snode(snode), indices(indices) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override;
 
@@ -506,7 +506,7 @@ class TensorElementExpression : public Expression {
     // TODO: shape & indices check
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   bool is_local_tensor() const;
 
@@ -549,7 +549,7 @@ class RangeAssumptionExpression : public Expression {
       : input(input), base(base), low(low), high(high) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << "assume_in_range({";
@@ -574,7 +574,7 @@ class LoopUniqueExpression : public Expression {
       : input(input), covers(covers) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override;
 
@@ -589,7 +589,7 @@ class IdExpression : public Expression {
   IdExpression(const Identifier &id) : id(id) {
   }
 
-  void type_check() override {
+  void type_check(CompileConfig *config) override {
   }
 
   void serialize(std::ostream &ss) override {
@@ -617,7 +617,7 @@ class AtomicOpExpression : public Expression {
       : op_type(op_type), dest(dest), val(val) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override;
 
@@ -642,7 +642,7 @@ class SNodeOpExpression : public Expression {
       : snode(snode), op_type(op_type), indices(indices), value(value) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override;
 
@@ -662,7 +662,7 @@ class ConstExpression : public Expression {
     ret_type = dt;
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << val.stringify();
@@ -686,7 +686,7 @@ class ExternalTensorShapeAlongAxisExpression : public Expression {
       : ptr(ptr), axis(axis) {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void flatten(FlattenContext *ctx) override;
 };
@@ -696,7 +696,7 @@ class FuncCallExpression : public Expression {
   Function *func;
   ExprGroup args;
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override;
 
@@ -714,7 +714,7 @@ class MeshPatchIndexExpression : public Expression {
   MeshPatchIndexExpression() {
   }
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << fmt::format("mesh_patch_idx()");
@@ -730,7 +730,7 @@ class MeshRelationAccessExpression : public Expression {
   mesh::MeshElementType to_type;
   Expr neighbor_idx;
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     if (neighbor_idx) {
@@ -772,7 +772,7 @@ class MeshIndexConversionExpression : public Expression {
   Expr idx;
   mesh::ConvType conv_type;
 
-  void type_check() override;
+  void type_check(CompileConfig *config) override;
 
   void serialize(std::ostream &ss) override {
     ss << "mesh_index_conversion(" << mesh::conv_type_name(conv_type) << ", "

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "gtest/gtest.h"
 
 #include "taichi/ir/frontend_ir.h"
@@ -8,19 +9,19 @@ namespace lang {
 
 TEST(FrontendTypeInference, Const) {
   auto const_i64 = Expr::make<ConstExpression, int64>(1LL << 63);
-  const_i64->type_check();
+  const_i64->type_check(nullptr);
   EXPECT_EQ(const_i64->ret_type, PrimitiveType::i64);
 }
 
 TEST(FrontendTypeInference, ArgLoad) {
   auto arg_load_u64 = Expr::make<ArgLoadExpression>(2, PrimitiveType::u64);
-  arg_load_u64->type_check();
+  arg_load_u64->type_check(nullptr);
   EXPECT_EQ(arg_load_u64->ret_type, PrimitiveType::u64);
 }
 
 TEST(FrontendTypeInference, Rand) {
   auto rand_f16 = Expr::make<RandExpression>(PrimitiveType::f16);
-  rand_f16->type_check();
+  rand_f16->type_check(nullptr);
   EXPECT_EQ(rand_f16->ret_type, PrimitiveType::f16);
 }
 
@@ -30,7 +31,7 @@ TEST(FrontendTypeInference, Id) {
   auto kernel = std::make_unique<Kernel>(*prog, func, "fake_kernel");
   Callable::CurrentCallableGuard _(kernel->program, kernel.get());
   auto const_i32 = Expr::make<ConstExpression, int32>(-(1 << 20));
-  const_i32->type_check();
+  const_i32->type_check(nullptr);
   auto id_i32 = prog->current_ast_builder()->make_var(const_i32);
   EXPECT_EQ(id_i32->ret_type, PrimitiveType::i32);
 }
@@ -39,38 +40,38 @@ TEST(FrontendTypeInference, BinaryOp) {
   auto prog = std::make_unique<Program>(Arch::x64);
   prog->config.default_fp = PrimitiveType::f64;
   auto const_i32 = Expr::make<ConstExpression, int32>(-(1 << 20));
-  const_i32->type_check();
+  const_i32->type_check(nullptr);
   auto const_f32 = Expr::make<ConstExpression, float32>(5.0);
-  const_f32->type_check();
+  const_f32->type_check(nullptr);
   auto truediv_f64 = expr_truediv(const_i32, const_f32);
-  truediv_f64->type_check();
+  truediv_f64->type_check(&prog->config);
   EXPECT_EQ(truediv_f64->ret_type, PrimitiveType::f64);
 }
 
 TEST(FrontendTypeInference, UnaryOp) {
   auto const_i16 = Expr::make<ConstExpression, int16>(-(1 << 10));
-  const_i16->type_check();
+  const_i16->type_check(nullptr);
   EXPECT_EQ(const_i16->ret_type, PrimitiveType::i16);
   auto cast_i8 = cast(const_i16, PrimitiveType::i8);
-  cast_i8->type_check();
+  cast_i8->type_check(nullptr);
   EXPECT_EQ(cast_i8->ret_type, PrimitiveType::i8);
   auto bit_not_i16 = ~const_i16;
-  bit_not_i16->type_check();
+  bit_not_i16->type_check(nullptr);
   EXPECT_EQ(bit_not_i16->ret_type, PrimitiveType::i16);
 }
 
 TEST(FrontendTypeInference, TernaryOp) {
   auto const_i16 = Expr::make<ConstExpression, int16>(-(1 << 10));
-  const_i16->type_check();
+  const_i16->type_check(nullptr);
   EXPECT_EQ(const_i16->ret_type, PrimitiveType::i16);
   auto cast_i8 = cast(const_i16, PrimitiveType::i8);
-  cast_i8->type_check();
+  cast_i8->type_check(nullptr);
   EXPECT_EQ(cast_i8->ret_type, PrimitiveType::i8);
   auto const_f32 = Expr::make<ConstExpression, float32>(5.0);
-  const_f32->type_check();
+  const_f32->type_check(nullptr);
   EXPECT_EQ(const_f32->ret_type, PrimitiveType::f32);
   auto ternary_f32 = expr_select(const_i16, cast_i8, const_f32);
-  ternary_f32->type_check();
+  ternary_f32->type_check(nullptr);
   EXPECT_EQ(ternary_f32->ret_type, PrimitiveType::f32);
 }
 
@@ -79,21 +80,21 @@ TEST(FrontendTypeInference, GlobalPtr_GlobalVariable) {
   snode->dt = PrimitiveType::u8;
   auto global_var = Expr::make<GlobalVariableExpression>(snode.get());
   auto index = Expr::make<ConstExpression, float32>(2);
-  index->type_check();
+  index->type_check(nullptr);
   auto global_ptr =
       Expr::make<GlobalPtrExpression>(global_var, ExprGroup(index));
-  global_ptr->type_check();
+  global_ptr->type_check(nullptr);
   EXPECT_EQ(global_ptr->ret_type, PrimitiveType::u8);
 }
 
 TEST(FrontendTypeInference, GlobalPtr_ExternalTensor) {
   auto index = Expr::make<ConstExpression, float32>(2);
-  index->type_check();
+  index->type_check(nullptr);
   auto external_tensor =
       Expr::make<ExternalTensorExpression>(PrimitiveType::u16, 1, 0, 0);
   auto global_ptr =
       Expr::make<GlobalPtrExpression>(external_tensor, ExprGroup(index));
-  EXPECT_THROW(global_ptr->type_check(), TaichiTypeError);
+  EXPECT_THROW(global_ptr->type_check(nullptr), TaichiTypeError);
 }
 
 TEST(FrontendTypeInference, TensorElement) {
@@ -108,21 +109,21 @@ TEST(FrontendTypeInference, TensorElement) {
       PrimitiveType::u32));
   var->ret_type = prog->current_ast_builder()->get_last_stmt()->ret_type;
   auto index = Expr::make<ConstExpression, int32>(2);
-  index->type_check();
+  index->type_check(nullptr);
   auto tensor_element =
       Expr::make<TensorElementExpression>(var, ExprGroup(index), shape, 1);
-  tensor_element->type_check();
+  tensor_element->type_check(nullptr);
   EXPECT_EQ(tensor_element->ret_type, PrimitiveType::u32);
 }
 
 TEST(FrontendTypeInference, AtomicOp) {
   auto const_i32 = Expr::make<ConstExpression, int32>(-(1 << 20));
-  const_i32->type_check();
+  const_i32->type_check(nullptr);
   auto const_f32 = Expr::make<ConstExpression, float32>(5.0);
-  const_f32->type_check();
+  const_f32->type_check(nullptr);
   auto atomic_add_i32 =
       Expr::make<AtomicOpExpression>(AtomicOpType::add, const_i32, const_f32);
-  atomic_add_i32->type_check();
+  atomic_add_i32->type_check(nullptr);
   EXPECT_EQ(atomic_add_i32->ret_type, PrimitiveType::i32);
 }
 
@@ -130,10 +131,10 @@ TEST(FrontendTypeInference, SNodeOp) {
   auto snode = std::make_unique<SNode>(0, SNodeType::root);
   snode->dt = PrimitiveType::u8;
   auto index = Expr::make<ConstExpression, int32>(2);
-  index->type_check();
+  index->type_check(nullptr);
   auto snode_op = Expr::make<SNodeOpExpression>(
       snode.get(), SNodeOpType::get_addr, ExprGroup(index));
-  snode_op->type_check();
+  snode_op->type_check(nullptr);
   EXPECT_EQ(snode_op->ret_type, PrimitiveType::u64);
 }
 
@@ -142,39 +143,39 @@ TEST(FrontendTypeInference, ExternalTensorShapeAlongAxis) {
       Expr::make<ExternalTensorExpression>(PrimitiveType::u64, 1, 0, 0);
   auto shape =
       Expr::make<ExternalTensorShapeAlongAxisExpression>(external_tensor, 0);
-  shape->type_check();
+  shape->type_check(nullptr);
   EXPECT_EQ(shape->ret_type, PrimitiveType::i32);
 }
 
 TEST(FrontendTypeInference, RangeAssumption) {
   auto const_f32_a = Expr::make<ConstExpression, float32>(5.0);
-  const_f32_a->type_check();
+  const_f32_a->type_check(nullptr);
   auto const_f32_b = Expr::make<ConstExpression, float32>(5.0);
-  const_f32_b->type_check();
+  const_f32_b->type_check(nullptr);
   auto valid =
       Expr::make<RangeAssumptionExpression>(const_f32_a, const_f32_b, 0, 1);
-  valid->type_check();
+  valid->type_check(nullptr);
   EXPECT_EQ(valid->ret_type, PrimitiveType::f32);
   auto const_f64 = Expr::make<ConstExpression, float64>(5.0);
-  const_f64->type_check();
+  const_f64->type_check(nullptr);
   auto invalid =
       Expr::make<RangeAssumptionExpression>(const_f32_a, const_f64, 0, 1);
-  EXPECT_THROW(invalid->type_check(), TaichiTypeError);
+  EXPECT_THROW(invalid->type_check(nullptr), TaichiTypeError);
 }
 
 TEST(FrontendTypeInference, LoopUnique) {
   auto const_i64 = Expr::make<ConstExpression, int64>(5);
-  const_i64->type_check();
+  const_i64->type_check(nullptr);
   auto loop_unique =
       Expr::make<LoopUniqueExpression>(const_i64, std::vector<SNode *>{});
-  loop_unique->type_check();
+  loop_unique->type_check(nullptr);
   EXPECT_EQ(loop_unique->ret_type, PrimitiveType::i64);
 }
 
 TEST(FrontendTypeInference, InternalFuncCall) {
   auto internal_func_call =
       Expr::make<InternalFuncCallExpression>("do_nothing", std::vector<Expr>{});
-  internal_func_call->type_check();
+  internal_func_call->type_check(nullptr);
   EXPECT_EQ(internal_func_call->ret_type, PrimitiveType::i32);
 }
 


### PR DESCRIPTION
Related issue = #3955 
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
