### PR TITLE
[type] [refactor] Decouple quant from SNode 2/n: Remove physical_type from QuantIntType

### DIFF
--- a/taichi/backends/cuda/codegen_cuda.cpp
+++ b/taichi/backends/cuda/codegen_cuda.cpp
@@ -539,11 +539,11 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           // Bit pointer case.
           auto val_type = ptr_type->get_pointee_type();
           if (auto qit = val_type->cast<QuantIntType>()) {
-            dtype = qit->get_physical_type();
+            dtype = get_ch->input_snode->physical_type;
             auto [data_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->src]);
             data_ptr = builder->CreateBitCast(data_ptr, llvm_ptr_type(dtype));
             auto data = create_intrinsic_load(dtype, data_ptr);
-            llvm_val[stmt] = extract_quant_int(data, bit_offset, val_type);
+            llvm_val[stmt] = extract_quant_int(data, bit_offset, qit, dtype);
           } else {
             // TODO: support __ldg
             TI_ASSERT(val_type->is<QuantFixedType>() ||

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1195,9 +1195,11 @@ llvm::Value *CodeGenLLVM::quant_type_atomic(AtomicOpStmt *stmt) {
 
   auto dst_type = stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
   if (auto qit = dst_type->cast<QuantIntType>()) {
-    return atomic_add_quant_int(stmt, qit,stmt->dest->as<GetChStmt>()->input_snode->physical_type);
+    return atomic_add_quant_int(
+        stmt, qit, stmt->dest->as<GetChStmt>()->input_snode->physical_type);
   } else if (auto qfxt = dst_type->cast<QuantFixedType>()) {
-    return atomic_add_quant_fixed(stmt, qfxt, stmt->dest->as<GetChStmt>()->input_snode->physical_type);
+    return atomic_add_quant_fixed(
+        stmt, qfxt, stmt->dest->as<GetChStmt>()->input_snode->physical_type);
   } else {
     return nullptr;
   }
@@ -1351,7 +1353,9 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         TI_ERROR("Bit array only supports quant int type.");
       }
     }
-    store_quant_int(llvm_val[stmt->dest], pointee_type->as<QuantIntType>(), stmt->dest->as<GetChStmt>()->input_snode->physical_type, llvm_val[stmt->val], true);
+    store_quant_int(llvm_val[stmt->dest], pointee_type->as<QuantIntType>(),
+                    stmt->dest->as<GetChStmt>()->input_snode->physical_type,
+                    llvm_val[stmt->val], true);
   } else {
     builder->CreateStore(llvm_val[stmt->val], llvm_val[stmt->dest]);
   }
@@ -1364,7 +1368,9 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   if (ptr_type->is_bit_pointer()) {
     auto val_type = ptr_type->get_pointee_type();
     if (auto qit = val_type->cast<QuantIntType>()) {
-      llvm_val[stmt] = load_quant_int(llvm_val[stmt->src], qit, stmt->src->as<GetChStmt>()->input_snode->physical_type);
+      llvm_val[stmt] = load_quant_int(
+          llvm_val[stmt->src], qit,
+          stmt->src->as<GetChStmt>()->input_snode->physical_type);
     } else {
       TI_ASSERT(val_type->is<QuantFixedType>() ||
                 val_type->is<QuantFloatType>());

--- a/taichi/codegen/codegen_llvm.cpp
+++ b/taichi/codegen/codegen_llvm.cpp
@@ -1195,9 +1195,9 @@ llvm::Value *CodeGenLLVM::quant_type_atomic(AtomicOpStmt *stmt) {
 
   auto dst_type = stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
   if (auto qit = dst_type->cast<QuantIntType>()) {
-    return atomic_add_quant_int(stmt, qit);
+    return atomic_add_quant_int(stmt, qit,stmt->dest->as<GetChStmt>()->input_snode->physical_type);
   } else if (auto qfxt = dst_type->cast<QuantFixedType>()) {
-    return atomic_add_quant_fixed(stmt, qfxt);
+    return atomic_add_quant_fixed(stmt, qfxt, stmt->dest->as<GetChStmt>()->input_snode->physical_type);
   } else {
     return nullptr;
   }
@@ -1351,10 +1351,7 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
         TI_ERROR("Bit array only supports quant int type.");
       }
     }
-    llvm::Value *store_value = nullptr;
-    auto *qit = pointee_type->as<QuantIntType>();
-    store_value = llvm_val[stmt->val];
-    store_quant_int(llvm_val[stmt->dest], qit, store_value, /*atomic=*/true);
+    store_quant_int(llvm_val[stmt->dest], pointee_type->as<QuantIntType>(), stmt->dest->as<GetChStmt>()->input_snode->physical_type, llvm_val[stmt->val], true);
   } else {
     builder->CreateStore(llvm_val[stmt->val], llvm_val[stmt->dest]);
   }
@@ -1366,8 +1363,8 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   auto ptr_type = stmt->src->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
     auto val_type = ptr_type->get_pointee_type();
-    if (val_type->is<QuantIntType>()) {
-      llvm_val[stmt] = load_quant_int(llvm_val[stmt->src], val_type);
+    if (auto qit = val_type->cast<QuantIntType>()) {
+      llvm_val[stmt] = load_quant_int(llvm_val[stmt->src], qit, stmt->src->as<GetChStmt>()->input_snode->physical_type);
     } else {
       TI_ASSERT(val_type->is<QuantFixedType>() ||
                 val_type->is<QuantFloatType>());

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -219,9 +219,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, QuantFixedType *qfxt);
+  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, QuantFixedType *qfxt, Type *physical_type);
 
-  llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, QuantIntType *qit);
+  llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, QuantIntType *qit, Type *physical_type);
 
   llvm::Value *quant_fixed_to_quant_int(QuantFixedType *qfxt,
                                         QuantIntType *qit,
@@ -248,12 +248,14 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void store_quant_int(llvm::Value *bit_ptr,
                        QuantIntType *qit,
+                       Type *physical_type,
                        llvm::Value *value,
                        bool atomic);
 
   void store_quant_int(llvm::Value *byte_ptr,
                        llvm::Value *bit_offset,
                        QuantIntType *qit,
+                       Type *physical_type,
                        llvm::Value *value,
                        bool atomic);
 
@@ -276,11 +278,12 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *extract_quant_float(llvm::Value *local_bit_struct,
                                    SNode *digits_snode);
 
-  llvm::Value *load_quant_int(llvm::Value *ptr, Type *load_type);
+  llvm::Value *load_quant_int(llvm::Value *ptr, QuantIntType *qit, Type *physical_type);
 
   llvm::Value *extract_quant_int(llvm::Value *physical_value,
                                  llvm::Value *bit_offset,
-                                 Type *load_type);
+                                 QuantIntType *qit,
+                                 Type *physical_type);
 
   llvm::Value *reconstruct_quant_fixed(llvm::Value *digits,
                                        QuantFixedType *qfxt);
@@ -288,6 +291,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *load_quant_float(llvm::Value *digits_bit_ptr,
                                 llvm::Value *exponent_bit_ptr,
                                 QuantFloatType *qflt,
+                                Type *physical_type,
                                 bool shared_exponent);
 
   llvm::Value *reconstruct_quant_float(llvm::Value *input_digits,

--- a/taichi/codegen/codegen_llvm.h
+++ b/taichi/codegen/codegen_llvm.h
@@ -219,9 +219,13 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, QuantFixedType *qfxt, Type *physical_type);
+  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt,
+                                      QuantFixedType *qfxt,
+                                      Type *physical_type);
 
-  llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, QuantIntType *qit, Type *physical_type);
+  llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt,
+                                    QuantIntType *qit,
+                                    Type *physical_type);
 
   llvm::Value *quant_fixed_to_quant_int(QuantFixedType *qfxt,
                                         QuantIntType *qit,
@@ -278,7 +282,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *extract_quant_float(llvm::Value *local_bit_struct,
                                    SNode *digits_snode);
 
-  llvm::Value *load_quant_int(llvm::Value *ptr, QuantIntType *qit, Type *physical_type);
+  llvm::Value *load_quant_int(llvm::Value *ptr,
+                              QuantIntType *qit,
+                              Type *physical_type);
 
   llvm::Value *extract_quant_int(llvm::Value *physical_value,
                                  llvm::Value *bit_offset,

--- a/taichi/codegen/codegen_llvm_quant.cpp
+++ b/taichi/codegen/codegen_llvm_quant.cpp
@@ -18,9 +18,9 @@ inline void update_mask(uint64 &mask, uint32 num_bits, uint32 offset) {
 }  // namespace
 
 llvm::Value *CodeGenLLVM::atomic_add_quant_int(AtomicOpStmt *stmt,
-                                               QuantIntType *qit) {
+                                               QuantIntType *qit,
+                                               Type *physical_type) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->dest]);
-  auto physical_type = qit->get_physical_type();
   return create_call(
       fmt::format("atomic_add_partial_bits_b{}", data_type_bits(physical_type)),
       {builder->CreateBitCast(byte_ptr, llvm_ptr_type(physical_type)),
@@ -30,13 +30,12 @@ llvm::Value *CodeGenLLVM::atomic_add_quant_int(AtomicOpStmt *stmt,
 }
 
 llvm::Value *CodeGenLLVM::atomic_add_quant_fixed(AtomicOpStmt *stmt,
-                                                 QuantFixedType *qfxt) {
+                                                 QuantFixedType *qfxt,
+                                                 Type *physical_type) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(llvm_val[stmt->dest]);
   auto qit = qfxt->get_digits_type()->as<QuantIntType>();
   auto val_store = quant_fixed_to_quant_int(qfxt, qit, llvm_val[stmt->val]);
-  auto physical_type = qit->get_physical_type();
   val_store = builder->CreateSExt(val_store, llvm_type(physical_type));
-
   return create_call(
       fmt::format("atomic_add_partial_bits_b{}", data_type_bits(physical_type)),
       {builder->CreateBitCast(byte_ptr, llvm_ptr_type(physical_type)),
@@ -70,26 +69,28 @@ llvm::Value *CodeGenLLVM::quant_fixed_to_quant_int(QuantFixedType *qfxt,
 
 void CodeGenLLVM::store_quant_int(llvm::Value *bit_ptr,
                                   QuantIntType *qit,
+                                  Type *physical_type,
                                   llvm::Value *value,
                                   bool atomic) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(bit_ptr);
-  store_quant_int(byte_ptr, bit_offset, qit, value, atomic);
+  store_quant_int(byte_ptr, bit_offset, qit, physical_type, value, atomic);
 }
 
 void CodeGenLLVM::store_quant_int(llvm::Value *byte_ptr,
                                   llvm::Value *bit_offset,
                                   QuantIntType *qit,
+                                  Type *physical_type,
                                   llvm::Value *value,
                                   bool atomic) {
   // TODO(type): CUDA only supports atomicCAS on 32- and 64-bit integers.
   // Try to support 8/16-bit physical types.
   create_call(fmt::format("{}set_partial_bits_b{}", atomic ? "atomic_" : "",
-                          data_type_bits(qit->get_physical_type())),
+                          data_type_bits(physical_type)),
               {builder->CreateBitCast(byte_ptr,
-                                      llvm_ptr_type(qit->get_physical_type())),
+                                      llvm_ptr_type(physical_type)),
                bit_offset, tlctx->get_constant(qit->get_num_bits()),
                builder->CreateIntCast(
-                   value, llvm_type(qit->get_physical_type()), false)});
+                   value, llvm_type(physical_type), false)});
 }
 
 void CodeGenLLVM::store_masked(llvm::Value *byte_ptr,
@@ -462,39 +463,37 @@ llvm::Value *CodeGenLLVM::extract_quant_float(llvm::Value *local_bit_struct,
   auto qflt = digits_snode->dt->as<QuantFloatType>();
   auto exponent_type = qflt->get_exponent_type()->as<QuantIntType>();
   auto digits_type = qflt->get_digits_type()->as<QuantIntType>();
+  auto physical_type = digits_snode->parent->physical_type;
   auto digits = extract_quant_int(local_bit_struct,
                                   tlctx->get_constant(digits_snode->bit_offset),
-                                  digits_type);
+                                  digits_type, physical_type);
   auto exponent = extract_quant_int(
       local_bit_struct,
-      tlctx->get_constant(digits_snode->exp_snode->bit_offset), exponent_type);
+      tlctx->get_constant(digits_snode->exp_snode->bit_offset), exponent_type, physical_type);
   return reconstruct_quant_float(digits, exponent, qflt,
                                  digits_snode->owns_shared_exponent);
 }
 
-llvm::Value *CodeGenLLVM::load_quant_int(llvm::Value *ptr, Type *load_type) {
-  auto *qit = load_type->as<QuantIntType>();
+llvm::Value *CodeGenLLVM::load_quant_int(llvm::Value *ptr, QuantIntType *qit, Type *physical_type) {
   auto [byte_ptr, bit_offset] = load_bit_pointer(ptr);
-
   auto bit_level_container = builder->CreateLoad(builder->CreateBitCast(
-      byte_ptr, llvm_ptr_type(qit->get_physical_type())));
-
-  return extract_quant_int(bit_level_container, bit_offset, load_type);
+      byte_ptr, llvm_ptr_type(physical_type)));
+  return extract_quant_int(bit_level_container, bit_offset, qit, physical_type);
 }
 
 llvm::Value *CodeGenLLVM::extract_quant_int(llvm::Value *physical_value,
                                             llvm::Value *bit_offset,
-                                            Type *load_type) {
+                                            QuantIntType *qit,
+                                            Type *physical_type) {
   //  bit shifting
   //    first left shift `physical_type - (offset + num_bits)`
   //    then right shift `physical_type - num_bits`
-  auto qit = load_type->as<QuantIntType>();
   auto bit_end =
       builder->CreateAdd(bit_offset, tlctx->get_constant(qit->get_num_bits()));
   auto left = builder->CreateSub(
-      tlctx->get_constant(data_type_bits(qit->get_physical_type())), bit_end);
+      tlctx->get_constant(data_type_bits(physical_type)), bit_end);
   auto right = builder->CreateSub(
-      tlctx->get_constant(data_type_bits(qit->get_physical_type())),
+      tlctx->get_constant(data_type_bits(physical_type)),
       tlctx->get_constant(qit->get_num_bits()));
   left = builder->CreateIntCast(left, physical_value->getType(), false);
   right = builder->CreateIntCast(right, physical_value->getType(), false);
@@ -528,10 +527,11 @@ llvm::Value *CodeGenLLVM::reconstruct_quant_fixed(llvm::Value *digits,
 llvm::Value *CodeGenLLVM::load_quant_float(llvm::Value *digits_bit_ptr,
                                            llvm::Value *exponent_bit_ptr,
                                            QuantFloatType *qflt,
+                                           Type *physical_type,
                                            bool shared_exponent) {
-  auto digits = load_quant_int(digits_bit_ptr, qflt->get_digits_type());
+  auto digits = load_quant_int(digits_bit_ptr, qflt->get_digits_type()->as<QuantIntType>(), physical_type);
   auto exponent_val = load_quant_int(
-      exponent_bit_ptr, qflt->get_exponent_type()->as<QuantIntType>());
+      exponent_bit_ptr, qflt->get_exponent_type()->as<QuantIntType>(), physical_type);
   return reconstruct_quant_float(digits, exponent_val, qflt, shared_exponent);
 }
 
@@ -637,6 +637,7 @@ llvm::Value *CodeGenLLVM::reconstruct_quant_float(
 llvm::Value *CodeGenLLVM::load_quant_fixed_or_quant_float(Stmt *ptr_stmt) {
   auto ptr = ptr_stmt->as<GetChStmt>();
   auto load_type = ptr->ret_type->as<PointerType>()->get_pointee_type();
+  auto physical_type = ptr->input_snode->physical_type;
   if (auto qflt = load_type->cast<QuantFloatType>()) {
     TI_ASSERT(ptr->width() == 1);
     auto digits_bit_ptr = llvm_val[ptr];
@@ -646,11 +647,11 @@ llvm::Value *CodeGenLLVM::load_quant_fixed_or_quant_float(Stmt *ptr_stmt) {
     TI_ASSERT(digits_snode->parent == exponent_snode->parent);
     auto exponent_bit_ptr = offset_bit_ptr(
         digits_bit_ptr, exponent_snode->bit_offset - digits_snode->bit_offset);
-    return load_quant_float(digits_bit_ptr, exponent_bit_ptr, qflt,
+    return load_quant_float(digits_bit_ptr, exponent_bit_ptr, qflt, physical_type,
                             digits_snode->owns_shared_exponent);
   } else {
     auto qfxt = load_type->as<QuantFixedType>();
-    auto digits = load_quant_int(llvm_val[ptr], qfxt->get_digits_type());
+    auto digits = load_quant_int(llvm_val[ptr], qfxt->get_digits_type()->as<QuantIntType>(), physical_type);
     return reconstruct_quant_fixed(digits, qfxt);
   }
 }

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -103,12 +103,8 @@ std::string QuantIntType::to_string() const {
   return fmt::format("q{}{}", is_signed_ ? 'i' : 'u', num_bits_);
 }
 
-QuantIntType::QuantIntType(int num_bits,
-                           bool is_signed,
-                           Type *compute_type)
-    : compute_type_(compute_type),
-      num_bits_(num_bits),
-      is_signed_(is_signed) {
+QuantIntType::QuantIntType(int num_bits, bool is_signed, Type *compute_type)
+    : compute_type_(compute_type), num_bits_(num_bits), is_signed_(is_signed) {
   if (compute_type == nullptr) {
     auto type_id = is_signed ? PrimitiveTypeID::i32 : PrimitiveTypeID::u32;
     this->compute_type_ =

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -105,10 +105,8 @@ std::string QuantIntType::to_string() const {
 
 QuantIntType::QuantIntType(int num_bits,
                            bool is_signed,
-                           Type *compute_type,
-                           Type *physical_type)
+                           Type *compute_type)
     : compute_type_(compute_type),
-      physical_type_(physical_type),
       num_bits_(num_bits),
       is_signed_(is_signed) {
   if (compute_type == nullptr) {

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -190,18 +190,9 @@ class QuantIntType : public Type {
  public:
   QuantIntType(int num_bits,
                bool is_signed,
-               Type *compute_type = nullptr,
-               Type *physical_type = nullptr);
+               Type *compute_type = nullptr);
 
   std::string to_string() const override;
-
-  void set_physical_type(Type *physical_type) {
-    this->physical_type_ = physical_type;
-  }
-
-  Type *get_physical_type() {
-    return physical_type_;
-  }
 
   Type *get_compute_type() override {
     return compute_type_;
@@ -219,7 +210,6 @@ class QuantIntType : public Type {
   // TODO(type): for now we can uniformly use i32 as the "compute_type". It may
   // be a good idea to make "compute_type" also customizable.
   Type *compute_type_{nullptr};
-  Type *physical_type_{nullptr};
   int num_bits_{32};
   bool is_signed_{true};
 };

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -188,9 +188,7 @@ class TensorType : public Type {
 
 class QuantIntType : public Type {
  public:
-  QuantIntType(int num_bits,
-               bool is_signed,
-               Type *compute_type = nullptr);
+  QuantIntType(int num_bits, bool is_signed, Type *compute_type = nullptr);
 
   std::string to_string() const override;
 

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -202,7 +202,6 @@ class BitStructTypeBuilder {
     } else {
       TI_ERROR("Only a QuantType can be a member of a BitStructType.");
     }
-    member_qit->set_physical_type(physical_type_);
     auto old_member_total_bits = member_total_bits_;
     member_total_bits_ += member_qit->get_num_bits();
     auto physical_bits = data_type_bits(physical_type_);

--- a/taichi/llvm/struct_llvm.cpp
+++ b/taichi/llvm/struct_llvm.cpp
@@ -92,7 +92,6 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
     TI_ASSERT(snode.ch.size() == 1);
     auto &ch = snode.ch[0];
     Type *ch_type = ch->dt;
-    ch->dt->as<QuantIntType>()->set_physical_type(snode.physical_type);
     if (!arch_is_cpu(arch_)) {
       TI_ERROR_IF(data_type_bits(snode.physical_type) <= 16,
                   "bit_array physical type must be at least 32 bits on "


### PR DESCRIPTION
Related issue = #4857

Having a `physical_type` in `QuantIntType` is simply wrong - a `QuantIntType` may be placed under different `bit_struct`s. The `physical_type` needs to be manually passed into functions.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
