### PR TITLE
[Example] Fix mass_spring_3d_ggui backend

### DIFF
--- a/python/taichi/examples/ggui_examples/mass_spring_3d_ggui.py
+++ b/python/taichi/examples/ggui_examples/mass_spring_3d_ggui.py
@@ -1,5 +1,7 @@
 import taichi as ti
-ti.init(arch=ti.gpu)  # Alternatively, ti.init(arch=ti.cpu)
+
+arch = ti.vulkan if ti._lib.core.with_vulkan() else ti.cuda
+ti.init(arch=arch)
 
 n = 128
 quad_size = 1.0 / n


### PR DESCRIPTION
Using `ti.gpu` as the default arch may cause problems when cuda is not available and `ti.opengl` is chosen.
Change it to `ti.vulkan` as other ggui examples.