### PR TITLE
[gui] [refactor] Avoid exposing different APIs with different GGUI_AVAILABLE values

### DIFF
--- a/python/taichi/ui/__init__.py
+++ b/python/taichi/ui/__init__.py
@@ -1,3 +1,2 @@
 from .gui import *
-from .imgui import *
 from .ui import *

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -86,4 +86,4 @@ class Canvas:
 
     def scene(self, scene):
         """Draw a 3D scene on the canvas"""
-        self.canvas.scene(scene)
+        self.canvas.scene(scene.scene)

--- a/python/taichi/ui/scene.py
+++ b/python/taichi/ui/scene.py
@@ -8,7 +8,7 @@ from taichi.types.primitive_types import f32
 
 from .staging_buffer import (copy_colors_to_vbo, copy_normals_to_vbo,
                              copy_vertices_to_vbo, get_vbo_field)
-from .utils import get_field_info
+from .utils import check_ggui_availability, get_field_info
 
 normals_field_cache = {}
 
@@ -72,11 +72,15 @@ def gen_normals(vertices, indices):
     return normals
 
 
-class Scene(_ti_core.PyScene):
+class Scene:
     """A 3D scene, which can contain meshes and particles, and can be rendered on a canvas
     """
+    def __init__(self):
+        check_ggui_availability()
+        self.scene = _ti_core.PyScene()
+
     def set_camera(self, camera):
-        super().set_camera(camera.ptr)
+        self.scene.set_camera(camera.ptr)
 
     def mesh(self,
              vertices,
@@ -106,8 +110,8 @@ class Scene(_ti_core.PyScene):
         vbo_info = get_field_info(vbo)
         indices_info = get_field_info(indices)
 
-        super().mesh(vbo_info, has_per_vertex_color, indices_info, color,
-                     two_sided)
+        self.scene.mesh(vbo_info, has_per_vertex_color, indices_info, color,
+                        two_sided)
 
     def particles(self,
                   centers,
@@ -128,7 +132,10 @@ class Scene(_ti_core.PyScene):
         if has_per_vertex_color:
             copy_colors_to_vbo(vbo, per_vertex_color)
         vbo_info = get_field_info(vbo)
-        super().particles(vbo_info, has_per_vertex_color, color, radius)
+        self.scene.particles(vbo_info, has_per_vertex_color, color, radius)
 
     def point_light(self, pos, color):  # pylint: disable=W0235
-        super().point_light(pos, color)
+        self.scene.point_light(pos, color)
+
+    def ambient_light(self, color):
+        self.scene.ambient_light(color)

--- a/python/taichi/ui/ui.py
+++ b/python/taichi/ui/ui.py
@@ -1,11 +1,11 @@
 from taichi._lib import core as _ti_core
 
-from .camera import Camera
-from .canvas import Canvas
-from .constants import *
-from .imgui import Gui
-from .scene import Scene
-from .window import Window
+from .camera import Camera  # pylint: disable=unused-import
+from .canvas import Canvas  # pylint: disable=unused-import
+from .constants import *  # pylint: disable=unused-import,wildcard-import
+from .imgui import Gui  # pylint: disable=unused-import
+from .scene import Scene  # pylint: disable=unused-import
+from .window import Window  # pylint: disable=unused-import
 from .utils import check_ggui_availability
 
 

--- a/python/taichi/ui/ui.py
+++ b/python/taichi/ui/ui.py
@@ -1,6 +1,6 @@
 from taichi._lib import core as _ti_core
 
-from .camera import Camera  # pylint: disable=unused-import
+from .camera import Camera
 from .canvas import Canvas  # pylint: disable=unused-import
 from .constants import *  # pylint: disable=unused-import,wildcard-import
 from .imgui import Gui  # pylint: disable=unused-import

--- a/python/taichi/ui/ui.py
+++ b/python/taichi/ui/ui.py
@@ -5,8 +5,8 @@ from .canvas import Canvas  # pylint: disable=unused-import
 from .constants import *  # pylint: disable=unused-import,wildcard-import
 from .imgui import Gui  # pylint: disable=unused-import
 from .scene import Scene  # pylint: disable=unused-import
-from .window import Window  # pylint: disable=unused-import
 from .utils import check_ggui_availability
+from .window import Window  # pylint: disable=unused-import
 
 
 def make_camera():

--- a/python/taichi/ui/ui.py
+++ b/python/taichi/ui/ui.py
@@ -1,33 +1,17 @@
 from taichi._lib import core as _ti_core
 
-GGUI_AVAILABLE = _ti_core.GGUI_AVAILABLE
+from .camera import Camera
+from .canvas import Canvas
+from .constants import *
+from .imgui import Gui
+from .scene import Scene
+from .window import Window
+from .utils import check_ggui_availability
 
-if GGUI_AVAILABLE:
 
-    from .camera import Camera  # pylint: disable=unused-import
-    from .canvas import Canvas  # pylint: disable=unused-import
-    from .constants import *  # pylint: disable=unused-import,wildcard-import
-    from .imgui import Gui  # pylint: disable=unused-import
-    from .scene import Scene  # pylint: disable=unused-import
-    from .window import Window  # pylint: disable=unused-import
+def make_camera():
+    check_ggui_availability()
+    return Camera(_ti_core.PyCamera())
 
-    def make_camera():
-        return Camera(_ti_core.PyCamera())
 
-    ProjectionMode = _ti_core.ProjectionMode
-
-else:
-
-    def err_no_ggui():
-        raise Exception("GGUI Not Available")
-
-    class Window:
-        def __init__(self, name, res, vsync=False):
-            err_no_ggui()
-
-    class Scene:
-        def __init__(self):
-            err_no_ggui()
-
-    def make_camera():
-        err_no_ggui()
+ProjectionMode = _ti_core.ProjectionMode if _ti_core.GGUI_AVAILABLE else None

--- a/python/taichi/ui/utils.py
+++ b/python/taichi/ui/utils.py
@@ -60,3 +60,8 @@ def vec_to_euler(v):
             yaw = -yaw
 
     return yaw, pitch
+
+
+def check_ggui_availability():
+    if not _ti_core.GGUI_AVAILABLE:
+        raise Exception("GGUI Not Available")

--- a/taichi/python/export_ggui.cpp
+++ b/taichi/python/export_ggui.cpp
@@ -322,8 +322,8 @@ void export_ggui(py::module &m) {
       .def("set_is_running", &PyWindow::set_is_running)
       .def("get_event", &PyWindow::get_event)
       .def("get_events", &PyWindow::get_events)
-      .def_property("event", &PyWindow::get_current_event,
-                    &PyWindow::set_current_event)
+      .def("get_current_event", &PyWindow::get_current_event)
+      .def("set_current_event", &PyWindow::set_current_event)
       .def("destroy", &PyWindow::destroy)
       .def("GUI", &PyWindow::GUI);
 

--- a/tests/python/test_ggui.py
+++ b/tests/python/test_ggui.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import taichi as ti
+from taichi._lib import core as _ti_core
 from tests import test_utils
 
 REGENERATE_GROUNDTRUTH_IMAGES = False
@@ -49,7 +50,7 @@ def verify_image(window, image_name, tolerence=0.1):
         os.remove(actual_name)
 
 
-@pytest.mark.skipif(not ti.ui.GGUI_AVAILABLE, reason="GGUI Not Available")
+@pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
 @test_utils.test(arch=supported_archs)
 def test_geometry_2d():
     window = ti.ui.Window('test', (640, 480), show_window=False)
@@ -150,7 +151,7 @@ def test_geometry_2d():
     window.destroy()
 
 
-@pytest.mark.skipif(not ti.ui.GGUI_AVAILABLE, reason="GGUI Not Available")
+@pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
 @test_utils.test(arch=supported_archs)
 def test_geometry_3d():
     window = ti.ui.Window('test', (640, 480), show_window=False)
@@ -242,7 +243,7 @@ def test_geometry_3d():
     window.destroy()
 
 
-@pytest.mark.skipif(not ti.ui.GGUI_AVAILABLE, reason="GGUI Not Available")
+@pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
 @test_utils.test(arch=supported_archs)
 def test_set_image():
     window = ti.ui.Window('test', (640, 480), show_window=False)
@@ -268,7 +269,7 @@ def test_set_image():
     window.destroy()
 
 
-@pytest.mark.skipif(not ti.ui.GGUI_AVAILABLE, reason="GGUI Not Available")
+@pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
 @test_utils.test(arch=supported_archs)
 def test_imgui():
     window = ti.ui.Window('test', (640, 480), show_window=False)

--- a/tests/python/test_ggui.py
+++ b/tests/python/test_ggui.py
@@ -5,9 +5,9 @@ import tempfile
 
 import numpy as np
 import pytest
+from taichi._lib import core as _ti_core
 
 import taichi as ti
-from taichi._lib import core as _ti_core
 from tests import test_utils
 
 REGENERATE_GROUNDTRUTH_IMAGES = False


### PR DESCRIPTION
Related issue = #3782

This PR replaces inheritance with composition to avoid inheriting from a class only available when GGUI is available. Now APIs  exposed from the `ui` subpackage will not depend on whether `GGUI_AVAILABLE=True`. Meanwhile, the error checking for using GGUI when `GGUI_AVAILABLE=False` remains the same.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
