### PR TITLE
[AOT] Added C-API for on-device memory copy

### DIFF
--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -140,10 +140,11 @@ TI_DLL_EXPORT void *TI_API_CALL ti_map_memory(TiRuntime runtime,
 TI_DLL_EXPORT void TI_API_CALL ti_unmap_memory(TiRuntime runtime,
                                                TiMemory memory);
 
-// function.copy_memory
-TI_DLL_EXPORT void TI_API_CALL ti_copy_memory(TiRuntime runtime,
-                                              const TiMemorySlice *dst_memory,
-                                              const TiMemorySlice *src_memory);
+// function.copy_memory_device_to_device
+TI_DLL_EXPORT void TI_API_CALL
+ti_copy_memory_device_to_device(TiRuntime runtime,
+                                const TiMemorySlice *dst_memory,
+                                const TiMemorySlice *src_memory);
 
 // function.launch_kernel
 TI_DLL_EXPORT void TI_API_CALL ti_launch_kernel(TiRuntime runtime,

--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -78,6 +78,13 @@ typedef struct TiMemoryAllocateInfo {
   TiMemoryUsageFlagBits usage;
 } TiMemoryAllocateInfo;
 
+// structure.memory_slice
+typedef struct TiMemorySlice {
+  TiMemory memory;
+  uint64_t offset;
+  uint64_t size;
+} TiMemorySlice;
+
 // structure.nd_shape
 typedef struct TiNdShape {
   uint32_t dim_count;
@@ -132,6 +139,11 @@ TI_DLL_EXPORT void *TI_API_CALL ti_map_memory(TiRuntime runtime,
 // function.unmap_memory
 TI_DLL_EXPORT void TI_API_CALL ti_unmap_memory(TiRuntime runtime,
                                                TiMemory memory);
+
+// function.copy_memory
+TI_DLL_EXPORT void TI_API_CALL ti_copy_memory(TiRuntime runtime,
+                                              const TiMemorySlice *dst_memory,
+                                              const TiMemorySlice *src_memory);
 
 // function.launch_kernel
 TI_DLL_EXPORT void TI_API_CALL ti_launch_kernel(TiRuntime runtime,

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -131,7 +131,7 @@ void ti_unmap_memory(TiRuntime runtime, TiMemory devmem) {
   runtime2->get().unmap(devmem2devalloc(*runtime2, devmem));
 }
 
-void ti_copy_memory(TiRuntime runtime,
+void ti_copy_memory_device_to_device(TiRuntime runtime,
                     const TiMemorySlice *dst_memory,
                     const TiMemorySlice *src_memory) {
   if (runtime == nullptr) {

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -131,6 +131,33 @@ void ti_unmap_memory(TiRuntime runtime, TiMemory devmem) {
   runtime2->get().unmap(devmem2devalloc(*runtime2, devmem));
 }
 
+void ti_copy_memory(
+  TiRuntime runtime,
+  const TiMemorySlice *dst_memory,
+  const TiMemorySlice *src_memory
+) {
+  if (runtime == nullptr) {
+    TI_WARN("ignored attempt to copy memory on runtime of null handle");
+    return;
+  }
+  if (dst_memory == nullptr || dst_memory->memory == nullptr) {
+    TI_WARN("ignored attempt to copy to dst memory of null handle");
+    return;
+  }
+  if (src_memory == nullptr || src_memory->memory == nullptr) {
+    TI_WARN("ignored attempt to copy from src memory of null handle");
+    return;
+  }
+  if (src_memory->size != dst_memory->size) {
+    TI_WARN("ignored attempt to copy memory of mismatched size");
+    return;
+  }
+  Runtime* runtime2 = (Runtime*)runtime;
+  auto dst = devmem2devalloc(*runtime2, dst_memory->memory).get_ptr(dst_memory->offset);
+  auto src = devmem2devalloc(*runtime2, src_memory->memory).get_ptr(src_memory->offset);
+  runtime2->buffer_copy(dst, src, dst_memory->size);
+}
+
 TiAotModule ti_load_aot_module(TiRuntime runtime, const char *module_path) {
   if (runtime == nullptr) {
     TI_WARN("ignored attempt to load aot module on runtime of null handle");

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -132,8 +132,8 @@ void ti_unmap_memory(TiRuntime runtime, TiMemory devmem) {
 }
 
 void ti_copy_memory_device_to_device(TiRuntime runtime,
-                    const TiMemorySlice *dst_memory,
-                    const TiMemorySlice *src_memory) {
+                                     const TiMemorySlice *dst_memory,
+                                     const TiMemorySlice *src_memory) {
   if (runtime == nullptr) {
     TI_WARN("ignored attempt to copy memory on runtime of null handle");
     return;

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -131,11 +131,9 @@ void ti_unmap_memory(TiRuntime runtime, TiMemory devmem) {
   runtime2->get().unmap(devmem2devalloc(*runtime2, devmem));
 }
 
-void ti_copy_memory(
-  TiRuntime runtime,
-  const TiMemorySlice *dst_memory,
-  const TiMemorySlice *src_memory
-) {
+void ti_copy_memory(TiRuntime runtime,
+                    const TiMemorySlice *dst_memory,
+                    const TiMemorySlice *src_memory) {
   if (runtime == nullptr) {
     TI_WARN("ignored attempt to copy memory on runtime of null handle");
     return;
@@ -152,9 +150,11 @@ void ti_copy_memory(
     TI_WARN("ignored attempt to copy memory of mismatched size");
     return;
   }
-  Runtime* runtime2 = (Runtime*)runtime;
-  auto dst = devmem2devalloc(*runtime2, dst_memory->memory).get_ptr(dst_memory->offset);
-  auto src = devmem2devalloc(*runtime2, src_memory->memory).get_ptr(src_memory->offset);
+  Runtime *runtime2 = (Runtime *)runtime;
+  auto dst = devmem2devalloc(*runtime2, dst_memory->memory)
+                 .get_ptr(dst_memory->offset);
+  auto src = devmem2devalloc(*runtime2, src_memory->memory)
+                 .get_ptr(src_memory->offset);
   runtime2->buffer_copy(dst, src, dst_memory->size);
 }
 

--- a/c_api/src/taichi_core_impl.h
+++ b/c_api/src/taichi_core_impl.h
@@ -27,7 +27,9 @@ class Runtime {
   virtual taichi::lang::Device &get() = 0;
 
   virtual TiAotModule load_aot_module(const char *module_path) = 0;
-  virtual void buffer_copy(const taichi::lang::DevicePtr& dst, const taichi::lang::DevicePtr& src, size_t size) = 0;
+  virtual void buffer_copy(const taichi::lang::DevicePtr &dst,
+                           const taichi::lang::DevicePtr &src,
+                           size_t size) = 0;
   virtual void submit() = 0;
   virtual void wait() = 0;
 

--- a/c_api/src/taichi_core_impl.h
+++ b/c_api/src/taichi_core_impl.h
@@ -27,6 +27,7 @@ class Runtime {
   virtual taichi::lang::Device &get() = 0;
 
   virtual TiAotModule load_aot_module(const char *module_path) = 0;
+  virtual void buffer_copy(const taichi::lang::DevicePtr& dst, const taichi::lang::DevicePtr& src, size_t size) = 0;
   virtual void submit() = 0;
   virtual void wait() = 0;
 

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -103,6 +103,9 @@ TiAotModule VulkanRuntime::load_aot_module(const char *module_path) {
   params.runtime->add_root_buffer(root_size);
   return (TiAotModule)(new AotModule(*this, std::move(aot_module)));
 }
+void VulkanRuntime::buffer_copy(const taichi::lang::DevicePtr& dst, const taichi::lang::DevicePtr& src, size_t size) {
+  get_gfx_runtime().buffer_copy(dst, src, size);
+}
 void VulkanRuntime::submit() {
   get_gfx_runtime().flush();
 }

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -103,7 +103,9 @@ TiAotModule VulkanRuntime::load_aot_module(const char *module_path) {
   params.runtime->add_root_buffer(root_size);
   return (TiAotModule)(new AotModule(*this, std::move(aot_module)));
 }
-void VulkanRuntime::buffer_copy(const taichi::lang::DevicePtr& dst, const taichi::lang::DevicePtr& src, size_t size) {
+void VulkanRuntime::buffer_copy(const taichi::lang::DevicePtr &dst,
+                                const taichi::lang::DevicePtr &src,
+                                size_t size) {
   get_gfx_runtime().buffer_copy(dst, src, size);
 }
 void VulkanRuntime::submit() {

--- a/c_api/src/taichi_vulkan_impl.h
+++ b/c_api/src/taichi_vulkan_impl.h
@@ -22,6 +22,7 @@ class VulkanRuntime : public Runtime {
   virtual taichi::lang::gfx::GfxRuntime &get_gfx_runtime() = 0;
 
   virtual TiAotModule load_aot_module(const char *module_path) override final;
+  virtual void buffer_copy(const taichi::lang::DevicePtr& dst, const taichi::lang::DevicePtr& src, size_t size) override final;
   virtual void submit() override final;
   virtual void wait() override final;
 };

--- a/c_api/src/taichi_vulkan_impl.h
+++ b/c_api/src/taichi_vulkan_impl.h
@@ -22,7 +22,9 @@ class VulkanRuntime : public Runtime {
   virtual taichi::lang::gfx::GfxRuntime &get_gfx_runtime() = 0;
 
   virtual TiAotModule load_aot_module(const char *module_path) override final;
-  virtual void buffer_copy(const taichi::lang::DevicePtr& dst, const taichi::lang::DevicePtr& src, size_t size) override final;
+  virtual void buffer_copy(const taichi::lang::DevicePtr &dst,
+                           const taichi::lang::DevicePtr &src,
+                           size_t size) override final;
   virtual void submit() override final;
   virtual void wait() override final;
 };

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -291,7 +291,7 @@
                     ]
                 },
                 {
-                    "name": "copy_memory",
+                    "name": "copy_memory_device_to_device",
                     "type": "function",
                     "parameters": [
                         {

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -116,6 +116,23 @@
                     ]
                 },
                 {
+                    "name": "memory_slice",
+                    "type": "structure",
+                    "fields": [
+                        {
+                            "type": "handle.memory"
+                        },
+                        {
+                            "name": "offset",
+                            "type": "uint64_t"
+                        },
+                        {
+                            "name": "size",
+                            "type": "uint64_t"
+                        }
+                    ]
+                },
+                {
                     "name": "nd_shape",
                     "type": "structure",
                     "fields": [
@@ -270,6 +287,25 @@
                         },
                         {
                             "type": "handle.memory"
+                        }
+                    ]
+                },
+                {
+                    "name": "copy_memory",
+                    "type": "function",
+                    "parameters": [
+                        {
+                            "type": "handle.runtime"
+                        },
+                        {
+                            "name": "dst_memory",
+                            "type": "structure.memory_slice",
+                            "by_ref": true
+                        },
+                        {
+                            "name": "src_memory",
+                            "type": "structure.memory_slice",
+                            "by_ref": true
                         }
                     ]
                 },

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -6,7 +6,6 @@
 #include "taichi/program/extension.h"
 #include "taichi/backends/cpu/codegen_cpu.h"
 #include "taichi/struct/struct.h"
-#include "taichi/codegen/llvm/struct_llvm.h"
 #include "taichi/runtime/metal/api.h"
 #include "taichi/runtime/wasm/aot_module_builder_impl.h"
 #include "taichi/runtime/program_impls/opengl/opengl_program.h"
@@ -23,6 +22,7 @@
 #include "taichi/math/arithmetic.h"
 #ifdef TI_WITH_LLVM
 #include "taichi/runtime/program_impls/llvm/llvm_program.h"
+#include "taichi/llvm/struct_llvm.h"
 #endif
 
 #if defined(TI_WITH_CC)

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -22,7 +22,7 @@
 #include "taichi/math/arithmetic.h"
 #ifdef TI_WITH_LLVM
 #include "taichi/runtime/program_impls/llvm/llvm_program.h"
-#include "taichi/llvm/struct_llvm.h"
+#include "taichi/codegen/llvm/struct_llvm.h"
 #endif
 
 #if defined(TI_WITH_CC)

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -465,12 +465,7 @@ void GfxRuntime::launch_kernel(KernelHandle handle, RuntimeContext *host_ctx) {
     ctx_blitter->host_to_device(any_arrays, ext_array_size);
   }
 
-  // Create new command list if current one is nullptr
-  if (!current_cmdlist_) {
-    ctx_buffers_.clear();
-    current_cmdlist_pending_since_ = high_res_clock::now();
-    current_cmdlist_ = device_->get_compute_stream()->new_command_list();
-  }
+  ensure_current_cmdlist();
 
   // Record commands
   const auto &task_attribs = ti_kernel->ti_kernel_attribs().tasks_attribs;
@@ -548,17 +543,13 @@ void GfxRuntime::launch_kernel(KernelHandle handle, RuntimeContext *host_ctx) {
     }
   }
 
-  // If we have accumulated some work but does not require sync
-  // and if the accumulated cmdlist has been pending for some time
-  // launch the cmdlist to start processing.
-  if (current_cmdlist_) {
-    constexpr uint64_t max_pending_time = 2000;  // 2000us = 2ms
-    auto duration = high_res_clock::now() - current_cmdlist_pending_since_;
-    if (std::chrono::duration_cast<std::chrono::microseconds>(duration)
-            .count() > max_pending_time) {
-      flush();
-    }
-  }
+  submit_current_cmdlist_if_timeout();
+}
+
+void GfxRuntime::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
+  ensure_current_cmdlist();
+  current_cmdlist_->buffer_copy(dst, src, size);
+  submit_current_cmdlist_if_timeout();
 }
 
 void GfxRuntime::synchronize() {
@@ -582,6 +573,28 @@ StreamSemaphore GfxRuntime::flush() {
 
 Device *GfxRuntime::get_ti_device() const {
   return device_;
+}
+
+void GfxRuntime::ensure_current_cmdlist() {
+  // Create new command list if current one is nullptr
+  if (!current_cmdlist_) {
+    ctx_buffers_.clear();
+    current_cmdlist_pending_since_ = high_res_clock::now();
+    current_cmdlist_ = device_->get_compute_stream()->new_command_list();
+  }
+}
+void GfxRuntime::submit_current_cmdlist_if_timeout() {
+  // If we have accumulated some work but does not require sync
+  // and if the accumulated cmdlist has been pending for some time
+  // launch the cmdlist to start processing.
+  if (current_cmdlist_) {
+    constexpr uint64_t max_pending_time = 2000;  // 2000us = 2ms
+    auto duration = high_res_clock::now() - current_cmdlist_pending_since_;
+    if (std::chrono::duration_cast<std::chrono::microseconds>(duration)
+      .count() > max_pending_time) {
+      flush();
+    }
+  }
 }
 
 void GfxRuntime::init_nonroot_buffers() {

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -591,7 +591,7 @@ void GfxRuntime::submit_current_cmdlist_if_timeout() {
     constexpr uint64_t max_pending_time = 2000;  // 2000us = 2ms
     auto duration = high_res_clock::now() - current_cmdlist_pending_since_;
     if (std::chrono::duration_cast<std::chrono::microseconds>(duration)
-      .count() > max_pending_time) {
+            .count() > max_pending_time) {
       flush();
     }
   }

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -100,6 +100,8 @@ class TI_DLL_EXPORT GfxRuntime {
 
   void launch_kernel(KernelHandle handle, RuntimeContext *host_ctx);
 
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size);
+
   void synchronize();
 
   StreamSemaphore flush();
@@ -114,6 +116,9 @@ class TI_DLL_EXPORT GfxRuntime {
 
  private:
   friend class taichi::lang::gfx::SNodeTreeManager;
+
+  void ensure_current_cmdlist();
+  void submit_current_cmdlist_if_timeout();
 
   void init_nonroot_buffers();
 


### PR DESCRIPTION
This PR introduces a new C-API of, `ti_copy_memory`, to enable on-device memory copy without interrupting sequences of kernel launches to eliminate host-device synchronization. It is especially useful when the user wants to transfer Taichi results to externally allocated device memory (which might not support compute shader write).