### PR TITLE
[ci] Fix nightly macos

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -36,8 +36,11 @@ else
     # Log hardware info for the current CI-bot
     # There's random CI failure caused by "import paddle" (Linux)
     # Top suspect is an issue with MKL support for specific CPU
+    echo "CI-bot CPU info:"
     if [[ $OSTYPE == "linux-"* ]]; then
         lscpu | grep "Model name"
+    elif [[ $OSTYPE == "darwin"* ]]; then
+        sysctl -a | grep machdep.cpu
     fi
 fi
 

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -34,9 +34,11 @@ else
     # Import Paddle's develop GPU package will occur error `Illegal Instruction`.
 
     # Log hardware info for the current CI-bot
-    # There's random CI failure caused by "import paddle"
+    # There's random CI failure caused by "import paddle" (Linux)
     # Top suspect is an issue with MKL support for specific CPU
-    lscpu | grep "Model name"
+    if [[ $OSTYPE == "linux-"* ]]; then
+        lscpu | grep "Model name"
+    fi
 fi
 
 ti diagnose


### PR DESCRIPTION
Nightly has been down for a week. https://github.com/taichi-dev/taichi/runs/6533328301?check_suite_focus=true#step:6:78 due to 

https://github.com/taichi-dev/taichi/blob/963b1c3b001514cf66acefd66d9355be23605e38/.github/workflows/scripts/unix_test.sh#L39

```
.github/workflows/scripts/unix_test.sh: line 39: lscpu: command not found
```
on m1 machines. 

This PR incorporates the fix.