### PR TITLE
[aot] Support specifying vk_api_version in CompileConfig

### DIFF
--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -72,7 +72,7 @@ make_vulkan_runtime_creator_params() {
 
   // FIXME: (penguinliong) Vulkan runtime should be created outside.
   taichi::lang::vulkan::VulkanDeviceCreator::Params params{};
-  params.api_version = VK_API_VERSION_1_3;
+  params.api_version = std::nullopt;
   params.additional_instance_extensions = extensions;
   params.additional_device_extensions = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
   return params;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -116,7 +116,7 @@ struct CompileConfig {
   double offline_cache_cleaning_factor{0.25};        // [0.f, 1.f]
 
   int num_compile_threads{0};
-  uint32_t spirv_version{0};
+  std::string vk_api_version;
 
   CompileConfig();
 };

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -116,6 +116,7 @@ struct CompileConfig {
   double offline_cache_cleaning_factor{0.25};        // [0.f, 1.f]
 
   int num_compile_threads{0};
+  uint32_t spirv_version{0};
 
   CompileConfig();
 };

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -245,8 +245,8 @@ void export_lang(py::module &m) {
                      &CompileConfig::offline_cache_max_size_of_files)
       .def_readwrite("offline_cache_cleaning_factor",
                      &CompileConfig::offline_cache_cleaning_factor)
-      .def_readwrite("num_compile_threads",
-                     &CompileConfig::num_compile_threads);
+      .def_readwrite("num_compile_threads", &CompileConfig::num_compile_threads)
+      .def_readwrite("spirv_version", &CompileConfig::spirv_version);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -246,7 +246,7 @@ void export_lang(py::module &m) {
       .def_readwrite("offline_cache_cleaning_factor",
                      &CompileConfig::offline_cache_cleaning_factor)
       .def_readwrite("num_compile_threads", &CompileConfig::num_compile_threads)
-      .def_readwrite("spirv_version", &CompileConfig::spirv_version);
+      .def_readwrite("vk_api_version", &CompileConfig::vk_api_version);
 
   m.def("reset_default_compile_config",
         [&]() { default_compile_config = CompileConfig(); });

--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -287,7 +287,7 @@ void VulkanDeviceCreator::create_instance(bool manual_create) {
   uint32_t num_instance_extensions = 0;
   if (!manual_create) {
     vkEnumerateInstanceExtensionProperties(nullptr, &num_instance_extensions,
-                                          nullptr);
+                                           nullptr);
   }
   std::vector<VkExtensionProperties> supported_extensions(
       num_instance_extensions);
@@ -441,10 +441,10 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
 
   if (manual_create) {
     TI_INFO("User decided to create Vulkan {} Device version {}.{}.{}",
-          VK_API_VERSION_VARIANT(api_version_),
-          VK_API_VERSION_MAJOR(api_version_),
-          VK_API_VERSION_MINOR(api_version_),
-          VK_API_VERSION_PATCH(api_version_));
+            VK_API_VERSION_VARIANT(api_version_),
+            VK_API_VERSION_MAJOR(api_version_),
+            VK_API_VERSION_MINOR(api_version_),
+            VK_API_VERSION_PATCH(api_version_));
   } else {
     api_version_ = physical_device_properties.apiVersion;
   }
@@ -466,7 +466,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
   uint32_t extension_count = 0;
   if (!manual_create) {
     vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
-                                        &extension_count, nullptr);
+                                         &extension_count, nullptr);
   }
   std::vector<VkExtensionProperties> extension_properties(extension_count);
   vkEnumerateDeviceExtensionProperties(
@@ -622,7 +622,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
                [=](const char *o) { return strcmp(ext, o) == 0; }) != \
       enabled_extensions.end()
 
-#define CHECK_VERSION(major, minor)        \
+#define CHECK_VERSION(major, minor) \
   api_version_ >= VK_MAKE_API_VERSION(0, major, minor, 0)
 
     // Variable ptr

--- a/taichi/rhi/vulkan/vulkan_device_creator.h
+++ b/taichi/rhi/vulkan/vulkan_device_creator.h
@@ -45,6 +45,9 @@ struct VulkanQueueFamilyIndices {
 class TI_DLL_EXPORT VulkanDeviceCreator {
  public:
   struct Params {
+    // User-provided API version. If assigned, the users MUST list all
+    // their desired extensions in `additional_instance_extensions` and
+    // `additional_device_extensions`; no extension is enabled by default.
     std::optional<uint32_t> api_version;
     bool is_for_ui{false};
     std::vector<std::string> additional_instance_extensions;
@@ -67,12 +70,13 @@ class TI_DLL_EXPORT VulkanDeviceCreator {
   }
 
  private:
-  void create_instance();
+  void create_instance(bool manual_create);
   void setup_debug_messenger();
   void create_surface();
   void pick_physical_device();
-  void create_logical_device();
+  void create_logical_device(bool manual_create);
 
+  uint32_t api_version_{VK_API_VERSION_1_0};
   VkInstance instance_{VK_NULL_HANDLE};
   VkDebugUtilsMessengerEXT debug_messenger_{VK_NULL_HANDLE};
   VkPhysicalDevice physical_device_{VK_NULL_HANDLE};

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -143,6 +143,10 @@ void VulkanProgramImpl::materialize_runtime(MemoryPool *memory_pool,
 #endif
 
   embedded_device_ = std::make_unique<VulkanDeviceCreator>(evd_params);
+  if (config->spirv_version != 0) {
+    embedded_device_->device()->set_cap(DeviceCapability::spirv_version,
+                                        config->spirv_version);
+  }
 
   gfx::GfxRuntime::Params params;
   params.host_result_buffer = *result_buffer_ptr;
@@ -191,6 +195,7 @@ std::unique_ptr<aot::Kernel> VulkanProgramImpl::make_aot_kernel(
   std::vector<gfx::CompiledSNodeStructs> compiled_structs;
   gfx::GfxRuntime::RegisterParams kparams =
       gfx::run_codegen(&kernel, get_compute_device(), compiled_structs);
+
   return std::make_unique<gfx::KernelImpl>(vulkan_runtime_.get(),
                                            std::move(kparams));
 }

--- a/taichi/ui/backends/vulkan/app_context.cpp
+++ b/taichi/ui/backends/vulkan/app_context.cpp
@@ -74,7 +74,7 @@ void AppContext::init(Program *prog,
   // there is no active current program (usage from external library for AOT
   // modules for example).
   if (config.ti_arch != Arch::vulkan || prog == nullptr) {
-    VulkanDeviceCreator::Params evd_params {};
+    VulkanDeviceCreator::Params evd_params{};
     evd_params.additional_instance_extensions =
         get_required_instance_extensions();
     evd_params.additional_device_extensions = get_required_device_extensions();

--- a/taichi/ui/backends/vulkan/app_context.cpp
+++ b/taichi/ui/backends/vulkan/app_context.cpp
@@ -74,7 +74,7 @@ void AppContext::init(Program *prog,
   // there is no active current program (usage from external library for AOT
   // modules for example).
   if (config.ti_arch != Arch::vulkan || prog == nullptr) {
-    VulkanDeviceCreator::Params evd_params;
+    VulkanDeviceCreator::Params evd_params {};
     evd_params.additional_instance_extensions =
         get_required_instance_extensions();
     evd_params.additional_device_extensions = get_required_device_extensions();

--- a/tests/cpp/aot/mpm88_graph_aot.py
+++ b/tests/cpp/aot/mpm88_graph_aot.py
@@ -9,7 +9,7 @@ args = parser.parse_args()
 
 
 def compile_mpm88_graph(arch):
-    ti.init(arch, spirv_version=0x10000)
+    ti.init(arch, vk_api_version="1.0")
     if ti.lang.impl.current_cfg().arch != arch:
         return
     n_particles = 8192

--- a/tests/cpp/aot/mpm88_graph_aot.py
+++ b/tests/cpp/aot/mpm88_graph_aot.py
@@ -9,7 +9,7 @@ args = parser.parse_args()
 
 
 def compile_mpm88_graph(arch):
-    ti.init(arch)
+    ti.init(arch, spirv_version=0x10000)
     if ti.lang.impl.current_cfg().arch != arch:
         return
     n_particles = 8192

--- a/tests/cpp/aot/vulkan/aot_save_load_test.cpp
+++ b/tests/cpp/aot/vulkan/aot_save_load_test.cpp
@@ -163,8 +163,7 @@ TEST(AotSaveLoad, Vulkan) {
 
   // Create Taichi Device for computation
   lang::vulkan::VulkanDeviceCreator::Params evd_params;
-  evd_params.api_version =
-      taichi::lang::vulkan::VulkanEnvSettings::kApiVersion();
+  evd_params.api_version = std::nullopt;
   auto embedded_device =
       std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
 
@@ -236,8 +235,7 @@ TEST(AotSaveLoad, VulkanNdarray) {
 
   // Create Taichi Device for computation
   lang::vulkan::VulkanDeviceCreator::Params evd_params;
-  evd_params.api_version =
-      taichi::lang::vulkan::VulkanEnvSettings::kApiVersion();
+  evd_params.api_version = std::nullopt;
   auto embedded_device =
       std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
 
@@ -343,8 +341,7 @@ TEST(AotLoadGraph, Vulkan) {
 
   // Create Taichi Device for computation
   lang::vulkan::VulkanDeviceCreator::Params evd_params;
-  evd_params.api_version =
-      taichi::lang::vulkan::VulkanEnvSettings::kApiVersion();
+  evd_params.api_version = std::nullopt;
   auto embedded_device =
       std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
   taichi::lang::vulkan::VulkanDevice *device_ =
@@ -422,8 +419,7 @@ TEST(AotLoadGraph, Mpm88) {
 
   // Create Taichi Device for computation
   lang::vulkan::VulkanDeviceCreator::Params evd_params;
-  evd_params.api_version =
-      taichi::lang::vulkan::VulkanEnvSettings::kApiVersion();
+  evd_params.api_version = std::nullopt;
   auto embedded_device =
       std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
   taichi::lang::vulkan::VulkanDevice *device_ =

--- a/tests/cpp/aot/vulkan/runtime_test.cpp
+++ b/tests/cpp/aot/vulkan/runtime_test.cpp
@@ -34,8 +34,7 @@ TEST(RuntimeTest, ViewDevAllocAsNdarray) {
 
   // Create Taichi Device for computation
   lang::vulkan::VulkanDeviceCreator::Params evd_params;
-  evd_params.api_version =
-      taichi::lang::vulkan::VulkanEnvSettings::kApiVersion();
+  evd_params.api_version = std::nullopt;
   auto embedded_device =
       std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
   taichi::lang::vulkan::VulkanDevice *device_ =


### PR DESCRIPTION
Ideally we should specify this in `ti.aot.Module` instead of `ti.init`
but tbh we need more refactor before we can compile to a target other
than the current running one. So let's use this to avoid complicating
other parts of the codebase, e.g. offline cache uses CompileConfig as
part of cache key.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
