### PR TITLE
[type] [llvm] [refactor] Fix function names in codegen_llvm_quant

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -548,10 +548,10 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
             auto [data_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->src]);
             data_ptr = builder->CreateBitCast(data_ptr, llvm_ptr_type(dtype));
             auto data = create_intrinsic_load(dtype, data_ptr);
-            llvm_val[stmt] = extract_custom_int(data, bit_offset, int_in_mem);
+            llvm_val[stmt] = extract_quant_int(data, bit_offset, int_in_mem);
           } else if (val_type->cast<CustomFloatType>()) {
             // TODO: support __ldg
-            llvm_val[stmt] = load_custom_float(stmt->src);
+            llvm_val[stmt] = load_quant_fixed_or_quant_float(stmt->src);
           } else {
             TI_NOT_IMPLEMENTED;
           }

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -1010,7 +1010,7 @@ class KernelCodegenImpl : public IRVisitor {
       const auto loaded = construct_load_as_custom_int(
           stmt->src, cft->get_digits_type()->as<CustomIntType>());
       // Computes `float(digits_expr) * scale`
-      // See LLVM backend's reconstruct_custom_float()
+      // See LLVM backend's reconstruct_quant_fixed()
       return fmt::format("(static_cast<float>({}) * {})", loaded,
                          cft->get_scale());
     }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1196,9 +1196,9 @@ llvm::Value *CodeGenLLVM::custom_type_atomic(AtomicOpStmt *stmt) {
 
   auto dst_type = stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
   if (auto cit = dst_type->cast<CustomIntType>()) {
-    return atomic_add_custom_int(stmt, cit);
+    return atomic_add_quant_int(stmt, cit);
   } else if (auto cft = dst_type->cast<CustomFloatType>()) {
-    return atomic_add_custom_float(stmt, cft);
+    return atomic_add_quant_fixed(stmt, cft);
   } else {
     return nullptr;
   }
@@ -1355,7 +1355,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
     llvm::Value *store_value = nullptr;
     auto *cit = pointee_type->as<CustomIntType>();
     store_value = llvm_val[stmt->val];
-    store_custom_int(llvm_val[stmt->dest], cit, store_value, /*atomic=*/true);
+    store_quant_int(llvm_val[stmt->dest], cit, store_value, /*atomic=*/true);
   } else {
     builder->CreateStore(llvm_val[stmt->val], llvm_val[stmt->dest]);
   }
@@ -1368,10 +1368,10 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   if (ptr_type->is_bit_pointer()) {
     auto val_type = ptr_type->get_pointee_type();
     if (val_type->is<CustomIntType>()) {
-      llvm_val[stmt] = load_as_custom_int(llvm_val[stmt->src], val_type);
+      llvm_val[stmt] = load_quant_int(llvm_val[stmt->src], val_type);
     } else if (val_type->cast<CustomFloatType>()) {
       TI_ASSERT(stmt->src->is<GetChStmt>());
-      llvm_val[stmt] = load_custom_float(stmt->src);
+      llvm_val[stmt] = load_quant_fixed_or_quant_float(stmt->src);
     } else {
       TI_NOT_IMPLEMENTED
     }

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -219,8 +219,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt,
-                                      CustomFloatType *cft);
+  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, CustomFloatType *cft);
 
   llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, CustomIntType *cit);
 
@@ -400,7 +399,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *extract_digits_from_f32(llvm::Value *f, bool full);
 
-  llvm::Value *extract_digits_from_quant_float_with_shared_exponent(llvm::Value *f, llvm::Value *shared_exp);
+  llvm::Value *extract_digits_from_quant_float_with_shared_exponent(
+      llvm::Value *f,
+      llvm::Value *shared_exp);
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -219,14 +219,14 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_custom_float(AtomicOpStmt *stmt,
-                                       CustomFloatType *cft);
+  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt,
+                                      CustomFloatType *cft);
 
-  llvm::Value *atomic_add_custom_int(AtomicOpStmt *stmt, CustomIntType *cit);
+  llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, CustomIntType *cit);
 
-  llvm::Value *float_to_custom_int(CustomFloatType *cft,
-                                   CustomIntType *cit,
-                                   llvm::Value *real);
+  llvm::Value *quant_fixed_to_quant_int(CustomFloatType *cft,
+                                        CustomIntType *cit,
+                                        llvm::Value *real);
 
   virtual llvm::Value *optimized_reduction(AtomicOpStmt *stmt);
 
@@ -247,16 +247,16 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(PtrOffsetStmt *stmt) override;
 
-  void store_custom_int(llvm::Value *bit_ptr,
-                        CustomIntType *cit,
-                        llvm::Value *value,
-                        bool atomic);
+  void store_quant_int(llvm::Value *bit_ptr,
+                       CustomIntType *cit,
+                       llvm::Value *value,
+                       bool atomic);
 
-  void store_custom_int(llvm::Value *byte_ptr,
-                        llvm::Value *bit_offset,
-                        CustomIntType *cit,
-                        llvm::Value *value,
-                        bool atomic);
+  void store_quant_int(llvm::Value *byte_ptr,
+                       llvm::Value *bit_offset,
+                       CustomIntType *cit,
+                       llvm::Value *value,
+                       bool atomic);
 
   void store_masked(llvm::Value *byte_ptr,
                     uint64 mask,
@@ -272,31 +272,31 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(BitStructStoreStmt *stmt) override;
 
-  void store_floats_with_shared_exponents(BitStructStoreStmt *stmt);
+  void store_quant_floats_with_shared_exponents(BitStructStoreStmt *stmt);
 
-  llvm::Value *reconstruct_float_from_bit_struct(llvm::Value *local_bit_struct,
-                                                 SNode *digits);
+  llvm::Value *extract_quant_float(llvm::Value *local_bit_struct,
+                                   SNode *digits_snode);
 
-  llvm::Value *load_as_custom_int(llvm::Value *ptr, Type *load_type);
+  llvm::Value *load_quant_int(llvm::Value *ptr, Type *load_type);
 
-  llvm::Value *extract_custom_int(llvm::Value *physical_value,
-                                  llvm::Value *bit_offset,
-                                  Type *load_type);
+  llvm::Value *extract_quant_int(llvm::Value *physical_value,
+                                 llvm::Value *bit_offset,
+                                 Type *load_type);
 
-  llvm::Value *reconstruct_custom_float(llvm::Value *digits,
-                                        CustomFloatType *load_type);
+  llvm::Value *reconstruct_quant_fixed(llvm::Value *digits,
+                                       CustomFloatType *cft);
 
-  llvm::Value *load_custom_float_with_exponent(llvm::Value *digits_bit_ptr,
-                                               llvm::Value *exponent_bit_ptr,
-                                               CustomFloatType *cft,
-                                               bool shared_exponent);
+  llvm::Value *load_quant_float(llvm::Value *digits_bit_ptr,
+                                llvm::Value *exponent_bit_ptr,
+                                CustomFloatType *cft,
+                                bool shared_exponent);
 
-  llvm::Value *reconstruct_custom_float_with_exponent(llvm::Value *digits,
-                                                      llvm::Value *exponent_val,
-                                                      CustomFloatType *cft,
-                                                      bool shared_exponent);
+  llvm::Value *reconstruct_quant_float(llvm::Value *input_digits,
+                                       llvm::Value *input_exponent_val,
+                                       CustomFloatType *cft,
+                                       bool shared_exponent);
 
-  llvm::Value *load_custom_float(Stmt *ptr_stmt);
+  llvm::Value *load_quant_fixed_or_quant_float(Stmt *ptr_stmt);
 
   void visit(GlobalLoadStmt *stmt) override;
 
@@ -396,12 +396,11 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *create_mesh_xlogue(std::unique_ptr<Block> &block);
 
-  llvm::Value *extract_exponent_from_float(llvm::Value *f);
+  llvm::Value *extract_exponent_from_f32(llvm::Value *f);
 
-  llvm::Value *extract_digits_from_float(llvm::Value *f, bool full);
+  llvm::Value *extract_digits_from_f32(llvm::Value *f, bool full);
 
-  llvm::Value *get_float_digits_with_shared_exponents(llvm::Value *f,
-                                                      llvm::Value *shared_exp);
+  llvm::Value *extract_digits_from_quant_float_with_shared_exponent(llvm::Value *f, llvm::Value *shared_exp);
 
   llvm::Value *get_exponent_offset(llvm::Value *exponent, CustomFloatType *cft);
 

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -17,8 +17,8 @@ inline void update_mask(uint64 &mask, uint32 num_bits, uint32 offset) {
 
 }  // namespace
 
-llvm::Value *CodeGenLLVM::atomic_add_custom_int(AtomicOpStmt *stmt,
-                                                CustomIntType *cit) {
+llvm::Value *CodeGenLLVM::atomic_add_quant_int(AtomicOpStmt *stmt,
+                                               CustomIntType *cit) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->dest]);
   auto physical_type = cit->get_physical_type();
   return create_call(
@@ -29,11 +29,11 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_int(AtomicOpStmt *stmt,
                               is_signed(stmt->val->ret_type))});
 }
 
-llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
-                                                  CustomFloatType *cft) {
+llvm::Value *CodeGenLLVM::atomic_add_quant_fixed(AtomicOpStmt *stmt,
+                                                 CustomFloatType *cft) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->dest]);
   auto cit = cft->get_digits_type()->as<CustomIntType>();
-  auto val_store = float_to_custom_int(cft, cit, llvm_val[stmt->val]);
+  auto val_store = quant_fixed_to_quant_int(cft, cit, llvm_val[stmt->val]);
   auto physical_type = cit->get_physical_type();
   val_store = builder->CreateSExt(val_store, llvm_type(physical_type));
 
@@ -43,9 +43,9 @@ llvm::Value *CodeGenLLVM::atomic_add_custom_float(AtomicOpStmt *stmt,
        bit_offset, tlctx->get_constant(cit->get_num_bits()), val_store});
 }
 
-llvm::Value *CodeGenLLVM::float_to_custom_int(CustomFloatType *cft,
-                                              CustomIntType *cit,
-                                              llvm::Value *real) {
+llvm::Value *CodeGenLLVM::quant_fixed_to_quant_int(CustomFloatType *cft,
+                                                   CustomIntType *cit,
+                                                   llvm::Value *real) {
   llvm::Value *s = nullptr;
 
   // Compute int(real * (1.0 / scale) + 0.5)
@@ -69,19 +69,19 @@ llvm::Value *CodeGenLLVM::float_to_custom_int(CustomFloatType *cft,
   }
 }
 
-void CodeGenLLVM::store_custom_int(llvm::Value *bit_ptr,
-                                   CustomIntType *cit,
-                                   llvm::Value *value,
-                                   bool atomic) {
+void CodeGenLLVM::store_quant_int(llvm::Value *bit_ptr,
+                                  CustomIntType *cit,
+                                  llvm::Value *value,
+                                  bool atomic) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(bit_ptr);
-  store_custom_int(byte_ptr, bit_offset, cit, value, atomic);
+  store_quant_int(byte_ptr, bit_offset, cit, value, atomic);
 }
 
-void CodeGenLLVM::store_custom_int(llvm::Value *byte_ptr,
-                                   llvm::Value *bit_offset,
-                                   CustomIntType *cit,
-                                   llvm::Value *value,
-                                   bool atomic) {
+void CodeGenLLVM::store_quant_int(llvm::Value *byte_ptr,
+                                  llvm::Value *bit_offset,
+                                  CustomIntType *cit,
+                                  llvm::Value *value,
+                                  bool atomic) {
   // TODO(type): CUDA only supports atomicCAS on 32- and 64-bit integers.
   // Try to support CustomInt/FloatType with 8/16-bit physical
   // types.
@@ -135,7 +135,7 @@ llvm::Value *CodeGenLLVM::custom_type_to_bits(llvm::Value *val,
   if (auto cft = input_type->cast<CustomFloatType>()) {
     TI_ASSERT(cft->get_exponent_type() == nullptr);
     cit = cft->get_digits_type()->as<CustomIntType>();
-    val = float_to_custom_int(cft, cit, val);
+    val = quant_fixed_to_quant_int(cft, cit, val);
   } else {
     cit = input_type->as<CustomIntType>();
   }
@@ -176,7 +176,7 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
   //  that don't own the shared exponent?
 
   if (has_shared_exponent) {
-    store_floats_with_shared_exponents(stmt);
+    store_quant_floats_with_shared_exponents(stmt);
   }
 
   llvm::Value *bit_struct_val = nullptr;
@@ -186,7 +186,7 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
     auto &ch = bit_struct_snode->ch[ch_id];
     if (has_shared_exponent && ch->exp_snode != nullptr &&
         ch->exp_snode->exponent_users.size() > 1) {
-      // already handled in store_floats_with_shared_exponents
+      // already handled in store_quant_floats_with_shared_exponents
       continue;
     }
     auto dtype = ch->dt;
@@ -282,7 +282,7 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       auto &ch = bit_struct_snode->ch[ch_id];
       if (has_shared_exponent && ch->exp_snode != nullptr &&
           ch->exp_snode->exponent_users.size() > 1) {
-        // already handled in store_floats_with_shared_exponents
+        // already handled in store_quant_floats_with_shared_exponents
         continue;
       }
       auto dtype = ch->dt;
@@ -306,7 +306,7 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
   }
 }
 
-void CodeGenLLVM::store_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
+void CodeGenLLVM::store_quant_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
   // handle each exponent separately
   auto snode = stmt->get_bit_struct_snode();
   auto bit_struct_physical_type =
@@ -333,15 +333,14 @@ void CodeGenLLVM::store_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
           input != stmt->ch_ids.end()) {
         floats.push_back(llvm_val[stmt->values[input - stmt->ch_ids.begin()]]);
       } else {
-        floats.push_back(
-            reconstruct_float_from_bit_struct(local_bit_struct, user));
+        floats.push_back(extract_quant_float(local_bit_struct, user));
       }
     }
     // convert to i32 for bit operations
     llvm::Value *max_exp_bits = nullptr;
     for (auto f : floats) {
       // TODO: we only support f32 here.
-      auto exp_bits = extract_exponent_from_float(f);
+      auto exp_bits = extract_exponent_from_f32(f);
       if (max_exp_bits) {
         max_exp_bits = create_call("max_u32", {max_exp_bits, exp_bits});
       } else {
@@ -374,8 +373,8 @@ void CodeGenLLVM::store_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
     for (int c = 0; c < (int)exp->exponent_users.size(); c++) {
       auto user = exp->exponent_users[c];
       auto ch_id = snode->child_id(user);
-      auto digits =
-          get_float_digits_with_shared_exponents(floats[c], max_exp_bits);
+      auto digits = extract_digits_from_quant_float_with_shared_exponent(
+          floats[c], max_exp_bits);
       auto digits_snode = snode->ch[ch_id].get();
       auto cft = digits_snode->dt->as<CustomFloatType>();
       auto digits_bit_offset = digits_snode->bit_offset;
@@ -418,14 +417,14 @@ void CodeGenLLVM::store_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
                stmt->is_atomic);
 }
 
-llvm::Value *CodeGenLLVM::extract_exponent_from_float(llvm::Value *f) {
+llvm::Value *CodeGenLLVM::extract_exponent_from_f32(llvm::Value *f) {
   TI_ASSERT(f->getType() == llvm::Type::getFloatTy(*llvm_context));
   f = builder->CreateBitCast(f, llvm::Type::getInt32Ty(*llvm_context));
   auto exp_bits = builder->CreateLShr(f, tlctx->get_constant(23));
   return builder->CreateAnd(exp_bits, tlctx->get_constant((1 << 8) - 1));
 }
 
-llvm::Value *CodeGenLLVM::extract_digits_from_float(llvm::Value *f, bool full) {
+llvm::Value *CodeGenLLVM::extract_digits_from_f32(llvm::Value *f, bool full) {
   TI_ASSERT(f->getType() == llvm::Type::getFloatTy(*llvm_context));
   f = builder->CreateBitCast(f, llvm::Type::getInt32Ty(*llvm_context));
   auto digits = builder->CreateAnd(f, tlctx->get_constant((1 << 23) - 1));
@@ -435,10 +434,10 @@ llvm::Value *CodeGenLLVM::extract_digits_from_float(llvm::Value *f, bool full) {
   return digits;
 }
 
-llvm::Value *CodeGenLLVM::get_float_digits_with_shared_exponents(
+llvm::Value *CodeGenLLVM::extract_digits_from_quant_float_with_shared_exponent(
     llvm::Value *f,
     llvm::Value *shared_exp) {
-  auto exp = extract_exponent_from_float(f);
+  auto exp = extract_exponent_from_f32(f);
   auto exp_offset = builder->CreateSub(shared_exp, exp);
   // TODO: handle negative digits
 
@@ -454,42 +453,42 @@ llvm::Value *CodeGenLLVM::get_float_digits_with_shared_exponents(
       builder->CreateZExt(exp_non_zero, llvm::Type::getInt32Ty(*llvm_context));
   auto implicit_bit = builder->CreateShl(exp_non_zero, tlctx->get_constant(23));
 
-  auto digits = extract_digits_from_float(f, true);
+  auto digits = extract_digits_from_f32(f, true);
   digits = builder->CreateOr(digits, implicit_bit);
   exp_offset = create_call("min_u32", {exp_offset, tlctx->get_constant(31)});
   return builder->CreateLShr(digits, exp_offset);
 }
 
-llvm::Value *CodeGenLLVM::reconstruct_float_from_bit_struct(
+llvm::Value *CodeGenLLVM::extract_quant_float(
     llvm::Value *local_bit_struct,
     SNode *digits_snode) {
   auto cft = digits_snode->dt->as<CustomFloatType>();
   auto exponent_type = cft->get_exponent_type()->as<CustomIntType>();
   auto digits_type = cft->get_digits_type()->as<CustomIntType>();
-  auto digits = extract_custom_int(
-      local_bit_struct, tlctx->get_constant(digits_snode->bit_offset),
-      digits_type);
-  auto exponent = extract_custom_int(
+  auto digits = extract_quant_int(local_bit_struct,
+                                  tlctx->get_constant(digits_snode->bit_offset),
+                                  digits_type);
+  auto exponent = extract_quant_int(
       local_bit_struct,
       tlctx->get_constant(digits_snode->exp_snode->bit_offset), exponent_type);
-  return reconstruct_custom_float_with_exponent(
-      digits, exponent, cft, digits_snode->owns_shared_exponent);
+  return reconstruct_quant_float(digits, exponent, cft,
+                                 digits_snode->owns_shared_exponent);
 }
 
-llvm::Value *CodeGenLLVM::load_as_custom_int(llvm::Value *ptr,
-                                             Type *load_type) {
+llvm::Value *CodeGenLLVM::load_quant_int(llvm::Value *ptr,
+                                         Type *load_type) {
   auto *cit = load_type->as<CustomIntType>();
   auto [byte_ptr, bit_offset] = load_bit_pointer(ptr);
 
   auto bit_level_container = builder->CreateLoad(builder->CreateBitCast(
       byte_ptr, llvm_ptr_type(cit->get_physical_type())));
 
-  return extract_custom_int(bit_level_container, bit_offset, load_type);
+  return extract_quant_int(bit_level_container, bit_offset, load_type);
 }
 
-llvm::Value *CodeGenLLVM::extract_custom_int(llvm::Value *physical_value,
-                                             llvm::Value *bit_offset,
-                                             Type *load_type) {
+llvm::Value *CodeGenLLVM::extract_quant_int(llvm::Value *physical_value,
+                                            llvm::Value *bit_offset,
+                                            Type *load_type) {
   //  bit shifting
   //    first left shift `physical_type - (offset + num_bits)`
   //    then right shift `physical_type - num_bits`
@@ -515,8 +514,8 @@ llvm::Value *CodeGenLLVM::extract_custom_int(llvm::Value *physical_value,
                                 cit->get_is_signed());
 }
 
-llvm::Value *CodeGenLLVM::reconstruct_custom_float(llvm::Value *digits,
-                                                   CustomFloatType *cft) {
+llvm::Value *CodeGenLLVM::reconstruct_quant_fixed(llvm::Value *digits,
+                                                  CustomFloatType *cft) {
   // Compute float(digits) * scale
   llvm::Value *cast = nullptr;
   auto compute_type = cft->get_compute_type()->as<PrimitiveType>();
@@ -531,7 +530,7 @@ llvm::Value *CodeGenLLVM::reconstruct_custom_float(llvm::Value *digits,
   return builder->CreateFMul(cast, s);
 }
 
-llvm::Value *CodeGenLLVM::load_custom_float_with_exponent(
+llvm::Value *CodeGenLLVM::load_quant_float(
     llvm::Value *digits_bit_ptr,
     llvm::Value *exponent_bit_ptr,
     CustomFloatType *cft,
@@ -540,15 +539,14 @@ llvm::Value *CodeGenLLVM::load_custom_float_with_exponent(
   // to support this in the future.
 
   TI_ASSERT(cft->get_scale() == 1);
-  auto digits = load_as_custom_int(digits_bit_ptr, cft->get_digits_type());
+  auto digits = load_quant_int(digits_bit_ptr, cft->get_digits_type());
 
-  auto exponent_val = load_as_custom_int(
+  auto exponent_val = load_quant_int(
       exponent_bit_ptr, cft->get_exponent_type()->as<CustomIntType>());
-  return reconstruct_custom_float_with_exponent(digits, exponent_val, cft,
-                                                shared_exponent);
+  return reconstruct_quant_float(digits, exponent_val, cft, shared_exponent);
 }
 
-llvm::Value *CodeGenLLVM::reconstruct_custom_float_with_exponent(
+llvm::Value *CodeGenLLVM::reconstruct_quant_float(
     llvm::Value *input_digits,
     llvm::Value *input_exponent_val,
     CustomFloatType *cft,
@@ -647,7 +645,7 @@ llvm::Value *CodeGenLLVM::reconstruct_custom_float_with_exponent(
   }
 }
 
-llvm::Value *CodeGenLLVM::load_custom_float(Stmt *ptr_stmt) {
+llvm::Value *CodeGenLLVM::load_quant_fixed_or_quant_float(Stmt *ptr_stmt) {
   auto ptr = ptr_stmt->as<GetChStmt>();
   auto cft = ptr->ret_type->as<PointerType>()
                  ->get_pointee_type()
@@ -661,12 +659,11 @@ llvm::Value *CodeGenLLVM::load_custom_float(Stmt *ptr_stmt) {
     TI_ASSERT(digits_snode->parent == exponent_snode->parent);
     auto exponent_bit_ptr = offset_bit_ptr(
         digits_bit_ptr, exponent_snode->bit_offset - digits_snode->bit_offset);
-    return load_custom_float_with_exponent(digits_bit_ptr, exponent_bit_ptr,
-                                           cft,
-                                           digits_snode->owns_shared_exponent);
+    return load_quant_float(digits_bit_ptr, exponent_bit_ptr, cft,
+                            digits_snode->owns_shared_exponent);
   } else {
-    auto digits = load_as_custom_int(llvm_val[ptr], cft->get_digits_type());
-    return reconstruct_custom_float(digits, cft);
+    auto digits = load_quant_int(llvm_val[ptr], cft->get_digits_type());
+    return reconstruct_quant_fixed(digits, cft);
   }
 }
 

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -306,7 +306,8 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
   }
 }
 
-void CodeGenLLVM::store_quant_floats_with_shared_exponents(BitStructStoreStmt *stmt) {
+void CodeGenLLVM::store_quant_floats_with_shared_exponents(
+    BitStructStoreStmt *stmt) {
   // handle each exponent separately
   auto snode = stmt->get_bit_struct_snode();
   auto bit_struct_physical_type =
@@ -459,9 +460,8 @@ llvm::Value *CodeGenLLVM::extract_digits_from_quant_float_with_shared_exponent(
   return builder->CreateLShr(digits, exp_offset);
 }
 
-llvm::Value *CodeGenLLVM::extract_quant_float(
-    llvm::Value *local_bit_struct,
-    SNode *digits_snode) {
+llvm::Value *CodeGenLLVM::extract_quant_float(llvm::Value *local_bit_struct,
+                                              SNode *digits_snode) {
   auto cft = digits_snode->dt->as<CustomFloatType>();
   auto exponent_type = cft->get_exponent_type()->as<CustomIntType>();
   auto digits_type = cft->get_digits_type()->as<CustomIntType>();
@@ -475,8 +475,7 @@ llvm::Value *CodeGenLLVM::extract_quant_float(
                                  digits_snode->owns_shared_exponent);
 }
 
-llvm::Value *CodeGenLLVM::load_quant_int(llvm::Value *ptr,
-                                         Type *load_type) {
+llvm::Value *CodeGenLLVM::load_quant_int(llvm::Value *ptr, Type *load_type) {
   auto *cit = load_type->as<CustomIntType>();
   auto [byte_ptr, bit_offset] = load_bit_pointer(ptr);
 
@@ -530,11 +529,10 @@ llvm::Value *CodeGenLLVM::reconstruct_quant_fixed(llvm::Value *digits,
   return builder->CreateFMul(cast, s);
 }
 
-llvm::Value *CodeGenLLVM::load_quant_float(
-    llvm::Value *digits_bit_ptr,
-    llvm::Value *exponent_bit_ptr,
-    CustomFloatType *cft,
-    bool shared_exponent) {
+llvm::Value *CodeGenLLVM::load_quant_float(llvm::Value *digits_bit_ptr,
+                                           llvm::Value *exponent_bit_ptr,
+                                           CustomFloatType *cft,
+                                           bool shared_exponent) {
   // TODO: we ignore "scale" for CustomFloatType with exponent for now. May need
   // to support this in the future.
 


### PR DESCRIPTION
Related issue = #4857, #3382

This is a first pass of fixing the function names in `codegen_llvm_quant.cpp`, with an emphasis on correcting the type names.
The original type names in function names are random to some extent, which makes code hard to read. Now I've figured out what these functions are doing, and enforced consistent use of `quant_int`, `quant_fixed`, `quant_float` or `f32` to refer to different types involved.

|From|To|
|-|-|
|`atomic_add_custom_int`|`atomic_add_quant_int`|
|`atomic_add_custom_float`|`atomic_add_quant_fixed`|
|`float_to_custom_int`|`quant_fixed_to_quant_int`|
|`store_custom_int`|`store_quant_int`|
|`store_floats_with_shared_exponents`|`store_quant_floats_with_shared_exponents`|
|`extract_exponent_from_float`|`extract_exponent_from_f32`|
|`extract_digits_from_float`|`extract_digits_from_f32`|
|`get_float_digits_with_shared_exponents`|`extract_digits_from_quant_float_with_shared_exponent`|
|`reconstruct_float_from_bit_struct`|`extract_quant_float`|
|`load_as_custom_int`|`load_quant_int`|
|`extract_custom_int`|`extract_quant_int`|
|`reconstruct_custom_float`|`reconstruct_quant_fixed`|
|`load_custom_float_with_exponent`|`load_quant_float`|
|`reconstruct_custom_float_with_exponent`|`reconstruct_quant_float`|
|`load_custom_float`|`load_quant_fixed_or_quant_float`|
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
