### PR TITLE
[refactor] Check field_dim mismatch in cgraph compilation and runtime

### DIFF
--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -37,10 +37,12 @@ def produce_injected_args(kernel, symbolic_args=None):
             if symbolic_args is not None:
                 element_shape = tuple(symbolic_args[i].element_shape)
                 element_dim = len(element_shape)
+                field_dim = symbolic_args[i].field_dim
                 dtype = symbolic_args[i].dtype()
             else:
                 element_shape = anno.element_shape
                 element_dim = anno.element_dim
+                field_dim = anno.field_dim
                 dtype = anno.dtype
 
             if element_shape is None or anno.field_dim is None:
@@ -48,6 +50,11 @@ def produce_injected_args(kernel, symbolic_args=None):
                     'Please either specify both `element_shape` and `field_dim` '
                     'in the param annotation, or provide an example '
                     f'ndarray for param={arg.name}')
+            if field_dim != anno.field_dim:
+                raise TaichiCompilationError(
+                    f'{field_dim} from Arg {arg.name} doesn\'t match kernel\'s annotated field_dim={anno.field_dim}'
+                )
+
             if element_dim is None or element_dim == 0:
                 injected_args.append(
                     ScalarNdarray(dtype, (2, ) * anno.field_dim))

--- a/python/taichi/examples/graph/mpm88_graph.py
+++ b/python/taichi/examples/graph/mpm88_graph.py
@@ -115,21 +115,31 @@ def main():
         sym_x = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                              'x',
                              ti.f32,
+                             field_dim=1,
                              element_shape=(2, ))
         sym_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                              'v',
                              ti.f32,
+                             field_dim=1,
                              element_shape=(2, ))
         sym_C = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                              'C',
                              ti.f32,
+                             field_dim=1,
                              element_shape=(2, 2))
-        sym_J = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'J', ti.f32)
+        sym_J = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                             'J',
+                             ti.f32,
+                             field_dim=1)
         sym_grid_v = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                                   'grid_v',
                                   ti.f32,
+                                  field_dim=2,
                                   element_shape=(2, ))
-        sym_grid_m = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'grid_m', ti.f32)
+        sym_grid_m = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                                  'grid_m',
+                                  ti.f32,
+                                  field_dim=2)
         g_init_builder = ti.graph.GraphBuilder()
         g_init_builder.dispatch(init_particles, sym_x, sym_v, sym_J)
 

--- a/python/taichi/examples/graph/stable_fluid_graph.py
+++ b/python/taichi/examples/graph/stable_fluid_graph.py
@@ -243,27 +243,39 @@ def main():
         velocities_pair_cur = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                                            'velocities_pair_cur',
                                            ti.f32,
+                                           field_dim=2,
                                            element_shape=(2, ))
         velocities_pair_nxt = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                                            'velocities_pair_nxt',
                                            ti.f32,
+                                           field_dim=2,
                                            element_shape=(2, ))
         dyes_pair_cur = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                                      'dyes_pair_cur',
                                      ti.f32,
+                                     field_dim=2,
                                      element_shape=(3, ))
         dyes_pair_nxt = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                                      'dyes_pair_nxt',
                                      ti.f32,
+                                     field_dim=2,
                                      element_shape=(3, ))
         pressures_pair_cur = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
-                                          'pressures_pair_cur', ti.f32)
+                                          'pressures_pair_cur',
+                                          ti.f32,
+                                          field_dim=2)
         pressures_pair_nxt = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
-                                          'pressures_pair_nxt', ti.f32)
-        velocity_divs = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'velocity_divs',
-                                     ti.f32)
-        mouse_data = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'mouse_data',
-                                  ti.f32)
+                                          'pressures_pair_nxt',
+                                          ti.f32,
+                                          field_dim=2)
+        velocity_divs = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                                     'velocity_divs',
+                                     ti.f32,
+                                     field_dim=2)
+        mouse_data = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                                  'mouse_data',
+                                  ti.f32,
+                                  field_dim=1)
 
         g1_builder = ti.graph.GraphBuilder()
         g1_builder.dispatch(advect, velocities_pair_cur, velocities_pair_cur,

--- a/python/taichi/graph/_graph.py
+++ b/python/taichi/graph/_graph.py
@@ -95,7 +95,7 @@ class Graph:
         self._compiled_graph.run(arg_ptrs, arg_ints, arg_floats, arg_doubles)
 
 
-def Arg(tag, name, dtype, element_shape=()):
+def Arg(tag, name, dtype, field_dim=0, element_shape=()):
     if isinstance(dtype, MatrixType):
         if len(element_shape) > 0:
             raise TaichiRuntimeError(
@@ -109,12 +109,12 @@ def Arg(tag, name, dtype, element_shape=()):
             for _ in range(mat_type.m):
                 arg_sublist.append(
                     _ti_core.Arg(tag, f'{name}_mat_arg_{i}', dtype.dtype,
-                                 element_shape))
+                                 field_dim, element_shape))
                 i += 1
             arg_list.append(arg_sublist)
         return arg_list
 
-    return _ti_core.Arg(tag, name, dtype, element_shape)
+    return _ti_core.Arg(tag, name, dtype, field_dim, element_shape)
 
 
 __all__ = ['GraphBuilder', 'Graph', 'Arg', 'ArgKind']

--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -25,6 +25,11 @@ void CompiledGraph::run(
         TI_ERROR_IF(arr->element_shape != symbolic_arg.element_shape,
                     "Mismatched shape information for argument {}",
                     symbolic_arg.name);
+        TI_ERROR_IF(arr->shape.size() != symbolic_arg.field_dim,
+                    "Dispatch node is compiled for argument {} with "
+                    "field_dim={} but got an ndarray with field_dim={}",
+                    symbolic_arg.name, symbolic_arg.field_dim,
+                    arr->shape.size());
 
         set_runtime_ctx_ndarray(&ctx, i, arr);
       } else if (ival.tag == aot::ArgKind::kScalar) {

--- a/taichi/aot/graph_data.h
+++ b/taichi/aot/graph_data.h
@@ -28,6 +28,7 @@ struct Arg {
   std::string name;
   // TODO: real element dtype = dtype + element_shape
   PrimitiveTypeID dtype_id;
+  size_t field_dim;
   std::vector<int> element_shape;
 
   // For serialization & deserialization
@@ -35,22 +36,34 @@ struct Arg {
       : tag(ArgKind::kUnknown),
         name(""),
         dtype_id(PrimitiveTypeID::unknown),
+        field_dim(0),
         element_shape({}) {
   }
 
   explicit Arg(ArgKind tag,
                const std::string &name,
+
                PrimitiveTypeID dtype_id,
+               size_t field_dim,
                const std::vector<int> &element_shape)
-      : tag(tag), name(name), dtype_id(dtype_id), element_shape(element_shape) {
+      : tag(tag),
+        name(name),
+        dtype_id(dtype_id),
+        field_dim(field_dim),
+        element_shape(element_shape) {
   }
 
   // Python/C++ interface that's user facing.
   explicit Arg(ArgKind tag,
                const std::string &name,
+
                const DataType &dtype,
+               size_t field_dim = 0,
                const std::vector<int> &element_shape = {})
-      : tag(tag), name(name), element_shape(element_shape) {
+      : tag(tag),
+        name(name),
+        field_dim(field_dim),
+        element_shape(element_shape) {
     dtype_id = dtype->as<PrimitiveType>()->type;
   }
 
@@ -60,10 +73,11 @@ struct Arg {
 
   bool operator==(const Arg &other) const {
     return tag == other.tag && name == other.name &&
-           dtype_id == other.dtype_id && element_shape == other.element_shape;
+           field_dim == other.field_dim && dtype_id == other.dtype_id &&
+           element_shape == other.element_shape;
   }
 
-  TI_IO_DEF(name, dtype_id, tag, element_shape);
+  TI_IO_DEF(name, dtype_id, field_dim, tag, element_shape);
 };
 
 /**

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -592,11 +592,13 @@ void export_lang(py::module &m) {
       .export_values();
 
   py::class_<aot::Arg>(m, "Arg")
-      .def(py::init<aot::ArgKind, std::string, DataType &, std::vector<int>>(),
+      .def(py::init<aot::ArgKind, std::string, DataType &, size_t,
+                    std::vector<int>>(),
            py::arg("tag"), py::arg("name"), py::arg("dtype"),
-           py::arg("element_shape") = py::tuple())
+           py::arg("field_dim"), py::arg("element_shape"))
       .def_readonly("name", &aot::Arg::name)
       .def_readonly("element_shape", &aot::Arg::element_shape)
+      .def_readonly("field_dim", &aot::Arg::field_dim)
       .def("dtype", &aot::Arg::dtype);
 
   py::class_<Node>(m, "Node");

--- a/tests/cpp/aot/vulkan/aot_save_load_test.cpp
+++ b/tests/cpp/aot/vulkan/aot_save_load_test.cpp
@@ -312,7 +312,7 @@ TEST(AotSaveLoad, VulkanNdarray) {
 
   auto g_builder = std::make_unique<GraphBuilder>();
   auto seq = g_builder->seq();
-  auto arr_arg = aot::Arg{aot::ArgKind::kNdarray, "arr", PrimitiveType::i32};
+  auto arr_arg = aot::Arg{aot::ArgKind::kNdarray, "arr", PrimitiveType::i32, 1};
   seq->dispatch(ker1.get(), {arr_arg});
   seq->dispatch(ker2.get(), {arr_arg, aot::Arg{aot::ArgKind::kScalar, "x",
                                                PrimitiveType::i32}});

--- a/tests/cpp/program/graph_test.cpp
+++ b/tests/cpp/program/graph_test.cpp
@@ -30,7 +30,7 @@ TEST(GraphTest, SimpleGraphRun) {
 
   auto g_builder = std::make_unique<GraphBuilder>();
   auto seq = g_builder->seq();
-  auto arr_arg = aot::Arg{aot::ArgKind::kNdarray, "arr", PrimitiveType::i32};
+  auto arr_arg = aot::Arg{aot::ArgKind::kNdarray, "arr", PrimitiveType::i32, 1};
   seq->dispatch(ker1.get(), {arr_arg});
   seq->dispatch(ker2.get(), {arr_arg, aot::Arg{
                                           aot::ArgKind::kScalar,

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from taichi.lang.exception import TaichiCompilationError
 
 import taichi as ti
 from tests import test_utils
@@ -14,7 +15,10 @@ def test_ndarray_int():
         for i in range(n):
             pos[i] = 1
 
-    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'pos', ti.i32)
+    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                           'pos',
+                           ti.i32,
+                           field_dim=1)
     g_init = ti.graph.GraphBuilder()
     g_init.dispatch(test, sym_pos)
     g = g_init.compile()
@@ -33,7 +37,10 @@ def test_ndarray_float():
         for i in range(n):
             pos[i] = 2.5
 
-    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'pos', ti.f32)
+    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                           'pos',
+                           ti.f32,
+                           field_dim=1)
     g_init = ti.graph.GraphBuilder()
     g_init.dispatch(test, sym_pos)
     g = g_init.compile()
@@ -41,6 +48,44 @@ def test_ndarray_float():
     a = ti.ndarray(ti.f32, shape=(n, ))
     g.run({'pos': a})
     assert (a.to_numpy() == (np.ones(4) * 2.5)).all()
+
+
+@test_utils.test(arch=ti.vulkan)
+def test_arg_mismatched_field_dim():
+    n = 4
+
+    @ti.kernel
+    def test(pos: ti.types.ndarray(field_dim=1)):
+        for i in range(n):
+            pos[i] = 2.5
+
+    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                           'pos',
+                           ti.f32,
+                           field_dim=2)
+    g_init = ti.graph.GraphBuilder()
+    with pytest.raises(TaichiCompilationError,
+                       match="doesn't match kernel's annotated field_dim"):
+        g_init.dispatch(test, sym_pos)
+
+
+@test_utils.test(arch=ti.vulkan)
+def test_arg_mismatched_field_dim_ndarray():
+    n = 4
+
+    @ti.kernel
+    def test(pos: ti.types.ndarray(field_dim=1)):
+        for i in range(n):
+            pos[i] = 2.5
+
+    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'pos', ti.f32, 1)
+    g_init = ti.graph.GraphBuilder()
+    g_init.dispatch(test, sym_pos)
+    g = g_init.compile()
+
+    a = ti.ndarray(ti.f32, shape=(n, n))
+    with pytest.raises(RuntimeError, match="Dispatch node is compiled for"):
+        g.run({'pos': a})
 
 
 @test_utils.test(arch=ti.vulkan)
@@ -57,7 +102,10 @@ def test_repeated_arg_name():
         for i in range(n):
             print(v)
 
-    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'pos', ti.f32)
+    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                           'pos',
+                           ti.f32,
+                           field_dim=1)
     sym_pos1 = ti.graph.Arg(ti.graph.ArgKind.SCALAR, 'pos', ti.f32)
     builder = ti.graph.GraphBuilder()
     builder.dispatch(test1, sym_pos)
@@ -74,7 +122,7 @@ def build_graph_vector(N, dtype):
 
     sym_A = ti.graph.Arg(ti.graph.ArgKind.MATRIX, 'mat',
                          ti.types.vector(N, dtype))
-    sym_res = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'res', dtype)
+    sym_res = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'res', dtype, field_dim=1)
     builder = ti.graph.GraphBuilder()
     builder.dispatch(vector_sum, sym_A, sym_res)
     graph = builder.compile()
@@ -89,7 +137,7 @@ def build_graph_matrix(N, dtype):
 
     sym_A = ti.graph.Arg(ti.graph.ArgKind.MATRIX, 'mat',
                          ti.types.matrix(N, 2, dtype))
-    sym_res = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'res', dtype)
+    sym_res = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, 'res', dtype, field_dim=1)
     builder = ti.graph.GraphBuilder()
     builder.dispatch(matrix_sum, sym_A, sym_res)
     graph = builder.compile()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5363
* #5362
* __->__ #5361
* #5360

Field_dim of ndarray args must match among (ti kernel annotation, graph
arg, runtime ndarray).