### PR TITLE
[build] [bug] Fix dependency for opengl_rhi target

### DIFF
--- a/taichi/backends/opengl/CMakeLists.txt
+++ b/taichi/backends/opengl/CMakeLists.txt
@@ -21,6 +21,8 @@ target_include_directories(${OPENGL_RHI}
     ${LLVM_INCLUDE_DIRS}
   )
 
+target_link_libraries(opengl_rhi PRIVATE glfw)
+
 set(SPIRV_CROSS_CLI false)
 add_subdirectory(${PROJECT_SOURCE_DIR}/external/SPIRV-Cross ${PROJECT_BINARY_DIR}/external/SPIRV-Cross)
 target_link_libraries(opengl_rhi PRIVATE spirv-cross-glsl spirv-cross-core)


### PR DESCRIPTION
After #5246, `opengl_api` is moved to target `opengl_rhi`, which introduces dependency on glfw.  This PR fixes the build error `undefined reference to glfwInit/CreateWindows`.

