### PR TITLE
[autodiff] Reduce the number of ad stack using knowledge of derivative formulas

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -254,14 +254,14 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
 class AdStackAllocaJudger : public BasicStmtVisitor {
  public:
   inline static const std::set<TernaryOpType> stack_needed_ternary_collections{
-        TernaryOpType::select};
+      TernaryOpType::select};
   inline static const std::set<UnaryOpType> stack_needed_unary_collections{
-    UnaryOpType::abs,  UnaryOpType::sin,  UnaryOpType::cos,
-    UnaryOpType::tanh, UnaryOpType::asin, UnaryOpType::acos,
-    UnaryOpType::exp,  UnaryOpType::log,  UnaryOpType::sqrt};
+      UnaryOpType::abs,  UnaryOpType::sin,  UnaryOpType::cos,
+      UnaryOpType::tanh, UnaryOpType::asin, UnaryOpType::acos,
+      UnaryOpType::exp,  UnaryOpType::log,  UnaryOpType::sqrt};
   inline static const std::set<BinaryOpType> stack_needed_binary_collections{
-        BinaryOpType::mul, BinaryOpType::div, BinaryOpType::atan2,
-        BinaryOpType::pow};
+      BinaryOpType::mul, BinaryOpType::div, BinaryOpType::atan2,
+      BinaryOpType::pow};
   using BasicStmtVisitor::visit;
   // Find the usage of the stmt recursively along the LocalLoadStmt
   void visit(LocalLoadStmt *stmt) override {

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -251,6 +251,106 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
   }
 };
 
+class AdStackAllocaJudger : public BasicStmtVisitor {
+ public:
+  inline static const std::set<TernaryOpType> stack_needed_ternary_collections{
+        TernaryOpType::select};
+  inline static const std::set<UnaryOpType> stack_needed_unary_collections{
+    UnaryOpType::abs,  UnaryOpType::sin,  UnaryOpType::cos,
+    UnaryOpType::tanh, UnaryOpType::asin, UnaryOpType::acos,
+    UnaryOpType::exp,  UnaryOpType::log,  UnaryOpType::sqrt};
+  inline static const std::set<BinaryOpType> stack_needed_binary_collections{
+        BinaryOpType::mul, BinaryOpType::div, BinaryOpType::atan2,
+        BinaryOpType::pow};
+  using BasicStmtVisitor::visit;
+  // Find the usage of the stmt recursively along the LocalLoadStmt
+  void visit(LocalLoadStmt *stmt) override {
+    if (stmt->has_source(target_alloca_)) {
+      local_loaded_ = true;
+      target_alloca_ = stmt;
+    }
+  }
+
+  // Check if there is a LocalLoadStmt - LocalStoreStmt cycle for an alloca
+  // Check if the alloca is load only
+  void visit(LocalStoreStmt *stmt) override {
+    if (stmt->dest == target_alloca_backup_)
+      load_only_ = false;
+    if (local_loaded_ && stmt->dest == target_alloca_backup_) {
+      is_stack_needed_ = true;
+    }
+  }
+
+  // Check if the alloca is load only
+  void visit(AtomicOpStmt *stmt) override {
+    if (stmt->dest == target_alloca_backup_)
+      load_only_ = false;
+  }
+
+  // The stack is needed if the alloc serves as the index of any global
+  // variables
+  void visit(GlobalPtrStmt *stmt) override {
+    if (is_stack_needed_)
+      return;
+    for (const auto &index : stmt->indices) {
+      if (index == target_alloca_)
+        is_stack_needed_ = true;
+    }
+  }
+
+  // Check whether the target stmt is used by the UnaryOpStmts who requires the
+  // ad stack
+  void visit(UnaryOpStmt *stmt) override {
+    if (is_stack_needed_)
+      return;
+    if (stack_needed_unary_collections.find(stmt->op_type) !=
+        stack_needed_unary_collections.end()) {
+      if (stmt->operand == target_alloca_)
+        is_stack_needed_ = true;
+    }
+  }
+
+  // Check whether the target stmt is used by the BinaryOpStmts who requires the
+  // ad stack
+  void visit(BinaryOpStmt *stmt) override {
+    if (is_stack_needed_)
+      return;
+    if (stack_needed_binary_collections.find(stmt->op_type) !=
+        stack_needed_binary_collections.end()) {
+      if (stmt->lhs == target_alloca_ || stmt->rhs == target_alloca_)
+        is_stack_needed_ = true;
+    }
+  }
+
+  // Check whether the target stmt is used by the TernaryOpStmts who requires
+  // the ad stack
+  void visit(TernaryOpStmt *stmt) override {
+    if (is_stack_needed_)
+      return;
+    if (stack_needed_ternary_collections.find(stmt->op_type) !=
+        stack_needed_ternary_collections.end()) {
+      if (stmt->op1 == target_alloca_ || stmt->op2 == target_alloca_ ||
+          stmt->op3 == target_alloca_)
+        is_stack_needed_ = true;
+    }
+  }
+
+  static bool run(AllocaStmt *target_alloca) {
+    AdStackAllocaJudger judger;
+    judger.target_alloca_ = target_alloca;
+    judger.target_alloca_backup_ = target_alloca;
+    target_alloca->parent->accept(&judger);
+    return (!judger.load_only_) && judger.is_stack_needed_;
+  }
+
+ private:
+  Stmt *target_alloca_;
+  Stmt *target_alloca_backup_;
+  bool is_stack_needed_ = false;
+  bool local_loaded_ = false;
+  bool load_only_ = true;
+};
+
 class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
@@ -261,17 +361,9 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
 
   void visit(AllocaStmt *alloc) override {
     TI_ASSERT(alloc->width() == 1);
-    bool load_only =
-        irpass::analysis::gather_statements(alloc->parent, [&](Stmt *s) {
-          if (auto store = s->cast<LocalStoreStmt>()) {
-            return store->dest == alloc;
-          } else if (auto atomic = s->cast<AtomicOpStmt>()) {
-            return atomic->dest == alloc;
-          } else {
-            return false;
-          }
-        }).empty();
-    if (!load_only) {
+
+    bool is_stack_needed = AdStackAllocaJudger::run(alloc);
+    if (is_stack_needed) {
       auto dtype = alloc->ret_type;
       auto stack_alloca = Stmt::make<AdStackAllocaStmt>(dtype, ad_stack_size);
       auto stack_alloca_ptr = stack_alloca.get();
@@ -295,7 +387,8 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
 
   void visit(LocalStoreStmt *stmt) override {
     TI_ASSERT(stmt->width() == 1);
-    stmt->replace_with(Stmt::make<AdStackPushStmt>(stmt->dest, stmt->val));
+    if (stmt->dest->is<AdStackAllocaStmt>())
+      stmt->replace_with(Stmt::make<AdStackPushStmt>(stmt->dest, stmt->val));
   }
 };
 
@@ -407,11 +500,19 @@ class MakeAdjoint : public IRVisitor {
  public:
   Block *current_block;
   Block *alloca_block;
+  // Backup the forward pass (the forward pass might be modified during the
+  // MakeAdjoint) for search whether a GlobalLoadStmt is inside a for-loop when
+  // allocating adjoint (see the function `adjoint`) Should be stored
+  // 1. Before entering a for-loop body
+  // 2. Before entering a if-stmt
+  // Should be restored after processing every statement in the two cases above
+  Block *forward_backup;
   std::map<Stmt *, Stmt *> adjoint_stmt;
 
   MakeAdjoint(Block *block) {
     current_block = nullptr;
     alloca_block = block;
+    forward_backup = block;
   }
 
   static void run(Block *block) {
@@ -477,7 +578,40 @@ class MakeAdjoint : public IRVisitor {
       // maybe it's better to use the statement data type than the default type
       auto alloca = Stmt::make<AllocaStmt>(1, stmt->ret_type);
       adjoint_stmt[stmt] = alloca.get();
-      alloca_block->insert(std::move(alloca), 0);
+
+      // We need to insert the alloca in the block of GlobalLoadStmt when the
+      // GlobalLoadStmt is not inside a range-for
+      // Code sample:
+      // a and b require grad
+      // Case 1 (GlobalLoadStmt is ouside the for-loop, compute 5 times and
+      // accumulate once, alloca history value is needed):
+      // for i in range(5):
+      //     p = a[i]
+      //     q = b[i]
+      //     for _ in range(5)
+      //         q += p
+
+      // Case 2 (GlobalLoadStmt is inside the for-loop, compute once and
+      // accumulate immediately, alloca history value can be discarded):
+      // for i in range(5):
+      //     q = b[i]
+      //     for _ in range(5)
+      //         q += a[i]
+      if (stmt->is<GlobalLoadStmt>() &&
+          stmt->parent->parent_stmt->is<RangeForStmt>()) {
+        // Check whether this GlobalLoadStmt is in the body of a for-loop by
+        // searching in the backup forward pass If not (Case 1), the alloca
+        // should not be clear every iteration, therefore, we need to insert the
+        // alloca in the block of the GlobalLoadStmt i.e., where GlobalLoadStmt
+        // is defined
+        if (forward_backup->locate(stmt->as<GlobalLoadStmt>()) == -1) {
+          stmt->as<GlobalLoadStmt>()->parent->insert(std::move(alloca), 0);
+        } else {
+          alloca_block->insert(std::move(alloca), 0);
+        }
+      } else {
+        alloca_block->insert(std::move(alloca), 0);
+      }
     }
     return adjoint_stmt[stmt];
   }
@@ -605,11 +739,15 @@ class MakeAdjoint : public IRVisitor {
     if (if_stmt->true_statements) {
       new_if->set_true_statements(std::make_unique<Block>());
       auto old_current_block = current_block;
+      // Backup forward pass
+      forward_backup = if_stmt->true_statements.get();
 
       current_block = new_if->true_statements.get();
       for (int i = if_stmt->true_statements->statements.size() - 1; i >= 0;
            i--) {
         if_stmt->true_statements->statements[i]->accept(this);
+        // Restore forward pass
+        forward_backup = if_stmt->true_statements.get();
       }
 
       current_block = old_current_block;
@@ -617,10 +755,16 @@ class MakeAdjoint : public IRVisitor {
     if (if_stmt->false_statements) {
       new_if->set_false_statements(std::make_unique<Block>());
       auto old_current_block = current_block;
+
+      // Backup forward pass
+      forward_backup = if_stmt->false_statements.get();
+
       current_block = new_if->false_statements.get();
       for (int i = if_stmt->false_statements->statements.size() - 1; i >= 0;
            i--) {
         if_stmt->false_statements->statements[i]->accept(this);
+        // Restore forward pass
+        forward_backup = if_stmt->false_statements.get();
       }
       current_block = old_current_block;
     }
@@ -665,11 +809,19 @@ class MakeAdjoint : public IRVisitor {
     }
     std::reverse(statements.begin(), statements.end());  // reverse-mode AD...
     auto old_alloca_block = alloca_block;
+    auto old_forward_backup =
+        forward_backup;  // store the block which is not inside the current IB,
+                         // such as outer most loop
+    // Backup the forward pass
+    forward_backup = for_stmt->body.get();
     for (auto stmt : statements) {
       alloca_block = new_for_ptr->body.get();
       current_block = new_for_ptr->body.get();
       stmt->accept(this);
+      // Restore the forward pass
+      forward_backup = for_stmt->body.get();
     }
+    forward_backup = old_forward_backup;
     alloca_block = old_alloca_block;
   }
 
@@ -682,8 +834,28 @@ class MakeAdjoint : public IRVisitor {
     // do nothing
   }
 
+  // Equivalent to AdStackLoadTopStmt when no stack is needed
   void visit(LocalLoadStmt *stmt) override {
     // TI_ASSERT(!needs_grad(stmt->ret_type));
+    if (needs_grad(stmt->ret_type))
+      accumulate(stmt->src.data[0].var, load(adjoint(stmt)));
+  }
+
+  // Equivalent to AdStackPushStmt when no stack is needed
+  void visit(LocalStoreStmt *stmt) override {
+    accumulate(stmt->val, load(adjoint(stmt->dest)));
+
+    // Clear the adjoint of the dest after local store,
+    // Because LocalStoreStmt overwrites the dest,
+    // 1. If the alloca is inside a loop, the adjoint of this alloca of this
+    // iteration should be cleared after this iteration has been done
+    // 2. If the alloca serves as the dest of multiple LocalStoreStmt, only the
+    // last LocalStoreStmt should be taken account of
+    if (needs_grad(stmt->dest->ret_type)) {
+      auto dtype = stmt->dest->ret_type;
+      auto zero = insert<ConstStmt>(TypedConstant(dtype, 0));
+      insert<LocalStoreStmt>(adjoint(stmt->dest), zero);
+    }
   }
 
   void visit(AdStackLoadTopStmt *stmt) override {


### PR DESCRIPTION
Reduce the number of ad stack using knowledge of derivative formulas. 
Also, fixed the adjoint of mutable local variables not accumulating inside a loop. (fixes #4412)

Benchmark on the use case of #4226.

- Stack Reduction
Reduce unused stacks from 65% to 13%.

- Compile Time Reduction
Reduce ~50% compile time of `auto_diff` pass, ~20% total compile time.

```
########################################################
 ---------------------- Before -----------------------
########################################################
1.039  s compile                       [14 x  74.194 ms]
...
    163.624 ms 88.10%  full_simplify         [44 x   3.719 ms]
    ...
    4.924 ms  2.65%  auto_diff             [1 x   4.924 ms]
    
########################################################
 ---------------------- After -----------------------
########################################################
835.418 ms compile                       [14 x  59.673 ms]
...
    146.115 ms 91.75%  full_simplify         [44 x   3.321 ms]
    ...
    2.516 ms  1.58%  auto_diff             [1 x   2.516 ms]
```


- Execution Time Reduction (repeated 100 times)

Reduce ~40%  execution time.

```
########################################################
 ---------------------- Before -----------------------
########################################################
[Taichi] version 0.9.0, llvm 10.0.0, commit 0c432a37, linux, python 3.8.10
[Taichi] Starting on arch=cuda
=========================================================================
Kernel Profiler(count, default) @ CUDA on NVIDIA GeForce RTX 3090
=========================================================================
[      %     total   count |      min       avg       max   ] Kernel name
-------------------------------------------------------------------------
[ 85.62%   1.249 s    100x |   12.118    12.491    17.907 ms] grid_op_c57_0_grad_grad_kernel_15_range_for
[ 13.78%   0.201 s      1x |  201.104   201.104   201.104 ms] runtime_initialize
[  0.35%   0.005 s    100x |    0.049     0.051     0.059 ms] grid_op_c56_0_kernel_13_range_for
[  0.07%   0.001 s    100x |    0.009     0.011     0.028 ms] clear_gradients_c32_1_kernel_8_range_for
[  0.03%   0.001 s    100x |    0.004     0.005     0.014 ms] clear_gradients_c32_3_kernel_10_range_for
[  0.03%   0.000 s    100x |    0.004     0.005     0.013 ms] clear_gradients_c32_0_kernel_7_range_for
[  0.02%   0.000 s    100x |    0.003     0.003     0.011 ms] clear_gradients_c32_4_kernel_11_range_for
[  0.02%   0.000 s    100x |    0.003     0.003     0.012 ms] clear_gradients_c32_2_kernel_9_range_for
[  0.02%   0.000 s    100x |    0.003     0.003     0.010 ms] clear_loss_c34_0_kernel_12_serial
[  0.02%   0.000 s     24x |    0.003     0.009     0.087 ms] jit_evaluator_0_kernel_0_serial
[  0.01%   0.000 s     49x |    0.003     0.004     0.011 ms] jit_evaluator_1_kernel_14_serial
[  0.01%   0.000 s      4x |    0.004     0.026     0.091 ms] runtime_memory_allocate_aligned
[  0.00%   0.000 s      4x |    0.005     0.006     0.007 ms] runtime_initialize_snodes
[  0.00%   0.000 s      1x |    0.019     0.019     0.019 ms] fill_matrix_c36_0_kernel_2_range_for
[  0.00%   0.000 s      1x |    0.014     0.014     0.014 ms] fill_tensor_c0_0_kernel_1_range_for
[  0.00%   0.000 s      1x |    0.013     0.013     0.013 ms] fill_matrix_c36_2_kernel_5_range_for
[  0.00%   0.000 s      1x |    0.012     0.012     0.012 ms] fill_tensor_c0_1_kernel_3_range_for
[  0.00%   0.000 s      1x |    0.011     0.011     0.011 ms] fill_matrix_c36_1_kernel_4_range_for
[  0.00%   0.000 s      1x |    0.011     0.011     0.011 ms] fill_matrix_c36_3_kernel_6_range_for
-------------------------------------------------------------------------
[100.00%] Total execution time:   1.459 s   number of results: 19
=========================================================================

########################################################
 ---------------------- After -----------------------
########################################################

[Taichi] version 0.9.2, llvm 10.0.0, commit b07b99ec, linux, python 3.8.10
[Taichi] Starting on arch=cuda
=========================================================================
Kernel Profiler(count, default) @ CUDA on NVIDIA GeForce RTX 3090
=========================================================================
[      %     total   count |      min       avg       max   ] Kernel name
-------------------------------------------------------------------------
[ 78.29%   0.764 s    100x |    7.194     7.641    11.180 ms] grid_op_c57_0_grad_grad_kernel_0_range_for
[ 20.80%   0.203 s      1x |  203.004   203.004   203.004 ms] runtime_initialize
[  0.52%   0.005 s    100x |    0.049     0.050     0.058 ms] grid_op_c56_0_kernel_0_range_for
[  0.11%   0.001 s    100x |    0.009     0.010     0.026 ms] clear_gradients_c32_1_kernel_0_range_for
[  0.05%   0.000 s    100x |    0.004     0.005     0.013 ms] clear_gradients_c32_3_kernel_0_range_for
[  0.05%   0.000 s    100x |    0.004     0.005     0.013 ms] clear_gradients_c32_0_kernel_0_range_for
[  0.04%   0.000 s     91x |    0.003     0.004     0.014 ms] jit_evaluator_1_kernel_0_serial
[  0.04%   0.000 s    100x |    0.003     0.004     0.012 ms] clear_gradients_c32_2_kernel_0_range_for
[  0.04%   0.000 s    100x |    0.003     0.004     0.011 ms] clear_gradients_c32_4_kernel_0_range_for
[  0.03%   0.000 s    100x |    0.003     0.003     0.011 ms] clear_loss_c34_0_kernel_0_serial
[  0.02%   0.000 s     24x |    0.003     0.009     0.092 ms] jit_evaluator_0_kernel_0_serial
[  0.01%   0.000 s      4x |    0.004     0.026     0.091 ms] runtime_memory_allocate_aligned
[  0.00%   0.000 s      1x |    0.019     0.019     0.019 ms] fill_matrix_c36_0_kernel_0_range_for
[  0.00%   0.000 s      4x |    0.003     0.004     0.005 ms] runtime_initialize_snodes
[  0.00%   0.000 s      1x |    0.014     0.014     0.014 ms] fill_tensor_c0_0_kernel_0_range_for
[  0.00%   0.000 s      1x |    0.012     0.012     0.012 ms] fill_matrix_c36_1_kernel_0_range_for
[  0.00%   0.000 s      1x |    0.012     0.012     0.012 ms] fill_matrix_c36_2_kernel_0_range_for
[  0.00%   0.000 s      1x |    0.010     0.010     0.010 ms] fill_tensor_c0_1_kernel_0_range_for
[  0.00%   0.000 s      1x |    0.010     0.010     0.010 ms] fill_matrix_c36_3_kernel_0_range_for
-------------------------------------------------------------------------
[100.00%] Total execution time:   0.976 s   number of results: 19
=========================================================================
```