### PR TITLE
[Doc] Fix 4 typos in doc

### DIFF
--- a/docs/lang/articles/advanced/meta.md
+++ b/docs/lang/articles/advanced/meta.md
@@ -170,7 +170,7 @@ def func():
 
 There are two reasons to use `ti.static` with for loops:
 
-- Loop unrolling for improving runtime performance (see section [Compile-time evaluations](##Compile-time evaluations)).
+- Loop unrolling for improving runtime performance (see [Compile-time evaluations](#compile-time-evaluations)).
 - Accessing elements of Taichi matrices/vectors. Indices for accessing Taichi fields can be runtime variables, while indices for Taichi matrices/vectors **must be a compile-time constant**.
 
 For example, when accessing a vector field `x` with `x[field_index][vector_component_index]`, the `field_index` can be a runtime variable, while the `vector_component_index` must be a compile-time constant:
@@ -190,7 +190,7 @@ def reset():
 
 A compile-time recursive function is a function with recursion that can be recursively inlined at compile time. The condition which determines whether to recurse is evaluated at compile time.
 
-You can combine [compile-time branching](#compile-time-evaluations) and [template](#template-metaprogramming) to write compile-time recursive functions.
+You can combine [compile-time branching](#compile-time-branching) and [template](#template-metaprogramming) to write compile-time recursive functions.
 
 For example, `sum_from_one_to` is a compile-time recursive function that calculates the sum of numbers from `1` to `n`.
 

--- a/docs/lang/articles/basic/differences_between_taichi_and_python_programs.md
+++ b/docs/lang/articles/basic/differences_between_taichi_and_python_programs.md
@@ -25,11 +25,11 @@ def error_kernel_no_return_annotation():
     return 0  # Error: Have return statement but have no return type annotation
 
 @ti.kernel
-def error_kernel_no_return() -> ti.i31:  # Error: Have return type annotation but have no return statement
+def error_kernel_no_return() -> ti.i32:  # Error: Have return type annotation but have no return statement
     pass
 
 @ti.func
-def error_func_no_return() -> ti.i31:  # Error: Have return type annotation but have no return statement
+def error_func_no_return() -> ti.i32:  # Error: Have return type annotation but have no return statement
     pass
 ```
 

--- a/docs/lang/articles/get-started/index.md
+++ b/docs/lang/articles/get-started/index.md
@@ -236,9 +236,7 @@ def fill_3d():
         x[i, j, k] = i + j + k
 ```
 
-:::caution
-
-Struct-for loops must live at the outer-most scope of kernels.
+:::note
 
 It is the loop **at the outermost scope** that gets parallelized, not
 the outermost loop.
@@ -270,6 +268,30 @@ Taichi, as it will only loop over active elements in a sparse field. In
 dense fields, all elements are active.
 :::
 
+:::caution
+
+Struct-for loops must live at the outer-most scope of kernels.
+
+It is the loop **at the outermost scope** that gets parallelized, not
+the outermost loop.
+
+```python
+x = [1, 2, 3]
+
+@ti.kernel
+def foo():
+    for i in x: # Parallelized :-)
+        ...
+
+@ti.kernel
+def bar(k: ti.i32):
+    # The outermost scope is a `if` statement
+    if k > 42:
+        for i in x: # Not allowed. Struct-fors must live in the outermost scope.
+            ...
+```
+
+:::
 
 :::caution
 

--- a/docs/lang/articles/get-started/index.md
+++ b/docs/lang/articles/get-started/index.md
@@ -236,7 +236,9 @@ def fill_3d():
         x[i, j, k] = i + j + k
 ```
 
-:::note
+:::caution
+
+Struct-for loops must live at the outer-most scope of kernels.
 
 It is the loop **at the outermost scope** that gets parallelized, not
 the outermost loop.
@@ -268,28 +270,6 @@ Taichi, as it will only loop over active elements in a sparse field. In
 dense fields, all elements are active.
 :::
 
-:::caution
-
-Struct-for loops must live at the outer-most scope of kernels.
-
-It is the loop **at the outermost scope** that gets parallelized, not
-the outermost loop.
-
-```python
-@ti.kernel
-def foo():
-    for i in x:
-        ...
-
-@ti.kernel
-def bar(k: ti.i32):
-    # The outermost scope is a `if` statement
-    if k > 42:
-        for i in x: # Not allowed. Struct-fors must live in the outermost scope.
-            ...
-```
-
-:::
 
 :::caution
 

--- a/docs/lang/articles/gui/gui_system.md
+++ b/docs/lang/articles/gui/gui_system.md
@@ -94,15 +94,13 @@ pos = np.random.random((50, 2))
 # 1 corresponds to 0xED553B
 # 2 corresponds to 0xEEEEF0
 indices = np.random.randint(0, 2, size=(50,))
-gui = ti.GUI("lines", res=(400, 400))
+gui = ti.GUI("circles", res=(400, 400))
 while gui.running:
-    gui.circles(pos, radius=1.5, palette=[0x068587, 0xED553B, 0xEEEEF0], palette_indices=indices)
+    gui.circles(pos, radius=5, palette=[0x068587, 0xED553B, 0xEEEEF0], palette_indices=indices)
     gui.show()
 ```
 
-
-
-![img](https://o9ixctz0o7.feishu.cn/space/api/box/stream/download/asynccode/?code=N2Y2M2YxMWZlZGM2NGM1ZGQ3Y2JlZmU3NzgyMjRmZWRfSEprR1JLempxWkVSOFllRnBkS1hMZGlGeFI3SWVNN0RfVG9rZW46Ym94Y25EZFhiUmwzeWxjakllME1SSXhNMjlnXzE2NDg2MzAzNjA6MTY0ODYzMzk2MF9WNA)
+![gui-circles](https://raw.githubusercontent.com/taichi-dev/public_files/master/taichi/doc/gui-circles.png)
 
 The following code draws five blue line segments whose width is 2, with `X` and `Y` representing the five starting points and the five ending points.
 
@@ -110,10 +108,13 @@ The following code draws five blue line segments whose width is 2, with `X` and 
 import numpy as np
 X = np.random.random((5, 2))
 Y = np.random.random((5, 2))
-gui.lines(begin=X, end=Y, radius=2, color=0x068587)
+gui = ti.GUI("lines", res=(400, 400))
+while gui.running:
+    gui.lines(begin=X, end=Y, radius=2, color=0x068587)
+    gui.show()
 ```
 
-![img](https://o9ixctz0o7.feishu.cn/space/api/box/stream/download/asynccode/?code=NDlhNDgxOTViYmNmNTBhZDQ2YjJhMmYxZjQxMWY4MDBfVjd6WURPM2d1M05TOW9FUk9tVHpIQlFtVVJMNjdudGlfVG9rZW46Ym94Y254dTk5dFI1ZEwzSTFHUGJKOWl2dG5mXzE2NDg2MzAzNjA6MTY0ODYzMzk2MF9WNA)
+![gui-lines](https://raw.githubusercontent.com/taichi-dev/public_files/master/taichi/doc/gui-lines.png)
 
 The following code draws two orange triangles orange, with `X`, `Y`, and `Z` representing the three points of the triangles.
 
@@ -122,13 +123,13 @@ import numpy as np
 X = np.random.random((2, 2))
 Y = np.random.random((2, 2))
 Z = np.random.random((2, 2))
-gui.triangles(a=X, b=Y, c=Z, color=0xED553B)
+gui = ti.GUI("triangles", res=(400, 400))
+while gui.running:
+    gui.triangles(a=X, b=Y, c=Z, color=0xED553B)
+    gui.show()
 ```
 
-
-
-![img](https://o9ixctz0o7.feishu.cn/space/api/box/stream/download/asynccode/?code=N2JkMDNmNWYxYTBiMTliNDVjNWRhNGNmNWMxY2Y4ZjlfQURQSTlIYVVjTWEyYjVIWThjVmxtNmFZNlI4QzJDWUJfVG9rZW46Ym94Y252bkpSeDVEUkhRY1pmanRpZ2hDY1lkXzE2NDg2MzAzNjA6MTY0ODYzMzk2MF9WNA)
-
+![gui-triangles](https://raw.githubusercontent.com/taichi-dev/public_files/master/taichi/doc/gui-triangles.png)
 
 
 ## Event handling

--- a/docs/lang/articles/gui/gui_system.md
+++ b/docs/lang/articles/gui/gui_system.md
@@ -84,7 +84,7 @@ The `pos` parameter of every drawing method accepts Taichi fields or NumPy array
 - `(0.0, 0.0)`: the lower-left corner of the window.
 - `(1.0, 1.0)`: the upper-right corner of the window.
 
-The following code draws 50 circles with a radius of `1.5` and in three different colors randomly assigned by `indices`, an integer array of the same size as `pos`.
+The following code draws 50 circles with a radius of `5` and in three different colors randomly assigned by `indices`, an integer array of the same size as `pos`.
 
 ```python
 import numpy as np


### PR DESCRIPTION
1. fix broken link in https://docs.taichi.graphics/lang/articles/meta#when-to-use-tistatic-with-for-loops
2. fix typo `ti.i31 -> ti.i32`
3. fix duplicated warning (appear twice) in getting start
4. fix broken images in https://docs.taichi.graphics/lang/articles/gui_system#draw-on-a-window

Related PR: https://github.com/taichi-dev/public_files/pull/9