### PR TITLE
[refactor] Move literal construction to expr module

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -64,7 +64,7 @@ class ASTTransformer(Builder):
             if isinstance(value, expr.Expr):
                 var = ti_ops.cast(value, anno)
             else:
-                var = impl.make_constant_expr(value, anno)
+                var = expr.Expr(value, dtype=anno)
             var = impl.expr_init(var)
             ctx.create_variable(target.id, var)
         else:

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -70,13 +70,15 @@ def _clamp_unsigned_to_range(npty, val):
 
 def make_constant_expr(val, dtype):
     if isinstance(val, (int, np.integer)):
-        constant_dtype = impl.get_runtime().default_ip if dtype is None else dtype
+        constant_dtype = impl.get_runtime(
+        ).default_ip if dtype is None else dtype
         _check_in_range(to_numpy_type(constant_dtype), val)
         return Expr(
             _ti_core.make_const_expr_int(
                 constant_dtype, _clamp_unsigned_to_range(np.int64, val)))
     if isinstance(val, (float, np.floating)):
-        constant_dtype = impl.get_runtime().default_fp if dtype is None else dtype
+        constant_dtype = impl.get_runtime(
+        ).default_fp if dtype is None else dtype
         return Expr(_ti_core.make_const_expr_fp(constant_dtype, val))
     raise TaichiTypeError(f'Invalid constant scalar data type: {type(val)}')
 

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -3,7 +3,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.exception import TaichiTypeError
-from taichi.lang.util import is_taichi_class
+from taichi.lang.util import is_taichi_class, to_numpy_type, to_taichi_type
 
 
 # Scalar, basic data type
@@ -30,7 +30,7 @@ class Expr(TaichiOperations):
                             "Only 0-dimensional numpy array can be used to initialize a scalar expression"
                         )
                     arg = arg.dtype.type(arg)
-                self.ptr = impl.make_constant_expr(arg, dtype).ptr
+                self.ptr = make_constant_expr(arg, dtype).ptr
         else:
             assert False
         if self.tb:
@@ -45,6 +45,40 @@ class Expr(TaichiOperations):
 
     def __repr__(self):
         return '<ti.Expr>'
+
+
+def _check_in_range(npty, val):
+    iif = np.iinfo(npty)
+    if not iif.min <= val <= iif.max:
+        # This isn't the case we want to deal with: |val| does't fall into the valid range of either
+        # the signed or the unsigned type.
+        raise TaichiTypeError(
+            f'Constant {val} has exceeded the range of {to_taichi_type(npty)}: [{iif.min}, {iif.max}]'
+        )
+
+
+def _clamp_unsigned_to_range(npty, val):
+    # npty: np.int32 or np.int64
+    iif = np.iinfo(npty)
+    if iif.min <= val <= iif.max:
+        return val
+    cap = (1 << iif.bits)
+    assert 0 <= val < cap
+    new_val = val - cap
+    return new_val
+
+
+def make_constant_expr(val, dtype):
+    if isinstance(val, (int, np.integer)):
+        constant_dtype = impl.get_runtime().default_ip if dtype is None else dtype
+        _check_in_range(to_numpy_type(constant_dtype), val)
+        return Expr(
+            _ti_core.make_const_expr_int(
+                constant_dtype, _clamp_unsigned_to_range(np.int64, val)))
+    if isinstance(val, (float, np.floating)):
+        constant_dtype = impl.get_runtime().default_fp if dtype is None else dtype
+        return Expr(_ti_core.make_const_expr_fp(constant_dtype, val))
+    raise TaichiTypeError(f'Invalid constant scalar data type: {type(val)}')
 
 
 def make_var_list(size):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -4,12 +4,11 @@ from typing import Iterable
 
 import numpy as np
 from taichi._lib import core as _ti_core
-from taichi._logging import error
 from taichi._snode.fields_builder import FieldsBuilder
 from taichi.lang._ndarray import ScalarNdarray
 from taichi.lang._ndrange import GroupedNDRange, _Ndrange
 from taichi.lang.any_array import AnyArray, AnyArrayAccess
-from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
+from taichi.lang.exception import TaichiRuntimeError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
@@ -23,8 +22,7 @@ from taichi.lang.snode import SNode
 from taichi.lang.struct import Struct, StructField, _IntermediateStruct
 from taichi.lang.tape import TapeImpl
 from taichi.lang.util import (cook_dtype, get_traceback, is_taichi_class,
-                              python_scope, taichi_scope, to_numpy_type,
-                              to_taichi_type, warning)
+                              python_scope, taichi_scope, warning)
 from taichi.types.primitive_types import f16, f32, f64, i32, i64
 
 
@@ -115,12 +113,6 @@ def begin_frontend_if(ast_builder, cond):
             'or\n'
             '    if any(x != y):\n')
     ast_builder.begin_frontend_if(Expr(cond).ptr)
-
-
-def wrap_scalar(x):
-    if type(x) in [int, float]:
-        return Expr(x)
-    return x
 
 
 @taichi_scope
@@ -390,47 +382,6 @@ pytaichi = PyTaichi()
 
 def get_runtime():
     return pytaichi
-
-
-def _check_in_range(npty, val):
-    iif = np.iinfo(npty)
-    if not iif.min <= val <= iif.max:
-        # This isn't the case we want to deal with: |val| does't fall into the valid range of either
-        # the signed or the unsigned type.
-        error(
-            f'Constant {val} has exceeded the range of {to_taichi_type(npty)}: [{iif.min}, {iif.max}]'
-        )
-
-
-def _clamp_unsigned_to_range(npty, val):
-    # npty: np.int32 or np.int64
-    iif = np.iinfo(npty)
-    if iif.min <= val <= iif.max:
-        return val
-    cap = (1 << iif.bits)
-    assert 0 <= val < cap
-    new_val = val - cap
-    return new_val
-
-
-@taichi_scope
-def make_constant_expr_i32(val):
-    assert isinstance(val, (int, np.integer))
-    return Expr(_ti_core.make_const_expr_int(i32, val))
-
-
-@taichi_scope
-def make_constant_expr(val, dtype):
-    if isinstance(val, (int, np.integer)):
-        constant_dtype = pytaichi.default_ip if dtype is None else dtype
-        _check_in_range(to_numpy_type(constant_dtype), val)
-        return Expr(
-            _ti_core.make_const_expr_int(
-                constant_dtype, _clamp_unsigned_to_range(np.int64, val)))
-    if isinstance(val, (float, np.floating)):
-        constant_dtype = pytaichi.default_fp if dtype is None else dtype
-        return Expr(_ti_core.make_const_expr_fp(constant_dtype, val))
-    raise TaichiTypeError(f'Invalid constant scalar data type: {type(val)}')
 
 
 def reset():

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -77,7 +77,7 @@ class Matrix(TaichiOperations):
                             list([
                                 impl.make_tensor_element_expr(
                                     self.local_tensor_proxy,
-                                    (impl.make_constant_expr_i32(i), ),
+                                    (expr.Expr(i, dtype=primitive_types.i32), ),
                                     (len(n), ), self.dynamic_index_stride)
                             ]))
             else:  # now init a Matrix
@@ -119,8 +119,8 @@ class Matrix(TaichiOperations):
                             mat[i].append(
                                 impl.make_tensor_element_expr(
                                     self.local_tensor_proxy,
-                                    (impl.make_constant_expr_i32(i),
-                                     impl.make_constant_expr_i32(j)),
+                                    (expr.Expr(i, dtype=primitive_types.i32),
+                                     expr.Expr(j, dtype=primitive_types.i32)),
                                     (len(n), len(n[0])),
                                     self.dynamic_index_stride))
             self.n = len(mat)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -76,8 +76,8 @@ class Matrix(TaichiOperations):
                         mat.append(
                             list([
                                 impl.make_tensor_element_expr(
-                                    self.local_tensor_proxy,
-                                    (expr.Expr(i, dtype=primitive_types.i32), ),
+                                    self.local_tensor_proxy, (expr.Expr(
+                                        i, dtype=primitive_types.i32), ),
                                     (len(n), ), self.dynamic_index_stride)
                             ]))
             else:  # now init a Matrix

--- a/tests/python/test_literal.py
+++ b/tests/python/test_literal.py
@@ -23,7 +23,7 @@ def test_literal_multi_args_error():
     def multi_args_error():
         a = ti.i64(1, 2)
 
-    with pytest.raises(ti.TaichiSyntaxError):
+    with pytest.raises(ti.TaichiSyntaxError, match="Type annotation can only be given to a single literal."):
         multi_args_error()
 
 
@@ -33,7 +33,7 @@ def test_literal_keywords_error():
     def keywords_error():
         a = ti.f64(1, x=2)
 
-    with pytest.raises(ti.TaichiSyntaxError):
+    with pytest.raises(ti.TaichiSyntaxError, match="Type annotation can only be given to a single literal."):
         keywords_error()
 
 
@@ -44,5 +44,5 @@ def test_literal_expr_error():
         a = 1
         b = ti.f16(a)
 
-    with pytest.raises(ti.TaichiSyntaxError):
+    with pytest.raises(ti.TaichiSyntaxError, match="Type annotation can only be given to a single literal."):
         expr_error()

--- a/tests/python/test_literal.py
+++ b/tests/python/test_literal.py
@@ -23,7 +23,9 @@ def test_literal_multi_args_error():
     def multi_args_error():
         a = ti.i64(1, 2)
 
-    with pytest.raises(ti.TaichiSyntaxError, match="Type annotation can only be given to a single literal."):
+    with pytest.raises(
+            ti.TaichiSyntaxError,
+            match="Type annotation can only be given to a single literal."):
         multi_args_error()
 
 
@@ -33,7 +35,9 @@ def test_literal_keywords_error():
     def keywords_error():
         a = ti.f64(1, x=2)
 
-    with pytest.raises(ti.TaichiSyntaxError, match="Type annotation can only be given to a single literal."):
+    with pytest.raises(
+            ti.TaichiSyntaxError,
+            match="Type annotation can only be given to a single literal."):
         keywords_error()
 
 
@@ -44,5 +48,7 @@ def test_literal_expr_error():
         a = 1
         b = ti.f16(a)
 
-    with pytest.raises(ti.TaichiSyntaxError, match="Type annotation can only be given to a single literal."):
+    with pytest.raises(
+            ti.TaichiSyntaxError,
+            match="Type annotation can only be given to a single literal."):
         expr_error()


### PR DESCRIPTION
This is a follow-up of #4440 which makes the codebase structure more clear.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
