### PR TITLE
[AOT] Save AOT module artifacts as zip archive

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -1,8 +1,8 @@
 from contextlib import contextmanager
 from glob import glob
 from pathlib import Path, PurePosixPath
-from random import randint
 from shutil import rmtree
+from tempfile import mkdtemp
 from zipfile import ZipFile
 
 from taichi.aot.utils import (produce_injected_args,
@@ -215,13 +215,7 @@ class Module:
         tcm_path = Path(filepath).absolute()
         assert tcm_path.parent.exists(), "Output directory doesn't exist"
 
-        temp_dir = None
-        while temp_dir is None:
-            temp_dir = Path(f"{tcm_path.parent}/_{randint(10000, 100000)}")
-            if temp_dir.exists():
-                temp_dir = None
-
-        Path.mkdir(temp_dir)
+        temp_dir = mkdtemp(prefix="tcm_")
         # Save first as usual.
         self.save(temp_dir, "")
 

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -11,7 +11,9 @@ from taichi.lang import impl, kernel_impl
 from taichi.lang.field import ScalarField
 from taichi.lang.matrix import MatrixField
 from taichi.types.annotations import template
+
 import taichi
+
 
 class KernelTemplate:
     def __init__(self, kernel_fn, aot_module):
@@ -226,7 +228,8 @@ class Module:
         # Package all artifacts into a zip archive and attach contend data.
         with ZipFile(tcm_path, "w") as zip:
             zip.writestr("__content__", '\n'.join(self._content))
-            zip.writestr("__version__", '.'.join(str(x) for x in taichi.__version__))
+            zip.writestr("__version__",
+                         '.'.join(str(x) for x in taichi.__version__))
             for path in glob(f"{temp_dir}/*", recursive=True):
                 zip.write(path, Path.relative_to(Path(path), temp_dir))
 

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -11,7 +11,7 @@ from taichi.lang import impl, kernel_impl
 from taichi.lang.field import ScalarField
 from taichi.lang.matrix import MatrixField
 from taichi.types.annotations import template
-
+import taichi
 
 class KernelTemplate:
     def __init__(self, kernel_fn, aot_module):
@@ -226,6 +226,7 @@ class Module:
         # Package all artifacts into a zip archive and attach contend data.
         with ZipFile(tcm_path, "w") as zip:
             zip.writestr("__content__", '\n'.join(self._content))
+            zip.writestr("__version__", '.'.join(str(x) for x in taichi.__version__))
             for path in glob(f"{temp_dir}/*", recursive=True):
                 zip.write(path, Path.relative_to(Path(path), temp_dir))
 

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -216,7 +216,7 @@ class Module:
         assert tcm_path.parent.exists(), "Output directory doesn't exist"
 
         temp_dir = None
-        while temp_dir == None:
+        while temp_dir is None:
             temp_dir = Path(f"{tcm_path.parent}/_{randint(10000, 100000)}")
             if temp_dir.exists():
                 temp_dir = None
@@ -226,12 +226,12 @@ class Module:
         self.save(temp_dir, "")
 
         # Package all artifacts into a zip archive and attach contend data.
-        with ZipFile(tcm_path, "w") as zip:
-            zip.writestr("__content__", '\n'.join(self._content))
-            zip.writestr("__version__",
-                         '.'.join(str(x) for x in taichi.__version__))
+        with ZipFile(tcm_path, "w") as z:
+            z.writestr("__content__", '\n'.join(self._content))
+            z.writestr("__version__",
+                       '.'.join(str(x) for x in taichi.__version__))
             for path in glob(f"{temp_dir}/*", recursive=True):
-                zip.write(path, Path.relative_to(Path(path), temp_dir))
+                z.write(path, Path.relative_to(Path(path), temp_dir))
 
         # Remove cached files
         rmtree(temp_dir)

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -557,6 +557,7 @@ def test_aot_ndarray_template_mixed():
             args_count = res['aot_data']['kernels']['run']['args_count']
             assert args_count == 2, res  # `arr` and `val1`
 
+
 @test_utils.test(arch=[ti.vulkan])
 def test_archive():
     density = ti.field(float, shape=(4, 4))
@@ -574,4 +575,5 @@ def test_archive():
         tcm_path = f"{tmpdir}/x.tcm"
         m.archive(tcm_path)
         with zipfile.ZipFile(tcm_path, 'r') as z:
-            assert z.read("__version__") == bytes('.'.join(str(x) for x in ti.__version__), 'utf-8')
+            assert z.read("__version__") == bytes(
+                '.'.join(str(x) for x in ti.__version__), 'utf-8')

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import tempfile
+import zipfile
 
 import numpy as np
 import pytest
@@ -555,3 +556,22 @@ def test_aot_ndarray_template_mixed():
             res = json.load(json_file)
             args_count = res['aot_data']['kernels']['run']['args_count']
             assert args_count == 2, res  # `arr` and `val1`
+
+@test_utils.test(arch=[ti.vulkan])
+def test_archive():
+    density = ti.field(float, shape=(4, 4))
+
+    @ti.kernel
+    def init():
+        for i, j in density:
+            density[i, j] = 1
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # note ti.aot.Module(ti.opengl) is no-op according to its docstring.
+        m = ti.aot.Module(ti.lang.impl.current_cfg().arch)
+        m.add_field('density', density)
+        m.add_kernel(init)
+        tcm_path = f"{tmpdir}/x.tcm"
+        m.archive(tcm_path)
+        with zipfile.ZipFile(tcm_path, 'r') as z:
+            assert z.read("__version__") == bytes('.'.join(str(x) for x in ti.__version__), 'utf-8')


### PR DESCRIPTION
AOT modules atm are saved as a list of files which leads to extra complexity importing to Unity. Unity only allows the user to load one file at a time via its provided Assets APIs for consistent cross-platform behavior; and files of different extensions will be imported as different C# types, making it frustratingly difficult to write glue codes.

This PR provides a (maybe temporary) solution to pack all baked files and metadata to a single zip. You only need to apply a minor change to shift from the existing `save` API to the zip API.

```diff
mod = ti.aot.Module(ti.vulkan)
mod.add_kernel(fractal,
                template_args={
                    'canvas': canvas,
                })
- mod.save("Assets/Resources/TaichiModules/module_directory", '')
+ mod.archive("Assets/Resources/TaichiModules/module_file.tcm")
```

In the generated zip archive (`.tcm`), you will find the following files:

- `__content__` - A list of names of kernels and compute graphs available in this module archive;
- `__version__` - Taichi compiler version (e.g. `1.0.4` atm);
- Compiled artifacts (`*.tcb`, `*.spv`, ...)

