### PR TITLE
[Lang] Support swizzles on all Matrix/Vector types

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -22,7 +22,7 @@ from taichi.types.compound_types import CompoundType
 
 def _gen_swizzles(cls):
     swizzle_gen = SwizzleGenerator()
-    KEMAP_SET = ['xyzw', 'rgba', 'uvw']
+    KEMAP_SET = ['xyzw', 'rgba', 'stpq']
     for key_group in KEMAP_SET:
         sw_patterns = swizzle_gen.generate(key_group, required_length=4)
         # len=1 accessors are handled specially

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1,6 +1,5 @@
 import numbers
 from collections.abc import Iterable
-from copy import deepcopy
 
 import numpy as np
 from taichi._lib import core as ti_core
@@ -25,9 +24,7 @@ def _gen_swizzles(cls):
     swizzle_gen = SwizzleGenerator()
     KEMAP_SET = ['xyzw', 'rgba', 'uvw']
     for key_group in KEMAP_SET:
-        sw_patterns = []
-        for pats_per_len in swizzle_gen.generate(key_group, required_length=4):
-            sw_patterns += pats_per_len
+        sw_patterns = swizzle_gen.generate(key_group, required_length=4)
 
         for pat in sw_patterns:
             # Create a function for value capturing

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -36,6 +36,9 @@ def _gen_swizzles(cls):
                     return Vector(res, is_ref=True)
 
                 def prop_setter(instance, value):
+                    if len(pattern) == 1:
+                        assert not isinstance(value, Iterable)
+                        value = [value, ]
                     if len(pattern) != len(value):
                         raise TaichiCompilationError(
                             'values does not match the attribute')

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -22,6 +22,7 @@ from taichi.types.compound_types import CompoundType
 
 def _gen_swizzles(cls):
     swizzle_gen = SwizzleGenerator()
+    # https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)#Swizzling
     KEMAP_SET = ['xyzw', 'rgba', 'stpq']
     for key_group in KEMAP_SET:
         sw_patterns = swizzle_gen.generate(key_group, required_length=4)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
 import numbers
 from collections.abc import Iterable
+from copy import deepcopy
 
 import numpy as np
 from taichi._lib import core as ti_core
@@ -13,12 +13,13 @@ from taichi.lang.enums import Layout
 from taichi.lang.exception import (TaichiCompilationError, TaichiSyntaxError,
                                    TaichiTypeError)
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
+from taichi.lang.swizzle_generator import SwizzleGenerator
 from taichi.lang.util import (cook_dtype, in_python_scope, python_scope,
                               taichi_scope, to_numpy_type, to_pytorch_type,
                               warning)
 from taichi.types import primitive_types
 from taichi.types.compound_types import CompoundType
-from taichi.lang.swizzle_generator import SwizzleGenerator
+
 
 def _gen_swizzles(cls):
     swizzle_gen = SwizzleGenerator()
@@ -27,7 +28,7 @@ def _gen_swizzles(cls):
         sw_patterns = []
         for pats_per_len in swizzle_gen.generate(key_group, required_length=4):
             sw_patterns += pats_per_len
-        
+
         for pat in sw_patterns:
             # Create a function for value capturing
             def gen_property(pattern, key_group):
@@ -39,7 +40,8 @@ def _gen_swizzles(cls):
 
                 def prop_setter(instance, value):
                     if len(pattern) != len(value):
-                        raise TaichiCompilationError('values does not match the attribute')
+                        raise TaichiCompilationError(
+                            'values does not match the attribute')
                     for ch, val in zip(pattern, value):
                         if in_python_scope():
                             instance[key_group.index(ch)] = val
@@ -49,9 +51,11 @@ def _gen_swizzles(cls):
                 prop = property(prop_getter, prop_setter)
                 prop_key = ''.join(pattern)
                 return prop_key, prop
+
             prop_key, prop = gen_property(pat, key_group)
             setattr(cls, prop_key, prop)
     return cls
+
 
 @_gen_swizzles
 class Matrix(TaichiOperations):
@@ -510,7 +514,6 @@ class Matrix(TaichiOperations):
     #         -1
     #     """
     #     self[3] = value
-
 
     def to_list(self):
         """Return this matrix as a 1D `list`.

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -25,6 +25,8 @@ def _gen_swizzles(cls):
     KEMAP_SET = ['xyzw', 'rgba', 'uvw']
     for key_group in KEMAP_SET:
         sw_patterns = swizzle_gen.generate(key_group, required_length=4)
+        # len=1 accessors are handled specially
+        sw_patterns = filter(lambda p: len(p) > 1, sw_patterns)
 
         for pat in sw_patterns:
             # Create a function for value capturing
@@ -36,9 +38,6 @@ def _gen_swizzles(cls):
                     return Vector(res, is_ref=True)
 
                 def prop_setter(instance, value):
-                    if len(pattern) == 1:
-                        assert not isinstance(value, Iterable)
-                        value = [value, ]
                     if len(pattern) != len(value):
                         raise TaichiCompilationError(
                             'values does not match the attribute')
@@ -402,118 +401,118 @@ class Matrix(TaichiOperations):
                                                  self.dynamic_index_stride)
         return self(i, j)
 
-    # @property
-    # def x(self):
-    #     """Get the first element of a matrix.
+    @property
+    def x(self):
+        """Get the first element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2])
-    #         >>> m.x
-    #         0
-    #     """
-    #     if impl.inside_kernel():
-    #         return self._subscript(0)
-    #     return self[0]
+            >>> m = ti.Matrix([0, 1, 2])
+            >>> m.x
+            0
+        """
+        if impl.inside_kernel():
+            return self._subscript(0)
+        return self[0]
 
-    # @property
-    # def y(self):
-    #     """Get the second element of a matrix.
+    @property
+    def y(self):
+        """Get the second element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2])
-    #         >>> m.y
-    #         1
-    #     """
-    #     if impl.inside_kernel():
-    #         return self._subscript(1)
-    #     return self[1]
+            >>> m = ti.Matrix([0, 1, 2])
+            >>> m.y
+            1
+        """
+        if impl.inside_kernel():
+            return self._subscript(1)
+        return self[1]
 
-    # @property
-    # def z(self):
-    #     """Get the third element of a matrix.
+    @property
+    def z(self):
+        """Get the third element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2])
-    #         >>> m.z
-    #         2
-    #     """
-    #     if impl.inside_kernel():
-    #         return self._subscript(2)
-    #     return self[2]
+            >>> m = ti.Matrix([0, 1, 2])
+            >>> m.z
+            2
+        """
+        if impl.inside_kernel():
+            return self._subscript(2)
+        return self[2]
 
-    # @property
-    # def w(self):
-    #     """Get the fourth element of a matrix.
+    @property
+    def w(self):
+        """Get the fourth element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2, 3])
-    #         >>> m.w
-    #         3
-    #     """
-    #     if impl.inside_kernel():
-    #         return self._subscript(3)
-    #     return self[3]
+            >>> m = ti.Matrix([0, 1, 2, 3])
+            >>> m.w
+            3
+        """
+        if impl.inside_kernel():
+            return self._subscript(3)
+        return self[3]
 
-    # # since Taichi-scope use v.x.assign() instead
-    # @x.setter
-    # @python_scope
-    # def x(self, value):
-    #     """Set the first element of a matrix.
+    # since Taichi-scope use v.x.assign() instead
+    @x.setter
+    @python_scope
+    def x(self, value):
+        """Set the first element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2])
-    #         >>> m.x = -1
-    #         >>> m.x
-    #         -1
-    #     """
-    #     self[0] = value
+            >>> m = ti.Matrix([0, 1, 2])
+            >>> m.x = -1
+            >>> m.x
+            -1
+        """
+        self[0] = value
 
-    # @y.setter
-    # @python_scope
-    # def y(self, value):
-    #     """Set the second element of a matrix.
+    @y.setter
+    @python_scope
+    def y(self, value):
+        """Set the second element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2])
-    #         >>> m.y = -1
-    #         >>> m.y
-    #         -1
-    #     """
-    #     self[1] = value
+            >>> m = ti.Matrix([0, 1, 2])
+            >>> m.y = -1
+            >>> m.y
+            -1
+        """
+        self[1] = value
 
-    # @z.setter
-    # @python_scope
-    # def z(self, value):
-    #     """Set the third element of a matrix.
+    @z.setter
+    @python_scope
+    def z(self, value):
+        """Set the third element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2])
-    #         >>> m.z = -1
-    #         >>> m.z
-    #         -1
-    #     """
-    #     self[2] = value
+            >>> m = ti.Matrix([0, 1, 2])
+            >>> m.z = -1
+            >>> m.z
+            -1
+        """
+        self[2] = value
 
-    # @w.setter
-    # @python_scope
-    # def w(self, value):
-    #     """Set the fourth element of a matrix.
+    @w.setter
+    @python_scope
+    def w(self, value):
+        """Set the fourth element of a matrix.
 
-    #     Example::
+        Example::
 
-    #         >>> m = ti.Matrix([0, 1, 2, 3])
-    #         >>> m.w = -1
-    #         >>> m.w
-    #         -1
-    #     """
-    #     self[3] = value
+            >>> m = ti.Matrix([0, 1, 2, 3])
+            >>> m.w = -1
+            >>> m.w
+            -1
+        """
+        self[3] = value
 
     def to_list(self):
         """Return this matrix as a 1D `list`.

--- a/python/taichi/lang/swizzle_generator.py
+++ b/python/taichi/lang/swizzle_generator.py
@@ -1,11 +1,11 @@
 from collections import namedtuple
 from itertools import combinations, permutations
-from typing import Iterable
+from typing import Iterable, List, Tuple
 
-NRE_LNG = namedtuple('NRE_LNG', ['num_required_elems', 'length'])
+NRE_LEN = namedtuple('NRE_LEN', ['num_required_elems', 'length'])
 
 
-def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
+def generate_num_required_elems_required_len_map(max_unique_elems=5):
     '''
     For example, if we want a sequence of length 4 to be composed by {'x', 'y'},
     we have the following options:
@@ -19,7 +19,7 @@ def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
     Each of these pattern is a seed. We can then do a permutation on it to get
     all the patterns for this seed.
 
-    NRE_LNG(2, 4) maps to [(4, 0), (1, 3), (2, 2), (3, 1), (0, 4)]
+    NRE_LEN(2, 4) maps to [(4, 0), (1, 3), (2, 2), (3, 1), (0, 4)]
     '''
     class InvalidPattern(Exception):
         pass
@@ -28,22 +28,23 @@ def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
     m[(0, 0)] = ()
 
     def _gen_impl(num_required_elems: int, required_len: int):
-        mkey = NRE_LNG(num_required_elems, required_len)
+        mkey = NRE_LEN(num_required_elems, required_len)
         try:
             return m[mkey]
         except KeyError:
             pass
+        invalid_pat = InvalidPattern(f'{num_required_elems} {required_len}')
         if num_required_elems > required_len:
-            raise InvalidPattern(f'{num_required_elems} {required_len}')
+            raise invalid_pat
         if num_required_elems == 0:
             if required_len == 0:
                 return []
-            raise InvalidPattern(f'{num_required_elems} {required_len}')
+            raise invalid_pat
         if num_required_elems == 1:
             if required_len > 0:
                 m[mkey] = ((required_len, ), )
                 return m[mkey]
-            raise InvalidPattern(f'{num_required_elems} {required_len}')
+            raise invalid_pat
 
         res = []
         for n in range(1, required_len + 1):
@@ -64,45 +65,41 @@ def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
     return m
 
 
-def generate_seed_patterns(acc, nrel_vals):
-    res = []
-    for val in nrel_vals:
-        assert len(acc) == len(val)
-        seed = []
-        for char, vi in zip(acc, val):
-            seed += [
-                char,
-            ] * vi
-        res.append(tuple(seed))
-    return res
-
-
 class SwizzleGenerator:
     def __init__(self, max_unique_elems=4):
-        self._nrel_map = generate_num_required_elems_to_required_len_map(
+        self._nrel_map = generate_num_required_elems_required_len_map(
             max_unique_elems)
 
-    def generate(self, accessors: Iterable[str], required_length: int):
-        res = [
-            self._gen_for_length(accessors, l)
-            for l in range(1, required_length + 1)
-        ]
+    def generate(self, accessors: Iterable[str], required_length: int)-> List[Tuple[int, ...]]:
+        res = []
+        for l in range(required_length):
+          res += self._gen_for_length(accessors, l + 1)
         return res
 
     def _gen_for_length(self, accessors, required_length):
         acc_list = list(accessors)
         res = []
-        for l in range(1, required_length + 1):
+        for num_required_elems in range(1, required_length + 1):
             cur_len_patterns = set()
-            for subacc in combinations(acc_list, l):
-                nrel_key = NRE_LNG(l, required_length)
+            for subacc in combinations(acc_list, num_required_elems):
+                nrel_key = NRE_LEN(num_required_elems, required_length)
                 nrel_vals = self._nrel_map[nrel_key]
-                seed_patterns = generate_seed_patterns(subacc, nrel_vals)
+                seed_patterns = self._generate_seed_patterns(subacc, nrel_vals)
                 for sp in seed_patterns:
                     for p in permutations(sp):
                         cur_len_patterns.add(p)
             res += sorted(list(cur_len_patterns))
         return res
+
+    def _generate_seed_patterns(self, acc, nrel_vals):
+      res = []
+      for val in nrel_vals:
+          assert len(acc) == len(val)
+          seed = []
+          for char, vi in zip(acc, val):
+              seed += [char] * vi
+          res.append(tuple(seed))
+      return res
 
 
 __all__ = [
@@ -111,7 +108,7 @@ __all__ = [
 
 if __name__ == '__main__':
     sg = SwizzleGenerator()
-    pats_per_len = sg.generate('xyz', 4)
+    pats_per_len = sg.generate('xyzw', 4)
     total = 0
     for i, pats in enumerate(pats_per_len):
         print(f'patterns at len={i}')

--- a/python/taichi/lang/swizzle_generator.py
+++ b/python/taichi/lang/swizzle_generator.py
@@ -106,15 +106,3 @@ class SwizzleGenerator:
 __all__ = [
     'SwizzleGenerator',
 ]
-
-if __name__ == '__main__':
-    sg = SwizzleGenerator()
-    pats_per_len = sg.generate('xyzw', 4)
-    total = 0
-    for i, pats in enumerate(pats_per_len):
-        print(f'patterns at len={i}')
-        for p in pats:
-            print(f'  {p}')
-        total += len(pats)
-    # https://jojendersie.de/performance-optimal-vector-swizzling-in-c/
-    print(f'total_patterns={total}')

--- a/python/taichi/lang/swizzle_generator.py
+++ b/python/taichi/lang/swizzle_generator.py
@@ -70,10 +70,11 @@ class SwizzleGenerator:
         self._nrel_map = generate_num_required_elems_required_len_map(
             max_unique_elems)
 
-    def generate(self, accessors: Iterable[str], required_length: int)-> List[Tuple[int, ...]]:
+    def generate(self, accessors: Iterable[str],
+                 required_length: int) -> List[Tuple[int, ...]]:
         res = []
         for l in range(required_length):
-          res += self._gen_for_length(accessors, l + 1)
+            res += self._gen_for_length(accessors, l + 1)
         return res
 
     def _gen_for_length(self, accessors, required_length):
@@ -92,14 +93,14 @@ class SwizzleGenerator:
         return res
 
     def _generate_seed_patterns(self, acc, nrel_vals):
-      res = []
-      for val in nrel_vals:
-          assert len(acc) == len(val)
-          seed = []
-          for char, vi in zip(acc, val):
-              seed += [char] * vi
-          res.append(tuple(seed))
-      return res
+        res = []
+        for val in nrel_vals:
+            assert len(acc) == len(val)
+            seed = []
+            for char, vi in zip(acc, val):
+                seed += [char] * vi
+            res.append(tuple(seed))
+        return res
 
 
 __all__ = [

--- a/python/taichi/lang/swizzle_generator.py
+++ b/python/taichi/lang/swizzle_generator.py
@@ -92,7 +92,8 @@ class SwizzleGenerator:
             res += sorted(list(cur_len_patterns))
         return res
 
-    def _generate_seed_patterns(self, acc, nrel_vals):
+    @staticmethod
+    def _generate_seed_patterns(acc, nrel_vals):
         res = []
         for val in nrel_vals:
             assert len(acc) == len(val)

--- a/python/taichi/lang/swizzle_generator.py
+++ b/python/taichi/lang/swizzle_generator.py
@@ -1,5 +1,5 @@
-from itertools import permutations, combinations
 from collections import namedtuple
+from itertools import combinations, permutations
 from typing import Iterable
 
 NRE_LNG = namedtuple('NRE_LNG', ['num_required_elems', 'length'])
@@ -26,7 +26,7 @@ def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
             raise InvalidPattern(f'{num_required_elems} {required_len}')
         if num_required_elems == 1:
             if required_len > 0:
-                m[mkey] = ((required_len,),)
+                m[mkey] = ((required_len, ), )
                 return m[mkey]
             raise InvalidPattern(f'{num_required_elems} {required_len}')
 
@@ -34,7 +34,7 @@ def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
         for n in range(1, required_len + 1):
             try:
                 cur = _gen_impl(num_required_elems - 1, required_len - n)
-                res += [(n,) + t for t in cur]
+                res += [(n, ) + t for t in cur]
             except InvalidPattern:
                 pass
         res = tuple(res)
@@ -55,7 +55,9 @@ def generate_seed_patterns(acc, nrel_vals):
         assert len(acc) == len(val)
         seed = []
         for char, vi in zip(acc, val):
-            seed += [char, ] * vi
+            seed += [
+                char,
+            ] * vi
         res.append(tuple(seed))
     return res
 
@@ -66,8 +68,10 @@ class SwizzleGenerator:
             max_unique_elems)
 
     def generate(self, accessors: Iterable[str], required_length: int):
-        res = [self._gen_for_length(accessors, l)
-               for l in range(1, required_length + 1)]
+        res = [
+            self._gen_for_length(accessors, l)
+            for l in range(1, required_length + 1)
+        ]
         return res
 
     def _gen_for_length(self, accessors, required_length):

--- a/python/taichi/lang/swizzle_generator.py
+++ b/python/taichi/lang/swizzle_generator.py
@@ -1,0 +1,103 @@
+from itertools import permutations, combinations
+from collections import namedtuple
+from typing import Iterable
+
+NRE_LNG = namedtuple('NRE_LNG', ['num_required_elems', 'length'])
+
+
+def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
+    class InvalidPattern(Exception):
+        pass
+
+    m = {}
+    m[(0, 0)] = ()
+
+    def _gen_impl(num_required_elems: int, required_len: int):
+        mkey = NRE_LNG(num_required_elems, required_len)
+        try:
+            return m[mkey]
+        except KeyError:
+            pass
+        if num_required_elems > required_len:
+            raise InvalidPattern(f'{num_required_elems} {required_len}')
+        if num_required_elems == 0:
+            if required_len == 0:
+                return []
+            raise InvalidPattern(f'{num_required_elems} {required_len}')
+        if num_required_elems == 1:
+            if required_len > 0:
+                m[mkey] = ((required_len,),)
+                return m[mkey]
+            raise InvalidPattern(f'{num_required_elems} {required_len}')
+
+        res = []
+        for n in range(1, required_len + 1):
+            try:
+                cur = _gen_impl(num_required_elems - 1, required_len - n)
+                res += [(n,) + t for t in cur]
+            except InvalidPattern:
+                pass
+        res = tuple(res)
+        m[mkey] = res
+        return res
+
+    upperbound = max_unique_elems + 1
+    for num_req in range(1, upperbound):
+        for required_len in range(num_req, upperbound):
+            _gen_impl(num_req, required_len)
+
+    return m
+
+
+def generate_seed_patterns(acc, nrel_vals):
+    res = []
+    for val in nrel_vals:
+        assert len(acc) == len(val)
+        seed = []
+        for char, vi in zip(acc, val):
+            seed += [char, ] * vi
+        res.append(tuple(seed))
+    return res
+
+
+class SwizzleGenerator:
+    def __init__(self, max_unique_elems=4):
+        self._nrel_map = generate_num_required_elems_to_required_len_map(
+            max_unique_elems)
+
+    def generate(self, accessors: Iterable[str], required_length: int):
+        res = [self._gen_for_length(accessors, l)
+               for l in range(1, required_length + 1)]
+        return res
+
+    def _gen_for_length(self, accessors, required_length):
+        acc_list = list(accessors)
+        res = []
+        for l in range(1, required_length + 1):
+            cur_len_patterns = set()
+            for subacc in combinations(acc_list, l):
+                nrel_key = NRE_LNG(l, required_length)
+                nrel_vals = self._nrel_map[nrel_key]
+                seed_patterns = generate_seed_patterns(subacc, nrel_vals)
+                for sp in seed_patterns:
+                    for p in permutations(sp):
+                        cur_len_patterns.add(p)
+            res += sorted(list(cur_len_patterns))
+        return res
+
+
+__all__ = [
+    'SwizzleGenerator',
+]
+
+if __name__ == '__main__':
+    sg = SwizzleGenerator()
+    pats_per_len = sg.generate('xyz', 4)
+    total = 0
+    for i, pats in enumerate(pats_per_len):
+        print(f'patterns at len={i}')
+        for p in pats:
+            print(f'  {p}')
+        total += len(pats)
+    # https://jojendersie.de/performance-optimal-vector-swizzling-in-c/
+    print(f'total_patterns={total}')

--- a/python/taichi/lang/swizzle_generator.py
+++ b/python/taichi/lang/swizzle_generator.py
@@ -6,6 +6,21 @@ NRE_LNG = namedtuple('NRE_LNG', ['num_required_elems', 'length'])
 
 
 def generate_num_required_elems_to_required_len_map(max_unique_elems=5):
+    '''
+    For example, if we want a sequence of length 4 to be composed by {'x', 'y'},
+    we have the following options:
+
+    * 'xxxx': 4 'x', 0 'y'
+    * 'xyyy': 1 'x', 3 'y'
+    * 'xxyy': 2 'x', 2 'y'
+    * 'xxxy': 3 'x', 1 'y'
+    * 'yyyy': 0 'x', 4 'y'
+
+    Each of these pattern is a seed. We can then do a permutation on it to get
+    all the patterns for this seed.
+
+    NRE_LNG(2, 4) maps to [(4, 0), (1, 3), (2, 2), (3, 1), (0, 4)]
+    '''
     class InvalidPattern(Exception):
         pass
 

--- a/python/taichi/math/vectypes.py
+++ b/python/taichi/math/vectypes.py
@@ -1,9 +1,7 @@
 import collections
-import functools
 import sys
 
 from taichi.lang.matrix import Matrix
-from taichi.lang.util import in_python_scope, python_scope
 from taichi.types.primitive_types import f32, i32
 
 

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -5,6 +5,32 @@ import pytest
 import taichi as ti
 from tests import test_utils
 
+
+def _get_matrix_swizzle_apis():
+    swizzle_gen = ti.lang.swizzle_generator.SwizzleGenerator()
+    KEMAP_SET = ['xyzw', 'rgba', 'stpq']
+    res = []
+    for key_group in KEMAP_SET:
+        sw_patterns = swizzle_gen.generate(key_group, required_length=4)
+        # len=1 accessors are handled specially
+        sw_patterns = filter(lambda p: len(p) > 1, sw_patterns)
+        sw_patterns = map(lambda p: ''.join(p), sw_patterns)
+        res += sw_patterns
+    return sorted(res)
+
+
+def _get_expected_matrix_apis():
+    base = [
+        'all', 'any', 'cast', 'cols', 'cross', 'determinant', 'diag', 'dot',
+        'field', 'fill', 'identity', 'inverse', 'max', 'min', 'ndarray', 'norm',
+        'norm_inv', 'norm_sqr', 'normalized', 'one', 'outer_product', 'rotation2d',
+        'rows', 'sum', 'to_list', 'to_numpy', 'trace', 'transpose', 'unit', 'w',
+        'x', 'y', 'z', 'zero'
+    ]
+    res = base + _get_matrix_swizzle_apis()
+    return sorted(res)
+
+
 user_api = {}
 user_api[ti] = [
     'CRITICAL', 'DEBUG', 'ERROR', 'Field', 'FieldsBuilder', 'GUI', 'INFO',
@@ -30,7 +56,7 @@ user_api[ti] = [
     'randn', 'random', 'raw_div', 'raw_mod', 'rescale_index', 'reset',
     'rgb_to_hex', 'root', 'round', 'rsqrt', 'select', 'set_logging_level',
     'simt', 'sin', 'solve', 'sparse_matrix_builder', 'sqrt', 'static',
-    'static_assert', 'static_print', 'stop_grad', 'svd', 'sym_eig', 'sync',
+    'static_assert', 'static_print', 'stop_grad', 'svd', 'swizzle_generator', 'sym_eig', 'sync',
     'tan', 'tanh', 'template', 'tools', 'types', 'u16', 'u32', 'u64', 'u8',
     'ui', 'uint16', 'uint32', 'uint64', 'uint8', 'vulkan', 'wasm', 'x64',
     'x86_64', 'zero'
@@ -50,13 +76,7 @@ user_api[ti.math] = [
     'radians', 'reflect', 'refract', 'sign', 'smoothstep', 'step', 'vec2',
     'vec3', 'vec4'
 ]
-user_api[ti.Matrix] = [
-    'all', 'any', 'cast', 'cols', 'cross', 'determinant', 'diag', 'dot',
-    'field', 'fill', 'identity', 'inverse', 'max', 'min', 'ndarray', 'norm',
-    'norm_inv', 'norm_sqr', 'normalized', 'one', 'outer_product', 'rotation2d',
-    'rows', 'sum', 'to_list', 'to_numpy', 'trace', 'transpose', 'unit', 'w',
-    'x', 'y', 'z', 'zero'
-]
+user_api[ti.Matrix] = _get_expected_matrix_apis()
 user_api[ti.MatrixField] = [
     'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch',
     'get_scalar_field', 'parent', 'shape', 'snode', 'to_numpy', 'to_torch'
@@ -92,6 +112,8 @@ user_api[ti.VectorNdarray] = [
 def test_api(src):
     # When Python version is below 3.7, deprecated names are
     # handled as normal names, which will fail this test.
-    assert sys.version_info < (3, 7) or [
+    expected = user_api[src]
+    actual = [
         s for s in dir(src) if not s.startswith('_')
-    ] == user_api[src]
+    ]
+    assert sys.version_info < (3, 7) or actual == expected, f'Failed for API={src}:\n  expected={expected}\n  actual={actual}'

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -22,10 +22,10 @@ def _get_matrix_swizzle_apis():
 def _get_expected_matrix_apis():
     base = [
         'all', 'any', 'cast', 'cols', 'cross', 'determinant', 'diag', 'dot',
-        'field', 'fill', 'identity', 'inverse', 'max', 'min', 'ndarray', 'norm',
-        'norm_inv', 'norm_sqr', 'normalized', 'one', 'outer_product', 'rotation2d',
-        'rows', 'sum', 'to_list', 'to_numpy', 'trace', 'transpose', 'unit', 'w',
-        'x', 'y', 'z', 'zero'
+        'field', 'fill', 'identity', 'inverse', 'max', 'min', 'ndarray',
+        'norm', 'norm_inv', 'norm_sqr', 'normalized', 'one', 'outer_product',
+        'rotation2d', 'rows', 'sum', 'to_list', 'to_numpy', 'trace',
+        'transpose', 'unit', 'w', 'x', 'y', 'z', 'zero'
     ]
     res = base + _get_matrix_swizzle_apis()
     return sorted(res)
@@ -56,10 +56,10 @@ user_api[ti] = [
     'randn', 'random', 'raw_div', 'raw_mod', 'rescale_index', 'reset',
     'rgb_to_hex', 'root', 'round', 'rsqrt', 'select', 'set_logging_level',
     'simt', 'sin', 'solve', 'sparse_matrix_builder', 'sqrt', 'static',
-    'static_assert', 'static_print', 'stop_grad', 'svd', 'swizzle_generator', 'sym_eig', 'sync',
-    'tan', 'tanh', 'template', 'tools', 'types', 'u16', 'u32', 'u64', 'u8',
-    'ui', 'uint16', 'uint32', 'uint64', 'uint8', 'vulkan', 'wasm', 'x64',
-    'x86_64', 'zero'
+    'static_assert', 'static_print', 'stop_grad', 'svd', 'swizzle_generator',
+    'sym_eig', 'sync', 'tan', 'tanh', 'template', 'tools', 'types', 'u16',
+    'u32', 'u64', 'u8', 'ui', 'uint16', 'uint32', 'uint64', 'uint8', 'vulkan',
+    'wasm', 'x64', 'x86_64', 'zero'
 ]
 user_api[ti.Field] = [
     'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'parent',
@@ -113,7 +113,7 @@ def test_api(src):
     # When Python version is below 3.7, deprecated names are
     # handled as normal names, which will fail this test.
     expected = user_api[src]
-    actual = [
-        s for s in dir(src) if not s.startswith('_')
-    ]
-    assert sys.version_info < (3, 7) or actual == expected, f'Failed for API={src}:\n  expected={expected}\n  actual={actual}'
+    actual = [s for s in dir(src) if not s.startswith('_')]
+    assert sys.version_info < (
+        3, 7
+    ) or actual == expected, f'Failed for API={src}:\n  expected={expected}\n  actual={actual}'

--- a/tests/python/test_math_vectors.py
+++ b/tests/python/test_math_vectors.py
@@ -3,15 +3,18 @@ import pytest
 import taichi as ti
 from tests import test_utils
 
+
 def _Vector_based_vec3_maker(*data):
-  if len(data) == 1:
-    data = data * 3
-  return ti.Vector(data, dt=ti.f32)
+    if len(data) == 1:
+        data = data * 3
+    return ti.Vector(data, dt=ti.f32)
+
 
 vec3_makers = [
-  ti.math.vec3,
-  _Vector_based_vec3_maker,
+    ti.math.vec3,
+    _Vector_based_vec3_maker,
 ]
+
 
 @pytest.mark.parametrize('make_vec3', vec3_makers)
 @test_utils.test()

--- a/tests/python/test_math_vectors.py
+++ b/tests/python/test_math_vectors.py
@@ -1,10 +1,22 @@
+import pytest
+
 import taichi as ti
 from tests import test_utils
 
+def _Vector_based_vec3_maker(*data):
+  if len(data) == 1:
+    data = data * 3
+  return ti.Vector(data, dt=ti.f32)
 
+vec3_makers = [
+  ti.math.vec3,
+  _Vector_based_vec3_maker,
+]
+
+@pytest.mark.parametrize('make_vec3', vec3_makers)
 @test_utils.test()
-def test_vector_swizzle_python():
-    a = ti.math.vec3(1, 2, 3)
+def test_vector_swizzle_python(make_vec3):
+    a = make_vec3(1, 2, 3)
     assert all(a.gbr == (2, 3, 1))
     a.bgr = (2, 3, 3)
     assert all(a.rgb == (3, 3, 2))
@@ -12,23 +24,24 @@ def test_vector_swizzle_python():
         1, 2, 3
     )  # FIXME: Taichi does not support += on matrices in python scope
     assert all(a.rgb == (6, 4, 4))
-    b = ti.math.vec3(1)
+    b = make_vec3(1)
     assert all((a + b).rrb == (7, 7, 5))
     M = ti.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     assert all((M @ b) == (1, 1, 1))
 
 
+@pytest.mark.parametrize('make_vec3', vec3_makers)
 @test_utils.test(debug=True)
-def test_vector_swizzle_taichi():
+def test_vector_swizzle_taichi(make_vec3):
     @ti.kernel
     def foo():
-        a = ti.math.vec3(1, 2, 3)
+        a = make_vec3(1, 2, 3)
         assert all(a.gbr == (2, 3, 1))
         a.bgr = (2, 3, 3)
         assert all(a.rgb == (3, 3, 2))
         a.gbr += (1, 2, 3)
         assert all(a.rgb == (6, 4, 4))
-        b = ti.math.vec3(1)
+        b = make_vec3(1)
         assert all((a + b).rrb == (7, 7, 5))
         M = ti.Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         assert all((M @ b) == (1, 1, 1))

--- a/tests/python/test_swizzle_generator.py
+++ b/tests/python/test_swizzle_generator.py
@@ -1,0 +1,9 @@
+import pytest
+from taichi.lang.swizzle_generator import SwizzleGenerator
+
+def test_swizzle_gen():
+  sg = SwizzleGenerator(max_unique_elems=4)
+  pats = sg.generate('xyzw', 4)
+  uniq_pats = set(pats)
+  # https://jojendersie.de/performance-optimal-vector-swizzling-in-c/
+  assert len(uniq_pats) == 340

--- a/tests/python/test_swizzle_generator.py
+++ b/tests/python/test_swizzle_generator.py
@@ -1,9 +1,10 @@
 import pytest
 from taichi.lang.swizzle_generator import SwizzleGenerator
 
+
 def test_swizzle_gen():
-  sg = SwizzleGenerator(max_unique_elems=4)
-  pats = sg.generate('xyzw', 4)
-  uniq_pats = set(pats)
-  # https://jojendersie.de/performance-optimal-vector-swizzling-in-c/
-  assert len(uniq_pats) == 340
+    sg = SwizzleGenerator(max_unique_elems=4)
+    pats = sg.generate('xyzw', 4)
+    uniq_pats = set(pats)
+    # https://jojendersie.de/performance-optimal-vector-swizzling-in-c/
+    assert len(uniq_pats) == 340


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/4810

Added a `SwizzleGenerator`, which generates all the combinatory patterns for a given set of accessors (e.g. `xyzw`). The next step would be to cleanup the `vecN` definitions.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
