### PR TITLE
[ir] [opt] Fix a bug about 'continue'  stmt in cfg_build

### DIFF
--- a/taichi/analysis/build_cfg.cpp
+++ b/taichi/analysis/build_cfg.cpp
@@ -51,7 +51,7 @@ namespace lang {
  * node_a {
  *   ...
  * } -> node_b, [node_c if "cond"];
- * means node_a has an edge to node_b, and node_a has an edge to node_b iff
+ * means node_a has an edge to node_b, and node_a has an edge to node_c iff
  * the condition "cond" is true.
  *
  * When there can be many CFGNodes in a Block, internal nodes are omitted for
@@ -390,11 +390,16 @@ class CFGBuilder : public IRVisitor {
         in_parallel_for_ = true;
       }
       stmt->body->accept(this);
+      auto block_begin = graph_->nodes[block_begin_index].get();
+      for (auto &node : continues_in_current_loop_) {
+        CFGNode::add_edge(node, block_begin);
+        prev_nodes_.push_back(node);
+      }
       in_parallel_for_ = false;
       prev_nodes_.push_back(graph_->back());
       // Container statements don't belong to any CFGNodes.
       begin_location_ = offload_stmt_id + 1;
-      CFGNode::add_edge(before_offload, graph_->nodes[block_begin_index].get());
+      CFGNode::add_edge(before_offload, block_begin);
     }
     if (stmt->bls_epilogue) {
       auto before_offload = new_node(-1);

--- a/tests/python/test_cfg_continue.py
+++ b/tests/python/test_cfg_continue.py
@@ -1,6 +1,6 @@
 import taichi as ti
-
 from tests import test_utils
+
 
 @test_utils.test()
 def test_cfg_continue():

--- a/tests/python/test_cfg_continue.py
+++ b/tests/python/test_cfg_continue.py
@@ -1,0 +1,21 @@
+import taichi as ti
+
+from tests import test_utils
+
+@test_utils.test()
+def test_cfg_continue():
+    x = ti.field(dtype=int, shape=1)
+    state = ti.field(dtype=int, shape=1)
+
+    @ti.kernel
+    def foo():
+        for p in range(1):
+            if state[p] == 0:
+                x[p] = 1
+                continue
+
+            if state[p] != 0:
+                print('test')
+
+    foo()
+    assert x[0] == 1


### PR DESCRIPTION
Related issue = fix #4494

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
In current taichi, there is a problem when a loop deals with `continue` stmts after being offloaded. This PR tries to fix this problem.
