### PR TITLE
[llvm] Drop code for llvm 15.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,10 @@ if (WIN32)
   #
   # FIXME: (penguinliong) This is fixed in later releases of LLVM so maybe
   # someday we can distribute `Debug` libraries, if it's ever needed.
-  SET(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+  if (NOT TI_LLVM_15)
+    SET(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+  endif()
+  message("CMAKE_MSVC_RUNTIME_LIBRARY: ${CMAKE_MSVC_RUNTIME_LIBRARY}")
 endif()
 
 # No support of Python for Android build; or in any case taichi is integrated

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -1,5 +1,6 @@
 option(USE_STDCPP "Use -stdlib=libc++" OFF)
 option(TI_WITH_LLVM "Build with LLVM backends" ON)
+option(TI_LLVM_15 "Switch to LLVM 15" OFF)
 option(TI_WITH_METAL "Build with the Metal backend" ON)
 option(TI_WITH_CUDA "Build with the CUDA backend" ON)
 option(TI_WITH_CUDA_TOOLKIT "Build with the CUDA toolkit" OFF)
@@ -140,6 +141,10 @@ if(TI_WITH_LLVM)
 else()
     file(GLOB TAICHI_LLVM_SOURCE "taichi/llvm/*.cpp" "taichi/llvm/*.h")
     list(REMOVE_ITEM TAICHI_CORE_SOURCE ${TAICHI_LLVM_SOURCE})
+endif()
+
+if (TI_LLVM_15)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_LLVM_15")
 endif()
 
 if (TI_WITH_CUDA)

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -64,6 +64,9 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     auto value_arr = builder->CreateAlloca(stype);
     for (int i = 0; i < values.size(); i++) {
       auto value_ptr = builder->CreateGEP(
+#ifdef TI_LLVM_15
+          stype,
+#endif
           value_arr, {tlctx->get_constant(0), tlctx->get_constant(i)});
       builder->CreateStore(values[i], value_ptr);
     }
@@ -323,8 +326,11 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
 
     // Use the value from the memory that atomicCAS operates on to initialize
     // cas_old_output.
-    llvm::Value *cas_old_output =
-        builder->CreateLoad(atomic_memory_address, "cas_old_output");
+    llvm::Value *cas_old_output = builder->CreateLoad(
+#ifdef TI_LLVM_15
+        atomic_type,
+#endif
+        atomic_memory_address, "cas_old_output");
     builder->CreateStore(cas_old_output, cas_old_output_address);
 
     llvm::BasicBlock *loop_body_bb =
@@ -337,21 +343,35 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     // loop body for one atomicCAS
     {
       // Use cas_old_output to initialize cas_new_output.
-      cas_old_output =
-          builder->CreateLoad(cas_old_output_address, "cas_old_output");
+      cas_old_output = builder->CreateLoad(
+#ifdef TI_LLVM_15
+          atomic_type,
+#endif
+          cas_old_output_address, "cas_old_output");
       builder->CreateStore(cas_old_output, cas_new_output_address);
 
-      auto binop_output = op(builder->CreateLoad(binop_output_address), val);
+      auto binop_output = op(builder->CreateLoad(
+#ifdef TI_LLVM_15
+                                 atomic_type,
+#endif
+                                 binop_output_address),
+                             val);
       builder->CreateStore(binop_output, binop_output_address);
 
-      llvm::Value *cas_new_output =
-          builder->CreateLoad(cas_new_output_address, "cas_new_output");
+      llvm::Value *cas_new_output = builder->CreateLoad(
+#ifdef TI_LLVM_15
+          atomic_type,
+#endif
+          cas_new_output_address, "cas_new_output");
 
       // Emit code to perform the atomicCAS operation
       // (cas_old_output, success) = atomicCAS(memory_address, cas_old_output,
       //                                       cas_new_output);
       llvm::Value *ret_value = builder->CreateAtomicCmpXchg(
           atomic_memory_address, cas_old_output, cas_new_output,
+#ifdef TI_LLVM_15
+          llvm::MaybeAlign(0),
+#endif
           llvm::AtomicOrdering::SequentiallyConsistent,
           llvm::AtomicOrdering::SequentiallyConsistent);
 
@@ -426,8 +446,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           llvm::BasicBlock::Create(*llvm_context, "loop_body", func);
       auto func_exit =
           llvm::BasicBlock::Create(*llvm_context, "func_exit", func);
-      auto loop_index =
-          create_entry_block_alloca(llvm::Type::getInt32Ty(*llvm_context));
+      auto i32_ty = llvm::Type::getInt32Ty(*llvm_context);
+      auto loop_index = create_entry_block_alloca(i32_ty);
       llvm::Value *thread_idx =
           builder->CreateIntrinsic(Intrinsic::nvvm_read_ptx_sreg_tid_x, {}, {});
       llvm::Value *block_dim = builder->CreateIntrinsic(
@@ -438,7 +458,12 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
       {
         builder->SetInsertPoint(loop_test_bb);
         auto cond = builder->CreateICmp(
-            llvm::CmpInst::Predicate::ICMP_SLT, builder->CreateLoad(loop_index),
+            llvm::CmpInst::Predicate::ICMP_SLT,
+            builder->CreateLoad(
+#ifdef TI_LLVM_15
+                i32_ty,
+#endif
+                loop_index),
             llvm_val[stmt->owned_num_local.find(stmt->major_from_type)
                          ->second]);
         builder->CreateCondBr(cond, loop_body_bb, func_exit);
@@ -451,9 +476,13 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
           auto &s = stmt->body->statements[i];
           s->accept(this);
         }
-        builder->CreateStore(
-            builder->CreateAdd(builder->CreateLoad(loop_index), block_dim),
-            loop_index);
+        builder->CreateStore(builder->CreateAdd(builder->CreateLoad(
+#ifdef TI_LLVM_15
+                                                    i32_ty,
+#endif
+                                                    loop_index),
+                                                block_dim),
+                             loop_index);
         builder->CreateBr(loop_test_bb);
         builder->SetInsertPoint(func_exit);
       }

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1616,14 +1616,14 @@ void CodeGenLLVM::visit(SNodeLookupStmt *stmt) {
   if (snode->type == SNodeType::root) {
 #ifdef TI_LLVM_15
     // FIXME: get parent_type from taichi instead of llvm.
-    llvm::Type *parent_type = builder->getInt8Ty();
+    llvm::Type *parent_ty = builder->getInt8Ty();
     if (auto bit_cast = llvm::dyn_cast<llvm::BitCastInst>(parent)) {
-      parent_type = bit_cast->getDestTy();
-      if (auto ptr_ty = llvm::dyn_cast<llvm::PointerType>(parent_type))
-        parent_type = ptr_ty->getPointerElementType();
+      parent_ty = bit_cast->getDestTy();
+      if (auto ptr_ty = llvm::dyn_cast<llvm::PointerType>(parent_ty))
+        parent_ty = ptr_ty->getPointerElementType();
     }
     llvm_val[stmt] =
-        builder->CreateGEP(parent_type, parent, llvm_val[stmt->input_index]);
+        builder->CreateGEP(parent_ty, parent, llvm_val[stmt->input_index]);
 #else
     llvm_val[stmt] = builder->CreateGEP(parent, llvm_val[stmt->input_index]);
 #endif

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1583,10 +1583,11 @@ std::tuple<llvm::Value *, llvm::Value *> CodeGenLLVM::load_bit_ptr(
   if (auto *AI = llvm::dyn_cast<llvm::AllocaInst>(bit_ptr))
     ptr_ty = AI->getAllocatedType();
   TI_ASSERT(ptr_ty);
+  auto *struct_ty = llvm::cast<llvm::StructType>(ptr_ty);
 #endif
   auto byte_ptr = builder->CreateLoad(
 #ifdef TI_LLVM_15
-      builder->getInt8PtrTy(),
+      struct_ty->getElementType(0),
 #endif
       builder->CreateGEP(
 #ifdef TI_LLVM_15
@@ -1595,7 +1596,7 @@ std::tuple<llvm::Value *, llvm::Value *> CodeGenLLVM::load_bit_ptr(
           bit_ptr, {tlctx->get_constant(0), tlctx->get_constant(0)}));
   auto bit_offset = builder->CreateLoad(
 #ifdef TI_LLVM_15
-      builder->getInt32Ty(),
+      struct_ty->getElementType(1),
 #endif
       builder->CreateGEP(
 #ifdef TI_LLVM_15

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1689,6 +1689,15 @@ void CodeGenLLVM::visit(PtrOffsetStmt *stmt) {
       ptr_ty = alloc->getAllocatedType();
     else if (auto *gv = llvm::dyn_cast<llvm::GlobalVariable>(val))
       ptr_ty = gv->getValueType();
+    else if (stmt->origin->is<GlobalTemporaryStmt>()) {
+      auto *tmpo_stmt = stmt->origin->cast<GlobalTemporaryStmt>();
+      if (tmpo_stmt->ret_type->is<TensorType>()) {
+        ptr_ty = tlctx->get_data_type(
+            tmpo_stmt->ret_type->cast<TensorType>()->get_element_type());
+      } else {
+        ptr_ty = tlctx->get_data_type(tmpo_stmt->ret_type.ptr_removed());
+      }
+    }
     TI_ASSERT(ptr_ty);
 #endif
     llvm_val[stmt] = builder->CreateGEP(

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1434,7 +1434,9 @@ void CodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   if (ptr_type->is_bit_pointer()) {
     auto val_type = ptr_type->get_pointee_type();
     if (auto qit = val_type->cast<QuantIntType>()) {
-      llvm_val[stmt] = load_quant_int(llvm_val[stmt->src], qit);
+      llvm_val[stmt] = load_quant_int(
+          llvm_val[stmt->src], qit,
+          stmt->src->as<GetChStmt>()->input_snode->physical_type);
     } else {
       TI_ASSERT(val_type->is<QuantFixedType>() ||
                 val_type->is<QuantFloatType>());

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1565,13 +1565,13 @@ llvm::Value *CodeGenLLVM::create_bit_ptr(llvm::Value *byte_ptr,
 #endif
                     bit_ptr, {tlctx->get_constant(0), tlctx->get_constant(0)}));
   // 4. store `bit_offset
-  builder->CreateStore(bit_offset,
-                       builder->CreateGEP(
+  builder->CreateStore(
+      bit_offset,
+      builder->CreateGEP(
 #ifdef TI_LLVM_15
-                         struct_type,
+          struct_type,
 #endif
-                         bit_ptr, {tlctx->get_constant(0),
-                                                    tlctx->get_constant(1)}));
+          bit_ptr, {tlctx->get_constant(0), tlctx->get_constant(1)}));
   return bit_ptr;
 }
 
@@ -1588,20 +1588,20 @@ std::tuple<llvm::Value *, llvm::Value *> CodeGenLLVM::load_bit_ptr(
 #ifdef TI_LLVM_15
       builder->getInt8PtrTy(),
 #endif
-    builder->CreateGEP(
+      builder->CreateGEP(
 #ifdef TI_LLVM_15
-      ptr_ty,
+          ptr_ty,
 #endif
-      bit_ptr, {tlctx->get_constant(0), tlctx->get_constant(0)}));
+          bit_ptr, {tlctx->get_constant(0), tlctx->get_constant(0)}));
   auto bit_offset = builder->CreateLoad(
 #ifdef TI_LLVM_15
       builder->getInt32Ty(),
 #endif
-    builder->CreateGEP(
+      builder->CreateGEP(
 #ifdef TI_LLVM_15
-      ptr_ty,
+          ptr_ty,
 #endif
-      bit_ptr, {tlctx->get_constant(0), tlctx->get_constant(1)}));
+          bit_ptr, {tlctx->get_constant(0), tlctx->get_constant(1)}));
   return std::make_tuple(byte_ptr, bit_offset);
 }
 
@@ -2051,9 +2051,9 @@ void CodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt, bool spmd) {
       auto is_active = call(leaf_block, element.get("element"), "is_active",
                             {builder->CreateLoad(
 #ifdef TI_LLVM_15
-                              loop_index_ty,
+                                loop_index_ty,
 #endif
-                              loop_index)});
+                                loop_index)});
       is_active =
           builder->CreateTrunc(is_active, llvm::Type::getInt1Ty(*llvm_context));
       exec_cond = builder->CreateAnd(exec_cond, is_active);

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -269,7 +269,9 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *extract_quant_float(llvm::Value *local_bit_struct,
                                    SNode *digits_snode);
 
-  llvm::Value *load_quant_int(llvm::Value *ptr, QuantIntType *qit);
+  llvm::Value *load_quant_int(llvm::Value *ptr,
+                              QuantIntType *qit,
+                              Type *physical_type);
 
   llvm::Value *extract_quant_int(llvm::Value *physical_value,
                                  llvm::Value *bit_offset,
@@ -281,6 +283,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   llvm::Value *load_quant_float(llvm::Value *digits_bit_ptr,
                                 llvm::Value *exponent_bit_ptr,
                                 QuantFloatType *qflt,
+                                Type *physical_type,
                                 bool shared_exponent);
 
   llvm::Value *reconstruct_quant_float(llvm::Value *input_digits,

--- a/taichi/codegen/llvm/codegen_llvm_quant.cpp
+++ b/taichi/codegen/llvm/codegen_llvm_quant.cpp
@@ -470,7 +470,7 @@ llvm::Value *CodeGenLLVM::load_quant_int(llvm::Value *ptr,
 #ifdef TI_LLVM_15
       llvm_type(physical_type),
 #endif
-    byte_ptr);
+      byte_ptr);
   return extract_quant_int(physical_value, bit_offset, qit);
 }
 
@@ -644,8 +644,7 @@ llvm::Value *CodeGenLLVM::load_quant_fixed_or_quant_float(Stmt *ptr_stmt) {
     auto exponent_bit_ptr = offset_bit_ptr(
         digits_bit_ptr, exponent_snode->bit_offset - digits_snode->bit_offset);
     return load_quant_float(digits_bit_ptr, exponent_bit_ptr, qflt,
-                            physical_type,
-                            digits_snode->owns_shared_exponent);
+                            physical_type, digits_snode->owns_shared_exponent);
   } else {
     auto qfxt = load_type->as<QuantFixedType>();
     auto digits = load_quant_int(llvm_val[ptr],

--- a/taichi/codegen/llvm/codegen_llvm_quant.cpp
+++ b/taichi/codegen/llvm/codegen_llvm_quant.cpp
@@ -295,7 +295,11 @@ void CodeGenLLVM::store_quant_floats_with_shared_exponents(
   auto snode = stmt->get_bit_struct_snode();
   auto bit_struct_physical_type =
       snode->dt->as<BitStructType>()->get_physical_type();
-  auto local_bit_struct = builder->CreateLoad(llvm_val[stmt->ptr]);
+  auto local_bit_struct = builder->CreateLoad(
+#ifdef TI_LLVM_15
+      llvm_type(bit_struct_physical_type),
+#endif
+      llvm_val[stmt->ptr]);
   // fuse all stores into a masked store
   llvm::Value *masked_val = nullptr;
   uint64 mask = 0;
@@ -460,7 +464,11 @@ llvm::Value *CodeGenLLVM::extract_quant_float(llvm::Value *local_bit_struct,
 
 llvm::Value *CodeGenLLVM::load_quant_int(llvm::Value *ptr, QuantIntType *qit) {
   auto [byte_ptr, bit_offset] = load_bit_ptr(ptr);
-  auto physical_value = builder->CreateLoad(byte_ptr);
+  auto physical_value = builder->CreateLoad(
+#ifdef TI_LLVM_15
+      llvm_type(qit->get_physical_type()),
+#endif
+    byte_ptr);
   return extract_quant_int(physical_value, bit_offset, qit);
 }
 

--- a/taichi/codegen/llvm/llvm_codegen_utils.cpp
+++ b/taichi/codegen/llvm/llvm_codegen_utils.cpp
@@ -16,7 +16,8 @@ void check_func_call_signature(llvm::Value *func,
   if (llvm::Function *fn = llvm::dyn_cast<llvm::Function>(func)) {
     func_type = fn->getFunctionType();
   } else if (auto *call = llvm::dyn_cast<llvm::CallInst>(func)) {
-    func_type = llvm::cast_or_null<llvm::FunctionType>(func->getType()->getPointerElementType()); 
+    func_type = llvm::cast_or_null<llvm::FunctionType>(
+        func->getType()->getPointerElementType());
   }
   int num_params = func_type->getFunctionNumParams();
   if (func_type->isFunctionVarArg()) {

--- a/taichi/codegen/llvm/llvm_codegen_utils.cpp
+++ b/taichi/codegen/llvm/llvm_codegen_utils.cpp
@@ -12,7 +12,12 @@ std::string type_name(llvm::Type *type) {
 
 void check_func_call_signature(llvm::Value *func,
                                std::vector<llvm::Value *> arglist) {
-  auto func_type = func->getType()->getPointerElementType();
+  llvm::FunctionType *func_type = nullptr;
+  if (llvm::Function *fn = llvm::dyn_cast<llvm::Function>(func)) {
+    func_type = fn->getFunctionType();
+  } else if (auto *call = llvm::dyn_cast<llvm::CallInst>(func)) {
+    func_type = llvm::cast_or_null<llvm::FunctionType>(func->getType()->getPointerElementType()); 
+  }
   int num_params = func_type->getFunctionNumParams();
   if (func_type->isFunctionVarArg()) {
     TI_ASSERT(num_params <= arglist.size());

--- a/taichi/codegen/llvm/struct_llvm.cpp
+++ b/taichi/codegen/llvm/struct_llvm.cpp
@@ -240,10 +240,18 @@ void StructCompilerLLVM::generate_child_accessors(SNode &snode) {
       args.push_back(&arg);
     }
     llvm::Value *ret;
+#ifdef TI_LLVM_15
+    ret = builder.CreateGEP(get_llvm_element_type(module.get(), parent),
+                            builder.CreateBitCast(args[0], inp_type),
+                            {tlctx_->get_constant(0),
+                             tlctx_->get_constant(parent->child_id(&snode))},
+                            "getch");
+#else
     ret = builder.CreateGEP(builder.CreateBitCast(args[0], inp_type),
                             {tlctx_->get_constant(0),
                              tlctx_->get_constant(parent->child_id(&snode))},
                             "getch");
+#endif
 
     builder.CreateRet(
         builder.CreateBitCast(ret, llvm::Type::getInt8PtrTy(*llvm_ctx_)));
@@ -293,7 +301,12 @@ llvm::Type *StructCompilerLLVM::get_stub(llvm::Module *module,
                                          uint32 index) {
   TI_ASSERT(module);
   TI_ASSERT(snode);
+#ifdef TI_LLVM_15
+  auto stub = llvm::StructType::getTypeByName(module->getContext(),
+                                              type_stub_name(snode));
+#else
   auto stub = module->getTypeByName(type_stub_name(snode));
+#endif
   TI_ASSERT(stub);
   TI_ASSERT(stub->getStructNumElements() == 4);
   TI_ASSERT(0 <= index && index < 4);

--- a/taichi/codegen/llvm/struct_llvm.cpp
+++ b/taichi/codegen/llvm/struct_llvm.cpp
@@ -141,7 +141,7 @@ void StructCompilerLLVM::generate_types(SNode &snode) {
 
   // Create a dummy function in the module with the type stub as return type
   // so that the type is referenced in the module
-  auto ft = llvm::FunctionType::get(llvm::PointerType::get(stub, 0), false);
+  auto ft = llvm::FunctionType::get(stub, false);
   create_function(ft, type_stub_name(&snode) + "_func");
 }
 

--- a/taichi/codegen/wasm/codegen_wasm.cpp
+++ b/taichi/codegen/wasm/codegen_wasm.cpp
@@ -64,12 +64,17 @@ class CodeGenLLVMWASM : public CodeGenLLVM {
       // test block
       builder->SetInsertPoint(loop_test);
       llvm::Value *cond;
+#ifdef TI_LLVM_15
+      auto *loop_var_load = builder->CreateLoad(begin->getType(), loop_var);
+#else
+      auto *loop_var_load = builder->CreateLoad(loop_var);
+#endif
       if (!stmt->reversed) {
         cond = builder->CreateICmp(llvm::CmpInst::Predicate::ICMP_SLT,
-                                   builder->CreateLoad(loop_var), end);
+                                   loop_var_load, end);
       } else {
         cond = builder->CreateICmp(llvm::CmpInst::Predicate::ICMP_SGE,
-                                   builder->CreateLoad(loop_var), begin);
+                                   loop_var_load, begin);
       }
       builder->CreateCondBr(cond, body, after_loop);
     }

--- a/taichi/runtime/cpu/jit_cpu.cpp
+++ b/taichi/runtime/cpu/jit_cpu.cpp
@@ -165,7 +165,7 @@ class JITSessionCPU : public JITSession {
     global_optimize_module_cpu(M.get());
     std::lock_guard<std::mutex> _(mut_);
 #ifdef TI_LLVM_15
-    auto &dylib_expect = es_.createJITDylib(fmt::format("{}", module_counter_));
+    auto dylib_expect = es_.createJITDylib(fmt::format("{}", module_counter_));
     TI_ASSERT(dylib_expect);
     auto &dylib = dylib_expect.get();
 #else

--- a/taichi/runtime/cuda/jit_cuda.cpp
+++ b/taichi/runtime/cuda/jit_cuda.cpp
@@ -89,9 +89,9 @@ std::string JITSessionCUDA::compile_module_to_ptx(
   }
 
   for (auto &f : module->globals())
-    f.setName(convert(f.getName()));
+    f.setName(convert(f.getName().str()));
   for (auto &f : *module)
-    f.setName(convert(f.getName()));
+    f.setName(convert(f.getName().str()));
 
   llvm::Triple triple(module->getTargetTriple());
 
@@ -103,7 +103,10 @@ std::string JITSessionCUDA::compile_module_to_ptx(
   TI_ERROR_UNLESS(target, err_str);
 
   TargetOptions options;
+#ifndef TI_LLVM_15
+  // PrintMachineCode is removed in https://reviews.llvm.org/D83275.
   options.PrintMachineCode = 0;
+#endif
   if (this->config_->fast_math) {
     options.AllowFPOpFusion = FPOpFusion::Fast;
     // See NVPTXISelLowering.cpp
@@ -121,7 +124,10 @@ std::string JITSessionCUDA::compile_module_to_ptx(
   options.HonorSignDependentRoundingFPMathOption = 0;
   options.NoZerosInBSS = 0;
   options.GuaranteedTailCallOpt = 0;
+#ifndef TI_LLVM_15
+  // StackAlignmentOverride is removed in https://reviews.llvm.org/D103048.
   options.StackAlignmentOverride = 0;
+#endif
 
   std::unique_ptr<TargetMachine> target_machine(target->createTargetMachine(
       triple.str(), CUDAContext::get_instance().get_mcpu(), cuda_mattrs(),

--- a/taichi/runtime/cuda/jit_cuda.h
+++ b/taichi/runtime/cuda/jit_cuda.h
@@ -15,7 +15,11 @@
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
+#ifdef TI_LLVM_15
+#include "llvm/MC/TargetRegistry.h"
+#else
 #include "llvm/Support/TargetRegistry.h"
+#endif
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 


### PR DESCRIPTION
Still use clang10 for COMPILE_LLVM_RUNTIME.
Most changes are related to the opaque ptr change in llvm 15.
It requires type when create Load and GEP. It would be nice to generate the type from taichi type.

Known issue.
Still some getPointerElementType use which is Deprecated for llvm 15.
Also some cases use hack to get llvm type for Load/GEP.

Only tested python tests/run_tests.py -v -t3 -a cpu -s on windows.
2 crashes.
crashes:
  fp16 crash for my hw not support fp16 for vulkan.
  element_wise crashed in llvm slp-vectorizer pass on skylake cpu, Already fixed upstream llvm.

Also tested clang15 for COMPILE_LLVM_RUNTIME, same result.

Related issue = #5276

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
