### PR TITLE
[autodiff] Add test for ternary operators in reverse mode autodiff

### DIFF
--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -281,9 +281,9 @@ def test_select():
     func.grad()
     for i in range(N):
         if i % 2:
-            loss[i] = i
+            assert loss[i] == i
         else:
-            loss[i] = -i
+            assert loss[i] == -i
         assert x.grad[i] == i % 2 * 1.0
         assert y.grad[i] == (not i % 2) * 1.0
 

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -260,6 +260,35 @@ def test_pow_f64(tifunc, npfunc):
 
 
 @test_utils.test()
+def test_select():
+    N = 5
+    loss = ti.field(ti.f32, shape=N)
+    x = ti.field(ti.f32, shape=N)
+    y = ti.field(ti.f32, shape=N)
+    ti.root.lazy_grad()
+
+    for i in range(N):
+        x[i] = i
+        y[i] = -i
+        loss.grad[i] = 1.0
+
+    @ti.kernel
+    def func():
+        for i in range(N):
+            loss[i] += ti.select(i % 2, x[i], y[i])
+
+    func()
+    func.grad()
+    for i in range(N):
+        if i % 2:
+            loss[i] = i
+        else:
+            loss[i] = -i
+        assert x.grad[i] == i % 2 * 1.0
+        assert y.grad[i] == (not i % 2) * 1.0
+
+
+@test_utils.test()
 def test_obey_kernel_simplicity():
     x = ti.field(ti.f32)
     y = ti.field(ti.f32)


### PR DESCRIPTION
Currently, there is no test for ternary operators in reverse mode autodiff. This PR adds a test for it.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
