### PR TITLE
[test] Fix ill-formed test_binary_func_ret

### DIFF
--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -29,12 +29,11 @@ def test_const_func_ret():
     assert func2() == 3
 
 
-@pytest.mark.parametrize("dt1,dt2,dt3,castor", [
-    (ti.i32, ti.f32, ti.f32, float),
-    (ti.f32, ti.i32, ti.f32, float),
-    (ti.i32, ti.f32, ti.i32, int),
-    (ti.f32, ti.i32, ti.i32, int)
-])
+@pytest.mark.parametrize("dt1,dt2,dt3,castor",
+                         [(ti.i32, ti.f32, ti.f32, float),
+                          (ti.f32, ti.i32, ti.f32, float),
+                          (ti.i32, ti.f32, ti.i32, int),
+                          (ti.f32, ti.i32, ti.i32, int)])
 @test_utils.test()
 def test_binary_func_ret(dt1, dt2, dt3, castor):
     @ti.kernel

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -29,8 +29,14 @@ def test_const_func_ret():
     assert func2() == 3
 
 
+@pytest.mark.parametrize("dt1,dt2,dt3,castor", [
+    (ti.i32, ti.f32, ti.f32, float),
+    (ti.f32, ti.i32, ti.f32, float),
+    (ti.i32, ti.f32, ti.i32, int),
+    (ti.f32, ti.i32, ti.i32, int)
+])
 @test_utils.test()
-def _test_binary_func_ret(dt1, dt2, dt3, castor):
+def test_binary_func_ret(dt1, dt2, dt3, castor):
     @ti.kernel
     def func(a: dt1, b: dt2) -> dt3:
         return a * b
@@ -47,13 +53,6 @@ def _test_binary_func_ret(dt1, dt2, dt3, castor):
 
     for x, y in zip(xs, ys):
         assert func(x, y) == test_utils.approx(castor(x * y))
-
-
-def test_binary_func_ret():
-    _test_binary_func_ret(ti.i32, ti.f32, ti.f32, float)
-    _test_binary_func_ret(ti.f32, ti.i32, ti.f32, float)
-    _test_binary_func_ret(ti.i32, ti.f32, ti.i32, int)
-    _test_binary_func_ret(ti.f32, ti.i32, ti.i32, int)
 
 
 @test_utils.test()


### PR DESCRIPTION
`test_binary_func_ret` doesn't conform to the new rules for writing tests (#4546) and seems causing troubles in nightly tests (https://github.com/taichi-dev/taichi/runs/5620468486?check_suite_focus=true). This PR fixes it.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
