### PR TITLE
[bug] Ndarray type should include primitive dtype as well

### DIFF
--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -4,7 +4,6 @@ from taichi.lang.exception import TaichiCompilationError
 from taichi.lang.matrix import MatrixNdarray, VectorNdarray
 from taichi.types.annotations import template
 from taichi.types.ndarray_type import NdarrayType
-from taichi.types.primitive_types import f32
 
 template_types = (NdarrayType, template)
 
@@ -29,15 +28,16 @@ def produce_injected_args_from_template(kernel, template_args):
 
 def produce_injected_args(kernel, symbolic_args=None):
     injected_args = []
-    for j, arg in enumerate(kernel.arguments):
+    for i, arg in enumerate(kernel.arguments):
         anno = arg.annotation
         if isinstance(anno, template_types):
             if not isinstance(anno, NdarrayType):
                 raise TaichiCompilationError(
                     f'Expected Ndaray type, got {anno}')
             if symbolic_args is not None:
-                anno.element_shape = tuple(symbolic_args[j].element_shape)
+                anno.element_shape = tuple(symbolic_args[i].element_shape)
                 anno.element_dim = len(anno.element_shape)
+                anno.dtype = symbolic_args[i].dtype()
 
             if anno.element_shape is None or anno.field_dim is None:
                 raise TaichiCompilationError(
@@ -45,19 +45,19 @@ def produce_injected_args(kernel, symbolic_args=None):
                     'in the param annotation, or provide an example '
                     f'ndarray for param={arg.name}')
             if anno.element_dim == 0:
-                injected_args.append(ScalarNdarray(f32,
-                                                   (2, ) * anno.field_dim))
+                injected_args.append(
+                    ScalarNdarray(anno.dtype, (2, ) * anno.field_dim))
             elif anno.element_dim == 1:
                 injected_args.append(
                     VectorNdarray(anno.element_shape[0],
-                                  dtype=f32,
+                                  dtype=anno.dtype,
                                   shape=(2, ) * anno.field_dim,
                                   layout=Layout.AOS))
             elif anno.element_dim == 2:
                 injected_args.append(
                     MatrixNdarray(anno.element_shape[0],
                                   anno.element_shape[1],
-                                  dtype=f32,
+                                  dtype=anno.dtype,
                                   shape=(2, ) * anno.field_dim,
                                   layout=Layout.AOS))
             else:

--- a/python/taichi/examples/graph/mpm88_graph.py
+++ b/python/taichi/examples/graph/mpm88_graph.py
@@ -113,12 +113,12 @@ if __name__ == "__main__":
     if not args.baseline:
         print('running in graph mode')
         # Build graph
-        sym_x = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'x', 'f32', element_shape=(2, ))
-        sym_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'v', 'f32', element_shape=(2, ))
-        sym_C = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'C', 'f32', element_shape=(2, 2))
-        sym_J = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'J', 'f32', element_shape=())
-        sym_grid_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'grid_v', 'f32', element_shape=(2, ))
-        sym_grid_m = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'grid_m', 'f32', element_shape=())
+        sym_x = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'x', ti.f32, element_shape=(2, ))
+        sym_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'v', ti.f32, element_shape=(2, ))
+        sym_C = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'C', ti.f32, element_shape=(2, 2))
+        sym_J = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'J', ti.f32)
+        sym_grid_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'grid_v', ti.f32, element_shape=(2, ))
+        sym_grid_m = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'grid_m', ti.f32)
         g_init = ti.graph.Graph()
         g_init.dispatch(init_particles, sym_x, sym_v, sym_J)
 

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -1,3 +1,6 @@
+from taichi.types.primitive_types import f32
+
+
 class NdarrayType:
     """Type annotation for arbitrary arrays, including external arrays (numpy ndarrays and torch tensors) and Taichi ndarrays.
 
@@ -11,6 +14,7 @@ class NdarrayType:
         layout (Union[Layout, NoneType], optional): None if not specified (will be treated as Layout.AOS for external arrays), Layout.AOS or Layout.SOA.
     """
     def __init__(self,
+                 dtype=f32,
                  element_dim=None,
                  element_shape=None,
                  field_dim=None,
@@ -24,6 +28,7 @@ class NdarrayType:
             raise ValueError(
                 f"Both element_shape and element_dim are specified, but shape doesn't match specified dim: {len(element_shape)}!={element_dim}"
             )
+        self.dtype = dtype
         self.element_shape = element_shape
         self.element_dim = len(
             element_shape) if element_shape is not None else element_dim

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -540,11 +540,12 @@ void export_lang(py::module &m) {
       .export_values();
 
   py::class_<aot::Arg>(m, "Arg")
-      .def(py::init<aot::ArgKind, std::string, std::string, std::vector<int>>(),
-           py::arg("tag"), py::arg("name"), py::arg("dtype_name"),
-           py::arg("element_shape"))
+      .def(py::init<aot::ArgKind, std::string, DataType &, std::vector<int>>(),
+           py::arg("tag"), py::arg("name"), py::arg("dtype"),
+           py::arg("element_shape") = py::tuple())
       .def_readonly("name", &aot::Arg::name)
-      .def_readonly("element_shape", &aot::Arg::element_shape);
+      .def_readonly("element_shape", &aot::Arg::element_shape)
+      .def("dtype", &aot::Arg::dtype);
 
   py::class_<Node>(m, "Node");
 

--- a/tests/cpp/aot/aot_save_load_test.cpp
+++ b/tests/cpp/aot/aot_save_load_test.cpp
@@ -311,12 +311,10 @@ TEST(AotSaveLoad, VulkanNdarray) {
 
   auto g_builder = std::make_unique<GraphBuilder>();
   auto seq = g_builder->seq();
-  auto arr_arg = aot::Arg{
-      aot::ArgKind::kNdarray, "arr", PrimitiveType::i32.to_string(), {}};
+  auto arr_arg = aot::Arg{aot::ArgKind::kNdarray, "arr", PrimitiveType::i32};
   seq->dispatch(ker1.get(), {arr_arg});
-  seq->dispatch(ker2.get(),
-                {arr_arg, aot::Arg{aot::ArgKind::kScalar, "x",
-                                   PrimitiveType::i32.to_string()}});
+  seq->dispatch(ker2.get(), {arr_arg, aot::Arg{aot::ArgKind::kScalar, "x",
+                                               PrimitiveType::i32}});
   auto graph = g_builder->compile();
 
   aot_builder->add_graph("test", *graph);

--- a/tests/cpp/program/graph_test.cpp
+++ b/tests/cpp/program/graph_test.cpp
@@ -30,13 +30,12 @@ TEST(GraphTest, SimpleGraphRun) {
 
   auto g_builder = std::make_unique<GraphBuilder>();
   auto seq = g_builder->seq();
-  auto arr_arg = aot::Arg{
-      aot::ArgKind::kNdarray, "arr", PrimitiveType::i32.to_string(), {}};
+  auto arr_arg = aot::Arg{aot::ArgKind::kNdarray, "arr", PrimitiveType::i32};
   seq->dispatch(ker1.get(), {arr_arg});
   seq->dispatch(ker2.get(), {arr_arg, aot::Arg{
                                           aot::ArgKind::kScalar,
                                           "x",
-                                          PrimitiveType::i32.to_string(),
+                                          PrimitiveType::i32,
                                       }});
 
   auto g = g_builder->compile();

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -714,27 +714,27 @@ def test_mpm88_ndarray_graph_aot():
 
     sym_x = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                          'x',
-                         'f32',
+                         ti.f32,
                          element_shape=(2, ))
     sym_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                          'v',
-                         'f32',
+                         ti.f32,
                          element_shape=(2, ))
     sym_C = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                          'C',
-                         'f32',
+                         ti.f32,
                          element_shape=(2, 2))
     sym_J = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                          'J',
-                         'f32',
+                         ti.f32,
                          element_shape=())
     sym_grid_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                               'grid_v',
-                              'f32',
+                              ti.f32,
                               element_shape=(2, ))
     sym_grid_m = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                               'grid_m',
-                              'f32',
+                              ti.f32,
                               element_shape=())
     g_init = ti.graph.Graph()
     g_init.dispatch(init_particles, sym_x, sym_v, sym_J)

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+import taichi as ti
+from tests import test_utils
+
+
+@test_utils.test(arch=ti.vulkan)
+def test_ndarray_int():
+    n = 4
+
+    @ti.kernel
+    def test(pos: ti.types.ndarray(field_dim=1, element_shape=())):
+        for i in range(n):
+            pos[i] = 1
+
+    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'pos', ti.i32)
+    g_init = ti.graph.Graph()
+    g_init.dispatch(test, sym_pos)
+    g_init.compile()
+
+    a = ti.ndarray(ti.i32, shape=(n, ))
+    g_init.run({'pos': a})
+    assert (a.to_numpy() == np.ones(4)).all()


### PR DESCRIPTION
This PR does three things:
- Switch cgraph `Arg` to take in `ti.f32/i32` instead of string
`f32/i32` as inputs
- Fix a bug that when we produce injected ndarray args for compilation
we only produced f32 ndarrays, which won't work for ndarray of other
primitive dtypes.
- No need to specify `element_shape` if it's scalar arg or scalar
ndarray arg.

Related issue = #4786 

Thanks to @YuCrazing for reporting the bug!

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
