### PR TITLE
[SIMT] Add shfl_up_i32/f32 warp intrinsics

### DIFF
--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -28,7 +28,8 @@ def shfl_i32(mask, val, offset):
 
 
 def shfl_down_i32(mask, val, offset):
-    # we use 31 as the last argument since 32 (warp size) does not work
+    # Here we use 31 as the last argument since 32 (warp size) does not work
+    # for some reason. Using 31 leads to the desired behavior.
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_down_sync_i32",

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -41,6 +41,7 @@ def shfl_up_i32(mask, val, offset):
             "cuda_shfl_up_sync_i32",
             expr.make_expr_group(mask, val, offset, 32), False))
 
+
 def shfl_up_f32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -28,6 +28,7 @@ def shfl_i32(mask, val, offset):
 
 
 def shfl_down_i32(mask, val, offset):
+    # we use 31 as the last argument since 32 (warp size) does not work
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_down_sync_i32",
@@ -35,8 +36,16 @@ def shfl_down_i32(mask, val, offset):
 
 
 def shfl_up_i32(mask, val, offset):
-    # TODO
-    pass
+    return expr.Expr(
+        _ti_core.insert_internal_func_call(
+            "cuda_shfl_up_sync_i32",
+            expr.make_expr_group(mask, val, offset, 32), False))
+
+def shfl_up_f32(mask, val, offset):
+    return expr.Expr(
+        _ti_core.insert_internal_func_call(
+            "cuda_shfl_up_sync_f32",
+            expr.make_expr_group(mask, val, offset, 32), False))
 
 
 def shfl_xor_i32(mask, val, offset):

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -365,6 +365,9 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_module(
     patch_intrinsic("cuda_shfl_down_sync_f32",
                     Intrinsic::nvvm_shfl_sync_down_f32);
 
+    patch_intrinsic("cuda_shfl_up_sync_i32", Intrinsic::nvvm_shfl_sync_up_i32);
+    patch_intrinsic("cuda_shfl_up_sync_f32", Intrinsic::nvvm_shfl_sync_up_f32);
+
     patch_intrinsic("cuda_match_any_sync_i32",
                     Intrinsic::nvvm_match_any_sync_i32);
 

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1028,6 +1028,14 @@ f32 cuda_shfl_down_f32(i32 delta, f32 val, int width) {
   return 0;
 }
 
+i32 cuda_shfl_up_sync_i32(u32 mask, i32 val, i32 delta, int width) {
+  return 0;
+}
+
+f32 cuda_shfl_up_sync_f32(u32 mask, f32 val, i32 delta, int width) {
+  return 0;
+}
+
 int32 cuda_ballot_sync(int32 mask, bool bit) {
   return 0;
 }

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -77,7 +77,7 @@ def test_shfl_up_i32():
 
     foo()
 
-    for i in range(1, 31):
+    for i in range(1, 32):
         assert a[i] == (i - 1) * (i - 1)
 
 

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -96,7 +96,7 @@ def test_shfl_up_f32():
 
     foo()
 
-    for i in range(1, 31):
+    for i in range(1, 32):
         assert a[i] == approx((i - 1) * (i - 1) * 0.9, abs=1e-4)
 
 

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -1,6 +1,7 @@
+from pytest import approx
+
 import taichi as ti
 from tests import test_utils
-from pytest import approx
 
 
 @test_utils.test(arch=ti.cuda)
@@ -72,12 +73,12 @@ def test_shfl_up_i32():
             a[i] = ti.simt.warp.shfl_up_i32(ti.u32(0xFFFFFFFF), a[i], 1)
 
     for i in range(32):
-        a[i] = i*i
+        a[i] = i * i
 
     foo()
 
     for i in range(1, 31):
-        assert a[i] == (i-1)*(i-1)
+        assert a[i] == (i - 1) * (i - 1)
 
 
 @test_utils.test(arch=ti.cuda)
@@ -91,12 +92,12 @@ def test_shfl_up_f32():
             a[i] = ti.simt.warp.shfl_up_f32(ti.u32(0xFFFFFFFF), a[i], 1)
 
     for i in range(32):
-        a[i] = i*i*0.9
+        a[i] = i * i * 0.9
 
     foo()
 
     for i in range(1, 31):
-        assert a[i] == approx((i-1)*(i-1)*0.9, abs=1e-4)
+        assert a[i] == approx((i - 1) * (i - 1) * 0.9, abs=1e-4)
 
 
 @test_utils.test(arch=ti.cuda)

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -1,5 +1,6 @@
 import taichi as ti
 from tests import test_utils
+from pytest import approx
 
 
 @test_utils.test(arch=ti.cuda)
@@ -58,6 +59,44 @@ def test_shfl_down_i32():
         assert a[i] == b[i + 1]
 
     # TODO: make this test case stronger
+
+
+@test_utils.test(arch=ti.cuda)
+def test_shfl_up_i32():
+    a = ti.field(dtype=ti.i32, shape=32)
+
+    @ti.kernel
+    def foo():
+        ti.loop_config(block_dim=32)
+        for i in range(32):
+            a[i] = ti.simt.warp.shfl_up_i32(ti.u32(0xFFFFFFFF), a[i], 1)
+
+    for i in range(32):
+        a[i] = i*i
+
+    foo()
+
+    for i in range(1, 31):
+        assert a[i] == (i-1)*(i-1)
+
+
+@test_utils.test(arch=ti.cuda)
+def test_shfl_up_f32():
+    a = ti.field(dtype=ti.f32, shape=32)
+
+    @ti.kernel
+    def foo():
+        ti.loop_config(block_dim=32)
+        for i in range(32):
+            a[i] = ti.simt.warp.shfl_up_f32(ti.u32(0xFFFFFFFF), a[i], 1)
+
+    for i in range(32):
+        a[i] = i*i*0.9
+
+    foo()
+
+    for i in range(1, 31):
+        assert a[i] == approx((i-1)*(i-1)*0.9, abs=1e-4)
 
 
 @test_utils.test(arch=ti.cuda)


### PR DESCRIPTION
Add `shfl_up_i32` and `shfl_up_f32` intrinsics for cuda backend. Related issue = #4631 .


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
