### PR TITLE
[Lang] Add append attribute to dynamic fields

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -607,6 +607,8 @@ class ASTTransformer(Builder):
         if node.attr.id == "append":
             if isinstance(node.value, ast.Subscript):
                 x = build_stmt(ctx, node.value.value)
+                if not isinstance(x, SNode) and (x.ptr.type != _ti_core.SNodeType.dynamic):
+                    raise TaichiSyntaxError(f"In Taichi scope you can only call `append` for dynamic SNodes, but {x} is encountered")
                 slice = build_stmt(ctx, node.value.slice)
                 node.ptr = lambda val: append(x.parent(), slice, val)
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -607,7 +607,7 @@ class ASTTransformer(Builder):
         if node.attr.id == "append":
             if isinstance(node.value, ast.Subscript):
                 x = build_stmt(ctx, node.value.value)
-                if not isinstance(x, SNode) and (x.ptr.type != _ti_core.SNodeType.dynamic):
+                if not isinstance(x, SNode) and (x.parent().ptr.type != _ti_core.SNodeType.dynamic):
                     raise TaichiSyntaxError(f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered")
                 slice = build_stmt(ctx, node.value.slice)
                 node.ptr = lambda val: append(x.parent(), slice, val)

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -18,7 +18,7 @@ from taichi.lang.util import is_taichi_class, to_taichi_type
 from taichi.types import (annotations, ndarray_type, primitive_types,
                           texture_type)
 from taichi.types.utils import is_integral
-from taichi.lang.snode import SNode, append
+from taichi.lang.snode import append
 
 if version_info < (3, 9):
     from astunparse import unparse
@@ -609,9 +609,9 @@ class ASTTransformer(Builder):
                 x = build_stmt(ctx, node.value.value)
                 if not hasattr(x, "parent") and x.parent().ptr.type != _ti_core.SNodeType.dynamic:
                     raise TaichiSyntaxError(f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered")
-                slice = build_stmt(ctx, node.value.slice)
+                index = build_stmt(ctx, node.value.slice)
                 node.value.ptr = None
-                node.ptr = lambda val: append(x.parent(), slice, val)
+                node.ptr = lambda val: append(x.parent(), index, val)
         else:
             build_stmt(ctx, node.value)
             node.ptr = getattr(node.value.ptr, node.attr)

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -607,7 +607,7 @@ class ASTTransformer(Builder):
         if node.attr.id == "append":
             if isinstance(node.value, ast.Subscript):
                 x = build_stmt(ctx, node.value.value)
-                if not isinstance(x, SNode) and (x.parent().ptr.type != _ti_core.SNodeType.dynamic):
+                if not hasattr(x, "parent") and not isinstance(x.parent(), SNode) and (x.parent().ptr.type != _ti_core.SNodeType.dynamic):
                     raise TaichiSyntaxError(f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered")
                 slice = build_stmt(ctx, node.value.slice)
                 node.ptr = lambda val: append(x.parent(), slice, val)

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -604,14 +604,14 @@ class ASTTransformer(Builder):
 
     @staticmethod
     def build_Attribute(ctx, node):
-        if node.attr.id == "append":
+        if node.attr == "append":
             if isinstance(node.value, ast.Subscript):
                 x = build_stmt(ctx, node.value.value)
                 if not hasattr(x, "parent") and x.parent().ptr.type != _ti_core.SNodeType.dynamic:
                     raise TaichiSyntaxError(f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered")
                 slice = build_stmt(ctx, node.value.slice)
+                node.value.ptr = None
                 node.ptr = lambda val: append(x.parent(), slice, val)
-
         else:
             build_stmt(ctx, node.value)
             node.ptr = getattr(node.value.ptr, node.attr)

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -608,7 +608,7 @@ class ASTTransformer(Builder):
             if isinstance(node.value, ast.Subscript):
                 x = build_stmt(ctx, node.value.value)
                 if not isinstance(x, SNode) and (x.ptr.type != _ti_core.SNodeType.dynamic):
-                    raise TaichiSyntaxError(f"In Taichi scope you can only call `append` for dynamic SNodes, but {x} is encountered")
+                    raise TaichiSyntaxError(f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered")
                 slice = build_stmt(ctx, node.value.slice)
                 node.ptr = lambda val: append(x.parent(), slice, val)
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -13,14 +13,14 @@ from taichi.lang.ast.ast_transformer_utils import (Builder, LoopStatus,
                                                    ReturnStatus)
 from taichi.lang.ast.symbol_resolver import ASTResolver
 from taichi.lang.exception import TaichiSyntaxError, TaichiTypeError
+from taichi.lang.field import Field
 from taichi.lang.matrix import (Matrix, MatrixType, _PyScopeMatrixImpl,
                                 _TiScopeMatrixImpl)
+from taichi.lang.snode import append
 from taichi.lang.util import in_taichi_scope, is_taichi_class, to_taichi_type
 from taichi.types import (annotations, ndarray_type, primitive_types,
                           texture_type)
 from taichi.types.utils import is_integral
-from taichi.lang.snode import append
-from taichi.lang.field import Field
 
 if version_info < (3, 9):
     from astunparse import unparse
@@ -641,8 +641,11 @@ class ASTTransformer(Builder):
     def build_Attribute(ctx, node):
         if node.attr == "append" and isinstance(node.value, ast.Subscript):
             x = build_stmt(ctx, node.value.value)
-            if not isinstance(x, Field) or x.parent().ptr.type != _ti_core.SNodeType.dynamic:
-                raise TaichiSyntaxError(f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered")
+            if not isinstance(x, Field) or x.parent(
+            ).ptr.type != _ti_core.SNodeType.dynamic:
+                raise TaichiSyntaxError(
+                    f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered"
+                )
             index = build_stmt(ctx, node.value.slice)
             node.value.ptr = None
             node.ptr = lambda val: append(x.parent(), index, val)

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -607,7 +607,7 @@ class ASTTransformer(Builder):
         if node.attr.id == "append":
             if isinstance(node.value, ast.Subscript):
                 x = build_stmt(ctx, node.value.value)
-                if not hasattr(x, "parent") and not isinstance(x.parent(), SNode) and (x.parent().ptr.type != _ti_core.SNodeType.dynamic):
+                if not hasattr(x, "parent") and x.parent().ptr.type != _ti_core.SNodeType.dynamic:
                     raise TaichiSyntaxError(f"In Taichi scope the `append` method is only defined for dynamic SNodes, but {x} is encountered")
                 slice = build_stmt(ctx, node.value.slice)
                 node.ptr = lambda val: append(x.parent(), slice, val)

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -2,6 +2,7 @@ import taichi.lang
 from taichi._lib import core as _ti_core
 from taichi.lang.util import (python_scope, to_numpy_type, to_paddle_type,
                               to_pytorch_type)
+from taichi.lang.snode import SNode
 
 
 class Field:

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -2,7 +2,6 @@ import taichi.lang
 from taichi._lib import core as _ti_core
 from taichi.lang.util import (python_scope, to_numpy_type, to_paddle_type,
                               to_pytorch_type)
-from taichi.lang.snode import SNode
 
 
 class Field:

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -13,15 +13,18 @@ def _test_dynamic_append_length(dt):
         for i in range(10):
             for j in range(i):
                 x[i].append(j)
-
+        for i in range(10):
+            assert(ti.length(x.parent(), i) == i)
+            for j in range(i):
+                assert(x[i, j] == j)
     test()
 
 
-@test_utils.test(arch=ti.cpu, default_fp=ti.f32)
+@test_utils.test(exclude=[ti.cc, ti.opengl], default_fp=ti.f32, debug=True)
 def test_dynamic_append_length_f32():
     _test_dynamic_append_length(ti.f32)
 
 
-@test_utils.test(default_fp=ti.f64, require=ti.extension.data64)
+@test_utils.test(exclude=[ti.cc, ti.opengl], default_fp=ti.f64, require=ti.extension.data64, debug=True)
 def test_dynamic_append_length_f64():
     _test_dynamic_append_length(ti.f64)

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -17,7 +17,7 @@ def _test_dynamic_append_length(dt):
     test()
 
 
-@test_utils.test(default_fp=ti.f32)
+@test_utils.test(arch=ti.cpu, default_fp=ti.f32)
 def test_dynamic_append_length_f32():
     _test_dynamic_append_length(ti.f32)
 

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -1,0 +1,27 @@
+import taichi as ti
+from tests import test_utils
+
+
+def _test_dynamic_append_length(dt):
+    x = ti.field(int)
+    block = ti.root.dense(ti.i, 10)
+    pixel = block.dynamic(ti.j, 10)
+    pixel.place(x)
+
+    @ti.kernel
+    def test():
+        for i in range(10):
+            for j in range(i):
+                x[i].append(j)
+
+    test()
+
+
+@test_utils.test(default_fp=ti.f32)
+def test_dynamic_append_length_f32():
+    _test_dynamic_append_length(ti.f32)
+
+
+@test_utils.test(default_fp=ti.f64, require=ti.extension.data64)
+def test_dynamic_append_length_f64():
+    _test_dynamic_append_length(ti.f64)

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -28,9 +28,3 @@ def test_dynamic_append_length_f32():
     _test_dynamic_append_length(ti.f32)
 
 
-@test_utils.test(exclude=[ti.cc, ti.opengl, ti.vulkan],
-                 default_fp=ti.f64,
-                 require=ti.extension.data64,
-                 debug=True)
-def test_dynamic_append_length_f64():
-    _test_dynamic_append_length(ti.f64)

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -26,5 +26,3 @@ def _test_dynamic_append_length(dt):
                  debug=True)
 def test_dynamic_append_length_f32():
     _test_dynamic_append_length(ti.f32)
-
-

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -21,12 +21,12 @@ def _test_dynamic_append_length(dt):
     test()
 
 
-@test_utils.test(exclude=[ti.cc, ti.opengl], default_fp=ti.f32, debug=True)
+@test_utils.test(exclude=[ti.cc, ti.opengl, ti.vulkan], default_fp=ti.f32, debug=True)
 def test_dynamic_append_length_f32():
     _test_dynamic_append_length(ti.f32)
 
 
-@test_utils.test(exclude=[ti.cc, ti.opengl],
+@test_utils.test(exclude=[ti.cc, ti.opengl, ti.vulkan],
                  default_fp=ti.f64,
                  require=ti.extension.data64,
                  debug=True)

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -14,9 +14,10 @@ def _test_dynamic_append_length(dt):
             for j in range(i):
                 x[i].append(j)
         for i in range(10):
-            assert(ti.length(x.parent(), i) == i)
+            assert (ti.length(x.parent(), i) == i)
             for j in range(i):
-                assert(x[i, j] == j)
+                assert (x[i, j] == j)
+
     test()
 
 
@@ -25,6 +26,9 @@ def test_dynamic_append_length_f32():
     _test_dynamic_append_length(ti.f32)
 
 
-@test_utils.test(exclude=[ti.cc, ti.opengl], default_fp=ti.f64, require=ti.extension.data64, debug=True)
+@test_utils.test(exclude=[ti.cc, ti.opengl],
+                 default_fp=ti.f64,
+                 require=ti.extension.data64,
+                 debug=True)
 def test_dynamic_append_length_f64():
     _test_dynamic_append_length(ti.f64)

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -21,7 +21,9 @@ def _test_dynamic_append_length(dt):
     test()
 
 
-@test_utils.test(exclude=[ti.cc, ti.opengl, ti.vulkan], default_fp=ti.f32, debug=True)
+@test_utils.test(exclude=[ti.cc, ti.opengl, ti.vulkan],
+                 default_fp=ti.f32,
+                 debug=True)
 def test_dynamic_append_length_f32():
     _test_dynamic_append_length(ti.f32)
 


### PR DESCRIPTION
related issue = #5420

Here is currently how we use `ti.append`:

```python
import taichi as ti
ti.init(arch=ti.cpu)

x = ti.field(int, shape=None)
q = ti.root.dynamic(ti.i, 5)
q.place(x)

@ti.kernel
def test():
    for i in range(5):
        ti.append(q, [], i)   # q = x.parent()
    print(ti.length(q, []))

test()
```
The `ti.append()` function is a bit confusing in that it requires two more positional arguments compared with the usual `append` method.

We hope to change it to something like `x[i].append(i)`, this is done in the ast part by replacing `x[indices].append(val)` with `ti.append(x.parent(), indices, val)`.