### PR TITLE
[ci] Fix: fill in the pull request body created by bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,6 @@ jobs:
           git commit -m "Bump version to $next_version"
           git push origin "bump/$next_version"
           # Create pull request
-          gh pr create -B master -t "[misc] Bump version to $next_version"
+          gh pr create -B master -t "[misc] Bump version to $next_version" -b "Bump version to $next_version"
         env:
           GITHUB_TOKEN: ${{ secrets.GARDENER_PAT }}


### PR DESCRIPTION
Here is an working example:
https://github.com/taichi-dev/test_actions/actions/runs/1961964091
Tag created by bot: https://github.com/taichi-dev/test_actions/releases/tag/v0.9.4
PR created by bot: taichi-dev/test_actions#142