### PR TITLE
[Bug] Only ban passing non contiguous torch tensors to taichi kernels.

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -487,9 +487,9 @@ class Kernel:
 
         assert has_torch
         assert isinstance(v, torch.Tensor)
-        if v._is_view():
+        if not v.is_contiguous():
             raise ValueError(
-                "Torch view tensors are not supported, please call tensor.clone() before passing it into taichi kernel."
+                "Non contiguous tensors are not supported, please call tensor.contiguous() before passing it into taichi kernel."
             )
         tmp = v
         taichi_arch = self.runtime.prog.config.arch

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -284,5 +284,5 @@ def test_torch_view():
     y = ti.ndarray(int, (3, 3))
 
     with pytest.raises(ValueError,
-                       match=r'Torch view tensors are not supported'):
+                       match=r'Non contiguous tensors are not supported'):
         copy(x, y)


### PR DESCRIPTION
Thanks to @ifsheldon for reporting the bug!

It's too strict to ban all view tensors as Pytorch view tensor return
itself as a new view Tensor when nothing changes.
So what we really wanted to ban was actually non contiguous tensors.

```
In [2]: a = torch.ones(4, 4)

In [4]: b = a.view(4, 4)

In [6]: b._is_view()
Out[6]: True

In [7]: b.is_contiguous()
Out[7]: True

In [8]: a._is_view()
Out[8]: False
```
FYI in `from_torch` we actually explicitly call `tensor.contiguous()` to
make sure it's valid. For ndarrays we want users to do that explicitly
so that they're aware of the memcpy.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
