### PR TITLE
[cuda] Add block and grid level intrinsic for cuda backend

### DIFF
--- a/python/taichi/lang/simt/__init__.py
+++ b/python/taichi/lang/simt/__init__.py
@@ -1,3 +1,3 @@
-from taichi.lang.simt import subgroup, warp
+from taichi.lang.simt import subgroup, warp, block, grid
 
-__all__ = ['warp', 'subgroup']
+__all__ = ['warp', 'subgroup', 'block', 'grid']

--- a/python/taichi/lang/simt/__init__.py
+++ b/python/taichi/lang/simt/__init__.py
@@ -1,3 +1,3 @@
-from taichi.lang.simt import subgroup, warp, block, grid
+from taichi.lang.simt import block, grid, subgroup, warp
 
 __all__ = ['warp', 'subgroup', 'block', 'grid']

--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -1,0 +1,5 @@
+from taichi.lang import impl
+
+
+def sync():
+    return impl.call_internal("block_barrier", with_runtime_context=False)

--- a/python/taichi/lang/simt/grid.py
+++ b/python/taichi/lang/simt/grid.py
@@ -1,0 +1,5 @@
+from taichi.lang import impl
+
+
+def memfence():
+    return impl.call_internal("grid_memfence", with_runtime_context=False)

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -323,7 +323,7 @@ def test_block_sync():
     def foo():
         ti.loop_config(block_dim=N)
         for i in range(N):
-            # Make 0-th thread runs slower intentionally
+            # Make the 0-th thread runs slower intentionally
             for j in range(N - i):
                 a[i] = j
             ti.simt.block.sync()

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -296,7 +296,7 @@ def test_active_mask():
 
 
 @test_utils.test(arch=ti.cuda)
-def test_sync():
+def test_warp_sync():
     a = ti.field(dtype=ti.u32, shape=32)
 
     @ti.kernel
@@ -312,6 +312,58 @@ def test_sync():
 
     for i in range(32):
         assert a[i] == i % 16 + 16
+
+
+@test_utils.test(arch=ti.cuda)
+def test_block_sync():
+    N = 1024
+    a = ti.field(dtype=ti.u32, shape=N)
+
+    @ti.kernel
+    def foo():
+        ti.loop_config(block_dim=N)
+        for i in range(N):
+            # Make 0-th thread runs slower intentionally
+            for j in range(N-i):
+                a[i] = j
+            ti.simt.block.sync()
+            if i > 0:
+                a[i] = a[0]
+
+    foo()
+
+    for i in range(N):
+        assert a[i] == N-1
+
+
+# TODO: replace this with a stronger test case
+@test_utils.test(arch=ti.cuda)
+def test_grid_memfence():
+    
+    N = 1000
+    BLOCK_SIZE = 1
+    a = ti.field(dtype=ti.u32, shape=N)
+
+    @ti.kernel
+    def foo():
+
+        block_counter = 0
+        ti.loop_config(block_dim=BLOCK_SIZE)
+        for i in range(N):
+
+            a[i] = 1
+            ti.simt.grid.memfence()
+
+            # Execute a prefix sum after all blocks finish
+            actual_order_of_block = ti.atomic_add(block_counter, 1)
+            if actual_order_of_block == N-1:
+                for j in range(1, N):
+                    a[j] += a[j-1]
+
+    foo()
+
+    for i in range(N):
+        assert a[i] == i+1
 
 
 # Higher level primitives test

--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -324,7 +324,7 @@ def test_block_sync():
         ti.loop_config(block_dim=N)
         for i in range(N):
             # Make 0-th thread runs slower intentionally
-            for j in range(N-i):
+            for j in range(N - i):
                 a[i] = j
             ti.simt.block.sync()
             if i > 0:
@@ -333,13 +333,13 @@ def test_block_sync():
     foo()
 
     for i in range(N):
-        assert a[i] == N-1
+        assert a[i] == N - 1
 
 
 # TODO: replace this with a stronger test case
 @test_utils.test(arch=ti.cuda)
 def test_grid_memfence():
-    
+
     N = 1000
     BLOCK_SIZE = 1
     a = ti.field(dtype=ti.u32, shape=N)
@@ -356,14 +356,14 @@ def test_grid_memfence():
 
             # Execute a prefix sum after all blocks finish
             actual_order_of_block = ti.atomic_add(block_counter, 1)
-            if actual_order_of_block == N-1:
+            if actual_order_of_block == N - 1:
                 for j in range(1, N):
-                    a[j] += a[j-1]
+                    a[j] += a[j - 1]
 
     foo()
 
     for i in range(N):
-        assert a[i] == i+1
+        assert a[i] == i + 1
 
 
 # Higher level primitives test


### PR DESCRIPTION
Add `ti.simt.block.sync()` and `ti.simt.grid.memfence()` instrinsics, which equivalent to `__syncthreads()` and `__threadfence()` in cuda.

Related issue = #4631 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/lang/articles/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/lang/articles/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
