### PR TITLE
[llvm] Use GEP for array access instead of ptrtoint/inttoptr

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -69,7 +69,7 @@ class Matrix(TaichiOperations):
                     self.local_tensor_proxy = impl.expr_init_local_tensor(
                         [len(n)], dt,
                         expr.make_expr_group([expr.Expr(x) for x in n]))
-                    self.dynamic_index_stride = ti_core.data_type_size(dt)
+                    self.dynamic_index_stride = 1
                     mat = []
                     for i in range(len(n)):
                         mat.append(
@@ -110,7 +110,7 @@ class Matrix(TaichiOperations):
                         [len(n), len(n[0])], dt,
                         expr.make_expr_group(
                             [expr.Expr(x) for row in n for x in row]))
-                    self.dynamic_index_stride = ti_core.data_type_size(dt)
+                    self.dynamic_index_stride = 1
                     mat = []
                     for i in range(len(n)):
                         mat.append([])

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -830,8 +830,7 @@ Expr ASTBuilder::expr_alloca_local_tensor(const std::vector<int> &shape,
     for (int d = 0; d < (int)shape.size(); ++d)
       indices.push_back(reversed_indices[(int)shape.size() - 1 - d]);
     this->insert(std::make_unique<FrontendAssignStmt>(
-        Expr::make<TensorElementExpression>(var, indices, shape,
-                                            data_type_size(element_type)),
+        Expr::make<TensorElementExpression>(var, indices, shape, 1),
         elements.exprs[i]));
   }
   return var;

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -39,7 +39,7 @@ CompileConfig::CompileConfig() {
   verbose = true;
   fast_math = true;
   async_mode = false;
-  dynamic_index = false;
+  dynamic_index = true;
   flatten_if = false;
   make_thread_local = true;
   make_block_local = true;

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -39,7 +39,7 @@ CompileConfig::CompileConfig() {
   verbose = true;
   fast_math = true;
   async_mode = false;
-  dynamic_index = true;
+  dynamic_index = false;
   flatten_if = false;
   make_thread_local = true;
   make_block_local = true;

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -187,7 +187,6 @@ def test_dense_dynamic_len():
 
 @test_utils.test(require=ti.extension.sparse)
 def test_dynamic_activate():
-    ti.init(arch=ti.metal)
     # record the lengths
     l = ti.field(ti.i32, 3)
     x = ti.field(ti.i32)


### PR DESCRIPTION
Related issue = #2590

Using `ptrtoint/inttoptr` for array access prevents LLVM from demoting array alloca into individual allocas, which further prevents mem2reg optimizations. After this PR, with `dynamic_index=True`, we can have the same runtime performance as with `dynamic_index=False` for old code which can only access matrices with constant indices.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
