### PR TITLE
[refactor] Turn off stack traceback info by default

### DIFF
--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -454,7 +454,7 @@ def init(arch=None,
 
     impl._root_fb = _snode.FieldsBuilder()
 
-    if not os.environ.get("TI_DISABLE_SIGNAL_HANDLERS", False):
+    if cfg.debug:
         impl.get_runtime()._register_signal_handlers()
 
     # Recover the current working directory (https://github.com/taichi-dev/taichi/issues/4811)


### PR DESCRIPTION
When Taichi program crashes we used to show a `Taichi Compiler Stack
Traceback` (a.k.a purple stack, example shown below) but this stack doesn't have enough symbol for developers, nor
it's readable for normal Taichi python users. So let's turn it off by
default to avoid confusion.
```
***********************************
* Taichi Compiler Stack Traceback *
***********************************
/home/ailing/github/taichi/python/taichi/_lib/core/taichi_core.cpython-38-x86_64-linux-gnu.so: taichi::Logger::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)
/home/ailing/github/taichi/python/taichi/_lib/core/taichi_core.cpython-38-x86_64-linux-gnu.so(+0x503753) [0x7f0d4bd19753]
/home/ailing/github/taichi/python/taichi/_lib/core/taichi_core.cpython-38-x86_64-linux-gnu.so(+0x503317) [0x7f0d4bd19317]
/home/ailing/github/taichi/python/taichi/_lib/core/taichi_core.cpython-38-x86_64-linux-gnu.so(+0x808a2d) [0x7f0d4c01ea2d]
/home/ailing/github/taichi/python/taichi/_lib/core/taichi_core.cpython-38-x86_64-linux-gnu.so(+0x7194b5) [0x7f0d4bf2f4b5]
python(+0x13c8ee) [0x55db2635b8ee]
python(_PyObject_MakeTpCall+0x3bf) [0x55db2635075f]
python(+0x166a80) [0x55db26385a80]
python(_PyEval_EvalFrameDefault+0x4fb3) [0x55db263f9b63]
python(_PyEval_EvalCodeWithName+0x260) [0x55db263eb480]
python(_PyFunction_Vectorcall+0x594) [0x55db263eca44]
python(_PyEval_EvalFrameDefault+0x4c0) [0x55db263f5070]
python(_PyEval_EvalCodeWithName+0xd52) [0x55db263ebf72]
python(_PyFunction_Vectorcall+0x594) [0x55db263eca44]
python(_PyEval_EvalFrameDefault+0x71b) [0x55db263f52cb]
python(_PyEval_EvalCodeWithName+0x260) [0x55db263eb480]
python(PyEval_EvalCode+0x23) [0x55db263ecd33]
python(+0x2414a2) [0x55db264604a2]
python(+0x252292) [0x55db26471292]
python(+0x25542b) [0x55db2647442b]
python(PyRun_SimpleFileExFlags+0x1bf) [0x55db2647460f]
python(Py_RunMain+0x3a9) [0x55db26474ae9]
python(Py_BytesMain+0x39) [0x55db26474ce9]
/lib/x86_64-linux-gnu/libc.so.6: __libc_start_main
python(+0x1f7847) [0x55db26416847]
```

Just in case someone still needs it, it can be brought back if you do
`ti.init(debug=True)`.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
