### PR TITLE
[llvm] Use serializer for LLVM cache

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -2378,7 +2378,8 @@ CodeGenLLVM::CompiledData CodeGenLLVM::run_compilation() {
 }
 
 bool CodeGenLLVM::maybe_read_compilation_from_cache(
-    const std::string &kernel_key, CompiledData *data) {
+    const std::string &kernel_key,
+    CompiledData *data) {
   const auto &config = prog->config;
   auto reader =
       LlvmOfflineCacheFileReader::make(config.offline_cache_file_path);

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -2354,28 +2354,13 @@ CodeGenLLVM::CompiledData CodeGenLLVM::run_compilation() {
       this->supports_offline_cache() && !kernel->is_evaluator) {
     kernel_key = get_hashed_offline_cache_key(&kernel->program->config, kernel);
 
-    LlvmOfflineCacheFileReader reader(config.offline_cache_file_path);
-    LlvmOfflineCache::KernelCacheData cache_data;
-    auto *tlctx =
-        this->prog->get_llvm_program_impl()->get_llvm_context(config.arch);
-    auto &llvm_ctx = *tlctx->get_this_thread_context();
-
-    if (reader.get_kernel_cache(cache_data, kernel_key, llvm_ctx)) {
-      this->module = std::move(cache_data.owned_module);
-      for (auto &task : cache_data.offloaded_task_list) {
-        auto &t = this->offloaded_tasks.emplace_back(this);
-        t.name = std::move(task.name);
-        t.block_dim = task.block_dim;
-        t.grid_dim = task.grid_dim;
-      }
-      kernel->set_from_offline_cache();
-      CompiledData res;
-      res.offloaded_tasks = std::move(this->offloaded_tasks);
-      res.llvm_module = std::move(this->module);
+    CompiledData res;
+    const bool ok = maybe_read_compilation_from_cache(kernel_key, &res);
+    if (ok) {
       return res;
-    } else {
-      needs_cache = true;
     }
+
+    needs_cache = true;
   }
 
   if (!kernel->lowered()) {
@@ -2390,6 +2375,36 @@ CodeGenLLVM::CompiledData CodeGenLLVM::run_compilation() {
   res.offloaded_tasks = std::move(this->offloaded_tasks);
   res.llvm_module = std::move(this->module);
   return res;
+}
+
+bool CodeGenLLVM::maybe_read_compilation_from_cache(
+    const std::string &kernel_key, CompiledData *data) {
+  const auto &config = prog->config;
+  auto reader =
+      LlvmOfflineCacheFileReader::make(config.offline_cache_file_path);
+  if (!reader) {
+    return false;
+  }
+
+  LlvmOfflineCache::KernelCacheData cache_data;
+  auto *tlctx =
+      this->prog->get_llvm_program_impl()->get_llvm_context(config.arch);
+  auto &llvm_ctx = *tlctx->get_this_thread_context();
+
+  if (!reader->get_kernel_cache(cache_data, kernel_key, llvm_ctx)) {
+    return false;
+  }
+  this->module = std::move(cache_data.owned_module);
+  for (auto &task : cache_data.offloaded_task_list) {
+    auto &t = this->offloaded_tasks.emplace_back(this);
+    t.name = std::move(task.name);
+    t.block_dim = task.block_dim;
+    t.grid_dim = task.grid_dim;
+  }
+  kernel->set_from_offline_cache();
+  data->offloaded_tasks = std::move(this->offloaded_tasks);
+  data->llvm_module = std::move(this->module);
+  return true;
 }
 
 FunctionType CodeGenLLVM::gen() {

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -4,8 +4,6 @@
 #include <set>
 #include <unordered_map>
 
-#define TI_WITH_LLVM 1
-
 #ifdef TI_WITH_LLVM
 
 #include "taichi/ir/ir.h"

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -4,6 +4,8 @@
 #include <set>
 #include <unordered_map>
 
+#define TI_WITH_LLVM 1
+
 #ifdef TI_WITH_LLVM
 
 #include "taichi/ir/ir.h"
@@ -404,6 +406,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   ~CodeGenLLVM() override = default;
 
  private:
+  bool maybe_read_compilation_from_cache(const std::string &kernel_key,
+                                         CompiledData *data);
+
   void cache_module(const std::string &kernel_key);
 };
 

--- a/taichi/common/serialization.h
+++ b/taichi/common/serialization.h
@@ -112,7 +112,7 @@ typename std::enable_if<!std::is_same<SER, TextSerializer>::value, void>::type
 serialize_kv_impl(SER &ser,
                   const std::array<std::string_view, N> &keys,
                   T &&head,
-                  Args &&...rest) {
+                  Args &&... rest) {
   constexpr auto i = (N - 1 - sizeof...(Args));
   std::string key{keys[i]};
   ser(key.c_str(), head);
@@ -126,7 +126,7 @@ typename std::enable_if<std::is_same<SER, TextSerializer>::value, void>::type
 serialize_kv_impl(SER &ser,
                   const std::array<std::string_view, N> &keys,
                   T &&head,
-                  Args &&...rest) {
+                  Args &&... rest) {
   constexpr auto i = (N - 1 - sizeof...(Args));
   std::string key{keys[i]};
   ser(key.c_str(), head, true);

--- a/taichi/common/serialization.h
+++ b/taichi/common/serialization.h
@@ -112,7 +112,7 @@ typename std::enable_if<!std::is_same<SER, TextSerializer>::value, void>::type
 serialize_kv_impl(SER &ser,
                   const std::array<std::string_view, N> &keys,
                   T &&head,
-                  Args &&... rest) {
+                  Args &&...rest) {
   constexpr auto i = (N - 1 - sizeof...(Args));
   std::string key{keys[i]};
   ser(key.c_str(), head);
@@ -126,7 +126,7 @@ typename std::enable_if<std::is_same<SER, TextSerializer>::value, void>::type
 serialize_kv_impl(SER &ser,
                   const std::array<std::string_view, N> &keys,
                   T &&head,
-                  Args &&... rest) {
+                  Args &&...rest) {
   constexpr auto i = (N - 1 - sizeof...(Args));
   std::string key{keys[i]};
   ser(key.c_str(), head, true);

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -57,7 +57,7 @@ bool LlvmOfflineCacheFileReader::get_kernel_cache(
     llvm::LLVMContext &llvm_ctx) {
   auto itr = data_.kernels.find(key);
   if (itr == data_.kernels.end()) {
-    TI_ERROR("Cannot find kernel={}", key);
+    TI_DEBUG("Cannot find kernel={}", key);
     return false;
   }
 

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -24,7 +24,8 @@ constexpr char kMetadataFilename[] = "metadata";
 
 // static
 std::unique_ptr<LlvmOfflineCacheFileReader> LlvmOfflineCacheFileReader::make(
-    const std::string &path, LlvmOfflineCache::Format format) {
+    const std::string &path,
+    LlvmOfflineCache::Format format) {
   std::stringstream tcb_ss;
   tcb_ss << path << "/" << kMetadataFilename << ".tcb";
   const auto tcb_path = tcb_ss.str();
@@ -44,9 +45,11 @@ std::unique_ptr<LlvmOfflineCacheFileReader> LlvmOfflineCacheFileReader::make(
 }
 
 LlvmOfflineCacheFileReader::LlvmOfflineCacheFileReader(
-    const std::string &path, LlvmOfflineCache &&data,
+    const std::string &path,
+    LlvmOfflineCache &&data,
     LlvmOfflineCache::Format format)
-    : path_(path), data_(std::move(data)), format_(format) {}
+    : path_(path), data_(std::move(data)), format_(format) {
+}
 
 bool LlvmOfflineCacheFileReader::get_kernel_cache(
     LlvmOfflineCache::KernelCacheData &res,

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -19,6 +19,15 @@ namespace {
 using Format = LlvmOfflineCache::Format;
 }  // namespace
 
+LlvmOfflineCacheFileReader::LlvmOfflineCacheFileReader(
+    const std::string &path,
+    LlvmOfflineCache::Format format)
+    : path_(path), format_(format) {
+  std::stringstream metafile_path_ss;
+  metafile_path_ss << path_ << "/" << kMetadataFilename << ".tcb";
+  read_from_binary_file(data_, metafile_path_ss.str());
+}
+
 bool LlvmOfflineCacheFileReader::get_kernel_cache(
     LlvmOfflineCache::KernelCacheData &res,
     const std::string &key,

--- a/taichi/llvm/llvm_offline_cache.cpp
+++ b/taichi/llvm/llvm_offline_cache.cpp
@@ -16,7 +16,10 @@
 namespace taichi {
 namespace lang {
 namespace {
+
 using Format = LlvmOfflineCache::Format;
+constexpr char kMetadataFilename[] = "metadata";
+
 }  // namespace
 
 LlvmOfflineCacheFileReader::LlvmOfflineCacheFileReader(

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -46,15 +46,18 @@ struct LlvmOfflineCache {
 
 class LlvmOfflineCacheFileReader {
  public:
-  LlvmOfflineCacheFileReader(
-      const std::string &path,
-      LlvmOfflineCache::Format format = LlvmOfflineCache::Format::LL);
-
   bool get_kernel_cache(LlvmOfflineCache::KernelCacheData &res,
                         const std::string &key,
                         llvm::LLVMContext &llvm_ctx);
 
+  static std::unique_ptr<LlvmOfflineCacheFileReader> make(
+      const std::string &path,
+      LlvmOfflineCache::Format format = LlvmOfflineCache::Format::LL);
+
  private:
+  LlvmOfflineCacheFileReader(const std::string &path, LlvmOfflineCache &&data,
+                             LlvmOfflineCache::Format format);
+
   std::unique_ptr<llvm::Module> load_module(const std::string &path_prefix,
                                             const std::string &key,
                                             llvm::LLVMContext &llvm_ctx) const;

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -55,7 +55,8 @@ class LlvmOfflineCacheFileReader {
       LlvmOfflineCache::Format format = LlvmOfflineCache::Format::LL);
 
  private:
-  LlvmOfflineCacheFileReader(const std::string &path, LlvmOfflineCache &&data,
+  LlvmOfflineCacheFileReader(const std::string &path,
+                             LlvmOfflineCache &&data,
                              LlvmOfflineCache::Format format);
 
   std::unique_ptr<llvm::Module> load_module(const std::string &path_prefix,

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -64,8 +64,8 @@ class LlvmOfflineCacheFileReader {
                                             llvm::LLVMContext &llvm_ctx) const;
 
   std::string path_;
-  LlvmOfflineCache::Format format_;
   LlvmOfflineCache data_;
+  LlvmOfflineCache::Format format_;
 };
 
 class LlvmOfflineCacheFileWriter {

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "taichi/common/core.h"
+#include "taichi/common/serialization.h"
 #include "taichi/program/kernel.h"
 #include "taichi/util/io.h"
 
@@ -19,38 +20,48 @@ struct LlvmOfflineCache {
     std::string name;
     int block_dim{0};
     int grid_dim{0};
+
+    TI_IO_DEF(name, block_dim, grid_dim);
   };
 
   struct KernelCacheData {
     std::string kernel_key;
+    std::vector<OffloadedTaskCacheData> offloaded_task_list;
+
     std::unique_ptr<llvm::Module> owned_module{nullptr};
     llvm::Module *module{nullptr};
-    std::vector<OffloadedTaskCacheData> offloaded_task_list;
 
     KernelCacheData() = default;
     KernelCacheData(KernelCacheData &&) = default;
     KernelCacheData &operator=(KernelCacheData &&) = default;
     ~KernelCacheData() = default;
+
+    TI_IO_DEF(kernel_key, offloaded_task_list);
   };
 
   std::unordered_map<std::string, KernelCacheData> kernels;
+
+  TI_IO_DEF(kernels);
 };
 
 class LlvmOfflineCacheFileReader {
  public:
   LlvmOfflineCacheFileReader(
       const std::string &path,
-      LlvmOfflineCache::Format format = LlvmOfflineCache::Format::LL)
-      : path_(path), format_(format) {
-  }
+      LlvmOfflineCache::Format format = LlvmOfflineCache::Format::LL);
 
   bool get_kernel_cache(LlvmOfflineCache::KernelCacheData &res,
                         const std::string &key,
                         llvm::LLVMContext &llvm_ctx);
 
  private:
+  std::unique_ptr<llvm::Module> load_module(const std::string &path_prefix,
+                                            const std::string &key,
+                                            llvm::LLVMContext &llvm_ctx) const;
+
   std::string path_;
   LlvmOfflineCache::Format format_;
+  LlvmOfflineCache data_;
 };
 
 class LlvmOfflineCacheFileWriter {

--- a/tests/cpp/llvm/llvm_offline_cache_test.cpp
+++ b/tests/cpp/llvm/llvm_offline_cache_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "taichi/common/platform_macros.h"
+#include "taichi/common/cleanup.h"
 
 #ifdef TI_WITH_LLVM
 
@@ -81,6 +82,7 @@ class LlvmOfflineCacheTest : public testing::TestWithParam<Format> {
 TEST_P(LlvmOfflineCacheTest, ReadWrite) {
   const auto llvm_fmt = GetParam();
   fs::path tmp_dir{fs::temp_directory_path() /= std::tmpnam(nullptr)};
+  auto cleanup = make_cleanup([tmp_dir]() { fs::remove_all(tmp_dir); });
   const auto tmp_dir_str{tmp_dir.u8string()};
   const bool dir_ok = fs::create_directories(tmp_dir);
   ASSERT_TRUE(dir_ok);
@@ -100,12 +102,16 @@ TEST_P(LlvmOfflineCacheTest, ReadWrite) {
     writer.dump(tmp_dir_str, llvm_fmt);
   }
 
+  auto *llvm_ctx = tlctx_->get_this_thread_context();
+  LlvmOfflineCacheFileReader reader{tmp_dir_str, llvm_fmt};
   {
-    auto *llvm_ctx = tlctx_->get_this_thread_context();
-    LlvmOfflineCacheFileReader reader{tmp_dir_str, llvm_fmt};
     LlvmOfflineCache::KernelCacheData kcache;
     const bool ok = reader.get_kernel_cache(kcache, kKernelName, *llvm_ctx);
     ASSERT_TRUE(ok);
+    EXPECT_EQ(kcache.kernel_key, kKernelName);
+    EXPECT_EQ(kcache.offloaded_task_list.size(), 1);
+    const auto &task0 = kcache.offloaded_task_list.front();
+    EXPECT_EQ(task0.name, kTaskName);
 
     ASSERT_NE(kcache.owned_module, nullptr);
     kcache.module->dump();
@@ -114,8 +120,13 @@ TEST_P(LlvmOfflineCacheTest, ReadWrite) {
     FuncType my_add = (FuncType)tlctx_->lookup_function_pointer(kTaskName);
     const auto res = my_add(40, 2);
     EXPECT_EQ(res, 42);
-  }
-  fs::remove_all(tmp_dir);
+  };
+  {
+    // Do it twice. No file IO this time.
+    LlvmOfflineCache::KernelCacheData kcache;
+    const bool ok = reader.get_kernel_cache(kcache, kKernelName, *llvm_ctx);
+    ASSERT_TRUE(ok);
+  };
 }
 
 INSTANTIATE_TEST_SUITE_P(Format,

--- a/tests/cpp/llvm/llvm_offline_cache_test.cpp
+++ b/tests/cpp/llvm/llvm_offline_cache_test.cpp
@@ -103,10 +103,10 @@ TEST_P(LlvmOfflineCacheTest, ReadWrite) {
   }
 
   auto *llvm_ctx = tlctx_->get_this_thread_context();
-  LlvmOfflineCacheFileReader reader{tmp_dir_str, llvm_fmt};
+  auto reader = LlvmOfflineCacheFileReader::make(tmp_dir_str, llvm_fmt);
   {
     LlvmOfflineCache::KernelCacheData kcache;
-    const bool ok = reader.get_kernel_cache(kcache, kKernelName, *llvm_ctx);
+    const bool ok = reader->get_kernel_cache(kcache, kKernelName, *llvm_ctx);
     ASSERT_TRUE(ok);
     EXPECT_EQ(kcache.kernel_key, kKernelName);
     EXPECT_EQ(kcache.offloaded_task_list.size(), 1);
@@ -124,7 +124,7 @@ TEST_P(LlvmOfflineCacheTest, ReadWrite) {
   {
     // Do it twice. No file IO this time.
     LlvmOfflineCache::KernelCacheData kcache;
-    const bool ok = reader.get_kernel_cache(kcache, kKernelName, *llvm_ctx);
+    const bool ok = reader->get_kernel_cache(kcache, kKernelName, *llvm_ctx);
     ASSERT_TRUE(ok);
   };
 }

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -14,7 +14,14 @@ supported_archs_offline_cache = [
     v for v in supported_archs_offline_cache
     if v in test_utils.expected_archs()
 ]
-cache_files_num_per_kernel = 2
+
+
+def get_expected_num_cache_files(num_kernels: int) -> int:
+    if num_kernels == 0:
+        return 0
+    NUM_CACHE_FILES_PER_KERNEL = 1
+    # metadata.{json, tcb}
+    return 2 + NUM_CACHE_FILES_PER_KERNEL * num_kernels
 
 
 def tmp_offline_cache_file_path():
@@ -73,9 +80,9 @@ def python_kernel3(a, mat):
 
 
 simple_kernels_to_test = [
-    (kernel0, (), python_kernel0),
-    (kernel1, (100, 200, 10.2), python_kernel1),
-    (kernel2, (1024, ), python_kernel2),
+    # (kernel0, (), python_kernel0),
+    # (kernel1, (100, 200, 10.2), python_kernel1),
+    # (kernel2, (1024, ), python_kernel2),
     (kernel3, (10, ti.Matrix([[1, 2], [256, 1024]], ti.i32)), python_kernel3),
 ]
 
@@ -121,20 +128,20 @@ def _test_offline_cache_for_a_kernel(curr_arch, kernel, args, result):
             **current_thread_ext_options())
     res1 = kernel(*args)
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
 
     ti.init(arch=curr_arch,
             enable_fallback=False,
             **current_thread_ext_options())
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 1 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(1)
     res2 = kernel(*args)
     assert res1 == test_utils.approx(result) and res1 == test_utils.approx(
         res2)
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 1 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(1)
 
 
 @_test_offline_cache_dec
@@ -146,20 +153,22 @@ def _test_closing_offline_cache_for_a_kernel(curr_arch, kernel, args, result):
             offline_cache_file_path=tmp_offline_cache_file_path())
     res1 = kernel(*args)
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
 
     ti.init(arch=curr_arch,
             enable_fallback=False,
             offline_cache_file_path=tmp_offline_cache_file_path())
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
     res2 = kernel(*args)
+
+    import pdb; pdb.set_trace()
     assert res1 == test_utils.approx(result) and res1 == test_utils.approx(
         res2)
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)
@@ -209,18 +218,18 @@ def test_multiple_ib_with_offline_cache(curr_arch):
             **current_thread_ext_options())
     helper()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
 
     ti.init(arch=curr_arch,
             enable_fallback=False,
             **current_thread_ext_options())
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 8 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(8)
     helper()
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 8 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(8)
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)
@@ -244,7 +253,7 @@ def test_calling_a_kernel_with_different_param_list(curr_arch):
     np_mat3 = mat3.to_numpy()
 
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
     ti.init(arch=curr_arch,
             enable_fallback=False,
             **current_thread_ext_options())
@@ -254,7 +263,7 @@ def test_calling_a_kernel_with_different_param_list(curr_arch):
             enable_fallback=False,
             **current_thread_ext_options())
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 1 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(1)
 
     assert (kernel(mat1, mat1).to_numpy() == np_kernel(np_mat1, np_mat1)).all()
     assert (kernel(mat1, mat2).to_numpy() == np_kernel(np_mat1, np_mat2)).all()
@@ -263,7 +272,7 @@ def test_calling_a_kernel_with_different_param_list(curr_arch):
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 1 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(1)
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)
@@ -286,7 +295,7 @@ def test_snode_reader_and_writer_with_offline_cache(curr_arch):
         assert y[None] == test_utils.approx(7.28)
 
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
     ti.init(arch=curr_arch,
             enable_fallback=False,
             **current_thread_ext_options())
@@ -296,12 +305,12 @@ def test_snode_reader_and_writer_with_offline_cache(curr_arch):
             enable_fallback=False,
             **current_thread_ext_options())
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 4 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(4)
     helper()
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 4 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(4)
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)
@@ -322,7 +331,7 @@ def test_ndarray_reader_and_writer_with_offline_cache(curr_arch, layout):
         assert a[4][9] == 9
 
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
     ti.init(arch=curr_arch,
             enable_fallback=False,
             **current_thread_ext_options())
@@ -332,12 +341,12 @@ def test_ndarray_reader_and_writer_with_offline_cache(curr_arch, layout):
             enable_fallback=False,
             **current_thread_ext_options())
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 2 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(2)
     helper()
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 2 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(2)
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)
@@ -354,19 +363,19 @@ def test_calling_many_kernels(curr_arch):
             **current_thread_ext_options())
     helper()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
 
     ti.init(arch=curr_arch,
             enable_fallback=False,
             **current_thread_ext_options())
-    assert len(listdir(
-        tmp_offline_cache_file_path())) - count_of_cache_file == len(
-            simple_kernels_to_test) * cache_files_num_per_kernel
+    assert len(listdir(tmp_offline_cache_file_path())
+               ) - count_of_cache_file == get_expected_num_cache_files(
+                   len(simple_kernels_to_test))
     helper()
     ti.reset()
-    assert len(listdir(
-        tmp_offline_cache_file_path())) - count_of_cache_file == len(
-            simple_kernels_to_test) * cache_files_num_per_kernel
+    assert len(listdir(tmp_offline_cache_file_path())
+               ) - count_of_cache_file == get_expected_num_cache_files(
+                   len(simple_kernels_to_test))
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)
@@ -383,7 +392,7 @@ def test_offline_cache_with_changing_compile_config(curr_arch):
             c += i
 
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 0 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(0)
     ti.init(arch=curr_arch,
             enable_fallback=False,
             default_fp=ti.f32,
@@ -395,12 +404,12 @@ def test_offline_cache_with_changing_compile_config(curr_arch):
             default_fp=ti.f64,
             **current_thread_ext_options())
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 1 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(1)
     helper()
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 2 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(2)
 
     ti.init(arch=curr_arch,
             enable_fallback=False,
@@ -411,4 +420,4 @@ def test_offline_cache_with_changing_compile_config(curr_arch):
 
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
-               ) - count_of_cache_file == 2 * cache_files_num_per_kernel
+               ) - count_of_cache_file == get_expected_num_cache_files(2)

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -80,9 +80,9 @@ def python_kernel3(a, mat):
 
 
 simple_kernels_to_test = [
-    # (kernel0, (), python_kernel0),
-    # (kernel1, (100, 200, 10.2), python_kernel1),
-    # (kernel2, (1024, ), python_kernel2),
+    (kernel0, (), python_kernel0),
+    (kernel1, (100, 200, 10.2), python_kernel1),
+    (kernel2, (1024, ), python_kernel2),
     (kernel3, (10, ti.Matrix([[1, 2], [256, 1024]], ti.i32)), python_kernel3),
 ]
 

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -162,7 +162,8 @@ def _test_closing_offline_cache_for_a_kernel(curr_arch, kernel, args, result):
                ) - count_of_cache_file == get_expected_num_cache_files(0)
     res2 = kernel(*args)
 
-    import pdb; pdb.set_trace()
+    import pdb
+    pdb.set_trace()
     assert res1 == test_utils.approx(result) and res1 == test_utils.approx(
         res2)
 

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -162,8 +162,6 @@ def _test_closing_offline_cache_for_a_kernel(curr_arch, kernel, args, result):
                ) - count_of_cache_file == get_expected_num_cache_files(0)
     res2 = kernel(*args)
 
-    import pdb
-    pdb.set_trace()
     assert res1 == test_utils.approx(result) and res1 == test_utils.approx(
         res2)
 
@@ -411,7 +409,6 @@ def test_offline_cache_with_changing_compile_config(curr_arch):
     ti.reset()
     assert len(listdir(tmp_offline_cache_file_path())
                ) - count_of_cache_file == get_expected_num_cache_files(2)
-
     ti.init(arch=curr_arch,
             enable_fallback=False,
             default_fp=ti.f32,


### PR DESCRIPTION
Related issue = #4800

@PGZXB FYI, I've switched the LLVM cache writer from the customized solution to Taichi's small serialization library. To see how it works, here are some examples: https://github.com/taichi-dev/taichi/blob/master/tests/cpp/common/serialization_test.cpp