### PR TITLE
[dx11] Materialize runtime, map and unmap

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -332,6 +332,12 @@ if (TI_WITH_OPENGL)
     target_link_libraries(${CORE_LIBRARY_NAME} spirv-cross-glsl spirv-cross-core)
 endif()
 
+if (TI_WITH_DX11)
+    set(SPIRV_CROSS_CLI false)
+    #target_include_directories(${CORE_LIBRARY_NAME} PRIVATE external/SPIRV-Cross)
+    target_link_libraries(${CORE_LIBRARY_NAME} spirv-cross-hlsl spirv-cross-core)
+endif()
+
 # SPIR-V codegen is always there, regardless of Vulkan
 set(SPIRV_SKIP_EXECUTABLES true)
 set(SPIRV-Headers_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/SPIRV-Headers)

--- a/taichi/backends/dx/dx_device.cpp
+++ b/taichi/backends/dx/dx_device.cpp
@@ -25,6 +25,108 @@ ResourceBinder *Dx11Pipeline::resource_binder() {
   return nullptr;
 }
 
+Dx11CommandList::Dx11CommandList(Dx11Device *ti_device) : device_(ti_device) {
+}
+
+Dx11CommandList::~Dx11CommandList() {
+}
+
+void Dx11CommandList::bind_pipeline(Pipeline *p) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::bind_resources(ResourceBinder *binder) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::bind_resources(ResourceBinder *binder, ResourceBinder::Bindings* bindings) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::buffer_barrier(DevicePtr ptr,
+                                     size_t size) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::buffer_barrier(DeviceAllocation alloc) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::memory_barrier() {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::buffer_fill(DevicePtr dst, size_t size, uint32_t data) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::dispatch(uint32_t x, uint32_t y, uint32_t z) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::begin_renderpass(int x0,
+                                       int y0,
+                                       int x1,
+                                       int y1,
+                                       uint32_t num_color_attachments,
+                                       DeviceAllocation *color_attachments,
+                                       bool *color_clear,
+                                       std::vector<float> *clear_colors,
+                                       DeviceAllocation *depth_attachment,
+                                       bool depth_clear) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::end_renderpass() {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::draw(uint32_t num_verticies, uint32_t start_vertex) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::clear_color(float r, float g, float b, float a) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::set_line_width(float width) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::draw_indexed(uint32_t num_indicies,
+                                   uint32_t start_vertex,
+                                   uint32_t start_index) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::image_transition(DeviceAllocation img,
+                                       ImageLayout old_layout,
+                                       ImageLayout new_layout) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::buffer_to_image(DeviceAllocation dst_img,
+                                      DevicePtr src_buf,
+                                      ImageLayout img_layout,
+                                      const BufferImageCopyParams &params) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::image_to_buffer(DevicePtr dst_buf,
+                                      DeviceAllocation src_img,
+                                      ImageLayout img_layout,
+                                      const BufferImageCopyParams &params) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11CommandList::run_commands() {
+  TI_NOT_IMPLEMENTED;
+}
+
 namespace {
 HRESULT create_compute_device(ID3D11Device **out_device,
                               ID3D11DeviceContext **out_context,
@@ -146,6 +248,8 @@ Dx11Device::Dx11Device() {
     info_queue_ = std::make_unique<Dx11InfoQueue>(device_);
   }
   set_cap(DeviceCapability::spirv_version, 0x10300);
+
+  stream_ = new Dx11Stream(this);
 }
 
 Dx11Device::~Dx11Device() {
@@ -247,7 +351,7 @@ void Dx11Device::memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) {
 }
 
 Stream *Dx11Device::get_compute_stream() {
-  TI_NOT_IMPLEMENTED;
+  return stream_;
 }
 
 std::unique_ptr<Pipeline> Dx11Device::create_raster_pipeline(
@@ -293,6 +397,30 @@ void Dx11Device::image_to_buffer(DevicePtr dst_buf,
                                  ImageLayout img_layout,
                                  const BufferImageCopyParams &params) {
   TI_NOT_IMPLEMENTED;
+}
+
+Dx11Stream::Dx11Stream(Dx11Device *device_) : device_(device_) {
+}
+
+Dx11Stream::~Dx11Stream() {
+}
+
+
+std::unique_ptr<CommandList> Dx11Stream::new_command_list() {
+  return std::make_unique<Dx11CommandList>(device_);
+}
+
+void Dx11Stream::submit(CommandList *cmdlist) {
+  TI_NOT_IMPLEMENTED;
+}
+
+// No difference for DX11
+void Dx11Stream::submit_synced(CommandList *cmdlist) {
+  TI_NOT_IMPLEMENTED;
+}
+
+void Dx11Stream::command_sync() {
+  // Not needed for DX11
 }
 
 }  // namespace directx11

--- a/taichi/backends/dx/dx_device.cpp
+++ b/taichi/backends/dx/dx_device.cpp
@@ -552,10 +552,9 @@ void Dx11Stream::command_sync() {
   // Not needed for DX11
 }
 
-
 Dx11Pipeline::Dx11Pipeline(const PipelineSourceDesc &desc,
                            const std::string &name,
-                           Dx11Device* device)
+                           Dx11Device *device)
     : device_(device) {
   // TODO: Currently, PipelineSourceType::hlsl_src still returns SPIRV binary.
   // Will need to update this section when that changes
@@ -578,9 +577,9 @@ Dx11Pipeline::Dx11Pipeline(const PipelineSourceDesc &desc,
   hr = compile_compute_shader_from_string(
       source, "main", device_->d3d11_device(), &shader_blob);
   if (SUCCEEDED(hr)) {
-    hr = device_->d3d11_device()->CreateComputeShader(shader_blob->GetBufferPointer(),
-                                     shader_blob->GetBufferSize(), nullptr,
-                                     &compute_shader_);
+    hr = device_->d3d11_device()->CreateComputeShader(
+        shader_blob->GetBufferPointer(), shader_blob->GetBufferSize(), nullptr,
+        &compute_shader_);
     shader_blob->Release();
     compute_shader_->SetPrivateData(WKPDID_D3DDebugObjectName, name.size(),
                                     name.c_str());
@@ -598,7 +597,6 @@ Dx11Pipeline::~Dx11Pipeline() {
 ResourceBinder *Dx11Pipeline::resource_binder() {
   return nullptr;
 }
-
 
 }  // namespace directx11
 }  // namespace lang

--- a/taichi/backends/dx/dx_device.h
+++ b/taichi/backends/dx/dx_device.h
@@ -58,7 +58,9 @@ class Dx11Device;
 
 class Dx11Pipeline : public Pipeline {
  public:
-  Dx11Pipeline(const PipelineSourceDesc &desc, const std::string &name, Dx11Device* device);
+  Dx11Pipeline(const PipelineSourceDesc &desc,
+               const std::string &name,
+               Dx11Device *device);
   ~Dx11Pipeline() override;
   ResourceBinder *resource_binder() override;
 
@@ -67,7 +69,6 @@ class Dx11Pipeline : public Pipeline {
   ID3D11ComputeShader *compute_shader_{};
   Dx11ResourceBinder binder_{};
 };
-
 
 class Dx11Stream : public Stream {
  public:
@@ -200,7 +201,7 @@ class Dx11Device : public GraphicsDevice {
   ID3D11Buffer *alloc_id_to_buffer(uint32_t alloc_id);
   ID3D11Buffer *alloc_id_to_buffer_cpu_copy(uint32_t alloc_id);
   ID3D11UnorderedAccessView *alloc_id_to_uav(uint32_t alloc_id);
-  ID3D11Device* d3d11_device() {
+  ID3D11Device *d3d11_device() {
     return device_;
   }
 

--- a/taichi/backends/dx/dx_program.cpp
+++ b/taichi/backends/dx/dx_program.cpp
@@ -15,7 +15,15 @@ FunctionType Dx11ProgramImpl::compile(Kernel *kernel,
 void Dx11ProgramImpl::materialize_runtime(MemoryPool *memory_pool,
                                           KernelProfilerBase *profiler,
                                           uint64 **result_buffer_ptr) {
-  TI_NOT_IMPLEMENTED;
+  *result_buffer_ptr = (uint64 *)memory_pool->allocate(
+      sizeof(uint64) * taichi_result_buffer_entries, 8);
+
+  device_ = std::make_unique<directx11::Dx11Device>();
+
+  vulkan::VkRuntime::Params params;
+  params.host_result_buffer = *result_buffer_ptr;
+  params.device = device_.get();
+  runtime_ = std::make_unique<vulkan::VkRuntime>(std::move(params));
 }
 
 void Dx11ProgramImpl::synchronize() {

--- a/taichi/backends/dx/dx_program.cpp
+++ b/taichi/backends/dx/dx_program.cpp
@@ -3,13 +3,25 @@
 
 namespace taichi {
 namespace lang {
+namespace directx11 {
+
+FunctionType compile_to_executable(Kernel *kernel, vulkan::VkRuntime *runtime) {
+  auto handle = runtime->register_taichi_kernel(std::move(vulkan::run_codegen(
+      kernel, runtime->get_ti_device(), runtime->get_compiled_structs())));
+  return [runtime, handle](RuntimeContext &ctx) {
+    runtime->launch_kernel(handle, &ctx);
+  };
+}
+
+}  // namespace directx11
 
 Dx11ProgramImpl::Dx11ProgramImpl(CompileConfig &config) : ProgramImpl(config) {
 }
 
 FunctionType Dx11ProgramImpl::compile(Kernel *kernel,
                                       OffloadedStmt *offloaded) {
-  TI_NOT_IMPLEMENTED;
+  spirv::lower(kernel);
+  return directx11::compile_to_executable(kernel, runtime_.get());
 }
 
 void Dx11ProgramImpl::materialize_runtime(MemoryPool *memory_pool,
@@ -34,7 +46,7 @@ void Dx11ProgramImpl::materialize_snode_tree(
     SNodeTree *tree,
     std::vector<std::unique_ptr<SNodeTree>> &snode_trees_,
     uint64 *result_buffer_ptr) {
-  TI_NOT_IMPLEMENTED;
+  runtime_->materialize_snode_tree(tree);
 }
 
 std::unique_ptr<AotModuleBuilder> Dx11ProgramImpl::make_aot_module_builder() {

--- a/taichi/backends/dx/dx_program.h
+++ b/taichi/backends/dx/dx_program.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "taichi/backends/dx/dx_device.h"
 #include "taichi/backends/vulkan/runtime.h"
 #include "taichi/program/program_impl.h"
 
@@ -28,7 +29,7 @@ class Dx11ProgramImpl : public ProgramImpl {
   void synchronize() override;
 
  private:
-  std::unique_ptr<Device> device_;
+  std::shared_ptr<directx11::Dx11Device> device_;
   std::unique_ptr<vulkan::VkRuntime> runtime_;
 };
 

--- a/taichi/backends/dx/dx_program.h
+++ b/taichi/backends/dx/dx_program.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "taichi/backends/vulkan/runtime.h"
 #include "taichi/program/program_impl.h"
 
 namespace taichi {
@@ -25,6 +26,10 @@ class Dx11ProgramImpl : public ProgramImpl {
       uint64 *result_buffer_ptr) override;
   virtual void destroy_snode_tree(SNodeTree *snode_tree) override;
   void synchronize() override;
+
+ private:
+  std::unique_ptr<Device> device_;
+  std::unique_ptr<vulkan::VkRuntime> runtime_;
 };
 
 }  // namespace lang

--- a/tests/cpp/backends/dx11_device_test.cpp
+++ b/tests/cpp/backends/dx11_device_test.cpp
@@ -116,9 +116,9 @@ TEST(Dx11ProgramTest, MaterializeRuntimeTest) {
         - Dx11Stream::buffer_fill
         - Dx11Stream::submit_synced
   */
-  // Will be enabled when the above Stream functions are implemented.
-  // uint64_t* result_buffer;
-  // program->materialize_runtime(pool.get(), nullptr, &result_buffer);
+
+  uint64_t *result_buffer;
+  program->materialize_runtime(pool.get(), nullptr, &result_buffer);
 }
 
 }  // namespace directx11

--- a/tests/cpp/backends/dx11_device_test.cpp
+++ b/tests/cpp/backends/dx11_device_test.cpp
@@ -45,6 +45,21 @@ TEST(Dx11DeviceCreationTest, CreateDeviceAndAllocateMemory) {
     EXPECT_EQ(count1 - count0, 2);
   }
 
+  // Map to CPU, write some values, then check those values
+  void *mapped = device->map(device_alloc);
+  int *mapped_int = reinterpret_cast<int *>(mapped);
+  for (int i = 0; i < 100; i++) {
+    mapped_int[i] = i;
+  }
+  device->unmap(device_alloc);
+
+  mapped = device->map(device_alloc);
+  mapped_int = reinterpret_cast<int *>(mapped);
+  for (int i = 0; i < 100; i++) {
+    EXPECT_EQ(mapped_int[i], i);
+  }
+  device->unmap(device_alloc);
+
   // The 2 objects should have been released.
   device->dealloc_memory(device_alloc);
   if (kD3d11DebugEnabled) {


### PR DESCRIPTION
Hello!

This change makes the dx11 backend progress to the "map and unmap" step. It also adds a minimal sets of functions needed in the command list.

Tested locally to make sure it builds and passes the unit tests.