### PR TITLE
[autodiff] Handle field accessing by zero for forward mode

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -276,7 +276,12 @@ class FwdMode:
 
         # Set seed for each variable
         if len(self.seed) == 1:
-            self.parameters.dual[None] = 1.0 * self.seed[0]
+            if not self.parameters.shape:
+                # e.g., x= ti.field(float, shape = ())
+                self.parameters.dual[None] = 1.0 * self.seed[0]
+            else:
+                # e.g., ti.root.dense(ti.i, 1).place(x.dual)
+                self.parameters.dual[0] = 1.0 * self.seed[0]
         else:
             for idx, s in enumerate(self.seed):
                 self.parameters.dual[idx] = 1.0 * s
@@ -306,7 +311,12 @@ class FwdMode:
     def clear_seed(self):
         # clear seed values
         if len(self.seed) == 1:
-            self.parameters.dual[None] = 0.0
+            if not self.parameters.shape:
+                # e.g., x= ti.field(float, shape = ())
+                self.parameters.dual[None] = 0.0
+            else:
+                # e.g., ti.root.dense(ti.i, 1).place(x.dual)
+                self.parameters.dual[0] = 0.0
         else:
             for idx, s in enumerate(self.seed):
                 self.parameters.dual[idx] = 0.0

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -276,7 +276,7 @@ class FwdMode:
 
         # Set seed for each variable
         if len(self.seed) == 1:
-            if not self.parameters.shape:
+            if len(self.parameters.shape) == 0:
                 # e.g., x= ti.field(float, shape = ())
                 self.parameters.dual[None] = 1.0 * self.seed[0]
             else:
@@ -311,7 +311,7 @@ class FwdMode:
     def clear_seed(self):
         # clear seed values
         if len(self.seed) == 1:
-            if not self.parameters.shape:
+            if len(self.parameters.shape) == 0:
                 # e.g., x= ti.field(float, shape = ())
                 self.parameters.dual[None] = 0.0
             else:

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -254,7 +254,7 @@ class FwdMode:
             return reduce((lambda x, y: x * y), list(shape))
 
         # Handle 0-D field
-        if len(self.parameters.shape) == 0:
+        if len(self.parameters.shape) != 0:
             parameters_shape_flatten = shape_flatten(self.parameters.shape)
         else:
             parameters_shape_flatten = 1

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -254,7 +254,7 @@ class FwdMode:
             return reduce((lambda x, y: x * y), list(shape))
 
         # Handle 0-D field
-        if self.parameters.shape:
+        if len(self.parameters.shape) == 0:
             parameters_shape_flatten = shape_flatten(self.parameters.shape)
         else:
             parameters_shape_flatten = 1

--- a/tests/python/test_ad_basics_fwd.py
+++ b/tests/python/test_ad_basics_fwd.py
@@ -82,7 +82,7 @@ def test_multiple_calls():
 
 
 @test_utils.test()
-def test_handle_zero_shape():
+def test_handle_shape_accessed_by_zero():
     a = ti.field(float)
     b = ti.field(float)
     ti.root.dense(ti.i, 1).place(a, b, a.dual, b.dual)
@@ -96,7 +96,7 @@ def test_handle_zero_shape():
 
 
 @test_utils.test()
-def test_handle_none_shape():
+def test_handle_shape_accessed_by_none():
     c = ti.field(float, shape=())
     d = ti.field(float, shape=())
     ti.root.lazy_dual()

--- a/tests/python/test_ad_basics_fwd.py
+++ b/tests/python/test_ad_basics_fwd.py
@@ -79,3 +79,31 @@ def test_multiple_calls():
                        seed=[1.0 for _ in range(N)]):
         multiple_calls()
     assert loss_2.dual[None] == 48
+
+
+@test_utils.test()
+def test_handle_zero_shape():
+    a = ti.field(float)
+    b = ti.field(float)
+    ti.root.dense(ti.i, 1).place(a, b, a.dual, b.dual)
+
+    @ti.kernel
+    def func():
+        pass
+
+    with ti.ad.FwdMode(loss=b, parameters=a):
+        func()
+
+
+@test_utils.test()
+def test_handle_none_shape():
+    c = ti.field(float, shape=())
+    d = ti.field(float, shape=())
+    ti.root.lazy_dual()
+
+    @ti.kernel
+    def func():
+        pass
+
+    with ti.ad.FwdMode(loss=d, parameters=c):
+        func()


### PR DESCRIPTION
Related issue = #5055 
To handle the case similar to `ti.root.dense(ti.i, 1).place(a, b, a.dual, b.dual)`. In this case, the field shape is one but not none comparing to `a = ti.field(float, shape=())`.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
