### PR TITLE
[llvm] [bug] Fix llvm_codegen_utils

### DIFF
--- a/taichi/codegen/llvm/llvm_codegen_utils.h
+++ b/taichi/codegen/llvm/llvm_codegen_utils.h
@@ -126,7 +126,7 @@ class LLVMModuleBuilder {
     std::vector<llvm::Value *> args = arglist;
     check_func_call_signature(func->getFunctionType(), func->getName(), args,
                               builder);
-    return builder->CreateCall(func, arglist);
+    return builder->CreateCall(func, args);
   }
 
   template <typename... Args>


### PR DESCRIPTION
Fixing the crash in release tests introduced by a typo in #5381 where we need a deep copy of arglist. 