### PR TITLE
[misc] Write version info right after creation of uuid

### DIFF
--- a/python/taichi/_version_check.py
+++ b/python/taichi/_version_check.py
@@ -91,7 +91,8 @@ def try_check_version():
                                    cur_date)
         else:
             cur_uuid = str(uuid.uuid4())
-            write_version_info({'status':0}, cur_uuid, version_info_path, cur_date)
+            write_version_info({'status': 0}, cur_uuid, version_info_path,
+                               cur_date)
             response = check_version(cur_uuid)
             write_version_info(response, cur_uuid, version_info_path, cur_date)
     # Wildcard exception to catch potential file writing errors.

--- a/python/taichi/_version_check.py
+++ b/python/taichi/_version_check.py
@@ -91,6 +91,7 @@ def try_check_version():
                                    cur_date)
         else:
             cur_uuid = str(uuid.uuid4())
+            write_version_info({'status':0}, cur_uuid, version_info_path, cur_date)
             response = check_version(cur_uuid)
             write_version_info(response, cur_uuid, version_info_path, cur_date)
     # Wildcard exception to catch potential file writing errors.


### PR DESCRIPTION
 To prevent creation of file only happens after success of server response.
Some Taichi program's execution time won't last to listen to server response.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
