### PR TITLE
[ci] Fix generate_example_videos.py

### DIFF
--- a/misc/generate_example_videos.py
+++ b/misc/generate_example_videos.py
@@ -11,6 +11,8 @@ output_dir = parser.parse_args().output_directory
 example_root = os.path.join('..', 'tests', 'python', 'examples')
 for example_dir in os.listdir(example_root):
     full_dir = os.path.join(example_root, example_dir)
+    if not os.path.isdir(full_dir):
+        continue
     for filename in os.listdir(full_dir):
         match = re.match(r'test_(\w+)\.py', filename)
         if match:
@@ -18,4 +20,5 @@ for example_dir in os.listdir(example_root):
                 "python",
                 os.path.join(full_dir, filename),
                 os.path.join(output_dir, match.group(1))
-            ])
+            ],
+                           check=True)

--- a/tests/python/examples/autodiff/test_minimization.py
+++ b/tests/python/examples/autodiff/test_minimization.py
@@ -1,7 +1,8 @@
 import random
 
+import pytest
+
 import taichi as ti
-from tests import test_utils
 
 
 def test_minimization():
@@ -18,4 +19,4 @@ def test_minimization():
         gradient_descent()
 
     for i in range(n):
-        assert x[i] == test_utils.approx(y[i], rel=1e-2)
+        assert x[i] == pytest.approx(y[i], rel=1e-2)


### PR DESCRIPTION
`generate_example_videos.py` doesn't throw when the subprocess fails. This PR fixes it.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
