### PR TITLE
[vulkan] Set kApiVersion to VK_API_VERSION_1_3

### DIFF
--- a/taichi/backends/vulkan/vulkan_utils.h
+++ b/taichi/backends/vulkan/vulkan_utils.h
@@ -21,11 +21,10 @@ namespace vulkan {
 
 class VulkanEnvSettings {
  public:
-
   // This version number is used to create a vkInstance, it should be
   // the highest API version that is designed to use.
   // Reference:
-  // https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkApplicationInfo.html 
+  // https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkApplicationInfo.html
   static constexpr uint32_t kApiVersion() {
     return VK_API_VERSION_1_3;
   }

--- a/taichi/backends/vulkan/vulkan_utils.h
+++ b/taichi/backends/vulkan/vulkan_utils.h
@@ -21,8 +21,13 @@ namespace vulkan {
 
 class VulkanEnvSettings {
  public:
+
+  // This version number is used to create a vkInstance, it should be
+  // the highest API version that is designed to use.
+  // Reference:
+  // https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkApplicationInfo.html 
   static constexpr uint32_t kApiVersion() {
-    return VK_API_VERSION_1_2;
+    return VK_API_VERSION_1_3;
   }
 };
 


### PR DESCRIPTION
This PR reopens #4958 as the original branch was removed.

According to the [manual](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkApplicationInfo.html), the `apiVersion` to create a Vulkan instance should be the highest version designed to use.

Let's see if this change could pass all tests in CI.