### PR TITLE
[autodiff] Allocate dual and adjoint snode

### DIFF
--- a/cpp_examples/autograd.cpp
+++ b/cpp_examples/autograd.cpp
@@ -106,12 +106,12 @@ void autograd() {
                                   builder.create_add(i, one));
       builder.create_global_store(builder.create_global_ptr(c, {i}), zero);
 
-      builder.create_global_store(builder.create_global_ptr(a->get_adjoint(), {i}),
-                                  zero);
-      builder.create_global_store(builder.create_global_ptr(b->get_adjoint(), {i}),
-                                  zero);
-      builder.create_global_store(builder.create_global_ptr(c->get_adjoint(), {i}),
-                                  one);
+      builder.create_global_store(
+          builder.create_global_ptr(a->get_adjoint(), {i}), zero);
+      builder.create_global_store(
+          builder.create_global_ptr(b->get_adjoint(), {i}), zero);
+      builder.create_global_store(
+          builder.create_global_ptr(c->get_adjoint(), {i}), one);
     }
 
     kernel_init =

--- a/cpp_examples/autograd.cpp
+++ b/cpp_examples/autograd.cpp
@@ -55,7 +55,10 @@ void autograd() {
       bool is_primal() const override {
         return true;
       }
-      SNode *grad_snode() const override {
+      SNode *adjoint_snode() const override {
+        return snode;
+      }
+      SNode *dual_snode() const override {
         return snode;
       }
     };
@@ -66,7 +69,10 @@ void autograd() {
       bool is_primal() const override {
         return false;
       }
-      SNode *grad_snode() const override {
+      SNode *adjoint_snode() const override {
+        return nullptr;
+      }
+      SNode *dual_snode() const override {
         return nullptr;
       }
     };
@@ -76,8 +82,8 @@ void autograd() {
     snode->dt = PrimitiveType::f32;
     snode->grad_info = std::make_unique<GradInfoPrimal>(
         &root->dense(Axis(0), n, false).insert_children(SNodeType::place));
-    snode->get_grad()->dt = PrimitiveType::f32;
-    snode->get_grad()->grad_info = std::make_unique<GradInfoAdjoint>();
+    snode->get_adjoint()->dt = PrimitiveType::f32;
+    snode->get_adjoint()->grad_info = std::make_unique<GradInfoAdjoint>();
     return snode;
   };
   auto *a = get_snode_grad(), *b = get_snode_grad(), *c = get_snode_grad();
@@ -100,11 +106,11 @@ void autograd() {
                                   builder.create_add(i, one));
       builder.create_global_store(builder.create_global_ptr(c, {i}), zero);
 
-      builder.create_global_store(builder.create_global_ptr(a->get_grad(), {i}),
+      builder.create_global_store(builder.create_global_ptr(a->get_adjoint(), {i}),
                                   zero);
-      builder.create_global_store(builder.create_global_ptr(b->get_grad(), {i}),
+      builder.create_global_store(builder.create_global_ptr(b->get_adjoint(), {i}),
                                   zero);
-      builder.create_global_store(builder.create_global_ptr(c->get_grad(), {i}),
+      builder.create_global_store(builder.create_global_ptr(c->get_adjoint(), {i}),
                                   one);
     }
 
@@ -141,13 +147,13 @@ void autograd() {
       auto *ext_a = builder.create_external_ptr(
           builder.create_arg_load(0, PrimitiveType::f32, true), {i});
       auto *a_grad_i = builder.create_global_load(
-          builder.create_global_ptr(a->get_grad(), {i}));
+          builder.create_global_ptr(a->get_adjoint(), {i}));
       builder.create_global_store(ext_a, a_grad_i);
 
       auto *ext_b = builder.create_external_ptr(
           builder.create_arg_load(1, PrimitiveType::f32, true), {i});
       auto *b_grad_i = builder.create_global_load(
-          builder.create_global_ptr(b->get_grad(), {i}));
+          builder.create_global_ptr(b->get_adjoint(), {i}));
       builder.create_global_store(ext_b, b_grad_i);
 
       auto *ext_c = builder.create_external_ptr(

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -93,7 +93,7 @@ class Field:
             taichi_core.Expr: Representative (first) field member.
         """
         return self.vars[0].ptr
-    
+
     def _set_grad(self, grad, reverse_mode=True):
         """Binds corresponding gradient field to adjoint or dual.
 
@@ -107,7 +107,7 @@ class Field:
         else:
             self._set_dual(grad)
             self.grad = self.dual
-    
+
     def _set_adjoint(self, adjoint):
         """Sets corresponding adjoint field (reverse mode).
 
@@ -115,7 +115,7 @@ class Field:
             adjoint (Field): Corresponding adjoint field.
         """
         self.adjoint = adjoint
-    
+
     def _set_dual(self, dual):
         """Sets corresponding dual field (forward mode).
 

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -19,6 +19,8 @@ class Field:
         self.vars = _vars
         self.host_accessors = None
         self.grad = None
+        self.adjoint = None
+        self.dual = None
 
     @property
     def snode(self):
@@ -91,14 +93,36 @@ class Field:
             taichi_core.Expr: Representative (first) field member.
         """
         return self.vars[0].ptr
-
-    def _set_grad(self, grad):
-        """Sets corresponding gradient field.
+    
+    def _set_grad(self, grad, reverse_mode=True):
+        """Binds corresponding gradient field to adjoint or dual.
 
         Args:
             grad (Field): Corresponding gradient field.
+            reverse_mode (Bool): set for reverse or forward mode
         """
-        self.grad = grad
+        if reverse_mode:
+            self._set_adjoint(grad)
+            self.grad = self.adjoint
+        else:
+            self._set_dual(grad)
+            self.grad = self.dual
+    
+    def _set_adjoint(self, adjoint):
+        """Sets corresponding adjoint field (reverse mode).
+
+        Args:
+            adjoint (Field): Corresponding adjoint field.
+        """
+        self.adjoint = adjoint
+    
+    def _set_dual(self, dual):
+        """Sets corresponding dual field (forward mode).
+
+        Args:
+            dual (Field): Corresponding dual field.
+        """
+        self.dual = dual
 
     @python_scope
     def fill(self, val):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -8,13 +8,12 @@ from taichi._snode.fields_builder import FieldsBuilder
 from taichi.lang._ndarray import ScalarNdarray
 from taichi.lang._ndrange import GroupedNDRange, _Ndrange
 from taichi.lang.any_array import AnyArray, AnyArrayAccess
-from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field, ScalarField
 from taichi.lang.kernel_arguments import SparseMatrixProxy
-from taichi.lang.matrix import (Matrix, MatrixField, MatrixNdarray, MatrixType,
-                                _IntermediateMatrix, _MatrixFieldElement)
+from taichi.lang.matrix import (Matrix, MatrixField, _IntermediateMatrix,
+                                _MatrixFieldElement)
 from taichi.lang.mesh import (ConvType, MeshElementFieldProxy, MeshInstance,
                               MeshRelationAccessProxy,
                               MeshReorderedMatrixFieldProxy,
@@ -24,7 +23,7 @@ from taichi.lang.struct import Struct, StructField, _IntermediateStruct
 from taichi.lang.tape import TapeImpl
 from taichi.lang.util import (cook_dtype, get_traceback, is_taichi_class,
                               python_scope, taichi_scope, warning)
-from taichi.types.primitive_types import f16, f32, f64, i32, i64, types
+from taichi.types.primitive_types import f16, f32, f64, i32, i64
 
 
 @taichi_scope
@@ -42,7 +41,7 @@ def expr_init(rhs):
     if isinstance(rhs, Matrix):
         return Matrix(rhs.to_list())
     if isinstance(rhs, Struct):
-        return Struct(rhs.to_dict(include_methods=True))
+        return Struct(rhs.to_dict())
     if isinstance(rhs, list):
         return [expr_init(e) for e in rhs]
     if isinstance(rhs, tuple):
@@ -169,9 +168,9 @@ def subscript(value, *_indices, skip_reordered=False):
         if isinstance(value, MatrixField):
             return _MatrixFieldElement(value, indices_expr_group)
         if isinstance(value, StructField):
-            entries = {k: subscript(v, *_indices) for k, v in value._items}
-            entries['__struct_methods'] = value.struct_methods
-            return _IntermediateStruct(entries)
+            return _IntermediateStruct(
+                {k: subscript(v, *_indices)
+                 for k, v in value._items})
         return Expr(_ti_core.subscript(_var, indices_expr_group))
     if isinstance(value, AnyArray):
         # TODO: deprecate using get_attribute to get dim
@@ -192,6 +191,14 @@ def subscript(value, *_indices, skip_reordered=False):
         ])
         ret.any_array_access = any_array_access
         return ret
+    if isinstance(value, SNode):
+        # When reading bit structure we only support the 0-D case for now.
+        field_dim = 0
+        if field_dim != index_dim:
+            raise IndexError(
+                f'Field with dim {field_dim} accessed with indices of dim {index_dim}'
+            )
+        return Expr(_ti_core.subscript(value.ptr, indices_expr_group))
     # Directly evaluate in Python for non-Taichi types
     return value.__getitem__(*_indices)
 
@@ -496,16 +503,16 @@ def create_field_member(dtype, name):
     x.ptr.set_is_primal(True)
     pytaichi.global_vars.append(x)
 
-    x_grad = None
+    x_adjoint = None
     if _ti_core.needs_grad(dtype):
         # adjoint
-        x_grad = Expr(get_runtime().prog.make_id_expr(""))
-        x_grad.ptr = _ti_core.global_new(x_grad.ptr, dtype)
-        x_grad.ptr.set_name(name + ".grad")
-        x_grad.ptr.set_is_primal(False)
-        x.ptr.set_grad(x_grad.ptr)
+        x_adjoint = Expr(get_runtime().prog.make_id_expr(""))
+        x_adjoint.ptr = _ti_core.global_new(x_adjoint.ptr, dtype)
+        x_adjoint.ptr.set_name(name + ".grad")
+        x_adjoint.ptr.set_is_primal(False)
+        x.ptr.set_adjoint(x_adjoint.ptr)
 
-    return x, x_grad
+    return x, x_adjoint
 
 
 @python_scope
@@ -552,47 +559,35 @@ def field(dtype, shape=None, name="", offset=None, needs_grad=False):
     assert (offset is None or shape
             is not None), 'The shape cannot be None when offset is being set'
 
-    x, x_grad = create_field_member(dtype, name)
-    x, x_grad = ScalarField(x), ScalarField(x_grad)
-    x._set_grad(x_grad)
+    x, x_adjoint = create_field_member(dtype, name)
+    x, x_adjoint = ScalarField(x), ScalarField(x_adjoint)
+    x._set_grad(x_adjoint, reverse_mode=True)
 
     if shape is not None:
         dim = len(shape)
         root.dense(index_nd(dim), shape).place(x, offset=offset)
         if needs_grad:
-            root.dense(index_nd(dim), shape).place(x_grad)
+            # Place gradient field for reverse mode only by default
+            root.dense(index_nd(dim), shape).place(x_adjoint)
     return x
 
 
 @python_scope
-def ndarray(dtype, shape, layout=Layout.NULL):
+def ndarray(dtype, shape):
     """Defines a Taichi ndarray with scalar elements.
 
     Args:
-        dtype (Union[DataType, MatrixType]): Data type of each element. This can be either a scalar type like ti.f32 or a compound type like ti.types.vector(3, ti.i32).
+        dtype (DataType): Data type of each value.
         shape (Union[int, tuple[int]]): Shape of the ndarray.
-        layout (Layout, optional): Layout of ndarray, only applicable when element is non-scalar type. Default is Layout.AOS.
 
     Example:
         The code below shows how a Taichi ndarray with scalar elements can be declared and defined::
 
-            >>> x = ti.ndarray(ti.f32, shape=(16, 8))  # ndarray of shape (16, 8), each element is ti.f32 scalar.
-            >>> vec3 = ti.types.vector(3, ti.i32)
-            >>> y = ti.ndarray(vec3, shape=(10, 2))  # ndarray of shape (10, 2), each element is a vector of 3 ti.i32 scalars.
-            >>> matrix_ty = ti.types.matrix(3, 4, float)
-            >>> z = ti.ndarray(matrix_ty, shape=(4, 5), layout=ti.Layout.SOA)  # ndarray of shape (4, 5), each element is a matrix of (3, 4) ti.float scalars.
+            >>> x = ti.ndarray(ti.f32, shape=(16, 8))
     """
     if isinstance(shape, numbers.Number):
         shape = (shape, )
-    if dtype in types:
-        assert layout == Layout.NULL
-        return ScalarNdarray(dtype, shape)
-    if isinstance(dtype, MatrixType):
-        layout = Layout.AOS if layout == Layout.NULL else layout
-        return MatrixNdarray(dtype.n, dtype.m, dtype.dtype, shape, layout)
-
-    raise TaichiRuntimeError(
-        f'{dtype} is not supported as ndarray element type')
+    return ScalarNdarray(dtype, shape)
 
 
 @taichi_scope
@@ -886,10 +881,6 @@ def call_internal(name, *args, with_runtime_context=True):
     return expr_init(
         _ti_core.insert_internal_func_call(name, make_expr_group(args),
                                            with_runtime_context))
-
-
-def get_cuda_compute_capability():
-    return _ti_core.query_int64("cuda_compute_capability")
 
 
 @taichi_scope

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -501,7 +501,7 @@ def create_field_member(dtype, name):
         # adjoint
         x_adjoint = Expr(get_runtime().prog.make_id_expr(""))
         x_adjoint.ptr = _ti_core.global_new(x_adjoint.ptr, dtype)
-        x_adjoint.ptr.set_name(name + ".grad")
+        x_adjoint.ptr.set_name(name + ".adjoint")
         x_adjoint.ptr.set_is_primal(False)
         x.ptr.set_adjoint(x_adjoint.ptr)
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -501,7 +501,7 @@ def create_field_member(dtype, name):
         # adjoint
         x_adjoint = Expr(get_runtime().prog.make_id_expr(""))
         x_adjoint.ptr = _ti_core.global_new(x_adjoint.ptr, dtype)
-        x_adjoint.ptr.set_name(name + ".adjoint")
+        x_adjoint.ptr.set_name(name + ".grad")
         x_adjoint.ptr.set_is_primal(False)
         x.ptr.set_adjoint(x_adjoint.ptr)
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1152,7 +1152,8 @@ class Matrix(TaichiOperations):
                                                                  offset=offset)
                 if needs_grad:
                     impl.root.dense(impl.index_nd(dim),
-                                    shape).place(entries_adjoint, offset=offset)
+                                    shape).place(entries_adjoint,
+                                                 offset=offset)
         return entries
 
     @classmethod

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -17,7 +17,7 @@ from taichi.lang.util import (cook_dtype, in_python_scope, python_scope,
                               taichi_scope, to_numpy_type, to_paddle_type,
                               to_pytorch_type, warning)
 from taichi.types import primitive_types
-from taichi.types.compound_types import CompoundType, TensorType
+from taichi.types.compound_types import CompoundType
 
 
 def _gen_swizzles(cls):
@@ -1117,10 +1117,10 @@ class Matrix(TaichiOperations):
         else:
             for _ in range(n * m):
                 entries.append(impl.create_field_member(dtype, name=name))
-        entries, entries_grad = zip(*entries)
-        entries, entries_grad = MatrixField(entries, n, m), MatrixField(
-            entries_grad, n, m)
-        entries._set_grad(entries_grad)
+        entries, entries_adjoint = zip(*entries)
+        entries, entries_adjoint = MatrixField(entries, n, m), MatrixField(
+            entries_adjoint, n, m)
+        entries._set_grad(entries_adjoint, reverse_mode=True)
         impl.get_runtime().matrix_fields.append(entries)
 
         if shape is None:
@@ -1688,16 +1688,12 @@ class MatrixNdarray(Ndarray):
         >>> arr = ti.MatrixNdarray(2, 2, ti.f32, shape=(3, 3), layout=Layout.SOA)
     """
     def __init__(self, n, m, dtype, shape, layout):
-        self.n = n
-        self.m = m
-        super().__init__()
-        self.dtype = cook_dtype(dtype)
         self.layout = layout
         self.shape = shape
-        self.element_type = TensorType((self.n, self.m), self.dtype)
-        # TODO: we should pass in element_type, shape, layout instead.
-        self.arr = impl.get_runtime().prog.create_ndarray(
-            self.element_type.dtype, shape, self.element_type.shape, layout)
+        self.n = n
+        self.m = m
+        arr_shape = (n, m) + shape if layout == Layout.SOA else shape + (n, m)
+        super().__init__(dtype, arr_shape)
 
     @property
     def element_shape(self):
@@ -1709,7 +1705,8 @@ class MatrixNdarray(Ndarray):
             >>> arr.element_shape
             (2, 2)
         """
-        return tuple(self.arr.element_shape)
+        arr_shape = tuple(self.arr.shape)
+        return arr_shape[:2] if self.layout == Layout.SOA else arr_shape[-2:]
 
     @python_scope
     def __setitem__(self, key, value):
@@ -1786,15 +1783,11 @@ class VectorNdarray(Ndarray):
         >>> a = ti.VectorNdarray(3, ti.f32, (3, 3), layout=Layout.SOA)
     """
     def __init__(self, n, dtype, shape, layout):
-        self.n = n
-        super().__init__()
-        self.dtype = cook_dtype(dtype)
         self.layout = layout
         self.shape = shape
-        self.element_type = TensorType((n, ), self.dtype)
-        # TODO: pass in element_type, shape, layout directly
-        self.arr = impl.get_runtime().prog.create_ndarray(
-            self.element_type.dtype, shape, self.element_type.shape, layout)
+        self.n = n
+        arr_shape = (n, ) + shape if layout == Layout.SOA else shape + (n, )
+        super().__init__(dtype, arr_shape)
 
     @property
     def element_shape(self):
@@ -1806,7 +1799,8 @@ class VectorNdarray(Ndarray):
             >>> a.element_shape
             (3,)
         """
-        return tuple(self.arr.element_shape)
+        arr_shape = tuple(self.arr.shape)
+        return arr_shape[:1] if self.layout == Layout.SOA else arr_shape[-1:]
 
     @python_scope
     def __setitem__(self, key, value):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -17,7 +17,7 @@ from taichi.lang.util import (cook_dtype, in_python_scope, python_scope,
                               taichi_scope, to_numpy_type, to_paddle_type,
                               to_pytorch_type, warning)
 from taichi.types import primitive_types
-from taichi.types.compound_types import CompoundType
+from taichi.types.compound_types import CompoundType, TensorType
 
 
 def _gen_swizzles(cls):
@@ -1688,12 +1688,16 @@ class MatrixNdarray(Ndarray):
         >>> arr = ti.MatrixNdarray(2, 2, ti.f32, shape=(3, 3), layout=Layout.SOA)
     """
     def __init__(self, n, m, dtype, shape, layout):
-        self.layout = layout
-        self.shape = shape
         self.n = n
         self.m = m
-        arr_shape = (n, m) + shape if layout == Layout.SOA else shape + (n, m)
-        super().__init__(dtype, arr_shape)
+        super().__init__()
+        self.dtype = cook_dtype(dtype)
+        self.layout = layout
+        self.shape = shape
+        self.element_type = TensorType((self.n, self.m), self.dtype)
+        # TODO: we should pass in element_type, shape, layout instead.
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            self.element_type.dtype, shape, self.element_type.shape, layout)
 
     @property
     def element_shape(self):
@@ -1705,8 +1709,7 @@ class MatrixNdarray(Ndarray):
             >>> arr.element_shape
             (2, 2)
         """
-        arr_shape = tuple(self.arr.shape)
-        return arr_shape[:2] if self.layout == Layout.SOA else arr_shape[-2:]
+        return tuple(self.arr.element_shape)
 
     @python_scope
     def __setitem__(self, key, value):
@@ -1783,11 +1786,15 @@ class VectorNdarray(Ndarray):
         >>> a = ti.VectorNdarray(3, ti.f32, (3, 3), layout=Layout.SOA)
     """
     def __init__(self, n, dtype, shape, layout):
+        self.n = n
+        super().__init__()
+        self.dtype = cook_dtype(dtype)
         self.layout = layout
         self.shape = shape
-        self.n = n
-        arr_shape = (n, ) + shape if layout == Layout.SOA else shape + (n, )
-        super().__init__(dtype, arr_shape)
+        self.element_type = TensorType((n, ), self.dtype)
+        # TODO: pass in element_type, shape, layout directly
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            self.element_type.dtype, shape, self.element_type.shape, layout)
 
     @property
     def element_shape(self):
@@ -1799,8 +1806,7 @@ class VectorNdarray(Ndarray):
             >>> a.element_shape
             (3,)
         """
-        arr_shape = tuple(self.arr.shape)
-        return arr_shape[:1] if self.layout == Layout.SOA else arr_shape[-1:]
+        return tuple(self.arr.element_shape)
 
     @python_scope
     def __setitem__(self, key, value):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1143,7 +1143,7 @@ class Matrix(TaichiOperations):
                     impl.root.dense(impl.index_nd(dim),
                                     shape).place(ScalarField(e), offset=offset)
                 if needs_grad:
-                    for e in entries_grad._get_field_members():
+                    for e in entries_adjoint._get_field_members():
                         impl.root.dense(impl.index_nd(dim),
                                         shape).place(ScalarField(e),
                                                      offset=offset)
@@ -1152,7 +1152,7 @@ class Matrix(TaichiOperations):
                                                                  offset=offset)
                 if needs_grad:
                     impl.root.dense(impl.index_nd(dim),
-                                    shape).place(entries_grad, offset=offset)
+                                    shape).place(entries_adjoint, offset=offset)
         return entries
 
     @classmethod

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -692,7 +692,7 @@ def Tape(loss, clear_gradients=True):
     if len(loss.shape) != 0:
         raise RuntimeError(
             'The loss of `Tape` must be a 0-D field, i.e. scalar')
-    if not loss.snode.ptr.has_grad():
+    if not loss.snode.ptr.has_adjoint():
         raise RuntimeError(
             'Gradients of loss are not allocated, please use ti.field(..., needs_grad=True)'
             ' for all fields that are required by autodiff.')

--- a/taichi/analysis/gen_offline_cache_key.cpp
+++ b/taichi/analysis/gen_offline_cache_key.cpp
@@ -136,6 +136,7 @@ class ASTSerializer : public IRVisitor, public ExpressionVisitor {
     emit(expr->ambient_value);
     emit(expr->is_primal);
     emit(expr->adjoint);
+    emit(expr->dual);
   }
 
   void visit(GlobalPtrExpression *expr) override {

--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -112,8 +112,11 @@ static void get_offline_cache_key_of_snode_impl(
     serializer(snode->ambient_val.stringify());
   }
   if (snode->grad_info && !snode->grad_info->is_primal()) {
-    if (auto *grad_snode = snode->grad_info->grad_snode()) {
-      get_offline_cache_key_of_snode_impl(grad_snode, serializer, visited);
+    if (auto *adjoint_snode = snode->grad_info->adjoint_snode()) {
+      get_offline_cache_key_of_snode_impl(adjoint_snode, serializer, visited);
+    }
+    if (auto *dual_snode = snode->grad_info->dual_snode()) {
+      get_offline_cache_key_of_snode_impl(dual_snode, serializer, visited);
     }
   }
   if (snode->exp_snode) {

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -50,8 +50,16 @@ SNode *Expr::snode() const {
   return cast<GlobalVariableExpression>()->snode;
 }
 
-void Expr::set_grad(const Expr &o) {
+Expr Expr::operator!() {
+  return Expr::make<UnaryOpExpression>(UnaryOpType::logic_not, expr);
+}
+
+void Expr::set_adjoint(const Expr &o) {
   this->cast<GlobalVariableExpression>()->adjoint.set(o);
+}
+
+void Expr::set_dual(const Expr &o) {
+  this->cast<GlobalVariableExpression>()->dual.set(o);
 }
 
 Expr::Expr(int16 x) : Expr() {

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -50,10 +50,6 @@ SNode *Expr::snode() const {
   return cast<GlobalVariableExpression>()->snode;
 }
 
-Expr Expr::operator!() {
-  return Expr::make<UnaryOpExpression>(UnaryOpType::logic_not, expr);
-}
-
 void Expr::set_adjoint(const Expr &o) {
   this->cast<GlobalVariableExpression>()->adjoint.set(o);
 }

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -83,6 +83,8 @@ class Expr {
 
   Expr operator[](const ExprGroup &indices) const;
 
+  Expr operator!();
+
   template <typename T, typename... Args>
   static Expr make(Args &&...args) {
     return Expr(std::make_shared<T>(std::forward<Args>(args)...));
@@ -93,7 +95,9 @@ class Expr {
   // traceback for type checking error message
   void set_tb(const std::string &tb);
 
-  void set_grad(const Expr &o);
+  void set_adjoint(const Expr &o);
+
+  void set_dual(const Expr &o);
 
   void set_attribute(const std::string &key, const std::string &value);
 

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -83,8 +83,6 @@ class Expr {
 
   Expr operator[](const ExprGroup &indices) const;
 
-  Expr operator!();
-
   template <typename T, typename... Args>
   static Expr make(Args &&...args) {
     return Expr(std::make_shared<T>(std::forward<Args>(args)...));

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -471,10 +471,6 @@ class GlobalPtrExpression : public Expression {
       : var(var), indices(indices) {
   }
 
-  GlobalPtrExpression(SNode *snode, const ExprGroup &indices)
-      : snode(snode), indices(indices) {
-  }
-
   void type_check(CompileConfig *config) override;
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -464,7 +464,6 @@ class GlobalVariableExpression : public Expression {
 
 class GlobalPtrExpression : public Expression {
  public:
-  SNode *snode{nullptr};
   Expr var;
   ExprGroup indices;
 

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -439,6 +439,7 @@ class GlobalVariableExpression : public Expression {
   TypedConstant ambient_value;
   bool is_primal{true};
   Expr adjoint;
+  Expr dual;
 
   GlobalVariableExpression(DataType dt, const Identifier &ident)
       : ident(ident), dt(dt) {
@@ -463,11 +464,16 @@ class GlobalVariableExpression : public Expression {
 
 class GlobalPtrExpression : public Expression {
  public:
+  SNode *snode{nullptr};
   Expr var;
   ExprGroup indices;
 
   GlobalPtrExpression(const Expr &var, const ExprGroup &indices)
       : var(var), indices(indices) {
+  }
+
+  GlobalPtrExpression(SNode *snode, const ExprGroup &indices)
+      : snode(snode), indices(indices) {
   }
 
   void type_check(CompileConfig *config) override;

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -304,13 +304,22 @@ bool SNode::is_primal() const {
   return grad_info->is_primal();
 }
 
-bool SNode::has_grad() const {
-  return is_primal() && (grad_info->grad_snode() != nullptr);
+bool SNode::has_adjoint() const {
+  return is_primal() && (grad_info->adjoint_snode() != nullptr);
 }
 
-SNode *SNode::get_grad() const {
-  TI_ASSERT(has_grad());
-  return grad_info->grad_snode();
+bool SNode::has_dual() const {
+  return is_primal() && (grad_info->dual_snode() != nullptr);
+}
+
+SNode *SNode::get_adjoint() const {
+  TI_ASSERT(has_adjoint());
+  return grad_info->adjoint_snode();
+}
+
+SNode *SNode::get_dual() const {
+  TI_ASSERT(has_dual());
+  return grad_info->dual_snode();
 }
 
 void SNode::set_snode_tree_id(int id) {

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -93,7 +93,8 @@ class SNode {
    public:
     virtual ~GradInfoProvider() = default;
     virtual bool is_primal() const = 0;
-    virtual SNode *grad_snode() const = 0;
+    virtual SNode *adjoint_snode() const = 0;
+    virtual SNode *dual_snode() const = 0;
 
     template <typename T>
     T *cast() {
@@ -286,9 +287,13 @@ class SNode {
 
   bool is_scalar() const;
 
-  bool has_grad() const;
+  bool has_adjoint() const;
 
-  SNode *get_grad() const;
+  SNode *get_adjoint() const;
+
+  bool has_dual() const;
+
+  SNode *get_dual() const;
 
   SNode *get_least_sparse_ancestor() const;
 

--- a/taichi/program/snode_expr_utils.cpp
+++ b/taichi/program/snode_expr_utils.cpp
@@ -16,12 +16,20 @@ class GradInfoImpl final : public SNode::GradInfoProvider {
     return glb_var_->is_primal;
   }
 
-  SNode *grad_snode() const override {
+  SNode *adjoint_snode() const override {
     auto &adj = glb_var_->adjoint;
     if (adj.expr == nullptr) {
       return nullptr;
     }
     return adj.snode();
+  }
+
+  SNode *dual_snode() const override {
+    auto &dual = glb_var_->dual;
+    if (dual.expr == nullptr) {
+      return nullptr;
+    }
+    return dual.snode();
   }
 
  private:
@@ -102,8 +110,9 @@ void make_lazy_grad(SNode *snode, SNodeGlobalVarExprMap *snode_to_exprs) {
   }
   std::vector<Expr> new_grads;
   for (auto &c : snode->ch) {
+    // TODO: handle the dual SNode
     if (c->type == SNodeType::place && c->is_primal() && needs_grad(c->dt) &&
-        !c->has_grad()) {
+        !c->has_adjoint()) {
       new_grads.push_back(snode_to_exprs->at(c.get())->adjoint);
     }
   }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -512,7 +512,8 @@ void export_lang(py::module &m) {
       .def("read_int", &SNode::read_int)
       .def("read_uint", &SNode::read_uint)
       .def("read_float", &SNode::read_float)
-      .def("has_grad", &SNode::has_grad)
+      .def("has_adjoint", &SNode::has_adjoint)
+      .def("has_dual", &SNode::has_dual)
       .def("is_primal", &SNode::is_primal)
       .def("is_place", &SNode::is_place)
       .def("get_expr", &SNode::get_expr)
@@ -661,7 +662,8 @@ void export_lang(py::module &m) {
            [&](Expr *expr, bool v) {
              expr->cast<GlobalVariableExpression>()->is_primal = v;
            })
-      .def("set_grad", &Expr::set_grad)
+      .def("set_adjoint", &Expr::set_adjoint)
+      .def("set_dual", &Expr::set_dual)
       .def("set_attribute", &Expr::set_attribute)
       .def("get_ret_type", &Expr::get_ret_type)
       .def("type_check", &Expr::type_check)


### PR DESCRIPTION
Related issue = #5055
Decompose the vague grad to adjoint (for reverse mode) and dual (for forward mode). Support allocating both adjoint and dual SNodes as we need both when computing second-order derivatives.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
