### PR TITLE
[type] [refactor] Decouple quant from SNode 8/n: Remove redundant handling of llvm15 in codegen_llvm_quant

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1235,9 +1235,15 @@ llvm::Value *CodeGenLLVM::quant_type_atomic(AtomicOpStmt *stmt) {
 
   auto dst_type = stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
   if (auto qit = dst_type->cast<QuantIntType>()) {
-    return atomic_add_quant_int(llvm_val[stmt->dest], llvm_type(stmt->dest->as<GetChStmt>()->input_snode->physical_type), qit, llvm_val[stmt->val], is_signed(stmt->val->ret_type));
+    return atomic_add_quant_int(
+        llvm_val[stmt->dest],
+        llvm_type(stmt->dest->as<GetChStmt>()->input_snode->physical_type), qit,
+        llvm_val[stmt->val], is_signed(stmt->val->ret_type));
   } else if (auto qfxt = dst_type->cast<QuantFixedType>()) {
-    return atomic_add_quant_fixed(llvm_val[stmt->dest], llvm_type(stmt->dest->as<GetChStmt>()->input_snode->physical_type), qfxt, llvm_val[stmt->val]);
+    return atomic_add_quant_fixed(
+        llvm_val[stmt->dest],
+        llvm_type(stmt->dest->as<GetChStmt>()->input_snode->physical_type),
+        qfxt, llvm_val[stmt->val]);
   } else {
     return nullptr;
   }

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1235,9 +1235,9 @@ llvm::Value *CodeGenLLVM::quant_type_atomic(AtomicOpStmt *stmt) {
 
   auto dst_type = stmt->dest->ret_type->as<PointerType>()->get_pointee_type();
   if (auto qit = dst_type->cast<QuantIntType>()) {
-    return atomic_add_quant_int(stmt, qit);
+    return atomic_add_quant_int(llvm_val[stmt->dest], llvm_type(stmt->dest->as<GetChStmt>()->input_snode->physical_type), qit, llvm_val[stmt->val], is_signed(stmt->val->ret_type));
   } else if (auto qfxt = dst_type->cast<QuantFixedType>()) {
-    return atomic_add_quant_fixed(stmt, qfxt);
+    return atomic_add_quant_fixed(llvm_val[stmt->dest], llvm_type(stmt->dest->as<GetChStmt>()->input_snode->physical_type), qfxt, llvm_val[stmt->val]);
   } else {
     return nullptr;
   }
@@ -1393,20 +1393,18 @@ void CodeGenLLVM::visit(GlobalStoreStmt *stmt) {
   auto ptr_type = stmt->dest->ret_type->as<PointerType>();
   if (ptr_type->is_bit_pointer()) {
     auto pointee_type = ptr_type->get_pointee_type();
-    if (stmt->dest->as<GetChStmt>()->input_snode->type ==
-        SNodeType::bit_struct) {
+    auto snode = stmt->dest->as<GetChStmt>()->input_snode;
+    if (snode->type == SNodeType::bit_struct) {
       TI_ERROR(
           "Bit struct stores with type {} should have been handled by "
           "BitStructStoreStmt.",
           pointee_type->to_string());
     }
     if (auto qit = pointee_type->cast<QuantIntType>()) {
-      store_quant_int(llvm_val[stmt->dest],
-                      stmt->dest->as<GetChStmt>()->input_snode->physical_type,
+      store_quant_int(llvm_val[stmt->dest], llvm_type(snode->physical_type),
                       qit, llvm_val[stmt->val], true);
     } else if (auto qfxt = pointee_type->cast<QuantFixedType>()) {
-      store_quant_fixed(llvm_val[stmt->dest],
-                        stmt->dest->as<GetChStmt>()->input_snode->physical_type,
+      store_quant_fixed(llvm_val[stmt->dest], llvm_type(snode->physical_type),
                         qfxt, llvm_val[stmt->val], true);
     } else {
       TI_NOT_IMPLEMENTED;

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -197,9 +197,16 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(SNodeOpStmt *stmt) override;
 
-  llvm::Value *atomic_add_quant_fixed(AtomicOpStmt *stmt, QuantFixedType *qfxt);
+  llvm::Value *atomic_add_quant_fixed(llvm::Value *ptr,
+                                      llvm::Type *physical_type,
+                                      QuantFixedType *qfxt,
+                                      llvm::Value *value);
 
-  llvm::Value *atomic_add_quant_int(AtomicOpStmt *stmt, QuantIntType *qit);
+  llvm::Value *atomic_add_quant_int(llvm::Value *ptr,
+                                    llvm::Type *physical_type,
+                                    QuantIntType *qit,
+                                    llvm::Value *value,
+                                    bool value_is_signed);
 
   llvm::Value *to_quant_fixed(llvm::Value *real, QuantFixedType *qfxt);
 
@@ -222,14 +229,14 @@ class CodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(PtrOffsetStmt *stmt) override;
 
-  void store_quant_int(llvm::Value *bit_ptr,
-                       PrimitiveType *physical_ty,
+  void store_quant_int(llvm::Value *ptr,
+                       llvm::Type *physical_type,
                        QuantIntType *qit,
                        llvm::Value *value,
                        bool atomic);
 
-  void store_quant_fixed(llvm::Value *bit_ptr,
-                         PrimitiveType *physical_ty,
+  void store_quant_fixed(llvm::Value *ptr,
+                         llvm::Type *physical_type,
                          QuantFixedType *qfxt,
                          llvm::Value *value,
                          bool atomic);


### PR DESCRIPTION
Related issue = #4857

After this PR, no snode appears in `codegen_llvm_quant.cpp`.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
