### PR TITLE
[llvm] [aot] CUDA-AOT PR #0: Refactored compile_module_to_executable() to CUDAModuleToFunctionConverter

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.h
+++ b/taichi/backends/cuda/codegen_cuda.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "taichi/codegen/codegen.h"
+#include "taichi/codegen/codegen_llvm.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -13,6 +14,23 @@ class CodeGenCUDA : public KernelCodeGen {
   }
 
   FunctionType codegen() override;
+};
+
+class CUDAModuleToFunctionConverter : public ModuleToFunctionConverter {
+ public:
+  explicit CUDAModuleToFunctionConverter(TaichiLLVMContext *tlctx,
+                                         LlvmProgramImpl *program)
+      : ModuleToFunctionConverter(tlctx, program) {
+  }
+
+  FunctionType convert(const std::string &kernel_name,
+                       const std::vector<LlvmLaunchArgInfo> &args,
+                       std::unique_ptr<llvm::Module> mod,
+                       std::vector<OffloadedTask> &&tasks) const override;
+
+  FunctionType convert(const Kernel *kernel,
+                       std::unique_ptr<llvm::Module> mod,
+                       std::vector<OffloadedTask> &&tasks) const override;
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -413,7 +413,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
 class LlvmProgramImpl;
 
-// This is for CPU, we need one for CUDA (AMDGPU) as well.
+// TODO: Make ModuleToFunctionConverter abstract,
+//       Move CPU implementation to "taichi/backend/cpu/"
 class ModuleToFunctionConverter {
  public:
   explicit ModuleToFunctionConverter(TaichiLLVMContext *tlctx,
@@ -426,9 +427,9 @@ class ModuleToFunctionConverter {
                                std::unique_ptr<llvm::Module> mod,
                                std::vector<OffloadedTask> &&tasks) const;
 
-  FunctionType convert(const Kernel *kernel,
-                       std::unique_ptr<llvm::Module> mod,
-                       std::vector<OffloadedTask> &&tasks) const;
+  virtual FunctionType convert(const Kernel *kernel,
+                               std::unique_ptr<llvm::Module> mod,
+                               std::vector<OffloadedTask> &&tasks) const;
 
  protected:
   TaichiLLVMContext *tlctx_{nullptr};


### PR DESCRIPTION
Related issue = #4800

`compile_module_to_executable()` was used in LLVM - CUDA backend to perform:
1. Transform llvm::Module into CudaJITModule (CudaModule in essense), to make the compiled functions executable.
2. Prepare the execution entrance: a lambda function that does some additional configurations to the RuntimeContext, then execute the offloaded_tasks iteratively.

In this Patch, we refactored `compile_module_to_executable()` to make it decoupled with `Kernel`. In this way, we dont have to recover the entire `Kernel` at AOT runtime. 

`compile_module_to_executable()` was further replaced by `CUDAModuleToFunctionConverter::convert()` to stay consistent with LLVM - CPU backend.
