### PR TITLE
[lang] Improve error message when literal val is out of range of default dtype

### DIFF
--- a/tests/python/test_literal.py
+++ b/tests/python/test_literal.py
@@ -80,3 +80,25 @@ def test_literal_float_annotation_error():
             "Floating-point literals must be annotated with a floating-point type. For type casting, use `ti.cast`."
     ):
         float_annotation_error()
+
+
+@test_utils.test()
+def test_literal_exceed_default_ip():
+    @ti.kernel
+    def func():
+        b = 0x80000000
+
+    with pytest.raises(ti.TaichiTypeError,
+                       match="exceeded the range of default_ip"):
+        func()
+
+
+@test_utils.test()
+def test_literal_exceed_specified_dtype():
+    @ti.kernel
+    def func():
+        b = ti.u16(-1)
+
+    with pytest.raises(ti.TaichiTypeError,
+                       match="exceeded the range of specified dtype"):
+        func()


### PR DESCRIPTION



I tried hacking around to be smart about the literal dtypes depending on
backends or passed in python/numpy value. But those cause various
inconsistencies as well so I decided to improve the error message
first...

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
