### PR TITLE
[Error] Raise an error when non-static condition is passed into ti.static_assert

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -8,7 +8,7 @@ from taichi._snode.fields_builder import FieldsBuilder
 from taichi.lang._ndarray import ScalarNdarray
 from taichi.lang._ndrange import GroupedNDRange, _Ndrange
 from taichi.lang.any_array import AnyArray, AnyArrayAccess
-from taichi.lang.exception import TaichiRuntimeError
+from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
@@ -376,6 +376,8 @@ def static_assert(cond, msg=None):
         >>>     ti.static_assert(year % 4 == 0, "the year must be a lunar year")
         AssertionError: the year must be a lunar year
     """
+    if isinstance(cond, Expr):
+        raise TaichiTypeError("Static assert with non-static condition")
     if msg is not None:
         assert cond, msg
     else:

--- a/tests/python/test_assert.py
+++ b/tests/python/test_assert.py
@@ -148,5 +148,6 @@ def test_static_assert_nonstatic_condition():
         value = False
         ti.static_assert(value, "Oh, no!")
 
-    with pytest.raises(ti.TaichiTypeError, match="Static assert with non-static condition"):
+    with pytest.raises(ti.TaichiTypeError,
+                       match="Static assert with non-static condition"):
         foo()

--- a/tests/python/test_assert.py
+++ b/tests/python/test_assert.py
@@ -108,16 +108,6 @@ def test_assert_ok():
 
 
 @test_utils.test(arch=get_host_arch_list())
-def test_static_assert_is_static():
-    @ti.kernel
-    def func():
-        x = 0
-        ti.static_assert(x)  # Expr is not None
-
-    func()
-
-
-@test_utils.test(arch=get_host_arch_list())
 def test_static_assert_message():
     x = 3
 
@@ -149,3 +139,14 @@ def test_static_assert_data_type_ok():
         ti.static_assert(x.dtype == ti.f32)
 
     func()
+
+
+@test_utils.test()
+def test_static_assert_nonstatic_condition():
+    @ti.kernel
+    def foo():
+        value = False
+        ti.static_assert(value, "Oh, no!")
+
+    with pytest.raises(ti.TaichiTypeError, match="Static assert with non-static condition"):
+        foo()


### PR DESCRIPTION
Related issue = close #4540 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
