### PR TITLE
[Lang] Redirect  kernel print to browser in jupyter notebook

### DIFF
--- a/python/taichi/_logging.py
+++ b/python/taichi/_logging.py
@@ -19,11 +19,14 @@ def _get_logging(name):
         if ti_core.logging_effective(name):
             msg_formatted = msg.format(*args, **kwargs)
             func = getattr(ti_core, name)
-            frame = inspect.currentframe().f_back
-            file_name, lineno, func_name, _, _ = inspect.getframeinfo(frame)
-            file_name = os.path.basename(file_name)
-            msg = f'[{file_name}:{func_name}@{lineno}] {msg_formatted}'
-            func(msg)
+            if kwargs.get('msg_only', False):
+                func(msg_formatted)
+            else:
+                frame = inspect.currentframe().f_back
+                file_name, lineno, func_name, _, _ = inspect.getframeinfo(frame)
+                file_name = os.path.basename(file_name)
+                msg = f'[{file_name}:{func_name}@{lineno}] {msg_formatted}'
+                func(msg)
 
     return logger
 

--- a/python/taichi/_logging.py
+++ b/python/taichi/_logging.py
@@ -21,12 +21,12 @@ def _get_logging(name):
             func = getattr(ti_core, name)
             if kwargs.get('msg_only', False):
                 func(msg_formatted)
-            else:
-                frame = inspect.currentframe().f_back
-                file_name, lineno, func_name, _, _ = inspect.getframeinfo(frame)
-                file_name = os.path.basename(file_name)
-                msg = f'[{file_name}:{func_name}@{lineno}] {msg_formatted}'
-                func(msg)
+                return
+            frame = inspect.currentframe().f_back
+            file_name, lineno, func_name, _, _ = inspect.getframeinfo(frame)
+            file_name = os.path.basename(file_name)
+            msg = f'[{file_name}:{func_name}@{lineno}] {msg_formatted}'
+            func(msg)
 
     return logger
 

--- a/python/taichi/examples/autodiff/diff_sph/diff_sph.py
+++ b/python/taichi/examples/autodiff/diff_sph/diff_sph.py
@@ -158,7 +158,7 @@ class Linear:
     @staticmethod
     @ti.kernel
     def copy_from_numpy(
-            dst: ti.template(), src: ti.ext_arr(), model_id: ti.i32):
+            dst: ti.template(), src: ti.types.ndarray(), model_id: ti.i32):
         for I in ti.grouped(src):
             dst[model_id, I] = src[I]
 
@@ -166,6 +166,7 @@ class Linear:
 def init_nn_model():
     global BATCH_SIZE, steps, input_states, fc1, fc2
     global training_sample_num, training_data, loss
+    global optimizer
     # NN model
     model_num = 1
     steps = 128
@@ -550,7 +551,7 @@ def copy_from_output_to_vis(t: ti.int32):
 
 
 @ti.kernel
-def fill_target_centers(current_pos: ti.int32, data: ti.any_arr()):
+def fill_target_centers(current_pos: ti.int32, data: ti.types.ndarray()):
     for i in range(current_pos, current_pos + BATCH_SIZE):
         for j in ti.static(range(3)):
             target_centers[i][j] = data[i, j]
@@ -596,7 +597,7 @@ def main():
                                            current_data_offset)
                 fc1.clear()
                 fc2.clear()
-                with ti.Tape(loss=loss):
+                with ti.ad.Tape(loss=loss):
                     for i in range(1, steps):
                         initialize_density(i - 1)
                         update_density(i - 1)

--- a/python/taichi/lang/shell.py
+++ b/python/taichi/lang/shell.py
@@ -37,6 +37,8 @@ def _shell_pop_print(old_call):
         ret = old_call(*args, **kwargs)
         # print's in kernel won't take effect until ti.sync(), discussion:
         # https://github.com/taichi-dev/taichi/pull/1303#discussion_r444897102
+        # in jupyter environment calling print in kernel is redirected to terminal,
+        # calling info to print an empty string fixes this, I don't know exactly why :P
         info("", end="\r", msg_only=True)
         print(_ti_core.pop_python_print_buffer(), end='')
         return ret

--- a/python/taichi/lang/shell.py
+++ b/python/taichi/lang/shell.py
@@ -37,6 +37,7 @@ def _shell_pop_print(old_call):
         ret = old_call(*args, **kwargs)
         # print's in kernel won't take effect until ti.sync(), discussion:
         # https://github.com/taichi-dev/taichi/pull/1303#discussion_r444897102
+        info("", end="\r", msg_only=True)
         print(_ti_core.pop_python_print_buffer(), end='')
         return ret
 


### PR DESCRIPTION
**Don't merge**

**Purpose**:  In jupyter notebook calling print in the kernel will print to the terminal, not the browser. And also the warning messages created in the kernels. This PR fixes this bug.

To reproduce: (run this code in jupyter)

```python
import taichi as ti
ti.init(arch=ti.cpu)

v = ti.Vector([0, 0, 0])

@ti.kernel
def test():
    x = 1
    x = 2.0
    print(v)

test()
```