### PR TITLE
[bug] Fix infinite recursion of get_offline_cache_key_of_snode_impl()

### DIFF
--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -74,7 +74,7 @@ static void get_offline_cache_key_of_snode_impl(
     BinaryOutputSerializer &serializer,
     std::unordered_set<int> &visited) {
   if (auto iter = visited.find(snode->id); iter != visited.end()) {
-    serializer(snode->id);  // Node: Use snode-id as placeholder
+    serializer(snode->id);  // Use snode->id as placeholder to identify a snode
     return;
   } else {
     visited.insert(snode->id);
@@ -146,7 +146,7 @@ std::string get_hashed_offline_cache_key_of_snode(SNode *snode) {
   BinaryOutputSerializer serializer;
   serializer.initialize();
   {
-    std::unordered_set<int> visited;  // Node: snode-id
+    std::unordered_set<int> visited;
     get_offline_cache_key_of_snode_impl(snode, serializer, visited);
   }
   serializer.finalize();

--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -74,7 +74,7 @@ static void get_offline_cache_key_of_snode_impl(
     BinaryOutputSerializer &serializer,
     std::unordered_set<int> &visited) {
   if (auto iter = visited.find(snode->id); iter != visited.end()) {
-    serializer(snode->id); // Node: Use snode-id as placeholder
+    serializer(snode->id);  // Node: Use snode-id as placeholder
     return;
   } else {
     visited.insert(snode->id);
@@ -146,7 +146,7 @@ std::string get_hashed_offline_cache_key_of_snode(SNode *snode) {
   BinaryOutputSerializer serializer;
   serializer.initialize();
   {
-    std::unordered_set<int> visited; // Node: snode-id
+    std::unordered_set<int> visited;  // Node: snode-id
     get_offline_cache_key_of_snode_impl(snode, serializer, visited);
   }
   serializer.finalize();

--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -76,9 +76,9 @@ static void get_offline_cache_key_of_snode_impl(
   if (auto iter = visited.find(snode->id); iter != visited.end()) {
     serializer(snode->id);  // Use snode->id as placeholder to identify a snode
     return;
-  } else {
-    visited.insert(snode->id);
   }
+
+  visited.insert(snode->id);
   for (auto &c : snode->ch) {
     get_offline_cache_key_of_snode_impl(c.get(), serializer, visited);
   }

--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -71,9 +71,16 @@ static std::vector<std::uint8_t> get_offline_cache_key_of_compile_config(
 
 static void get_offline_cache_key_of_snode_impl(
     SNode *snode,
-    BinaryOutputSerializer &serializer) {
+    BinaryOutputSerializer &serializer,
+    std::unordered_set<int> &visited) {
+  if (auto iter = visited.find(snode->id); iter != visited.end()) {
+    serializer(snode->id); // Node: Use snode-id as placeholder
+    return;
+  } else {
+    visited.insert(snode->id);
+  }
   for (auto &c : snode->ch) {
-    get_offline_cache_key_of_snode_impl(c.get(), serializer);
+    get_offline_cache_key_of_snode_impl(c.get(), serializer, visited);
   }
   for (int i = 0; i < taichi_max_num_indices; ++i) {
     auto &extractor = snode->extractors[i];
@@ -106,21 +113,21 @@ static void get_offline_cache_key_of_snode_impl(
   }
   if (snode->grad_info && !snode->grad_info->is_primal()) {
     if (auto *grad_snode = snode->grad_info->grad_snode()) {
-      get_offline_cache_key_of_snode_impl(grad_snode, serializer);
+      get_offline_cache_key_of_snode_impl(grad_snode, serializer, visited);
     }
   }
   if (snode->exp_snode) {
-    get_offline_cache_key_of_snode_impl(snode->exp_snode, serializer);
+    get_offline_cache_key_of_snode_impl(snode->exp_snode, serializer, visited);
   }
   serializer(snode->bit_offset);
   serializer(snode->placing_shared_exp);
   serializer(snode->owns_shared_exponent);
   for (auto s : snode->exponent_users) {
-    get_offline_cache_key_of_snode_impl(s, serializer);
+    get_offline_cache_key_of_snode_impl(s, serializer, visited);
   }
   if (snode->currently_placing_exp_snode) {
     get_offline_cache_key_of_snode_impl(snode->currently_placing_exp_snode,
-                                        serializer);
+                                        serializer, visited);
   }
   if (snode->currently_placing_exp_snode_dtype) {
     serializer(snode->currently_placing_exp_snode_dtype->to_string());
@@ -138,7 +145,10 @@ std::string get_hashed_offline_cache_key_of_snode(SNode *snode) {
 
   BinaryOutputSerializer serializer;
   serializer.initialize();
-  get_offline_cache_key_of_snode_impl(snode, serializer);
+  {
+    std::unordered_set<int> visited; // Node: snode-id
+    get_offline_cache_key_of_snode_impl(snode, serializer, visited);
+  }
   serializer.finalize();
 
   picosha2::hash256_one_by_one hasher;


### PR DESCRIPTION
Related issue = #4401 

Fix  bug (reported by:
* running test_custom_float_exponents.py with `offline_cache=True`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/lang/articles/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/lang/articles/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
