### PR TITLE
[gui] Let gui and renderer manage the resource they own

### DIFF
--- a/taichi/ui/backends/vulkan/gui.cpp
+++ b/taichi/ui/backends/vulkan/gui.cpp
@@ -216,6 +216,9 @@ void Gui::cleanup() {
   ImGui::DestroyContext();
 }
 
+Gui::~Gui() {
+  cleanup();
+}
 bool Gui::is_empty() {
   return is_empty_;
 }

--- a/taichi/ui/backends/vulkan/gui.h
+++ b/taichi/ui/backends/vulkan/gui.h
@@ -24,6 +24,7 @@ namespace vulkan {
 class TI_DLL_EXPORT Gui final : public GuiBase {
  public:
   Gui(AppContext *app_context, SwapChain *swap_chain, TaichiWindow *window);
+  ~Gui();
   void cleanup();
 
   void init_render_resources(VkRenderPass render_pass);

--- a/taichi/ui/backends/vulkan/renderer.cpp
+++ b/taichi/ui/backends/vulkan/renderer.cpp
@@ -111,6 +111,10 @@ void Renderer::scene(Scene *scene) {
   scene->point_lights_.clear();
 }
 
+Renderer::~Renderer() {
+  cleanup();
+}
+
 void Renderer::cleanup() {
   render_complete_semaphore_ = nullptr;
   for (auto &renderable : renderables_) {

--- a/taichi/ui/backends/vulkan/renderer.h
+++ b/taichi/ui/backends/vulkan/renderer.h
@@ -44,6 +44,7 @@ namespace vulkan {
 class TI_DLL_EXPORT Renderer {
  public:
   void init(lang::Program *prog, TaichiWindow *window, const AppConfig &config);
+  ~Renderer();
   void cleanup();
 
   void prepare_for_next_frame();

--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -85,8 +85,8 @@ void Window::present_frame() {
 }
 
 Window::~Window() {
-  gui_->cleanup();
-  renderer_->cleanup();
+  gui_.reset();
+  renderer_.reset();
   if (config_.show_window) {
     glfwTerminate();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5227
* __->__ #5226

Tbh it's better to also refactor `Renderer::cleanup()` as well but it's
a bit more involved.
