### PR TITLE
[dx11] [wip] (do not submit yet) Redirect global_tmps_buffer_i32 to u32 so DX11 doesn't bind 2 UAVs pointing to the same resource

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -25,8 +25,8 @@ from taichi.lang.snode import SNode
 from taichi.lang.struct import Struct, StructField, _IntermediateStruct
 from taichi.lang.util import (cook_dtype, get_traceback, is_taichi_class,
                               python_scope, taichi_scope, warning)
-from taichi.types.primitive_types import (all_types, f16, f32, f64, i32, i64, u8,
-                                          u32, u64)
+from taichi.types.primitive_types import (all_types, f16, f32, f64, i32, i64,
+                                          u8, u32, u64)
 
 
 @taichi_scope

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -2069,7 +2069,6 @@ class TaskCodegen : public IRVisitor {
     }
 
     if (buffer.type == BufferType::GlobalTmps) {
-
       // FORCE U32
       auto type_u32 = ir_->get_taichi_uint_type(PrimitiveType::u32);
       auto type_primitive_u32 = ir_->get_primitive_type(type_u32);
@@ -2180,13 +2179,14 @@ class TaskCodegen : public IRVisitor {
   std::vector<BufferBind> get_buffer_binds() {
     std::vector<BufferBind> result;
     for (auto &[key, val] : buffer_binding_map_) {
-      BufferBind bb {key.first, int(val)};
+      BufferBind bb{key.first, int(val)};
 
-      #ifdef TI_WITH_DX11
-      if (buffer_root_id_override_.find(key) != buffer_root_id_override_.end()) {
+#ifdef TI_WITH_DX11
+      if (buffer_root_id_override_.find(key) !=
+          buffer_root_id_override_.end()) {
         bb.buffer.root_id = buffer_root_id_override_[key];
       }
-      #endif
+#endif
 
       result.push_back(bb);
     }
@@ -2246,8 +2246,8 @@ class TaskCodegen : public IRVisitor {
   std::vector<TextureBind> texture_binds_;
 
   // for distinguishing between i32 and u32
-  std::unordered_map<std::pair<BufferInfo, int>, int,
-                     BufferInfoTypeTupleHasher> buffer_root_id_override_;
+  std::unordered_map<std::pair<BufferInfo, int>, int, BufferInfoTypeTupleHasher>
+      buffer_root_id_override_;
 
   spirv::Value kernel_function_;
   spirv::Label kernel_return_label_;

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -270,7 +270,7 @@ constexpr size_t kListGenBufferSize = 32 << 20;
 CompiledTaichiKernel::CompiledTaichiKernel(const Params &ti_params)
     : ti_kernel_attribs_(*ti_params.ti_kernel_attribs),
       device_(ti_params.device) {
-  BufferInfo bi = { BufferType::GlobalTmps, 1 };
+  BufferInfo bi = {BufferType::GlobalTmps, 1};
   input_buffers_[bi] = ti_params.global_tmps_buffer_i32;
   bi.root_id = 2;
   input_buffers_[bi] = ti_params.global_tmps_buffer_u32;
@@ -646,9 +646,11 @@ void GfxRuntime::init_nonroot_buffers() {
   Stream *stream = device_->get_compute_stream();
   auto cmdlist = stream->new_command_list();
 
-  cmdlist->buffer_fill(global_tmps_buffer_i32_->get_ptr(0), kBufferSizeEntireSize,
+  cmdlist->buffer_fill(global_tmps_buffer_i32_->get_ptr(0),
+                       kBufferSizeEntireSize,
                        /*data=*/0);
-  cmdlist->buffer_fill(global_tmps_buffer_u32_->get_ptr(0), kBufferSizeEntireSize,
+  cmdlist->buffer_fill(global_tmps_buffer_u32_->get_ptr(0),
+                       kBufferSizeEntireSize,
                        /*data=*/0);
   cmdlist->buffer_fill(listgen_buffer_->get_ptr(0), kBufferSizeEntireSize,
                        /*data=*/0);

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -41,7 +41,8 @@ class CompiledTaichiKernel {
 
     Device *device{nullptr};
     std::vector<DeviceAllocation *> root_buffers;
-    DeviceAllocation *global_tmps_buffer{nullptr};
+    DeviceAllocation *global_tmps_buffer_i32{nullptr};
+    DeviceAllocation *global_tmps_buffer_u32{nullptr};
     DeviceAllocation *listgen_buffer{nullptr};
   };
 
@@ -130,7 +131,8 @@ class TI_DLL_EXPORT GfxRuntime {
   uint64_t *const host_result_buffer_;
 
   std::vector<std::unique_ptr<DeviceAllocationGuard>> root_buffers_;
-  std::unique_ptr<DeviceAllocationGuard> global_tmps_buffer_;
+  std::unique_ptr<DeviceAllocationGuard> global_tmps_buffer_i32_;
+  std::unique_ptr<DeviceAllocationGuard> global_tmps_buffer_u32_;
   // FIXME: Support proper multiple lists
   std::unique_ptr<DeviceAllocationGuard> listgen_buffer_;
 


### PR DESCRIPTION
It seems in the SPIR-V program, `global_tmps_buffer_u32` and `global_tmps_buffer_i32` point to the same underlying resource.

In DX11, this means 2 UAVs can point to the same "global temp buffer" resource, and be bound to the same pipeline.

It seems this behavior is fine with the Vulkan backend, but will cause the following warning with the DX11 backend:
```
Resource being set to CS UnorderedAccessView slot X is already bound on output elsewhere. [ STATE_SETTING WARNING #2097354: DEVICE_CSSETUNORDEREDACCESSVIEWS_HAZARD
```

This can cause incorrect behavior, and may be reproduced with the following Taichi kernel:
```
import taichi as ti
ti.init(arch=ti.dx11)
idx = ti.field(dtype=ti.i32, shape=())
scratch = ti.field(dtype=ti.f32, shape=20)

@ti.kernel
def hey():
  ix = idx[None]
  idx[None] += 1
  for i in range(ix):
    if True:
      scratch[ix] += 233
for i in range(6): hey()
```

Output before the fix:
```
[3495.    0.    0.    0.    0.    0.    0.    0.    0.    0.    0.    0.
    0.    0.    0.    0.    0.    0.    0.    0.]
```

Expected result:
```
[   0.  233.  466.  699.  932. 1165.    0.    0.    0.    0.    0.    0.
    0.    0.    0.    0.    0.    0.    0.    0.]
```

The way it happens is: the `hey` Taichi kernel gets compiled into 2 HLSL kernels. The first one saves the current value of `idx[None]`, or `ix`, to `global_tmps_buffer_u32`. However, for some reason the second kernel decides to read the loop count (`ix`) from `global_tmps_buffer_i32`.

The first kernel looks like:
```
static const uint3 gl_WorkGroupSize = uint3(1u, 1u, 1u);

RWByteAddressBuffer root_buffer_0 : register(u2);
RWByteAddressBuffer global_tmps_buffer_u32 : register(u3);

static uint3 gl_GlobalInvocationID;
struct SPIRV_Cross_Input
{
    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
};

void comp_main()
{
    if (gl_GlobalInvocationID.x == 0u)
    {
        uint _41 = root_buffer_0.Load(0);       <-------------- Get the current value of idx[None], or "ix"
        int tmp2_i32 = int(_41);
        global_tmps_buffer_u32.Store(0, uint(tmp2_i32));   <--------------- Store the current value of ix to global temp
        root_buffer_0.Store(0, uint(tmp2_i32 + 1)); <----------------- Increment idx[None] by 1
    }
}

[numthreads(1, 1, 1)]
void main(SPIRV_Cross_Input stage_input)
{
    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
    comp_main();
}
```

The second kernel looks like:
```
static const uint3 gl_WorkGroupSize = uint3(128u, 1u, 1u);

RWByteAddressBuffer global_tmps_buffer_i32 : register(u2);      <----------- Note these two
RWByteAddressBuffer global_tmps_buffer_u32 : register(u3);     <----------- UAV slots
RWByteAddressBuffer root_buffer_0 : register(u4);
cbuffer SPIRV_Cross_NumWorkgroups
{
    uint3 SPIRV_Cross_NumWorkgroups_1_count : packoffset(c0);
};


static uint3 gl_GlobalInvocationID;
struct SPIRV_Cross_Input
{
    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
};

void comp_main()
{
    int begin_ = int(gl_GlobalInvocationID.x) + 0;
    int end_ = (int(global_tmps_buffer_i32.Load((0 >> 2) * 4 + 0)) - 0) + 0;   <------------- The loop range, ix, comes from i32 not u32 !
    int total_invocs = int(SPIRV_Cross_NumWorkgroups_1_count.x * 128u);
    uint _77;
    for (int ii_i32 = begin_; ii_i32 < end_; ii_i32 += total_invocs)
    {
        uint _74 = ((((0u + (uint(0) * 132u)) + 4u) + (uint(int(global_tmps_buffer_u32.Load(int(uint(0) >> uint(2)) * 4 + 0)) & 31) * 4u)) + 0u) >> 2u;
        for (;;)
        {
            uint _84 = root_buffer_0.Load(_74 * 4 + 0);
            uint _88;
            root_buffer_0.InterlockedCompareExchange(_74 * 4 + 0, _84, asuint(asfloat(_84) + 233.0f), _88);
            _77 = _88;
            if (_88 == _84)
            {
                break;
            }
            continue;
        }
    }
}

[numthreads(128, 1, 1)]
void main(SPIRV_Cross_Input stage_input)
{
    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
    comp_main();
}
```

As shown above, With the current code, the `i32` and `u32` versions of the global temp buffer gets two UAVs, u2 and u3 respectively. However, since they are pointing to the same buffer allocation, the following DX runtime warning will happen:
```
Resource being set to CS UnorderedAccessView slot is already bound on output elsewhere. [ STATE_SETTING WARNING #2097354: DEVICE_CSSETUNORDEREDACCESSVIEWS_HAZARD
```

The DX runtime will bind either `u2` and `u3` to NULL, depending on which one is the bound later than the other. This will cause `_74` in the second kernel to have a value of 0 so only the first element in `scratch` gets incremented.

--------------------------------------------------------------------------------------------

This change attempts to fix this bug by redirecting all operations on "i32" to "u32" (since u32 seems to be present by default)

This has not yet been extensively tested and may need to be improved a bit, I wonder if there is a better way? Any comments will be appreciated.

Thanks!

Related issue = #