### PR TITLE
[CUDA] Fix the fp32 to fp64 promotion due to incorrect fmax/fmin call

### DIFF
--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1100,14 +1100,14 @@ i32 op_min_i32(i32 a, i32 b) {
   return fmin(a, b);
 }
 f32 op_min_f32(f32 a, f32 b) {
-  return fmin(a, b);
+  return fminf(a, b);
 }
 
 i32 op_max_i32(i32 a, i32 b) {
   return fmax(a, b);
 }
 f32 op_max_f32(f32 a, f32 b) {
-  return fmax(a, b);
+  return fmaxf(a, b);
 }
 
 i32 op_and_i32(i32 a, i32 b) {

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1097,17 +1097,17 @@ f32 op_add_f32(f32 a, f32 b) {
 }
 
 i32 op_min_i32(i32 a, i32 b) {
-  return fmin(a, b);
+  return std::min(a, b);
 }
 f32 op_min_f32(f32 a, f32 b) {
-  return fminf(a, b);
+  return std::min(a, b);
 }
 
 i32 op_max_i32(i32 a, i32 b) {
-  return fmax(a, b);
+  return std::max(a, b);
 }
 f32 op_max_f32(f32 a, f32 b) {
-  return fmaxf(a, b);
+  return std::max(a, b);
 }
 
 i32 op_and_i32(i32 a, i32 b) {


### PR DESCRIPTION
Related issue = #4659

The precision promotion in fp32 min/max reduction is caused by the `fmax` func which actually has fp64 type. [Reference](https://en.cppreference.com/w/c/numeric/math/fmax)

Fix by changing fmin / fmax to fminf / fmaxf.