### PR TITLE
[Bug] [ir] Fix implicit cast warning for global stores

### DIFF
--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -215,16 +215,14 @@ class TypeCheck : public IRVisitor {
       // Casting from compute_type to physical_type is handled in codegen.
       dst_value_type = dst_value_type->get_compute_type();
     }
-    auto promoted = promoted_type(dst_value_type, stmt->val->ret_type);
-    auto input_type = stmt->val->ret_data_type_name();
     if (dst_value_type != stmt->val->ret_type) {
+      auto promoted = promoted_type(dst_value_type, stmt->val->ret_type);
+      if (dst_value_type != promoted) {
+        TI_WARN("[{}] Global store may lose precision: {} <- {}, at\n{}",
+                stmt->name(), dst_value_type->to_string(),
+                stmt->val->ret_data_type_name(), stmt->tb);
+      }
       stmt->val = insert_type_cast_before(stmt, stmt->val, dst_value_type);
-    }
-    // TODO: do not use "promoted" here since u8 + u8 = i32 in C++ and storing
-    // u8 to u8 leads to extra warnings.
-    if (dst_value_type != promoted && dst_value_type != stmt->val->ret_type) {
-      TI_WARN("[{}] Global store may lose precision: {} <- {}, at\n{}",
-              stmt->name(), dst_value_type->to_string(), input_type, stmt->tb);
     }
   }
 


### PR DESCRIPTION
Related issue = fix #4833

The previous logic is buggy because `dst_value_type != stmt->val->ret_type` can never happen after inserting the implicit type cast.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi.graphics/lang/articles/contribution/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi.graphics/lang/articles/contribution/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
