### PR TITLE
[Lang] Fix potential precision bug when using math vector and matrix types

### DIFF
--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -71,10 +71,11 @@ def vector_to_fast_image(img: template(), out: ndarray_type.ndarray()):
         r, g, b = 0, 0, 0
         color = img[i, img.shape[1] - 1 - j]
         if static(img.dtype in [f16, f32, f64]):
-            r, g, b = min(255, max(0, int(color * 255)))
+            r, g, b = min(255, max(0, int(color * 255)))[:3]
         else:
             static_assert(img.dtype == u8)
-            r, g, b = color
+            r, g, b = color[:3]
+
         idx = j * img.shape[0] + i
         # We use i32 for |out| since OpenGL and Metal doesn't support u8 types
         if static(get_os_name() != 'osx'):

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -633,8 +633,8 @@ def determinant(m):
 
 @ti.func
 def _inverse2x2(m):
-    return mat2(m[1, 1], -m[0, 1], -m[1, 0],
-                m[0, 0]) / (m[0, 0] * m[1, 1] - m[0, 1] * m[1, 0])
+    return mat2([[m[1, 1], -m[0, 1]], [-m[1, 0], m[0, 0]]
+                 ]) / (m[0, 0] * m[1, 1] - m[0, 1] * m[1, 0])
 
 
 @ti.func
@@ -652,9 +652,9 @@ def _inverse3x3(m):
     b11 = -a22 * a10 + a12 * a20
     b21 = a21 * a10 - a11 * a20
     det = a00 * b01 + a01 * b11 + a02 * b21
-    return mat3(b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11), b11,
-                (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10), b21,
-                (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det
+    return mat3([[b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11), b11],
+                 [(a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10), b21],
+                 [(-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)]]) / det
 
 
 @ti.func
@@ -688,16 +688,25 @@ def _inverse4x4(m):
     b10 = a21 * a33 - a23 * a31
     b11 = a22 * a33 - a23 * a32
     det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06
-    return mat4(
+    return mat4([[
         a11 * b11 - a12 * b10 + a13 * b09, a02 * b10 - a01 * b11 - a03 * b09,
-        a31 * b05 - a32 * b04 + a33 * b03, a22 * b04 - a21 * b05 - a23 * b03,
-        a12 * b08 - a10 * b11 - a13 * b07, a00 * b11 - a02 * b08 + a03 * b07,
-        a32 * b02 - a30 * b05 - a33 * b01, a20 * b05 - a22 * b02 + a23 * b01,
-        a10 * b10 - a11 * b08 + a13 * b06, a01 * b08 - a00 * b10 - a03 * b06,
-        a30 * b04 - a31 * b02 + a33 * b00, a21 * b02 - a20 * b04 - a23 * b00,
-        a11 * b07 - a10 * b09 - a12 * b06, a00 * b09 - a01 * b07 + a02 * b06,
-        a31 * b01 - a30 * b03 - a32 * b00,
-        a20 * b03 - a21 * b01 + a22 * b00) / det
+        a31 * b05 - a32 * b04 + a33 * b03, a22 * b04 - a21 * b05 - a23 * b03
+    ],
+                 [
+                     a12 * b08 - a10 * b11 - a13 * b07, a00 * b11 - a02 * b08 +
+                     a03 * b07, a32 * b02 - a30 * b05 - a33 * b01,
+                     a20 * b05 - a22 * b02 + a23 * b01
+                 ],
+                 [
+                     a10 * b10 - a11 * b08 + a13 * b06, a01 * b08 - a00 * b10 -
+                     a03 * b06, a30 * b04 - a31 * b02 + a33 * b00,
+                     a21 * b02 - a20 * b04 - a23 * b00
+                 ],
+                 [
+                     a11 * b07 - a10 * b09 - a12 * b06, a00 * b09 - a01 * b07 +
+                     a02 * b06, a31 * b01 - a30 * b03 - a32 * b00,
+                     a20 * b03 - a21 * b01 + a22 * b00
+                 ]]) / det
 
 
 @ti.func
@@ -711,11 +720,6 @@ def inverse(mat):  # pylint: disable=R1710
 
     Returns:
         Inverse of the input matrix.
-
-    Example::
-
-        >>> m = mat3(vec3(1, 1, 0), vec3(0, 1, 1), vec3(0, 0, 1))
-        >>> inverse(m)
     """
     assert mat.m == mat.n and 2 <= mat.m <= 4, "A 2x2, 3x3 or 4x4 matrix is expected"
     if ti.static(mat.m == 2):

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -72,13 +72,20 @@ def _gen_matrix_type(n, *args):
     dt = impl.get_runtime().default_fp
     if len(args) == n:
         for x in args:
-            assert isinstance(x, ti.Matrix) and x.m == 1 and x.n == n
+            if isinstance(x, ti.Matrix):
+                assert x.m == 1 and x.n == n, f"Non-vector object encoutered: {x}"
+
+            if isinstance(x, (tuple, list)):
+                assert len(x) == n, f"A list of length != {n} encoutered"
 
         data = [[v[k] for k in range(n)] for v in args]
         return ti.Matrix(data, dt)
 
     if len(args) == 1:
         x, = args
+        if isinstance(x, (tuple, list)) and len(x) == n * n:
+            x = [[x[i * n + k] for k in range(n)] for i in range(n)]
+
         return ti.Matrix(x, dt)
 
     if len(args) == n * n:

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -4,7 +4,7 @@ Math functions for glsl-like functions and other stuff.
 """
 from math import e, pi
 
-from taichi.lang import impl
+from taichi.lang import exception, impl
 from taichi.lang.ops import (acos, asin, atan2, ceil, cos, exp, floor, log,
                              max, min, pow, round, sin, sqrt, tan, tanh)
 
@@ -68,22 +68,43 @@ def uvec4(*args):
     return ti.types.vector(4, _get_uint_ip())(*args)  # pylint: disable=E1101
 
 
+def _gen_matrix_type(n, *args):
+    dt = impl.get_runtime().default_fp
+    if len(args) == n:
+        for x in args:
+            assert isinstance(x, ti.Matrix) and x.m == 1 and x.n == n
+
+        data = [[v[k] for k in range(n)] for v in args]
+        return ti.Matrix(data, dt)
+
+    if len(args) == 1:
+        x, = args
+        return ti.Matrix(x, dt)
+
+    if len(args) == n * n:
+        data = [[args[i * n + k] for k in range(n)] for i in range(n)]
+        return ti.Matrix(data, dt)
+
+    raise exception.TaichiTypeError(
+        "A matrix, a list of scalars or vectors are expected")
+
+
 def mat2(*args):
     """2x2 floating matrix type.
     """
-    return ti.types.matrix(2, 2, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+    return _gen_matrix_type(2, *args)  # pylint: disable=E1101
 
 
 def mat3(*args):
     """3x3 floating matrix type.
     """
-    return ti.types.matrix(3, 3, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+    return _gen_matrix_type(3, *args)  # pylint: disable=E1101
 
 
 def mat4(*args):
     """4x4 floating matrix type.
     """
-    return ti.types.matrix(4, 4, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+    return _gen_matrix_type(4, *args)  # pylint: disable=E1101
 
 
 @ti.func

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -734,7 +734,7 @@ def inverse(mat):  # pylint: disable=R1710
          [0.000000, 1.000000, -1.000000],
          [0.000000, 0.000000, 1.000000]]
     """
-    assert mat.m == mat.n and 2 <= mat.m <= 4, "A 2x2, 3x3 or 4x4 matrix is expected"
+    assert mat.m == mat.n and 2 <= mat.m <= 4, "A 2x2 or a 3x3 or a 4x4 matrix is expected"
     if ti.static(mat.m == 2):
         return _inverse2x2(mat)
 

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -68,17 +68,22 @@ def uvec4(*args):
     return ti.types.vector(4, _get_uint_ip())(*args)  # pylint: disable=E1101
 
 
-mat2 = ti.types.matrix(2, 2, impl.get_runtime().default_fp)  # pylint: disable=E1101
-"""2x2 floating matrix type.
-"""
+def mat2(*args):
+    """2x2 floating matrix type.
+    """
+    return ti.types.matrix(2, 2, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
 
-mat3 = ti.types.matrix(3, 3, impl.get_runtime().default_fp)  # pylint: disable=E1101
-"""3x3 floating matrix type.
-"""
 
-mat4 = ti.types.matrix(4, 4, impl.get_runtime().default_fp)  # pylint: disable=E1101
-"""4x4 floating matrix type.
-"""
+def mat3(*args):
+    """3x3 floating matrix type.
+    """
+    return ti.types.matrix(3, 3, impl.get_runtime().default_fp)  # pylint: disable=E1101
+
+
+def mat4(*args):
+    """4x4 floating matrix type.
+    """
+    return ti.types.matrix(4, 4, impl.get_runtime().default_fp)  # pylint: disable=E1101
 
 
 @ti.func
@@ -632,85 +637,6 @@ def determinant(m):
 
 
 @ti.func
-def _inverse2x2(m):
-    return mat2([[m[1, 1], -m[0, 1]], [-m[1, 0], m[0, 0]]
-                 ]) / (m[0, 0] * m[1, 1] - m[0, 1] * m[1, 0])
-
-
-@ti.func
-def _inverse3x3(m):
-    a00 = m[0, 0]
-    a01 = m[0, 1]
-    a02 = m[0, 2]
-    a10 = m[1, 0]
-    a11 = m[1, 1]
-    a12 = m[1, 2]
-    a20 = m[2, 0]
-    a21 = m[2, 1]
-    a22 = m[2, 2]
-    b01 = a22 * a11 - a12 * a21
-    b11 = -a22 * a10 + a12 * a20
-    b21 = a21 * a10 - a11 * a20
-    det = a00 * b01 + a01 * b11 + a02 * b21
-    return mat3([[b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11)],
-                 [b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10)],
-                 [b21, (-a21 * a00 + a01 * a20),
-                  (a11 * a00 - a01 * a10)]]) / det
-
-
-@ti.func
-def _inverse4x4(m):
-    a00 = m[0, 0]
-    a01 = m[0, 1]
-    a02 = m[0, 2]
-    a03 = m[0, 3]
-    a10 = m[1, 0]
-    a11 = m[1, 1]
-    a12 = m[1, 2]
-    a13 = m[1, 3]
-    a20 = m[2, 0]
-    a21 = m[2, 1]
-    a22 = m[2, 2]
-    a23 = m[2, 3]
-    a30 = m[3, 0]
-    a31 = m[3, 1]
-    a32 = m[3, 2]
-    a33 = m[3, 3]
-    b00 = a00 * a11 - a01 * a10
-    b01 = a00 * a12 - a02 * a10
-    b02 = a00 * a13 - a03 * a10
-    b03 = a01 * a12 - a02 * a11
-    b04 = a01 * a13 - a03 * a11
-    b05 = a02 * a13 - a03 * a12
-    b06 = a20 * a31 - a21 * a30
-    b07 = a20 * a32 - a22 * a30
-    b08 = a20 * a33 - a23 * a30
-    b09 = a21 * a32 - a22 * a31
-    b10 = a21 * a33 - a23 * a31
-    b11 = a22 * a33 - a23 * a32
-    det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06
-    return mat4([[
-        a11 * b11 - a12 * b10 + a13 * b09, a02 * b10 - a01 * b11 - a03 * b09,
-        a31 * b05 - a32 * b04 + a33 * b03, a22 * b04 - a21 * b05 - a23 * b03
-    ],
-                 [
-                     a12 * b08 - a10 * b11 - a13 * b07, a00 * b11 - a02 * b08 +
-                     a03 * b07, a32 * b02 - a30 * b05 - a33 * b01,
-                     a20 * b05 - a22 * b02 + a23 * b01
-                 ],
-                 [
-                     a10 * b10 - a11 * b08 + a13 * b06, a01 * b08 - a00 * b10 -
-                     a03 * b06, a30 * b04 - a31 * b02 + a33 * b00,
-                     a21 * b02 - a20 * b04 - a23 * b00
-                 ],
-                 [
-                     a11 * b07 - a10 * b09 - a12 * b06, a00 * b09 - a01 * b07 +
-                     a02 * b06, a31 * b01 - a30 * b03 - a32 * b00,
-                     a20 * b03 - a21 * b01 + a22 * b00
-                 ]]) / det
-
-
-@ti.func
 def inverse(mat):  # pylint: disable=R1710
     """Calculate the inverse of a matrix.
 
@@ -734,15 +660,7 @@ def inverse(mat):  # pylint: disable=R1710
          [0.000000, 1.000000, -1.000000],
          [0.000000, 0.000000, 1.000000]]
     """
-    assert mat.m == mat.n and 2 <= mat.m <= 4, "A 2x2 or a 3x3 or a 4x4 matrix is expected"
-    if ti.static(mat.m == 2):
-        return _inverse2x2(mat)
-
-    if ti.static(mat.m == 3):
-        return _inverse3x3(mat)
-
-    if ti.static(mat.m == 4):
-        return _inverse4x4(mat)
+    return mat.inverse()
 
 
 __all__ = [

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -17,37 +17,37 @@ _get_uint_ip = lambda: ti.u32 if impl.get_runtime(
 def vec2(*args):
     """2D floating vector type.
     """
-    return ti.types.vector(2, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+    return ti.types.vector(2, float)(*args)  # pylint: disable=E1101
 
 
 def vec3(*args):
     """3D floating vector type.
     """
-    return ti.types.vector(3, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+    return ti.types.vector(3, float)(*args)  # pylint: disable=E1101
 
 
 def vec4(*args):
     """4D floating vector type.
     """
-    return ti.types.vector(4, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+    return ti.types.vector(4, float)(*args)  # pylint: disable=E1101
 
 
 def ivec2(*args):
     """2D signed int vector type.
     """
-    return ti.types.vector(2, impl.get_runtime().default_ip)(*args)  # pylint: disable=E1101
+    return ti.types.vector(2, int)(*args)  # pylint: disable=E1101
 
 
 def ivec3(*args):
     """3D signed int vector type.
     """
-    return ti.types.vector(3, impl.get_runtime().default_ip)(*args)  # pylint: disable=E1101
+    return ti.types.vector(3, int)(*args)  # pylint: disable=E1101
 
 
 def ivec4(*args):
     """4D signed int vector type.
     """
-    return ti.types.vector(4, impl.get_runtime().default_ip)(*args)  # pylint: disable=E1101
+    return ti.types.vector(4, int)(*args)  # pylint: disable=E1101
 
 
 def uvec2(*args):
@@ -71,19 +71,19 @@ def uvec4(*args):
 def mat2(*args):
     """2x2 floating matrix type.
     """
-    return ti.types.matrix(2, 2, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+    return ti.types.matrix(2, 2, float)(*args)  # pylint: disable=E1101
 
 
 def mat3(*args):
     """3x3 floating matrix type.
     """
-    return ti.types.matrix(3, 3, impl.get_runtime().default_fp)  # pylint: disable=E1101
+    return ti.types.matrix(3, 3, float)(*args)  # pylint: disable=E1101
 
 
 def mat4(*args):
     """4x4 floating matrix type.
     """
-    return ti.types.matrix(4, 4, impl.get_runtime().default_fp)  # pylint: disable=E1101
+    return ti.types.matrix(4, 4, float)(*args)  # pylint: disable=E1101
 
 
 @ti.func

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -10,44 +10,44 @@ from taichi.lang.ops import (acos, asin, atan2, ceil, cos, exp, floor, log,
 
 import taichi as ti
 
-vec2 = ti.types.vector(2, float)  # pylint: disable=E1101
-"""2D float vector type.
-"""
-
-vec3 = ti.types.vector(3, float)  # pylint: disable=E1101
-"""3D float vector type.
-"""
-
-vec4 = ti.types.vector(4, float)  # pylint: disable=E1101
-"""4D float vector type.
-"""
-
-ivec2 = ti.types.vector(2, int)  # pylint: disable=E1101
-"""2D int vector type.
-"""
-
-ivec3 = ti.types.vector(3, int)  # pylint: disable=E1101
-"""3D int vector type.
-"""
-
-ivec4 = ti.types.vector(4, int)  # pylint: disable=E1101
-"""4D int vector type.
-"""
-
-mat2 = ti.types.matrix(2, 2, float)  # pylint: disable=E1101
-"""2x2 float matrix type.
-"""
-
-mat3 = ti.types.matrix(3, 3, float)  # pylint: disable=E1101
-"""3x3 float matrix type.
-"""
-
-mat4 = ti.types.matrix(4, 4, float)  # pylint: disable=E1101
-"""4x4 float matrix type.
-"""
-
 _get_uint_ip = lambda: ti.u32 if impl.get_runtime(
 ).default_ip == ti.i32 else ti.u64
+
+
+def vec2(*args):
+    """2D floating vector type.
+    """
+    return ti.types.vector(2, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+
+
+def vec3(*args):
+    """3D floating vector type.
+    """
+    return ti.types.vector(3, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+
+
+def vec4(*args):
+    """4D floating vector type.
+    """
+    return ti.types.vector(4, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+
+
+def ivec2(*args):
+    """2D signed int vector type.
+    """
+    return ti.types.vector(2, impl.get_runtime().default_ip)(*args)  # pylint: disable=E1101
+
+
+def ivec3(*args):
+    """3D signed int vector type.
+    """
+    return ti.types.vector(3, impl.get_runtime().default_ip)(*args)  # pylint: disable=E1101
+
+
+def ivec4(*args):
+    """4D signed int vector type.
+    """
+    return ti.types.vector(4, impl.get_runtime().default_ip)(*args)  # pylint: disable=E1101
 
 
 def uvec2(*args):
@@ -66,6 +66,24 @@ def uvec4(*args):
     """4D unsigned int vector type.
     """
     return ti.types.vector(4, _get_uint_ip())(*args)  # pylint: disable=E1101
+
+
+def mat2(*args):
+    """2x2 floating matrix type.
+    """
+    return ti.types.matrix(2, 2, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+
+
+def mat3(*args):
+    """3x3 floating matrix type.
+    """
+    return ti.types.matrix(3, 3, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
+
+
+def mat4(*args):
+    """4x4 floating matrix type.
+    """
+    return ti.types.matrix(4, 4, impl.get_runtime().default_fp)(*args)  # pylint: disable=E1101
 
 
 @ti.func

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -652,9 +652,10 @@ def _inverse3x3(m):
     b11 = -a22 * a10 + a12 * a20
     b21 = a21 * a10 - a11 * a20
     det = a00 * b01 + a01 * b11 + a02 * b21
-    return mat3([[b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11), b11],
-                 [(a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10), b21],
-                 [(-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)]]) / det
+    return mat3([[b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11)],
+                 [b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10)],
+                 [b21, (-a21 * a00 + a01 * a20),
+                  (a11 * a00 - a01 * a10)]]) / det
 
 
 @ti.func
@@ -720,6 +721,18 @@ def inverse(mat):  # pylint: disable=R1710
 
     Returns:
         Inverse of the input matrix.
+
+    Example::
+
+        >>> @ti.kernel
+        >>> def test():
+        >>>     m = mat3([(1, 1, 0), (0, 1, 1), (0, 0, 1)])
+        >>>     print(inverse(m))
+        >>>
+        >>> test()
+        [[1.000000, -1.000000, 1.000000],
+         [0.000000, 1.000000, -1.000000],
+         [0.000000, 0.000000, 1.000000]]
     """
     assert mat.m == mat.n and 2 <= mat.m <= 4, "A 2x2, 3x3 or 4x4 matrix is expected"
     if ti.static(mat.m == 2):

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -98,13 +98,13 @@ user_api[ti.FieldsBuilder] = [
 ]
 user_api[ti.math] = [
     'acos', 'asin', 'atan2', 'cconj', 'cdiv', 'ceil', 'cexp', 'cinv', 'clamp',
-    'clog', 'cmul', 'cos', 'cpow', 'cross', 'csqrt', 'degrees', 'distance',
-    'dot', 'e', 'exp', 'eye', 'floor', 'fract', 'ivec2', 'ivec3', 'ivec4',
-    'length', 'log', 'log2', 'mat2', 'mat3', 'mat4', 'max', 'min', 'mix',
-    'mod', 'normalize', 'pi', 'pow', 'radians', 'reflect', 'refract', 'rot2',
-    'rot3', 'rotate2d', 'rotate3d', 'round', 'sign', 'sin', 'smoothstep',
-    'sqrt', 'step', 'tan', 'tanh', 'uvec2', 'uvec3', 'uvec4', 'vec2', 'vec3',
-    'vec4'
+    'clog', 'cmul', 'cos', 'cpow', 'cross', 'csqrt', 'degrees', 'determinant',
+    'distance', 'dot', 'e', 'exp', 'eye', 'floor', 'fract', 'inverse', 'ivec2',
+    'ivec3', 'ivec4', 'length', 'log', 'log2', 'mat2', 'mat3', 'mat4', 'max',
+    'min', 'mix', 'mod', 'normalize', 'pi', 'pow', 'radians', 'reflect',
+    'refract', 'rot2', 'rot3', 'rotate2d', 'rotate3d', 'round', 'sign', 'sin',
+    'smoothstep', 'sqrt', 'step', 'tan', 'tanh', 'uvec2', 'uvec3', 'uvec4',
+    'vec2', 'vec3', 'vec4'
 ]
 user_api[ti.Matrix] = _get_expected_matrix_apis()
 user_api[ti.MatrixField] = [


### PR DESCRIPTION
Purpose: In the [current implementation](https://github.com/taichi-dev/taichi/blob/master/python/taichi/math/mathimpl.py#L13) of vector and matrix types, the type `float` is indeed determined when the module is imported, hence always `ti.f32`. This PR fixes this problem.

Also added two new functions `determinant` and `inverse` to the math module.