### PR TITLE
[llvm] [build] Dispatched LlvmProgramImpl with template specialization

### DIFF
--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -18,6 +18,13 @@ if (MINGW)
 endif ()
 
 if (WIN32)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS} -fno-lto")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -fno-lto")
+    endif()
+endif()
+
+if (WIN32)
     link_directories(${CMAKE_CURRENT_SOURCE_DIR}/external/lib)
     if (MSVC)
         set(CMAKE_CXX_FLAGS

--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -17,14 +17,6 @@ if (MINGW)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
 endif ()
 
-# Do not enable lto for APPLE since it made linking extremely slow.
-if (WIN32)
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS} -flto=thin")
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -flto=thin")
-    endif()
-endif()
-
 if (WIN32)
     link_directories(${CMAKE_CURRENT_SOURCE_DIR}/external/lib)
     if (MSVC)

--- a/taichi/inc/archs.inc.h
+++ b/taichi/inc/archs.inc.h
@@ -15,3 +15,6 @@ PER_ARCH(dx11)    // Microsoft DirectX 11, WIP
 PER_ARCH(opencl)  // OpenCL, N/A
 PER_ARCH(amdgpu)  // AMD GPU, N/A
 PER_ARCH(vulkan)  // Vulkan
+
+// LLVM
+PER_ARCH(llvm)

--- a/taichi/llvm/llvm_program.cpp
+++ b/taichi/llvm/llvm_program.cpp
@@ -26,6 +26,13 @@
 
 namespace taichi {
 namespace lang {
+
+template <>
+std::unique_ptr<ProgramImpl> ProgramDispatcher::instantiate_program_impl<
+    Arch::llvm>(CompileConfig &config, KernelProfilerBase *profiler) {
+  return std::make_unique<LlvmProgramImpl>(config, profiler);
+}
+
 namespace {
 void assert_failed_host(const char *msg) {
   TI_ERROR("Assertion failure: {}", msg);

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -20,9 +20,6 @@
 #include "taichi/program/snode_expr_utils.h"
 #include "taichi/util/statistics.h"
 #include "taichi/math/arithmetic.h"
-#ifdef TI_WITH_LLVM
-#include "taichi/llvm/llvm_program.h"
-#endif
 
 #if defined(TI_WITH_CC)
 #include "taichi/backends/cc/cc_program.h"
@@ -43,6 +40,9 @@
 
 namespace taichi {
 namespace lang {
+
+#include <iostream>
+
 std::atomic<int> Program::num_instances_;
 
 Program::Program(Arch desired_arch)
@@ -74,11 +74,9 @@ Program::Program(Arch desired_arch)
 
   profiler = make_profiler(config.arch, config.kernel_profiler);
   if (arch_uses_llvm(config.arch)) {
-#ifdef TI_WITH_LLVM
-    program_impl_ = std::make_unique<LlvmProgramImpl>(config, profiler.get());
-#else
-    TI_ERROR("This taichi is not compiled with LLVM");
-#endif
+    program_impl_ = ProgramDispatcher::instantiate_program_impl<Arch::llvm>(
+        config, profiler.get());
+
   } else if (config.arch == Arch::metal) {
 #ifdef TI_WITH_METAL
     TI_ASSERT(metal::is_metal_api_available());

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -41,7 +41,16 @@
 namespace taichi {
 namespace lang {
 
-#include <iostream>
+template <Arch arch>
+std::unique_ptr<ProgramImpl> ProgramDispatcher::instantiate_program_impl(
+    CompileConfig &config,
+    KernelProfilerBase *profiler) {
+  if (arch_uses_llvm(config.arch)) {
+    TI_ERROR("This taichi is not compiled with LLVM");
+  }
+
+  return nullptr;
+}
 
 std::atomic<int> Program::num_instances_;
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -36,15 +36,9 @@ namespace lang {
 
 struct ProgramDispatcher {
   template <Arch arch>
-  static std::unique_ptr<ProgramImpl> instantiate_program_impl(
+  static inline std::unique_ptr<ProgramImpl> instantiate_program_impl(
       CompileConfig &config,
-      KernelProfilerBase *profiler) {
-    if (arch_uses_llvm(config.arch)) {
-      TI_ERROR("This taichi is not compiled with LLVM");
-    }
-
-    return nullptr;
-  }
+      KernelProfilerBase *profiler);
 };
 
 struct JITEvaluatorId {

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -34,6 +34,19 @@
 namespace taichi {
 namespace lang {
 
+struct ProgramDispatcher {
+  template <Arch arch>
+  static std::unique_ptr<ProgramImpl> instantiate_program_impl(
+      CompileConfig &config,
+      KernelProfilerBase *profiler) {
+    if (arch_uses_llvm(config.arch)) {
+      TI_ERROR("This taichi is not compiled with LLVM");
+    }
+
+    return nullptr;
+  }
+};
+
 struct JITEvaluatorId {
   std::thread::id thread_id;
   // Note that on certain backends (e.g. CUDA), functions created in one

--- a/tests/cpp/backends/llvm/field_aot_test.cpp
+++ b/tests/cpp/backends/llvm/field_aot_test.cpp
@@ -1,13 +1,16 @@
 #include "gtest/gtest.h"
 
 #include "taichi/program/kernel_profiler.h"
-#include "taichi/llvm/llvm_program.h"
 #include "taichi/system/memory_pool.h"
 #include "taichi/backends/cpu/aot_module_loader_impl.h"
 #include "taichi/backends/cuda/aot_module_loader_impl.h"
-#include "taichi/llvm/llvm_aot_module_loader.h"
 #include "taichi/backends/cuda/cuda_driver.h"
 #include "taichi/platform/cuda/detect_cuda.h"
+
+#if TI_WITH_LLVM
+#include "taichi/llvm/llvm_aot_module_loader.h"
+#include "taichi/llvm/llvm_program.h"
+#endif
 
 #define TI_RUNTIME_HOST
 #include "taichi/program/context.h"
@@ -16,6 +19,7 @@
 namespace taichi {
 namespace lang {
 
+#if TI_WITH_LLVM
 void run_field_tests(aot::Module *mod,
                      LlvmProgramImpl *prog,
                      uint64 *result_buffer) {
@@ -95,8 +99,10 @@ void run_field_tests(aot::Module *mod,
   // Check assertion error from ti.kernel
   prog->check_runtime_error(result_buffer);
 }
+#endif
 
 TEST(LlvmAotTest, CpuField) {
+#if TI_WITH_LLVM
   CompileConfig cfg;
   cfg.arch = Arch::x64;
   cfg.kernel_profiler = false;
@@ -120,9 +126,11 @@ TEST(LlvmAotTest, CpuField) {
   std::unique_ptr<aot::Module> mod = cpu::make_aot_module(aot_params);
 
   run_field_tests(mod.get(), &prog, result_buffer);
+#endif
 }
 
 TEST(LlvmAotTest, CudaField) {
+#if TI_WITH_LLVM
   if (is_cuda_api_available()) {
     CompileConfig cfg;
     cfg.arch = Arch::cuda;
@@ -146,6 +154,7 @@ TEST(LlvmAotTest, CudaField) {
 
     run_field_tests(mod.get(), &prog, result_buffer);
   }
+#endif
 }
 
 }  // namespace lang

--- a/tests/cpp/backends/llvm/kernel_aot_test.cpp
+++ b/tests/cpp/backends/llvm/kernel_aot_test.cpp
@@ -1,12 +1,15 @@
 #include "gtest/gtest.h"
 
 #include "taichi/program/kernel_profiler.h"
-#include "taichi/llvm/llvm_program.h"
 #include "taichi/system/memory_pool.h"
 #include "taichi/backends/cpu/aot_module_loader_impl.h"
 #include "taichi/backends/cuda/aot_module_loader_impl.h"
 #include "taichi/backends/cuda/cuda_driver.h"
 #include "taichi/platform/cuda/detect_cuda.h"
+
+#if TI_WITH_LLVM
+#include "taichi/llvm/llvm_program.h"
+#endif
 
 #define TI_RUNTIME_HOST
 #include "taichi/program/context.h"
@@ -16,6 +19,7 @@ namespace taichi {
 namespace lang {
 
 TEST(LlvmAotTest, CpuKernel) {
+#if TI_WITH_LLVM
   CompileConfig cfg;
   cfg.arch = Arch::x64;
   cfg.kernel_profiler = false;
@@ -53,9 +57,11 @@ TEST(LlvmAotTest, CpuKernel) {
   for (int i = 0; i < kArrLen; ++i) {
     EXPECT_EQ(data[i], i);
   }
+#endif
 }
 
 TEST(LlvmAotTest, CudaKernel) {
+#if TI_WITH_LLVM
   if (is_cuda_api_available()) {
     CompileConfig cfg;
     cfg.arch = Arch::cuda;
@@ -99,6 +105,7 @@ TEST(LlvmAotTest, CudaKernel) {
       EXPECT_EQ(cpu_data[i], i);
     }
   }
+#endif
 }
 
 }  // namespace lang


### PR DESCRIPTION
Related issue = #5193

Taking advantage of the ProgramDispatcher class, we completely decoupled `program.cpp` and `program.h` with LLVM backend:
1. Includes no llvm header files
2. Uses no TI_WITH_LLVM macros (there's one left for WASM backend, which is another story)

Error message when LLVM used without compiled:
![2022-06-21 11-32-33 的屏幕截图](https://user-images.githubusercontent.com/22334008/174712124-8b0c9060-e5a6-4d7e-8cc4-a6e43dc15bc6.png)

