### PR TITLE
[mac] Fix external_func test failures on arm backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ endmacro()
 
 if (APPLE)
   set(CLANG_OSX_FLAGS "-isysroot${CMAKE_OSX_SYSROOT}")
-  set(CLANG_HIGHEST_VERSION "13")
+  set(CLANG_HIGHEST_VERSION "12")
 else()
   set(CLANG_HIGHEST_VERSION "11")
 endif()

--- a/tests/python/test_external_func.py
+++ b/tests/python/test_external_func.py
@@ -11,7 +11,7 @@ from tests import test_utils
 
 
 @pytest.mark.skipif(not has_clangpp(), reason='Clang not installed.')
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test(arch=[ti.x64, ti.cuda])
 def test_source_builder_from_source():
     source_bc = '''
     extern "C" {
@@ -47,7 +47,7 @@ def test_source_builder_from_source():
 
 
 @pytest.mark.skipif(not has_clangpp(), reason='Clang not installed.')
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test(arch=[ti.x64, ti.cuda])
 def test_source_builder_from_file():
     source_code = '''
     extern "C" {


### PR DESCRIPTION
These tests failed on my M1 mac when building from source. It passed CI
machine mainly because the tests were skipped due to
https://github.com/taichi-dev/taichi/blob/master/tests/python/test_external_func.py#L13.

We actually limit external_func to `x64` backend not `cpu`.
(Although I've tried on arm64 and it worked, I'll leave enabling it on
arm64 to a separate PR)

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
