### PR TITLE
[vulkan] [aot] Add aot namespace Vulkan

### DIFF
--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -2,8 +2,9 @@
 
 namespace taichi {
 namespace lang {
+namespace aot {
 
-AotKernel *AotModuleLoader::get_kernel(const std::string &name) {
+Kernel *ModuleLoader::get_kernel(const std::string &name) {
   auto itr = loaded_kernels_.find(name);
   if (itr != loaded_kernels_.end()) {
     return itr->second.get();
@@ -14,5 +15,6 @@ AotKernel *AotModuleLoader::get_kernel(const std::string &name) {
   return kptr;
 }
 
+}  // namespace aot
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -13,7 +13,7 @@
 namespace taichi {
 namespace lang {
 
-  class RuntimeContext;
+class RuntimeContext;
 
 namespace aot {
 
@@ -64,8 +64,7 @@ class TI_DLL_EXPORT ModuleLoader {
   virtual size_t get_root_size() const = 0;
 
  protected:
-  virtual std::unique_ptr<Kernel> make_new_kernel(
-      const std::string &name) = 0;
+  virtual std::unique_ptr<Kernel> make_new_kernel(const std::string &name) = 0;
 
  private:
   std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -13,19 +13,19 @@
 namespace taichi {
 namespace lang {
 
-class RuntimeContext;
+  class RuntimeContext;
 
-// TODO: Instead of prefixing all these classes with "Aot", just put them into
-// the `aot` namespace.
-class TI_DLL_EXPORT AotKernel {
+namespace aot {
+
+class TI_DLL_EXPORT Kernel {
  public:
   // Rule of 5 to make MSVC happy
-  AotKernel() = default;
-  virtual ~AotKernel() = default;
-  AotKernel(const AotKernel &) = delete;
-  AotKernel &operator=(const AotKernel &) = delete;
-  AotKernel(AotKernel &&) = default;
-  AotKernel &operator=(AotKernel &&) = default;
+  Kernel() = default;
+  virtual ~Kernel() = default;
+  Kernel(const Kernel &) = delete;
+  Kernel &operator=(const Kernel &) = delete;
+  Kernel(Kernel &&) = default;
+  Kernel &operator=(Kernel &&) = default;
 
   /**
    * @brief Launches the kernel to the device
@@ -37,15 +37,15 @@ class TI_DLL_EXPORT AotKernel {
   virtual void launch(RuntimeContext *ctx) = 0;
 };
 
-class TI_DLL_EXPORT AotModuleLoader {
+class TI_DLL_EXPORT ModuleLoader {
  public:
   // Rule of 5 to make MSVC happy
-  AotModuleLoader() = default;
-  virtual ~AotModuleLoader() = default;
-  AotModuleLoader(const AotModuleLoader &) = delete;
-  AotModuleLoader &operator=(const AotModuleLoader &) = delete;
-  AotModuleLoader(AotModuleLoader &&) = default;
-  AotModuleLoader &operator=(AotModuleLoader &&) = default;
+  ModuleLoader() = default;
+  virtual ~ModuleLoader() = default;
+  ModuleLoader(const ModuleLoader &) = delete;
+  ModuleLoader &operator=(const ModuleLoader &) = delete;
+  ModuleLoader(ModuleLoader &&) = default;
+  ModuleLoader &operator=(ModuleLoader &&) = default;
 
   // TODO: Add method get_kernel(...) once the kernel field data will be
   // generic/common across all backends.
@@ -57,24 +57,24 @@ class TI_DLL_EXPORT AotModuleLoader {
    * @brief Get the kernel object
    *
    * @param name Name of the kernel
-   * @return AotKernel*
+   * @return Kernel*
    */
-  AotKernel *get_kernel(const std::string &name);
+  Kernel *get_kernel(const std::string &name);
 
   virtual size_t get_root_size() const = 0;
 
  protected:
-  virtual std::unique_ptr<AotKernel> make_new_kernel(
+  virtual std::unique_ptr<Kernel> make_new_kernel(
       const std::string &name) = 0;
 
  private:
-  std::unordered_map<std::string, std::unique_ptr<AotKernel>> loaded_kernels_;
+  std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;
 };
 
 // Only responsible for reporting device capabilities
-class AotTargetDevice : public Device {
+class TargetDevice : public Device {
  public:
-  AotTargetDevice(Arch arch) {
+  TargetDevice(Arch arch) {
     // TODO: make this configurable
     set_default_caps(arch);
   }
@@ -116,5 +116,6 @@ class AotTargetDevice : public Device {
   }
 };
 
+}  // namespace aot
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -80,7 +80,7 @@ class AotDataConverter {
 AotModuleBuilderImpl::AotModuleBuilderImpl(
     const std::vector<CompiledSNodeStructs> &compiled_structs)
     : compiled_structs_(compiled_structs) {
-  aot_target_device_ = std::make_unique<AotTargetDevice>(Arch::vulkan);
+  aot_target_device_ = std::make_unique<aot::TargetDevice>(Arch::vulkan);
   if (!compiled_structs.empty()) {
     ti_aot_data_.root_buffer_size = compiled_structs[0].root_size;
   }

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -12,7 +12,7 @@ namespace {
 
 using KernelHandle = VkRuntime::KernelHandle;
 
-class KernelImpl : public AotKernel {
+class KernelImpl : public aot::Kernel {
  public:
   explicit KernelImpl(VkRuntime *runtime, KernelHandle handle)
       : runtime_(runtime), handle_(handle) {
@@ -76,7 +76,7 @@ bool AotModuleLoaderImpl::get_kernel(const std::string &name,
   return false;
 }
 
-std::unique_ptr<AotKernel> AotModuleLoaderImpl::make_new_kernel(
+std::unique_ptr<aot::Kernel> AotModuleLoaderImpl::make_new_kernel(
     const std::string &name) {
   VkRuntime::RegisterParams kparams;
   if (!get_kernel(name, kparams)) {

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -27,7 +27,8 @@ class TI_DLL_EXPORT AotModuleLoaderImpl : public aot::ModuleLoader {
   size_t get_root_size() const override;
 
  private:
-  std::unique_ptr<aot::Kernel> make_new_kernel(const std::string &name) override;
+  std::unique_ptr<aot::Kernel> make_new_kernel(
+      const std::string &name) override;
   std::vector<uint32_t> read_spv_file(const std::string &output_dir,
                                       const TaskAttributes &k);
 

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -15,7 +15,7 @@ namespace vulkan {
 
 class VkRuntime;
 
-class TI_DLL_EXPORT AotModuleLoaderImpl : public AotModuleLoader {
+class TI_DLL_EXPORT AotModuleLoaderImpl : public aot::ModuleLoader {
  public:
   explicit AotModuleLoaderImpl(const std::string &output_dir);
 
@@ -27,7 +27,7 @@ class TI_DLL_EXPORT AotModuleLoaderImpl : public AotModuleLoader {
   size_t get_root_size() const override;
 
  private:
-  std::unique_ptr<AotKernel> make_new_kernel(const std::string &name) override;
+  std::unique_ptr<aot::Kernel> make_new_kernel(const std::string &name) override;
   std::vector<uint32_t> read_spv_file(const std::string &output_dir,
                                       const TaskAttributes &k);
 


### PR DESCRIPTION
Related issue = #3642 

Resolve the following TODO: "Instead of prefixing all classes with "Aot", just put them into the `aot` namespace."

Next step: AotModuleLoader --> aot::Module::load()