### PR TITLE
[build] Warning Suppression PR #1: Enabled -Wno-ignored-attributes option and rearranged CMAKE_CXX_FLAGS

### DIFF
--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -46,7 +46,11 @@ else()
         message("Invalid compiler ${CMAKE_CXX_COMPILER_ID} detected.")
         message(FATAL_ERROR "clang and MSVC are the only supported compilers for Taichi compiler development. Consider using 'cmake -DCMAKE_CXX_COMPILER=clang' if you are on Linux.")
     endif()
+    # [Global] CXX compilation option to enable all warnings
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ")
+
+    # [Global] CXX compilation option to suppress warnings when compiler ignores an attribute.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-attributes ")
 endif ()
 
 message("Building for processor ${CMAKE_SYSTEM_PROCESSOR}")
@@ -88,3 +92,39 @@ if (TI_USE_MPI)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_USE_MPI")
     message("Using MPI")
 endif ()
+
+if(TI_EMSCRIPTENED)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_EMSCRIPTENED")
+endif()
+
+if(TI_WITH_LLVM)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_LLVM")
+endif()
+
+if (TI_WITH_CUDA)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CUDA")
+endif()
+
+if (TI_WITH_METAL)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_METAL")
+endif()
+
+if (TI_WITH_OPENGL)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_OPENGL")
+endif()
+
+if (TI_WITH_CC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CC")
+endif()
+
+if (TI_WITH_VULKAN)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_VULKAN")
+endif()
+
+if (TI_WITH_DX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_DX11")
+endif()
+
+if (TI_WITH_CUDA_TOOLKIT)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CUDA_TOOLKIT")
+endif()

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -41,7 +41,6 @@ if(TI_EMSCRIPTENED)
     set(TI_WITH_DX11 OFF)
 
     set(TI_WITH_VULKAN ON)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_EMSCRIPTENED")
 endif()
 
 if(UNIX AND NOT APPLE)
@@ -147,7 +146,6 @@ file(GLOB TAICHI_OPENGL_REQUIRED_SOURCE
 list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_BACKEND_SOURCE})
 
 if(TI_WITH_LLVM)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_LLVM")
     list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CPU_SOURCE})
     list(APPEND TAICHI_CORE_SOURCE ${TAICHI_WASM_SOURCE})
 else()
@@ -159,7 +157,6 @@ list(APPEND TAICHI_CORE_SOURCE ${TAICHI_INTEROP_SOURCE})
 
 
 if (TI_WITH_CUDA)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CUDA")
   list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CUDA_SOURCE})
 endif()
 
@@ -172,13 +169,11 @@ endif()
 # As of right now, on non-macOS platforms, the metal backend won't work at all.
 # We have future plans to allow metal AOT to run on non-macOS devices.
 if (TI_WITH_METAL)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_METAL")
     list(APPEND TAICHI_CORE_SOURCE ${TAICHI_METAL_SOURCE})
 endif()
 
 
 if (TI_WITH_OPENGL)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_OPENGL")
   # Q: Why not external/glad/src/*.c?
   # A: To ensure glad submodule exists when TI_WITH_OPENGL is ON.
   file(GLOB TAICHI_GLAD_SOURCE "external/glad/src/gl.c" "external/glad/src/egl.c")
@@ -188,19 +183,16 @@ endif()
 list(APPEND TAICHI_CORE_SOURCE ${TAICHI_OPENGL_REQUIRED_SOURCE})
 
 if (TI_WITH_CC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CC")
   list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CC_SOURCE})
 endif()
 
 
 if (TI_WITH_VULKAN)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_VULKAN")
     list(APPEND TAICHI_CORE_SOURCE ${TAICHI_VULKAN_SOURCE})
 endif()
 
 
 if (TI_WITH_DX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_DX11")
     list(APPEND TAICHI_CORE_SOURCE ${TAICHI_DX11_SOURCE})
 endif()
 
@@ -338,7 +330,6 @@ if (TI_WITH_CUDA_TOOLKIT)
     else()
         message(STATUS "TI_WITH_CUDA_TOOLKIT = ON")
         message(STATUS "CUDA_TOOLKIT_ROOT_DIR=$ENV{CUDA_TOOLKIT_ROOT_DIR}")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_CUDA_TOOLKIT")
         include_directories($ENV{CUDA_TOOLKIT_ROOT_DIR}/include)
         link_directories($ENV{CUDA_TOOLKIT_ROOT_DIR}/lib64)
         #libraries for cuda kernel profiler CuptiToolkit


### PR DESCRIPTION
Related issue = #3335, #2927

1. Turned on -Wno-ignored-attributes compilation option to mute the compiler when ignoring c++ attribute.
2. Moved all CMAKE_CXX_FLAGS back to TaichiCXXFlags.cmake.