### PR TITLE
[vulkan] [aot] Move add_root_buffer to public members

### DIFF
--- a/taichi/backends/vulkan/runtime.h
+++ b/taichi/backends/vulkan/runtime.h
@@ -104,12 +104,12 @@ class TI_DLL_EXPORT VkRuntime {
 
   Device *get_ti_device() const;
 
+  void add_root_buffer(size_t root_buffer_size);
+
  private:
   friend class taichi::lang::vulkan::SNodeTreeManager;
 
   void init_nonroot_buffers();
-
-  void add_root_buffer(size_t root_buffer_size);
 
   Device *device_{nullptr};
   uint64_t *const host_result_buffer_;


### PR DESCRIPTION
This is requires for AOT module when loaded to create the initial root
buffer otherwise they cannot create the buffer, only the SNodeTreeManager 
class has access to it which is not used in the case of AOT.

Related issue = #3642
