### PR TITLE
Remove global instance of DecoratorRecorder

### DIFF
--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -100,7 +100,8 @@ def reset():
 
     This would destroy all the fields and kernels.
     """
-    _ti_core.reset_snode_access_flag()
+    assert get_runtime().prog is None or get_runtime(
+    ).prog.current_ast_builder() is None  #FIXME:Delete it
     impl.reset()
     global runtime
     runtime = impl.get_runtime()
@@ -379,21 +380,21 @@ def block_local(*args):
         impl.current_cfg().opt_level = 1
     for a in args:
         for v in a.get_field_members():
-            _ti_core.insert_snode_access_flag(
+            get_runtime().prog.current_ast_builder().insert_snode_access_flag(
                 _ti_core.SNodeAccessFlag.block_local, v.ptr)
 
 
 def mesh_local(*args):
     for a in args:
         for v in a.get_field_members():
-            _ti_core.insert_snode_access_flag(
+            get_runtime().prog.current_ast_builder().insert_snode_access_flag(
                 _ti_core.SNodeAccessFlag.mesh_local, v.ptr)
 
 
 def cache_read_only(*args):
     for a in args:
         for v in a.get_field_members():
-            _ti_core.insert_snode_access_flag(
+            get_runtime().prog.current_ast_builder().insert_snode_access_flag(
                 _ti_core.SNodeAccessFlag.read_only, v.ptr)
 
 
@@ -412,9 +413,15 @@ def loop_unique(val, covers=None):
     return _ti_core.expr_loop_unique(Expr(val).ptr, covers)
 
 
-parallelize = _ti_core.parallelize
+def parallelize(v):
+    get_runtime().prog.current_ast_builder().parallelize(v)
+
+
 serialize = lambda: parallelize(1)
-block_dim = _ti_core.block_dim
+
+
+def block_dim(v):
+    get_runtime().prog.current_ast_builder().block_dim(v)
 
 
 def global_thread_idx():

--- a/taichi/ir/frontend.cpp
+++ b/taichi/ir/frontend.cpp
@@ -16,13 +16,4 @@ Expr global_new(DataType dt, std::string name) {
   auto id_expr = std::make_shared<IdExpression>(name);
   return Expr::make<GlobalVariableExpression>(dt, id_expr->id);
 }
-
-void insert_snode_access_flag(SNodeAccessFlag v, const Expr &field) {
-  dec.mem_access_opt.add_flag(field.snode(), v);
-}
-
-void reset_snode_access_flag() {
-  dec.reset();
-}
-
 TLANG_NAMESPACE_END

--- a/taichi/ir/frontend.h
+++ b/taichi/ir/frontend.h
@@ -99,9 +99,4 @@ inline Expr AssumeInRange(const Expr &expr,
 inline Expr LoopUnique(const Expr &input, const std::vector<SNode *> &covers) {
   return Expr::make<LoopUniqueExpression>(input, covers);
 }
-
-void insert_snode_access_flag(SNodeAccessFlag v, const Expr &field);
-
-void reset_snode_access_flag();
-
 TLANG_NAMESPACE_END

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -23,15 +23,6 @@ std::string snode_access_flag_name(SNodeAccessFlag type) {
   }
 }
 
-void DecoratorRecorder::reset() {
-  bit_vectorize = -1;
-  num_cpu_threads = 0;
-  uniform = false;
-  mem_access_opt.clear();
-  block_dim = 0;
-  strictly_serialized = false;
-}
-
 int Identifier::id_counter = 0;
 std::string Identifier::raw_name() const {
   if (name_.empty())

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -71,22 +71,6 @@ class MemoryAccessOptions {
 #include "taichi/inc/statements.inc.h"
 #undef PER_STATEMENT
 
-class DecoratorRecorder {
- public:
-  int bit_vectorize;
-  int num_cpu_threads;
-  bool strictly_serialized;
-  MemoryAccessOptions mem_access_opt;
-  int block_dim;
-  bool uniform;
-
-  DecoratorRecorder() {
-    reset();
-  }
-
-  void reset();
-};
-
 class Identifier {
  public:
   static int id_counter;
@@ -704,25 +688,6 @@ struct LocalAddress {
 
   LocalAddress(Stmt *var, int offset);
 };
-
-extern DecoratorRecorder dec;
-
-inline void BitVectorize(int v) {
-  dec.bit_vectorize = v;
-}
-
-inline void Parallelize(int v) {
-  dec.num_cpu_threads = v;
-}
-
-inline void StrictlySerialize() {
-  dec.strictly_serialized = true;
-}
-
-inline void BlockDim(int v) {
-  TI_ASSERT(bit::is_power_of_two(v));
-  dec.block_dim = v;
-}
 
 class VectorElement {
  public:

--- a/taichi/math/svd.h
+++ b/taichi/math/svd.h
@@ -164,7 +164,7 @@ sifakis_svd_export(ASTBuilder *ast_builder,
   ast_builder->insert_assignment(Ss33, Stmp1 + Ss33);
   ast_builder->insert_assignment(Stmp1, Sa33 * Sa33);
   ast_builder->insert_assignment(Ss33, Stmp1 + Ss33);
-  StrictlySerialize();
+  ast_builder->strictly_serialize();
   ast_builder->insert_for(0, num_iters, [&](Expr sweep) {
     ast_builder->insert_assignment(Ssh, Ss21 * Sone_half);
     ast_builder->insert_assignment(Stmp5, Ss11 - Ss22);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -248,6 +248,12 @@ void export_lang(py::module &m) {
       .def_readwrite("metric_values",
                      &KernelProfileTracedRecord::metric_values);
 
+  py::enum_<SNodeAccessFlag>(m, "SNodeAccessFlag", py::arithmetic())
+      .value("block_local", SNodeAccessFlag::block_local)
+      .value("read_only", SNodeAccessFlag::read_only)
+      .value("mesh_local", SNodeAccessFlag::mesh_local)
+      .export_values();
+
   // Export ASTBuilder
   py::class_<ASTBuilder>(m, "ASTBuilder")
       .def("create_kernel_exprgroup_return",
@@ -281,7 +287,12 @@ void export_lang(py::module &m) {
       .def("insert_patch_idx_expr", &ASTBuilder::insert_patch_idx_expr)
       .def("sifakis_svd_f32", sifakis_svd_export<float32, int32>)
       .def("sifakis_svd_f64", sifakis_svd_export<float64, int64>)
-      .def("expr_var", &ASTBuilder::make_var);
+      .def("expr_var", &ASTBuilder::make_var)
+      .def("bit_vectorize", &ASTBuilder::bit_vectorize)
+      .def("parallelize", &ASTBuilder::parallelize)
+      .def("block_dim", &ASTBuilder::block_dim)
+      .def("insert_snode_access_flag", &ASTBuilder::insert_snode_access_flag)
+      .def("reset_snode_access_flag", &ASTBuilder::reset_snode_access_flag);
 
   py::class_<Program>(m, "Program")
       .def(py::init<>())
@@ -792,19 +803,6 @@ void export_lang(py::module &m) {
       TI_INFO("caught");
     }
   });
-  // Schedules
-  m.def("parallelize", Parallelize);
-  m.def("bit_vectorize", BitVectorize);
-  m.def("block_dim", BlockDim);
-
-  py::enum_<SNodeAccessFlag>(m, "SNodeAccessFlag", py::arithmetic())
-      .value("block_local", SNodeAccessFlag::block_local)
-      .value("read_only", SNodeAccessFlag::read_only)
-      .value("mesh_local", SNodeAccessFlag::mesh_local)
-      .export_values();
-
-  m.def("insert_snode_access_flag", insert_snode_access_flag);
-  m.def("reset_snode_access_flag", reset_snode_access_flag);
 
   m.def("test_throw", [] { throw IRModified(); });
   m.def("needs_grad", needs_grad);

--- a/tests/python/test_bit_array_vectorization.py
+++ b/tests/python/test_bit_array_vectorization.py
@@ -1,3 +1,5 @@
+from taichi.lang.impl import get_runtime
+
 import taichi as ti
 
 
@@ -27,7 +29,7 @@ def test_vectorized_struct_for():
 
     @ti.kernel
     def assign_vectorized():
-        ti._lib.core.bit_vectorize(32)
+        get_runtime().prog.current_ast_builder().bit_vectorize(32)
         for i, j in x:
             y[i, j] = x[i, j]
 
@@ -72,7 +74,7 @@ def test_offset_load():
 
     @ti.kernel
     def assign_vectorized(dx: ti.template(), dy: ti.template()):
-        ti._lib.core.bit_vectorize(32)
+        get_runtime().prog.current_ast_builder().bit_vectorize(32)
         for i, j in x:
             y[i, j] = x[i + dx, j + dy]
             z[i, j] = x[i + dx, j + dy]
@@ -132,7 +134,7 @@ def test_evolve():
 
     @ti.kernel
     def evolve_vectorized(x: ti.template(), y: ti.template()):
-        ti._lib.core.bit_vectorize(32)
+        get_runtime().prog.current_ast_builder().bit_vectorize(32)
         for i, j in x:
             num_active_neighbors = 0
             num_active_neighbors += ti.cast(x[i - 1, j - 1], ti.u32)


### PR DESCRIPTION
Related issue = #2768

Move `DecoratorRecorder` into `ASTBuilder` -> Use member of `ASTBuilder` instead of global instance
Renaming : `DecoratorRecorder` -> `ForLoopDecoratorRecorder`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
