### PR TITLE
[Lang] [refactor] Remove legacy ways to construct matrices

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -938,15 +938,14 @@ class Matrix(TaichiOperations):
                     0].n, "Input vectors must share the same shape"
             # l-value copy:
             return Matrix([[row(i) for i in range(row.n)] for row in rows])
-        elif isinstance(rows[0], list):
+        if isinstance(rows[0], list):
             for row in rows:
                 assert len(row) == len(
                     rows[0]), "Input lists share the same shape"
             # l-value copy:
             return Matrix([[x for x in row] for row in rows])
-        else:
-            raise Exception(
-                "Cols/rows must be a list of lists, or a list of vectors")
+        raise Exception(
+            "Cols/rows must be a list of lists, or a list of vectors")
 
     @staticmethod
     def cols(cols):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -34,12 +34,13 @@ class Matrix(TaichiOperations):
         self.dynamic_index_stride = None
 
         if not isinstance(arr, (list, tuple, np.ndarray)):
-            raise TaichiTypeError("An Matrix/Vector can only be initialized with an array-like object")
+            raise TaichiTypeError(
+                "An Matrix/Vector can only be initialized with an array-like object"
+            )
         if len(arr) == 0:
             mat = []
         elif isinstance(arr[0], Matrix):
-            raise Exception(
-                'cols/rows required when using list of vectors')
+            raise Exception('cols/rows required when using list of vectors')
         elif not isinstance(arr[0], Iterable):  # now init a Vector
             if in_python_scope():
                 mat = [[x] for x in arr]
@@ -76,9 +77,9 @@ class Matrix(TaichiOperations):
                     mat.append(
                         list([
                             impl.make_tensor_element_expr(
-                                self.local_tensor_proxy, (expr.Expr(
-                                    i, dtype=primitive_types.i32), ),
-                                (len(arr),), self.dynamic_index_stride)
+                                self.local_tensor_proxy,
+                                (expr.Expr(i, dtype=primitive_types.i32), ),
+                                (len(arr), ), self.dynamic_index_stride)
                         ]))
         else:  # now init a Matrix
             if in_python_scope():
@@ -570,7 +571,8 @@ class Matrix(TaichiOperations):
 
         """
         # TODO: need a more systematic way to create a "0" with the right type
-        return Matrix([[val if i == j else 0 * val for j in range(dim)] for i in range(dim)])
+        return Matrix([[val if i == j else 0 * val for j in range(dim)]
+                       for i in range(dim)])
 
     def sum(self):
         """Return the sum of all elements."""


### PR DESCRIPTION
Related issue = #2880

After this PR, the only way to use `Matrix.__init__()` is by passing initial values.

Hint for reviewers: the git diff looks a bit messy, but the most modifications (L38-L132) in `Matrix.__init__()` simply cancels the indentation after removing the check of `n`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
