### PR TITLE
[spirv] Fix buffer info compare to fix external array bind point

### DIFF
--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -39,7 +39,7 @@ struct TaskAttributes {
       if (type != other.type) {
         return false;
       }
-      if (type == BufferType::Root) {
+      if (type == BufferType::Root || type == BufferType::ExtArr) {
         return root_id == other.root_id;
       }
       return true;


### PR DESCRIPTION
Otherwise we will bind the same buffer over and over again.