### PR TITLE
[ci] Add python 3.6 and 3.10 to nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,16 +49,38 @@ jobs:
       - id: set-matrix
         run: |
           if [ -n "$RELEASE_VERSION" ]; then
-            # For production release, we run on four python versions.
-            echo '::set-output name=matrix::{"include":[{"name":"taichi","python":"3.6","conda_python":"py36"},{"name":"taichi","python":"3.7","conda_python":"py37"},{"name":"taichi","python":"3.8","conda_python":"py38"},{"name":"taichi","python":"3.9","conda_python":"py39"},{"name":"taichi","python":"3.10","conda_python":"py310"}]}"'
+            # For production release, we run on five python versions.
+            echo >-
+              '::set-output name=matrix::{"include":[
+                {"name":"taichi","python":"3.6","conda_python":"py36"},
+                {"name":"taichi","python":"3.7","conda_python":"py37"},
+                {"name":"taichi","python":"3.8","conda_python":"py38"},
+                {"name":"taichi","python":"3.9","conda_python":"py39"},
+                {"name":"taichi","python":"3.10","conda_python":"py310"}
+              ]}"'
 
-            echo '::set-output name=matrix_osx::{"include":[{"name":"taichi","python":"3.8"},{"name":"taichi","python":"3.9"},{"name":"taichi","python":"3.10"}]}"'
+            # M1 only supports py38, py39, and py310(conda), so change matrix.
+            echo >-
+              '::set-output name=matrix_osx::{"include":[
+                {"name":"taichi","python":"3.8"},
+                {"name":"taichi","python":"3.9"},
+                {"name":"taichi","python":"3.10"}
+              ]}"'
           else
-            # For nightly release, we only run on python 3.8
-            echo '::set-output name=matrix::{"include":[{"name":"taichi-nightly","python":"3.8","conda_python":"py38"}]}"'
+            # For nightly release, we run on three python versions.
+            echo >-
+              '::set-output name=matrix::{"include":[
+                {"name":"taichi-nightly","python":"3.6","conda_python":"py36"},
+                {"name":"taichi-nightly","python":"3.8","conda_python":"py38"},
+                {"name":"taichi-nightly","python":"3.10","conda_python":"py310"}
+              ]}"'
 
-            # M1 only supports py38 and py39(conda), so change matrix.
-            echo '::set-output name=matrix_osx::{"include":[{"name":"taichi-nightly","python":"3.8"}]}"'
+            # M1 only supports py38 and py310(conda), so change matrix.
+            echo >-
+              '::set-output name=matrix_osx::{"include":[
+                {"name":"taichi-nightly","python":"3.8"},
+                {"name":"taichi-nightly","python":"3.10","conda_python":"py310"}
+              ]}"'
           fi
 
   build_and_test_linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             echo >-
               '::set-output name=matrix_osx::{"include":[
                 {"name":"taichi-nightly","python":"3.8"},
-                {"name":"taichi-nightly","python":"3.10","conda_python":"py310"}
+                {"name":"taichi-nightly","python":"3.10"}
               ]}"'
           fi
 


### PR DESCRIPTION
Since we have switched to our own self-hosted PyPI cloud, Python 3.6 and 3.10 can be enabled to cover more releases in nightly.