### PR TITLE
[Lang] [type] Refactor quant type definition APIs

### DIFF
--- a/python/taichi/types/quantized_types.py
+++ b/python/taichi/types/quantized_types.py
@@ -28,10 +28,8 @@ def _custom_float(significand_type,
         compute_type = impl.get_runtime().default_fp
     if isinstance(compute_type, _ti_core.DataType):
         compute_type = compute_type.get_ptr()
-    return _type_factory.get_custom_float_type(significand_type,
-                                               exponent_type,
-                                               compute_type,
-                                               scale)
+    return _type_factory.get_custom_float_type(significand_type, exponent_type,
+                                               compute_type, scale)
 
 
 def int(bits, signed=True, compute=None):  # pylint: disable=W0622

--- a/python/taichi/types/quantized_types.py
+++ b/python/taichi/types/quantized_types.py
@@ -9,24 +9,6 @@ from taichi.types.primitive_types import i32
 _type_factory = _ti_core.get_type_factory_instance()
 
 
-def _custom_int(bits, signed=True, compute_type=None):
-    """Generates a custom int type.
-
-    Args:
-        bits (int): Number of bits.
-        signed (bool): Signed or unsigned.
-        compute_type (DataType): Type for computation.
-
-    Returns:
-        DataType: The specified type.
-    """
-    if compute_type is None:
-        compute_type = impl.get_runtime().default_ip
-    if isinstance(compute_type, _ti_core.DataType):
-        compute_type = compute_type.get_ptr()
-    return _type_factory.get_custom_int_type(bits, signed, compute_type)
-
-
 def _custom_float(significand_type,
                   exponent_type=None,
                   compute_type=None,
@@ -49,10 +31,10 @@ def _custom_float(significand_type,
     return _type_factory.get_custom_float_type(significand_type,
                                                exponent_type,
                                                compute_type,
-                                               scale=scale)
+                                               scale)
 
 
-def int(bits, signed=False, compute=None):  # pylint: disable=W0622
+def int(bits, signed=True, compute=None):  # pylint: disable=W0622
     """Generates a quantized type for integers.
 
     Args:
@@ -65,10 +47,12 @@ def int(bits, signed=False, compute=None):  # pylint: disable=W0622
     """
     if compute is None:
         compute = impl.get_runtime().default_ip
-    return _custom_int(bits, signed, compute)
+    if isinstance(compute, _ti_core.DataType):
+        compute = compute.get_ptr()
+    return _type_factory.get_custom_int_type(bits, signed, compute)
 
 
-def fixed(frac, signed=True, range=1.0, compute=None):  # pylint: disable=W0622
+def fixed(frac, signed=True, range=1.0, compute=None, scale=None):  # pylint: disable=W0622
     """Generates a quantized type for fixed-point real numbers.
 
     Args:
@@ -76,18 +60,18 @@ def fixed(frac, signed=True, range=1.0, compute=None):  # pylint: disable=W0622
         signed (bool): Signed or unsigned.
         range (float): Range of the number.
         compute (DataType): Type for computation.
+        scale (float): Scaling factor. The argument is prioritized over range.
 
     Returns:
         DataType: The specified type.
     """
     # TODO: handle cases with frac > 32
     frac_type = int(bits=frac, signed=signed, compute=i32)
-    if signed:
-        scale = range / 2**(frac - 1)
-    else:
-        scale = range / 2**frac
-    if compute is None:
-        compute = impl.get_runtime().default_fp
+    if scale is None:
+        if signed:
+            scale = range / 2**(frac - 1)
+        else:
+            scale = range / 2**frac
     return _custom_float(frac_type, None, compute, scale)
 
 
@@ -107,8 +91,6 @@ def float(exp, frac, signed=True, compute=None):  # pylint: disable=W0622
     exp_type = int(bits=exp, signed=False, compute=i32)
     # TODO: handle cases with frac > 32
     frac_type = int(bits=frac, signed=signed, compute=i32)
-    if compute is None:
-        compute = impl.get_runtime().default_fp
     return _custom_float(significand_type=frac_type,
                          exponent_type=exp_type,
                          compute_type=compute)

--- a/tests/python/test_custom_float.py
+++ b/tests/python/test_custom_float.py
@@ -57,8 +57,7 @@ def test_custom_matrix_rotation():
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_float_implicit_cast():
-    ci13 = ti.types.quant.int(bits=13)
-    cft = ti.types.quant._custom_float(significand_type=ci13, scale=0.1)
+    cft = ti.types.quant.fixed(frac=13, scale=0.1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -73,8 +72,7 @@ def test_custom_float_implicit_cast():
 
 @test_utils.test(require=ti.extension.quant_basic)
 def test_cache_read_only():
-    ci15 = ti.types.quant.int(bits=15)
-    cft = ti.types.quant._custom_float(significand_type=ci15, scale=0.1)
+    cft = ti.types.quant.fixed(frac=15, scale=0.1)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_float_exponents.py
+++ b/tests/python/test_custom_float_exponents.py
@@ -8,11 +8,7 @@ from tests import test_utils
 
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_unsigned():
-    cu13 = ti.types.quant.int(13, False)
-    exp = ti.types.quant.int(6, False)
-    cft = ti.types.quant._custom_float(significand_type=cu13,
-                                       exponent_type=exp,
-                                       scale=1)
+    cft = ti.types.quant.float(exp=6, frac=13, signed=False)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -31,11 +27,7 @@ def test_custom_float_unsigned():
 
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_signed():
-    cu13 = ti.types.quant.int(13, True)
-    exp = ti.types.quant.int(6, False)
-    cft = ti.types.quant._custom_float(significand_type=cu13,
-                                       exponent_type=exp,
-                                       scale=1)
+    cft = ti.types.quant.float(exp=6, frac=13, signed=True)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -63,11 +55,7 @@ def test_custom_float_signed():
 @pytest.mark.parametrize('digits_bits', [23, 24])
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_precision(digits_bits):
-    cu24 = ti.types.quant.int(digits_bits, True)
-    exp = ti.types.quant.int(8, False)
-    cft = ti.types.quant._custom_float(significand_type=cu24,
-                                       exponent_type=exp,
-                                       scale=1)
+    cft = ti.types.quant.float(exp=8, frac=digits_bits)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -88,11 +76,7 @@ def test_custom_float_precision(digits_bits):
 @pytest.mark.parametrize('signed', [True, False])
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_truncation(signed):
-    cit = ti.types.quant.int(2, signed)
-    exp = ti.types.quant.int(5, False)
-    cft = ti.types.quant._custom_float(significand_type=cit,
-                                       exponent_type=exp,
-                                       scale=1)
+    cft = ti.types.quant.float(exp=5, frac=2, signed=signed)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)
@@ -120,11 +104,7 @@ def test_custom_float_truncation(signed):
 
 @test_utils.test(require=ti.extension.quant)
 def test_custom_float_atomic_demotion():
-    cit = ti.types.quant.int(2, True)
-    exp = ti.types.quant.int(5, False)
-    cft = ti.types.quant._custom_float(significand_type=cit,
-                                       exponent_type=exp,
-                                       scale=1)
+    cft = ti.types.quant.float(exp=5, frac=2)
     x = ti.field(dtype=cft)
 
     ti.root.bit_struct(num_bits=32).place(x)

--- a/tests/python/test_custom_float_shared_exp.py
+++ b/tests/python/test_custom_float_shared_exp.py
@@ -8,15 +8,8 @@ from tests import test_utils
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_shared_exponents(exponent_bits):
-    exp = ti.types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quant.int(10, False)
-    cit2 = ti.types.quant.int(14, False)
-    cft1 = ti.types.quant._custom_float(significand_type=cit1,
-                                        exponent_type=exp,
-                                        scale=1)
-    cft2 = ti.types.quant._custom_float(significand_type=cit2,
-                                        exponent_type=exp,
-                                        scale=1)
+    cft1 = ti.types.quant.float(exp=exponent_bits, frac=10, signed=False)
+    cft2 = ti.types.quant.float(exp=exponent_bits, frac=14, signed=False)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)
@@ -78,15 +71,8 @@ def test_shared_exponents(exponent_bits):
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_shared_exponent_add(exponent_bits):
-    exp = ti.types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quant.int(10, False)
-    cit2 = ti.types.quant.int(14, False)
-    cft1 = ti.types.quant._custom_float(significand_type=cit1,
-                                        exponent_type=exp,
-                                        scale=1)
-    cft2 = ti.types.quant._custom_float(significand_type=cit2,
-                                        exponent_type=exp,
-                                        scale=1)
+    cft1 = ti.types.quant.float(exp=exponent_bits, frac=10, signed=False)
+    cft2 = ti.types.quant.float(exp=exponent_bits, frac=14, signed=False)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)
@@ -118,15 +104,8 @@ def test_shared_exponent_add(exponent_bits):
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_shared_exponent_borrow(exponent_bits):
-    exp = ti.types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quant.int(10, False)
-    cit2 = ti.types.quant.int(14, False)
-    cft1 = ti.types.quant._custom_float(significand_type=cit1,
-                                        exponent_type=exp,
-                                        scale=1)
-    cft2 = ti.types.quant._custom_float(significand_type=cit2,
-                                        exponent_type=exp,
-                                        scale=1)
+    cft1 = ti.types.quant.float(exp=exponent_bits, frac=10, signed=False)
+    cft2 = ti.types.quant.float(exp=exponent_bits, frac=14, signed=False)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)
@@ -151,15 +130,8 @@ def test_shared_exponent_borrow(exponent_bits):
 @pytest.mark.parametrize('exponent_bits', [5, 6, 7, 8])
 @test_utils.test(require=ti.extension.quant)
 def test_negative(exponent_bits):
-    exp = ti.types.quant.int(exponent_bits, False)
-    cit1 = ti.types.quant.int(10, False)
-    cit2 = ti.types.quant.int(14, True)
-    cft1 = ti.types.quant._custom_float(significand_type=cit1,
-                                        exponent_type=exp,
-                                        scale=1)
-    cft2 = ti.types.quant._custom_float(significand_type=cit2,
-                                        exponent_type=exp,
-                                        scale=1)
+    cft1 = ti.types.quant.float(exp=exponent_bits, frac=10, signed=False)
+    cft2 = ti.types.quant.float(exp=exponent_bits, frac=14, signed=True)
     a = ti.field(dtype=cft1)
     b = ti.field(dtype=cft2)
     ti.root.bit_struct(num_bits=32).place(a, b, shared_exponent=True)

--- a/tests/python/test_custom_float_time_integration.py
+++ b/tests/python/test_custom_float_time_integration.py
@@ -14,11 +14,7 @@ from tests import test_utils
 def test_custom_float_time_integration(use_cft, use_exponent, use_shared_exp):
     if use_cft:
         if use_exponent:
-            exp = ti.types.quant.int(6, False)
-            cit = ti.types.quant.int(13, True)
-            cft = ti.types.quant._custom_float(significand_type=cit,
-                                               exponent_type=exp,
-                                               scale=1)
+            cft = ti.types.quant.float(exp=6, frac=13)
             x = ti.Vector.field(2, dtype=cft)
             if use_shared_exp:
                 ti.root.bit_struct(num_bits=32).place(x, shared_exponent=True)
@@ -26,9 +22,7 @@ def test_custom_float_time_integration(use_cft, use_exponent, use_shared_exp):
                 ti.root.bit_struct(num_bits=32).place(x.get_scalar_field(0))
                 ti.root.bit_struct(num_bits=32).place(x.get_scalar_field(1))
         else:
-            cit = ti.types.quant.int(16, True)
-            cft = ti.types.quant._custom_float(significand_type=cit,
-                                               scale=1 / 2**14)
+            cft = ti.types.quant.fixed(frac=16, range=2)
             x = ti.Vector.field(2, dtype=cft)
             ti.root.bit_struct(num_bits=32).place(x)
     else:

--- a/tests/python/test_custom_type_atomics.py
+++ b/tests/python/test_custom_type_atomics.py
@@ -68,10 +68,8 @@ def test_custom_int_atomics_b64():
 
 @test_utils.test(require=ti.extension.quant_basic, debug=True)
 def test_custom_float_atomics():
-    ci13 = ti.types.quant.int(13, True)
-    ci19 = ti.types.quant.int(19, False)
-    cft13 = ti.types.quant._custom_float(significand_type=ci13, scale=0.1)
-    cft19 = ti.types.quant._custom_float(significand_type=ci19, scale=0.1)
+    cft13 = ti.types.quant.fixed(frac=13, signed=True, scale=0.1)
+    cft19 = ti.types.quant.fixed(frac=19, signed=False, scale=0.1)
 
     x = ti.field(dtype=cft13)
     y = ti.field(dtype=cft19)

--- a/tests/python/test_matrix_different_type.py
+++ b/tests/python/test_matrix_different_type.py
@@ -71,9 +71,9 @@ def test_matrix():
 @test_utils.test(require=ti.extension.quant_basic)
 def test_custom_type():
     cit1 = ti.types.quant.int(bits=10, signed=True)
-    cft1 = ti.types.quant._custom_float(cit1, scale=0.1)
+    cft1 = ti.types.quant.fixed(frac=10, signed=True, scale=0.1)
     cit2 = ti.types.quant.int(bits=22, signed=False)
-    cft2 = ti.types.quant._custom_float(cit2, scale=0.1)
+    cft2 = ti.types.quant.fixed(frac=22, signed=False, scale=0.1)
     type_list = [[cit1, cft2], [cft1, cit2]]
     a = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list)
     b = ti.Matrix.field(len(type_list), len(type_list[0]), dtype=type_list)

--- a/tests/python/test_snode_layout_inspection.py
+++ b/tests/python/test_snode_layout_inspection.py
@@ -41,9 +41,8 @@ def test_primitives():
 
 @test_utils.test(arch=ti.cpu)
 def test_bit_struct():
-    cit = ti.types.quant.int(16, False)
-    x = ti.field(dtype=cit)
-    y = ti.field(dtype=ti.types.quant._custom_float(significand_type=cit))
+    x = ti.field(dtype=ti.types.quant.int(16, False))
+    y = ti.field(dtype=ti.types.quant.fixed(16, False))
     z = ti.field(dtype=ti.f32)
 
     n1 = ti.root.dense(ti.i, 32)


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/4857#issuecomment-1130043445

This PR does the following:
- For `ti.types.quant.int`, set the default value of `signed` to `True`.
- Add a `scale` parameter to `ti.types.quant.fixed`.
- Replace all occurrences of `ti.types.quant._custom_float` with `ti.types.quant.float/fixed`.
- Remove redundant logic.

After this PR, users only need to know three public APIs for quant type definition - `ti.types.quant.int/fixed/float`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
