### PR TITLE
[build] [refactor] Rename taichi core and taichi python targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,8 @@ runtimes/Release
 runtimes/Debug
 runtimes/RelWithDebInfo
 runtimes/*.png
-runtimes/taichi_core*
-runtimes/libtaichi_core*
+runtimes/taichi_python*
+runtimes/libtaichi_python*
 .pypirc
 dist/
 python/MANIFEST

--- a/benchmarks/microbenchmarks/_utils.py
+++ b/benchmarks/microbenchmarks/_utils.py
@@ -1,6 +1,6 @@
 from time import perf_counter
 
-from taichi._lib import core as ti_core
+from taichi._lib import core as ti_python_core
 
 import taichi as ti
 

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -2,7 +2,7 @@ import os
 import warnings
 
 from suite_microbenchmarks import MicroBenchmark
-from taichi._lib import core as ti_core
+from taichi._lib import core as ti_python_core
 from utils import datatime_with_format, dump2json
 
 benchmark_suites = [MicroBenchmark]
@@ -11,7 +11,7 @@ benchmark_suites = [MicroBenchmark]
 class BenchmarkInfo:
     def __init__(self):
         """init with commit info"""
-        self.commit_hash = ti_core.get_commit_hash()
+        self.commit_hash = ti_python_core.get_commit_hash()
         self.datetime = datatime_with_format()
         self.suites = {}
         print(f'commit_hash = {self.commit_hash}')

--- a/cmake/TaichiCAPI.cmake
+++ b/cmake/TaichiCAPI.cmake
@@ -4,7 +4,7 @@ set(TAICHI_C_API_NAME taichi_c_api)
 
 file(GLOB_RECURSE C_API_SOURCE "c_api/src/*.cpp")
 add_library(${TAICHI_C_API_NAME} SHARED ${C_API_SOURCE})
-target_link_libraries(${TAICHI_C_API_NAME} PRIVATE taichi_isolated_core)
+target_link_libraries(${TAICHI_C_API_NAME} PRIVATE taichi_core)
 
 set(C_API_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 set_target_properties(${TAICHI_C_API_NAME} PROPERTIES

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -89,8 +89,6 @@ if(NOT TI_WITH_LLVM)
     set(TI_WITH_CUDA_TOOLKIT OFF)
 endif()
 
-
-## TODO 4832: Split source per target, do not include everything in taichi_core_source
 file(GLOB TAICHI_CORE_SOURCE
     "taichi/analysis/*.cpp" "taichi/analysis/*.h" #IR
     "taichi/aot/*.cpp" "taichi/aot/*.h" #RT?
@@ -194,11 +192,7 @@ endif()
 #
 # However, the better strategy is probably to rename the actual library:
 #
-# taichi_core --> taichi_pylib (this requires python-side refactoring...)
 # taichi_isolated_core --> taichi_core
-#
-# But this requires more efforts, because taichi_core is already referenced
-# everywhere in python.
 set(CORE_LIBRARY_NAME taichi_isolated_core)
 add_library(${CORE_LIBRARY_NAME} OBJECT ${TAICHI_CORE_SOURCE})
 

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -163,11 +163,11 @@ endif()
 # library into a shared lib.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# The short-term goal is to have a sub-library, "taichi_isolated_core", that is
+# The short-term goal is to have a sub-library, "taichi_core", that is
 # mostly Taichi-focused, free from the "application" layer such as pybind11 or
 # GUI. At a minimum, we must decouple from pybind11/python-environment. Then we
 # can 1) unit test a major part of Taichi, and 2) integrate a new frontend lang
-# with "taichi_isolated_core".
+# with "taichi_core".
 #
 # TODO(#2198): Long-term speaking, we should create a separate library for each
 # sub-module. This way we can guarantee that the lib dependencies form a DAG.
@@ -186,14 +186,7 @@ if (TAICHI_EMBIND_SOURCE)
 endif()
 
 
-# TODO(#2196): Rename these CMAKE variables:
-# CORE_LIBRARY_NAME --> TAICHI_ISOLATED_CORE_LIB_NAME
-# CORE_WITH_PYBIND_LIBRARY_NAME --> TAICHI_CORE_LIB_NAME
-#
-# However, the better strategy is probably to rename the actual library:
-#
-# taichi_isolated_core --> taichi_core
-set(CORE_LIBRARY_NAME taichi_isolated_core)
+set(CORE_LIBRARY_NAME taichi_core)
 add_library(${CORE_LIBRARY_NAME} OBJECT ${TAICHI_CORE_SOURCE})
 
 if (APPLE)

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -469,7 +469,7 @@ endforeach ()
 message("PYTHON_LIBRARIES: " ${PYTHON_LIBRARIES})
 
 if(TI_WITH_PYTHON AND NOT TI_EMSCRIPTENED)
-    set(CORE_WITH_PYBIND_LIBRARY_NAME taichi_core)
+    set(CORE_WITH_PYBIND_LIBRARY_NAME taichi_python)
     # Cannot compile Python source code with Android, but TI_EXPORT_CORE should be set and
     # Android should only use the isolated library ignoring those source code.
     if (NOT ANDROID)

--- a/cmake/TaichiExamples.cmake
+++ b/cmake/TaichiExamples.cmake
@@ -21,7 +21,7 @@ if (WIN32)
     set_target_properties(${EXAMPLES_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${EXAMPLES_OUTPUT_DIR})
     set_target_properties(${EXAMPLES_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${EXAMPLES_OUTPUT_DIR})
 endif()
-target_link_libraries(${EXAMPLES_NAME} PRIVATE taichi_isolated_core)
+target_link_libraries(${EXAMPLES_NAME} PRIVATE taichi_core)
 target_link_libraries(${EXAMPLES_NAME} PRIVATE
 	metal_program_impl
 	metal_runtime

--- a/cmake/TaichiExportCore.cmake
+++ b/cmake/TaichiExportCore.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 set(TAICHI_EXPORT_CORE_NAME taichi_export_core)
 
 add_library(${TAICHI_EXPORT_CORE_NAME} SHARED)
-target_link_libraries(${TAICHI_EXPORT_CORE_NAME} PRIVATE taichi_isolated_core)
+target_link_libraries(${TAICHI_EXPORT_CORE_NAME} PRIVATE taichi_core)
 set_target_properties(${TAICHI_EXPORT_CORE_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -34,7 +34,7 @@ if (WIN32)
     set_target_properties(${TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${TESTS_OUTPUT_DIR})
     set_target_properties(${TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${TESTS_OUTPUT_DIR})
 endif()
-target_link_libraries(${TESTS_NAME} PRIVATE taichi_isolated_core)
+target_link_libraries(${TESTS_NAME} PRIVATE taichi_core)
 target_link_libraries(${TESTS_NAME} PRIVATE gtest_main)
 
 target_include_directories(${TESTS_NAME}

--- a/docs/lang/articles/faqs/install.md
+++ b/docs/lang/articles/faqs/install.md
@@ -129,9 +129,9 @@ sidebar_position: 2
 
   ... (many lines, omitted)
 
-  /lib/python3.8/site-packages/taichi/core/../lib/taichi_core.so: _glfwPlatformCreateWindow
-  /lib/python3.8/site-packages/taichi/core/../lib/taichi_core.so: glfwCreateWindow
-  /lib/python3.8/site-packages/taichi/core/../lib/taichi_core.so: taichi::lang::opengl::initialize_opengl(bool)
+  /lib/python3.8/site-packages/taichi/core/../lib/taichi_python.so: _glfwPlatformCreateWindow
+  /lib/python3.8/site-packages/taichi/core/../lib/taichi_python.so: glfwCreateWindow
+  /lib/python3.8/site-packages/taichi/core/../lib/taichi_python.so: taichi::lang::opengl::initialize_opengl(bool)
 
   ... (many lines, omitted)
   ```

--- a/python/taichi/_lib/__init__.py
+++ b/python/taichi/_lib/__init__.py
@@ -1,1 +1,1 @@
-from taichi._lib.utils import ti_core as core
+from taichi._lib.utils import ti_python_core as core

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -31,7 +31,7 @@ def get_os_name():
     assert False, f"Unknown platform name {name}"
 
 
-def import_ti_core():
+def import_ti_python_core():
     if get_os_name() != 'win':
         # pylint: disable=E1101
         old_flags = sys.getdlopenflags()
@@ -41,10 +41,10 @@ def import_ti_core():
         os.environ['PATH'] += os.pathsep + pyddir
     try:
         from taichi._lib.core import \
-            taichi_core as core  # pylint: disable=C0415
+            taichi_python as core  # pylint: disable=C0415
     except Exception as e:
         if isinstance(e, ImportError):
-            print(Fore.YELLOW + "Share object taichi_core import failed, "
+            print(Fore.YELLOW + "Share object taichi_python import failed, "
                   "check this page for possible solutions:\n"
                   "https://docs.taichi-lang.org/docs/install" + Fore.RESET)
             if get_os_name() == 'win':
@@ -83,7 +83,7 @@ package_root = os.path.join(
 
 def get_core_shared_object():
     directory = os.path.join(package_root, '_lib')
-    return os.path.join(directory, 'libtaichi_core.so')
+    return os.path.join(directory, 'libtaichi_python.so')
 
 
 def print_red_bold(*args, **kwargs):
@@ -99,13 +99,13 @@ def check_exists(src):
         )
 
 
-ti_core = import_ti_core()
+ti_python_core = import_ti_python_core()
 
-ti_core.set_python_package_dir(package_root)
+ti_python_core.set_python_package_dir(package_root)
 
 log_level = os.environ.get('TI_LOG_LEVEL', '')
 if log_level:
-    ti_core.set_logging_level(log_level)
+    ti_python_core.set_logging_level(log_level)
 
 
 def get_dll_name(name):
@@ -119,7 +119,7 @@ def get_dll_name(name):
 
 
 def at_startup():
-    ti_core.set_core_state_python_imported(True)
+    ti_python_core.set_core_state_python_imported(True)
 
 
 at_startup()
@@ -133,23 +133,23 @@ def compare_version(latest, current):
 
 def _print_taichi_header():
     header = '[Taichi] '
-    header += f'version {ti_core.get_version_string()}, '
+    header += f'version {ti_python_core.get_version_string()}, '
 
     try:
-        timestamp_path = os.path.join(ti_core.get_repo_dir(), 'timestamp')
+        timestamp_path = os.path.join(ti_python_core.get_repo_dir(), 'timestamp')
         if os.path.exists(timestamp_path):
             latest_version = ''
             with open(timestamp_path, 'r') as f:
                 latest_version = f.readlines()[1].rstrip()
-            if compare_version(latest_version, ti_core.get_version_string()):
+            if compare_version(latest_version, ti_python_core.get_version_string()):
                 header += f'latest version {latest_version}, '
     except:
         pass
 
-    llvm_target_support = ti_core.get_llvm_target_support()
+    llvm_target_support = ti_python_core.get_llvm_target_support()
     header += f'llvm {llvm_target_support}, '
 
-    commit_hash = ti_core.get_commit_hash()
+    commit_hash = ti_python_core.get_commit_hash()
     commit_hash = commit_hash[:8]
     header += f'commit {commit_hash}, '
 

--- a/python/taichi/_logging.py
+++ b/python/taichi/_logging.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 
-from taichi._lib import core as ti_core
+from taichi._lib import core as ti_python_core
 
 
 def _get_logging(name):
@@ -16,9 +16,9 @@ def _get_logging(name):
     """
     def logger(msg, *args, **kwargs):
         # Python inspection takes time (~0.1ms) so avoid it as much as possible
-        if ti_core.logging_effective(name):
+        if ti_python_core.logging_effective(name):
             msg_formatted = msg.format(*args, **kwargs)
-            func = getattr(ti_core, name)
+            func = getattr(ti_python_core, name)
             frame = inspect.currentframe().f_back
             file_name, lineno, func_name, _, _ = inspect.getframeinfo(frame)
             file_name = os.path.basename(file_name)
@@ -45,7 +45,7 @@ def set_logging_level(level):
 
         >>> set_logging_level('debug')
     """
-    ti_core.set_logging_level(level)
+    ti_python_core.set_logging_level(level)
 
 
 def is_logging_effective(level):
@@ -72,7 +72,7 @@ def is_logging_effective(level):
         >>> print(ti.is_logging_effective("error"))     # True
         >>> print(ti.is_logging_effective("critical"))  # True
     """
-    return ti_core.logging_effective(level)
+    return ti_python_core.logging_effective(level)
 
 
 # ------------------------

--- a/python/taichi/_snode/snode_tree.py
+++ b/python/taichi/_snode/snode_tree.py
@@ -1,5 +1,5 @@
-# The reason we import just the taichi.core.util module, instead of the ti_core
-# object within it, is that ti_core is stateful. While in practice ti_core is
+# The reason we import just the taichi.core.util module, instead of the ti_python_core
+# object within it, is that ti_python_core is stateful. While in practice ti_python_core is
 # loaded during the import procedure, it's probably still good to delay the
 # access to it.
 

--- a/python/taichi/aot/record.py
+++ b/python/taichi/aot/record.py
@@ -1,10 +1,10 @@
 import os
 
-from taichi._lib import core as ti_core
+from taichi._lib import core as ti_python_core
 
 
 def record_action_entry(name, contents):
-    ti_core.record_action_entry(name, list(contents.items()))
+    ti_python_core.record_action_entry(name, list(contents.items()))
 
 
 def record_action_hint(name, content=None):
@@ -44,7 +44,7 @@ def start_recording(filename):
         >>>     compute_loss()
         >>> do_some_works()
     """
-    ti_core.start_recording(filename)
+    ti_python_core.start_recording(filename)
 
 
 def stop_recording():
@@ -52,7 +52,7 @@ def stop_recording():
 
     This function should be called in pair with :func:`~ti.aot.start_recording`.
     """
-    ti_core.stop_recording()
+    ti_python_core.stop_recording()
 
 
 class RecordKernelGroup:

--- a/python/taichi/lang/any_array.py
+++ b/python/taichi/lang/any_array.py
@@ -8,7 +8,7 @@ class AnyArray:
     """Class for arbitrary arrays in Python AST.
 
     Args:
-        ptr (taichi_core.Expr): A taichi_core.Expr wrapping a taichi_core.ExternalTensorExpression.
+        ptr (taichi_python.Expr): A taichi_python.Expr wrapping a taichi_python.ExternalTensorExpression.
         element_shape (Tuple[Int]): () if scalar elements (default), (n) if vector elements, and (n, m) if matrix elements.
         layout (Layout): Memory layout.
     """
@@ -39,12 +39,12 @@ class AnyArray:
 
     @taichi_scope
     def _loop_range(self):
-        """Gets the corresponding taichi_core.Expr to serve as loop range.
+        """Gets the corresponding taichi_python.Expr to serve as loop range.
 
         This is not in use now because struct fors on AnyArrays are not supported yet.
 
         Returns:
-            taichi_core.Expr: See above.
+            taichi_python.Expr: See above.
         """
         return self.ptr
 

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -89,7 +89,7 @@ class Field:
         """Gets representative field member for loop range info.
 
         Returns:
-            taichi_core.Expr: Representative (first) field member.
+            taichi_python.Expr: Representative (first) field member.
         """
         return self.vars[0].ptr
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -2,7 +2,7 @@ import numbers
 from collections.abc import Iterable
 
 import numpy as np
-from taichi._lib import core as ti_core
+from taichi._lib import core as ti_python_core
 from taichi.lang import expr, impl
 from taichi.lang import ops as ops_mod
 from taichi.lang import runtime_ops
@@ -293,7 +293,7 @@ class _MatrixEntriesInitializer:
             return impl.get_runtime().default_fp
         if isinstance(entry, expr.Expr):
             dt = entry.ptr.get_ret_type()
-            if dt == ti_core.DataType_unknown:
+            if dt == ti_python_core.DataType_unknown:
                 raise TypeError(
                     'Element type of the matrix cannot be inferred. Please set dt instead for now.'
                 )
@@ -424,9 +424,9 @@ class Matrix(TaichiOperations):
             elif not impl.current_cfg().dynamic_index:
                 mat = initializer.no_dynamic_index(arr, dt)
             else:
-                if not ti_core.is_extension_supported(
+                if not ti_python_core.is_extension_supported(
                         impl.current_cfg().arch,
-                        ti_core.Extension.dynamic_index):
+                        ti_python_core.Extension.dynamic_index):
                     raise Exception(
                         f"Backend {impl.current_cfg().arch} doesn't support dynamic index"
                     )
@@ -954,7 +954,7 @@ class Matrix(TaichiOperations):
             to invoke `repr` to show the object... e.g.:
 
             TypeError: make_const_expr_f32(): incompatible function arguments. The following argument types are supported:
-                1. (arg0: float) -> taichi_core.Expr
+                1. (arg0: float) -> taichi_python.Expr
 
             Invoked with: <Taichi 2x1 Matrix>
 
@@ -1427,11 +1427,11 @@ class _MatrixFieldElement(_IntermediateMatrix):
 
     Args:
         field (MatrixField): The matrix field.
-        indices (taichi_core.ExprGroup): Indices of the element.
+        indices (taichi_python.ExprGroup): Indices of the element.
     """
     def __init__(self, field, indices):
         super().__init__(field.n, field.m, [
-            expr.Expr(ti_core.subscript(e.ptr, indices))
+            expr.Expr(ti_python_core.subscript(e.ptr, indices))
             for e in field._get_field_members()
         ])
         self._impl.dynamic_index_stride = field.dynamic_index_stride
@@ -1475,7 +1475,7 @@ class MatrixField(Field):
             return
         length = len(paths[0])
         if any(
-                len(path) != length or ti_core.is_quant(path[length -
+                len(path) != length or ti_python_core.is_quant(path[length -
                                                              1]._dtype)
                 for path in paths):
             return
@@ -1484,7 +1484,7 @@ class MatrixField(Field):
                 depth_below_lca = i
                 break
         for i in range(depth_below_lca, length - 1):
-            if any(path[i].ptr.type != ti_core.SNodeType.dense
+            if any(path[i].ptr.type != ti_python_core.SNodeType.dense
                    or path[i]._cell_size_bytes != paths[0][i]._cell_size_bytes
                    or path[i + 1]._offset_bytes_in_parent_cell != paths[0][
                        i + 1]._offset_bytes_in_parent_cell for path in paths):

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -182,8 +182,8 @@ def is_extension_supported(arch, ext):
     """Checks whether an extension is supported on an arch.
 
     Args:
-        arch (taichi_core.Arch): Specified arch.
-        ext (taichi_core.Extension): Specified extension.
+        arch (taichi_python.Arch): Specified arch.
+        ext (taichi_python.Extension): Specified extension.
 
     Returns:
         bool: Whether `ext` is supported on `arch`.
@@ -261,7 +261,7 @@ class _SpecialConfig:
 def prepare_sandbox():
     '''
     Returns a temporary directory, which will be automatically deleted on exit.
-    It may contain the taichi_core shared object or some misc. files.
+    It may contain the taichi_python shared object or some misc. files.
     '''
     tmp_dir = tempfile.mkdtemp(prefix='taichi-')
     atexit.register(shutil.rmtree, tmp_dir)
@@ -703,7 +703,7 @@ def is_arch_supported(arch, use_gles=False):
     """Checks whether an arch is supported on the machine.
 
     Args:
-        arch (taichi_core.Arch): Specified arch.
+        arch (taichi_python.Arch): Specified arch.
         use_gles (bool): If True, check is GLES is available otherwise
           check if GLSL is available. Only effective when `arch` is `ti.opengl`.
           Default is `False`.

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -238,10 +238,10 @@ class SNode:
         return ret
 
     def _loop_range(self):
-        """Gets the taichi_core.Expr wrapping the taichi_core.GlobalVariableExpression corresponding to `self` to serve as loop range.
+        """Gets the taichi_python.Expr wrapping the taichi_python.GlobalVariableExpression corresponding to `self` to serve as loop range.
 
         Returns:
-            taichi_core.Expr: See above.
+            taichi_python.Expr: See above.
         """
         return impl.get_runtime().prog.global_var_expr_from_snode(self.ptr)
 

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -498,7 +498,7 @@ class StructField(Field):
         """Gets representative field member for loop range info.
 
         Returns:
-            taichi_core.Expr: Representative (first) field member.
+            taichi_python.Expr: Representative (first) field member.
         """
         return self._members[0]._loop_range()
 

--- a/python/taichi/types/primitive_types.py
+++ b/python/taichi/types/primitive_types.py
@@ -1,11 +1,11 @@
-from taichi._lib import core as ti_core
+from taichi._lib import core as ti_python_core
 
 # ========================================
 # real types
 
 # ----------------------------------------
 
-float16 = ti_core.DataType_f16
+float16 = ti_python_core.DataType_f16
 """16-bit precision floating point data type.
 """
 
@@ -17,7 +17,7 @@ f16 = float16
 
 # ----------------------------------------
 
-float32 = ti_core.DataType_f32
+float32 = ti_python_core.DataType_f32
 """32-bit single precision floating point data type.
 """
 
@@ -29,7 +29,7 @@ f32 = float32
 
 # ----------------------------------------
 
-float64 = ti_core.DataType_f64
+float64 = ti_python_core.DataType_f64
 """64-bit double precision floating point data type.
 """
 
@@ -45,7 +45,7 @@ f64 = float64
 
 # ----------------------------------------
 
-int8 = ti_core.DataType_i8
+int8 = ti_python_core.DataType_i8
 """8-bit signed integer data type.
 """
 
@@ -57,7 +57,7 @@ i8 = int8
 
 # ----------------------------------------
 
-int16 = ti_core.DataType_i16
+int16 = ti_python_core.DataType_i16
 """16-bit signed integer data type.
 """
 
@@ -69,7 +69,7 @@ i16 = int16
 
 # ----------------------------------------
 
-int32 = ti_core.DataType_i32
+int32 = ti_python_core.DataType_i32
 """32-bit signed integer data type.
 """
 
@@ -81,7 +81,7 @@ i32 = int32
 
 # ----------------------------------------
 
-int64 = ti_core.DataType_i64
+int64 = ti_python_core.DataType_i64
 """64-bit signed integer data type.
 """
 
@@ -93,7 +93,7 @@ i64 = int64
 
 # ----------------------------------------
 
-uint8 = ti_core.DataType_u8
+uint8 = ti_python_core.DataType_u8
 """8-bit unsigned integer data type.
 """
 
@@ -105,7 +105,7 @@ u8 = uint8
 
 # ----------------------------------------
 
-uint16 = ti_core.DataType_u16
+uint16 = ti_python_core.DataType_u16
 """16-bit unsigned integer data type.
 """
 
@@ -117,7 +117,7 @@ u16 = uint16
 
 # ----------------------------------------
 
-uint32 = ti_core.DataType_u32
+uint32 = ti_python_core.DataType_u32
 """32-bit unsigned integer data type.
 """
 
@@ -129,7 +129,7 @@ u32 = uint32
 
 # ----------------------------------------
 
-uint64 = ti_core.DataType_u64
+uint64 = ti_python_core.DataType_u64
 """64-bit unsigned integer data type.
 """
 

--- a/python/taichi/types/quantized_types.py
+++ b/python/taichi/types/quantized_types.py
@@ -2,11 +2,11 @@
 This module defines generators of quantized types.
 For more details, read https://yuanming.taichi.graphics/publication/2021-quantaichi/quantaichi.pdf.
 """
-from taichi._lib.utils import ti_core as _ti_core
+from taichi._lib.utils import ti_python_core as _ti_python_core
 from taichi.lang import impl
 from taichi.types.primitive_types import i32
 
-_type_factory = _ti_core.get_type_factory_instance()
+_type_factory = _ti_python_core.get_type_factory_instance()
 
 
 def int(bits, signed=True, compute=None):  # pylint: disable=W0622
@@ -22,7 +22,7 @@ def int(bits, signed=True, compute=None):  # pylint: disable=W0622
     """
     if compute is None:
         compute = impl.get_runtime().default_ip
-    if isinstance(compute, _ti_core.DataType):
+    if isinstance(compute, _ti_python_core.DataType):
         compute = compute.get_ptr()
     return _type_factory.get_quant_int_type(bits, signed, compute)
 
@@ -42,7 +42,7 @@ def fixed(frac, signed=True, range=1.0, compute=None, scale=None):  # pylint: di
     """
     if compute is None:
         compute = impl.get_runtime().default_fp
-    if isinstance(compute, _ti_core.DataType):
+    if isinstance(compute, _ti_python_core.DataType):
         compute = compute.get_ptr()
     # TODO: handle cases with frac > 32
     frac_type = int(bits=frac, signed=signed, compute=i32)
@@ -68,7 +68,7 @@ def float(exp, frac, signed=True, compute=None):  # pylint: disable=W0622
     """
     if compute is None:
         compute = impl.get_runtime().default_fp
-    if isinstance(compute, _ti_core.DataType):
+    if isinstance(compute, _ti_python_core.DataType):
         compute = compute.get_ptr()
     # Exponent is always unsigned
     exp_type = int(bits=exp, signed=False, compute=i32)

--- a/python/taichi/types/utils.py
+++ b/python/taichi/types/utils.py
@@ -1,7 +1,7 @@
-from taichi._lib import core as ti_core
+from taichi._lib import core as ti_python_core
 
-is_signed = ti_core.is_signed
+is_signed = ti_python_core.is_signed
 
-is_integral = ti_core.is_integral
+is_integral = ti_python_core.is_integral
 
 __all__ = ['is_signed', 'is_integral']

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 # Optional environment variables supported by setup.py:
 #   {DEBUG, RELWITHDEBINFO, MINSIZEREL}
-#     build the C++ taichi_core extension with various build types.
+#     build the C++ taichi_python extension with various build types.
 #
 #   TAICHI_CMAKE_ARGS
-#     extra cmake args for C++ taichi_core extension.
+#     extra cmake args for C++ taichi_python extension.
 
 import glob
 import multiprocessing

--- a/taichi/codegen/llvm/llvm_codegen_utils.h
+++ b/taichi/codegen/llvm/llvm_codegen_utils.h
@@ -126,7 +126,7 @@ class LLVMModuleBuilder {
     std::vector<llvm::Value *> args = arglist;
     check_func_call_signature(func->getFunctionType(), func->getName(), args,
                               builder);
-    return builder->CreateCall(func, arglist);
+    return builder->CreateCall(func, args);
   }
 
   template <typename... Args>

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -35,7 +35,7 @@
 
 // Avoid dependency on glibc 2.27
 #if defined(TI_PLATFORM_LINUX) && defined(TI_ARCH_x64)
-// objdump -T libtaichi_core.so| grep  GLIBC_2.27
+// objdump -T libtaichi_python.so| grep  GLIBC_2.27
 __asm__(".symver logf,logf@GLIBC_2.2.5");
 __asm__(".symver powf,powf@GLIBC_2.2.5");
 __asm__(".symver expf,expf@GLIBC_2.2.5");

--- a/taichi/python/export.cpp
+++ b/taichi/python/export.cpp
@@ -9,8 +9,8 @@
 
 TI_NAMESPACE_BEGIN
 
-PYBIND11_MODULE(taichi_core, m) {
-  m.doc() = "taichi_core";
+PYBIND11_MODULE(taichi_python, m) {
+  m.doc() = "taichi_python";
 
   for (auto &kv : InterfaceHolder::get_instance()->methods) {
     kv.second(&m);

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -93,8 +93,8 @@ def test_xdg_basedir(tmpdir):
         # environment to the native C++ code.
         os.putenv("XDG_CACHE_HOME", str(tmpdir))
 
-        ti_core = ti._lib.utils.import_ti_core()
-        repo_dir = ti_core.get_repo_dir()
+        ti_python_core = ti._lib.utils.import_ti_python_core()
+        repo_dir = ti_python_core.get_repo_dir()
 
         repo_path = pathlib.Path(repo_dir).resolve()
         expected_path = pathlib.Path(tmpdir / "taichi").resolve()
@@ -157,19 +157,19 @@ def test_init_bad_arg():
 
 
 def test_init_require_version():
-    ti_core = ti._lib.utils.import_ti_core()
-    require_version = '{}.{}.{}'.format(ti_core.get_version_major(),
-                                        ti_core.get_version_minor(),
-                                        ti_core.get_version_patch())
+    ti_python_core = ti._lib.utils.import_ti_python_core()
+    require_version = '{}.{}.{}'.format(ti_python_core.get_version_major(),
+                                        ti_python_core.get_version_minor(),
+                                        ti_python_core.get_version_patch())
     ti.init(_test_mode=True, debug=True, require_version=require_version)
 
 
 def test_init_bad_require_version():
     with pytest.raises(Exception):
-        ti_core = ti._lib.utils.import_ti_core()
+        ti_python_core = ti._lib.utils.import_ti_python_core()
         bad_require_version = '{}.{}.{}'.format(
-            ti_core.get_version_major(), ti_core.get_version_minor(),
-            ti_core.get_version_patch() + 1)
+            ti_python_core.get_version_major(), ti_python_core.get_version_minor(),
+            ti_python_core.get_version_patch() + 1)
         ti.init(_test_mode=True,
                 debug=True,
                 require_version=bad_require_version)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -155,7 +155,7 @@ def expected_archs():
     all supported archs except archs specified in it will be returned.
     If `TI_WANTED_ARCHS` is not set, all supported archs will be returned.
     Returns:
-        List[taichi_core.Arch]: All expected archs on the machine.
+        List[taichi_python.Arch]: All expected archs on the machine.
     """
     archs = set([cpu, cuda, metal, vulkan, opengl, cc])
     # TODO: now expected_archs is not called per test so we cannot test it


### PR DESCRIPTION
Related issue = #4832 

Changes:

- Rename the taichi target that includes frontend AST, IR, Analysis etc to `taichi_core`. The old name was `taichi_isolated_core`.  
- Rename the taichi python target that depends on `taichi_core` to `taichi_python`. The old name was `taichi_core`.
- On the python side, rename `ti_core` to `ti_python_core`.
