### PR TITLE
[bug] Simplify scalar handling in cgraph and relax field_dim check

### DIFF
--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -52,12 +52,12 @@ def produce_injected_args(kernel, symbolic_args=None):
                 field_dim = anno.field_dim
                 dtype = anno.dtype
 
-            if element_shape is None or anno.field_dim is None:
+            if element_shape is None or field_dim is None:
                 raise TaichiCompilationError(
                     'Please either specify both `element_shape` and `field_dim` '
                     'in the param annotation, or provide an example '
                     f'ndarray for param={arg.name}')
-            if field_dim != anno.field_dim:
+            if anno.field_dim is not None and field_dim != anno.field_dim:
                 raise TaichiCompilationError(
                     f'{field_dim} from Arg {arg.name} doesn\'t match kernel\'s annotated field_dim={anno.field_dim}'
                 )
@@ -69,20 +69,19 @@ def produce_injected_args(kernel, symbolic_args=None):
                 )
 
             if element_dim is None or element_dim == 0:
-                injected_args.append(
-                    ScalarNdarray(dtype, (2, ) * anno.field_dim))
+                injected_args.append(ScalarNdarray(dtype, (2, ) * field_dim))
             elif element_dim == 1:
                 injected_args.append(
                     VectorNdarray(element_shape[0],
                                   dtype=dtype,
-                                  shape=(2, ) * anno.field_dim,
+                                  shape=(2, ) * field_dim,
                                   layout=Layout.AOS))
             elif element_dim == 2:
                 injected_args.append(
                     MatrixNdarray(element_shape[0],
                                   element_shape[1],
                                   dtype=dtype,
-                                  shape=(2, ) * anno.field_dim,
+                                  shape=(2, ) * field_dim,
                                   layout=Layout.AOS))
             else:
                 raise RuntimeError('')

--- a/python/taichi/graph/_graph.py
+++ b/python/taichi/graph/_graph.py
@@ -62,37 +62,24 @@ class Graph:
         # Support native python numerical types (int, float), Ndarray.
         # Taichi Matrix types are flattened into (int, float) arrays.
         # TODO diminish the flatten behavior when Matrix becomes a Taichi native type.
-        arg_ptrs = {}
-        arg_ints = {}
-        arg_floats = {}
-        arg_doubles = {}
-
+        flattened = {}
         for k, v in args.items():
             if isinstance(v, Ndarray):
-                arg_ptrs[k] = v.arr
-            elif isinstance(v, int):
-                arg_ints[k] = v
-            elif isinstance(v, float):
-                arg_floats[k] = v
+                flattened[k] = v.arr
             elif isinstance(v, Matrix):
                 mat_val_id = 0
                 for a in range(v.n):
                     for b in range(v.m):
                         key = f"{k}_mat_arg_{mat_val_id}"
                         mat_val_id += 1
-                        if isinstance(v[a, b], int):
-                            arg_ints[key] = int(v[a, b])
-                        elif isinstance(v[a, b], float):
-                            arg_floats[key] = float(v[a, b])
-                        else:
-                            raise TaichiRuntimeError(
-                                f'Only python int, float are supported as matrix runtime arguments but got {type(v)}'
-                            )
+                        flattened[key] = v[a, b]
+            elif isinstance(v, (int, float)):
+                flattened[k] = v
             else:
                 raise TaichiRuntimeError(
-                    f'Only python int, float and ti.Ndarray are supported as runtime arguments but got {type(v)}'
+                    f'Only python int, float, ti.Matrix and ti.Ndarray are supported as runtime arguments but got {type(v)}'
                 )
-        self._compiled_graph.run(arg_ptrs, arg_ints, arg_floats, arg_doubles)
+        self._compiled_graph.run(flattened)
 
 
 def Arg(tag, name, dtype, field_dim=0, element_shape=()):

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -619,49 +619,46 @@ void export_lang(py::module &m) {
       .def("seq", &GraphBuilder::seq, py::return_value_policy::reference);
 
   py::class_<aot::CompiledGraph>(m, "CompiledGraph")
-      .def("run", [](aot::CompiledGraph *self, const py::dict &arg_ptrs,
-                     const py::dict &arg_ints, const py::dict &arg_floats,
-                     const py::dict &arg_doubles) {
+      .def("run", [](aot::CompiledGraph *self, const py::dict &pyargs) {
         std::unordered_map<std::string, aot::IValue> args;
-        for (auto it : arg_ptrs) {
-          auto &val = it.second.cast<Ndarray &>();
-          args.insert(
-              {py::cast<std::string>(it.first), aot::IValue::create(val)});
-        }
-        for (auto it : arg_ints) {
+        for (auto it : pyargs) {
           std::string arg_name = py::cast<std::string>(it.first);
-          auto expected_dtype = self->args[arg_name].dtype();
-          if (expected_dtype == PrimitiveType::i32) {
+          auto tag = self->args[arg_name].tag;
+          if (tag == aot::ArgKind::kNdarray) {
+            auto &val = it.second.cast<Ndarray &>();
             args.insert(
-                {arg_name, aot::IValue::create(py::cast<int>(it.second))});
-          } else if (expected_dtype == PrimitiveType::i64) {
-            args.insert(
-                {arg_name, aot::IValue::create(py::cast<int64>(it.second))});
-          } else if (expected_dtype == PrimitiveType::i16) {
-            args.insert(
-                {arg_name, aot::IValue::create(py::cast<int16>(it.second))});
-          } else if (expected_dtype == PrimitiveType::u32) {
-            args.insert(
-                {arg_name, aot::IValue::create(py::cast<uint32>(it.second))});
-          } else if (expected_dtype == PrimitiveType::u64) {
-            args.insert(
-                {arg_name, aot::IValue::create(py::cast<uint64>(it.second))});
-          } else if (expected_dtype == PrimitiveType::u16) {
-            args.insert(
-                {arg_name, aot::IValue::create(py::cast<uint16>(it.second))});
-          } else {
-            TI_NOT_IMPLEMENTED;
-          }
-        }
-        for (auto it : arg_floats) {
-          std::string arg_name = py::cast<std::string>(it.first);
-          auto expected_dtype = self->args[arg_name].dtype();
-          if (expected_dtype == PrimitiveType::f32) {
-            args.insert(
-                {arg_name, aot::IValue::create(py::cast<float>(it.second))});
-          } else if (expected_dtype == PrimitiveType::f64) {
-            args.insert(
-                {arg_name, aot::IValue::create(py::cast<double>(it.second))});
+                {py::cast<std::string>(it.first), aot::IValue::create(val)});
+          } else if (tag == aot::ArgKind::kScalar ||
+                     tag == aot::ArgKind::kMatrix) {
+            std::string arg_name = py::cast<std::string>(it.first);
+            auto expected_dtype = self->args[arg_name].dtype();
+            if (expected_dtype == PrimitiveType::i32) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<int>(it.second))});
+            } else if (expected_dtype == PrimitiveType::i64) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<int64>(it.second))});
+            } else if (expected_dtype == PrimitiveType::f32) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<float>(it.second))});
+            } else if (expected_dtype == PrimitiveType::f64) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<double>(it.second))});
+            } else if (expected_dtype == PrimitiveType::i16) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<int16>(it.second))});
+            } else if (expected_dtype == PrimitiveType::u32) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<uint32>(it.second))});
+            } else if (expected_dtype == PrimitiveType::u64) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<uint64>(it.second))});
+            } else if (expected_dtype == PrimitiveType::u16) {
+              args.insert(
+                  {arg_name, aot::IValue::create(py::cast<uint16>(it.second))});
+            } else {
+              TI_NOT_IMPLEMENTED;
+            }
           } else {
             TI_NOT_IMPLEMENTED;
           }

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -35,6 +35,25 @@ def test_ndarray_int():
 
 
 @test_utils.test(arch=ti.vulkan)
+def test_ndarray_0dim():
+    @ti.kernel
+    def test(pos: ti.types.ndarray(dtype=ti.i32, field_dim=0)):
+        pos[None] = 1
+
+    sym_pos = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                           'pos',
+                           ti.i32,
+                           field_dim=0)
+    g_init = ti.graph.GraphBuilder()
+    g_init.dispatch(test, sym_pos)
+    g = g_init.compile()
+
+    a = ti.ndarray(ti.i32, shape=())
+    g.run({'pos': a})
+    assert a.to_numpy() == 1
+
+
+@test_utils.test(arch=ti.vulkan)
 def test_ndarray_float():
     n = 4
 

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -636,3 +636,27 @@ def test_different_shape():
     y = ti.ndarray(dtype=ti.f32, shape=(n2, n2))
     init(3, y)
     assert (y.to_numpy() == (np.ones(shape=(n2, n2)) * 3)).all()
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_grouped():
+    @ti.kernel
+    def func(a: ti.types.ndarray()):
+        for i in ti.grouped(a):
+            for j, k in ti.ndrange(2, 2):
+                a[i][j, k] = j * j
+
+    a1 = ti.Matrix.ndarray(2, 2, ti.i32, shape=5)
+    func(a1)
+    for i in range(5):
+        for j in range(2):
+            for k in range(2):
+                assert a1[i][j, k] == j * j
+
+    a2 = ti.Matrix.ndarray(2, 2, ti.i32, shape=(3, 3))
+    func(a2)
+    for i in range(3):
+        for j in range(3):
+            for k in range(2):
+                for p in range(2):
+                    assert a2[i, j][k, p] == k * k


### PR DESCRIPTION
This PR fixes two issues showed up while porting implicit_fem demo:
- field_dim check can be relaxed, for example when users write `for I in
ti.grouped(arr)` it actually works for ndarrays with different
`field_dim`s.
- passing scalars to c++ shouldn't be seperated based on python
type and it was not correct to do so. For example users can pass a `0`
(python int) to a `ti.f32` graph argument.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
