### PR TITLE
[bug] Fix bug that calling std::getenv when cpp-tests running will fail

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -31,6 +31,10 @@ def _test_cpp():
             e: os.getenv(e)
             for e in env_used_by_taichi_core
         }
+        env_used_by_taichi_core = {
+            k: v
+            for k, v in env_used_by_taichi_core.items() if v is not None
+        }
         subprocess.check_call(f'./{cpp_test_filename}',
                               env={
                                   'TI_LIB_DIR': ti_lib_dir,

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -17,8 +17,25 @@ def _test_cpp():
     curr_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(curr_dir, '../build')
     if os.path.exists(os.path.join(build_dir, cpp_test_filename)):
+        env_used_by_taichi_core = [
+            'HOME',
+            'XDG_CACHE_HOME',
+            'PYTEST_CURRENT_TEST',
+            'TI_BENCHMARK_OUTPUT_DIR',
+            'TI_ENABLE_CUDA',
+            'TI_ENABLE_METAL',
+            'TI_USE_METAL_SIMDGROUP',
+            'TI_ENABLE_OPENGL',
+        ]
+        env_used_by_taichi_core = {
+            e: os.getenv(e)
+            for e in env_used_by_taichi_core
+        }
         subprocess.check_call(f'./{cpp_test_filename}',
-                              env={'TI_LIB_DIR': ti_lib_dir},
+                              env={
+                                  'TI_LIB_DIR': ti_lib_dir,
+                                  **env_used_by_taichi_core
+                              },
                               cwd=build_dir)
     else:
         warnings.warn(

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -17,29 +17,10 @@ def _test_cpp():
     curr_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(curr_dir, '../build')
     if os.path.exists(os.path.join(build_dir, cpp_test_filename)):
-        env_used_by_taichi_core = [
-            'HOME',
-            'XDG_CACHE_HOME',
-            'PYTEST_CURRENT_TEST',
-            'TI_BENCHMARK_OUTPUT_DIR',
-            'TI_ENABLE_CUDA',
-            'TI_ENABLE_METAL',
-            'TI_USE_METAL_SIMDGROUP',
-            'TI_ENABLE_OPENGL',
-        ]
-        env_used_by_taichi_core = {
-            e: os.getenv(e)
-            for e in env_used_by_taichi_core
-        }
-        env_used_by_taichi_core = {
-            k: v
-            for k, v in env_used_by_taichi_core.items() if v is not None
-        }
+        env_copy = os.environ.copy()
+        env_copy['TI_LIB_DIR'] = ti_lib_dir
         subprocess.check_call(f'./{cpp_test_filename}',
-                              env={
-                                  'TI_LIB_DIR': ti_lib_dir,
-                                  **env_used_by_taichi_core
-                              },
+                              env=env_copy,
                               cwd=build_dir)
     else:
         warnings.warn(


### PR DESCRIPTION
Related issue = #

Cpp-tests is called by `subprocess.check_call()`, which causes env-variables missing, so calling `std::getenv()` in cpp-test will fail ( See https://github.com/taichi-dev/taichi/runs/5534004071?check_suite_focus=true
The pr fix the bug.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
