### PR TITLE
[metal] Support memcpy_internal via buffer_copy

### DIFF
--- a/taichi/backends/metal/device.cpp
+++ b/taichi/backends/metal/device.cpp
@@ -355,7 +355,10 @@ class DeviceImpl : public Device, public AllocToMTLBufferMapper {
   }
 
   void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
-    TI_NOT_IMPLEMENTED;
+    Stream *stream = get_compute_stream();
+    std::unique_ptr<CommandList> cmd = stream->new_command_list();
+    cmd->buffer_copy(dst, src, size);
+    stream->submit_synced(cmd.get());
   }
 
   Stream *get_compute_stream() override {


### PR DESCRIPTION
There isn't a standalone test for this yet but will try to add one in
the followup PRs.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
