### PR TITLE
[refactor] Enable adaptive block_dim selection for CPU backend

### DIFF
--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -589,7 +589,10 @@ def _block_dim(dim):
 def _block_dim_adaptive(block_dim_adaptive):
     """Enable/Disable backends set block_dim adaptively.
     """
-    get_runtime().prog.config.cpu_block_dim_adaptive = block_dim_adaptive
+    if get_runtime().prog.config.arch != cpu:
+        _logging.warn('Adaptive block_dim is supported on CPU backend only')
+    else:
+        get_runtime().prog.config.cpu_block_dim_adaptive = block_dim_adaptive
 
 
 def loop_config(*,

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -586,13 +586,24 @@ def _block_dim(dim):
     get_runtime().prog.current_ast_builder().block_dim(dim)
 
 
-def loop_config(*, block_dim=None, serialize=False, parallelize=None):
+def _block_dim_adaptive(block_dim_adaptive):
+    """Enable/Disable backends set block_dim adaptively.
+    """
+    get_runtime().prog.config.cpu_block_dim_adaptive = block_dim_adaptive
+
+
+def loop_config(*,
+                block_dim=None,
+                serialize=False,
+                parallelize=None,
+                block_dim_adaptive=True):
     """Sets directives for the next loop
 
     Args:
         block_dim (int): The number of threads in a block on GPU
         serialize (bool): Whether to let the for loop execute serially, `serialize=True` equals to `parallelize=1`
         parallelize (int): The number of threads to use on CPU
+        block_dim_adaptive (bool): Whether to allow backends set block_dim adaptively, enabled by default
 
     Examples::
 
@@ -625,6 +636,9 @@ def loop_config(*, block_dim=None, serialize=False, parallelize=None):
         _parallelize(1)
     elif parallelize is not None:
         _parallelize(parallelize)
+
+    if not block_dim_adaptive:
+        _block_dim_adaptive(block_dim_adaptive)
 
 
 def global_thread_idx():

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -34,6 +34,7 @@ CompileConfig::CompileConfig() {
   verbose_kernel_launches = false;
   kernel_profiler = false;
   default_cpu_block_dim = 32;
+  cpu_block_dim_adaptive = true;
   default_gpu_block_dim = 128;
   gpu_max_reg = 0;  // 0 means using the default value from the CUDA driver.
   verbose = true;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -48,6 +48,7 @@ struct CompileConfig {
   DataType default_ip;
   std::string extra_flags;
   int default_cpu_block_dim;
+  bool cpu_block_dim_adaptive;
   int default_gpu_block_dim;
   int gpu_max_reg;
   int ad_stack_size{0};  // 0 = adaptive

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -162,6 +162,8 @@ void export_lang(py::module &m) {
                      &CompileConfig::move_loop_invariant_outside_if)
       .def_readwrite("default_cpu_block_dim",
                      &CompileConfig::default_cpu_block_dim)
+      .def_readwrite("cpu_block_dim_adaptive",
+                     &CompileConfig::cpu_block_dim_adaptive)
       .def_readwrite("default_gpu_block_dim",
                      &CompileConfig::default_gpu_block_dim)
       .def_readwrite("gpu_max_reg", &CompileConfig::gpu_max_reg)

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1467,13 +1467,6 @@ void cpu_parallel_range_for(RuntimeContext *context,
     taichi_printf(context->runtime, "step must not be %d\n", step);
     exit(-1);
   }
-  if (block_dim == 0) {
-    // adaptive block dim
-    auto num_items = (ctx.end - ctx.begin) / std::abs(step);
-    // ensure each thread has at least ~32 tasks for load balancing
-    // and each task has at least 512 items to amortize scheduler overhead
-    block_dim = std::min(512, std::max(1, num_items / (num_threads * 32)));
-  }
   ctx.block_size = block_dim;
   auto runtime = context->runtime;
   runtime->parallel_for(runtime->thread_pool,

--- a/tests/python/test_parallel_range_for.py
+++ b/tests/python/test_parallel_range_for.py
@@ -71,7 +71,7 @@ def test_loop_config_serial_for():
     assert foo() == 50
 
 
-@test_utils.test()
+@test_utils.test(arch=[ti.cpu])
 def test_loop_config_block_dim_adaptive():
     n = 4096
     val = ti.field(ti.i32, shape=(n))

--- a/tests/python/test_parallel_range_for.py
+++ b/tests/python/test_parallel_range_for.py
@@ -69,3 +69,21 @@ def test_loop_config_serial_for():
         return a
 
     assert foo() == 50
+
+
+@test_utils.test()
+def test_loop_config_block_dim_adaptive():
+    n = 4096
+    val = ti.field(ti.i32, shape=(n))
+
+    @ti.kernel
+    def fill():
+        ti.loop_config(block_dim_adaptive=False)
+        for i in range(n):
+            val[i] = i
+
+    fill()
+    # To speed up
+    val_np = val.to_numpy()
+    for i in range(n):
+        assert val_np[i] == i


### PR DESCRIPTION
Related issue = #3750 #4541

For kernels with `arch=ti.cpu`, users tend to rely on the default `block_dim` settings. The default value is always 32 for CPU backends, which leads to slow execution for simple kernels. This PR adds the option to adaptive select block_dim during codegen. This leads to a 1.4x speedup for a simple kernel as mentioned in #4541:

```
@ti.kernel
def reduce_para()->ti.f32:
    n = v1.shape[0]
    sum = 0.0
    ti.loop_config(block_dim_adaptive=False)
    for i in range(n):
        sum += v1[i]*v2[i]
    return sum
```
