### PR TITLE
[Lang] [bug] Make comparisons always return i32

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -783,7 +783,9 @@ class ASTTransformer(Builder):
                     raise TaichiSyntaxError(
                         f'"{type(node_op).__name__}" is not supported in Taichi kernels.'
                     )
-            val = op(l, r) if val is True else ti_ops.bit_and(val, op(l, r))
+            val = ti_ops.bit_and(val, op(l, r))
+        if not isinstance(val, bool):
+            val = ti_ops.cast(val, primitive_types.i32)
         node.ptr = val
         return node.ptr
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -783,7 +783,7 @@ class ASTTransformer(Builder):
                     raise TaichiSyntaxError(
                         f'"{type(node_op).__name__}" is not supported in Taichi kernels.'
                     )
-            val = ti_ops.bit_and(val, op(l, r))
+            val = op(l, r) if val is True else ti_ops.bit_and(val, op(l, r))
         node.ptr = val
         return node.ptr
 

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -198,3 +198,17 @@ def test_non_static_is():
             return tp is ti.f32
 
         is_f32(ti.f32)
+
+
+@test_utils.test(default_ip=ti.i64, require=ti.extension.data64)
+def test_compare_ret_type():
+    # The purpose of this test is to make sure a comparison returns i32
+    # regardless of default_ip so that it can always serve as the condition of
+    # an if statement.
+    @ti.kernel
+    def foo():
+        for i in range(100):
+            if i == 0:
+                pass
+
+    foo()


### PR DESCRIPTION
Related issue = fix #5466 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
