### PR TITLE
[bug] Minor fix for ndarray element_shape in graph mode

### DIFF
--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -26,10 +26,7 @@ void CompiledGraph::run(
         Ndarray *arr = reinterpret_cast<Ndarray *>(ival.val);
         TI_ERROR_IF(ival.tag != aot::ArgKind::kNdarray,
                     "Required a ndarray for argument {}", symbolic_arg.name);
-        auto ndarray_elem_shape = std::vector<int>(
-            arr->shape.end() - symbolic_arg.element_shape.size(),
-            arr->shape.end());
-        TI_ERROR_IF(ndarray_elem_shape != symbolic_arg.element_shape,
+        TI_ERROR_IF(arr->element_shape != symbolic_arg.element_shape,
                     "Mismatched shape information for argument {}",
                     symbolic_arg.name);
         set_runtime_ctx_ndarray(&ctx, i, arr);


### PR DESCRIPTION
Now that ndarray's element_shape is separated from shape, this hack can
be removed.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
