### PR TITLE
[opengl] Use element shape as compile information for OpenGL backend

### DIFF
--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -61,8 +61,9 @@ def decl_any_arr_arg(dtype, dim, element_shape, layout):
     if layout == Layout.AOS:
         element_dim = -element_dim
     return AnyArray(
-        _ti_core.make_external_tensor_expr(dtype, dim, arg_id, element_dim),
-        element_shape, layout)
+        _ti_core.make_external_tensor_expr(dtype, dim, arg_id, element_dim,
+                                           element_shape), element_shape,
+        layout)
 
 
 def decl_ret(dtype):

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -532,29 +532,29 @@ class KernelGen : public IRVisitor {
     auto element_shape = stmt->element_shape;
     std::vector<std::string> size_var_names;
     std::vector<std::string> element_shape_size_var_names;
-    const int layout_SOA = 1;
-    const int layout_AOS = 0;
-    int layout = stmt->element_dim <= 0 ? layout_AOS : layout_SOA;
+    enum ExternalArrayLayout { layout_AOS = 0, layout_SOA = 1 };
+    auto layout = stmt->element_dim <= 0 ? layout_AOS : layout_SOA;
 
     if (element_shape.size() > 0) {
-      int elem_beg = num_indices - element_shape.size();
-      int elem_end = num_indices;
+      int elem_beg(0), elem_end(0);
       if (layout == layout_SOA) {
         elem_beg = 0;
         elem_end = element_shape.size();
+      } else {
+        elem_beg = num_indices - element_shape.size();
+        elem_end = num_indices;
       }
       for (int i = elem_beg; i < elem_end; i++) {
         used.int32 = true;
         std::string var_name = fmt::format("_s{}_{}{}", i, "arr", arg_id);
         if (!loaded_args_.count(var_name)) {
-          // The passed element shape vector is reversed w.r.t. to args buffer
           emit("int {} = {};", var_name, element_shape[i - elem_beg]);
           loaded_args_.insert(var_name);
         }
         element_shape_size_var_names.push_back(std::move(var_name));
       }
     }
-    // Args buffer arrange dimensions higher to lower
+    // Args buffer arrange dimensions from outer to inner
     // AoS args buffer:   array_shape|element_shape
     // SoA args buffer: element_shape|array_shape
     //
@@ -563,11 +563,13 @@ class KernelGen : public IRVisitor {
     // ti.Matrix.ndarray(3, 2, ti.f32, (5, 4), layout=ti.Layout.SOA)
     // args buffer: 3, 2, 5, 4
 
-    int ind_beg = 0;
-    int ind_end = num_indices - element_shape.size();
+    int ind_beg(0), ind_end(0);
     if (layout == layout_SOA) {
       ind_beg = element_shape.size();
       ind_end = num_indices;
+    } else {
+      ind_beg = 0;
+      ind_end = num_indices - element_shape.size();
     }
     for (int i = ind_beg; i < ind_end; i++) {
       used.buf_args = true;

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -536,7 +536,8 @@ class KernelGen : public IRVisitor {
     auto layout = stmt->element_dim <= 0 ? layout_AOS : layout_SOA;
 
     if (element_shape.size() > 0) {
-      int elem_beg(0), elem_end(0);
+      int elem_beg = 0;
+      int elem_end = 0;
       if (layout == layout_SOA) {
         elem_beg = 0;
         elem_end = element_shape.size();
@@ -562,8 +563,8 @@ class KernelGen : public IRVisitor {
     // args buffer: 5, 4, 3, 2
     // ti.Matrix.ndarray(3, 2, ti.f32, (5, 4), layout=ti.Layout.SOA)
     // args buffer: 3, 2, 5, 4
-
-    int ind_beg(0), ind_end(0);
+    int ind_beg = 0;
+    int ind_end = 0;
     if (layout == layout_SOA) {
       ind_beg = element_shape.size();
       ind_end = num_indices;

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -529,8 +529,47 @@ class KernelGen : public IRVisitor {
     const auto *argload = stmt->base_ptrs[0]->as<ArgLoadStmt>();
     const int arg_id = argload->arg_id;
     const int num_indices = stmt->indices.size();
+    auto element_shape = stmt->element_shape;
     std::vector<std::string> size_var_names;
-    for (int i = 0; i < num_indices; i++) {
+    std::vector<std::string> element_shape_size_var_names;
+    const int layout_SOA = 1;
+    const int layout_AOS = 0;
+    int layout = stmt->element_dim <= 0 ? layout_AOS : layout_SOA;
+
+    if (element_shape.size() > 0) {
+      int elem_beg = num_indices - element_shape.size();
+      int elem_end = num_indices;
+      if (layout == layout_SOA) {
+        elem_beg = 0;
+        elem_end = element_shape.size();
+      }
+      for (int i = elem_beg; i < elem_end; i++) {
+        used.int32 = true;
+        std::string var_name = fmt::format("_s{}_{}{}", i, "arr", arg_id);
+        if (!loaded_args_.count(var_name)) {
+          // The passed element shape vector is reversed w.r.t. to args buffer
+          emit("int {} = {};", var_name, element_shape[i - elem_beg]);
+          loaded_args_.insert(var_name);
+        }
+        element_shape_size_var_names.push_back(std::move(var_name));
+      }
+    }
+    // Args buffer arrange dimensions higher to lower
+    // AoS args buffer:   array_shape|element_shape
+    // SoA args buffer: element_shape|array_shape
+    //
+    // ti.Matrix.ndarray(3, 2, ti.f32, (5, 4), layout=ti.Layout.AOS)
+    // args buffer: 5, 4, 3, 2
+    // ti.Matrix.ndarray(3, 2, ti.f32, (5, 4), layout=ti.Layout.SOA)
+    // args buffer: 3, 2, 5, 4
+
+    int ind_beg = 0;
+    int ind_end = num_indices - element_shape.size();
+    if (layout == layout_SOA) {
+      ind_beg = element_shape.size();
+      ind_end = num_indices;
+    }
+    for (int i = ind_beg; i < ind_end; i++) {
       used.buf_args = true;
       used.int32 = true;
       std::string var_name = fmt::format("_s{}_{}{}", i, "arr", arg_id);
@@ -542,6 +581,16 @@ class KernelGen : public IRVisitor {
         loaded_args_.insert(var_name);
       }
       size_var_names.push_back(std::move(var_name));
+    }
+    // Arrange index stride and offsets in correct order
+    if (layout == layout_SOA) {
+      size_var_names.insert(size_var_names.begin(),
+                            element_shape_size_var_names.begin(),
+                            element_shape_size_var_names.end());
+    } else {
+      size_var_names.insert(size_var_names.end(),
+                            element_shape_size_var_names.begin(),
+                            element_shape_size_var_names.end());
     }
 
     emit("int {} = {};", linear_index_name,

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -350,8 +350,9 @@ void GlobalPtrExpression::flatten(FlattenContext *ctx) {
   } else {
     TI_ASSERT(var.is<ExternalTensorExpression>());
     flatten_lvalue(var, ctx);
+    auto expr = var.cast<ExternalTensorExpression>();
     ctx->push_back(std::make_unique<ExternalPtrStmt>(
-        var.cast<ExternalTensorExpression>()->stmt, index_stmts));
+        expr->stmt, index_stmts, expr->element_shape, expr->element_dim));
   }
   stmt = ctx->back_stmt();
 }

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -415,12 +415,11 @@ class ExternalTensorExpression : public Expression {
                            int dim,
                            int arg_id,
                            int element_dim)
-      : dt(dt),
-        dim(dim),
-        arg_id(arg_id),
-        element_dim(element_dim),
-        element_shape() {
-    set_attribute("dim", std::to_string(dim));
+      : ExternalTensorExpression(dt,
+                                 dim,
+                                 arg_id,
+                                 element_dim,
+                                 std::vector<int>()) {
   }
 
   ExternalTensorExpression(const DataType &dt,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -415,11 +415,8 @@ class ExternalTensorExpression : public Expression {
                            int dim,
                            int arg_id,
                            int element_dim)
-      : ExternalTensorExpression(dt,
-                                 dim,
-                                 arg_id,
-                                 element_dim,
-                                 std::vector<int>()) {
+      : dt(dt), dim(dim), arg_id(arg_id), element_dim(element_dim) {
+    set_attribute("dim", std::to_string(dim));
   }
 
   ExternalTensorExpression(const DataType &dt,
@@ -427,12 +424,8 @@ class ExternalTensorExpression : public Expression {
                            int arg_id,
                            int element_dim,
                            const std::vector<int> &element_shape)
-      : dt(dt),
-        dim(dim),
-        arg_id(arg_id),
-        element_dim(element_dim),
-        element_shape(element_shape) {
-    set_attribute("dim", std::to_string(dim));
+      : ExternalTensorExpression(dt, dim, arg_id, element_dim) {
+    this->element_shape = element_shape;
   }
 
   void type_check(CompileConfig *config) override {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -408,11 +408,31 @@ class ExternalTensorExpression : public Expression {
   int element_dim;  // 0: scalar; 1: vector (SOA); 2: matrix (SOA); -1: vector
                     // (AOS); -2: matrix (AOS)
 
+  // Fill element shape if compile-time specialization is desired.
+  std::vector<int> element_shape;
+
   ExternalTensorExpression(const DataType &dt,
                            int dim,
                            int arg_id,
                            int element_dim)
-      : dt(dt), dim(dim), arg_id(arg_id), element_dim(element_dim) {
+      : dt(dt),
+        dim(dim),
+        arg_id(arg_id),
+        element_dim(element_dim),
+        element_shape() {
+    set_attribute("dim", std::to_string(dim));
+  }
+
+  ExternalTensorExpression(const DataType &dt,
+                           int dim,
+                           int arg_id,
+                           int element_dim,
+                           const std::vector<int> &element_shape)
+      : dt(dt),
+        dim(dim),
+        arg_id(arg_id),
+        element_dim(element_dim),
+        element_shape(element_shape) {
     set_attribute("dim", std::to_string(dim));
   }
 

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -427,7 +427,7 @@ GlobalPtrStmt *IRBuilder::create_global_ptr(
 ExternalPtrStmt *IRBuilder::create_external_ptr(
     ArgLoadStmt *ptr,
     const std::vector<Stmt *> &indices) {
-  return insert(Stmt::make_typed<ExternalPtrStmt>(ptr, indices));
+  return insert(Stmt::make_typed<ExternalPtrStmt>(ptr, indices, std::vector<int>(), 0));
 }
 
 AdStackAllocaStmt *IRBuilder::create_ad_stack(const DataType &dt,

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -427,7 +427,8 @@ GlobalPtrStmt *IRBuilder::create_global_ptr(
 ExternalPtrStmt *IRBuilder::create_external_ptr(
     ArgLoadStmt *ptr,
     const std::vector<Stmt *> &indices) {
-  return insert(Stmt::make_typed<ExternalPtrStmt>(ptr, indices, std::vector<int>(), 0));
+  return insert(
+      Stmt::make_typed<ExternalPtrStmt>(ptr, indices, std::vector<int>(), 0));
 }
 
 AdStackAllocaStmt *IRBuilder::create_ad_stack(const DataType &dt,

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -26,9 +26,15 @@ bool UnaryOpStmt::same_operation(UnaryOpStmt *o) const {
   return false;
 }
 
-ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
-                                 const std::vector<Stmt *> &indices)
-    : base_ptrs(base_ptrs), indices(indices) {
+ExternalPtrStmt::ExternalPtrStmt(
+    const LaneAttribute<Stmt *> &base_ptrs,
+    const std::vector<Stmt *> &indices,
+    const std::vector<int> &element_shape = std::vector<int>(),
+    const int element_dim = 0)
+    : base_ptrs(base_ptrs),
+      indices(indices),
+      element_shape(element_shape),
+      element_dim(element_dim) {
   DataType dt = PrimitiveType::f32;
   for (int i = 0; i < (int)base_ptrs.size(); i++) {
     TI_ASSERT(base_ptrs[i] != nullptr);

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -26,11 +26,15 @@ bool UnaryOpStmt::same_operation(UnaryOpStmt *o) const {
   return false;
 }
 
-ExternalPtrStmt::ExternalPtrStmt(
-    const LaneAttribute<Stmt *> &base_ptrs,
-    const std::vector<Stmt *> &indices,
-    const std::vector<int> &element_shape = std::vector<int>(),
-    const int element_dim = 0)
+ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
+                                 const std::vector<Stmt *> &indices)
+    : ExternalPtrStmt(base_ptrs, indices, std::vector<int>(), 0) 
+      {}
+
+ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
+                                 const std::vector<Stmt *> &indices,
+                                 const std::vector<int> &element_shape,
+                                 const int element_dim)
     : base_ptrs(base_ptrs),
       indices(indices),
       element_shape(element_shape),

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -28,8 +28,8 @@ bool UnaryOpStmt::same_operation(UnaryOpStmt *o) const {
 
 ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
                                  const std::vector<Stmt *> &indices)
-    : ExternalPtrStmt(base_ptrs, indices, std::vector<int>(), 0) 
-      {}
+    : ExternalPtrStmt(base_ptrs, indices, std::vector<int>(), 0) {
+}
 
 ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
                                  const std::vector<Stmt *> &indices,

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -28,17 +28,7 @@ bool UnaryOpStmt::same_operation(UnaryOpStmt *o) const {
 
 ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
                                  const std::vector<Stmt *> &indices)
-    : ExternalPtrStmt(base_ptrs, indices, std::vector<int>(), 0) {
-}
-
-ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
-                                 const std::vector<Stmt *> &indices,
-                                 const std::vector<int> &element_shape,
-                                 const int element_dim)
-    : base_ptrs(base_ptrs),
-      indices(indices),
-      element_shape(element_shape),
-      element_dim(element_dim) {
+    : base_ptrs(base_ptrs), indices(indices) {
   DataType dt = PrimitiveType::f32;
   for (int i = 0; i < (int)base_ptrs.size(); i++) {
     TI_ASSERT(base_ptrs[i] != nullptr);
@@ -47,6 +37,15 @@ ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
   TI_ASSERT(base_ptrs.size() == 1);
   element_type() = dt;
   TI_STMT_REG_FIELDS;
+}
+
+ExternalPtrStmt::ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
+                                 const std::vector<Stmt *> &indices,
+                                 const std::vector<int> &element_shape,
+                                 int element_dim)
+    : ExternalPtrStmt(base_ptrs, indices) {
+  this->element_shape = element_shape;
+  this->element_dim = element_dim;
 }
 
 GlobalPtrStmt::GlobalPtrStmt(const LaneAttribute<SNode *> &snodes,

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -263,9 +263,15 @@ class ExternalPtrStmt : public Stmt {
  public:
   LaneAttribute<Stmt *> base_ptrs;
   std::vector<Stmt *> indices;
+  std::vector<int> element_shape;
+  // AOS: element_dim < 0
+  // SOA: element_dim > 0
+  int element_dim;
 
   ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
-                  const std::vector<Stmt *> &indices);
+                  const std::vector<Stmt *> &indices,
+                  const std::vector<int> &element_shape,
+                  const int element_dim);
 
   bool has_global_side_effect() const override {
     return false;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -269,6 +269,9 @@ class ExternalPtrStmt : public Stmt {
   int element_dim;
 
   ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
+                  const std::vector<Stmt *> &indices);
+
+  ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
                   const std::vector<Stmt *> &indices,
                   const std::vector<int> &element_shape,
                   const int element_dim);

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -274,7 +274,7 @@ class ExternalPtrStmt : public Stmt {
   ExternalPtrStmt(const LaneAttribute<Stmt *> &base_ptrs,
                   const std::vector<Stmt *> &indices,
                   const std::vector<int> &element_shape,
-                  const int element_dim);
+                  int element_dim);
 
   bool has_global_side_effect() const override {
     return false;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -643,7 +643,8 @@ void export_lang(py::module &m) {
         Expr::make<ArgLoadExpression, int, const DataType &>);
 
   m.def("make_external_tensor_expr",
-        Expr::make<ExternalTensorExpression, const DataType &, int, int, int>);
+        Expr::make<ExternalTensorExpression, const DataType &, int, int, int,
+                   const std::vector<int> &>);
 
   m.def("make_id_expr", Expr::make<IdExpression, std::string>);
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -522,15 +522,15 @@ class IRPrinter : public IRVisitor {
       }
     }
     s += "]";
-    if (stmt->element_shape.size() ) {
+    if (stmt->element_shape.size()) {
       s += ", (";
-    for (int i = 0; i < (int)stmt->element_shape.size(); i++) {
-      s += fmt::format("{}", stmt->element_shape[i]);
-      if (i + 1 < (int)stmt->element_shape.size()) {
-        s += ", ";
+      for (int i = 0; i < (int)stmt->element_shape.size(); i++) {
+        s += fmt::format("{}", stmt->element_shape[i]);
+        if (i + 1 < (int)stmt->element_shape.size()) {
+          s += ", ";
+        }
       }
-    }
-    s += ")";
+      s += ")";
     }
 
     print(fmt::format("{}{} = external_ptr {}", stmt->type_hint(), stmt->name(),

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -522,6 +522,16 @@ class IRPrinter : public IRVisitor {
       }
     }
     s += "]";
+    if (stmt->element_shape.size() ) {
+      s += ", (";
+    for (int i = 0; i < (int)stmt->element_shape.size(); i++) {
+      s += fmt::format("{}", stmt->element_shape[i]);
+      if (i + 1 < (int)stmt->element_shape.size()) {
+        s += ", ";
+      }
+    }
+    s += ")";
+    }
 
     print(fmt::format("{}{} = external_ptr {}", stmt->type_hint(), stmt->name(),
                       s));


### PR DESCRIPTION
Related issue = #3903

Motivation:

Taichi automatically re-compiles the kernel when element shapes change. Therefore, element shape is compile-time static. This PR embed the element shape information into shader code for OpenGL backend.

Briefings:
* Changed `ExternalTensorExpression` and `ExternalPtrStmt` to get layout and element shape information.
* Changed OpenGL codegen to embed the shapes.