### PR TITLE
[ci] Reduce test parallelism for m1

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -42,17 +42,29 @@ else
         python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a cuda
     fi
     if [[ $TI_WANTED_ARCHS == *"cpu"* ]]; then
-        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a cpu
+        if [[ $ARCH == *"m1"* ]]; then
+            python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a cpu
+	else
+            python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a cpu
+	fi
     fi
     if [[ $TI_WANTED_ARCHS == *"vulkan"* ]]; then
-        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a vulkan
+        if [[ $ARCH == *"m1"* ]]; then
+            python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a vulkan
+	else
+            python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a vulkan
+	fi
     fi
     if [[ $TI_WANTED_ARCHS == *"opengl"* ]]; then
         python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a opengl
     fi
     # Run metal and vulkan separately so that they don't use M1 chip simultaneously.
     if [[ $TI_WANTED_ARCHS == *"metal"* ]]; then
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a metal
+        if [[ $ARCH == *"m1"* ]]; then
+            python3 tests/run_tests.py -vr2 -t2 -k "not torch" -a metal
+	else
+            python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a metal
+	fi
     fi
     python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
 fi

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -59,8 +59,5 @@ else
     if [[ $TI_WANTED_ARCHS == *"opengl"* ]]; then
         python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a opengl
     fi
-    if [[ $TI_WANTED_ARCHS == *"metal"* ]]; then
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a metal
-    fi
     python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
 fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -465,3 +465,4 @@ jobs:
           TI_WANTED_ARCHS: "metal,vulkan,cpu"
           PY: ${{ matrix.python }}
           GPU_TEST: ON
+          ARCH: "m1"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -464,5 +464,4 @@ jobs:
         env:
           TI_WANTED_ARCHS: "metal,vulkan,cpu"
           PY: ${{ matrix.python }}
-          GPU_TEST: ON
-          ARCH: "m1"
+          PLATFORM: "m1"


### PR DESCRIPTION
Lets reduce the test parallelism for m1 to get rid of the flaky test issue. This won't affect our CI build time as m1 is much faster.