### PR TITLE
[SIMT] Add shfl_sync_i32/f32 warp intrinsics

### DIFF
--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -27,15 +27,15 @@ def ballot(predicate):
 def shfl_sync_i32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
-            "cuda_shfl_sync_i32",
-            expr.make_expr_group(mask, val, offset, 32), False))
+            "cuda_shfl_sync_i32", expr.make_expr_group(mask, val, offset, 32),
+            False))
 
 
 def shfl_sync_f32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
-            "cuda_shfl_sync_f32",
-            expr.make_expr_group(mask, val, offset, 32), False))
+            "cuda_shfl_sync_f32", expr.make_expr_group(mask, val, offset, 32),
+            False))
 
 
 def shfl_down_i32(mask, val, offset):

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -24,9 +24,18 @@ def ballot(predicate):
                                            False))
 
 
-def shfl_i32(mask, val, offset):
-    # TODO
-    pass
+def shfl_sync_i32(mask, val, offset):
+    return expr.Expr(
+        _ti_core.insert_internal_func_call(
+            "cuda_shfl_sync_i32",
+            expr.make_expr_group(mask, val, offset, 32), False))
+
+
+def shfl_sync_f32(mask, val, offset):
+    return expr.Expr(
+        _ti_core.insert_internal_func_call(
+            "cuda_shfl_sync_f32",
+            expr.make_expr_group(mask, val, offset, 32), False))
 
 
 def shfl_down_i32(mask, val, offset):

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -368,6 +368,12 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_module(
     patch_intrinsic("cuda_shfl_up_sync_i32", Intrinsic::nvvm_shfl_sync_up_i32);
     patch_intrinsic("cuda_shfl_up_sync_f32", Intrinsic::nvvm_shfl_sync_up_f32);
 
+    patch_intrinsic("cuda_shfl_sync_i32",
+                    Intrinsic::nvvm_shfl_sync_idx_i32);
+
+    patch_intrinsic("cuda_shfl_sync_f32",
+                    Intrinsic::nvvm_shfl_sync_idx_f32);
+
     patch_intrinsic("cuda_match_any_sync_i32",
                     Intrinsic::nvvm_match_any_sync_i32);
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -368,11 +368,9 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_module(
     patch_intrinsic("cuda_shfl_up_sync_i32", Intrinsic::nvvm_shfl_sync_up_i32);
     patch_intrinsic("cuda_shfl_up_sync_f32", Intrinsic::nvvm_shfl_sync_up_f32);
 
-    patch_intrinsic("cuda_shfl_sync_i32",
-                    Intrinsic::nvvm_shfl_sync_idx_i32);
+    patch_intrinsic("cuda_shfl_sync_i32", Intrinsic::nvvm_shfl_sync_idx_i32);
 
-    patch_intrinsic("cuda_shfl_sync_f32",
-                    Intrinsic::nvvm_shfl_sync_idx_f32);
+    patch_intrinsic("cuda_shfl_sync_f32", Intrinsic::nvvm_shfl_sync_idx_f32);
 
     patch_intrinsic("cuda_match_any_sync_i32",
                     Intrinsic::nvvm_match_any_sync_i32);

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1036,6 +1036,14 @@ f32 cuda_shfl_up_sync_f32(u32 mask, f32 val, i32 delta, int width) {
   return 0;
 }
 
+i32 cuda_shfl_sync_i32(u32 mask, i32 val, i32 delta, int width) {
+  return 0;
+}
+
+f32 cuda_shfl_sync_f32(u32 mask, f32 val, i32 delta, int width) {
+  return 0;
+}
+
 int32 cuda_ballot_sync(int32 mask, bool bit) {
   return 0;
 }

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -47,9 +47,41 @@ def test_ballot():
 
 
 @test_utils.test(arch=ti.cuda)
-def test_shfl_i32():
-    # TODO
-    pass
+def test_shfl_sync_i32():
+    a = ti.field(dtype=ti.i32, shape=32)
+
+    @ti.kernel
+    def foo():
+        ti.loop_config(block_dim=32)
+        for i in range(32):
+            a[i] = ti.simt.warp.shfl_sync_i32(ti.u32(0xFFFFFFFF), a[i], 0)
+
+    for i in range(32):
+        a[i] = i + 1
+
+    foo()
+
+    for i in range(1, 32):
+        assert a[i] == 1
+
+
+@test_utils.test(arch=ti.cuda)
+def test_shfl_sync_f32():
+    a = ti.field(dtype=ti.f32, shape=32)
+
+    @ti.kernel
+    def foo():
+        ti.loop_config(block_dim=32)
+        for i in range(32):
+            a[i] = ti.simt.warp.shfl_sync_f32(ti.u32(0xFFFFFFFF), a[i], 0)
+
+    for i in range(32):
+        a[i] = i + 1.0
+
+    foo()
+
+    for i in range(1, 32):
+        assert a[i] == approx(1.0, abs=1e-4)
 
 
 @test_utils.test(arch=ti.cuda)


### PR DESCRIPTION
Related issue = #4631 
Add shfl_sync_i32/f32 intrinsics for cuda backend.
Broadcast a single value across warps using shfl_sync_i32/f32 intrinsics.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
