### PR TITLE
[build] Use Ninja generator on Windows and skip generator test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,8 +118,12 @@ def get_cmake_args():
         cfg = 'MinSizeRel'
     else:
         cfg = None
+    build_options = []
     if cfg:
-        sys.argv[2:2] = ['--build-type', cfg]
+        build_options.extend(['--build-type', cfg])
+    if sys.platform == 'win32':
+        build_options.extend(['-G', 'Ninja', '--skip-generator-test'])
+    sys.argv[2:2] = build_options
 
     cmake_args += [
         f'-DTI_VERSION_MAJOR={TI_VERSION_MAJOR}',


### PR DESCRIPTION
After adoption of skbuild, it can't select Ninja as the generator on Windows, making it not able to use parallel build.

This PR sets the generator explicitly and skips skbuild's generator tests.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/lang/articles/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/lang/articles/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
