### PR TITLE
[bug] [lang] Let matrix initialize to the target type

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -80,7 +80,7 @@ class Matrix(TaichiOperations):
             if in_python_scope():
                 mat = [[x] for x in arr]
             elif not impl.current_cfg().dynamic_index:
-                mat = [[impl.expr_init(x)] for x in arr]
+                mat = [[impl.expr_init(ops_mod.cast(x, dt) if dt else x)] for x in arr]
             else:
                 if not ti_core.is_extension_supported(
                         impl.current_cfg().arch,
@@ -120,7 +120,7 @@ class Matrix(TaichiOperations):
             if in_python_scope():
                 mat = [list(row) for row in arr]
             elif not impl.current_cfg().dynamic_index:
-                mat = [[impl.expr_init(x) for x in row] for row in arr]
+                mat = [[impl.expr_init(ops_mod.cast(x, dt) if dt else x) for x in row] for row in arr]
             else:
                 if not ti_core.is_extension_supported(
                         impl.current_cfg().arch,

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -27,38 +27,46 @@ def ballot(predicate):
 def shfl_sync_i32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
-            "cuda_shfl_sync_i32", expr.make_expr_group(mask, val, offset, 32),
+            # lane offset is 31 for warp size 32
+            "cuda_shfl_sync_i32",
+            expr.make_expr_group(mask, val, offset, 31),
             False))
 
 
 def shfl_sync_f32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
-            "cuda_shfl_sync_f32", expr.make_expr_group(mask, val, offset, 32),
+            # lane offset is 31 for warp size 32
+            "cuda_shfl_sync_f32",
+            expr.make_expr_group(mask, val, offset, 31),
             False))
 
 
 def shfl_down_i32(mask, val, offset):
-    # Here we use 31 as the last argument since 32 (warp size) does not work
-    # for some reason. Using 31 leads to the desired behavior.
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_down_sync_i32",
-            expr.make_expr_group(mask, val, offset, 31), False))
+            # lane offset is 31 for warp size 32
+            expr.make_expr_group(mask, val, offset, 31),
+            False))
 
 
 def shfl_up_i32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_up_sync_i32",
-            expr.make_expr_group(mask, val, offset, 32), False))
+            # lane offset is 0 for warp size 32
+            expr.make_expr_group(mask, val, offset, 0),
+            False))
 
 
 def shfl_up_f32(mask, val, offset):
     return expr.Expr(
         _ti_core.insert_internal_func_call(
             "cuda_shfl_up_sync_f32",
-            expr.make_expr_group(mask, val, offset, 32), False))
+            # lane offset is 0 for warp size 32
+            expr.make_expr_group(mask, val, offset, 0),
+            False))
 
 
 def shfl_xor_i32(mask, val, offset):

--- a/python/taichi/math/vectypes.py
+++ b/python/taichi/math/vectypes.py
@@ -94,7 +94,7 @@ class _VectorType(Matrix):
 
 def _wrap_ops(cls):
     def wrapped(func):
-        return lambda self, other: cls(*func(self, other))
+        return lambda *args, **kwargs: cls(*func(*args, **kwargs))
 
     methods = [
         '__neg__', '__abs__', '__add__', '__radd__', '__sub__', '__rsub__',

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -211,7 +211,9 @@ def test_fractal_f16():
     def paint(t: float):
         for i, j in pixels:  # Parallelized over all pixels
             c = ti.Vector([-0.8, ti.cos(t) * 0.2], dt=ti.f16)
-            z = ti.Vector([i / n - 1, j / n - 0.5]) * 2  # FIXME: the kernel crashes when z stores f16
+            z = ti.Vector([
+                i / n - 1, j / n - 0.5
+            ]) * 2  # FIXME: the kernel crashes when z stores f16
             iterations = 0
             while z.norm() < 20 and iterations < 50:
                 z = complex_sqr(z) + c

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -211,7 +211,7 @@ def test_fractal_f16():
     def paint(t: float):
         for i, j in pixels:  # Parallelized over all pixels
             c = ti.Vector([-0.8, ti.cos(t) * 0.2], dt=ti.f16)
-            z = ti.Vector([i / n - 1, j / n - 0.5], dt=ti.f16) * 2
+            z = ti.Vector([i / n - 1, j / n - 0.5]) * 2  # FIXME: the kernel crashes when z stores f16
             iterations = 0
             while z.norm() < 20 and iterations < 50:
                 z = complex_sqr(z) + c

--- a/tests/python/test_math_vectors.py
+++ b/tests/python/test_math_vectors.py
@@ -28,3 +28,16 @@ def test_vector_swizzle_taichi():
         assert all((M @ b) == (1, 1, 1))
 
     foo()
+
+
+@test_utils.test(debug=True)
+def test_vector_dtype():
+    @ti.kernel
+    def foo():
+        a = ti.math.vec3(1, 2, 3)
+        a /= 2
+        assert all(abs(a - (0.5, 1., 1.5)) < 1e-6)
+        b = ti.math.ivec3(1.5, 2.5, 3.5)
+        assert all(b == (1, 2, 3))
+
+    foo()

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -524,3 +524,29 @@ def test_local_vector_initialized_in_a_loop():
                 assert p[i] == c * (i + 1)
 
     foo()
+
+
+@test_utils.test(debug=True)
+def test_vector_dtype():
+    @ti.kernel
+    def foo():
+        a = ti.Vector([1, 2, 3], ti.f32)
+        a /= 2
+        assert all(abs(a - (0.5, 1., 1.5)) < 1e-6)
+        b = ti.Vector([1.5, 2.5, 3.5], ti.i32)
+        assert all(b == (1, 2, 3))
+
+    foo()
+
+
+@test_utils.test(debug=True)
+def test_matrix_dtype():
+    @ti.kernel
+    def foo():
+        a = ti.Vector([[1, 2], [3, 4]], ti.f32)
+        a /= 2
+        assert all(abs(a - ((0.5, 1.), (1.5, 2.))) < 1e-6)
+        b = ti.Vector([[1.5, 2.5], [3.5, 4.5]], ti.i32)
+        assert all(b == ((1, 2), (3, 4)))
+
+    foo()


### PR DESCRIPTION
Related issue = close #4741 
[test_f16.py::test_fractal_f16](https://github.com/taichi-dev/taichi/blob/master/tests/python/test_f16.py#L202) fails when dtype of  `z` is f16 as described in #4757 , so I temporarily removed the dtype parameter. When this is fixed, the dtype parameter should be added back.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
