### PR TITLE
[test] Parametrize the test cases with pytest.mark

### DIFF
--- a/.github/workflows/scripts/unix_build.sh
+++ b/.github/workflows/scripts/unix_build.sh
@@ -68,7 +68,7 @@ build() {
 setup_sccache
 setup_python
 build
-cat "$SCCACHE_ERROR_LOG"
+cat "$SCCACHE_ERROR_LOG" || true
 NUM_WHL=$(ls dist/*.whl | wc -l)
 if [ $NUM_WHL -ne 1 ]; then echo "ERROR: created more than 1 whl." && exit 1; fi
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,9 +1,10 @@
-import os
-
 import pytest
 
+import taichi as ti
 
-@pytest.fixture(autouse=True,
-                params=("arch=" + os.getenv("TI_WANTED_ARCHS", ""), ))
-def wanted_arch(request):
-    return request.param
+
+@pytest.fixture(autouse=True)
+def wanted_arch(req_arch, req_options):
+    ti.init(arch=req_arch, enable_fallback=False, **req_options)
+    yield
+    ti.reset()

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import taichi as ti
@@ -5,6 +6,16 @@ import taichi as ti
 
 @pytest.fixture(autouse=True)
 def wanted_arch(req_arch, req_options):
-    ti.init(arch=req_arch, enable_fallback=False, **req_options)
+    if req_arch is not None:
+        ti.init(arch=req_arch, enable_fallback=False, **req_options)
     yield
-    ti.reset()
+    if req_arch is not None:
+        ti.reset()
+
+
+def pytest_generate_tests(metafunc):
+    if not getattr(metafunc.function, '__ti_test__', False):
+        # For test functions not wrapped with @test_utils.test(),
+        # fill with empty values to avoid undefined fixtures
+        metafunc.parametrize('req_arch,req_options', [(None, None)],
+                             ids=[os.getenv('TI_WANTED_ARCHS', '')])

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 import taichi as ti

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -19,4 +19,4 @@ def pytest_generate_tests(metafunc):
         # For test functions not wrapped with @test_utils.test(),
         # fill with empty values to avoid undefined fixtures
         metafunc.parametrize('req_arch,req_options', [(None, None)],
-                             ids=[os.getenv('TI_WANTED_ARCHS', '')])
+                             ids=['none'])

--- a/tests/python/test_div.py
+++ b/tests/python/test_div.py
@@ -1,11 +1,26 @@
+import pytest
 from taichi.lang import impl
 
 import taichi as ti
 from tests import test_utils
 
 
+@pytest.mark.parametrize("arg1,a,arg2,b,arg3,c", [
+    (ti.i32, 10, ti.i32, 3, ti.f32, 3),
+    (ti.f32, 10, ti.f32, 3, ti.f32, 3),
+    (ti.i32, 10, ti.f32, 3, ti.f32, 3),
+    (ti.f32, 10, ti.i32, 3, ti.f32, 3),
+    (ti.i32, -10, ti.i32, 3, ti.f32, -4),
+    (ti.f32, -10, ti.f32, 3, ti.f32, -4),
+    (ti.i32, -10, ti.f32, 3, ti.f32, -4),
+    (ti.f32, -10, ti.i32, 3, ti.f32, -4),
+    (ti.i32, 10, ti.i32, -3, ti.f32, -4),
+    (ti.f32, 10, ti.f32, -3, ti.f32, -4),
+    (ti.i32, 10, ti.f32, -3, ti.f32, -4),
+    (ti.f32, 10, ti.i32, -3, ti.f32, -4),
+])
 @test_utils.test()
-def _test_floor_div(arg1, a, arg2, b, arg3, c):
+def test_floor_div(arg1, a, arg2, b, arg3, c):
     z = ti.field(arg3, shape=())
 
     @ti.kernel
@@ -16,8 +31,20 @@ def _test_floor_div(arg1, a, arg2, b, arg3, c):
     assert z[None] == c
 
 
+@pytest.mark.parametrize("arg1,a,arg2,b,arg3,c", [
+    (ti.i32, 3, ti.i32, 2, ti.f32, 1.5),
+    (ti.f32, 3, ti.f32, 2, ti.f32, 1.5),
+    (ti.i32, 3, ti.f32, 2, ti.f32, 1.5),
+    (ti.f32, 3, ti.i32, 2, ti.f32, 1.5),
+    (ti.f32, 3, ti.i32, 2, ti.i32, 1),
+    (ti.i32, -3, ti.i32, 2, ti.f32, -1.5),
+    (ti.f32, -3, ti.f32, 2, ti.f32, -1.5),
+    (ti.i32, -3, ti.f32, 2, ti.f32, -1.5),
+    (ti.f32, -3, ti.i32, 2, ti.f32, -1.5),
+    (ti.f32, -3, ti.i32, 2, ti.i32, -1),
+])
 @test_utils.test()
-def _test_true_div(arg1, a, arg2, b, arg3, c):
+def test_true_div(arg1, a, arg2, b, arg3, c):
     z = ti.field(arg3, shape=())
 
     @ti.kernel
@@ -26,37 +53,6 @@ def _test_true_div(arg1, a, arg2, b, arg3, c):
 
     func(a, b)
     assert z[None] == c
-
-
-def test_floor_div():
-    _test_floor_div(ti.i32, 10, ti.i32, 3, ti.f32, 3)
-    _test_floor_div(ti.f32, 10, ti.f32, 3, ti.f32, 3)
-    _test_floor_div(ti.i32, 10, ti.f32, 3, ti.f32, 3)
-    _test_floor_div(ti.f32, 10, ti.i32, 3, ti.f32, 3)
-
-    _test_floor_div(ti.i32, -10, ti.i32, 3, ti.f32, -4)
-    _test_floor_div(ti.f32, -10, ti.f32, 3, ti.f32, -4)
-    _test_floor_div(ti.i32, -10, ti.f32, 3, ti.f32, -4)
-    _test_floor_div(ti.f32, -10, ti.i32, 3, ti.f32, -4)
-
-    _test_floor_div(ti.i32, 10, ti.i32, -3, ti.f32, -4)
-    _test_floor_div(ti.f32, 10, ti.f32, -3, ti.f32, -4)
-    _test_floor_div(ti.i32, 10, ti.f32, -3, ti.f32, -4)
-    _test_floor_div(ti.f32, 10, ti.i32, -3, ti.f32, -4)
-
-
-def test_true_div():
-    _test_true_div(ti.i32, 3, ti.i32, 2, ti.f32, 1.5)
-    _test_true_div(ti.f32, 3, ti.f32, 2, ti.f32, 1.5)
-    _test_true_div(ti.i32, 3, ti.f32, 2, ti.f32, 1.5)
-    _test_true_div(ti.f32, 3, ti.i32, 2, ti.f32, 1.5)
-    _test_true_div(ti.f32, 3, ti.i32, 2, ti.i32, 1)
-
-    _test_true_div(ti.i32, -3, ti.i32, 2, ti.f32, -1.5)
-    _test_true_div(ti.f32, -3, ti.f32, 2, ti.f32, -1.5)
-    _test_true_div(ti.i32, -3, ti.f32, 2, ti.f32, -1.5)
-    _test_true_div(ti.f32, -3, ti.i32, 2, ti.f32, -1.5)
-    _test_true_div(ti.f32, -3, ti.i32, 2, ti.i32, -1)
 
 
 @test_utils.test()

--- a/tests/python/test_eig.py
+++ b/tests/python/test_eig.py
@@ -108,29 +108,27 @@ def _test_sym_eig2x2(dt):
     _eigen_vector_equal(w_ti[:, idx_ti[1]], w_np[:, idx_np[1]], tol)
 
 
-def test_eig2x2():
-    for func in [_test_eig2x2_real, _test_eig2x2_complex]:
-        for fp in [ti.f32, ti.f64]:
-
-            @test_utils.test(
-                require=ti.extension.data64 if fp == ti.f64 else [],
-                default_fp=fp,
-                fast_math=False)
-            def wrapped():
-                func(fp)
-
-            wrapped()
+@pytest.mark.parametrize("func", [_test_eig2x2_real, _test_eig2x2_complex])
+@test_utils.test(default_fp=ti.f32, fast_math=False)
+def test_eig2x2_f32(func):
+    func(ti.f32)
 
 
-def test_sym_eig2x2():
-    for func in [_test_sym_eig2x2]:
-        for fp in [ti.f32, ti.f64]:
+@pytest.mark.parametrize("func", [_test_eig2x2_real, _test_eig2x2_complex])
+@test_utils.test(require=ti.extension.data64,
+                 default_fp=ti.f64,
+                 fast_math=False)
+def test_eig2x2_f64(func):
+    func(ti.f64)
 
-            @test_utils.test(
-                require=ti.extension.data64 if fp == ti.f64 else [],
-                default_fp=fp,
-                fast_math=False)
-            def wrapped():
-                func(fp)
 
-            wrapped()
+@test_utils.test(default_fp=ti.f32, fast_math=False)
+def test_sym_eig2x2_f32():
+    _test_sym_eig2x2(ti.f32)
+
+
+@test_utils.test(require=ti.extension.data64,
+                 default_fp=ti.f64,
+                 fast_math=False)
+def test_sym_eig2x2_f64():
+    _test_sym_eig2x2(ti.f64)

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -184,17 +184,16 @@ def _test_polar_decomp(dim, dt):
             assert D[None][i, j] == test_utils.approx(0, abs=tol)
 
 
-def test_polar_decomp():
-    for dim in [2, 3]:
-        for dt in [ti.f32, ti.f64]:
+@pytest.mark.parametrize("dim", [2, 3])
+@test_utils.test(default_fp=ti.f32)
+def test_polar_decomp_f32(dim):
+    _test_polar_decomp(dim, ti.f32)
 
-            @test_utils.test(
-                require=ti.extension.data64 if dt == ti.f64 else [],
-                default_fp=dt)
-            def wrapped():
-                _test_polar_decomp(dim, dt)
 
-            wrapped()
+@pytest.mark.parametrize("dim", [2, 3])
+@test_utils.test(require=ti.extension.data64, default_fp=ti.f64)
+def test_polar_decomp_f64(dim):
+    _test_polar_decomp(dim, ti.f64)
 
 
 @test_utils.test()
@@ -221,8 +220,9 @@ def test_matrix():
         assert x[i][1, 1] == 1 + i
 
 
+@pytest.mark.parametrize("n", range(1, 5))
 @test_utils.test()
-def _test_mat_inverse_size(n):
+def test_mat_inverse_size(n):
     m = ti.Matrix.field(n, n, dtype=ti.f32, shape=())
     M = np.empty(shape=(n, n), dtype=np.float32)
     for i in range(n):
@@ -240,11 +240,6 @@ def _test_mat_inverse_size(n):
 
     m_np = m.to_numpy(keep_dims=True)
     np.testing.assert_almost_equal(m_np, np.linalg.inv(M))
-
-
-def test_mat_inverse():
-    for n in range(1, 5):
-        _test_mat_inverse_size(n)
 
 
 @test_utils.test()

--- a/tests/python/test_mod.py
+++ b/tests/python/test_mod.py
@@ -1,53 +1,46 @@
+import pytest
 import taichi as ti
 from tests import test_utils
 
 
+@pytest.mark.parametrize("a,b", [
+    (10, 3),
+    (-10, 3),
+    (10, -3),
+    (-10, -3),
+])
 @test_utils.test()
-def _test_py_style_mod(arg1, a, arg2, b, arg3, c):
-    z = ti.field(arg3, shape=())
+def test_py_style_mod(a, b):
+    z = ti.field(ti.i32, shape=())
 
     @ti.kernel
-    def func(x: arg1, y: arg2):
+    def func(x: ti.i32, y: ti.i32):
         z[None] = x % y
 
     func(a, b)
-    assert z[None] == c
+    assert z[None] == a % b
 
 
+@pytest.mark.parametrize("a,b", [
+    (10, 3),
+    (-10, 3),
+    (10, -3),
+    (-10, -3),
+])
 @test_utils.test()
-def _test_c_style_mod(arg1, a, arg2, b, arg3, c):
-    z = ti.field(arg3, shape=())
+def test_c_style_mod(a, b):
+    z = ti.field(ti.i32, shape=())
 
     @ti.kernel
-    def func(x: arg1, y: arg2):
+    def func(x: ti.i32, y: ti.i32):
         z[None] = ti.raw_mod(x, y)
 
     func(a, b)
-    assert z[None] == c
-
-
-def test_py_style_mod():
-    def func(a, b):
-        _test_py_style_mod(ti.i32, a, ti.i32, b, ti.i32, a % b)
-
-    func(10, 3)
-    func(-10, 3)
-    func(10, -3)
-    func(-10, -3)
+    assert z[None] == _c_mod(a, b)
 
 
 def _c_mod(a, b):
     return a - b * int(float(a) / b)
-
-
-def test_c_style_mod():
-    def func(a, b):
-        _test_c_style_mod(ti.i32, a, ti.i32, b, ti.i32, _c_mod(a, b))
-
-    func(10, 3)
-    func(-10, 3)
-    func(10, -3)
-    func(-10, -3)
 
 
 @test_utils.test()

--- a/tests/python/test_mod.py
+++ b/tests/python/test_mod.py
@@ -1,4 +1,5 @@
 import pytest
+
 import taichi as ti
 from tests import test_utils
 

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -1,9 +1,11 @@
+import pytest
 import taichi as ti
 from tests import test_utils
 
 
+@pytest.mark.parametrize("round", range(10))
 @test_utils.test()
-def test_linear():
+def test_linear(round):
     x = ti.field(ti.i32)
     y = ti.field(ti.i32)
 
@@ -19,11 +21,6 @@ def test_linear():
     for i in range(n):
         assert x[i] == i
         assert y[i] == i + 123
-
-
-def test_linear_repeated():
-    for i in range(10):
-        test_linear()
 
 
 @test_utils.test()

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -1,4 +1,5 @@
 import pytest
+
 import taichi as ti
 from tests import test_utils
 

--- a/tests/python/test_svd.py
+++ b/tests/python/test_svd.py
@@ -63,13 +63,15 @@ def _test_svd(dt, n):
 
 
 @pytest.mark.parametrize("dim", [2, 3])
-@test_utils.test(default_fp=ti.f32)
+@test_utils.test(default_fp=ti.f32, fast_math=False)
 def test_svd_f32(dim):
     _test_svd(ti.f32, dim)
 
 
 @pytest.mark.parametrize("dim", [2, 3])
-@test_utils.test(require=ti.extension.data64, default_fp=ti.f64)
+@test_utils.test(require=ti.extension.data64,
+                 default_fp=ti.f64,
+                 fast_math=False)
 def test_svd_f64(dim):
     _test_svd(ti.f64, dim)
 

--- a/tests/python/test_svd.py
+++ b/tests/python/test_svd.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import taichi as ti
 from tests import test_utils
@@ -61,18 +62,16 @@ def _test_svd(dt, n):
                 assert sigma[None][i, j] == test_utils.approx(0)
 
 
-def test_svd():
-    for fp in [ti.f32, ti.f64]:
-        for d in [2, 3]:
+@pytest.mark.parametrize("dim", [2, 3])
+@test_utils.test(default_fp=ti.f32)
+def test_svd_f32(dim):
+    _test_svd(ti.f32, dim)
 
-            @test_utils.test(
-                require=ti.extension.data64 if fp == ti.f64 else [],
-                default_fp=fp,
-                fast_math=False)
-            def wrapped():
-                _test_svd(fp, d)
 
-            wrapped()
+@pytest.mark.parametrize("dim", [2, 3])
+@test_utils.test(require=ti.extension.data64, default_fp=ti.f64)
+def test_svd_f64(dim):
+    _test_svd(ti.f64, dim)
 
 
 @test_utils.test()

--- a/tests/python/test_tensor_dimensionality.py
+++ b/tests/python/test_tensor_dimensionality.py
@@ -1,9 +1,11 @@
+import pytest
 import taichi as ti
 from tests import test_utils
 
 
+@pytest.mark.parametrize("d", range(2, ti._lib.core.get_max_num_indices() + 1))
 @test_utils.test()
-def _test_dimensionality(d):
+def test_dimensionality(d):
     x = ti.Vector.field(2, dtype=ti.i32, shape=(2, ) * d)
 
     @ti.kernel
@@ -25,8 +27,3 @@ def _test_dimensionality(d):
         for j in range(d):
             indices.append(i // (2**j) % 2)
         assert x.__getitem__(tuple(indices))[0] == sum(indices) * 3
-
-
-def test_dimensionality():
-    for i in range(2, ti._lib.core.get_max_num_indices() + 1):
-        _test_dimensionality(i)

--- a/tests/python/test_tensor_dimensionality.py
+++ b/tests/python/test_tensor_dimensionality.py
@@ -1,4 +1,5 @@
 import pytest
+
 import taichi as ti
 from tests import test_utils
 

--- a/tests/python/test_test.py
+++ b/tests/python/test_test.py
@@ -127,15 +127,7 @@ def test_allclose_rel_reordered2(x, allclose):
 @pytest.mark.skipif(ti._lib.core.with_metal(),
                     reason="Skip metal because metal is used as the example")
 def test_disable_fallback():
-    old_environ = os.environ.get('TI_WANTED_ARCHS', '')
-    os.environ['TI_WANTED_ARCHS'] = "metal"
 
     with pytest.raises(RuntimeError):
-
-        @test_utils.test(ti.metal)
-        def test():
-            pass
-
-        test()
-        os.environ['TI_WANTED_ARCHS'] = old_environ
-    os.environ['TI_WANTED_ARCHS'] = old_environ
+        ti.init(arch=ti.metal, enable_fallback=False)
+        ti.reset()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,8 @@ import os
 from errno import EEXIST
 from tempfile import mkstemp
 
+import pytest
+
 from taichi._lib import core as _ti_core
 from taichi.lang import cc, cpu, cuda, gpu, metal, opengl, vulkan
 from taichi.lang.misc import is_arch_supported
@@ -164,52 +166,51 @@ def test(arch=None, exclude=None, require=None, **options):
     if len(arch) == 0:
         arch = archs_expected
     else:
-        arch = list(filter(lambda x: x in archs_expected, arch))
+        arch = [v for v in arch if v in archs_expected]
+
+    marks = []  # A list of pytest.marks to apply on the test function
+    if len(arch) == 0:
+        marks.append(pytest.mark.skip(reason='No supported archs'))
+    else:
+        arch_params_sets = [arch, *_test_features.values()]
+        # List of (arch, options) to parametrize the test function
+        parameters = []
+        for req_arch, *req_params in itertools.product(*arch_params_sets):
+            if (req_arch not in arch) or (req_arch in exclude):
+                continue
+
+            if not all(
+                    _ti_core.is_extension_supported(req_arch, e)
+                    for e in require):
+                continue
+
+            skip = False
+            current_options = copy.deepcopy(options)
+            for feature, param in zip(_test_features, req_params):
+                value = param.value
+                required_extensions = param.required_extensions
+                if current_options.get(feature, value) != value or any(
+                        not _ti_core.is_extension_supported(req_arch, e)
+                        for e in required_extensions):
+                    skip = True
+                else:
+                    # Fill in the missing feature
+                    current_options[feature] = value
+            if not skip:
+                parameters.append((req_arch, current_options))
+        if not parameters:
+            marks.append(pytest.mark.skip(reason='No supported archs'))
+        else:
+            marks.append(
+                pytest.mark.parametrize(
+                    "req_arch,req_options",
+                    parameters,
+                    ids=[f"arch={arch.name}" for arch, _ in parameters]))
 
     def decorator(foo):
-        @functools.wraps(foo)
-        def wrapped(*args, **kwargs):
-            if len(arch) == 0:
-                print('No supported arch found. Skipping.')
-                return
-
-            arch_params_sets = [arch, *_test_features.values()]
-            arch_params_combinations = list(
-                itertools.product(*arch_params_sets))
-
-            for arch_params in arch_params_combinations:
-                req_arch, req_params = arch_params[0], arch_params[1:]
-
-                if (req_arch not in arch) or (req_arch in exclude):
-                    continue
-
-                if not all(
-                        _ti_core.is_extension_supported(req_arch, e)
-                        for e in require):
-                    continue
-
-                skip = False
-                current_options = copy.deepcopy(options)
-                for feature, param in zip(_test_features, req_params):
-                    value = param.value
-                    required_extensions = param.required_extensions
-                    if current_options.get(feature, value) != value or any(
-                            not _ti_core.is_extension_supported(req_arch, e)
-                            for e in required_extensions):
-                        skip = True
-                    else:
-                        # Fill in the missing feature
-                        current_options[feature] = value
-                if skip:
-                    continue
-
-                ti.init(arch=req_arch,
-                        enable_fallback=False,
-                        **current_options)
-                foo(*args, **kwargs)
-                ti.reset()
-
-        return wrapped
+        for mark in reversed(marks):  # Apply the marks in reverse order
+            foo = mark(foo)
+        return foo
 
     return decorator
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ from errno import EEXIST
 from tempfile import mkstemp
 
 import pytest
-
 from taichi._lib import core as _ti_core
 from taichi.lang import cc, cpu, cuda, gpu, metal, opengl, vulkan
 from taichi.lang.misc import is_arch_supported

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -209,11 +209,11 @@ def test(arch=None, exclude=None, require=None, **options):
                         for i, (arch, _) in enumerate(parameters)
                     ]))
 
-    def decorator(foo):
-        foo.__ti_test__ = True
+    def decorator(func):
+        func.__ti_test__ = True  # Mark the function as a taichi test
         for mark in reversed(marks):  # Apply the marks in reverse order
-            foo = mark(foo)
-        return foo
+            func = mark(func)
+        return func
 
     return decorator
 


### PR DESCRIPTION
Related: #3128, #4528


Change the test orchestration by replacing the for-loop in `@test_utils.test()` by `@pytest.mark.parametrize`. 

- By default, each arch matched for a specific test function will be splitted into two test cases(test features). All of the test cases will be collected by pytest and run in parallel.
- As a result, the test cases number is almost doubled, from ~1300 to ~2500. 
- All test funcitons decorated by `@test_utils.test()` MUST be placed in the top level rather than nested in child scope, and the function name MUST NOT start with `_`. 
- We are able to apply other parametrization matrix on the `@test_utils.test()` decorated test functions.
   
   Put `@test_utils.test()` right above the test function, under any other `pytest.mark` decorators:
   ```python
    @pytest.mark.parametrize('n', range(5))
    @test_utils.test()
    def test_foo(n):
        ...
    ```
    This is to make sure the `arch=arm64` hint appears first in the bracket.

- With this method, `@test_utils.test()` itself CANNOT be parametrized nor nested in a for-loop.
- Last but not least, this PR only changes the test code and should not have any effect on the source.

## Example output:
```
[gw6] [ 94%] PASSED tests/python/test_syntax_errors.py::test_raise[arch=arm64-1] 
tests/python/test_types.py::test_type_operator[arch=arm64-1-dt3] 
[gw2] [ 94%] PASSED tests/python/test_types.py::test_type_operator[arch=arm64-0-dt6] 
tests/python/test_types.py::test_type_operator[arch=arm64-1-dt0] 
[gw4] [ 94%] PASSED tests/python/test_types.py::test_type_assign_argument[arch=arm64-1-dt0] 
tests/python/test_types.py::test_type_operator64[arch=arm64-0-dt1] 
[gw7] [ 94%] PASSED tests/python/test_types.py::test_type_assign_argument64[arch=arm64-1-dt1] 
tests/python/test_types.py::test_type_assign_argument64[arch=arm64-1-dt2]
...
```