### PR TITLE
[bug] Fixed numerical error for Atomic-Sub between unsigned values with different number of bits

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -481,6 +481,11 @@ void AtomicOpExpression::type_check(CompileConfig *) {
 void AtomicOpExpression::flatten(FlattenContext *ctx) {
   // replace atomic sub with negative atomic add
   if (op_type == AtomicOpType::sub) {
+    if (val->ret_type != ret_type) {
+      val.set(Expr::make<UnaryOpExpression>(UnaryOpType::cast_value, val,
+                                            ret_type));
+    }
+
     val.set(Expr::make<UnaryOpExpression>(UnaryOpType::neg, val));
     op_type = AtomicOpType::add;
   }


### PR DESCRIPTION
Related issue = #4986

1. Issue
```
x: ti.uint16 = 1000
y: ti.uint8 = 1
ti.atomic_sub(x, y)
```
The above code gives `x = 1255` instead of 999. 

2. Diagnose
Taichi transforms `atomic_sub(x, y)` into `neg_y = negate(y); atomic_add(x, neg_y)` during `irpass::lower_ast()`, therefore the following type promotion will bit_cast "neg_y" (1's complement of y) into another unsigned integer, which breaks the interpretation of 1's complement.

![](https://user-images.githubusercontent.com/22334008/169048132-fb432174-3f0b-4101-b50a-92db0b1c9b88.png)

3. Solution
We should perform the cast before negating rhs's value.

<img width="342" alt="image" src="https://user-images.githubusercontent.com/22334008/169192642-0617dfe7-5dc5-42bd-85a2-18485025ab68.png">

4. Other comments
Frontend IR does not seem to be a good place for transformations. Shall we write a CHI IR pass for `atomic_sub -> atomic_add` to replace the one inside irpass::lower_ast()?