### PR TITLE
[aot] Remove redundant module_path argument

### DIFF
--- a/taichi/aot/module_loader.cpp
+++ b/taichi/aot/module_loader.cpp
@@ -29,9 +29,7 @@ Kernel *KernelTemplate::get_kernel(
   return kptr;
 }
 
-std::unique_ptr<Module> Module::load(const std::string &path,
-                                     Arch arch,
-                                     std::any mod_params) {
+std::unique_ptr<Module> Module::load(Arch arch, std::any mod_params) {
   if (arch == Arch::vulkan) {
 #ifdef TI_WITH_VULKAN
     return vulkan::make_aot_module(mod_params);

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -97,9 +97,7 @@ class TI_DLL_EXPORT Module {
   Module(Module &&) = default;
   Module &operator=(Module &&) = default;
 
-  static std::unique_ptr<Module> load(const std::string &path,
-                                      Arch arch,
-                                      std::any mod_params);
+  static std::unique_ptr<Module> load(Arch arch, std::any mod_params);
 
   // Module metadata
   // TODO: Instead of virtualize these simple properties, just store them as

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -124,7 +124,7 @@ TEST(AotSaveLoad, Vulkan) {
   mod_params.runtime = vulkan_runtime.get();
 
   std::unique_ptr<aot::Module> vk_module =
-      aot::Module::load(".", Arch::vulkan, mod_params);
+      aot::Module::load(Arch::vulkan, mod_params);
   EXPECT_TRUE(vk_module);
 
   // Retrieve kernels/fields/etc from AOT module


### PR DESCRIPTION
We already pass module path inside mod_params so it's redundant for
`load()` to take module_path.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
