### PR TITLE
[aot] [refactor] Refactor AOT runtime API to use module

### DIFF
--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -11,10 +11,11 @@ std::unique_ptr<Module> Module::load(const std::string &path,
                                      Arch arch,
                                      std::any mod_params) {
   if (arch == Arch::vulkan) {
-    // TODO: unify the types here between vk with metal
-    std::string vk_params = std::any_cast<std::string &>(mod_params);
-    return std::make_unique<vulkan::AotModuleImpl>(vk_params);
+    vulkan::AotModuleParams vulkan_params =
+        std::any_cast<vulkan::AotModuleParams &>(vulkan_params);
+    return vulkan::make_aot_module(vulkan_params);
   } else if (arch == Arch::metal) {
+
     metal::AotModuleParams metal_params =
         std::any_cast<metal::AotModuleParams &>(mod_params);
     return metal::make_aot_module(metal_params);

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -7,7 +7,7 @@ namespace aot {
 std::unique_ptr<Module> Module::load(const std::string &path,
                                      Arch arch,
                                      std::any mod_params) {
-//  arch_ = arch;
+  //  arch_ = arch;
   if (arch == Arch::vulkan) {
 #ifdef TI_WITH_VULKAN
     return vulkan::make_aot_module(mod_params);
@@ -21,7 +21,7 @@ std::unique_ptr<Module> Module::load(const std::string &path,
   }
 }
 
-//Arch Module::arch() const {
+// Arch Module::arch() const {
 //  return arch_;
 //}
 

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -12,7 +12,7 @@ std::unique_ptr<Module> Module::load(const std::string &path,
                                      std::any mod_params) {
   if (arch == Arch::vulkan) {
     vulkan::AotModuleParams vulkan_params =
-        std::any_cast<vulkan::AotModuleParams &>(vulkan_params);
+        std::any_cast<vulkan::AotModuleParams &>(mod_params);
     return vulkan::make_aot_module(vulkan_params);
   } else if (arch == Arch::metal) {
 

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -7,7 +7,6 @@ namespace aot {
 std::unique_ptr<Module> Module::load(const std::string &path,
                                      Arch arch,
                                      std::any mod_params) {
-  //  arch_ = arch;
   if (arch == Arch::vulkan) {
 #ifdef TI_WITH_VULKAN
     return vulkan::make_aot_module(mod_params);
@@ -20,10 +19,6 @@ std::unique_ptr<Module> Module::load(const std::string &path,
     TI_NOT_IMPLEMENTED;
   }
 }
-
-// Arch Module::arch() const {
-//  return arch_;
-//}
 
 }  // namespace aot
 }  // namespace lang

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -1,7 +1,11 @@
 #include "taichi/aot/module_loader.h"
 
+#ifdef TI_WITH_VULKAN
 #include "taichi/backends/vulkan/aot_module_loader_impl.h"
+#endif
+#ifdef TI_WITH_METAL
 #include "taichi/backends/metal/aot_module_loader_impl.h"
+#endif
 
 namespace taichi {
 namespace lang {

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -11,13 +11,17 @@ std::unique_ptr<Module> Module::load(const std::string &path,
                                      Arch arch,
                                      std::any mod_params) {
   if (arch == Arch::vulkan) {
+#ifdef TI_WITH_VULKAN
     vulkan::AotModuleParams vulkan_params =
         std::any_cast<vulkan::AotModuleParams &>(mod_params);
     return vulkan::make_aot_module(vulkan_params);
+#endif
   } else if (arch == Arch::metal) {
+#ifdef TI_WITH_METAL
     metal::AotModuleParams metal_params =
         std::any_cast<metal::AotModuleParams &>(mod_params);
     return metal::make_aot_module(metal_params);
+#endif
   } else {
     TI_NOT_IMPLEMENTED;
   }

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -15,7 +15,6 @@ std::unique_ptr<Module> Module::load(const std::string &path,
         std::any_cast<vulkan::AotModuleParams &>(mod_params);
     return vulkan::make_aot_module(vulkan_params);
   } else if (arch == Arch::metal) {
-
     metal::AotModuleParams metal_params =
         std::any_cast<metal::AotModuleParams &>(mod_params);
     return metal::make_aot_module(metal_params);

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -1,18 +1,25 @@
 #include "taichi/aot/module_loader.h"
 
+#include "taichi/backends/vulkan/aot_module_loader_impl.h"
+#include "taichi/backends/metal/aot_module_loader_impl.h"
+
 namespace taichi {
 namespace lang {
 namespace aot {
 
-Kernel *ModuleLoader::get_kernel(const std::string &name) {
-  auto itr = loaded_kernels_.find(name);
-  if (itr != loaded_kernels_.end()) {
-    return itr->second.get();
+std::unique_ptr<Module> Module::load(const std::string &path,
+                                      Arch arch,
+                                      std::any mod_params) {
+  if (arch == Arch::vulkan) {
+    // TODO: unify the types here between vk with metal 
+    std::string vk_params = std::any_cast<std::string&>(mod_params);
+    return std::make_unique<vulkan::AotModuleImpl>(vk_params);
+  } else if (arch == Arch::metal) {
+    metal::AotModuleParams metal_params = std::any_cast<metal::AotModuleParams&>(mod_params);
+    return metal::make_aot_module(metal_params);
+  } else {
+    TI_NOT_IMPLEMENTED;
   }
-  auto k = make_new_kernel(name);
-  auto *kptr = k.get();
-  loaded_kernels_[name] = std::move(k);
-  return kptr;
 }
 
 }  // namespace aot

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -7,12 +7,12 @@ namespace aot {
 std::unique_ptr<Module> Module::load(const std::string &path,
                                      Arch arch,
                                      std::any mod_params) {
-  arch_ = arch;
-  if (arch_ == Arch::vulkan) {
+//  arch_ = arch;
+  if (arch == Arch::vulkan) {
 #ifdef TI_WITH_VULKAN
     return vulkan::make_aot_module(mod_params);
 #endif
-  } else if (arch_ == Arch::metal) {
+  } else if (arch == Arch::metal) {
 #ifdef TI_WITH_METAL
     return metal::make_aot_module(mod_params);
 #endif
@@ -21,9 +21,9 @@ std::unique_ptr<Module> Module::load(const std::string &path,
   }
 }
 
-Arch Module::arch() const {
-  return arch_;
-}
+//Arch Module::arch() const {
+//  return arch_;
+//}
 
 }  // namespace aot
 }  // namespace lang

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -1,5 +1,8 @@
 #include "taichi/aot/module_loader.h"
 
+#include "taichi/backends/vulkan/aot_module_loader_impl.h"
+#include "taichi/backends/metal/aot_module_loader_impl.h"
+
 namespace taichi {
 namespace lang {
 namespace aot {

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -1,12 +1,5 @@
 #include "taichi/aot/module_loader.h"
 
-#ifdef TI_WITH_VULKAN
-#include "taichi/backends/vulkan/aot_module_loader_impl.h"
-#endif
-#ifdef TI_WITH_METAL
-#include "taichi/backends/metal/aot_module_loader_impl.h"
-#endif
-
 namespace taichi {
 namespace lang {
 namespace aot {
@@ -16,15 +9,11 @@ std::unique_ptr<Module> Module::load(const std::string &path,
                                      std::any mod_params) {
   if (arch == Arch::vulkan) {
 #ifdef TI_WITH_VULKAN
-    vulkan::AotModuleParams vulkan_params =
-        std::any_cast<vulkan::AotModuleParams &>(mod_params);
-    return vulkan::make_aot_module(vulkan_params);
+    return vulkan::make_aot_module(mod_params);
 #endif
   } else if (arch == Arch::metal) {
 #ifdef TI_WITH_METAL
-    metal::AotModuleParams metal_params =
-        std::any_cast<metal::AotModuleParams &>(mod_params);
-    return metal::make_aot_module(metal_params);
+    return metal::make_aot_module(mod_params);
 #endif
   } else {
     TI_NOT_IMPLEMENTED;

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -7,17 +7,22 @@ namespace aot {
 std::unique_ptr<Module> Module::load(const std::string &path,
                                      Arch arch,
                                      std::any mod_params) {
-  if (arch == Arch::vulkan) {
+  arch_ = arch;
+  if (arch_ == Arch::vulkan) {
 #ifdef TI_WITH_VULKAN
     return vulkan::make_aot_module(mod_params);
 #endif
-  } else if (arch == Arch::metal) {
+  } else if (arch_ == Arch::metal) {
 #ifdef TI_WITH_METAL
     return metal::make_aot_module(mod_params);
 #endif
   } else {
     TI_NOT_IMPLEMENTED;
   }
+}
+
+Arch Module::arch() const {
+  return arch_;
 }
 
 }  // namespace aot

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -8,14 +8,15 @@ namespace lang {
 namespace aot {
 
 std::unique_ptr<Module> Module::load(const std::string &path,
-                                      Arch arch,
-                                      std::any mod_params) {
+                                     Arch arch,
+                                     std::any mod_params) {
   if (arch == Arch::vulkan) {
-    // TODO: unify the types here between vk with metal 
-    std::string vk_params = std::any_cast<std::string&>(mod_params);
+    // TODO: unify the types here between vk with metal
+    std::string vk_params = std::any_cast<std::string &>(mod_params);
     return std::make_unique<vulkan::AotModuleImpl>(vk_params);
   } else if (arch == Arch::metal) {
-    metal::AotModuleParams metal_params = std::any_cast<metal::AotModuleParams&>(mod_params);
+    metal::AotModuleParams metal_params =
+        std::any_cast<metal::AotModuleParams &>(mod_params);
     return metal::make_aot_module(metal_params);
   } else {
     TI_NOT_IMPLEMENTED;

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -51,6 +51,7 @@ class TI_DLL_EXPORT Module {
   static std::unique_ptr<Module> load(const std::string &path,
                                       Arch arch,
                                       std::any mod_params);
+
   // TODO
   // Module metadata
   // Arch arch() const;
@@ -118,5 +119,14 @@ class TargetDevice : public Device {
 };
 
 }  // namespace aot
+
+namespace vulkan {
+std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
+}  // namespace vulkan 
+
+namespace metal {
+std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
+}  // namespace metal 
+
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -53,7 +53,7 @@ class TI_DLL_EXPORT Module {
                                       std::any mod_params);
 
   // Module metadata
-  //Arch arch() const;
+  // Arch arch() const;
   // uint64_t version() const;
 
   // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -64,12 +64,8 @@ class TI_DLL_EXPORT Module {
                                       std::any mod_params);
 
   // Module metadata
-  Arch arch() const;
-  uint64_t version() const;
-
-  /**
-   * Intended to be overriden by each backend's implementation.
-   */
+  virtual Arch arch() const = 0;
+  virtual uint64_t version() const = 0;
   virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
   virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
   virtual size_t get_root_size() const = 0;

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -51,10 +51,12 @@ class TI_DLL_EXPORT Module {
   static std::unique_ptr<Module> load(const std::string &path,
                                       Arch arch,
                                       std::any mod_params);
-  // Module metadata
   // TODO
+  // Module metadata
   // Arch arch() const;
   // uint64_t version() const;
+
+  // TODO
   // APIs to be overriden by each backend.
   // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
   // virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
@@ -62,6 +64,7 @@ class TI_DLL_EXPORT Module {
 
  protected:
   virtual std::unique_ptr<Kernel> make_new_kernel(const std::string &name) = 0;
+  // TODO, replace this with the above pure virtual function
   virtual bool get_field(const std::string &name,
                          aot::CompiledFieldData &field) = 0;
 

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -52,15 +52,14 @@ class TI_DLL_EXPORT Module {
                                       Arch arch,
                                       std::any mod_params);
 
-  // TODO
   // Module metadata
-  // Arch arch() const;
+  Arch arch() const;
   // uint64_t version() const;
 
   // TODO
   // APIs to be overriden by each backend.
   // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
-  // virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
+  virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
   virtual size_t get_root_size() const = 0;
 
  protected:
@@ -71,6 +70,7 @@ class TI_DLL_EXPORT Module {
 
  private:
   std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;
+  static Arch arch_;
 };
 
 // Only responsible for reporting device capabilities

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -18,6 +18,17 @@ class RuntimeContext;
 
 namespace aot {
 
+class TI_DLL_EXPORT Field {
+ public:
+  // Rule of 5 to make MSVC happy
+  Field() = default;
+  virtual ~Field() = default;
+  Field(const Field &) = delete;
+  Field &operator=(const Field &) = delete;
+  Field(Field &&) = default;
+  Field &operator=(Field &&) = default;
+};
+
 class TI_DLL_EXPORT Kernel {
  public:
   // Rule of 5 to make MSVC happy
@@ -56,15 +67,15 @@ class TI_DLL_EXPORT Module {
   Arch arch() const;
   uint64_t version() const;
 
-  // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
+  /**
+   * Intended to be overriden by each backend's implementation.
+   */
   virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
+  virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
   virtual size_t get_root_size() const = 0;
 
  protected:
   virtual std::unique_ptr<Kernel> make_new_kernel(const std::string &name) = 0;
-  // TODO, replace this with the above pure virtual function
-  virtual bool get_field(const std::string &name,
-                         aot::CompiledFieldData &field) = 0;
 
  private:
   std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -127,14 +127,5 @@ class TargetDevice : public Device {
 };
 
 }  // namespace aot
-
-namespace vulkan {
-std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
-}  // namespace vulkan
-
-namespace metal {
-std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
-}  // namespace metal
-
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -57,7 +57,7 @@ class TI_DLL_EXPORT Module {
   // uint64_t version() const;
   // APIs to be overriden by each backend.
   // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
-  // virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
+  //virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
   virtual size_t get_root_size() const = 0;
 
  protected:

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -18,9 +18,6 @@ class RuntimeContext;
 
 namespace aot {
 
-// TODO Field, Ndarray, how to reuse
-// TODO how to put runtime info into module
-
 class TI_DLL_EXPORT Kernel {
  public:
   // Rule of 5 to make MSVC happy

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -57,7 +57,7 @@ class TI_DLL_EXPORT Module {
   // uint64_t version() const;
   // APIs to be overriden by each backend.
   // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
-  //virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
+  // virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
   virtual size_t get_root_size() const = 0;
 
  protected:

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -122,11 +122,11 @@ class TargetDevice : public Device {
 
 namespace vulkan {
 std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
-}  // namespace vulkan 
+}  // namespace vulkan
 
 namespace metal {
 std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
-}  // namespace metal 
+}  // namespace metal
 
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -53,11 +53,9 @@ class TI_DLL_EXPORT Module {
                                       std::any mod_params);
 
   // Module metadata
-  Arch arch() const;
+  //Arch arch() const;
   // uint64_t version() const;
 
-  // TODO
-  // APIs to be overriden by each backend.
   // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
   virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
   virtual size_t get_root_size() const = 0;

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -8,8 +8,8 @@
 
 #include "taichi/aot/module_data.h"
 #include "taichi/backends/device.h"
-#include "taichi/ir/snode.h" 
-#include "taichi/aot/module_data.h" 
+#include "taichi/ir/snode.h"
+#include "taichi/aot/module_data.h"
 
 namespace taichi {
 namespace lang {
@@ -20,7 +20,6 @@ namespace aot {
 
 // TODO Field, Ndarray, how to reuse
 // TODO how to put runtime info into module
-
 
 class TI_DLL_EXPORT Kernel {
  public:
@@ -57,21 +56,21 @@ class TI_DLL_EXPORT Module {
                                       std::any mod_params);
   // Module metadata
   // TODO
-  //Arch arch() const;
-  //uint64_t version() const;
+  // Arch arch() const;
+  // uint64_t version() const;
   // APIs to be overriden by each backend.
-  //virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
-  //virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0; 
+  // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
+  // virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
   virtual size_t get_root_size() const = 0;
 
  protected:
   virtual std::unique_ptr<Kernel> make_new_kernel(const std::string &name) = 0;
   virtual bool get_field(const std::string &name,
                          aot::CompiledFieldData &field) = 0;
+
  private:
   std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;
 };
-
 
 // Only responsible for reporting device capabilities
 class TargetDevice : public Device {

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <any>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -7,8 +8,8 @@
 
 #include "taichi/aot/module_data.h"
 #include "taichi/backends/device.h"
-#include "taichi/ir/snode.h"
-#include "taichi/aot/module_data.h"
+#include "taichi/ir/snode.h" 
+#include "taichi/aot/module_data.h" 
 
 namespace taichi {
 namespace lang {
@@ -16,6 +17,10 @@ namespace lang {
 class RuntimeContext;
 
 namespace aot {
+
+// TODO Field, Ndarray, how to reuse
+// TODO how to put runtime info into module
+
 
 class TI_DLL_EXPORT Kernel {
  public:
@@ -37,38 +42,36 @@ class TI_DLL_EXPORT Kernel {
   virtual void launch(RuntimeContext *ctx) = 0;
 };
 
-class TI_DLL_EXPORT ModuleLoader {
+class TI_DLL_EXPORT Module {
  public:
   // Rule of 5 to make MSVC happy
-  ModuleLoader() = default;
-  virtual ~ModuleLoader() = default;
-  ModuleLoader(const ModuleLoader &) = delete;
-  ModuleLoader &operator=(const ModuleLoader &) = delete;
-  ModuleLoader(ModuleLoader &&) = default;
-  ModuleLoader &operator=(ModuleLoader &&) = default;
+  Module() = default;
+  virtual ~Module() = default;
+  Module(const Module &) = delete;
+  Module &operator=(const Module &) = delete;
+  Module(Module &&) = default;
+  Module &operator=(Module &&) = default;
 
-  // TODO: Add method get_kernel(...) once the kernel field data will be
-  // generic/common across all backends.
-
-  virtual bool get_field(const std::string &name,
-                         aot::CompiledFieldData &field) = 0;
-
-  /**
-   * @brief Get the kernel object
-   *
-   * @param name Name of the kernel
-   * @return Kernel*
-   */
-  Kernel *get_kernel(const std::string &name);
-
+  static std::unique_ptr<Module> load(const std::string &path,
+                                      Arch arch,
+                                      std::any mod_params);
+  // Module metadata
+  // TODO
+  //Arch arch() const;
+  //uint64_t version() const;
+  // APIs to be overriden by each backend.
+  //virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
+  //virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0; 
   virtual size_t get_root_size() const = 0;
 
  protected:
   virtual std::unique_ptr<Kernel> make_new_kernel(const std::string &name) = 0;
-
+  virtual bool get_field(const std::string &name,
+                         aot::CompiledFieldData &field) = 0;
  private:
   std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;
 };
+
 
 // Only responsible for reporting device capabilities
 class TargetDevice : public Device {

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -53,8 +53,8 @@ class TI_DLL_EXPORT Module {
                                       std::any mod_params);
 
   // Module metadata
-  // Arch arch() const;
-  // uint64_t version() const;
+  Arch arch() const;
+  uint64_t version() const;
 
   // virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
   virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
@@ -68,7 +68,6 @@ class TI_DLL_EXPORT Module {
 
  private:
   std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;
-  static Arch arch_;
 };
 
 // Only responsible for reporting device capabilities

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -23,9 +23,9 @@ class KernelImpl : public aot::Kernel {
   const std::string kernel_name_;
 };
 
-class AotModuleLoaderImpl : public aot::ModuleLoader {
+class AotModuleImpl : public aot::Module {
  public:
-  explicit AotModuleLoaderImpl(const AotModuleParams &params)
+  explicit AotModuleImpl(const AotModuleParams &params)
       : runtime_(params.runtime) {
     const std::string bin_path =
         fmt::format("{}/metadata.tcb", params.module_path);
@@ -68,9 +68,9 @@ class AotModuleLoaderImpl : public aot::ModuleLoader {
 
 }  // namespace
 
-std::unique_ptr<aot::ModuleLoader> make_aot_module_loader(
+std::unique_ptr<aot::Module> make_aot_module(
     const AotModuleParams &params) {
-  return std::make_unique<AotModuleLoaderImpl>(params);
+  return std::make_unique<AotModuleImpl>(params);
 }
 
 }  // namespace metal

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -36,6 +36,10 @@ class AotModuleImpl : public aot::Module {
     }
   }
 
+  std::unique_ptr<aot::Kernel> get_kernel(const std::string &name) override {
+    return make_new_kernel(name);
+  }
+
   bool get_field(const std::string &name,
                  aot::CompiledFieldData &field) override {
     TI_ERROR("AOT: get_field for Metal not implemented yet");

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -50,6 +50,14 @@ class AotModuleImpl : public aot::Module {
     return aot_data_.metadata.root_buffer_size;
   }
 
+  // Module metadata
+  Arch arch() const {
+    return Arch::metal;
+  }
+  uint64_t version() const {
+    TI_NOT_IMPLEMENTED;
+  }
+
  private:
   std::unique_ptr<aot::Kernel> make_new_kernel(
       const std::string &name) override {

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -68,8 +68,7 @@ class AotModuleImpl : public aot::Module {
 
 }  // namespace
 
-std::unique_ptr<aot::Module> make_aot_module(
-    const AotModuleParams &params) {
+std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params) {
   return std::make_unique<AotModuleImpl>(params);
 }
 

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -40,10 +40,8 @@ class AotModuleImpl : public aot::Module {
     return make_new_kernel(name);
   }
 
-  bool get_field(const std::string &name,
-                 aot::CompiledFieldData &field) override {
-    TI_ERROR("AOT: get_field for Metal not implemented yet");
-    return false;
+  std::unique_ptr<aot::Field> get_field(const std::string &name) override {
+    TI_NOT_IMPLEMENTED;
   }
 
   size_t get_root_size() const override {

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -68,7 +68,8 @@ class AotModuleImpl : public aot::Module {
 
 }  // namespace
 
-std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params) {
+std::unique_ptr<aot::Module> make_aot_module(std::any mod_params) {
+  AotModuleParams params = std::any_cast<AotModuleParams &>(mod_params);
   return std::make_unique<AotModuleImpl>(params);
 }
 

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -49,10 +49,10 @@ class AotModuleImpl : public aot::Module {
   }
 
   // Module metadata
-  Arch arch() const {
+  Arch arch() const override {
     return Arch::metal;
   }
-  uint64_t version() const {
+  uint64_t version() const override {
     TI_NOT_IMPLEMENTED;
   }
 

--- a/taichi/backends/metal/aot_module_loader_impl.h
+++ b/taichi/backends/metal/aot_module_loader_impl.h
@@ -17,6 +17,7 @@ struct AotModuleParams {
   KernelManager *runtime{nullptr};
 };
 
+std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
 }  // namespace metal
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/metal/aot_module_loader_impl.h
+++ b/taichi/backends/metal/aot_module_loader_impl.h
@@ -17,7 +17,7 @@ struct AotModuleParams {
   KernelManager *runtime{nullptr};
 };
 
-std::unique_ptr<aot::ModuleLoader> make_aot_module_loader(
+std::unique_ptr<aot::Module> make_aot_module(
     const AotModuleParams &params);
 
 }  // namespace metal

--- a/taichi/backends/metal/aot_module_loader_impl.h
+++ b/taichi/backends/metal/aot_module_loader_impl.h
@@ -17,8 +17,7 @@ struct AotModuleParams {
   KernelManager *runtime{nullptr};
 };
 
-std::unique_ptr<aot::Module> make_aot_module(
-    const AotModuleParams &params);
+std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params);
 
 }  // namespace metal
 }  // namespace lang

--- a/taichi/backends/metal/aot_module_loader_impl.h
+++ b/taichi/backends/metal/aot_module_loader_impl.h
@@ -17,8 +17,6 @@ struct AotModuleParams {
   KernelManager *runtime{nullptr};
 };
 
-std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params);
-
 }  // namespace metal
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -29,7 +29,7 @@ class KernelImpl : public aot::Kernel {
 
 class AotModuleImpl : public aot::Module {
  public:
-  explicit AotModuleImpl(const AotModuleParams &params) 
+  explicit AotModuleImpl(const AotModuleParams &params)
       : runtime_(params.runtime) {
     const std::string bin_path =
         fmt::format("{}/metadata.tcb", params.module_path);
@@ -73,8 +73,8 @@ class AotModuleImpl : public aot::Module {
                                  VkRuntime::RegisterParams &kernel) {
     for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
       // Offloaded task names encode more than the name of the function, but for
-      // AOT, only use the name of the function which should be the first part of
-      // the struct
+      // AOT, only use the name of the function which should be the first part
+      // of the struct
       if (ti_aot_data_.kernels[i].name.rfind(name, 0) == 0) {
         kernel.kernel_attribs = ti_aot_data_.kernels[i];
         kernel.task_spirv_source_codes = ti_aot_data_.spirv_codes[i];

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -101,7 +101,8 @@ size_t AotModuleImpl::get_root_size() const {
   return ti_aot_data_.root_buffer_size;
 }
 
-std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params) {
+std::unique_ptr<aot::Module> make_aot_module(std::any mod_params) {
+  AotModuleParams params = std::any_cast<AotModuleParams &>(mod_params);
   return std::make_unique<AotModuleImpl>(params);
 }
 

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -27,87 +27,96 @@ class KernelImpl : public aot::Kernel {
   const KernelHandle handle_;
 };
 
+class AotModuleImpl : public aot::Module {
+ public:
+  explicit AotModuleImpl(const AotModuleParams &params) 
+      : runtime_(params.runtime) {
+    const std::string bin_path =
+        fmt::format("{}/metadata.tcb", params.module_path);
+    read_from_binary_file(ti_aot_data_, bin_path);
+
+    for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
+      auto k = ti_aot_data_.kernels[i];
+
+      std::vector<std::vector<uint32_t>> spirv_sources_codes;
+      for (int j = 0; j < k.tasks_attribs.size(); ++j) {
+        std::vector<uint32_t> res =
+            read_spv_file(params.module_path, k.tasks_attribs[j]);
+        spirv_sources_codes.push_back(res);
+      }
+      ti_aot_data_.spirv_codes.push_back(spirv_sources_codes);
+    }
+  }
+
+  std::unique_ptr<aot::Kernel> get_kernel(const std::string &name) override {
+    return make_new_kernel(name);
+  }
+
+  std::unique_ptr<aot::Field> get_field(const std::string &name) override {
+    TI_NOT_IMPLEMENTED;
+  }
+
+  size_t get_root_size() const override {
+    return ti_aot_data_.root_buffer_size;
+  }
+
+  // Module metadata
+  Arch arch() const {
+    return Arch::vulkan;
+  }
+  uint64_t version() const {
+    TI_NOT_IMPLEMENTED;
+  }
+
+ private:
+  bool get_kernel_params_by_name(const std::string &name,
+                                 VkRuntime::RegisterParams &kernel) {
+    for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
+      // Offloaded task names encode more than the name of the function, but for
+      // AOT, only use the name of the function which should be the first part of
+      // the struct
+      if (ti_aot_data_.kernels[i].name.rfind(name, 0) == 0) {
+        kernel.kernel_attribs = ti_aot_data_.kernels[i];
+        kernel.task_spirv_source_codes = ti_aot_data_.spirv_codes[i];
+        // We don't have to store the number of SNodeTree in |ti_aot_data_| yet,
+        // because right now we only support a single SNodeTree during AOT.
+        // TODO: Support multiple SNodeTrees in AOT.
+        kernel.num_snode_trees = 1;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::unique_ptr<aot::Kernel> make_new_kernel(
+      const std::string &name) override {
+    VkRuntime::RegisterParams kparams;
+    if (!get_kernel_params_by_name(name, kparams)) {
+      TI_DEBUG("Failed to load kernel {}", name);
+      return nullptr;
+    }
+    auto handle = runtime_->register_taichi_kernel(kparams);
+    return std::make_unique<KernelImpl>(runtime_, handle);
+  }
+
+  std::vector<uint32_t> read_spv_file(const std::string &output_dir,
+                                      const TaskAttributes &k) {
+    const std::string spv_path = fmt::format("{}/{}.spv", output_dir, k.name);
+    std::vector<uint32_t> source_code;
+    std::ifstream fs(spv_path, std::ios_base::binary | std::ios::ate);
+    size_t size = fs.tellg();
+    fs.seekg(0, std::ios::beg);
+    source_code.resize(size / sizeof(uint32_t));
+    fs.read((char *)source_code.data(), size);
+    fs.close();
+    return source_code;
+  }
+
+  TaichiAotData ti_aot_data_;
+  VkRuntime *runtime_{nullptr};
+};
+
 }  // namespace
-
-AotModuleImpl::AotModuleImpl(const AotModuleParams &params)
-    : runtime_(params.runtime) {
-  const std::string bin_path =
-      fmt::format("{}/metadata.tcb", params.module_path);
-  read_from_binary_file(ti_aot_data_, bin_path);
-
-  for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
-    auto k = ti_aot_data_.kernels[i];
-
-    std::vector<std::vector<uint32_t>> spirv_sources_codes;
-    for (int j = 0; j < k.tasks_attribs.size(); ++j) {
-      std::vector<uint32_t> res =
-          read_spv_file(params.module_path, k.tasks_attribs[j]);
-      spirv_sources_codes.push_back(res);
-    }
-    ti_aot_data_.spirv_codes.push_back(spirv_sources_codes);
-  }
-}
-
-std::vector<uint32_t> AotModuleImpl::read_spv_file(
-    const std::string &output_dir,
-    const TaskAttributes &k) {
-  const std::string spv_path = fmt::format("{}/{}.spv", output_dir, k.name);
-  std::vector<uint32_t> source_code;
-  std::ifstream fs(spv_path, std::ios_base::binary | std::ios::ate);
-  size_t size = fs.tellg();
-  fs.seekg(0, std::ios::beg);
-  source_code.resize(size / sizeof(uint32_t));
-  fs.read((char *)source_code.data(), size);
-  fs.close();
-  return source_code;
-}
-
-std::unique_ptr<aot::Kernel> AotModuleImpl::get_kernel(
-    const std::string &name) {
-  return make_new_kernel(name);
-}
-
-bool AotModuleImpl::get_kernel_params_by_name(
-    const std::string &name,
-    VkRuntime::RegisterParams &kernel) {
-  for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
-    // Offloaded task names encode more than the name of the function, but for
-    // AOT, only use the name of the function which should be the first part of
-    // the struct
-    if (ti_aot_data_.kernels[i].name.rfind(name, 0) == 0) {
-      kernel.kernel_attribs = ti_aot_data_.kernels[i];
-      kernel.task_spirv_source_codes = ti_aot_data_.spirv_codes[i];
-      // We don't have to store the number of SNodeTree in |ti_aot_data_| yet,
-      // because right now we only support a single SNodeTree during AOT.
-      // TODO: Support multiple SNodeTrees in AOT.
-      kernel.num_snode_trees = 1;
-      return true;
-    }
-  }
-
-  return false;
-}
-
-std::unique_ptr<aot::Kernel> AotModuleImpl::make_new_kernel(
-    const std::string &name) {
-  VkRuntime::RegisterParams kparams;
-  if (!get_kernel_params_by_name(name, kparams)) {
-    TI_DEBUG("Failed to load kernel {}", name);
-    return nullptr;
-  }
-  auto handle = runtime_->register_taichi_kernel(kparams);
-  return std::make_unique<KernelImpl>(runtime_, handle);
-}
-
-bool AotModuleImpl::get_field(const std::string &name,
-                              aot::CompiledFieldData &field) {
-  TI_ERROR("AOT: get_field for Vulkan not implemented yet");
-  return false;
-}
-
-size_t AotModuleImpl::get_root_size() const {
-  return ti_aot_data_.root_buffer_size;
-}
 
 std::unique_ptr<aot::Module> make_aot_module(std::any mod_params) {
   AotModuleParams params = std::any_cast<AotModuleParams &>(mod_params);

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -30,7 +30,7 @@ class KernelImpl : public aot::Kernel {
 }  // namespace
 
 AotModuleImpl::AotModuleImpl(const AotModuleParams &params)
-  : runtime_(params.runtime) {
+    : runtime_(params.runtime) {
   const std::string bin_path =
       fmt::format("{}/metadata.tcb", params.module_path);
   read_from_binary_file(ti_aot_data_, bin_path);
@@ -62,7 +62,8 @@ std::vector<uint32_t> AotModuleImpl::read_spv_file(
   return source_code;
 }
 
-std::unique_ptr<aot::Kernel> AotModuleImpl::get_kernel(const std::string &name) {
+std::unique_ptr<aot::Kernel> AotModuleImpl::get_kernel(
+    const std::string &name) {
   return make_new_kernel(name);
 }
 

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -28,7 +28,6 @@ class KernelImpl : public aot::Kernel {
 };
 }  // namespace
 
-
 AotModuleImpl::AotModuleImpl(const std::string &output_dir) {
   const std::string bin_path = fmt::format("{}/metadata.tcb", output_dir);
   read_from_binary_file(ti_aot_data_, bin_path);
@@ -60,7 +59,7 @@ std::vector<uint32_t> AotModuleImpl::read_spv_file(
 }
 
 bool AotModuleImpl::get_kernel(const std::string &name,
-                                     VkRuntime::RegisterParams &kernel) {
+                               VkRuntime::RegisterParams &kernel) {
   for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
     // Offloaded task names encode more than the name of the function, but for
     // AOT, only use the name of the function which should be the first part of
@@ -91,7 +90,7 @@ std::unique_ptr<aot::Kernel> AotModuleImpl::make_new_kernel(
 }
 
 bool AotModuleImpl::get_field(const std::string &name,
-                                    aot::CompiledFieldData &field) {
+                              aot::CompiledFieldData &field) {
   TI_ERROR("AOT: get_field for Vulkan not implemented yet");
   return false;
 }

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -66,8 +66,9 @@ std::unique_ptr<Kernel> AotModuleImpl::get_kernel(const std::string &name) {
   return make_new_kernel(name);
 }
 
-bool AotModuleImpl::get_kernel_params_by_name(const std::string &name,
-                                     VkRuntime::RegisterParams &kernel) {
+bool AotModuleImpl::get_kernel_params_by_name(
+    const std::string &name,
+    VkRuntime::RegisterParams &kernel) {
   for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
     // Offloaded task names encode more than the name of the function, but for
     // AOT, only use the name of the function which should be the first part of

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -29,7 +29,8 @@ class KernelImpl : public aot::Kernel {
 
 }  // namespace
 
-AotModuleImpl::AotModuleImpl(const AotModuleParams &params) {
+AotModuleImpl::AotModuleImpl(const AotModuleParams &params)
+  : runtime_(params.runtime) {
   const std::string bin_path =
       fmt::format("{}/metadata.tcb", params.module_path);
   read_from_binary_file(ti_aot_data_, bin_path);
@@ -45,7 +46,6 @@ AotModuleImpl::AotModuleImpl(const AotModuleParams &params) {
     }
     ti_aot_data_.spirv_codes.push_back(spirv_sources_codes);
   }
-  runtime_ = params.runtime;
 }
 
 std::vector<uint32_t> AotModuleImpl::read_spv_file(
@@ -62,7 +62,7 @@ std::vector<uint32_t> AotModuleImpl::read_spv_file(
   return source_code;
 }
 
-std::unique_ptr<Kernel> AotModuleImpl::get_kernel(const std::string &name) {
+std::unique_ptr<aot::Kernel> AotModuleImpl::get_kernel(const std::string &name) {
   return make_new_kernel(name);
 }
 

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -28,11 +28,14 @@ class KernelImpl : public aot::Kernel {
 };
 }  // namespace
 
-AotModuleLoaderImpl::AotModuleLoaderImpl(const std::string &output_dir) {
+
+AotModuleImpl::AotModuleImpl(const std::string &output_dir) {
   const std::string bin_path = fmt::format("{}/metadata.tcb", output_dir);
   read_from_binary_file(ti_aot_data_, bin_path);
+
   for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
     auto k = ti_aot_data_.kernels[i];
+
     std::vector<std::vector<uint32_t>> spirv_sources_codes;
     for (int j = 0; j < k.tasks_attribs.size(); ++j) {
       std::vector<uint32_t> res = read_spv_file(output_dir, k.tasks_attribs[j]);
@@ -42,7 +45,7 @@ AotModuleLoaderImpl::AotModuleLoaderImpl(const std::string &output_dir) {
   }
 }
 
-std::vector<uint32_t> AotModuleLoaderImpl::read_spv_file(
+std::vector<uint32_t> AotModuleImpl::read_spv_file(
     const std::string &output_dir,
     const TaskAttributes &k) {
   const std::string spv_path = fmt::format("{}/{}.spv", output_dir, k.name);
@@ -56,7 +59,7 @@ std::vector<uint32_t> AotModuleLoaderImpl::read_spv_file(
   return source_code;
 }
 
-bool AotModuleLoaderImpl::get_kernel(const std::string &name,
+bool AotModuleImpl::get_kernel(const std::string &name,
                                      VkRuntime::RegisterParams &kernel) {
   for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
     // Offloaded task names encode more than the name of the function, but for
@@ -76,7 +79,7 @@ bool AotModuleLoaderImpl::get_kernel(const std::string &name,
   return false;
 }
 
-std::unique_ptr<aot::Kernel> AotModuleLoaderImpl::make_new_kernel(
+std::unique_ptr<aot::Kernel> AotModuleImpl::make_new_kernel(
     const std::string &name) {
   VkRuntime::RegisterParams kparams;
   if (!get_kernel(name, kparams)) {
@@ -87,15 +90,16 @@ std::unique_ptr<aot::Kernel> AotModuleLoaderImpl::make_new_kernel(
   return std::make_unique<KernelImpl>(runtime_, handle);
 }
 
-bool AotModuleLoaderImpl::get_field(const std::string &name,
+bool AotModuleImpl::get_field(const std::string &name,
                                     aot::CompiledFieldData &field) {
   TI_ERROR("AOT: get_field for Vulkan not implemented yet");
   return false;
 }
 
-size_t AotModuleLoaderImpl::get_root_size() const {
+size_t AotModuleImpl::get_root_size() const {
   return ti_aot_data_.root_buffer_size;
 }
+
 }  // namespace vulkan
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -61,10 +61,10 @@ class AotModuleImpl : public aot::Module {
   }
 
   // Module metadata
-  Arch arch() const {
+  Arch arch() const override {
     return Arch::vulkan;
   }
-  uint64_t version() const {
+  uint64_t version() const override {
     TI_NOT_IMPLEMENTED;
   }
 

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -29,7 +29,8 @@ class KernelImpl : public aot::Kernel {
 }  // namespace
 
 AotModuleImpl::AotModuleImpl(const AotModuleParams &params) {
-  const std::string bin_path = fmt::format("{}/metadata.tcb", params.module_path);
+  const std::string bin_path =
+      fmt::format("{}/metadata.tcb", params.module_path);
   read_from_binary_file(ti_aot_data_, bin_path);
 
   for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
@@ -37,7 +38,8 @@ AotModuleImpl::AotModuleImpl(const AotModuleParams &params) {
 
     std::vector<std::vector<uint32_t>> spirv_sources_codes;
     for (int j = 0; j < k.tasks_attribs.size(); ++j) {
-      std::vector<uint32_t> res = read_spv_file(params.module_path, k.tasks_attribs[j]);
+      std::vector<uint32_t> res =
+          read_spv_file(params.module_path, k.tasks_attribs[j]);
       spirv_sources_codes.push_back(res);
     }
     ti_aot_data_.spirv_codes.push_back(spirv_sources_codes);

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -28,8 +28,8 @@ class KernelImpl : public aot::Kernel {
 };
 }  // namespace
 
-AotModuleImpl::AotModuleImpl(const std::string &output_dir) {
-  const std::string bin_path = fmt::format("{}/metadata.tcb", output_dir);
+AotModuleImpl::AotModuleImpl(const AotModuleParams &params) {
+  const std::string bin_path = fmt::format("{}/metadata.tcb", params.module_path);
   read_from_binary_file(ti_aot_data_, bin_path);
 
   for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
@@ -37,7 +37,7 @@ AotModuleImpl::AotModuleImpl(const std::string &output_dir) {
 
     std::vector<std::vector<uint32_t>> spirv_sources_codes;
     for (int j = 0; j < k.tasks_attribs.size(); ++j) {
-      std::vector<uint32_t> res = read_spv_file(output_dir, k.tasks_attribs[j]);
+      std::vector<uint32_t> res = read_spv_file(params.module_path, k.tasks_attribs[j]);
       spirv_sources_codes.push_back(res);
     }
     ti_aot_data_.spirv_codes.push_back(spirv_sources_codes);
@@ -97,6 +97,10 @@ bool AotModuleImpl::get_field(const std::string &name,
 
 size_t AotModuleImpl::get_root_size() const {
   return ti_aot_data_.root_buffer_size;
+}
+
+std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params) {
+  return std::make_unique<AotModuleImpl>(params);
 }
 
 }  // namespace vulkan

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -38,7 +38,6 @@ class TI_DLL_EXPORT AotModuleImpl : public aot::Module {
   VkRuntime *runtime_{nullptr};
 };
 
-
 std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params);
 
 }  // namespace vulkan

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -24,12 +24,14 @@ class AotModuleImpl : public aot::Module {
  public:
   explicit AotModuleImpl(const AotModuleParams &params);
 
-  bool get_kernel(const std::string &name, VkRuntime::RegisterParams &kernel);
+  std::unique_ptr<aot::Kernel> get_kernel(const std::string &name) override;
+
   bool get_field(const std::string &name,
                  aot::CompiledFieldData &field) override;
   size_t get_root_size() const override;
 
  private:
+  bool get_kernel_params_by_name(const std::string &name, VkRuntime::RegisterParams &kernel);
   std::unique_ptr<aot::Kernel> make_new_kernel(
       const std::string &name) override;
   std::vector<uint32_t> read_spv_file(const std::string &output_dir,

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -33,6 +33,14 @@ class TI_DLL_EXPORT AotModuleImpl : public aot::Module {
   VkRuntime *runtime_{nullptr};
 };
 
+
+struct AotModuleParams {
+  std::string module_path;
+  VkRuntime *runtime{nullptr};
+};
+
+std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params);
+
 }  // namespace vulkan
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -20,7 +20,7 @@ struct AotModuleParams {
   VkRuntime *runtime{nullptr};
 };
 
-class TI_DLL_EXPORT AotModuleImpl : public aot::Module {
+class AotModuleImpl : public aot::Module {
  public:
   explicit AotModuleImpl(const AotModuleParams &params);
 

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -15,15 +15,12 @@ namespace vulkan {
 
 class VkRuntime;
 
-class TI_DLL_EXPORT AotModuleLoaderImpl : public aot::ModuleLoader {
+class TI_DLL_EXPORT AotModuleImpl : public aot::Module {
  public:
-  explicit AotModuleLoaderImpl(const std::string &output_dir);
+  explicit AotModuleImpl(const std::string &output_dir);
 
   bool get_kernel(const std::string &name, VkRuntime::RegisterParams &kernel);
-
-  bool get_field(const std::string &name,
-                 aot::CompiledFieldData &field) override;
-
+  bool get_field(const std::string &name, aot::CompiledFieldData &field) override;
   size_t get_root_size() const override;
 
  private:
@@ -31,7 +28,6 @@ class TI_DLL_EXPORT AotModuleLoaderImpl : public aot::ModuleLoader {
       const std::string &name) override;
   std::vector<uint32_t> read_spv_file(const std::string &output_dir,
                                       const TaskAttributes &k);
-
   TaichiAotData ti_aot_data_;
   VkRuntime *runtime_{nullptr};
 };

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -20,35 +20,6 @@ struct AotModuleParams {
   VkRuntime *runtime{nullptr};
 };
 
-class AotModuleImpl : public aot::Module {
- public:
-  explicit AotModuleImpl(const AotModuleParams &params);
-
-  std::unique_ptr<aot::Kernel> get_kernel(const std::string &name) override;
-
-  bool get_field(const std::string &name,
-                 aot::CompiledFieldData &field) override;
-  size_t get_root_size() const override;
-
-  // Module metadata
-  Arch arch() const {
-    return Arch::vulkan;
-  }
-  uint64_t version() const {
-    TI_NOT_IMPLEMENTED;
-  }
-
- private:
-  bool get_kernel_params_by_name(const std::string &name,
-                                 VkRuntime::RegisterParams &kernel);
-  std::unique_ptr<aot::Kernel> make_new_kernel(
-      const std::string &name) override;
-  std::vector<uint32_t> read_spv_file(const std::string &output_dir,
-                                      const TaskAttributes &k);
-  TaichiAotData ti_aot_data_;
-  VkRuntime *runtime_{nullptr};
-};
-
 }  // namespace vulkan
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -20,6 +20,7 @@ struct AotModuleParams {
   VkRuntime *runtime{nullptr};
 };
 
+std::unique_ptr<aot::Module> make_aot_module(std::any mod_params);
 }  // namespace vulkan
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -30,6 +30,14 @@ class AotModuleImpl : public aot::Module {
                  aot::CompiledFieldData &field) override;
   size_t get_root_size() const override;
 
+  // Module metadata
+  Arch arch() const {
+    return Arch::vulkan;
+  }
+  uint64_t version() const {
+    TI_NOT_IMPLEMENTED;
+  }
+
  private:
   bool get_kernel_params_by_name(const std::string &name,
                                  VkRuntime::RegisterParams &kernel);

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -15,9 +15,14 @@ namespace vulkan {
 
 class VkRuntime;
 
+struct AotModuleParams {
+  std::string module_path;
+  VkRuntime *runtime{nullptr};
+};
+
 class TI_DLL_EXPORT AotModuleImpl : public aot::Module {
  public:
-  explicit AotModuleImpl(const std::string &output_dir);
+  explicit AotModuleImpl(const AotModuleParams &params);
 
   bool get_kernel(const std::string &name, VkRuntime::RegisterParams &kernel);
   bool get_field(const std::string &name,
@@ -33,11 +38,6 @@ class TI_DLL_EXPORT AotModuleImpl : public aot::Module {
   VkRuntime *runtime_{nullptr};
 };
 
-
-struct AotModuleParams {
-  std::string module_path;
-  VkRuntime *runtime{nullptr};
-};
 
 std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params);
 

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -31,7 +31,8 @@ class AotModuleImpl : public aot::Module {
   size_t get_root_size() const override;
 
  private:
-  bool get_kernel_params_by_name(const std::string &name, VkRuntime::RegisterParams &kernel);
+  bool get_kernel_params_by_name(const std::string &name,
+                                 VkRuntime::RegisterParams &kernel);
   std::unique_ptr<aot::Kernel> make_new_kernel(
       const std::string &name) override;
   std::vector<uint32_t> read_spv_file(const std::string &output_dir,

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -20,7 +20,8 @@ class TI_DLL_EXPORT AotModuleImpl : public aot::Module {
   explicit AotModuleImpl(const std::string &output_dir);
 
   bool get_kernel(const std::string &name, VkRuntime::RegisterParams &kernel);
-  bool get_field(const std::string &name, aot::CompiledFieldData &field) override;
+  bool get_field(const std::string &name,
+                 aot::CompiledFieldData &field) override;
   size_t get_root_size() const override;
 
  private:

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -38,8 +38,6 @@ class AotModuleImpl : public aot::Module {
   VkRuntime *runtime_{nullptr};
 };
 
-std::unique_ptr<aot::Module> make_aot_module(const AotModuleParams &params);
-
 }  // namespace vulkan
 }  // namespace lang
 }  // namespace taichi

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -9,7 +9,6 @@
 #include "taichi/backends/vulkan/vulkan_device_creator.h"
 #include "taichi/backends/vulkan/vulkan_loader.h"
 #include "taichi/backends/vulkan/vulkan_utils.h"
-
 #endif
 
 using namespace taichi;
@@ -126,8 +125,15 @@ TEST(AotSaveLoad, Vulkan) {
       aot::Module::load(".", Arch::vulkan, mod_params);
   EXPECT_TRUE(vk_module);
 
+  // Retrieve kernels/fields/etc from AOT module to initialize runtime
+  auto root_size = vk_module->get_root_size();
+  EXPECT_EQ(root_size, 64);
+  vulkan_runtime->add_root_buffer(root_size);
+
   // TODO
   // vulkan::VkRuntime::RegisterParams init_kernel, ret_kernel;
+  // auto init_kernel = vk_module->get_kernel("init");
+  // EXPECT_TRUE(init_kernel);
 
   // auto ret = vk_module.get_kernel("init", init_kernel);
   // EXPECT_TRUE(ret);
@@ -139,6 +145,5 @@ TEST(AotSaveLoad, Vulkan) {
   // EXPECT_FALSE(ret);
 
   // auto root_size = vk_module.get_root_size();
-  // EXPECT_EQ(root_size, 64);
 }
 #endif

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -98,20 +98,25 @@ TEST(AotSaveLoad, Vulkan) {
 
   // Initialize Vulkan program
   taichi::uint64 *result_buffer{nullptr};
-  auto memory_pool = std::make_unique<taichi::lang::MemoryPool>(Arch::vulkan, nullptr);
-  result_buffer = (taichi::uint64 *)memory_pool->allocate(sizeof(taichi::uint64) * taichi_result_buffer_entries, 8);
+  auto memory_pool =
+      std::make_unique<taichi::lang::MemoryPool>(Arch::vulkan, nullptr);
+  result_buffer = (taichi::uint64 *)memory_pool->allocate(
+      sizeof(taichi::uint64) * taichi_result_buffer_entries, 8);
 
   // Create Taichi Device for computation
   lang::vulkan::VulkanDeviceCreator::Params evd_params;
-  evd_params.api_version = taichi::lang::vulkan::VulkanEnvSettings::kApiVersion();
-  auto embedded_device = std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
+  evd_params.api_version =
+      taichi::lang::vulkan::VulkanEnvSettings::kApiVersion();
+  auto embedded_device =
+      std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
 
   // Create Vulkan runtime
   vulkan::VkRuntime::Params params;
   params.host_result_buffer = result_buffer;
   params.device = embedded_device->device();
-  auto vulkan_runtime = std::make_unique<taichi::lang::vulkan::VkRuntime>(std::move(params));
-  
+  auto vulkan_runtime =
+      std::make_unique<taichi::lang::vulkan::VkRuntime>(std::move(params));
+
   // Run AOT module loader
   vulkan::AotModuleParams mod_params;
   mod_params.module_path = ".";
@@ -122,18 +127,18 @@ TEST(AotSaveLoad, Vulkan) {
   EXPECT_TRUE(vk_module);
 
   // TODO
-  //vulkan::VkRuntime::RegisterParams init_kernel, ret_kernel;
+  // vulkan::VkRuntime::RegisterParams init_kernel, ret_kernel;
 
-  //auto ret = vk_module.get_kernel("init", init_kernel);
-  //EXPECT_TRUE(ret);
+  // auto ret = vk_module.get_kernel("init", init_kernel);
+  // EXPECT_TRUE(ret);
 
-  //ret = vk_module.get_kernel("ret", ret_kernel);
-  //EXPECT_TRUE(ret);
+  // ret = vk_module.get_kernel("ret", ret_kernel);
+  // EXPECT_TRUE(ret);
 
-  //ret = vk_module.get_kernel("ret2", ret_kernel);
-  //EXPECT_FALSE(ret);
+  // ret = vk_module.get_kernel("ret2", ret_kernel);
+  // EXPECT_FALSE(ret);
 
-  //auto root_size = vk_module.get_root_size();
-  //EXPECT_EQ(root_size, 64);
+  // auto root_size = vk_module.get_root_size();
+  // EXPECT_EQ(root_size, 64);
 }
 #endif

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -91,7 +91,7 @@ TEST(AotSaveLoad, Vulkan) {
 
   aot_save();
 
-  vulkan::AotModuleLoaderImpl aot_loader(".");
+  vulkan::AotModuleImpl aot_loader(".");
   vulkan::VkRuntime::RegisterParams init_kernel, ret_kernel;
 
   auto ret = aot_loader.get_kernel("init", init_kernel);

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -133,25 +133,25 @@ TEST(AotSaveLoad, Vulkan) {
   vulkan_runtime->add_root_buffer(root_size);
 
   // TODO
-  //auto init_kernel = vk_module->get_kernel("init");
-  //EXPECT_TRUE(init_kernel);
- 
-  //auto substep_kernel = vk_module->get_kernel("substep");
-  //EXPECT_TRUE(substep_kernel);
+  // auto init_kernel = vk_module->get_kernel("init");
+  // EXPECT_TRUE(init_kernel);
+
+  // auto substep_kernel = vk_module->get_kernel("substep");
+  // EXPECT_TRUE(substep_kernel);
 
   // Run kernels
-  //int n_particles = 8192;
-  //std::vector<float> x{n_particles * 2}; 
+  // int n_particles = 8192;
+  // std::vector<float> x{n_particles * 2};
 
   // init_kernel
-  //init_kernel->launch(&host_ctx)
-  //for (int i = 0; i < 50; i++) {
+  // init_kernel->launch(&host_ctx)
+  // for (int i = 0; i < 50; i++) {
   //  substep_kernel->launch(&host_ctx);
   //}
-  //vulkan_runtime->synchronize();
+  // vulkan_runtime->synchronize();
 
-  //auto x_field = vk_module.get_field("x");
-  //EXPECT_TRUE(x_field);
-  //x_field.copy_to(/*dst=*/x.get());
+  // auto x_field = vk_module.get_field("x");
+  // EXPECT_TRUE(x_field);
+  // x_field.copy_to(/*dst=*/x.get());
 }
 #endif

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -133,8 +133,8 @@ TEST(AotSaveLoad, Vulkan) {
   vulkan_runtime->add_root_buffer(root_size);
 
   // TODO
-  // auto init_kernel = vk_module->get_kernel("init");
-  // EXPECT_TRUE(init_kernel);
+  auto init_kernel = vk_module->get_kernel("init");
+  EXPECT_TRUE(init_kernel);
 
   // auto substep_kernel = vk_module->get_kernel("substep");
   // EXPECT_TRUE(substep_kernel);

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -132,23 +132,19 @@ TEST(AotSaveLoad, Vulkan) {
   EXPECT_EQ(root_size, 64);
   vulkan_runtime->add_root_buffer(root_size);
 
-  // TODO
   auto init_kernel = vk_module->get_kernel("init");
   EXPECT_TRUE(init_kernel);
 
-  // auto substep_kernel = vk_module->get_kernel("substep");
-  // EXPECT_TRUE(substep_kernel);
+  auto ret_kernel = vk_module->get_kernel("ret");
+  EXPECT_TRUE(ret_kernel);
+
+  auto ret2_kernel = vk_module->get_kernel("ret2");
+  EXPECT_FALSE(ret2_kernel);
 
   // Run kernels
-  // int n_particles = 8192;
-  // std::vector<float> x{n_particles * 2};
-
-  // init_kernel
-  // init_kernel->launch(&host_ctx)
-  // for (int i = 0; i < 50; i++) {
-  //  substep_kernel->launch(&host_ctx);
-  //}
-  // vulkan_runtime->synchronize();
+  init_kernel->launch(&host_ctx);
+  ret_kernel->launch(&host_ctx);
+  vulkan_runtime->synchronize();
 
   // auto x_field = vk_module.get_field("x");
   // EXPECT_TRUE(x_field);

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -95,8 +95,10 @@ TEST(AotSaveLoad, Vulkan) {
 
   aot_save();
 
+  // API based on proposal https://github.com/taichi-dev/taichi/issues/3642
   // Initialize Vulkan program
   taichi::uint64 *result_buffer{nullptr};
+  taichi::lang::RuntimeContext host_ctx;
   auto memory_pool =
       std::make_unique<taichi::lang::MemoryPool>(Arch::vulkan, nullptr);
   result_buffer = (taichi::uint64 *)memory_pool->allocate(
@@ -131,19 +133,25 @@ TEST(AotSaveLoad, Vulkan) {
   vulkan_runtime->add_root_buffer(root_size);
 
   // TODO
-  // vulkan::VkRuntime::RegisterParams init_kernel, ret_kernel;
-  // auto init_kernel = vk_module->get_kernel("init");
-  // EXPECT_TRUE(init_kernel);
+  //auto init_kernel = vk_module->get_kernel("init");
+  //EXPECT_TRUE(init_kernel);
+ 
+  //auto substep_kernel = vk_module->get_kernel("substep");
+  //EXPECT_TRUE(substep_kernel);
 
-  // auto ret = vk_module.get_kernel("init", init_kernel);
-  // EXPECT_TRUE(ret);
+  // Run kernels
+  //int n_particles = 8192;
+  //std::vector<float> x{n_particles * 2}; 
 
-  // ret = vk_module.get_kernel("ret", ret_kernel);
-  // EXPECT_TRUE(ret);
+  // init_kernel
+  //init_kernel->launch(&host_ctx)
+  //for (int i = 0; i < 50; i++) {
+  //  substep_kernel->launch(&host_ctx);
+  //}
+  //vulkan_runtime->synchronize();
 
-  // ret = vk_module.get_kernel("ret2", ret_kernel);
-  // EXPECT_FALSE(ret);
-
-  // auto root_size = vk_module.get_root_size();
+  //auto x_field = vk_module.get_field("x");
+  //EXPECT_TRUE(x_field);
+  //x_field.copy_to(/*dst=*/x.get());
 }
 #endif


### PR DESCRIPTION
Towards a simpler AOT runtime API as suggested in issue #3642.

This PR makes the following changes 
- [x] `ModuleLoader` to `Module.load()`
- [x] `module->get_kernel()`
- [x] `kernel->launch()`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
