### PR TITLE
[type] Decouple quant from SNode 4/n: Add exponent info to BitStructType

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm_quant.cpp
+++ b/taichi/codegen/llvm/codegen_llvm_quant.cpp
@@ -1,8 +1,6 @@
 #ifdef TI_WITH_LLVM
 #include "taichi/codegen/llvm/codegen_llvm.h"
-
 #include "taichi/ir/statements.h"
-#include "taichi/codegen/llvm/struct_llvm.h"
 
 TLANG_NAMESPACE_BEGIN
 

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -139,6 +139,7 @@ class SNode {
   std::unique_ptr<BitStructTypeBuilder> bit_struct_type_builder{nullptr};
   SNode *exp_snode{nullptr};  // for QuantFloatType
   int bit_offset{0};          // for children of bit_struct only
+  int id_in_bit_struct{0};    // for children of bit_struct only
   bool placing_shared_exp{false};
   SNode *currently_placing_exp_snode{nullptr};
   Type *currently_placing_exp_snode_dtype{nullptr};

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -166,12 +166,13 @@ bool QuantFloatType::get_is_signed() const {
   return digits_type_->as<QuantIntType>()->get_is_signed();
 }
 
-BitStructType::BitStructType(PrimitiveType *physical_type,
-                             std::vector<Type *> member_types,
-                             std::vector<int> member_bit_offsets,
-                             std::vector<bool> member_owns_shared_exponents,
-                             std::vector<int> member_exponents,
-                             std::vector<std::vector<int>> member_exponent_users)
+BitStructType::BitStructType(
+    PrimitiveType *physical_type,
+    std::vector<Type *> member_types,
+    std::vector<int> member_bit_offsets,
+    std::vector<bool> member_owns_shared_exponents,
+    std::vector<int> member_exponents,
+    std::vector<std::vector<int>> member_exponent_users)
     : physical_type_(physical_type),
       member_types_(member_types),
       member_bit_offsets_(member_bit_offsets),
@@ -203,7 +204,9 @@ std::string BitStructType::to_string() const {
     str += fmt::format("{}: {}@{}", i, member_types_[i]->to_string(),
                        member_bit_offsets_[i]);
     if (member_exponents_[i] != -1) {
-      str += fmt::format(" {}exp={}", member_owns_shared_exponents_[i] ? "shared_" : "", member_exponents_[i]);
+      str += fmt::format(" {}exp={}",
+                         member_owns_shared_exponents_[i] ? "shared_" : "",
+                         member_exponents_[i]);
     }
     if (i + 1 < num_members) {
       str += ", ";

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -206,9 +206,11 @@ BitStructType::BitStructType(
       TI_ASSERT(exponent != -1);
     }
     if (exponent != -1) {
-      TI_ASSERT(std::find(member_exponent_users_[exponent].begin(), member_exponent_users_[exponent].end(), i) != member_exponent_users_[exponent].end());
+      TI_ASSERT(std::find(member_exponent_users_[exponent].begin(),
+                          member_exponent_users_[exponent].end(),
+                          i) != member_exponent_users_[exponent].end());
     }
-    for (auto user: member_exponent_users_[i]) {
+    for (auto user : member_exponent_users_[i]) {
       TI_ASSERT(member_exponents_[user] == i);
     }
   }

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -168,10 +168,16 @@ bool QuantFloatType::get_is_signed() const {
 
 BitStructType::BitStructType(PrimitiveType *physical_type,
                              std::vector<Type *> member_types,
-                             std::vector<int> member_bit_offsets)
+                             std::vector<int> member_bit_offsets,
+                             std::vector<bool> member_owns_shared_exponents,
+                             std::vector<int> member_exponents,
+                             std::vector<std::vector<int>> member_exponent_users)
     : physical_type_(physical_type),
       member_types_(member_types),
-      member_bit_offsets_(member_bit_offsets) {
+      member_bit_offsets_(member_bit_offsets),
+      member_owns_shared_exponents_(member_owns_shared_exponents),
+      member_exponents_(member_exponents),
+      member_exponent_users_(member_exponent_users) {
   TI_ASSERT(member_types_.size() == member_bit_offsets_.size());
   int physical_type_bits = data_type_bits(physical_type);
   for (auto i = 0; i < member_types_.size(); ++i) {
@@ -194,8 +200,11 @@ std::string BitStructType::to_string() const {
   std::string str = "bs(";
   int num_members = (int)member_bit_offsets_.size();
   for (int i = 0; i < num_members; i++) {
-    str += fmt::format("{}@{}", member_types_[i]->to_string(),
+    str += fmt::format("{}: {}@{}", i, member_types_[i]->to_string(),
                        member_bit_offsets_[i]);
+    if (member_exponents_[i] != -1) {
+      str += fmt::format(" {}exp={}", member_owns_shared_exponents_[i] ? "shared_" : "", member_exponents_[i]);
+    }
     if (i + 1 < num_members) {
       str += ", ";
     }

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -168,11 +168,11 @@ bool QuantFloatType::get_is_signed() const {
 
 BitStructType::BitStructType(
     PrimitiveType *physical_type,
-    std::vector<Type *> member_types,
-    std::vector<int> member_bit_offsets,
-    std::vector<bool> member_owns_shared_exponents,
-    std::vector<int> member_exponents,
-    std::vector<std::vector<int>> member_exponent_users)
+    const std::vector<Type *> &member_types,
+    const std::vector<int> &member_bit_offsets,
+    const std::vector<bool> &member_owns_shared_exponents,
+    const std::vector<int> &member_exponents,
+    const std::vector<std::vector<int>> &member_exponent_users)
     : physical_type_(physical_type),
       member_types_(member_types),
       member_bit_offsets_(member_bit_offsets),

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -272,7 +272,10 @@ class BitStructType : public Type {
  public:
   BitStructType(PrimitiveType *physical_type,
                 std::vector<Type *> member_types,
-                std::vector<int> member_bit_offsets);
+                std::vector<int> member_bit_offsets,
+                std::vector<bool> member_owns_shared_exponents,
+                std::vector<int> member_exponents,
+                std::vector<std::vector<int>> member_exponent_users);
 
   std::string to_string() const override;
 
@@ -280,7 +283,7 @@ class BitStructType : public Type {
     return physical_type_;
   }
 
-  int get_num_memebrs() const {
+  int get_num_members() const {
     return (int)member_types_.size();
   }
 
@@ -292,10 +295,25 @@ class BitStructType : public Type {
     return member_bit_offsets_[i];
   }
 
+  bool get_member_owns_shard_exponent(int i) const {
+    return member_owns_shared_exponents_[i];
+  }
+
+  int get_member_exponent(int i) const {
+    return member_exponents_[i];
+  }
+
+  const std::vector<int> &get_member_exponent_users(int i) const {
+    return member_exponent_users_[i];
+  }
+
  private:
   PrimitiveType *physical_type_;
   std::vector<Type *> member_types_;
   std::vector<int> member_bit_offsets_;
+  std::vector<bool> member_owns_shared_exponents_;
+  std::vector<int> member_exponents_;
+  std::vector<std::vector<int>> member_exponent_users_;
 };
 
 class QuantArrayType : public Type {

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -271,11 +271,11 @@ class QuantFloatType : public Type {
 class BitStructType : public Type {
  public:
   BitStructType(PrimitiveType *physical_type,
-                std::vector<Type *> member_types,
-                std::vector<int> member_bit_offsets,
-                std::vector<bool> member_owns_shared_exponents,
-                std::vector<int> member_exponents,
-                std::vector<std::vector<int>> member_exponent_users);
+                const std::vector<Type *> &member_types,
+                const std::vector<int> &member_bit_offsets,
+                const std::vector<bool> &member_owns_shared_exponents,
+                const std::vector<int> &member_exponents,
+                const std::vector<std::vector<int>> &member_exponent_users);
 
   std::string to_string() const override;
 

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -295,7 +295,7 @@ class BitStructType : public Type {
     return member_bit_offsets_[i];
   }
 
-  bool get_member_owns_shard_exponent(int i) const {
+  bool get_member_owns_shared_exponent(int i) const {
     return member_owns_shared_exponents_[i];
   }
 

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -78,13 +78,16 @@ Type *TypeFactory::get_quant_float_type(Type *digits_type,
   return quant_float_types_[key].get();
 }
 
-Type *TypeFactory::get_bit_struct_type(PrimitiveType *physical_type,
-                                       std::vector<Type *> member_types,
-                                       std::vector<int> member_bit_offsets,
-                                       std::vector<bool> member_owns_shared_exponents,
-                                       std::vector<int> member_exponents,
-                                       std::vector<std::vector<int>> member_exponent_users) {
-  bit_struct_types_.push_back(std::make_unique<BitStructType>(physical_type, member_types, member_bit_offsets, member_owns_shared_exponents, member_exponents, member_exponent_users));
+Type *TypeFactory::get_bit_struct_type(
+    PrimitiveType *physical_type,
+    std::vector<Type *> member_types,
+    std::vector<int> member_bit_offsets,
+    std::vector<bool> member_owns_shared_exponents,
+    std::vector<int> member_exponents,
+    std::vector<std::vector<int>> member_exponent_users) {
+  bit_struct_types_.push_back(std::make_unique<BitStructType>(
+      physical_type, member_types, member_bit_offsets,
+      member_owns_shared_exponents, member_exponents, member_exponent_users));
   return bit_struct_types_.back().get();
 }
 

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -80,11 +80,11 @@ Type *TypeFactory::get_quant_float_type(Type *digits_type,
 
 Type *TypeFactory::get_bit_struct_type(
     PrimitiveType *physical_type,
-    std::vector<Type *> member_types,
-    std::vector<int> member_bit_offsets,
-    std::vector<bool> member_owns_shared_exponents,
-    std::vector<int> member_exponents,
-    std::vector<std::vector<int>> member_exponent_users) {
+    const std::vector<Type *> &member_types,
+    const std::vector<int> &member_bit_offsets,
+    const std::vector<bool> &member_owns_shared_exponents,
+    const std::vector<int> &member_exponents,
+    const std::vector<std::vector<int>> &member_exponent_users) {
   bit_struct_types_.push_back(std::make_unique<BitStructType>(
       physical_type, member_types, member_bit_offsets,
       member_owns_shared_exponents, member_exponents, member_exponent_users));

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -80,9 +80,11 @@ Type *TypeFactory::get_quant_float_type(Type *digits_type,
 
 Type *TypeFactory::get_bit_struct_type(PrimitiveType *physical_type,
                                        std::vector<Type *> member_types,
-                                       std::vector<int> member_bit_offsets) {
-  bit_struct_types_.push_back(std::make_unique<BitStructType>(
-      physical_type, member_types, member_bit_offsets));
+                                       std::vector<int> member_bit_offsets,
+                                       std::vector<bool> member_owns_shared_exponents,
+                                       std::vector<int> member_exponents,
+                                       std::vector<std::vector<int>> member_exponent_users) {
+  bit_struct_types_.push_back(std::make_unique<BitStructType>(physical_type, member_types, member_bit_offsets, member_owns_shared_exponents, member_exponents, member_exponent_users));
   return bit_struct_types_.back().get();
 }
 

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -35,7 +35,10 @@ class TypeFactory {
 
   Type *get_bit_struct_type(PrimitiveType *physical_type,
                             std::vector<Type *> member_types,
-                            std::vector<int> member_bit_offsets);
+                            std::vector<int> member_bit_offsets,
+                            std::vector<bool> member_owns_shared_exponents,
+                            std::vector<int> member_exponents,
+                            std::vector<std::vector<int>> member_exponent_users);
 
   Type *get_quant_array_type(PrimitiveType *physical_type,
                              Type *element_type,

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -35,11 +35,11 @@ class TypeFactory {
 
   Type *get_bit_struct_type(
       PrimitiveType *physical_type,
-      std::vector<Type *> member_types,
-      std::vector<int> member_bit_offsets,
-      std::vector<bool> member_owns_shared_exponents,
-      std::vector<int> member_exponents,
-      std::vector<std::vector<int>> member_exponent_users);
+      const std::vector<Type *> &member_types,
+      const std::vector<int> &member_bit_offsets,
+      const std::vector<bool> &member_owns_shared_exponents,
+      const std::vector<int> &member_exponents,
+      const std::vector<std::vector<int>> &member_exponent_users);
 
   Type *get_quant_array_type(PrimitiveType *physical_type,
                              Type *element_type,

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -33,12 +33,13 @@ class TypeFactory {
                              Type *exponent_type,
                              Type *compute_type);
 
-  Type *get_bit_struct_type(PrimitiveType *physical_type,
-                            std::vector<Type *> member_types,
-                            std::vector<int> member_bit_offsets,
-                            std::vector<bool> member_owns_shared_exponents,
-                            std::vector<int> member_exponents,
-                            std::vector<std::vector<int>> member_exponent_users);
+  Type *get_bit_struct_type(
+      PrimitiveType *physical_type,
+      std::vector<Type *> member_types,
+      std::vector<int> member_bit_offsets,
+      std::vector<bool> member_owns_shared_exponents,
+      std::vector<int> member_exponents,
+      std::vector<std::vector<int>> member_exponent_users);
 
   Type *get_quant_array_type(PrimitiveType *physical_type,
                              Type *element_type,

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -225,7 +225,9 @@ class BitStructTypeBuilder {
 
   Type *build() const {
     return TypeFactory::get_instance().get_bit_struct_type(
-        physical_type_, member_types_, member_bit_offsets_, member_owns_shared_exponents_, member_exponents_, member_exponent_users_);
+        physical_type_, member_types_, member_bit_offsets_,
+        member_owns_shared_exponents_, member_exponents_,
+        member_exponent_users_);
   }
 
  private:

--- a/taichi/program/snode_expr_utils.cpp
+++ b/taichi/program/snode_expr_utils.cpp
@@ -66,7 +66,7 @@ void place_child(Expr *expr_arg,
       } else {
         auto &exp_node = parent->insert_children(SNodeType::place);
         exp_node.dt = exp;
-        exp_node.bit_offset = parent->bit_struct_type_builder->add_member(exp);
+        std::tie(exp_node.id_in_bit_struct, exp_node.bit_offset) = parent->bit_struct_type_builder->add_member(exp);
         exp_node.name = glb_var_expr->ident.raw_name() + "_exp";
         new_exp_snode = &exp_node;
         if (parent->placing_shared_exp) {
@@ -89,16 +89,19 @@ void place_child(Expr *expr_arg,
     glb_var_expr->snode->grad_info =
         std::make_unique<GradInfoImpl>(glb_var_expr.get());
     (*snode_to_exprs)[glb_var_expr->snode] = glb_var_expr;
-    if (parent->placing_shared_exp) {
-      child.owns_shared_exponent = true;
-    }
     child.dt = glb_var_expr->dt;
     if (parent->bit_struct_type_builder) {
-      child.bit_offset = parent->bit_struct_type_builder->add_member(child.dt);
-    }
-    if (new_exp_snode) {
-      child.exp_snode = new_exp_snode;
-      new_exp_snode->exponent_users.push_back(&child);
+      std::tie(child.id_in_bit_struct, child.bit_offset) = parent->bit_struct_type_builder->add_member(child.dt);
+      if (parent->placing_shared_exp) {
+        child.owns_shared_exponent = true;
+        parent->bit_struct_type_builder->set_member_owns_shared_exponent(child.id_in_bit_struct);
+      }
+      if (new_exp_snode) {
+        child.exp_snode = new_exp_snode;
+        parent->bit_struct_type_builder->set_member_exponent(child.id_in_bit_struct, new_exp_snode->id_in_bit_struct);
+        new_exp_snode->exponent_users.push_back(&child);
+        parent->bit_struct_type_builder->add_member_exponent_user(new_exp_snode->id_in_bit_struct, child.id_in_bit_struct);
+      }
     }
     if (!offset.empty())
       child.set_index_offsets(offset);

--- a/taichi/program/snode_expr_utils.cpp
+++ b/taichi/program/snode_expr_utils.cpp
@@ -66,7 +66,8 @@ void place_child(Expr *expr_arg,
       } else {
         auto &exp_node = parent->insert_children(SNodeType::place);
         exp_node.dt = exp;
-        std::tie(exp_node.id_in_bit_struct, exp_node.bit_offset) = parent->bit_struct_type_builder->add_member(exp);
+        std::tie(exp_node.id_in_bit_struct, exp_node.bit_offset) =
+            parent->bit_struct_type_builder->add_member(exp);
         exp_node.name = glb_var_expr->ident.raw_name() + "_exp";
         new_exp_snode = &exp_node;
         if (parent->placing_shared_exp) {
@@ -91,16 +92,20 @@ void place_child(Expr *expr_arg,
     (*snode_to_exprs)[glb_var_expr->snode] = glb_var_expr;
     child.dt = glb_var_expr->dt;
     if (parent->bit_struct_type_builder) {
-      std::tie(child.id_in_bit_struct, child.bit_offset) = parent->bit_struct_type_builder->add_member(child.dt);
+      std::tie(child.id_in_bit_struct, child.bit_offset) =
+          parent->bit_struct_type_builder->add_member(child.dt);
       if (parent->placing_shared_exp) {
         child.owns_shared_exponent = true;
-        parent->bit_struct_type_builder->set_member_owns_shared_exponent(child.id_in_bit_struct);
+        parent->bit_struct_type_builder->set_member_owns_shared_exponent(
+            child.id_in_bit_struct);
       }
       if (new_exp_snode) {
         child.exp_snode = new_exp_snode;
-        parent->bit_struct_type_builder->set_member_exponent(child.id_in_bit_struct, new_exp_snode->id_in_bit_struct);
+        parent->bit_struct_type_builder->set_member_exponent(
+            child.id_in_bit_struct, new_exp_snode->id_in_bit_struct);
         new_exp_snode->exponent_users.push_back(&child);
-        parent->bit_struct_type_builder->add_member_exponent_user(new_exp_snode->id_in_bit_struct, child.id_in_bit_struct);
+        parent->bit_struct_type_builder->add_member_exponent_user(
+            new_exp_snode->id_in_bit_struct, child.id_in_bit_struct);
       }
     }
     if (!offset.empty())

--- a/tests/cpp/ir/type_test.cpp
+++ b/tests/cpp/ir/type_test.cpp
@@ -19,9 +19,9 @@ TEST(Type, BitTypes) {
   auto u16 = TypeFactory::get_instance().get_primitive_int_type(16, false);
 
   auto bs =
-      TypeFactory::get_instance().get_bit_struct_type(u16, {qi5, qu11}, {0, 5});
+      TypeFactory::get_instance().get_bit_struct_type(u16, {qi5, qu11}, {0, 5}, {false, false}, {-1, -1}, {{}, {}});
 
-  EXPECT_EQ(bs->to_string(), "bs(qi5@0, qu11@5)");
+  EXPECT_EQ(bs->to_string(), "bs(0: qi5@0, 1: qu11@5)");
 
   auto qi1 = TypeFactory::get_instance().get_quant_int_type(1, true, i32);
   auto qa = TypeFactory::get_instance().get_quant_array_type(i32, qi1, 32);

--- a/tests/cpp/ir/type_test.cpp
+++ b/tests/cpp/ir/type_test.cpp
@@ -22,12 +22,18 @@ TEST(Type, TypeToString) {
   EXPECT_EQ(bs1->to_string(), "bs(0: qi5@0, 1: qu7@5)");
 
   auto bs2 = TypeFactory::get_instance().get_bit_struct_type(
-      u32, {qu7, qfl, qu7, qfl}, {0, 7, 12, 19}, {false, false, false, false}, {-1, 0, -1, 2}, {{1}, {}, {3}, {}});
-  EXPECT_EQ(bs2->to_string(), "bs(0: qu7@0, 1: qfl(d=qi5 e=qu7 c=f32)@7 exp=0, 2: qu7@12, 3: qfl(d=qi5 e=qu7 c=f32)@19 exp=2)");
+      u32, {qu7, qfl, qu7, qfl}, {0, 7, 12, 19}, {false, false, false, false},
+      {-1, 0, -1, 2}, {{1}, {}, {3}, {}});
+  EXPECT_EQ(bs2->to_string(),
+            "bs(0: qu7@0, 1: qfl(d=qi5 e=qu7 c=f32)@7 exp=0, 2: qu7@12, 3: "
+            "qfl(d=qi5 e=qu7 c=f32)@19 exp=2)");
 
   auto bs3 = TypeFactory::get_instance().get_bit_struct_type(
-      u32, {qu7, qfl, qfl}, {0, 7, 12}, {false, true, true}, {-1, 0, 0}, {{1, 2}, {}, {}});
-  EXPECT_EQ(bs3->to_string(), "bs(0: qu7@0, 1: qfl(d=qi5 e=qu7 c=f32)@7 shared_exp=0, 2: qfl(d=qi5 e=qu7 c=f32)@12 shared_exp=0)");
+      u32, {qu7, qfl, qfl}, {0, 7, 12}, {false, true, true}, {-1, 0, 0},
+      {{1, 2}, {}, {}});
+  EXPECT_EQ(bs3->to_string(),
+            "bs(0: qu7@0, 1: qfl(d=qi5 e=qu7 c=f32)@7 shared_exp=0, 2: "
+            "qfl(d=qi5 e=qu7 c=f32)@12 shared_exp=0)");
 
   auto qi1 = TypeFactory::get_instance().get_quant_int_type(1, true, i32);
   auto qa = TypeFactory::get_instance().get_quant_array_type(i32, qi1, 32);

--- a/tests/cpp/ir/type_test.cpp
+++ b/tests/cpp/ir/type_test.cpp
@@ -18,8 +18,8 @@ TEST(Type, BitTypes) {
   auto qu11 = TypeFactory::get_instance().get_quant_int_type(11, false, i32);
   auto u16 = TypeFactory::get_instance().get_primitive_int_type(16, false);
 
-  auto bs =
-      TypeFactory::get_instance().get_bit_struct_type(u16, {qi5, qu11}, {0, 5}, {false, false}, {-1, -1}, {{}, {}});
+  auto bs = TypeFactory::get_instance().get_bit_struct_type(
+      u16, {qi5, qu11}, {0, 5}, {false, false}, {-1, -1}, {{}, {}});
 
   EXPECT_EQ(bs->to_string(), "bs(0: qi5@0, 1: qu11@5)");
 

--- a/tests/cpp/ir/type_test.cpp
+++ b/tests/cpp/ir/type_test.cpp
@@ -1,31 +1,36 @@
 #include "gtest/gtest.h"
 
-#include "taichi/util/testing.h"
-#include "taichi/ir/type.h"
 #include "taichi/ir/type_factory.h"
 
 namespace taichi {
 namespace lang {
 
-TEST(Type, BitTypes) {
-  auto f16 =
-      TypeFactory::get_instance().get_primitive_type(PrimitiveTypeID::f16);
+TEST(Type, TypeToString) {
+  auto f16 = TypeFactory::get_instance().get_primitive_real_type(16);
   EXPECT_EQ(f16->to_string(), "f16");
-  auto i32 = TypeFactory::get_instance()
-                 .get_primitive_type(PrimitiveTypeID::i32)
-                 ->as<PrimitiveType>();
-  auto qi5 = TypeFactory::get_instance().get_quant_int_type(5, true, i32);
-  auto qu11 = TypeFactory::get_instance().get_quant_int_type(11, false, i32);
+
+  auto f32 = TypeFactory::get_instance().get_primitive_real_type(32);
+  auto i32 = TypeFactory::get_instance().get_primitive_int_type(32, true);
+  auto u32 = TypeFactory::get_instance().get_primitive_int_type(32, false);
   auto u16 = TypeFactory::get_instance().get_primitive_int_type(16, false);
+  auto qi5 = TypeFactory::get_instance().get_quant_int_type(5, true, i32);
+  auto qu7 = TypeFactory::get_instance().get_quant_int_type(7, false, i32);
+  auto qfl = TypeFactory::get_instance().get_quant_float_type(qi5, qu7, f32);
 
-  auto bs = TypeFactory::get_instance().get_bit_struct_type(
-      u16, {qi5, qu11}, {0, 5}, {false, false}, {-1, -1}, {{}, {}});
+  auto bs1 = TypeFactory::get_instance().get_bit_struct_type(
+      u16, {qi5, qu7}, {0, 5}, {false, false}, {-1, -1}, {{}, {}});
+  EXPECT_EQ(bs1->to_string(), "bs(0: qi5@0, 1: qu7@5)");
 
-  EXPECT_EQ(bs->to_string(), "bs(0: qi5@0, 1: qu11@5)");
+  auto bs2 = TypeFactory::get_instance().get_bit_struct_type(
+      u32, {qu7, qfl, qu7, qfl}, {0, 7, 12, 19}, {false, false, false, false}, {-1, 0, -1, 2}, {{1}, {}, {3}, {}});
+  EXPECT_EQ(bs2->to_string(), "bs(0: qu7@0, 1: qfl(d=qi5 e=qu7 c=f32)@7 exp=0, 2: qu7@12, 3: qfl(d=qi5 e=qu7 c=f32)@19 exp=2)");
+
+  auto bs3 = TypeFactory::get_instance().get_bit_struct_type(
+      u32, {qu7, qfl, qfl}, {0, 7, 12}, {false, true, true}, {-1, 0, 0}, {{1, 2}, {}, {}});
+  EXPECT_EQ(bs3->to_string(), "bs(0: qu7@0, 1: qfl(d=qi5 e=qu7 c=f32)@7 shared_exp=0, 2: qfl(d=qi5 e=qu7 c=f32)@12 shared_exp=0)");
 
   auto qi1 = TypeFactory::get_instance().get_quant_int_type(1, true, i32);
   auto qa = TypeFactory::get_instance().get_quant_array_type(i32, qi1, 32);
-
   EXPECT_EQ(qa->to_string(), "qa(qi1x32)");
 }
 


### PR DESCRIPTION
Related issue = #4857

Previously, `BitStructType` only contained member types and member offsets, which were not enough to handle `QuantFloatType`, making quant codegen rely on SNode info. This PR adds exponent info to `BitStructType` so that it becomes possible to handle `QuantFloatType` (with or without shared exponent) without SNode info.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
