### PR TITLE
[AOT] Support on-device event

### DIFF
--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -26,6 +26,9 @@ typedef struct TiRuntime_t *TiRuntime;
 // handle.aot_module
 typedef struct TiAotModule_t *TiAotModule;
 
+// handle.event
+typedef struct TiEvent_t *TiEvent;
+
 // handle.memory
 typedef struct TiMemory_t *TiMemory;
 
@@ -160,6 +163,12 @@ TI_DLL_EXPORT void *TI_API_CALL ti_map_memory(TiRuntime runtime,
 TI_DLL_EXPORT void TI_API_CALL ti_unmap_memory(TiRuntime runtime,
                                                TiMemory memory);
 
+// function.create_event
+TI_DLL_EXPORT TiEvent TI_API_CALL ti_create_event(TiRuntime runtime);
+
+// function.destroy_event
+TI_DLL_EXPORT void TI_API_CALL ti_destroy_event(TiEvent event);
+
 // function.copy_memory_device_to_device
 TI_DLL_EXPORT void TI_API_CALL
 ti_copy_memory_device_to_device(TiRuntime runtime,
@@ -178,6 +187,13 @@ ti_launch_compute_graph(TiRuntime runtime,
                         TiComputeGraph compute_graph,
                         uint32_t arg_count,
                         const TiNamedArgument *args);
+
+// function.signal_event
+TI_DLL_EXPORT void TI_API_CALL ti_signal_event(TiRuntime runtime,
+                                               TiEvent event);
+
+// function.reset_event
+TI_DLL_EXPORT void TI_API_CALL ti_reset_event(TiRuntime runtime, TiEvent event);
 
 // function.submit
 TI_DLL_EXPORT void TI_API_CALL ti_submit(TiRuntime runtime);

--- a/c_api/include/taichi/taichi_vulkan.h
+++ b/c_api/include/taichi/taichi_vulkan.h
@@ -25,6 +25,11 @@ typedef struct TiVulkanMemoryInteropInfo {
   VkBufferUsageFlags usage;
 } TiVulkanMemoryInteropInfo;
 
+// structure.vulkan_event_interop_info
+typedef struct TiVulkanEventInteropInfo {
+  VkEvent event;
+} TiVulkanEventInteropInfo;
+
 // function.create_vulkan_runtime
 TI_DLL_EXPORT TiRuntime TI_API_CALL
 ti_create_vulkan_runtime_ext(uint32_t api_version,
@@ -53,9 +58,16 @@ ti_export_vulkan_memory(TiRuntime runtime,
                         TiMemory memory,
                         TiVulkanMemoryInteropInfo *interop_info);
 
-// function.submit_and_signal_vulkan_event
+// function.import_vulkan_event
+TI_DLL_EXPORT TiEvent TI_API_CALL
+ti_import_vulkan_event(TiRuntime runtime,
+                       const TiVulkanEventInteropInfo *interop_info);
+
+// function.export_vulkan_event
 TI_DLL_EXPORT void TI_API_CALL
-ti_submit_and_signal_vulkan_event_ext(TiRuntime runtime, VkEvent event);
+ti_export_vulkan_event(TiRuntime runtime,
+                       TiEvent event,
+                       TiVulkanEventInteropInfo *interop_info);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/c_api/include/taichi/taichi_vulkan.h
+++ b/c_api/include/taichi/taichi_vulkan.h
@@ -53,6 +53,10 @@ ti_export_vulkan_memory(TiRuntime runtime,
                         TiMemory memory,
                         TiVulkanMemoryInteropInfo *interop_info);
 
+// function.submit_and_signal_vulkan_event
+TI_DLL_EXPORT void TI_API_CALL
+ti_submit_and_signal_vulkan_event_ext(TiRuntime runtime, VkEvent event);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -435,7 +435,7 @@ void ti_reset_event(TiRuntime runtime, TiEvent event) {
 }
 
 void ti_wait_event(TiRuntime runtime, TiEvent event) {
-  ((Runtime*)runtime)->wait_event(&((Event*)event)->get());
+  ((Runtime *)runtime)->wait_event(&((Event *)event)->get());
 }
 
 void ti_submit(TiRuntime runtime) {

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -46,15 +46,14 @@ Runtime &AotModule::runtime() {
   return *runtime_;
 }
 
-Event::Event(
-  Runtime& runtime,
-  std::unique_ptr<taichi::lang::DeviceEvent> event
-) : runtime_(&runtime), event_(std::move(event)) {}
+Event::Event(Runtime &runtime, std::unique_ptr<taichi::lang::DeviceEvent> event)
+    : runtime_(&runtime), event_(std::move(event)) {
+}
 
-taichi::lang::DeviceEvent& Event::get() {
+taichi::lang::DeviceEvent &Event::get() {
   return *event_;
 }
-Runtime& Event::runtime() {
+Runtime &Event::runtime() {
   return *runtime_;
 }
 
@@ -165,8 +164,9 @@ void ti_unmap_memory(TiRuntime runtime, TiMemory devmem) {
 
 TiEvent ti_create_event(TiRuntime runtime) {
   Runtime *runtime2 = (Runtime *)runtime;
-  std::unique_ptr<taichi::lang::DeviceEvent> event = runtime2->get().create_event();
-  Event* event2 = new Event(*runtime2, std::move(event));
+  std::unique_ptr<taichi::lang::DeviceEvent> event =
+      runtime2->get().create_event();
+  Event *event2 = new Event(*runtime2, std::move(event));
   return (TiEvent)event2;
 }
 void ti_destroy_event(TiEvent event) {
@@ -175,7 +175,7 @@ void ti_destroy_event(TiEvent event) {
     return;
   }
 
-  delete (Event*)event;
+  delete (Event *)event;
 }
 
 void ti_copy_memory_device_to_device(TiRuntime runtime,
@@ -427,11 +427,11 @@ void ti_launch_compute_graph(TiRuntime runtime,
 }
 
 void ti_signal_event(TiRuntime runtime, TiEvent event) {
-  ((Runtime*)runtime)->signal_event(&((Event*)event)->get());
+  ((Runtime *)runtime)->signal_event(&((Event *)event)->get());
 }
 
 void ti_reset_event(TiRuntime runtime, TiEvent event) {
-  ((Runtime*)runtime)->reset_event(&((Event*)event)->get());
+  ((Runtime *)runtime)->reset_event(&((Event *)event)->get());
 }
 
 void ti_submit(TiRuntime runtime) {

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -434,6 +434,10 @@ void ti_reset_event(TiRuntime runtime, TiEvent event) {
   ((Runtime *)runtime)->reset_event(&((Event *)event)->get());
 }
 
+void ti_wait_event(TiRuntime runtime, TiEvent event) {
+  ((Runtime*)runtime)->wait_event(&((Event*)event)->get());
+}
+
 void ti_submit(TiRuntime runtime) {
   if (runtime == nullptr) {
     TI_WARN("ignored attempt to submit to runtime of null handle");

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -165,7 +165,9 @@ void ti_unmap_memory(TiRuntime runtime, TiMemory devmem) {
 
 TiEvent ti_create_event(TiRuntime runtime) {
   Runtime *runtime2 = (Runtime *)runtime;
-  return (TiEvent)runtime2->get().create_event().release();
+  std::unique_ptr<taichi::lang::DeviceEvent> event = runtime2->get().create_event();
+  Event* event2 = new Event(*runtime2, std::move(event));
+  return (TiEvent)event2;
 }
 void ti_destroy_event(TiEvent event) {
   if (event == nullptr) {

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -24,7 +24,7 @@ taichi::lang::DeviceAllocation Runtime::allocate_memory(
 }
 
 AotModule::AotModule(Runtime &runtime,
-                     std::unique_ptr<taichi::lang::aot::Module> &&aot_module)
+                     std::unique_ptr<taichi::lang::aot::Module> aot_module)
     : runtime_(&runtime), aot_module_(std::move(aot_module)) {
 }
 
@@ -43,6 +43,18 @@ taichi::lang::aot::Module &AotModule::get() {
   return *aot_module_;
 }
 Runtime &AotModule::runtime() {
+  return *runtime_;
+}
+
+Event::Event(
+  Runtime& runtime,
+  std::unique_ptr<taichi::lang::DeviceEvent> event
+) : runtime_(&runtime), event_(std::move(event)) {}
+
+taichi::lang::DeviceEvent& Event::get() {
+  return *event_;
+}
+Runtime& Event::runtime() {
   return *runtime_;
 }
 
@@ -149,6 +161,19 @@ void ti_unmap_memory(TiRuntime runtime, TiMemory devmem) {
   }
   Runtime *runtime2 = (Runtime *)runtime;
   runtime2->get().unmap(devmem2devalloc(*runtime2, devmem));
+}
+
+TiEvent ti_create_event(TiRuntime runtime) {
+  Runtime *runtime2 = (Runtime *)runtime;
+  return (TiEvent)runtime2->get().create_event().release();
+}
+void ti_destroy_event(TiEvent event) {
+  if (event == nullptr) {
+    TI_WARN("ignored attempt to destroy event of null handle");
+    return;
+  }
+
+  delete (Event*)event;
 }
 
 void ti_copy_memory_device_to_device(TiRuntime runtime,
@@ -398,6 +423,15 @@ void ti_launch_compute_graph(TiRuntime runtime,
   }
   ((taichi::lang::aot::CompiledGraph *)compute_graph)->run(arg_map);
 }
+
+void ti_signal_event(TiRuntime runtime, TiEvent event) {
+  ((Runtime*)runtime)->signal_event(&((Event*)event)->get());
+}
+
+void ti_reset_event(TiRuntime runtime, TiEvent event) {
+  ((Runtime*)runtime)->reset_event(&((Event*)event)->get());
+}
+
 void ti_submit(TiRuntime runtime) {
   if (runtime == nullptr) {
     TI_WARN("ignored attempt to submit to runtime of null handle");

--- a/c_api/src/taichi_core_impl.h
+++ b/c_api/src/taichi_core_impl.h
@@ -38,6 +38,9 @@ class Runtime {
   virtual void reset_event(taichi::lang::DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
+  virtual void wait_event(taichi::lang::DeviceEvent* event) {
+    TI_NOT_IMPLEMENTED
+  }
   virtual void submit() = 0;
   virtual void wait() = 0;
 

--- a/c_api/src/taichi_core_impl.h
+++ b/c_api/src/taichi_core_impl.h
@@ -32,10 +32,10 @@ class Runtime {
   virtual void buffer_copy(const taichi::lang::DevicePtr &dst,
                            const taichi::lang::DevicePtr &src,
                            size_t size) = 0;
-  virtual void signal_event(taichi::lang::DeviceEvent* event) {
+  virtual void signal_event(taichi::lang::DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
-  virtual void reset_event(taichi::lang::DeviceEvent* event) {
+  virtual void reset_event(taichi::lang::DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
   virtual void submit() = 0;
@@ -61,14 +61,14 @@ class AotModule {
 };
 
 class Event {
-  Runtime* runtime_;
+  Runtime *runtime_;
   std::unique_ptr<taichi::lang::DeviceEvent> event_;
-public:
-  Event(Runtime& runtime,
-        std::unique_ptr<taichi::lang::DeviceEvent> event);
 
-  taichi::lang::DeviceEvent& get();
-  Runtime& runtime();
+ public:
+  Event(Runtime &runtime, std::unique_ptr<taichi::lang::DeviceEvent> event);
+
+  taichi::lang::DeviceEvent &get();
+  Runtime &runtime();
 };
 
 namespace {

--- a/c_api/src/taichi_core_impl.h
+++ b/c_api/src/taichi_core_impl.h
@@ -32,6 +32,12 @@ class Runtime {
   virtual void buffer_copy(const taichi::lang::DevicePtr &dst,
                            const taichi::lang::DevicePtr &src,
                            size_t size) = 0;
+  virtual void signal_event(taichi::lang::DeviceEvent* event) {
+    TI_NOT_IMPLEMENTED
+  }
+  virtual void reset_event(taichi::lang::DeviceEvent* event) {
+    TI_NOT_IMPLEMENTED
+  }
   virtual void submit() = 0;
   virtual void wait() = 0;
 
@@ -47,11 +53,22 @@ class AotModule {
 
  public:
   AotModule(Runtime &runtime,
-            std::unique_ptr<taichi::lang::aot::Module> &&aot_module);
+            std::unique_ptr<taichi::lang::aot::Module> aot_module);
 
   taichi::lang::aot::CompiledGraph &get_cgraph(const std::string &name);
   taichi::lang::aot::Module &get();
   Runtime &runtime();
+};
+
+class Event {
+  Runtime* runtime_;
+  std::unique_ptr<taichi::lang::DeviceEvent> event_;
+public:
+  Event(Runtime& runtime,
+        std::unique_ptr<taichi::lang::DeviceEvent> event);
+
+  taichi::lang::DeviceEvent& get();
+  Runtime& runtime();
 };
 
 namespace {

--- a/c_api/src/taichi_core_impl.h
+++ b/c_api/src/taichi_core_impl.h
@@ -38,7 +38,7 @@ class Runtime {
   virtual void reset_event(taichi::lang::DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
-  virtual void wait_event(taichi::lang::DeviceEvent* event) {
+  virtual void wait_event(taichi::lang::DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
   virtual void submit() = 0;

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -126,10 +126,10 @@ void VulkanRuntime::buffer_copy(const taichi::lang::DevicePtr &dst,
 void VulkanRuntime::submit() {
   get_gfx_runtime().flush();
 }
-void VulkanRuntime::signal_event(taichi::lang::DeviceEvent* event) {
+void VulkanRuntime::signal_event(taichi::lang::DeviceEvent *event) {
   get_gfx_runtime().signal_event(event);
 }
-void VulkanRuntime::reset_event(taichi::lang::DeviceEvent* event) {
+void VulkanRuntime::reset_event(taichi::lang::DeviceEvent *event) {
   get_gfx_runtime().reset_event(event);
 }
 void VulkanRuntime::wait() {
@@ -258,12 +258,10 @@ void ti_export_vulkan_memory(TiRuntime runtime,
   interop_info->usage = buffer.get()->usage;
 }
 
-TiEvent ti_import_vulkan_event(
-    TiRuntime runtime,
-    const TiVulkanEventInteropInfo *interop_info) {
+TiEvent ti_import_vulkan_event(TiRuntime runtime,
+                               const TiVulkanEventInteropInfo *interop_info) {
   if (runtime == nullptr) {
-    TI_WARN(
-        "ignored attempt to import vulkan event to runtime of null handle");
+    TI_WARN("ignored attempt to import vulkan event to runtime of null handle");
     return TI_NULL_HANDLE;
   }
   Runtime *runtime2 = (Runtime *)runtime;
@@ -278,13 +276,13 @@ TiEvent ti_import_vulkan_event(
   event->external = true;
 
   std::unique_ptr<taichi::lang::DeviceEvent> event2(
-    new taichi::lang::vulkan::VulkanDeviceEvent(std::move(event)));
+      new taichi::lang::vulkan::VulkanDeviceEvent(std::move(event)));
 
-  return (TiEvent)new Event(*runtime2, std::move(event2));
+  return (TiEvent) new Event(*runtime2, std::move(event2));
 }
 void ti_export_vulkan_event(TiRuntime runtime,
-                             TiEvent event,
-                             TiVulkanEventInteropInfo *interop_info) {
+                            TiEvent event,
+                            TiVulkanEventInteropInfo *interop_info) {
   if (runtime == nullptr) {
     TI_WARN(
         "ignored attempt to export vulkan memory from runtime of null handle");
@@ -294,7 +292,8 @@ void ti_export_vulkan_event(TiRuntime runtime,
     TI_WARN("ignored attempt to export vulkan memory of null handle");
     return;
   }
-  auto event2 = (taichi::lang::vulkan::VulkanDeviceEvent*)(&((Event*)event)->get());
+  auto event2 =
+      (taichi::lang::vulkan::VulkanDeviceEvent *)(&((Event *)event)->get());
   interop_info->event = event2->vkapi_ref->event;
 }
 

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -252,4 +252,14 @@ void ti_export_vulkan_memory(TiRuntime runtime,
   interop_info->usage = buffer.get()->usage;
 }
 
+void ti_submit_and_signal_vulkan_event_ext(TiRuntime runtime, VkEvent event) {
+  if (runtime == nullptr) {
+    TI_WARN(
+        "ignored attempt to set vulkan event from runtime of null handle");
+    return;
+  }
+  VulkanRuntime *runtime2 = ((Runtime *)runtime)->as_vk();
+  runtime2->submit_and_signal_event(event);
+}
+
 #endif  // TI_WITH_VULKAN

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -132,6 +132,9 @@ void VulkanRuntime::signal_event(taichi::lang::DeviceEvent *event) {
 void VulkanRuntime::reset_event(taichi::lang::DeviceEvent *event) {
   get_gfx_runtime().reset_event(event);
 }
+void VulkanRuntime::wait_event(taichi::lang::DeviceEvent* event) {
+  get_gfx_runtime().wait_event(event);
+}
 void VulkanRuntime::wait() {
   // (penguinliong) It's currently waiting for the entire runtime to stop.
   // Should be simply waiting for its fence to finish.

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -132,7 +132,7 @@ void VulkanRuntime::signal_event(taichi::lang::DeviceEvent *event) {
 void VulkanRuntime::reset_event(taichi::lang::DeviceEvent *event) {
   get_gfx_runtime().reset_event(event);
 }
-void VulkanRuntime::wait_event(taichi::lang::DeviceEvent* event) {
+void VulkanRuntime::wait_event(taichi::lang::DeviceEvent *event) {
   get_gfx_runtime().wait_event(event);
 }
 void VulkanRuntime::wait() {

--- a/c_api/src/taichi_vulkan_impl.h
+++ b/c_api/src/taichi_vulkan_impl.h
@@ -25,6 +25,8 @@ class VulkanRuntime : public Runtime {
   virtual void buffer_copy(const taichi::lang::DevicePtr &dst,
                            const taichi::lang::DevicePtr &src,
                            size_t size) override final;
+  virtual void signal_event(taichi::lang::DeviceEvent* event) override final;
+  virtual void reset_event(taichi::lang::DeviceEvent* event) override final;
   virtual void submit() override final;
   virtual void wait() override final;
 };

--- a/c_api/src/taichi_vulkan_impl.h
+++ b/c_api/src/taichi_vulkan_impl.h
@@ -27,6 +27,7 @@ class VulkanRuntime : public Runtime {
                            size_t size) override final;
   virtual void signal_event(taichi::lang::DeviceEvent *event) override final;
   virtual void reset_event(taichi::lang::DeviceEvent *event) override final;
+  virtual void wait_event(taichi::lang::DeviceEvent *event) override final;
   virtual void submit() override final;
   virtual void wait() override final;
 };

--- a/c_api/src/taichi_vulkan_impl.h
+++ b/c_api/src/taichi_vulkan_impl.h
@@ -25,8 +25,8 @@ class VulkanRuntime : public Runtime {
   virtual void buffer_copy(const taichi::lang::DevicePtr &dst,
                            const taichi::lang::DevicePtr &src,
                            size_t size) override final;
-  virtual void signal_event(taichi::lang::DeviceEvent* event) override final;
-  virtual void reset_event(taichi::lang::DeviceEvent* event) override final;
+  virtual void signal_event(taichi::lang::DeviceEvent *event) override final;
+  virtual void reset_event(taichi::lang::DeviceEvent *event) override final;
   virtual void submit() override final;
   virtual void wait() override final;
 };

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -417,6 +417,19 @@
                     ]
                 },
                 {
+                    "name": "wait_event",
+                    "type": "function",
+                    "is_device_command": true,
+                    "parameters": [
+                        {
+                            "type": "handle.runtime"
+                        },
+                        {
+                            "type": "handle.event"
+                        }
+                    ]
+                },
+                {
                     "name": "submit",
                     "type": "function",
                     "parameters": [

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -51,6 +51,11 @@
                     "is_dispatchable": true
                 },
                 {
+                    "name": "event",
+                    "type": "handle",
+                    "is_dispatchable": true
+                },
+                {
                     "name": "memory",
                     "type": "handle",
                     "is_dispatchable": false
@@ -300,8 +305,31 @@
                     ]
                 },
                 {
+                    "name": "create_event",
+                    "type": "function",
+                    "parameters": [
+                        {
+                            "name": "@return",
+                            "type": "handle.event"
+                        },
+                        {
+                            "type": "handle.runtime"
+                        }
+                    ]
+                },
+                {
+                    "name": "destroy_event",
+                    "type": "function",
+                    "parameters": [
+                        {
+                            "type": "handle.event"
+                        }
+                    ]
+                },
+                {
                     "name": "copy_memory_device_to_device",
                     "type": "function",
+                    "is_device_command": true,
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -321,6 +349,7 @@
                 {
                     "name": "launch_kernel",
                     "type": "function",
+                    "is_device_command": true,
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -342,6 +371,7 @@
                 {
                     "name": "launch_compute_graph",
                     "type": "function",
+                    "is_device_command": true,
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -357,6 +387,32 @@
                             "name": "args",
                             "type": "structure.named_argument",
                             "count": "arg_count"
+                        }
+                    ]
+                },
+                {
+                    "name": "signal_event",
+                    "type": "function",
+                    "is_device_command": true,
+                    "parameters": [
+                        {
+                            "type": "handle.runtime"
+                        },
+                        {
+                            "type": "handle.event"
+                        }
+                    ]
+                },
+                {
+                    "name": "reset_event",
+                    "type": "function",
+                    "is_device_command": true,
+                    "parameters": [
+                        {
+                            "type": "handle.runtime"
+                        },
+                        {
+                            "type": "handle.event"
                         }
                     ]
                 },
@@ -504,6 +560,16 @@
                     ]
                 },
                 {
+                    "name": "vulkan_event_interop_info",
+                    "type": "structure",
+                    "fields": [
+                        {
+                            "name": "event",
+                            "type": "VkEvent"
+                        }
+                    ]
+                },
+                {
                     "name": "create_vulkan_runtime",
                     "type": "function",
                     "is_extension": true,
@@ -599,16 +665,37 @@
                     ]
                 },
                 {
-                    "name": "submit_and_signal_vulkan_event",
-                    "is_extension": true,
+                    "name": "import_vulkan_event",
+                    "type": "function",
+                    "parameters": [
+                        {
+                            "name": "@return",
+                            "type": "handle.event"
+                        },
+                        {
+                            "type": "handle.runtime"
+                        },
+                        {
+                            "name": "interop_info",
+                            "type": "structure.vulkan_event_interop_info",
+                            "by_ref": true
+                        }
+                    ]
+                },
+                {
+                    "name": "export_vulkan_event",
                     "type": "function",
                     "parameters": [
                         {
                             "type": "handle.runtime"
                         },
                         {
-                            "name": "event",
-                            "type": "VkEvent"
+                            "type": "handle.event"
+                        },
+                        {
+                            "name": "interop_info",
+                            "type": "structure.vulkan_event_interop_info",
+                            "by_mut": true
                         }
                     ]
                 }

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -597,6 +597,20 @@
                             "by_mut": true
                         }
                     ]
+                },
+                {
+                    "name": "submit_and_signal_vulkan_event",
+                    "is_extension": true,
+                    "type": "function",
+                    "parameters": [
+                        {
+                            "type": "handle.runtime"
+                        },
+                        {
+                            "name": "event",
+                            "type": "VkEvent"
+                        }
+                    ]
                 }
             ]
         },

--- a/misc/generate_c_api.py
+++ b/misc/generate_c_api.py
@@ -158,6 +158,7 @@ if __name__ == "__main__":
         BuiltInType("VkQueue", "VkQueue"),
         BuiltInType("VkBuffer", "VkBuffer"),
         BuiltInType("VkBufferUsageFlags", "VkBufferUsageFlags"),
+        BuiltInType("VkEvent", "VkEvent"),
     }
 
     for module in Module.load_all(builtin_tys):

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -395,6 +395,9 @@ class CommandList {
   virtual void reset_event(DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
+  virtual void wait_event(DeviceEvent* event) {
+    TI_NOT_IMPLEMENTED
+  }
 };
 
 struct PipelineSourceDesc {

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -296,8 +296,9 @@ struct ImageCopyParams {
 };
 
 class DeviceEvent {
-public:
-  virtual ~DeviceEvent() {}
+ public:
+  virtual ~DeviceEvent() {
+  }
 };
 
 class CommandList {
@@ -388,10 +389,10 @@ class CommandList {
                           const ImageCopyParams &params) {
     TI_NOT_IMPLEMENTED
   }
-  virtual void signal_event(DeviceEvent* event) {
+  virtual void signal_event(DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
-  virtual void reset_event(DeviceEvent* event) {
+  virtual void reset_event(DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
 };
@@ -478,9 +479,7 @@ class Device {
       const PipelineSourceDesc &src,
       std::string name = "Pipeline") = 0;
 
-  virtual std::unique_ptr<DeviceEvent> create_event() {
-    TI_NOT_IMPLEMENTED
-  }
+  virtual std::unique_ptr<DeviceEvent> create_event(){TI_NOT_IMPLEMENTED}
 
   std::unique_ptr<DeviceAllocationGuard> allocate_memory_unique(
       const AllocParams &params) {

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -295,6 +295,11 @@ struct ImageCopyParams {
   uint32_t depth{1};
 };
 
+class DeviceEvent {
+public:
+  virtual ~DeviceEvent() {}
+};
+
 class CommandList {
  public:
   virtual ~CommandList() {
@@ -383,6 +388,12 @@ class CommandList {
                           const ImageCopyParams &params) {
     TI_NOT_IMPLEMENTED
   }
+  virtual void signal_event(DeviceEvent* event) {
+    TI_NOT_IMPLEMENTED
+  }
+  virtual void reset_event(DeviceEvent* event) {
+    TI_NOT_IMPLEMENTED
+  }
 };
 
 struct PipelineSourceDesc {
@@ -466,6 +477,10 @@ class Device {
   virtual std::unique_ptr<Pipeline> create_pipeline(
       const PipelineSourceDesc &src,
       std::string name = "Pipeline") = 0;
+
+  virtual std::unique_ptr<DeviceEvent> create_event() {
+    TI_NOT_IMPLEMENTED
+  }
 
   std::unique_ptr<DeviceAllocationGuard> allocate_memory_unique(
       const AllocParams &params) {

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -395,7 +395,7 @@ class CommandList {
   virtual void reset_event(DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
-  virtual void wait_event(DeviceEvent* event) {
+  virtual void wait_event(DeviceEvent *event) {
     TI_NOT_IMPLEMENTED
   }
 };

--- a/taichi/rhi/vulkan/vulkan_api.cpp
+++ b/taichi/rhi/vulkan/vulkan_api.cpp
@@ -98,12 +98,12 @@ IDeviceObj create_device_obj(VkDevice device) {
 }
 
 IVkEvent create_event(VkDevice device,
-  VkSemaphoreCreateFlags flags,
-  void* pnext) {
+                      VkSemaphoreCreateFlags flags,
+                      void *pnext) {
   IVkEvent obj = std::make_shared<DeviceObjVkEvent>();
   obj->device = device;
 
-  VkEventCreateInfo info {};
+  VkEventCreateInfo info{};
   info.sType = VK_STRUCTURE_TYPE_EVENT_CREATE_INFO;
   info.pNext = pnext;
   info.flags = flags;

--- a/taichi/rhi/vulkan/vulkan_api.cpp
+++ b/taichi/rhi/vulkan/vulkan_api.cpp
@@ -54,6 +54,12 @@ DeviceObjVkFramebuffer::~DeviceObjVkFramebuffer() {
   vkDestroyFramebuffer(device, framebuffer, nullptr);
 }
 
+DeviceObjVkEvent::~DeviceObjVkEvent() {
+  if (!external) {
+    vkDestroyEvent(device, event, nullptr);
+  }
+}
+
 DeviceObjVkSemaphore::~DeviceObjVkSemaphore() {
   vkDestroySemaphore(device, semaphore, nullptr);
 }
@@ -88,6 +94,21 @@ DeviceObjVkAccelerationStructureKHR::~DeviceObjVkAccelerationStructureKHR() {
 IDeviceObj create_device_obj(VkDevice device) {
   IDeviceObj obj = std::make_shared<DeviceObj>();
   obj->device = device;
+  return obj;
+}
+
+IVkEvent create_event(VkDevice device,
+  VkSemaphoreCreateFlags flags,
+  void* pnext) {
+  IVkEvent obj = std::make_shared<DeviceObjVkEvent>();
+  obj->device = device;
+
+  VkEventCreateInfo info {};
+  info.sType = VK_STRUCTURE_TYPE_EVENT_CREATE_INFO;
+  info.pNext = pnext;
+  info.flags = flags;
+
+  vkCreateEvent(device, &info, nullptr, &obj->event);
   return obj;
 }
 

--- a/taichi/rhi/vulkan/vulkan_api.h
+++ b/taichi/rhi/vulkan/vulkan_api.h
@@ -21,11 +21,13 @@ IDeviceObj create_device_obj(VkDevice device);
 // VkEvent
 struct DeviceObjVkEvent : public DeviceObj {
   bool external{false};
-  VkEvent event { VK_NULL_HANDLE };
+  VkEvent event{VK_NULL_HANDLE};
   ~DeviceObjVkEvent() override;
 };
 using IVkEvent = std::shared_ptr<DeviceObjVkEvent>;
-IVkEvent create_event(VkDevice device, VkEventCreateFlags flags, void *pnext = nullptr);
+IVkEvent create_event(VkDevice device,
+                      VkEventCreateFlags flags,
+                      void *pnext = nullptr);
 
 // VkSemaphore
 struct DeviceObjVkSemaphore : public DeviceObj {

--- a/taichi/rhi/vulkan/vulkan_api.h
+++ b/taichi/rhi/vulkan/vulkan_api.h
@@ -18,6 +18,15 @@ struct DeviceObj {
 using IDeviceObj = std::shared_ptr<DeviceObj>;
 IDeviceObj create_device_obj(VkDevice device);
 
+// VkEvent
+struct DeviceObjVkEvent : public DeviceObj {
+  bool external{false};
+  VkEvent event { VK_NULL_HANDLE };
+  ~DeviceObjVkEvent() override;
+};
+using IVkEvent = std::shared_ptr<DeviceObjVkEvent>;
+IVkEvent create_event(VkDevice device, VkEventCreateFlags flags, void *pnext = nullptr);
+
 // VkSemaphore
 struct DeviceObjVkSemaphore : public DeviceObj {
   VkSemaphore semaphore{VK_NULL_HANDLE};

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1254,6 +1254,12 @@ void VulkanCommandList::reset_event(DeviceEvent *event) {
   vkCmdResetEvent(buffer_->buffer, event2->vkapi_ref->event,
                   VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 }
+void VulkanCommandList::wait_event(DeviceEvent* event) {
+  VulkanDeviceEvent* event2 = static_cast<VulkanDeviceEvent*>(event);
+  vkCmdWaitEvents(buffer_->buffer, 1, &event2->vkapi_ref->event,
+    VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+    0, nullptr, 0, nullptr, 0, nullptr);
+}
 
 void VulkanCommandList::set_line_width(float width) {
   if (ti_device_->get_cap(DeviceCapability::wide_lines)) {

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1244,6 +1244,15 @@ void VulkanCommandList::blit_image(DeviceAllocation dst_img,
   buffer_->refs.push_back(src_vk_image);
 }
 
+void VulkanCommandList::signal_event(DeviceEvent* event) {
+  VulkanDeviceEvent* event2 = static_cast<VulkanDeviceEvent*>(event);
+  vkCmdSetEvent(buffer_->buffer, event2->vkapi_ref->event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+}
+void VulkanCommandList::reset_event(DeviceEvent* event) {
+  VulkanDeviceEvent* event2 = static_cast<VulkanDeviceEvent*>(event);
+  vkCmdResetEvent(buffer_->buffer, event2->vkapi_ref->event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+}
+
 void VulkanCommandList::set_line_width(float width) {
   if (ti_device_->get_cap(DeviceCapability::wide_lines)) {
     vkCmdSetLineWidth(buffer_->buffer, width);
@@ -1332,6 +1341,10 @@ std::unique_ptr<Pipeline> VulkanDevice::create_pipeline(
   params.name = name;
 
   return std::make_unique<VulkanPipeline>(params);
+}
+
+std::unique_ptr<DeviceEvent> VulkanDevice::create_event() {
+  return std::unique_ptr<DeviceEvent>(new VulkanDeviceEvent(vkapi::create_event(device_, 0)));
 }
 
 // #define TI_VULKAN_DEBUG_ALLOCATIONS

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1254,11 +1254,12 @@ void VulkanCommandList::reset_event(DeviceEvent *event) {
   vkCmdResetEvent(buffer_->buffer, event2->vkapi_ref->event,
                   VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 }
-void VulkanCommandList::wait_event(DeviceEvent* event) {
-  VulkanDeviceEvent* event2 = static_cast<VulkanDeviceEvent*>(event);
+void VulkanCommandList::wait_event(DeviceEvent *event) {
+  VulkanDeviceEvent *event2 = static_cast<VulkanDeviceEvent *>(event);
   vkCmdWaitEvents(buffer_->buffer, 1, &event2->vkapi_ref->event,
-    VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-    0, nullptr, 0, nullptr, 0, nullptr);
+                  VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                  VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, nullptr, 0, nullptr, 0,
+                  nullptr);
 }
 
 void VulkanCommandList::set_line_width(float width) {

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1244,13 +1244,15 @@ void VulkanCommandList::blit_image(DeviceAllocation dst_img,
   buffer_->refs.push_back(src_vk_image);
 }
 
-void VulkanCommandList::signal_event(DeviceEvent* event) {
-  VulkanDeviceEvent* event2 = static_cast<VulkanDeviceEvent*>(event);
-  vkCmdSetEvent(buffer_->buffer, event2->vkapi_ref->event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+void VulkanCommandList::signal_event(DeviceEvent *event) {
+  VulkanDeviceEvent *event2 = static_cast<VulkanDeviceEvent *>(event);
+  vkCmdSetEvent(buffer_->buffer, event2->vkapi_ref->event,
+                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 }
-void VulkanCommandList::reset_event(DeviceEvent* event) {
-  VulkanDeviceEvent* event2 = static_cast<VulkanDeviceEvent*>(event);
-  vkCmdResetEvent(buffer_->buffer, event2->vkapi_ref->event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+void VulkanCommandList::reset_event(DeviceEvent *event) {
+  VulkanDeviceEvent *event2 = static_cast<VulkanDeviceEvent *>(event);
+  vkCmdResetEvent(buffer_->buffer, event2->vkapi_ref->event,
+                  VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 }
 
 void VulkanCommandList::set_line_width(float width) {
@@ -1344,7 +1346,8 @@ std::unique_ptr<Pipeline> VulkanDevice::create_pipeline(
 }
 
 std::unique_ptr<DeviceEvent> VulkanDevice::create_event() {
-  return std::unique_ptr<DeviceEvent>(new VulkanDeviceEvent(vkapi::create_event(device_, 0)));
+  return std::unique_ptr<DeviceEvent>(
+      new VulkanDeviceEvent(vkapi::create_event(device_, 0)));
 }
 
 // #define TI_VULKAN_DEBUG_ALLOCATIONS

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1596,14 +1596,10 @@ std::unique_ptr<CommandList> VulkanStream::new_command_list() {
   return std::make_unique<VulkanCommandList>(&device_, this, buffer);
 }
 
-StreamSemaphore VulkanStream::submit_and_signal_event(
+StreamSemaphore VulkanStream::submit(
     CommandList *cmdlist_,
-    const std::vector<StreamSemaphore> &wait_semaphores,
-    VkEvent event) {
+    const std::vector<StreamSemaphore> &wait_semaphores) {
   VulkanCommandList *cmdlist = static_cast<VulkanCommandList *>(cmdlist_);
-  if (event != VK_NULL_HANDLE) {
-    cmdlist->signal_event(event);
-  }
   vkapi::IVkCommandBuffer buffer = cmdlist->finalize();
 
   /*
@@ -1659,12 +1655,6 @@ StreamSemaphore VulkanStream::submit_and_signal_event(
                         "failed to submit command buffer");
 
   return std::make_shared<VulkanStreamSemaphoreObject>(semaphore);
-}
-
-StreamSemaphore VulkanStream::submit(
-    CommandList *cmdlist_,
-    const std::vector<StreamSemaphore> &wait_semaphores) {
-  return submit_and_signal_event(cmdlist_, wait_semaphores, VK_NULL_HANDLE);
 }
 
 StreamSemaphore VulkanStream::submit_synced(

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -418,6 +418,7 @@ class VulkanCommandList : public CommandList {
 
   void signal_event(DeviceEvent *event) override;
   void reset_event(DeviceEvent *event) override;
+  void wait_event(DeviceEvent *event) override;
 
   vkapi::IVkRenderPass current_renderpass();
 

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -349,6 +349,15 @@ class VulkanPipeline : public Pipeline {
   vkapi::IVkPipelineLayout pipeline_layout_{VK_NULL_HANDLE};
 };
 
+class VulkanDeviceEvent : public DeviceEvent {
+public:
+  VulkanDeviceEvent(vkapi::IVkEvent event) : vkapi_ref(event) {}
+  ~VulkanDeviceEvent() {
+  }
+
+  vkapi::IVkEvent vkapi_ref { nullptr };
+};
+
 class VulkanCommandList : public CommandList {
  public:
   VulkanCommandList(VulkanDevice *ti_device,
@@ -406,7 +415,8 @@ class VulkanCommandList : public CommandList {
                   ImageLayout src_img_layout,
                   const ImageCopyParams &params) override;
 
-  void signal_event(VkEvent event);
+  void signal_event(DeviceEvent* event) override;
+  void reset_event(DeviceEvent* event) override;
 
   vkapi::IVkRenderPass current_renderpass();
 
@@ -529,12 +539,6 @@ class VulkanStream : public Stream {
   // Command pools are per-thread
   vkapi::IVkCommandPool command_pool_;
   std::vector<TrackedCmdbuf> submitted_cmdbuffers_;
-
-  StreamSemaphore submit_and_signal_event(
-      CommandList *cmdlist,
-      const std::vector<StreamSemaphore> &wait_semaphores,
-      VkEvent event);
-
 };
 
 class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
@@ -556,6 +560,7 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
   std::unique_ptr<Pipeline> create_pipeline(
       const PipelineSourceDesc &src,
       std::string name = "Pipeline") override;
+  std::unique_ptr<DeviceEvent> create_event() override;
 
   DeviceAllocation allocate_memory(const AllocParams &params) override;
   void dealloc_memory(DeviceAllocation handle) override;

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -406,6 +406,8 @@ class VulkanCommandList : public CommandList {
                   ImageLayout src_img_layout,
                   const ImageCopyParams &params) override;
 
+  void signal_event(VkEvent event);
+
   vkapi::IVkRenderPass current_renderpass();
 
   // Vulkan specific functions
@@ -527,6 +529,12 @@ class VulkanStream : public Stream {
   // Command pools are per-thread
   vkapi::IVkCommandPool command_pool_;
   std::vector<TrackedCmdbuf> submitted_cmdbuffers_;
+
+  StreamSemaphore submit_and_signal_event(
+      CommandList *cmdlist,
+      const std::vector<StreamSemaphore> &wait_semaphores,
+      VkEvent event);
+
 };
 
 class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -350,12 +350,13 @@ class VulkanPipeline : public Pipeline {
 };
 
 class VulkanDeviceEvent : public DeviceEvent {
-public:
-  VulkanDeviceEvent(vkapi::IVkEvent event) : vkapi_ref(event) {}
+ public:
+  VulkanDeviceEvent(vkapi::IVkEvent event) : vkapi_ref(event) {
+  }
   ~VulkanDeviceEvent() {
   }
 
-  vkapi::IVkEvent vkapi_ref { nullptr };
+  vkapi::IVkEvent vkapi_ref{nullptr};
 };
 
 class VulkanCommandList : public CommandList {
@@ -415,8 +416,8 @@ class VulkanCommandList : public CommandList {
                   ImageLayout src_img_layout,
                   const ImageCopyParams &params) override;
 
-  void signal_event(DeviceEvent* event) override;
-  void reset_event(DeviceEvent* event) override;
+  void signal_event(DeviceEvent *event) override;
+  void reset_event(DeviceEvent *event) override;
 
   vkapi::IVkRenderPass current_renderpass();
 

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -571,6 +571,11 @@ void GfxRuntime::reset_event(DeviceEvent *event) {
   current_cmdlist_->reset_event(event);
   submit_current_cmdlist_if_timeout();
 }
+void GfxRuntime::wait_event(DeviceEvent* event) {
+  ensure_current_cmdlist();
+  current_cmdlist_->wait_event(event);
+  submit_current_cmdlist_if_timeout();
+}
 
 void GfxRuntime::synchronize() {
   flush();

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -571,7 +571,7 @@ void GfxRuntime::reset_event(DeviceEvent *event) {
   current_cmdlist_->reset_event(event);
   submit_current_cmdlist_if_timeout();
 }
-void GfxRuntime::wait_event(DeviceEvent* event) {
+void GfxRuntime::wait_event(DeviceEvent *event) {
   ensure_current_cmdlist();
   current_cmdlist_->wait_event(event);
   submit_current_cmdlist_if_timeout();

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -561,6 +561,17 @@ void GfxRuntime::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
   submit_current_cmdlist_if_timeout();
 }
 
+void GfxRuntime::signal_event(DeviceEvent* event) {
+  ensure_current_cmdlist();
+  current_cmdlist_->signal_event(event);
+  submit_current_cmdlist_if_timeout();
+}
+void GfxRuntime::reset_event(DeviceEvent* event) {
+  ensure_current_cmdlist();
+  current_cmdlist_->reset_event(event);
+  submit_current_cmdlist_if_timeout();
+}
+
 void GfxRuntime::synchronize() {
   flush();
   device_->wait_idle();

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -561,12 +561,12 @@ void GfxRuntime::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
   submit_current_cmdlist_if_timeout();
 }
 
-void GfxRuntime::signal_event(DeviceEvent* event) {
+void GfxRuntime::signal_event(DeviceEvent *event) {
   ensure_current_cmdlist();
   current_cmdlist_->signal_event(event);
   submit_current_cmdlist_if_timeout();
 }
-void GfxRuntime::reset_event(DeviceEvent* event) {
+void GfxRuntime::reset_event(DeviceEvent *event) {
   ensure_current_cmdlist();
   current_cmdlist_->reset_event(event);
   submit_current_cmdlist_if_timeout();

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -102,8 +102,8 @@ class TI_DLL_EXPORT GfxRuntime {
 
   void buffer_copy(DevicePtr dst, DevicePtr src, size_t size);
 
-  void signal_event(DeviceEvent* event);
-  void reset_event(DeviceEvent* event);
+  void signal_event(DeviceEvent *event);
+  void reset_event(DeviceEvent *event);
 
   void synchronize();
 

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -102,6 +102,9 @@ class TI_DLL_EXPORT GfxRuntime {
 
   void buffer_copy(DevicePtr dst, DevicePtr src, size_t size);
 
+  void signal_event(DeviceEvent* event);
+  void reset_event(DeviceEvent* event);
+
   void synchronize();
 
   StreamSemaphore flush();

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -104,6 +104,7 @@ class TI_DLL_EXPORT GfxRuntime {
 
   void signal_event(DeviceEvent *event);
   void reset_event(DeviceEvent *event);
+  void wait_event(DeviceEvent *event);
 
   void synchronize();
 


### PR DESCRIPTION
This PR implements an experimental abstraction of on-device event. Event is a type of synchronization primitive available on most modern graphics APIs to synchronize on-device execution. It enables the users to immediately kick off rendering after Taichi kernel launches, without any interaction with the host.

Event is different from semaphore. Event only synchronizes execution flows on device and can be signaled and awaited at any point in the command stream. Semaphores can only be signaled at the end of a stream, and awaited in the beginning. There exists cases that the users don't have the control over command buffer submission, like in Unity, which means that semaphores might not the best primitive to use. So the support for event is considered plausible.
