### PR TITLE
[Vulkan] Enable Vulkan device selection when using cuda

### DIFF
--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -330,7 +330,7 @@ def init(arch=None,
 
     # user selected visible device
     visible_device = os.environ.get("TI_VISIBLE_DEVICE")
-    if visible_device and cfg.arch == vulkan:
+    if visible_device and cfg.arch in [vulkan, cuda]:
         _ti_core.set_vulkan_visible_device(visible_device)
 
     if _test_mode:

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -333,7 +333,7 @@ def init(arch=None,
 
     # user selected visible device
     visible_device = os.environ.get("TI_VISIBLE_DEVICE")
-    if visible_device and cfg.arch in [vulkan, cuda]:
+    if visible_device and (cfg.arch == vulkan or _ti_core.GGUI_AVAILABLE):
         _ti_core.set_vulkan_visible_device(visible_device)
 
     if _test_mode:

--- a/taichi/backends/vulkan/vulkan_device_creator.cpp
+++ b/taichi/backends/vulkan/vulkan_device_creator.cpp
@@ -168,20 +168,6 @@ bool is_device_suitable(VkPhysicalDevice device, VkSurfaceKHR surface) {
   }
 }
 
-bool is_device_visible(VkPhysicalDevice device) {
-  auto device_id = VulkanLoader::instance().visible_device_id;
-  if (device_id.empty()) {
-    // user did not specify, all devices visible
-    return true;
-  }
-
-  VkPhysicalDeviceProperties device_properties{};
-  vkGetPhysicalDeviceProperties(device, &device_properties);
-  std::stringstream id_sstream;
-  id_sstream << std::hex << device_properties.deviceID;
-  return id_sstream.str() == device_id;
-}
-
 }  // namespace
 
 VulkanDeviceCreator::VulkanDeviceCreator(
@@ -348,10 +334,32 @@ void VulkanDeviceCreator::pick_physical_device() {
   vkEnumeratePhysicalDevices(instance_, &device_count, devices.data());
   physical_device_ = VK_NULL_HANDLE;
 
-  for (const auto &device : devices) {
-    if (is_device_suitable(device, surface_) && (is_device_visible(device))) {
-      physical_device_ = device;
-      break;
+  for (int i = 0; i < device_count; i++) {
+    VkPhysicalDeviceProperties properties{};
+    vkGetPhysicalDeviceProperties(devices[i], &properties);
+    TI_INFO("Found Vulkan Device {} ({})", i, properties.deviceName);
+  }
+
+  auto device_id = VulkanLoader::instance().visible_device_id;
+  bool has_visible_device{0};
+  if (!device_id.empty()) {
+    int id = std::stoi(device_id);
+    TI_ASSERT_INFO((id >= 0) && (id < device_count),
+                   "TI_VISIBLE_DEVICE={} is not valid, found {} devices available",
+                   id, device_count);
+    if (is_device_suitable(devices[id], surface_)) {
+      physical_device_ = devices[id];
+      has_visible_device = 1;
+    }
+  }
+
+  if (!has_visible_device) {
+    // could not find a user defined visible device, use the first one suitable
+    for (const auto &device : devices) {
+      if (is_device_suitable(device, surface_)) {
+        physical_device_ = device;
+        break;
+      }
     }
   }
   TI_ASSERT_INFO(physical_device_ != VK_NULL_HANDLE,

--- a/taichi/backends/vulkan/vulkan_device_creator.cpp
+++ b/taichi/backends/vulkan/vulkan_device_creator.cpp
@@ -177,7 +177,9 @@ bool is_device_visible(VkPhysicalDevice device) {
 
   VkPhysicalDeviceProperties device_properties{};
   vkGetPhysicalDeviceProperties(device, &device_properties);
-  return device_properties.deviceID == std::stoul(device_id);
+  std::stringstream id_sstream;
+  id_sstream << std::hex << device_properties.deviceID;
+  return id_sstream.str() == device_id;
 }
 
 }  // namespace

--- a/taichi/backends/vulkan/vulkan_device_creator.cpp
+++ b/taichi/backends/vulkan/vulkan_device_creator.cpp
@@ -344,9 +344,10 @@ void VulkanDeviceCreator::pick_physical_device() {
   bool has_visible_device{0};
   if (!device_id.empty()) {
     int id = std::stoi(device_id);
-    TI_ASSERT_INFO((id >= 0) && (id < device_count),
-                   "TI_VISIBLE_DEVICE={} is not valid, found {} devices available",
-                   id, device_count);
+    TI_ASSERT_INFO(
+        (id >= 0) && (id < device_count),
+        "TI_VISIBLE_DEVICE={} is not valid, found {} devices available", id,
+        device_count);
     if (is_device_suitable(devices[id], surface_)) {
       physical_device_ = devices[id];
       has_visible_device = 1;

--- a/taichi/backends/vulkan/vulkan_loader.cpp
+++ b/taichi/backends/vulkan/vulkan_loader.cpp
@@ -70,10 +70,6 @@ bool VulkanLoader::check_vulkan_device() {
           }
         }
 
-        VkPhysicalDeviceProperties properties{};
-        vkGetPhysicalDeviceProperties(physical_device, &properties);
-
-        TI_INFO("Found Vulkan Device {} ({})", i, properties.deviceName);
       }
     }
   } while (false);

--- a/taichi/backends/vulkan/vulkan_loader.cpp
+++ b/taichi/backends/vulkan/vulkan_loader.cpp
@@ -69,7 +69,6 @@ bool VulkanLoader::check_vulkan_device() {
             found_device_with_compute = true;
           }
         }
-
       }
     }
   } while (false);


### PR DESCRIPTION
Changes made to allow the use of `TI_VISIBLE_DEVICE` to select Vulkan device. Users can use the env var to pick the desired device. 

```
[vulkan_device_creator.cpp:pick_physical_device@340] Found Vulkan Device 0 (Intel(R) Graphics (RKL GT1))
[vulkan_device_creator.cpp:pick_physical_device@340] Found Vulkan Device 1 (NVIDIA GeForce RTX 3080)
[vulkan_device_creator.cpp:pick_physical_device@340] Found Vulkan Device 2 (llvmpipe (LLVM 12.0.0, 256 bits))
```
use export `TI_VISIBLE_DEVICE` to select 0, 1, or 2