### PR TITLE
[build] Export cmake config to ease clients usage in Cmake

### DIFF
--- a/cmake/TaichiExportCore.cmake
+++ b/cmake/TaichiExportCore.cmake
@@ -69,12 +69,13 @@ install(DIRECTORY
       ${PROJECT_SOURCE_DIR}/external/spdlog/include/spdlog
       ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
       ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
-      ${PROJECT_SOURCE_DIR}/external/glm
+      ${PROJECT_SOURCE_DIR}/external/glm/glm
       ${PROJECT_SOURCE_DIR}/external/eigen
     DESTINATION include
     FILES_MATCHING
     PATTERN *.h
     PATTERN *.hpp
+    PATTERN *.inl
     )
 install(DIRECTORY
       ${PROJECT_SOURCE_DIR}/external/eigen/Eigen

--- a/cmake/TaichiExportCore.cmake
+++ b/cmake/TaichiExportCore.cmake
@@ -4,6 +4,85 @@ set(TAICHI_EXPORT_CORE_NAME taichi_export_core)
 
 add_library(${TAICHI_EXPORT_CORE_NAME} SHARED)
 target_link_libraries(${TAICHI_EXPORT_CORE_NAME} PRIVATE taichi_isolated_core)
+
 set_target_properties(${TAICHI_EXPORT_CORE_NAME} PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_INSTALL_LIBDIR}")
+
+target_include_directories(${TAICHI_EXPORT_CORE_NAME}
+    PUBLIC
+        # Used when building the library:
+        $<BUILD_INTERFACE:${taichi_export_core_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${taichi_export_core_SOURCE_DIR}/include>
+        # Used when installing the library:
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        # Used only when building the library:
+        ${PROJECT_SOURCE_DIR})
+
+include(GNUInstallDirs)
+install(TARGETS ${TAICHI_EXPORT_CORE_NAME} EXPORT ${TAICHI_EXPORT_CORE_NAME}Targets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+  )
+# Install the export set
+install(EXPORT ${TAICHI_EXPORT_CORE_NAME}Targets
+  FILE ${TAICHI_EXPORT_CORE_NAME}Targets.cmake
+  NAMESPACE ${TAICHI_EXPORT_CORE_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
+  )
+
+# For generating the ${TAICHI_EXPORT_CORE_NAME}Config*.cmake
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/cmake/${TAICHI_EXPORT_CORE_NAME}Config.cmake.in"
+    "${PROJECT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}Config.cmake"
+  INSTALL_DESTINATION
+     ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
+  )
+
+set(${TAICHI_EXPORT_CORE_NAME}_VERSION "${TI_VERSION_MAJOR}.${TI_VERSION_MINOR}.${TI_VERSION_PATCH}")
+write_basic_package_version_file(
+  "${TAICHI_EXPORT_CORE_NAME}ConfigVersion.cmake"
+  VERSION ${${TAICHI_EXPORT_CORE_NAME}_VERSION}
+  COMPATIBILITY SameMajorVersion
+  )
+
+# Install the meta data of targets, namely the export set
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}Config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}ConfigVersion.cmake"
+  DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
+  )
+
+## Install headers
+install(DIRECTORY
+    ${PROJECT_SOURCE_DIR}/taichi
+    ${PROJECT_SOURCE_DIR}/external/spdlog/include/spdlog
+    ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
+    ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
+    ${PROJECT_SOURCE_DIR}/external/glm
+    ${PROJECT_SOURCE_DIR}/external/eigen
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN *.h
+  PATTERN *.hpp
+)
+install(DIRECTORY
+    ${PROJECT_SOURCE_DIR}/external/eigen/Eigen
+  DESTINATION include
+)
+
+file(GLOB TAICHI_PUBLIC_HEADERS
+	"external/volk/*.h" "external/volk/*.hpp"
+	"external/imgui/*.h" "external/imgui/*.hpp"
+	"external/imgui/backends/*.h" "external/imgui/backends/*.hpp"
+	"external/VulkanMemoryAllocator/include/*.h"
+    )
+install(FILES
+    ${TAICHI_PUBLIC_HEADERS}
+  DESTINATION include
+)

--- a/cmake/TaichiExportCore.cmake
+++ b/cmake/TaichiExportCore.cmake
@@ -4,10 +4,9 @@ set(TAICHI_EXPORT_CORE_NAME taichi_export_core)
 
 add_library(${TAICHI_EXPORT_CORE_NAME} SHARED)
 target_link_libraries(${TAICHI_EXPORT_CORE_NAME} PRIVATE taichi_isolated_core)
-
 set_target_properties(${TAICHI_EXPORT_CORE_NAME} PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_INSTALL_LIBDIR}"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_INSTALL_LIBDIR}")
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 
 target_include_directories(${TAICHI_EXPORT_CORE_NAME}
     PUBLIC
@@ -20,69 +19,74 @@ target_include_directories(${TAICHI_EXPORT_CORE_NAME}
         # Used only when building the library:
         ${PROJECT_SOURCE_DIR})
 
+# This helper provides us standard locations across Linux/Windows/MacOS
 include(GNUInstallDirs)
+
 install(TARGETS ${TAICHI_EXPORT_CORE_NAME} EXPORT ${TAICHI_EXPORT_CORE_NAME}Targets
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
-  )
-# Install the export set
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+    )
+
+# Install the export set, which contains the meta data of the target
 install(EXPORT ${TAICHI_EXPORT_CORE_NAME}Targets
-  FILE ${TAICHI_EXPORT_CORE_NAME}Targets.cmake
-  NAMESPACE ${TAICHI_EXPORT_CORE_NAME}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
-  )
+    FILE ${TAICHI_EXPORT_CORE_NAME}Targets.cmake
+    NAMESPACE ${TAICHI_EXPORT_CORE_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
+    )
 
-# For generating the ${TAICHI_EXPORT_CORE_NAME}Config*.cmake
 include(CMakePackageConfigHelpers)
-configure_package_config_file(
-    "${PROJECT_SOURCE_DIR}/cmake/${TAICHI_EXPORT_CORE_NAME}Config.cmake.in"
-    "${PROJECT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}Config.cmake"
-  INSTALL_DESTINATION
-     ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
-  )
 
+# Generate the config file
+configure_package_config_file(
+      "${PROJECT_SOURCE_DIR}/cmake/${TAICHI_EXPORT_CORE_NAME}Config.cmake.in"
+      "${PROJECT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}Config.cmake"
+    INSTALL_DESTINATION
+       ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
+    )
+
+# Generate the config version file
 set(${TAICHI_EXPORT_CORE_NAME}_VERSION "${TI_VERSION_MAJOR}.${TI_VERSION_MINOR}.${TI_VERSION_PATCH}")
 write_basic_package_version_file(
-  "${TAICHI_EXPORT_CORE_NAME}ConfigVersion.cmake"
-  VERSION ${${TAICHI_EXPORT_CORE_NAME}_VERSION}
-  COMPATIBILITY SameMajorVersion
-  )
+    "${TAICHI_EXPORT_CORE_NAME}ConfigVersion.cmake"
+    VERSION ${${TAICHI_EXPORT_CORE_NAME}_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
 
-# Install the meta data of targets, namely the export set
+# Install the config files
 install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}Config.cmake"
-  "${CMAKE_CURRENT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}ConfigVersion.cmake"
-  DESTINATION
-  ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
-  )
+    "${CMAKE_CURRENT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${TAICHI_EXPORT_CORE_NAME}ConfigVersion.cmake"
+    DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${TAICHI_EXPORT_CORE_NAME}
+    )
 
-## Install headers
+# Install public headers for this target
+# TODO: Replace files here with public headers when ready.
 install(DIRECTORY
-    ${PROJECT_SOURCE_DIR}/taichi
-    ${PROJECT_SOURCE_DIR}/external/spdlog/include/spdlog
-    ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
-    ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
-    ${PROJECT_SOURCE_DIR}/external/glm
-    ${PROJECT_SOURCE_DIR}/external/eigen
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN *.h
-  PATTERN *.hpp
-)
+      ${PROJECT_SOURCE_DIR}/taichi
+      ${PROJECT_SOURCE_DIR}/external/spdlog/include/spdlog
+      ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
+      ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan
+      ${PROJECT_SOURCE_DIR}/external/glm
+      ${PROJECT_SOURCE_DIR}/external/eigen
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN *.h
+    PATTERN *.hpp
+    )
 install(DIRECTORY
-    ${PROJECT_SOURCE_DIR}/external/eigen/Eigen
-  DESTINATION include
-)
-
-file(GLOB TAICHI_PUBLIC_HEADERS
-	"external/volk/*.h" "external/volk/*.hpp"
-	"external/imgui/*.h" "external/imgui/*.hpp"
-	"external/imgui/backends/*.h" "external/imgui/backends/*.hpp"
-	"external/VulkanMemoryAllocator/include/*.h"
+      ${PROJECT_SOURCE_DIR}/external/eigen/Eigen
+    DESTINATION include
+    )
+file(GLOB TAICHI_PUBLIC_HEADERS_TEMP
+    "external/volk/*.h" "external/volk/*.hpp"
+    "external/imgui/*.h" "external/imgui/*.hpp"
+    "external/imgui/backends/*.h" "external/imgui/backends/*.hpp"
+    "external/VulkanMemoryAllocator/include/*.h"
     )
 install(FILES
-    ${TAICHI_PUBLIC_HEADERS}
-  DESTINATION include
-)
+      ${TAICHI_PUBLIC_HEADERS_TEMP}
+    DESTINATION include
+    )

--- a/cmake/taichi_export_coreConfig.cmake.in
+++ b/cmake/taichi_export_coreConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/taichi_export_coreTargets.cmake")
+
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Related issue = #4832 

When using `taichi_export_core` library in Cmake, clients have to manually linking the .so library and providing include paths etc. This PR enables Taichi to generate cmake configuration files. This allows anyone linking the library in just two cmake instructions:

```
find_package(taichi_export_core REQUIRED CONFIG)
target_link_libraries(implicit_fem PUBLIC taichi_export_core::taichi_export_core)
```

An example AOT usage (implicit_fem) can be found at this PR https://github.com/taichi-dev/taichi-aot-demo/pull/21