### PR TITLE
[Lang] Add more initialization routines for glsl matrix types

### DIFF
--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -68,22 +68,46 @@ def uvec4(*args):
     return ti.types.vector(4, _get_uint_ip())(*args)  # pylint: disable=E1101
 
 
+def _gen_matrix(n, *args):
+    """Supports more matrix construction routines.
+
+    1. Usual contruction (from a 2d list or a single scalar).
+    2. From a 1-D array of n*n elements (glsl style).
+    3. From a list of n-D vectors (glsl style).
+    """
+    if len(args) == n:  # initialize with n vectors
+        # Matrix.rows() will do implict type inference
+        data = [list(x) for x in args]
+        return ti.Matrix(data, float)
+
+    if len(args) == 1:  # initialize with a scalar, a matrix of a 1d list
+        x = args[0]
+        if isinstance(x, ti.Matrix):
+            return x
+
+        if hasattr(x, "__len__") and len(x) == n * n:
+            data = [[x[k * n + i] for i in range(n)] for k in range(n)]
+            return ti.Matrix(data, float)
+
+    return ti.types.matrix(n, n, float)(*args)  # pylint: disable=E1101
+
+
 def mat2(*args):
     """2x2 floating matrix type.
     """
-    return ti.types.matrix(2, 2, float)(*args)  # pylint: disable=E1101
+    return _gen_matrix(2, *args)
 
 
 def mat3(*args):
     """3x3 floating matrix type.
     """
-    return ti.types.matrix(3, 3, float)(*args)  # pylint: disable=E1101
+    return _gen_matrix(3, *args)
 
 
 def mat4(*args):
     """4x4 floating matrix type.
     """
-    return ti.types.matrix(4, 4, float)(*args)  # pylint: disable=E1101
+    return _gen_matrix(4, *args)
 
 
 @ti.func

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -75,12 +75,16 @@ def _gen_matrix(n, *args):
     2. From a 1-D array of n*n elements (glsl style).
     3. From a list of n-D vectors (glsl style).
     """
+    if len(args) == n * n:  # initialize with n*n scalars
+        data = [[args[k * n + i] for i in range(n)] for k in range(n)]
+        return ti.Matrix(data, float)
+
     if len(args) == n:  # initialize with n vectors
         # Matrix.rows() will do implict type inference
         data = [list(x) for x in args]
         return ti.Matrix(data, float)
 
-    if len(args) == 1:  # initialize with a scalar, a matrix of a 1d list
+    if len(args) == 1:  # initialize with a scalar, a matrix or a 1d list
         x = args[0]
         if isinstance(x, ti.Matrix):
             return x


### PR DESCRIPTION
This PR is intended for adding support for glsl style matrix constructions.

Feature added:

1. Use n vectors to initialize a matrix.
```python
x = vec3(1, 0, 0)
y = vec3(1, 1, 0)
z = vec3(1, 1, 1)
m = mat3(x, y, z)
```

2. Use a 1d list, or simple n*n scalars to initialize a matrix:

```python
x = mat2(1, 0, 0, 1)
y = mat2([1, 0, 0, 0])
```

3. The usual way: (without this PR)

```python
x = mat2([[1, 0], [0, 1]])
y = mat2(1)
```