### PR TITLE
[llvm] [refactor] Use LLVM native atomic ops if possible

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1231,11 +1231,16 @@ llvm::Value *CodeGenLLVM::integral_type_atomic(AtomicOpStmt *stmt) {
   if (!is_integral(stmt->val->ret_type)) {
     return nullptr;
   }
+
   std::unordered_map<AtomicOpType, llvm::AtomicRMWInst::BinOp> bin_op;
   bin_op[AtomicOpType::add] = llvm::AtomicRMWInst::BinOp::Add;
-  bin_op[AtomicOpType::min] = llvm::AtomicRMWInst::BinOp::Min;
-  bin_op[AtomicOpType::max] = llvm::AtomicRMWInst::BinOp::Max;
-
+  if (is_signed(stmt->val->ret_type)) {
+    bin_op[AtomicOpType::min] = llvm::AtomicRMWInst::BinOp::Min;
+    bin_op[AtomicOpType::max] = llvm::AtomicRMWInst::BinOp::Max;
+  } else {
+    bin_op[AtomicOpType::min] = llvm::AtomicRMWInst::BinOp::UMin;
+    bin_op[AtomicOpType::max] = llvm::AtomicRMWInst::BinOp::UMax;
+  }
   bin_op[AtomicOpType::bit_and] = llvm::AtomicRMWInst::BinOp::And;
   bin_op[AtomicOpType::bit_or] = llvm::AtomicRMWInst::BinOp::Or;
   bin_op[AtomicOpType::bit_xor] = llvm::AtomicRMWInst::BinOp::Xor;
@@ -1280,12 +1285,14 @@ llvm::Value *CodeGenLLVM::atomic_op_using_cas(
   return old_val;
 }
 
-llvm::Value *CodeGenLLVM::real_or_unsigned_type_atomic(AtomicOpStmt *stmt) {
-  if (!stmt->val->ret_type->is<PrimitiveType>()) {
+llvm::Value *CodeGenLLVM::real_type_atomic(AtomicOpStmt *stmt) {
+  if (!is_real(stmt->val->ret_type)) {
     return nullptr;
   }
+
+  PrimitiveTypeID prim_type = stmt->val->ret_type->cast<PrimitiveType>()->type;
   AtomicOpType op = stmt->op_type;
-  if (stmt->val->ret_type->is_primitive(PrimitiveTypeID::f16)) {
+  if (prim_type == PrimitiveTypeID::f16) {
     switch (op) {
       case AtomicOpType::add:
         return atomic_op_using_cas(
@@ -1304,32 +1311,20 @@ llvm::Value *CodeGenLLVM::real_or_unsigned_type_atomic(AtomicOpStmt *stmt) {
     }
   }
 
-  PrimitiveTypeID prim_type = stmt->val->ret_type->cast<PrimitiveType>()->type;
+  if (op == AtomicOpType::add) {
+    return builder->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd,
+                                    llvm_val[stmt->dest], llvm_val[stmt->val],
+                                    llvm::AtomicOrdering::SequentiallyConsistent);
+  }
 
   std::unordered_map<PrimitiveTypeID,
-                     std::unordered_map<AtomicOpType, std::string>>
-      atomics;
-
-  atomics[PrimitiveTypeID::f32][AtomicOpType::add] = "atomic_add_f32";
-  atomics[PrimitiveTypeID::f64][AtomicOpType::add] = "atomic_add_f64";
+                     std::unordered_map<AtomicOpType, std::string>> atomics;
   atomics[PrimitiveTypeID::f32][AtomicOpType::min] = "atomic_min_f32";
   atomics[PrimitiveTypeID::f64][AtomicOpType::min] = "atomic_min_f64";
   atomics[PrimitiveTypeID::f32][AtomicOpType::max] = "atomic_max_f32";
   atomics[PrimitiveTypeID::f64][AtomicOpType::max] = "atomic_max_f64";
-  atomics[PrimitiveTypeID::u32][AtomicOpType::min] = "atomic_min_u32";
-  atomics[PrimitiveTypeID::u64][AtomicOpType::min] = "atomic_min_u64";
-  atomics[PrimitiveTypeID::u32][AtomicOpType::max] = "atomic_max_u32";
-  atomics[PrimitiveTypeID::u64][AtomicOpType::max] = "atomic_max_u64";
-
-  if (atomics.find(prim_type) == atomics.end()) {
-    return nullptr;
-  }
-  if (is_integral(stmt->val->ret_type) &&
-      atomics.at(prim_type).find(op) == atomics.at(prim_type).end()) {
-    return nullptr;
-  }
+  TI_ASSERT(atomics.find(prim_type) != atomics.end());
   TI_ASSERT(atomics.at(prim_type).find(op) != atomics.at(prim_type).end());
-
   return create_call(atomics.at(prim_type).at(op),
                      {llvm_val[stmt->dest], llvm_val[stmt->val]});
 }
@@ -1347,7 +1342,7 @@ void CodeGenLLVM::visit(AtomicOpStmt *stmt) {
       old_value = result;
     } else if (llvm::Value *result = custom_type_atomic(stmt)) {
       old_value = result;
-    } else if (llvm::Value *result = real_or_unsigned_type_atomic(stmt)) {
+    } else if (llvm::Value *result = real_type_atomic(stmt)) {
       old_value = result;
     } else if (llvm::Value *result = integral_type_atomic(stmt)) {
       old_value = result;

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1312,13 +1312,14 @@ llvm::Value *CodeGenLLVM::real_type_atomic(AtomicOpStmt *stmt) {
   }
 
   if (op == AtomicOpType::add) {
-    return builder->CreateAtomicRMW(llvm::AtomicRMWInst::FAdd,
-                                    llvm_val[stmt->dest], llvm_val[stmt->val],
-                                    llvm::AtomicOrdering::SequentiallyConsistent);
+    return builder->CreateAtomicRMW(
+        llvm::AtomicRMWInst::FAdd, llvm_val[stmt->dest], llvm_val[stmt->val],
+        llvm::AtomicOrdering::SequentiallyConsistent);
   }
 
   std::unordered_map<PrimitiveTypeID,
-                     std::unordered_map<AtomicOpType, std::string>> atomics;
+                     std::unordered_map<AtomicOpType, std::string>>
+      atomics;
   atomics[PrimitiveTypeID::f32][AtomicOpType::min] = "atomic_min_f32";
   atomics[PrimitiveTypeID::f64][AtomicOpType::min] = "atomic_min_f64";
   atomics[PrimitiveTypeID::f32][AtomicOpType::max] = "atomic_max_f32";

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -241,7 +241,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
       llvm::Value *val,
       std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op);
 
-  virtual llvm::Value *real_or_unsigned_type_atomic(AtomicOpStmt *stmt);
+  virtual llvm::Value *real_type_atomic(AtomicOpStmt *stmt);
 
   void visit(AtomicOpStmt *stmt) override;
 


### PR DESCRIPTION
This is a follow-up PR of #5086. `FAdd`, `UMin`, `UMax` are actually supported by LLVM, so there is no need to call manually-implemented functions. The code is also refactored in a cleaner way (no more `real_or_unsigned_type_atomic`).

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
