### PR TITLE
[aot] Build and run graph without serialization

### DIFF
--- a/taichi/aot/graph_data.h
+++ b/taichi/aot/graph_data.h
@@ -1,0 +1,90 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include "taichi/aot/module_data.h"
+
+namespace taichi {
+namespace lang {
+class AotModuleBuilder;
+class Ndarray;
+namespace aot {
+// Currently only scalar and ndarray are supported.
+enum ArgKind { SCALAR, NDARRAY, UNKNOWN };
+
+/*
+ * Symbolic argument used in building `Dispatch` nodes in the `Graph`.
+ */
+struct Arg {
+  std::string name;
+  // TODO: real element dtype = dtype + element_shape
+  std::string dtype_name;
+  ArgKind tag;
+  std::vector<int> element_shape;
+
+  TI_IO_DEF(name, dtype_name, tag, element_shape);
+};
+
+/*
+ * Runtime value used in graph execution.
+ */
+struct IValue {
+ public:
+  uint64 val;
+  ArgKind tag;
+
+  static IValue create(const Ndarray &ndarray) {
+    return IValue(reinterpret_cast<intptr_t>(&ndarray), ArgKind::NDARRAY);
+  }
+
+  template <typename T>
+  static IValue create(T v) {
+    return IValue(taichi_union_cast_with_different_sizes<uint64>(v),
+                  ArgKind::SCALAR);
+  }
+
+ private:
+  IValue(uint64 val, ArgKind tag) : val(val), tag(tag) {
+  }
+};
+class TI_DLL_EXPORT Kernel {
+ public:
+  // Rule of 5 to make MSVC happy
+  Kernel() = default;
+  virtual ~Kernel() = default;
+  Kernel(const Kernel &) = delete;
+  Kernel &operator=(const Kernel &) = delete;
+  Kernel(Kernel &&) = default;
+  Kernel &operator=(Kernel &&) = default;
+
+  /**
+   * @brief Launches the kernel to the device
+   *
+   * This does not manage the device to host synchronization.
+   *
+   * @param ctx Host context
+   */
+  virtual void launch(RuntimeContext *ctx) = 0;
+
+  virtual void save_to_module(AotModuleBuilder *builder) {
+    TI_NOT_IMPLEMENTED;
+  }
+};
+
+struct CompiledDispatch {
+  std::string kernel_name;
+  std::vector<Arg> symbolic_args;
+  Kernel *compiled_kernel{nullptr};
+
+  TI_IO_DEF(kernel_name, symbolic_args);
+};
+
+struct CompiledGraph {
+  std::vector<CompiledDispatch> dispatches;
+
+  TI_IO_DEF(dispatches);
+};
+
+}  // namespace aot
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/aot/graph_data.h
+++ b/taichi/aot/graph_data.h
@@ -10,9 +10,9 @@ class AotModuleBuilder;
 class Ndarray;
 namespace aot {
 // Currently only scalar and ndarray are supported.
-enum ArgKind { SCALAR, NDARRAY, UNKNOWN };
+enum class ArgKind { SCALAR, NDARRAY, UNKNOWN };
 
-/*
+/**
  * Symbolic argument used in building `Dispatch` nodes in the `Graph`.
  */
 struct Arg {
@@ -25,7 +25,7 @@ struct Arg {
   TI_IO_DEF(name, dtype_name, tag, element_shape);
 };
 
-/*
+/**
  * Runtime value used in graph execution.
  */
 struct IValue {
@@ -37,7 +37,8 @@ struct IValue {
     return IValue(reinterpret_cast<intptr_t>(&ndarray), ArgKind::NDARRAY);
   }
 
-  template <typename T>
+  template <typename T,
+            typename = std::enable_if_t<!std::is_same<T, Ndarray>::value, void>>
   static IValue create(T v) {
     return IValue(taichi_union_cast_with_different_sizes<uint64>(v),
                   ArgKind::SCALAR);
@@ -47,6 +48,7 @@ struct IValue {
   IValue(uint64 val, ArgKind tag) : val(val), tag(tag) {
   }
 };
+
 class TI_DLL_EXPORT Kernel {
  public:
   // Rule of 5 to make MSVC happy

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -10,7 +10,7 @@
 #include "taichi/aot/module_data.h"
 #include "taichi/backends/device.h"
 #include "taichi/ir/snode.h"
-#include "taichi/aot/module_data.h"
+#include "taichi/aot/graph_data.h"
 
 namespace taichi {
 namespace lang {
@@ -28,26 +28,6 @@ class TI_DLL_EXPORT Field {
   Field &operator=(const Field &) = delete;
   Field(Field &&) = default;
   Field &operator=(Field &&) = default;
-};
-
-class TI_DLL_EXPORT Kernel {
- public:
-  // Rule of 5 to make MSVC happy
-  Kernel() = default;
-  virtual ~Kernel() = default;
-  Kernel(const Kernel &) = delete;
-  Kernel &operator=(const Kernel &) = delete;
-  Kernel(Kernel &&) = default;
-  Kernel &operator=(Kernel &&) = default;
-
-  /**
-   * @brief Launches the kernel to the device
-   *
-   * This does not manage the device to host synchronization.
-   *
-   * @param ctx Host context
-   */
-  virtual void launch(RuntimeContext *ctx) = 0;
 };
 
 class TI_DLL_EXPORT KernelTemplateArg {

--- a/taichi/backends/vulkan/aot_module_loader_impl.cpp
+++ b/taichi/backends/vulkan/aot_module_loader_impl.cpp
@@ -9,9 +9,6 @@ namespace taichi {
 namespace lang {
 namespace vulkan {
 namespace {
-
-using KernelHandle = VkRuntime::KernelHandle;
-
 class FieldImpl : public aot::Field {
  public:
   explicit FieldImpl(VkRuntime *runtime, const aot::CompiledFieldData &field)
@@ -21,21 +18,6 @@ class FieldImpl : public aot::Field {
  private:
   VkRuntime *const runtime_;
   aot::CompiledFieldData field_;
-};
-
-class KernelImpl : public aot::Kernel {
- public:
-  explicit KernelImpl(VkRuntime *runtime, KernelHandle handle)
-      : runtime_(runtime), handle_(handle) {
-  }
-
-  void launch(RuntimeContext *ctx) override {
-    runtime_->launch_kernel(handle_, ctx);
-  }
-
- private:
-  VkRuntime *const runtime_;
-  const KernelHandle handle_;
 };
 
 class AotModuleImpl : public aot::Module {
@@ -109,8 +91,7 @@ class AotModuleImpl : public aot::Module {
       TI_DEBUG("Failed to load kernel {}", name);
       return nullptr;
     }
-    auto handle = runtime_->register_taichi_kernel(kparams);
-    return std::make_unique<KernelImpl>(runtime_, handle);
+    return std::make_unique<KernelImpl>(runtime_, std::move(kparams));
   }
 
   std::unique_ptr<aot::KernelTemplate> make_new_kernel_template(

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -16,6 +16,21 @@ namespace vulkan {
 
 class VkRuntime;
 
+class KernelImpl : public aot::Kernel {
+ public:
+  explicit KernelImpl(VkRuntime *runtime, VkRuntime::RegisterParams &&params)
+      : runtime_(runtime), params_(std::move(params)) {
+  }
+
+  void launch(RuntimeContext *ctx) override {
+    auto handle = runtime_->register_taichi_kernel(params_);
+    runtime_->launch_kernel(handle, ctx);
+  }
+
+ private:
+  VkRuntime *const runtime_;
+  const VkRuntime::RegisterParams params_;
+};
 struct TI_DLL_EXPORT AotModuleParams {
   std::string module_path;
   VkRuntime *runtime{nullptr};

--- a/taichi/backends/vulkan/aot_module_loader_impl.h
+++ b/taichi/backends/vulkan/aot_module_loader_impl.h
@@ -31,6 +31,7 @@ class KernelImpl : public aot::Kernel {
   VkRuntime *const runtime_;
   const VkRuntime::RegisterParams params_;
 };
+
 struct TI_DLL_EXPORT AotModuleParams {
   std::string module_path;
   VkRuntime *runtime{nullptr};

--- a/taichi/backends/vulkan/vulkan_program.h
+++ b/taichi/backends/vulkan/vulkan_program.h
@@ -82,6 +82,8 @@ class VulkanProgramImpl : public ProgramImpl {
     return snode_tree_mgr_->get_snode_tree_device_ptr(tree_id);
   }
 
+  std::unique_ptr<aot::Kernel> make_aot_kernel(Kernel &kernel) override;
+
   ~VulkanProgramImpl();
 
  private:

--- a/taichi/program/graph.cpp
+++ b/taichi/program/graph.cpp
@@ -76,13 +76,17 @@ void Graph::run(
       const aot::IValue &ival = found->second;
       if (ival.tag == aot::ArgKind::NDARRAY) {
         Ndarray *arr = reinterpret_cast<Ndarray *>(ival.val);
-        TI_ERROR_IF((symbolic_arg.tag != ival.tag) ||
-                        (symbolic_arg.element_shape != arr->shape),
+        TI_ERROR_IF(ival.tag != aot::ArgKind::NDARRAY,
+                    "Required a ndarray for argument {}", symbolic_arg.name);
+        auto ndarray_elem_shape = std::vector<int>(
+            arr->shape.end() - symbolic_arg.element_shape.size(),
+            arr->shape.end());
+        TI_ERROR_IF(ndarray_elem_shape != symbolic_arg.element_shape,
                     "Mismatched shape information for argument {}",
                     symbolic_arg.name);
         set_runtime_ctx_ndarray(&ctx, i, arr);
       } else {
-        TI_ERROR_IF(symbolic_arg.tag != aot::ArgKind::SCALAR,
+        TI_ERROR_IF(ival.tag != aot::ArgKind::SCALAR,
                     "Required a scalar for argument {}", symbolic_arg.name);
         ctx.set_arg(i, ival.val);
       }

--- a/taichi/program/graph.cpp
+++ b/taichi/program/graph.cpp
@@ -1,0 +1,95 @@
+#include "taichi/program/graph.h"
+#include "taichi/program/kernel.h"
+#include "taichi/aot/module_builder.h"
+#include "spdlog/fmt/fmt.h"
+
+#include <fstream>
+
+namespace taichi {
+namespace lang {
+
+void Dispatch::compile(
+    std::vector<aot::CompiledDispatch> &compiled_dispatches) {
+  compiled_kernel_ = kernel_->compile_to_aot_kernel();
+  aot::CompiledDispatch dispatch{kernel_->get_name(), symbolic_args_,
+                                 compiled_kernel_.get()};
+  compiled_dispatches.push_back(std::move(dispatch));
+}
+
+void Sequential::compile(
+    std::vector<aot::CompiledDispatch> &compiled_dispatches) {
+  // In the future we can do more across-kernel optimization here.
+  for (Node *n : sequence_) {
+    n->compile(compiled_dispatches);
+  }
+}
+
+void Sequential::append(Node *node) {
+  sequence_.push_back(node);
+}
+
+void Sequential::emplace(Kernel *kernel, const std::vector<aot::Arg> &args) {
+  Node *n = owning_graph_->create_dispatch(kernel, args);
+  sequence_.push_back(n);
+}
+
+Graph::Graph(std::string name) : name_(name) {
+  seq_ = std::make_unique<Sequential>(this);
+}
+Node *Graph::create_dispatch(Kernel *kernel,
+                             const std::vector<aot::Arg> &args) {
+  all_nodes_.push_back(std::make_unique<Dispatch>(kernel, args));
+  return all_nodes_.back().get();
+}
+
+Sequential *Graph::create_sequential() {
+  all_nodes_.push_back(std::make_unique<Sequential>(this));
+  return static_cast<Sequential *>(all_nodes_.back().get());
+}
+
+void Graph::compile() {
+  seq()->compile(compiled_graph_.dispatches);
+}
+
+Sequential *Graph::seq() const {
+  return seq_.get();
+}
+
+void Graph::emplace(Kernel *kernel, const std::vector<aot::Arg> &args) {
+  seq()->emplace(kernel, args);
+}
+
+void Graph::run(
+    const std::unordered_map<std::string, aot::IValue> &args) const {
+  RuntimeContext ctx;
+  for (const auto &dispatch : compiled_graph_.dispatches) {
+    memset(&ctx, 0, sizeof(RuntimeContext));
+
+    TI_ASSERT(dispatch.compiled_kernel);
+    // Populate args metadata into RuntimeContext
+    const auto &symbolic_args_ = dispatch.symbolic_args;
+    for (int i = 0; i < symbolic_args_.size(); ++i) {
+      auto &symbolic_arg = symbolic_args_[i];
+      auto found = args.find(symbolic_arg.name);
+      TI_ERROR_IF(found == args.end(), "Missing runtime value for {}",
+                  symbolic_arg.name);
+      const aot::IValue &ival = found->second;
+      if (ival.tag == aot::ArgKind::NDARRAY) {
+        Ndarray *arr = reinterpret_cast<Ndarray *>(ival.val);
+        TI_ERROR_IF((symbolic_arg.tag != ival.tag) ||
+                        (symbolic_arg.element_shape != arr->shape),
+                    "Mismatched shape information for argument {}",
+                    symbolic_arg.name);
+        set_runtime_ctx_ndarray(&ctx, i, arr);
+      } else {
+        TI_ERROR_IF(symbolic_arg.tag != aot::ArgKind::SCALAR,
+                    "Required a scalar for argument {}", symbolic_arg.name);
+        ctx.set_arg(i, ival.val);
+      }
+    }
+
+    dispatch.compiled_kernel->launch(&ctx);
+  }
+}
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/program/graph.h
+++ b/taichi/program/graph.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_set>
+
+#include "taichi/program/ndarray.h"
+#include "taichi/program/program.h"
+#include "taichi/ir/type.h"
+#include "taichi/aot/graph_data.h"
+#include "taichi/aot/module_builder.h"
+
+namespace taichi {
+namespace lang {
+class Kernel;
+class Graph;
+
+class Node {
+ public:
+  Node() = default;
+  virtual ~Node() = default;
+  Node(const Node &) = delete;
+  Node &operator=(const Node &) = delete;
+  Node(Node &&) = default;
+  Node &operator=(Node &&) = default;
+
+  virtual void compile(
+      std::vector<aot::CompiledDispatch> &compiled_dispatches) = 0;
+};
+class Dispatch : public Node {
+ public:
+  explicit Dispatch(Kernel *kernel, const std::vector<aot::Arg> &args)
+      : kernel_(kernel), symbolic_args_(args) {
+  }
+
+  void compile(
+      std::vector<aot::CompiledDispatch> &compiled_dispatches) override;
+
+ private:
+  mutable bool serialized_{false};
+  Kernel *kernel_{nullptr};
+  std::unique_ptr<aot::Kernel> compiled_kernel_{nullptr};
+  std::vector<aot::Arg> symbolic_args_;
+};
+
+class Sequential : public Node {
+ public:
+  explicit Sequential(Graph *graph) : owning_graph_(graph) {
+  }
+
+  void append(Node *node);
+
+  void emplace(Kernel *kernel, const std::vector<aot::Arg> &args);
+
+  void compile(
+      std::vector<aot::CompiledDispatch> &compiled_dispatches) override;
+
+ private:
+  std::vector<Node *> sequence_;
+  Graph *owning_graph_{nullptr};
+};
+
+/*
+ * Graph class works as both builder and runner.
+ *
+ * Two typical workflows using Graph:
+ * - build graph -> compile -> run
+ * - build graph -> compile -> serialize -> deserialize -> run
+ *
+ * Thus Graph can be constructed in two ways, either as an empty object
+ * or from an `aot::CompiledGraph` loaded from aot module.
+ *
+ * Currently Graph only supports sequential launches without returning value
+ * to host.
+ */
+class Graph {
+ public:
+  explicit Graph(std::string name);
+
+  explicit Graph(std::string name, const aot::CompiledGraph &compiled)
+      : name_(name), compiled_graph_(compiled) {
+  }
+
+  // TODO: compile() can take in Arch argument
+  void compile();
+
+  void run(const std::unordered_map<std::string, aot::IValue> &args) const;
+
+  Node *create_dispatch(Kernel *kernel, const std::vector<aot::Arg> &args);
+
+  Sequential *create_sequential();
+
+  void emplace(Kernel *kernel, const std::vector<aot::Arg> &args);
+
+  Sequential *seq() const;
+
+  aot::CompiledGraph compiled_graph() const {
+    return compiled_graph_;
+  }
+
+  std::string name() const {
+    return name_;
+  }
+
+ private:
+  std::string name_;
+  std::unique_ptr<Sequential> seq_{nullptr};
+  std::vector<std::unique_ptr<Node>> all_nodes_;
+  aot::CompiledGraph compiled_graph_;
+};
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/program/graph.h
+++ b/taichi/program/graph.h
@@ -50,7 +50,7 @@ class Sequential : public Node {
 
   void append(Node *node);
 
-  void emplace(Kernel *kernel, const std::vector<aot::Arg> &args);
+  void dispatch(Kernel *kernel, const std::vector<aot::Arg> &args);
 
   void compile(
       std::vector<aot::CompiledDispatch> &compiled_dispatches) override;
@@ -86,11 +86,11 @@ class Graph {
 
   void run(const std::unordered_map<std::string, aot::IValue> &args) const;
 
-  Node *create_dispatch(Kernel *kernel, const std::vector<aot::Arg> &args);
+  Node *new_dispatch_node(Kernel *kernel, const std::vector<aot::Arg> &args);
 
-  Sequential *create_sequential();
+  Sequential *new_sequential_node();
 
-  void emplace(Kernel *kernel, const std::vector<aot::Arg> &args);
+  void dispatch(Kernel *kernel, const std::vector<aot::Arg> &args);
 
   Sequential *seq() const;
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -64,6 +64,10 @@ void Kernel::compile() {
   compiled_ = program->compile(*this);
 }
 
+std::unique_ptr<aot::Kernel> Kernel::compile_to_aot_kernel() {
+  return program->make_aot_kernel(*this);
+}
+
 void Kernel::lower(bool to_executable) {
   TI_ASSERT(!lowered_);
   TI_ASSERT(supports_lowering(arch));

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -6,6 +6,7 @@
 #include "taichi/backends/arch.h"
 #include "taichi/program/callable.h"
 #include "taichi/program/ndarray.h"
+#include "taichi/aot/graph_data.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -86,6 +87,7 @@ class TI_DLL_EXPORT Kernel : public Callable {
 
   void compile();
 
+  std::unique_ptr<aot::Kernel> compile_to_aot_kernel();
   /**
    * Lowers |ir| to CHI IR level
    *

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -83,10 +83,10 @@ void Ndarray::write_float(const std::vector<int> &i, float64 val) {
   rw_accessors_bank_->get(this).write_float(i, val);
 }
 
-void set_runtime_ctx_ndarray(RuntimeContext &ctx,
+void set_runtime_ctx_ndarray(RuntimeContext *ctx,
                              int arg_id,
-                             Ndarray &ndarray) {
-  ctx.set_arg_devalloc(arg_id, ndarray.ndarray_alloc_, ndarray.shape);
+                             Ndarray *ndarray) {
+  ctx->set_arg_devalloc(arg_id, ndarray->ndarray_alloc_, ndarray->shape);
 }
 
 }  // namespace lang

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -60,7 +60,6 @@ class Ndarray {
 
 // TODO: move this as a method inside RuntimeContext once Ndarray is decoupled
 // with Program
-void set_runtime_ctx_ndarray(RuntimeContext &ctx, int arg_id, Ndarray &ndarray);
-
+void set_runtime_ctx_ndarray(RuntimeContext *ctx, int arg_id, Ndarray *ndarray);
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -199,6 +199,10 @@ class TI_DLL_EXPORT Program {
   // future.
   FunctionType compile(Kernel &kernel, OffloadedStmt *offloaded = nullptr);
 
+  std::unique_ptr<aot::Kernel> make_aot_kernel(Kernel &kernel) {
+    return program_impl_->make_aot_kernel(kernel);
+  }
+
   void check_runtime_error();
 
   Kernel &get_snode_reader(SNode *snode);

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -8,6 +8,7 @@
 #include "taichi/program/snode_expr_utils.h"
 #include "taichi/program/kernel_profiler.h"
 #include "taichi/backends/device.h"
+#include "taichi/aot/graph_data.h"
 
 namespace taichi {
 namespace lang {
@@ -65,6 +66,13 @@ class ProgramImpl {
    * Make a AotModulerBuilder, currently only supported by metal and wasm.
    */
   virtual std::unique_ptr<AotModuleBuilder> make_aot_module_builder() = 0;
+
+  /**
+   * Compile a taichi::lang::Kernel to taichi::lang::aot::Kernel.
+   */
+  virtual std::unique_ptr<aot::Kernel> make_aot_kernel(Kernel &kernel) {
+    TI_NOT_IMPLEMENTED;
+  }
 
   /**
    * Dump Offline-cache data to disk

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -271,8 +271,7 @@ TEST(AotSaveLoad, VulkanNdarray) {
   DeviceAllocation devalloc_arr_ =
       embedded_device->device()->allocate_memory(alloc_params);
   Ndarray arr = Ndarray(devalloc_arr_, PrimitiveType::i32, {size});
-  taichi::lang::set_runtime_ctx_ndarray(host_ctx, 0, arr);
-
+  taichi::lang::set_runtime_ctx_ndarray(&host_ctx, 0, &arr);
   int src[size] = {0};
   src[0] = 2;
   src[2] = 40;

--- a/tests/cpp/program/graph_test.cpp
+++ b/tests/cpp/program/graph_test.cpp
@@ -1,0 +1,52 @@
+#include "gtest/gtest.h"
+#include "taichi/ir/ir_builder.h"
+#include "taichi/ir/statements.h"
+#include "taichi/inc/constants.h"
+#include "taichi/program/program.h"
+#include "tests/cpp/program/test_program.h"
+#include "taichi/program/graph.h"
+#include "tests/cpp/ir/ndarray_kernel.h"
+#ifdef TI_WITH_VULKAN
+#include "taichi/backends/vulkan/vulkan_loader.h"
+#endif
+
+using namespace taichi;
+using namespace lang;
+#ifdef TI_WITH_VULKAN
+TEST(GraphTest, SimpleGraphRun) {
+  // Otherwise will segfault on macOS VM,
+  // where Vulkan is installed but no devices are present
+  if (!vulkan::is_vulkan_api_available()) {
+    return;
+  }
+  TestProgram test_prog;
+  test_prog.setup(Arch::vulkan);
+
+  const int size = 10;
+
+  auto ker1 = setup_kernel1(test_prog.prog());
+  auto ker2 = setup_kernel2(test_prog.prog());
+
+  auto g = std::make_unique<Graph>("test");
+  auto seq = g->seq();
+  auto arr_arg = aot::Arg{
+      "arr", PrimitiveType::i32.to_string(), aot::ArgKind::NDARRAY, {size}};
+  seq->emplace(ker1.get(), {arr_arg});
+  seq->emplace(ker2.get(),
+               {arr_arg, aot::Arg{"x", PrimitiveType::i32.to_string(),
+                                  aot::ArgKind::SCALAR}});
+  g->compile();
+
+  auto array = Ndarray(test_prog.prog(), PrimitiveType::i32, {size});
+  array.write_int({0}, 2);
+  array.write_int({2}, 40);
+  std::unordered_map<std::string, aot::IValue> args;
+  args.insert({"arr", aot::IValue::create(array)});
+  args.insert({"x", aot::IValue::create<int>(2)});
+
+  g->run(args);
+  EXPECT_EQ(array.read_int({0}), 2);
+  EXPECT_EQ(array.read_int({1}), 2);
+  EXPECT_EQ(array.read_int({2}), 42);
+}
+#endif

--- a/tests/cpp/program/graph_test.cpp
+++ b/tests/cpp/program/graph_test.cpp
@@ -31,10 +31,10 @@ TEST(GraphTest, SimpleGraphRun) {
   auto seq = g->seq();
   auto arr_arg = aot::Arg{
       "arr", PrimitiveType::i32.to_string(), aot::ArgKind::NDARRAY, {}};
-  seq->emplace(ker1.get(), {arr_arg});
-  seq->emplace(ker2.get(),
-               {arr_arg, aot::Arg{"x", PrimitiveType::i32.to_string(),
-                                  aot::ArgKind::SCALAR}});
+  seq->dispatch(ker1.get(), {arr_arg});
+  seq->dispatch(ker2.get(),
+                {arr_arg, aot::Arg{"x", PrimitiveType::i32.to_string(),
+                                   aot::ArgKind::SCALAR}});
   g->compile();
 
   auto array = Ndarray(test_prog.prog(), PrimitiveType::i32, {size});

--- a/tests/cpp/program/graph_test.cpp
+++ b/tests/cpp/program/graph_test.cpp
@@ -30,7 +30,7 @@ TEST(GraphTest, SimpleGraphRun) {
   auto g = std::make_unique<Graph>("test");
   auto seq = g->seq();
   auto arr_arg = aot::Arg{
-      "arr", PrimitiveType::i32.to_string(), aot::ArgKind::NDARRAY, {size}};
+      "arr", PrimitiveType::i32.to_string(), aot::ArgKind::NDARRAY, {}};
   seq->emplace(ker1.get(), {arr_arg});
   seq->emplace(ker2.get(),
                {arr_arg, aot::Arg{"x", PrimitiveType::i32.to_string(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5017
* #5016
* __->__ #5015
* #5014

This PR servces as the base PR with a minimal example of building and
running a Graph. Runtime values for graph arguments can be either
scalars or ndarrays.

For detailed proposal please see #4786.

Things handled in this PR:
- Maximize common code/runtime shared by the two workflows below:
  1. build -> compile -> run
  2. build -> compile -> serialize -> deserilize -> run
- Graph arguments are annotated with dtype and element shape for ndarray (temporary
until we have vec3 types in C++)

Things that we've discussed but not included in this PR:
- C API: I'll leave that for a unified C API PR in the future.
- bind IValues to graph: easy, will add later.