### PR TITLE
[doc] Fix broken links in the results exporting doc.

### DIFF
--- a/docs/lang/articles/misc/export_results.md
+++ b/docs/lang/articles/misc/export_results.md
@@ -94,13 +94,13 @@ print(f'The image has been saved to {filename}')
 :::note
 All Taichi fields have their own data types, such as `ti.u8` and
 `ti.f32`. Different data types can lead to different behaviors of
-`ti.imwrite`. Please check out [GUI system](./gui.md) for
+`ti.imwrite`. Please check out [GUI system](../gui/gui.md) for
 more details.
 :::
 
 - Taichi offers other helper functions that read and show images in
   addition to `ti.imwrite`. They are also demonstrated in
-  [GUI system./gui.md).
+  [GUI system](../gui/gui.md).
 
 ## Export videos
 


### PR DESCRIPTION
Related issue = #

Fix the issue identified in https://github.com/taichi-dev/docs.taichi.graphics/pull/196, basically, there's a broken link after we moved the `get-started` doc.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
