### PR TITLE
[metal] Turn off only_for_dev_allocation in rhi_device

### DIFF
--- a/taichi/runtime/metal/kernel_manager.cpp
+++ b/taichi/runtime/metal/kernel_manager.cpp
@@ -655,7 +655,7 @@ class KernelManager::Impl {
       ComputeDeviceParams rhi_params;
       rhi_params.device = device_.get();
       rhi_params.mem_pool = mem_pool_;
-      rhi_params.only_for_dev_allocation = true;
+      rhi_params.only_for_dev_allocation = false;
       auto make_res = make_compute_device(rhi_params);
       rhi_device_ = std::move(make_res.device);
       TI_ASSERT(rhi_device_ != nullptr);


### PR DESCRIPTION
Related issue = #
We need this when doing memcpy_internal. 
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
