### PR TITLE
[Lang] [ir] Add short-circuit if-then-else operator

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -495,7 +495,7 @@ class ASTTransformer(Builder):
                 else:
                     ctx.global_vars[
                         arg.arg] = kernel_arguments.decl_scalar_arg(
-                            ctx.func.arguments[i].annotation)
+                        ctx.func.arguments[i].annotation)
             # remove original args
             node.args.args = []
 
@@ -591,7 +591,7 @@ class ASTTransformer(Builder):
             ast.Div: lambda l, r: l / r,
             ast.FloorDiv: lambda l, r: l // r,
             ast.Mod: lambda l, r: l % r,
-            ast.Pow: lambda l, r: l**r,
+            ast.Pow: lambda l, r: l ** r,
             ast.LShift: lambda l, r: l << r,
             ast.RShift: lambda l, r: l >> r,
             ast.BitOr: lambda l, r: l | r,
@@ -1108,17 +1108,7 @@ class ASTTransformer(Builder):
                 node.ptr = build_stmt(ctx, node.orelse)
             return node.ptr
 
-        val = impl.expr_init(None)
-
-        impl.begin_frontend_if(ctx.ast_builder, node.test.ptr)
-        ctx.ast_builder.begin_frontend_if_true()
-        val._assign(node.body.ptr)
-        ctx.ast_builder.pop_scope()
-        ctx.ast_builder.begin_frontend_if_false()
-        val._assign(node.orelse.ptr)
-        ctx.ast_builder.pop_scope()
-
-        node.ptr = val
+        node.ptr = ti_ops.ifte(node.test.ptr, node.body.ptr, node.orelse.ptr)
         return node.ptr
 
     @staticmethod
@@ -1142,7 +1132,7 @@ class ASTTransformer(Builder):
         msg = build_stmt(ctx, node.left)
         args = build_stmt(ctx, node.right)
         if not isinstance(args, collections.abc.Sequence):
-            args = (args, )
+            args = (args,)
         args = [expr.Expr(x).ptr for x in args]
         return msg, args
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -495,7 +495,7 @@ class ASTTransformer(Builder):
                 else:
                     ctx.global_vars[
                         arg.arg] = kernel_arguments.decl_scalar_arg(
-                        ctx.func.arguments[i].annotation)
+                            ctx.func.arguments[i].annotation)
             # remove original args
             node.args.args = []
 
@@ -591,7 +591,7 @@ class ASTTransformer(Builder):
             ast.Div: lambda l, r: l / r,
             ast.FloorDiv: lambda l, r: l // r,
             ast.Mod: lambda l, r: l % r,
-            ast.Pow: lambda l, r: l ** r,
+            ast.Pow: lambda l, r: l**r,
             ast.LShift: lambda l, r: l << r,
             ast.RShift: lambda l, r: l >> r,
             ast.BitOr: lambda l, r: l | r,
@@ -1132,7 +1132,7 @@ class ASTTransformer(Builder):
         msg = build_stmt(ctx, node.left)
         args = build_stmt(ctx, node.right)
         if not isinstance(args, collections.abc.Sequence):
-            args = (args,)
+            args = (args, )
         args = [expr.Expr(x).ptr for x in args]
         return msg, args
 

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -344,6 +344,7 @@ def rsqrt(x):
     Returns:
         The reciprocal of `sqrt(x)`.
     """
+
     def _rsqrt(x):
         return 1 / math.sqrt(x)
 
@@ -691,6 +692,7 @@ def mod(x1, x2):
         >>> test()
         [1.0, 0.0, 4.0]
     """
+
     def expr_python_mod(a, b):
         # a % b = a - (a // b) * b
         quotient = expr.Expr(_ti_core.expr_floordiv(a, b))
@@ -840,6 +842,7 @@ def raw_div(x1, x2):
         >>>     z = 4.0
         >>>     print(raw_div(x, z))  # 1.25
     """
+
     def c_div(a, b):
         if isinstance(a, int) and isinstance(b, int):
             return a // b
@@ -869,6 +872,7 @@ def raw_mod(x1, x2):
         >>>     print(ti.mod(-4, 3))  # 2
         >>>     print(ti.raw_mod(-4, 3))  # -1
     """
+
     def c_mod(x, y):
         return x - y * int(float(x) / y)
 
@@ -1141,6 +1145,29 @@ def select(cond, x1, x2):
         return x1 * cond + x2 * (1 - cond)
 
     return _ternary_operation(_ti_core.expr_select, py_select, cond, x1, x2)
+
+
+@ternary
+def ifte(cond, x1, x2):
+    """Evaluate and return `x1` if `cond` is true; otherwise evaluate and return `x2`. This operator guarantees
+    short-circuit semantics: exactly one of `x1` or `x2` will be evaluated.
+
+    Args:
+        cond (:mod:`~taichi.types.primitive_types`): \
+            The condition.
+        x1, x2 (:mod:`~taichi.types.primitive_types`): \
+            The outputs.
+
+    Returns:
+        `x1` if `cond` is true and `x2` otherwise.
+    """
+    # TODO: systematically resolve `-1 = True` problem by introducing u1:
+    cond = logical_not(logical_not(cond))
+
+    def py_ifte(cond, x1, x2):
+        return x1 if cond else x2
+
+    return _ternary_operation(_ti_core.expr_ifte, py_ifte, cond, x1, x2)
 
 
 @writeback_binary

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -344,7 +344,6 @@ def rsqrt(x):
     Returns:
         The reciprocal of `sqrt(x)`.
     """
-
     def _rsqrt(x):
         return 1 / math.sqrt(x)
 
@@ -692,7 +691,6 @@ def mod(x1, x2):
         >>> test()
         [1.0, 0.0, 4.0]
     """
-
     def expr_python_mod(a, b):
         # a % b = a - (a // b) * b
         quotient = expr.Expr(_ti_core.expr_floordiv(a, b))
@@ -842,7 +840,6 @@ def raw_div(x1, x2):
         >>>     z = 4.0
         >>>     print(raw_div(x, z))  # 1.25
     """
-
     def c_div(a, b):
         if isinstance(a, int) and isinstance(b, int):
             return a // b
@@ -872,7 +869,6 @@ def raw_mod(x1, x2):
         >>>     print(ti.mod(-4, 3))  # 2
         >>>     print(ti.raw_mod(-4, 3))  # -1
     """
-
     def c_mod(x, y):
         return x - y * int(float(x) / y)
 

--- a/taichi/ir/expression_ops.h
+++ b/taichi/ir/expression_ops.h
@@ -124,6 +124,7 @@ DEFINE_EXPRESSION_FUNC_BINARY(floordiv)
 DEFINE_EXPRESSION_FUNC_BINARY(bit_shr)
 
 DEFINE_EXPRESSION_FUNC_TERNARY(select)
+DEFINE_EXPRESSION_FUNC_TERNARY(ifte)
 
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -252,6 +252,37 @@ void BinaryOpExpression::flatten(FlattenContext *ctx) {
   stmt = ctx->back_stmt();
 }
 
+void make_ifte(Expression::FlattenContext *ctx,
+               DataType ret_type,
+               Expr cond,
+               Expr true_val,
+               Expr false_val) {
+  auto result = ctx->push_back<AllocaStmt>(ret_type);
+  flatten_rvalue(cond, ctx);
+  auto if_stmt = ctx->push_back<IfStmt>(cond->stmt);
+
+  Expression::FlattenContext lctx;
+  lctx.current_block = ctx->current_block;
+  flatten_rvalue(true_val, &lctx);
+  lctx.push_back<LocalStoreStmt>(result, true_val->stmt);
+
+  Expression::FlattenContext rctx;
+  rctx.current_block = ctx->current_block;
+  flatten_rvalue(false_val, &rctx);
+  rctx.push_back<LocalStoreStmt>(result, false_val->stmt);
+
+  auto true_block = std::make_unique<Block>();
+  true_block->set_statements(std::move(lctx.stmts));
+  if_stmt->set_true_statements(std::move(true_block));
+
+  auto false_block = std::make_unique<Block>();
+  false_block->set_statements(std::move(rctx.stmts));
+  if_stmt->set_false_statements(std::move(false_block));
+
+  ctx->push_back<LocalLoadStmt>(LocalAddress(result, 0));
+  return;
+}
+
 void TernaryOpExpression::type_check(CompileConfig *) {
   TI_ASSERT_TYPE_CHECKED(op1);
   TI_ASSERT_TYPE_CHECKED(op2);
@@ -265,8 +296,9 @@ void TernaryOpExpression::type_check(CompileConfig *) {
                     ternary_type_name(type), op1->ret_type->to_string(),
                     op2->ret_type->to_string(), op3->ret_type->to_string()));
   };
-  if (!is_integral(op1_type) || !op2_type->is<PrimitiveType>() ||
-      !op3_type->is<PrimitiveType>())
+  if (op1_type != PrimitiveType::i32)
+    error();
+  if (!op2_type->is<PrimitiveType>() || !op3_type->is<PrimitiveType>())
     error();
   ret_type = promoted_type(op2_type, op3_type);
 }
@@ -274,12 +306,17 @@ void TernaryOpExpression::type_check(CompileConfig *) {
 void TernaryOpExpression::flatten(FlattenContext *ctx) {
   // if (stmt)
   //  return;
-  flatten_rvalue(op1, ctx);
-  flatten_rvalue(op2, ctx);
-  flatten_rvalue(op3, ctx);
-  ctx->push_back(
-      std::make_unique<TernaryOpStmt>(type, op1->stmt, op2->stmt, op3->stmt));
+  if (type == TernaryOpType::select) {
+    flatten_rvalue(op1, ctx);
+    flatten_rvalue(op2, ctx);
+    flatten_rvalue(op3, ctx);
+    ctx->push_back(
+        std::make_unique<TernaryOpStmt>(type, op1->stmt, op2->stmt, op3->stmt));
+  } else if (type == TernaryOpType::ifte) {
+    make_ifte(ctx, ret_type, op1, op2, op3);
+  }
   stmt = ctx->back_stmt();
+  stmt->tb = tb;
 }
 
 void InternalFuncCallExpression::type_check(CompileConfig *) {

--- a/taichi/ir/stmt_op_types.cpp
+++ b/taichi/ir/stmt_op_types.cpp
@@ -77,6 +77,7 @@ std::string ternary_type_name(TernaryOpType type) {
     return #i;
 
     REGISTER_TYPE(select);
+    REGISTER_TYPE(ifte);
 
 #undef REGISTER_TYPE
     default:

--- a/taichi/ir/stmt_op_types.h
+++ b/taichi/ir/stmt_op_types.h
@@ -62,7 +62,7 @@ inline bool is_bit_op(BinaryOpType type) {
 
 std::string binary_op_type_symbol(BinaryOpType type);
 
-enum class TernaryOpType : int { select, undefined };
+enum class TernaryOpType : int { select, ifte, undefined };
 
 std::string ternary_type_name(TernaryOpType type);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -706,6 +706,7 @@ void export_lang(py::module &m) {
   DEFINE_EXPRESSION_OP(log)
 
   DEFINE_EXPRESSION_OP(select)
+  DEFINE_EXPRESSION_OP(ifte)
 
   DEFINE_EXPRESSION_OP(cmp_le)
   DEFINE_EXPRESSION_OP(cmp_lt)

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -66,16 +66,16 @@ TEST(FrontendTypeInference, UnaryOp) {
 }
 
 TEST(FrontendTypeInference, TernaryOp) {
-  auto const_i16 = value<int16>(-(1 << 10));
-  const_i16->type_check(nullptr);
-  EXPECT_EQ(const_i16->ret_type, PrimitiveType::i16);
-  auto cast_i8 = cast(const_i16, PrimitiveType::i8);
+  auto const_i32 = value<int32>(-(1 << 10));
+  const_i32->type_check(nullptr);
+  EXPECT_EQ(const_i32->ret_type, PrimitiveType::i32);
+  auto cast_i8 = cast(const_i32, PrimitiveType::i8);
   cast_i8->type_check(nullptr);
   EXPECT_EQ(cast_i8->ret_type, PrimitiveType::i8);
   auto const_f32 = value<float32>(5.0);
   const_f32->type_check(nullptr);
   EXPECT_EQ(const_f32->ret_type, PrimitiveType::f32);
-  auto ternary_f32 = expr_select(const_i16, cast_i8, const_f32);
+  auto ternary_f32 = expr_select(const_i32, cast_i8, const_f32);
   ternary_f32->type_check(nullptr);
   EXPECT_EQ(ternary_f32->ret_type, PrimitiveType::f32);
 }

--- a/tests/python/test_type_check.py
+++ b/tests/python/test_type_check.py
@@ -41,7 +41,7 @@ def test_ternary_op():
         d = b if a else c
 
     with pytest.raises(TypeError,
-                       match="`if` conditions must be of type int32"):
+                       match="unsupported operand type\\(s\\) for 'ifte'"):
         select()
 
 


### PR DESCRIPTION
Related issue = #3572, #3635

This PR introduces a new ternary operator `ifte` at the frontend IR level that supports short-circuit semantics:

```
select(c, x, y) ==> 
  eval c, eval x, eval y, 
  if c 
    then return x 
    else return y

ifte(c, x, y) ==>
  eval c,
  if c
    then eval x, return x
    else eval y, return y
```

On the python side, `IfExp` now uses this operator instead of directly translating into if statements; this guarantees the return type is consistent.

@strongoier: For now `ifte(c, x, y)` does *not* force `x` and `y` to be the same type. Is this desired semantics?

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
