### PR TITLE
[refactor] Synchronize should always be called in non-async mode

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -227,15 +227,14 @@ void Program::check_runtime_error() {
 }
 
 void Program::synchronize() {
-  if (!sync) {
-    if (config.async_mode) {
-      async_engine->synchronize();
-    }
-    if (arch_uses_llvm(config.arch) || config.arch == Arch::metal ||
-        config.arch == Arch::vulkan || config.arch == Arch::opengl) {
-      program_impl_->synchronize();
-    }
+  if (config.async_mode && !sync) {
+    async_engine->synchronize();
     sync = true;
+  }
+  // Normal mode shouldn't be affected by `sync` flag.
+  if (arch_uses_llvm(config.arch) || config.arch == Arch::metal ||
+      config.arch == Arch::vulkan || config.arch == Arch::opengl) {
+    program_impl_->synchronize();
   }
 }
 

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.h
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.h
@@ -47,7 +47,9 @@ class VulkanProgramImpl : public ProgramImpl {
   void materialize_snode_tree(SNodeTree *tree, uint64 *result_buffer) override;
 
   void synchronize() override {
-    vulkan_runtime_->synchronize();
+    if (vulkan_runtime_) {
+      vulkan_runtime_->synchronize();
+    }
   }
 
   StreamSemaphore flush() override {

--- a/tests/cpp/program/graph_test.cpp
+++ b/tests/cpp/program/graph_test.cpp
@@ -48,10 +48,7 @@ TEST(GraphTest, SimpleGraphRun) {
   args.insert({"x", aot::IValue::create<int>(2)});
 
   g->run(args);
-  // TODO: this should be synchronize() indeed but it currently has a shortcut
-  // `sync=True` to return which is pretty error-prone. We should change this to
-  // synchronize() after getting rid of the shortcut.
-  test_prog.prog()->flush();
+  test_prog.prog()->synchronize();
   EXPECT_EQ(array.read_int({0}), 2);
   EXPECT_EQ(array.read_int({1}), 2);
   EXPECT_EQ(array.read_int({2}), 42);


### PR DESCRIPTION
Related issue = #
I got tripped over a few times by `sync` flag that calling `prog.synchronize()` didn't really synchronize due to a fake `sync=True`. Having a manual `sync` flag requires us to know exactly every place could potentially submit jobs and set the flag properly. IMHO this is pretty error prone -  when I call `sync` I'd prefer it to be 100% synchronized even though it might cause 1 extra no-op sync compared to the current `sync` flag solution. 

Originally I wanted to get rid of this flag completely but realized that it's used in the async mode so this PR only decouples it with normal mode. 
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
