### PR TITLE
[bug] [simt] Fix the problem that some intrinsics are never called

### DIFF
--- a/python/taichi/lang/simt/subgroup.py
+++ b/python/taichi/lang/simt/subgroup.py
@@ -35,7 +35,9 @@ def broadcast_first(value):
 
 
 def broadcast(value, index):
-    return impl.call_internal("subgroupBroadcast", value, index,
+    return impl.call_internal("subgroupBroadcast",
+                              value,
+                              index,
                               with_runtime_context=False)
 
 
@@ -77,37 +79,44 @@ def reduce_xor(value):
 
 
 def inclusive_add(value):
-    return impl.call_internal("subgroupInclusiveAdd", value,
+    return impl.call_internal("subgroupInclusiveAdd",
+                              value,
                               with_runtime_context=False)
 
 
 def inclusive_mul(value):
-    return impl.call_internal("subgroupInclusiveMul", value,
+    return impl.call_internal("subgroupInclusiveMul",
+                              value,
                               with_runtime_context=False)
 
 
 def inclusive_min(value):
-    return impl.call_internal("subgroupInclusiveMin", value,
+    return impl.call_internal("subgroupInclusiveMin",
+                              value,
                               with_runtime_context=False)
 
 
 def inclusive_max(value):
-    return impl.call_internal("subgroupInclusiveMax", value,
+    return impl.call_internal("subgroupInclusiveMax",
+                              value,
                               with_runtime_context=False)
 
 
 def inclusive_and(value):
-    return impl.call_internal("subgroupInclusiveAnd", value,
+    return impl.call_internal("subgroupInclusiveAnd",
+                              value,
                               with_runtime_context=False)
 
 
 def inclusive_or(value):
-    return impl.call_internal("subgroupInclusiveOr", value,
+    return impl.call_internal("subgroupInclusiveOr",
+                              value,
                               with_runtime_context=False)
 
 
 def inclusive_xor(value):
-    return impl.call_internal("subgroupInclusiveXor", value,
+    return impl.call_internal("subgroupInclusiveXor",
+                              value,
                               with_runtime_context=False)
 
 

--- a/python/taichi/lang/simt/subgroup.py
+++ b/python/taichi/lang/simt/subgroup.py
@@ -6,8 +6,8 @@ def barrier():
 
 
 def memory_barrier():
-    return impl.call_internal(
-        "subgroupMemoryBarrier", with_runtime_context=False)
+    return impl.call_internal("subgroupMemoryBarrier",
+                              with_runtime_context=False)
 
 
 def elect():
@@ -35,8 +35,10 @@ def broadcast_first(value):
 
 
 def broadcast(value, index):
-    return impl.call_internal(
-        "subgroupBroadcast", value, index, with_runtime_context=False)
+    return impl.call_internal("subgroupBroadcast",
+                              value,
+                              index,
+                              with_runtime_context=False)
 
 
 def group_size():
@@ -44,8 +46,8 @@ def group_size():
 
 
 def invocation_id():
-    return impl.call_internal(
-        "subgroupInvocationId", with_runtime_context=False)
+    return impl.call_internal("subgroupInvocationId",
+                              with_runtime_context=False)
 
 
 def reduce_add(value):
@@ -77,38 +79,45 @@ def reduce_xor(value):
 
 
 def inclusive_add(value):
-    return impl.call_internal(
-        "subgroupInclusiveAdd", value, with_runtime_context=False)
+    return impl.call_internal("subgroupInclusiveAdd",
+                              value,
+                              with_runtime_context=False)
 
 
 def inclusive_mul(value):
-    return impl.call_internal(
-        "subgroupInclusiveMul", value, with_runtime_context=False)
+    return impl.call_internal("subgroupInclusiveMul",
+                              value,
+                              with_runtime_context=False)
 
 
 def inclusive_min(value):
-    return impl.call_internal(
-        "subgroupInclusiveMin", value, with_runtime_context=False)
+    return impl.call_internal("subgroupInclusiveMin",
+                              value,
+                              with_runtime_context=False)
 
 
 def inclusive_max(value):
-    return impl.call_internal(
-        "subgroupInclusiveMax", value, with_runtime_context=False)
+    return impl.call_internal("subgroupInclusiveMax",
+                              value,
+                              with_runtime_context=False)
 
 
 def inclusive_and(value):
-    return impl.call_internal(
-        "subgroupInclusiveAnd", value, with_runtime_context=False)
+    return impl.call_internal("subgroupInclusiveAnd",
+                              value,
+                              with_runtime_context=False)
 
 
 def inclusive_or(value):
-    return impl.call_internal(
-        "subgroupInclusiveOr", value, with_runtime_context=False)
+    return impl.call_internal("subgroupInclusiveOr",
+                              value,
+                              with_runtime_context=False)
 
 
 def inclusive_xor(value):
-    return impl.call_internal(
-        "subgroupInclusiveXor", value, with_runtime_context=False)
+    return impl.call_internal("subgroupInclusiveXor",
+                              value,
+                              with_runtime_context=False)
 
 
 def exclusive_add(value):

--- a/python/taichi/lang/simt/subgroup.py
+++ b/python/taichi/lang/simt/subgroup.py
@@ -6,8 +6,8 @@ def barrier():
 
 
 def memory_barrier():
-    return impl.call_internal("subgroupMemoryBarrier",
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupMemoryBarrier", with_runtime_context=False)
 
 
 def elect():
@@ -35,10 +35,8 @@ def broadcast_first(value):
 
 
 def broadcast(value, index):
-    return impl.call_internal("subgroupBroadcast",
-                              value,
-                              index,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupBroadcast", value, index, with_runtime_context=False)
 
 
 def group_size():
@@ -46,8 +44,8 @@ def group_size():
 
 
 def invocation_id():
-    return impl.call_internal("subgroupInvocationId",
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInvocationId", with_runtime_context=False)
 
 
 def reduce_add(value):
@@ -79,45 +77,38 @@ def reduce_xor(value):
 
 
 def inclusive_add(value):
-    return impl.call_internal("subgroupInclusiveAdd",
-                              value,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInclusiveAdd", value, with_runtime_context=False)
 
 
 def inclusive_mul(value):
-    return impl.call_internal("subgroupInclusiveMul",
-                              value,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInclusiveMul", value, with_runtime_context=False)
 
 
 def inclusive_min(value):
-    return impl.call_internal("subgroupInclusiveMin",
-                              value,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInclusiveMin", value, with_runtime_context=False)
 
 
 def inclusive_max(value):
-    return impl.call_internal("subgroupInclusiveMax",
-                              value,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInclusiveMax", value, with_runtime_context=False)
 
 
 def inclusive_and(value):
-    return impl.call_internal("subgroupInclusiveAnd",
-                              value,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInclusiveAnd", value, with_runtime_context=False)
 
 
 def inclusive_or(value):
-    return impl.call_internal("subgroupInclusiveOr",
-                              value,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInclusiveOr", value, with_runtime_context=False)
 
 
 def inclusive_xor(value):
-    return impl.call_internal("subgroupInclusiveXor",
-                              value,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "subgroupInclusiveXor", value, with_runtime_context=False)
 
 
 def exclusive_add(value):

--- a/python/taichi/lang/simt/subgroup.py
+++ b/python/taichi/lang/simt/subgroup.py
@@ -1,24 +1,17 @@
-from taichi._lib import core as _ti_core
-from taichi.lang import expr
-from taichi.types import i32
+from taichi.lang import impl
 
 
 def barrier():
-    return expr.Expr(
-        _ti_core.insert_internal_func_call("subgroupBarrier",
-                                           expr.make_expr_group(), False))
+    return impl.call_internal("subgroupBarrier", with_runtime_context=False)
 
 
 def memory_barrier():
-    return expr.Expr(
-        _ti_core.insert_internal_func_call("subgroupMemoryBarrier",
-                                           expr.make_expr_group(), False))
+    return impl.call_internal("subgroupMemoryBarrier",
+                              with_runtime_context=False)
 
 
 def elect():
-    return expr.Expr(
-        _ti_core.insert_internal_func_call("subgroupElect",
-                                           expr.make_expr_group(), False))
+    return impl.call_internal("subgroupElect", with_runtime_context=False)
 
 
 def all_true(cond):
@@ -41,107 +34,81 @@ def broadcast_first(value):
     pass
 
 
-def broadcast(value, index: i32):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call("subgroupBroadcast",
-                                           expr.make_expr_group(value, index),
-                                           False))
+def broadcast(value, index):
+    return impl.call_internal("subgroupBroadcast", value, index,
+                              with_runtime_context=False)
 
 
 def group_size():
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupSize", expr.make_expr_group(), False),
-                     dtype=i32)
+    return impl.call_internal("subgroupSize", with_runtime_context=False)
 
 
 def invocation_id():
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInvocationId", expr.make_expr_group(), False),
-                     dtype=i32)
+    return impl.call_internal("subgroupInvocationId",
+                              with_runtime_context=False)
 
 
 def reduce_add(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupAdd", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupAdd", value, with_runtime_context=False)
 
 
 def reduce_mul(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupMul", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupMul", value, with_runtime_context=False)
 
 
 def reduce_min(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupMin", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupMin", value, with_runtime_context=False)
 
 
 def reduce_max(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupMax", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupMax", value, with_runtime_context=False)
 
 
 def reduce_and(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupAnd", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupAnd", value, with_runtime_context=False)
 
 
 def reduce_or(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupOr", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupOr", value, with_runtime_context=False)
 
 
 def reduce_xor(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupXor", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupXor", value, with_runtime_context=False)
 
 
 def inclusive_add(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInclusiveAdd", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupInclusiveAdd", value,
+                              with_runtime_context=False)
 
 
 def inclusive_mul(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInclusiveMul", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupInclusiveMul", value,
+                              with_runtime_context=False)
 
 
 def inclusive_min(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInclusiveMin", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupInclusiveMin", value,
+                              with_runtime_context=False)
 
 
 def inclusive_max(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInclusiveMax", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupInclusiveMax", value,
+                              with_runtime_context=False)
 
 
 def inclusive_and(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInclusiveAnd", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupInclusiveAnd", value,
+                              with_runtime_context=False)
 
 
 def inclusive_or(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInclusiveOr", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupInclusiveOr", value,
+                              with_runtime_context=False)
 
 
 def inclusive_xor(value):
-    return expr.Expr(_ti_core.insert_internal_func_call(
-        "subgroupInclusiveXor", expr.make_expr_group(value), False),
-                     dtype=value.ptr.get_ret_type())
+    return impl.call_internal("subgroupInclusiveXor", value,
+                              with_runtime_context=False)
 
 
 def exclusive_add(value):

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -1,91 +1,65 @@
-from taichi._lib import core as _ti_core
-from taichi.lang import expr
+from taichi.lang import impl
 
 
 def all_nonzero(mask, predicate):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_all_sync_i32", expr.make_expr_group(mask, predicate), False))
+    return impl.call_internal("cuda_all_sync_i32", mask, predicate,
+                              with_runtime_context=False)
 
 
 def any_nonzero(mask, predicate):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_any_sync_i32", expr.make_expr_group(mask, predicate), False))
+    return impl.call_internal("cuda_any_sync_i32", mask, predicate,
+                              with_runtime_context=False)
 
 
 def unique(mask, predicate):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_uni_sync_i32", expr.make_expr_group(mask, predicate), False))
+    return impl.call_internal("cuda_uni_sync_i32", mask, predicate,
+                              with_runtime_context=False)
 
 
 def ballot(predicate):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call("cuda_ballot_i32",
-                                           expr.make_expr_group(predicate),
-                                           False))
+    return impl.call_internal("cuda_ballot_i32", predicate,
+                              with_runtime_context=False)
 
 
 def shfl_sync_i32(mask, val, offset):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            # lane offset is 31 for warp size 32
-            "cuda_shfl_sync_i32",
-            expr.make_expr_group(mask, val, offset, 31),
-            False))
+    # lane offset is 31 for warp size 32
+    return impl.call_internal("cuda_shfl_sync_i32", mask, val, offset, 31,
+                              with_runtime_context=False)
 
 
 def shfl_sync_f32(mask, val, offset):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            # lane offset is 31 for warp size 32
-            "cuda_shfl_sync_f32",
-            expr.make_expr_group(mask, val, offset, 31),
-            False))
-
-
-def shfl_down_i32(mask, val, offset):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_shfl_down_sync_i32",
-            # lane offset is 31 for warp size 32
-            expr.make_expr_group(mask, val, offset, 31),
-            False))
+    # lane offset is 31 for warp size 32
+    return impl.call_internal("cuda_shfl_sync_f32", mask, val, offset, 31,
+                              with_runtime_context=False)
 
 
 def shfl_up_i32(mask, val, offset):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_shfl_up_sync_i32",
-            # lane offset is 0 for warp size 32
-            expr.make_expr_group(mask, val, offset, 0),
-            False))
+    # lane offset is 0 for warp size 32
+    return impl.call_internal("cuda_shfl_up_sync_i32", mask, val, offset, 0,
+                              with_runtime_context=False)
 
 
 def shfl_up_f32(mask, val, offset):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_shfl_up_sync_f32",
-            # lane offset is 0 for warp size 32
-            expr.make_expr_group(mask, val, offset, 0),
-            False))
+    # lane offset is 0 for warp size 32
+    return impl.call_internal("cuda_shfl_up_sync_f32", mask, val, offset, 0,
+                              with_runtime_context=False)
+
+
+def shfl_down_i32(mask, val, offset):
+    # lane offset is 31 for warp size 32
+    return impl.call_internal("cuda_shfl_down_sync_i32", mask, val, offset, 31,
+                              with_runtime_context=False)
 
 
 def shfl_down_f32(mask, val, offset):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_shfl_down_sync_f32",
-            # lane offset is 31 for warp size 32
-            expr.make_expr_group(mask, val, offset, 31),
-            False))
+    # lane offset is 31 for warp size 32
+    return impl.call_internal("cuda_shfl_down_sync_f32", mask, val, offset, 31,
+                              with_runtime_context=False)
 
 
 def shfl_xor_i32(mask, val, offset):
-    return expr.Expr(
-        _ti_core.insert_internal_func_call(
-            "cuda_shfl_xor_sync_i32",
-            expr.make_expr_group(mask, val, offset, 31), False))
+    return impl.call_internal("cuda_shfl_xor_sync_i32", mask, val, offset, 31,
+                              with_runtime_context=False)
 
 
 def match_any():
@@ -99,15 +73,11 @@ def match_all():
 
 
 def active_mask():
-    return expr.Expr(
-        _ti_core.insert_internal_func_call("cuda_active_mask",
-                                           expr.make_expr_group(), False))
+    return impl.call_internal("cuda_active_mask", with_runtime_context=False)
 
 
 def sync(mask):
-    expr.Expr(
-        _ti_core.insert_internal_func_call("warp_barrier",
-                                           expr.make_expr_group(mask), False))
+    return impl.call_internal("warp_barrier", mask, with_runtime_context=False)
 
 
 __all__ = [
@@ -115,9 +85,13 @@ __all__ = [
     'any_nonzero',
     'unique',
     'ballot',
-    'shfl_i32',
+    'shfl_sync_i32',
+    'shfl_sync_f32',
     'shfl_up_i32',
+    'shfl_up_f32',
     'shfl_down_i32',
+    'shfl_down_f32',
+    'shfl_xor_i32',
     'match_any',
     'match_all',
     'active_mask',

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -2,63 +2,98 @@ from taichi.lang import impl
 
 
 def all_nonzero(mask, predicate):
-    return impl.call_internal("cuda_all_sync_i32", mask, predicate,
+    return impl.call_internal("cuda_all_sync_i32",
+                              mask,
+                              predicate,
                               with_runtime_context=False)
 
 
 def any_nonzero(mask, predicate):
-    return impl.call_internal("cuda_any_sync_i32", mask, predicate,
+    return impl.call_internal("cuda_any_sync_i32",
+                              mask,
+                              predicate,
                               with_runtime_context=False)
 
 
 def unique(mask, predicate):
-    return impl.call_internal("cuda_uni_sync_i32", mask, predicate,
+    return impl.call_internal("cuda_uni_sync_i32",
+                              mask,
+                              predicate,
                               with_runtime_context=False)
 
 
 def ballot(predicate):
-    return impl.call_internal("cuda_ballot_i32", predicate,
+    return impl.call_internal("cuda_ballot_i32",
+                              predicate,
                               with_runtime_context=False)
 
 
 def shfl_sync_i32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_sync_i32", mask, val, offset, 31,
+    return impl.call_internal("cuda_shfl_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              31,
                               with_runtime_context=False)
 
 
 def shfl_sync_f32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_sync_f32", mask, val, offset, 31,
+    return impl.call_internal("cuda_shfl_sync_f32",
+                              mask,
+                              val,
+                              offset,
+                              31,
                               with_runtime_context=False)
 
 
 def shfl_up_i32(mask, val, offset):
     # lane offset is 0 for warp size 32
-    return impl.call_internal("cuda_shfl_up_sync_i32", mask, val, offset, 0,
+    return impl.call_internal("cuda_shfl_up_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              0,
                               with_runtime_context=False)
 
 
 def shfl_up_f32(mask, val, offset):
     # lane offset is 0 for warp size 32
-    return impl.call_internal("cuda_shfl_up_sync_f32", mask, val, offset, 0,
+    return impl.call_internal("cuda_shfl_up_sync_f32",
+                              mask,
+                              val,
+                              offset,
+                              0,
                               with_runtime_context=False)
 
 
 def shfl_down_i32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_down_sync_i32", mask, val, offset, 31,
+    return impl.call_internal("cuda_shfl_down_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              31,
                               with_runtime_context=False)
 
 
 def shfl_down_f32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_down_sync_f32", mask, val, offset, 31,
+    return impl.call_internal("cuda_shfl_down_sync_f32",
+                              mask,
+                              val,
+                              offset,
+                              31,
                               with_runtime_context=False)
 
 
 def shfl_xor_i32(mask, val, offset):
-    return impl.call_internal("cuda_shfl_xor_sync_i32", mask, val, offset, 31,
+    return impl.call_internal("cuda_shfl_xor_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              31,
                               with_runtime_context=False)
 
 

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -2,71 +2,99 @@ from taichi.lang import impl
 
 
 def all_nonzero(mask, predicate):
-    return impl.call_internal(
-        "cuda_all_sync_i32", mask, predicate, with_runtime_context=False)
+    return impl.call_internal("cuda_all_sync_i32",
+                              mask,
+                              predicate,
+                              with_runtime_context=False)
 
 
 def any_nonzero(mask, predicate):
-    return impl.call_internal(
-        "cuda_any_sync_i32", mask, predicate, with_runtime_context=False)
+    return impl.call_internal("cuda_any_sync_i32",
+                              mask,
+                              predicate,
+                              with_runtime_context=False)
 
 
 def unique(mask, predicate):
-    return impl.call_internal(
-        "cuda_uni_sync_i32", mask, predicate, with_runtime_context=False)
+    return impl.call_internal("cuda_uni_sync_i32",
+                              mask,
+                              predicate,
+                              with_runtime_context=False)
 
 
 def ballot(predicate):
-    return impl.call_internal(
-        "cuda_ballot_i32", predicate, with_runtime_context=False)
+    return impl.call_internal("cuda_ballot_i32",
+                              predicate,
+                              with_runtime_context=False)
 
 
 def shfl_sync_i32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal(
-        "cuda_shfl_sync_i32", mask, val, offset, 31,
-        with_runtime_context=False)
+    return impl.call_internal("cuda_shfl_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              31,
+                              with_runtime_context=False)
 
 
 def shfl_sync_f32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal(
-        "cuda_shfl_sync_f32", mask, val, offset, 31,
-        with_runtime_context=False)
+    return impl.call_internal("cuda_shfl_sync_f32",
+                              mask,
+                              val,
+                              offset,
+                              31,
+                              with_runtime_context=False)
 
 
 def shfl_up_i32(mask, val, offset):
     # lane offset is 0 for warp size 32
-    return impl.call_internal(
-        "cuda_shfl_up_sync_i32", mask, val, offset, 0,
-        with_runtime_context=False)
+    return impl.call_internal("cuda_shfl_up_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              0,
+                              with_runtime_context=False)
 
 
 def shfl_up_f32(mask, val, offset):
     # lane offset is 0 for warp size 32
-    return impl.call_internal(
-        "cuda_shfl_up_sync_f32", mask, val, offset, 0,
-        with_runtime_context=False)
+    return impl.call_internal("cuda_shfl_up_sync_f32",
+                              mask,
+                              val,
+                              offset,
+                              0,
+                              with_runtime_context=False)
 
 
 def shfl_down_i32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal(
-        "cuda_shfl_down_sync_i32", mask, val, offset, 31,
-        with_runtime_context=False)
+    return impl.call_internal("cuda_shfl_down_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              31,
+                              with_runtime_context=False)
 
 
 def shfl_down_f32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal(
-        "cuda_shfl_down_sync_f32", mask, val, offset, 31,
-        with_runtime_context=False)
+    return impl.call_internal("cuda_shfl_down_sync_f32",
+                              mask,
+                              val,
+                              offset,
+                              31,
+                              with_runtime_context=False)
 
 
 def shfl_xor_i32(mask, val, offset):
-    return impl.call_internal(
-        "cuda_shfl_xor_sync_i32", mask, val, offset, 31,
-        with_runtime_context=False)
+    return impl.call_internal("cuda_shfl_xor_sync_i32",
+                              mask,
+                              val,
+                              offset,
+                              31,
+                              with_runtime_context=False)
 
 
 def match_any():

--- a/python/taichi/lang/simt/warp.py
+++ b/python/taichi/lang/simt/warp.py
@@ -2,99 +2,71 @@ from taichi.lang import impl
 
 
 def all_nonzero(mask, predicate):
-    return impl.call_internal("cuda_all_sync_i32",
-                              mask,
-                              predicate,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_all_sync_i32", mask, predicate, with_runtime_context=False)
 
 
 def any_nonzero(mask, predicate):
-    return impl.call_internal("cuda_any_sync_i32",
-                              mask,
-                              predicate,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_any_sync_i32", mask, predicate, with_runtime_context=False)
 
 
 def unique(mask, predicate):
-    return impl.call_internal("cuda_uni_sync_i32",
-                              mask,
-                              predicate,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_uni_sync_i32", mask, predicate, with_runtime_context=False)
 
 
 def ballot(predicate):
-    return impl.call_internal("cuda_ballot_i32",
-                              predicate,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_ballot_i32", predicate, with_runtime_context=False)
 
 
 def shfl_sync_i32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_sync_i32",
-                              mask,
-                              val,
-                              offset,
-                              31,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_shfl_sync_i32", mask, val, offset, 31,
+        with_runtime_context=False)
 
 
 def shfl_sync_f32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_sync_f32",
-                              mask,
-                              val,
-                              offset,
-                              31,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_shfl_sync_f32", mask, val, offset, 31,
+        with_runtime_context=False)
 
 
 def shfl_up_i32(mask, val, offset):
     # lane offset is 0 for warp size 32
-    return impl.call_internal("cuda_shfl_up_sync_i32",
-                              mask,
-                              val,
-                              offset,
-                              0,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_shfl_up_sync_i32", mask, val, offset, 0,
+        with_runtime_context=False)
 
 
 def shfl_up_f32(mask, val, offset):
     # lane offset is 0 for warp size 32
-    return impl.call_internal("cuda_shfl_up_sync_f32",
-                              mask,
-                              val,
-                              offset,
-                              0,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_shfl_up_sync_f32", mask, val, offset, 0,
+        with_runtime_context=False)
 
 
 def shfl_down_i32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_down_sync_i32",
-                              mask,
-                              val,
-                              offset,
-                              31,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_shfl_down_sync_i32", mask, val, offset, 31,
+        with_runtime_context=False)
 
 
 def shfl_down_f32(mask, val, offset):
     # lane offset is 31 for warp size 32
-    return impl.call_internal("cuda_shfl_down_sync_f32",
-                              mask,
-                              val,
-                              offset,
-                              31,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_shfl_down_sync_f32", mask, val, offset, 31,
+        with_runtime_context=False)
 
 
 def shfl_xor_i32(mask, val, offset):
-    return impl.call_internal("cuda_shfl_xor_sync_i32",
-                              mask,
-                              val,
-                              offset,
-                              31,
-                              with_runtime_context=False)
+    return impl.call_internal(
+        "cuda_shfl_xor_sync_i32", mask, val, offset, 31,
+        with_runtime_context=False)
 
 
 def match_any():


### PR DESCRIPTION
Related issue = #4631, fix #4954

Internal func calls are expressions, and they will not be inserted into Taichi AST if they are not assigned to others. The correct and simpler way to insert these intrinsics is to use the `impl.call_internal()` wrapper which includes forced assignment.

BTW in `subgroup.py`, those `dtype`s are removed because they only apply to constants, which are not feasible here.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/lang/articles/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/lang/articles/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
