### PR TITLE
[Doc] Taichi spec: list and dictionary displays

### DIFF
--- a/docs/lang/articles/reference.md
+++ b/docs/lang/articles/reference.md
@@ -171,7 +171,7 @@ display is one of:
 compute the container items.
 
 ```
-list_display ::=  "[" [expression_list | list_comprehension] "]"
+list_display       ::= "[" [expression_list | list_comprehension] "]"
 list_comprehension ::= assignment_expression comp_for
 
 dict_display       ::= "{" [key_datum_list | dict_comprehension] "}"

--- a/docs/lang/articles/reference.md
+++ b/docs/lang/articles/reference.md
@@ -160,11 +160,33 @@ A parenthesized expression list is evaluated to whatever the expression list is
 evaluated to. An empty pair of parentheses is evaluated to an empty tuple at
 compile time.
 
-#### Displays for lists and dictionaries
+#### List and dictionary displays
 
-#### List displays
+Taichi supports
+[displays](https://docs.python.org/3/reference/expressions.html#displays-for-lists-sets-and-dictionaries)
+for container (list and dictionary only) construction. Like in Python, a
+display is one of:
+- listing the container items explicitly;
+- providing a *comprehension* (a set of looping and filtering instructions) to
+compute the container items.
 
-#### Dictionary displays
+```
+list_display ::=  "[" [expression_list | list_comprehension] "]"
+list_comprehension ::= assignment_expression comp_for
+
+dict_display       ::= "{" [key_datum_list | dict_comprehension] "}"
+key_datum_list     ::= key_datum ("," key_datum)* [","]
+key_datum          ::= expression ":" expression
+dict_comprehension ::= key_datum comp_for
+
+comp_for           ::= "for" target_list "in" or_test [comp_iter]
+comp_iter          ::= comp_for | comp_if
+comp_if            ::= "if" or_test [comp_iter]
+```
+
+The semantics of list and dict displays in Taichi mainly follow Python. Note
+that they are evaluated at compile time, so all expressions in `comp_for`,
+as well as keys in `key_datum`, are required to be evaluated to Python values.
 
 ### Primaries
 

--- a/docs/lang/articles/reference.md
+++ b/docs/lang/articles/reference.md
@@ -188,6 +188,17 @@ The semantics of list and dict displays in Taichi mainly follow Python. Note
 that they are evaluated at compile time, so all expressions in `comp_for`,
 as well as keys in `key_datum`, are required to be evaluated to Python values.
 
+For example, in the following code snippet, `a` can be successfully defined
+while `b` cannot because `p` cannot be evaluated to a Python value at compile
+time.
+
+```python
+@ti.kernel
+def test(p: ti.i32):
+    a = ti.Matrix([i * p for i in range(10)])  # valid
+    b = ti.Matrix([i * p for i in range(p)])  # compile error
+```
+
 ### Primaries
 
 #### Attribute references


### PR DESCRIPTION
Related issue = #4602

The three subsections, `Displays for lists and dictionaries`, `List displays` and `Dictionary displays` in the original plan are merged into one `List and dictionary displays` subsection because we don't have to repeat many parts same as Python.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
