### PR TITLE
[doc] Update OS names in dev install

### DIFF
--- a/docs/lang/articles/contribution/dev_install.md
+++ b/docs/lang/articles/contribution/dev_install.md
@@ -37,7 +37,7 @@ Installation instructions vary depending on which operating system (OS) you are 
 <Tabs
   defaultValue="unix"
   values={[
-    {label: 'Linux/Unix/Mac', value: 'unix'},
+    {label: 'Linux/Mac', value: 'unix'},
     {label: 'Windows', value: 'windows'}
   ]}>
 


### PR DESCRIPTION
It is a bit strange to see `Linux/Unix/Mac`. Since Linux and Mac are both Unix, let's just remove Unix.