### PR TITLE
[Lang] Support sparse matrix datatype and storage format configuration

### DIFF
--- a/misc/sparse_matrix.py
+++ b/misc/sparse_matrix.py
@@ -13,8 +13,8 @@ def fill(A: ti.types.sparse_matrix_builder(),
          b: ti.types.sparse_matrix_builder(), interval: ti.i32):
     for i in range(n):
         if i > 0:
-            A[i - 1, i] += -1.0
-            A[i, i] += 1
+            A[i - 1, i] += -2.0
+            A[i, i] += 1.0
         if i < n - 1:
             A[i + 1, i] += -1.0
             A[i, i] += 1.0
@@ -33,32 +33,36 @@ A = K.build()
 print(">>>> A = K.build()")
 print(A)
 
-print(">>>> Summation: C = A + A")
-C = A + A
+print(">>>> Summation: B = A + A")
+B = A + A
+print(B)
+
+print(">>>> Summation: B += A")
+B += A
+print(B)
+
+print(">>>> Subtraction: C = B - A")
+C = B - A
 print(C)
 
-print(">>>> Multiplication with a scalar on the right: E = A * 3.0")
-E = A * 3.0
-print(E)
+print(">>>> Subtraction: C -= A")
+C -= A
+print(C)
 
-print(">>>> Multiplication with a scalar on the left: E = 3.0 * A")
-E = 3.0 * A
-print(E)
-
-print(">>>> Subtraction: D = A - A")
-D = A - A
+print(">>>> Multiplication with a scalar on the right: D = A * 3.0")
+D = A * 3.0
 print(D)
 
-# print(">>>> Transpose: F = A.transpose()")
-# F = A.transpose()
-# print(F)
+print(">>>> Multiplication with a scalar on the left: D = 3.0 * A")
+D = 3.0 * A
+print(D)
 
-# print(">>>> Matrix multiplication: G = E @ A")
-# G = E @ A
-# print(G)
+print(">>>> Transpose: E = D.transpose()")
+E = D.transpose()
+print(E)
 
-# print(">>>> Element-wise multiplication: H = E * A")
-# H = E * A
-# print(H)
+print(">>>> Matrix multiplication: F= E @ A")
+F = E @ A
+print(F)
 
-# print(f">>>> Element Access: A[0,0] = {A[0,0]}")
+print(f">>>> Element Access: F[0,0] = {F[0,0]}")

--- a/misc/sparse_matrix.py
+++ b/misc/sparse_matrix.py
@@ -4,8 +4,16 @@ ti.init(arch=ti.x64)
 
 n = 8
 
-K = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=100)
-f = ti.linalg.SparseMatrixBuilder(n, 1, max_num_triplets=100)
+K = ti.linalg.SparseMatrixBuilder(n,
+                                  n,
+                                  max_num_triplets=100,
+                                  dtype=ti.f32,
+                                  storage_format='col_major')
+f = ti.linalg.SparseMatrixBuilder(n,
+                                  1,
+                                  max_num_triplets=100,
+                                  dtype=ti.f32,
+                                  storage_format='col_major')
 
 
 @ti.kernel

--- a/misc/sparse_matrix.py
+++ b/misc/sparse_matrix.py
@@ -37,17 +37,17 @@ print(">>>> Summation: C = A + A")
 C = A + A
 print(C)
 
-# print(">>>> Subtraction: D = A - A")
-# D = A - A
-# print(D)
+print(">>>> Multiplication with a scalar on the right: E = A * 3.0")
+E = A * 3.0
+print(E)
 
-# print(">>>> Multiplication with a scalar on the right: E = A * 3.0")
-# E = A * 3.0
-# print(E)
+print(">>>> Multiplication with a scalar on the left: E = 3.0 * A")
+E = 3.0 * A
+print(E)
 
-# print(">>>> Multiplication with a scalar on the left: E = 3.0 * A")
-# E = 3.0 * A
-# print(E)
+print(">>>> Subtraction: D = A - A")
+D = A - A
+print(D)
 
 # print(">>>> Transpose: F = A.transpose()")
 # F = A.transpose()

--- a/misc/sparse_matrix.py
+++ b/misc/sparse_matrix.py
@@ -33,32 +33,32 @@ A = K.build()
 print(">>>> A = K.build()")
 print(A)
 
-print(">>>> Summation: C = A + A")
-C = A + A
-print(C)
+# print(">>>> Summation: C = A + A")
+# C = A + A
+# print(C)
 
-print(">>>> Subtraction: D = A - A")
-D = A - A
-print(D)
+# print(">>>> Subtraction: D = A - A")
+# D = A - A
+# print(D)
 
-print(">>>> Multiplication with a scalar on the right: E = A * 3.0")
-E = A * 3.0
-print(E)
+# print(">>>> Multiplication with a scalar on the right: E = A * 3.0")
+# E = A * 3.0
+# print(E)
 
-print(">>>> Multiplication with a scalar on the left: E = 3.0 * A")
-E = 3.0 * A
-print(E)
+# print(">>>> Multiplication with a scalar on the left: E = 3.0 * A")
+# E = 3.0 * A
+# print(E)
 
-print(">>>> Transpose: F = A.transpose()")
-F = A.transpose()
-print(F)
+# print(">>>> Transpose: F = A.transpose()")
+# F = A.transpose()
+# print(F)
 
-print(">>>> Matrix multiplication: G = E @ A")
-G = E @ A
-print(G)
+# print(">>>> Matrix multiplication: G = E @ A")
+# G = E @ A
+# print(G)
 
-print(">>>> Element-wise multiplication: H = E * A")
-H = E * A
-print(H)
+# print(">>>> Element-wise multiplication: H = E * A")
+# H = E * A
+# print(H)
 
-print(f">>>> Element Access: A[0,0] = {A[0,0]}")
+# print(f">>>> Element Access: A[0,0] = {A[0,0]}")

--- a/misc/sparse_matrix.py
+++ b/misc/sparse_matrix.py
@@ -33,9 +33,9 @@ A = K.build()
 print(">>>> A = K.build()")
 print(A)
 
-# print(">>>> Summation: C = A + A")
-# C = A + A
-# print(C)
+print(">>>> Summation: C = A + A")
+C = A + A
+print(C)
 
 # print(">>>> Subtraction: D = A - A")
 # D = A - A

--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -15,11 +15,17 @@ class SparseMatrix:
         m (int): the second dimension of a sparse matrix.
         sm (SparseMatrix): another sparse matrix that will be built from.
     """
-    def __init__(self, n=None, m=None, sm=None, dtype=f32):
+    def __init__(self,
+                 n=None,
+                 m=None,
+                 sm=None,
+                 dtype=f32,
+                 storage_format="col_major"):
         if sm is None:
             self.n = n
             self.m = m if m else n
-            self.matrix = get_runtime().prog.create_sparse_matrix(n, m, dtype)
+            self.matrix = get_runtime().prog.create_sparse_matrix(
+                n, m, dtype, storage_format)
         else:
             self.n = sm.num_rows()
             self.m = sm.num_cols()
@@ -32,8 +38,8 @@ class SparseMatrix:
             The result sparse matrix of the addition.
         """
         assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
-        sm = self.matrix + other.matrix
-        return SparseMatrix(sm=sm)
+        self.matrix += other.matrix
+        return SparseMatrix(sm=self.matrix)
 
     def __sub__(self, other):
         """Subtraction operation for sparse matrix.

--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -48,8 +48,8 @@ class SparseMatrix:
              The result sparse matrix of the subtraction.
         """
         assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
-        sm = self.matrix - other.matrix
-        return SparseMatrix(sm=sm)
+        self.matrix -= other.matrix
+        return SparseMatrix(sm=self.matrix)
 
     def __mul__(self, other):
         """Sparse matrix's multiplication against real numbers or the hadamard product against another matrix
@@ -60,8 +60,8 @@ class SparseMatrix:
             The result of multiplication.
         """
         if isinstance(other, float):
-            sm = self.matrix * other
-            return SparseMatrix(sm=sm)
+            self.matrix *= other
+            return SparseMatrix(sm=self.matrix)
         if isinstance(other, SparseMatrix):
             assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
             sm = self.matrix * other.matrix
@@ -78,8 +78,8 @@ class SparseMatrix:
             The result of multiplication.
         """
         if isinstance(other, float):
-            sm = other * self.matrix
-            return SparseMatrix(sm=sm)
+            self.matrix *= other
+            return SparseMatrix(sm=self.matrix)
 
         return None
 

--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -161,18 +161,21 @@ class SparseMatrixBuilder:
         num_rows (int): the first dimension of a sparse matrix.
         num_cols (int): the second dimension of a sparse matrix.
         max_num_triplets (int): the maximum number of triplets.
+        dtype (ti.dtype): the data type of the sparse matrix.
+        storage_format (str): the storage format of the sparse matrix.
     """
     def __init__(self,
                  num_rows=None,
                  num_cols=None,
                  max_num_triplets=0,
-                 dtype=f32):
+                 dtype=f32,
+                 storage_format="col_major"):
         self.num_rows = num_rows
         self.num_cols = num_cols if num_cols else num_rows
         self.dtype = dtype
         if num_rows is not None:
             self.ptr = get_runtime().prog.create_sparse_matrix_builder(
-                num_rows, num_cols, max_num_triplets, dtype)
+                num_rows, num_cols, max_num_triplets, dtype, storage_format)
 
     def _get_addr(self):
         """Get the address of the sparse matrix"""

--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -19,7 +19,7 @@ class SparseMatrix:
         if sm is None:
             self.n = n
             self.m = m if m else n
-            self.matrix = get_runtime().prog.create_sparse_matrix(n, m)
+            self.matrix = get_runtime().prog.create_sparse_matrix(n, m, dtype)
         else:
             self.n = sm.num_rows()
             self.m = sm.num_cols()

--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -31,7 +31,7 @@ class SparseMatrix:
             self.m = sm.num_cols()
             self.matrix = sm
 
-    def __add__(self, other):
+    def __iadd__(self, other):
         """Addition operation for sparse matrix.
 
         Returns:
@@ -39,7 +39,27 @@ class SparseMatrix:
         """
         assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
         self.matrix += other.matrix
-        return SparseMatrix(sm=self.matrix)
+        return self
+
+    def __add__(self, other):
+        """Addition operation for sparse matrix.
+
+        Returns:
+            The result sparse matrix of the addition.
+        """
+        assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
+        sm = self.matrix + other.matrix
+        return SparseMatrix(sm=sm)
+
+    def __isub__(self, other):
+        """Subtraction operation for sparse matrix.
+
+        Returns:
+             The result sparse matrix of the subtraction.
+        """
+        assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
+        self.matrix -= other.matrix
+        return self
 
     def __sub__(self, other):
         """Subtraction operation for sparse matrix.
@@ -48,8 +68,8 @@ class SparseMatrix:
              The result sparse matrix of the subtraction.
         """
         assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
-        self.matrix -= other.matrix
-        return SparseMatrix(sm=self.matrix)
+        sm = self.matrix - other.matrix
+        return SparseMatrix(sm=sm)
 
     def __mul__(self, other):
         """Sparse matrix's multiplication against real numbers or the hadamard product against another matrix
@@ -60,8 +80,8 @@ class SparseMatrix:
             The result of multiplication.
         """
         if isinstance(other, float):
-            self.matrix *= other
-            return SparseMatrix(sm=self.matrix)
+            sm = other * self.matrix
+            return SparseMatrix(sm=sm)
         if isinstance(other, SparseMatrix):
             assert self.n == other.n and self.m == other.m, f"Dimension mismatch between sparse matrices ({self.n}, {self.m}) and ({other.n}, {other.m})"
             sm = self.matrix * other.matrix
@@ -78,8 +98,8 @@ class SparseMatrix:
             The result of multiplication.
         """
         if isinstance(other, float):
-            self.matrix *= other
-            return SparseMatrix(sm=self.matrix)
+            sm = self.matrix * other
+            return SparseMatrix(sm=sm)
 
         return None
 

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -97,64 +97,6 @@ const std::string EigenSparseMatrix<EigenMatrix>::to_string() const {
   return ostr.str();
 }
 
-// const int SparseMatrix::num_rows() const {
-//   return matrix_.rows();
-// }
-// const int SparseMatrix::num_cols() const {
-//   return matrix_.cols();
-// }
-
-// Eigen::SparseMatrix<float32> &SparseMatrix::get_matrix() {
-//   return matrix_;
-// }
-
-// const Eigen::SparseMatrix<float32> &SparseMatrix::get_matrix() const {
-//   return matrix_;
-// }
-
-
-// SparseMatrix operator-(const SparseMatrix &sm1, const SparseMatrix &sm2) {
-//   Eigen::SparseMatrix<float32> res(sm1.matrix_ - sm2.matrix_);
-//   return SparseMatrix(res);
-// }
-
-// SparseMatrix operator*(float scale, const SparseMatrix &sm) {
-//   Eigen::SparseMatrix<float32> res(scale * sm.matrix_);
-//   return SparseMatrix(res);
-// }
-
-// SparseMatrix operator*(const SparseMatrix &sm, float scale) {
-//   return scale * sm;
-// }
-
-// SparseMatrix operator*(const SparseMatrix &sm1, const SparseMatrix &sm2) {
-//   Eigen::SparseMatrix<float32> res(sm1.matrix_.cwiseProduct(sm2.matrix_));
-//   return SparseMatrix(res);
-// }
-
-// SparseMatrix SparseMatrix::matmul(const SparseMatrix &sm) {
-//   Eigen::SparseMatrix<float32> res(matrix_ * sm.matrix_);
-//   return SparseMatrix(res);
-// }
-
-// Eigen::VectorXf SparseMatrix::mat_vec_mul(
-//     const Eigen::Ref<const Eigen::VectorXf> &b) {
-//   return matrix_ * b;
-// }
-
-// SparseMatrix SparseMatrix::transpose() {
-//   Eigen::SparseMatrix<float32> res(matrix_.transpose());
-//   return SparseMatrix(res);
-// }
-
-// float32 SparseMatrix::get_element(int row, int col) {
-//   return matrix_.coeff(row, col);
-// }
-
-// void SparseMatrix::set_element(int row, int col, float32 value) {
-//   matrix_.coeffRef(row, col) = value;
-// }
-
 template <class EigenMatrix>
 void EigenSparseMatrix<EigenMatrix>::build_triplets(void *triplets_adr) {
   if (taichi::lang::data_type_name(dtype_) == "f32") {

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -88,6 +88,7 @@ void SparseMatrixBuilder::clear() {
 
 template <class EigenMatrix>
 const std::string EigenSparseMatrix<EigenMatrix>::to_string() const {
+  std::cout << "print happended in derived class " << std::endl;
   Eigen::IOFormat clean_fmt(4, 0, ", ", "\n", "[", "]");
   // Note that the code below first converts the sparse matrix into a dense one.
   // https://stackoverflow.com/questions/38553335/how-can-i-print-in-console-a-formatted-sparse-matrix-with-eigen
@@ -172,7 +173,8 @@ std::unique_ptr<SparseMatrix> make_sparse_matrix(
     int cols,
     DataType dt,
     const std::string &storage_format) {
-  if (taichi::lang::data_type_name(dt) == "f32" && storage_format == "cm") {
+  if (taichi::lang::data_type_name(dt) == "f32" &&
+      storage_format == "col_major") {
     using FC = Eigen::SparseMatrix<float, Eigen::ColMajor>;
     return std::make_unique<EigenSparseMatrix<FC>>(rows, cols, dt);
   }

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -86,12 +86,6 @@ void SparseMatrixBuilder::clear() {
   num_triplets_ = 0;
 }
 
-// SparseMatrix::SparseMatrix(Eigen::SparseMatrix<float32> &matrix) {
-//   this->matrix_ = matrix;
-// }
-
-// SparseMatrix::SparseMatrix(int rows, int cols) : matrix_(rows, cols) {
-// }
 template <class EigenMatrix>
 const std::string EigenSparseMatrix<EigenMatrix>::to_string() const {
   Eigen::IOFormat clean_fmt(4, 0, ", ", "\n", "[", "]");

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -112,10 +112,6 @@ const std::string EigenSparseMatrix<EigenMatrix>::to_string() const {
 //   return matrix_;
 // }
 
-// SparseMatrix operator+(const SparseMatrix &sm1, const SparseMatrix &sm2) {
-//   Eigen::SparseMatrix<float32> res(sm1.matrix_ + sm2.matrix_);
-//   return SparseMatrix(res);
-// }
 
 // SparseMatrix operator-(const SparseMatrix &sm1, const SparseMatrix &sm2) {
 //   Eigen::SparseMatrix<float32> res(sm1.matrix_ - sm2.matrix_);

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -50,7 +50,7 @@ void SparseMatrixBuilder::print_triplets() {
 }
 
 template <typename T, typename G>
-SparseMatrix SparseMatrixBuilder::build_template() {
+void SparseMatrixBuilder::build_template(std::unique_ptr<SparseMatrix> &m) {
   using V = Eigen::Triplet<T>;
   std::vector<V> triplets;
   T *data = reinterpret_cast<T *>(data_base_ptr_.get());
@@ -58,25 +58,27 @@ SparseMatrix SparseMatrixBuilder::build_template() {
     triplets.push_back(V(((G *)data)[i * 3], ((G *)data)[i * 3 + 1],
                          taichi_union_cast<T>(data[i * 3 + 2])));
   }
-  SparseMatrix sm(rows_, cols_);
-  sm.get_matrix().setFromTriplets(triplets.begin(), triplets.end());
+  m->build_triplets(static_cast<void *>(&triplets));
   clear();
-  return sm;
 }
 
-SparseMatrix SparseMatrixBuilder::build() {
+std::unique_ptr<SparseMatrix> SparseMatrixBuilder::build() {
   TI_ASSERT(built_ == false);
   built_ = true;
+  auto sm = make_sparse_matrix(rows_, cols_, dtype_, "col");
   auto element_size = data_type_size(dtype_);
   switch (element_size) {
     case 4:
-      return build_template<float32, int32>();
+      build_template<float32, int32>(sm);
+      break;
     case 8:
-      return build_template<float64, int64>();
+      build_template<float64, int64>(sm);
+      break;
     default:
       TI_ERROR("Unsupported sparse matrix data type!");
       break;
   }
+  return sm;
 }
 
 void SparseMatrixBuilder::clear() {
@@ -84,14 +86,14 @@ void SparseMatrixBuilder::clear() {
   num_triplets_ = 0;
 }
 
-SparseMatrix::SparseMatrix(Eigen::SparseMatrix<float32> &matrix) {
-  this->matrix_ = matrix;
-}
+// SparseMatrix::SparseMatrix(Eigen::SparseMatrix<float32> &matrix) {
+//   this->matrix_ = matrix;
+// }
 
-SparseMatrix::SparseMatrix(int rows, int cols) : matrix_(rows, cols) {
-}
-
-const std::string SparseMatrix::to_string() const {
+// SparseMatrix::SparseMatrix(int rows, int cols) : matrix_(rows, cols) {
+// }
+template <class EigenMatrix>
+const std::string EigenSparseMatrix<EigenMatrix>::to_string() const {
   Eigen::IOFormat clean_fmt(4, 0, ", ", "\n", "[", "]");
   // Note that the code below first converts the sparse matrix into a dense one.
   // https://stackoverflow.com/questions/38553335/how-can-i-print-in-console-a-formatted-sparse-matrix-with-eigen
@@ -100,66 +102,86 @@ const std::string SparseMatrix::to_string() const {
   return ostr.str();
 }
 
-const int SparseMatrix::num_rows() const {
-  return matrix_.rows();
-}
-const int SparseMatrix::num_cols() const {
-  return matrix_.cols();
+// const int SparseMatrix::num_rows() const {
+//   return matrix_.rows();
+// }
+// const int SparseMatrix::num_cols() const {
+//   return matrix_.cols();
+// }
+
+// Eigen::SparseMatrix<float32> &SparseMatrix::get_matrix() {
+//   return matrix_;
+// }
+
+// const Eigen::SparseMatrix<float32> &SparseMatrix::get_matrix() const {
+//   return matrix_;
+// }
+
+// SparseMatrix operator+(const SparseMatrix &sm1, const SparseMatrix &sm2) {
+//   Eigen::SparseMatrix<float32> res(sm1.matrix_ + sm2.matrix_);
+//   return SparseMatrix(res);
+// }
+
+// SparseMatrix operator-(const SparseMatrix &sm1, const SparseMatrix &sm2) {
+//   Eigen::SparseMatrix<float32> res(sm1.matrix_ - sm2.matrix_);
+//   return SparseMatrix(res);
+// }
+
+// SparseMatrix operator*(float scale, const SparseMatrix &sm) {
+//   Eigen::SparseMatrix<float32> res(scale * sm.matrix_);
+//   return SparseMatrix(res);
+// }
+
+// SparseMatrix operator*(const SparseMatrix &sm, float scale) {
+//   return scale * sm;
+// }
+
+// SparseMatrix operator*(const SparseMatrix &sm1, const SparseMatrix &sm2) {
+//   Eigen::SparseMatrix<float32> res(sm1.matrix_.cwiseProduct(sm2.matrix_));
+//   return SparseMatrix(res);
+// }
+
+// SparseMatrix SparseMatrix::matmul(const SparseMatrix &sm) {
+//   Eigen::SparseMatrix<float32> res(matrix_ * sm.matrix_);
+//   return SparseMatrix(res);
+// }
+
+// Eigen::VectorXf SparseMatrix::mat_vec_mul(
+//     const Eigen::Ref<const Eigen::VectorXf> &b) {
+//   return matrix_ * b;
+// }
+
+// SparseMatrix SparseMatrix::transpose() {
+//   Eigen::SparseMatrix<float32> res(matrix_.transpose());
+//   return SparseMatrix(res);
+// }
+
+// float32 SparseMatrix::get_element(int row, int col) {
+//   return matrix_.coeff(row, col);
+// }
+
+// void SparseMatrix::set_element(int row, int col, float32 value) {
+//   matrix_.coeffRef(row, col) = value;
+// }
+
+template <class EigenMatrix>
+void EigenSparseMatrix<EigenMatrix>::build_triplets(void *triplets_adr) {
+  if (taichi::lang::data_type_name(dtype_) == "f32") {
+    using T = Eigen::Triplet<float32>;
+    std::vector<T> *triplets = static_cast<std::vector<T> *>(triplets_adr);
+    matrix_.setFromTriplets(triplets->begin(), triplets->end());
+  }
 }
 
-Eigen::SparseMatrix<float32> &SparseMatrix::get_matrix() {
-  return matrix_;
-}
-
-const Eigen::SparseMatrix<float32> &SparseMatrix::get_matrix() const {
-  return matrix_;
-}
-
-SparseMatrix operator+(const SparseMatrix &sm1, const SparseMatrix &sm2) {
-  Eigen::SparseMatrix<float32> res(sm1.matrix_ + sm2.matrix_);
-  return SparseMatrix(res);
-}
-
-SparseMatrix operator-(const SparseMatrix &sm1, const SparseMatrix &sm2) {
-  Eigen::SparseMatrix<float32> res(sm1.matrix_ - sm2.matrix_);
-  return SparseMatrix(res);
-}
-
-SparseMatrix operator*(float scale, const SparseMatrix &sm) {
-  Eigen::SparseMatrix<float32> res(scale * sm.matrix_);
-  return SparseMatrix(res);
-}
-
-SparseMatrix operator*(const SparseMatrix &sm, float scale) {
-  return scale * sm;
-}
-
-SparseMatrix operator*(const SparseMatrix &sm1, const SparseMatrix &sm2) {
-  Eigen::SparseMatrix<float32> res(sm1.matrix_.cwiseProduct(sm2.matrix_));
-  return SparseMatrix(res);
-}
-
-SparseMatrix SparseMatrix::matmul(const SparseMatrix &sm) {
-  Eigen::SparseMatrix<float32> res(matrix_ * sm.matrix_);
-  return SparseMatrix(res);
-}
-
-Eigen::VectorXf SparseMatrix::mat_vec_mul(
-    const Eigen::Ref<const Eigen::VectorXf> &b) {
-  return matrix_ * b;
-}
-
-SparseMatrix SparseMatrix::transpose() {
-  Eigen::SparseMatrix<float32> res(matrix_.transpose());
-  return SparseMatrix(res);
-}
-
-float32 SparseMatrix::get_element(int row, int col) {
-  return matrix_.coeff(row, col);
-}
-
-void SparseMatrix::set_element(int row, int col, float32 value) {
-  matrix_.coeffRef(row, col) = value;
+std::unique_ptr<SparseMatrix> make_sparse_matrix(
+    int rows,
+    int cols,
+    DataType dt,
+    const std::string &storage_format) {
+  if (taichi::lang::data_type_name(dt) == "f32" && storage_format == "cm") {
+    using FC = Eigen::SparseMatrix<float, Eigen::ColMajor>;
+    return std::make_unique<EigenSparseMatrix<FC>>(rows, cols, dt);
+  }
 }
 
 }  // namespace lang

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -18,7 +18,7 @@
 #define MAKE_MATRIX(TYPE, STORAGE)                                             \
   {                                                                            \
     Pair("f" #TYPE, #STORAGE),                                                 \
-        [](int cols, int rows, DataType dt) -> std::unique_ptr<SparseMatrix> { \
+        [](int rows, int cols, DataType dt) -> std::unique_ptr<SparseMatrix> { \
           using FC = Eigen::SparseMatrix<float##TYPE, Eigen::STORAGE>;         \
           return std::make_unique<EigenSparseMatrix<FC>>(rows, cols, dt);      \
         }                                                                      \

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -47,7 +47,7 @@ SparseMatrixBuilder::SparseMatrixBuilder(int rows,
       cols_(cols),
       max_num_triplets_(max_num_triplets),
       dtype_(dtype),
-      storage_format(storage_format) {
+      storage_format_(storage_format) {
   auto element_size = data_type_size(dtype);
   TI_ASSERT((element_size == 4 || element_size == 8));
   data_base_ptr_ =
@@ -97,7 +97,7 @@ void SparseMatrixBuilder::build_template(std::unique_ptr<SparseMatrix> &m) {
 std::unique_ptr<SparseMatrix> SparseMatrixBuilder::build() {
   TI_ASSERT(built_ == false);
   built_ = true;
-  auto sm = make_sparse_matrix(rows_, cols_, dtype_, storage_format);
+  auto sm = make_sparse_matrix(rows_, cols_, dtype_, storage_format_);
   auto element_size = data_type_size(dtype_);
   switch (element_size) {
     case 4:

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -74,11 +74,15 @@ class SparseMatrix {
     return nullptr;
   }
 
-  virtual float32 get_element(int row, int col) {
+  template <class T>
+  T get_element(int row, int col) {
+    std::cout << "get_element not implemented" << std::endl;
     return 0;
   }
 
-  virtual void set_element(int row, int col, float32 value) {
+  template <class T>
+  void set_element(int row, int col, T value) {
+    std::cout << "set_element not implemented" << std::endl;
     return;
   }
 
@@ -147,6 +151,11 @@ class EigenSparseMatrix : public SparseMatrix {
     return EigenSparseMatrix(sm.matrix_ * scale);
   }
 
+  friend EigenSparseMatrix operator*(const EigenSparseMatrix &lhs,
+                                     const EigenSparseMatrix &rhs) {
+    return EigenSparseMatrix(lhs.matrix_.cwiseProduct(rhs.matrix_));
+  }
+
   EigenSparseMatrix transpose() {
     return EigenSparseMatrix(matrix_.transpose());
   }
@@ -155,11 +164,13 @@ class EigenSparseMatrix : public SparseMatrix {
     return EigenSparseMatrix(matrix_ * sm.matrix_);
   }
 
-  virtual float32 get_element(int row, int col) override {
+  template <typename T>
+  T get_element(int row, int col) {
     return matrix_.coeff(row, col);
   }
 
-  void set_element(int row, int col, float32 value) override {
+  template <typename T>
+  void set_element(int row, int col, T value) {
     matrix_.coeffRef(row, col) = value;
   }
 

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -60,7 +60,6 @@ class SparseMatrix {
     return cols_;
   }
   virtual const std::string to_string() const {
-    std::cout << "Print happended in parent class " << std::endl;
     return nullptr;
   }
   virtual const void *get_matrix() const {
@@ -69,9 +68,15 @@ class SparseMatrix {
   // float32 get_element(int row, int col);
   // void set_element(int row, int col, float32 value);
 
-  virtual SparseMatrix operator+=(const SparseMatrix &other) {
-    return *this;
-  }
+  // virtual SparseMatrix& operator+=(const SparseMatrix &other) {
+  //   return *this;
+  // }
+  // virtual SparseMatrix& operator-=(const SparseMatrix &other) {
+  //   return *this;
+  // }
+  // virtual SparseMatrix& operator*=(float scale) {
+  //   return *this;
+  // }
 
   // friend SparseMatrix operator+(const SparseMatrix &sm1,
   //                               const SparseMatrix &sm2);
@@ -117,11 +122,18 @@ class EigenSparseMatrix : public SparseMatrix {
     return &matrix_;
   };
 
-  virtual EigenSparseMatrix operator+=(const EigenSparseMatrix &other) {
+  virtual EigenSparseMatrix &operator+=(const EigenSparseMatrix &other) {
     this->matrix_ += other.matrix_;
     return *this;
   };
-
+  virtual EigenSparseMatrix &operator-=(const EigenSparseMatrix &other) {
+    this->matrix_ -= other.matrix_;
+    return *this;
+  }
+  virtual EigenSparseMatrix &operator*=(float scale) {
+    this->matrix_ *= scale;
+    return *this;
+  }
  private:
   EigenMatrix matrix_;
 };

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -46,6 +46,9 @@ class SparseMatrix {
   SparseMatrix(SparseMatrix &sm)
       : rows_(sm.rows_), cols_(sm.cols_), dtype_(sm.dtype_) {
   }
+  SparseMatrix(SparseMatrix &&sm)
+      : rows_(sm.rows_), cols_(sm.cols_), dtype_(sm.dtype_) {
+  }
   virtual ~SparseMatrix() = default;
 
   virtual void build_triplets(void *triplets_adr){};
@@ -57,15 +60,19 @@ class SparseMatrix {
     return cols_;
   }
   virtual const std::string to_string() const {
+    std::cout << "Print happended in parent class " << std::endl;
     return nullptr;
   }
   virtual const void *get_matrix() const {
     return nullptr;
   }
-  // Eigen::SparseMatrix<float32> &get_matrix();
-  // const Eigen::SparseMatrix<float32> &get_matrix() const;
   // float32 get_element(int row, int col);
   // void set_element(int row, int col, float32 value);
+
+  virtual SparseMatrix operator+=(const SparseMatrix &other) {
+    std::cout << "Addition happended parent class " << std::endl;
+    return *this;
+  }
 
   // friend SparseMatrix operator+(const SparseMatrix &sm1,
   //                               const SparseMatrix &sm2);
@@ -96,12 +103,24 @@ class EigenSparseMatrix : public SparseMatrix {
       : SparseMatrix(sm.num_rows(), sm.num_cols(), sm.dtype_),
         matrix_(sm.matrix_) {
   }
+  EigenSparseMatrix(EigenSparseMatrix &&sm)
+      : SparseMatrix(sm.num_rows(), sm.num_cols(), sm.dtype_),
+        matrix_(sm.matrix_) {
+  }
+  EigenSparseMatrix(EigenMatrix &em) : matrix_(em) {
+  }
+
   virtual ~EigenSparseMatrix() override = default;
   virtual void build_triplets(void *triplets_adr) override;
   virtual const std::string to_string() const override;
 
   virtual const void *get_matrix() const override {
     return &matrix_;
+  };
+
+  virtual EigenSparseMatrix operator+=(const EigenSparseMatrix &other) {
+    std::cout << "Addition happened in derived class" << std::endl;
+    return *this;
   };
 
  private:

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -40,7 +40,7 @@ class SparseMatrixBuilder {
   uint64 max_num_triplets_{0};
   bool built_{false};
   DataType dtype_{PrimitiveType::f32};
-  std::string storage_format{"col_major"};
+  std::string storage_format_{"col_major"};
 };
 
 class SparseMatrix {

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -13,7 +13,11 @@ class SparseMatrix;
 
 class SparseMatrixBuilder {
  public:
-  SparseMatrixBuilder(int rows, int cols, int max_num_triplets, DataType dtype);
+  SparseMatrixBuilder(int rows,
+                      int cols,
+                      int max_num_triplets,
+                      DataType dtype,
+                      const std::string &storage_format);
 
   void print_triplets();
 
@@ -36,6 +40,7 @@ class SparseMatrixBuilder {
   uint64 max_num_triplets_{0};
   bool built_{false};
   DataType dtype_{PrimitiveType::f32};
+  std::string storage_format{"col_major"};
 };
 
 class SparseMatrix {
@@ -69,7 +74,13 @@ class SparseMatrix {
     return nullptr;
   }
 
-  // Eigen::VectorXf mat_vec_mul(const Eigen::Ref<const Eigen::VectorXf> &b);
+  virtual float32 get_element(int row, int col) {
+    return 0;
+  }
+
+  virtual void set_element(int row, int col, float32 value) {
+    return;
+  }
 
  protected:
   int rows_{0};
@@ -144,12 +155,17 @@ class EigenSparseMatrix : public SparseMatrix {
     return EigenSparseMatrix(matrix_ * sm.matrix_);
   }
 
-  float32 get_element(int row, int col) {
+  virtual float32 get_element(int row, int col) override {
     return matrix_.coeff(row, col);
   }
 
-  void set_element(int row, int col, float32 value) {
+  void set_element(int row, int col, float32 value) override {
     matrix_.coeffRef(row, col) = value;
+  }
+
+  template <class VT>
+  VT mat_vec_mul(const Eigen::Ref<const VT> &b) {
+    return matrix_ * b;
   }
 
  private:

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -70,7 +70,6 @@ class SparseMatrix {
   // void set_element(int row, int col, float32 value);
 
   virtual SparseMatrix operator+=(const SparseMatrix &other) {
-    std::cout << "Addition happended parent class " << std::endl;
     return *this;
   }
 
@@ -119,7 +118,7 @@ class EigenSparseMatrix : public SparseMatrix {
   };
 
   virtual EigenSparseMatrix operator+=(const EigenSparseMatrix &other) {
-    std::cout << "Addition happened in derived class" << std::endl;
+    this->matrix_ += other.matrix_;
     return *this;
   };
 

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -95,14 +95,14 @@ class SparseMatrix {
 template <class EigenMatrix>
 class EigenSparseMatrix : public SparseMatrix {
  public:
-  EigenSparseMatrix(int rows, int cols, DataType dt)
+  explicit EigenSparseMatrix(int rows, int cols, DataType dt)
       : SparseMatrix(rows, cols, dt), matrix_(rows, cols) {
   }
   explicit EigenSparseMatrix(EigenSparseMatrix &sm)
       : SparseMatrix(sm.num_rows(), sm.num_cols(), sm.dtype_),
         matrix_(sm.matrix_) {
   }
-  EigenSparseMatrix(EigenSparseMatrix &&sm)
+  explicit EigenSparseMatrix(EigenSparseMatrix &&sm)
       : SparseMatrix(sm.num_rows(), sm.num_cols(), sm.dtype_),
         matrix_(sm.matrix_) {
   }
@@ -110,11 +110,11 @@ class EigenSparseMatrix : public SparseMatrix {
       : SparseMatrix(em.rows(), em.cols()), matrix_(em) {
   }
 
-  virtual ~EigenSparseMatrix() override = default;
-  virtual void build_triplets(void *triplets_adr) override;
-  virtual const std::string to_string() const override;
+  virtual ~EigenSparseMatrix() = default;
+  void build_triplets(void *triplets_adr) override;
+  const std::string to_string() const override;
 
-  virtual const void *get_matrix() const override {
+  const void *get_matrix() const override {
     return &matrix_;
   };
 

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -41,7 +41,8 @@ class SparseMatrixBuilder {
 class SparseMatrix {
  public:
   SparseMatrix() = delete;
-  SparseMatrix(int rows, int cols) : rows_{rows}, cols_(cols){};
+  SparseMatrix(int rows, int cols, DataType dt = PrimitiveType::f32)
+      : rows_{rows}, cols_(cols), dtype_(dt){};
   virtual ~SparseMatrix() = default;
 
   virtual void build_triplets(void *triplets_adr){};
@@ -73,25 +74,29 @@ class SparseMatrix {
 
   // SparseMatrix transpose();
 
- private:
+ protected:
   int rows_{0};
   int cols_{0};
+  DataType dtype_;
 };
 
 template <class EigenMatrix>
 class EigenSparseMatrix : public SparseMatrix {
  public:
   EigenSparseMatrix(int rows, int cols, DataType dt)
-      : SparseMatrix(rows, cols), matrix_(rows, cols), dtype_(dt) {
+      : SparseMatrix(rows, cols, dt), matrix_(rows, cols) {
   }
 
   virtual ~EigenSparseMatrix() override = default;
   virtual void build_triplets(void *triplets_adr) override;
   virtual const std::string to_string() const override;
 
+  EigenMatrix &get_matrix() {
+    return matrix_;
+  };
+
  private:
   EigenMatrix matrix_;
-  DataType dtype_;
 };
 
 std::unique_ptr<SparseMatrix> make_sparse_matrix(

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -110,7 +110,7 @@ class EigenSparseMatrix : public SparseMatrix {
       : SparseMatrix(em.rows(), em.cols()), matrix_(em) {
   }
 
-  virtual ~EigenSparseMatrix() = default;
+  ~EigenSparseMatrix() override = default;
   void build_triplets(void *triplets_adr) override;
   const std::string to_string() const override;
 

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -43,6 +43,9 @@ class SparseMatrix {
   SparseMatrix() = delete;
   SparseMatrix(int rows, int cols, DataType dt = PrimitiveType::f32)
       : rows_{rows}, cols_(cols), dtype_(dt){};
+  SparseMatrix(SparseMatrix &sm)
+      : rows_(sm.rows_), cols_(sm.cols_), dtype_(sm.dtype_) {
+  }
   virtual ~SparseMatrix() = default;
 
   virtual void build_triplets(void *triplets_adr){};
@@ -54,6 +57,9 @@ class SparseMatrix {
     return cols_;
   }
   virtual const std::string to_string() const {
+    return nullptr;
+  }
+  virtual const void *get_matrix() const {
     return nullptr;
   }
   // Eigen::SparseMatrix<float32> &get_matrix();
@@ -86,13 +92,16 @@ class EigenSparseMatrix : public SparseMatrix {
   EigenSparseMatrix(int rows, int cols, DataType dt)
       : SparseMatrix(rows, cols, dt), matrix_(rows, cols) {
   }
-
+  EigenSparseMatrix(EigenSparseMatrix &sm)
+      : SparseMatrix(sm.num_rows(), sm.num_cols(), sm.dtype_),
+        matrix_(sm.matrix_) {
+  }
   virtual ~EigenSparseMatrix() override = default;
   virtual void build_triplets(void *triplets_adr) override;
   virtual const std::string to_string() const override;
 
-  EigenMatrix &get_matrix() {
-    return matrix_;
+  virtual const void *get_matrix() const override {
+    return &matrix_;
   };
 
  private:

--- a/taichi/program/sparse_solver.cpp
+++ b/taichi/program/sparse_solver.cpp
@@ -9,7 +9,8 @@
     {#dt, #type, #order}, []() -> std::unique_ptr<SparseSolver> {              \
       using T = Eigen::Simplicial##type<Eigen::SparseMatrix<dt>, Eigen::Lower, \
                                         Eigen::order##Ordering<int>>;          \
-      return std::make_unique<EigenSparseSolver<T>>();                         \
+      return std::make_unique<                                                 \
+          EigenSparseSolver<T, Eigen::SparseMatrix<dt>>>();                    \
     }                                                                          \
   }
 
@@ -28,32 +29,41 @@ struct key_hash {
 namespace taichi {
 namespace lang {
 
-template <class EigenSolver>
-bool EigenSparseSolver<EigenSolver>::compute(const SparseMatrix &sm) {
-  // solver_.compute(sm.get_matrix());
+#define GET_EM(sm) \
+  const EigenMatrix *mat = (const EigenMatrix *)(sm.get_matrix());
+
+template <class EigenSolver, class EigenMatrix>
+bool EigenSparseSolver<EigenSolver, EigenMatrix>::compute(
+    const SparseMatrix &sm) {
+  GET_EM(sm);
+  solver_.compute(*mat);
   if (solver_.info() != Eigen::Success) {
     return false;
   } else
     return true;
 }
-template <class EigenSolver>
-void EigenSparseSolver<EigenSolver>::analyze_pattern(const SparseMatrix &sm) {
-  // solver_.analyzePattern(sm.get_matrix());
+template <class EigenSolver, class EigenMatrix>
+void EigenSparseSolver<EigenSolver, EigenMatrix>::analyze_pattern(
+    const SparseMatrix &sm) {
+  GET_EM(sm);
+  solver_.analyzePattern(*mat);
 }
 
-template <class EigenSolver>
-void EigenSparseSolver<EigenSolver>::factorize(const SparseMatrix &sm) {
-  // solver_.factorize(sm.get_matrix());
+template <class EigenSolver, class EigenMatrix>
+void EigenSparseSolver<EigenSolver, EigenMatrix>::factorize(
+    const SparseMatrix &sm) {
+  GET_EM(sm);
+  solver_.factorize(*mat);
 }
 
-template <class EigenSolver>
-Eigen::VectorXf EigenSparseSolver<EigenSolver>::solve(
+template <class EigenSolver, class EigenMatrix>
+Eigen::VectorXf EigenSparseSolver<EigenSolver, EigenMatrix>::solve(
     const Eigen::Ref<const Eigen::VectorXf> &b) {
   return solver_.solve(b);
 }
 
-template <class EigenSolver>
-bool EigenSparseSolver<EigenSolver>::info() {
+template <class EigenSolver, class EigenMatrix>
+bool EigenSparseSolver<EigenSolver, EigenMatrix>::info() {
   return solver_.info() == Eigen::Success;
 }
 
@@ -78,8 +88,9 @@ std::unique_ptr<SparseSolver> make_sparse_solver(DataType dt,
     auto solver_func = solver_factory.at(solver_key);
     return solver_func();
   } else if (solver_type == "LU") {
-    using LU = Eigen::SparseLU<Eigen::SparseMatrix<float32>>;
-    return std::make_unique<EigenSparseSolver<LU>>();
+    using EigenMatrix = Eigen::SparseMatrix<float32>;
+    using LU = Eigen::SparseLU<EigenMatrix>;
+    return std::make_unique<EigenSparseSolver<LU, EigenMatrix>>();
   } else
     TI_ERROR("Not supported sparse solver type: {}", solver_type);
 }

--- a/taichi/program/sparse_solver.cpp
+++ b/taichi/program/sparse_solver.cpp
@@ -30,7 +30,7 @@ namespace lang {
 
 template <class EigenSolver>
 bool EigenSparseSolver<EigenSolver>::compute(const SparseMatrix &sm) {
-  solver_.compute(sm.get_matrix());
+  // solver_.compute(sm.get_matrix());
   if (solver_.info() != Eigen::Success) {
     return false;
   } else
@@ -38,12 +38,12 @@ bool EigenSparseSolver<EigenSolver>::compute(const SparseMatrix &sm) {
 }
 template <class EigenSolver>
 void EigenSparseSolver<EigenSolver>::analyze_pattern(const SparseMatrix &sm) {
-  solver_.analyzePattern(sm.get_matrix());
+  // solver_.analyzePattern(sm.get_matrix());
 }
 
 template <class EigenSolver>
 void EigenSparseSolver<EigenSolver>::factorize(const SparseMatrix &sm) {
-  solver_.factorize(sm.get_matrix());
+  // solver_.factorize(sm.get_matrix());
 }
 
 template <class EigenSolver>

--- a/taichi/program/sparse_solver.h
+++ b/taichi/program/sparse_solver.h
@@ -17,7 +17,7 @@ class SparseSolver {
   virtual bool info() = 0;
 };
 
-template <class EigenSolver>
+template <class EigenSolver, class EigenMatrix>
 class EigenSparseSolver : public SparseSolver {
  private:
   EigenSolver solver_;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -945,8 +945,8 @@ void export_lang(py::module &m) {
            py::arg("dt") = PrimitiveType::f32)
       .def(py::init<SparseMatrix &>())
       .def("to_string", &SparseMatrix::to_string)
-      .def("get_element", &SparseMatrix::get_element)
-      .def("set_element", &SparseMatrix::set_element)
+      .def("get_element", &SparseMatrix::get_element<float32>)
+      .def("set_element", &SparseMatrix::set_element<float32>)
       .def("num_rows", &SparseMatrix::num_rows)
       .def("num_cols", &SparseMatrix::num_cols);
 
@@ -965,13 +965,16 @@ void export_lang(py::module &m) {
       .def(py::self *= float##TYPE())                                        \
       .def(py::self *float##TYPE())                                          \
       .def(float##TYPE() * py::self)                                         \
+      .def(py::self *py::self)                                               \
       .def("matmul", &EigenSparseMatrix<STORAGE##TYPE##EigenMatrix>::matmul) \
       .def("transpose",                                                      \
            &EigenSparseMatrix<STORAGE##TYPE##EigenMatrix>::transpose)        \
       .def("get_element",                                                    \
-           &EigenSparseMatrix<STORAGE##TYPE##EigenMatrix>::get_element)      \
+           &EigenSparseMatrix<STORAGE##TYPE##EigenMatrix>::get_element<      \
+               float##TYPE>)                                                 \
       .def("set_element",                                                    \
-           &EigenSparseMatrix<STORAGE##TYPE##EigenMatrix>::set_element)      \
+           &EigenSparseMatrix<STORAGE##TYPE##EigenMatrix>::set_element<      \
+               float##TYPE>)                                                 \
       .def("mat_vec_mul",                                                    \
            &EigenSparseMatrix<STORAGE##TYPE##EigenMatrix>::mat_vec_mul<      \
                Eigen::VectorX##VTYPE>);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -363,10 +363,11 @@ void export_lang(py::module &m) {
            py::return_value_policy::reference)
       .def("create_sparse_matrix_builder",
            [](Program *program, int n, int m, uint64 max_num_entries,
-              DataType dtype) {
+              DataType dtype, const std::string &storage_format) {
              TI_ERROR_IF(!arch_is_cpu(program->config.arch),
                          "SparseMatrix only supports CPU for now.");
-             return SparseMatrixBuilder(n, m, max_num_entries, dtype);
+             return SparseMatrixBuilder(n, m, max_num_entries, dtype,
+                                        storage_format);
            })
       .def("create_sparse_matrix",
            [](Program *program, int n, int m, DataType dtype,
@@ -944,9 +945,8 @@ void export_lang(py::module &m) {
            py::arg("dt") = PrimitiveType::f32)
       .def(py::init<SparseMatrix &>())
       .def("to_string", &SparseMatrix::to_string)
-      // .def("mat_vec_mul", &SparseMatrix::mat_vec_mul)
-      // .def("get_element", &SparseMatrix::get_element)
-      // .def("set_element", &SparseMatrix::set_element)
+      .def("get_element", &SparseMatrix::get_element)
+      .def("set_element", &SparseMatrix::set_element)
       .def("num_rows", &SparseMatrix::num_rows)
       .def("num_cols", &SparseMatrix::num_cols);
 
@@ -966,7 +966,9 @@ void export_lang(py::module &m) {
       .def("matmul", &EigenSparseMatrix<EigenMatrix>::matmul)
       .def("transpose", &EigenSparseMatrix<EigenMatrix>::transpose)
       .def("get_element", &EigenSparseMatrix<EigenMatrix>::get_element)
-      .def("set_element", &EigenSparseMatrix<EigenMatrix>::set_element);
+      .def("set_element", &EigenSparseMatrix<EigenMatrix>::set_element)
+      .def("mat_vec_mul",
+           &EigenSparseMatrix<EigenMatrix>::mat_vec_mul<Eigen::VectorXf>);
 
   py::class_<SparseSolver>(m, "SparseSolver")
       .def("compute", &SparseSolver::compute)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -369,10 +369,11 @@ void export_lang(py::module &m) {
              return SparseMatrixBuilder(n, m, max_num_entries, dtype);
            })
       .def("create_sparse_matrix",
-           [](Program *program, int n, int m, DataType dtype) {
+           [](Program *program, int n, int m, DataType dtype,
+              std::string storage_format) {
              TI_ERROR_IF(!arch_is_cpu(program->config.arch),
                          "SparseMatrix only supports CPU for now.");
-             return SparseMatrix(n, m, dtype);
+             return make_sparse_matrix(n, m, dtype, storage_format);
            })
       .def(
           "dump_dot",
@@ -939,6 +940,7 @@ void export_lang(py::module &m) {
 
   py::class_<SparseMatrix>(m, "SparseMatrix")
       .def("to_string", &SparseMatrix::to_string)
+      .def(py::self += py::self, py::return_value_policy::take_ownership)
       // .def(py::self + py::self, py::return_value_policy::reference_internal)
       // .def(py::self - py::self, py::return_value_policy::reference_internal)
       // .def(float() * py::self, py::return_value_policy::reference_internal)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -934,6 +934,7 @@ void export_lang(py::module &m) {
       },
       py::return_value_policy::reference);
 
+  // Sparse Matrix
   py::class_<SparseMatrixBuilder>(m, "SparseMatrixBuilder")
       .def("print_triplets", &SparseMatrixBuilder::print_triplets)
       .def("build", &SparseMatrixBuilder::build)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -939,18 +939,18 @@ void export_lang(py::module &m) {
 
   py::class_<SparseMatrix>(m, "SparseMatrix")
       .def("to_string", &SparseMatrix::to_string)
-      .def(py::self + py::self, py::return_value_policy::reference_internal)
-      .def(py::self - py::self, py::return_value_policy::reference_internal)
-      .def(float() * py::self, py::return_value_policy::reference_internal)
-      .def(py::self * float(), py::return_value_policy::reference_internal)
-      .def(py::self * py::self, py::return_value_policy::reference_internal)
-      .def("matmul", &SparseMatrix::matmul,
-           py::return_value_policy::reference_internal)
-      .def("mat_vec_mul", &SparseMatrix::mat_vec_mul)
-      .def("transpose", &SparseMatrix::transpose,
-           py::return_value_policy::reference_internal)
-      .def("get_element", &SparseMatrix::get_element)
-      .def("set_element", &SparseMatrix::set_element)
+      // .def(py::self + py::self, py::return_value_policy::reference_internal)
+      // .def(py::self - py::self, py::return_value_policy::reference_internal)
+      // .def(float() * py::self, py::return_value_policy::reference_internal)
+      // .def(py::self * float(), py::return_value_policy::reference_internal)
+      // .def(py::self * py::self, py::return_value_policy::reference_internal)
+      // .def("matmul", &SparseMatrix::matmul,
+      //      py::return_value_policy::reference_internal)
+      // .def("mat_vec_mul", &SparseMatrix::mat_vec_mul)
+      // .def("transpose", &SparseMatrix::transpose,
+      //      py::return_value_policy::reference_internal)
+      // .def("get_element", &SparseMatrix::get_element)
+      // .def("set_element", &SparseMatrix::set_element)
       .def("num_rows", &SparseMatrix::num_rows)
       .def("num_cols", &SparseMatrix::num_cols);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -940,17 +940,18 @@ void export_lang(py::module &m) {
 
   py::class_<SparseMatrix>(m, "SparseMatrix")
       .def("to_string", &SparseMatrix::to_string)
-      .def(py::self += py::self)
-      // .def(py::self + py::self, py::return_value_policy::reference_internal)
-      // .def(py::self - py::self, py::return_value_policy::reference_internal)
-      // .def(float() * py::self, py::return_value_policy::reference_internal)
-      // .def(py::self * float(), py::return_value_policy::reference_internal)
-      // .def(py::self * py::self, py::return_value_policy::reference_internal)
-      // .def("matmul", &SparseMatrix::matmul,
-      //      py::return_value_policy::reference_internal)
+      // .def(py::self += py::self)
+      // .def(py::self -= py::self)
+      // .def(py::self *= py::self)
+      // .def(py::self *= float())
+      // .def(py::self + py::self)
+      // .def(py::self - py::self)
+      // .def(float() * py::self)
+      // .def(py::self * float())
+      // .def(py::self * py::self)
+      // .def("matmul", &SparseMatrix::matmul)
       // .def("mat_vec_mul", &SparseMatrix::mat_vec_mul)
-      // .def("transpose", &SparseMatrix::transpose,
-      //      py::return_value_policy::reference_internal)
+      // .def("transpose", &SparseMatrix::transpose)
       // .def("get_element", &SparseMatrix::get_element)
       // .def("set_element", &SparseMatrix::set_element)
       .def("num_rows", &SparseMatrix::num_rows)
@@ -958,7 +959,9 @@ void export_lang(py::module &m) {
 
   py::class_<EigenSparseMatrix<Eigen::SparseMatrix<float32, Eigen::ColMajor>>,
              SparseMatrix>(m, "EigenSparseMatrix")
-      .def(py::self += py::self);
+      .def(py::self += py::self)
+      .def(py::self -= py::self)
+      .def(py::self *= float());
 
   py::class_<SparseSolver>(m, "SparseSolver")
       .def("compute", &SparseSolver::compute)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -369,10 +369,10 @@ void export_lang(py::module &m) {
              return SparseMatrixBuilder(n, m, max_num_entries, dtype);
            })
       .def("create_sparse_matrix",
-           [](Program *program, int n, int m) {
+           [](Program *program, int n, int m, Datatype dtype) {
              TI_ERROR_IF(!arch_is_cpu(program->config.arch),
                          "SparseMatrix only supports CPU for now.");
-             return SparseMatrix(n, m);
+             return SparseMatrix(n, m, dtype);
            })
       .def(
           "dump_dot",

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -369,7 +369,7 @@ void export_lang(py::module &m) {
              return SparseMatrixBuilder(n, m, max_num_entries, dtype);
            })
       .def("create_sparse_matrix",
-           [](Program *program, int n, int m, Datatype dtype) {
+           [](Program *program, int n, int m, DataType dtype) {
              TI_ERROR_IF(!arch_is_cpu(program->config.arch),
                          "SparseMatrix only supports CPU for now.");
              return SparseMatrix(n, m, dtype);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -940,7 +940,7 @@ void export_lang(py::module &m) {
 
   py::class_<SparseMatrix>(m, "SparseMatrix")
       .def("to_string", &SparseMatrix::to_string)
-      .def(py::self += py::self, py::return_value_policy::take_ownership)
+      .def(py::self += py::self)
       // .def(py::self + py::self, py::return_value_policy::reference_internal)
       // .def(py::self - py::self, py::return_value_policy::reference_internal)
       // .def(float() * py::self, py::return_value_policy::reference_internal)
@@ -955,6 +955,10 @@ void export_lang(py::module &m) {
       // .def("set_element", &SparseMatrix::set_element)
       .def("num_rows", &SparseMatrix::num_rows)
       .def("num_cols", &SparseMatrix::num_cols);
+
+  py::class_<EigenSparseMatrix<Eigen::SparseMatrix<float32, Eigen::ColMajor>>,
+             SparseMatrix>(m, "EigenSparseMatrix")
+      .def(py::self += py::self);
 
   py::class_<SparseSolver>(m, "SparseSolver")
       .def("compute", &SparseSolver::compute)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -939,29 +939,34 @@ void export_lang(py::module &m) {
       .def("get_addr", [](SparseMatrixBuilder *mat) { return uint64(mat); });
 
   py::class_<SparseMatrix>(m, "SparseMatrix")
+      .def(py::init<>())
+      .def(py::init<int, int, DataType>(), py::arg("rows"), py::arg("cols"),
+           py::arg("dt") = PrimitiveType::f32)
+      .def(py::init<SparseMatrix &>())
       .def("to_string", &SparseMatrix::to_string)
-      // .def(py::self += py::self)
-      // .def(py::self -= py::self)
-      // .def(py::self *= py::self)
-      // .def(py::self *= float())
-      // .def(py::self + py::self)
-      // .def(py::self - py::self)
-      // .def(float() * py::self)
-      // .def(py::self * float())
-      // .def(py::self * py::self)
-      // .def("matmul", &SparseMatrix::matmul)
       // .def("mat_vec_mul", &SparseMatrix::mat_vec_mul)
-      // .def("transpose", &SparseMatrix::transpose)
       // .def("get_element", &SparseMatrix::get_element)
       // .def("set_element", &SparseMatrix::set_element)
       .def("num_rows", &SparseMatrix::num_rows)
       .def("num_cols", &SparseMatrix::num_cols);
 
-  py::class_<EigenSparseMatrix<Eigen::SparseMatrix<float32, Eigen::ColMajor>>,
-             SparseMatrix>(m, "EigenSparseMatrix")
+  using EigenMatrix = Eigen::SparseMatrix<float32, Eigen::ColMajor>;
+  py::class_<EigenSparseMatrix<EigenMatrix>, SparseMatrix>(m,
+                                                           "EigenSparseMatrix")
+      .def(py::init<int, int, DataType>())
+      .def(py::init<EigenSparseMatrix<EigenMatrix> &>())
+      .def(py::init<const EigenMatrix &>())
       .def(py::self += py::self)
+      .def(py::self + py::self)
       .def(py::self -= py::self)
-      .def(py::self *= float());
+      .def(py::self - py::self)
+      .def(py::self *= float())
+      .def(py::self * float())
+      .def(float() * py::self)
+      .def("matmul", &EigenSparseMatrix<EigenMatrix>::matmul)
+      .def("transpose", &EigenSparseMatrix<EigenMatrix>::transpose)
+      .def("get_element", &EigenSparseMatrix<EigenMatrix>::get_element)
+      .def("set_element", &EigenSparseMatrix<EigenMatrix>::set_element);
 
   py::class_<SparseSolver>(m, "SparseSolver")
       .def("compute", &SparseSolver::compute)

--- a/tests/python/test_sparse_matrix.py
+++ b/tests/python/test_sparse_matrix.py
@@ -18,7 +18,7 @@ def test_sparse_matrix_builder_deprecated_anno(dtype, storage_format):
                                              storage_format=storage_format)
 
     @ti.kernel
-    def fill(Abuilder: ti.linalg.sparse_matrix_builder()):
+    def fill(Abuilder: ti.types.sparse_matrix_builder()):
         for i, j in ti.ndrange(n, n):
             Abuilder[i, j] += i + j
 

--- a/tests/python/test_sparse_matrix.py
+++ b/tests/python/test_sparse_matrix.py
@@ -14,7 +14,7 @@ def test_sparse_matrix_builder_deprecated_anno(dtype):
                                              dtype=dtype)
 
     @ti.kernel
-    def fill(Abuilder: ti.types.sparse_matrix_builder()):
+    def fill(Abuilder: ti.linalg.sparse_matrix_builder()):
         for i, j in ti.ndrange(n, n):
             Abuilder[i, j] += i + j
 

--- a/tests/python/test_sparse_matrix.py
+++ b/tests/python/test_sparse_matrix.py
@@ -4,14 +4,18 @@ import taichi as ti
 from tests import test_utils
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_builder_deprecated_anno(dtype):
+def test_sparse_matrix_builder_deprecated_anno(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.linalg.sparse_matrix_builder()):
@@ -25,14 +29,18 @@ def test_sparse_matrix_builder_deprecated_anno(dtype):
             assert A[i, j] == i + j
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_builder(dtype):
+def test_sparse_matrix_builder(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder()):
@@ -46,14 +54,18 @@ def test_sparse_matrix_builder(dtype):
             assert A[i, j] == i + j
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_shape(dtype):
+def test_sparse_matrix_shape(dtype, storage_format):
     n, m = 8, 9
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              m,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder()):
@@ -65,14 +77,18 @@ def test_sparse_matrix_shape(dtype):
     assert A.shape() == (n, m)
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_element_access(dtype):
+def test_sparse_matrix_element_access(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder()):
@@ -85,14 +101,18 @@ def test_sparse_matrix_element_access(dtype):
         assert A[i, i] == i
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_element_modify(dtype):
+def test_sparse_matrix_element_modify(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder()):
@@ -105,18 +125,23 @@ def test_sparse_matrix_element_modify(dtype):
     assert A[0, 0] == 1024.0
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_addition(dtype):
+def test_sparse_matrix_addition(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     Bbuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder(),
@@ -134,18 +159,23 @@ def test_sparse_matrix_addition(dtype):
             assert C[i, j] == 2 * i
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_subtraction(dtype):
+def test_sparse_matrix_subtraction(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     Bbuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder(),
@@ -163,14 +193,18 @@ def test_sparse_matrix_subtraction(dtype):
             assert C[i, j] == 2 * j
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_scalar_multiplication(dtype):
+def test_sparse_matrix_scalar_multiplication(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder()):
@@ -185,14 +219,18 @@ def test_sparse_matrix_scalar_multiplication(dtype):
             assert B[i, j] == 3 * (i + j)
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_transpose(dtype):
+def test_sparse_matrix_transpose(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder()):
@@ -207,18 +245,23 @@ def test_sparse_matrix_transpose(dtype):
             assert B[i, j] == A[j, i]
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_elementwise_multiplication(dtype):
+def test_sparse_matrix_elementwise_multiplication(dtype, storage_format):
     n = 8
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     Bbuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder(),
@@ -236,18 +279,23 @@ def test_sparse_matrix_elementwise_multiplication(dtype):
             assert C[i, j] == (i + j) * (i - j)
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_multiplication(dtype):
+def test_sparse_matrix_multiplication(dtype, storage_format):
     n = 2
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     Bbuilder = ti.linalg.SparseMatrixBuilder(n,
                                              n,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder(),
@@ -266,18 +314,23 @@ def test_sparse_matrix_multiplication(dtype):
     assert C[1, 1] == -1.0
 
 
-@pytest.mark.parametrize('dtype', [ti.f32, ti.f64])
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_nonsymmetric_multiplication(dtype):
+def test_sparse_matrix_nonsymmetric_multiplication(dtype, storage_format):
     n, k, m = 2, 3, 4
     Abuilder = ti.linalg.SparseMatrixBuilder(n,
                                              k,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     Bbuilder = ti.linalg.SparseMatrixBuilder(k,
                                              m,
                                              max_num_triplets=100,
-                                             dtype=dtype)
+                                             dtype=dtype,
+                                             storage_format=storage_format)
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder(),

--- a/tests/python/test_spmv.py
+++ b/tests/python/test_spmv.py
@@ -1,11 +1,21 @@
+import pytest
+
 import taichi as ti
 from tests import test_utils
 
 
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_vector_multiplication1():
+def test_sparse_matrix_vector_multiplication1(dtype, storage_format):
     n = 8
-    Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=100)
+    Abuilder = ti.linalg.SparseMatrixBuilder(n,
+                                             n,
+                                             max_num_triplets=100,
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     b = ti.field(ti.f32, shape=n)
 
     @ti.kernel
@@ -23,10 +33,18 @@ def test_sparse_matrix_vector_multiplication1():
         assert x[i] == 8 * i
 
 
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_vector_multiplication2():
+def test_sparse_matrix_vector_multiplication2(dtype, storage_format):
     n = 8
-    Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=100)
+    Abuilder = ti.linalg.SparseMatrixBuilder(n,
+                                             n,
+                                             max_num_triplets=100,
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     b = ti.field(ti.f32, shape=n)
 
     @ti.kernel
@@ -47,10 +65,18 @@ def test_sparse_matrix_vector_multiplication2():
         assert x[i] == res[i]
 
 
+@pytest.mark.parametrize('dtype, storage_format', [(ti.f32, 'col_major'),
+                                                   (ti.f32, 'row_major'),
+                                                   (ti.f64, 'col_major'),
+                                                   (ti.f64, 'row_major')])
 @test_utils.test(arch=ti.cpu)
-def test_sparse_matrix_vector_multiplication3():
+def test_sparse_matrix_vector_multiplication3(dtype, storage_format):
     n = 8
-    Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=100)
+    Abuilder = ti.linalg.SparseMatrixBuilder(n,
+                                             n,
+                                             max_num_triplets=100,
+                                             dtype=dtype,
+                                             storage_format=storage_format)
     b = ti.field(ti.f32, shape=n)
 
     @ti.kernel


### PR DESCRIPTION
Related issue = #2906

This PR seems messy for the reviewer. 
For short, the eigen sparse matrix is warpped using `EigenSparseMatrix` class which is derived from the abstract class `SparseMatrix`. 
The data type and storage format is configured using `SparseMatrixBuilder `interface. The `EigenSparseMatrix` is created and built from triplets in `SparseMatrixBuilder`.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
