### PR TITLE
[refactor] Pass element_shape and layout to C++ Ndarray

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -14,14 +14,13 @@ class Ndarray:
         dtype (DataType): Data type of each value.
         shape (Tuple[int]): Shape of the Ndarray.
     """
-    def __init__(self, dtype, arr_shape):
+    def __init__(self):
         self.host_accessor = None
         self.layout = None
         self.shape = None
         self.element_type = None
-        self.dtype = cook_dtype(dtype)
-        self.arr = impl.get_runtime().prog.create_ndarray(
-            cook_dtype(dtype), arr_shape)
+        self.dtype = None
+        self.arr = None
 
     def get_type(self):
         return SpecializeNdarrayType(self.element_type, self.shape,
@@ -215,7 +214,10 @@ class ScalarNdarray(Ndarray):
         shape (Tuple[int]): Shape of the ndarray.
     """
     def __init__(self, dtype, arr_shape):
-        super().__init__(dtype, arr_shape)
+        super().__init__()
+        self.dtype = cook_dtype(dtype)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            self.dtype, arr_shape)
         self.shape = tuple(self.arr.shape)
         self.element_type = dtype
 

--- a/python/taichi/lang/enums.py
+++ b/python/taichi/lang/enums.py
@@ -1,14 +1,5 @@
-from enum import Enum, unique
+from taichi._lib import core as _ti_core
 
-
-@unique
-class Layout(Enum):
-    """Layout of a Taichi field or ndarray.
-
-    Currently, AOS (array of structures) and SOA (structure of arrays) are supported.
-    """
-    AOS = 1
-    SOA = 2
-
+Layout = _ti_core.Layout
 
 __all__ = ['Layout']

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1690,9 +1690,11 @@ class MatrixNdarray(Ndarray):
     def __init__(self, n, m, dtype, shape, layout):
         self.n = n
         self.m = m
+        super().__init__()
+        self.dtype = cook_dtype(dtype)
         # TODO: we should pass in element_type, shape, layout instead.
-        arr_shape = (n, m) + shape if layout == Layout.SOA else shape + (n, m)
-        super().__init__(dtype, arr_shape)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            self.dtype, shape, (n, m), layout)
         self.layout = layout
         self.shape = shape
         self.element_type = MatrixType(self.n, self.m, dtype)
@@ -1786,9 +1788,11 @@ class VectorNdarray(Ndarray):
     """
     def __init__(self, n, dtype, shape, layout):
         self.n = n
+        super().__init__()
+        self.dtype = cook_dtype(dtype)
         # TODO: pass in element_type, shape, layout directly
-        arr_shape = (n, ) + shape if layout == Layout.SOA else shape + (n, )
-        super().__init__(dtype, arr_shape)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            self.dtype, shape, (n, ), layout)
         self.layout = layout
         self.shape = shape
         self.element_type = MatrixType(n, 1, dtype)

--- a/taichi/backends/opengl/codegen_opengl.cpp
+++ b/taichi/backends/opengl/codegen_opengl.cpp
@@ -486,13 +486,14 @@ class KernelGen : public IRVisitor {
     const auto &element_shape = stmt->element_shape;
     std::vector<std::string> size_var_names;
     std::vector<std::string> element_shape_size_var_names;
-    enum ExternalArrayLayout { layout_AOS = 0, layout_SOA = 1 };
-    const auto layout = stmt->element_dim <= 0 ? layout_AOS : layout_SOA;
+
+    const auto layout = stmt->element_dim <= 0 ? ExternalArrayLayout::kAOS
+                                               : ExternalArrayLayout::kSOA;
 
     if (element_shape.size() > 0) {
       int elem_beg = 0;
       int elem_end = 0;
-      if (layout == layout_SOA) {
+      if (layout == ExternalArrayLayout::kSOA) {
         elem_beg = 0;
         elem_end = element_shape.size();
       } else {
@@ -519,7 +520,7 @@ class KernelGen : public IRVisitor {
     // args buffer: 3, 2, 5, 4
     int ind_beg = 0;
     int ind_end = 0;
-    if (layout == layout_SOA) {
+    if (layout == ExternalArrayLayout::kSOA) {
       ind_beg = element_shape.size();
       ind_end = num_indices;
     } else {
@@ -540,7 +541,7 @@ class KernelGen : public IRVisitor {
       size_var_names.push_back(std::move(var_name));
     }
     // Arrange index stride and offsets in correct order
-    if (layout == layout_SOA) {
+    if (layout == ExternalArrayLayout::kSOA) {
       size_var_names.insert(size_var_names.begin(),
                             element_shape_size_var_names.begin(),
                             element_shape_size_var_names.end());

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -46,3 +46,5 @@ T taichi_union_cast(G g) {
   static_assert(sizeof(T) == sizeof(G));
   return taichi_union_cast_with_different_sizes<T>(g);
 }
+
+enum class ExternalArrayLayout { kAOS, kSOA, kNull };

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -22,7 +22,9 @@ class TI_DLL_EXPORT Ndarray {
    */
   explicit Ndarray(Program *prog,
                    const DataType type,
-                   const std::vector<int> &shape);
+                   const std::vector<int> &shape,
+                   const std::vector<int> &element_shape = {},
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
 
   /* Constructs a Ndarray from an existing DeviceAllocation
    * It doesn't handle the allocation and deallocation.
@@ -32,10 +34,12 @@ class TI_DLL_EXPORT Ndarray {
                    const std::vector<int> &shape);
   DeviceAllocation ndarray_alloc_{kDeviceNullAllocation};
   DataType dtype;
+  std::vector<int> element_shape;
   // Invariant: Since ndarray indices are flattened for vector/matrix, this is
   // always true:
   //   num_active_indices = shape.size()
   std::vector<int> shape;
+  ExternalArrayLayout layout{ExternalArrayLayout::kNull};
   int num_active_indices{0};
 
   intptr_t get_data_ptr_as_int() const;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -555,8 +555,11 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 }
 
 Ndarray *Program::create_ndarray(const DataType type,
-                                 const std::vector<int> &shape) {
-  ndarrays_.emplace_back(std::make_unique<Ndarray>(this, type, shape));
+                                 const std::vector<int> &shape,
+                                 const std::vector<int> &element_shape,
+                                 ExternalArrayLayout layout) {
+  ndarrays_.emplace_back(
+      std::make_unique<Ndarray>(this, type, shape, element_shape, layout));
   return ndarrays_.back().get();
 }
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -321,7 +321,11 @@ class TI_DLL_EXPORT Program {
     return program_impl_->allocate_memory_ndarray(alloc_size, result_buffer);
   }
 
-  Ndarray *create_ndarray(const DataType type, const std::vector<int> &shape);
+  Ndarray *create_ndarray(
+      const DataType type,
+      const std::vector<int> &shape,
+      const std::vector<int> &element_shape = {},
+      ExternalArrayLayout layout = ExternalArrayLayout::kNull);
 
   intptr_t get_ndarray_data_ptr_as_int(const Ndarray *ndarray);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -89,6 +89,11 @@ void export_lang(py::module &m) {
 #undef PER_EXTENSION
       .export_values();
 
+  py::enum_<ExternalArrayLayout>(m, "Layout", py::arithmetic())
+      .value("AOS", ExternalArrayLayout::kAOS)
+      .value("SOA", ExternalArrayLayout::kSOA)
+      .export_values();
+
   // TODO(type): This should be removed
   py::class_<DataType>(m, "DataType")
       .def(py::init<Type *>())
@@ -427,9 +432,14 @@ void export_lang(py::module &m) {
       .def(
           "create_ndarray",
           [&](Program *program, const DataType &dt,
-              const std::vector<int> &shape) -> Ndarray * {
-            return program->create_ndarray(dt, shape);
+              const std::vector<int> &shape,
+              const std::vector<int> &element_shape,
+              ExternalArrayLayout layout) -> Ndarray * {
+            return program->create_ndarray(dt, shape, element_shape, layout);
           },
+          py::arg("dt"), py::arg("shape"),
+          py::arg("element_shape") = py::tuple(),
+          py::arg("layout") = ExternalArrayLayout::kNull,
           py::return_value_policy::reference)
       .def("get_ndarray_data_ptr_as_int",
            [](Program *program, Ndarray *ndarray) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5073
* __->__ #5066
* #5065

Note we still flatten element_shape in the C++ Ndarray, which is blocked by the accessors and will be fixed
in the following PRs.