### PR TITLE
[bug] [llvm] Initialize the field to 0 when finalizing a field

### DIFF
--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -180,7 +180,6 @@ void LlvmProgramImpl::initialize_llvm_runtime_snodes(const SNodeTree *tree,
   TI_TRACE("Allocating data structure of size {} bytes", scomp->root_size);
   std::size_t rounded_size =
       taichi::iroundup(scomp->root_size, taichi_page_size);
-  printf("size: %zu\n", rounded_size);
 
   Ptr root_buffer = snode_tree_buffer_manager_->allocate(
       runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree->id(),

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -184,7 +184,7 @@ void LlvmProgramImpl::initialize_llvm_runtime_snodes(const SNodeTree *tree,
   Ptr root_buffer = snode_tree_buffer_manager_->allocate(
       runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree->id(),
       result_buffer);
-  std::cout << "ptr: " << root_buffer << std::endl;
+  std::cout << "ptr: " << uint64_t(root_buffer) << std::endl;
   if (config->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
     CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -180,6 +180,7 @@ void LlvmProgramImpl::initialize_llvm_runtime_snodes(const SNodeTree *tree,
   TI_TRACE("Allocating data structure of size {} bytes", scomp->root_size);
   std::size_t rounded_size =
       taichi::iroundup(scomp->root_size, taichi_page_size);
+  printf("size: %zu\n", rounded_size);
 
   Ptr root_buffer = snode_tree_buffer_manager_->allocate(
       runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree->id(),

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -184,7 +184,6 @@ void LlvmProgramImpl::initialize_llvm_runtime_snodes(const SNodeTree *tree,
   Ptr root_buffer = snode_tree_buffer_manager_->allocate(
       runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree->id(),
       result_buffer);
-  std::cout << "ptr: " << uint64_t(root_buffer) << std::endl;
   if (config->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
     CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -184,6 +184,11 @@ void LlvmProgramImpl::initialize_llvm_runtime_snodes(const SNodeTree *tree,
   Ptr root_buffer = snode_tree_buffer_manager_->allocate(
       runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree->id(),
       result_buffer);
+  if (config->arch == Arch::cuda) {
+    CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);
+  } else {
+    std::memset(root_buffer, 0, rounded_size);
+  }
 
   DeviceAllocation alloc{kDeviceNullAllocation};
 

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -184,6 +184,7 @@ void LlvmProgramImpl::initialize_llvm_runtime_snodes(const SNodeTree *tree,
   Ptr root_buffer = snode_tree_buffer_manager_->allocate(
       runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree->id(),
       result_buffer);
+  std::cout << "ptr: " << root_buffer << std::endl;
   if (config->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
     CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -185,7 +185,11 @@ void LlvmProgramImpl::initialize_llvm_runtime_snodes(const SNodeTree *tree,
       runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree->id(),
       result_buffer);
   if (config->arch == Arch::cuda) {
+#if defined(TI_WITH_CUDA)
     CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);
+#else
+    TI_NOT_IMPLEMENTED
+#endif
   } else {
     std::memset(root_buffer, 0, rounded_size);
   }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -940,7 +940,6 @@ void runtime_initialize_snodes(LLVMRuntime *runtime,
                                bool all_dense) {
   // For Metal runtime, we have to make sure that both the beginning address
   // and the size of the root buffer memory are aligned to page size.
-  std::memset(ptr, 0, rounded_size);
   runtime->root_mem_sizes[snode_tree_id] = rounded_size;
   runtime->roots[snode_tree_id] = ptr;
   // runtime->request_allocate_aligned ready to use

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -940,6 +940,7 @@ void runtime_initialize_snodes(LLVMRuntime *runtime,
                                bool all_dense) {
   // For Metal runtime, we have to make sure that both the beginning address
   // and the size of the root buffer memory are aligned to page size.
+  std::memset(ptr, 0, rounded_size);
   runtime->root_mem_sizes[snode_tree_id] = rounded_size;
   runtime->roots[snode_tree_id] = ptr;
   // runtime->request_allocate_aligned ready to use

--- a/taichi/system/virtual_memory.h
+++ b/taichi/system/virtual_memory.h
@@ -21,7 +21,7 @@ class VirtualMemoryAllocator {
 #if defined(TI_PLATFORM_UNIX)
 #if defined(TI_PLATFORM_LINUX)
     ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
-               MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #else
     // BSD does not have MAP_NONREVERSE
     ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE,

--- a/taichi/system/virtual_memory.h
+++ b/taichi/system/virtual_memory.h
@@ -19,14 +19,8 @@ class VirtualMemoryAllocator {
   explicit VirtualMemoryAllocator(size_t size) : size(size) {
 // http://pages.cs.wisc.edu/~sifakis/papers/SPGrid.pdf Sec 3.1
 #if defined(TI_PLATFORM_UNIX)
-#if defined(TI_PLATFORM_LINUX)
     ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-#else
-    // BSD does not have MAP_NONREVERSE
-    ptr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
-               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-#endif
     TI_ERROR_IF(ptr == MAP_FAILED, "Virtual memory allocation ({} B) failed.",
                 size);
 #else

--- a/tests/python/test_fields_builder.py
+++ b/tests/python/test_fields_builder.py
@@ -178,3 +178,18 @@ def test_fields_builder_destroy(test_1d_size, field_type):
         with pytest.raises(TaichiRuntimeError):
             c.destroy()
             c.destroy()
+
+
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan, ti.metal])
+def test_field_initialize_zero():
+    fb0 = ti.FieldsBuilder()
+    a = ti.field(ti.i32)
+    fb0.dense(ti.i, 1).place(a)
+    c = fb0.finalize()
+    a[0] = 5
+    c.destroy()
+    fb1 = ti.FieldsBuilder()
+    b = ti.field(ti.i32)
+    fb1.dense(ti.i, 1).place(b)
+    d = fb1.finalize()
+    assert b[0] == 0

--- a/tests/python/test_fields_builder.py
+++ b/tests/python/test_fields_builder.py
@@ -180,7 +180,7 @@ def test_fields_builder_destroy(test_1d_size, field_type):
             c.destroy()
 
 
-@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan, ti.metal])
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan])
 def test_field_initialize_zero():
     fb0 = ti.FieldsBuilder()
     a = ti.field(ti.i32)

--- a/tests/python/test_indices_assert.py
+++ b/tests/python/test_indices_assert.py
@@ -11,12 +11,12 @@ from tests import test_utils
 @test_utils.test(debug=True, gdb_trigger=False, packed=False, arch=[ti.cpu])
 def test_indices_assert():
 
-    overflow = ti.field(ti.f16, (3, 1073741824))
+    overflow = ti.field(ti.u8, (3, 715827883))
 
     @ti.kernel
     def access_overflow():
-        overflow[0, 0] = 10
-        print(overflow[2, 1073741823])
+        overflow[0, 5] = 10
+        print(overflow[2, 715827882])
 
     with pytest.raises(RuntimeError,
                        match='The indices provided are too big!'):

--- a/tests/python/test_indices_assert.py
+++ b/tests/python/test_indices_assert.py
@@ -16,7 +16,7 @@ def test_indices_assert():
     @ti.kernel
     def access_overflow():
         overflow[0, 5] = 10
-        print(overflow[2, 715827882])
+        overflow[2, 715827882] = 10
 
     with pytest.raises(RuntimeError,
                        match='The indices provided are too big!'):

--- a/tests/python/test_indices_assert.py
+++ b/tests/python/test_indices_assert.py
@@ -15,7 +15,6 @@ def test_indices_assert():
 
     @ti.kernel
     def access_overflow():
-        overflow[0, 5] = 10
         overflow[2, 715827882] = 10
 
     with pytest.raises(RuntimeError,

--- a/tests/python/test_indices_assert.py
+++ b/tests/python/test_indices_assert.py
@@ -1,23 +1,23 @@
-import platform
-
-import pytest
-
-import taichi as ti
-from tests import test_utils
-
-
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason="Too much virtual memory for github windows env.")
-@test_utils.test(debug=True, gdb_trigger=False, packed=False, arch=[ti.cpu])
-def test_indices_assert():
-
-    overflow = ti.field(ti.i32, (334, 334, 334, 2 * 10))
-
-    @ti.kernel
-    def access_overflow():
-        overflow[0, 0, 0, 0] = 10
-        print(overflow[333, 333, 333, 0])
-
-    with pytest.raises(RuntimeError,
-                       match='The indices provided are too big!'):
-        access_overflow()
+# import platform
+#
+# import pytest
+#
+# import taichi as ti
+# from tests import test_utils
+#
+#
+# @pytest.mark.skipif(platform.system() == 'Windows',
+#                     reason="Too much virtual memory for github windows env.")
+# @test_utils.test(debug=True, gdb_trigger=False, packed=False, arch=[ti.cpu])
+# def test_indices_assert():
+#
+#     overflow = ti.field(ti.i32, (334, 334, 334, 2 * 10))
+#
+#     @ti.kernel
+#     def access_overflow():
+#         overflow[0, 0, 0, 0] = 10
+#         print(overflow[333, 333, 333, 0])
+#
+#     with pytest.raises(RuntimeError,
+#                        match='The indices provided are too big!'):
+#         access_overflow()

--- a/tests/python/test_indices_assert.py
+++ b/tests/python/test_indices_assert.py
@@ -1,23 +1,23 @@
-# import platform
-#
-# import pytest
-#
-# import taichi as ti
-# from tests import test_utils
-#
-#
-# @pytest.mark.skipif(platform.system() == 'Windows',
-#                     reason="Too much virtual memory for github windows env.")
-# @test_utils.test(debug=True, gdb_trigger=False, packed=False, arch=[ti.cpu])
-# def test_indices_assert():
-#
-#     overflow = ti.field(ti.i32, (334, 334, 334, 2 * 10))
-#
-#     @ti.kernel
-#     def access_overflow():
-#         overflow[0, 0, 0, 0] = 10
-#         print(overflow[333, 333, 333, 0])
-#
-#     with pytest.raises(RuntimeError,
-#                        match='The indices provided are too big!'):
-#         access_overflow()
+import platform
+
+import pytest
+
+import taichi as ti
+from tests import test_utils
+
+
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason="Too much virtual memory for github windows env.")
+@test_utils.test(debug=True, gdb_trigger=False, packed=False, arch=[ti.cpu])
+def test_indices_assert():
+
+    overflow = ti.field(ti.i32, (334, 334, 334, 2 * 10))
+
+    @ti.kernel
+    def access_overflow():
+        overflow[0, 0, 0, 0] = 10
+        print(overflow[333, 333, 333, 0])
+
+    with pytest.raises(RuntimeError,
+                       match='The indices provided are too big!'):
+        access_overflow()

--- a/tests/python/test_indices_assert.py
+++ b/tests/python/test_indices_assert.py
@@ -11,12 +11,12 @@ from tests import test_utils
 @test_utils.test(debug=True, gdb_trigger=False, packed=False, arch=[ti.cpu])
 def test_indices_assert():
 
-    overflow = ti.field(ti.i32, (334, 334, 334, 2 * 10))
+    overflow = ti.field(ti.f16, (3, 1073741824))
 
     @ti.kernel
     def access_overflow():
-        overflow[0, 0, 0, 0] = 10
-        print(overflow[333, 333, 333, 0])
+        overflow[0, 0] = 10
+        print(overflow[2, 1073741823])
 
     with pytest.raises(RuntimeError,
                        match='The indices provided are too big!'):


### PR DESCRIPTION
Related issue = #4016 #4334 
MAP_NORESERVE flag for mmap is meaningless if we memset the field to 0 at initialization because memset will visit all the memory, and it will be killed if there's not enough memory.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
