### PR TITLE
[type] [bug] Refine SNode with quant 1/n: Fix (atomic_)set_mask_b##N

### DIFF
--- a/taichi/codegen/metal/shaders/snode_bit_pointer.metal.h
+++ b/taichi/codegen/metal/shaders/snode_bit_pointer.metal.h
@@ -63,7 +63,7 @@ STR(
       bool ok = false;
       while (!ok) {
         P old_val = *(bp.base);
-        P new_val = (old_val & (~mask)) | (value << bp.offset);
+        P new_val = (old_val & (~mask)) | ((value << bp.offset) & mask);
         ok = atomic_compare_exchange_weak_explicit(atm_ptr, &old_val, new_val,
                                                    metal::memory_order_relaxed,
                                                    metal::memory_order_relaxed);

--- a/taichi/runtime/llvm/runtime.cpp
+++ b/taichi/runtime/llvm/runtime.cpp
@@ -1821,7 +1821,7 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
 #define DEFINE_SET_PARTIAL_BITS(N)                                            \
   void set_mask_b##N(u##N *ptr, u64 mask, u##N value) {                       \
     u##N mask_N = (u##N)mask;                                                 \
-    *ptr = (*ptr & (~mask_N)) | value;                                        \
+    *ptr = (*ptr & (~mask_N)) | (value & mask);                               \
   }                                                                           \
                                                                               \
   void atomic_set_mask_b##N(u##N *ptr, u64 mask, u##N value) {                \
@@ -1830,7 +1830,7 @@ void stack_push(Ptr stack, size_t max_num_elements, std::size_t element_size) {
     u##N old_value = *ptr;                                                    \
     do {                                                                      \
       old_value = *ptr;                                                       \
-      new_value = (old_value & (~mask_N)) | value;                            \
+      new_value = (old_value & (~mask_N)) | (value & mask);                   \
     } while (                                                                 \
         !__atomic_compare_exchange(ptr, &old_value, &new_value, true,         \
                                    std::memory_order::memory_order_seq_cst,   \

--- a/tests/python/test_bit_array.py
+++ b/tests/python/test_bit_array.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 import taichi as ti
 from tests import test_utils
 
@@ -29,10 +27,27 @@ def test_1D_bit_array():
 
 
 @test_utils.test(require=ti.extension.quant, debug=True)
-def test_2D_bit_array():
-    qi1 = ti.types.quant.int(1, False)
+def test_1D_bit_array_negative():
+    N = 4
+    qi7 = ti.types.quant.int(7)
+    x = ti.field(dtype=qi7)
+    ti.root.bit_array(ti.i, N, num_bits=32).place(x)
 
-    x = ti.field(dtype=qi1)
+    @ti.kernel
+    def assign():
+        for i in range(N):
+            assert x[i] == 0
+            x[i] = -i
+            assert x[i] == -i
+
+    assign()
+
+
+@test_utils.test(require=ti.extension.quant, debug=True)
+def test_2D_bit_array():
+    qu1 = ti.types.quant.int(1, False)
+
+    x = ti.field(dtype=qu1)
 
     M, N = 4, 8
 

--- a/tests/python/test_bit_array_vectorization.py
+++ b/tests/python/test_bit_array_vectorization.py
@@ -47,13 +47,13 @@ def test_vectorized_struct_for():
     verify()
 
 
-@test_utils.test(require=ti.extension.quant)
+@test_utils.test(require=ti.extension.quant, debug=True)
 def test_offset_load():
-    qi1 = ti.types.quant.int(1, False)
+    qu1 = ti.types.quant.int(1, False)
 
-    x = ti.field(dtype=qi1)
-    y = ti.field(dtype=qi1)
-    z = ti.field(dtype=qi1)
+    x = ti.field(dtype=qu1)
+    y = ti.field(dtype=qu1)
+    z = ti.field(dtype=qu1)
 
     N = 4096
     n_blocks = 4
@@ -109,11 +109,11 @@ def test_offset_load():
 
 @test_utils.test(require=ti.extension.quant, debug=True)
 def test_evolve():
-    qi1 = ti.types.quant.int(1, False)
+    qu1 = ti.types.quant.int(1, False)
 
-    x = ti.field(dtype=qi1)
-    y = ti.field(dtype=qi1)
-    z = ti.field(dtype=qi1)
+    x = ti.field(dtype=qu1)
+    y = ti.field(dtype=qu1)
+    z = ti.field(dtype=qu1)
 
     N = 4096
     n_blocks = 4


### PR DESCRIPTION
Related issue = #4857

https://github.com/taichi-dev/taichi/blob/b1ba4572a1c0fef12fe71b63c8e28b289c77e2ad/taichi/runtime/llvm/runtime.cpp#L1827-L1838
In the above function, the argument `value` is not guaranteed to contain zeros at non-masked positions. This is especially buggy when `value` is originally a negative number. We need to replace `value` with `(value & mask)` to avoid pollute other positions. A related test case is added.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
