### PR TITLE
[aot] Fix get_kernel API semantics

### DIFF
--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<Module> Module::load(const std::string &path,
   }
 }
 
-Kernel* Module::get_kernel(const std::string &name) {
+Kernel *Module::get_kernel(const std::string &name) {
   auto itr = loaded_kernels_.find(name);
   if (itr != loaded_kernels_.end()) {
     return itr->second.get();

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -24,7 +24,7 @@ std::unique_ptr<Module> Module::load(const std::string &path,
 }
 
 Kernel* Module::get_kernel(const std::string &name) {
-    auto itr = loaded_kernels_.find(name);
+  auto itr = loaded_kernels_.find(name);
   if (itr != loaded_kernels_.end()) {
     return itr->second.get();
   }

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -35,9 +35,14 @@ Kernel *Module::get_kernel(const std::string &name) {
 }
 
 Field *Module::get_field(const std::string &name) {
-  // TODO: Implement this
-  TI_NOT_IMPLEMENTED;
-  return nullptr;
+  auto itr = loaded_fields_.find(name);
+  if (itr != loaded_fields_.end()) {
+    return itr->second.get();
+  }
+  auto k = make_new_field(name);
+  auto *kptr = k.get();
+  loaded_fields_[name] = std::move(k);
+  return kptr;
 }
 
 }  // namespace aot

--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -23,6 +23,23 @@ std::unique_ptr<Module> Module::load(const std::string &path,
   }
 }
 
+Kernel* Module::get_kernel(const std::string &name) {
+    auto itr = loaded_kernels_.find(name);
+  if (itr != loaded_kernels_.end()) {
+    return itr->second.get();
+  }
+  auto k = make_new_kernel(name);
+  auto *kptr = k.get();
+  loaded_kernels_[name] = std::move(k);
+  return kptr;
+}
+
+Field *Module::get_field(const std::string &name) {
+  // TODO: Implement this
+  TI_NOT_IMPLEMENTED;
+  return nullptr;
+}
+
 }  // namespace aot
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -72,9 +72,11 @@ class TI_DLL_EXPORT Module {
 
  protected:
   virtual std::unique_ptr<Kernel> make_new_kernel(const std::string &name) = 0;
+  virtual std::unique_ptr<Field> make_new_field(const std::string &name) = 0;
 
  private:
   std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;
+  std::unordered_map<std::string, std::unique_ptr<Field>> loaded_fields_;
 };
 
 // Only responsible for reporting device capabilities

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -66,12 +66,15 @@ class TI_DLL_EXPORT Module {
   // Module metadata
   virtual Arch arch() const = 0;
   virtual uint64_t version() const = 0;
-  virtual std::unique_ptr<Kernel> get_kernel(const std::string &name) = 0;
-  virtual std::unique_ptr<Field> get_field(const std::string &name) = 0;
+  Kernel *get_kernel(const std::string &name);
+  Field *get_field(const std::string &name);
   virtual size_t get_root_size() const = 0;
 
  protected:
   virtual std::unique_ptr<Kernel> make_new_kernel(const std::string &name) = 0;
+
+ private:
+  std::unordered_map<std::string, std::unique_ptr<Kernel>> loaded_kernels_;
 };
 
 // Only responsible for reporting device capabilities

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -74,6 +74,11 @@ class AotModuleImpl : public aot::Module {
     return std::make_unique<KernelImpl>(runtime_, name);
   }
 
+  std::unique_ptr<aot::Field> make_new_field(const std::string &name) override {
+    TI_NOT_IMPLEMENTED;
+    return nullptr;
+  }
+
   KernelManager *const runtime_;
   TaichiAotData aot_data_;
   std::unordered_map<std::string, const CompiledKernelData *> kernels_;

--- a/taichi/backends/metal/aot_module_loader_impl.cpp
+++ b/taichi/backends/metal/aot_module_loader_impl.cpp
@@ -47,14 +47,6 @@ class AotModuleImpl : public aot::Module {
     }
   }
 
-  std::unique_ptr<aot::Kernel> get_kernel(const std::string &name) override {
-    return make_new_kernel(name);
-  }
-
-  std::unique_ptr<aot::Field> get_field(const std::string &name) override {
-    TI_NOT_IMPLEMENTED;
-  }
-
   size_t get_root_size() const override {
     return aot_data_.metadata.root_buffer_size;
   }

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -59,11 +59,7 @@ class AotModuleImpl : public aot::Module {
     }
   }
 
-  std::unique_ptr<aot::Kernel> get_kernel(const std::string &name) override {
-    return make_new_kernel(name);
-  }
-
-  std::unique_ptr<aot::Field> get_field(const std::string &name) override {
+  std::unique_ptr<aot::Field> get_field(const std::string &name) {
     aot::CompiledFieldData field;
     if (!get_field_data_by_name(name, field)) {
       TI_DEBUG("Failed to load field {}", name);

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -59,15 +59,6 @@ class AotModuleImpl : public aot::Module {
     }
   }
 
-  std::unique_ptr<aot::Field> get_field(const std::string &name) {
-    aot::CompiledFieldData field;
-    if (!get_field_data_by_name(name, field)) {
-      TI_DEBUG("Failed to load field {}", name);
-      return nullptr;
-    }
-    return std::make_unique<FieldImpl>(runtime_, field);
-  }
-
   size_t get_root_size() const override {
     return ti_aot_data_.root_buffer_size;
   }
@@ -120,6 +111,15 @@ class AotModuleImpl : public aot::Module {
     }
     auto handle = runtime_->register_taichi_kernel(kparams);
     return std::make_unique<KernelImpl>(runtime_, handle);
+  }
+
+  std::unique_ptr<aot::Field> make_new_field(const std::string &name) override {
+    aot::CompiledFieldData field;
+    if (!get_field_data_by_name(name, field)) {
+      TI_DEBUG("Failed to load field {}", name);
+      return nullptr;
+    }
+    return std::make_unique<FieldImpl>(runtime_, field);
   }
 
   std::vector<uint32_t> read_spv_file(const std::string &output_dir,


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/pull/4437

We should return a raw pointer, not `unique_ptr`. The module object owns the kernel.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
