### PR TITLE
[gui] [vulkan] Surpport for getting depth information for python users.

### DIFF
--- a/python/taichi/ui/window.py
+++ b/python/taichi/ui/window.py
@@ -133,7 +133,7 @@ class Window:
             2d numpy array: [width, height] with (0.0~1.0) float-format.
         """
         return self.window.get_depth_buffer()
-        
+
     def get_image_buffer(self):
         """Get the window content to numpy array.
 

--- a/python/taichi/ui/window.py
+++ b/python/taichi/ui/window.py
@@ -126,6 +126,14 @@ class Window:
         """
         return self.window.write_image(filename)
 
+    def get_depth_buffer(self):
+        """Get the depth information of current scene to numpy array.
+
+        Returns:
+            2d numpy array: [width, height] with (0.0~1.0) float-format.
+        """
+        return self.window.get_depth_buffer()
+        
     def get_image_buffer(self):
         """Get the window content to numpy array.
 

--- a/taichi/python/export_ggui.cpp
+++ b/taichi/python/export_ggui.cpp
@@ -291,6 +291,16 @@ struct PyWindow {
     window->write_image(filename);
   }
 
+  py::array_t<float> get_depth_buffer() {
+    uint32_t w, h;
+    auto &depth_buffer = window->get_depth_buffer(w, h);
+
+    return py::array_t<float>(
+        py::detail::any_container<ssize_t>({w, h}),
+        py::detail::any_container<ssize_t>({sizeof(float) * h, sizeof(float)}),
+        depth_buffer.data(), nullptr);
+  }
+
   py::array_t<float> get_image_buffer() {
     uint32_t w, h;
     auto &img_buffer = window->get_image_buffer(w, h);
@@ -388,6 +398,7 @@ void export_ggui(py::module &m) {
       .def("get_canvas", &PyWindow::get_canvas)
       .def("show", &PyWindow::show)
       .def("write_image", &PyWindow::write_image)
+      .def("get_depth_buffer", &PyWindow::get_depth_buffer)
       .def("get_image_buffer", &PyWindow::get_image_buffer)
       .def("is_pressed", &PyWindow::is_pressed)
       .def("get_cursor_pos", &PyWindow::py_get_cursor_pos)

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -286,6 +286,7 @@ struct BufferImageCopyParams {
   } image_extent;
   uint32_t image_base_layer{0};
   uint32_t image_layer_count{1};
+  uint32_t image_aspect_flag{0};
 };
 
 struct ImageCopyParams {
@@ -531,6 +532,7 @@ class Surface {
   virtual int get_image_count() = 0;
   virtual BufferFormat image_format() = 0;
   virtual void resize(uint32_t width, uint32_t height) = 0;
+  virtual DeviceAllocation get_depth_data(DeviceAllocation& depth_alloc) = 0;
   virtual DeviceAllocation get_image_data() {
     TI_NOT_IMPLEMENTED
   }

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -532,7 +532,7 @@ class Surface {
   virtual int get_image_count() = 0;
   virtual BufferFormat image_format() = 0;
   virtual void resize(uint32_t width, uint32_t height) = 0;
-  virtual DeviceAllocation get_depth_data(DeviceAllocation& depth_alloc) = 0;
+  virtual DeviceAllocation get_depth_data(DeviceAllocation &depth_alloc) = 0;
   virtual DeviceAllocation get_image_data() {
     TI_NOT_IMPLEMENTED
   }

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -286,7 +286,7 @@ struct BufferImageCopyParams {
   } image_extent;
   uint32_t image_base_layer{0};
   uint32_t image_layer_count{1};
-  uint32_t image_aspect_flag{0};
+  uint32_t image_aspect_flag{1};
 };
 
 struct ImageCopyParams {

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1148,9 +1148,10 @@ inline void buffer_image_copy_ti_to_vk(VkBufferImageCopy &copy_info,
   copy_info.imageOffset.z = params.image_offset.z;
   copy_info.imageSubresource.aspectMask =
       params.image_aspect_flag;  // FIXME: add option in BufferImageCopyParams
-                                  // to support copying depth images
-                                  // FIXED: added an option in BufferImageCopyParams
-                                  // as image_aspect_flag by yuhaoLong(mocki)
+                                 // to support copying depth images
+                                 // FIXED: added an option in
+                                 // BufferImageCopyParams as image_aspect_flag
+                                 // by yuhaoLong(mocki)
   copy_info.imageSubresource.baseArrayLayer = params.image_base_layer;
   copy_info.imageSubresource.layerCount = params.image_layer_count;
   copy_info.imageSubresource.mipLevel = params.image_mip_level;
@@ -2449,9 +2450,9 @@ void VulkanSurface::present_image(
   device_->wait_idle();
 }
 
-DeviceAllocation VulkanSurface::get_depth_data(DeviceAllocation& depth_alloc) {
+DeviceAllocation VulkanSurface::get_depth_data(DeviceAllocation &depth_alloc) {
   auto *stream = device_->get_graphics_stream();
-  
+
   auto [w, h] = get_size();
   size_t size_bytes = w * h * 4;
 

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
+#include <unordered_map>
 #include <vector>
 #include <array>
 #include <set>
@@ -239,6 +240,10 @@ void VulkanPipeline::create_descriptor_set_layout(const Params &params) {
                    SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
           resource_binder_.image(set, desc_binding->binding,
                                  kDeviceNullAllocation, {});
+        } else if (desc_binding->descriptor_type ==
+                   SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+          resource_binder_.rw_image(set, desc_binding->binding,
+                                    kDeviceNullAllocation, {});
         } else {
           TI_WARN("unrecognized binding");
         }
@@ -653,6 +658,22 @@ void VulkanResourceBinder::image(uint32_t set,
   }
 }
 
+void VulkanResourceBinder::rw_image(uint32_t set,
+                                    uint32_t binding,
+                                    DeviceAllocation alloc,
+                                    int lod) {
+  CHECK_SET_BINDINGS
+  if (layout_locked_) {
+    TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+  } else {
+    if (bindings.find(binding) != bindings.end()) {
+      TI_WARN("Overriding last binding");
+    }
+  }
+  bindings[binding] = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, alloc.get_ptr(0),
+                       VK_WHOLE_SIZE};
+}
+
 #undef CHECK_SET_BINDINGS
 
 void VulkanResourceBinder::vertex_buffer(DevicePtr ptr, uint32_t binding) {
@@ -685,20 +706,31 @@ void VulkanResourceBinder::write_to_set(uint32_t index,
       VkDescriptorBufferInfo &buffer_info = buffer_infos.emplace_back();
       VkDescriptorImageInfo &image_info = image_infos.emplace_back();
 
-      if (pair.second.sampler == VK_NULL_HANDLE) {
+      if (pair.second.type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER ||
+          pair.second.type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
         auto buffer = device.get_vkbuffer(pair.second.ptr);
         buffer_info.buffer = buffer->buffer;
         buffer_info.offset = pair.second.ptr.offset;
         buffer_info.range = pair.second.size;
         is_image.push_back(false);
         set->ref_binding_objs[binding] = buffer;
-      } else {
+      } else if (pair.second.type ==
+                 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
         auto view = std::get<1>(device.get_vk_image(pair.second.ptr));
         image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         image_info.imageView = view->view;
         image_info.sampler = pair.second.sampler;
         is_image.push_back(true);
         set->ref_binding_objs[binding] = view;
+      } else if (pair.second.type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+        auto view =
+            device.get_vk_lod_imageview(pair.second.ptr, pair.second.image_lod);
+        image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+        image_info.imageView = view->view;
+        is_image.push_back(true);
+        set->ref_binding_objs[binding] = view;
+      } else {
+        TI_NOT_IMPLEMENTED;
       }
 
       VkWriteDescriptorSet &write = desc_writes.emplace_back();
@@ -1074,8 +1106,8 @@ void VulkanCommandList::image_transition(DeviceAllocation img,
 
   static std::unordered_map<VkImageLayout, VkAccessFlagBits> access;
   access[VK_IMAGE_LAYOUT_UNDEFINED] = (VkAccessFlagBits)0;
-  access[VK_IMAGE_LAYOUT_GENERAL] = VkAccessFlagBits(
-      VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT);
+  access[VK_IMAGE_LAYOUT_GENERAL] =
+      VkAccessFlagBits(VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
   access[VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL] = VK_ACCESS_TRANSFER_WRITE_BIT;
   access[VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL] = VK_ACCESS_TRANSFER_READ_BIT;
   access[VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL] = VK_ACCESS_MEMORY_READ_BIT;
@@ -1115,10 +1147,8 @@ inline void buffer_image_copy_ti_to_vk(VkBufferImageCopy &copy_info,
   copy_info.imageOffset.y = params.image_offset.y;
   copy_info.imageOffset.z = params.image_offset.z;
   copy_info.imageSubresource.aspectMask =
-      params.image_aspect_flag;   // FIXME: add option in BufferImageCopyParams
+      VK_IMAGE_ASPECT_COLOR_BIT;  // FIXME: add option in BufferImageCopyParams
                                   // to support copying depth images
-                                  // FIXED: added an option in BufferImageCopyParams
-                                  // as image_aspect_flag by yuhaoLong(mocki)
   copy_info.imageSubresource.baseArrayLayer = params.image_base_layer;
   copy_info.imageSubresource.layerCount = params.image_layer_count;
   copy_info.imageSubresource.mipLevel = params.image_mip_level;
@@ -1746,6 +1776,12 @@ vkapi::IVkImageView VulkanDevice::get_vk_imageview(
   return std::get<1>(get_vk_image(alloc));
 }
 
+vkapi::IVkImageView VulkanDevice::get_vk_lod_imageview(
+    const DeviceAllocation &alloc,
+    int lod) const {
+  return image_allocations_.at(alloc.alloc_id).view_lods[lod];
+}
+
 DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   DeviceAllocation handle;
   handle.device = this;
@@ -1753,6 +1789,8 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
 
   image_allocations_[handle.alloc_id] = {};
   ImageAllocInternal &alloc = image_allocations_[handle.alloc_id];
+
+  int num_mip_levels = 1;
 
   bool is_depth = params.format == BufferFormat::depth16 ||
                   params.format == BufferFormat::depth24stencil8 ||
@@ -1771,14 +1809,14 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   image_info.extent.width = params.x;
   image_info.extent.height = params.y;
   image_info.extent.depth = params.z;
-  image_info.mipLevels = 1;
+  image_info.mipLevels = num_mip_levels;
   image_info.arrayLayers = 1;
   image_info.format = buffer_format_ti_to_vk(params.format);
   image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
   image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-  image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT |
-                     VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-                     VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  image_info.usage =
+      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+      VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
   if (is_depth) {
     image_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
   } else {
@@ -1847,11 +1885,18 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   view_info.subresourceRange.aspectMask =
       is_depth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
   view_info.subresourceRange.baseMipLevel = 0;
-  view_info.subresourceRange.levelCount = 1;
+  view_info.subresourceRange.levelCount = num_mip_levels;
   view_info.subresourceRange.baseArrayLayer = 0;
   view_info.subresourceRange.layerCount = 1;
 
   alloc.view = vkapi::create_image_view(device_, alloc.image, &view_info);
+
+  for (int i = 0; i < num_mip_levels; i++) {
+    view_info.subresourceRange.baseMipLevel = i;
+    view_info.subresourceRange.levelCount = 1;
+    alloc.view_lods.push_back(
+        vkapi::create_image_view(device_, alloc.image, &view_info));
+  }
 
   if (params.initial_layout != ImageLayout::undefined) {
     image_transition(handle, ImageLayout::undefined, params.initial_layout);
@@ -2332,9 +2377,6 @@ VulkanSurface::~VulkanSurface() {
     }
     swapchain_images_.clear();
   }
-  if (depth_buffer_ != kDeviceNullAllocation) {
-    device_->dealloc_memory(depth_buffer_);
-  }
   if (screenshot_buffer_ != kDeviceNullAllocation) {
     device_->dealloc_memory(screenshot_buffer_);
   }
@@ -2402,38 +2444,6 @@ void VulkanSurface::present_image(
   device_->wait_idle();
 }
 
-DeviceAllocation VulkanSurface::get_depth_data(DeviceAllocation& depth_alloc) {
-  auto *stream = device_->get_graphics_stream();
-  
-  auto [w, h] = get_size();
-  size_t size_bytes = w * h * 4;
-
-  if (depth_buffer_ == kDeviceNullAllocation) {
-    Device::AllocParams params{size_bytes, /*host_wrtie*/ false,
-                               /*host_read*/ true, /*export_sharing*/ false,
-                               AllocUsage::Uniform};
-    depth_buffer_ = device_->allocate_memory(params);
-  }
-
-  device_->image_transition(depth_alloc, ImageLayout::present_src,
-                            ImageLayout::transfer_src);
-
-  std::unique_ptr<CommandList> cmd_list{nullptr};
-
-  BufferImageCopyParams copy_params;
-  copy_params.image_extent.x = w;
-  copy_params.image_extent.y = h;
-  copy_params.image_aspect_flag = VK_IMAGE_ASPECT_DEPTH_BIT;
-  cmd_list = stream->new_command_list();
-  cmd_list->image_to_buffer(depth_buffer_.get_ptr(), depth_alloc,
-                            ImageLayout::transfer_src, copy_params);
-  cmd_list->image_transition(depth_alloc, ImageLayout::transfer_src,
-                             ImageLayout::present_src);
-  stream->submit_synced(cmd_list.get());
-
-  return depth_buffer_;
-}
-
 DeviceAllocation VulkanSurface::get_image_data() {
   auto *stream = device_->get_graphics_stream();
   DeviceAllocation img_alloc = swapchain_images_[image_index_];
@@ -2481,7 +2491,6 @@ DeviceAllocation VulkanSurface::get_image_data() {
   BufferImageCopyParams copy_params;
   copy_params.image_extent.x = w;
   copy_params.image_extent.y = h;
-  copy_params.image_aspect_flag = VK_IMAGE_ASPECT_COLOR_BIT;
   cmd_list = stream->new_command_list();
   // TODO: directly map the image to cpu memory
   cmd_list->image_to_buffer(screenshot_buffer_.get_ptr(), img_alloc,

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1147,8 +1147,10 @@ inline void buffer_image_copy_ti_to_vk(VkBufferImageCopy &copy_info,
   copy_info.imageOffset.y = params.image_offset.y;
   copy_info.imageOffset.z = params.image_offset.z;
   copy_info.imageSubresource.aspectMask =
-      VK_IMAGE_ASPECT_COLOR_BIT;  // FIXME: add option in BufferImageCopyParams
+      params.image_aspect_flag;  // FIXME: add option in BufferImageCopyParams
                                   // to support copying depth images
+                                  // FIXED: added an option in BufferImageCopyParams
+                                  // as image_aspect_flag by yuhaoLong(mocki)
   copy_info.imageSubresource.baseArrayLayer = params.image_base_layer;
   copy_info.imageSubresource.layerCount = params.image_layer_count;
   copy_info.imageSubresource.mipLevel = params.image_mip_level;
@@ -2377,6 +2379,9 @@ VulkanSurface::~VulkanSurface() {
     }
     swapchain_images_.clear();
   }
+  if (depth_buffer_ != kDeviceNullAllocation) {
+    device_->dealloc_memory(depth_buffer_);
+  }
   if (screenshot_buffer_ != kDeviceNullAllocation) {
     device_->dealloc_memory(screenshot_buffer_);
   }
@@ -2444,6 +2449,38 @@ void VulkanSurface::present_image(
   device_->wait_idle();
 }
 
+DeviceAllocation VulkanSurface::get_depth_data(DeviceAllocation& depth_alloc) {
+  auto *stream = device_->get_graphics_stream();
+  
+  auto [w, h] = get_size();
+  size_t size_bytes = w * h * 4;
+
+  if (depth_buffer_ == kDeviceNullAllocation) {
+    Device::AllocParams params{size_bytes, /*host_wrtie*/ false,
+                               /*host_read*/ true, /*export_sharing*/ false,
+                               AllocUsage::Uniform};
+    depth_buffer_ = device_->allocate_memory(params);
+  }
+
+  device_->image_transition(depth_alloc, ImageLayout::present_src,
+                            ImageLayout::transfer_src);
+
+  std::unique_ptr<CommandList> cmd_list{nullptr};
+
+  BufferImageCopyParams copy_params;
+  copy_params.image_extent.x = w;
+  copy_params.image_extent.y = h;
+  copy_params.image_aspect_flag = VK_IMAGE_ASPECT_DEPTH_BIT;
+  cmd_list = stream->new_command_list();
+  cmd_list->image_to_buffer(depth_buffer_.get_ptr(), depth_alloc,
+                            ImageLayout::transfer_src, copy_params);
+  cmd_list->image_transition(depth_alloc, ImageLayout::transfer_src,
+                             ImageLayout::present_src);
+  stream->submit_synced(cmd_list.get());
+
+  return depth_buffer_;
+}
+
 DeviceAllocation VulkanSurface::get_image_data() {
   auto *stream = device_->get_graphics_stream();
   DeviceAllocation img_alloc = swapchain_images_[image_index_];
@@ -2491,6 +2528,7 @@ DeviceAllocation VulkanSurface::get_image_data() {
   BufferImageCopyParams copy_params;
   copy_params.image_extent.x = w;
   copy_params.image_extent.y = h;
+  copy_params.image_aspect_flag = VK_IMAGE_ASPECT_COLOR_BIT;
   cmd_list = stream->new_command_list();
   // TODO: directly map the image to cpu memory
   cmd_list->image_to_buffer(screenshot_buffer_.get_ptr(), img_alloc,

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -4,7 +4,6 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
-#include <unordered_map>
 #include <vector>
 #include <array>
 #include <set>
@@ -240,10 +239,6 @@ void VulkanPipeline::create_descriptor_set_layout(const Params &params) {
                    SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
           resource_binder_.image(set, desc_binding->binding,
                                  kDeviceNullAllocation, {});
-        } else if (desc_binding->descriptor_type ==
-                   SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
-          resource_binder_.rw_image(set, desc_binding->binding,
-                                    kDeviceNullAllocation, {});
         } else {
           TI_WARN("unrecognized binding");
         }
@@ -658,22 +653,6 @@ void VulkanResourceBinder::image(uint32_t set,
   }
 }
 
-void VulkanResourceBinder::rw_image(uint32_t set,
-                                    uint32_t binding,
-                                    DeviceAllocation alloc,
-                                    int lod) {
-  CHECK_SET_BINDINGS
-  if (layout_locked_) {
-    TI_ASSERT(bindings.at(binding).type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
-  } else {
-    if (bindings.find(binding) != bindings.end()) {
-      TI_WARN("Overriding last binding");
-    }
-  }
-  bindings[binding] = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, alloc.get_ptr(0),
-                       VK_WHOLE_SIZE};
-}
-
 #undef CHECK_SET_BINDINGS
 
 void VulkanResourceBinder::vertex_buffer(DevicePtr ptr, uint32_t binding) {
@@ -706,31 +685,20 @@ void VulkanResourceBinder::write_to_set(uint32_t index,
       VkDescriptorBufferInfo &buffer_info = buffer_infos.emplace_back();
       VkDescriptorImageInfo &image_info = image_infos.emplace_back();
 
-      if (pair.second.type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER ||
-          pair.second.type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
+      if (pair.second.sampler == VK_NULL_HANDLE) {
         auto buffer = device.get_vkbuffer(pair.second.ptr);
         buffer_info.buffer = buffer->buffer;
         buffer_info.offset = pair.second.ptr.offset;
         buffer_info.range = pair.second.size;
         is_image.push_back(false);
         set->ref_binding_objs[binding] = buffer;
-      } else if (pair.second.type ==
-                 VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+      } else {
         auto view = std::get<1>(device.get_vk_image(pair.second.ptr));
         image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         image_info.imageView = view->view;
         image_info.sampler = pair.second.sampler;
         is_image.push_back(true);
         set->ref_binding_objs[binding] = view;
-      } else if (pair.second.type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
-        auto view =
-            device.get_vk_lod_imageview(pair.second.ptr, pair.second.image_lod);
-        image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-        image_info.imageView = view->view;
-        is_image.push_back(true);
-        set->ref_binding_objs[binding] = view;
-      } else {
-        TI_NOT_IMPLEMENTED;
       }
 
       VkWriteDescriptorSet &write = desc_writes.emplace_back();
@@ -1106,8 +1074,8 @@ void VulkanCommandList::image_transition(DeviceAllocation img,
 
   static std::unordered_map<VkImageLayout, VkAccessFlagBits> access;
   access[VK_IMAGE_LAYOUT_UNDEFINED] = (VkAccessFlagBits)0;
-  access[VK_IMAGE_LAYOUT_GENERAL] =
-      VkAccessFlagBits(VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
+  access[VK_IMAGE_LAYOUT_GENERAL] = VkAccessFlagBits(
+      VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT);
   access[VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL] = VK_ACCESS_TRANSFER_WRITE_BIT;
   access[VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL] = VK_ACCESS_TRANSFER_READ_BIT;
   access[VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL] = VK_ACCESS_MEMORY_READ_BIT;
@@ -1147,8 +1115,10 @@ inline void buffer_image_copy_ti_to_vk(VkBufferImageCopy &copy_info,
   copy_info.imageOffset.y = params.image_offset.y;
   copy_info.imageOffset.z = params.image_offset.z;
   copy_info.imageSubresource.aspectMask =
-      VK_IMAGE_ASPECT_COLOR_BIT;  // FIXME: add option in BufferImageCopyParams
+      params.image_aspect_flag;   // FIXME: add option in BufferImageCopyParams
                                   // to support copying depth images
+                                  // FIXED: added an option in BufferImageCopyParams
+                                  // as image_aspect_flag by yuhaoLong(mocki)
   copy_info.imageSubresource.baseArrayLayer = params.image_base_layer;
   copy_info.imageSubresource.layerCount = params.image_layer_count;
   copy_info.imageSubresource.mipLevel = params.image_mip_level;
@@ -1776,12 +1746,6 @@ vkapi::IVkImageView VulkanDevice::get_vk_imageview(
   return std::get<1>(get_vk_image(alloc));
 }
 
-vkapi::IVkImageView VulkanDevice::get_vk_lod_imageview(
-    const DeviceAllocation &alloc,
-    int lod) const {
-  return image_allocations_.at(alloc.alloc_id).view_lods[lod];
-}
-
 DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   DeviceAllocation handle;
   handle.device = this;
@@ -1789,8 +1753,6 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
 
   image_allocations_[handle.alloc_id] = {};
   ImageAllocInternal &alloc = image_allocations_[handle.alloc_id];
-
-  int num_mip_levels = 1;
 
   bool is_depth = params.format == BufferFormat::depth16 ||
                   params.format == BufferFormat::depth24stencil8 ||
@@ -1809,14 +1771,14 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   image_info.extent.width = params.x;
   image_info.extent.height = params.y;
   image_info.extent.depth = params.z;
-  image_info.mipLevels = num_mip_levels;
+  image_info.mipLevels = 1;
   image_info.arrayLayers = 1;
   image_info.format = buffer_format_ti_to_vk(params.format);
   image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
   image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-  image_info.usage =
-      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-      VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+  image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT |
+                     VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                     VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
   if (is_depth) {
     image_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
   } else {
@@ -1885,18 +1847,11 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   view_info.subresourceRange.aspectMask =
       is_depth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
   view_info.subresourceRange.baseMipLevel = 0;
-  view_info.subresourceRange.levelCount = num_mip_levels;
+  view_info.subresourceRange.levelCount = 1;
   view_info.subresourceRange.baseArrayLayer = 0;
   view_info.subresourceRange.layerCount = 1;
 
   alloc.view = vkapi::create_image_view(device_, alloc.image, &view_info);
-
-  for (int i = 0; i < num_mip_levels; i++) {
-    view_info.subresourceRange.baseMipLevel = i;
-    view_info.subresourceRange.levelCount = 1;
-    alloc.view_lods.push_back(
-        vkapi::create_image_view(device_, alloc.image, &view_info));
-  }
 
   if (params.initial_layout != ImageLayout::undefined) {
     image_transition(handle, ImageLayout::undefined, params.initial_layout);
@@ -2377,6 +2332,9 @@ VulkanSurface::~VulkanSurface() {
     }
     swapchain_images_.clear();
   }
+  if (depth_buffer_ != kDeviceNullAllocation) {
+    device_->dealloc_memory(depth_buffer_);
+  }
   if (screenshot_buffer_ != kDeviceNullAllocation) {
     device_->dealloc_memory(screenshot_buffer_);
   }
@@ -2444,6 +2402,38 @@ void VulkanSurface::present_image(
   device_->wait_idle();
 }
 
+DeviceAllocation VulkanSurface::get_depth_data(DeviceAllocation& depth_alloc) {
+  auto *stream = device_->get_graphics_stream();
+  
+  auto [w, h] = get_size();
+  size_t size_bytes = w * h * 4;
+
+  if (depth_buffer_ == kDeviceNullAllocation) {
+    Device::AllocParams params{size_bytes, /*host_wrtie*/ false,
+                               /*host_read*/ true, /*export_sharing*/ false,
+                               AllocUsage::Uniform};
+    depth_buffer_ = device_->allocate_memory(params);
+  }
+
+  device_->image_transition(depth_alloc, ImageLayout::present_src,
+                            ImageLayout::transfer_src);
+
+  std::unique_ptr<CommandList> cmd_list{nullptr};
+
+  BufferImageCopyParams copy_params;
+  copy_params.image_extent.x = w;
+  copy_params.image_extent.y = h;
+  copy_params.image_aspect_flag = VK_IMAGE_ASPECT_DEPTH_BIT;
+  cmd_list = stream->new_command_list();
+  cmd_list->image_to_buffer(depth_buffer_.get_ptr(), depth_alloc,
+                            ImageLayout::transfer_src, copy_params);
+  cmd_list->image_transition(depth_alloc, ImageLayout::transfer_src,
+                             ImageLayout::present_src);
+  stream->submit_synced(cmd_list.get());
+
+  return depth_buffer_;
+}
+
 DeviceAllocation VulkanSurface::get_image_data() {
   auto *stream = device_->get_graphics_stream();
   DeviceAllocation img_alloc = swapchain_images_[image_index_];
@@ -2491,6 +2481,7 @@ DeviceAllocation VulkanSurface::get_image_data() {
   BufferImageCopyParams copy_params;
   copy_params.image_extent.x = w;
   copy_params.image_extent.y = h;
+  copy_params.image_aspect_flag = VK_IMAGE_ASPECT_COLOR_BIT;
   cmd_list = stream->new_command_list();
   // TODO: directly map the image to cpu memory
   cmd_list->image_to_buffer(screenshot_buffer_.get_ptr(), img_alloc,

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -449,7 +449,7 @@ class VulkanSurface : public Surface {
   BufferFormat image_format() override;
   void resize(uint32_t width, uint32_t height) override;
 
-  DeviceAllocation get_depth_data(DeviceAllocation& depth_alloc) override;
+  DeviceAllocation get_depth_data(DeviceAllocation &depth_alloc) override;
   DeviceAllocation get_image_data() override;
 
  private:

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -101,7 +101,10 @@ class VulkanResourceBinder : public ResourceBinder {
     VkDescriptorType type;
     DevicePtr ptr;
     VkDeviceSize size;
-    VkSampler sampler{VK_NULL_HANDLE};  // used only for images
+    union {
+      VkSampler sampler{VK_NULL_HANDLE};  // used only for images
+      int image_lod;
+    };
 
     bool operator==(const Binding &other) const {
       return other.type == type && other.ptr == ptr && other.size == size &&
@@ -221,6 +224,10 @@ class VulkanResourceBinder : public ResourceBinder {
              uint32_t binding,
              DeviceAllocation alloc,
              ImageSamplerConfig sampler_config) override;
+  void rw_image(uint32_t set,
+                uint32_t binding,
+                DeviceAllocation alloc,
+                int lod) override;
   void vertex_buffer(DevicePtr ptr, uint32_t binding = 0) override;
   void index_buffer(DevicePtr ptr, size_t index_width) override;
 
@@ -442,7 +449,6 @@ class VulkanSurface : public Surface {
   BufferFormat image_format() override;
   void resize(uint32_t width, uint32_t height) override;
 
-  DeviceAllocation get_depth_data(DeviceAllocation& depth_alloc) override;
   DeviceAllocation get_image_data() override;
 
  private:
@@ -467,7 +473,6 @@ class VulkanSurface : public Surface {
   std::vector<DeviceAllocation> swapchain_images_;
 
   // DeviceAllocation screenshot_image_{kDeviceNullAllocation};
-  DeviceAllocation depth_buffer_{kDeviceNullAllocation};
   DeviceAllocation screenshot_buffer_{kDeviceNullAllocation};
 };
 
@@ -619,6 +624,9 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
 
   vkapi::IVkImageView get_vk_imageview(const DeviceAllocation &alloc) const;
 
+  vkapi::IVkImageView get_vk_lod_imageview(const DeviceAllocation &alloc,
+                                           int lod) const;
+
   vkapi::IVkRenderPass get_renderpass(const VulkanRenderPassDesc &desc);
 
   vkapi::IVkFramebuffer get_framebuffer(const VulkanFramebufferDesc &desc);
@@ -668,6 +676,7 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
     VmaAllocationInfo alloc_info;
     vkapi::IVkImage image;
     vkapi::IVkImageView view;
+    std::vector<vkapi::IVkImageView> view_lods;
     VkFormat format;
   };
 

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -101,10 +101,7 @@ class VulkanResourceBinder : public ResourceBinder {
     VkDescriptorType type;
     DevicePtr ptr;
     VkDeviceSize size;
-    union {
-      VkSampler sampler{VK_NULL_HANDLE};  // used only for images
-      int image_lod;
-    };
+    VkSampler sampler{VK_NULL_HANDLE};  // used only for images
 
     bool operator==(const Binding &other) const {
       return other.type == type && other.ptr == ptr && other.size == size &&
@@ -224,10 +221,6 @@ class VulkanResourceBinder : public ResourceBinder {
              uint32_t binding,
              DeviceAllocation alloc,
              ImageSamplerConfig sampler_config) override;
-  void rw_image(uint32_t set,
-                uint32_t binding,
-                DeviceAllocation alloc,
-                int lod) override;
   void vertex_buffer(DevicePtr ptr, uint32_t binding = 0) override;
   void index_buffer(DevicePtr ptr, size_t index_width) override;
 
@@ -449,6 +442,7 @@ class VulkanSurface : public Surface {
   BufferFormat image_format() override;
   void resize(uint32_t width, uint32_t height) override;
 
+  DeviceAllocation get_depth_data(DeviceAllocation& depth_alloc) override;
   DeviceAllocation get_image_data() override;
 
  private:
@@ -473,6 +467,7 @@ class VulkanSurface : public Surface {
   std::vector<DeviceAllocation> swapchain_images_;
 
   // DeviceAllocation screenshot_image_{kDeviceNullAllocation};
+  DeviceAllocation depth_buffer_{kDeviceNullAllocation};
   DeviceAllocation screenshot_buffer_{kDeviceNullAllocation};
 };
 
@@ -624,9 +619,6 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
 
   vkapi::IVkImageView get_vk_imageview(const DeviceAllocation &alloc) const;
 
-  vkapi::IVkImageView get_vk_lod_imageview(const DeviceAllocation &alloc,
-                                           int lod) const;
-
   vkapi::IVkRenderPass get_renderpass(const VulkanRenderPassDesc &desc);
 
   vkapi::IVkFramebuffer get_framebuffer(const VulkanFramebufferDesc &desc);
@@ -676,7 +668,6 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
     VmaAllocationInfo alloc_info;
     vkapi::IVkImage image;
     vkapi::IVkImageView view;
-    std::vector<vkapi::IVkImageView> view_lods;
     VkFormat format;
   };
 

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -449,6 +449,7 @@ class VulkanSurface : public Surface {
   BufferFormat image_format() override;
   void resize(uint32_t width, uint32_t height) override;
 
+  DeviceAllocation get_depth_data(DeviceAllocation& depth_alloc) override;
   DeviceAllocation get_image_data() override;
 
  private:
@@ -473,6 +474,7 @@ class VulkanSurface : public Surface {
   std::vector<DeviceAllocation> swapchain_images_;
 
   // DeviceAllocation screenshot_image_{kDeviceNullAllocation};
+  DeviceAllocation depth_buffer_{kDeviceNullAllocation};
   DeviceAllocation screenshot_buffer_{kDeviceNullAllocation};
 };
 

--- a/taichi/ui/backends/vulkan/swap_chain.cpp
+++ b/taichi/ui/backends/vulkan/swap_chain.cpp
@@ -63,7 +63,7 @@ uint32_t SwapChain::height() {
 taichi::lang::Surface &SwapChain::surface() {
   return *(surface_.get());
 }
-std::vector<float32> &SwapChain::dump_depth_buffer() {
+std::vector<float> &SwapChain::dump_depth_buffer() {
   auto [w, h] = surface_->get_size();
   curr_width_ = w;
   curr_height_ = h;

--- a/taichi/ui/backends/vulkan/swap_chain.cpp
+++ b/taichi/ui/backends/vulkan/swap_chain.cpp
@@ -74,7 +74,7 @@ std::vector<float32> &SwapChain::dump_depth_buffer() {
 
   for (int i = 0; i < w; i++) {
     for (int j = 0; j < h; j++) {
-        depth_buffer_data_[i * h + (h - j - 1)] = ptr[j * w + i];
+      depth_buffer_data_[i * h + (h - j - 1)] = ptr[j * w + i];
     }
   }
   app_context_->device().unmap(depth_buffer);

--- a/taichi/ui/backends/vulkan/swap_chain.cpp
+++ b/taichi/ui/backends/vulkan/swap_chain.cpp
@@ -63,6 +63,23 @@ uint32_t SwapChain::height() {
 taichi::lang::Surface &SwapChain::surface() {
   return *(surface_.get());
 }
+std::vector<float32> &SwapChain::dump_depth_buffer() {
+  auto [w, h] = surface_->get_size();
+  curr_width_ = w;
+  curr_height_ = h;
+  depth_buffer_data_.clear();
+  depth_buffer_data_.resize(w * h);
+  DeviceAllocation depth_buffer = surface_->get_depth_data(depth_allocation_);
+  float *ptr = (float *)app_context_->device().map(depth_buffer);
+
+  for (int i = 0; i < w; i++) {
+    for (int j = 0; j < h; j++) {
+        depth_buffer_data_[i * h + (h - j - 1)] = ptr[j * w + i];
+    }
+  }
+  app_context_->device().unmap(depth_buffer);
+  return depth_buffer_data_;
+}
 std::vector<uint32_t> &SwapChain::dump_image_buffer() {
   auto [w, h] = surface_->get_size();
   curr_width_ = w;

--- a/taichi/ui/backends/vulkan/swap_chain.h
+++ b/taichi/ui/backends/vulkan/swap_chain.h
@@ -16,6 +16,8 @@ class TI_DLL_EXPORT SwapChain {
 
   void resize(uint32_t width, uint32_t height);
 
+  std::vector<float> &dump_depth_buffer();
+
   std::vector<uint32_t> &dump_image_buffer();
 
   void write_image(const std::string &filename);
@@ -28,6 +30,8 @@ class TI_DLL_EXPORT SwapChain {
   taichi::lang::DeviceAllocation depth_allocation_;
 
   std::unique_ptr<taichi::lang::Surface> surface_;
+
+  std::vector<float> depth_buffer_data_;
 
   std::vector<uint32_t> image_buffer_data_;
 

--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -102,6 +102,19 @@ void Window::write_image(const std::string &filename) {
   }
 }
 
+std::vector<float> &Window::get_depth_buffer(uint32_t &w, uint32_t &h) {
+  if (!drawn_frame_) {
+    draw_frame();
+  }
+  w = renderer_->swap_chain().width();
+  h = renderer_->swap_chain().height();
+  auto &depth_buffer = renderer_->swap_chain().dump_depth_buffer();
+  if (!config_.show_window) {
+    prepare_for_next_frame();
+  }
+  return depth_buffer;
+}
+
 std::vector<uint32_t> &Window::get_image_buffer(uint32_t &w, uint32_t &h) {
   if (!drawn_frame_) {
     draw_frame();

--- a/taichi/ui/backends/vulkan/window.h
+++ b/taichi/ui/backends/vulkan/window.h
@@ -42,6 +42,8 @@ class Window final : public WindowBase {
 
   void write_image(const std::string &filename) override;
 
+  std::vector<float> &get_depth_buffer(uint32_t &w, uint32_t &h) override;
+
   std::vector<uint32_t> &get_image_buffer(uint32_t &w, uint32_t &h) override;
 
   ~Window();

--- a/taichi/ui/common/window_base.h
+++ b/taichi/ui/common/window_base.h
@@ -41,6 +41,8 @@ class WindowBase {
 
   virtual void write_image(const std::string &filename) = 0;
 
+  virtual std::vector<float> &get_depth_buffer(uint32_t &w, uint32_t &h) = 0;
+
   virtual std::vector<uint32_t> &get_image_buffer(uint32_t &w, uint32_t &h) = 0;
 
   virtual GuiBase *GUI();


### PR DESCRIPTION
Usage:
``` python
window = ti.ui.Window("Test for getting depth buffer from ggui", (768, 768), vsync=True)
video = ti.tools.VideoManager("OutputDir")

while window.running:
    render_scene()
    depth = window.get_depth_buffer()
    video.write_frame(depth)
    window.show()
```
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
