### PR TITLE
[aot] [llvm] LLVM AOT Field #0: Implemented FieldCacheData & refactored initialize_llvm_runtime_snodes()

### DIFF
--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -45,7 +45,7 @@ struct LlvmOfflineCache {
   struct FieldCacheData {
     struct SNodeCacheData {
       int id;
-      int type;
+      SNodeType type;
       size_t cell_size_bytes;
       size_t chunk_size;
 
@@ -53,6 +53,7 @@ struct LlvmOfflineCache {
     };
 
     int tree_id;
+    int root_id;
     size_t root_size;
     std::vector<SNodeCacheData> snode_metas;
 

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -45,19 +45,19 @@ struct LlvmOfflineCache {
   struct FieldCacheData {
     struct SNodeCacheData {
       int id;
-      SNodeType type;
-      size_t cell_size_bytes;
-      size_t chunk_size;
+      SNodeType type = SNodeType::undefined;
+      size_t cell_size_bytes{0};
+      size_t chunk_size{0};
 
       TI_IO_DEF(id, type, cell_size_bytes, chunk_size);
     };
 
-    int tree_id;
-    int root_id;
-    size_t root_size;
+    int tree_id{0};
+    int root_id{0};
+    size_t root_size{0};
     std::vector<SNodeCacheData> snode_metas;
 
-    TI_IO_DEF(tree_id, root_size, snode_metas);
+    TI_IO_DEF(tree_id, root_id, root_size, snode_metas);
 
     // TODO(zhanlue)
     //  Serialize/Deserialize the llvm::Module from StructCompiler

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -42,7 +42,36 @@ struct LlvmOfflineCache {
     TI_IO_DEF(kernel_key, args, offloaded_task_list);
   };
 
-  std::unordered_map<std::string, KernelCacheData> kernels;
+  struct FieldCacheData {
+    struct SNodeCacheData {
+      int id;
+      int type;
+      size_t cell_size_bytes;
+      size_t chunk_size;
+
+      TI_IO_DEF(id, type, cell_size_bytes, chunk_size);
+    };
+
+    int tree_id;
+    size_t root_size;
+    std::vector<SNodeCacheData> snode_metas;
+
+    TI_IO_DEF(tree_id, root_size, snode_metas);
+
+    // TODO(zhanlue)
+    //  Serialize/Deserialize the llvm::Module from StructCompiler
+    //  At runtime, make sure loaded Field-Modules and Kernel-Modules are linked
+    //  altogether.
+  };
+
+  // TODO(zhanlue): we need a better identifier for each FieldCacheData
+  // (SNodeTree) Given that snode_tree_id is not continuous, it is ridiculous to
+  // ask the users to remember each of the snode_tree_ids
+  // ** Find a way to name each SNodeTree **
+  std::unordered_map<int, FieldCacheData> fields;  // key = snode_tree_id
+
+  std::unordered_map<std::string, KernelCacheData>
+      kernels;  // key = kernel_name
 
   TI_IO_DEF(kernels);
 };

--- a/taichi/llvm/llvm_offline_cache.h
+++ b/taichi/llvm/llvm_offline_cache.h
@@ -44,7 +44,7 @@ struct LlvmOfflineCache {
 
   struct FieldCacheData {
     struct SNodeCacheData {
-      int id;
+      int id{0};
       SNodeType type = SNodeType::undefined;
       size_t cell_size_bytes{0};
       size_t chunk_size{0};

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -160,102 +160,93 @@ LlvmProgramImpl::clone_struct_compiler_initial_context(
 
 void LlvmProgramImpl::initialize_llvm_runtime_snodes(
     const LlvmOfflineCache::FieldCacheData &field_cache_data,
-    uint64 *result_buffer);
-TaichiLLVMContext *tlctx = nullptr;
-if (config->arch == Arch::cuda) {
+    uint64 *result_buffer) {
+  TaichiLLVMContext *tlctx = nullptr;
+  if (config->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-  tlctx = llvm_context_device_.get();
+    tlctx = llvm_context_device_.get();
 #else
-  TI_NOT_IMPLEMENTED
+    TI_NOT_IMPLEMENTED
 #endif
-} else {
-  tlctx = llvm_context_host_.get();
-}
-
-auto *const runtime_jit = tlctx -> runtime_jit_module;
-// By the time this creator is called, "this" is already destroyed.
-// Therefore it is necessary to capture members by values.
-size_t root_size = field_cache_data.root_size;
-const auto snode_metas = field_cache_data.snode_metas;
-const int root_id = field_cache_data.tree_id;
-
-TI_TRACE("Allocating data structure of size {} bytes", root_size);
-std::size_t rounded_size = taichi::iroundup(root_size, taichi_page_size);
-
-Ptr root_buffer = snode_tree_buffer_manager_->allocate(runtime_jit,
-                                                       llvm_runtime_,
-                                                       rounded_size,
-                                                       taichi_page_size,
-                                                       root_id,
-                                                       result_buffer);
-if (config->arch == Arch::cuda) {
-#if defined(TI_WITH_CUDA)
-  CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);
-#else
-  TI_NOT_IMPLEMENTED
-#endif
-} else {
-  std::memset(root_buffer, 0, rounded_size);
-}
-
-DeviceAllocation alloc{kDeviceNullAllocation};
-
-if (config->arch == Arch::cuda) {
-#if defined(TI_WITH_CUDA)
-  alloc = cuda_device()->import_memory(root_buffer, rounded_size);
-#else
-  TI_NOT_IMPLEMENTED
-#endif
-} else {
-  alloc = cpu_device()->import_memory(root_buffer, rounded_size);
-}
-
-snode_tree_allocs_[tree->id()] = alloc;
-
-bool all_dense = config->demote_dense_struct_fors;
-for (size_t i = 0; i < snode_metas.size(); i++) {
-  if (snode_metas[i]->type != SNodeType::dense &&
-      snode_metas[i]->type != SNodeType::place &&
-      snode_metas[i]->type != SNodeType::root) {
-    all_dense = false;
-    break;
+  } else {
+    tlctx = llvm_context_host_.get();
   }
-}
 
-runtime_jit->call<void *, std::size_t, int, int, int, std::size_t, Ptr>(
-    "runtime_initialize_snodes",
-    llvm_runtime_,
-    root_size,
-    root_id,
-    (int)snode_metas.size(),
-    root_id,
-    rounded_size,
-    root_buffer,
-    all_dense);
+  auto *const runtime_jit = tlctx->runtime_jit_module;
+  // By the time this creator is called, "this" is already destroyed.
+  // Therefore it is necessary to capture members by values.
+  size_t root_size = field_cache_data.root_size;
+  const auto snode_metas = field_cache_data.snode_metas;
+  const int tree_id = field_cache_data.tree_id;
+  const int root_id = field_cache_data.root_id;
 
-for (size_t i = 0; i < snode_metas.size(); i++) {
-  if (is_gc_able(snode_metas[i]->type)) {
-    const auto snode_id = snode_metas[i].id;
-    std::size_t node_size;
-    auto element_size = snode_metas[i].cell_size_bytes;
-    if (snode_metas[i].type == SNodeType::pointer) {
-      // pointer. Allocators are for single elements
-      node_size = element_size;
-    } else {
-      // dynamic. Allocators are for the chunks
-      node_size = sizeof(void *) + element_size * snode_metas[i].chunk_size;
+  TI_TRACE("Allocating data structure of size {} bytes", root_size);
+  std::size_t rounded_size = taichi::iroundup(root_size, taichi_page_size);
+
+  Ptr root_buffer = snode_tree_buffer_manager_->allocate(
+      runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree_id,
+      result_buffer);
+  if (config->arch == Arch::cuda) {
+#if defined(TI_WITH_CUDA)
+    CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);
+#else
+    TI_NOT_IMPLEMENTED
+#endif
+  } else {
+    std::memset(root_buffer, 0, rounded_size);
+  }
+
+  DeviceAllocation alloc{kDeviceNullAllocation};
+
+  if (config->arch == Arch::cuda) {
+#if defined(TI_WITH_CUDA)
+    alloc = cuda_device()->import_memory(root_buffer, rounded_size);
+#else
+    TI_NOT_IMPLEMENTED
+#endif
+  } else {
+    alloc = cpu_device()->import_memory(root_buffer, rounded_size);
+  }
+
+  snode_tree_allocs_[tree_id] = alloc;
+
+  bool all_dense = config->demote_dense_struct_fors;
+  for (size_t i = 0; i < snode_metas.size(); i++) {
+    if (snode_metas[i].type != SNodeType::dense &&
+        snode_metas[i].type != SNodeType::place &&
+        snode_metas[i].type != SNodeType::root) {
+      all_dense = false;
+      break;
     }
-    TI_TRACE("Initializing allocator for snode {} (node size {})", snode_id,
-             node_size);
-    auto rt = llvm_runtime_;
-    runtime_jit->call<void *, int, std::size_t>(
-        "runtime_NodeAllocator_initialize", rt, snode_id, node_size);
-    TI_TRACE("Allocating ambient element for snode {} (node size {})", snode_id,
-             node_size);
-    runtime_jit->call<void *, int>("runtime_allocate_ambient", rt, snode_id,
-                                   node_size);
   }
-}
+
+  runtime_jit->call<void *, std::size_t, int, int, int, std::size_t, Ptr>(
+      "runtime_initialize_snodes", llvm_runtime_, root_size, root_id,
+      (int)snode_metas.size(), tree_id, rounded_size, root_buffer, all_dense);
+
+  for (size_t i = 0; i < snode_metas.size(); i++) {
+    if (is_gc_able(snode_metas[i].type)) {
+      const auto snode_id = snode_metas[i].id;
+      std::size_t node_size;
+      auto element_size = snode_metas[i].cell_size_bytes;
+      if (snode_metas[i].type == SNodeType::pointer) {
+        // pointer. Allocators are for single elements
+        node_size = element_size;
+      } else {
+        // dynamic. Allocators are for the chunks
+        node_size = sizeof(void *) + element_size * snode_metas[i].chunk_size;
+      }
+      TI_TRACE("Initializing allocator for snode {} (node size {})", snode_id,
+               node_size);
+      auto rt = llvm_runtime_;
+      runtime_jit->call<void *, int, std::size_t>(
+          "runtime_NodeAllocator_initialize", rt, snode_id, node_size);
+      TI_TRACE("Allocating ambient element for snode {} (node size {})",
+               snode_id, node_size);
+      runtime_jit->call<void *, int>("runtime_allocate_ambient", rt, snode_id,
+                                     node_size);
+    }
+  }
 }
 
 std::unique_ptr<StructCompiler> LlvmProgramImpl::compile_snode_tree_types_impl(
@@ -288,10 +279,9 @@ void LlvmProgramImpl::compile_snode_tree_types(SNodeTree *tree) {
 static LlvmOfflineCache::FieldCacheData construct_filed_cache_data(
     const SNodeTree &tree,
     const StructCompiler &struct_compiler) {
-  TI_ASSERT(tree.id == tree.root()->id);
-
   LlvmOfflineCache::FieldCacheData ret;
-  ret.tree_id = tree.id;
+  ret.tree_id = tree.id();
+  ret.root_id = tree.root()->id;
   ret.root_size = struct_compiler.root_size;
 
   const auto &snodes = struct_compiler.snodes;

--- a/taichi/llvm/llvm_program.h
+++ b/taichi/llvm/llvm_program.h
@@ -132,9 +132,9 @@ class LlvmProgramImpl : public ProgramImpl {
   /**
    * Initializes the SNodes for LLVM based backends.
    */
-  void initialize_llvm_runtime_snodes(const SNodeTree *tree,
-                                      StructCompiler *scomp,
-                                      uint64 *result_buffer);
+  void initialize_llvm_runtime_snodes(
+      const LlvmOfflineCache::FieldCacheData &field_cache_data,
+      uint64 *result_buffer);
 
   uint64 fetch_result_uint64(int i, uint64 *result_buffer);
 


### PR DESCRIPTION
Related issue = #4800 

1. Implemented `FieldCacheData` to serialize necessary compiled information used for field initialization at runtime.

2. Refactored field runtime initialization function "initialize_llvm_runtime_snodes()", so that it only uses compiled information stored in  FieldCacheData.