### PR TITLE
[ci] Create another branch if release run on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: "recursive"
+          submodules: 'recursive'
 
       - name: Get sccache cache
         uses: actions/cache@v2
@@ -186,7 +186,7 @@ jobs:
         env:
           PY: ${{ matrix.conda_python }}
           GPU_TEST: ON
-          TI_WANTED_ARCHS: "cuda,cpu"
+          TI_WANTED_ARCHS: 'cuda,cpu'
 
       - name: clean docker container
         if: always()
@@ -475,12 +475,15 @@ jobs:
           version_parts[2]=$(expr ${version_parts[2]} + 1)
           next_version=$(IFS=.; echo "${version_parts[*]}")
           # Update version.txt
-          git checkout -b "bump/$next_version"
+          if [[ "$GITHUB_REF_NAME" == "master" ]]; then
+              branch="bump/$next_version"
+              git checkout -b "$branch"
+          fi
           echo "$next_version" > version.txt
           git add version.txt
           # Commit and push changes
           git commit -m "Bump version to $next_version"
-          git push origin "bump/$next_version"
+          git push origin $branch
           # Create pull request
           gh pr create -B master -t "[misc] Bump version to $next_version" -b "Bump version to $next_version"
         env:


### PR DESCRIPTION
If release workflow is triggered on the RC branch, the bot will directly create PR based on that branch. Otherwise, it will create another branch for PR. This can make sure any changes on the RC branch are merged back to the master.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
