### PR TITLE
[example] Fix implicit_fem example command line arguments

### DIFF
--- a/python/taichi/examples/simulation/implicit_fem.py
+++ b/python/taichi/examples/simulation/implicit_fem.py
@@ -11,6 +11,7 @@ parser.add_argument('--exp',
                     default='implicit')
 parser.add_argument('--dim', type=int, default=3)
 parser.add_argument('--gui', choices=['auto', 'ggui', 'cpu'], default='auto')
+parser.add_argument('place_holder', nargs='*')
 args = parser.parse_args()
 
 ti.init(arch=ti.gpu, dynamic_index=True)


### PR DESCRIPTION
Related issue = #4371

Small fix to treat redundant command line arguments.

Before this PR:
```
{15:17}~/playground:master ✗ ➭ ti example implicit_fem
[Taichi] version 0.9.1, llvm 10.0.0, commit 69969997, linux, python 3.8.5

*******************************************
**      Taichi Programming Language      **
*******************************************

Docs:   https://docs.taichi.graphics/
GitHub: https://github.com/taichi-dev/taichi/
Forum:  https://forum.taichi.graphics/

Running example implicit_fem ...
usage: implicit_fem.py [-h] [--exp {implicit,explicit}] [--dim DIM] [--gui {auto,ggui,cpu}]
implicit_fem.py: error: unrecognized arguments: example implicit_fem
```


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
