### PR TITLE
[android] Disable XDG on non-supported platform

### DIFF
--- a/taichi/common/core.cpp
+++ b/taichi/common/core.cpp
@@ -30,6 +30,11 @@ void set_python_package_dir(const std::string &dir) {
 std::string get_repo_dir() {
 #if defined(TI_PLATFORM_WINDOWS)
   return "C:/taichi_cache/";
+#elif defined(TI_PLATFORM_ANDROID)
+  // @FIXME: Not supported on Android. A possibility would be to return the
+  // application cache directory. This feature is not used yet on this OS so
+  // it should not break anything (yet!)
+  return "";
 #else
   auto xdg_cache = std::getenv("XDG_CACHE_HOME");
 


### PR DESCRIPTION
XDG is not support on Android and there is no home directory so for now,
we just 'disable' it by returning an empty string.
This is not called/used on Android.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
