### PR TITLE
[Doc] Taichi spec: parenthesized forms; expression lists

### DIFF
--- a/docs/lang/articles/reference.md
+++ b/docs/lang/articles/reference.md
@@ -121,7 +121,7 @@ are also categorized syntactically as atoms.
 
 ```
 atom      ::= identifier | literal | enclosure
-enclosure ::= parenth_form | list_display | dict_display | set_display
+enclosure ::= parenth_form | list_display | dict_display
 ```
 
 #### Identifiers (Names)
@@ -152,11 +152,17 @@ Literals are evaluated to Python values at compile time.
 
 #### Parenthesized forms
 
-#### Displays for lists, sets and dictionaries
+```
+parenth_form ::=  "(" [expression_list] ")"
+```
+
+A parenthesized expression list is evaluated to whatever the expression list is
+evaluated to. An empty pair of parentheses is evaluated to an empty tuple at
+compile time.
+
+#### Displays for lists and dictionaries
 
 #### List displays
-
-#### Set displays
 
 #### Dictionary displays
 
@@ -193,6 +199,18 @@ Literals are evaluated to Python values at compile time.
 ### Conditional expressions
 
 ### Expression lists
+
+```
+expression_list ::= expression ("," expression)* [","]
+```
+
+Except when part of a list display, an expression list containing at least one
+comma is evaluated to a tuple at compile time. The component expressions are
+evaluated from left to right.
+
+The trailing comma is required only to create a tuple with length 1; it is
+optional in all other cases. A single expression without a trailing comma
+is evaluated to the value of that expression.
 
 ## Simple statements
 

--- a/docs/lang/articles/reference.md
+++ b/docs/lang/articles/reference.md
@@ -153,7 +153,7 @@ Literals are evaluated to Python values at compile time.
 #### Parenthesized forms
 
 ```
-parenth_form ::=  "(" [expression_list] ")"
+parenth_form ::= "(" [expression_list] ")"
 ```
 
 A parenthesized expression list is evaluated to whatever the expression list is


### PR DESCRIPTION
Related issue = #4602

Subsection "set displays" is removed by the way because it is not supported in Taichi.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
