### PR TITLE
[test] Show arch info in the verbose test report

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 
-@pytest.fixture(autouse=True, params=(os.getenv("TI_WANTED_ARCHS", ""), ))
+@pytest.fixture(autouse=True,
+                params=("arch=" + os.getenv("TI_WANTED_ARCHS", ""), ))
 def wanted_arch(request):
     return request.param

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,7 @@
+import os
+import pytest
+
+
+@pytest.fixture(autouse=True, params=(os.getenv("TI_WANTED_ARCHS", ""), ))
+def wanted_arch(request):
+    return request.param


### PR DESCRIPTION
Related issue = 

Close #3128
Supersede #3983 

## After Change:

```
[gw2] [  0%] PASSED tests/python/test_ad_basics.py::test_size1[arch=cpu] 
tests/python/test_ad_basics.py::test_poly[arch=cpu-<lambda>7] 
[gw0] [  0%] PASSED tests/python/test_abs.py::test_abs[arch=cpu] 
tests/python/test_ad_basics.py::test_poly[arch=cpu-<lambda>5] 
[gw1] [  0%] PASSED tests/python/test_ad_atomic.py::test_ad_reduce[arch=cpu] 
tests/python/test_ad_basics.py::test_poly[arch=cpu-<lambda>6] 
[gw7] [  0%] PASSED tests/python/test_ad_basics.py::test_poly[arch=cpu-<lambda>4]
...
```

If there are no other parameters, will show as `<test_name>[arch=<arch>]`, otherwise the arch info will be combined with other parameters wrapped in the same `[]`.

Let me know if this meets the requirement.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
