### PR TITLE
[bug] Revert freeing ndarray memory when python GC triggers

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -18,19 +18,6 @@ class Ndarray:
         self.dtype = cook_dtype(dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
             cook_dtype(dtype), arr_shape)
-        self._gen = impl.get_runtime().generation
-
-    def __del__(self):
-        # - impl.get_runtime().prog == None:
-        #   ti.reset() is called but ti.init() isn't re-initialized yet.
-        #   At this point all ndarrays allocated in the previous program
-        #   are freed along with program destruction.
-        # - impl.get_generation() != self.gen
-        #   This ndarray was created from previous prog which was destructed.
-        #   So its memory was freed already.
-        if impl.get_runtime().prog is not None and impl.get_runtime(
-        ).generation == self._gen:
-            impl.get_runtime().prog.delete_ndarray(self.arr)
 
     @property
     def element_shape(self):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -1,5 +1,4 @@
 import numbers
-from itertools import count
 from types import FunctionType, MethodType
 from typing import Iterable
 
@@ -224,8 +223,6 @@ class SrcInfoGuard:
 
 
 class PyTaichi:
-    _gen = count(0)
-
     def __init__(self, kernels=None):
         self.materialized = False
         self.prog = None
@@ -242,7 +239,6 @@ class PyTaichi:
         self.grad_replaced = False
         self.kernels = kernels or []
         self._signal_handler_registry = None
-        self.generation = next(self._gen)
 
     def get_num_compiled_functions(self):
         return len(self.compiled_functions) + len(self.compiled_grad_functions)

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -508,8 +508,6 @@ void Program::finalize() {
     }
   }
 
-  ndarrays_.clear();
-
   synchronize();
   memory_pool_->terminate();
 
@@ -557,16 +555,8 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 
 Ndarray *Program::create_ndarray(const DataType type,
                                  const std::vector<int> &shape) {
-  // TODO: allocate DeviceAllocation first and then create Ndarray
-  auto arr = std::make_unique<Ndarray>(this, type, shape);
-  auto arr_ptr = arr.get();
-  ndarrays_.insert({arr_ptr, std::move(arr)});
-  return arr_ptr;
-}
-
-void Program::delete_ndarray(Ndarray *ndarray) {
-  TI_ASSERT(ndarrays_.count(ndarray));
-  ndarrays_.erase(ndarray);
+  ndarrays_.emplace_back(std::make_unique<Ndarray>(this, type, shape));
+  return ndarrays_.back().get();
 }
 
 intptr_t Program::get_ndarray_data_ptr_as_int(Ndarray *ndarray) {

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -323,8 +323,6 @@ class TI_DLL_EXPORT Program {
 
   Ndarray *create_ndarray(const DataType type, const std::vector<int> &shape);
 
-  void delete_ndarray(Ndarray *ndarray);
-
   intptr_t get_ndarray_data_ptr_as_int(Ndarray *ndarray);
 
   void fill_ndarray_fast(Ndarray *ndarray, uint32_t val);
@@ -359,7 +357,7 @@ class TI_DLL_EXPORT Program {
   bool finalized_{false};
 
   std::unique_ptr<MemoryPool> memory_pool_{nullptr};
-  std::unordered_map<void *, std::unique_ptr<Ndarray>> ndarrays_;
+  std::vector<std::unique_ptr<Ndarray>> ndarrays_;
 };
 
 }  // namespace lang

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -423,7 +423,6 @@ void export_lang(py::module &m) {
             return program->create_ndarray(dt, shape);
           },
           py::return_value_policy::reference)
-      .def("delete_ndarray", &Program::delete_ndarray)
       .def("get_ndarray_data_ptr_as_int",
            [](Program *program, Ndarray *ndarray) {
              return program->get_ndarray_data_ptr_as_int(ndarray);

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -341,15 +341,6 @@ def test_ndarray_numpy_io():
     _test_ndarray_numpy_io()
 
 
-@test_utils.test(arch=supported_archs_taichi_ndarray)
-def test_ndarray_reset():
-    n = 8
-    c = ti.Matrix.ndarray(4, 4, ti.f32, shape=(n))
-    del c
-    d = ti.Matrix.ndarray(4, 4, ti.f32, shape=(n))
-    ti.reset()
-
-
 def _test_ndarray_matrix_numpy_io(layout):
     n = 5
     m = 2
@@ -622,16 +613,3 @@ def test_different_shape():
     y = ti.ndarray(dtype=ti.f32, shape=(n2, n2))
     init(3, y)
     assert (y.to_numpy() == (np.ones(shape=(n2, n2)) * 3)).all()
-
-
-@test_utils.test(arch=supported_archs_taichi_ndarray)
-def test_generation():
-    curr_arch = ti.lang.impl.current_cfg().arch
-    n1 = 4
-    x = ti.ndarray(dtype=ti.f32, shape=(n1, n1))
-    prev_gen = x._gen
-    ti.reset()  # gen++
-    ti.init(curr_arch)  # calls ti.reset(), gen++
-    y = ti.ndarray(dtype=ti.f32, shape=(n1, ))
-    assert y._gen > prev_gen
-    del x


### PR DESCRIPTION
I realized that our implementation of ndarray lifetime is not perfect.
For example, when I run
```
import taichi as ti

ti.init(ti.vulkan)

def test():
    z = ti.ndarray(float, (8192))

test()
```
This works fine but if I do
```
import taichi as ti

ti.init(ti.vulkan)

z = ti.ndarray(float, (8192))
```
I actually got an error `'NoneType' object is not callable`.

The root cause is python doesn't guarantee destruction order, so it's
possible that
```
def __del__(self):
    if impl.get_runtime().prog is not None:
        print(impl.get_runtime().prog) # Error! PyTaichi object got destructed
right after the check above!
```
I'm thinking that we might be able to workaround this using weak
reference but want to revert this PR first to make sure master is
healthy.

Related issue = #4999 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
