### PR TITLE
[refactor] Program owns allocated ndarrays.

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -16,8 +16,8 @@ class Ndarray:
     def __init__(self, dtype, arr_shape):
         self.host_accessor = None
         self.dtype = cook_dtype(dtype)
-        self.arr = _ti_core.Ndarray(impl.get_runtime().prog, cook_dtype(dtype),
-                                    arr_shape)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            cook_dtype(dtype), arr_shape)
 
     @property
     def element_shape(self):

--- a/taichi/backends/opengl/opengl_program.cpp
+++ b/taichi/backends/opengl/opengl_program.cpp
@@ -40,10 +40,6 @@ DeviceAllocation OpenglProgramImpl::allocate_memory_ndarray(
        /*export_sharing=*/false});
 }
 
-std::shared_ptr<Device> OpenglProgramImpl::get_device_shared() {
-  return opengl_runtime_->device;
-}
-
 void OpenglProgramImpl::compile_snode_tree_types(SNodeTree *tree) {
   // TODO: support materializing multiple snode trees
   opengl::OpenglStructCompiler scomp;

--- a/taichi/backends/opengl/opengl_program.h
+++ b/taichi/backends/opengl/opengl_program.h
@@ -43,8 +43,6 @@ class OpenglProgramImpl : public ProgramImpl {
   DeviceAllocation allocate_memory_ndarray(std::size_t alloc_size,
                                            uint64 *result_buffer) override;
 
-  std::shared_ptr<Device> get_device_shared() override;
-
   std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
 
   void destroy_snode_tree(SNodeTree *snode_tree) override {

--- a/taichi/backends/vulkan/vulkan_program.cpp
+++ b/taichi/backends/vulkan/vulkan_program.cpp
@@ -178,15 +178,12 @@ std::unique_ptr<AotModuleBuilder> VulkanProgramImpl::make_aot_module_builder() {
 DeviceAllocation VulkanProgramImpl::allocate_memory_ndarray(
     std::size_t alloc_size,
     uint64 *result_buffer) {
-  auto &ndarray =
-      ref_ndarry_.emplace_back(get_compute_device()->allocate_memory_unique(
-          {alloc_size, /*host_write=*/false, /*host_read=*/false,
-           /*export_sharing=*/false}));
-  return *ndarray;
+  return get_compute_device()->allocate_memory(
+      {alloc_size, /*host_write=*/false, /*host_read=*/false,
+       /*export_sharing=*/false});
 }
 
 VulkanProgramImpl::~VulkanProgramImpl() {
-  ref_ndarry_.clear();
   vulkan_runtime_.reset();
   embedded_device_.reset();
 }

--- a/taichi/backends/vulkan/vulkan_program.h
+++ b/taichi/backends/vulkan/vulkan_program.h
@@ -89,9 +89,6 @@ class VulkanProgramImpl : public ProgramImpl {
   std::unique_ptr<vulkan::VkRuntime> vulkan_runtime_{nullptr};
   std::unique_ptr<vulkan::SNodeTreeManager> snode_tree_mgr_{nullptr};
   std::vector<spirv::CompiledSNodeStructs> aot_compiled_snode_structs_;
-
-  // This is a hack until NDArray is properlly owned by programs
-  std::vector<std::unique_ptr<DeviceAllocationGuard>> ref_ndarry_;
 };
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -615,10 +615,6 @@ DeviceAllocation LlvmProgramImpl::allocate_memory_ndarray(
        result_buffer});
 }
 
-std::shared_ptr<Device> LlvmProgramImpl::get_device_shared() {
-  return device_;
-}
-
 uint64_t *LlvmProgramImpl::get_ndarray_alloc_info_ptr(
     const DeviceAllocation &alloc) {
   if (config->arch == Arch::cuda) {

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -107,8 +107,6 @@ class LlvmProgramImpl : public ProgramImpl {
 
   uint64_t *get_ndarray_alloc_info_ptr(const DeviceAllocation &alloc);
 
-  std::shared_ptr<Device> get_device_shared() override;
-
   void fill_ndarray(const DeviceAllocation &alloc,
                     std::size_t size,
                     uint32_t data);

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -22,7 +22,7 @@ Ndarray::Ndarray(Program *prog,
                                 1,
                                 std::multiplies<>())),
       element_size_(data_type_size(dtype)),
-      device_(prog->get_device_shared()),
+      prog_(prog),
       prog_impl_(prog->get_llvm_program_impl()),
       rw_accessors_bank_(&prog->get_ndarray_rw_accessors_bank()) {
   ndarray_alloc_ = prog->allocate_memory_ndarray(nelement_ * element_size_,
@@ -39,8 +39,8 @@ Ndarray::Ndarray(Program *prog,
 }
 
 Ndarray::~Ndarray() {
-  if (device_) {
-    device_->dealloc_memory(ndarray_alloc_);
+  if (prog_) {
+    ndarray_alloc_.device->dealloc_memory(ndarray_alloc_);
   }
 }
 

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -42,20 +42,17 @@ class Ndarray {
   ~Ndarray();
 
  private:
+  void buffer_fill(uint32_t val);
+
   DeviceAllocation ndarray_alloc_{kDeviceNullAllocation};
   // Invariant:
   //   data_ptr_ is not nullptr iff arch is a llvm backend
   uint64_t *data_ptr_{nullptr};
   std::size_t nelement_{1};
   std::size_t element_size_{1};
-  // Ndarrays manage their own |DeviceAllocation| so this must be shared with
-  // |OpenGlRuntime|. Without the ownership, when the program exits |device_|
-  // might be destructed earlier than Ndarray object, leaving a segfault when
-  // you try to deallocate in Ndarray destructor.
-  // Note that we might consider changing this logic later if we implement
-  // dynamic tensor rematerialization.
-  std::shared_ptr<Device> device_{nullptr};
-  void buffer_fill(uint32_t val);
+
+  Program *prog_{nullptr};
+  // TODO: maybe remove these?
   LlvmProgramImpl *prog_impl_{nullptr};
   NdarrayRwAccessorsBank *rw_accessors_bank_{nullptr};
 };

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -553,6 +553,12 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
                                                             result_buffer);
 }
 
+Ndarray *Program::create_ndarray(const DataType type,
+                                 const std::vector<int> &shape) {
+  ndarrays_.emplace_back(std::make_unique<Ndarray>(this, type, shape));
+  return ndarrays_.back().get();
+}
+
 Program::~Program() {
   if (!finalized_)
     finalize();

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -311,16 +311,13 @@ class TI_DLL_EXPORT Program {
     return program_impl_->get_graphics_device();
   }
 
-  std::shared_ptr<Device> get_device_shared() {
-    return program_impl_->get_device_shared();
-  }
-
   // TODO: do we still need result_buffer?
   DeviceAllocation allocate_memory_ndarray(std::size_t alloc_size,
                                            uint64 *result_buffer) {
     return program_impl_->allocate_memory_ndarray(alloc_size, result_buffer);
   }
 
+  Ndarray *create_ndarray(const DataType type, const std::vector<int> &shape);
   ASTBuilder *current_ast_builder() {
     return current_callable ? &current_callable->context->builder() : nullptr;
   }
@@ -351,6 +348,7 @@ class TI_DLL_EXPORT Program {
   bool finalized_{false};
 
   std::unique_ptr<MemoryPool> memory_pool_{nullptr};
+  std::vector<std::unique_ptr<Ndarray>> ndarrays_;
 };
 
 }  // namespace lang

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -80,10 +80,6 @@ class ProgramImpl {
     return nullptr;
   }
 
-  virtual std::shared_ptr<Device> get_device_shared() {
-    return nullptr;
-  }
-
   virtual DevicePtr get_snode_tree_device_ptr(int tree_id) {
     return kDeviceNullPtr;
   }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -416,6 +416,13 @@ void export_lang(py::module &m) {
            [](Program *program, const std::string &name) {
              return Expr::make<IdExpression>(program->get_next_global_id(name));
            })
+      .def(
+          "create_ndarray",
+          [&](Program *program, const DataType &dt,
+              const std::vector<int> &shape) -> Ndarray * {
+            return program->create_ndarray(dt, shape);
+          },
+          py::return_value_policy::reference)
       .def("global_var_expr_from_snode", [](Program *program, SNode *snode) {
         return Expr::make<GlobalVariableExpression>(
             snode, program->get_next_global_id());
@@ -495,7 +502,6 @@ void export_lang(py::module &m) {
       });
 
   py::class_<Ndarray>(m, "Ndarray")
-      .def(py::init<Program *, const DataType &, const std::vector<int> &>())
       .def("data_ptr", &Ndarray::get_data_ptr_as_int)
       .def("device_allocation_ptr", &Ndarray::get_device_allocation_ptr_as_int)
       .def("element_size", &Ndarray::get_element_size)

--- a/taichi/runtime/opengl/opengl_api.cpp
+++ b/taichi/runtime/opengl/opengl_api.cpp
@@ -543,7 +543,7 @@ DeviceCompiledTaichiKernel::DeviceCompiledTaichiKernel(
 OpenGlRuntime::OpenGlRuntime() {
   initialize_opengl();
 
-  device = std::make_shared<GLDevice>();
+  device = std::make_unique<GLDevice>();
 
   impl = std::make_unique<OpenGlRuntimeImpl>();
 

--- a/taichi/runtime/opengl/opengl_kernel_launcher.h
+++ b/taichi/runtime/opengl/opengl_kernel_launcher.h
@@ -17,7 +17,7 @@ class GLBuffer;
 class DeviceCompiledTaichiKernel;
 
 struct OpenGlRuntime {
-  std::shared_ptr<Device> device{nullptr};
+  std::unique_ptr<Device> device{nullptr};
   std::unique_ptr<OpenGlRuntimeImpl> impl{nullptr};
   std::vector<std::unique_ptr<DeviceAllocationGuard>> saved_arg_bufs;
   OpenGlRuntime();

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -273,7 +273,7 @@ def test_torch_zero():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan])
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.opengl, ti.vulkan])
 def test_torch_view():
     @ti.kernel
     def copy(x: ti.types.ndarray(), y: ti.types.ndarray()):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5004
* #5002
* #4999
* #4998
* #4997
* __->__ #4996

The end goal of this refactor is let Ndarray be a simple wrapper around
(DeviceAllocation, dtype, shape) without having to worry about memory
allocation/deallocation. But its current implementation heavily couples
with Program*, so an intermediate state would be:
- If created from Program, Ndarray handles deviceallocation in
ctor/dtor.
- We'll add another ctor simply constructing Ndarray from
(DeviceAllocation, dtype, shape) and update the codebase to it.