### PR TITLE
[refactor] Check dtype mismatch in cgraph compilation and runtime

### DIFF
--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -54,7 +54,10 @@ def produce_injected_args(kernel, symbolic_args=None):
                 raise TaichiCompilationError(
                     f'{field_dim} from Arg {arg.name} doesn\'t match kernel\'s annotated field_dim={anno.field_dim}'
                 )
-
+            if dtype != anno.dtype:
+                raise TaichiCompilationError(
+                    f' Arg {arg.name}\'s dtype {dtype.to_string()} doesn\'t match kernel\'s annotated dtype={anno.dtype.to_string()}'
+                )
             if element_dim is None or element_dim == 0:
                 injected_args.append(
                     ScalarNdarray(dtype, (2, ) * anno.field_dim))
@@ -87,6 +90,15 @@ def produce_injected_args(kernel, symbolic_args=None):
                 )
             injected_args.append(Matrix([0] * anno.n * anno.m, dt=anno.dtype))
         else:
+            if symbolic_args is not None:
+                dtype = symbolic_args[i].dtype()
+            else:
+                dtype = anno
+
+            if dtype != anno:
+                raise TaichiCompilationError(
+                    f' Arg {arg.name}\'s dtype {dtype.to_string()} doesn\'t match kernel\'s annotated dtype={anno.to_string()}'
+                )
             # For primitive types, we can just inject a dummy value.
             injected_args.append(0)
     return injected_args

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -20,12 +20,13 @@ class NdarrayType:
         field_dim (Union[Int, NoneType]): None if not specified, number of field dimensions. This argument is ignored for external arrays for now.
         layout (Union[Layout, NoneType], optional): None if not specified (will be treated as Layout.AOS for external arrays), Layout.AOS or Layout.SOA.
     """
-    def __init__(self,
-                 dtype=f32,
-                 element_dim=None,
-                 element_shape=None,
-                 field_dim=None,
-                 layout=None):
+    def __init__(
+            self,
+            dtype=f32,  # TODO: default should be None
+            element_dim=None,
+            element_shape=None,
+            field_dim=None,
+            layout=None):
         if element_dim is not None and (element_dim < 0 or element_dim > 2):
             raise ValueError(
                 "Only scalars, vectors, and matrices are allowed as elements of ti.types.ndarray()"

--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -30,6 +30,11 @@ void CompiledGraph::run(
                     "field_dim={} but got an ndarray with field_dim={}",
                     symbolic_arg.name, symbolic_arg.field_dim,
                     arr->shape.size());
+        TI_ERROR_IF(arr->dtype != symbolic_arg.dtype(),
+                    "Dispatch node is compiled for argument {} with "
+                    "dtype={} but got an ndarray with dtype={}",
+                    symbolic_arg.name, symbolic_arg.dtype().to_string(),
+                    arr->dtype.to_string());
 
         set_runtime_ctx_ndarray(&ctx, i, arr);
       } else if (ival.tag == aot::ArgKind::kScalar) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5363
* __->__ #5362
* #5361
* #5360

Dtype of scalar and ndarray args must match among (kernel annotation,
graph arg, runtime scalar/ndarray).