### PR TITLE
[AOT] Fixed Vulkan device import capability settings

### DIFF
--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -28,11 +28,22 @@ VulkanRuntimeImported::Workaround::Workaround(
   taichi::lang::vulkan::VulkanLoader::instance().load_device(params.device);
   vk_device.set_cap(taichi::lang::DeviceCapability::vk_api_version,
                     api_version);
+
+  vk_device.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10000);
+  if (api_version >= VK_API_VERSION_1_3) {
+    vk_device.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10500);
+  } else if (api_version >= VK_API_VERSION_1_2) {
+    vk_device.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10500);
+  } else if (api_version >= VK_API_VERSION_1_1) {
+    vk_device.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10300);
+  }
+
   if (api_version > VK_API_VERSION_1_0) {
     vk_device.set_cap(
         taichi::lang::DeviceCapability::spirv_has_physical_storage_buffer,
         true);
   }
+
   vk_device.init_vulkan_structs(
       const_cast<taichi::lang::vulkan::VulkanDevice::Params &>(params));
 }

--- a/taichi/codegen/cpu/codegen_cpu.h
+++ b/taichi/codegen/cpu/codegen_cpu.h
@@ -18,13 +18,14 @@ class CodeGenCPU : public KernelCodeGen {
 #ifdef TI_WITH_LLVM
   static std::unique_ptr<CodeGenLLVM> make_codegen_llvm(Kernel *kernel,
                                                         IRNode *ir);
-#endif  // TI_WITH_LLVM
 
   bool supports_offline_cache() const override {
     return true;
   }
   LLVMCompiledData modulegen(std::unique_ptr<llvm::Module> &&module = nullptr,
                              OffloadedStmt *stmt = nullptr) override;
+
+#endif  // TI_WITH_LLVM
 
   FunctionType codegen() override;
 };

--- a/taichi/runtime/llvm/llvm_offline_cache.h
+++ b/taichi/runtime/llvm/llvm_offline_cache.h
@@ -127,9 +127,10 @@ class LlvmOfflineCacheFileReader {
                              LlvmOfflineCache &&data,
                              LlvmOfflineCache::Format format);
 
-  std::unique_ptr<struct llvm::Module> load_module(const std::string &path_prefix,
-                                            const std::string &key,
-                                            llvm::LLVMContext &llvm_ctx) const;
+  std::unique_ptr<struct llvm::Module> load_module(
+      const std::string &path_prefix,
+      const std::string &key,
+      llvm::LLVMContext &llvm_ctx) const;
 
   std::string path_;
   LlvmOfflineCache data_;
@@ -194,4 +195,4 @@ class LlvmOfflineCacheFileWriter {
 
 }  // namespace lang
 }  // namespace taichi
-#endif // TI_WITH_LLVM
+#endif  // TI_WITH_LLVM

--- a/taichi/runtime/llvm/llvm_offline_cache.h
+++ b/taichi/runtime/llvm/llvm_offline_cache.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#ifdef TI_WITH_LLVM
 #include "llvm/IR/Module.h"
 #include "taichi/common/core.h"
 #include "taichi/common/serialization.h"
@@ -126,7 +127,7 @@ class LlvmOfflineCacheFileReader {
                              LlvmOfflineCache &&data,
                              LlvmOfflineCache::Format format);
 
-  std::unique_ptr<llvm::Module> load_module(const std::string &path_prefix,
+  std::unique_ptr<struct llvm::Module> load_module(const std::string &path_prefix,
                                             const std::string &key,
                                             llvm::LLVMContext &llvm_ctx) const;
 
@@ -193,3 +194,4 @@ class LlvmOfflineCacheFileWriter {
 
 }  // namespace lang
 }  // namespace taichi
+#endif // TI_WITH_LLVM

--- a/taichi/runtime/llvm/llvm_offline_cache.h
+++ b/taichi/runtime/llvm/llvm_offline_cache.h
@@ -127,10 +127,9 @@ class LlvmOfflineCacheFileReader {
                              LlvmOfflineCache &&data,
                              LlvmOfflineCache::Format format);
 
-  std::unique_ptr<struct llvm::Module> load_module(
-      const std::string &path_prefix,
-      const std::string &key,
-      llvm::LLVMContext &llvm_ctx) const;
+  std::unique_ptr<llvm::Module> load_module(const std::string &path_prefix,
+                                            const std::string &key,
+                                            llvm::LLVMContext &llvm_ctx) const;
 
   std::string path_;
   LlvmOfflineCache data_;

--- a/taichi/runtime/llvm/llvm_runtime_executor.h
+++ b/taichi/runtime/llvm/llvm_runtime_executor.h
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <memory>
 
+#ifdef TI_WITH_LLVM
+
 #include "taichi/rhi/llvm/llvm_device.h"
 #include "taichi/runtime/llvm/llvm_offline_cache.h"
 #include "taichi/runtime/llvm/snode_tree_buffer_manager.h"
@@ -161,3 +163,5 @@ class LlvmRuntimeExecutor {
 
 }  // namespace lang
 }  // namespace taichi
+
+#endif // TI_WITH_LLVM

--- a/taichi/runtime/llvm/llvm_runtime_executor.h
+++ b/taichi/runtime/llvm/llvm_runtime_executor.h
@@ -164,4 +164,4 @@ class LlvmRuntimeExecutor {
 }  // namespace lang
 }  // namespace taichi
 
-#endif // TI_WITH_LLVM
+#endif  // TI_WITH_LLVM


### PR DESCRIPTION
This PR fixed Vulkan device capability settings and solved some crashes when AOT module is prepared for a lower version of SPIR-V; and guarded some LLVM codes with `TI_WITH_LLVM` to tolerate Vulkan-only builds.