### PR TITLE
[SIMT] [cuda] Use correct source lane offset for warp intrinsics

### DIFF
--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -28,7 +28,8 @@ def shfl_sync_i32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             # lane offset is 31 for warp size 32
-            "cuda_shfl_sync_i32", expr.make_expr_group(mask, val, offset, 31),
+            "cuda_shfl_sync_i32",
+            expr.make_expr_group(mask, val, offset, 31),
             False))
 
 
@@ -36,7 +37,8 @@ def shfl_sync_f32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             # lane offset is 31 for warp size 32
-            "cuda_shfl_sync_f32", expr.make_expr_group(mask, val, offset, 31),
+            "cuda_shfl_sync_f32",
+            expr.make_expr_group(mask, val, offset, 31),
             False))
 
 
@@ -45,7 +47,8 @@ def shfl_down_i32(mask, val, offset):
         _ti_core.insert_internal_func_call(
             "cuda_shfl_down_sync_i32",
             # lane offset is 31 for warp size 32
-            expr.make_expr_group(mask, val, offset, 31), False))
+            expr.make_expr_group(mask, val, offset, 31),
+            False))
 
 
 def shfl_up_i32(mask, val, offset):
@@ -53,7 +56,8 @@ def shfl_up_i32(mask, val, offset):
         _ti_core.insert_internal_func_call(
             "cuda_shfl_up_sync_i32",
             # lane offset is 0 for warp size 32
-            expr.make_expr_group(mask, val, offset, 0), False))
+            expr.make_expr_group(mask, val, offset, 0),
+            False))
 
 
 def shfl_up_f32(mask, val, offset):
@@ -61,7 +65,8 @@ def shfl_up_f32(mask, val, offset):
         _ti_core.insert_internal_func_call(
             "cuda_shfl_up_sync_f32",
             # lane offset is 0 for warp size 32
-            expr.make_expr_group(mask, val, offset, 0), False))
+            expr.make_expr_group(mask, val, offset, 0),
+            False))
 
 
 def shfl_xor_i32(mask, val, offset):

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -27,23 +27,24 @@ def ballot(predicate):
 def shfl_sync_i32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
-            "cuda_shfl_sync_i32", expr.make_expr_group(mask, val, offset, 32),
+            # lane offset is 31 for warp size 32
+            "cuda_shfl_sync_i32", expr.make_expr_group(mask, val, offset, 31),
             False))
 
 
 def shfl_sync_f32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
-            "cuda_shfl_sync_f32", expr.make_expr_group(mask, val, offset, 32),
+            # lane offset is 31 for warp size 32
+            "cuda_shfl_sync_f32", expr.make_expr_group(mask, val, offset, 31),
             False))
 
 
 def shfl_down_i32(mask, val, offset):
-    # Here we use 31 as the last argument since 32 (warp size) does not work
-    # for some reason. Using 31 leads to the desired behavior.
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_down_sync_i32",
+            # lane offset is 31 for warp size 32
             expr.make_expr_group(mask, val, offset, 31), False))
 
 
@@ -51,14 +52,16 @@ def shfl_up_i32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_up_sync_i32",
-            expr.make_expr_group(mask, val, offset, 32), False))
+            # lane offset is 0 for warp size 32
+            expr.make_expr_group(mask, val, offset, 0), False))
 
 
 def shfl_up_f32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_up_sync_f32",
-            expr.make_expr_group(mask, val, offset, 32), False))
+            # lane offset is 0 for warp size 32
+            expr.make_expr_group(mask, val, offset, 0), False))
 
 
 def shfl_xor_i32(mask, val, offset):


### PR DESCRIPTION
Related issue = #4631 

For warp size of 32, correct lane offset is 0 for `shfl_up*` and 31 for `shfl_down*`. 
ref https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-shfl-sync