### PR TITLE
[aot] Bind graph APIs to python and add mpm88 example

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -9,7 +9,7 @@ from taichi.types.annotations import *
 # Provide a shortcut to types since they're commonly used.
 from taichi.types.primitive_types import *
 
-from taichi import ad, experimental, linalg, math, tools
+from taichi import ad, experimental, graph, linalg, math, tools
 from taichi.ui import GUI, hex_to_rgb, rgb_to_hex, ui
 
 # Issue#2223: Do not reorder, or we're busted with partially initialized module

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -1,15 +1,12 @@
 from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
 
+from taichi.aot.utils import (produce_injected_args,
+                              produce_injected_args_from_template)
 from taichi.lang import impl, kernel_impl
-from taichi.lang._ndarray import ScalarNdarray
-from taichi.lang.enums import Layout
-from taichi.lang.exception import TaichiCompilationError
 from taichi.lang.field import ScalarField
-from taichi.lang.matrix import MatrixField, MatrixNdarray, VectorNdarray
+from taichi.lang.matrix import MatrixField
 from taichi.types.annotations import template
-from taichi.types.ndarray_type import NdarrayType
-from taichi.types.primitive_types import f32
 
 
 class KernelTemplate:
@@ -139,59 +136,19 @@ class Module:
         kernel_name = name or kernel_fn.__name__
         kernel = kernel_fn._primal
         assert isinstance(kernel, kernel_impl.Kernel)
-        injected_args = []
-        template_types = (NdarrayType, template)
-        num_template_args = len([
-            arg.annotation for arg in kernel.arguments
-            if isinstance(arg.annotation, template_types)
-        ])
-        if template_args is not None and num_template_args != len(
-                template_args):
-            raise TaichiCompilationError(
-                f'Need {num_template_args} inputs to instantiate the template '
-                f'parameters, got {len(template_args)}')
-        i = 0
-        for arg in kernel.arguments:
-            anno = arg.annotation
-            if isinstance(anno, template_types):
-                if template_args:
-                    injected_args.append(template_args[arg.name])
-                else:
-                    if not isinstance(anno, NdarrayType):
-                        raise TaichiCompilationError(
-                            f'Expected Ndaray type, got {anno}')
-                    if anno.element_shape is None or anno.field_dim is None:
-                        raise TaichiCompilationError(
-                            'Please either specify both `element_shape` and `field_dim` '
-                            'in the param annotation, or provide an example '
-                            f'ndarray for param={name}')
-                    if anno.element_dim == 0:
-                        injected_args.append(
-                            ScalarNdarray(f32, (2, ) * anno.field_dim))
-                    elif anno.element_dim == 1:
-                        injected_args.append(
-                            VectorNdarray(anno.element_shape[0],
-                                          dtype=f32,
-                                          shape=(2, ) * anno.field_dim,
-                                          layout=Layout.AOS))
-                    elif anno.element_dim == 2:
-                        injected_args.append(
-                            MatrixNdarray(anno.element_shape[0],
-                                          anno.element_shape[1],
-                                          dtype=f32,
-                                          shape=(2, ) * anno.field_dim,
-                                          layout=Layout.AOS))
-                    else:
-                        raise RuntimeError('')
-                i = i + 1
-            else:
-                # For primitive types, we can just inject a dummy value.
-                injected_args.append(0)
+        if template_args is not None:
+            injected_args = produce_injected_args_from_template(
+                kernel, template_args)
+        else:
+            injected_args = produce_injected_args(kernel)
         kernel.ensure_compiled(*injected_args)
         self._aot_builder.add(kernel_name, kernel.kernel_cpp)
 
         # kernel AOT
         self._kernels.append(kernel)
+
+    def add_graph(self, name, graph):
+        self._aot_builder.add_graph(name, graph._compiled_graph)
 
     @contextmanager
     def add_kernel_template(self, kernel_fn):

--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -1,0 +1,68 @@
+from taichi.lang._ndarray import ScalarNdarray
+from taichi.lang.enums import Layout
+from taichi.lang.exception import TaichiCompilationError
+from taichi.lang.matrix import MatrixNdarray, VectorNdarray
+from taichi.types.annotations import template
+from taichi.types.ndarray_type import NdarrayType
+from taichi.types.primitive_types import f32
+
+template_types = (NdarrayType, template)
+
+
+def produce_injected_args_from_template(kernel, template_args):
+    injected_args = []
+    num_template_args = len([
+        arg.annotation for arg in kernel.arguments
+        if isinstance(arg.annotation, template_types)
+    ])
+    assert num_template_args == len(
+        template_args
+    ), f'Need {num_template_args} inputs to instantiate the template parameters, got {len(template_args)}'
+    for arg in kernel.arguments:
+        anno = arg.annotation
+        if isinstance(anno, template_types):
+            injected_args.append(template_args[arg.name])
+        else:
+            injected_args.append(0)
+    return injected_args
+
+
+def produce_injected_args(kernel, symbolic_args=None):
+    injected_args = []
+    for j, arg in enumerate(kernel.arguments):
+        anno = arg.annotation
+        if isinstance(anno, template_types):
+            if not isinstance(anno, NdarrayType):
+                raise TaichiCompilationError(
+                    f'Expected Ndaray type, got {anno}')
+            if symbolic_args is not None:
+                anno.element_shape = tuple(symbolic_args[j].element_shape)
+                anno.element_dim = len(anno.element_shape)
+
+            if anno.element_shape is None or anno.field_dim is None:
+                raise TaichiCompilationError(
+                    'Please either specify both `element_shape` and `field_dim` '
+                    'in the param annotation, or provide an example '
+                    f'ndarray for param={arg.name}')
+            if anno.element_dim == 0:
+                injected_args.append(ScalarNdarray(f32,
+                                                   (2, ) * anno.field_dim))
+            elif anno.element_dim == 1:
+                injected_args.append(
+                    VectorNdarray(anno.element_shape[0],
+                                  dtype=f32,
+                                  shape=(2, ) * anno.field_dim,
+                                  layout=Layout.AOS))
+            elif anno.element_dim == 2:
+                injected_args.append(
+                    MatrixNdarray(anno.element_shape[0],
+                                  anno.element_shape[1],
+                                  dtype=f32,
+                                  shape=(2, ) * anno.field_dim,
+                                  layout=Layout.AOS))
+            else:
+                raise RuntimeError('')
+        else:
+            # For primitive types, we can just inject a dummy value.
+            injected_args.append(0)
+    return injected_args

--- a/python/taichi/examples/graph/mpm88_graph.py
+++ b/python/taichi/examples/graph/mpm88_graph.py
@@ -1,0 +1,168 @@
+import argparse
+import numpy as np
+import taichi as ti
+
+ti.init(arch=ti.vulkan)
+n_particles = 8192
+n_grid = 128
+dx = 1 / n_grid
+dt = 2e-4
+
+p_rho = 1
+p_vol = (dx * 0.5)**2
+p_mass = p_vol * p_rho
+gravity = 9.8
+bound = 3
+E = 400
+N_ITER = 500  # Use 500 to make speed diff more obvious
+
+
+
+@ti.kernel
+def substep_reset_grid(grid_v: ti.any_arr(field_dim=2),
+                       grid_m: ti.any_arr(field_dim=2)):
+    for i, j in grid_m:
+        grid_v[i, j] = [0, 0]
+        grid_m[i, j] = 0
+
+
+@ti.kernel
+def substep_p2g(x: ti.any_arr(field_dim=1), v: ti.any_arr(field_dim=1),
+                C: ti.any_arr(field_dim=1), J: ti.any_arr(field_dim=1),
+                grid_v: ti.any_arr(field_dim=2),
+                grid_m: ti.any_arr(field_dim=2)):
+    for p in x:
+        Xp = x[p] / dx
+        base = int(Xp - 0.5)
+        fx = Xp - base
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+        stress = -dt * 4 * E * p_vol * (J[p] - 1) / dx**2
+        affine = ti.Matrix([[stress, 0], [0, stress]]) + p_mass * C[p]
+        for i, j in ti.static(ti.ndrange(3, 3)):
+            offset = ti.Vector([i, j])
+            dpos = (offset - fx) * dx
+            weight = w[i].x * w[j].y
+            grid_v[base + offset] += weight * (p_mass * v[p] + affine @ dpos)
+            grid_m[base + offset] += weight * p_mass
+
+
+@ti.kernel
+def substep_update_grid_v(grid_v: ti.any_arr(field_dim=2),
+                          grid_m: ti.any_arr(field_dim=2)):
+    for i, j in grid_m:
+        if grid_m[i, j] > 0:
+            grid_v[i, j] /= grid_m[i, j]
+        grid_v[i, j].y -= dt * gravity
+        if i < bound and grid_v[i, j].x < 0:
+            grid_v[i, j].x = 0
+        if i > n_grid - bound and grid_v[i, j].x > 0:
+            grid_v[i, j].x = 0
+        if j < bound and grid_v[i, j].y < 0:
+            grid_v[i, j].y = 0
+        if j > n_grid - bound and grid_v[i, j].y > 0:
+            grid_v[i, j].y = 0
+
+
+@ti.kernel
+def substep_g2p(x: ti.any_arr(field_dim=1), v: ti.any_arr(field_dim=1),
+                C: ti.any_arr(field_dim=1), J: ti.any_arr(field_dim=1),
+                grid_v: ti.any_arr(field_dim=2)):
+    for p in x:
+        Xp = x[p] / dx
+        base = int(Xp - 0.5)
+        fx = Xp - base
+        w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+        new_v = ti.Vector.zero(float, 2)
+        new_C = ti.Matrix.zero(float, 2, 2)
+        for i, j in ti.static(ti.ndrange(3, 3)):
+            offset = ti.Vector([i, j])
+            dpos = (offset - fx) * dx
+            weight = w[i].x * w[j].y
+            g_v = grid_v[base + offset]
+            new_v += weight * g_v
+            new_C += 4 * weight * g_v.outer_product(dpos) / dx**2
+        v[p] = new_v
+        x[p] += dt * v[p]
+        J[p] *= 1 + dt * new_C.trace()
+        C[p] = new_C
+
+
+@ti.kernel
+def init_particles(x: ti.any_arr(field_dim=1), v: ti.any_arr(field_dim=1),
+                   J: ti.any_arr(field_dim=1)):
+    for i in range(n_particles):
+        x[i] = [ti.random() * 0.4 + 0.2, ti.random() * 0.4 + 0.2]
+        v[i] = [0, -1]
+        J[i] = 1
+
+x = ti.Vector.ndarray(2, ti.f32, shape=(n_particles))
+v = ti.Vector.ndarray(2, ti.f32, shape=(n_particles))
+
+C = ti.Matrix.ndarray(2, 2, ti.f32, shape=(n_particles))
+J = ti.ndarray(ti.f32, shape=(n_particles))
+grid_v = ti.Vector.ndarray(2, ti.f32, shape=(n_grid, n_grid))
+grid_m = ti.ndarray(ti.f32, shape=(n_grid, n_grid))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--baseline',
+        action='store_true')
+    args, unknown = parser.parse_known_args()
+
+    if not args.baseline:
+        print('running in graph mode')
+        # Build graph
+        sym_x = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'x', 'f32', element_shape=(2, ))
+        sym_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'v', 'f32', element_shape=(2, ))
+        sym_C = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'C', 'f32', element_shape=(2, 2))
+        sym_J = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'J', 'f32', element_shape=())
+        sym_grid_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'grid_v', 'f32', element_shape=(2, ))
+        sym_grid_m = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'grid_m', 'f32', element_shape=())
+        g_init = ti.graph.Graph()
+        g_init.dispatch(init_particles, sym_x, sym_v, sym_J)
+
+        g_update = ti.graph.Graph()
+        substep = g_update.create_sequential()
+
+        substep.dispatch(substep_reset_grid, sym_grid_v, sym_grid_m)
+        substep.dispatch(substep_p2g, sym_x, sym_v, sym_C, sym_J, sym_grid_v,
+                        sym_grid_m)
+        substep.dispatch(substep_update_grid_v, sym_grid_v, sym_grid_m)
+        substep.dispatch(substep_g2p, sym_x, sym_v, sym_C, sym_J, sym_grid_v)
+
+        for i in range(N_ITER):
+            g_update.append(substep)
+
+        # Compile
+        g_init.compile()
+        g_update.compile()
+
+        # Run
+        g_init.run({'x': x, 'v': v, 'J': J})
+
+        gui = ti.GUI('MPM88')
+        while gui.running:
+            g_update.run({
+                'x': x,
+                'v': v,
+                'C': C,
+                'J': J,
+                'grid_v': grid_v,
+                'grid_m': grid_m
+            })
+            gui.clear(0x112F41)
+            gui.circles(x.to_numpy(), radius=1.5, color=0x068587)
+            gui.show()
+    else:
+        init_particles(x, v, J)
+        gui = ti.GUI('MPM88')
+        while gui.running and not gui.get_event(gui.ESCAPE):
+            for s in range(N_ITER):
+                substep_reset_grid(grid_v, grid_m)
+                substep_p2g(x, v, C, J, grid_v, grid_m)
+                substep_update_grid_v(grid_v, grid_m)
+                substep_g2p(x, v, C, J, grid_v)
+            gui.clear(0x112F41)
+            gui.circles(x.to_numpy(), radius=1.5, color=0x068587)
+            gui.show()

--- a/python/taichi/graph/__init__.py
+++ b/python/taichi/graph/__init__.py
@@ -1,0 +1,1 @@
+from ._graph import *

--- a/python/taichi/graph/_graph.py
+++ b/python/taichi/graph/_graph.py
@@ -1,0 +1,51 @@
+from taichi._lib import core as _ti_core
+from taichi.aot.utils import produce_injected_args
+from taichi.lang import kernel_impl
+
+ArgKind = _ti_core.ArgKind
+Arg = _ti_core.Arg
+
+
+def gen_cpp_kernel(kernel_fn, args):
+    kernel = kernel_fn._primal
+    assert isinstance(kernel, kernel_impl.Kernel)
+    injected_args = produce_injected_args(kernel, symbolic_args=args)
+    kernel.ensure_compiled(*injected_args)
+    return kernel.kernel_cpp
+
+
+class Sequential:
+    def __init__(self, seq):
+        self.seq_ = seq
+
+    def dispatch(self, kernel_fn, *args):
+        kernel_cpp = gen_cpp_kernel(kernel_fn, args)
+        self.seq_.dispatch(kernel_cpp, args)
+
+
+class Graph:
+    def __init__(self):
+        self._graph_builder = _ti_core.GraphBuilder()
+        self._compiled_graph = None
+
+    def dispatch(self, kernel_fn, *args):
+        kernel_cpp = gen_cpp_kernel(kernel_fn, args)
+        self._graph_builder.dispatch(kernel_cpp, args)
+
+    def create_sequential(self):
+        return Sequential(self._graph_builder.create_sequential())
+
+    def append(self, node):
+        # TODO: support appending dispatch node as well.
+        assert isinstance(node, Sequential)
+        self._graph_builder.seq().append(node.seq_)
+
+    def compile(self):
+        self._compiled_graph = self._graph_builder.compile()
+
+    def run(self, args):
+        arg_ptrs = {k: args[k].arr for k in args.keys()}
+        self._compiled_graph.run(arg_ptrs)
+
+
+__all__ = ['Graph', 'Arg', 'ArgKind']

--- a/taichi/aot/graph_data.h
+++ b/taichi/aot/graph_data.h
@@ -32,7 +32,7 @@ struct Arg {
 /**
  * Runtime value used in graph execution.
  */
-struct IValue {
+struct TI_DLL_EXPORT IValue {
  public:
   uint64 val;
   ArgKind tag;
@@ -81,7 +81,7 @@ struct CompiledDispatch {
   TI_IO_DEF(kernel_name, symbolic_args);
 };
 
-struct CompiledGraph {
+struct TI_DLL_EXPORT CompiledGraph {
   std::vector<CompiledDispatch> dispatches;
 
   void run(const std::unordered_map<std::string, IValue> &args) const;

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -14,7 +14,7 @@ class Program;
 class LlvmProgramImpl;
 class NdarrayRwAccessorsBank;
 
-class Ndarray {
+class TI_DLL_EXPORT Ndarray {
  public:
   /* Constructs a Ndarray managed by Program.
    * Memory allocation and deallocation is handled by Program.

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -620,3 +620,150 @@ def test_aot_ndarray_template_mixed():
             res = json.load(json_file)
             args_count = res['aot_data']['kernels']['run']['args_count']
             assert args_count == 2, res  # `arr` and `val1`
+
+
+@test_utils.test(arch=ti.vulkan)
+def test_mpm88_ndarray_graph_aot():
+    n_particles = 8192
+    n_grid = 128
+    dx = 1 / n_grid
+    dt = 2e-4
+
+    p_rho = 1
+    p_vol = (dx * 0.5)**2
+    p_mass = p_vol * p_rho
+    gravity = 9.8
+    bound = 3
+    E = 400
+
+    @ti.kernel
+    def substep_reset_grid(grid_v: ti.any_arr(field_dim=2),
+                           grid_m: ti.any_arr(field_dim=2)):
+        for i, j in grid_m:
+            grid_v[i, j] = [0, 0]
+            grid_m[i, j] = 0
+
+    @ti.kernel
+    def substep_p2g(x: ti.any_arr(field_dim=1), v: ti.any_arr(field_dim=1),
+                    C: ti.any_arr(field_dim=1), J: ti.any_arr(field_dim=1),
+                    grid_v: ti.any_arr(field_dim=2),
+                    grid_m: ti.any_arr(field_dim=2)):
+        for p in x:
+            Xp = x[p] / dx
+            base = int(Xp - 0.5)
+            fx = Xp - base
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+            stress = -dt * 4 * E * p_vol * (J[p] - 1) / dx**2
+            affine = ti.Matrix([[stress, 0], [0, stress]]) + p_mass * C[p]
+            for i, j in ti.static(ti.ndrange(3, 3)):
+                offset = ti.Vector([i, j])
+                dpos = (offset - fx) * dx
+                weight = w[i].x * w[j].y
+                grid_v[base +
+                       offset] += weight * (p_mass * v[p] + affine @ dpos)
+                grid_m[base + offset] += weight * p_mass
+
+    @ti.kernel
+    def substep_update_grid_v(grid_v: ti.any_arr(field_dim=2),
+                              grid_m: ti.any_arr(field_dim=2)):
+        for i, j in grid_m:
+            if grid_m[i, j] > 0:
+                grid_v[i, j] /= grid_m[i, j]
+            grid_v[i, j].y -= dt * gravity
+            if i < bound and grid_v[i, j].x < 0:
+                grid_v[i, j].x = 0
+            if i > n_grid - bound and grid_v[i, j].x > 0:
+                grid_v[i, j].x = 0
+            if j < bound and grid_v[i, j].y < 0:
+                grid_v[i, j].y = 0
+            if j > n_grid - bound and grid_v[i, j].y > 0:
+                grid_v[i, j].y = 0
+
+    @ti.kernel
+    def substep_g2p(x: ti.any_arr(field_dim=1), v: ti.any_arr(field_dim=1),
+                    C: ti.any_arr(field_dim=1), J: ti.any_arr(field_dim=1),
+                    grid_v: ti.any_arr(field_dim=2)):
+        for p in x:
+            Xp = x[p] / dx
+            base = int(Xp - 0.5)
+            fx = Xp - base
+            w = [0.5 * (1.5 - fx)**2, 0.75 - (fx - 1)**2, 0.5 * (fx - 0.5)**2]
+            new_v = ti.Vector.zero(float, 2)
+            new_C = ti.Matrix.zero(float, 2, 2)
+            for i, j in ti.static(ti.ndrange(3, 3)):
+                offset = ti.Vector([i, j])
+                dpos = (offset - fx) * dx
+                weight = w[i].x * w[j].y
+                g_v = grid_v[base + offset]
+                new_v += weight * g_v
+                new_C += 4 * weight * g_v.outer_product(dpos) / dx**2
+            v[p] = new_v
+            x[p] += dt * v[p]
+            J[p] *= 1 + dt * new_C.trace()
+            C[p] = new_C
+
+    @ti.kernel
+    def init_particles(x: ti.any_arr(field_dim=1), v: ti.any_arr(field_dim=1),
+                       J: ti.any_arr(field_dim=1)):
+        for i in range(n_particles):
+            x[i] = [ti.random() * 0.4 + 0.2, ti.random() * 0.4 + 0.2]
+            v[i] = [0, -1]
+            J[i] = 1
+
+    N_ITER = 50
+
+    sym_x = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                         'x',
+                         'f32',
+                         element_shape=(2, ))
+    sym_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                         'v',
+                         'f32',
+                         element_shape=(2, ))
+    sym_C = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                         'C',
+                         'f32',
+                         element_shape=(2, 2))
+    sym_J = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                         'J',
+                         'f32',
+                         element_shape=())
+    sym_grid_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                              'grid_v',
+                              'f32',
+                              element_shape=(2, ))
+    sym_grid_m = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                              'grid_m',
+                              'f32',
+                              element_shape=())
+    g_init = ti.graph.Graph()
+    g_init.dispatch(init_particles, sym_x, sym_v, sym_J)
+
+    g_update = ti.graph.Graph()
+    substep = g_update.create_sequential()
+
+    substep.dispatch(substep_reset_grid, sym_grid_v, sym_grid_m)
+    substep.dispatch(substep_p2g, sym_x, sym_v, sym_C, sym_J, sym_grid_v,
+                     sym_grid_m)
+    substep.dispatch(substep_update_grid_v, sym_grid_v, sym_grid_m)
+    substep.dispatch(substep_g2p, sym_x, sym_v, sym_C, sym_J, sym_grid_v)
+
+    for i in range(N_ITER):
+        g_update.append(substep)
+
+    g_init.compile()
+    g_update.compile()
+
+    x = ti.Vector.ndarray(2, ti.f32, shape=(n_particles))
+    v = ti.Vector.ndarray(2, ti.f32, shape=(n_particles))
+
+    C = ti.Matrix.ndarray(2, 2, ti.f32, shape=(n_particles))
+    J = ti.ndarray(ti.f32, shape=(n_particles))
+    grid_v = ti.Vector.ndarray(2, ti.f32, shape=(n_grid, n_grid))
+    grid_m = ti.ndarray(ti.f32, shape=(n_grid, n_grid))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        mod = ti.aot.Module(ti.vulkan)
+        mod.add_graph('init', g_init)
+        mod.add_graph('update', g_update)
+        mod.save(tmpdir, '')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5023
* #5017
* #5016

This PR supports graph builder and runner APIs in python. Note for
simplicity I've merged builder and runner in the same Python class.
Please feel free to comment if you have any suggestions.

This PR also adds a test of saving mpm88 graph in aot module, as well
as an example script to demonstrate the speed improvement (15fps ->
45fps) compared to the current taichi.