### PR TITLE
[lang] Make ti.cfg an alias of runtime cfg

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -47,6 +47,11 @@ if sys.version_info.minor < 7:
 else:
 
     def __getattr__(attr):
+        # There's no easy way to hook accessing attribute with function calls in python3.6.
+        # So let's skip it for now.
+        if attr == 'cfg':
+            return None if lang.impl.get_runtime(
+            ).prog is None else lang.impl.current_cfg()
         if attr in __deprecated_names__:
             lang.util.warning(
                 f'ti.{attr} is deprecated. Please use ti.{__deprecated_names__[attr]} instead.',

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -32,7 +32,6 @@ ikl = axes(0, 2, 3)
 jkl = axes(1, 2, 3)
 ijkl = axes(0, 1, 2, 3)
 
-cfg = impl.default_cfg()
 x86_64 = _ti_core.x64
 """The x64 CPU backend.
 """
@@ -238,6 +237,7 @@ def init(arch=None,
     # Check version for users every 7 days if not disabled by users.
     _version_check.start_version_check_thread()
 
+    cfg = impl.default_cfg()
     # Check if installed version meets the requirements.
     if require_version is not None:
         check_require_version(require_version)
@@ -496,30 +496,6 @@ def clear_all_gradients():
         visit(root_fb)
 
 
-def stat_write(key, value):
-    import yaml  # pylint: disable=C0415
-    case_name = os.environ.get('TI_CURRENT_BENCHMARK')
-    if case_name is None:
-        return
-    if case_name.startswith('benchmark_'):
-        case_name = case_name[10:]
-    arch_name = _ti_core.arch_name(cfg.arch)
-    async_mode = 'async' if cfg.async_mode else 'sync'
-    output_dir = os.environ.get('TI_BENCHMARK_OUTPUT_DIR', '.')
-    filename = f'{output_dir}/benchmark.yml'
-    try:
-        with open(filename, 'r') as f:
-            data = yaml.load(f, Loader=yaml.SafeLoader)
-    except FileNotFoundError:
-        data = {}
-    data.setdefault(case_name, {})
-    data[case_name].setdefault(key, {})
-    data[case_name][key].setdefault(arch_name, {})
-    data[case_name][key][arch_name][async_mode] = value
-    with open(filename, 'w') as f:
-        yaml.dump(data, f, Dumper=yaml.SafeDumper)
-
-
 def is_arch_supported(arch, use_gles=False):
     """Checks whether an arch is supported on the machine.
 
@@ -575,9 +551,9 @@ def get_host_arch_list():
 
 __all__ = [
     'i', 'ij', 'ijk', 'ijkl', 'ijl', 'ik', 'ikl', 'il', 'j', 'jk', 'jkl', 'jl',
-    'k', 'kl', 'l', 'cfg', 'x86_64', 'x64', 'dx11', 'wasm', 'arm64', 'cc',
-    'cpu', 'cuda', 'gpu', 'metal', 'opengl', 'vulkan', 'extension',
-    'parallelize', 'block_dim', 'global_thread_idx', 'Tape', 'assume_in_range',
-    'block_local', 'cache_read_only', 'clear_all_gradients', 'init',
-    'mesh_local', 'no_activate', 'reset', 'mesh_patch_idx'
+    'k', 'kl', 'l', 'x86_64', 'x64', 'dx11', 'wasm', 'arm64', 'cc', 'cpu',
+    'cuda', 'gpu', 'metal', 'opengl', 'vulkan', 'extension', 'parallelize',
+    'block_dim', 'global_thread_idx', 'Tape', 'assume_in_range', 'block_local',
+    'cache_read_only', 'clear_all_gradients', 'init', 'mesh_local',
+    'no_activate', 'reset', 'mesh_patch_idx'
 ]

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -30,9 +30,11 @@ def if_has_autograd(func):
 def grad_test(tifunc, npfunc=None):
     npfunc = npfunc or tifunc
 
-    print(f'arch={ti.cfg.arch} default_fp={ti.cfg.default_fp}')
-    x = ti.field(ti.cfg.default_fp)
-    y = ti.field(ti.cfg.default_fp)
+    print(
+        f'arch={ti.lang.impl.current_cfg().arch} default_fp={ti.lang.impl.current_cfg().default_fp}'
+    )
+    x = ti.field(ti.lang.impl.current_cfg().default_fp)
+    y = ti.field(ti.lang.impl.current_cfg().default_fp)
 
     ti.root.dense(ti.i, 1).place(x, x.grad, y, y.grad)
 

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -105,7 +105,7 @@ def test_element_size_alignment():
     c = ti.field(ti.i32, shape=())
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        s = ti.aot.Module(ti.cfg.arch)
+        s = ti.aot.Module(ti.lang.impl.current_cfg().arch)
         s.add_field('a', a)
         s.add_field('b', b)
         s.add_field('c', c)
@@ -130,7 +130,7 @@ def test_save():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # note ti.aot.Module(ti.opengl) is no-op according to its docstring.
-        m = ti.aot.Module(ti.cfg.arch)
+        m = ti.aot.Module(ti.lang.impl.current_cfg().arch)
         m.add_field('density', density)
         m.add_kernel(init)
         m.save(tmpdir, '')
@@ -149,7 +149,7 @@ def test_save_template_kernel():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # note ti.aot.Module(ti.opengl) is no-op according to its docstring.
-        m = ti.aot.Module(ti.cfg.arch)
+        m = ti.aot.Module(ti.lang.impl.current_cfg().arch)
         m.add_field('density', density)
         with m.add_kernel_template(foo) as kt:
             kt.instantiate(n=6)
@@ -169,7 +169,7 @@ def test_non_dense_snode():
     blk.dense(ti.i, n).place(y)
 
     with pytest.raises(RuntimeError, match='AOT: only supports dense field'):
-        m = ti.aot.Module(ti.cfg.arch)
+        m = ti.aot.Module(ti.lang.impl.current_cfg().arch)
         m.add_field('x', x)
         m.add_field('y', y)
 
@@ -254,7 +254,7 @@ def test_mpm88_aot():
             J[i] = 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        m = ti.aot.Module(ti.cfg.arch)
+        m = ti.aot.Module(ti.lang.impl.current_cfg().arch)
         m.add_field("x", x)
         m.add_field("v", v)
         m.add_field("C", C)
@@ -460,7 +460,7 @@ def test_mpm99_aot():
             Jp[i] = 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        m = ti.aot.Module(ti.cfg.arch)
+        m = ti.aot.Module(ti.lang.impl.current_cfg().arch)
         m.add_field('x', x)
         m.add_field('v', v)
         m.add_field('C', C)

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -141,7 +141,7 @@ def test_dense_dynamic():
     # being that appending to Taichi's dynamic node messes up its length. See
     # https://stackoverflow.com/questions/65995357/cuda-spinlock-implementation-with-independent-thread-scheduling-supported
     # CUDA 11.2 didn't fix this bug, unfortunately.
-    if ti.cfg.arch == ti.cuda:
+    if ti.lang.impl.current_cfg().arch == ti.cuda:
         pytest.skip('CUDA spinlock bug')
 
     n = 128

--- a/tests/python/test_global_store_grad.py
+++ b/tests/python/test_global_store_grad.py
@@ -1,7 +1,7 @@
 """
 import taichi as ti
 
-ti.cfg.print_ir = True
+ti.lang.impl.current_cfg().print_ir = True
 
 
 def test_global_store_branching():

--- a/tests/python/test_reduction.py
+++ b/tests/python/test_reduction.py
@@ -33,8 +33,8 @@ np_ops = {
 
 def _test_reduction_single(dtype, criterion, op):
     N = 1024 * 1024
-    if (ti.cfg.arch == ti.opengl
-            or ti.cfg.arch == ti.vulkan) and dtype == ti.f32:
+    if (ti.lang.impl.current_cfg().arch == ti.opengl or
+            ti.lang.impl.current_cfg().arch == ti.vulkan) and dtype == ti.f32:
         # OpenGL/Vulkan are not capable of such large number in its float32...
         N = 1024 * 16
 

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -59,7 +59,6 @@ init_args = {
     'flatten_if': [False, TF],
     'simplify_before_lower_access': [True, TF],
     'simplify_after_lower_access': [True, TF],
-    'print_benchmark_stat': [False, TF],
     'kernel_profiler': [False, TF],
     'check_out_of_bound': [False, TF],
     'print_accessor_ir': [False, TF],
@@ -86,11 +85,12 @@ def test_init_arg(key, values):
 
     # helper function:
     def test_arg(key, value, kwargs={}):
-        spec_cfg = ti.init(_test_mode=True, **kwargs)
         if key in special_init_cfgs:
+            spec_cfg = ti.init(_test_mode=True, **kwargs)
             cfg = spec_cfg
         else:
-            cfg = ti.cfg
+            ti.init(**kwargs)
+            cfg = ti.lang.impl.current_cfg()
         assert getattr(cfg, key) == value
 
     with patch_os_environ_helper({}, excludes=env_configs):
@@ -115,11 +115,11 @@ def test_init_arg(key, values):
 def test_init_arch(arch):
     with patch_os_environ_helper({}, excludes=['TI_ARCH']):
         ti.init(arch=arch)
-        assert ti.cfg.arch == arch
+        assert ti.lang.impl.current_cfg().arch == arch
     with patch_os_environ_helper({'TI_ARCH': ti._lib.core.arch_name(arch)},
                                  excludes=['TI_ARCH']):
         ti.init(arch=ti.cc)
-        assert ti.cfg.arch == arch
+        assert ti.lang.impl.current_cfg().arch == arch
 
 
 def test_init_bad_arg():

--- a/tests/python/test_svd.py
+++ b/tests/python/test_svd.py
@@ -26,7 +26,7 @@ def mat_equal(A, B, tol=1e-6):
 
 def _test_svd(dt, n):
     print(
-        f'arch={ti.cfg.arch} default_fp={ti.cfg.default_fp} fast_math={ti.cfg.fast_math} dim={n}'
+        f'arch={ti.lang.impl.current_cfg().arch} default_fp={ti.lang.impl.current_cfg().default_fp} fast_math={ti.lang.impl.current_cfg().fast_math} dim={n}'
     )
     A = ti.Matrix.field(n, n, dtype=dt, shape=())
     A_reconstructed = ti.Matrix.field(n, n, dtype=dt, shape=())

--- a/tests/python/test_tensor_dimensionality.py
+++ b/tests/python/test_tensor_dimensionality.py
@@ -18,7 +18,7 @@ def _test_dimensionality(d):
         x.__getitem__(tuple(indices))[0] = sum(indices) * 2
     fill()
     # FIXME(yuanming-hu): snode_writer needs 9 arguments actually..
-    if ti.cfg.arch == ti.cc and d >= 8:
+    if ti.lang.impl.current_cfg().arch == ti.cc and d >= 8:
         return
     for i in range(2**d):
         indices = []

--- a/tests/python/test_test.py
+++ b/tests/python/test_test.py
@@ -15,59 +15,59 @@ from tests import test_utils
 
 @test_utils.test()
 def test_all_archs():
-    assert ti.cfg.arch in test_utils.expected_archs()
+    assert ti.lang.impl.current_cfg().arch in test_utils.expected_archs()
 
 
 @test_utils.test(arch=ti.cpu)
 def test_arch_cpu():
-    assert ti.cfg.arch in [ti.cpu]
+    assert ti.lang.impl.current_cfg().arch in [ti.cpu]
 
 
 @test_utils.test(arch=[ti.cpu])
 def test_arch_list_cpu():
-    assert ti.cfg.arch in [ti.cpu]
+    assert ti.lang.impl.current_cfg().arch in [ti.cpu]
 
 
 @test_utils.test(exclude=ti.cpu)
 def test_exclude_cpu():
-    assert ti.cfg.arch not in [ti.cpu]
+    assert ti.lang.impl.current_cfg().arch not in [ti.cpu]
 
 
 @test_utils.test(exclude=[ti.cpu])
 def test_exclude_list_cpu():
-    assert ti.cfg.arch not in [ti.cpu]
+    assert ti.lang.impl.current_cfg().arch not in [ti.cpu]
 
 
 @test_utils.test(arch=ti.opengl)
 def test_arch_opengl():
-    assert ti.cfg.arch in [ti.opengl]
+    assert ti.lang.impl.current_cfg().arch in [ti.opengl]
 
 
 @test_utils.test(arch=[ti.cpu, ti.opengl, ti.metal])
 def test_multiple_archs():
-    assert ti.cfg.arch in [ti.cpu, ti.opengl, ti.metal]
+    assert ti.lang.impl.current_cfg().arch in [ti.cpu, ti.opengl, ti.metal]
 
 
 @test_utils.test(arch=ti.cpu, debug=True, advanced_optimization=False)
 def test_init_args():
-    assert ti.cfg.debug == True
-    assert ti.cfg.advanced_optimization == False
+    assert ti.lang.impl.current_cfg().debug == True
+    assert ti.lang.impl.current_cfg().advanced_optimization == False
 
 
 @test_utils.test(require=ti.extension.sparse)
 def test_require_extensions_1():
-    assert ti.cfg.arch in [ti.cpu, ti.cuda, ti.metal]
+    assert ti.lang.impl.current_cfg().arch in [ti.cpu, ti.cuda, ti.metal]
 
 
 @test_utils.test(arch=[ti.cpu, ti.opengl], require=ti.extension.sparse)
 def test_require_extensions_2():
-    assert ti.cfg.arch in [ti.cpu]
+    assert ti.lang.impl.current_cfg().arch in [ti.cpu]
 
 
 @test_utils.test(arch=[ti.cpu, ti.opengl],
                  require=[ti.extension.sparse, ti.extension.bls])
 def test_require_extensions_2():
-    assert ti.cfg.arch in [ti.cuda]
+    assert ti.lang.impl.current_cfg().arch in [ti.cuda]
 
 
 ### `test_utils.approx` and `test_utils.allclose`

--- a/tests/python/test_unary_ops.py
+++ b/tests/python/test_unary_ops.py
@@ -5,7 +5,9 @@ from tests import test_utils
 
 
 def _test_op(dt, taichi_op, np_op):
-    print('arch={} default_fp={}'.format(ti.cfg.arch, ti.cfg.default_fp))
+    print('arch={} default_fp={}'.format(
+        ti.lang.impl.current_cfg().arch,
+        ti.lang.impl.current_cfg().default_fp))
     n = 4
     val = ti.field(dt, shape=n)
 
@@ -24,9 +26,10 @@ def _test_op(dt, taichi_op, np_op):
         if dt == ti.f64:
             assert abs(np_op(float(f(i))) - val[i]) < 1e-15
         else:
-            assert abs(
-                np_op(float(f(i))) - val[i]
-            ) < 1e-6 if ti.cfg.arch != ti.opengl and ti.cfg.arch != ti.vulkan else 1e-5
+            assert abs(np_op(float(f(i))) -
+                       val[i]) < 1e-6 if ti.lang.impl.current_cfg(
+                       ).arch != ti.opengl and ti.lang.impl.current_cfg(
+                       ).arch != ti.vulkan else 1e-5
 
 
 def test_f64_trig():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ import taichi as ti
 
 # Helper functions
 def get_rel_eps():
-    arch = ti.cfg.arch
+    arch = ti.lang.impl.current_cfg().arch
     if arch == ti.opengl:
         return 1e-3
     if arch == ti.metal:


### PR DESCRIPTION
Before this PR we have `ti.cfg` and `ti.lang.impl.current_cfg()` and
they're different objects. It's confusing to have both so let's just
make `ti.cfg` an alias of the other. (it's a bit difficult to hook ti.cfg as function call in python3.6 so let's just skip it for now.)

Note `ti.cfg` used to be default_config before `ti.init()` is called and
now it's `None`. It's safe to change this behavior as nothing can be
done without `ti.init()`.

Related issue = #3782 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
