### PR TITLE
[ci] Disable win cpu docker job test

### DIFF
--- a/.github/workflows/scripts/win_build_test_cpu.ps1
+++ b/.github/workflows/scripts/win_build_test_cpu.ps1
@@ -81,7 +81,8 @@ if (-not $?) { exit 1 }
 WriteInfo("Build finished")
 ccache -s -v
 
-$env:TI_ENABLE_PADDLE = "0"
-WriteInfo("Testing Taichi")
-python tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a cpu
-WriteInfo("Test finished")
+# We skip the test for the moment due to the long job execution time.
+#$env:TI_ENABLE_PADDLE = "0"
+#WriteInfo("Testing Taichi")
+#python tests/run_tests.py -vr2 -t4 -k "not torch and not paddle" -a cpu
+#WriteInfo("Test finished")

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -83,7 +83,7 @@ jobs:
           CI_SETUP_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=ON -DTI_WITH_VULKAN:BOOL=OFF -DTI_BUILD_TESTS:BOOL=OFF
 
   build_and_test_cpu_linux:
-    name: Build and Test linux (CPU)
+    name: Build and Test Linux (CPU)
     needs: check_files
     timeout-minutes: 60
     strategy:
@@ -172,13 +172,14 @@ jobs:
           docker rm taichi_build taichi_test -f
 
   build_and_test_cpu_mac:
-    name: Build and Test macos (CPU)
+    name: Build and Test MacOS (Intel)
     needs: check_files
     timeout-minutes: 60
     strategy:
       matrix:
         include:
           - os: macos-10.15
+            cpu: 'Intel'
             python: 3.7
             with_cc: OFF
             with_cpp_tests: ON
@@ -291,7 +292,7 @@ jobs:
           docker rm taichi_build_test -f
 
   build_and_test_gpu_linux:
-    name: Build and Test (GPU)
+    name: Build and Test Linux (GPU)
     needs: check_files
     timeout-minutes: 60
     strategy:
@@ -369,7 +370,7 @@ jobs:
           docker rm taichi_build taichi_test -f
 
   build_and_test_windows:
-    name: Build and Test Windows
+    name: Build and Test Windows (GPU)
     needs: check_files
     runs-on: [self-hosted, windows, gpu]
     timeout-minutes: 90
@@ -421,13 +422,14 @@ jobs:
           TI_DEVICE_MEMORY_GB: '0.7'
 
   build_and_test_m1:
-    name: Build and Test (Apple M1)
+    name: Build and Test MacOS (M1)
     needs: check_files
     timeout-minutes: 60
     strategy:
       matrix:
         include:
           - os: macos-latest
+            cpu: 'M1'
             python: 3.8
     defaults:
       run:
@@ -474,7 +476,7 @@ jobs:
           TI_CI: 1
 
   build_libtaichi_export:
-    name: Build libtaichi_export.so(GPU)
+    name: Build libtaichi_export.so (GPU)
     needs: check_files
     runs-on: [self-hosted, cuda, vulkan, cn]
     timeout-minutes: 60

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -83,7 +83,7 @@ jobs:
           CI_SETUP_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=ON -DTI_WITH_VULKAN:BOOL=OFF -DTI_BUILD_TESTS:BOOL=OFF
 
   build_and_test_cpu_linux:
-    name: Build and Test Linux (CPU)
+    name: Build and Test linux (CPU)
     needs: check_files
     timeout-minutes: 60
     strategy:
@@ -172,14 +172,13 @@ jobs:
           docker rm taichi_build taichi_test -f
 
   build_and_test_cpu_mac:
-    name: Build and Test MacOS (Intel)
+    name: Build and Test macos (CPU)
     needs: check_files
     timeout-minutes: 60
     strategy:
       matrix:
         include:
           - os: macos-10.15
-            cpu: 'Intel'
             python: 3.7
             with_cc: OFF
             with_cpp_tests: ON
@@ -292,7 +291,7 @@ jobs:
           docker rm taichi_build_test -f
 
   build_and_test_gpu_linux:
-    name: Build and Test Linux (GPU)
+    name: Build and Test (GPU)
     needs: check_files
     timeout-minutes: 60
     strategy:
@@ -370,7 +369,7 @@ jobs:
           docker rm taichi_build taichi_test -f
 
   build_and_test_windows:
-    name: Build and Test Windows (GPU)
+    name: Build and Test Windows
     needs: check_files
     runs-on: [self-hosted, windows, gpu]
     timeout-minutes: 90
@@ -422,14 +421,13 @@ jobs:
           TI_DEVICE_MEMORY_GB: '0.7'
 
   build_and_test_m1:
-    name: Build and Test MacOS (M1)
+    name: Build and Test (Apple M1)
     needs: check_files
     timeout-minutes: 60
     strategy:
       matrix:
         include:
           - os: macos-latest
-            cpu: 'M1'
             python: 3.8
     defaults:
       run:
@@ -476,7 +474,7 @@ jobs:
           TI_CI: 1
 
   build_libtaichi_export:
-    name: Build libtaichi_export.so (GPU)
+    name: Build libtaichi_export.so(GPU)
     needs: check_files
     runs-on: [self-hosted, cuda, vulkan, cn]
     timeout-minutes: 60


### PR DESCRIPTION
- Disable test in the windows cpu job to reduce total execution time.