### PR TITLE
[bug] Update children_offsets & stride info to align as elem_stride

### DIFF
--- a/taichi/backends/opengl/struct_opengl.h
+++ b/taichi/backends/opengl/struct_opengl.h
@@ -21,11 +21,12 @@ class OpenglStructCompiler {
   CompiledResult run(SNode &node);
 
  private:
-  void collect_snodes(SNode &snode);
+  void collect_snodes(const SNode &snode);
   void generate_types(const SNode &snode);
-  size_t compute_snode_size(const SNode &sn);
+  void generate_snode_tree(const SNode &root);
+  void align_as_elem_stride(const SNode &sn);
 
-  std::vector<SNode *> snodes_;
+  std::vector<const SNode *> snodes_;
   std::unordered_map<SNodeId, SNodeInfo> snode_map_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #4345
* #4344

Currently we run 2 passes to generate snode tree layout in opengl
codegen.
1. One pass from leaf to root so that we can calculate the real size &
elem_stride for each snode and sort the children from small to large.
2. Another pass from root to leaf so that we can align as elem_stride.

Note we cannot eliminate the first pass due to
https://github.com/taichi-dev/taichi/blob/master/taichi/backends/opengl/struct_opengl.cpp#L50.

The fix for the alignment issue was simple: we used children_offsets
information in the codegen but didn't update it in the second pass.
This PR fixes the issue and also reorganizes the code a bit to make it
easier to read and understand.