### PR TITLE
[misc] Make result of irpass::print hold more information

### DIFF
--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -446,7 +446,8 @@ class ExternalTensorExpression : public Expression {
   }
 
   void serialize(std::ostream &ss) override {
-    ss << fmt::format("{}d_ext_arr", dim);
+    ss << fmt::format("{}d_ext_arr (element_dim={}, dt={})", dim, element_dim,
+                      dt->to_string());
   }
 
   void flatten(FlattenContext *ctx) override;
@@ -487,6 +488,10 @@ class GlobalVariableExpression : public Expression {
 
   void serialize(std::ostream &ss) override {
     ss << "#" << ident.name();
+    if (snode)
+      ss << fmt::format(" (snode={})", snode->get_node_type_name_hinted());
+    else
+      ss << fmt::format(" (dt={})", dt->to_string());
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -117,7 +117,7 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(FrontendAssertStmt *assert) override {
-    print("{} : assert {}", assert->id, assert->cond.serialize());
+    print("{} : assert {}", assert->name(), assert->cond.serialize());
   }
 
   void visit(AssertStmt *assert) override {


### PR DESCRIPTION
Related issue = #4401 

Result of `irpass::print` will be used as AST-Key (maybe temporary), which needs more information/details to implement [offline-cache](https://github.com/taichi-dev/taichi/issues/4401#issuecomment-1063559899).

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
