### PR TITLE
[llvm] [refactor] (Decomp of #5251 2/n) Make modulegen a virtual function and let LLVMCompiledData replace ModuleGenValue

### DIFF
--- a/taichi/codegen/codegen.h
+++ b/taichi/codegen/codegen.h
@@ -1,9 +1,14 @@
 // Driver class for kernel code generators.
 
 #pragma once
-
+#include "taichi/ir/ir.h"
 #include "taichi/program/program.h"
-
+#ifdef TI_WITH_LLVM
+#include "llvm/IR/Module.h"
+#include "taichi/codegen/llvm/codegen_llvm.h"
+#include "taichi/runtime/llvm/launch_arg_info.h"
+#include "taichi/codegen/llvm/llvm_codegen_utils.h"
+#endif
 TLANG_NAMESPACE_BEGIN
 
 class KernelCodeGen {
@@ -22,6 +27,11 @@ class KernelCodeGen {
                                                Stmt *stmt = nullptr);
 
   virtual FunctionType codegen() = 0;
+  virtual LLVMCompiledData modulegen(
+      std::unique_ptr<llvm::Module> &&module = nullptr,
+      OffloadedStmt *stmt = nullptr) {
+    TI_NOT_IMPLEMENTED
+  }
 };
 
 TLANG_NAMESPACE_END

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -42,8 +42,8 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     CUDAModuleToFunctionConverter converter{tlctx,
                                             llvm_prog->get_runtime_executor()};
 
-    return converter.convert(this->kernel, std::move(compiled_res.llvm_module),
-                             std::move(compiled_res.offloaded_tasks));
+    return converter.convert(this->kernel, std::move(compiled_res.module),
+                             std::move(compiled_res.tasks));
   }
 
   llvm::Value *create_print(std::string tag,

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -44,6 +44,11 @@ class FunctionCreationGuard {
   ~FunctionCreationGuard();
 };
 
+struct LLVMCompiledData {
+  std::vector<OffloadedTask> tasks;
+  std::unique_ptr<llvm::Module> module{nullptr};
+};
+
 class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
  public:
   Kernel *kernel;
@@ -121,18 +126,15 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void eliminate_unused_functions();
 
-  struct CompiledData {
-    std::vector<OffloadedTask> offloaded_tasks;
-    std::unique_ptr<llvm::Module> llvm_module{nullptr};
-  };
+
   /**
    * @brief Runs the codegen and produces the compiled result.
    *
-   * After this call, `module` and `offloaded_tasks` will be moved.
+   * After this call, `module` and `tasks` will be moved.
    *
-   * @return CompiledData
+   * @return LLVMCompiledData
    */
-  CompiledData run_compilation();
+  LLVMCompiledData run_compilation();
 
   // TODO: This function relies largely on `run_compilation()`. Name it better.
   virtual FunctionType gen();
@@ -406,7 +408,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
  private:
   bool maybe_read_compilation_from_cache(const std::string &kernel_key,
-                                         CompiledData *data);
+                                         LLVMCompiledData *data);
 
   void cache_module(const std::string &kernel_key);
 };

--- a/taichi/codegen/wasm/codegen_wasm.h
+++ b/taichi/codegen/wasm/codegen_wasm.h
@@ -11,18 +11,6 @@
 namespace taichi {
 namespace lang {
 
-#ifdef TI_WITH_LLVM
-class ModuleGenValue {
- public:
-  ModuleGenValue(std::unique_ptr<llvm::Module> module,
-                 const std::vector<std::string> &name_list)
-      : module(std::move(module)), name_list(name_list) {
-  }
-  std::unique_ptr<llvm::Module> module;
-  std::vector<std::string> name_list;
-};
-#endif
-
 class CodeGenWASM : public KernelCodeGen {
  public:
   CodeGenWASM(Kernel *kernel, IRNode *ir = nullptr)
@@ -32,8 +20,9 @@ class CodeGenWASM : public KernelCodeGen {
   FunctionType codegen() override;
 
 #ifdef TI_WITH_LLVM
-  std::unique_ptr<ModuleGenValue> modulegen(
-      std::unique_ptr<llvm::Module> &&module);  // AOT Module Gen
+  LLVMCompiledData modulegen(
+      std::unique_ptr<llvm::Module> &&module = nullptr,
+      OffloadedStmt *stmt = nullptr) override;  // AOT Module Gen
 #endif
 };
 

--- a/taichi/runtime/cpu/aot_module_builder_impl.cpp
+++ b/taichi/runtime/cpu/aot_module_builder_impl.cpp
@@ -9,7 +9,7 @@ namespace taichi {
 namespace lang {
 namespace cpu {
 
-CodeGenLLVM::CompiledData AotModuleBuilderImpl::compile_kernel(Kernel *kernel) {
+LLVMCompiledData AotModuleBuilderImpl::compile_kernel(Kernel *kernel) {
   auto cgen = CodeGenCPU::make_codegen_llvm(kernel, /*ir=*/nullptr);
   return cgen->run_compilation();
 }

--- a/taichi/runtime/cpu/aot_module_builder_impl.h
+++ b/taichi/runtime/cpu/aot_module_builder_impl.h
@@ -15,7 +15,7 @@ class AotModuleBuilderImpl : public LlvmAotModuleBuilder {
   }
 
  private:
-  CodeGenLLVM::CompiledData compile_kernel(Kernel *kernel) override;
+  LLVMCompiledData compile_kernel(Kernel *kernel) override;
 };
 
 }  // namespace cpu

--- a/taichi/runtime/cuda/aot_module_builder_impl.cpp
+++ b/taichi/runtime/cuda/aot_module_builder_impl.cpp
@@ -9,7 +9,7 @@ namespace taichi {
 namespace lang {
 namespace cuda {
 
-CodeGenLLVM::CompiledData AotModuleBuilderImpl::compile_kernel(Kernel *kernel) {
+LLVMCompiledData AotModuleBuilderImpl::compile_kernel(Kernel *kernel) {
   auto cgen = CodeGenCUDA::make_codegen_llvm(kernel, /*ir=*/nullptr);
   return cgen->run_compilation();
 }

--- a/taichi/runtime/cuda/aot_module_builder_impl.h
+++ b/taichi/runtime/cuda/aot_module_builder_impl.h
@@ -15,7 +15,7 @@ class AotModuleBuilderImpl : public LlvmAotModuleBuilder {
   }
 
  private:
-  CodeGenLLVM::CompiledData compile_kernel(Kernel *kernel) override;
+  LLVMCompiledData compile_kernel(Kernel *kernel) override;
 };
 
 }  // namespace cuda

--- a/taichi/runtime/llvm/llvm_aot_module_builder.cpp
+++ b/taichi/runtime/llvm/llvm_aot_module_builder.cpp
@@ -22,9 +22,9 @@ void LlvmAotModuleBuilder::add_per_backend(const std::string &identifier,
   auto compiled = compile_kernel(kernel);
   LlvmOfflineCache::KernelCacheData kcache;
   kcache.kernel_key = identifier;
-  kcache.module = compiled.llvm_module.get();
-  kcache.owned_module = std::move(compiled.llvm_module);
-  const auto &tasks = compiled.offloaded_tasks;
+  kcache.module = compiled.module.get();
+  kcache.owned_module = std::move(compiled.module);
+  const auto &tasks = compiled.tasks;
   kcache.args = infer_launch_args(kernel);
   kcache.offloaded_task_list.resize(tasks.size());
   std::transform(tasks.begin(), tasks.end(), kcache.offloaded_task_list.begin(),

--- a/taichi/runtime/llvm/llvm_aot_module_builder.h
+++ b/taichi/runtime/llvm/llvm_aot_module_builder.h
@@ -17,7 +17,7 @@ class LlvmAotModuleBuilder : public AotModuleBuilder {
 
  protected:
   void add_per_backend(const std::string &identifier, Kernel *kernel) override;
-  virtual CodeGenLLVM::CompiledData compile_kernel(Kernel *kernel) = 0;
+  virtual LLVMCompiledData compile_kernel(Kernel *kernel) = 0;
 
   void add_field_per_backend(const std::string &identifier,
                              const SNode *rep_snode,

--- a/taichi/runtime/wasm/aot_module_builder_impl.cpp
+++ b/taichi/runtime/wasm/aot_module_builder_impl.cpp
@@ -36,10 +36,10 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
 void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
                                            Kernel *kernel) {
   auto module_info = CodeGenWASM(kernel, nullptr).modulegen(std::move(module_));
-  module_ = std::move(module_info->module);
+  module_ = std::move(module_info.module);
 
-  for (auto &name : module_info->name_list)
-    name_list_.push_back(name);
+  for (auto &task : module_info.tasks)
+    name_list_.push_back(task.name);
 }
 
 void AotModuleBuilderImpl::add_field_per_backend(const std::string &identifier,


### PR DESCRIPTION
Related issue = #5252
Decomposition of #5251

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
