### PR TITLE
[AOT] Supported inclusion of taichi as subdirectory for AOT modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,9 @@ if (${CLANG_VERSION_MAJOR} VERSION_GREATER ${CLANG_HIGHEST_VERSION})
   endif()
 endif()
 
-add_subdirectory(taichi/runtime/llvm)
+if (TI_WITH_LLVM)
+  add_subdirectory(taichi/runtime/llvm)
+endif()
 
 configure_file(taichi/common/version.h.in ${CMAKE_SOURCE_DIR}/taichi/common/version.h)
 configure_file(taichi/common/commit_hash.h.in ${CMAKE_SOURCE_DIR}/taichi/common/commit_hash.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,10 @@ if (WIN32)
   SET(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 endif()
 
-# No support of Python for Android build
-if (NOT ANDROID)
+# No support of Python for Android build; or in any case taichi is integrated
+# in another project as submodule.
+option(TI_WITH_PYTHON "Build with Python language binding" ON)
+if (TI_WITH_PYTHON AND NOT ANDROID)
     include(cmake/PythonNumpyPybind11.cmake)
 endif()
 include(cmake/TaichiCXXFlags.cmake)

--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -52,8 +52,10 @@ else()
 
 # Due to limited CI coverage, -Werror is only turned on with Clang-compiler for now.
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    # [Global] CXX compilation option to treat all warnings as errors.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror ")
+    if (NOT ANDROID) # (penguinliong) Blocking builds on Android.
+        # [Global] CXX compilation option to treat all warnings as errors.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror ")
+    endif()
 endif()
 
     # [Global] By default, CXX compiler will throw a warning if it decides to ignore an attribute, for example "[[ maybe unused ]]".

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -252,7 +252,7 @@ if (APPLE)
 endif()
 
 # TODO: replace these includes per target basis
-include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(external/include)
 include_directories(external/spdlog/include)
 include_directories(external/glad/include)
@@ -462,7 +462,7 @@ endforeach ()
 
 message("PYTHON_LIBRARIES: " ${PYTHON_LIBRARIES})
 
-if(NOT TI_EMSCRIPTENED)
+if(TI_WITH_PYTHON AND NOT TI_EMSCRIPTENED)
     set(CORE_WITH_PYBIND_LIBRARY_NAME taichi_core)
     # Cannot compile Python source code with Android, but TI_EXPORT_CORE should be set and
     # Android should only use the isolated library ignoring those source code.


### PR DESCRIPTION
- Allowed Python not to be built in case of non-Android platforms;
- Skiped byte code generation when `TI_WITH_LLVM=OFF`;
- Fixed include directory path relativity when included as a subdirectory;
- Temporarily disabled warning-as-error on Android.