### PR TITLE
[bug] Remove redundant AllocStmt when lowering FrontendWhileStmt

### DIFF
--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -156,7 +156,6 @@ class LowerAST : public IRVisitor {
     stmts->insert(
         std::make_unique<WhileControlStmt>(new_while->mask, cond_stmt),
         fctx.stmts.size());
-    stmt->insert_before_me(std::make_unique<AllocaStmt>(PrimitiveType::i32));
     auto &&const_stmt =
         std::make_unique<ConstStmt>(TypedConstant((int32)0xFFFFFFFF));
     auto const_stmt_ptr = const_stmt.get();


### PR DESCRIPTION
Related issue = #

Simple example:
```
@ti.kernel
def load_while(c: ti.i32):
    while c < 0:
        y[0] = c + 1.0 
````
After lowered to CHI IR, note that the highlighted variable "$0" has never been used: 

![image](https://user-images.githubusercontent.com/22334008/165456002-0bb6f664-8f8b-4b69-8e3a-2266783d5e17.png)
