### PR TITLE
[bug] Fix metal linker error when TI_WITH_METAL=OFF

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -81,8 +81,12 @@ Program::Program(Arch desired_arch)
     TI_ERROR("This taichi is not compiled with LLVM");
 #endif
   } else if (config.arch == Arch::metal) {
+#ifdef TI_WITH_METAL
     TI_ASSERT(metal::is_metal_api_available());
     program_impl_ = std::make_unique<MetalProgramImpl>(config);
+#else
+    TI_ERROR("This taichi is not compiled with Metal")
+#endif
   } else if (config.arch == Arch::vulkan) {
 #ifdef TI_WITH_VULKAN
     TI_ASSERT(vulkan::is_vulkan_api_available());


### PR DESCRIPTION
Related issue = #4464

This PR fixes the following linker error 
```
/usr/bin/ld: CMakeFiles/taichi_isolated_core.dir/taichi/program/program.cpp.o: in function `taichi::lang::Program::Program(taichi::Arch)':
program.cpp:(.text+0x561): undefined reference to `taichi::lang::metal::is_metal_api_available()'
/usr/bin/ld: program.cpp:(.text+0x581): undefined reference to `taichi::lang::MetalProgramImpl::MetalProgramImpl(taichi::lang::CompileConfig&)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

To reproduce: https://github.com/taichi-dev/taichi/issues/4464#issuecomment-1060295541