### PR TITLE
[refactor] Free ndarray's memory when python GC triggers

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -18,6 +18,19 @@ class Ndarray:
         self.dtype = cook_dtype(dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
             cook_dtype(dtype), arr_shape)
+        self.gen = impl.get_generation()
+
+    def __del__(self):
+        # - impl.get_runtime().prog == None:
+        #   ti.reset() is called but ti.init() isn't re-initialized yet.
+        #   At this point all ndarrays allocated in the previous program
+        #   are freed along with program destruction.
+        # - impl.get_generation() != self.gen
+        #   This ndarray was created from previous prog which was destructed.
+        #   So its memory was freed already.
+        if impl.get_runtime().prog is not None and impl.get_generation(
+        ) == self.gen:
+            impl.get_runtime().prog.delete_ndarray(self.arr)
 
     @property
     def element_shape(self):

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -18,7 +18,7 @@ class Ndarray:
         self.dtype = cook_dtype(dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
             cook_dtype(dtype), arr_shape)
-        self.gen = impl.get_generation()
+        self._gen = impl.get_runtime().generation
 
     def __del__(self):
         # - impl.get_runtime().prog == None:
@@ -28,8 +28,8 @@ class Ndarray:
         # - impl.get_generation() != self.gen
         #   This ndarray was created from previous prog which was destructed.
         #   So its memory was freed already.
-        if impl.get_runtime().prog is not None and impl.get_generation(
-        ) == self.gen:
+        if impl.get_runtime().prog is not None and impl.get_runtime(
+        ).generation == self._gen:
             impl.get_runtime().prog.delete_ndarray(self.arr)
 
     @property

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -1,4 +1,5 @@
 import numbers
+from itertools import count
 from types import FunctionType, MethodType
 from typing import Iterable
 
@@ -223,6 +224,8 @@ class SrcInfoGuard:
 
 
 class PyTaichi:
+    _gen = count(0)
+
     def __init__(self, kernels=None):
         self.materialized = False
         self.prog = None
@@ -239,6 +242,7 @@ class PyTaichi:
         self.grad_replaced = False
         self.kernels = kernels or []
         self._signal_handler_registry = None
+        self.generation = next(self._gen)
 
     def get_num_compiled_functions(self):
         return len(self.compiled_functions) + len(self.compiled_grad_functions)
@@ -355,20 +359,10 @@ def get_runtime():
     return pytaichi
 
 
-generation = 0
-
-
-def get_generation():
-    global generation
-    return generation
-
-
 def reset():
     global pytaichi
-    global generation
     old_kernels = pytaichi.kernels
     pytaichi.clear()
-    generation += 1
     pytaichi = PyTaichi(old_kernels)
     for k in old_kernels:
         k.reset()

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -355,10 +355,20 @@ def get_runtime():
     return pytaichi
 
 
+generation = 0
+
+
+def get_generation():
+    global generation
+    return generation
+
+
 def reset():
     global pytaichi
+    global generation
     old_kernels = pytaichi.kernels
     pytaichi.clear()
+    generation += 1
     pytaichi = PyTaichi(old_kernels)
     for k in old_kernels:
         k.reset()

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -318,6 +318,7 @@ class TI_DLL_EXPORT Program {
   }
 
   Ndarray *create_ndarray(const DataType type, const std::vector<int> &shape);
+  void delete_ndarray(Ndarray *ndarray);
   ASTBuilder *current_ast_builder() {
     return current_callable ? &current_callable->context->builder() : nullptr;
   }
@@ -348,7 +349,7 @@ class TI_DLL_EXPORT Program {
   bool finalized_{false};
 
   std::unique_ptr<MemoryPool> memory_pool_{nullptr};
-  std::vector<std::unique_ptr<Ndarray>> ndarrays_;
+  std::unordered_map<void *, std::unique_ptr<Ndarray>> ndarrays_;
 };
 
 }  // namespace lang

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -423,6 +423,7 @@ void export_lang(py::module &m) {
             return program->create_ndarray(dt, shape);
           },
           py::return_value_policy::reference)
+      .def("delete_ndarray", &Program::delete_ndarray)
       .def("global_var_expr_from_snode", [](Program *program, SNode *snode) {
         return Expr::make<GlobalVariableExpression>(
             snode, program->get_next_global_id());

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -335,6 +335,15 @@ def test_ndarray_numpy_io():
     _test_ndarray_numpy_io()
 
 
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_reset():
+    n = 8
+    c = ti.Matrix.ndarray(4, 4, ti.f32, shape=(n))
+    del c
+    d = ti.Matrix.ndarray(4, 4, ti.f32, shape=(n))
+    ti.reset()
+
+
 def _test_ndarray_matrix_numpy_io(layout):
     n = 5
     m = 2
@@ -607,3 +616,15 @@ def test_different_shape():
     y = ti.ndarray(dtype=ti.f32, shape=(n2, n2))
     init(3, y)
     assert (y.to_numpy() == (np.ones(shape=(n2, n2)) * 3)).all()
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_generation():
+    curr_arch = ti.lang.impl.current_cfg().arch
+    n1 = 4
+    x = ti.ndarray(dtype=ti.f32, shape=(n1, n1))
+    curr_gen = x.gen
+    ti.reset()  # gen++
+    ti.init(curr_arch)  # calls ti.reset() again, gen++
+    y = ti.ndarray(dtype=ti.f32, shape=(n1, ))
+    assert y.gen == curr_gen + 2

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -623,8 +623,8 @@ def test_generation():
     curr_arch = ti.lang.impl.current_cfg().arch
     n1 = 4
     x = ti.ndarray(dtype=ti.f32, shape=(n1, n1))
-    curr_gen = x.gen
+    curr_gen = x._gen
     ti.reset()  # gen++
-    ti.init(curr_arch)  # calls ti.reset() again, gen++
+    ti.init(curr_arch)  # calls ti.reset(), gen++
     y = ti.ndarray(dtype=ti.f32, shape=(n1, ))
-    assert y.gen == curr_gen + 2
+    assert y._gen == curr_gen + 2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5004
* #5002
* __->__ #4999
* #4998
* #4997
* #4996

Previously Program manages lifetime of all allocated ndarrays. So when
you call `del ndarray` in python, its memory was not freed. This PR
changes the behavior that `ndarray` memory gets deallocated when python
GC triggers, or its containing `Program` gets destructed, whichever
happens first. There're some quirks around how we handle the async
python GC and manual `ti.reset()`. Thanks to @k-ye, we now added a
`generation` number to track the containing program instance of ndarrays
so that memory deallocation happens correctly.