### PR TITLE
[CLI] Fix a few bugs in taichi gallery command

### DIFF
--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -151,8 +151,7 @@ class TaichiMain:
         image_source = utils.package_root + '/assets/**/ti_gallery.png'
         gallery_image_path = glob.glob(image_source, recursive=True)[0]
         gallery_image = ti.tools.imread(gallery_image_path)
-        gallery_image = gallery_image[:, :
-                                      -top_margin]  # crop the top bar in image
+        gallery_image = gallery_image[:, :-top_margin]
         width, height = gallery_image.shape[:2]
 
         # create the gui, 2x4 tiles
@@ -169,14 +168,20 @@ class TaichiMain:
             "mpm128", "pbf2d", "mass_spring_game"
         ]
 
+        def valid_mouse_position(mou_x, mou_y):
+            xmin = left_margin / width
+            xmax = 1 - xmin
+            ymin = bottom_margin / height
+            ymax = 1 - horizontal_margin / height
+            return (xmin <= mou_x <= xmax) and (ymin <= mou_y <= ymax)
+
         def get_tile_from_mouse(mou_x, mou_y):
             """Find the image tile that the mouse is hovering over."""
             x = int(mou_x * width)
             y = int(mou_y * height)
             rind = (y - bottom_margin) // (vertical_margin + tile_size)
             cind = (x - left_margin) // (horizontal_margin + tile_size)
-            valid = (0 <= rind < nrows and 0 <= cind < ncols)
-            return valid, rind, cind
+            return rind, cind
 
         def draw_bounding_box(rind, cind):
             x0 = cind * (horizontal_margin + tile_size) + left_margin
@@ -194,8 +199,8 @@ class TaichiMain:
             try:
                 import rich.console  # pylint: disable=C0415
                 import rich.syntax  # pylint: disable=C0415
-                content = rich.syntax.Syntax.from_path(script,
-                                                       line_numbers=True)
+                content = rich.syntax.Syntax.from_path(
+                    script, line_numbers=True)
                 console = rich.console.Console()
                 console.print(content)
             except ImportError:
@@ -207,10 +212,10 @@ class TaichiMain:
         while gui.running:
             gui.set_image(gallery_image)
             mou_x, mou_y = gui.get_cursor_pos()
-            gui.get_event(ti.GUI.PRESS)
-            valid, rind, cind = get_tile_from_mouse(mou_x, mou_y)
-            if valid:
+            if valid_mouse_position(mou_x, mou_y):
+                rind, cind = get_tile_from_mouse(mou_x, mou_y)
                 draw_bounding_box(rind, cind)
+                gui.get_event(ti.GUI.PRESS)
                 if gui.is_pressed(ti.GUI.LMB):
                     gui.close()
                     index = cind + rind * ncols

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -151,7 +151,8 @@ class TaichiMain:
         image_source = utils.package_root + '/assets/**/ti_gallery.png'
         gallery_image_path = glob.glob(image_source, recursive=True)[0]
         gallery_image = ti.tools.imread(gallery_image_path)
-        gallery_image = gallery_image[:, :-top_margin]  # crop the top bar in image
+        gallery_image = gallery_image[:, :
+                                      -top_margin]  # crop the top bar in image
         width, height = gallery_image.shape[:2]
 
         # create the gui, 2x4 tiles
@@ -193,8 +194,8 @@ class TaichiMain:
             try:
                 import rich.console  # pylint: disable=C0415
                 import rich.syntax  # pylint: disable=C0415
-                content = rich.syntax.Syntax.from_path(
-                    script, line_numbers=True)
+                content = rich.syntax.Syntax.from_path(script,
+                                                       line_numbers=True)
                 console = rich.console.Console()
                 console.print(content)
             except ImportError:

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -199,8 +199,8 @@ class TaichiMain:
             try:
                 import rich.console  # pylint: disable=C0415
                 import rich.syntax  # pylint: disable=C0415
-                content = rich.syntax.Syntax.from_path(
-                    script, line_numbers=True)
+                content = rich.syntax.Syntax.from_path(script,
+                                                       line_numbers=True)
                 console = rich.console.Console()
                 console.print(content)
             except ImportError:

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -139,23 +139,25 @@ class TaichiMain:
     @register
     def gallery(self, argumets: list = sys.argv[2:]):
         """Use mouse to select and run taichi examples in an interactive gui."""
+        # set the spacing parameters in the gallery image
+        top_margin = 14
+        left_margin = 7
+        bottom_margin = 23
+        vertical_margin = 32
+        horizontal_margin = 11
+        tile_size = 128
+
         # load the gallery image
         image_source = utils.package_root + '/assets/**/ti_gallery.png'
         gallery_image_path = glob.glob(image_source, recursive=True)[0]
         gallery_image = ti.tools.imread(gallery_image_path)
+        gallery_image = gallery_image[:, :-top_margin]  # crop the top bar in image
         width, height = gallery_image.shape[:2]
 
         # create the gui, 2x4 tiles
         gui = ti.GUI("Taichi Gallery", res=(width, height))
         nrows = 2
         ncols = 4
-
-        # set the spacing parameters in the gallery image
-        left_margin = 7
-        bottom_margin = 23
-        vertical_margin = 32
-        horizontal_margin = 11
-        tile_size = 128
 
         # side length of a tile
         dx = tile_size / width
@@ -171,7 +173,7 @@ class TaichiMain:
             x = int(mou_x * width)
             y = int(mou_y * height)
             rind = (y - bottom_margin) // (vertical_margin + tile_size)
-            cind = (x - left_margin) // (vertical_margin + tile_size)
+            cind = (x - left_margin) // (horizontal_margin + tile_size)
             valid = (0 <= rind < nrows and 0 <= cind < ncols)
             return valid, rind, cind
 
@@ -188,31 +190,30 @@ class TaichiMain:
         def on_mouse_click_callback(example_name):
             examples_dir = TaichiMain._get_examples_dir()
             script = list(examples_dir.rglob(f"{example_name}.py"))[0]
-            with open(script, "r") as f:
-                try:
-                    import rich.console  # pylint: disable=C0415
-                    import rich.syntax  # pylint: disable=C0415
-                    content = rich.syntax.Syntax.from_path(script,
-                                                           line_numbers=True)
-                    console = rich.console.Console()
-                    console.print(content)
-                except ImportError:
-                    content = f.readlines()
-                    print(content)
+            try:
+                import rich.console  # pylint: disable=C0415
+                import rich.syntax  # pylint: disable=C0415
+                content = rich.syntax.Syntax.from_path(
+                    script, line_numbers=True)
+                console = rich.console.Console()
+                console.print(content)
+            except ImportError:
+                with open(script, "r") as f:
+                    shutil.copyfileobj(f, sys.stdout)
 
             self._exec_python_file(script)
 
         while gui.running:
             gui.set_image(gallery_image)
-            if gui.get_events(gui.MOTION):
-                mou_x, mou_y = gui.get_cursor_pos()
-                valid, rind, cind = get_tile_from_mouse(mou_x, mou_y)
-                if valid:
-                    draw_bounding_box(rind, cind)
-                    if gui.get_event(ti.GUI.PRESS, ti.GUI.LMB):
-                        gui.close()
-                        index = cind + rind * ncols
-                        on_mouse_click_callback(examples[index])
+            mou_x, mou_y = gui.get_cursor_pos()
+            gui.get_event(ti.GUI.PRESS)
+            valid, rind, cind = get_tile_from_mouse(mou_x, mou_y)
+            if valid:
+                draw_bounding_box(rind, cind)
+                if gui.is_pressed(ti.GUI.LMB):
+                    gui.close()
+                    index = cind + rind * ncols
+                    on_mouse_click_callback(examples[index])
 
             gui.show()
 

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -140,22 +140,24 @@ class TaichiMain:
     def gallery(self, argumets: list = sys.argv[2:]):
         """Use mouse to select and run taichi examples in an interactive gui."""
         # set the spacing parameters in the gallery image
-        top_margin = 14
+        slide_bar = 14
+        top_margin = 6
         left_margin = 7
         bottom_margin = 23
-        vertical_margin = 32
-        horizontal_margin = 11
+        row_spacing = 32
+        col_spacing = 11
         tile_size = 128
 
         # load the gallery image
         image_source = utils.package_root + '/assets/**/ti_gallery.png'
         gallery_image_path = glob.glob(image_source, recursive=True)[0]
         gallery_image = ti.tools.imread(gallery_image_path)
-        gallery_image = gallery_image[:, :-top_margin]
+        gallery_image = gallery_image[:, :-slide_bar]
         width, height = gallery_image.shape[:2]
 
         # create the gui, 2x4 tiles
         gui = ti.GUI("Taichi Gallery", res=(width, height))
+        ncols = 4
 
         # side length of a tile
         dx = tile_size / width
@@ -170,20 +172,20 @@ class TaichiMain:
             xmin = left_margin / width
             xmax = 1 - xmin
             ymin = bottom_margin / height
-            ymax = 1 - horizontal_margin / height
+            ymax = 1 - top_margin / height
             return (xmin <= mou_x <= xmax) and (ymin <= mou_y <= ymax)
 
         def get_tile_from_mouse(mou_x, mou_y):
             """Find the image tile that the mouse is hovering over."""
             x = int(mou_x * width)
             y = int(mou_y * height)
-            rind = (y - bottom_margin) // (vertical_margin + tile_size)
-            cind = (x - left_margin) // (horizontal_margin + tile_size)
+            rind = (y - bottom_margin) // (row_spacing + tile_size)
+            cind = (x - left_margin) // (col_spacing + tile_size)
             return rind, cind
 
         def draw_bounding_box(rind, cind):
-            x0 = cind * (horizontal_margin + tile_size) + left_margin
-            y0 = rind * (vertical_margin + tile_size) + bottom_margin
+            x0 = cind * (col_spacing + tile_size) + left_margin
+            y0 = rind * (row_spacing + tile_size) + bottom_margin
             x0 /= width
             y0 /= height
             pts = [(x0, y0), (x0 + dx, y0), (x0 + dx, y0 + dy), (x0, y0 + dy),
@@ -197,8 +199,8 @@ class TaichiMain:
             try:
                 import rich.console  # pylint: disable=C0415
                 import rich.syntax  # pylint: disable=C0415
-                content = rich.syntax.Syntax.from_path(script,
-                                                       line_numbers=True)
+                content = rich.syntax.Syntax.from_path(
+                    script, line_numbers=True)
                 console = rich.console.Console()
                 console.print(content)
             except ImportError:

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -171,7 +171,7 @@ class TaichiMain:
         def valid_mouse_position(mou_x, mou_y):
             xmin = left_margin / width
             xmax = 1 - xmin
-            ymin = bottom_margin / height
+            ymin = 0
             ymax = 1 - top_margin / height
             return (xmin <= mou_x <= xmax) and (ymin <= mou_y <= ymax)
 
@@ -179,7 +179,7 @@ class TaichiMain:
             """Find the image tile that the mouse is hovering over."""
             x = int(mou_x * width)
             y = int(mou_y * height)
-            rind = (y - bottom_margin) // (row_spacing + tile_size)
+            rind = y // (row_spacing + tile_size)
             cind = (x - left_margin) // (col_spacing + tile_size)
             return rind, cind
 

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -201,8 +201,8 @@ class TaichiMain:
             try:
                 import rich.console  # pylint: disable=C0415
                 import rich.syntax  # pylint: disable=C0415
-                content = rich.syntax.Syntax.from_path(
-                    script, line_numbers=True)
+                content = rich.syntax.Syntax.from_path(script,
+                                                       line_numbers=True)
                 console = rich.console.Console()
                 console.print(content)
             except ImportError:

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -156,8 +156,6 @@ class TaichiMain:
 
         # create the gui, 2x4 tiles
         gui = ti.GUI("Taichi Gallery", res=(width, height))
-        nrows = 2
-        ncols = 4
 
         # side length of a tile
         dx = tile_size / width

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -196,6 +196,8 @@ class TaichiMain:
         def on_mouse_click_callback(example_name):
             examples_dir = TaichiMain._get_examples_dir()
             script = list(examples_dir.rglob(f"{example_name}.py"))[0]
+            print("Demo source code:")
+            print()
             try:
                 import rich.console  # pylint: disable=C0415
                 import rich.syntax  # pylint: disable=C0415

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -214,16 +214,18 @@ class TaichiMain:
         while gui.running:
             gui.set_image(gallery_image)
             mou_x, mou_y = gui.get_cursor_pos()
+            gui.get_event(ti.GUI.PRESS)
             if valid_mouse_position(mou_x, mou_y):
                 rind, cind = get_tile_from_mouse(mou_x, mou_y)
                 draw_bounding_box(rind, cind)
-                gui.get_event(ti.GUI.PRESS)
                 if gui.is_pressed(ti.GUI.LMB):
                     gui.close()
                     index = cind + rind * ncols
-                    on_mouse_click_callback(examples[index])
+                    break
 
             gui.show()
+
+        on_mouse_click_callback(examples[index])
 
     @register
     def example(self, arguments: list = sys.argv[2:]):


### PR DESCRIPTION
This PR fixes some bugs reported by @yuanming-hu when running the `taichi gallery` command. The main changes are:

1. Crop the slide bar on top of the image.
2. Fix the problem that some mouse positions give wrong tiles.
3. Deactivate keyboard input.
4. Fix the problem caused by `readlines()` when printing the code to console, use `shutil.copyfileobj` instead.
5. Add mouse position check to fix the problem that dragging the slide bar also triggers events.