### PR TITLE
[Lang] Load cuSparse and cuSolver library for preparing sparse matrix on GPU

### DIFF
--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -14,7 +14,8 @@ TLANG_NAMESPACE_BEGIN
 
 CUDAContext::CUDAContext()
     : profiler_(nullptr), driver_(CUDADriver::get_instance_without_context()), 
-                            cusparse_driver_(CUSPARSEDriver::get_instance()) {
+                            cusparse_driver_(CUSPARSEDriver::get_instance()), 
+                            cusolver_driver_(CUSOLVERDriver::get_instance()) {
   // CUDA initialization
   dev_count_ = 0;
   driver_.init(0);

--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -13,9 +13,10 @@
 TLANG_NAMESPACE_BEGIN
 
 CUDAContext::CUDAContext()
-    : profiler_(nullptr), driver_(CUDADriver::get_instance_without_context()), 
-                            cusparse_driver_(CUSPARSEDriver::get_instance()), 
-                            cusolver_driver_(CUSOLVERDriver::get_instance()) {
+    : profiler_(nullptr),
+      driver_(CUDADriver::get_instance_without_context()),
+      cusparse_driver_(CUSPARSEDriver::get_instance()),
+      cusolver_driver_(CUSOLVERDriver::get_instance()) {
   // CUDA initialization
   dev_count_ = 0;
   driver_.init(0);

--- a/taichi/backends/cuda/cuda_context.cpp
+++ b/taichi/backends/cuda/cuda_context.cpp
@@ -13,7 +13,8 @@
 TLANG_NAMESPACE_BEGIN
 
 CUDAContext::CUDAContext()
-    : profiler_(nullptr), driver_(CUDADriver::get_instance_without_context()) {
+    : profiler_(nullptr), driver_(CUDADriver::get_instance_without_context()), 
+                            cusparse_driver_(CUSPARSEDriver::get_instance()) {
   // CUDA initialization
   dev_count_ = 0;
   driver_.init(0);

--- a/taichi/backends/cuda/cuda_context.h
+++ b/taichi/backends/cuda/cuda_context.h
@@ -16,6 +16,7 @@ TLANG_NAMESPACE_BEGIN
 
 class CUDADriver;
 class CUSPARSEDriver;
+class CUSOLVERDriver;
 
 class CUDAContext {
  private:
@@ -28,6 +29,7 @@ class CUDAContext {
   KernelProfilerBase *profiler_;
   CUDADriver &driver_;
   CUSPARSEDriver & cusparse_driver_;
+  CUSOLVERDriver & cusolver_driver_;
   bool debug_;
 
  public:

--- a/taichi/backends/cuda/cuda_context.h
+++ b/taichi/backends/cuda/cuda_context.h
@@ -28,8 +28,8 @@ class CUDAContext {
   std::mutex lock_;
   KernelProfilerBase *profiler_;
   CUDADriver &driver_;
-  CUSPARSEDriver & cusparse_driver_;
-  CUSOLVERDriver & cusolver_driver_;
+  CUSPARSEDriver &cusparse_driver_;
+  CUSOLVERDriver &cusolver_driver_;
   bool debug_;
 
  public:

--- a/taichi/backends/cuda/cuda_context.h
+++ b/taichi/backends/cuda/cuda_context.h
@@ -15,6 +15,7 @@ TLANG_NAMESPACE_BEGIN
 // cases such as unit testing where many Taichi programs are created/destroyed.
 
 class CUDADriver;
+class CUSPARSEDriver;
 
 class CUDAContext {
  private:
@@ -26,6 +27,7 @@ class CUDAContext {
   std::mutex lock_;
   KernelProfilerBase *profiler_;
   CUDADriver &driver_;
+  CUSPARSEDriver & cusparse_driver_;
   bool debug_;
 
  public:

--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -80,6 +80,7 @@ CUDADriver &CUDADriver::get_instance() {
 
 
 CUSPARSEDriver::CUSPARSEDriver() {
+  // TODO: enable cusparse and cusolver flag env variable.
   auto disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
   if (disabled_by_env_) {
     TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");
@@ -87,7 +88,7 @@ CUSPARSEDriver::CUSPARSEDriver() {
   }
 
 #if defined(TI_PLATFORM_LINUX)
-  auto loader_ = std::make_unique<DynamicLoader>("libcusparse.so");
+  loader_ = std::make_unique<DynamicLoader>("libcusparse.so");
 #elif defined(TI_PLATFORM_WINDOWS)
   loader_ = std::make_unique<DynamicLoader>("cusparse.dll");
 #else
@@ -95,7 +96,7 @@ CUSPARSEDriver::CUSPARSEDriver() {
 #endif
 
   if (!loader_->loaded()) {
-    TI_WARN("CUSPARSE driver not found.");
+    TI_WARN("CUSPARSE lib not found.");
     return;
   }
   else {
@@ -105,6 +106,36 @@ CUSPARSEDriver::CUSPARSEDriver() {
 
 CUSPARSEDriver& CUSPARSEDriver::get_instance() {
   static CUSPARSEDriver* instance = new CUSPARSEDriver();
+  return *instance;
+}
+
+CUSOLVERDriver::CUSOLVERDriver() {
+  // TODO: enable cusparse and cusolver flag env variable.
+  auto disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
+  if (disabled_by_env_) {
+    TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");
+    return;
+  }
+
+#if defined(TI_PLATFORM_LINUX)
+  loader_ = std::make_unique<DynamicLoader>("libcusolver.so");
+#elif defined(TI_PLATFORM_WINDOWS)
+  loader_ = std::make_unique<DynamicLoader>("cusolver.dll");
+#else
+  static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
+#endif
+
+  if (!loader_->loaded()) {
+    TI_WARN("cusolver lib not found.");
+    return;
+  }
+  else {
+    TI_TRACE("cusolver loaded!");
+  }
+}
+
+CUSOLVERDriver& CUSOLVERDriver::get_instance() {
+  static CUSOLVERDriver* instance = new CUSOLVERDriver();
   return *instance;
 }
 

--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -99,18 +99,17 @@ void CUDADriverBase::load_lib(std::string lib_linux, std::string lib_windows) {
   if (!loader_->loaded()) {
     TI_WARN("CUSPARSE lib not found.");
     return;
-  }
-  else {
+  } else {
     TI_TRACE("cusparse loaded!");
   }
 }
 
-CUSPARSEDriver::CUSPARSEDriver(){
+CUSPARSEDriver::CUSPARSEDriver() {
   load_lib("libcusparse.so", "cusparse.dll");
 }
 
-CUSPARSEDriver& CUSPARSEDriver::get_instance() {
-  static CUSPARSEDriver* instance = new CUSPARSEDriver();
+CUSPARSEDriver &CUSPARSEDriver::get_instance() {
+  static CUSPARSEDriver *instance = new CUSPARSEDriver();
   return *instance;
 }
 
@@ -118,8 +117,8 @@ CUSOLVERDriver::CUSOLVERDriver() {
   load_lib("libcusolver.so", "cusolver.dll");
 }
 
-CUSOLVERDriver& CUSOLVERDriver::get_instance() {
-  static CUSOLVERDriver* instance = new CUSOLVERDriver();
+CUSOLVERDriver &CUSOLVERDriver::get_instance() {
+  static CUSOLVERDriver *instance = new CUSOLVERDriver();
   return *instance;
 }
 

--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -20,24 +20,26 @@ bool CUDADriver::detected() {
 }
 
 CUDADriver::CUDADriver() {
-  disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
-  if (disabled_by_env_) {
-    TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");
-    return;
-  }
+//   disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
+//   if (disabled_by_env_) {
+//     TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");
+//     return;
+//   }
 
-#if defined(TI_PLATFORM_LINUX)
-  loader_ = std::make_unique<DynamicLoader>("libcuda.so");
-#elif defined(TI_PLATFORM_WINDOWS)
-  loader_ = std::make_unique<DynamicLoader>("nvcuda.dll");
-#else
-  static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
-#endif
+// #if defined(TI_PLATFORM_LINUX)
+//   loader_ = std::make_unique<DynamicLoader>("libcuda.so");
+// #elif defined(TI_PLATFORM_WINDOWS)
+//   loader_ = std::make_unique<DynamicLoader>("nvcuda.dll");
+// #else
+//   static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
+// #endif
 
-  if (!loader_->loaded()) {
-    TI_WARN("CUDA driver not found.");
-    return;
-  }
+  // if (!loader_->loaded()) {
+  //   TI_WARN("CUDA driver not found.");
+  //   return;
+  // }
+
+  load_lib("libcuda.so", "nvcuda.dll");
 
   loader_->load_function("cuGetErrorName", get_error_name);
   loader_->load_function("cuGetErrorString", get_error_string);
@@ -80,7 +82,7 @@ CUDADriver &CUDADriver::get_instance() {
 
 CUDADriverBase::CUDADriverBase() {
   // TODO: enable cusparse and cusolver flag env variable.
-  auto disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
+  disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
   if (disabled_by_env_) {
     TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");
     return;
@@ -89,18 +91,26 @@ CUDADriverBase::CUDADriverBase() {
 
 void CUDADriverBase::load_lib(std::string lib_linux, std::string lib_windows) {
 #if defined(TI_PLATFORM_LINUX)
-  loader_ = std::make_unique<DynamicLoader>(lib_linux);
+  auto lib_name = lib_linux;
 #elif defined(TI_PLATFORM_WINDOWS)
-  loader_ = std::make_unique<DynamicLoader>(lib_windows);
+  auto lib_name = lib_windows;
 #else
   static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
 #endif
-
+// #if defined(TI_PLATFORM_LINUX)
+//   loader_ = std::make_unique<DynamicLoader>(lib_linux);
+// #elif defined(TI_PLATFORM_WINDOWS)
+//   loader_ = std::make_unique<DynamicLoader>(lib_windows);
+// #else
+//   static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
+// #endif
+  loader_ = std::make_unique<DynamicLoader>(lib_name);
   if (!loader_->loaded()) {
-    TI_WARN("CUSPARSE lib not found.");
+    TI_WARN("{} lib not found.", lib_name);
     return;
-  } else {
-    TI_TRACE("cusparse loaded!");
+  }
+  else {
+    TI_TRACE("{} loaded!", lib_name);
   }
 }
 

--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -20,25 +20,6 @@ bool CUDADriver::detected() {
 }
 
 CUDADriver::CUDADriver() {
-//   disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
-//   if (disabled_by_env_) {
-//     TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");
-//     return;
-//   }
-
-// #if defined(TI_PLATFORM_LINUX)
-//   loader_ = std::make_unique<DynamicLoader>("libcuda.so");
-// #elif defined(TI_PLATFORM_WINDOWS)
-//   loader_ = std::make_unique<DynamicLoader>("nvcuda.dll");
-// #else
-//   static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
-// #endif
-
-  // if (!loader_->loaded()) {
-  //   TI_WARN("CUDA driver not found.");
-  //   return;
-  // }
-
   load_lib("libcuda.so", "nvcuda.dll");
 
   loader_->load_function("cuGetErrorName", get_error_name);
@@ -97,13 +78,7 @@ void CUDADriverBase::load_lib(std::string lib_linux, std::string lib_windows) {
 #else
   static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
 #endif
-// #if defined(TI_PLATFORM_LINUX)
-//   loader_ = std::make_unique<DynamicLoader>(lib_linux);
-// #elif defined(TI_PLATFORM_WINDOWS)
-//   loader_ = std::make_unique<DynamicLoader>(lib_windows);
-// #else
-//   static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
-// #endif
+
   loader_ = std::make_unique<DynamicLoader>(lib_name);
   if (!loader_->loaded()) {
     TI_WARN("{} lib not found.", lib_name);

--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -62,7 +62,6 @@ CUDADriver &CUDADriver::get_instance() {
 }
 
 CUDADriverBase::CUDADriverBase() {
-  // TODO: enable cusparse and cusolver flag env variable.
   disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
   if (disabled_by_env_) {
     TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");

--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -83,8 +83,7 @@ void CUDADriverBase::load_lib(std::string lib_linux, std::string lib_windows) {
   if (!loader_->loaded()) {
     TI_WARN("{} lib not found.", lib_name);
     return;
-  }
-  else {
+  } else {
     TI_TRACE("{} loaded!", lib_name);
   }
 }

--- a/taichi/backends/cuda/cuda_driver.cpp
+++ b/taichi/backends/cuda/cuda_driver.cpp
@@ -78,4 +78,34 @@ CUDADriver &CUDADriver::get_instance() {
   return get_instance_without_context();
 }
 
+
+CUSPARSEDriver::CUSPARSEDriver() {
+  auto disabled_by_env_ = (get_environ_config("TI_ENABLE_CUDA", 1) == 0);
+  if (disabled_by_env_) {
+    TI_TRACE("CUDA driver disabled by enviroment variable \"TI_ENABLE_CUDA\".");
+    return;
+  }
+
+#if defined(TI_PLATFORM_LINUX)
+  auto loader_ = std::make_unique<DynamicLoader>("libcusparse.so");
+#elif defined(TI_PLATFORM_WINDOWS)
+  loader_ = std::make_unique<DynamicLoader>("cusparse.dll");
+#else
+  static_assert(false, "Taichi CUDA driver supports only Windows and Linux.");
+#endif
+
+  if (!loader_->loaded()) {
+    TI_WARN("CUSPARSE driver not found.");
+    return;
+  }
+  else {
+    TI_TRACE("cusparse loaded!");
+  }
+}
+
+CUSPARSEDriver& CUSPARSEDriver::get_instance() {
+  static CUSPARSEDriver* instance = new CUSPARSEDriver();
+  return *instance;
+}
+
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -127,24 +127,30 @@ class CUDADriver {
   bool cuda_version_valid_{false};
 };
 
+class CUDADriverBase {
 
+protected:
+  std::unique_ptr<DynamicLoader> loader_;
+  CUDADriverBase();
 
-class CUSPARSEDriver {
+  void load_lib(std::string lib_linux, std::string lib_windows);
+
+};
+
+class CUSPARSEDriver: protected CUDADriverBase {
 public:
   static CUSPARSEDriver &get_instance();
 
 private:
-  std::unique_ptr<DynamicLoader> loader_;
   CUSPARSEDriver();
 
 };
 
-class CUSOLVERDriver {
+class CUSOLVERDriver: protected CUDADriverBase {
 public:
   static CUSOLVERDriver &get_instance();
 
 private:
-  std::unique_ptr<DynamicLoader> loader_;
   CUSOLVERDriver();
 
 };

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -95,7 +95,22 @@ class CUDADriverFunction {
   std::mutex *driver_lock_{nullptr};
 };
 
-class CUDADriver {
+
+class CUDADriverBase {
+
+public:
+  ~CUDADriverBase() = default;
+
+protected:
+  std::unique_ptr<DynamicLoader> loader_;
+  CUDADriverBase();
+
+  void load_lib(std::string lib_linux, std::string lib_windows);
+
+  bool disabled_by_env_{false};
+};
+
+class CUDADriver: protected CUDADriverBase {
   // TODO: make CUDADriver a derived class of CUDADriverBase.
  public:
 #define PER_CUDA_FUNCTION(name, symbol_name, ...) \
@@ -111,7 +126,7 @@ class CUDADriver {
 
   bool detected();
 
-  ~CUDADriver() = default;
+  // ~CUDADriver() = default;
 
   static CUDADriver &get_instance();
 
@@ -120,21 +135,14 @@ class CUDADriver {
  private:
   CUDADriver();
 
-  std::unique_ptr<DynamicLoader> loader_;
+  // std::unique_ptr<DynamicLoader> loader_;
 
   std::mutex lock_;
 
-  bool disabled_by_env_{false};
+  // bool disabled_by_env_{false};
   bool cuda_version_valid_{false};
 };
 
-class CUDADriverBase {
- protected:
-  std::unique_ptr<DynamicLoader> loader_;
-  CUDADriverBase();
-
-  void load_lib(std::string lib_linux, std::string lib_windows);
-};
 
 class CUSPARSEDriver : protected CUDADriverBase {
  public:

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -129,33 +129,27 @@ class CUDADriver {
 };
 
 class CUDADriverBase {
-
-protected:
+ protected:
   std::unique_ptr<DynamicLoader> loader_;
   CUDADriverBase();
 
   void load_lib(std::string lib_linux, std::string lib_windows);
-
 };
 
-class CUSPARSEDriver: protected CUDADriverBase {
-public:
+class CUSPARSEDriver : protected CUDADriverBase {
+ public:
   static CUSPARSEDriver &get_instance();
 
-private:
+ private:
   CUSPARSEDriver();
-
 };
 
-class CUSOLVERDriver: protected CUDADriverBase {
-public:
+class CUSOLVERDriver : protected CUDADriverBase {
+ public:
   static CUSOLVERDriver &get_instance();
 
-private:
+ private:
   CUSOLVERDriver();
-
 };
-
-
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -95,13 +95,11 @@ class CUDADriverFunction {
   std::mutex *driver_lock_{nullptr};
 };
 
-
 class CUDADriverBase {
-
-public:
+ public:
   ~CUDADriverBase() = default;
 
-protected:
+ protected:
   std::unique_ptr<DynamicLoader> loader_;
   CUDADriverBase();
 
@@ -110,7 +108,7 @@ protected:
   bool disabled_by_env_{false};
 };
 
-class CUDADriver: protected CUDADriverBase {
+class CUDADriver : protected CUDADriverBase {
  public:
 #define PER_CUDA_FUNCTION(name, symbol_name, ...) \
   CUDADriverFunction<__VA_ARGS__> name;
@@ -137,8 +135,7 @@ class CUDADriver: protected CUDADriverBase {
   bool cuda_version_valid_{false};
 };
 
-
-class CUSPARSEDriver: protected CUDADriverBase {
+class CUSPARSEDriver : protected CUDADriverBase {
  public:
   // TODO: Add cusparse function APIs
   static CUSPARSEDriver &get_instance();
@@ -147,7 +144,7 @@ class CUSPARSEDriver: protected CUDADriverBase {
   CUSPARSEDriver();
 };
 
-class CUSOLVERDriver: protected CUDADriverBase {
+class CUSOLVERDriver : protected CUDADriverBase {
  public:
   // TODO: Add cusolver function APIs
   static CUSOLVERDriver &get_instance();

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -127,15 +127,28 @@ class CUDADriver {
   bool cuda_version_valid_{false};
 };
 
+
+
 class CUSPARSEDriver {
 public:
   static CUSPARSEDriver &get_instance();
 
 private:
-  CUSPARSEDriver* instance;
+  std::unique_ptr<DynamicLoader> loader_;
   CUSPARSEDriver();
 
 };
+
+class CUSOLVERDriver {
+public:
+  static CUSOLVERDriver &get_instance();
+
+private:
+  std::unique_ptr<DynamicLoader> loader_;
+  CUSOLVERDriver();
+
+};
+
 
 
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -127,4 +127,15 @@ class CUDADriver {
   bool cuda_version_valid_{false};
 };
 
+class CUSPARSEDriver {
+public:
+  static CUSPARSEDriver &get_instance();
+
+private:
+  CUSPARSEDriver* instance;
+  CUSPARSEDriver();
+
+};
+
+
 TLANG_NAMESPACE_END

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -111,7 +111,6 @@ protected:
 };
 
 class CUDADriver: protected CUDADriverBase {
-  // TODO: make CUDADriver a derived class of CUDADriverBase.
  public:
 #define PER_CUDA_FUNCTION(name, symbol_name, ...) \
   CUDADriverFunction<__VA_ARGS__> name;
@@ -126,8 +125,6 @@ class CUDADriver: protected CUDADriverBase {
 
   bool detected();
 
-  // ~CUDADriver() = default;
-
   static CUDADriver &get_instance();
 
   static CUDADriver &get_instance_without_context();
@@ -135,25 +132,24 @@ class CUDADriver: protected CUDADriverBase {
  private:
   CUDADriver();
 
-  // std::unique_ptr<DynamicLoader> loader_;
-
   std::mutex lock_;
 
-  // bool disabled_by_env_{false};
   bool cuda_version_valid_{false};
 };
 
 
-class CUSPARSEDriver : protected CUDADriverBase {
+class CUSPARSEDriver: protected CUDADriverBase {
  public:
+  // TODO: Add cusparse function APIs
   static CUSPARSEDriver &get_instance();
 
  private:
   CUSPARSEDriver();
 };
 
-class CUSOLVERDriver : protected CUDADriverBase {
+class CUSOLVERDriver: protected CUDADriverBase {
  public:
+  // TODO: Add cusolver function APIs
   static CUSOLVERDriver &get_instance();
 
  private:

--- a/taichi/backends/cuda/cuda_driver.h
+++ b/taichi/backends/cuda/cuda_driver.h
@@ -96,6 +96,7 @@ class CUDADriverFunction {
 };
 
 class CUDADriver {
+  // TODO: make CUDADriver a derived class of CUDADriverBase.
  public:
 #define PER_CUDA_FUNCTION(name, symbol_name, ...) \
   CUDADriverFunction<__VA_ARGS__> name;


### PR DESCRIPTION
Related issue = #2906 

Start to support sparse matrix on CUDA backend from this pr.

We first load the `cuSparse` and `cuSolver` libs via the `DynamicLoader` class in this pr. 

A new class, `CUDADriverBase` is introduced as the base class for the driver classes of these libs, which might also be helpful for the potential libs that we can use in the future.

