### PR TITLE
[SIMT] Add shfl_xor_i32 warp intrinsics

### DIFF
--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -62,8 +62,10 @@ def shfl_up_f32(mask, val, offset):
 
 
 def shfl_xor_i32(mask, val, offset):
-    # TODO
-    pass
+    return expr.Expr(
+        _ti_core.insert_internal_func_call(
+            "cuda_shfl_xor_sync_i32",
+            expr.make_expr_group(mask, val, offset, 31), False))
 
 
 def match_any():

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -372,6 +372,9 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_module(
 
     patch_intrinsic("cuda_shfl_sync_f32", Intrinsic::nvvm_shfl_sync_idx_f32);
 
+    patch_intrinsic("cuda_shfl_xor_sync_i32",
+                    Intrinsic::nvvm_shfl_sync_bfly_i32);
+
     patch_intrinsic("cuda_match_any_sync_i32",
                     Intrinsic::nvvm_match_any_sync_i32);
 

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1028,6 +1028,10 @@ f32 cuda_shfl_down_f32(i32 delta, f32 val, int width) {
   return 0;
 }
 
+i32 cuda_shfl_xor_sync_i32(u32 mask, i32 val, i32 delta, int width) {
+  return 0;
+}
+
 i32 cuda_shfl_up_sync_i32(u32 mask, i32 val, i32 delta, int width) {
   return 0;
 }

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -100,7 +100,8 @@ def test_shfl_xor_i32():
         for i in range(32):
             for j in range(5):
                 offset = 1 << j
-                a[i] += ti.simt.warp.shfl_xor_i32(ti.u32(0xFFFFFFFF), a[i], offset)
+                a[i] += ti.simt.warp.shfl_xor_i32(ti.u32(0xFFFFFFFF), a[i],
+                                                  offset)
 
     value = 0
     for i in range(32):

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -91,6 +91,29 @@ def test_shfl_up_i32():
 
 
 @test_utils.test(arch=ti.cuda)
+def test_shfl_xor_i32():
+    a = ti.field(dtype=ti.i32, shape=32)
+
+    @ti.kernel
+    def foo():
+        ti.loop_config(block_dim=32)
+        for i in range(32):
+            for j in range(5):
+                offset = 1 << j
+                a[i] += ti.simt.warp.shfl_xor_i32(ti.u32(0xFFFFFFFF), a[i], offset)
+
+    value = 0
+    for i in range(32):
+        a[i] = i
+        value += i
+
+    foo()
+
+    for i in range(32):
+        assert a[i] == value
+
+
+@test_utils.test(arch=ti.cuda)
 def test_shfl_down_i32():
     a = ti.field(dtype=ti.i32, shape=32)
     b = ti.field(dtype=ti.i32, shape=32)


### PR DESCRIPTION
Related issue = #4632 
Add shfl_xor_i32 warp intrinsics for cuda backend.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
