### PR TITLE
[misc] Improve TI_STATIC_ASSERT compatibility

### DIFF
--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -109,7 +109,7 @@ static_assert(__cplusplus >= 201402L, "C++14 required.");
 #define DEBUG_TRIGGER
 #endif
 
-#define TI_STATIC_ASSERT(x) static_assert((x), #x);
+#define TI_STATIC_ASSERT(x) static_assert((x), #x)
 
 #define TI_NAMESPACE_BEGIN namespace taichi {
 #define TI_NAMESPACE_END }

--- a/taichi/system/profiler.h
+++ b/taichi/system/profiler.h
@@ -13,7 +13,7 @@
 
 #include "taichi/common/core.h"
 #include "taichi/system/timer.h"
-#include "spdlog/fmt/bundled/color.h"
+// #include "spdlog/fmt/bundled/color.h"
 
 TI_NAMESPACE_BEGIN
 

--- a/taichi/system/profiler.h
+++ b/taichi/system/profiler.h
@@ -13,7 +13,7 @@
 
 #include "taichi/common/core.h"
 #include "taichi/system/timer.h"
-// #include "spdlog/fmt/bundled/color.h"
+#include "spdlog/fmt/bundled/color.h"
 
 TI_NAMESPACE_BEGIN
 


### PR DESCRIPTION
It should have the exact same behavior as `static_assert`: you need a semicolon after it.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
