### PR TITLE
[bug] Added type promotion support for atan2

### DIFF
--- a/docs/lang/articles/basic/type.md
+++ b/docs/lang/articles/basic/type.md
@@ -125,9 +125,12 @@ A few exceptions:
 - `u8 << i32 -> u8`
 - `i16 << i8 -> i16`
 
-2. logical operations: always return i32
-3. comparison operations: always return i32
-4. atan2 operation: follows the same type promotion rule as [std::atan2](https://en.cppreference.com/w/cpp/numeric/math/atan2).
+2. atan2 operation: return fp64 if either lhs or rhs is fp64, otherwise return fp32.
+- `i32 atan f32 -> f32`
+- `i32 atan f64 -> f64`
+
+3. logical operations: always return i32
+4. comparison operations: always return i32
 
 #### Implicit type casting in assignments
 

--- a/docs/lang/articles/basic/type.md
+++ b/docs/lang/articles/basic/type.md
@@ -127,6 +127,7 @@ A few exceptions:
 
 2. logical operations: always return i32
 3. comparison operations: always return i32
+4. atan2 operation: follows the same type promotion rule as [std::atan2](https://en.cppreference.com/w/cpp/numeric/math/atan2).
 
 #### Implicit type casting in assignments
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -202,6 +202,15 @@ void BinaryOpExpression::type_check(CompileConfig *config) {
     return;
   }
 
+  // Consistent with type promotion for std::atan2
+  // https://en.cppreference.com/w/cpp/numeric/math/atan2
+  if (type == BinaryOpType::atan2) {
+    if (lhs_type != PrimitiveType::f32 || rhs_type != PrimitiveType::f32) {
+      ret_type = PrimitiveType::f64;
+    }
+    return;
+  }
+
   if (type == BinaryOpType::truediv) {
     auto default_fp = config->default_fp;
     if (!is_real(lhs_type)) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -205,7 +205,9 @@ void BinaryOpExpression::type_check(CompileConfig *config) {
   // Consistent with type promotion for std::atan2
   // https://en.cppreference.com/w/cpp/numeric/math/atan2
   if (type == BinaryOpType::atan2) {
-    if (lhs_type != PrimitiveType::f32 || rhs_type != PrimitiveType::f32) {
+    if (lhs_type == PrimitiveType::f32 && rhs_type == PrimitiveType::f32) {
+      ret_type = PrimitiveType::f32;
+    } else {
       ret_type = PrimitiveType::f64;
     }
     return;

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -202,13 +202,13 @@ void BinaryOpExpression::type_check(CompileConfig *config) {
     return;
   }
 
-  // Consistent with type promotion for std::atan2
-  // https://en.cppreference.com/w/cpp/numeric/math/atan2
+  // Some backends such as vulkan doesn't support fp64
+  // Try not promoting to fp64 unless neccessary
   if (type == BinaryOpType::atan2) {
-    if (lhs_type == PrimitiveType::f32 && rhs_type == PrimitiveType::f32) {
-      ret_type = PrimitiveType::f32;
-    } else {
+    if (lhs_type == PrimitiveType::f64 || rhs_type == PrimitiveType::f64) {
       ret_type = PrimitiveType::f64;
+    } else {
+      ret_type = PrimitiveType::f32;
     }
     return;
   }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -301,6 +301,22 @@ class TypeCheck : public IRVisitor {
       stmt->op_type = BinaryOpType::div;
     }
 
+    // Consistent with type promotion for std::atan2
+    // https://en.cppreference.com/w/cpp/numeric/math/atan2
+    if (stmt->op_type == BinaryOpType::atan2) {
+      if (stmt->rhs->ret_type != PrimitiveType::f32 ||
+          stmt->lhs->ret_type != PrimitiveType::f32) {
+        stmt->ret_type = PrimitiveType::f64;
+        if (stmt->rhs->ret_type != PrimitiveType::f64) {
+          cast(stmt->rhs, PrimitiveType::f64);
+        }
+
+        if (stmt->lhs->ret_type != PrimitiveType::f64) {
+          cast(stmt->lhs, PrimitiveType::f64);
+        }
+      }
+    }
+
     if (stmt->lhs->ret_type != stmt->rhs->ret_type) {
       auto promote_custom_int_type = [&](Stmt *stmt, Stmt *hs) {
         if (auto cit = hs->ret_type->cast<CustomIntType>()) {

--- a/tests/python/test_type_promotion.py
+++ b/tests/python/test_type_promotion.py
@@ -66,7 +66,7 @@ def test_sqrt():
 def test_atan2():
     N = 1
     x = ti.field(ti.i32, shape=(N, ))
-    y = ti.field(ti.i16, shape=(N, ))
+    y = ti.field(ti.i32, shape=(N, ))
 
     @ti.kernel
     def test_case_0() -> ti.f64:
@@ -81,7 +81,7 @@ def test_atan2():
     @ti.kernel
     def test_case_2() -> ti.f64:
         x[0] = ti.i32(3)
-        y[0] = ti.i16(1)
+        y[0] = ti.i32(1)
         return ti.atan2(x[0], y[0])
 
     ti_res0 = test_case_0()

--- a/tests/python/test_type_promotion.py
+++ b/tests/python/test_type_promotion.py
@@ -60,3 +60,39 @@ def test_sqrt():
     func()
 
     assert np.allclose(y.to_numpy(), np.sqrt(x.to_numpy()))
+
+
+@test_utils.test()
+def test_atan2():
+    N = 1
+    x = ti.field(ti.i32, shape=(N, ))
+    y = ti.field(ti.i16, shape=(N, ))
+
+    @ti.kernel
+    def test_case_0() -> ti.f64:
+        i = ti.i32(2)
+        return ti.atan2(i, 1)
+
+    @ti.kernel
+    def test_case_1() -> ti.f64:
+        x[0] = ti.i32(2)
+        return ti.atan2(x[0], 1)
+
+    @ti.kernel
+    def test_case_2() -> ti.f64:
+        x[0] = ti.i32(3)
+        y[0] = ti.i16(1)
+        return ti.atan2(x[0], y[0])
+
+    ti_res0 = test_case_0()
+    np_res0 = np.arctan2(2, 1)
+
+    ti_res1 = test_case_1()
+    np_res1 = np.arctan2(2, 1)
+
+    ti_res2 = test_case_2()
+    np_res2 = np.arctan2(3, 1)
+
+    assert np.allclose(ti_res0, np_res0)
+    assert np.allclose(ti_res1, np_res1)
+    assert np.allclose(ti_res2, np_res2)

--- a/tests/python/test_type_promotion.py
+++ b/tests/python/test_type_promotion.py
@@ -69,17 +69,17 @@ def test_atan2():
     y = ti.field(ti.i32, shape=(N, ))
 
     @ti.kernel
-    def test_case_0() -> ti.f64:
+    def test_case_0() -> ti.f32:
         i = ti.i32(2)
         return ti.atan2(i, 1)
 
     @ti.kernel
-    def test_case_1() -> ti.f64:
+    def test_case_1() -> ti.f32:
         x[0] = ti.i32(2)
         return ti.atan2(x[0], 1)
 
     @ti.kernel
-    def test_case_2() -> ti.f64:
+    def test_case_2() -> ti.f32:
         x[0] = ti.i32(3)
         y[0] = ti.i32(1)
         return ti.atan2(x[0], y[0])


### PR DESCRIPTION
Related issue = fix #3092

Type promotion for `ti.atan2` is slightly different from that for `std::atan2`: https://en.cppreference.com/w/cpp/numeric/math/atan2. While `std::atan2` uses "double" as the default return type, we decided to use "float" as the default promoted type for `ti.atan2`, since some of the backends (Vulkan, etc) doesn't support float64.