### PR TITLE
[llvm] [refactor] LLVMProgramImpl code clean up: part-1

### DIFF
--- a/taichi/backends/cuda/jit_cuda.cpp
+++ b/taichi/backends/cuda/jit_cuda.cpp
@@ -1,5 +1,5 @@
 #include "taichi/backends/cuda/jit_cuda.h"
-#include "taichi/llvm/llvm_program.h"
+#include "taichi/llvm/llvm_context.h"
 
 TLANG_NAMESPACE_BEGIN
 
@@ -8,7 +8,7 @@ TLANG_NAMESPACE_BEGIN
 JITModule *JITSessionCUDA ::add_module(std::unique_ptr<llvm::Module> M,
                                        int max_reg) {
   auto ptx = compile_module_to_ptx(M);
-  if (this->llvm_prog()->config->print_kernel_nvptx) {
+  if (this->config_->print_kernel_nvptx) {
     static FileSequenceWriter writer("taichi_kernel_nvptx_{:04d}.ptx",
                                      "module NVPTX");
     writer.write(ptx);
@@ -82,7 +82,7 @@ std::string JITSessionCUDA::compile_module_to_ptx(
 
   using namespace llvm;
 
-  if (this->llvm_prog()->config->print_kernel_llvm_ir) {
+  if (this->config_->print_kernel_llvm_ir) {
     static FileSequenceWriter writer("taichi_kernel_cuda_llvm_ir_{:04d}.ll",
                                      "unoptimized LLVM IR (CUDA)");
     writer.write(module.get());
@@ -104,7 +104,7 @@ std::string JITSessionCUDA::compile_module_to_ptx(
 
   TargetOptions options;
   options.PrintMachineCode = 0;
-  if (this->llvm_prog()->config->fast_math) {
+  if (this->config_->fast_math) {
     options.AllowFPOpFusion = FPOpFusion::Fast;
     // See NVPTXISelLowering.cpp
     // Setting UnsafeFPMath true will result in approximations such as
@@ -207,7 +207,7 @@ std::string JITSessionCUDA::compile_module_to_ptx(
     module_pass_manager.run(*module);
   }
 
-  if (this->llvm_prog()->config->print_kernel_llvm_ir_optimized) {
+  if (this->config_->print_kernel_llvm_ir_optimized) {
     static FileSequenceWriter writer(
         "taichi_kernel_cuda_llvm_ir_optimized_{:04d}.ll",
         "optimized LLVM IR (CUDA)");
@@ -222,18 +222,20 @@ std::string JITSessionCUDA::compile_module_to_ptx(
 }
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(
-    LlvmProgramImpl *llvm_prog,
+    TaichiLLVMContext *tlctx,
+    CompileConfig *config,
     Arch arch) {
   TI_ASSERT(arch == Arch::cuda);
   // https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#data-layout
   auto data_layout = llvm::DataLayout(
       "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-"
       "f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
-  return std::make_unique<JITSessionCUDA>(llvm_prog, data_layout);
+  return std::make_unique<JITSessionCUDA>(tlctx, config, data_layout);
 }
 #else
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(
-    LlvmProgramImpl *llvm_prog,
+    TaichiLLVMContext *tlctx,
+    CompileConfig *config,
     Arch arch) {
   TI_NOT_IMPLEMENTED
 }

--- a/taichi/backends/cuda/jit_cuda.h
+++ b/taichi/backends/cuda/jit_cuda.h
@@ -83,8 +83,10 @@ class JITSessionCUDA : public JITSession {
  public:
   llvm::DataLayout data_layout;
 
-  JITSessionCUDA(LlvmProgramImpl *llvm_prog, llvm::DataLayout data_layout)
-      : JITSession(llvm_prog), data_layout(data_layout) {
+  JITSessionCUDA(TaichiLLVMContext *tlctx,
+                 CompileConfig *config,
+                 llvm::DataLayout data_layout)
+      : JITSession(tlctx, config), data_layout(data_layout) {
   }
 
   JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg) override;
@@ -100,7 +102,8 @@ class JITSessionCUDA : public JITSession {
 #endif
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(
-    LlvmProgramImpl *llvm_prog,
+    TaichiLLVMContext *tlctx,
+    CompileConfig *config,
     Arch arch);
 
 TLANG_NAMESPACE_END

--- a/taichi/jit/jit_session.cpp
+++ b/taichi/jit/jit_session.cpp
@@ -8,25 +8,29 @@ TLANG_NAMESPACE_BEGIN
 
 #ifdef TI_WITH_LLVM
 std::unique_ptr<JITSession> create_llvm_jit_session_cpu(
-    LlvmProgramImpl *llvm_prog,
+    TaichiLLVMContext *tlctx,
+    CompileConfig *config,
     Arch arch);
 
 std::unique_ptr<JITSession> create_llvm_jit_session_cuda(
-    LlvmProgramImpl *llvm_prog,
+    TaichiLLVMContext *tlctx,
+    CompileConfig *config,
     Arch arch);
 #endif
 
-JITSession::JITSession(LlvmProgramImpl *llvm_prog) : llvm_prog_(llvm_prog) {
+JITSession::JITSession(TaichiLLVMContext *tlctx, CompileConfig *config)
+    : tlctx_(tlctx), config_(config) {
 }
 
-std::unique_ptr<JITSession> JITSession::create(LlvmProgramImpl *llvm_prog,
+std::unique_ptr<JITSession> JITSession::create(TaichiLLVMContext *tlctx,
+                                               CompileConfig *config,
                                                Arch arch) {
 #ifdef TI_WITH_LLVM
   if (arch_is_cpu(arch)) {
-    return create_llvm_jit_session_cpu(llvm_prog, arch);
+    return create_llvm_jit_session_cpu(tlctx, config, arch);
   } else if (arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-    return create_llvm_jit_session_cuda(llvm_prog, arch);
+    return create_llvm_jit_session_cuda(tlctx, config, arch);
 #else
     TI_NOT_IMPLEMENTED
 #endif

--- a/taichi/jit/jit_session.h
+++ b/taichi/jit/jit_session.h
@@ -11,17 +11,18 @@ TLANG_NAMESPACE_BEGIN
 
 // Backend JIT compiler for all archs
 
-class LlvmProgramImpl;
+class TaichiLLVMContext;
+struct CompileConfig;
 
 class JITSession {
- private:
-  LlvmProgramImpl *llvm_prog_;
-
  protected:
+  TaichiLLVMContext *tlctx_;
+  CompileConfig *config_;
+
   std::vector<std::unique_ptr<JITModule>> modules;
 
  public:
-  JITSession(LlvmProgramImpl *llvm_prog);
+  JITSession(TaichiLLVMContext *tlctx, CompileConfig *config);
 
   virtual JITModule *add_module(std::unique_ptr<llvm::Module> M,
                                 int max_reg = 0) = 0;
@@ -34,18 +35,14 @@ class JITSession {
 
   virtual llvm::DataLayout get_data_layout() = 0;
 
-  static std::unique_ptr<JITSession> create(LlvmProgramImpl *llvm_prog,
+  static std::unique_ptr<JITSession> create(TaichiLLVMContext *tlctx,
+                                            CompileConfig *config,
                                             Arch arch);
 
   virtual void global_optimize_module(llvm::Module *module) {
   }
 
   virtual ~JITSession() = default;
-
- protected:
-  LlvmProgramImpl *llvm_prog() const {
-    return llvm_prog_;
-  }
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/llvm/llvm_context.cpp
+++ b/taichi/llvm/llvm_context.cpp
@@ -41,6 +41,7 @@
 #include "taichi/common/task.h"
 #include "taichi/util/environ_config.h"
 #include "llvm_context.h"
+#include "taichi/llvm/llvm_program.h"
 
 #ifdef _WIN32
 // Travis CI seems doesn't support <filesystem>...
@@ -93,7 +94,7 @@ TaichiLLVMContext::TaichiLLVMContext(LlvmProgramImpl *llvm_prog, Arch arch)
     TI_NOT_IMPLEMENTED
 #endif
   }
-  jit = JITSession::create(llvm_prog, arch);
+  jit = JITSession::create(this, llvm_prog->config, arch);
   TI_TRACE("Taichi llvm context created.");
 }
 

--- a/taichi/llvm/llvm_context.h
+++ b/taichi/llvm/llvm_context.h
@@ -18,6 +18,7 @@ namespace taichi {
 namespace lang {
 
 class JITSessionCPU;
+class LlvmProgramImpl;
 
 /**
  * Manages an LLVMContext for Taichi's usage.

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -415,11 +415,7 @@ void Kernel::init(Program &program,
   this->autodiff_mode = autodiff_mode;
   this->lowered_ = false;
   this->program = &program;
-#ifdef TI_WITH_LLVM
-  if (auto *llvm_program_impl = program.get_llvm_program_impl()) {
-    llvm_program_impl->maybe_initialize_cuda_llvm_context();
-  }
-#endif
+
   is_accessor = false;
   is_evaluator = false;
   compiled_ = nullptr;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -125,13 +125,6 @@ Program::Program(Arch desired_arch)
   total_compilation_time_ = 0;
   num_instances_ += 1;
   SNode::counter = 0;
-  if (arch_uses_llvm(config.arch)) {
-#if TI_WITH_LLVM
-    static_cast<LlvmProgramImpl *>(program_impl_.get())->initialize_host();
-#else
-    TI_NOT_IMPLEMENTED
-#endif
-  }
 
   result_buffer = nullptr;
   current_callable = nullptr;


### PR DESCRIPTION
Related issue = #5114, #4800

Moved `maybe_initialize_cuda_llvm_context()` and `initialize_host()` to LlvmProgramImpl's constructor. In the past, this didn't work because `initialize_host()` is involved with member access to LlvmProgramImpl, which is incomplete during construction.

In this PR, we refactored JITSession to avoid its attempt of accessing LlvmProgramImpl's members during `initialize_host()`, so as to safely move it to `LlvmProgramImpl::LlvmProgramImpl()`