### PR TITLE
[test] Eliminate the warnings in test suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
           docker cp ./requirements_test.txt taichi_test:/home/dev/requirements_test.txt
           docker cp shared/dist/ taichi_test:/home/dev/
           docker cp shared/build/ taichi_test:/home/dev/
+          docker cp pyproject.toml taichi_test:/home/dev/
           docker cp tests/ taichi_test:/home/dev/
           docker start -a taichi_test
         env:
@@ -178,6 +179,7 @@ jobs:
           docker cp ./requirements_test.txt taichi_test:/home/dev/requirements_test.txt
           docker cp shared/dist/ taichi_test:/home/dev/
           docker cp shared/build/ taichi_test:/home/dev/
+          docker cp pyproject.toml taichi_test:/home/dev/
           docker cp tests/ taichi_test:/home/dev/
           docker start -a taichi_test
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -221,6 +221,7 @@ jobs:
           docker cp shared/build/ taichi_test:/home/dev/
           docker cp ./requirements_test.txt taichi_test:/home/dev/requirements_test.txt
           docker cp tests/ taichi_test:/home/dev/
+          docker cp pyproject.toml taichi_test:/home/dev/
           docker start -a taichi_test
         env:
           PY: ${{ matrix.python }}
@@ -354,6 +355,7 @@ jobs:
           docker cp .github/workflows/scripts/unix_test.sh taichi_test:/home/dev/unix_test.sh
           docker cp shared/dist/ taichi_test:/home/dev/
           docker cp shared/build/ taichi_test:/home/dev/
+          docker cp pyproject.toml taichi_test:/home/dev/
           docker cp tests/ taichi_test:/home/dev/
           docker cp requirements_test.txt taichi_test:/home/dev/requirements_test.txt
           docker start -a taichi_test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy", "pybind11", "cmake"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:Calling non-taichi function",
+    "ignore:`np.int` is a deprecated alias",
+    "ignore:Operator \"is\" in Taichi scope is deprecated",
+    "ignore:Operator \"is not\" in Taichi scope is deprecated"
+]

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -200,7 +200,7 @@ def sort_stage(keys: template(), use_values: int, values: template(), N: int,
                p: int, k: int, invocations: int):
     for inv in range(invocations):
         j = k % p + inv * 2 * k
-        for i in range(0, min(k, N - j - k)):
+        for i in range(0, ops.min(k, N - j - k)):
             a = i + j
             b = i + j + k
             if int(a / (p * 2)) == int(b / (p * 2)):

--- a/python/taichi/examples/rendering/cornell_box.py
+++ b/python/taichi/examples/rendering/cornell_box.py
@@ -171,11 +171,11 @@ def intersect_aabb(box_min, box_max, o, d):
             i1 = (box_min[i] - o[i]) / d[i]
             i2 = (box_max[i] - o[i]) / d[i]
 
-            new_far_t = max(i1, i2)
-            new_near_t = min(i1, i2)
+            new_far_t = ti.max(i1, i2)
+            new_near_t = ti.min(i1, i2)
             new_near_is_max = i2 < i1
 
-            far_t = min(new_far_t, far_t)
+            far_t = ti.min(new_far_t, far_t)
             if new_near_t > near_t:
                 near_t = new_near_t
                 near_face = int(i)
@@ -300,7 +300,7 @@ def visible_to_light(pos, ray_dir):
 
 @ti.func
 def dot_or_zero(n, l):
-    return max(0.0, n.dot(l))
+    return ti.max(0.0, n.dot(l))
 
 
 @ti.func
@@ -360,7 +360,7 @@ def sample_brdf(normal):
     v = normal.cross(u)
     costt, sintt = ti.cos(theta), ti.sin(theta)
     xy = (u * costt + v * sintt) * r
-    zlen = ti.sqrt(max(0.0, 1.0 - xy.dot(xy)))
+    zlen = ti.sqrt(ti.max(0.0, 1.0 - xy.dot(xy)))
     return xy + zlen * normal
 
 
@@ -410,7 +410,7 @@ def sample_ray_dir(indir, normal, hit_pos, mat):
     pdf = 1.0
     if mat == mat_lambertian:
         u = sample_brdf(normal)
-        pdf = max(eps, compute_brdf_pdf(normal, u))
+        pdf = ti.max(eps, compute_brdf_pdf(normal, u))
     elif mat == mat_specular:
         u = reflect(indir, normal)
     elif mat == mat_glass:

--- a/python/taichi/examples/simulation/mpm99.py
+++ b/python/taichi/examples/simulation/mpm99.py
@@ -51,8 +51,8 @@ def substep():
         for d in ti.static(range(2)):
             new_sig = sig[d, d]
             if material[p] == 2:  # Snow
-                new_sig = min(max(sig[d, d], 1 - 2.5e-2),
-                              1 + 4.5e-3)  # Plasticity
+                new_sig = ti.min(ti.max(sig[d, d], 1 - 2.5e-2),
+                                 1 + 4.5e-3)  # Plasticity
             Jp[p] *= sig[d, d] / new_sig
             sig[d, d] = new_sig
             J *= new_sig

--- a/tests/python/test_ad_if.py
+++ b/tests/python/test_ad_if.py
@@ -187,7 +187,7 @@ def test_ad_if_parallel_complex():
 
     @ti.kernel
     def func():
-        ti.parallelize(1)
+        ti.loop_config(parallelize=1)
         for i in range(2):
             t = 0.0
             if x[i] > 0:
@@ -216,7 +216,7 @@ def test_ad_if_parallel_complex_f64():
 
     @ti.kernel
     def func():
-        ti.parallelize(1)
+        ti.loop_config(parallelize=1)
         for i in range(2):
             t = 0.0
             if x[i] > 0:

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -417,8 +417,8 @@ def test_mpm99_aot():
             for d in ti.static(range(2)):
                 new_sig = sig[d, d]
                 if material[p] == 2:  # Snow
-                    new_sig = min(max(sig[d, d], 1 - 2.5e-2),
-                                  1 + 4.5e-3)  # Plasticity
+                    new_sig = ti.min(ti.max(sig[d, d], 1 - 2.5e-2),
+                                     1 + 4.5e-3)  # Plasticity
                 Jp[p] *= sig[d, d] / new_sig
                 sig[d, d] = new_sig
                 J *= new_sig

--- a/tests/python/test_ast_refactor.py
+++ b/tests/python/test_ast_refactor.py
@@ -171,7 +171,7 @@ def test_compare_fail():
 
         @ti.kernel
         def foo():
-            1 is [1]
+            None is None
 
         foo()
 

--- a/tests/python/test_element_wise.py
+++ b/tests/python/test_element_wise.py
@@ -335,7 +335,7 @@ def test_ternary_i(is_mat):
 
     @ti.kernel
     def func():
-        x[0] = z[None] if y[None] else w[None]
+        x[0] = ti.select(y[None], z[None], w[None])
 
     func()
     x = x.to_numpy()

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -87,7 +87,7 @@ def test_from_torch():
     n = 16
     y = ti.field(dtype=ti.f16, shape=n)
     # torch doesn't have rand implementation for float16 so we need to create float first and then convert
-    x = torch.range(0, n - 1).to(torch.float16)
+    x = torch.arange(0, n).to(torch.float16)
     y.from_torch(x)
 
     @ti.kernel

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -26,7 +26,7 @@ def test_save_image_without_window(dtype):
         gui.set_image(pixels)
         image_path = test_utils.make_temp_file(suffix='.png')
         gui.show(image_path)
-        image = ti.imread(image_path)
+        image = ti.tools.imread(image_path)
         delta = (image - i).sum()
         assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(
             delta)

--- a/tests/python/test_image_io.py
+++ b/tests/python/test_image_io.py
@@ -28,10 +28,10 @@ def test_image_io(resx, resy, comp, ext, is_field, dt):
         pixel_t.from_numpy(pixel)
     fn = test_utils.make_temp_file(suffix='.' + ext)
     if is_field:
-        ti.imwrite(pixel_t, fn)
+        ti.tools.imwrite(pixel_t, fn)
     else:
-        ti.imwrite(pixel, fn)
-    pixel_r = ti.imread(fn)
+        ti.tools.imwrite(pixel, fn)
+    pixel_r = ti.tools.imread(fn)
     if comp == 1:
         # from (resx, resy, 1) to (resx, resy)
         pixel_r = pixel_r.reshape((resx, resy))
@@ -49,8 +49,8 @@ def test_image_io_vector(resx, resy, comp, ext, dt):
     pixel_t = ti.Vector.field(comp, dt, shape)
     pixel_t.from_numpy(pixel)
     fn = test_utils.make_temp_file(suffix='.' + ext)
-    ti.imwrite(pixel_t, fn)
-    pixel_r = (ti.imread(fn).astype(to_numpy_type(dt)) + 0.5) / 256.0
+    ti.tools.imwrite(pixel_t, fn)
+    pixel_r = (ti.tools.imread(fn).astype(to_numpy_type(dt)) + 0.5) / 256.0
     assert np.allclose(pixel_r, pixel, atol=2e-2)
     os.remove(fn)
 
@@ -69,8 +69,8 @@ def test_image_io_uint(resx, resy, comp, ext, dt):
     pixel_t = ti.Vector.field(comp, dt, shape)
     pixel_t.from_numpy(pixel)
     fn = test_utils.make_temp_file(suffix='.' + ext)
-    ti.imwrite(pixel_t, fn)
-    pixel_r = ti.imread(fn).astype(np_type) * np_max
+    ti.tools.imwrite(pixel_t, fn)
+    pixel_r = ti.tools.imread(fn).astype(np_type) * np_max
     assert (pixel_r == pixel).all()
     os.remove(fn)
 
@@ -85,7 +85,7 @@ def test_image_resize_sum(resx, resy, comp, scale):
         shape = shape + (comp, )
     old_img = np.random.rand(*shape).astype(np.float32)
     if resx == resy:
-        new_img = ti.imresize(old_img, resx * scale)
+        new_img = ti.tools.imresize(old_img, resx * scale)
     else:
-        new_img = ti.imresize(old_img, resx * scale, resy * scale)
+        new_img = ti.tools.imresize(old_img, resx * scale, resy * scale)
     assert np.sum(old_img) * scale**2 == test_utils.approx(np.sum(new_img))

--- a/tests/python/test_mpm_particle_list.py
+++ b/tests/python/test_mpm_particle_list.py
@@ -32,7 +32,7 @@ class MPMSolver:
 
     @ti.kernel
     def build_pid(self):
-        ti.block_dim(256)
+        ti.loop_config(block_dim=256)
         for p in self.x:
             base = ti.floor(self.x[p] * self.inv_dx - 0.5).cast(int) + 1
             ti.append(self.pid.parent(), base, p)

--- a/tests/python/test_native_functions.py
+++ b/tests/python/test_native_functions.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import taichi as ti
 from tests import test_utils
@@ -71,7 +72,10 @@ def test_minmax():
         y[i] = N - i
         z[i] = i - 2 if i % 2 else i + 2
 
-    func()
+    with pytest.warns(DeprecationWarning,
+                      match="Calling builtin function") as records:
+        func()
+    assert len(records) > 0
 
     assert np.allclose(
         minimum.to_numpy(),

--- a/tests/python/test_parallel_range_for.py
+++ b/tests/python/test_parallel_range_for.py
@@ -10,8 +10,7 @@ def test_parallel_range_for():
 
     @ti.kernel
     def fill():
-        ti.loop_config(parallelize=8)
-        ti.loop_config(block_dim=8)
+        ti.loop_config(parallelize=8, block_dim=8)
         for i in range(n):
             val[i] = i
 

--- a/tests/python/test_parallel_range_for.py
+++ b/tests/python/test_parallel_range_for.py
@@ -10,8 +10,8 @@ def test_parallel_range_for():
 
     @ti.kernel
     def fill():
-        ti.parallelize(8)
-        ti.block_dim(8)
+        ti.loop_config(parallelize=8)
+        ti.loop_config(block_dim=8)
         for i in range(n):
             val[i] = i
 
@@ -27,7 +27,7 @@ def test_serial_for():
     @ti.kernel
     def foo() -> ti.i32:
         a = 0
-        ti.serialize()
+        ti.loop_config(serialize=True)
         for i in range(100):
             a = a + 1
             if a == 50:

--- a/tests/python/test_simple_matrix_slice.py
+++ b/tests/python/test_simple_matrix_slice.py
@@ -55,14 +55,14 @@ def test_no_dyn():
     with pytest.raises(
             ti.TaichiCompilationError,
             match=
-            'The 0-th index of a Matrix/Vector must be a compile-time constant '
-            "integer, got <class 'taichi.lang.expr.Expr'>.\n"
-            'This is because matrix operations will be \*\*unrolled\*\* at compile-time '
-            'for performance reason.\n'
-            'If you want to \*iterate through matrix elements\*, use a static range:\n'
-            '  for i in ti.static\(range\(3\)\):\n'
-            '    print\(i, "-th component is", vec\[i\]\)\n'
-            'See https://docs.taichi.graphics/lang/articles/advanced/meta#when-to-use-for-loops-with-tistatic for more details.'
-            'Or turn on ti.init\(..., dynamic_index=True\) to support indexing with variables!'
+            r'The 0-th index of a Matrix/Vector must be a compile-time constant '
+            r"integer, got <class 'taichi.lang.expr.Expr'>.\n"
+            r'This is because matrix operations will be \*\*unrolled\*\* at compile-time '
+            r'for performance reason.\n'
+            r'If you want to \*iterate through matrix elements\*, use a static range:\n'
+            r'  for i in ti.static\(range\(3\)\):\n'
+            r'    print\(i, "-th component is", vec\[i\]\)\n'
+            r'See https://docs.taichi.graphics/lang/articles/advanced/meta#when-to-use-for-loops-with-tistatic for more details.'
+            r'Or turn on ti.init\(..., dynamic_index=True\) to support indexing with variables!'
     ):
         test_one_col_slice()


### PR DESCRIPTION
There are lots of warnings after test run:

```
tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
  /home/dev/miniconda/envs/py39/lib/python3.9/site-packages/taichi/examples/rendering/cornell_box.py:303: DeprecationWarning: Calling builtin function "max" in Taichi scope is deprecated. Please use "ti.max" instead.
    return max(0.0, n.dot(l))

tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
  /home/dev/miniconda/envs/py39/lib/python3.9/site-packages/taichi/examples/rendering/cornell_box.py:363: DeprecationWarning: Calling builtin function "max" in Taichi scope is deprecated. Please use "ti.max" instead.
    zlen = ti.sqrt(max(0.0, 1.0 - xy.dot(xy)))

tests/python/examples/rendering/test_cornell_box.py::test_cornell_box[none]
  /home/dev/miniconda/envs/py39/lib/python3.9/site-packages/taichi/examples/rendering/cornell_box.py:413: DeprecationWarning: Calling builtin function "max" in Taichi scope is deprecated. Please use "ti.max" instead.
    pdf = max(eps, compute_brdf_pdf(normal, u))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========= 3258 passed, 44 skipped, 671 warnings in 1514.03s (0:25:14) ==========
```

This PR is to eliminate ALL of them.

## After change

```
================ 3258 passed, 44 skipped in 1274.81s (0:21:14) =================
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
