### PR TITLE
[workflow] Add issues to the project board when opened

### DIFF
--- a/.github/workflows/issue_open.yml
+++ b/.github/workflows/issue_open.yml
@@ -1,0 +1,16 @@
+name: Add issues to Taichi project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/taichi-dev/projects/1
+          github-token: ${{ secrets.GARDENER_PAT }}


### PR DESCRIPTION
I used an action maintained by the official team though they said the API may be unstable.