### PR TITLE
[Lang] Support in-place operator of ti.Matrix in python scope

### DIFF
--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -1,6 +1,7 @@
 import warnings
 
 from taichi.lang import ops
+from taichi.lang.util import in_python_scope
 
 
 class TaichiOperations:
@@ -176,52 +177,77 @@ class TaichiOperations:
             :class:`~taichi.lang.expr.Expr`: The computing expression of atomic or."""
         return ops.atomic_or(self, other)
 
+    # In-place operators in python scope returns NotImplemented to fall back to normal operators
     def __iadd__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._atomic_add(other)
         return self
 
     def __isub__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._atomic_sub(other)
         return self
 
     def __iand__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._atomic_and(other)
         return self
 
     def __ixor__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._atomic_xor(other)
         return self
 
     def __ior__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._atomic_or(other)
         return self
 
     # we don't support atomic_mul/truediv/floordiv/mod yet:
     def __imul__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._assign(ops.mul(self, other))
         return self
 
     def __itruediv__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._assign(ops.truediv(self, other))
         return self
 
     def __ifloordiv__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._assign(ops.floordiv(self, other))
         return self
 
     def __imod__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._assign(ops.mod(self, other))
         return self
 
     def __ilshift__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._assign(ops.bit_shl(self, other))
         return self
 
     def __irshift__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._assign(ops.bit_shr(self, other))
         return self
 
     def __ipow__(self, other):
+        if in_python_scope():
+            return NotImplemented
         self._assign(ops.pow(self, other))
         return self
 

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -552,8 +552,11 @@ def test_matrix_dtype():
     foo()
 
 
-inplace_operation_types = [operator.iadd, operator.isub, operator.imul, operator.ifloordiv, operator.imod, operator.ilshift, operator.irshift,
-                                  operator.ior, operator.ixor, operator.iand]
+inplace_operation_types = [
+    operator.iadd, operator.isub, operator.imul, operator.ifloordiv,
+    operator.imod, operator.ilshift, operator.irshift, operator.ior,
+    operator.ixor, operator.iand
+]
 
 
 @test_utils.test()

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -550,3 +550,16 @@ def test_matrix_dtype():
         assert all(b == ((1, 2), (3, 4)))
 
     foo()
+
+
+inplace_operation_types = [operator.iadd, operator.isub, operator.imul, operator.ifloordiv, operator.imod, operator.ilshift, operator.irshift,
+                                  operator.ior, operator.ixor, operator.iand]
+
+
+@test_utils.test()
+def test_python_scope_inplace_operator():
+    for ops in inplace_operation_types:
+        a, b = test_matrix_arrays[:2]
+        m1, m2 = ti.Matrix(a), ti.Matrix(b)
+        m1 = ops(m1, m2)
+        assert np.allclose(m1.to_numpy(), ops(a, b))


### PR DESCRIPTION
Related issue = fix #4739 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
