### PR TITLE
[gui] Hack to make GUI.close() work on macOS

### DIFF
--- a/taichi/gui/cocoa.cpp
+++ b/taichi/gui/cocoa.cpp
@@ -1,5 +1,6 @@
-#include "taichi/common/task.h"
 #include "taichi/gui/gui.h"
+
+#include "taichi/common/task.h"
 #include "taichi/util/bit.h"
 
 #if defined(TI_GUI_COCOA)
@@ -7,6 +8,7 @@
 #include <algorithm>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 
 #include "taichi/platform/mac/objc_api.h"
@@ -422,6 +424,11 @@ void GUI::redraw() {
 }
 
 GUI::~GUI() {
+  if (show_gui) {
+    call(window, "close");
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    process_event();
+  }
 }
 
 TI_NAMESPACE_END


### PR DESCRIPTION
Had to use this sleeping-hack to make closing the window work. Not sure if there's an event handler we can register to control this behavior much more accurately.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
