### PR TITLE
[Lang] [test] Copy-free interaction between Taichi and PaddlePaddle

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -23,7 +23,7 @@ if [ -z "$GPU_TEST" ]; then
     python3 -m pip install -r requirements_test.txt
     python3 -m pip install "torch; python_version < '3.10'"
     # Paddle's develop package doesn't support CI's MACOS machine at present
-    if [[ $PLATFORM == *"linux"* ]]; then
+    if [[ $OSTYPE == "linux-"* ]]; then
         python3 -m pip install "paddlepaddle==0.0.0; python_version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
     fi
 else
@@ -49,7 +49,7 @@ if [ -z "$GPU_TEST" ]; then
         python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
     else
         # Fail fast, give priority to the error-prone tests
-        if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        if [[ $OSTYPE == "linux-"* ]]; then
             python3 tests/run_tests.py -vr2 -t1 -k "paddle" -a "$TI_WANTED_ARCHS"
         fi
         python3 tests/run_tests.py -vr2 -t4 -k "not paddle" -a "$TI_WANTED_ARCHS"

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -31,6 +31,7 @@ else
     export PATH=$PATH:$HOME/.local/bin
     # pip will skip packages if already installed
     python3 -m pip install -r requirements_test.txt
+    # Import Paddle's develop GPU package will occur error `Illegal Instruction`.
 fi
 ti diagnose
 ti changelog

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -50,7 +50,7 @@ if [ -z "$GPU_TEST" ]; then
     else
         # Fail fast, give priority to the error-prone tests
         if [[ "$OSTYPE" == "linux-gnu" ]]; then
-            python3 tests/run_tests.py -vr2 -t4 -k "paddle" -a "$TI_WANTED_ARCHS"
+            python3 tests/run_tests.py -vr2 -t1 -k "paddle" -a "$TI_WANTED_ARCHS"
         fi
         python3 tests/run_tests.py -vr2 -t4 -k "not paddle" -a "$TI_WANTED_ARCHS"
     fi

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -22,6 +22,10 @@ python3 -m pip install dist/*.whl
 if [ -z "$GPU_TEST" ]; then
     python3 -m pip install -r requirements_test.txt
     python3 -m pip install "torch; python_version < '3.10'"
+    # Paddle's develop package doesn't support CI's MACOS machine at present
+    if [[ $PLATFORM == *"linux"* ]]; then
+        python3 -m pip install "paddlepaddle==0.0.0; python_version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
+    fi
 else
     ## Only GPU machine uses system python.
     export PATH=$PATH:$HOME/.local/bin
@@ -38,27 +42,32 @@ TI_LIB_DIR="$TI_PATH/_lib/runtime" ./build/taichi_cpp_tests
 if [ -z "$GPU_TEST" ]; then
     if [[ $PLATFORM == *"m1"* ]]; then
 	# Split per arch to avoid flaky test
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a cpu
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a cpu
         # Run metal and vulkan separately so that they don't use M1 chip simultaneously.
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a vulkan
-        python3 tests/run_tests.py -vr2 -t2 -k "not torch" -a metal
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a vulkan
+        python3 tests/run_tests.py -vr2 -t2 -k "not torch and not paddle" -a metal
         python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
     else
-        python3 tests/run_tests.py -vr2 -t4 -a "$TI_WANTED_ARCHS"
+        # Fail fast, give priority to the error-prone tests
+        if [[ "$OSTYPE" == "linux-gnu" ]]; then
+            python3 tests/run_tests.py -vr2 -t4 -k "paddle" -a "$TI_WANTED_ARCHS"
+        fi
+        python3 tests/run_tests.py -vr2 -t4 -k "not paddle" -a "$TI_WANTED_ARCHS"
     fi
 else
     # Split per arch to increase parallelism for linux GPU tests
     if [[ $TI_WANTED_ARCHS == *"cuda"* ]]; then
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a cuda
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a cuda
     fi
     if [[ $TI_WANTED_ARCHS == *"cpu"* ]]; then
-        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a cpu
+        python3 tests/run_tests.py -vr2 -t8 -k "not torch and not paddle" -a cpu
     fi
     if [[ $TI_WANTED_ARCHS == *"vulkan"* ]]; then
-        python3 tests/run_tests.py -vr2 -t8 -k "not torch" -a vulkan
+        python3 tests/run_tests.py -vr2 -t8 -k "not torch and not paddle" -a vulkan
     fi
     if [[ $TI_WANTED_ARCHS == *"opengl"* ]]; then
-        python3 tests/run_tests.py -vr2 -t4 -k "not torch" -a opengl
+        python3 tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a opengl
     fi
     python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
+    # Paddle's paddle.fluid.core.Tensor._ptr() is only available on develop branch, and CUDA version on linux will get error `Illegal Instruction`
 fi

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -9,19 +9,23 @@ pip install -r requirements_test.txt
 # TODO relax this when torch supports 3.10
 if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
     pip install "torch==1.10.1+cu113; python_version < '3.10'" -f https://download.pytorch.org/whl/cu113/torch_stable.html
+    pip install "paddlepaddle-gpu==0.0.0.post112; python version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
 } else {
     pip install "torch; python_version < '3.10'"
+    pip install "paddlepaddle==0.0.0; python version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/windows/cpu-mkl-avx/develop.html
 }
+# Fail fast, give priority to the error-prone tests
+python tests/run_tests.py -vr2 -t2 -k "paddle" -a "$env:TI_WANTED_ARCHS"
 if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
-  python tests/run_tests.py -vr2 -t4 -k "not torch" -a cuda
+  python tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a cuda
   if (-not $?) { exit 1 }
 }
 if ("$env:TI_WANTED_ARCHS".Contains("cpu")) {
-  python tests/run_tests.py -vr2 -t6 -k "not torch" -a cpu
+  python tests/run_tests.py -vr2 -t6 -k "not torch and not paddle" -a cpu
   if (-not $?) { exit 1 }
 }
 if ("$env:TI_WANTED_ARCHS".Contains("opengl")) {
-  python tests/run_tests.py -vr2 -t4 -k "not torch" -a opengl
+  python tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a opengl
   if (-not $?) { exit 1 }
 }
 python tests/run_tests.py -vr2 -t2 -k "torch" -a "$env:TI_WANTED_ARCHS"

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -9,10 +9,10 @@ pip install -r requirements_test.txt
 # TODO relax this when torch supports 3.10
 if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
     pip install "torch==1.10.1+cu113; python_version < '3.10'" -f https://download.pytorch.org/whl/cu113/torch_stable.html
-    pip install "paddlepaddle-gpu==0.0.0.post112; python version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
+    pip install "paddlepaddle-gpu==0.0.0.post112; python_version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/windows/gpu/develop.html
 } else {
     pip install "torch; python_version < '3.10'"
-    pip install "paddlepaddle==0.0.0; python version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/windows/cpu-mkl-avx/develop.html
+    pip install "paddlepaddle==0.0.0; python_version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/windows/cpu-mkl-avx/develop.html
 }
 # Fail fast, give priority to the error-prone tests
 python tests/run_tests.py -vr2 -t1 -k "paddle" -a "$env:TI_WANTED_ARCHS"

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -15,7 +15,7 @@ if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
     pip install "paddlepaddle==0.0.0; python version < '3.10'" -f https://www.paddlepaddle.org.cn/whl/windows/cpu-mkl-avx/develop.html
 }
 # Fail fast, give priority to the error-prone tests
-python tests/run_tests.py -vr2 -t2 -k "paddle" -a "$env:TI_WANTED_ARCHS"
+python tests/run_tests.py -vr2 -t1 -k "paddle" -a "$env:TI_WANTED_ARCHS"
 if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
   python tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a cuda
   if (-not $?) { exit 1 }
@@ -28,5 +28,5 @@ if ("$env:TI_WANTED_ARCHS".Contains("opengl")) {
   python tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a opengl
   if (-not $?) { exit 1 }
 }
-python tests/run_tests.py -vr2 -t2 -k "torch" -a "$env:TI_WANTED_ARCHS"
+python tests/run_tests.py -vr2 -t1 -k "torch" -a "$env:TI_WANTED_ARCHS"
 if (-not $?) { exit 1 }

--- a/ci/scripts/ubuntu_build_test.sh
+++ b/ci/scripts/ubuntu_build_test.sh
@@ -31,5 +31,6 @@ export TI_IN_DOCKER=true
 
 # Run tests
 ti diagnose
-python tests/run_tests.py -vr2 -t2 -k "not ndarray and not torch"
+# Paddle's paddle.fluid.core.Tensor._ptr() is only available on develop branch, and CUDA version on linux will get error `Illegal Instruction`
+python tests/run_tests.py -vr2 -t2 -k "not ndarray and not torch and not paddle"
 python tests/run_tests.py -vr2 -t1 -k "ndarray or torch"

--- a/ci/scripts/ubuntu_build_test_cpu.sh
+++ b/ci/scripts/ubuntu_build_test_cpu.sh
@@ -22,6 +22,8 @@ git clone --recursive https://github.com/taichi-dev/taichi --branch=master
 cd taichi
 git checkout $SHA
 python3 -m pip install -r requirements_dev.txt -i http://repo.taichigraphics.com/repository/pypi/simple --trusted-host repo.taichigraphics.com
+# Paddle's paddle.fluid.core.Tensor._ptr() is only available on develop branch
+python3 -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
 TAICHI_CMAKE_ARGS="-DTI_WITH_VULKAN:BOOL=OFF -DTI_WITH_CUDA:BOOL=OFF -DTI_WITH_OPENGL:BOOL=OFF" python3 setup.py install
 
 # Add Docker specific ENV
@@ -29,5 +31,5 @@ export TI_IN_DOCKER=true
 
 # Run tests
 ti diagnose
-python tests/run_tests.py -vr2 -t2 -k "not ndarray and not torch"
-python tests/run_tests.py -vr2 -t1 -k "ndarray or torch"
+python tests/run_tests.py -vr2 -t2 -k "not ndarray and not torch and not paddle"
+python tests/run_tests.py -vr2 -t1 -k "ndarray or torch or paddle"

--- a/ci/windows/win_build_test.ps1
+++ b/ci/windows/win_build_test.ps1
@@ -59,5 +59,5 @@ python setup.py develop
 WriteInfo("Build finished")
 
 WriteInfo("Testing Taichi")
-python tests/run_tests.py -vr2 -t2 -k "not torch" -a cpu
+python tests/run_tests.py -vr2 -t2 -k "not torch and not paddle" -a cpu
 WriteInfo("Test finished")

--- a/docs/lang/articles/misc/global_settings.md
+++ b/docs/lang/articles/misc/global_settings.md
@@ -29,6 +29,7 @@ sidebar_position: 7
 - To start program in debug mode: `ti.init(debug=True)` or
   `ti debug your_script.py`.
 - To disable importing torch on start up: `export TI_ENABLE_TORCH=0`.
+- To disable importing paddle on start up: `export TI_ENABLE_PADDLE=0`.
 
 ## Logging
 

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -134,11 +134,11 @@ class Field:
         raise NotImplementedError()
 
     @python_scope
-    def to_paddle(self, device=None):
+    def to_paddle(self, place=None):
         """Converts `self` to a paddle tensor.
 
         Args:
-            device (paddle.CPUPlace()/CUDAPlace(n), optional): The desired device of returned tensor.
+            place (paddle.CPUPlace()/CUDAPlace(n), optional): The desired place of returned tensor.
 
         Returns:
             paddle.Tensor: The result paddle tensor.
@@ -292,13 +292,16 @@ class ScalarField(Field):
         return arr
 
     @python_scope
-    def to_paddle(self, device=None):
+    def to_paddle(self, place=None):
         """Converts this field to a `paddle.Tensor`.
         """
         import paddle  # pylint: disable=C0415
 
         # pylint: disable=E1101
-        arr = paddle.zeros(shape=self.shape, dtype=to_paddle_type(self.dtype))
+        # paddle.empty() doesn't support argument `place``
+        arr = paddle.to_tensor(paddle.zeros(self.shape,
+                                            to_paddle_type(self.dtype)),
+                               place=place)
         from taichi._kernels import tensor_to_ext_arr  # pylint: disable=C0415
         tensor_to_ext_arr(self, arr)
         taichi.lang.runtime_ops.sync()

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -1,6 +1,7 @@
 import taichi.lang
 from taichi._lib import core as _ti_core
-from taichi.lang.util import python_scope, to_numpy_type, to_pytorch_type, to_paddle_type
+from taichi.lang.util import (python_scope, to_numpy_type, to_paddle_type,
+                              to_pytorch_type)
 
 
 class Field:
@@ -298,8 +299,8 @@ class ScalarField(Field):
 
         # pylint: disable=E1101
         arr = paddle.zeros(size=self.shape,
-                          dtype=to_paddle_type(self.dtype),
-                          device=device)
+                           dtype=to_paddle_type(self.dtype),
+                           device=device)
         from taichi._kernels import tensor_to_ext_arr  # pylint: disable=C0415
         tensor_to_ext_arr(self, arr)
         taichi.lang.runtime_ops.sync()

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -298,9 +298,7 @@ class ScalarField(Field):
         import paddle  # pylint: disable=C0415
 
         # pylint: disable=E1101
-        arr = paddle.zeros(size=self.shape,
-                           dtype=to_paddle_type(self.dtype),
-                           device=device)
+        arr = paddle.zeros(shape=self.shape, dtype=to_paddle_type(self.dtype))
         from taichi._kernels import tensor_to_ext_arr  # pylint: disable=C0415
         tensor_to_ext_arr(self, arr)
         taichi.lang.runtime_ops.sync()

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -138,7 +138,7 @@ class Field:
         """Converts `self` to a paddle tensor.
 
         Args:
-            device (paddle.CPUPlace()/CUDAPlace(), optional): The desired device of returned tensor.
+            device (paddle.CPUPlace()/CUDAPlace(n), optional): The desired device of returned tensor.
 
         Returns:
             paddle.Tensor: The result paddle tensor.

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -658,7 +658,8 @@ class Kernel:
                         ndarray_type.NdarrayType) and (self.match_ext_arr(v)):
                     has_external_arrays = True
                     is_numpy = isinstance(v, np.ndarray)
-                    is_torch = isinstance(v, torch.Tensor)
+                    is_torch = isinstance(v,
+                                          torch.Tensor) if has_torch else False
                     if is_numpy:
                         tmp = np.ascontiguousarray(v)
                         # Purpose: DO NOT GC |tmp|!

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -676,7 +676,7 @@ class Kernel:
                             actual_argument_slot, int(tmp.data_ptr()),
                             tmp.element_size() * tmp.nelement(), v.shape)
                     else:
-                        # For now, paddle.fluid.core.Tensor._ptr() is only available on PaddlePaddle's develop branch
+                        # For now, paddle.fluid.core.Tensor._ptr() is only available on develop branch
                         tmp, paddle_callbacks = self.get_paddle_callbacks(
                             v, has_pp)
                         callbacks += paddle_callbacks

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -644,7 +644,7 @@ class Kernel:
                         tmp = v.value().get_tensor()
                         launch_ctx.set_arg_external_array_with_shape(
                             actual_argument_slot, int(tmp._ptr()),
-                            v.element_size() * v.size(), v.shape)
+                            v.element_size() * v.size, v.shape)
 
                 elif isinstance(needed, MatrixType):
                     if id(needed.dtype) in primitive_types.real_type_ids:

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1456,10 +1456,10 @@ class MatrixField(Field):
         return arr
 
     def to_paddle(self, device=None, keep_dims=False):
-        """Converts the field instance to a PaddlePaddle tensor.
+        """Converts the field instance to a Paddle tensor.
 
         Args:
-            device (paddle.CPUPlace()/CUDAPlace(), optional): The desired device of returned tensor.
+            device (paddle.CPUPlace()/CUDAPlace(n), optional): The desired device of returned tensor.
             keep_dims (bool, optional): Whether to keep the dimension after conversion.
                 See :meth:`~taichi.lang.field.MatrixField.to_numpy` for more detailed explanation.
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -14,7 +14,7 @@ from taichi.lang.exception import (TaichiCompilationError, TaichiSyntaxError,
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.swizzle_generator import SwizzleGenerator
 from taichi.lang.util import (cook_dtype, in_python_scope, python_scope,
-                              taichi_scope, to_numpy_type, to_pytorch_type,
+                              taichi_scope, to_numpy_type, to_pytorch_type, to_paddle_type,
                               warning)
 from taichi.types import primitive_types
 from taichi.types.compound_types import CompoundType
@@ -1449,6 +1449,29 @@ class MatrixField(Field):
         # pylint: disable=E1101
         arr = torch.empty(self.shape + shape_ext,
                           dtype=to_pytorch_type(self.dtype),
+                          device=device)
+        from taichi._kernels import matrix_to_ext_arr  # pylint: disable=C0415
+        matrix_to_ext_arr(self, arr, as_vector)
+        runtime_ops.sync()
+        return arr
+
+    def to_paddle(self, device=None, keep_dims=False):
+        """Converts the field instance to a PaddlePaddle tensor.
+
+        Args:
+            device (paddle.CPUPlace()/CUDAPlace(), optional): The desired device of returned tensor.
+            keep_dims (bool, optional): Whether to keep the dimension after conversion.
+                See :meth:`~taichi.lang.field.MatrixField.to_numpy` for more detailed explanation.
+
+        Returns:
+            paddle.Tensor: The result paddle tensor.
+        """
+        import paddle  # pylint: disable=C0415
+        as_vector = self.m == 1 and not keep_dims
+        shape_ext = (self.n, ) if as_vector else (self.n, self.m)
+        # pylint: disable=E1101
+        arr = paddle.empty(self.shape + shape_ext,
+                          dtype=to_paddle_type(self.dtype),
                           device=device)
         from taichi._kernels import matrix_to_ext_arr  # pylint: disable=C0415
         matrix_to_ext_arr(self, arr, as_vector)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1455,11 +1455,11 @@ class MatrixField(Field):
         runtime_ops.sync()
         return arr
 
-    def to_paddle(self, device=None, keep_dims=False):
+    def to_paddle(self, place=None, keep_dims=False):
         """Converts the field instance to a Paddle tensor.
 
         Args:
-            device (paddle.CPUPlace()/CUDAPlace(n), optional): The desired device of returned tensor.
+            place (paddle.CPUPlace()/CUDAPlace(n), optional): The desired place of returned tensor.
             keep_dims (bool, optional): Whether to keep the dimension after conversion.
                 See :meth:`~taichi.lang.field.MatrixField.to_numpy` for more detailed explanation.
 
@@ -1470,9 +1470,10 @@ class MatrixField(Field):
         as_vector = self.m == 1 and not keep_dims
         shape_ext = (self.n, ) if as_vector else (self.n, self.m)
         # pylint: disable=E1101
-        arr = paddle.empty(self.shape + shape_ext,
-                           dtype=to_paddle_type(self.dtype),
-                           device=device)
+        # paddle.empty() doesn't support argument `place``
+        arr = paddle.to_tensor(paddle.empty(self.shape + shape_ext,
+                                            to_paddle_type(self.dtype)),
+                               place=place)
         from taichi._kernels import matrix_to_ext_arr  # pylint: disable=C0415
         matrix_to_ext_arr(self, arr, as_vector)
         runtime_ops.sync()

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -14,8 +14,8 @@ from taichi.lang.exception import (TaichiCompilationError, TaichiSyntaxError,
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.swizzle_generator import SwizzleGenerator
 from taichi.lang.util import (cook_dtype, in_python_scope, python_scope,
-                              taichi_scope, to_numpy_type, to_pytorch_type, to_paddle_type,
-                              warning)
+                              taichi_scope, to_numpy_type, to_paddle_type,
+                              to_pytorch_type, warning)
 from taichi.types import primitive_types
 from taichi.types.compound_types import CompoundType
 
@@ -1471,8 +1471,8 @@ class MatrixField(Field):
         shape_ext = (self.n, ) if as_vector else (self.n, self.m)
         # pylint: disable=E1101
         arr = paddle.empty(self.shape + shape_ext,
-                          dtype=to_paddle_type(self.dtype),
-                          device=device)
+                           dtype=to_paddle_type(self.dtype),
+                           device=device)
         from taichi._kernels import matrix_to_ext_arr  # pylint: disable=C0415
         matrix_to_ext_arr(self, arr, as_vector)
         runtime_ops.sync()

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -172,12 +172,21 @@ class MeshElementField:
             v.from_torch(array_dict[k])
 
     @python_scope
+    def from_paddle(self, array_dict):
+        for k, v in self._items:
+            v.from_paddle(array_dict[k])
+
+    @python_scope
     def to_numpy(self):
         return {k: v.to_numpy() for k, v in self._items}
 
     @python_scope
     def to_torch(self, device=None):
         return {k: v.to_torch(device=device) for k, v in self._items}
+
+    @python_scope
+    def to_paddle(self, device=None):
+        return {k: v.to_paddle(device=device) for k, v in self._items}
 
     @python_scope
     def __len__(self):

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -185,8 +185,8 @@ class MeshElementField:
         return {k: v.to_torch(device=device) for k, v in self._items}
 
     @python_scope
-    def to_paddle(self, device=None):
-        return {k: v.to_paddle(device=device) for k, v in self._items}
+    def to_paddle(self, place=None):
+        return {k: v.to_paddle(place=place) for k, v in self._items}
 
     @python_scope
     def __len__(self):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -543,20 +543,20 @@ class StructField(Field):
         return {k: v.to_torch(device=device) for k, v in self._items}
 
     @python_scope
-    def to_paddle(self, device=None):
+    def to_paddle(self, place=None):
         """Converts the Struct field instance to a dictionary of Paddle tensors.
 
         The dictionary may be nested when converting nested structs.
 
         Args:
-            device (paddle.CPUPlace()/CUDAPlace(n), optional): The
-                desired device of returned tensor.
+            place (paddle.CPUPlace()/CUDAPlace(n), optional): The
+                desired place of returned tensor.
 
         Returns:
             Dict[str, Union[paddle.Tensor, Dict]]: The result
                 Paddle tensor.
         """
-        return {k: v.to_paddle(device=device) for k, v in self._items}
+        return {k: v.to_paddle(place=place) for k, v in self._items}
 
     @python_scope
     def __setitem__(self, indices, element):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -505,6 +505,17 @@ class StructField(Field):
             v.from_torch(array_dict[k])
 
     @python_scope
+    def from_paddle(self, array_dict):
+        """Copies the data from a set of `paddle.Tensor` into this field.
+
+        The argument `array_dict` must be a dictionay-like object, it
+        contains all the keys in this field and the copying process
+        between corresponding items can be performed.
+        """
+        for k, v in self._items:
+            v.from_paddle(array_dict[k])
+
+    @python_scope
     def to_numpy(self):
         """Converts the Struct field instance to a dictionary of NumPy arrays.
 
@@ -530,6 +541,22 @@ class StructField(Field):
                 PyTorch tensor.
         """
         return {k: v.to_torch(device=device) for k, v in self._items}
+
+    @python_scope
+    def to_paddle(self, device=None):
+        """Converts the Struct field instance to a dictionary of PaddlePaddle tensors.
+
+        The dictionary may be nested when converting nested structs.
+
+        Args:
+            device (paddle.CPUPlace()/CUDAPlace(), optional): The
+                desired device of returned tensor.
+
+        Returns:
+            Dict[str, Union[paddle.Tensor, Dict]]: The result
+                PaddlePaddle tensor.
+        """
+        return {k: v.to_paddle(device=device) for k, v in self._items}
 
     @python_scope
     def __setitem__(self, indices, element):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -544,17 +544,17 @@ class StructField(Field):
 
     @python_scope
     def to_paddle(self, device=None):
-        """Converts the Struct field instance to a dictionary of PaddlePaddle tensors.
+        """Converts the Struct field instance to a dictionary of Paddle tensors.
 
         The dictionary may be nested when converting nested structs.
 
         Args:
-            device (paddle.CPUPlace()/CUDAPlace(), optional): The
+            device (paddle.CPUPlace()/CUDAPlace(n), optional): The
                 desired device of returned tensor.
 
         Returns:
             Dict[str, Union[paddle.Tensor, Dict]]: The result
-                PaddlePaddle tensor.
+                Paddle tensor.
         """
         return {k: v.to_paddle(device=device) for k, v in self._items}
 

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -29,6 +29,25 @@ def has_pytorch():
     """
     return _has_pytorch
 
+_has_paddle = False
+
+_env_paddle = os.environ.get('TI_ENABLE_PADDLE', '1')
+if not _env_paddle or int(_env_paddle):
+    try:
+        import paddle
+        _has_paddle = True
+    except:
+        pass
+
+
+def has_paddle():
+    """Whether has paddle in the current Python environment.
+
+    Returns:
+        bool: True if has paddle else False.
+    """
+    return _has_paddle
+
 
 from distutils.spawn import find_executable
 
@@ -127,6 +146,37 @@ def to_pytorch_type(dt):
     assert False
 
 
+def to_paddle_type(dt):
+    """Convert taichi data type to its counterpart in paddle.
+
+    Args:
+        dt (DataType): The desired data type to convert.
+
+    Returns:
+        DataType: The counterpart data type in paddle.
+
+    """
+    if dt == f32:
+        return paddle.float32
+    if dt == f64:
+        return paddle.float64
+    if dt == i32:
+        return paddle.int32
+    if dt == i64:
+        return paddle.int64
+    if dt == i8:
+        return paddle.int8
+    if dt == i16:
+        return paddle.int16
+    if dt == u8:
+        return paddle.uint8
+    if dt == f16:
+        return paddle.float16
+    if dt in (u16, u32, u64):
+        raise RuntimeError(
+            f'Paddle doesn\'t support {dt.to_string()} data type.')
+    assert False
+
 def to_taichi_type(dt):
     """Convert numpy or torch data type to its counterpart in taichi.
 
@@ -184,6 +234,27 @@ def to_taichi_type(dt):
         if dt in (u16, u32, u64):
             raise RuntimeError(
                 f'PyTorch doesn\'t support {dt.to_string()} data type.')
+
+    if has_paddle():
+        if dt == paddle.float32:
+            return f32
+        if dt == paddle.float64:
+            return f64
+        if dt == paddle.int32:
+            return i32
+        if dt == paddle.int64:
+            return i64
+        if dt == paddle.int8:
+            return i8
+        if dt == paddle.int16:
+            return i16
+        if dt == paddle.uint8:
+            return u8
+        if dt == paddle.float16:
+            return f16
+        if dt in (u16, u32, u64):
+            raise RuntimeError(
+                f'Paddle doesn\'t support {dt.to_string()} data type.')
 
     raise AssertionError(f"Unknown type {dt}")
 

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -10,12 +10,21 @@ from taichi.types.primitive_types import (f16, f32, f64, i8, i16, i32, i64, u8,
                                           u16, u32, u64)
 
 _has_pytorch = False
+_has_paddle = False
 
 _env_torch = os.environ.get('TI_ENABLE_TORCH', '1')
 if not _env_torch or int(_env_torch):
     try:
         import torch
         _has_pytorch = True
+    except:
+        pass
+
+_env_paddle = os.environ.get('TI_ENABLE_PADDLE', '1')
+if not _env_paddle or int(_env_paddle):
+    try:
+        import paddle
+        _has_paddle = True
     except:
         pass
 
@@ -28,16 +37,6 @@ def has_pytorch():
 
     """
     return _has_pytorch
-
-_has_paddle = False
-
-_env_paddle = os.environ.get('TI_ENABLE_PADDLE', '1')
-if not _env_paddle or int(_env_paddle):
-    try:
-        import paddle
-        _has_paddle = True
-    except:
-        pass
 
 
 def has_paddle():
@@ -177,8 +176,9 @@ def to_paddle_type(dt):
             f'Paddle doesn\'t support {dt.to_string()} data type.')
     assert False
 
+
 def to_taichi_type(dt):
-    """Convert numpy or torch data type to its counterpart in taichi.
+    """Convert numpy or torch or paddle data type to its counterpart in taichi.
 
     Args:
         dt (DataType): The desired data type to convert.

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -60,8 +60,8 @@ user_api[ti] = [
     'wasm', 'x64', 'x86_64', 'zero'
 ]
 user_api[ti.Field] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'parent',
-    'shape', 'snode', 'to_numpy', 'to_torch'
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
+    'parent', 'shape', 'snode', 'to_numpy', 'to_torch', 'to_paddle'
 ]
 user_api[ti.FieldsBuilder] = [
     'bit_array', 'bit_struct', 'bitmasked', 'deactivate_all', 'dense',
@@ -77,8 +77,9 @@ user_api[ti.math] = [
 ]
 user_api[ti.Matrix] = _get_expected_matrix_apis()
 user_api[ti.MatrixField] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch',
-    'get_scalar_field', 'parent', 'shape', 'snode', 'to_numpy', 'to_torch'
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
+    'get_scalar_field', 'parent', 'shape', 'snode', 'to_numpy', 'to_torch',
+    'to_paddle'
 ]
 user_api[ti.MatrixNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'to_numpy'
@@ -89,17 +90,17 @@ user_api[ti.SNode] = [
     'dynamic', 'lazy_grad', 'parent', 'place', 'pointer', 'shape'
 ]
 user_api[ti.ScalarField] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'parent',
-    'shape', 'snode', 'to_numpy', 'to_torch'
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
+    'parent', 'shape', 'snode', 'to_numpy', 'to_torch', 'to_paddle'
 ]
 user_api[ti.ScalarNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'to_numpy'
 ]
 user_api[ti.Struct] = ['field', 'fill', 'items', 'keys', 'to_dict']
 user_api[ti.StructField] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch',
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
     'get_member_field', 'keys', 'parent', 'shape', 'snode', 'to_numpy',
-    'to_torch'
+    'to_torch', 'to_paddle'
 ]
 user_api[ti.VectorNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'to_numpy'

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -60,8 +60,8 @@ user_api[ti] = [
     'wasm', 'x64', 'x86_64', 'zero'
 ]
 user_api[ti.Field] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
-    'parent', 'shape', 'snode', 'to_numpy', 'to_torch', 'to_paddle'
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
+    'parent', 'shape', 'snode', 'to_numpy', 'to_paddle', 'to_torch'
 ]
 user_api[ti.FieldsBuilder] = [
     'bit_array', 'bit_struct', 'bitmasked', 'deactivate_all', 'dense',
@@ -77,9 +77,9 @@ user_api[ti.math] = [
 ]
 user_api[ti.Matrix] = _get_expected_matrix_apis()
 user_api[ti.MatrixField] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
-    'get_scalar_field', 'parent', 'shape', 'snode', 'to_numpy', 'to_torch',
-    'to_paddle'
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
+    'get_scalar_field', 'parent', 'shape', 'snode', 'to_numpy', 'to_paddle',
+    'to_torch'
 ]
 user_api[ti.MatrixNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'to_numpy'
@@ -90,17 +90,17 @@ user_api[ti.SNode] = [
     'dynamic', 'lazy_grad', 'parent', 'place', 'pointer', 'shape'
 ]
 user_api[ti.ScalarField] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
-    'parent', 'shape', 'snode', 'to_numpy', 'to_torch', 'to_paddle'
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
+    'parent', 'shape', 'snode', 'to_numpy', 'to_paddle', 'to_torch'
 ]
 user_api[ti.ScalarNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'to_numpy'
 ]
 user_api[ti.Struct] = ['field', 'fill', 'items', 'keys', 'to_dict']
 user_api[ti.StructField] = [
-    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_torch', 'from_paddle',
+    'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
     'get_member_field', 'keys', 'parent', 'shape', 'snode', 'to_numpy',
-    'to_torch', 'to_paddle'
+    'to_paddle', 'to_torch'
 ]
 user_api[ti.VectorNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'to_numpy'

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -102,7 +102,7 @@ def test_from_torch():
 
 
 @pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
-@test_utils.test(arch=archs_support_f16)
+@test_utils.test(arch=archs_support_f16, exclude=ti.vulkan)
 def test_to_paddle():
     import paddle
     n = 16
@@ -123,7 +123,7 @@ def test_to_paddle():
 
 
 @pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
-@test_utils.test(arch=archs_support_f16)
+@test_utils.test(arch=archs_support_f16, exclude=ti.vulkan)
 def test_from_paddle():
     import paddle
     n = 16

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -104,6 +104,7 @@ def test_from_torch():
 @pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
 @test_utils.test(arch=archs_support_f16)
 def test_to_paddle():
+    import paddle
     n = 16
     x = ti.field(ti.f16, shape=n)
 
@@ -114,6 +115,8 @@ def test_to_paddle():
 
     init()
     y = x.to_paddle()
+    # paddle's operator slice doesn't have kernel for f16, so cast to f32
+    y = y.cast(paddle.float32)
     print(y)
     for i in range(n):
         assert (y[i] == 2 * i)
@@ -136,6 +139,8 @@ def test_from_paddle():
 
     init()
     z = y.to_paddle()
+    # paddle's operator slice doesn't have kernel for f16, so cast to f32
+    z = z.cast(paddle.float32)
     for i in range(n):
         assert (z[i] == i * 3)
 

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -101,7 +101,7 @@ def test_from_torch():
         assert (z[i] == i * 3)
 
 
-@pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
 @test_utils.test(arch=archs_support_f16, exclude=ti.vulkan)
 def test_to_paddle():
     import paddle
@@ -122,7 +122,7 @@ def test_to_paddle():
         assert (y[i] == 2 * i)
 
 
-@pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
 @test_utils.test(arch=archs_support_f16, exclude=ti.vulkan)
 def test_from_paddle():
     import paddle

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -75,7 +75,7 @@ def test_get_external_tensor_shape_access_ndarray(size):
             idx, y_ref, y_hat)
 
 
-@pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
 @pytest.mark.parametrize('size', [[1, 2, 3, 4]])
 @test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_get_external_tensor_shape_access_paddle(size):

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -77,7 +77,7 @@ def test_get_external_tensor_shape_access_ndarray(size):
 
 @pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
 @pytest.mark.parametrize('size', [[1, 2, 3, 4]])
-@test_utils.test(exclude=ti.opengl)
+@test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_get_external_tensor_shape_access_paddle(size):
     @ti.kernel
     def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -78,7 +78,7 @@ def test_get_external_tensor_shape_access_ndarray(size):
 @pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
 @pytest.mark.parametrize('size', [[1, 2, 3, 4]])
 @test_utils.test(exclude=ti.opengl)
-def test_get_external_tensor_shape_access_torch(size):
+def test_get_external_tensor_shape_access_paddle(size):
     @ti.kernel
     def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:
         return x.shape[index]

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -83,7 +83,7 @@ def test_get_external_tensor_shape_access_paddle(size):
     def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:
         return x.shape[index]
 
-    x_hat = paddle.ones([size], dtype=paddle.int32)
+    x_hat = paddle.ones(shape=size, dtype=paddle.int32)
     for idx, y_ref in enumerate(size):
         y_hat = func(x_hat, idx)
         assert y_ref == y_hat, "Size of axis {} should equal {} and not {}.".format(

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -83,7 +83,7 @@ def test_get_external_tensor_shape_access_paddle(size):
     def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:
         return x.shape[index]
 
-    x_hat = paddle.ones(size, dtype=paddle.int32, device=paddle.CPUPlace())
+    x_hat = paddle.ones([size], dtype=paddle.int32)
     for idx, y_ref in enumerate(size):
         y_hat = func(x_hat, idx)
         assert y_ref == y_hat, "Size of axis {} should equal {} and not {}.".format(

--- a/tests/python/test_get_external_tensor_shape.py
+++ b/tests/python/test_get_external_tensor_shape.py
@@ -1,12 +1,15 @@
 import numpy as np
 import pytest
-from taichi.lang.util import has_pytorch
+from taichi.lang.util import has_paddle, has_pytorch
 
 import taichi as ti
 from tests import test_utils
 
 if has_pytorch():
     import torch
+
+if has_paddle():
+    import paddle
 
 
 @pytest.mark.parametrize('size', [[1], [1, 2, 3, 4]])
@@ -66,6 +69,21 @@ def test_get_external_tensor_shape_access_ndarray(size):
         return x.shape[index]
 
     x_hat = ti.ndarray(ti.i32, shape=size)
+    for idx, y_ref in enumerate(size):
+        y_hat = func(x_hat, idx)
+        assert y_ref == y_hat, "Size of axis {} should equal {} and not {}.".format(
+            idx, y_ref, y_hat)
+
+
+@pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
+@pytest.mark.parametrize('size', [[1, 2, 3, 4]])
+@test_utils.test(exclude=ti.opengl)
+def test_get_external_tensor_shape_access_torch(size):
+    @ti.kernel
+    def func(x: ti.types.ndarray(), index: ti.template()) -> ti.i32:
+        return x.shape[index]
+
+    x_hat = paddle.ones(size, dtype=paddle.int32, device=paddle.CPUPlace())
     for idx, y_ref in enumerate(size):
         y_hat = func(x_hat, idx)
         assert y_ref == y_hat, "Size of axis {} should equal {} and not {}.".format(

--- a/tests/python/test_paddle_io.py
+++ b/tests/python/test_paddle_io.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+from taichi.lang import impl
+from taichi.lang.util import has_paddle
+
+import taichi as ti
+from tests import test_utils
+
+if has_paddle():
+    import paddle
+
+
+@pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
+@test_utils.test(exclude=[ti.opengl, ti.vulkan])
+def test_io_devices():
+    n = 32
+    x = ti.field(dtype=ti.i32, shape=n)
+
+    @ti.kernel
+    def load(y: ti.types.ndarray()):
+        for i in x:
+            x[i] = y[i] + 10
+
+    @ti.kernel
+    def inc():
+        for i in x:
+            x[i] += i
+
+    @ti.kernel
+    def store(y: ti.types.ndarray()):
+        for i in x:
+            y[i] = x[i] * 2
+
+    devices = [paddle.CPUPlace()]
+    if paddle.device.is_compiled_with_cuda():
+        devices.append(paddle.CUDAPlace(0))
+    for device in devices:
+        y = paddle.to_tensor(np.ones(shape=n, dtype=np.int32), place=device)
+
+        load(y)
+        inc()
+        store(y)
+
+        y = y.cpu().numpy()
+
+        for i in range(n):
+            assert y[i] == (11 + i) * 2

--- a/tests/python/test_paddle_io.py
+++ b/tests/python/test_paddle_io.py
@@ -10,7 +10,7 @@ if has_paddle():
     import paddle
 
 
-@pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
 @test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_io_devices():
     n = 32

--- a/tests/python/test_paddle_io.py
+++ b/tests/python/test_paddle_io.py
@@ -11,7 +11,7 @@ if has_paddle():
 
 
 @pytest.mark.skipif(not has_paddle(), reason='PaddlePaddle not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan])
+@test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_io_devices():
     n = 32
     x = ti.field(dtype=ti.i32, shape=n)

--- a/tests/python/test_paddle_io.py
+++ b/tests/python/test_paddle_io.py
@@ -45,3 +45,98 @@ def test_io_devices():
 
         for i in range(n):
             assert y[i] == (11 + i) * 2
+
+
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_io():
+    n = 32
+
+    @ti.kernel
+    def paddle_kernel(zero: ti.types.ndarray()):
+        for i in range(n):
+            zero[i] += i * i
+
+    x_zero = paddle.zeros(shape=[n], dtype=paddle.int32)
+    paddle_kernel(x_zero)
+    for i in range(n):
+        assert x_zero[i] == i * i
+
+
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_io_2d():
+    n = 32
+
+    @ti.kernel
+    def paddle_kernel(zero: ti.types.ndarray()):
+        for i in range(n):
+            for j in range(n):
+                zero[i, j] += i * j
+
+    x_zero = paddle.zeros(shape=(n, n), dtype=paddle.int32)
+    paddle_kernel(x_zero)
+    for i in range(n):
+        for j in range(n):
+            assert x_zero[i, j] == i * j
+
+
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_io_3d():
+    n = 32
+
+    @ti.kernel
+    def paddle_kernel(zero: ti.types.ndarray()):
+        for i in range(n):
+            for j in range(n):
+                for k in range(n):
+                    zero[i, j, k] += i * j * k
+
+    x_zero = paddle.zeros(shape=(n, n, n), dtype=paddle.int32)
+    paddle_kernel(x_zero)
+    for i in range(n):
+        for j in range(n):
+            for k in range(n):
+                assert x_zero[i, j, k] == i * j * k
+
+
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_io_simple():
+    n = 32
+
+    x1 = ti.field(ti.f32, shape=(n, n))
+    p1 = paddle.Tensor(3 * np.ones((n, n), dtype=np.float32))
+
+    x2 = ti.Matrix.field(2, 3, ti.f32, shape=(n, n))
+    p2 = paddle.Tensor(3 * np.ones((n, n, 2, 3), dtype=np.float32))
+
+    x1.from_paddle(p1)
+    for i in range(n):
+        for j in range(n):
+            assert x1[i, j] == 3
+
+    x2.from_paddle(p2)
+    for i in range(n):
+        for j in range(n):
+            for k in range(2):
+                for l in range(3):
+                    assert x2[i, j][k, l] == 3
+
+    p3 = x2.to_paddle()
+    assert (p2 == p3).all()
+
+
+@pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_io_zeros():
+    mat = ti.Matrix.field(2, 6, dtype=ti.f32, shape=(), needs_grad=True)
+    zeros = paddle.zeros((2, 6))
+    zeros[1, 2] = 3
+    mat.from_paddle(zeros + 1)
+
+    assert mat[None][1, 2] == 4
+
+    zeros = mat.to_paddle()
+    assert zeros[1, 2] == 4


### PR DESCRIPTION
Related issue = [hackathon](https://github.com/taichi-dev/hackathons/issues/3)

`paddle.fluid.core.Tensor()._ptr()` is only avaliable on develop branch. I encounter 2 problems with develop package in build process.
1. I started with CUDA-configured WSL as my development environment. After installing the develop version package on CPU and CUDA. `import paddle` causes an `Illegal Instruction` error and exits the Python environment.  So I gave up using WSL.
2. Then I developed directly on Windows . Firstly, I used the develop version of paddlepaddle-gpu. Although the actual file is less than 2GB. When I `import paddle` I got error `Windows FATAL Exception: access violation`. A .pyd file is too large for the page to load.  My computer has 16GB of memory, and rebooting still doesn't fix the problem. 

Therefore, I tried the CPU version of paddlepaddle-0.0.0 and it worked.
Refer to the implementation of PyTorch in Taichi. My implementation should support the interactions in CPU-CPU/CPU-GPU/GPU-CPU/GPU-GPU between Taichi and Paddle. But for now, on my development enviroment only CPU-CPU test could be verified.