### PR TITLE
[autodiff] Support basic operations for forward mode autodiff

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1111,11 +1111,15 @@ class MakeDual : public ADTransform {
     if (stmt->op_type == UnaryOpType::neg) {
       accumulate(stmt, negate(dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::abs) {
-      accumulate(stmt, sgn(dual(stmt->operand)));
+      accumulatgit e(stmt, sgn(dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::sin) {
       accumulate(stmt, mul(cos(stmt->operand), dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::cos) {
       accumulate(stmt, negate(mul(sin(stmt->operand), dual(stmt->operand))));
+    } else if (stmt->op_type == UnaryOpType::cast_value) {
+      if (is_real(stmt->cast_type) && is_real(stmt->operand->ret_type)) {
+        accumulate(stmt, dual(stmt->operand));
+      }
     } else {
       TI_P(unary_op_type_name(stmt->op_type));
       TI_NOT_IMPLEMENTED

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1072,6 +1072,119 @@ class MakeDual : public ADTransform {
       stmt->accept(this);
     }
   }
+
+  // Accumulate [value] to the dual of [primal]
+  void accumulate(Stmt *primal, Stmt *value) {
+    auto alloca_ = dual(primal);
+    if (!alloca_ || alloca_->is<ConstStmt>())
+      return;  // primal may be int variable
+
+    TI_ASSERT(alloca_->is<AllocaStmt>());
+    auto alloca = alloca_->as<AllocaStmt>();
+    TI_ASSERT(alloca->width() == 1);
+    auto local_load = insert<LocalLoadStmt>(LocalAddress(alloca, 0));
+    insert<LocalStoreStmt>(alloca, add(local_load, value));
+  }
+
+  Stmt *dual(Stmt *stmt) {
+    if (!needs_grad(stmt->ret_type)) {
+      return constant(0);
+    }
+    if (dual_stmt.find(stmt) == dual_stmt.end()) {
+      // normal SSA cases
+
+      // create the alloca
+      // auto alloca =
+      //    Stmt::make<AllocaStmt>(1, get_current_program().config.gradient_dt);
+      // maybe it's better to use the statement data type than the default type
+      auto alloca = Stmt::make<AllocaStmt>(1, stmt->ret_type);
+      dual_stmt[stmt] = alloca.get();
+
+      // TODO: check whether this is correct when in for-loop
+      // check whether each stmt has a parent...
+      current_stmt->parent->insert(std::move(alloca), 0);
+    }
+    return dual_stmt[stmt];
+  }
+
+  void visit(UnaryOpStmt *stmt) override {
+    if (stmt->op_type == UnaryOpType::neg) {
+      accumulate(stmt, negate(dual(stmt->operand)));
+    } else if (stmt->op_type == UnaryOpType::abs) {
+      accumulate(stmt, sgn(dual(stmt->operand)));
+    } else if (stmt->op_type == UnaryOpType::sin) {
+      accumulate(stmt, mul(cos(stmt->operand), dual(stmt->operand)));
+    } else if (stmt->op_type == UnaryOpType::cos) {
+      accumulate(stmt, negate(mul(sin(stmt->operand), dual(stmt->operand))));
+    } else {
+      TI_P(unary_op_type_name(stmt->op_type));
+      TI_NOT_IMPLEMENTED
+    }
+  }
+
+  void visit(BinaryOpStmt *bin) override {
+    if (bin->op_type == BinaryOpType::add) {
+      accumulate(bin, dual(bin->lhs));
+      accumulate(bin, dual(bin->rhs));
+    } else if (bin->op_type == BinaryOpType::sub) {
+      accumulate(bin, dual(bin->lhs));
+      accumulate(bin, negate(dual(bin->rhs)));
+    } else if (bin->op_type == BinaryOpType::mul) {
+      // d (x * y) = y * dx + x * dy
+      accumulate(bin, mul(bin->lhs, dual(bin->rhs)));
+      accumulate(bin, mul(bin->rhs, dual(bin->lhs)));
+    } else {
+      TI_WARN("gradient of binary op {}", binary_op_type_name(bin->op_type));
+      TI_NOT_IMPLEMENTED
+    }
+  }
+
+  void visit(GlobalLoadStmt *stmt) override {
+    // issue global store to dual
+    GlobalPtrStmt *src = stmt->src->as<GlobalPtrStmt>();
+    TI_ASSERT(src->width() == 1);
+    auto snodes = src->snodes;
+    if (!snodes[0]->has_dual()) {
+      // No dual SNode. Do nothing
+      return;
+    }
+    if (gradients_stopped(stmt, snodes[0])) {
+      // gradients stopped, do nothing.
+      return;
+    }
+    TI_ASSERT(snodes[0]->get_dual() != nullptr);
+    snodes[0] = snodes[0]->get_dual();
+    auto dual_ptr = insert<GlobalPtrStmt>(snodes, src->indices);
+    accumulate(stmt, insert<GlobalLoadStmt>(dual_ptr));
+  }
+
+  void visit(GlobalStoreStmt *stmt) override {
+    GlobalPtrStmt *dest = stmt->dest->as<GlobalPtrStmt>();
+    TI_ASSERT(dest->width() == 1);
+    auto snodes = dest->snodes;
+    if (!snodes[0]->has_dual()) {
+      // no gradient (likely integer types)
+      return;
+    }
+    TI_ASSERT(snodes[0]->get_dual() != nullptr);
+    snodes[0] = snodes[0]->get_dual();
+    auto dual_ptr = insert<GlobalPtrStmt>(snodes, dest->indices);
+    insert<AtomicOpStmt>(AtomicOpType::add, dual_ptr, load(dual(stmt->val)));
+  }
+
+  void visit(AtomicOpStmt *stmt) override {
+    GlobalPtrStmt *dest = stmt->dest->as<GlobalPtrStmt>();
+    TI_ASSERT(dest->width() == 1);
+    auto snodes = dest->snodes;
+    if (!snodes[0]->has_dual()) {
+      // no gradient (likely integer types)
+      return;
+    }
+    TI_ASSERT(snodes[0]->get_dual() != nullptr);
+    snodes[0] = snodes[0]->get_dual();
+    auto dual_ptr = insert<GlobalPtrStmt>(snodes, dest->indices);
+    insert<AtomicOpStmt>(AtomicOpType::add, dual_ptr, load(dual(stmt->val)));
+  }
 };
 
 class BackupSSA : public BasicStmtVisitor {

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1111,7 +1111,7 @@ class MakeDual : public ADTransform {
     if (stmt->op_type == UnaryOpType::neg) {
       accumulate(stmt, negate(dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::abs) {
-      accumulatgit e(stmt, sgn(dual(stmt->operand)));
+      accumulate(stmt, sgn(dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::sin) {
       accumulate(stmt, mul(cos(stmt->operand), dual(stmt->operand)));
     } else if (stmt->op_type == UnaryOpType::cos) {

--- a/tests/python/test_ad_basics_fwd.py
+++ b/tests/python/test_ad_basics_fwd.py
@@ -1,0 +1,40 @@
+import taichi as ti
+from tests import test_utils
+
+
+@test_utils.test(arch=[ti.cpu, ti.gpu])
+def test_ad_fwd_add():
+    N = 5
+    x = ti.field(ti.f32, shape=N)
+    loss = ti.field(ti.f32, shape=N)
+
+    for i in range(N):
+        x[i] = i
+
+    @ti.kernel
+    def ad_fwd_add():
+        loss[1] += 2 * x[3]
+
+    with ti.fwdAD(loss=[loss], parameters=x, seed=[0, 0, 0, 1, 0]):
+        ad_fwd_add()
+
+    assert loss.grad[1] == 2
+
+
+@test_utils.test(arch=[ti.cpu, ti.gpu])
+def test_ad_fwd_multiply():
+    N = 5
+    x = ti.field(ti.f32, shape=N)
+    loss = ti.field(ti.f32, shape=N)
+
+    for i in range(N):
+        x[i] = i
+
+    @ti.kernel
+    def ad_fwd_multiply():
+        loss[1] += x[3] * x[4]
+
+    with ti.fwdAD(loss=[loss], parameters=x, seed=[0, 0, 0, 1, 1]):
+        ad_fwd_multiply()
+
+    assert loss.grad[1] == 7


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #5147
* #5146

Support cpu and gpu backends. The cc backend has an issue on FieldBuilder ref to #5143.
The opengl backend currently does not support materializing multiple snode trees (see [OpenglProgramImpl::compile_snode_tree_types](https://github.com/taichi-dev/taichi/blob/master/taichi/backends/opengl/opengl_program.cpp#L45)), thus `FieldBuilder` is not supported.