### PR TITLE
[ggui] Fix the device memory leak when GGUI terminates

### DIFF
--- a/taichi/python/export_ggui.cpp
+++ b/taichi/python/export_ggui.cpp
@@ -231,7 +231,9 @@ struct PyCanvas {
 };
 
 struct PyWindow {
-  std::unique_ptr<WindowBase> window{nullptr};
+  // std::unique_ptr<WindowBase> window{nullptr};
+  WindowBase *window{nullptr};
+  bool need_clean{false};
 
   PyWindow(Program *prog,
            std::string name,
@@ -248,7 +250,12 @@ struct PyWindow {
     if (!lang::vulkan::is_vulkan_api_available()) {
       throw std::runtime_error("Vulkan must be available for GGUI");
     }
-    window = std::make_unique<vulkan::Window>(prog, config);
+    // if (ti_arch == Arch::vulkan || prog == nullptr) {
+    window = new vulkan::Window(prog, config);
+    need_clean = true;
+    //} else {
+    // window = prog->create_window(config);
+    //}
   }
 
   void write_image(const std::string &filename) {
@@ -305,8 +312,11 @@ struct PyWindow {
   }
 
   void destroy() {
-    if (window) {
-      window.reset();
+    // if (window) {
+    // window.reset();
+    //}
+    if (need_clean) {
+      delete window;
     }
   }
 };

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -385,6 +385,7 @@ GfxRuntime::~GfxRuntime() {
     tmp.swap(ti_kernels_);
   }
   global_tmps_buffer_.reset();
+  listgen_buffer_.reset();
 }
 
 GfxRuntime::KernelHandle GfxRuntime::register_taichi_kernel(

--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -85,6 +85,7 @@ void Window::present_frame() {
 }
 
 Window::~Window() {
+  std::cout << "destroy window" << std::endl;
   gui_.reset();
   renderer_.reset();
   if (config_.show_window) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

`ti example diff_sph` usually crashes at termination on my desktop
complaining unfreeed device memory. The root cause for it is that
PyWindow's lifetime is controlled by python, however it shares the same
underlying `VulkanDevice` with `Program` (when ti.arch==vulkan). During
Python shutdown, we don't have a good way to enforce the destruction order of `PyWindow` and
`Program` so it's possible that `VulkanDevice` (uniquely owned by
`Program`) get destructed first and relealized some allocations
allocated for GGUI aren't freed properly. This PR kinda worked around
the problem by enforcing deallocation upon device destruction.
Tbh a better approach to fix it is just let GGUI gets a `shared_ptr` of
device instead of a raw pointer, we had some concern about  perf before
so let's delay that until it's necessary.