### PR TITLE
[llvm] Add missing pre-processor macro in cpp-tests when LLVM is disabled

### DIFF
--- a/tests/cpp/codegen/refine_coordinates_test.cpp
+++ b/tests/cpp/codegen/refine_coordinates_test.cpp
@@ -1,3 +1,4 @@
+#ifdef TI_WITH_LLVM
 #include "gtest/gtest.h"
 
 #include <memory>
@@ -164,3 +165,4 @@ TEST_F(RefineCoordinatesTest, Basic) {
 }  // namespace
 }  // namespace lang
 }  // namespace taichi
+#endif  // #ifdef TI_WITH_LLVM


### PR DESCRIPTION
Related issue = #1659 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
