### PR TITLE
[aot] Add binding_id of root/gtmp/rets/args bufs to CompiledOffloadedTask

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -151,8 +151,7 @@ class Module:
                     assert anno.element_shape is not None and anno.field_dim is not None, 'Please either specify element_shape & field_dim in the kernel arg annotation or provide a dict of example ndarrays.'
                     if anno.element_dim == 0:
                         injected_args.append(
-                            ScalarNdarray(dtype=f32,
-                                          shape=(2, ) * anno.field_dim))
+                            ScalarNdarray(f32, (2, ) * anno.field_dim))
                     elif anno.element_dim == 1:
                         injected_args.append(
                             VectorNdarray(anno.element_shape[0],
@@ -168,10 +167,10 @@ class Module:
                                           layout=Layout.AOS))
                     else:
                         raise RuntimeError('')
+                i = i + 1
             else:
                 # For primitive types, we can just inject a dummy value.
                 injected_args.append(0)
-            i = i + 1
         kernel.ensure_compiled(*injected_args)
         self._aot_builder.add(name, kernel.kernel_cpp)
 

--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -28,6 +28,22 @@ struct CompiledFieldData {
             element_shape);
 };
 
+enum class BufferType { Root, GlobalTmps, Args, Rets };
+
+struct BufferInfo {
+  BufferType type;
+  int id{-1};  // only used if type==Root
+
+  TI_IO_DEF(type, id);
+};
+
+struct BufferBind {
+  BufferInfo buffer;
+  int binding{0};
+
+  TI_IO_DEF(buffer, binding);
+};
+
 struct CompiledOffloadedTask {
   std::string type;
   std::string range_hint;
@@ -36,7 +52,9 @@ struct CompiledOffloadedTask {
   std::string source_path;
   int gpu_block_size{0};
 
-  TI_IO_DEF(type, range_hint, name, source_path, gpu_block_size);
+  std::vector<BufferBind> buffer_binds;
+
+  TI_IO_DEF(type, range_hint, name, source_path, gpu_block_size, buffer_binds);
 };
 
 struct ScalarArg {

--- a/taichi/backends/vulkan/aot_module_builder_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_builder_impl.cpp
@@ -72,6 +72,25 @@ class AotDataConverter {
                                       in.range_for_attribs->begin);
     }
     res.gpu_block_size = in.advisory_num_threads_per_group;
+    for (auto &buffer_bind : in.buffer_binds) {
+      if (buffer_bind.buffer.type == BufferType::Root) {
+        res.buffer_binds.push_back(
+            {{aot::BufferType::Root, buffer_bind.buffer.root_id},
+             buffer_bind.binding});
+      } else if (buffer_bind.buffer.type == BufferType::Rets) {
+        res.buffer_binds.push_back(
+            {{aot::BufferType::Rets, buffer_bind.buffer.root_id},
+             buffer_bind.binding});
+      } else if (buffer_bind.buffer.type == BufferType::GlobalTmps) {
+        res.buffer_binds.push_back(
+            {{aot::BufferType::GlobalTmps, buffer_bind.buffer.root_id},
+             buffer_bind.binding});
+      } else if (buffer_bind.buffer.type == BufferType::Args) {
+        res.buffer_binds.push_back(
+            {{aot::BufferType::Args, buffer_bind.buffer.root_id},
+             buffer_bind.binding});
+      }
+    }
     return res;
   }
 };


### PR DESCRIPTION

Adding binding id of root/gtmp/rets/args to the serialized json file. 
Note this PR doesn't handle multiple root buffers in aot yet. 

Also added a test case with both scalar and ndarray args, which fixes #3961.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
