### PR TITLE
[Lang] [type] Refine SNode with quant 7/n: Support placing QuantFixedType under quant_array

### DIFF
--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -560,9 +560,9 @@ class CodeGenLLVMCUDA : public CodeGenLLVM {
     if (auto get_ch = stmt->src->cast<GetChStmt>()) {
       bool should_cache_as_read_only = current_offload->mem_access_opt.has_flag(
           get_ch->output_snode, SNodeAccessFlag::read_only);
-      global_load(stmt, should_cache_as_read_only);
+      create_global_load(stmt, should_cache_as_read_only);
     } else {
-      global_load(stmt, false);
+      create_global_load(stmt, false);
     }
   }
 

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1394,9 +1394,11 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
   auto ptr_type = stmt->dest->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
     auto pointee_type = ptr_type->get_pointee_type();
-    if (stmt->dest->as<GetChStmt>()->input_snode->type == SNodeType::bit_struct) {
+    if (stmt->dest->as<GetChStmt>()->input_snode->type ==
+        SNodeType::bit_struct) {
       TI_ERROR(
-          "Bit struct stores with type {} should have been handled by BitStructStoreStmt.",
+          "Bit struct stores with type {} should have been handled by "
+          "BitStructStoreStmt.",
           pointee_type->to_string());
     }
     if (auto qit = pointee_type->cast<QuantIntType>()) {

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -229,9 +229,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, QuantIntType *qit);
 
-  llvm::Value *quant_fixed_to_quant_int(QuantFixedType *qfxt,
-                                        QuantIntType *qit,
-                                        llvm::Value *real);
+  llvm::Value *to_quant_fixed(llvm::Value *real, QuantFixedType *qfxt);
 
   virtual llvm::Value *optimized_reduction(AtomicOpStmt *stmt);
 
@@ -256,6 +254,11 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                        QuantIntType *qit,
                        llvm::Value *value,
                        bool atomic);
+
+  void store_quant_fixed(llvm::Value *bit_ptr,
+                         QuantFixedType *qfxt,
+                         llvm::Value *value,
+                         bool atomic);
 
   void store_masked(llvm::Value *byte_ptr,
                     uint64 mask,
@@ -313,7 +316,7 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
                                        QuantFloatType *qflt,
                                        bool shared_exponent);
 
-  void global_load(GlobalLoadStmt *stmt, bool should_cache_as_read_only);
+  void create_global_load(GlobalLoadStmt *stmt, bool should_cache_as_read_only);
 
   void visit(GlobalLoadStmt *stmt) override;
 

--- a/taichi/codegen/llvm/codegen_llvm_quant.cpp
+++ b/taichi/codegen/llvm/codegen_llvm_quant.cpp
@@ -42,10 +42,12 @@ llvm::Value *CodeGenLLVM::atomic_add_quant_fixed(AtomicOpStmt *stmt,
                       tlctx->get_constant(qit->get_num_bits()), val_store});
 }
 
-llvm::Value *CodeGenLLVM::to_quant_fixed(llvm::Value *real, QuantFixedType *qfxt) {
+llvm::Value *CodeGenLLVM::to_quant_fixed(llvm::Value *real,
+                                         QuantFixedType *qfxt) {
   // Compute int(real * (1.0 / scale) + 0.5)
   auto compute_type = qfxt->get_compute_type();
-  auto s = builder->CreateFPCast(tlctx->get_constant(1.0 / qfxt->get_scale()), llvm_type(compute_type));
+  auto s = builder->CreateFPCast(tlctx->get_constant(1.0 / qfxt->get_scale()),
+                                 llvm_type(compute_type));
   auto input_real = builder->CreateFPCast(real, llvm_type(compute_type));
   auto scaled = builder->CreateFMul(input_real, s);
 
@@ -80,7 +82,8 @@ void CodeGenLLVM::store_quant_fixed(llvm::Value *bit_ptr,
                                     QuantFixedType *qfxt,
                                     llvm::Value *value,
                                     bool atomic) {
-  store_quant_int(bit_ptr, qfxt->get_digits_type()->as<QuantIntType>(), to_quant_fixed(value, qfxt), atomic);
+  store_quant_int(bit_ptr, qfxt->get_digits_type()->as<QuantIntType>(),
+                  to_quant_fixed(value, qfxt), atomic);
 }
 
 void CodeGenLLVM::store_masked(llvm::Value *byte_ptr,

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -309,7 +309,8 @@ class QuantArrayType : public Type {
     if (auto qit = element_type_->cast<QuantIntType>()) {
       element_num_bits_ = qit->get_num_bits();
     } else if (auto qfxt = element_type_->cast<QuantFixedType>()) {
-      element_num_bits_ = qfxt->get_digits_type()->as<QuantIntType>()->get_num_bits();
+      element_num_bits_ =
+          qfxt->get_digits_type()->as<QuantIntType>()->get_num_bits();
     } else {
       TI_ERROR("Quant array only supports quant int/fixed type for now.");
     }

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -306,9 +306,13 @@ class QuantArrayType : public Type {
       : physical_type_(physical_type),
         element_type_(element_type_),
         num_elements_(num_elements_) {
-    // TODO: avoid assertion?
-    TI_ASSERT(element_type_->is<QuantIntType>());
-    element_num_bits_ = element_type_->as<QuantIntType>()->get_num_bits();
+    if (auto qit = element_type_->cast<QuantIntType>()) {
+      element_num_bits_ = qit->get_num_bits();
+    } else if (auto qfxt = element_type_->cast<QuantFixedType>()) {
+      element_num_bits_ = qfxt->get_digits_type()->as<QuantIntType>()->get_num_bits();
+    } else {
+      TI_ERROR("Quant array only supports quant int/fixed type for now.");
+    }
   }
 
   std::string to_string() const override;

--- a/tests/python/test_quant_array.py
+++ b/tests/python/test_quant_array.py
@@ -44,6 +44,30 @@ def test_1D_quant_array_negative():
 
 
 @test_utils.test(require=ti.extension.quant, debug=True)
+def test_1D_quant_array_fixed():
+    qfxt = ti.types.quant.fixed(frac=8, range=2)
+
+    x = ti.field(dtype=qfxt)
+
+    N = 4
+
+    ti.root.quant_array(ti.i, N, num_bits=32).place(x)
+
+    @ti.kernel
+    def set_val():
+        for i in range(N):
+            x[i] = i * 0.5
+
+    @ti.kernel
+    def verify_val():
+        for i in range(N):
+            assert x[i] == i * 0.5
+
+    set_val()
+    verify_val()
+
+
+@test_utils.test(require=ti.extension.quant, debug=True)
 def test_2D_quant_array():
     qu1 = ti.types.quant.int(1, False)
 


### PR DESCRIPTION
Related issue = #4857

This PR ends the `bit_array` SNode refinement plan in https://github.com/taichi-dev/taichi/issues/4857#issuecomment-1173647894.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
