### PR TITLE
[Build] Script for Android build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ imgui.ini
 /venv/
 /_skbuild/
 .cache
+/out
+/build-android-aarch64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 
 macro(check_clang_version)
   execute_process(COMMAND ${CLANG_EXECUTABLE} --version OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
-  string(REGEX MATCH "([0-9]+)\\.[0-9]+(\\.[0-9]+)?" CLANG_VERSION "${CLANG_VERSION_OUTPUT}")
+  string(REGEX MATCH "([0-9]+)\\.[0-9]+(\\.[0-9]+)" CLANG_VERSION "${CLANG_VERSION_OUTPUT}")
   message("${CLANG_EXECUTABLE} --version: ${CLANG_VERSION}")
 
   set(CLANG_VERSION_MAJOR "${CMAKE_MATCH_1}")

--- a/build-android.ps1
+++ b/build-android.ps1
@@ -1,0 +1,26 @@
+if (-not(Test-Path "build-android-aarch64")) {
+    New-Item "build-android-aarch64" -ItemType Directory
+}
+
+Push-Location "build-android-aarch64"
+cmake -DCMAKE_BUILD_TYPE=Release `
+    -DCMAKE_INSTALL_PREFIX="${pwd}/../build-android-aarch64/install" `
+    -DCMAKE_TOOLCHAIN_FILE="$env:ANDROID_NDK/build/cmake/android.toolchain.cmake" `
+    -DCLANG_EXECUTABLE="${pwd}/../tmp/taichi-clang/bin/clang++.exe" `
+    -DANDROID_ABI="arm64-v8a" `
+    -DANDROID_PLATFORM=android-26 `
+    -G "Ninja" `
+    -DTI_WITH_CC=OFF `
+    -DTI_WITH_CUDA=OFF `
+    -DTI_WITH_CUDA_TOOLKIT=OFF `
+    -DTI_WITH_C_API=ON `
+    -DTI_WITH_DX11=OFF `
+    -DTI_WITH_LLVM=OFF `
+    -DTI_WITH_METAL=OFF `
+    -DTI_WITH_OPENGL=OFF `
+    -DTI_WITH_PYTHON=OFF `
+    -DTI_WITH_VULKAN=ON `
+    ..
+cmake --build . -t taichi_c_api
+cmake --build . -t install
+Pop-Location


### PR DESCRIPTION
This PR proposes a simple script to build C-API library for Android. This is opened only as an archive. Lets see how it could be integrated into the CI process.

Note that Android 8.0 Oreo (API Level 26) is required for proper Vulkan support, or at least Android 7.0 Nougat (API Level 24) which is the first version Vulkan got supported.