### PR TITLE
[lang] Fix bls_buffer allocation of x64 crashed in py3.10

### DIFF
--- a/taichi/backends/cpu/codegen_cpu.cpp
+++ b/taichi/backends/cpu/codegen_cpu.cpp
@@ -130,12 +130,13 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
   void create_bls_buffer(OffloadedStmt *stmt) {
     auto type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*llvm_context),
                                      stmt->bls_size);
-    /*bls_buffer = new llvm::GlobalVariable(
-        *module, type, false, llvm::GlobalValue::ExternalLinkage, nullptr,
-        "bls_buffer", nullptr, llvm::GlobalVariable::LocalExecTLSModel, 0);*/ // JIT session error: Symbols not found: [ __emutls_get_address ] in python 3.10
-    module->getOrInsertGlobal("bls_buffer", type);
+      bls_buffer = new llvm::GlobalVariable(
+          *module, type, false, llvm::GlobalValue::ExternalLinkage, nullptr,
+          "bls_buffer", nullptr, llvm::GlobalVariable::LocalExecTLSModel, 0);
+    /* module->getOrInsertGlobal("bls_buffer", type);
     bls_buffer = module->getNamedGlobal("bls_buffer");
-    bls_buffer->setAlignment(llvm::MaybeAlign(8));
+    bls_buffer->setAlignment(llvm::MaybeAlign(8));*/ // TODO(changyu): Fix JIT session error: Symbols not found: [ __emutls_get_address ] in python 3.10
+    
     // initialize the variable with an undef value to ensure it is added to the
     // symbol table
     bls_buffer->setInitializer(llvm::UndefValue::get(type));

--- a/taichi/backends/cpu/codegen_cpu.cpp
+++ b/taichi/backends/cpu/codegen_cpu.cpp
@@ -130,13 +130,13 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
   void create_bls_buffer(OffloadedStmt *stmt) {
     auto type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*llvm_context),
                                      stmt->bls_size);
-      bls_buffer = new llvm::GlobalVariable(
-          *module, type, false, llvm::GlobalValue::ExternalLinkage, nullptr,
-          "bls_buffer", nullptr, llvm::GlobalVariable::LocalExecTLSModel, 0);
+    bls_buffer = new llvm::GlobalVariable(
+        *module, type, false, llvm::GlobalValue::ExternalLinkage, nullptr,
+        "bls_buffer", nullptr, llvm::GlobalVariable::LocalExecTLSModel, 0);
     /* module->getOrInsertGlobal("bls_buffer", type);
     bls_buffer = module->getNamedGlobal("bls_buffer");
     bls_buffer->setAlignment(llvm::MaybeAlign(8));*/ // TODO(changyu): Fix JIT session error: Symbols not found: [ __emutls_get_address ] in python 3.10
-    
+
     // initialize the variable with an undef value to ensure it is added to the
     // symbol table
     bls_buffer->setInitializer(llvm::UndefValue::get(type));

--- a/taichi/backends/cpu/codegen_cpu.cpp
+++ b/taichi/backends/cpu/codegen_cpu.cpp
@@ -130,9 +130,11 @@ class CodeGenLLVMCPU : public CodeGenLLVM {
   void create_bls_buffer(OffloadedStmt *stmt) {
     auto type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*llvm_context),
                                      stmt->bls_size);
-    bls_buffer = new llvm::GlobalVariable(
+    /*bls_buffer = new llvm::GlobalVariable(
         *module, type, false, llvm::GlobalValue::ExternalLinkage, nullptr,
-        "bls_buffer", nullptr, llvm::GlobalVariable::LocalExecTLSModel, 0);
+        "bls_buffer", nullptr, llvm::GlobalVariable::LocalExecTLSModel, 0);*/ // JIT session error: Symbols not found: [ __emutls_get_address ] in python 3.10
+    module->getOrInsertGlobal("bls_buffer", type);
+    bls_buffer = module->getNamedGlobal("bls_buffer");
     bls_buffer->setAlignment(llvm::MaybeAlign(8));
     // initialize the variable with an undef value to ensure it is added to the
     // symbol table

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -189,7 +189,7 @@ void offload_to_executable(IRNode *ir,
   if (is_extension_supported(config.arch, Extension::mesh)) {
     irpass::make_mesh_thread_local(ir, config, {kernel->get_name()});
     print("Make mesh thread local");
-    if (config.make_mesh_block_local) {
+    if (config.make_mesh_block_local && config.arch == Arch::cuda) {
       irpass::make_mesh_block_local(ir, config, {kernel->get_name()});
       print("Make mesh block local");
       irpass::full_simplify(ir, config, {false, kernel->program});


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/4266

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
