### PR TITLE
[error] Throw proper error message when an Ndarray is passed in via ti.template

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -335,6 +335,10 @@ class TaichiCallableTemplateMapper:
                 return tuple(
                     TaichiCallableTemplateMapper.extract_arg(item, anno)
                     for item in arg)
+            if isinstance(arg, taichi.lang._ndarray.Ndarray):
+                raise TaichiRuntimeTypeError(
+                    'Ndarray shouldn\'t be passed in via `ti.template()`, please annotate your kernel using `ti.types.ndarray(...)` instead'
+                )
             return arg
         if isinstance(anno, texture_type.TextureType):
             return '#'

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -660,3 +660,17 @@ def test_ndarray_grouped():
             for k in range(2):
                 for p in range(2):
                     assert a2[i, j][k, p] == k * k
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_as_template():
+    @ti.kernel
+    def func(arr_src: ti.template(), arr_dst: ti.template()):
+        for i, j in ti.ndrange(*arr_src.shape):
+            arr_dst[i, j] = arr_src[i, j]
+
+    arr_0 = ti.ndarray(ti.f32, shape=(5, 10))
+    arr_1 = ti.ndarray(ti.f32, shape=(5, 10))
+    with pytest.raises(ti.TaichiRuntimeTypeError,
+                       match=r"Ndarray shouldn't be passed in via"):
+        func(arr_0, arr_1)


### PR DESCRIPTION
ti.types.ndarray itself is a template type so let's throw a better error
message when users misuse it.

fixes #5452 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
