### PR TITLE
[doc] Fix deprecated profiler APIs in docs, tests, and examples

### DIFF
--- a/benchmarks/microbenchmarks/_metric.py
+++ b/benchmarks/microbenchmarks/_metric.py
@@ -21,10 +21,10 @@ def kernel_executor(repeat, func, *args):
     # compile & warmup
     for i in range(repeat):
         func(*args)
-    ti.clear_kernel_profile_info()
+    ti.profiler.clear_kernel_profiler_info()
     for i in range(repeat):
         func(*args)
-    return ti.kernel_profiler_total_time() * 1000 / repeat  #ms
+    return ti.profiler.get_kernel_profiler_total_time() * 1000 / repeat  #ms
 
 
 class MetricType(BenchmarkItem):

--- a/docs/lang/articles/misc/profiler.md
+++ b/docs/lang/articles/misc/profiler.md
@@ -20,7 +20,7 @@ Currently, Taichi provides the following profiling tools:
 `ScopedProfiler` tracks the time spent on **host tasks** such as JIT compilation.
 
 1. This profiler is automatically on.
-2. Call `ti.print_profile_info()` to display results in a hierarchical format.
+2. Call `ti.profiler.print_scoped_profiler_info()` to display results in a hierarchical format.
 
 For example:
 
@@ -36,7 +36,7 @@ def compute():
     print("Setting var[0] =", var[0])
 
 compute()
-ti.print_profile_info()
+ti.profiler.print_scoped_profiler_info()
 ```
 
 :::note
@@ -49,12 +49,12 @@ ti.print_profile_info()
 `KernelProfiler` acquires the kernel profiling records from the backend, counts them in Python-scope, and prints the results to the console.
 
 1. To enable this profiler, set `kernel_profiler=True` in `ti.init`.
-2. To display the profiling results, call `ti.print_kernel_profile_info()`. There are two modes of printing:
+2. To display the profiling results, call `ti.profiler.print_kernel_profiler_info()`. There are two modes of printing:
     - In `'count'` mode (default), the profiling records with the same kernel name are counted as a profiling result,
     and then the statistics are presented.
     - In `'trace'` mode, the profiler shows you a list of kernels that were launched on hardware during the profiling period.
     This mode provides more detailed performance information and runtime hardware metrics for each kernel.
-3. To clear records in this profiler, call `ti.clear_kernel_profile_info()`.
+3. To clear records in this profiler, call `ti.profiler.clear_kernel_profiler_info()`.
 
 For example:
 
@@ -71,12 +71,12 @@ def fill():
 
 for i in range(8):
     fill()
-ti.print_kernel_profile_info('trace')
-ti.clear_kernel_profile_info() # clear all records
+ti.profiler.print_kernel_profiler_info('trace')
+ti.profiler.clear_kernel_profiler_info()  # clear all records
 
 for i in range(100):
     fill()
-ti.print_kernel_profile_info() # default mode: 'count'
+ti.profiler.print_kernel_profiler_info()  # default mode: 'count'
 ```
 
 The outputs would be:

--- a/python/taichi/examples/algorithm/mgpcg.py
+++ b/python/taichi/examples/algorithm/mgpcg.py
@@ -209,4 +209,4 @@ for i in range(400):
     gui.set_image(pixels)
     gui.show()
 
-ti.print_kernel_profile_info()
+ti.profiler.print_kernel_profiler_info()

--- a/python/taichi/examples/algorithm/mgpcg_advanced.py
+++ b/python/taichi/examples/algorithm/mgpcg_advanced.py
@@ -273,7 +273,7 @@ class MGPCG_Example(MGPCG):
         self.solve(max_iters=400, verbose=verbose)
         self.paint()
         ti.imshow(self.pixels)
-        ti.print_kernel_profile_info()
+        ti.profiler.print_kernel_profiler_info()
 
 
 if __name__ == '__main__':

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -98,7 +98,7 @@ def bls_test_template(dim,
 
     check()
 
-    ti.print_kernel_profile_info()
+    ti.profiler.print_kernel_profiler_info()
 
     assert mismatch[None] == 0
 


### PR DESCRIPTION
This is a follow-up PR of #4165 and #4194.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
