### PR TITLE
[autodiff] Set default seed only for scalar parameter to avoid silent unexpected results

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -265,8 +265,8 @@ class FwdMode:
                 self.seed = [1.0]
             else:
                 raise RuntimeError(
-                    'Seed is not set for non 0-D field, please specify.'
-                    ' Seed is a list to specify which parameters the computed derivatives respect to.'
+                    '`seed` is not set for non 0-D field, please specify.'
+                    ' `seed` is a list to specify which parameters the computed derivatives respect to. The length of the `seed` should be same to that of the `parameters`'
                     ' E.g. Given a loss `loss = ti.field(float, shape=3)`, parameter `x = ti.field(float, shape=3)`'
                     '      seed = [0, 0, 1] indicates compute derivative respect to the third element of `x`.'
                     '      seed = [1, 1, 1] indicates compute the sum of derivatives respect to all three element of `x`, i.e., Jacobian-vector product(Jvp) for each element in `loss`'

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -260,9 +260,17 @@ class FwdMode:
             parameters_shape_flatten = 1
 
         if not self.seed:
-            # Compute the derivative respect to the first variable by default
-            self.seed = [0.0 for _ in range(parameters_shape_flatten)]
-            self.seed[0] = 1.0
+            if parameters_shape_flatten == 1:
+                # Compute the derivative respect to the first variable by default
+                self.seed = [1.0]
+            else:
+                raise RuntimeError(
+                    'Seed is not set for non 0-D field, please specify.'
+                    ' Seed is a list to specify which parameters the computed derivatives respect to.'
+                    ' E.g. Given a loss `loss = ti.field(float, shape=3)`, parameter `x = ti.field(float, shape=3)`'
+                    '      seed = [0, 0, 1] indicates compute derivative respect to the third element of `x`.'
+                    '      seed = [1, 1, 1] indicates compute the sum of derivatives respect to all three element of `x`, i.e., Jacobian-vector product(Jvp) for each element in `loss`'
+                )
         else:
             assert parameters_shape_flatten == len(self.seed)
 


### PR DESCRIPTION
Set default seed only for scalar parameter to avoid silent unexpected results.
The user should specify the `seed` if the `parameter` is not a 0-D field.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
