### PR TITLE
[opengl] Speedup compilation for Nvidia cards

### DIFF
--- a/taichi/codegen/spirv/snode_struct_compiler.cpp
+++ b/taichi/codegen/spirv/snode_struct_compiler.cpp
@@ -92,7 +92,7 @@ class StructCompiler {
         auto &ch = sn->ch[i];
         auto child_offset = cell_stride;
         auto *ch_snode = ch.get();
-        cell_stride += compute_snode_size(ch_snode);
+        cell_stride += snode_size;
         snode_descriptors_.find(ch_snode->id)
             ->second.mem_offset_in_parent_cell = child_offset;
       }

--- a/taichi/codegen/spirv/snode_struct_compiler.cpp
+++ b/taichi/codegen/spirv/snode_struct_compiler.cpp
@@ -72,8 +72,24 @@ class StructCompiler {
       sn_desc.cell_stride = data_type_size(sn->dt);
       sn_desc.container_stride = sn_desc.cell_stride;
     } else {
-      std::size_t cell_stride = 0;
+      // Sort by size, so that smaller subfields are placed first.
+      // This accelerates Nvidia's GLSL compiler, as the compiler tries to
+      // place all statically accessed fields
+      std::vector<std::pair<size_t, int>> element_strides;
+      int i = 0;
       for (auto &ch : sn->ch) {
+        element_strides.push_back({compute_snode_size(ch.get()), i});
+        i += 1;
+      }
+      std::sort(element_strides.begin(), element_strides.end(),
+                [](const std::pair<size_t, int> &a,
+                   const std::pair<size_t, int> &b) {
+                  return a.first < b.first;
+                });
+
+      std::size_t cell_stride = 0;
+      for (auto &[snode_size, i] : element_strides) {
+        auto &ch = sn->ch[i];
         auto child_offset = cell_stride;
         auto *ch_snode = ch.get();
         cell_stride += compute_snode_size(ch_snode);

--- a/taichi/codegen/spirv/snode_struct_compiler.cpp
+++ b/taichi/codegen/spirv/snode_struct_compiler.cpp
@@ -81,11 +81,11 @@ class StructCompiler {
         element_strides.push_back({compute_snode_size(ch.get()), i});
         i += 1;
       }
-      std::sort(element_strides.begin(), element_strides.end(),
-                [](const std::pair<size_t, int> &a,
-                   const std::pair<size_t, int> &b) {
-                  return a.first < b.first;
-                });
+      std::sort(
+          element_strides.begin(), element_strides.end(),
+          [](const std::pair<size_t, int> &a, const std::pair<size_t, int> &b) {
+            return a.first < b.first;
+          });
 
       std::size_t cell_stride = 0;
       for (auto &[snode_size, i] : element_strides) {


### PR DESCRIPTION
Nvidia GLSL compilers will try to extract statically accessed array elements and place all of them directly, and it is a bit too smart for its own good.

e.g.
```
int arr[];

arr[8000] = 3.0;
```
will be detected as static and the array will be replaced with a sized one: ```int arr[8000]```. This slows down the driver's GLSL compiler as it places all 8000 elements. This PR sorts the fields according to the size so that all the statically accessed fields (mostly matrices and global states) come first and the driver will not place extra elements.