### PR TITLE
[autodiff] Fix nullptr during adjoint codegen

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -656,6 +656,7 @@ class MakeAdjoint : public IRVisitor {
       //     for _ in range(5)
       //         q += a[i]
       if (stmt->is<GlobalLoadStmt>() &&
+          (stmt->parent->parent_stmt != nullptr) &&
           stmt->parent->parent_stmt->is<RangeForStmt>()) {
         // Check whether this GlobalLoadStmt is in the body of a for-loop by
         // searching in the backup forward pass If not (Case 1), the alloca


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/pull/4512/

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
