### PR TITLE
[vulkan] Fix OpBranch for reversed RangeForStmt

### DIFF
--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1315,7 +1315,6 @@ class TaskCodegen : public IRVisitor {
     spirv::Label body_label = ir_->new_label();
     spirv::Label continue_label = ir_->new_label();
     spirv::Label merge_label = ir_->new_label();
-    ir_->make_inst(spv::OpBranch, head_label);
 
     spirv::Value begin_ = ir_->query_value(for_stmt->begin->raw_name());
     spirv::Value end_ = ir_->query_value(for_stmt->end->raw_name());
@@ -1329,6 +1328,7 @@ class TaskCodegen : public IRVisitor {
       init_value = ir_->sub(end_, ir_->const_i32_one_);
       extent_value = begin_;
     }
+    ir_->make_inst(spv::OpBranch, head_label);
 
     // Loop head
     ir_->start_label(head_label);

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -2,6 +2,22 @@ import taichi as ti
 from tests import test_utils
 
 
+@test_utils.test()
+def test_ad_nested_for():
+    N = 5
+
+    loss = ti.field(float, shape=(), needs_grad=True)
+
+    @ti.kernel
+    def nested_for():
+        for i in range(N):
+            for j in range(N):
+                pass
+
+    with ti.ad.Tape(loss=loss):
+        nested_for()
+
+
 @test_utils.test(require=ti.extension.adstack)
 def test_ad_sum():
     N = 10


### PR DESCRIPTION
Related issue = #5239 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
