### PR TITLE
[test] Check repeated arg names in cgraph

### DIFF
--- a/taichi/aot/graph_data.h
+++ b/taichi/aot/graph_data.h
@@ -58,6 +58,11 @@ struct Arg {
     return PrimitiveType::get(dtype_id);
   }
 
+  bool operator==(const Arg &other) const {
+    return tag == other.tag && name == other.name &&
+           dtype_id == other.dtype_id && element_shape == other.element_shape;
+  }
+
   TI_IO_DEF(name, dtype_id, tag, element_shape);
 };
 

--- a/taichi/program/graph_builder.cpp
+++ b/taichi/program/graph_builder.cpp
@@ -37,6 +37,13 @@ GraphBuilder::GraphBuilder() {
 
 Node *GraphBuilder::new_dispatch_node(Kernel *kernel,
                                       const std::vector<aot::Arg> &args) {
+  for (const auto &arg : args) {
+    if (all_args_.find(arg.name) != all_args_.end()) {
+      TI_ASSERT(all_args_[arg.name] == arg);
+    } else {
+      all_args_[arg.name] = arg;
+    }
+  }
   all_nodes_.push_back(std::make_unique<Dispatch>(kernel, args));
   return all_nodes_.back().get();
 }

--- a/taichi/program/graph_builder.h
+++ b/taichi/program/graph_builder.h
@@ -73,6 +73,7 @@ class GraphBuilder {
 
  private:
   std::unique_ptr<Sequential> seq_{nullptr};
+  std::unordered_map<std::string, aot::Arg> all_args_;
   std::vector<std::unique_ptr<Node>> all_nodes_;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5363
* #5362
* #5361
* __->__ #5360

Arg name should be an unique identifier in the same graph so adding a
test to prevent two different args having the same name.