### PR TITLE
[vulkan] Fix a memory leak caused by a typo

### DIFF
--- a/taichi/backends/vulkan/vulkan_api.cpp
+++ b/taichi/backends/vulkan/vulkan_api.cpp
@@ -21,7 +21,7 @@ DeviceObjVkCommandPool::~DeviceObjVkCommandPool() {
 }
 
 DeviceObjVkCommandBuffer::~DeviceObjVkCommandBuffer() {
-  if (this->level = VK_COMMAND_BUFFER_LEVEL_PRIMARY) {
+  if (this->level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) {
     ref_pool->free_primary.push(buffer);
   } else {
     ref_pool->free_secondary.push(buffer);


### PR DESCRIPTION
This means all of our recycled command buffer is stored into the wrong recycling pool and therefore causing the allocation of new command buffers every time.

TLDR: tiny mistakes can be quite lethal (and hard to find)