### PR TITLE
[Error] Add error message when the number of elements in kernel arguments exceed

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -609,15 +609,15 @@ class Kernel:
                 self.runtime.target_tape.insert(self, args)
 
             if actual_argument_slot > 8 and (
-                    _ti_core.arch_name(impl.current_cfg().arch) == 'opengl'
-                    or _ti_core.arch_name(impl.current_cfg().arch) == 'cc'):
+                    impl.current_cfg().arch == _ti_core.opengl
+                    or impl.current_cfg().arch == _ti_core.cc):
                 raise TaichiRuntimeError(
                     f"The number of elements in kernel arguments is too big! Do not exceed 8 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
                 )
 
             if actual_argument_slot > 64 and (
-                (_ti_core.arch_name(impl.current_cfg().arch) != 'opengl'
-                 and _ti_core.arch_name(impl.current_cfg().arch) != 'cc')):
+                (impl.current_cfg().arch != _ti_core.opengl
+                 and impl.current_cfg().arch != _ti_core.cc)):
                 raise TaichiRuntimeError(
                     f"The number of elements in kernel arguments is too big! Do not exceed 64 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
                 )

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -608,6 +608,20 @@ class Kernel:
             if not self.is_grad and self.runtime.target_tape and not self.runtime.grad_replaced:
                 self.runtime.target_tape.insert(self, args)
 
+            if actual_argument_slot > 8 and (
+                    _ti_core.arch_name(impl.current_cfg().arch) == 'opengl'
+                    or _ti_core.arch_name(impl.current_cfg().arch) == 'cc'):
+                raise TaichiSyntaxError(
+                    f"The number of elements in kernel arguments is too big! Do not exceed 8 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
+                )
+
+            if actual_argument_slot > 64 and (
+                (_ti_core.arch_name(impl.current_cfg().arch) != 'opengl'
+                 and _ti_core.arch_name(impl.current_cfg().arch) != 'cc')):
+                raise TaichiSyntaxError(
+                    f"The number of elements in kernel arguments is too big! Do not exceed 64 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
+                )
+
             t_kernel(launch_ctx)
 
             ret = None

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -12,7 +12,7 @@ from taichi.lang import impl, runtime_ops
 from taichi.lang.ast import (ASTTransformerContext, KernelSimplicityASTChecker,
                              transform_tree)
 from taichi.lang.enums import Layout
-from taichi.lang.exception import (TaichiCompilationError,
+from taichi.lang.exception import (TaichiCompilationError, TaichiRuntimeError,
                                    TaichiRuntimeTypeError, TaichiSyntaxError)
 from taichi.lang.expr import Expr
 from taichi.lang.matrix import Matrix, MatrixType
@@ -611,14 +611,14 @@ class Kernel:
             if actual_argument_slot > 8 and (
                     _ti_core.arch_name(impl.current_cfg().arch) == 'opengl'
                     or _ti_core.arch_name(impl.current_cfg().arch) == 'cc'):
-                raise RuntimeError(
+                raise TaichiRuntimeError(
                     f"The number of elements in kernel arguments is too big! Do not exceed 8 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
                 )
 
             if actual_argument_slot > 64 and (
                 (_ti_core.arch_name(impl.current_cfg().arch) != 'opengl'
                  and _ti_core.arch_name(impl.current_cfg().arch) != 'cc')):
-                raise RuntimeError(
+                raise TaichiRuntimeError(
                     f"The number of elements in kernel arguments is too big! Do not exceed 64 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
                 )
 

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -611,14 +611,14 @@ class Kernel:
             if actual_argument_slot > 8 and (
                     _ti_core.arch_name(impl.current_cfg().arch) == 'opengl'
                     or _ti_core.arch_name(impl.current_cfg().arch) == 'cc'):
-                raise TaichiSyntaxError(
+                raise RuntimeError(
                     f"The number of elements in kernel arguments is too big! Do not exceed 8 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
                 )
 
             if actual_argument_slot > 64 and (
                 (_ti_core.arch_name(impl.current_cfg().arch) != 'opengl'
                  and _ti_core.arch_name(impl.current_cfg().arch) != 'cc')):
-                raise TaichiSyntaxError(
+                raise RuntimeError(
                     f"The number of elements in kernel arguments is too big! Do not exceed 64 on {_ti_core.arch_name(impl.current_cfg().arch)} backend."
                 )
 

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -4,7 +4,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(arch=[ti.opengl, ti.cc])
+@test_utils.test(arch=ti.opengl)
 def test_exceed_max_eight():
     @ti.kernel
     def foo1(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
@@ -18,11 +18,37 @@ def test_exceed_max_eight():
              g: ti.i32, h: ti.i32, i: ti.i32) -> ti.i32:
         return a + b + c + d + e + f + g + h + i
 
-    with pytest.raises(ti.TaichiRuntimeError):
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+            match=
+            "The number of elements in kernel arguments is too big! Do not exceed 8 on opengl backend."
+    ):
         foo2(1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 
-@test_utils.test(exclude=[ti.opengl, ti.cc])
+@test_utils.test(arch=ti.cc)
+def test_exceed_max_eight():
+    @ti.kernel
+    def foo1(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
+             g: ti.i32, h: ti.i32) -> ti.i32:
+        return a + b + c + d + e + f + g + h
+
+    assert foo1(1, 2, 3, 4, 5, 6, 7, 8) == 36
+
+    @ti.kernel
+    def foo2(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
+             g: ti.i32, h: ti.i32, i: ti.i32) -> ti.i32:
+        return a + b + c + d + e + f + g + h + i
+
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+            match=
+            "The number of elements in kernel arguments is too big! Do not exceed 8 on cc backend."
+    ):
+        foo2(1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+
+@test_utils.test(arch=ti.cuda)
 def test_exceed_max_64():
     N = 64
 
@@ -41,5 +67,117 @@ def test_exceed_max_64():
 
     A = ti.Vector([1] * N)
 
-    with pytest.raises(ti.TaichiRuntimeError):
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+            match=
+            "The number of elements in kernel arguments is too big! Do not exceed 64 on cuda backend."
+    ):
+        foo2(A)
+
+
+@test_utils.test(arch=ti.metal)
+def test_exceed_max_64():
+    N = 64
+
+    @ti.kernel
+    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+    assert foo1(A) == 64
+
+    N = 65
+
+    @ti.kernel
+    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+            match=
+            "The number of elements in kernel arguments is too big! Do not exceed 64 on metal backend."
+    ):
+        foo2(A)
+
+
+@test_utils.test(arch=ti.vulkan)
+def test_exceed_max_64():
+    N = 64
+
+    @ti.kernel
+    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+    assert foo1(A) == 64
+
+    N = 65
+
+    @ti.kernel
+    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+            match=
+            "The number of elements in kernel arguments is too big! Do not exceed 64 on vulkan backend."
+    ):
+        foo2(A)
+
+
+@test_utils.test(arch=ti.x64)
+def test_exceed_max_64():
+    N = 64
+
+    @ti.kernel
+    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+    assert foo1(A) == 64
+
+    N = 65
+
+    @ti.kernel
+    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+            match=
+            "The number of elements in kernel arguments is too big! Do not exceed 64 on x64 backend."
+    ):
+        foo2(A)
+
+
+@test_utils.test(arch=ti.arm64)
+def test_exceed_max_64():
+    N = 64
+
+    @ti.kernel
+    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+    assert foo1(A) == 64
+
+    N = 65
+
+    @ti.kernel
+    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+            match=
+            "The number of elements in kernel arguments is too big! Do not exceed 64 on arm64 backend."
+    ):
         foo2(A)

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -4,7 +4,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(arch=ti.opengl)
+@test_utils.test(arch=[ti.opengl, ti.cc])
 def test_exceed_max_eight():
     @ti.kernel
     def foo1(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
@@ -21,34 +21,12 @@ def test_exceed_max_eight():
     with pytest.raises(
             ti.TaichiRuntimeError,
             match=
-            "The number of elements in kernel arguments is too big! Do not exceed 8 on opengl backend."
+            f"The number of elements in kernel arguments is too big! Do not exceed 8 on {ti.lang._ti_core.arch_name(ti.lang.impl.current_cfg().arch)} backend."
     ):
         foo2(1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 
-@test_utils.test(arch=ti.cc)
-def test_exceed_max_eight():
-    @ti.kernel
-    def foo1(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
-             g: ti.i32, h: ti.i32) -> ti.i32:
-        return a + b + c + d + e + f + g + h
-
-    assert foo1(1, 2, 3, 4, 5, 6, 7, 8) == 36
-
-    @ti.kernel
-    def foo2(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
-             g: ti.i32, h: ti.i32, i: ti.i32) -> ti.i32:
-        return a + b + c + d + e + f + g + h + i
-
-    with pytest.raises(
-            ti.TaichiRuntimeError,
-            match=
-            "The number of elements in kernel arguments is too big! Do not exceed 8 on cc backend."
-    ):
-        foo2(1, 2, 3, 4, 5, 6, 7, 8, 9)
-
-
-@test_utils.test(arch=ti.cuda)
+@test_utils.test(exclude=[ti.opengl, ti.cc])
 def test_exceed_max_64():
     N = 64
 
@@ -70,114 +48,6 @@ def test_exceed_max_64():
     with pytest.raises(
             ti.TaichiRuntimeError,
             match=
-            "The number of elements in kernel arguments is too big! Do not exceed 64 on cuda backend."
-    ):
-        foo2(A)
-
-
-@test_utils.test(arch=ti.metal)
-def test_exceed_max_64():
-    N = 64
-
-    @ti.kernel
-    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-    assert foo1(A) == 64
-
-    N = 65
-
-    @ti.kernel
-    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-
-    with pytest.raises(
-            ti.TaichiRuntimeError,
-            match=
-            "The number of elements in kernel arguments is too big! Do not exceed 64 on metal backend."
-    ):
-        foo2(A)
-
-
-@test_utils.test(arch=ti.vulkan)
-def test_exceed_max_64():
-    N = 64
-
-    @ti.kernel
-    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-    assert foo1(A) == 64
-
-    N = 65
-
-    @ti.kernel
-    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-
-    with pytest.raises(
-            ti.TaichiRuntimeError,
-            match=
-            "The number of elements in kernel arguments is too big! Do not exceed 64 on vulkan backend."
-    ):
-        foo2(A)
-
-
-@test_utils.test(arch=ti.x64)
-def test_exceed_max_64():
-    N = 64
-
-    @ti.kernel
-    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-    assert foo1(A) == 64
-
-    N = 65
-
-    @ti.kernel
-    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-
-    with pytest.raises(
-            ti.TaichiRuntimeError,
-            match=
-            "The number of elements in kernel arguments is too big! Do not exceed 64 on x64 backend."
-    ):
-        foo2(A)
-
-
-@test_utils.test(arch=ti.arm64)
-def test_exceed_max_64():
-    N = 64
-
-    @ti.kernel
-    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-    assert foo1(A) == 64
-
-    N = 65
-
-    @ti.kernel
-    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-
-    with pytest.raises(
-            ti.TaichiRuntimeError,
-            match=
-            "The number of elements in kernel arguments is too big! Do not exceed 64 on arm64 backend."
+            f"The number of elements in kernel arguments is too big! Do not exceed 64 on {ti.lang._ti_core.arch_name(ti.lang.impl.current_cfg().arch)} backend."
     ):
         foo2(A)

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -1,0 +1,45 @@
+import pytest
+
+import taichi as ti
+from tests import test_utils
+
+
+@test_utils.test(arch=[ti.opengl, ti.cc])
+def test_exceed_max_eight():
+    @ti.kernel
+    def foo1(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
+             g: ti.i32, h: ti.i32) -> ti.i32:
+        return a + b + c + d + e + f + g + h
+
+    assert foo1(1, 2, 3, 4, 5, 6, 7, 8) == 36
+
+    @ti.kernel
+    def foo2(a: ti.i32, b: ti.i32, c: ti.i32, d: ti.i32, e: ti.i32, f: ti.i32,
+             g: ti.i32, h: ti.i32, i: ti.i32) -> ti.i32:
+        return a + b + c + d + e + f + g + h + i
+
+    with pytest.raises(ti.TaichiRuntimeError):
+        foo2(1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+
+@test_utils.test(exclude=[ti.opengl, ti.cc])
+def test_exceed_max_64():
+    N = 64
+
+    @ti.kernel
+    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+    assert foo1(A) == 64
+
+    N = 65
+
+    @ti.kernel
+    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
+        return a.sum()
+
+    A = ti.Vector([1] * N)
+
+    with pytest.raises(ti.TaichiRuntimeError):
+        foo2(A)


### PR DESCRIPTION
Add error message when the number of elements in kernel arguments exceeds.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
