### PR TITLE
[ci] Run vulkan and metal separately on M1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,7 @@ jobs:
         env:
           TI_WANTED_ARCHS: "metal,vulkan,cpu"
           PYTHON: ${{ matrix.python }}
+          GPU_TEST: ON
 
       - name: Upload PyPI
         env:

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -39,16 +39,20 @@ if [ -z "$GPU_TEST" ]; then
 else
     # only split per arch for self_hosted GPU tests
     if [[ $TI_WANTED_ARCHS == *"cuda"* ]]; then
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a cuda 
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a cuda
     fi
     if [[ $TI_WANTED_ARCHS == *"cpu"* ]]; then
         python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a cpu
     fi
     if [[ $TI_WANTED_ARCHS == *"vulkan"* ]]; then
-        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a vulkan 
+        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a vulkan
     fi
     if [[ $TI_WANTED_ARCHS == *"opengl"* ]]; then
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a opengl 
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a opengl
+    fi
+    # Run metal and vulkan separately so that they don't use M1 chip simultaneously.
+    if [[ $TI_WANTED_ARCHS == *"metal"* ]]; then
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a metal
     fi
     python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
 fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -463,3 +463,4 @@ jobs:
         env:
           TI_WANTED_ARCHS: "metal,vulkan,cpu"
           PYTHON: ${{ matrix.python }}
+          GPU_TEST: ON


### PR DESCRIPTION
Related issue = #
This seem to help fix the random failure in M1 CI. My guess was that vulkan and metal backend using M1 chip simultaneously might cause some weird behavior....


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
