### PR TITLE
[llvm] [aot] CUDA-AOT PR #1: Extracted common logics from CPUAotModuleImpl into LLVMAotModule

### DIFF
--- a/taichi/backends/cpu/aot_module_loader_impl.cpp
+++ b/taichi/backends/cpu/aot_module_loader_impl.cpp
@@ -20,7 +20,7 @@ class AotModuleImpl : public LlvmAotModule {
   }
 
  private:
-  virtual FunctionType convert_module_to_function(
+  FunctionType convert_module_to_function(
       const std::string &name,
       LlvmOfflineCache::KernelCacheData &&loaded) override {
     auto *tlctx = program_->get_llvm_context(program_->config->arch);

--- a/taichi/backends/cpu/aot_module_loader_impl.cpp
+++ b/taichi/backends/cpu/aot_module_loader_impl.cpp
@@ -1,4 +1,5 @@
 #include "taichi/backends/cpu/aot_module_loader_impl.h"
+#include "taichi/llvm/llvm_aot_module_loader.h"
 
 #include "taichi/llvm/llvm_offline_cache.h"
 #include "taichi/llvm/llvm_program.h"
@@ -6,51 +7,23 @@
 
 namespace taichi {
 namespace lang {
-namespace cpu {
 namespace {
 
-class KernelImpl : public aot::Kernel {
+class AotModuleImpl : public LLVMAotModule {
  public:
-  explicit KernelImpl(FunctionType fn) : fn_(fn) {
-  }
-
-  void launch(RuntimeContext *ctx) override {
-    fn_(*ctx);
-  }
-
- private:
-  FunctionType fn_;
-};
-
-class AotModuleImpl : public aot::Module {
- public:
-  explicit AotModuleImpl(const AotModuleParams &params)
-      : program_(params.program),
-        cache_reader_(LlvmOfflineCacheFileReader::make(params.module_path)) {
-    TI_ASSERT(program_ != nullptr);
+  explicit AotModuleImpl(const cpu::AotModuleParams &params)
+      : LLVMAotModule(params.module_path, params.program) {
   }
 
   Arch arch() const override {
     return Arch::x64;
   }
 
-  uint64_t version() const override {
-    return 0;
-  }
-
-  size_t get_root_size() const override {
-    return 0;
-  }
-
  private:
-  std::unique_ptr<aot::Kernel> make_new_kernel(
-      const std::string &name) override {
-    TI_ASSERT(cache_reader_ != nullptr);
+  virtual FunctionType convert_module_to_function(
+      const std::string &name,
+      LlvmOfflineCache::KernelCacheData &&loaded) override {
     auto *tlctx = program_->get_llvm_context(program_->config->arch);
-    LlvmOfflineCache::KernelCacheData loaded;
-    auto ok = cache_reader_->get_kernel_cache(
-        loaded, name, *tlctx->get_this_thread_context());
-    TI_ERROR_IF(!ok, "Failed to load kernel={}", name);
 
     const auto &tasks = loaded.offloaded_task_list;
     std::vector<OffloadedTask> offloaded_tasks;
@@ -62,11 +35,10 @@ class AotModuleImpl : public aot::Module {
       ot.grid_dim = t.grid_dim;
       offloaded_tasks.push_back(std::move(ot));
     }
+
     ModuleToFunctionConverter converter{tlctx, program_};
-    auto fn =
-        converter.convert(name, loaded.args, std::move(loaded.owned_module),
-                          std::move(offloaded_tasks));
-    return std::make_unique<KernelImpl>(fn);
+    return converter.convert(name, loaded.args, std::move(loaded.owned_module),
+                             std::move(offloaded_tasks));
   }
 
   std::unique_ptr<aot::KernelTemplate> make_new_kernel_template(
@@ -79,12 +51,11 @@ class AotModuleImpl : public aot::Module {
     TI_NOT_IMPLEMENTED;
     return nullptr;
   }
-
-  LlvmProgramImpl *const program_{nullptr};
-  std::unique_ptr<LlvmOfflineCacheFileReader> cache_reader_{nullptr};
 };
 
 }  // namespace
+
+namespace cpu {
 
 std::unique_ptr<aot::Module> make_aot_module(std::any mod_params) {
   auto mod = std::make_unique<AotModuleImpl>(

--- a/taichi/backends/cpu/aot_module_loader_impl.cpp
+++ b/taichi/backends/cpu/aot_module_loader_impl.cpp
@@ -9,10 +9,10 @@ namespace taichi {
 namespace lang {
 namespace {
 
-class AotModuleImpl : public LLVMAotModule {
+class AotModuleImpl : public LlvmAotModule {
  public:
   explicit AotModuleImpl(const cpu::AotModuleParams &params)
-      : LLVMAotModule(params.module_path, params.program) {
+      : LlvmAotModule(params.module_path, params.program) {
   }
 
   Arch arch() const override {

--- a/taichi/llvm/llvm_aot_module_loader.cpp
+++ b/taichi/llvm/llvm_aot_module_loader.cpp
@@ -1,0 +1,41 @@
+#include "taichi/llvm/llvm_aot_module_loader.h"
+
+namespace taichi {
+namespace lang {
+namespace {
+
+class KernelImpl : public aot::Kernel {
+ public:
+  explicit KernelImpl(FunctionType fn) : fn_(fn) {
+  }
+
+  void launch(RuntimeContext *ctx) override {
+    fn_(*ctx);
+  }
+
+ private:
+  FunctionType fn_;
+};
+
+}  // namespace
+
+LlvmOfflineCache::KernelCacheData LLVMAotModule::load_kernel_from_cache(
+    const std::string &name) {
+  TI_ASSERT(cache_reader_ != nullptr);
+  auto *tlctx = program_->get_llvm_context(program_->config->arch);
+  LlvmOfflineCache::KernelCacheData loaded;
+  auto ok = cache_reader_->get_kernel_cache(loaded, name,
+                                            *tlctx->get_this_thread_context());
+  TI_ERROR_IF(!ok, "Failed to load kernel={}", name);
+  return loaded;
+}
+
+std::unique_ptr<aot::Kernel> LLVMAotModule::make_new_kernel(
+    const std::string &name) {
+  auto loaded = load_kernel_from_cache(name);
+  auto fn = convert_module_to_function(name, std::move(loaded));
+  return std::make_unique<KernelImpl>(fn);
+}
+
+}  // namespace lang
+}  // namespace taichi

--- a/taichi/llvm/llvm_aot_module_loader.cpp
+++ b/taichi/llvm/llvm_aot_module_loader.cpp
@@ -19,7 +19,7 @@ class KernelImpl : public aot::Kernel {
 
 }  // namespace
 
-LlvmOfflineCache::KernelCacheData LLVMAotModule::load_kernel_from_cache(
+LlvmOfflineCache::KernelCacheData LlvmAotModule::load_kernel_from_cache(
     const std::string &name) {
   TI_ASSERT(cache_reader_ != nullptr);
   auto *tlctx = program_->get_llvm_context(program_->config->arch);
@@ -30,7 +30,7 @@ LlvmOfflineCache::KernelCacheData LLVMAotModule::load_kernel_from_cache(
   return loaded;
 }
 
-std::unique_ptr<aot::Kernel> LLVMAotModule::make_new_kernel(
+std::unique_ptr<aot::Kernel> LlvmAotModule::make_new_kernel(
     const std::string &name) {
   auto loaded = load_kernel_from_cache(name);
   auto fn = convert_module_to_function(name, std::move(loaded));

--- a/taichi/llvm/llvm_aot_module_loader.h
+++ b/taichi/llvm/llvm_aot_module_loader.h
@@ -6,9 +6,9 @@
 namespace taichi {
 namespace lang {
 
-class LLVMAotModule : public aot::Module {
+class LlvmAotModule : public aot::Module {
  public:
-  explicit LLVMAotModule(const std::string &module_path,
+  explicit LlvmAotModule(const std::string &module_path,
                          LlvmProgramImpl *program)
       : program_(program),
         cache_reader_(LlvmOfflineCacheFileReader::make(module_path)) {

--- a/taichi/llvm/llvm_aot_module_loader.h
+++ b/taichi/llvm/llvm_aot_module_loader.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "taichi/aot/module_loader.h"
+#include "taichi/llvm/llvm_program.h"
+
+namespace taichi {
+namespace lang {
+
+class LLVMAotModule : public aot::Module {
+ public:
+  explicit LLVMAotModule(const std::string &module_path,
+                         LlvmProgramImpl *program)
+      : program_(program),
+        cache_reader_(LlvmOfflineCacheFileReader::make(module_path)) {
+    TI_ASSERT(program_ != nullptr);
+  }
+
+  uint64_t version() const override {
+    return 0;
+  }
+
+  size_t get_root_size() const override {
+    return 0;
+  }
+
+ protected:
+  virtual FunctionType convert_module_to_function(
+      const std::string &name,
+      LlvmOfflineCache::KernelCacheData &&loaded) = 0;
+
+  LlvmOfflineCache::KernelCacheData load_kernel_from_cache(
+      const std::string &name);
+
+  std::unique_ptr<aot::Kernel> make_new_kernel(
+      const std::string &name) override;
+
+  LlvmProgramImpl *const program_{nullptr};
+  std::unique_ptr<LlvmOfflineCacheFileReader> cache_reader_{nullptr};
+};
+
+}  // namespace lang
+}  // namespace taichi


### PR DESCRIPTION
Related issue = #4800

For AotModuleImpl, the only difference between CPU and CUDA backend lies in the various ModuleToFunctionConverter they used. Therefore we extracted common methods and members into LLVMAotModule, so that CPUAotModuleImpl and CUDAAotModuleImpl only need to override the `convert_module_to_function()` method.