### PR TITLE
[refactor] Make sure Ndarray shape is field shape

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -81,7 +81,8 @@ class Ndarray:
         Returns:
             numpy.ndarray: The result numpy array.
         """
-        arr = np.zeros(shape=self.arr.shape, dtype=to_numpy_type(self.dtype))
+        arr = np.zeros(shape=self.arr.total_shape(),
+                       dtype=to_numpy_type(self.dtype))
         from taichi._kernels import ndarray_to_ext_arr  # pylint: disable=C0415
         ndarray_to_ext_arr(self, arr)
         impl.get_runtime().sync()
@@ -93,7 +94,8 @@ class Ndarray:
         Returns:
             numpy.ndarray: The result numpy array.
         """
-        arr = np.zeros(shape=self.arr.shape, dtype=to_numpy_type(self.dtype))
+        arr = np.zeros(shape=self.arr.total_shape(),
+                       dtype=to_numpy_type(self.dtype))
         from taichi._kernels import \
             ndarray_matrix_to_ext_arr  # pylint: disable=C0415
         layout_is_aos = 1 if layout == Layout.AOS else 0
@@ -109,7 +111,7 @@ class Ndarray:
         """
         if not isinstance(arr, np.ndarray):
             raise TypeError(f"{np.ndarray} expected, but {type(arr)} provided")
-        if tuple(self.arr.shape) != tuple(arr.shape):
+        if tuple(self.arr.total_shape()) != tuple(arr.shape):
             raise ValueError(
                 f"Mismatch shape: {tuple(self.arr.shape)} expected, but {tuple(arr.shape)} provided"
             )
@@ -128,7 +130,7 @@ class Ndarray:
         """
         if not isinstance(arr, np.ndarray):
             raise TypeError(f"{np.ndarray} expected, but {type(arr)} provided")
-        if tuple(self.arr.shape) != tuple(arr.shape):
+        if tuple(self.arr.total_shape()) != tuple(arr.shape):
             raise ValueError(
                 f"Mismatch shape: {tuple(self.arr.shape)} expected, but {tuple(arr.shape)} provided"
             )
@@ -195,7 +197,7 @@ class Ndarray:
             key = ()
         if not isinstance(key, (tuple, list)):
             key = (key, )
-        assert len(key) == len(self.arr.shape)
+        assert len(key) == len(self.arr.total_shape())
         return key
 
     def _initialize_host_accessor(self):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1693,7 +1693,7 @@ class MatrixNdarray(Ndarray):
         super().__init__()
         self.dtype = cook_dtype(dtype)
         self.layout = layout
-        self.shape = shape
+        self.shape = tuple(shape)
         self.element_type = TensorType((self.n, self.m), self.dtype)
         # TODO: we should pass in element_type, shape, layout instead.
         self.arr = impl.get_runtime().prog.create_ndarray(
@@ -1790,7 +1790,7 @@ class VectorNdarray(Ndarray):
         super().__init__()
         self.dtype = cook_dtype(dtype)
         self.layout = layout
-        self.shape = shape
+        self.shape = tuple(shape)
         self.element_type = TensorType((n, ), self.dtype)
         # TODO: pass in element_type, shape, layout directly
         self.arr = impl.get_runtime().prog.create_ndarray(

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -269,8 +269,17 @@ void Kernel::LaunchContextBuilder::set_arg_ndarray(int arg_id,
                                /*is_device_allocation=*/true);
   TI_ASSERT_INFO(arr.shape.size() <= taichi_max_num_indices,
                  "External array cannot have > {max_num_indices} indices");
-  for (uint64 i = 0; i < arr.shape.size(); ++i) {
-    this->set_extra_arg_int(arg_id, i, arr.shape[i]);
+  // TODO: Update the codegen so that we don't reserve slots for element_shape
+  // in extra_args, especially in SOA case.
+  if (arr.layout == ExternalArrayLayout::kAOS) {
+    for (uint64 i = 0; i < arr.shape.size(); ++i) {
+      this->set_extra_arg_int(arg_id, i, arr.shape[i]);
+    }
+  } else {
+    auto element_dim = arr.element_shape.size();
+    for (uint64 i = element_dim; i < arr.total_shape().size(); ++i) {
+      this->set_extra_arg_int(arg_id, i, arr.shape[i - element_dim]);
+    }
   }
 }
 

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -31,17 +31,16 @@ Ndarray::Ndarray(Program *prog,
                                     std::multiplies<>())),
       prog_(prog),
       rw_accessors_bank_(&prog->get_ndarray_rw_accessors_bank()) {
-  // TODO: Instead of flattening the element, shape/nelement_/num_active_indices
-  // should refer to field shape only.
-  // The only blocker left is the accessors should handle vector/matrix as well
-  // instead of scalar only.
+  // Now that we have two shapes which may be concatenated differently
+  // depending on layout, total_shape_ comes handy.
+  total_shape_ = shape;
   if (layout == ExternalArrayLayout::kAOS) {
-    shape.insert(shape.end(), element_shape.begin(), element_shape.end());
+    total_shape_.insert(total_shape_.end(), element_shape.begin(),
+                        element_shape.end());
   } else if (layout == ExternalArrayLayout::kSOA) {
-    shape.insert(shape.begin(), element_shape.begin(), element_shape.end());
+    total_shape_.insert(total_shape_.begin(), element_shape.begin(),
+                        element_shape.end());
   }
-
-  num_active_indices = shape.size();
 
   ndarray_alloc_ = prog->allocate_memory_ndarray(nelement_ * element_size_,
                                                  prog->result_buffer);
@@ -53,7 +52,6 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
     : ndarray_alloc_(devalloc),
       dtype(type),
       shape(shape),
-      num_active_indices(shape.size()),
       nelement_(std::accumulate(std::begin(shape),
                                 std::end(shape),
                                 1,

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -40,7 +40,6 @@ class TI_DLL_EXPORT Ndarray {
   //   num_active_indices = shape.size()
   std::vector<int> shape;
   ExternalArrayLayout layout{ExternalArrayLayout::kNull};
-  int num_active_indices{0};
 
   intptr_t get_data_ptr_as_int() const;
   intptr_t get_device_allocation_ptr_as_int() const;
@@ -51,11 +50,16 @@ class TI_DLL_EXPORT Ndarray {
   float64 read_float(const std::vector<int> &i);
   void write_int(const std::vector<int> &i, int64 val);
   void write_float(const std::vector<int> &i, float64 val);
+
+  const std::vector<int> &total_shape() const {
+    return total_shape_;
+  }
   ~Ndarray();
 
  private:
   std::size_t nelement_{1};
   std::size_t element_size_{1};
+  std::vector<int> total_shape_;
 
   Program *prog_{nullptr};
   // TODO: maybe remove these?

--- a/taichi/program/ndarray_rw_accessors_bank.cpp
+++ b/taichi/program/ndarray_rw_accessors_bank.cpp
@@ -15,15 +15,17 @@ void set_kernel_args(const std::vector<int> &I,
 void set_kernel_extra_args(const Ndarray *ndarray,
                            int arg_id,
                            Kernel::LaunchContextBuilder *launch_ctx) {
-  for (int i = 0; i < ndarray->num_active_indices; i++) {
-    launch_ctx->set_extra_arg_int(arg_id, i, ndarray->shape[i]);
+  // accessor kernels are special as they use element_shape as runtime
+  // information so it's required to use total_shape here.
+  for (int i = 0; i < ndarray->total_shape().size(); ++i) {
+    launch_ctx->set_extra_arg_int(arg_id, i, ndarray->total_shape()[i]);
   }
 }
 }  // namespace
 
 NdarrayRwAccessorsBank::Accessors NdarrayRwAccessorsBank::get(
     Ndarray *ndarray) {
-  NdarrayRwKeys keys{ndarray->num_active_indices, ndarray->dtype};
+  NdarrayRwKeys keys{ndarray->total_shape().size(), ndarray->dtype};
   if (ndarray_to_kernels_.find(keys) == ndarray_to_kernels_.end()) {
     ndarray_to_kernels_[keys] = {&(program_->get_ndarray_reader(ndarray)),
                                  &(program_->get_ndarray_writer(ndarray))};
@@ -45,14 +47,14 @@ NdarrayRwAccessorsBank::Accessors::Accessors(const Ndarray *ndarray,
 void NdarrayRwAccessorsBank::Accessors::write_float(const std::vector<int> &I,
                                                     float64 val) {
   auto launch_ctx = writer_->make_launch_context();
-  set_kernel_args(I, ndarray_->num_active_indices, &launch_ctx);
-  launch_ctx.set_arg_float(ndarray_->num_active_indices, val);
+  set_kernel_args(I, ndarray_->total_shape().size(), &launch_ctx);
+  launch_ctx.set_arg_float(ndarray_->total_shape().size(), val);
   launch_ctx.set_arg_external_array(
-      ndarray_->num_active_indices + 1,
+      ndarray_->total_shape().size() + 1,
       ndarray_->get_device_allocation_ptr_as_int(),
       ndarray_->get_nelement() * ndarray_->get_element_size(),
       /*is_device_allocation=*/true);
-  set_kernel_extra_args(ndarray_, ndarray_->num_active_indices + 1,
+  set_kernel_extra_args(ndarray_, ndarray_->total_shape().size() + 1,
                         &launch_ctx);
   prog_->synchronize();
   (*writer_)(launch_ctx);
@@ -62,13 +64,13 @@ float64 NdarrayRwAccessorsBank::Accessors::read_float(
     const std::vector<int> &I) {
   prog_->synchronize();
   auto launch_ctx = reader_->make_launch_context();
-  set_kernel_args(I, ndarray_->num_active_indices, &launch_ctx);
+  set_kernel_args(I, ndarray_->total_shape().size(), &launch_ctx);
   launch_ctx.set_arg_external_array(
-      ndarray_->num_active_indices,
+      ndarray_->total_shape().size(),
       ndarray_->get_device_allocation_ptr_as_int(),
       ndarray_->get_nelement() * ndarray_->get_element_size(),
       /*is_device_allocation=*/true);
-  set_kernel_extra_args(ndarray_, ndarray_->num_active_indices, &launch_ctx);
+  set_kernel_extra_args(ndarray_, ndarray_->total_shape().size(), &launch_ctx);
   (*reader_)(launch_ctx);
   prog_->synchronize();
   auto ret = reader_->get_ret_float(0);
@@ -79,14 +81,14 @@ float64 NdarrayRwAccessorsBank::Accessors::read_float(
 void NdarrayRwAccessorsBank::Accessors::write_int(const std::vector<int> &I,
                                                   int64 val) {
   auto launch_ctx = writer_->make_launch_context();
-  set_kernel_args(I, ndarray_->num_active_indices, &launch_ctx);
-  launch_ctx.set_arg_int(ndarray_->num_active_indices, val);
+  set_kernel_args(I, ndarray_->total_shape().size(), &launch_ctx);
+  launch_ctx.set_arg_int(ndarray_->total_shape().size(), val);
   launch_ctx.set_arg_external_array(
-      ndarray_->num_active_indices + 1,
+      ndarray_->total_shape().size() + 1,
       ndarray_->get_device_allocation_ptr_as_int(),
       ndarray_->get_nelement() * ndarray_->get_element_size(),
       /*is_device_allocation=*/true);
-  set_kernel_extra_args(ndarray_, ndarray_->num_active_indices + 1,
+  set_kernel_extra_args(ndarray_, ndarray_->total_shape().size() + 1,
                         &launch_ctx);
   prog_->synchronize();
   (*writer_)(launch_ctx);
@@ -95,13 +97,13 @@ void NdarrayRwAccessorsBank::Accessors::write_int(const std::vector<int> &I,
 int64 NdarrayRwAccessorsBank::Accessors::read_int(const std::vector<int> &I) {
   prog_->synchronize();
   auto launch_ctx = reader_->make_launch_context();
-  set_kernel_args(I, ndarray_->num_active_indices, &launch_ctx);
+  set_kernel_args(I, ndarray_->total_shape().size(), &launch_ctx);
   launch_ctx.set_arg_external_array(
-      ndarray_->num_active_indices,
+      ndarray_->total_shape().size(),
       ndarray_->get_device_allocation_ptr_as_int(),
       ndarray_->get_nelement() * ndarray_->get_element_size(),
       /*is_device_allocation=*/true);
-  set_kernel_extra_args(ndarray_, ndarray_->num_active_indices, &launch_ctx);
+  set_kernel_extra_args(ndarray_, ndarray_->total_shape().size(), &launch_ctx);
   (*reader_)(launch_ctx);
   prog_->synchronize();
   auto ret = reader_->get_ret_int(0);

--- a/taichi/program/ndarray_rw_accessors_bank.h
+++ b/taichi/program/ndarray_rw_accessors_bank.h
@@ -25,7 +25,7 @@ class Ndarray;
  * in get_ndarray_reader/writer in program.cpp.
  */
 struct NdarrayRwKeys {
-  int num_active_indices;
+  size_t num_active_indices;
   DataType dtype;
 
   struct Hasher {

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -407,7 +407,7 @@ Kernel &Program::get_snode_writer(SNode *snode) {
 Kernel &Program::get_ndarray_reader(Ndarray *ndarray) {
   auto kernel_name =
       fmt::format("ndarray_reader_{}", ndarray_reader_counter_++);
-  NdarrayRwKeys keys{ndarray->num_active_indices, ndarray->dtype};
+  NdarrayRwKeys keys{ndarray->total_shape().size(), ndarray->dtype};
   auto &ker = kernel([keys, this] {
     ExprGroup indices;
     for (int i = 0; i < keys.num_active_indices; i++) {
@@ -433,7 +433,7 @@ Kernel &Program::get_ndarray_reader(Ndarray *ndarray) {
 Kernel &Program::get_ndarray_writer(Ndarray *ndarray) {
   auto kernel_name =
       fmt::format("ndarray_writer_{}", ndarray_writer_counter_++);
-  NdarrayRwKeys keys{ndarray->num_active_indices, ndarray->dtype};
+  NdarrayRwKeys keys{ndarray->total_shape().size(), ndarray->dtype};
   auto &ker = kernel([keys, this] {
     ExprGroup indices;
     for (int i = 0; i < keys.num_active_indices; i++) {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -548,6 +548,7 @@ void export_lang(py::module &m) {
       .def("read_float", &Ndarray::read_float)
       .def("write_int", &Ndarray::write_int)
       .def("write_float", &Ndarray::write_float)
+      .def("total_shape", &Ndarray::total_shape)
       .def_readonly("dtype", &Ndarray::dtype)
       .def_readonly("element_shape", &Ndarray::element_shape)
       .def_readonly("shape", &Ndarray::shape);

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -303,13 +303,13 @@ def test_ndarray_fill():
     assert (a.to_numpy() == anp).all()
 
     b = ti.Vector.ndarray(4, ti.f32, shape=(n))
-    bnp = np.ones(shape=b.arr.shape, dtype=np.float32)
+    bnp = np.ones(shape=b.arr.total_shape(), dtype=np.float32)
     b.fill(2.5)
     bnp.fill(2.5)
     assert (b.to_numpy() == bnp).all()
 
     c = ti.Matrix.ndarray(4, 4, ti.f32, shape=(n))
-    cnp = np.ones(shape=c.arr.shape, dtype=np.float32)
+    cnp = np.ones(shape=c.arr.total_shape(), dtype=np.float32)
     c.fill(1.5)
     cnp.fill(1.5)
     assert (c.to_numpy() == cnp).all()


### PR DESCRIPTION
#5044 
This PR makes sure Ndarray shape is field shape instead of flattened field shape + element shape. It also got rid of `num_active_indices` in Ndarray class as it's just redundant. 

Now that we have two shapes which may be ordered differently depending on layout, a unified `total_shape` still comes in handy in some implementations. But it shouldn't be used by users directly (if they want they should sum up element_shape and field_shape themselves). 

[Update: this is fixed. We still need to update codegen but at runtime we no longer set element_shape in extra_args] ~Note this PR still need to set element_shape in extra_args in the `set_arg_ndarray`. It's blocked by the fact that predefined kernels like `fill_ndarray_matrix` is supposed to work for all element_shapes. In other words element_shape is a runtime information for them. I'll leave that for @turbo0628 ;).~