### PR TITLE
[autodiff] Add has_grad for checking grad field

### DIFF
--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -100,6 +100,15 @@ class Field:
         """
         self.grad = grad
 
+    def has_grad(self):
+        """Check whether the field has a grad field (reverse mode).
+        Args:
+            bool: True has a grad field otherwise False.
+        """
+        if self._snode.ptr is None:
+            return False
+        return self._snode.ptr.has_adjoint() and self.grad is not None
+
     def _set_dual(self, dual):
         """Sets corresponding dual field (forward mode).
 

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -509,6 +509,15 @@ class StructField(Field):
         """
         return self.field_dict[key]
 
+    def has_grad(self):
+        has_grad = True
+        for _, item in self.field_dict.items():
+            if not item.has_grad():
+                return False
+        if len(self.field_dict) == 0:
+            has_grad = False
+        return has_grad
+
     @python_scope
     def from_numpy(self, array_dict):
         """Copies the data from a set of `numpy.array` into this field.

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -351,3 +351,43 @@ def test_ad_frac():
     expected = np.modf(randoms)[0] * 2
     for i in range(n):
         assert grads[i] == test_utils.approx(expected[i], rel=1e-4)
+
+
+@test_utils.test()
+def test_ad_has_grad():
+
+    x = ti.field(float, shape=(), needs_grad=True)
+    assert x.has_grad()
+
+    x = ti.field(float, shape=())
+    assert not x.has_grad()
+
+    x = ti.field(float, needs_grad=True)
+    assert not x.has_grad()
+
+    x = ti.field(float)
+    assert not x.has_grad()
+
+    x = ti.Vector.field(3, float, shape=(), needs_grad=True)
+    assert x.has_grad()
+
+    x = ti.Vector.field(3, float, shape=())
+    assert not x.has_grad()
+
+    x = ti.Vector.field(3, float, needs_grad=True)
+    assert not x.has_grad()
+
+    x = ti.Vector.field(3, float)
+    assert not x.has_grad()
+
+    x = ti.Matrix.field(3, 2, float, shape=(), needs_grad=True)
+    assert x.has_grad()
+
+    x = ti.Matrix.field(3, 2, float, shape=())
+    assert not x.has_grad()
+
+    x = ti.Matrix.field(3, 2, float, needs_grad=True)
+    assert not x.has_grad()
+
+    x = ti.Matrix.field(3, 2, float)
+    assert not x.has_grad()

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -356,6 +356,7 @@ def test_ad_frac():
 @test_utils.test()
 def test_ad_has_grad():
 
+    # Test for scalar field
     x = ti.field(float, shape=(), needs_grad=True)
     assert x.has_grad()
 
@@ -368,6 +369,7 @@ def test_ad_has_grad():
     x = ti.field(float)
     assert not x.has_grad()
 
+    # Test for Vector and Matrix field
     x = ti.Vector.field(3, float, shape=(), needs_grad=True)
     assert x.has_grad()
 
@@ -391,3 +393,43 @@ def test_ad_has_grad():
 
     x = ti.Matrix.field(3, 2, float)
     assert not x.has_grad()
+
+    # Test for Struct field
+    particle_field = ti.Struct.field(
+        {
+            "pos": ti.types.vector(3, float),
+            "vel": ti.types.vector(3, float),
+            "acc": ti.types.vector(3, float),
+            "mass": ti.f32,
+        },
+        shape=(5, ),
+        needs_grad=True)
+    assert particle_field.has_grad()
+
+    particle_field = ti.Struct.field(
+        {
+            "pos": ti.types.vector(3, float),
+            "vel": ti.types.vector(3, float),
+            "acc": ti.types.vector(3, float),
+            "mass": ti.f32,
+        },
+        shape=(5, ))
+    assert not particle_field.has_grad()
+
+    particle_field = ti.Struct.field(
+        {
+            "pos": ti.types.vector(3, float),
+            "vel": ti.types.vector(3, float),
+            "acc": ti.types.vector(3, float),
+            "mass": ti.f32,
+        },
+        needs_grad=True)
+    assert not particle_field.has_grad()
+
+    particle_field = ti.Struct.field({
+        "pos": ti.types.vector(3, float),
+        "vel": ti.types.vector(3, float),
+        "acc": ti.types.vector(3, float),
+        "mass": ti.f32,
+    })
+    assert not particle_field.has_grad()

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -94,7 +94,7 @@ user_api[ti.ad] = [
 ]
 user_api[ti.Field] = [
     'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
-    'parent', 'shape', 'snode', 'to_numpy', 'to_paddle', 'to_torch'
+    'has_grad', 'parent', 'shape', 'snode', 'to_numpy', 'to_paddle', 'to_torch'
 ]
 user_api[ti.FieldsBuilder] = [
     'bit_array', 'bit_struct', 'bitmasked', 'deactivate_all', 'dense',
@@ -113,8 +113,8 @@ user_api[ti.math] = [
 user_api[ti.Matrix] = _get_expected_matrix_apis()
 user_api[ti.MatrixField] = [
     'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
-    'get_scalar_field', 'parent', 'shape', 'snode', 'to_numpy', 'to_paddle',
-    'to_torch'
+    'get_scalar_field', 'has_grad', 'parent', 'shape', 'snode', 'to_numpy',
+    'to_paddle', 'to_torch'
 ]
 user_api[ti.MatrixNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'get_type', 'to_numpy'
@@ -127,7 +127,7 @@ user_api[ti.SNode] = [
 ]
 user_api[ti.ScalarField] = [
     'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
-    'parent', 'shape', 'snode', 'to_numpy', 'to_paddle', 'to_torch'
+    'has_grad', 'parent', 'shape', 'snode', 'to_numpy', 'to_paddle', 'to_torch'
 ]
 user_api[ti.ScalarNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'get_type', 'to_numpy'
@@ -135,8 +135,8 @@ user_api[ti.ScalarNdarray] = [
 user_api[ti.Struct] = ['field', 'fill', 'items', 'keys', 'to_dict']
 user_api[ti.StructField] = [
     'copy_from', 'dtype', 'fill', 'from_numpy', 'from_paddle', 'from_torch',
-    'get_member_field', 'keys', 'parent', 'shape', 'snode', 'to_numpy',
-    'to_paddle', 'to_torch'
+    'get_member_field', 'has_grad', 'keys', 'parent', 'shape', 'snode',
+    'to_numpy', 'to_paddle', 'to_torch'
 ]
 user_api[ti.VectorNdarray] = [
     'copy_from', 'element_shape', 'fill', 'from_numpy', 'get_type', 'to_numpy'


### PR DESCRIPTION
Related issue = #5274 
Add a public API `field.has_grad()` for checking whether a field has a grad field for reverse mode autodiff.
So that users can avoid using internal functions `field.snode.ptr.has_adjoint() ` to achieve the same goal.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
