### PR TITLE
[type] [refactor] Separate CustomFixedType from CustomFloatType

### DIFF
--- a/python/taichi/types/quantized_types.py
+++ b/python/taichi/types/quantized_types.py
@@ -9,29 +9,6 @@ from taichi.types.primitive_types import i32
 _type_factory = _ti_core.get_type_factory_instance()
 
 
-def _custom_float(significand_type,
-                  exponent_type=None,
-                  compute_type=None,
-                  scale=1.0):
-    """Generates a custom float type.
-
-    Args:
-        significand_type (DataType): Type of significand.
-        exponent_type (DataType): Type of exponent.
-        compute_type (DataType): Type for computation.
-        scale (float): Scaling factor.
-
-    Returns:
-        DataType: The specified type.
-    """
-    if compute_type is None:
-        compute_type = impl.get_runtime().default_fp
-    if isinstance(compute_type, _ti_core.DataType):
-        compute_type = compute_type.get_ptr()
-    return _type_factory.get_custom_float_type(significand_type, exponent_type,
-                                               compute_type, scale)
-
-
 def int(bits, signed=True, compute=None):  # pylint: disable=W0622
     """Generates a quantized type for integers.
 
@@ -63,6 +40,10 @@ def fixed(frac, signed=True, range=1.0, compute=None, scale=None):  # pylint: di
     Returns:
         DataType: The specified type.
     """
+    if compute is None:
+        compute = impl.get_runtime().default_fp
+    if isinstance(compute, _ti_core.DataType):
+        compute = compute.get_ptr()
     # TODO: handle cases with frac > 32
     frac_type = int(bits=frac, signed=signed, compute=i32)
     if scale is None:
@@ -70,7 +51,7 @@ def fixed(frac, signed=True, range=1.0, compute=None, scale=None):  # pylint: di
             scale = range / 2**(frac - 1)
         else:
             scale = range / 2**frac
-    return _custom_float(frac_type, None, compute, scale)
+    return _type_factory.get_custom_fixed_type(frac_type, compute, scale)
 
 
 def float(exp, frac, signed=True, compute=None):  # pylint: disable=W0622
@@ -85,13 +66,15 @@ def float(exp, frac, signed=True, compute=None):  # pylint: disable=W0622
     Returns:
         DataType: The specified type.
     """
+    if compute is None:
+        compute = impl.get_runtime().default_fp
+    if isinstance(compute, _ti_core.DataType):
+        compute = compute.get_ptr()
     # Exponent is always unsigned
     exp_type = int(bits=exp, signed=False, compute=i32)
     # TODO: handle cases with frac > 32
     frac_type = int(bits=frac, signed=signed, compute=i32)
-    return _custom_float(significand_type=frac_type,
-                         exponent_type=exp_type,
-                         compute_type=compute)
+    return _type_factory.get_custom_float_type(frac_type, exp_type, compute)
 
 
 __all__ = ['int', 'fixed', 'float']

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -538,14 +538,12 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
             ptr_type->is_bit_pointer()) {
           // Bit pointer case.
           auto val_type = ptr_type->get_pointee_type();
-          Type *int_in_mem = nullptr;
           if (auto cit = val_type->cast<CustomIntType>()) {
-            int_in_mem = val_type;
             dtype = cit->get_physical_type();
             auto [data_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->src]);
             data_ptr = builder->CreateBitCast(data_ptr, llvm_ptr_type(dtype));
             auto data = create_intrinsic_load(dtype, data_ptr);
-            llvm_val[stmt] = extract_quant_int(data, bit_offset, int_in_mem);
+            llvm_val[stmt] = extract_quant_int(data, bit_offset, val_type);
           } else {
             // TODO: support __ldg
             TI_ASSERT(val_type->is<CustomFixedType>() ||

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -548,7 +548,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
             llvm_val[stmt] = extract_quant_int(data, bit_offset, int_in_mem);
           } else {
             // TODO: support __ldg
-            TI_ASSERT(val_type->is<CustomFixedType>() || val_type->is<CustomFloatType>());
+            TI_ASSERT(val_type->is<CustomFixedType>() ||
+                      val_type->is<CustomFloatType>());
             llvm_val[stmt] = load_quant_fixed_or_quant_float(stmt->src);
           }
         } else {

--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -539,9 +539,6 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           // Bit pointer case.
           auto val_type = ptr_type->get_pointee_type();
           Type *int_in_mem = nullptr;
-          // For CustomIntType "int_in_mem" refers to the type itself;
-          // for CustomFloatType "int_in_mem" refers to the CustomIntType of the
-          // digits.
           if (auto cit = val_type->cast<CustomIntType>()) {
             int_in_mem = val_type;
             dtype = cit->get_physical_type();
@@ -549,11 +546,10 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
             data_ptr = builder->CreateBitCast(data_ptr, llvm_ptr_type(dtype));
             auto data = create_intrinsic_load(dtype, data_ptr);
             llvm_val[stmt] = extract_quant_int(data, bit_offset, int_in_mem);
-          } else if (val_type->cast<CustomFloatType>()) {
-            // TODO: support __ldg
-            llvm_val[stmt] = load_quant_fixed_or_quant_float(stmt->src);
           } else {
-            TI_NOT_IMPLEMENTED;
+            // TODO: support __ldg
+            TI_ASSERT(val_type->is<CustomFixedType>() || val_type->is<CustomFloatType>());
+            llvm_val[stmt] = load_quant_fixed_or_quant_float(stmt->src);
           }
         } else {
           // Byte pointer case.

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -92,10 +92,7 @@ bool is_full_bits(int bits) {
   return bits == (sizeof(uint32_t) * 8);
 }
 
-void validate_cft_for_metal(CustomFloatType *cft) {
-  if (cft->get_exponent_type() != nullptr) {
-    TI_NOT_IMPLEMENTED;
-  }
+void validate_cfxt_for_metal(CustomFixedType *cft) {
   if (cft->get_compute_type()->as<PrimitiveType>() != PrimitiveType::f32) {
     TI_ERROR("Metal only supports 32-bit float");
   }
@@ -977,12 +974,12 @@ class KernelCodegenImpl : public IRVisitor {
     if (auto *cit_cast = pointee_type->cast<CustomIntType>()) {
       cit = cit_cast;
       store_value_expr = stmt->val->raw_name();
-    } else if (auto *cft = pointee_type->cast<CustomFloatType>()) {
-      validate_cft_for_metal(cft);
-      auto *digits_cit = cft->get_digits_type()->as<CustomIntType>();
+    } else if (auto *cfxt = pointee_type->cast<CustomFixedType>()) {
+      validate_cfxt_for_metal(cfxt);
+      auto *digits_cit = cfxt->get_digits_type()->as<CustomIntType>();
       cit = digits_cit;
       store_value_expr = construct_quant_fixed_to_quant_int_expr(
-          stmt->val, cft->get_scale(), digits_cit);
+          stmt->val, cfxt->get_scale(), digits_cit);
     } else {
       TI_NOT_IMPLEMENTED;
     }
@@ -1005,14 +1002,14 @@ class KernelCodegenImpl : public IRVisitor {
     auto *pointee_type = ptr_type->get_pointee_type();
     if (auto *cit = pointee_type->cast<CustomIntType>()) {
       return construct_load_quant_int(stmt->src, cit);
-    } else if (auto *cft = pointee_type->cast<CustomFloatType>()) {
-      validate_cft_for_metal(cft);
+    } else if (auto *cfxt = pointee_type->cast<CustomFixedType>()) {
+      validate_cfxt_for_metal(cfxt);
       const auto loaded = construct_load_quant_int(
-          stmt->src, cft->get_digits_type()->as<CustomIntType>());
+          stmt->src, cfxt->get_digits_type()->as<CustomIntType>());
       // Computes `float(digits_expr) * scale`
       // See LLVM backend's reconstruct_quant_fixed()
       return fmt::format("(static_cast<float>({}) * {})", loaded,
-                         cft->get_scale());
+                         cfxt->get_scale());
     }
     TI_NOT_IMPLEMENTED;
     return "";
@@ -1031,10 +1028,10 @@ class KernelCodegenImpl : public IRVisitor {
     if (auto *cit_cast = pointee_type->cast<CustomIntType>()) {
       cit = cit_cast;
       val_expr = stmt->val->raw_name();
-    } else if (auto *cft = pointee_type->cast<CustomFloatType>()) {
-      cit = cft->get_digits_type()->as<CustomIntType>();
+    } else if (auto *cfxt = pointee_type->cast<CustomFixedType>()) {
+      cit = cfxt->get_digits_type()->as<CustomIntType>();
       val_expr = construct_quant_fixed_to_quant_int_expr(stmt->val,
-                                                         cft->get_scale(), cit);
+                                                         cfxt->get_scale(), cit);
     } else {
       TI_NOT_IMPLEMENTED;
     }

--- a/taichi/backends/metal/codegen_metal.cpp
+++ b/taichi/backends/metal/codegen_metal.cpp
@@ -1030,8 +1030,8 @@ class KernelCodegenImpl : public IRVisitor {
       val_expr = stmt->val->raw_name();
     } else if (auto *cfxt = pointee_type->cast<CustomFixedType>()) {
       cit = cfxt->get_digits_type()->as<CustomIntType>();
-      val_expr = construct_quant_fixed_to_quant_int_expr(stmt->val,
-                                                         cfxt->get_scale(), cit);
+      val_expr = construct_quant_fixed_to_quant_int_expr(
+          stmt->val, cfxt->get_scale(), cit);
     } else {
       TI_NOT_IMPLEMENTED;
     }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1370,7 +1370,8 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
     if (val_type->is<CustomIntType>()) {
       llvm_val[stmt] = load_quant_int(llvm_val[stmt->src], val_type);
     } else {
-      TI_ASSERT(val_type->is<CustomFixedType>() || val_type->is<CustomFloatType>());
+      TI_ASSERT(val_type->is<CustomFixedType>() ||
+                val_type->is<CustomFloatType>());
       TI_ASSERT(stmt->src->is<GetChStmt>());
       llvm_val[stmt] = load_quant_fixed_or_quant_float(stmt->src);
     }

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1197,8 +1197,8 @@ llvm::Value *CodeGenLLVM::custom_type_atomic(AtomicOpStmt *stmt) {
   auto dst_type = stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
   if (auto cit = dst_type->cast<CustomIntType>()) {
     return atomic_add_quant_int(stmt, cit);
-  } else if (auto cft = dst_type->cast<CustomFloatType>()) {
-    return atomic_add_quant_fixed(stmt, cft);
+  } else if (auto cfxt = dst_type->cast<CustomFixedType>()) {
+    return atomic_add_quant_fixed(stmt, cfxt);
   } else {
     return nullptr;
   }
@@ -1369,11 +1369,10 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
     auto val_type = ptr_type->get_pointee_type();
     if (val_type->is<CustomIntType>()) {
       llvm_val[stmt] = load_quant_int(llvm_val[stmt->src], val_type);
-    } else if (val_type->cast<CustomFloatType>()) {
+    } else {
+      TI_ASSERT(val_type->is<CustomFixedType>() || val_type->is<CustomFloatType>());
       TI_ASSERT(stmt->src->is<GetChStmt>());
       llvm_val[stmt] = load_quant_fixed_or_quant_float(stmt->src);
-    } else {
-      TI_NOT_IMPLEMENTED
     }
   } else {
     llvm_val[stmt] = builder->CreateLoad(tlctx->get_data_type(stmt->ret_type),

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -219,7 +219,8 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, CustomFixedType *cfxt);
+  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt,
+                                      CustomFixedType *cfxt);
 
   llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, CustomIntType *cit);
 

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -219,11 +219,11 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, CustomFloatType *cft);
+  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, CustomFixedType *cfxt);
 
   llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, CustomIntType *cit);
 
-  llvm::Value *quant_fixed_to_quant_int(CustomFloatType *cft,
+  llvm::Value *quant_fixed_to_quant_int(CustomFixedType *cfxt,
                                         CustomIntType *cit,
                                         llvm::Value *real);
 
@@ -283,7 +283,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                                  Type *load_type);
 
   llvm::Value *reconstruct_quant_fixed(llvm::Value *digits,
-                                       CustomFloatType *cft);
+                                       CustomFixedType *cfxt);
 
   llvm::Value *load_quant_float(llvm::Value *digits_bit_ptr,
                                 llvm::Value *exponent_bit_ptr,

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -30,10 +30,10 @@ llvm::Value *CodeGenLLVM::atomic_add_quant_int(AtomicOpStmt *stmt,
 }
 
 llvm::Value *CodeGenLLVM::atomic_add_quant_fixed(AtomicOpStmt *stmt,
-                                                 CustomFloatType *cft) {
+                                                 CustomFixedType *cfxt) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->dest]);
-  auto cit = cft->get_digits_type()->as<CustomIntType>();
-  auto val_store = quant_fixed_to_quant_int(cft, cit, llvm_val[stmt->val]);
+  auto cit = cfxt->get_digits_type()->as<CustomIntType>();
+  auto val_store = quant_fixed_to_quant_int(cfxt, cit, llvm_val[stmt->val]);
   auto physical_type = cit->get_physical_type();
   val_store = builder->CreateSExt(val_store, llvm_type(physical_type));
 
@@ -43,14 +43,14 @@ llvm::Value *CodeGenLLVM::atomic_add_quant_fixed(AtomicOpStmt *stmt,
        bit_offset, tlctx->get_constant(cit->get_num_bits()), val_store});
 }
 
-llvm::Value *CodeGenLLVM::quant_fixed_to_quant_int(CustomFloatType *cft,
+llvm::Value *CodeGenLLVM::quant_fixed_to_quant_int(CustomFixedType *cfxt,
                                                    CustomIntType *cit,
                                                    llvm::Value *real) {
   llvm::Value *s = nullptr;
 
   // Compute int(real * (1.0 / scale) + 0.5)
-  auto s_numeric = 1.0 / cft->get_scale();
-  auto compute_type = cft->get_compute_type();
+  auto s_numeric = 1.0 / cfxt->get_scale();
+  auto compute_type = cfxt->get_compute_type();
   s = builder->CreateFPCast(tlctx->get_constant(s_numeric),
                             llvm_type(compute_type));
   auto input_real = builder->CreateFPCast(real, llvm_type(compute_type));
@@ -131,10 +131,9 @@ llvm::Value *CodeGenLLVM::quant_int_or_quant_fixed_to_bits(llvm::Value *val,
                                                            Type *input_type,
                                                            Type *output_type) {
   CustomIntType *cit = nullptr;
-  if (auto cft = input_type->cast<CustomFloatType>()) {
-    TI_ASSERT(cft->get_exponent_type() == nullptr);
-    cit = cft->get_digits_type()->as<CustomIntType>();
-    val = quant_fixed_to_quant_int(cft, cit, val);
+  if (auto cfxt = input_type->cast<CustomFixedType>()) {
+    cit = cfxt->get_digits_type()->as<CustomIntType>();
+    val = quant_fixed_to_quant_int(cfxt, cit, val);
   } else {
     cit = input_type->as<CustomIntType>();
   }
@@ -190,10 +189,8 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
     }
     auto dtype = ch->dt;
 
-    if (dtype->is<CustomFloatType>() &&
-        dtype->as<CustomFloatType>()->get_exponent_type() != nullptr) {
+    if (auto cft = dtype->cast<CustomFloatType>()) {
       // Custom float type with non-shared exponent.
-      auto cft = dtype->as<CustomFloatType>();
       llvm::Value *digit_bits = nullptr;
       // Extract exponent and digits from compute type (assumed to be f32 for
       // now).
@@ -288,14 +285,14 @@ void CodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       auto dtype = ch->dt;
       CustomIntType *cit = nullptr;
       if (auto cft = dtype->cast<CustomFloatType>()) {
-        if (cft->get_exponent_type() != nullptr) {
-          auto exp = cft->get_exponent_type();
-          auto exponent_cit = exp->as<CustomIntType>();
-          auto exponent_snode = ch->exp_snode;
-          update_mask(mask, exponent_cit->get_num_bits(),
-                      exponent_snode->bit_offset);
-        }
+        auto exp = cft->get_exponent_type();
+        auto exponent_cit = exp->as<CustomIntType>();
+        auto exponent_snode = ch->exp_snode;
+        update_mask(mask, exponent_cit->get_num_bits(),
+                    exponent_snode->bit_offset);
         cit = cft->get_digits_type()->as<CustomIntType>();
+      } else if (auto cfxt = dtype->cast<CustomFixedType>()) {
+        cit = cfxt->get_digits_type()->as<CustomIntType>();
       } else {
         cit = dtype->as<CustomIntType>();
       }
@@ -514,16 +511,16 @@ llvm::Value *CodeGenLLVM::extract_quant_int(llvm::Value *physical_value,
 }
 
 llvm::Value *CodeGenLLVM::reconstruct_quant_fixed(llvm::Value *digits,
-                                                  CustomFloatType *cft) {
+                                                  CustomFixedType *cfxt) {
   // Compute float(digits) * scale
   llvm::Value *cast = nullptr;
-  auto compute_type = cft->get_compute_type()->as<PrimitiveType>();
-  if (cft->get_is_signed()) {
+  auto compute_type = cfxt->get_compute_type()->as<PrimitiveType>();
+  if (cfxt->get_is_signed()) {
     cast = builder->CreateSIToFP(digits, llvm_type(compute_type));
   } else {
     cast = builder->CreateUIToFP(digits, llvm_type(compute_type));
   }
-  llvm::Value *s = tlctx->get_constant(cft->get_scale());
+  llvm::Value *s = tlctx->get_constant(cfxt->get_scale());
   s = builder->CreateFPCast(s, llvm_type(compute_type));
   return builder->CreateFMul(cast, s);
 }
@@ -532,12 +529,7 @@ llvm::Value *CodeGenLLVM::load_quant_float(llvm::Value *digits_bit_ptr,
                                            llvm::Value *exponent_bit_ptr,
                                            CustomFloatType *cft,
                                            bool shared_exponent) {
-  // TODO: we ignore "scale" for CustomFloatType with exponent for now. May need
-  // to support this in the future.
-
-  TI_ASSERT(cft->get_scale() == 1);
   auto digits = load_quant_int(digits_bit_ptr, cft->get_digits_type());
-
   auto exponent_val = load_quant_int(
       exponent_bit_ptr, cft->get_exponent_type()->as<CustomIntType>());
   return reconstruct_quant_float(digits, exponent_val, cft, shared_exponent);
@@ -644,10 +636,8 @@ llvm::Value *CodeGenLLVM::reconstruct_quant_float(
 
 llvm::Value *CodeGenLLVM::load_quant_fixed_or_quant_float(Stmt *ptr_stmt) {
   auto ptr = ptr_stmt->as<GetChStmt>();
-  auto cft = ptr->ret_type->as<PointerType>()
-                 ->get_pointee_type()
-                 ->as<CustomFloatType>();
-  if (cft->get_exponent_type()) {
+  auto load_type = ptr->ret_type->as<PointerType>()->get_pointee_type();
+  if (auto cft = load_type->cast<CustomFloatType>()) {
     TI_ASSERT(ptr->width() == 1);
     auto digits_bit_ptr = llvm_val[ptr];
     auto digits_snode = ptr->output_snode;
@@ -659,8 +649,9 @@ llvm::Value *CodeGenLLVM::load_quant_fixed_or_quant_float(Stmt *ptr_stmt) {
     return load_quant_float(digits_bit_ptr, exponent_bit_ptr, cft,
                             digits_snode->owns_shared_exponent);
   } else {
-    auto digits = load_quant_int(llvm_val[ptr], cft->get_digits_type());
-    return reconstruct_quant_fixed(digits, cft);
+    auto cfxt = load_type->as<CustomFixedType>();
+    auto digits = load_quant_int(llvm_val[ptr], cfxt->get_digits_type());
+    return reconstruct_quant_fixed(digits, cfxt);
   }
 }
 

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -135,7 +135,7 @@ class SNode {
   // Note: parent will not be set until structural nodes are compiled!
   SNode *parent{nullptr};
   std::unique_ptr<GradInfoProvider> grad_info{nullptr};
-  SNode *exp_snode{nullptr};  // for CustomFloatType with exponent bits
+  SNode *exp_snode{nullptr};  // for CustomFloatType
   int bit_offset{0};          // for children of bit_struct only
   bool placing_shared_exp{false};
   SNode *currently_placing_exp_snode{nullptr};

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -128,7 +128,8 @@ CustomFixedType::CustomFixedType(Type *digits_type,
 }
 
 std::string CustomFixedType::to_string() const {
-  return fmt::format("cfx(d={} c={} s={})", digits_type_->to_string(), compute_type_->to_string(), scale_);
+  return fmt::format("cfx(d={} c={} s={})", digits_type_->to_string(),
+                     compute_type_->to_string(), scale_);
 }
 
 bool CustomFixedType::get_is_signed() const {
@@ -152,7 +153,8 @@ CustomFloatType::CustomFloatType(Type *digits_type,
 }
 
 std::string CustomFloatType::to_string() const {
-  return fmt::format("cf(d={} e={} c={})", digits_type_->to_string(), exponent_type_->to_string(), compute_type_->to_string());
+  return fmt::format("cf(d={} e={} c={})", digits_type_->to_string(),
+                     exponent_type_->to_string(), compute_type_->to_string());
 }
 
 int CustomFloatType::get_exponent_conversion_offset() const {

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -118,37 +118,41 @@ CustomIntType::CustomIntType(int num_bits,
   }
 }
 
-CustomFloatType::CustomFloatType(Type *digits_type,
-                                 Type *exponent_type,
+CustomFixedType::CustomFixedType(Type *digits_type,
                                  Type *compute_type,
                                  float64 scale)
-    : digits_type_(digits_type),
-      exponent_type_(exponent_type),
-      compute_type_(compute_type),
-      scale_(scale) {
+    : digits_type_(digits_type), compute_type_(compute_type), scale_(scale) {
   TI_ASSERT(digits_type->is<CustomIntType>());
   TI_ASSERT(compute_type->is<PrimitiveType>());
-  TI_ASSERT(is_real(compute_type->as<PrimitiveType>()));
+  TI_ASSERT(is_real(compute_type));
+}
 
-  if (exponent_type_) {
-    // We only support f32 as compute type when when using exponents
-    TI_ASSERT(compute_type_->is_primitive(PrimitiveTypeID::f32));
-    // Exponent must be unsigned custom int
-    TI_ASSERT(exponent_type->is<CustomIntType>());
-    TI_ASSERT(exponent_type->as<CustomIntType>()->get_num_bits() <= 8);
-    TI_ASSERT(exponent_type->as<CustomIntType>()->get_is_signed() == false);
-    TI_ASSERT(get_digit_bits() <= 23);
-  }
+std::string CustomFixedType::to_string() const {
+  return fmt::format("cfx(d={} c={} s={})", digits_type_->to_string(), compute_type_->to_string(), scale_);
+}
+
+bool CustomFixedType::get_is_signed() const {
+  return digits_type_->as<CustomIntType>()->get_is_signed();
+}
+
+CustomFloatType::CustomFloatType(Type *digits_type,
+                                 Type *exponent_type,
+                                 Type *compute_type)
+    : digits_type_(digits_type),
+      exponent_type_(exponent_type),
+      compute_type_(compute_type) {
+  TI_ASSERT(digits_type->is<CustomIntType>());
+  // We only support f32 as compute type when when using exponents
+  TI_ASSERT(compute_type_->is_primitive(PrimitiveTypeID::f32));
+  // Exponent must be unsigned custom int
+  TI_ASSERT(exponent_type->is<CustomIntType>());
+  TI_ASSERT(exponent_type->as<CustomIntType>()->get_num_bits() <= 8);
+  TI_ASSERT(exponent_type->as<CustomIntType>()->get_is_signed() == false);
+  TI_ASSERT(get_digit_bits() <= 23);
 }
 
 std::string CustomFloatType::to_string() const {
-  std::string e, s;
-  if (exponent_type_)
-    e = fmt::format(" e={}", exponent_type_->to_string());
-  if (scale_ != 1)
-    s = fmt::format(" s={}", scale_);
-  return fmt::format("cf(d={}{} c={}{})", digits_type_->to_string(), e,
-                     compute_type_->to_string(), s);
+  return fmt::format("cf(d={} e={} c={})", digits_type_->to_string(), exponent_type_->to_string(), compute_type_->to_string());
 }
 
 int CustomFloatType::get_exponent_conversion_offset() const {
@@ -178,6 +182,8 @@ BitStructType::BitStructType(PrimitiveType *physical_type,
     CustomIntType *component_cit = nullptr;
     if (auto cit = member_types_[i]->cast<CustomIntType>()) {
       component_cit = cit;
+    } else if (auto cfxt = member_types_[i]->cast<CustomFixedType>()) {
+      component_cit = cfxt->get_digits_type()->as<CustomIntType>();
     } else if (auto cft = member_types_[i]->cast<CustomFloatType>()) {
       component_cit = cft->get_digits_type()->as<CustomIntType>();
     } else {

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -226,9 +226,7 @@ class CustomIntType : public Type {
 
 class CustomFixedType : public Type {
  public:
-  CustomFixedType(Type *digits_type,
-                  Type *compute_type,
-                  float64 scale);
+  CustomFixedType(Type *digits_type, Type *compute_type, float64 scale);
 
   std::string to_string() const override;
 
@@ -254,9 +252,7 @@ class CustomFixedType : public Type {
 
 class CustomFloatType : public Type {
  public:
-  CustomFloatType(Type *digits_type,
-                  Type *exponent_type,
-                  Type *compute_type);
+  CustomFloatType(Type *digits_type, Type *exponent_type, Type *compute_type);
 
   std::string to_string() const override;
 

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -224,18 +224,41 @@ class CustomIntType : public Type {
   bool is_signed_{true};
 };
 
-class CustomFloatType : public Type {
+class CustomFixedType : public Type {
  public:
-  CustomFloatType(Type *digits_type,
-                  Type *exponent_type,
+  CustomFixedType(Type *digits_type,
                   Type *compute_type,
                   float64 scale);
 
   std::string to_string() const override;
 
+  bool get_is_signed() const;
+
+  Type *get_digits_type() {
+    return digits_type_;
+  }
+
+  Type *get_compute_type() override {
+    return compute_type_;
+  }
+
   float64 get_scale() const {
     return scale_;
   }
+
+ private:
+  Type *digits_type_{nullptr};
+  Type *compute_type_{nullptr};
+  float64 scale_{1.0};
+};
+
+class CustomFloatType : public Type {
+ public:
+  CustomFloatType(Type *digits_type,
+                  Type *exponent_type,
+                  Type *compute_type);
+
+  std::string to_string() const override;
 
   Type *get_digits_type() {
     return digits_type_;
@@ -259,7 +282,6 @@ class CustomFloatType : public Type {
   Type *digits_type_{nullptr};
   Type *exponent_type_{nullptr};
   Type *compute_type_{nullptr};
-  float64 scale_;
 };
 
 class BitStructType : public Type {

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -61,8 +61,8 @@ Type *TypeFactory::get_custom_fixed_type(Type *digits_type,
                                          float64 scale) {
   auto key = std::make_tuple(digits_type, compute_type, scale);
   if (custom_fixed_types_.find(key) == custom_fixed_types_.end()) {
-    custom_fixed_types_[key] = std::make_unique<CustomFixedType>(
-        digits_type, compute_type, scale);
+    custom_fixed_types_[key] =
+        std::make_unique<CustomFixedType>(digits_type, compute_type, scale);
   }
   return custom_fixed_types_[key].get();
 }

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -56,14 +56,24 @@ Type *TypeFactory::get_custom_int_type(int num_bits,
   return custom_int_types_[key].get();
 }
 
-Type *TypeFactory::get_custom_float_type(Type *digits_type,
-                                         Type *exponent_type,
+Type *TypeFactory::get_custom_fixed_type(Type *digits_type,
                                          Type *compute_type,
                                          float64 scale) {
-  auto key = std::make_tuple(digits_type, exponent_type, compute_type, scale);
+  auto key = std::make_tuple(digits_type, compute_type, scale);
+  if (custom_fixed_types_.find(key) == custom_fixed_types_.end()) {
+    custom_fixed_types_[key] = std::make_unique<CustomFixedType>(
+        digits_type, compute_type, scale);
+  }
+  return custom_fixed_types_[key].get();
+}
+
+Type *TypeFactory::get_custom_float_type(Type *digits_type,
+                                         Type *exponent_type,
+                                         Type *compute_type) {
+  auto key = std::make_tuple(digits_type, exponent_type, compute_type);
   if (custom_float_types_.find(key) == custom_float_types_.end()) {
     custom_float_types_[key] = std::make_unique<CustomFloatType>(
-        digits_type, exponent_type, compute_type, scale);
+        digits_type, exponent_type, compute_type);
   }
   return custom_float_types_[key].get();
 }

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -25,10 +25,13 @@ class TypeFactory {
 
   Type *get_custom_int_type(int num_bits, bool is_signed, Type *compute_type);
 
-  Type *get_custom_float_type(Type *digits_type,
-                              Type *exponent_type,
+  Type *get_custom_fixed_type(Type *digits_type,
                               Type *compute_type,
                               float64 scale);
+
+  Type *get_custom_float_type(Type *digits_type,
+                              Type *exponent_type,
+                              Type *compute_type);
 
   Type *get_bit_struct_type(PrimitiveType *physical_type,
                             std::vector<Type *> member_types,
@@ -63,7 +66,11 @@ class TypeFactory {
       custom_int_types_;
 
   // TODO: use unordered map
-  std::map<std::tuple<Type *, Type *, Type *, float64>, std::unique_ptr<Type>>
+  std::map<std::tuple<Type *, Type *, float64>, std::unique_ptr<Type>>
+      custom_fixed_types_;
+
+  // TODO: use unordered map
+  std::map<std::tuple<Type *, Type *, Type *>, std::unique_ptr<Type>>
       custom_float_types_;
 
   // TODO: avoid duplication

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -74,13 +74,15 @@ inline PrimitiveTypeID get_primitive_data_type() {
 }
 
 inline bool is_quant(DataType dt) {
-  return dt->is<CustomIntType>() || dt->is<CustomFixedType>() || dt->is<CustomFloatType>();
+  return dt->is<CustomIntType>() || dt->is<CustomFixedType>() ||
+         dt->is<CustomFloatType>();
 }
 
 inline bool is_real(DataType dt) {
   return dt->is_primitive(PrimitiveTypeID::f16) ||
          dt->is_primitive(PrimitiveTypeID::f32) ||
-         dt->is_primitive(PrimitiveTypeID::f64) || dt->is<CustomFixedType>() || dt->is<CustomFloatType>();
+         dt->is_primitive(PrimitiveTypeID::f64) || dt->is<CustomFixedType>() ||
+         dt->is<CustomFloatType>();
 }
 
 inline bool is_integral(DataType dt) {

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -74,13 +74,13 @@ inline PrimitiveTypeID get_primitive_data_type() {
 }
 
 inline bool is_quant(DataType dt) {
-  return dt->is<CustomIntType>() || dt->is<CustomFloatType>();
+  return dt->is<CustomIntType>() || dt->is<CustomFixedType>() || dt->is<CustomFloatType>();
 }
 
 inline bool is_real(DataType dt) {
   return dt->is_primitive(PrimitiveTypeID::f16) ||
          dt->is_primitive(PrimitiveTypeID::f32) ||
-         dt->is_primitive(PrimitiveTypeID::f64) || dt->is<CustomFloatType>();
+         dt->is_primitive(PrimitiveTypeID::f64) || dt->is<CustomFixedType>() || dt->is<CustomFloatType>();
 }
 
 inline bool is_integral(DataType dt) {

--- a/taichi/program/snode_expr_utils.cpp
+++ b/taichi/program/snode_expr_utils.cpp
@@ -53,25 +53,24 @@ void place_child(Expr *expr_arg,
                 "This variable has been placed.");
     SNode *new_exp_snode = nullptr;
     if (auto cft = glb_var_expr->dt->cast<CustomFloatType>()) {
-      if (auto exp = cft->get_exponent_type()) {
-        // Non-empty exponent type. First create a place SNode for the
-        // exponent value.
-        if (parent->placing_shared_exp &&
-            parent->currently_placing_exp_snode != nullptr) {
-          // Reuse existing exponent
-          TI_ASSERT_INFO(parent->currently_placing_exp_snode_dtype == exp,
-                         "CustomFloatTypes with shared exponents must have "
-                         "exactly the same exponent type.");
-          new_exp_snode = parent->currently_placing_exp_snode;
-        } else {
-          auto &exp_node = parent->insert_children(SNodeType::place);
-          exp_node.dt = exp;
-          exp_node.name = glb_var_expr->ident.raw_name() + "_exp";
-          new_exp_snode = &exp_node;
-          if (parent->placing_shared_exp) {
-            parent->currently_placing_exp_snode = new_exp_snode;
-            parent->currently_placing_exp_snode_dtype = exp;
-          }
+      auto exp = cft->get_exponent_type();
+      // Non-empty exponent type. First create a place SNode for the
+      // exponent value.
+      if (parent->placing_shared_exp &&
+          parent->currently_placing_exp_snode != nullptr) {
+        // Reuse existing exponent
+        TI_ASSERT_INFO(parent->currently_placing_exp_snode_dtype == exp,
+                       "CustomFloatTypes with shared exponents must have "
+                       "exactly the same exponent type.");
+        new_exp_snode = parent->currently_placing_exp_snode;
+      } else {
+        auto &exp_node = parent->insert_children(SNodeType::place);
+        exp_node.dt = exp;
+        exp_node.name = glb_var_expr->ident.raw_name() + "_exp";
+        new_exp_snode = &exp_node;
+        if (parent->placing_shared_exp) {
+          parent->currently_placing_exp_snode = new_exp_snode;
+          parent->currently_placing_exp_snode_dtype = exp;
         }
       }
     }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1013,10 +1013,12 @@ void export_lang(py::module &m) {
       .def("get_custom_int_type", &TypeFactory::get_custom_int_type,
            py::arg("num_bits"), py::arg("is_signed"), py::arg("compute_type"),
            py::return_value_policy::reference)
+      .def("get_custom_fixed_type", &TypeFactory::get_custom_fixed_type,
+           py::arg("digits_type"), py::arg("compute_type"), py::arg("scale"),
+           py::return_value_policy::reference)
       .def("get_custom_float_type", &TypeFactory::get_custom_float_type,
            py::arg("digits_type"), py::arg("exponent_type"),
-           py::arg("compute_type"), py::arg("scale"),
-           py::return_value_policy::reference);
+           py::arg("compute_type"), py::return_value_policy::reference);
 
   m.def("get_type_factory_instance", TypeFactory::get_instance,
         py::return_value_policy::reference);

--- a/taichi/struct/struct_llvm.cpp
+++ b/taichi/struct/struct_llvm.cpp
@@ -92,6 +92,8 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
       CustomIntType *component_cit = nullptr;
       if (auto cit = ch->dt->cast<CustomIntType>()) {
         component_cit = cit;
+      } else if (auto cfxt = ch->dt->cast<CustomFixedType>()) {
+        component_cit = cfxt->get_digits_type()->as<CustomIntType>();
       } else if (auto cft = ch->dt->cast<CustomFloatType>()) {
         component_cit = cft->get_digits_type()->as<CustomIntType>();
       } else {

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -105,14 +105,11 @@ class DemoteAtomics : public BasicStmtVisitor {
     }
 
     if (auto dest_pointer_type = stmt->dest->ret_type->cast<PointerType>()) {
-      if (auto cft =
-              dest_pointer_type->get_pointee_type()->cast<CustomFloatType>()) {
-        if (cft->get_exponent_type()) {
-          TI_WARN(
-              "AtomicOp on CustomFloatType with exponent is not supported. "
-              "Demoting to non-atomic RMW.");
-          demote = true;
-        }
+      if (dest_pointer_type->get_pointee_type()->is<CustomFloatType>()) {
+        TI_WARN(
+            "AtomicOp on CustomFloatType is not supported. "
+            "Demoting to non-atomic RMW.");
+        demote = true;
       }
     }
 


### PR DESCRIPTION
Related issue = #4857, #3382

Previously, `ti.types.quant.fixed` and `ti.types.quant.float` are both represented as `CustomFloatType`. However, they are essentially different things, and indeed handled in almost completely different code paths. The heavy dispatch and misleading names make the code hard to maintain. This PR separates a `CustomFixedType` out for `ti.types.quant.fixed`. 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
