### PR TITLE
[bug] Fixed type promotion rule for bit-shift operations

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -197,6 +197,11 @@ void BinaryOpExpression::type_check(CompileConfig *config) {
     ret_type = PrimitiveType::i32;
     return;
   }
+  if (is_shift_op(type)) {
+    ret_type = lhs_type;
+    return;
+  }
+
   if (type == BinaryOpType::truediv) {
     auto default_fp = config->default_fp;
     if (!is_real(lhs_type)) {

--- a/taichi/ir/stmt_op_types.h
+++ b/taichi/ir/stmt_op_types.h
@@ -47,6 +47,11 @@ inline bool binary_is_logical(BinaryOpType t) {
 
 std::string binary_op_type_name(BinaryOpType type);
 
+inline bool is_shift_op(BinaryOpType type) {
+  return type == BinaryOpType::bit_sar || type == BinaryOpType::bit_shl ||
+         type == BinaryOpType::bit_shr;
+}
+
 inline bool is_comparison(BinaryOpType type) {
   return starts_with(binary_op_type_name(type), "cmp");
 }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -5,7 +5,6 @@
 #include "taichi/ir/transforms.h"
 #include "taichi/ir/analysis.h"
 #include "taichi/ir/frontend_ir.h"
-#include <iostream>
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -245,21 +245,7 @@ class TypeCheck : public IRVisitor {
   }
 
   void insert_shift_op_assertion_before(Stmt *stmt, Stmt *lhs, Stmt *rhs) {
-    int rhs_limit = 64;
-    if (lhs->ret_type->is_primitive(PrimitiveTypeID::u1)) {
-      rhs_limit = 1;
-    } else if (lhs->ret_type->is_primitive(PrimitiveTypeID::u8) ||
-               lhs->ret_type->is_primitive(PrimitiveTypeID::i8)) {
-      rhs_limit = 8;
-    } else if (lhs->ret_type->is_primitive(PrimitiveTypeID::u16) ||
-               lhs->ret_type->is_primitive(PrimitiveTypeID::i16) ||
-               lhs->ret_type->is_primitive(PrimitiveTypeID::f16)) {
-      rhs_limit = 16;
-    } else if (lhs->ret_type->is_primitive(PrimitiveTypeID::u32) ||
-               lhs->ret_type->is_primitive(PrimitiveTypeID::i32) ||
-               lhs->ret_type->is_primitive(PrimitiveTypeID::f32)) {
-      rhs_limit = 32;
-    }
+    int rhs_limit = data_type_bits(lhs->ret_type);
     auto const_stmt =
         Stmt::make<ConstStmt>(TypedConstant(rhs->ret_type, rhs_limit));
     auto cond_stmt =
@@ -338,8 +324,9 @@ class TypeCheck : public IRVisitor {
         ret_type = stmt->lhs->ret_type;
 
         // Insert AssertStmt
-        insert_shift_op_assertion_before(stmt, stmt->lhs, stmt->rhs);
-
+        if (config_.debug) {
+          insert_shift_op_assertion_before(stmt, stmt->lhs, stmt->rhs);
+        }
       } else {
         ret_type = promoted_type(stmt->lhs->ret_type, stmt->rhs->ret_type);
       }

--- a/tests/cpp/ir/ir_type_promotion_test.cpp
+++ b/tests/cpp/ir/ir_type_promotion_test.cpp
@@ -1,0 +1,31 @@
+#include "gtest/gtest.h"
+
+#include "taichi/ir/statements.h"
+#include "taichi/ir/ir_builder.h"
+#include "taichi/ir/transforms.h"
+#include "tests/cpp/program/test_program.h"
+
+namespace taichi {
+namespace lang {
+
+TEST(IRTypePromotionTest, ShiftOp) {
+  IRBuilder builder;
+
+  // (u8)x << (i32)1 -> (u8)res
+  auto *lhs = builder.create_arg_load(0, get_data_type<uint8>(), false);
+  auto *res = builder.create_shl(lhs, builder.get_int32(1));
+  auto ir = builder.extract_ir();
+
+  ASSERT_TRUE(ir->is<Block>());
+  auto *ir_block = ir->as<Block>();
+  irpass::type_check(ir_block, CompileConfig());
+
+  EXPECT_TRUE(ir_block->statements.back()->is<BinaryOpStmt>());
+  auto *binary_stmt = ir_block->statements.back()->as<BinaryOpStmt>();
+
+  auto ret_type = binary_stmt->ret_type;
+  EXPECT_TRUE(ret_type->is_primitive(PrimitiveTypeID::u8));
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/tests/python/test_type_promotion.py
+++ b/tests/python/test_type_promotion.py
@@ -64,9 +64,11 @@ def test_sqrt():
 
 @test_utils.test()
 def test_shift_ops():
+    val = 1
+
     @ti.kernel
     def test():
-        rhs = ti.cast(1, ti.i32)
+        rhs = ti.cast(val, ti.i32)
         lhs = ti.cast(16, ti.u8)
 
         res = lhs << rhs

--- a/tests/python/test_type_promotion.py
+++ b/tests/python/test_type_promotion.py
@@ -60,19 +60,3 @@ def test_sqrt():
     func()
 
     assert np.allclose(y.to_numpy(), np.sqrt(x.to_numpy()))
-
-
-@test_utils.test()
-def test_shift_ops():
-    val = 1
-
-    @ti.kernel
-    def test():
-        rhs = ti.cast(val, ti.i32)
-        lhs = ti.cast(16, ti.u8)
-
-        res = lhs << rhs
-        ti.static_assert(res.ptr.get_ret_type().to_string() == 'u8',
-                         "Incorrect type promotion for shift operations.")
-
-    test()

--- a/tests/python/test_type_promotion.py
+++ b/tests/python/test_type_promotion.py
@@ -60,3 +60,17 @@ def test_sqrt():
     func()
 
     assert np.allclose(y.to_numpy(), np.sqrt(x.to_numpy()))
+
+
+@test_utils.test()
+def test_shift_ops():
+    @ti.kernel
+    def test():
+        rhs = ti.cast(1, ti.i32)
+        lhs = ti.cast(16, ti.u8)
+
+        res = lhs << rhs
+        ti.static_assert(res.ptr.get_ret_type().to_string() == 'u8',
+                         "Incorrect type promotion for shift operations.")
+
+    test()


### PR DESCRIPTION
Related issue = fix #4795

bit-shift ops should not follow the same type promotion rule as numerical, for example:
- ops numerical ops: `u8 + i32 = i32`
- shift_ops:                `u8 << i32 = u8` (follow lhs's dtype)

As truncating rhs(i32) to u8 risks an overflow (very unlikely though), we inserted an AssertStmt to warn user of this potential overflow if initialized with debug=True.

Before:
![image](https://user-images.githubusercontent.com/22334008/165691675-4deaf285-cb68-47a0-b3c0-3e10306b7172.png)


After this patch (with debug=True): 
![image](https://user-images.githubusercontent.com/22334008/165691053-7c110705-c03e-434d-8207-72819dfbcb12.png)
