### PR TITLE
[ci] Increase ci test parallelism

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -35,8 +35,20 @@ TI_PATH=$(python3 -c "import taichi;print(taichi.__path__[0])" | tail -1)
 TI_LIB_DIR="$TI_PATH/_lib/runtime" ./build/taichi_cpp_tests
 
 if [ -z "$GPU_TEST" ]; then
-    python3 tests/run_tests.py -vr2 -t2 -a "$TI_WANTED_ARCHS"
+    python3 tests/run_tests.py -vr2 -t4 -a "$TI_WANTED_ARCHS"
 else
-    python3 tests/run_tests.py -vr2 -t2 -k "not ndarray and not torch" -a "$TI_WANTED_ARCHS"
-    python3 tests/run_tests.py -vr2 -t1 -k "ndarray or torch" -a "$TI_WANTED_ARCHS"
+    # only split per arch for self_hosted GPU tests
+    if [[ $TI_WANTED_ARCHS == *"cuda"* ]]; then
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a cuda 
+    fi
+    if [[ $TI_WANTED_ARCHS == *"cpu"* ]]; then
+        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a cpu
+    fi
+    if [[ $TI_WANTED_ARCHS == *"vulkan"* ]]; then
+        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a vulkan 
+    fi
+    if [[ $TI_WANTED_ARCHS == *"opengl"* ]]; then
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a opengl 
+    fi
+    python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
 fi

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -9,4 +9,13 @@ if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
 } else {
     pip install torch
 }
-python tests/run_tests.py -vr2 -t2 -a "$env:TI_WANTED_ARCHS"
+if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
+  python tests/run_tests.py -vr2 -t6 -k "not torch" -a cuda
+}
+if ("$env:TI_WANTED_ARCHS".Contains("cpu")) {
+  python tests/run_tests.py -vr2 -t8 -k "not torch" -a cpu
+}
+if ("$env:TI_WANTED_ARCHS".Contains("opengl")) {
+  python tests/run_tests.py -vr2 -t6 -k "not torch" -a opengl
+}
+python tests/run_tests.py -vr2 -t2 -k "torch" -a "$env:TI_WANTED_ARCHS"

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -11,7 +11,7 @@ from taichi.types.primitive_types import (f16, f32, f64, i8, i16, i32, i64, u8,
 
 _has_pytorch = False
 
-_env_torch = os.environ.get('TI_ENABLE_TORCH', '0')
+_env_torch = os.environ.get('TI_ENABLE_TORCH', '1')
 if not _env_torch or int(_env_torch):
     try:
         import torch


### PR DESCRIPTION
Split the GPU and Windows tests by per arch to increase parallelism and reduce the total time used. This can reduce our CI from ~40 mins to ~30 mins.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
