### PR TITLE
[AOT] Fixed certain crashes in C-API

### DIFF
--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -277,7 +277,8 @@ void ti_launch_compute_graph(TiRuntime runtime,
 
   Runtime &runtime2 = *((Runtime *)runtime);
   std::unordered_map<std::string, taichi::lang::aot::IValue> arg_map{};
-  std::vector<taichi::lang::Ndarray> ndarrays{};
+  std::vector<taichi::lang::Ndarray> ndarrays;
+  ndarrays.reserve(arg_count);
 
   for (uint32_t i = 0; i < arg_count; ++i) {
     const auto &arg = args[i];
@@ -304,12 +305,15 @@ void ti_launch_compute_graph(TiRuntime runtime,
           return;
         }
         const TiNdArray &ndarray = arg.argument.value.ndarray;
-
+        
         std::vector<int> shape(ndarray.shape.dims,
                                ndarray.shape.dims + ndarray.shape.dim_count);
 
+        std::vector<int> elem_shape(ndarray.elem_shape.dims,
+                                    ndarray.elem_shape.dims + ndarray.elem_shape.dim_count);
+        
         ndarrays.emplace_back(taichi::lang::Ndarray(
-            devalloc, taichi::lang::PrimitiveType::f32, shape));
+            devalloc, taichi::lang::PrimitiveType::f32, shape, elem_shape));
         arg_map.emplace(std::make_pair(
             arg.name, taichi::lang::aot::IValue::create(ndarrays.back())));
         break;

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -305,13 +305,14 @@ void ti_launch_compute_graph(TiRuntime runtime,
           return;
         }
         const TiNdArray &ndarray = arg.argument.value.ndarray;
-        
+
         std::vector<int> shape(ndarray.shape.dims,
                                ndarray.shape.dims + ndarray.shape.dim_count);
 
-        std::vector<int> elem_shape(ndarray.elem_shape.dims,
-                                    ndarray.elem_shape.dims + ndarray.elem_shape.dim_count);
-        
+        std::vector<int> elem_shape(
+            ndarray.elem_shape.dims,
+            ndarray.elem_shape.dims + ndarray.elem_shape.dim_count);
+
         ndarrays.emplace_back(taichi::lang::Ndarray(
             devalloc, taichi::lang::PrimitiveType::f32, shape, elem_shape));
         arg_map.emplace(std::make_pair(

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -22,8 +22,6 @@ VulkanRuntimeImported::Workaround::Workaround(
   }
   taichi::lang::vulkan::VulkanLoader::instance().load_instance(params.instance);
   taichi::lang::vulkan::VulkanLoader::instance().load_device(params.device);
-  vk_device.init_vulkan_structs(
-      const_cast<taichi::lang::vulkan::VulkanDevice::Params &>(params));
   vk_device.set_cap(taichi::lang::DeviceCapability::vk_api_version,
                     api_version);
   if (api_version > VK_API_VERSION_1_0) {
@@ -31,6 +29,8 @@ VulkanRuntimeImported::Workaround::Workaround(
         taichi::lang::DeviceCapability::spirv_has_physical_storage_buffer,
         true);
   }
+  vk_device.init_vulkan_structs(
+      const_cast<taichi::lang::vulkan::VulkanDevice::Params &>(params));
 }
 VulkanRuntimeImported::VulkanRuntimeImported(
     uint32_t api_version,


### PR DESCRIPTION
This PR fixed certain crashes with C-API.
- Initialization call order for imported Vulkan runtime was wrong;
- Named NDArray argument map allocation were not stable.