### PR TITLE
[Lang] Support type annotations for literals

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -366,7 +366,8 @@ class ASTTransformer(Builder):
         func = node.func.ptr
         if id(func) in primitive_types.type_ids:
             if len(args) != 1 or keywords or isinstance(args[0], expr.Expr):
-                raise TaichiSyntaxError("Type annotation can only be given to a single literal.")
+                raise TaichiSyntaxError(
+                    "Type annotation can only be given to a single literal.")
             node.ptr = expr.Expr(args[0], dtype=func)
             return True
         return False

--- a/tests/python/test_literal.py
+++ b/tests/python/test_literal.py
@@ -9,7 +9,8 @@ def test_literal_u32():
     @ti.kernel
     def pcg_hash(inp: ti.u32) -> ti.u32:
         state: ti.u32 = inp * ti.u32(747796405) + ti.u32(2891336453)
-        word: ti.u32 = ((state >> ((state >> ti.u32(28)) + ti.u32(4))) ^ state) * ti.u32(277803737)
+        word: ti.u32 = ((state >> (
+            (state >> ti.u32(28)) + ti.u32(4))) ^ state) * ti.u32(277803737)
         return (word >> ti.u32(22)) ^ word
 
     assert pcg_hash(12345678) == 119515934

--- a/tests/python/test_literal.py
+++ b/tests/python/test_literal.py
@@ -1,0 +1,47 @@
+import pytest
+
+import taichi as ti
+from tests import test_utils
+
+
+@test_utils.test()
+def test_literal_u32():
+    @ti.kernel
+    def pcg_hash(inp: ti.u32) -> ti.u32:
+        state: ti.u32 = inp * ti.u32(747796405) + ti.u32(2891336453)
+        word: ti.u32 = ((state >> ((state >> ti.u32(28)) + ti.u32(4))) ^ state) * ti.u32(277803737)
+        return (word >> ti.u32(22)) ^ word
+
+    assert pcg_hash(12345678) == 119515934
+    assert pcg_hash(98765432) == 4244201195
+
+
+@test_utils.test()
+def test_literal_multi_args_error():
+    @ti.kernel
+    def multi_args_error():
+        a = ti.i64(1, 2)
+
+    with pytest.raises(ti.TaichiSyntaxError):
+        multi_args_error()
+
+
+@test_utils.test()
+def test_literal_keywords_error():
+    @ti.kernel
+    def keywords_error():
+        a = ti.f64(1, x=2)
+
+    with pytest.raises(ti.TaichiSyntaxError):
+        keywords_error()
+
+
+@test_utils.test()
+def test_literal_expr_error():
+    @ti.kernel
+    def expr_error():
+        a = 1
+        b = ti.f16(a)
+
+    with pytest.raises(ti.TaichiSyntaxError):
+        expr_error()


### PR DESCRIPTION
Related issue = #4230

This PR implements the approach 1 in #4230. After this PR, the way to give a type to a literal is `ti.u32(12345678)` instead of
```python
a: ti.u32 = 12345678
```
Of course, you can specify both types of the literal and the variable:
```python
a: ti.u32 = ti.u32(12345678)
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
