### PR TITLE
[build] Guard llvm usage inside TI_WITH_LLVM

### DIFF
--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -15,8 +15,10 @@
 #include "taichi/ir/type_factory.h"
 #include "taichi/util/short_name.h"
 
+#ifdef TI_WITH_LLVM
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/MapVector.h"
+#endif
 
 namespace taichi {
 namespace lang {
@@ -105,8 +107,11 @@ class Identifier {
   }
 };
 
+#ifdef TI_WITH_LLVM
 using stmt_vector = llvm::SmallVector<pStmt, 8>;
-// using stmt_vector = std::vector<pStmt>;
+#else
+using stmt_vector = std::vector<pStmt>;
+#endif
 
 class VecStatement {
  public:


### PR DESCRIPTION
Related issue = #
Fixing the build breakage for libtaichi_export_core.so. 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
