### PR TITLE
[llvm] (Decomp of #5251 5/n) Add the parallel compilation worker to LlvmProgramImpl

### DIFF
--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -58,7 +58,7 @@ CompileConfig::CompileConfig() {
   print_kernel_llvm_ir = false;
   print_kernel_nvptx = false;
   print_kernel_llvm_ir_optimized = false;
-  compile_thread_num = 0;
+  num_compile_threads = 0;
 
   // CUDA backend options:
   device_memory_GB = 1;  // by default, preallocate 1 GB GPU memory

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -58,6 +58,7 @@ CompileConfig::CompileConfig() {
   print_kernel_llvm_ir = false;
   print_kernel_nvptx = false;
   print_kernel_llvm_ir_optimized = false;
+  compile_thread_num = 0;
 
   // CUDA backend options:
   device_memory_GB = 1;  // by default, preallocate 1 GB GPU memory

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -115,7 +115,7 @@ struct CompileConfig {
   int offline_cache_max_size_of_files{1024 * 1024};  // bytes
   double offline_cache_cleaning_factor{0.25};        // [0.f, 1.f]
 
-  int compile_thread_num{0};
+  int num_compile_threads{0};
 
   CompileConfig();
 };

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -115,6 +115,8 @@ struct CompileConfig {
   int offline_cache_max_size_of_files{1024 * 1024};  // bytes
   double offline_cache_cleaning_factor{0.25};        // [0.f, 1.f]
 
+  int compile_thread_num{0};
+
   CompileConfig();
 };
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -43,10 +43,6 @@ bool test_threading();
 TI_NAMESPACE_END
 
 TLANG_NAMESPACE_BEGIN
-void async_print_sfg();
-
-std::string async_dump_dot(std::optional<std::string> rankdir,
-                           int embed_states_threshold);
 
 Expr expr_index(const Expr &expr, const Expr &index) {
   return expr[index];
@@ -244,7 +240,8 @@ void export_lang(py::module &m) {
       .def_readwrite("offline_cache_max_size_of_files",
                      &CompileConfig::offline_cache_max_size_of_files)
       .def_readwrite("offline_cache_cleaning_factor",
-                     &CompileConfig::offline_cache_cleaning_factor);
+                     &CompileConfig::offline_cache_cleaning_factor)
+      .def_readwrite("compile_thread_num", &CompileConfig::compile_thread_num);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -43,6 +43,10 @@ bool test_threading();
 TI_NAMESPACE_END
 
 TLANG_NAMESPACE_BEGIN
+void async_print_sfg();
+
+std::string async_dump_dot(std::optional<std::string> rankdir,
+                           int embed_states_threshold);
 
 Expr expr_index(const Expr &expr, const Expr &index) {
   return expr[index];

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -245,7 +245,8 @@ void export_lang(py::module &m) {
                      &CompileConfig::offline_cache_max_size_of_files)
       .def_readwrite("offline_cache_cleaning_factor",
                      &CompileConfig::offline_cache_cleaning_factor)
-      .def_readwrite("num_compile_threads", &CompileConfig::num_compile_threads);
+      .def_readwrite("num_compile_threads",
+                     &CompileConfig::num_compile_threads);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -245,7 +245,7 @@ void export_lang(py::module &m) {
                      &CompileConfig::offline_cache_max_size_of_files)
       .def_readwrite("offline_cache_cleaning_factor",
                      &CompileConfig::offline_cache_cleaning_factor)
-      .def_readwrite("compile_thread_num", &CompileConfig::compile_thread_num);
+      .def_readwrite("num_compile_threads", &CompileConfig::num_compile_threads);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -19,7 +19,7 @@ namespace lang {
 
 LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
                                  KernelProfilerBase *profiler)
-    : ProgramImpl(config_) {
+    : ProgramImpl(config_), compilation_workers("compile", config_.compile_thread_num) {
   runtime_exec_ = std::make_unique<LlvmRuntimeExecutor>(config_, profiler);
   cache_data_ = std::make_unique<LlvmOfflineCache>();
 }

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -20,7 +20,7 @@ namespace lang {
 LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
                                  KernelProfilerBase *profiler)
     : ProgramImpl(config_),
-      compilation_workers("compile", config_.compile_thread_num) {
+      compilation_workers("compile", config_.num_compile_threads) {
   runtime_exec_ = std::make_unique<LlvmRuntimeExecutor>(config_, profiler);
   cache_data_ = std::make_unique<LlvmOfflineCache>();
 }

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -19,7 +19,8 @@ namespace lang {
 
 LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
                                  KernelProfilerBase *profiler)
-    : ProgramImpl(config_), compilation_workers("compile", config_.compile_thread_num) {
+    : ProgramImpl(config_),
+      compilation_workers("compile", config_.compile_thread_num) {
   runtime_exec_ = std::make_unique<LlvmRuntimeExecutor>(config_, profiler);
   cache_data_ = std::make_unique<LlvmOfflineCache>();
 }

--- a/taichi/runtime/program_impls/llvm/llvm_program.h
+++ b/taichi/runtime/program_impls/llvm/llvm_program.h
@@ -8,7 +8,7 @@
 #include "taichi/runtime/llvm/llvm_runtime_executor.h"
 #include "taichi/system/memory_pool.h"
 #include "taichi/program/program_impl.h"
-
+#include "taichi/program/parallel_executor.h"
 #define TI_RUNTIME_HOST
 #include "taichi/program/context.h"
 #undef TI_RUNTIME_HOST
@@ -269,6 +269,7 @@ class LlvmProgramImpl : public ProgramImpl {
     // 2. Destructs runtime_exec_
     runtime_exec_.reset();
   }
+  ParallelExecutor compilation_workers;  // parallel compilation
 
  private:
   std::size_t num_snode_trees_processed_{0};


### PR DESCRIPTION
Related issue = #5252 
Decomposition of #5251 
We can configure the thread number by `ti.init(compile_thread_num=xxx)`, 0 stands for serial.
It‘s not in use in this PR, but it will be used in the following PRs.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
