### PR TITLE
[lang] Add support for operators "is" and "is not" in static scope and deprecate them

### DIFF
--- a/docs/lang/articles/basic/differences_between_taichi_and_python_programs.md
+++ b/docs/lang/articles/basic/differences_between_taichi_and_python_programs.md
@@ -159,4 +159,4 @@ The iterators and conditions are implicitly in [static scope](/lang/articles/adv
 
 ### Operator `is`
 
-Currently, Taichi does not support operator `is` and `is not`.
+Operator `is` and `is not` only works in  [static scope](/lang/articles/advanced/meta#static-scope) (inside `ti.static()`).

--- a/docs/lang/articles/basic/differences_between_taichi_and_python_programs.md
+++ b/docs/lang/articles/basic/differences_between_taichi_and_python_programs.md
@@ -159,4 +159,4 @@ The iterators and conditions are implicitly in [static scope](/lang/articles/adv
 
 ### Operator `is`
 
-Operator `is` and `is not` only works in  [static scope](/lang/articles/advanced/meta#static-scope) (inside `ti.static()`).
+Currently, Taichi does not support operator `is` and `is not`.

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -677,6 +677,8 @@ class ASTTransformer(Builder):
         ops_static = {
             ast.In: lambda l, r: l in r,
             ast.NotIn: lambda l, r: l not in r,
+            ast.Is: lambda l, r: l is r,
+            ast.IsNot: lambda l, r: l is not r,
         }
         if ctx.is_in_static_scope():
             ops = {**ops, **ops_static}

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -689,6 +689,12 @@ class ASTTransformer(Builder):
             l = operands[i]
             r = operands[i + 1]
             op = ops.get(type(node_op))
+            if isinstance(node_op, (ast.Is, ast.IsNot)):
+                name = "is" if isinstance(node_op, ast.Is) else "is not"
+                warnings.warn_explicit(
+                    f'Operator "{name}" in Taichi scope is deprecated. Please avoid using it.',
+                    DeprecationWarning, ctx.file,
+                    node.lineno + ctx.lineno_offset)
             if op is None:
                 if type(node_op) in ops_static:
                     raise TaichiSyntaxError(

--- a/tests/python/test_ast_refactor.py
+++ b/tests/python/test_ast_refactor.py
@@ -161,7 +161,7 @@ def test_boolop():
 @test_utils.test()
 def test_compare_fail():
     with pytest.raises(ti.TaichiCompilationError,
-                       match='"Is" is not supported in Taichi kernels.'):
+                       match='"Is" is only supported inside `ti.static`.'):
 
         @ti.kernel
         def foo():

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -170,3 +170,31 @@ def test_non_static_in():
             return b
 
         foo(ti.i32)
+
+
+@test_utils.test()
+def test_static_is():
+    @ti.kernel
+    def is_f32(tp: ti.template()) -> ti.i32:
+        return ti.static(tp is ti.f32)
+
+    @ti.kernel
+    def is_not_f32(tp: ti.template()) -> ti.i32:
+        return ti.static(tp is not ti.f32)
+
+    assert is_f32(ti.f32) == 1
+    assert is_f32(ti.i32) == 0
+    assert is_not_f32(ti.f32) == 0
+    assert is_not_f32(ti.i32) == 1
+
+
+@test_utils.test()
+def test_non_static_is():
+    with pytest.raises(ti.TaichiCompilationError,
+                       match='"Is" is only supported inside `ti.static`.'):
+
+        @ti.kernel
+        def is_f32(tp: ti.template()) -> ti.i32:
+            return tp is ti.f32
+
+        is_f32(ti.f32)


### PR DESCRIPTION
Related issue = close #4341 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
