### PR TITLE
[misc] Temporarily disable a flaky test

### DIFF
--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -153,7 +153,7 @@ def _test_closing_offline_cache_for_a_kernel(curr_arch, kernel, args, result):
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)
-def test_closing_offline_cache(curr_arch):
+def _test_closing_offline_cache(curr_arch):
     for kernel, args, get_res in simple_kernels_to_test:
         _test_closing_offline_cache_for_a_kernel(curr_arch=curr_arch,
                                                  kernel=kernel,


### PR DESCRIPTION
https://github.com/taichi-dev/taichi/runs/5750005177?check_suite_focus=true shows that `test_closing_offline_cache` fails on Python 3.10.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
