### PR TITLE
[SIMT] Add all_sync warp intrinsics

### DIFF
--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -4,9 +4,8 @@ from taichi.lang import expr
 
 def all_nonzero(mask, predicate):
     return expr.Expr(
-        _ti_core.insert_internal_func_call("cuda_all_sync_i32",
-                                           expr.make_expr_group(mask, predicate),
-                                           False))
+        _ti_core.insert_internal_func_call(
+            "cuda_all_sync_i32", expr.make_expr_group(mask, predicate), False))
 
 
 def any_nonzero():

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -2,9 +2,11 @@ from taichi._lib import core as _ti_core
 from taichi.lang import expr
 
 
-def all_nonzero():
-    # TODO
-    pass
+def all_nonzero(mask, predicate):
+    return expr.Expr(
+        _ti_core.insert_internal_func_call("cuda_all_sync_i32",
+                                           expr.make_expr_group(mask, predicate),
+                                           False))
 
 
 def any_nonzero():

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -357,6 +357,9 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_module(
     patch_intrinsic("grid_memfence", Intrinsic::nvvm_membar_gl, false);
     patch_intrinsic("system_memfence", Intrinsic::nvvm_membar_sys, false);
 
+    patch_intrinsic("cuda_all", Intrinsic::nvvm_vote_all);
+    patch_intrinsic("cuda_all_sync", Intrinsic::nvvm_vote_all_sync);
+
     patch_intrinsic("cuda_ballot", Intrinsic::nvvm_vote_ballot);
     patch_intrinsic("cuda_ballot_sync", Intrinsic::nvvm_vote_ballot_sync);
 

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -359,7 +359,7 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::clone_module(
 
     patch_intrinsic("cuda_all", Intrinsic::nvvm_vote_all);
     patch_intrinsic("cuda_all_sync", Intrinsic::nvvm_vote_all_sync);
-    
+
     patch_intrinsic("cuda_any", Intrinsic::nvvm_vote_any);
     patch_intrinsic("cuda_any_sync", Intrinsic::nvvm_vote_any_sync);
 

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1048,6 +1048,14 @@ f32 cuda_shfl_sync_f32(u32 mask, f32 val, i32 delta, int width) {
   return 0;
 }
 
+bool cuda_all_sync(u32 mask, bool bit) {
+  return false;
+}
+
+int32 cuda_all_sync_i32(u32 mask, int32 predicate) {
+  return (int32)cuda_all_sync(mask, (bool)predicate);
+}
+
 int32 cuda_ballot_sync(int32 mask, bool bit) {
   return 0;
 }

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1020,9 +1020,6 @@ i32 cuda_shfl_down_i32(i32 delta, i32 val, int width) {
   return 0;
 }
 
-  
-  
-  
 f32 cuda_shfl_down_sync_f32(u32 mask, f32 val, i32 delta, int width) {
   return 0;
 }

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -8,8 +8,30 @@ from tests import test_utils
 
 @test_utils.test(arch=ti.cuda)
 def test_all_nonzero():
-    # TODO
-    pass
+    a = ti.field(dtype=ti.i32, shape=32)
+    b = ti.field(dtype=ti.i32, shape=32)
+
+    @ti.kernel
+    def foo():
+        ti.loop_config(block_dim=32)
+        for i in range(32):
+            a[i] = ti.simt.warp.all_nonzero(ti.u32(0xFFFFFFFF), b[i])
+
+    for i in range(32):
+        b[i] = 1
+        a[i] = -1
+
+    foo()
+
+    for i in range(32):
+        assert a[i] == 1
+
+    b[np.random.randint(0, 32)] = 0
+
+    foo()
+
+    for i in range(32):
+        assert a[i] == 0
 
 
 @test_utils.test(arch=ti.cuda)


### PR DESCRIPTION
Related issue = #4631
Add all_sync intrinsics for cuda backend.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
