### PR TITLE
[Lang] Struct Classes implementation

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -210,6 +210,18 @@ def make_tensor_element_expr(_var, _indices, shape, stride):
                                           shape, stride))
 
 
+class SrcInfoGuard:
+    def __init__(self, info_stack, info):
+        self.info_stack = info_stack
+        self.info = info
+
+    def __enter__(self):
+        self.info_stack.append(self.info)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.info_stack.pop()
+
+
 class PyTaichi:
     def __init__(self, kernels=None):
         self.materialized = False
@@ -230,6 +242,12 @@ class PyTaichi:
 
     def get_num_compiled_functions(self):
         return len(self.compiled_functions) + len(self.compiled_grad_functions)
+
+    def src_info_guard(self, info):
+        return SrcInfoGuard(self.src_info_stack, info)
+
+    def get_current_src_info(self):
+        return self.src_info_stack[-1]
 
     def set_default_fp(self, fp):
         assert fp in [f16, f32, f64]

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -23,7 +23,7 @@ class Struct(TaichiOperations):
     Args:
         entries (Dict[str, Union[Dict, Expr, Matrix, Struct]]): \
             keys and values for struct members. Entries can optionally
-            include a dictionary of functions with the key '__struct_methods' 
+            include a dictionary of functions with the key '__struct_methods'
             which will be attached to the struct for executing on the struct data.
 
     Returns:

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -6,7 +6,6 @@ from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
-from taichi.lang.kernel_impl import func
 from taichi.lang.matrix import Matrix
 from taichi.lang.util import (cook_dtype, in_python_scope, is_taichi_class,
                               python_scope, taichi_scope)
@@ -108,9 +107,6 @@ class Struct(TaichiOperations):
         for name, method in self.methods.items():
             # use MethodType to pass self (this object) to the method
             setattr(self, name, MethodType(method, self))
-            if getattr(method, '_is_taichi_function', False) is True:
-                # mark as a taichi function
-                func(getattr(self, name))
 
     def __getitem__(self, key):
         ret = self.entries[key]
@@ -700,7 +696,7 @@ def struct_class(cls):
     fields = cls.__annotations__
     # get the class methods to be attached to the struct types
     fields['__struct_methods'] = {
-        attribute: ti.func(getattr(cls, attribute))
+        attribute: getattr(cls, attribute)
         for attribute in dir(cls)
         if callable(getattr(cls, attribute)) and not attribute.startswith('__')
     }

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -689,7 +689,8 @@ def struct_class(cls):
         >>>     @ti.func
         >>>     def area(self):
         >>>         return 4 * 3.14 * self.radius * self.radius
-        >>> my_spheres = Sphere.field(shape=(n,))
+        >>>
+        >>> my_spheres = Sphere.field(shape=(n, ))
         >>> my_sphere[2].area()
 
     Args:

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -666,7 +666,7 @@ class StructType(CompoundType):
 
 
 def struct_class(cls):
-    ''' Turns a Class with field annotations into a struct type for use as a data field
+    ''' Converts a class with field annotations into a struct type for use as a taichi field
         ex:
 
         @ti.stuct_class
@@ -678,15 +678,23 @@ def struct_class(cls):
             def area(self):
                 return 4 * 3.14 * self.radius * self.radius
 
-        Classes with this decorator can be treated as a normal taichi struct, and fields generated
-        from them.  Functions in the class can be run on the struct instance.
+        This will return a normal custom struct type, with the functions added to it.
+        Struct fields can be generated in the normal way from the struct type.
+        Functions in the class can be run on the struct instance.
 
         my_spheres = Sphere.field(shape=(n,))
         my_sphere[2].area()
 
         This class decorator inspects the class for annotations and methods and
             1.  Sets the annotations as fields for the struct
-            2.  Attaches the methods to __struct_methods
+            2.  Attaches the methods to the struct type
+
+        Args:
+            cls (Class): the class with annotations and methods to convert
+
+        Returns:
+            A custom taichi struct with the annotations as fields
+            and methods from the class attached.
      '''
     # save the annotaion fields for the struct
     fields = cls.__annotations__

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -669,7 +669,7 @@ class StructType(CompoundType):
 
 
 def struct_class(cls):
-    """ Converts a class with field annotations into a struct type for use as a taichi field
+    """Converts a class with field annotations and methods into a taichi struct type.
 
     This will return a normal custom struct type, with the functions added to it.
     Struct fields can be generated in the normal way from the struct type.

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -1,18 +1,18 @@
 import numbers
 from functools import partial
+from types import MethodType
 
 from taichi.lang import expr, impl, ops
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
+from taichi.lang.kernel_impl import func
 from taichi.lang.matrix import Matrix
 from taichi.lang.util import (cook_dtype, in_python_scope, is_taichi_class,
                               python_scope, taichi_scope)
 from taichi.types import primitive_types
 from taichi.types.compound_types import CompoundType
-from taichi.lang.kernel_impl import func
-from types import MethodType
 
 
 class Struct(TaichiOperations):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -250,6 +250,7 @@ class Struct(TaichiOperations):
         Args:
             include_methods (bool): Whether any struct methods should be included
                 in the result dictionary under the key '__struct_methods'.
+
         Returns:
             Dict: The result dictionary.
         """

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -83,10 +83,10 @@ user_api[ti] = [
     'randn', 'random', 'raw_div', 'raw_mod', 'ref', 'rescale_index', 'reset',
     'rgb_to_hex', 'root', 'round', 'rsqrt', 'select', 'set_logging_level',
     'simt', 'sin', 'solve', 'sparse_matrix_builder', 'sqrt', 'static',
-    'static_assert', 'static_print', 'stop_grad', 'svd', 'swizzle_generator',
-    'sym_eig', 'sync', 'tan', 'tanh', 'template', 'tools', 'types', 'u16',
-    'u32', 'u64', 'u8', 'ui', 'uint16', 'uint32', 'uint64', 'uint8', 'vulkan',
-    'wasm', 'x64', 'x86_64', 'zero'
+    'static_assert', 'static_print', 'stop_grad', 'struct_class', 'svd',
+    'swizzle_generator', 'sym_eig', 'sync', 'tan', 'tanh', 'template', 'tools',
+    'types', 'u16', 'u32', 'u64', 'u8', 'ui', 'uint16', 'uint32', 'uint64',
+    'uint8', 'vulkan', 'wasm', 'x64', 'x86_64', 'zero'
 ]
 user_api[ti.Field] = [
     'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -205,6 +205,43 @@ def test_struct_type():
 
 
 @test_utils.test()
+def test_struct_class():
+    # example struct class type
+    vec3f = ti.types.vector(3, float)
+    @ti.struct_class
+    class Sphere:
+        center: vec3f
+        radius: ti.f32
+
+        @ti.func
+        def area(self):
+            return 4 * 3.14 * self.radius * self.radius
+
+        def py_scope_area(self):
+            return 4 * 3.14 * self.radius * self.radius
+
+    # test function usage from python scope
+    assert np.isclose(Sphere(center=vec3f(0.0), radius=2.0).py_scope_area(), 4.0 * 3.14 * 4.0)
+
+    # test function usage from taichi scope
+    @ti.kernel
+    def get_area() -> ti.f32:
+        sphere = Sphere(center=vec3f(0.0), radius=2.0)
+        return sphere.area()
+
+    assert np.isclose(get_area(), 4.0 * 3.14 * 4.0)
+
+    # test function usage from taichi scope with field
+    struct_field = Sphere.field(shape=(4,))
+    struct_field[3] = Sphere(center=vec3f(0.0), radius=2.0)
+
+    @ti.kernel
+    def get_area_field() -> ti.f32:
+        return struct_field[3].area()
+
+    assert np.isclose(get_area_field(), 4.0 * 3.14 * 4.0)
+
+@test_utils.test()
 def test_struct_assign():
     n = 32
     vec3f = ti.types.vector(3, float)


### PR DESCRIPTION
Related issue = #4965

### TLDR.  Turns this:
```python
@ti.struct_class
class Sphere:
    center: vec3
    radius: ti.f32

    @ti.func
    def area(self):
        return 4 * 3.14 * self.radius * self.radius
```
Into a taichi struct (with methods!)

As discussed in the issue, this is a (draft) Pull request to implement `struct_classes`.  
`struct_class` is a decorator that can be attached to a python class definition that allows two things:

1.  Class field annotations are turned into struct fields (inspired by python Dataclasses)
2.  Class methods are attached to the struct and used like class methods.

IMO this allows a better syntax for structs and of course allows the struct methods.  Additionally it might ease much of what people would do with `ti.data_oriented` for complex arrays of structures in classes.  

**NOTE THIS IS A DRAFT PR**.  I am looking for feedback of the style and naming.  Also note I copied this from my working version so might need tweaking to work on your side.

### **Some technical notes**. 
There are basically two main things added here:
1.  Struct python type https://github.com/taichi-dev/taichi/blob/09de043b1e5fc522d642e7fb14a9dfed3283c8f3/python/taichi/lang/struct.py#L15 now can handle an optional `__struct_methods` object passed to it which contains the methods attached to the struct type.  I am open to other suggestions how to handle this.  But it should not have much overhead as the struct methods are only kept on the python side.  
2.  The new class decorator that turns a class with annotations fields into a struct and passes the methods.


### Example to test
```python
@ti.struct_class
class Sphere:
    center: vec3
    radius: ti.f32

    @ti.func
    def area(self):
        return 4 * 3.14 * self.radius * self.radius

n = 10
my_spheres = Sphere.field(shape=(n,))
print(my_spheres.radius)

# one struct
my_sphere = Sphere(center=vec3(2.0, 1.0, 9.0), radius=4.0)
# add to field
my_spheres[4] = my_sphere
print('done setup')

@ti.kernel
def kernel():
    sphere = my_spheres[4]
    center = sphere.center
    rad = sphere.radius
    area = sphere.area()
    
kernel()
```