### PR TITLE
[misc] Add deserialization tool for benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,41 @@
+Install a few of extra requirements:
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+## Run
+
+To run all benchmarks:
+```bash
+python3 run.py
+```
+
+## Result
+
+The benchmark results will be stored in the `results` folder in your current directory.
+If you wish to save the results as a single json file (`./results/results.json`):
+```bash
+python3 deserialize.py
+```
+Or you can specify the input and output path:
+```bash
+python3 deserialize.py --folder PATH_OF_RESULTS_FOLDER --output_path PATH_YOU_WIHS_TO_STORE
+```
+
+## Tools
+
+After getting benchmark results (`./results`), you can use a visualization tool to profile performance problems:
+```bash
+python3 visualization.py
+```
+
+You can specify the results file path:
+```bash
+python3 visualization.py --folder PATH_OF_RESULTS_FOLDER
+```
+
+The default host and port is `localhost:5006\visualization`.
+If you want to enable remote access, take the following steps:
+```bash
+python3 visualization.py --host YOUR_IP_ADDRESS --port PORT_YOU_WISH_TO_USE
+```

--- a/benchmarks/deserialize.py
+++ b/benchmarks/deserialize.py
@@ -88,6 +88,17 @@ if __name__ == '__main__':
                         type=str,
                         help='Path of result folder. Defaults to ./results')
 
-    results = ResultsBuilder(parser.parse_args().folder)
+    parser.add_argument('-o',
+                        '--output_path',
+                        default='./results',
+                        dest='output_path',
+                        type=str,
+                        help='Path of result folder. Defaults to ./results')
+
+    args = parser.parse_args()
+    result_folder = args.folder
+    output_path = args.output_path
+
+    results = ResultsBuilder(result_folder)
+    results.save_results_as_json(output_path)
     results.print_info()
-    results.save_results_as_json()

--- a/benchmarks/deserialize.py
+++ b/benchmarks/deserialize.py
@@ -3,15 +3,7 @@ import json
 import os
 from copy import deepcopy
 
-import jsbeautifier
-
-
-# Decouple from taichi by not importing from utils
-def dump2json(obj):
-    obj2dict = obj if type(obj) is dict else obj.__dict__
-    options = jsbeautifier.default_options()
-    options.indent_size = 4
-    return jsbeautifier.beautify(json.dumps(obj2dict), options)
+from utils import dump2json
 
 
 class ResultsBuilder():

--- a/benchmarks/deserialize.py
+++ b/benchmarks/deserialize.py
@@ -1,0 +1,101 @@
+import argparse
+import json
+import os
+from copy import deepcopy
+
+import jsbeautifier
+
+
+# Decouple from taichi by not importing from utils
+def dump2json(obj):
+    obj2dict = obj if type(obj) is dict else obj.__dict__
+    options = jsbeautifier.default_options()
+    options.indent_size = 4
+    return jsbeautifier.beautify(json.dumps(obj2dict), options)
+
+
+class ResultsBuilder():
+    def __init__(self, results_file_path=None):
+        self._suites_result = {}
+        if results_file_path is not None:
+            self._file_path = results_file_path
+        else:
+            print('Enter path of result file:')
+            self._file_path = input()
+        self.load_suites_result()
+
+    def load_suites_result(self):
+        # benchmark info
+        info_path = os.path.join(self._file_path, '_info.json')
+        with open(info_path, 'r') as f:
+            info_dict = json.load(f)['suites']
+            # suite info
+            for suite_name, attrs in info_dict.items():
+                self._suites_result[suite_name] = {}
+                for arch in attrs['archs']:
+                    self._suites_result[suite_name][arch] = {}
+                    suite_info_path = os.path.join(self._file_path, suite_name,
+                                                   arch, "_info.json")
+                    with open(suite_info_path, 'r') as f:
+                        suite_info_dict = json.load(f)
+                    # case info
+                    for case_name in suite_info_dict:
+                        items = suite_info_dict[case_name]
+                        items.pop('name')
+                        items['metrics'] = items.pop('get_metric')
+                        self._suites_result[suite_name][arch][case_name] = {
+                            'items': items
+                        }
+        # cases result
+        for suite_name in self._suites_result:
+            for arch in self._suites_result[suite_name]:
+                for case_name in self._suites_result[suite_name][arch]:
+                    case_info_path = os.path.join(self._file_path, suite_name,
+                                                  arch, case_name + ".json")
+                    with open(case_info_path, 'r') as f:
+                        case_results = json.load(f)
+                        remove_none_list = []
+                        for name, data in case_results.items():
+                            # data['metric'] = data['tags'][-1]
+                            data['tags'] = data['tags'][
+                                1:]  # remove case_name & metric
+                            if data['result'] is None:
+                                remove_none_list.append(name)
+                        for name in remove_none_list:
+                            case_results.pop(name)
+                        self._suites_result[suite_name][arch][case_name][
+                            'results'] = case_results
+
+    def get_suites_result(self):
+        return self._suites_result
+
+    def save_results_as_json(self, costomized_dir=None):
+        file_path = os.path.join(self._file_path, 'results.json')
+        if costomized_dir != None:
+            file_path = os.path.join(costomized_dir, 'results.json')
+        with open(file_path, 'w') as f:
+            print(dump2json(self._suites_result), file=f)
+
+    def print_info(self):
+        # remove 'results' in self._suites_result, than print
+        info_dict = deepcopy(self._suites_result)
+        for suite_name in info_dict:
+            for arch in info_dict[suite_name]:
+                for case in info_dict[suite_name][arch]:
+                    info_dict[suite_name][arch][case].pop('results')
+        print(dump2json(info_dict))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-f',
+                        '--folder',
+                        default='./results',
+                        dest='folder',
+                        type=str,
+                        help='Path of result folder. Defaults to ./results')
+
+    results = ResultsBuilder(parser.parse_args().folder)
+    results.print_info()
+    results.save_results_as_json()

--- a/benchmarks/deserialize.py
+++ b/benchmarks/deserialize.py
@@ -7,13 +7,9 @@ from utils import dump2json
 
 
 class ResultsBuilder():
-    def __init__(self, results_file_path=None):
+    def __init__(self, results_file_path: str):
         self._suites_result = {}
-        if results_file_path is not None:
-            self._file_path = results_file_path
-        else:
-            print('Enter path of result file:')
-            self._file_path = input()
+        self._file_path = results_file_path
         self.load_suites_result()
 
     def load_suites_result(self):
@@ -48,9 +44,8 @@ class ResultsBuilder():
                         case_results = json.load(f)
                         remove_none_list = []
                         for name, data in case_results.items():
-                            # data['metric'] = data['tags'][-1]
-                            data['tags'] = data['tags'][
-                                1:]  # remove case_name & metric
+                            # remove case_name
+                            data['tags'] = data['tags'][1:]
                             if data['result'] is None:
                                 remove_none_list.append(name)
                         for name in remove_none_list:
@@ -69,7 +64,7 @@ class ResultsBuilder():
             print(dump2json(self._suites_result), file=f)
 
     def print_info(self):
-        # remove 'results' in self._suites_result, than print
+        # remove 'results' in self._suites_result, then print
         info_dict = deepcopy(self._suites_result)
         for suite_name in info_dict:
             for arch in info_dict[suite_name]:

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,0 +1,1 @@
+jsbeautifier

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,1 +1,2 @@
 jsbeautifier
+bokeh

--- a/misc/code_format.py
+++ b/misc/code_format.py
@@ -77,19 +77,12 @@ def format_py_file(filename):
     format_plain_text(filename)
 
 
-def main(all=False, diff=None):
+def main(all=True, diff=None):
     repo = Repo(repo_dir)
 
     if all:
         directories = [
-            'taichi',
-            'tests',
-            'examples',
-            'misc',
-            'python',
             'benchmarks',
-            'docs',
-            'cmake',
         ]
         files = list(Path(repo_dir).glob(
             '*'))  # Include all files under the root folder

--- a/misc/code_format.py
+++ b/misc/code_format.py
@@ -77,12 +77,19 @@ def format_py_file(filename):
     format_plain_text(filename)
 
 
-def main(all=True, diff=None):
+def main(all=False, diff=None):
     repo = Repo(repo_dir)
 
     if all:
         directories = [
+            'taichi',
+            'tests',
+            'examples',
+            'misc',
+            'python',
             'benchmarks',
+            'docs',
+            'cmake',
         ]
         files = list(Path(repo_dir).glob(
             '*'))  # Include all files under the root folder


### PR DESCRIPTION
Related issue = #4058

Reads the results of benchmarks from a folder (default: `./results`).
Stores the data as a dictionary, and can be saved as a single file (`results.json`).