### PR TITLE
[bug] Set SNode tree id to all SNodes

### DIFF
--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -325,7 +325,7 @@ SNode *SNode::get_dual() const {
 
 void SNode::set_snode_tree_id(int id) {
   snode_tree_id_ = id;
-  for (auto &child: ch) {
+  for (auto &child : ch) {
     child->set_snode_tree_id(id);
   }
 }

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -325,6 +325,9 @@ SNode *SNode::get_dual() const {
 
 void SNode::set_snode_tree_id(int id) {
   snode_tree_id_ = id;
+  for (auto &child: ch) {
+    child->set_snode_tree_id(id);
+  }
 }
 
 int SNode::get_snode_tree_id() const {


### PR DESCRIPTION
Related issue = #4401 
Fixes wrong answers on `test_mesh.py` when offline cache is on which are caused by getting `snode_tree_id` of non-root SNodes whose `snode_tree_id`s are not set.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
