### PR TITLE
[llvm] [refactor] Move load_bit_pointer() to CodeGenLLVM

### DIFF
--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1541,16 +1541,17 @@ llvm::Value *CodeGenLLVM::offset_bit_ptr(llvm::Value *input_bit_ptr,
   return create_bit_ptr_struct(byte_ptr_base, new_bit_offset);
 }
 
-std::tuple<llvm::Value *, llvm::Value *> CodeGenLLVM::load_bit_pointer(llvm::Value *ptr) {
+std::tuple<llvm::Value *, llvm::Value *> CodeGenLLVM::load_bit_pointer(
+    llvm::Value *ptr) {
   // 1. load byte pointer
-  auto byte_ptr_in_bit_struct = builder->CreateGEP(
-      ptr, {tlctx->get_constant(0), tlctx->get_constant(0)});
+  auto byte_ptr_in_bit_struct =
+      builder->CreateGEP(ptr, {tlctx->get_constant(0), tlctx->get_constant(0)});
   auto byte_ptr = builder->CreateLoad(byte_ptr_in_bit_struct);
   TI_ASSERT(byte_ptr->getType()->getPointerElementType()->isIntegerTy(8));
 
   // 2. load bit offset
-  auto bit_offset_in_bit_struct = builder->CreateGEP(
-      ptr, {tlctx->get_constant(0), tlctx->get_constant(1)});
+  auto bit_offset_in_bit_struct =
+      builder->CreateGEP(ptr, {tlctx->get_constant(0), tlctx->get_constant(1)});
   auto bit_offset = builder->CreateLoad(bit_offset_in_bit_struct);
   TI_ASSERT(bit_offset->getType()->isIntegerTy(32));
   return std::make_tuple(byte_ptr, bit_offset);

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1541,6 +1541,21 @@ llvm::Value *CodeGenLLVM::offset_bit_ptr(llvm::Value *input_bit_ptr,
   return create_bit_ptr_struct(byte_ptr_base, new_bit_offset);
 }
 
+std::tuple<llvm::Value *, llvm::Value *> CodeGenLLVM::load_bit_pointer(llvm::Value *ptr) {
+  // 1. load byte pointer
+  auto byte_ptr_in_bit_struct = builder->CreateGEP(
+      ptr, {tlctx->get_constant(0), tlctx->get_constant(0)});
+  auto byte_ptr = builder->CreateLoad(byte_ptr_in_bit_struct);
+  TI_ASSERT(byte_ptr->getType()->getPointerElementType()->isIntegerTy(8));
+
+  // 2. load bit offset
+  auto bit_offset_in_bit_struct = builder->CreateGEP(
+      ptr, {tlctx->get_constant(0), tlctx->get_constant(1)});
+  auto bit_offset = builder->CreateLoad(bit_offset_in_bit_struct);
+  TI_ASSERT(bit_offset->getType()->isIntegerTy(32));
+  return std::make_tuple(byte_ptr, bit_offset);
+}
+
 void CodeGenLLVM::visit(SNodeLookupStmt *stmt) {
   llvm::Value *parent = nullptr;
   parent = llvm_val[stmt->input_snode];

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -317,6 +317,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *offset_bit_ptr(llvm::Value *input_bit_ptr, int bit_offset_delta);
 
+  std::tuple<llvm::Value *, llvm::Value *> load_bit_pointer(llvm::Value *ptr);
+
   void visit(SNodeLookupStmt *stmt) override;
 
   void visit(GetChStmt *stmt) override;

--- a/taichi/llvm/llvm_codegen_utils.h
+++ b/taichi/llvm/llvm_codegen_utils.h
@@ -124,21 +124,6 @@ class LLVMModuleBuilder {
   llvm::Value *call(const std::string &func_name, Args &&...args) {
     return call(this->builder.get(), func_name, std::forward<Args>(args)...);
   }
-
-  std::tuple<llvm::Value *, llvm::Value *> load_bit_pointer(llvm::Value *ptr) {
-    // 1. load byte pointer
-    auto byte_ptr_in_bit_struct = builder->CreateGEP(
-        ptr, {tlctx->get_constant(0), tlctx->get_constant(0)});
-    auto byte_ptr = builder->CreateLoad(byte_ptr_in_bit_struct);
-    TI_ASSERT(byte_ptr->getType()->getPointerElementType()->isIntegerTy(8));
-
-    // 2. load bit offset
-    auto bit_offset_in_bit_struct = builder->CreateGEP(
-        ptr, {tlctx->get_constant(0), tlctx->get_constant(1)});
-    auto bit_offset = builder->CreateLoad(bit_offset_in_bit_struct);
-    TI_ASSERT(bit_offset->getType()->isIntegerTy(32));
-    return std::make_tuple(byte_ptr, bit_offset);
-  }
 };
 
 class RuntimeObject {


### PR DESCRIPTION
Related issue = #4857, #3382

`load_bit_pointer()` is a function paired with `create_bit_ptr_struct()`, which belongs to `CodeGenLLVM` instead of `LLVMModuleBuilder`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
