### PR TITLE
[bug] Added overflow check for range_for boundaries

### DIFF
--- a/tests/python/test_types.py
+++ b/tests/python/test_types.py
@@ -137,6 +137,23 @@ def test_overflow64(dt, n):
     _test_overflow(dt, n)
 
 
+@test_utils.test(arch=ti.cpu, debug=True)
+def test_range_for_boundary_overflow():
+
+    x = ti.field(ti.i64, shape=(1))
+    m = 30000000000  # m > MAX_INT32
+
+    @ti.kernel
+    def calc():
+        for i in range(ti.i64(m)):
+            x[0] += 1
+
+    with pytest.raises(
+            ti.TaichiAssertionError,
+            match=r"Detected arithmatic overflow in range_for boundaries"):
+        calc()
+
+
 @pytest.mark.parametrize('dt,val', [
     (ti.u32, 0xffffffff),
     (ti.u64, 0xffffffffffffffff),


### PR DESCRIPTION
Related issue = fix #5217

RangeFor boundaries are always casted to ti.i32 upon lowering. For cases where RangeFor boundary uses ti.i64 dtype, this implicit type cast will risk an arithmetic overflow.

![image](https://user-images.githubusercontent.com/22334008/175469712-6a6c3b9d-a590-44c8-adac-1da10d62aeae.png)


This PR adds overflow check for RangeFor boundaries with ti.i64 dtype.