### PR TITLE
[test] Add arch-supporting-checking for some tests

### DIFF
--- a/tests/python/examples/rendering/test_cornell_box.py
+++ b/tests/python/examples/rendering/test_cornell_box.py
@@ -6,14 +6,14 @@ from tests import test_utils
 FRAMES = 200
 
 
-@test_utils.test(arch=ti.gpu)
 def test_cornell_box():
-    from taichi.examples.rendering.cornell_box import render, tonemap
-    for i in range(FRAMES):
-        render()
-        interval = 10
-        if i % interval == 0:
-            tonemap(i)
+    if len(set(ti.gpu) & set(test_utils.expected_archs())) > 0:
+        from taichi.examples.rendering.cornell_box import render, tonemap
+        for i in range(FRAMES):
+            render()
+            interval = 10
+            if i % interval == 0:
+                tonemap(i)
 
 
 def video_cornell_box(result_dir):

--- a/tests/python/examples/rendering/test_cornell_box.py
+++ b/tests/python/examples/rendering/test_cornell_box.py
@@ -1,10 +1,12 @@
 import argparse
 
 import taichi as ti
+from tests import test_utils
 
 FRAMES = 200
 
 
+@test_utils.test(arch=ti.gpu)
 def test_cornell_box():
     from taichi.examples.rendering.cornell_box import render, tonemap
     for i in range(FRAMES):

--- a/tests/python/examples/simulation/test_mpm99.py
+++ b/tests/python/examples/simulation/test_mpm99.py
@@ -1,10 +1,12 @@
 import argparse
 
 import taichi as ti
+from tests import test_utils
 
 FRAMES = 100
 
 
+@test_utils.test(arch=ti.gpu)
 def test_mpm99():
     from taichi.examples.simulation.mpm99 import dt, initialize, substep
 

--- a/tests/python/examples/simulation/test_mpm99.py
+++ b/tests/python/examples/simulation/test_mpm99.py
@@ -6,14 +6,13 @@ from tests import test_utils
 FRAMES = 100
 
 
-@test_utils.test(arch=ti.gpu)
 def test_mpm99():
-    from taichi.examples.simulation.mpm99 import dt, initialize, substep
-
-    initialize()
-    for i in range(FRAMES):
-        for s in range(int(2e-3 // dt)):
-            substep()
+    if len(set(ti.gpu) & set(test_utils.expected_archs())) > 0:
+        from taichi.examples.simulation.mpm99 import dt, initialize, substep
+        initialize()
+        for i in range(FRAMES):
+            for s in range(int(2e-3 // dt)):
+                substep()
 
 
 def video_mpm99(result_dir):

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -254,6 +254,7 @@ def _test_ndarray_deepcopy():
     assert y[4][1, 0] == 9
 
 
+@test_utils.test(arch=[ti.cuda])
 def test_ndarray_cuda_caching_allocator():
     ti.init(arch=ti.cuda, ndarray_use_cached_allocator=True)
     n = 8


### PR DESCRIPTION
Related issue = #

Some cases always fail when I run tests with `-a cpu` on my computer because they are initialized forcibly with unsupported archs by my pc like `ti.cuda` or `ti.gpu`. In the pr, I add arch-supporting-checking for them.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
