### PR TITLE
[lang] Hide dtype and needs_grad from SNode

### DIFF
--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -44,7 +44,7 @@ class Field:
         Returns:
             DataType: Data type of each individual value.
         """
-        return self.snode.dtype
+        return self.snode._dtype
 
     @property
     def name(self):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1129,7 +1129,7 @@ class MatrixField(Field):
         length = len(paths[0])
         if any(
                 len(path) != length or ti_core.is_custom_type(path[length -
-                                                                   1].dtype)
+                                                                   1]._dtype)
                 for path in paths):
             return
         for i in range(length):

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -201,7 +201,7 @@ class SNode:
         return res
 
     @property
-    def dtype(self):
+    def _dtype(self):
         """Gets the data type of `self`.
 
         Returns:
@@ -254,15 +254,6 @@ class SNode:
             SNode: `self`.
         """
         return self
-
-    @property
-    def needs_grad(self):
-        """Checks whether `self` has a corresponding gradient :class:`~taichi.lang.SNode`.
-
-        Returns:
-            bool: Whether `self` has a corresponding gradient :class:`~taichi.lang.SNode`.
-        """
-        return self.ptr.has_grad()
 
     def _get_children(self):
         """Gets all children components of `self`.


### PR DESCRIPTION
Related issue = #3782

Both of them only apply to leaf SNodes, i.e., fields. So users should get the info from a `Field` instance instead of a `SNode`. After this PR, `dtype` of `SNode` is hidden and `needs_grad` is removed.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
