### PR TITLE
[refactor] Remove legacy usage of ext_arr/any_arr in codebase

### DIFF
--- a/benchmarks/microbenchmarks/_utils.py
+++ b/benchmarks/microbenchmarks/_utils.py
@@ -69,12 +69,12 @@ def fill_random(dst, dtype, container):
             dst[I] = ti.random(dtype)
 
     @ti.kernel
-    def fill_1d_array(dst: ti.any_arr()):
+    def fill_1d_array(dst: ti.types.ndarray()):
         for i in dst:
             dst[i] = ti.random(dtype)
 
     @ti.kernel
-    def fill_2d_array(dst: ti.any_arr()):
+    def fill_2d_array(dst: ti.types.ndarray()):
         for i, j in dst:
             dst[i, j] = ti.random(dtype)
 

--- a/benchmarks/microbenchmarks/atomic_ops.py
+++ b/benchmarks/microbenchmarks/atomic_ops.py
@@ -21,7 +21,7 @@ def reduction_default(arch, repeat, atomic_op, container, dtype, dsize,
             atomic_op(y[None], x[i])
 
     @ti.kernel
-    def reduction_array(y: ti.any_arr(), x: ti.any_arr()):
+    def reduction_array(y: ti.types.ndarray(), x: ti.types.ndarray()):
         for i in x:
             atomic_op(y[None], x[i])
 

--- a/benchmarks/microbenchmarks/fill.py
+++ b/benchmarks/microbenchmarks/fill.py
@@ -13,7 +13,7 @@ def fill_default(arch, repeat, container, dtype, dsize, get_metric):
             dst[I] = ti.cast(0.7, dtype)
 
     @ti.kernel
-    def fill_array(dst: ti.any_arr()):
+    def fill_array(dst: ti.types.ndarray()):
         for i in dst:
             dst[i] = ti.cast(0.7, dtype)
 

--- a/benchmarks/microbenchmarks/memcpy.py
+++ b/benchmarks/microbenchmarks/memcpy.py
@@ -13,7 +13,7 @@ def memcpy_default(arch, repeat, container, dtype, dsize, get_metric):
             dst[I] = src[I]
 
     @ti.kernel
-    def memcpy_array(dst: ti.any_arr(), src: ti.any_arr()):
+    def memcpy_array(dst: ti.types.ndarray(), src: ti.types.ndarray()):
         for I in ti.grouped(dst):
             dst[I] = src[I]
 

--- a/benchmarks/microbenchmarks/saxpy.py
+++ b/benchmarks/microbenchmarks/saxpy.py
@@ -21,7 +21,7 @@ def saxpy_default(arch, repeat, container, dtype, dsize, get_metric):
             z[i] = 17 * x[i] + y[i]
 
     @ti.kernel
-    def saxpy_array(z: ti.any_arr(), x: ti.any_arr(), y: ti.any_arr()):
+    def saxpy_array(z: ti.types.ndarray(), x: ti.types.ndarray(), y: ti.types.ndarray()):
         for i in z:
             z[i] = 17 * x[i] + y[i]
 

--- a/benchmarks/microbenchmarks/saxpy.py
+++ b/benchmarks/microbenchmarks/saxpy.py
@@ -21,7 +21,8 @@ def saxpy_default(arch, repeat, container, dtype, dsize, get_metric):
             z[i] = 17 * x[i] + y[i]
 
     @ti.kernel
-    def saxpy_array(z: ti.types.ndarray(), x: ti.types.ndarray(), y: ti.types.ndarray()):
+    def saxpy_array(z: ti.types.ndarray(), x: ti.types.ndarray(),
+                    y: ti.types.ndarray()):
         for i in z:
             z[i] = 17 * x[i] + y[i]
 

--- a/benchmarks/microbenchmarks/stencil2d.py
+++ b/benchmarks/microbenchmarks/stencil2d.py
@@ -32,7 +32,7 @@ def stencil_2d_default(arch, repeat, scatter, bls, container, dtype, dsize_2d,
                 y[I] = s
 
     @ti.kernel
-    def stencil_2d_array(y: ti.any_arr(), x: ti.any_arr()):
+    def stencil_2d_array(y: ti.types.ndarray(), x: ti.types.ndarray()):
         for I in ti.grouped(x):
             if ti.static(scatter):
                 for offset in ti.static(stencil_common):

--- a/docs/lang/articles/basic/external.md
+++ b/docs/lang/articles/basic/external.md
@@ -131,7 +131,7 @@ field.from_numpy(array_dict) # the input array must have the same keys as the fi
 
 ## Using external arrays as Taichi kernel arguments
 
-Use type hint `ti.ext_arr()` or `ti.any_arr()` to pass external arrays as kernel
+Use type hint `ti.types.ndarray()` to pass external arrays as kernel
 arguments. For example:
 
 ```python {10}
@@ -144,7 +144,7 @@ n, m = 4, 7
 
 
 @ti.kernel
-def test_numpy(arr: ti.ext_arr()):
+def test_numpy(arr: ti.types.ndarray()):
     for i in range(n):
         for j in range(m):
             arr[i, j] += i + j
@@ -167,7 +167,7 @@ Note that the elements in an external array must be indexed using a single squar
 This contrasts with a Taichi vector or matrix field where field and matrix indices are indexed separately:
 ```python
 @ti.kernel
-def copy_vector(x: ti.template(), y: ti.ext_arr()):
+def copy_vector(x: ti.template(), y: ti.types.ndarray()):
     for i, j in ti.ndrange(n, m):
         for k in ti.static(range(3)):
             y[i, j, k] = x[i, j][k] # correct
@@ -179,7 +179,7 @@ this implies that the PyTorch tensor [needs to be made contiguous](https://pytor
 before being passed into a Taichi kernel:
 ```python
 @ti.kernel
-def copy_scalar(x: ti.template(), y: ti.ext_arr()):
+def copy_scalar(x: ti.template(), y: ti.types.ndarray()):
     for i, j in x:
         y[i, j] = x[i, j]
 

--- a/docs/lang/articles/basic/syntax.md
+++ b/docs/lang/articles/basic/syntax.md
@@ -104,7 +104,7 @@ def error_too_many_arguments(u: ti.i32, v: ti.i64, w: ti.types.matrix(7, 9, ti.i
 A kernel can also take the following two types of advanced arguments:
 
 - Template arguments: Use `ti.template()` as their type hints. See [Template metaprogramming](../advanced/meta.md#template-metaprogramming).
-- External array arguments: Use `ti.ext_arr()` as their type hints. See [Interacting with external arrays](./external.md).
+- External array arguments: Use `ti.types.ndarray()` as their type hints. See [Interacting with external arrays](./external.md).
 
 </details>
 

--- a/docs/lang/articles/tutorials/ndarray_android.md
+++ b/docs/lang/articles/tutorials/ndarray_android.md
@@ -81,7 +81,7 @@ substepping = 10
 
 # Define Taichi kernels
 @ti.kernel
-def initialize(pos: ti.any_arr(element_dim=1), vel: ti.any_arr(element_dim=1)):
+def initialize(pos: ti.types.ndarray(element_dim=1), vel: ti.types.ndarray(element_dim=1)):
     center=ti.Vector([0.5, 0.5])
     for i in pos:
         theta = ti.random() * 2 * PI
@@ -92,7 +92,7 @@ def initialize(pos: ti.any_arr(element_dim=1), vel: ti.any_arr(element_dim=1)):
         vel[i] *= init_vel
 
 @ti.kernel
-def compute_force(pos: ti.any_arr(element_dim=1), vel: ti.any_arr(element_dim=1), force: ti.any_arr(element_dim=1)):
+def compute_force(pos: ti.types.ndarray(element_dim=1), vel: ti.types.ndarray(element_dim=1), force: ti.types.ndarray(element_dim=1)):
     for i in pos:
         force[i] = ti.Vector([0.0, 0.0])
     for i in pos:

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -122,12 +122,12 @@ class Module:
                                     field.dtype, field.snode.shape, row_num,
                                     column_num)
 
-    def add_kernel(self, kernel_fn, example_any_arrays=None, name=None):
+    def add_kernel(self, kernel_fn, example_ndarrays=None, name=None):
         """Add a taichi kernel to the AOT module.
 
         Args:
           kernel_fn (Function): the function decorated by taichi `kernel`.
-          example_any_arrays (Dict[int, ti.ndarray]): a dict where key is arg_id and key is example ndarray input.
+          example_ndarrays (Dict[int, ti.ndarray]): a dict where key is arg_id and key is example ndarray input.
           name (str): Name to identify this kernel in the module. If not
             provided, uses the built-in ``__name__`` attribute of `kernel_fn`.
 
@@ -140,14 +140,14 @@ class Module:
             anno for anno in kernel.argument_annotations
             if isinstance(anno, NdarrayType)
         ])
-        assert example_any_arrays is None or num_arr == len(
-            example_any_arrays
-        ), f'Need {num_arr} example ndarray inputs but got {len(example_any_arrays)}'
+        assert example_ndarrays is None or num_arr == len(
+            example_ndarrays
+        ), f'Need {num_arr} example ndarray inputs but got {len(example_ndarrays)}'
         i = 0
         for anno in kernel.argument_annotations:
             if isinstance(anno, NdarrayType):
-                if example_any_arrays:
-                    injected_args.append(example_any_arrays[i])
+                if example_ndarrays:
+                    injected_args.append(example_ndarrays[i])
                 else:
                     assert anno.element_shape is not None and anno.field_dim is not None, 'Please either specify element_shape & field_dim in the kernel arg annotation or provide a dict of example ndarrays.'
                     if anno.element_dim == 0:

--- a/python/taichi/examples/ggui_examples/mpm3d_ggui.py
+++ b/python/taichi/examples/ggui_examples/mpm3d_ggui.py
@@ -197,7 +197,7 @@ def init_vols(vols):
 
 
 @ti.kernel
-def set_color_by_material(material_colors: ti.ext_arr()):
+def set_color_by_material(material_colors: ti.types.ndarray()):
     for i in range(n_particles):
         mat = materials[i]
         colors[i] = ti.Vector([

--- a/python/taichi/examples/ggui_examples/stable_fluid_ggui.py
+++ b/python/taichi/examples/ggui_examples/stable_fluid_ggui.py
@@ -98,7 +98,7 @@ def advect(vf: ti.template(), qf: ti.template(), new_qf: ti.template()):
 
 @ti.kernel
 def apply_impulse(vf: ti.template(), dyef: ti.template(),
-                  imp_data: ti.ext_arr()):
+                  imp_data: ti.types.ndarray()):
     g_dir = -ti.Vector([0, 9.8]) * 300
     for i, j in vf:
         omx, omy = imp_data[2], imp_data[3]

--- a/python/taichi/examples/simulation/implicit_mass_spring.py
+++ b/python/taichi/examples/simulation/implicit_mass_spring.py
@@ -160,7 +160,7 @@ class Cloth:
                 D[2 * idx2 + m, 2 * idx2 + n] -= self.Jv[i][m, n]
 
     @ti.kernel
-    def updatePosVel(self, h: ti.f32, dv: ti.ext_arr()):
+    def updatePosVel(self, h: ti.f32, dv: ti.types.ndarray()):
         for i in self.pos:
             self.vel[i] += ti.Vector([dv[2 * i], dv[2 * i + 1]])
             self.pos[i] += h * self.vel[i]

--- a/python/taichi/examples/simulation/stable_fluid.py
+++ b/python/taichi/examples/simulation/stable_fluid.py
@@ -148,7 +148,7 @@ def advect(vf: ti.template(), qf: ti.template(), new_qf: ti.template()):
 
 @ti.kernel
 def apply_impulse(vf: ti.template(), dyef: ti.template(),
-                  imp_data: ti.ext_arr()):
+                  imp_data: ti.types.ndarray()):
     g_dir = -ti.Vector([0, 9.8]) * 300
     for i, j in vf:
         omx, omy = imp_data[2], imp_data[3]
@@ -245,7 +245,7 @@ def copy_divergence(div_in: ti.template(), div_out: ti.template()):
 
 
 @ti.kernel
-def apply_pressure(p_in: ti.ext_arr(), p_out: ti.template()):
+def apply_pressure(p_in: ti.types.ndarray(), p_out: ti.template()):
     for I in ti.grouped(p_out):
         p_out[I] = p_in[I[0] * res + I[1]]
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -92,7 +92,7 @@ def expr_init_func(
 def begin_frontend_struct_for(ast_builder, group, loop_range):
     if not isinstance(loop_range, (AnyArray, Field, SNode, _Root)):
         raise TypeError(
-            'Can only iterate through Taichi fields/snodes (via template) or dense arrays (via any_arr)'
+            'Can only iterate through Taichi fields/snodes (via template) or dense arrays (via types.ndarray)'
         )
     if group.size() != len(loop_range.shape):
         raise IndexError(

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -5,7 +5,7 @@
 constexpr int taichi_max_num_indices = 8;
 // legacy: only used in cc and opengl backends
 constexpr int taichi_max_num_args = 8;
-// used in llvm backend: only the first 16 arguments can be ext_arr/any_arr
+// used in llvm backend: only the first 16 arguments can be types.ndarray
 // TODO: refine argument passing
 constexpr int taichi_max_num_args_total = 64;
 constexpr int taichi_max_num_args_extra = 16;

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -84,7 +84,8 @@ def test_aot_bind_id():
     density1 = ti.ndarray(dtype=ti.f32, shape=(8, 8))
 
     @ti.kernel
-    def init(x: ti.f32, density1: ti.types.ndarray(field_dim=2, element_shape=())):
+    def init(x: ti.f32, density1: ti.types.ndarray(field_dim=2,
+                                                   element_shape=())):
         for i, j in density1:
             density[i, j] = x
             density1[i, j] = x + 1
@@ -306,9 +307,10 @@ def test_opengl_8_ssbo():
     density6 = ti.ndarray(dtype=ti.f32, shape=(4, 4))
 
     @ti.kernel
-    def init(d: ti.i32, density1: ti.types.ndarray(), density2: ti.types.ndarray(),
-             density3: ti.types.ndarray(), density4: ti.types.ndarray(),
-             density5: ti.types.ndarray(), density6: ti.types.ndarray()):
+    def init(d: ti.i32, density1: ti.types.ndarray(),
+             density2: ti.types.ndarray(), density3: ti.types.ndarray(),
+             density4: ti.types.ndarray(), density5: ti.types.ndarray(),
+             density6: ti.types.ndarray()):
         for i, j in density1:
             density1[i, j] = d + 1
             density2[i, j] = d + 2
@@ -340,10 +342,11 @@ def test_opengl_exceed_max_ssbo():
     density8 = ti.ndarray(dtype=ti.f32, shape=(n, n))
 
     @ti.kernel
-    def init(d: ti.i32, density1: ti.types.ndarray(), density2: ti.types.ndarray(),
-             density3: ti.types.ndarray(), density4: ti.types.ndarray(),
-             density5: ti.types.ndarray(), density6: ti.types.ndarray(),
-             density7: ti.types.ndarray(), density8: ti.types.ndarray()):
+    def init(d: ti.i32, density1: ti.types.ndarray(),
+             density2: ti.types.ndarray(), density3: ti.types.ndarray(),
+             density4: ti.types.ndarray(), density5: ti.types.ndarray(),
+             density6: ti.types.ndarray(), density7: ti.types.ndarray(),
+             density8: ti.types.ndarray()):
         for i, j in density1:
             density1[i, j] = d + 1
             density2[i, j] = d + 2
@@ -519,9 +522,11 @@ def test_mpm88_ndarray():
     E = 400
 
     @ti.kernel
-    def substep(x: ti.types.ndarray(element_dim=1), v: ti.types.ndarray(element_dim=1),
+    def substep(x: ti.types.ndarray(element_dim=1),
+                v: ti.types.ndarray(element_dim=1),
                 C: ti.types.ndarray(element_dim=2), J: ti.types.ndarray(),
-                grid_v: ti.types.ndarray(element_dim=1), grid_m: ti.types.ndarray()):
+                grid_v: ti.types.ndarray(element_dim=1),
+                grid_m: ti.types.ndarray()):
         for p in x:
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -84,7 +84,7 @@ def test_aot_bind_id():
     density1 = ti.ndarray(dtype=ti.f32, shape=(8, 8))
 
     @ti.kernel
-    def init(x: ti.f32, density1: ti.any_arr(field_dim=2, element_shape=())):
+    def init(x: ti.f32, density1: ti.types.ndarray(field_dim=2, element_shape=())):
         for i, j in density1:
             density[i, j] = x
             density1[i, j] = x + 1
@@ -109,7 +109,7 @@ def test_aot_ndarray_range_hint():
     density = ti.ndarray(dtype=ti.f32, shape=(8, 8))
 
     @ti.kernel
-    def init(density: ti.any_arr()):
+    def init(density: ti.types.ndarray()):
         for i, j in density:
             density[i, j] = 1
 
@@ -306,9 +306,9 @@ def test_opengl_8_ssbo():
     density6 = ti.ndarray(dtype=ti.f32, shape=(4, 4))
 
     @ti.kernel
-    def init(d: ti.i32, density1: ti.any_arr(), density2: ti.any_arr(),
-             density3: ti.any_arr(), density4: ti.any_arr(),
-             density5: ti.any_arr(), density6: ti.any_arr()):
+    def init(d: ti.i32, density1: ti.types.ndarray(), density2: ti.types.ndarray(),
+             density3: ti.types.ndarray(), density4: ti.types.ndarray(),
+             density5: ti.types.ndarray(), density6: ti.types.ndarray()):
         for i, j in density1:
             density1[i, j] = d + 1
             density2[i, j] = d + 2
@@ -340,10 +340,10 @@ def test_opengl_exceed_max_ssbo():
     density8 = ti.ndarray(dtype=ti.f32, shape=(n, n))
 
     @ti.kernel
-    def init(d: ti.i32, density1: ti.any_arr(), density2: ti.any_arr(),
-             density3: ti.any_arr(), density4: ti.any_arr(),
-             density5: ti.any_arr(), density6: ti.any_arr(),
-             density7: ti.any_arr(), density8: ti.any_arr()):
+    def init(d: ti.i32, density1: ti.types.ndarray(), density2: ti.types.ndarray(),
+             density3: ti.types.ndarray(), density4: ti.types.ndarray(),
+             density5: ti.types.ndarray(), density6: ti.types.ndarray(),
+             density7: ti.types.ndarray(), density8: ti.types.ndarray()):
         for i, j in density1:
             density1[i, j] = d + 1
             density2[i, j] = d + 2
@@ -519,9 +519,9 @@ def test_mpm88_ndarray():
     E = 400
 
     @ti.kernel
-    def substep(x: ti.any_arr(element_dim=1), v: ti.any_arr(element_dim=1),
-                C: ti.any_arr(element_dim=2), J: ti.any_arr(),
-                grid_v: ti.any_arr(element_dim=1), grid_m: ti.any_arr()):
+    def substep(x: ti.types.ndarray(element_dim=1), v: ti.types.ndarray(element_dim=1),
+                C: ti.types.ndarray(element_dim=2), J: ti.types.ndarray(),
+                grid_v: ti.types.ndarray(element_dim=1), grid_m: ti.types.ndarray()):
         for p in x:
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)

--- a/tests/python/test_arg_load.py
+++ b/tests/python/test_arg_load.py
@@ -53,14 +53,14 @@ def test_arg_load_f64():
 
 
 @test_utils.test()
-def test_ext_arr():
+def test_ndarray():
     N = 128
     x = ti.field(ti.f32)
 
     ti.root.dense(ti.i, N).place(x)
 
     @ti.kernel
-    def set_f32(v: ti.ext_arr()):
+    def set_f32(v: ti.types.ndarray()):
         for i in range(N):
             x[i] = v[i] + i
 

--- a/tests/python/test_ast_refactor.py
+++ b/tests/python/test_ast_refactor.py
@@ -906,8 +906,8 @@ def test_ndarray():
     m = 7
 
     @ti.kernel
-    def run(x: ti.any_arr(element_dim=2, layout=ti.Layout.AOS),
-            y: ti.any_arr()):
+    def run(x: ti.types.ndarray(element_dim=2, layout=ti.Layout.AOS),
+            y: ti.types.ndarray()):
         for i in ti.static(range(n)):
             for j in ti.static(range(m)):
                 x[i, j][0, 0] += i + j + y[i, j]

--- a/tests/python/test_async.py
+++ b/tests/python/test_async.py
@@ -26,7 +26,7 @@ def test_numpy():
     n = 10000
 
     @ti.kernel
-    def inc(a: ti.ext_arr()):
+    def inc(a: ti.types.ndarray()):
         for i in range(n):
             a[i] += i
 

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -112,13 +112,13 @@ def test_bit_struct():
         ti.root.bit_struct(num_bits=physical_type).place(a, b, c)
 
         @ti.kernel
-        def set_val(test_val: ti.ext_arr()):
+        def set_val(test_val: ti.types.ndarray()):
             a[None] = test_val[0]
             b[None] = test_val[1]
             c[None] = test_val[2]
 
         @ti.kernel
-        def verify_val(test_val: ti.ext_arr()):
+        def verify_val(test_val: ti.types.ndarray()):
             assert a[None] == test_val[0]
             assert b[None] == test_val[1]
             assert c[None] == test_val[2]

--- a/tests/python/test_callable_template_mapper.py
+++ b/tests/python/test_callable_template_mapper.py
@@ -41,7 +41,7 @@ def test_callable_template_mapper_numpy():
 
     ti.root.place(x, y)
 
-    annotations = (ti.template(), ti.template(), ti.ext_arr())
+    annotations = (ti.template(), ti.template(), ti.types.ndarray())
 
     import numpy as np
 

--- a/tests/python/test_empty.py
+++ b/tests/python/test_empty.py
@@ -14,7 +14,7 @@ def test_empty():
 @test_utils.test()
 def test_empty_args():
     @ti.kernel
-    def func(x: ti.i32, arr: ti.ext_arr()):
+    def func(x: ti.i32, arr: ti.types.ndarray()):
         pass
 
     import numpy as np

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -13,7 +13,7 @@ if has_pytorch():
 @test_utils.test()
 def test_get_external_tensor_shape_access_numpy(size):
     @ti.kernel
-    def func(x: ti.ext_arr(), index: ti.template()) -> ti.i32:
+    def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:
         return x.shape[index]
 
     x_hat = np.ones(size, dtype=np.int32)
@@ -27,7 +27,7 @@ def test_get_external_tensor_shape_access_numpy(size):
 @test_utils.test()
 def test_get_external_tensor_shape_sum_numpy(size):
     @ti.kernel
-    def func(x: ti.ext_arr()) -> ti.i32:
+    def func(x: ti.types.ndarray()) -> ti.i32:
         y = 0
         for i in range(x.shape[0]):
             for j in range(x.shape[1]):
@@ -47,7 +47,7 @@ def test_get_external_tensor_shape_sum_numpy(size):
 @test_utils.test(exclude=ti.opengl)
 def test_get_external_tensor_shape_access_torch(size):
     @ti.kernel
-    def func(x: ti.ext_arr(), index: ti.template()) -> ti.i32:
+    def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:
         return x.shape[index]
 
     x_hat = torch.ones(size, dtype=torch.int32, device='cpu')
@@ -62,7 +62,7 @@ def test_get_external_tensor_shape_access_torch(size):
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.opengl])
 def test_get_external_tensor_shape_access_ndarray(size):
     @ti.kernel
-    def func(x: ti.any_arr(), index: ti.template()) -> ti.i32:
+    def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:
         return x.shape[index]
 
     x_hat = ti.ndarray(ti.i32, shape=size)

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -166,7 +166,7 @@ def test_taichi_scope_matrix_operations_with_global_matrices(ops):
 @test_utils.test()
 def test_matrix_non_constant_index_numpy():
     @ti.kernel
-    def func1(a: ti.any_arr(element_dim=2)):
+    def func1(a: ti.types.ndarray(element_dim=2)):
         for i in range(5):
             for j, k in ti.ndrange(2, 2):
                 a[i][j, k] = j * j + k * k
@@ -179,7 +179,7 @@ def test_matrix_non_constant_index_numpy():
     assert m[4][0, 1] == 1
 
     @ti.kernel
-    def func2(b: ti.any_arr(element_dim=1, layout=ti.Layout.SOA)):
+    def func2(b: ti.types.ndarray(element_dim=1, layout=ti.Layout.SOA)):
         for i in range(5):
             for j in range(4):
                 b[i][j * j] = j * j

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -142,9 +142,11 @@ def test_mpm88_numpy_and_ndarray():
     E = 400
 
     @ti.kernel
-    def substep(x: ti.types.ndarray(element_dim=1), v: ti.types.ndarray(element_dim=1),
+    def substep(x: ti.types.ndarray(element_dim=1),
+                v: ti.types.ndarray(element_dim=1),
                 C: ti.types.ndarray(element_dim=2), J: ti.types.ndarray(),
-                grid_v: ti.types.ndarray(element_dim=1), grid_m: ti.types.ndarray()):
+                grid_v: ti.types.ndarray(element_dim=1),
+                grid_m: ti.types.ndarray()):
         for p in x:
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -142,9 +142,9 @@ def test_mpm88_numpy_and_ndarray():
     E = 400
 
     @ti.kernel
-    def substep(x: ti.any_arr(element_dim=1), v: ti.any_arr(element_dim=1),
-                C: ti.any_arr(element_dim=2), J: ti.any_arr(),
-                grid_v: ti.any_arr(element_dim=1), grid_m: ti.any_arr()):
+    def substep(x: ti.types.ndarray(element_dim=1), v: ti.types.ndarray(element_dim=1),
+                C: ti.types.ndarray(element_dim=2), J: ti.types.ndarray(),
+                grid_v: ti.types.ndarray(element_dim=1), grid_m: ti.types.ndarray()):
         for p in x:
             base = (x[p] * inv_dx - 0.5).cast(int)
             fx = x[p] * inv_dx - base.cast(float)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -111,7 +111,7 @@ def test_ndarray_1d():
     n = 4
 
     @ti.kernel
-    def run(x: ti.any_arr(), y: ti.any_arr()):
+    def run(x: ti.types.ndarray(), y: ti.types.ndarray()):
         for i in range(n):
             x[i] += i + y[i]
 
@@ -132,7 +132,7 @@ def _test_ndarray_2d():
     m = 7
 
     @ti.kernel
-    def run(x: ti.any_arr(), y: ti.any_arr()):
+    def run(x: ti.types.ndarray(), y: ti.types.ndarray()):
         for i in range(n):
             for j in range(m):
                 x[i, j] += i + j + y[i, j]
@@ -383,7 +383,7 @@ def test_matrix_ndarray_python_scope(layout):
 
 def _test_matrix_ndarray_taichi_scope(layout):
     @ti.kernel
-    def func(a: ti.any_arr()):
+    def func(a: ti.types.ndarray()):
         for i in range(5):
             for j, k in ti.ndrange(2, 2):
                 a[i][j, k] = j * j + k * k
@@ -405,7 +405,7 @@ def test_matrix_ndarray_taichi_scope(layout):
 
 def _test_matrix_ndarray_taichi_scope_struct_for(layout):
     @ti.kernel
-    def func(a: ti.any_arr()):
+    def func(a: ti.types.ndarray()):
         for i in a:
             for j, k in ti.ndrange(2, 2):
                 a[i][j, k] = j * j + k * k
@@ -443,7 +443,7 @@ def test_vector_ndarray_python_scope(layout):
 @test_utils.test(arch=supported_archs_taichi_ndarray)
 def test_vector_ndarray_taichi_scope(layout):
     @ti.kernel
-    def func(a: ti.any_arr()):
+    def func(a: ti.types.ndarray()):
         for i in range(5):
             for j in range(4):
                 a[i][j * j] = j * j
@@ -462,7 +462,7 @@ def test_vector_ndarray_taichi_scope(layout):
 
 def _test_compiled_functions():
     @ti.kernel
-    def func(a: ti.any_arr(element_dim=1)):
+    def func(a: ti.types.ndarray(element_dim=1)):
         for i in range(5):
             for j in range(4):
                 a[i][j * j] = j * j
@@ -491,7 +491,7 @@ def test_compiled_functions():
 
 def _test_arg_not_match():
     @ti.kernel
-    def func1(a: ti.any_arr(element_dim=1)):
+    def func1(a: ti.types.ndarray(element_dim=1)):
         pass
 
     x = ti.Matrix.ndarray(2, 3, ti.i32, shape=(4, 7))
@@ -503,7 +503,7 @@ def _test_arg_not_match():
         func1(x)
 
     @ti.kernel
-    def func2(a: ti.any_arr(element_dim=2)):
+    def func2(a: ti.types.ndarray(element_dim=2)):
         pass
 
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
@@ -515,7 +515,7 @@ def _test_arg_not_match():
         func2(x)
 
     @ti.kernel
-    def func3(a: ti.any_arr(layout=ti.Layout.AOS)):
+    def func3(a: ti.types.ndarray(layout=ti.Layout.AOS)):
         pass
 
     x = ti.Matrix.ndarray(2, 3, ti.i32, shape=(4, 7), layout=ti.Layout.SOA)
@@ -527,7 +527,7 @@ def _test_arg_not_match():
         func3(x)
 
     @ti.kernel
-    def func4(a: ti.any_arr(layout=ti.Layout.SOA)):
+    def func4(a: ti.types.ndarray(layout=ti.Layout.SOA)):
         pass
 
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
@@ -539,7 +539,7 @@ def _test_arg_not_match():
         func4(x)
 
     @ti.kernel
-    def func5(a: ti.any_arr(element_shape=(2, 3))):
+    def func5(a: ti.types.ndarray(element_shape=(2, 3))):
         pass
 
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
@@ -555,11 +555,11 @@ def _test_arg_not_match():
             match=r'Both element_shape and element_dim are specified'):
 
         @ti.kernel
-        def func6(a: ti.any_arr(element_dim=1, element_shape=(2, 3))):
+        def func6(a: ti.types.ndarray(element_dim=1, element_shape=(2, 3))):
             pass
 
     @ti.kernel
-    def func7(a: ti.any_arr(field_dim=2)):
+    def func7(a: ti.types.ndarray(field_dim=2)):
         pass
 
     x = ti.ndarray(ti.i32, shape=(3, ))
@@ -597,7 +597,7 @@ def test_different_shape():
     x = ti.ndarray(dtype=ti.f32, shape=(n1, n1))
 
     @ti.kernel
-    def init(d: ti.i32, arr: ti.any_arr()):
+    def init(d: ti.i32, arr: ti.types.ndarray()):
         for i, j in arr:
             arr[i, j] = d
 

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -13,7 +13,7 @@ def with_data_type(dt):
     ti.root.dense(ti.i, n).place(val)
 
     @ti.kernel
-    def test_numpy(arr: ti.ext_arr()):
+    def test_numpy(arr: ti.types.ndarray()):
         for i in range(n):
             arr[i] = arr[i]**2
 
@@ -58,7 +58,7 @@ def test_numpy_2d():
     ti.root.dense(ti.i, n).dense(ti.j, m).place(val)
 
     @ti.kernel
-    def test_numpy(arr: ti.ext_arr()):
+    def test_numpy(arr: ti.types.ndarray()):
         for i in range(n):
             for j in range(m):
                 arr[i, j] += i + j
@@ -86,7 +86,7 @@ def test_numpy_2d_transpose():
     ti.root.dense(ti.ij, (n, m)).place(val)
 
     @ti.kernel
-    def test_numpy(arr: ti.ext_arr()):
+    def test_numpy(arr: ti.types.ndarray()):
         for i in ti.grouped(val):
             val[i] = arr[i]
 
@@ -114,7 +114,7 @@ def test_numpy_3d():
     ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     @ti.kernel
-    def test_numpy(arr: ti.ext_arr()):
+    def test_numpy(arr: ti.types.ndarray()):
         for i in range(n):
             for j in range(m):
                 for k in range(p):
@@ -146,7 +146,7 @@ def test_numpy_3d_error():
     ti.root.dense(ti.i, n).dense(ti.j, m).dense(ti.k, p).place(val)
 
     @ti.kernel
-    def test_numpy(arr: ti.ext_arr()):
+    def test_numpy(arr: ti.types.ndarray()):
         for i in range(n):
             for j in range(m):
                 for k in range(p):
@@ -164,7 +164,7 @@ def test_numpy_multiple_external_arrays():
     n = 4
 
     @ti.kernel
-    def test_numpy(a: ti.ext_arr(), b: ti.ext_arr()):
+    def test_numpy(a: ti.types.ndarray(), b: ti.types.ndarray()):
         for i in range(n):
             a[i] = a[i] * b[i]
             b[i] = a[i] + b[i]
@@ -190,7 +190,7 @@ def test_index_mismatch():
 @test_utils.test()
 def test_numpy_zero():
     @ti.kernel
-    def test_numpy(arr: ti.ext_arr()):
+    def test_numpy(arr: ti.types.ndarray()):
         pass
 
     test_numpy(np.empty(shape=(0), dtype=np.int32))
@@ -201,7 +201,7 @@ def test_numpy_zero():
 @test_utils.test()
 def test_numpy_struct_for():
     @ti.kernel
-    def func1(a: ti.any_arr()):
+    def func1(a: ti.types.ndarray()):
         for i, j in a:
             a[i, j] = i + j
 
@@ -212,7 +212,7 @@ def test_numpy_struct_for():
             assert m[i, j] == i + j
 
     @ti.kernel
-    def func2(a: ti.any_arr()):
+    def func2(a: ti.types.ndarray()):
         for I in ti.grouped(a):
             a[I] = I.sum()
 

--- a/tests/python/test_reduction.py
+++ b/tests/python/test_reduction.py
@@ -132,9 +132,9 @@ def test_reduction_different_scale():
 
 
 @test_utils.test()
-def test_reduction_any_arr():
+def test_reduction_ndarray():
     @ti.kernel
-    def reduce(a: ti.any_arr()) -> ti.i32:
+    def reduce(a: ti.types.ndarray()) -> ti.i32:
         s = 0
         for i in a:
             ti.atomic_add(s, a[i])

--- a/tests/python/test_sparse_linear_solver.py
+++ b/tests/python/test_sparse_linear_solver.py
@@ -42,7 +42,7 @@ def test_sparse_LLT_solver(dtype, solver_type, ordering):
 
     @ti.kernel
     def fill(Abuilder: ti.types.sparse_matrix_builder(),
-             InputArray: ti.ext_arr(), b: ti.template()):
+             InputArray: ti.types.ndarray(), b: ti.template()):
         for i, j in ti.ndrange(n, n):
             Abuilder[i, j] += InputArray[i, j]
         for i in range(n):

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -17,7 +17,7 @@ def test_io_devices():
     x = ti.field(dtype=ti.i32, shape=n)
 
     @ti.kernel
-    def load(y: ti.ext_arr()):
+    def load(y: ti.types.ndarray()):
         for i in x:
             x[i] = y[i] + 10
 
@@ -27,7 +27,7 @@ def test_io_devices():
             x[i] += i
 
     @ti.kernel
-    def store(y: ti.ext_arr()):
+    def store(y: ti.types.ndarray()):
         for i in x:
             y[i] = x[i] * 2
 
@@ -53,13 +53,13 @@ def test_io():
     n = 32
 
     @ti.kernel
-    def torch_kernel(t: ti.ext_arr(), o: ti.ext_arr()):
+    def torch_kernel(t: ti.types.ndarray(), o: ti.types.ndarray()):
         for i in range(n):
             o[i] = t[i] * t[i]
 
     @ti.kernel
-    def torch_kernel_2(t_grad: ti.ext_arr(), t: ti.ext_arr(),
-                       o_grad: ti.ext_arr()):
+    def torch_kernel_2(t_grad: ti.types.ndarray(), t: ti.types.ndarray(),
+                       o_grad: ti.types.ndarray()):
         for i in range(n):
             t_grad[i] = 2 * t[i] * o_grad[i]
 
@@ -93,7 +93,7 @@ def test_io_2d():
     n = 32
 
     @ti.kernel
-    def torch_kernel(t: ti.ext_arr(), o: ti.ext_arr()):
+    def torch_kernel(t: ti.types.ndarray(), o: ti.types.ndarray()):
         for i in range(n):
             for j in range(n):
                 o[i, j] = t[i, j] * t[i, j]
@@ -117,7 +117,7 @@ def test_io_3d():
     n = 16
 
     @ti.kernel
-    def torch_kernel(t: ti.ext_arr(), o: ti.ext_arr()):
+    def torch_kernel(t: ti.types.ndarray(), o: ti.types.ndarray()):
         for i in range(n):
             for j in range(n):
                 for k in range(n):
@@ -264,7 +264,7 @@ def test_shape_vector():
 @test_utils.test(exclude=[ti.opengl, ti.vulkan])
 def test_torch_zero():
     @ti.kernel
-    def test_torch(arr: ti.ext_arr()):
+    def test_torch(arr: ti.types.ndarray()):
         pass
 
     test_torch(torch.zeros((0), dtype=torch.int32))
@@ -276,7 +276,7 @@ def test_torch_zero():
 @test_utils.test(exclude=[ti.opengl, ti.vulkan])
 def test_torch_view():
     @ti.kernel
-    def copy(x: ti.any_arr(), y: ti.any_arr()):
+    def copy(x: ti.types.ndarray(), y: ti.types.ndarray()):
         for i, j in x:
             y[i, j] = x[i, j]
 

--- a/tests/python/test_type_check.py
+++ b/tests/python/test_type_check.py
@@ -51,11 +51,11 @@ def test_subscript():
     a = ti.ndarray(ti.i32, shape=(10, 10))
 
     @ti.kernel
-    def any_array(x: ti.any_arr()):
+    def ndarray(x: ti.types.ndarray()):
         b = x[3, 1.1]
 
     with pytest.raises(ti.TaichiTypeError, match="indices must be integers"):
-        any_array(a)
+        ndarray(a)
 
 
 @test_utils.test()


### PR DESCRIPTION
A follow-up of #4598.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
