### PR TITLE
[Error] Add error messages for wrong type annotations of literals

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -4,6 +4,7 @@ from taichi.lang import impl
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.exception import TaichiTypeError
 from taichi.lang.util import is_taichi_class, to_numpy_type, to_taichi_type
+from taichi.types.primitive_types import integer_types, real_types
 
 
 # Scalar, basic data type
@@ -72,6 +73,8 @@ def make_constant_expr(val, dtype):
     if isinstance(val, (int, np.integer)):
         constant_dtype = impl.get_runtime(
         ).default_ip if dtype is None else dtype
+        if constant_dtype not in integer_types:
+            raise TaichiTypeError('Integer literals must be annotated with a integer type. For type casting, use `ti.cast`.')
         _check_in_range(to_numpy_type(constant_dtype), val)
         return Expr(
             _ti_core.make_const_expr_int(
@@ -79,6 +82,8 @@ def make_constant_expr(val, dtype):
     if isinstance(val, (float, np.floating)):
         constant_dtype = impl.get_runtime(
         ).default_fp if dtype is None else dtype
+        if constant_dtype not in real_types:
+            raise TaichiTypeError('Floating-point literals must be annotated with a floating-point type. For type casting, use `ti.cast`.')
         return Expr(_ti_core.make_const_expr_fp(constant_dtype, val))
     raise TaichiTypeError(f'Invalid constant scalar data type: {type(val)}')
 

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -74,7 +74,9 @@ def make_constant_expr(val, dtype):
         constant_dtype = impl.get_runtime(
         ).default_ip if dtype is None else dtype
         if constant_dtype not in integer_types:
-            raise TaichiTypeError('Integer literals must be annotated with a integer type. For type casting, use `ti.cast`.')
+            raise TaichiTypeError(
+                'Integer literals must be annotated with a integer type. For type casting, use `ti.cast`.'
+            )
         _check_in_range(to_numpy_type(constant_dtype), val)
         return Expr(
             _ti_core.make_const_expr_int(
@@ -83,7 +85,9 @@ def make_constant_expr(val, dtype):
         constant_dtype = impl.get_runtime(
         ).default_fp if dtype is None else dtype
         if constant_dtype not in real_types:
-            raise TaichiTypeError('Floating-point literals must be annotated with a floating-point type. For type casting, use `ti.cast`.')
+            raise TaichiTypeError(
+                'Floating-point literals must be annotated with a floating-point type. For type casting, use `ti.cast`.'
+            )
         return Expr(_ti_core.make_const_expr_fp(constant_dtype, val))
     raise TaichiTypeError(f'Invalid constant scalar data type: {type(val)}')
 

--- a/tests/python/test_literal.py
+++ b/tests/python/test_literal.py
@@ -62,7 +62,9 @@ def test_literal_int_annotation_error():
 
     with pytest.raises(
             ti.TaichiTypeError,
-            match="Integer literals must be annotated with a integer type. For type casting, use `ti.cast`."):
+            match=
+            "Integer literals must be annotated with a integer type. For type casting, use `ti.cast`."
+    ):
         int_annotation_error()
 
 
@@ -74,5 +76,7 @@ def test_literal_float_annotation_error():
 
     with pytest.raises(
             ti.TaichiTypeError,
-            match="Floating-point literals must be annotated with a floating-point type. For type casting, use `ti.cast`."):
+            match=
+            "Floating-point literals must be annotated with a floating-point type. For type casting, use `ti.cast`."
+    ):
         float_annotation_error()

--- a/tests/python/test_literal.py
+++ b/tests/python/test_literal.py
@@ -52,3 +52,27 @@ def test_literal_expr_error():
             ti.TaichiSyntaxError,
             match="Type annotation can only be given to a single literal."):
         expr_error()
+
+
+@test_utils.test()
+def test_literal_int_annotation_error():
+    @ti.kernel
+    def int_annotation_error():
+        a = ti.f32(0)
+
+    with pytest.raises(
+            ti.TaichiTypeError,
+            match="Integer literals must be annotated with a integer type. For type casting, use `ti.cast`."):
+        int_annotation_error()
+
+
+@test_utils.test()
+def test_literal_float_annotation_error():
+    @ti.kernel
+    def float_annotation_error():
+        a = ti.i32(0.0)
+
+    with pytest.raises(
+            ti.TaichiTypeError,
+            match="Floating-point literals must be annotated with a floating-point type. For type casting, use `ti.cast`."):
+        float_annotation_error()


### PR DESCRIPTION
Related issue = fixes #4451

In fact, the problem in #4451 is already solved by #4440. This PR further adds error messages under our new type annotation mechanism for literals.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
