### PR TITLE
[vulkan] Set kApiVersion to VK_API_VERSION_1_3

### DIFF
--- a/taichi/backends/vulkan/vulkan_utils.h
+++ b/taichi/backends/vulkan/vulkan_utils.h
@@ -22,7 +22,7 @@ namespace vulkan {
 class VulkanEnvSettings {
  public:
   static constexpr uint32_t kApiVersion() {
-    return VK_API_VERSION_1_2;
+    return VK_API_VERSION_1_3;
   }
 };
 


### PR DESCRIPTION
This change fixes issue #4900. On certain AMD GPUs (such as RX 5500), the Vullkan version needs to be 1.3 in order for Volk to correctly populate the "vkGetDeviceBufferMemoryRequirements" function pointer. If the version is 1.2, the pointer will be NULL and cause an assertion failure.

Tested by running the voxel challenge program and see the program working as expected on a Windows PC.

According to the [manual page](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceBufferMemoryRequirements.html), this function appears to be from Vulkan 1.3, and as such I guess kApiVersion would need to be set to 1.3 as well. I'm not sure if this means legacy devices would be excluded?

Related issue = #4900 #4951