### PR TITLE
[misc] Add SNode to offline-cache key

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -2380,7 +2380,7 @@ FunctionType CodeGenLLVM::gen() {
   std::string kernel_key;
   if (config.offline_cache && this->supports_offline_cache() &&
       !kernel->is_evaluator) {
-    kernel_key = get_offline_cache_key(&kernel->program->config, kernel);
+    kernel_key = get_hashed_offline_cache_key(&kernel->program->config, kernel);
 
     LlvmOfflineCacheFileReader reader(config.offline_cache_file_path);
     LlvmOfflineCache::KernelCacheData cache_data;

--- a/taichi/ir/expression_printer.h
+++ b/taichi/ir/expression_printer.h
@@ -3,6 +3,7 @@
 #include "taichi/ir/expr.h"
 #include "taichi/ir/expression.h"
 #include "taichi/ir/frontend_ir.h"
+#include "taichi/program/program.h"
 #include "taichi/llvm/llvm_offline_cache.h"
 
 namespace taichi {
@@ -259,14 +260,14 @@ class ExpressionHumanFriendlyPrinter : public ExpressionPrinter {
 class ExpressionOfflineCacheKeyGenerator
     : public ExpressionHumanFriendlyPrinter {
  public:
-  explicit ExpressionOfflineCacheKeyGenerator(std::ostream *os = nullptr)
-      : ExpressionHumanFriendlyPrinter(os) {
+  explicit ExpressionOfflineCacheKeyGenerator(Program *prog, std::ostream *os = nullptr)
+      : ExpressionHumanFriendlyPrinter(os), prog_(prog) {
   }
 
   void visit(GlobalVariableExpression *expr) override {
     emit("#", expr->ident.name());
     if (expr->snode) {
-      emit("(snode=", get_hashed_offline_cache_key_of_snode(expr->snode), ')');
+      emit("(snode=", this->get_hashed_key_of_snode(expr->snode), ')');
     } else {
       emit("(dt=", expr->dt->to_string(), ')');
     }
@@ -274,7 +275,7 @@ class ExpressionOfflineCacheKeyGenerator
 
   void visit(GlobalPtrExpression *expr) override {
     if (expr->snode) {
-      emit(get_hashed_offline_cache_key_of_snode(expr->snode));
+      emit(this->get_hashed_key_of_snode(expr->snode));
     } else {
       expr->var->accept(this);
     }
@@ -285,7 +286,7 @@ class ExpressionOfflineCacheKeyGenerator
 
   void visit(SNodeOpExpression *expr) override {
     emit(snode_op_type_name(expr->op_type));
-    emit('(', get_hashed_offline_cache_key_of_snode(expr->snode), ", [");
+    emit('(', this->get_hashed_key_of_snode(expr->snode), ", [");
     emit_vector(expr->indices.exprs);
     emit(']');
     if (expr->value.expr) {
@@ -294,6 +295,30 @@ class ExpressionOfflineCacheKeyGenerator
     }
     emit(')');
   }
+ private:
+  const std::string &cache_snode_tree_key(int snode_tree_id, std::string &&key) {
+    if (snode_tree_id >= snode_tree_key_cache_.size()) {
+      snode_tree_key_cache_.resize(snode_tree_id + 1);
+    }
+    return snode_tree_key_cache_[snode_tree_id] = std::move(key);
+  }
+
+  std::string get_hashed_key_of_snode(SNode *snode) {
+    TI_ASSERT(snode && prog_);
+    auto snode_tree_id = snode->get_snode_tree_id();
+    std::string res;
+    if (snode_tree_id < snode_tree_key_cache_.size() && !snode_tree_key_cache_[snode_tree_id].empty()) {
+      res = snode_tree_key_cache_[snode_tree_id];
+    } else {
+      auto *snode_tree_root = prog_->get_snode_root(snode_tree_id);
+      auto snode_tree_key = get_hashed_offline_cache_key_of_snode(snode_tree_root);
+      res = cache_snode_tree_key(snode_tree_id, std::move(snode_tree_key));
+    }
+    return res.append(std::to_string(snode->id));
+  }
+
+  Program *prog_{nullptr};
+  std::vector<std::string> snode_tree_key_cache_;
 };
 
 }  // namespace lang

--- a/taichi/ir/expression_printer.h
+++ b/taichi/ir/expression_printer.h
@@ -21,13 +21,15 @@ class ExpressionPrinter : public ExpressionVisitor {
     TI_ASSERT(os_);
     return *os_;
   }
+
  private:
   std::ostream *os_{nullptr};
 };
 
 class ExpressionHumanFriendlyPrinter : public ExpressionPrinter {
  public:
-  explicit ExpressionHumanFriendlyPrinter(std::ostream *os = nullptr) : ExpressionPrinter(os) {
+  explicit ExpressionHumanFriendlyPrinter(std::ostream *os = nullptr)
+      : ExpressionPrinter(os) {
   }
 
   void visit(ExprGroup &expr_group) override {
@@ -254,10 +256,11 @@ class ExpressionHumanFriendlyPrinter : public ExpressionPrinter {
 };
 
 // Temporary reuse ExpressionHumanFriendlyPrinter
-class ExpressionOfflineCacheKeyGenerator : public ExpressionHumanFriendlyPrinter {
+class ExpressionOfflineCacheKeyGenerator
+    : public ExpressionHumanFriendlyPrinter {
  public:
   explicit ExpressionOfflineCacheKeyGenerator(std::ostream *os = nullptr)
-   : ExpressionHumanFriendlyPrinter(os) {
+      : ExpressionHumanFriendlyPrinter(os) {
   }
 
   void visit(GlobalVariableExpression *expr) override {

--- a/taichi/ir/expression_printer.h
+++ b/taichi/ir/expression_printer.h
@@ -260,7 +260,8 @@ class ExpressionHumanFriendlyPrinter : public ExpressionPrinter {
 class ExpressionOfflineCacheKeyGenerator
     : public ExpressionHumanFriendlyPrinter {
  public:
-  explicit ExpressionOfflineCacheKeyGenerator(Program *prog, std::ostream *os = nullptr)
+  explicit ExpressionOfflineCacheKeyGenerator(Program *prog,
+                                              std::ostream *os = nullptr)
       : ExpressionHumanFriendlyPrinter(os), prog_(prog) {
   }
 
@@ -295,8 +296,10 @@ class ExpressionOfflineCacheKeyGenerator
     }
     emit(')');
   }
+
  private:
-  const std::string &cache_snode_tree_key(int snode_tree_id, std::string &&key) {
+  const std::string &cache_snode_tree_key(int snode_tree_id,
+                                          std::string &&key) {
     if (snode_tree_id >= snode_tree_key_cache_.size()) {
       snode_tree_key_cache_.resize(snode_tree_id + 1);
     }
@@ -307,11 +310,13 @@ class ExpressionOfflineCacheKeyGenerator
     TI_ASSERT(snode && prog_);
     auto snode_tree_id = snode->get_snode_tree_id();
     std::string res;
-    if (snode_tree_id < snode_tree_key_cache_.size() && !snode_tree_key_cache_[snode_tree_id].empty()) {
+    if (snode_tree_id < snode_tree_key_cache_.size() &&
+        !snode_tree_key_cache_[snode_tree_id].empty()) {
       res = snode_tree_key_cache_[snode_tree_id];
     } else {
       auto *snode_tree_root = prog_->get_snode_root(snode_tree_id);
-      auto snode_tree_key = get_hashed_offline_cache_key_of_snode(snode_tree_root);
+      auto snode_tree_key =
+          get_hashed_offline_cache_key_of_snode(snode_tree_root);
       res = cache_snode_tree_key(snode_tree_id, std::move(snode_tree_key));
     }
     return res.append(std::to_string(snode->id));

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -47,6 +47,7 @@ void full_simplify(IRNode *root,
                    const CompileConfig &config,
                    const FullSimplifyPass::Args &args);
 void print(IRNode *root, std::string *output = nullptr);
+void gen_offline_cache_key(IRNode *root, std::string *output);
 void frontend_type_check(IRNode *root);
 void lower_ast(IRNode *root);
 void type_check(IRNode *root, const CompileConfig &config);

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -47,7 +47,7 @@ void full_simplify(IRNode *root,
                    const CompileConfig &config,
                    const FullSimplifyPass::Args &args);
 void print(IRNode *root, std::string *output = nullptr);
-void gen_offline_cache_key(IRNode *root, std::string *output);
+void gen_offline_cache_key(Program *program, IRNode *root, std::string *output);
 void frontend_type_check(IRNode *root);
 void lower_ast(IRNode *root);
 void type_check(IRNode *root, const CompileConfig &config);

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -107,7 +107,7 @@ static TI_FORCE_INLINE void get_offline_cache_key_of_snode_impl(
   if (!snode->ambient_val.dt->is_primitive(PrimitiveTypeID::unknown)) {
     serializer(snode->ambient_val.stringify());
   }
-  if (!snode->grad_info->is_primal()) {
+  if (snode->grad_info && !snode->grad_info->is_primal()) {
     if (auto *grad_snode = snode->grad_info->grad_snode()) {
       get_offline_cache_key_of_snode_impl(grad_snode, serializer);
     }
@@ -155,7 +155,7 @@ std::string get_hashed_offline_cache_key(CompileConfig *config,
                                          Kernel *kernel) {
   std::string kernel_ast_string;
   if (kernel) {
-    irpass::gen_offline_cache_key(kernel->ir.get(), &kernel_ast_string);
+    irpass::gen_offline_cache_key(kernel->program, kernel->ir.get(), &kernel_ast_string);
   }
 
   std::vector<std::uint8_t> compile_config_key;

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -72,8 +72,9 @@ get_offline_cache_key_of_compile_config(CompileConfig *config) {
   return serializer.data;
 }
 
-static TI_FORCE_INLINE void
-get_offline_cache_key_of_snode_impl(SNode *snode, BinaryOutputSerializer &serializer) {
+static TI_FORCE_INLINE void get_offline_cache_key_of_snode_impl(
+    SNode *snode,
+    BinaryOutputSerializer &serializer) {
   for (auto &c : snode->ch) {
     get_offline_cache_key_of_snode_impl(c.get(), serializer);
   }
@@ -121,7 +122,8 @@ get_offline_cache_key_of_snode_impl(SNode *snode, BinaryOutputSerializer &serial
     get_offline_cache_key_of_snode_impl(s, serializer);
   }
   if (snode->currently_placing_exp_snode) {
-    get_offline_cache_key_of_snode_impl(snode->currently_placing_exp_snode, serializer);
+    get_offline_cache_key_of_snode_impl(snode->currently_placing_exp_snode,
+                                        serializer);
   }
   if (snode->currently_placing_exp_snode_dtype) {
     serializer(snode->currently_placing_exp_snode_dtype->to_string());
@@ -136,7 +138,7 @@ get_offline_cache_key_of_snode_impl(SNode *snode, BinaryOutputSerializer &serial
 
 std::string get_hashed_offline_cache_key_of_snode(SNode *snode) {
   TI_ASSERT(snode);
-  
+
   BinaryOutputSerializer serializer;
   serializer.initialize();
   get_offline_cache_key_of_snode_impl(snode, serializer);
@@ -149,7 +151,8 @@ std::string get_hashed_offline_cache_key_of_snode(SNode *snode) {
   return picosha2::get_hash_hex_string(hasher);
 }
 
-std::string get_hashed_offline_cache_key(CompileConfig *config, Kernel *kernel) {
+std::string get_hashed_offline_cache_key(CompileConfig *config,
+                                         Kernel *kernel) {
   std::string kernel_ast_string;
   if (kernel) {
     irpass::gen_offline_cache_key(kernel->ir.get(), &kernel_ast_string);

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -155,7 +155,8 @@ std::string get_hashed_offline_cache_key(CompileConfig *config,
                                          Kernel *kernel) {
   std::string kernel_ast_string;
   if (kernel) {
-    irpass::gen_offline_cache_key(kernel->program, kernel->ir.get(), &kernel_ast_string);
+    irpass::gen_offline_cache_key(kernel->program, kernel->ir.get(),
+                                  &kernel_ast_string);
   }
 
   std::vector<std::uint8_t> compile_config_key;

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -72,11 +72,87 @@ get_offline_cache_key_of_compile_config(CompileConfig *config) {
   return serializer.data;
 }
 
-std::string get_offline_cache_key(CompileConfig *config, Kernel *kernel) {
+static TI_FORCE_INLINE void
+get_offline_cache_key_of_snode_impl(SNode *snode, BinaryOutputSerializer &serializer) {
+  for (auto &c : snode->ch) {
+    get_offline_cache_key_of_snode_impl(c.get(), serializer);
+  }
+  for (int i = 0; i < taichi_max_num_indices; ++i) {
+    auto &extractor = snode->extractors[i];
+    serializer(extractor.num_elements_from_root);
+    serializer(extractor.shape);
+    serializer(extractor.acc_shape);
+    serializer(extractor.num_bits);
+    serializer(extractor.acc_offset);
+    serializer(extractor.active);
+  }
+  serializer(snode->index_offsets);
+  serializer(snode->num_active_indices);
+  serializer(snode->physical_index_position);
+  serializer(snode->id);
+  serializer(snode->depth);
+  serializer(snode->name);
+  serializer(snode->num_cells_per_container);
+  serializer(snode->total_num_bits);
+  serializer(snode->total_bit_start);
+  serializer(snode->chunk_size);
+  serializer(snode->cell_size_bytes);
+  serializer(snode->offset_bytes_in_parent_cell);
+  if (snode->physical_type) {
+    serializer(snode->physical_type->to_string());
+  }
+  serializer(snode->dt->to_string());
+  serializer(snode->has_ambient);
+  if (!snode->ambient_val.dt->is_primitive(PrimitiveTypeID::unknown)) {
+    serializer(snode->ambient_val.stringify());
+  }
+  if (!snode->grad_info->is_primal()) {
+    if (auto *grad_snode = snode->grad_info->grad_snode()) {
+      get_offline_cache_key_of_snode_impl(grad_snode, serializer);
+    }
+  }
+  if (snode->exp_snode) {
+    get_offline_cache_key_of_snode_impl(snode->exp_snode, serializer);
+  }
+  serializer(snode->bit_offset);
+  serializer(snode->placing_shared_exp);
+  serializer(snode->owns_shared_exponent);
+  for (auto s : snode->exponent_users) {
+    get_offline_cache_key_of_snode_impl(s, serializer);
+  }
+  if (snode->currently_placing_exp_snode) {
+    get_offline_cache_key_of_snode_impl(snode->currently_placing_exp_snode, serializer);
+  }
+  if (snode->currently_placing_exp_snode_dtype) {
+    serializer(snode->currently_placing_exp_snode_dtype->to_string());
+  }
+  serializer(snode->is_bit_level);
+  serializer(snode->is_path_all_dense);
+  serializer(snode->node_type_name);
+  serializer(snode->type);
+  serializer(snode->_morton);
+  serializer(snode->get_snode_tree_id());
+}
+
+std::string get_hashed_offline_cache_key_of_snode(SNode *snode) {
+  TI_ASSERT(snode);
+  
+  BinaryOutputSerializer serializer;
+  serializer.initialize();
+  get_offline_cache_key_of_snode_impl(snode, serializer);
+  serializer.finalize();
+
+  picosha2::hash256_one_by_one hasher;
+  hasher.process(serializer.data.begin(), serializer.data.end());
+  hasher.finish();
+
+  return picosha2::get_hash_hex_string(hasher);
+}
+
+std::string get_hashed_offline_cache_key(CompileConfig *config, Kernel *kernel) {
   std::string kernel_ast_string;
   if (kernel) {
-    irpass::re_id(kernel->ir.get());
-    irpass::print(kernel->ir.get(), &kernel_ast_string);
+    irpass::gen_offline_cache_key(kernel->ir.get(), &kernel_ast_string);
   }
 
   std::vector<std::uint8_t> compile_config_key;

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -2,13 +2,15 @@
 
 #include "taichi/common/core.h"
 #include "taichi/program/kernel.h"
-#include "taichi/llvm/llvm_fwd.h"
 #include "taichi/util/io.h"
+
+#include "llvm/IR/Module.h"
 
 namespace taichi {
 namespace lang {
 
-std::string get_offline_cache_key(CompileConfig *config, Kernel *kernel);
+std::string get_hashed_offline_cache_key_of_snode(SNode *snode);
+std::string get_hashed_offline_cache_key(CompileConfig *config, Kernel *kernel);
 
 struct LlvmOfflineCache {
   struct OffloadedTaskCacheData {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -55,8 +55,9 @@ class IRPrinter : public IRVisitor {
   std::string *output{nullptr};
   std::stringstream ss;
 
-  IRPrinter(ExpressionPrinter *expr_printer = nullptr, std::string *output = nullptr)
-   : expr_printer_(expr_printer), output(output) {
+  IRPrinter(ExpressionPrinter *expr_printer = nullptr,
+            std::string *output = nullptr)
+      : expr_printer_(expr_printer), output(output) {
   }
 
   template <typename... Args>
@@ -75,7 +76,9 @@ class IRPrinter : public IRVisitor {
     }
   }
 
-  static void run(ExpressionPrinter *expr_printer, IRNode *node, std::string *output) {
+  static void run(ExpressionPrinter *expr_printer,
+                  IRNode *node,
+                  std::string *output) {
     if (node == nullptr) {
       TI_WARN("IRPrinter: Printing nullptr.");
       if (output) {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -47,16 +47,16 @@ std::string to_string(const LaneAttribute<LocalAddress> &ptr) {
 
 class IRPrinter : public IRVisitor {
  private:
-  ExpressionHumanFriendlyPrinter expr_printer_;
+  ExpressionPrinter *expr_printer_{nullptr};
 
  public:
-  int current_indent;
+  int current_indent{0};
 
-  std::string *output;
+  std::string *output{nullptr};
   std::stringstream ss;
 
-  IRPrinter(std::string *output = nullptr) : output(output) {
-    current_indent = 0;
+  IRPrinter(ExpressionPrinter *expr_printer = nullptr, std::string *output = nullptr)
+   : expr_printer_(expr_printer), output(output) {
   }
 
   template <typename... Args>
@@ -75,7 +75,7 @@ class IRPrinter : public IRVisitor {
     }
   }
 
-  static void run(IRNode *node, std::string *output) {
+  static void run(ExpressionPrinter *expr_printer, IRNode *node, std::string *output) {
     if (node == nullptr) {
       TI_WARN("IRPrinter: Printing nullptr.");
       if (output) {
@@ -83,7 +83,7 @@ class IRPrinter : public IRVisitor {
       }
       return;
     }
-    auto p = IRPrinter(output);
+    auto p = IRPrinter(expr_printer, output);
     p.print("kernel {{");
     node->accept(&p);
     p.print("}}");
@@ -777,16 +777,18 @@ class IRPrinter : public IRVisitor {
   }
 
   std::string expr_to_string(Expression *expr) {
+    TI_ASSERT(expr_printer_);
     std::ostringstream oss;
-    expr_printer_.set_ostream(&oss);
-    expr->accept(&expr_printer_);
+    expr_printer_->set_ostream(&oss);
+    expr->accept(expr_printer_);
     return oss.str();
   }
 
   std::string expr_group_to_string(ExprGroup &expr_group) {
+    TI_ASSERT(expr_printer_);
     std::ostringstream oss;
-    expr_printer_.set_ostream(&oss);
-    expr_printer_.visit(expr_group);
+    expr_printer_->set_ostream(&oss);
+    expr_printer_->visit(expr_group);
     return oss.str();
   }
 };
@@ -796,7 +798,14 @@ class IRPrinter : public IRVisitor {
 namespace irpass {
 
 void print(IRNode *root, std::string *output) {
-  return IRPrinter::run(root, output);
+  ExpressionHumanFriendlyPrinter expr_printer;
+  return IRPrinter::run(&expr_printer, root, output);
+}
+
+void gen_offline_cache_key(IRNode *root, std::string *output) {
+  irpass::re_id(root);
+  ExpressionOfflineCacheKeyGenerator cache_key_generator;
+  return IRPrinter::run(&cache_key_generator, root, output);
 }
 
 }  // namespace irpass

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -805,9 +805,9 @@ void print(IRNode *root, std::string *output) {
   return IRPrinter::run(&expr_printer, root, output);
 }
 
-void gen_offline_cache_key(IRNode *root, std::string *output) {
+void gen_offline_cache_key(Program *prog, IRNode *root, std::string *output) {
   irpass::re_id(root);
-  ExpressionOfflineCacheKeyGenerator cache_key_generator;
+  ExpressionOfflineCacheKeyGenerator cache_key_generator(prog);
   return IRPrinter::run(&cache_key_generator, root, output);
 }
 


### PR DESCRIPTION
Related issue = #4401

Temporary:
1. Reusing `ExpressionHumanFriendlyPrinter` to impl `ExpressionOfflineCacheKeyGenerator`
2. `get_hashed_offline_cache_key_of_snode` and `get_hashed_offline_cache_key` are declared/defined in `llvm_offline_cache.*`. I will move them to `offline_cache_util.*`


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
