### PR TITLE
[misc] Remove some unnecessary attributes from offline-cache key of compile-config

### DIFF
--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -20,26 +20,20 @@ get_offline_cache_key_of_compile_config(CompileConfig *config) {
   serializer(config->debug);
   serializer(config->cfg_optimization);
   serializer(config->check_out_of_bound);
-  serializer(config->simd_width);
   serializer(config->opt_level);
   serializer(config->external_optimization_level);
-  serializer(config->max_vector_width);
   serializer(config->packed);
-  serializer(config->serial_schedule);
   serializer(config->move_loop_invariant_outside_if);
   serializer(config->demote_dense_struct_fors);
   serializer(config->advanced_optimization);
   serializer(config->constant_folding);
-  serializer(config->use_llvm);
   serializer(config->fast_math);
-  serializer(config->dynamic_index);
   serializer(config->flatten_if);
   serializer(config->make_thread_local);
   serializer(config->make_block_local);
   serializer(config->detect_read_only);
   serializer(config->default_fp->to_string());
   serializer(config->default_ip.to_string());
-  serializer(config->extra_flags);
   if (arch_is_cpu(config->arch)) {
     serializer(config->default_cpu_block_dim);
     serializer(config->cpu_max_num_threads);


### PR DESCRIPTION
Related issue = #4401 

Remove:
* `simd_width`
* `max_vector_width`
* `serial_schedule`
* `use_llvm`
* `dynamic_index`
* `extra_flags`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
