### PR TITLE
[Lang] [type] Refactor quantized_types module and make quant APIs public

### DIFF
--- a/misc/benchmark_bit_struct_stores.py
+++ b/misc/benchmark_bit_struct_stores.py
@@ -7,7 +7,7 @@ quant = True
 n = 1024 * 1024 * 256
 
 if quant:
-    ci16 = ti.types.quantized_types.quant.int(16, True)
+    ci16 = ti.types.quant.int(16, True)
 
     x = ti.field(dtype=ci16)
     y = ti.field(dtype=ci16)

--- a/misc/visualize_quant_types.py
+++ b/misc/visualize_quant_types.py
@@ -7,9 +7,9 @@ import taichi as ti
 
 ti.init()
 
-f19 = ti.types.quantized_types.quant.float(exp=6, frac=13, signed=True)
-f16 = ti.types.quantized_types.quant.float(exp=5, frac=11, signed=True)
-fixed16 = ti.types.quantized_types.quant.fixed(frac=16, range=2)
+f19 = ti.types.quant.float(exp=6, frac=13, signed=True)
+f16 = ti.types.quant.float(exp=5, frac=11, signed=True)
+fixed16 = ti.types.quant.fixed(frac=16, range=2)
 
 vf19 = ti.Vector.field(2, dtype=f19)
 bs_vf19 = ti.root.bit_struct(num_bits=32)

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -37,8 +37,6 @@ __deprecated_names__ = {
     'imresize': 'tools.imresize',
     'imshow': 'tools.imshow',
     'imwrite': 'tools.imwrite',
-    'quant': 'types.quantized_types.quant',
-    'type_factory': 'types.quantized_types.type_factory',
     'ext_arr': 'types.ndarray',
     'any_arr': 'types.ndarray'
 }

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1435,7 +1435,6 @@ class MatrixField(Field):
 
     def get_scalar_field(self, *indices):
         """Creates a ScalarField using a specific field member.
-        Only used for quant.
 
         Args:
             indices (Tuple[Int]): Specified indices of the field member.

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -170,9 +170,6 @@ When this is used, Taichi automatically picks the matching CPU backend.
 timeline_clear = lambda: impl.get_runtime().prog.timeline_clear()  # pylint: disable=unnecessary-lambda
 timeline_save = lambda fn: impl.get_runtime().prog.timeline_save(fn)  # pylint: disable=unnecessary-lambda
 
-# Legacy API
-type_factory_ = _ti_core.get_type_factory_instance()
-
 extension = _ti_core.Extension
 """An instance of Taichi extension.
 

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -472,7 +472,7 @@ class StructField(Field):
             v._initialize_host_accessors()
 
     def get_member_field(self, key):
-        """Creates a ScalarField using a specific field member. Only used for quant.
+        """Creates a ScalarField using a specific field member.
 
         Args:
             key (str): Specified key of the field member.

--- a/python/taichi/types/__init__.py
+++ b/python/taichi/types/__init__.py
@@ -7,9 +7,9 @@ This module defines data types in Taichi:
 - ndarray: for arbitrary arrays.
 - quantized: for quantized types, see "https://yuanming.taichi.graphics/publication/2021-quantaichi/quantaichi.pdf"
 """
+from taichi.types import quantized_types as quant
 from taichi.types.annotations import *
 from taichi.types.compound_types import *
 from taichi.types.ndarray_type import *
 from taichi.types.primitive_types import *
-from taichi.types.quantized_types import *
 from taichi.types.utils import *

--- a/python/taichi/types/quantized_types.py
+++ b/python/taichi/types/quantized_types.py
@@ -52,7 +52,7 @@ def _custom_float(significand_type,
                                                scale=scale)
 
 
-def int(bits, signed=False, compute=None):
+def int(bits, signed=False, compute=None):  # pylint: disable=W0622
     """Generates a quantized type for integers.
 
     Args:
@@ -91,7 +91,7 @@ def fixed(frac, signed=True, num_range=1.0, compute=None):
     return _custom_float(frac_type, None, compute, scale)
 
 
-def float(exp, frac, signed=True, compute=None):
+def float(exp, frac, signed=True, compute=None):  # pylint: disable=W0622
     """Generates a quantized type for floating-point real numbers.
 
     Args:

--- a/python/taichi/types/quantized_types.py
+++ b/python/taichi/types/quantized_types.py
@@ -6,7 +6,6 @@ from taichi._lib.utils import ti_core as _ti_core
 from taichi.lang import impl
 from taichi.types.primitive_types import i32
 
-
 _type_factory = _ti_core.get_type_factory_instance()
 
 

--- a/python/taichi/types/quantized_types.py
+++ b/python/taichi/types/quantized_types.py
@@ -1,129 +1,118 @@
+"""
+This module defines generators of quantized types.
+For more details, read https://yuanming.taichi.graphics/publication/2021-quantaichi/quantaichi.pdf.
+"""
 from taichi._lib.utils import ti_core as _ti_core
 from taichi.lang import impl
 from taichi.types.primitive_types import i32
 
 
-class TypeFactory:
-    """A Python-side TypeFactory wrapper."""
-    def __init__(self):
-        self.core = _ti_core.get_type_factory_instance()
+_type_factory = _ti_core.get_type_factory_instance()
 
-    def custom_int(self, bits, signed=True, compute_type=None):
-        """Generates a custom int type.
 
-        Args:
-            bits (int): Number of bits.
-            signed (bool): Signed or unsigned.
-            compute_type (DataType): Type for computation.
+def _custom_int(bits, signed=True, compute_type=None):
+    """Generates a custom int type.
 
-        Returns:
-            DataType: The specified type.
-        """
-        if compute_type is None:
-            compute_type = impl.get_runtime().default_ip
-        if isinstance(compute_type, _ti_core.DataType):
-            compute_type = compute_type.get_ptr()
-        return self.core.get_custom_int_type(bits, signed, compute_type)
+    Args:
+        bits (int): Number of bits.
+        signed (bool): Signed or unsigned.
+        compute_type (DataType): Type for computation.
 
-    def custom_float(self,
-                     significand_type,
-                     exponent_type=None,
-                     compute_type=None,
-                     scale=1.0):
-        """Generates a custom float type.
+    Returns:
+        DataType: The specified type.
+    """
+    if compute_type is None:
+        compute_type = impl.get_runtime().default_ip
+    if isinstance(compute_type, _ti_core.DataType):
+        compute_type = compute_type.get_ptr()
+    return _type_factory.get_custom_int_type(bits, signed, compute_type)
 
-        Args:
-            significand_type (DataType): Type of significand.
-            exponent_type (DataType): Type of exponent.
-            compute_type (DataType): Type for computation.
-            scale (float): Scaling factor.
 
-        Returns:
-            DataType: The specified type.
-        """
-        if compute_type is None:
-            compute_type = impl.get_runtime().default_fp
-        if isinstance(compute_type, _ti_core.DataType):
-            compute_type = compute_type.get_ptr()
-        return self.core.get_custom_float_type(significand_type,
+def _custom_float(significand_type,
+                  exponent_type=None,
+                  compute_type=None,
+                  scale=1.0):
+    """Generates a custom float type.
+
+    Args:
+        significand_type (DataType): Type of significand.
+        exponent_type (DataType): Type of exponent.
+        compute_type (DataType): Type for computation.
+        scale (float): Scaling factor.
+
+    Returns:
+        DataType: The specified type.
+    """
+    if compute_type is None:
+        compute_type = impl.get_runtime().default_fp
+    if isinstance(compute_type, _ti_core.DataType):
+        compute_type = compute_type.get_ptr()
+    return _type_factory.get_custom_float_type(significand_type,
                                                exponent_type,
                                                compute_type,
                                                scale=scale)
 
 
-# Unstable API
-type_factory = TypeFactory()
+def int(bits, signed=False, compute=None):
+    """Generates a quantized type for integers.
 
+    Args:
+        bits (int): Number of bits.
+        signed (bool): Signed or unsigned.
+        compute (DataType): Type for computation.
 
-class Quant:
-    """Generator of quantized types.
-
-    For more details, read https://yuanming.taichi.graphics/publication/2021-quantaichi/quantaichi.pdf.
+    Returns:
+        DataType: The specified type.
     """
-    @staticmethod
-    def int(bits, signed=False, compute=None):
-        """Generates a quantized type for integers.
-
-        Args:
-            bits (int): Number of bits.
-            signed (bool): Signed or unsigned.
-            compute (DataType): Type for computation.
-
-        Returns:
-            DataType: The specified type.
-        """
-        if compute is None:
-            compute = impl.get_runtime().default_ip
-        return type_factory.custom_int(bits, signed, compute)
-
-    @staticmethod
-    def fixed(frac, signed=True, num_range=1.0, compute=None):
-        """Generates a quantized type for fixed-point real numbers.
-
-        Args:
-            frac (int): Number of bits.
-            signed (bool): Signed or unsigned.
-            num_range (float): Range of the number.
-            compute (DataType): Type for computation.
-
-        Returns:
-            DataType: The specified type.
-        """
-        # TODO: handle cases with frac > 32
-        frac_type = Quant.int(bits=frac, signed=signed, compute=i32)
-        if signed:
-            scale = num_range / 2**(frac - 1)
-        else:
-            scale = num_range / 2**frac
-        if compute is None:
-            compute = impl.get_runtime().default_fp
-        return type_factory.custom_float(frac_type, None, compute, scale)
-
-    @staticmethod
-    def float(exp, frac, signed=True, compute=None):
-        """Generates a quantized type for floating-point real numbers.
-
-        Args:
-            exp (int): Number of exponent bits.
-            frac (int): Number of fraction bits.
-            signed (bool): Signed or unsigned.
-            compute (DataType): Type for computation.
-
-        Returns:
-            DataType: The specified type.
-        """
-        # Exponent is always unsigned
-        exp_type = Quant.int(bits=exp, signed=False, compute=i32)
-        # TODO: handle cases with frac > 32
-        frac_type = Quant.int(bits=frac, signed=signed, compute=i32)
-        if compute is None:
-            compute = impl.get_runtime().default_fp
-        return type_factory.custom_float(significand_type=frac_type,
-                                         exponent_type=exp_type,
-                                         compute_type=compute)
+    if compute is None:
+        compute = impl.get_runtime().default_ip
+    return _custom_int(bits, signed, compute)
 
 
-# Unstable API
-quant = Quant
+def fixed(frac, signed=True, num_range=1.0, compute=None):
+    """Generates a quantized type for fixed-point real numbers.
 
-__all__ = []
+    Args:
+        frac (int): Number of bits.
+        signed (bool): Signed or unsigned.
+        num_range (float): Range of the number.
+        compute (DataType): Type for computation.
+
+    Returns:
+        DataType: The specified type.
+    """
+    # TODO: handle cases with frac > 32
+    frac_type = int(bits=frac, signed=signed, compute=i32)
+    if signed:
+        scale = num_range / 2**(frac - 1)
+    else:
+        scale = num_range / 2**frac
+    if compute is None:
+        compute = impl.get_runtime().default_fp
+    return _custom_float(frac_type, None, compute, scale)
+
+
+def float(exp, frac, signed=True, compute=None):
+    """Generates a quantized type for floating-point real numbers.
+
+    Args:
+        exp (int): Number of exponent bits.
+        frac (int): Number of fraction bits.
+        signed (bool): Signed or unsigned.
+        compute (DataType): Type for computation.
+
+    Returns:
+        DataType: The specified type.
+    """
+    # Exponent is always unsigned
+    exp_type = int(bits=exp, signed=False, compute=i32)
+    # TODO: handle cases with frac > 32
+    frac_type = int(bits=frac, signed=signed, compute=i32)
+    if compute is None:
+        compute = impl.get_runtime().default_fp
+    return _custom_float(significand_type=frac_type,
+                         exponent_type=exp_type,
+                         compute_type=compute)
+
+
+__all__ = ['int', 'fixed', 'float']

--- a/tests/python/test_bit_array.py
+++ b/tests/python/test_bit_array.py
@@ -6,7 +6,7 @@ from tests import test_utils
 
 @test_utils.test(require=ti.extension.quant, debug=True)
 def test_1D_bit_array():
-    cu1 = ti.types.quantized_types.quant.int(1, False)
+    cu1 = ti.types.quant.int(1, False)
 
     x = ti.field(dtype=cu1)
 
@@ -30,7 +30,7 @@ def test_1D_bit_array():
 
 @test_utils.test(require=ti.extension.quant, debug=True)
 def test_2D_bit_array():
-    ci1 = ti.types.quantized_types.quant.int(1, False)
+    ci1 = ti.types.quant.int(1, False)
 
     x = ti.field(dtype=ci1)
 

--- a/tests/python/test_bit_array_vectorization.py
+++ b/tests/python/test_bit_array_vectorization.py
@@ -8,7 +8,7 @@ from tests import test_utils
                  debug=True,
                  cfg_optimization=False)
 def test_vectorized_struct_for():
-    cu1 = ti.types.quantized_types.quant.int(1, False)
+    cu1 = ti.types.quant.int(1, False)
 
     x = ti.field(dtype=cu1)
     y = ti.field(dtype=cu1)
@@ -49,7 +49,7 @@ def test_vectorized_struct_for():
 
 @test_utils.test(require=ti.extension.quant)
 def test_offset_load():
-    ci1 = ti.types.quantized_types.quant.int(1, False)
+    ci1 = ti.types.quant.int(1, False)
 
     x = ti.field(dtype=ci1)
     y = ti.field(dtype=ci1)
@@ -109,7 +109,7 @@ def test_offset_load():
 
 @test_utils.test(require=ti.extension.quant, debug=True)
 def test_evolve():
-    ci1 = ti.types.quantized_types.quant.int(1, False)
+    ci1 = ti.types.quant.int(1, False)
 
     x = ti.field(dtype=ci1)
     y = ti.field(dtype=ci1)

--- a/tests/python/test_bit_struct.py
+++ b/tests/python/test_bit_struct.py
@@ -7,8 +7,8 @@ from tests import test_utils
 
 @test_utils.test(require=ti.extension.quant_basic, debug=True)
 def test_simple_array():
-    ci13 = ti.types.quantized_types.quant.int(13, True)
-    cu19 = ti.types.quantized_types.quant.int(19, False)
+    ci13 = ti.types.quant.int(13, True)
+    cu19 = ti.types.quant.int(19, False)
 
     x = ti.field(dtype=ci13)
     y = ti.field(dtype=cu19)
@@ -42,9 +42,9 @@ def test_simple_array():
                  exclude=[ti.metal],
                  debug=True)
 def test_custom_int_load_and_store():
-    ci13 = ti.types.quantized_types.quant.int(13, True)
-    cu14 = ti.types.quantized_types.quant.int(14, False)
-    ci5 = ti.types.quantized_types.quant.int(5, True)
+    ci13 = ti.types.quant.int(13, True)
+    cu14 = ti.types.quant.int(14, False)
+    ci5 = ti.types.quant.int(5, True)
 
     x = ti.field(dtype=ci13)
     y = ti.field(dtype=cu14)
@@ -83,7 +83,7 @@ def test_custom_int_load_and_store():
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_int_full_struct():
-    cit = ti.types.quantized_types.quant.int(32, True)
+    cit = ti.types.quant.int(32, True)
     x = ti.field(dtype=cit)
     ti.root.dense(ti.i, 1).bit_struct(num_bits=32).place(x)
 
@@ -99,12 +99,9 @@ def test_bit_struct():
                                test_case):
         ti.init(arch=ti.cpu, debug=True)
 
-        cit1 = ti.types.quantized_types.quant.int(custom_bits[0], True,
-                                                  compute_type)
-        cit2 = ti.types.quantized_types.quant.int(custom_bits[1], False,
-                                                  compute_type)
-        cit3 = ti.types.quantized_types.quant.int(custom_bits[2], True,
-                                                  compute_type)
+        cit1 = ti.types.quant.int(custom_bits[0], True, compute_type)
+        cit2 = ti.types.quant.int(custom_bits[1], False, compute_type)
+        cit3 = ti.types.quant.int(custom_bits[2], True, compute_type)
 
         a = ti.field(dtype=cit1)
         b = ti.field(dtype=cit2)
@@ -151,7 +148,7 @@ def test_bit_struct_struct_for():
     block_size = 16
     N = 64
     cell = ti.root.pointer(ti.i, N // block_size)
-    fixed32 = ti.types.quantized_types.quant.fixed(frac=32, num_range=1024)
+    fixed32 = ti.types.quant.fixed(frac=32, num_range=1024)
 
     x = ti.field(dtype=fixed32)
     cell.dense(ti.i, block_size).bit_struct(32).place(x)

--- a/tests/python/test_cast.py
+++ b/tests/python/test_cast.py
@@ -145,8 +145,8 @@ def test_custom_int_extension():
     x = ti.field(dtype=ti.i32, shape=2)
     y = ti.field(dtype=ti.u32, shape=2)
 
-    ci5 = ti.types.quantized_types.quant.int(5, True, ti.i16)
-    cu7 = ti.types.quantized_types.quant.int(7, False, ti.u16)
+    ci5 = ti.types.quant.int(5, True, ti.i16)
+    cu7 = ti.types.quant.int(7, False, ti.u16)
 
     a = ti.field(dtype=ci5)
     b = ti.field(dtype=cu7)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -8,7 +8,7 @@ from tests import test_utils
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_float():
-    cft = ti.types.quantized_types.quant.fixed(frac=32, num_range=2)
+    cft = ti.types.quant.fixed(frac=32, num_range=2)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -29,7 +29,7 @@ def test_custom_float():
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_matrix_rotation():
-    cft = ti.types.quantized_types.quant.fixed(frac=16, num_range=1.2)
+    cft = ti.types.quant.fixed(frac=16, num_range=1.2)
 
     x = ti.Matrix.field(2, 2, dtype=cft)
 
@@ -57,9 +57,8 @@ def test_custom_matrix_rotation():
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_float_implicit_cast():
-    ci13 = ti.types.quantized_types.quant.int(bits=13)
-    cft = ti.types.quantized_types.type_factory.custom_float(
-        significand_type=ci13, scale=0.1)
+    ci13 = ti.types.quant.int(bits=13)
+    cft = ti.types.quant._custom_float(significand_type=ci13, scale=0.1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -74,9 +73,8 @@ def test_custom_float_implicit_cast():
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_cache_read_only():
-    ci15 = ti.types.quantized_types.quant.int(bits=15)
-    cft = ti.types.quantized_types.type_factory.custom_float(
-        significand_type=ci15, scale=0.1)
+    ci15 = ti.types.quant.int(bits=15)
+    cft = ti.types.quant._custom_float(significand_type=ci15, scale=0.1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -10,8 +10,9 @@ from tests import test_utils
 def test_custom_float_unsigned():
     cu13 = ti.types.quant.int(13, False)
     exp = ti.types.quant.int(6, False)
-    cft = ti.types.quant._custom_float(
-        significand_type=cu13, exponent_type=exp, scale=1)
+    cft = ti.types.quant._custom_float(significand_type=cu13,
+                                       exponent_type=exp,
+                                       scale=1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -32,8 +33,9 @@ def test_custom_float_unsigned():
 def test_custom_float_signed():
     cu13 = ti.types.quant.int(13, True)
     exp = ti.types.quant.int(6, False)
-    cft = ti.types.quant._custom_float(
-        significand_type=cu13, exponent_type=exp, scale=1)
+    cft = ti.types.quant._custom_float(significand_type=cu13,
+                                       exponent_type=exp,
+                                       scale=1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -63,8 +65,9 @@ def test_custom_float_signed():
 def test_custom_float_precision(digits_bits):
     cu24 = ti.types.quant.int(digits_bits, True)
     exp = ti.types.quant.int(8, False)
-    cft = ti.types.quant._custom_float(
-        significand_type=cu24, exponent_type=exp, scale=1)
+    cft = ti.types.quant._custom_float(significand_type=cu24,
+                                       exponent_type=exp,
+                                       scale=1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -87,8 +90,9 @@ def test_custom_float_precision(digits_bits):
 def test_custom_float_truncation(signed):
     cit = ti.types.quant.int(2, signed)
     exp = ti.types.quant.int(5, False)
-    cft = ti.types.quant._custom_float(
-        significand_type=cit, exponent_type=exp, scale=1)
+    cft = ti.types.quant._custom_float(significand_type=cit,
+                                       exponent_type=exp,
+                                       scale=1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -118,8 +122,9 @@ def test_custom_float_truncation(signed):
 def test_custom_float_atomic_demotion():
     cit = ti.types.quant.int(2, True)
     exp = ti.types.quant.int(5, False)
-    cft = ti.types.quant._custom_float(
-        significand_type=cit, exponent_type=exp, scale=1)
+    cft = ti.types.quant._custom_float(significand_type=cit,
+                                       exponent_type=exp,
+                                       scale=1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -8,9 +8,9 @@ from tests import test_utils
 
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_unsigned():
-    cu13 = ti.types.quantized_types.quant.int(13, False)
-    exp = ti.types.quantized_types.quant.int(6, False)
-    cft = ti.types.quantized_types.type_factory.custom_float(
+    cu13 = ti.types.quant.int(13, False)
+    exp = ti.types.quant.int(6, False)
+    cft = ti.types.quant._custom_float(
         significand_type=cu13, exponent_type=exp, scale=1)
     x = ti.field(dtype=cft)
 
@@ -30,9 +30,9 @@ def test_custom_float_unsigned():
 
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_signed():
-    cu13 = ti.types.quantized_types.quant.int(13, True)
-    exp = ti.types.quantized_types.quant.int(6, False)
-    cft = ti.types.quantized_types.type_factory.custom_float(
+    cu13 = ti.types.quant.int(13, True)
+    exp = ti.types.quant.int(6, False)
+    cft = ti.types.quant._custom_float(
         significand_type=cu13, exponent_type=exp, scale=1)
     x = ti.field(dtype=cft)
 
@@ -61,9 +61,9 @@ def test_custom_float_signed():
 @pytest.mark.parametrize('digits_bits', [23, 24])
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_precision(digits_bits):
-    cu24 = ti.types.quantized_types.quant.int(digits_bits, True)
-    exp = ti.types.quantized_types.quant.int(8, False)
-    cft = ti.types.quantized_types.type_factory.custom_float(
+    cu24 = ti.types.quant.int(digits_bits, True)
+    exp = ti.types.quant.int(8, False)
+    cft = ti.types.quant._custom_float(
         significand_type=cu24, exponent_type=exp, scale=1)
     x = ti.field(dtype=cft)
 
@@ -85,9 +85,9 @@ def test_custom_float_precision(digits_bits):
 @pytest.mark.parametrize('signed', [True, False])
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_truncation(signed):
-    cit = ti.types.quantized_types.quant.int(2, signed)
-    exp = ti.types.quantized_types.quant.int(5, False)
-    cft = ti.types.quantized_types.type_factory.custom_float(
+    cit = ti.types.quant.int(2, signed)
+    exp = ti.types.quant.int(5, False)
+    cft = ti.types.quant._custom_float(
         significand_type=cit, exponent_type=exp, scale=1)
     x = ti.field(dtype=cft)
 
@@ -116,9 +116,9 @@ def test_custom_float_truncation(signed):
 
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_atomic_demotion():
-    cit = ti.types.quantized_types.quant.int(2, True)
-    exp = ti.types.quantized_types.quant.int(5, False)
-    cft = ti.types.quantized_types.type_factory.custom_float(
+    cit = ti.types.quant.int(2, True)
+    exp = ti.types.quant.int(5, False)
+    cft = ti.types.quant._custom_float(
         significand_type=cit, exponent_type=exp, scale=1)
     x = ti.field(dtype=cft)
 

--- a/tests/python/test_custom_float_shared_exp.py
+++ b/tests/python/test_custom_float_shared_exp.py
@@ -8,12 +8,12 @@ from tests import test_utils
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_shared_exponents(exponent_bits):
-    exp = ti.types.quantized_types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quantized_types.quant.int(10, False)
-    cit2 = ti.types.quantized_types.quant.int(14, False)
-    cft1 = ti.types.quantized_types.type_factory.custom_float(
+    exp = ti.types.quant.int(exponent_bits, False)
+    cit1 = ti.types.quant.int(10, False)
+    cit2 = ti.types.quant.int(14, False)
+    cft1 = ti.types.quant._custom_float(
         significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quantized_types.type_factory.custom_float(
+    cft2 = ti.types.quant._custom_float(
         significand_type=cit2, exponent_type=exp, scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
@@ -76,12 +76,12 @@ def test_shared_exponents(exponent_bits):
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_shared_exponent_add(exponent_bits):
-    exp = ti.types.quantized_types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quantized_types.quant.int(10, False)
-    cit2 = ti.types.quantized_types.quant.int(14, False)
-    cft1 = ti.types.quantized_types.type_factory.custom_float(
+    exp = ti.types.quant.int(exponent_bits, False)
+    cit1 = ti.types.quant.int(10, False)
+    cit2 = ti.types.quant.int(14, False)
+    cft1 = ti.types.quant._custom_float(
         significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quantized_types.type_factory.custom_float(
+    cft2 = ti.types.quant._custom_float(
         significand_type=cit2, exponent_type=exp, scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
@@ -114,12 +114,12 @@ def test_shared_exponent_add(exponent_bits):
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_shared_exponent_borrow(exponent_bits):
-    exp = ti.types.quantized_types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quantized_types.quant.int(10, False)
-    cit2 = ti.types.quantized_types.quant.int(14, False)
-    cft1 = ti.types.quantized_types.type_factory.custom_float(
+    exp = ti.types.quant.int(exponent_bits, False)
+    cit1 = ti.types.quant.int(10, False)
+    cit2 = ti.types.quant.int(14, False)
+    cft1 = ti.types.quant._custom_float(
         significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quantized_types.type_factory.custom_float(
+    cft2 = ti.types.quant._custom_float(
         significand_type=cit2, exponent_type=exp, scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
@@ -145,12 +145,12 @@ def test_shared_exponent_borrow(exponent_bits):
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_negative(exponent_bits):
-    exp = ti.types.quantized_types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quantized_types.quant.int(10, False)
-    cit2 = ti.types.quantized_types.quant.int(14, True)
-    cft1 = ti.types.quantized_types.type_factory.custom_float(
+    exp = ti.types.quant.int(exponent_bits, False)
+    cit1 = ti.types.quant.int(10, False)
+    cit2 = ti.types.quant.int(14, True)
+    cft1 = ti.types.quant._custom_float(
         significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quantized_types.type_factory.custom_float(
+    cft2 = ti.types.quant._custom_float(
         significand_type=cit2, exponent_type=exp, scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)

--- a/tests/python/test_custom_float_shared_exp.py
+++ b/tests/python/test_custom_float_shared_exp.py
@@ -11,10 +11,12 @@ def test_shared_exponents(exponent_bits):
     exp = ti.types.quant.int(exponent_bits, False)
     cit1 = ti.types.quant.int(10, False)
     cit2 = ti.types.quant.int(14, False)
-    cft1 = ti.types.quant._custom_float(
-        significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quant._custom_float(
-        significand_type=cit2, exponent_type=exp, scale=1)
+    cft1 = ti.types.quant._custom_float(significand_type=cit1,
+                                        exponent_type=exp,
+                                        scale=1)
+    cft2 = ti.types.quant._custom_float(significand_type=cit2,
+                                        exponent_type=exp,
+                                        scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)
@@ -79,10 +81,12 @@ def test_shared_exponent_add(exponent_bits):
     exp = ti.types.quant.int(exponent_bits, False)
     cit1 = ti.types.quant.int(10, False)
     cit2 = ti.types.quant.int(14, False)
-    cft1 = ti.types.quant._custom_float(
-        significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quant._custom_float(
-        significand_type=cit2, exponent_type=exp, scale=1)
+    cft1 = ti.types.quant._custom_float(significand_type=cit1,
+                                        exponent_type=exp,
+                                        scale=1)
+    cft2 = ti.types.quant._custom_float(significand_type=cit2,
+                                        exponent_type=exp,
+                                        scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)
@@ -117,10 +121,12 @@ def test_shared_exponent_borrow(exponent_bits):
     exp = ti.types.quant.int(exponent_bits, False)
     cit1 = ti.types.quant.int(10, False)
     cit2 = ti.types.quant.int(14, False)
-    cft1 = ti.types.quant._custom_float(
-        significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quant._custom_float(
-        significand_type=cit2, exponent_type=exp, scale=1)
+    cft1 = ti.types.quant._custom_float(significand_type=cit1,
+                                        exponent_type=exp,
+                                        scale=1)
+    cft2 = ti.types.quant._custom_float(significand_type=cit2,
+                                        exponent_type=exp,
+                                        scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)
@@ -148,10 +154,12 @@ def test_negative(exponent_bits):
     exp = ti.types.quant.int(exponent_bits, False)
     cit1 = ti.types.quant.int(10, False)
     cit2 = ti.types.quant.int(14, True)
-    cft1 = ti.types.quant._custom_float(
-        significand_type=cit1, exponent_type=exp, scale=1)
-    cft2 = ti.types.quant._custom_float(
-        significand_type=cit2, exponent_type=exp, scale=1)
+    cft1 = ti.types.quant._custom_float(significand_type=cit1,
+                                        exponent_type=exp,
+                                        scale=1)
+    cft2 = ti.types.quant._custom_float(significand_type=cit2,
+                                        exponent_type=exp,
+                                        scale=1)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)

--- a/tests/python/test_custom_float_time_integration.py
+++ b/tests/python/test_custom_float_time_integration.py
@@ -16,8 +16,9 @@ def test_custom_float_time_integration(use_cft, use_exponent, use_shared_exp):
         if use_exponent:
             exp = ti.types.quant.int(6, False)
             cit = ti.types.quant.int(13, True)
-            cft = ti.types.quant._custom_float(
-                significand_type=cit, exponent_type=exp, scale=1)
+            cft = ti.types.quant._custom_float(significand_type=cit,
+                                               exponent_type=exp,
+                                               scale=1)
             x = ti.Vector.field(2, dtype=cft)
             if use_shared_exp:
                 ti.root.bit_struct(num_bits=32).place(x, shared_exponent=True)
@@ -26,8 +27,8 @@ def test_custom_float_time_integration(use_cft, use_exponent, use_shared_exp):
                 ti.root.bit_struct(num_bits=32).place(x.get_scalar_field(1))
         else:
             cit = ti.types.quant.int(16, True)
-            cft = ti.types.quant._custom_float(
-                significand_type=cit, scale=1 / 2**14)
+            cft = ti.types.quant._custom_float(significand_type=cit,
+                                               scale=1 / 2**14)
             x = ti.Vector.field(2, dtype=cft)
             ti.root.bit_struct(num_bits=32).place(x)
     else:

--- a/tests/python/test_custom_float_time_integration.py
+++ b/tests/python/test_custom_float_time_integration.py
@@ -14,9 +14,9 @@ from tests import test_utils
 def test_custom_float_time_integration(use_cft, use_exponent, use_shared_exp):
     if use_cft:
         if use_exponent:
-            exp = ti.types.quantized_types.quant.int(6, False)
-            cit = ti.types.quantized_types.quant.int(13, True)
-            cft = ti.types.quantized_types.type_factory.custom_float(
+            exp = ti.types.quant.int(6, False)
+            cit = ti.types.quant.int(13, True)
+            cft = ti.types.quant._custom_float(
                 significand_type=cit, exponent_type=exp, scale=1)
             x = ti.Vector.field(2, dtype=cft)
             if use_shared_exp:
@@ -25,8 +25,8 @@ def test_custom_float_time_integration(use_cft, use_exponent, use_shared_exp):
                 ti.root.bit_struct(num_bits=32).place(x.get_scalar_field(0))
                 ti.root.bit_struct(num_bits=32).place(x.get_scalar_field(1))
         else:
-            cit = ti.types.quantized_types.quant.int(16, True)
-            cft = ti.types.quantized_types.type_factory.custom_float(
+            cit = ti.types.quant.int(16, True)
+            cft = ti.types.quant._custom_float(
                 significand_type=cit, scale=1 / 2**14)
             x = ti.Vector.field(2, dtype=cft)
             ti.root.bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_int.py
+++ b/tests/python/test_custom_int.py
@@ -4,7 +4,7 @@ from tests import test_utils
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_int_implicit_cast():
-    ci13 = ti.types.quantized_types.quant.int(13, True)
+    ci13 = ti.types.quant.int(13, True)
     x = ti.field(dtype=ci13)
 
     ti.root.bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_type_atomics.py
+++ b/tests/python/test_custom_type_atomics.py
@@ -9,9 +9,9 @@ from tests import test_utils
                  exclude=[ti.metal],
                  debug=True)
 def test_custom_int_atomics():
-    ci13 = ti.types.quantized_types.quant.int(13, True)
-    ci5 = ti.types.quantized_types.quant.int(5, True)
-    cu2 = ti.types.quantized_types.quant.int(2, False)
+    ci13 = ti.types.quant.int(13, True)
+    ci5 = ti.types.quant.int(5, True)
+    cu2 = ti.types.quant.int(2, False)
 
     x = ti.field(dtype=ci13)
     y = ti.field(dtype=ci5)
@@ -44,7 +44,7 @@ def test_custom_int_atomics():
 @test_utils.test(require=[ti.extension.quant_basic, ti.extension.data64],
                  debug=True)
 def test_custom_int_atomics_b64():
-    ci13 = ti.types.quantized_types.quant.int(13, True)
+    ci13 = ti.types.quant.int(13, True)
 
     x = ti.field(dtype=ci13)
 
@@ -68,12 +68,10 @@ def test_custom_int_atomics_b64():
 
 @test_utils.test(require=ti.extension.quant_basic, debug=True)
 def test_custom_float_atomics():
-    ci13 = ti.types.quantized_types.quant.int(13, True)
-    ci19 = ti.types.quantized_types.quant.int(19, False)
-    cft13 = ti.types.quantized_types.type_factory.custom_float(
-        significand_type=ci13, scale=0.1)
-    cft19 = ti.types.quantized_types.type_factory.custom_float(
-        significand_type=ci19, scale=0.1)
+    ci13 = ti.types.quant.int(13, True)
+    ci19 = ti.types.quant.int(19, False)
+    cft13 = ti.types.quant._custom_float(significand_type=ci13, scale=0.1)
+    cft19 = ti.types.quant._custom_float(significand_type=ci19, scale=0.1)
 
     x = ti.field(dtype=cft13)
     y = ti.field(dtype=cft19)

--- a/tests/python/test_matrix_different_type.py
+++ b/tests/python/test_matrix_different_type.py
@@ -70,10 +70,10 @@ def test_matrix():
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_type():
-    cit1 = ti.types.quantized_types.quant.int(bits=10, signed=True)
-    cft1 = ti.types.quantized_types.type_factory.custom_float(cit1, scale=0.1)
-    cit2 = ti.types.quantized_types.quant.int(bits=22, signed=False)
-    cft2 = ti.types.quantized_types.type_factory.custom_float(cit2, scale=0.1)
+    cit1 = ti.types.quant.int(bits=10, signed=True)
+    cft1 = ti.types.quant._custom_float(cit1, scale=0.1)
+    cit2 = ti.types.quant.int(bits=22, signed=False)
+    cft2 = ti.types.quant._custom_float(cit2, scale=0.1)
     type_list = [[cit1, cft2], [cft1, cit2]]
     a = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list)
     b = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list)

--- a/tests/python/test_snode_layout_inspection.py
+++ b/tests/python/test_snode_layout_inspection.py
@@ -41,10 +41,9 @@ def test_primitives():
 
 @test_utils.test(arch=ti.cpu)
 def test_bit_struct():
-    cit = ti.types.quantized_types.quant.int(16, False)
+    cit = ti.types.quant.int(16, False)
     x = ti.field(dtype=cit)
-    y = ti.field(dtype=ti.types.quantized_types.type_factory.custom_float(
-        significand_type=cit))
+    y = ti.field(dtype=ti.types.quant._custom_float(significand_type=cit))
     z = ti.field(dtype=ti.f32)
 
     n1 = ti.root.dense(ti.i, 32)

--- a/tests/python/test_struct_for.py
+++ b/tests/python/test_struct_for.py
@@ -267,7 +267,7 @@ def test_struct_for_pointer_block():
 def test_struct_for_quant():
     n = 8
 
-    ci13 = ti.types.quantized_types.quant.int(13, True)
+    ci13 = ti.types.quant.int(13, True)
     x = ti.field(dtype=ci13)
 
     ti.root.dense(ti.i, n).bit_struct(num_bits=32).place(x)


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/4857#issuecomment-1122134432

This PR mainly corresponds to Subtask A.1. After this PR, for type definitions of quantized types, we provide public APIs `ti.types.quant.int/fixed/float` and private APIs `ti.types.quant._custom_int/_custom_float`. There are no more `Quant` or `TypeFactory` classes in Python - these APIs are put directly under the `quantized_types` module, which is now imported as `quant`. All usages in the codebase are replaced.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/lang/articles/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/lang/articles/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
