### PR TITLE
[AOT] Prefixed device commands with cmd to hint the user

### DIFF
--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -171,29 +171,34 @@ TI_DLL_EXPORT void TI_API_CALL ti_destroy_event(TiEvent event);
 
 // function.copy_memory_device_to_device
 TI_DLL_EXPORT void TI_API_CALL
-ti_copy_memory_device_to_device(TiRuntime runtime,
-                                const TiMemorySlice *dst_memory,
-                                const TiMemorySlice *src_memory);
+ti_cmd_copy_memory_device_to_device(TiRuntime runtime,
+                                    const TiMemorySlice *dst_memory,
+                                    const TiMemorySlice *src_memory);
 
 // function.launch_kernel
-TI_DLL_EXPORT void TI_API_CALL ti_launch_kernel(TiRuntime runtime,
-                                                TiKernel kernel,
-                                                uint32_t arg_count,
-                                                const TiArgument *args);
+TI_DLL_EXPORT void TI_API_CALL ti_cmd_launch_kernel(TiRuntime runtime,
+                                                    TiKernel kernel,
+                                                    uint32_t arg_count,
+                                                    const TiArgument *args);
 
 // function.launch_compute_graph
 TI_DLL_EXPORT void TI_API_CALL
-ti_launch_compute_graph(TiRuntime runtime,
-                        TiComputeGraph compute_graph,
-                        uint32_t arg_count,
-                        const TiNamedArgument *args);
+ti_cmd_launch_compute_graph(TiRuntime runtime,
+                            TiComputeGraph compute_graph,
+                            uint32_t arg_count,
+                            const TiNamedArgument *args);
 
 // function.signal_event
-TI_DLL_EXPORT void TI_API_CALL ti_signal_event(TiRuntime runtime,
-                                               TiEvent event);
+TI_DLL_EXPORT void TI_API_CALL ti_cmd_signal_event(TiRuntime runtime,
+                                                   TiEvent event);
 
 // function.reset_event
-TI_DLL_EXPORT void TI_API_CALL ti_reset_event(TiRuntime runtime, TiEvent event);
+TI_DLL_EXPORT void TI_API_CALL ti_cmd_reset_event(TiRuntime runtime,
+                                                  TiEvent event);
+
+// function.wait_event
+TI_DLL_EXPORT void TI_API_CALL ti_cmd_wait_event(TiRuntime runtime,
+                                                 TiEvent event);
 
 // function.submit
 TI_DLL_EXPORT void TI_API_CALL ti_submit(TiRuntime runtime);

--- a/c_api/include/taichi/taichi_unity.h
+++ b/c_api/include/taichi/taichi_unity.h
@@ -13,24 +13,24 @@ TI_DLL_EXPORT TiRuntime TI_API_CALL tix_import_native_runtime_unity();
 
 // function.launch_kernel_async
 TI_DLL_EXPORT void TI_API_CALL
-tix_launch_kernel_async_unity(TiRuntime runtime,
-                              TiKernel kernel,
-                              uint32_t arg_count,
-                              const TiArgument *args);
+tix_cmd_launch_kernel_async_unity(TiRuntime runtime,
+                                  TiKernel kernel,
+                                  uint32_t arg_count,
+                                  const TiArgument *args);
 
 // function.launch_compute_graph_async
 TI_DLL_EXPORT void TI_API_CALL
-tix_launch_compute_graph_async_unity(TiRuntime runtime,
-                                     TiComputeGraph compute_graph,
-                                     uint32_t arg_count,
-                                     const TiNamedArgument *args);
+tix_cmd_launch_compute_graph_async_unity(TiRuntime runtime,
+                                         TiComputeGraph compute_graph,
+                                         uint32_t arg_count,
+                                         const TiNamedArgument *args);
 
 // function.copy_memory_to_native_buffer_async
 TI_DLL_EXPORT void TI_API_CALL
-tix_copy_memory_to_native_buffer_async_unity(TiRuntime runtime,
-                                             TixNativeBufferUnity dst,
-                                             uint64_t dst_offset,
-                                             const TiMemorySlice *src);
+tix_cmd_copy_memory_to_native_buffer_async_unity(TiRuntime runtime,
+                                                 TixNativeBufferUnity dst,
+                                                 uint64_t dst_offset,
+                                                 const TiMemorySlice *src);
 
 // function.copy_memory_device_to_host
 TI_DLL_EXPORT void TI_API_CALL
@@ -47,7 +47,7 @@ tix_copy_memory_host_to_device_unity(TiRuntime runtime,
                                      uint64_t src_offset);
 
 // function.submit_async
-TI_DLL_EXPORT void *TI_API_CALL tix_submit_async_unity(TiRuntime runtime);
+TI_DLL_EXPORT void *TI_API_CALL tix_cmd_submit_async_unity(TiRuntime runtime);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -188,8 +188,8 @@ void ti_destroy_event(TiEvent event) {
 }
 
 void ti_cmd_copy_memory_device_to_device(TiRuntime runtime,
-                                     const TiMemorySlice *dst_memory,
-                                     const TiMemorySlice *src_memory) {
+                                         const TiMemorySlice *dst_memory,
+                                         const TiMemorySlice *src_memory) {
   if (runtime == nullptr) {
     TI_WARN("ignored attempt to copy memory on runtime of null handle");
     return;
@@ -255,9 +255,9 @@ TiComputeGraph ti_get_aot_module_compute_graph(TiAotModule mod,
 }
 
 void ti_cmd_launch_kernel(TiRuntime runtime,
-                      TiKernel kernel,
-                      uint32_t arg_count,
-                      const TiArgument *args) {
+                          TiKernel kernel,
+                          uint32_t arg_count,
+                          const TiArgument *args) {
   if (runtime == nullptr) {
     TI_WARN("ignored attempt to launch kernel on runtime of null handle");
     return;
@@ -331,9 +331,9 @@ void ti_cmd_launch_kernel(TiRuntime runtime,
 }
 
 void ti_cmd_launch_compute_graph(TiRuntime runtime,
-                             TiComputeGraph compute_graph,
-                             uint32_t arg_count,
-                             const TiNamedArgument *args) {
+                                 TiComputeGraph compute_graph,
+                                 uint32_t arg_count,
+                                 const TiNamedArgument *args) {
   if (runtime == nullptr) {
     TI_WARN(
         "ignored attempt to launch compute graph on runtime of null handle");

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -187,7 +187,7 @@ void ti_destroy_event(TiEvent event) {
   delete (Event *)event;
 }
 
-void ti_copy_memory_device_to_device(TiRuntime runtime,
+void ti_cmd_copy_memory_device_to_device(TiRuntime runtime,
                                      const TiMemorySlice *dst_memory,
                                      const TiMemorySlice *src_memory) {
   if (runtime == nullptr) {
@@ -254,7 +254,7 @@ TiComputeGraph ti_get_aot_module_compute_graph(TiAotModule mod,
   return (TiComputeGraph)&aot_module->get_cgraph(name);
 }
 
-void ti_launch_kernel(TiRuntime runtime,
+void ti_cmd_launch_kernel(TiRuntime runtime,
                       TiKernel kernel,
                       uint32_t arg_count,
                       const TiArgument *args) {
@@ -330,7 +330,7 @@ void ti_launch_kernel(TiRuntime runtime,
   ((taichi::lang::aot::Kernel *)kernel)->launch(&runtime_context);
 }
 
-void ti_launch_compute_graph(TiRuntime runtime,
+void ti_cmd_launch_compute_graph(TiRuntime runtime,
                              TiComputeGraph compute_graph,
                              uint32_t arg_count,
                              const TiNamedArgument *args) {
@@ -437,15 +437,15 @@ void ti_launch_compute_graph(TiRuntime runtime,
   ((taichi::lang::aot::CompiledGraph *)compute_graph)->run(arg_map);
 }
 
-void ti_signal_event(TiRuntime runtime, TiEvent event) {
+void ti_cmd_signal_event(TiRuntime runtime, TiEvent event) {
   ((Runtime *)runtime)->signal_event(&((Event *)event)->get());
 }
 
-void ti_reset_event(TiRuntime runtime, TiEvent event) {
+void ti_cmd_reset_event(TiRuntime runtime, TiEvent event) {
   ((Runtime *)runtime)->reset_event(&((Event *)event)->get());
 }
 
-void ti_wait_event(TiRuntime runtime, TiEvent event) {
+void ti_cmd_wait_event(TiRuntime runtime, TiEvent event) {
   ((Runtime *)runtime)->wait_event(&((Event *)event)->get());
 }
 

--- a/c_api/src/taichi_llvm_impl.cpp
+++ b/c_api/src/taichi_llvm_impl.cpp
@@ -119,7 +119,10 @@ void LlvmRuntime::buffer_copy(const taichi::lang::DevicePtr &dst,
 }
 
 void LlvmRuntime::submit() {
-  TI_NOT_IMPLEMENTED;
+  // Currently implementations in LLVM backends don't support asynchronous
+  // submit so the submit semantic is already fulfilled at this point. Return
+  // right away.
+  return;
 }
 
 void LlvmRuntime::wait() {

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -741,6 +741,7 @@
                     "name": "launch_kernel_async",
                     "vendor": "unity",
                     "type": "function",
+                    "is_device_command": true,
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -763,6 +764,7 @@
                     "name": "launch_compute_graph_async",
                     "vendor": "unity",
                     "type": "function",
+                    "is_device_command": true,
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -785,6 +787,7 @@
                     "name": "copy_memory_to_native_buffer_async",
                     "vendor": "unity",
                     "type": "function",
+                    "is_device_command": true,
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -854,6 +857,7 @@
                     "name": "submit_async",
                     "vendor": "unity",
                     "type": "function",
+                    "is_device_command": true,
                     "parameters": [
                         {
                             "name": "@return",

--- a/c_api/tests/c_api_aot_test.cpp
+++ b/c_api/tests/c_api_aot_test.cpp
@@ -45,9 +45,6 @@ void kernel_aot_test(TiArch arch) {
 
   ti_cmd_launch_kernel(runtime, k_run, arg_count, &args[0]);
 
-  ti_submit(runtime);
-  ti_wait(runtime);
-
   // Check Results
   auto *data = reinterpret_cast<int32_t *>(ti_map_memory(runtime, memory));
 

--- a/c_api/tests/c_api_aot_test.cpp
+++ b/c_api/tests/c_api_aot_test.cpp
@@ -43,7 +43,10 @@ void kernel_aot_test(TiArch arch) {
   constexpr uint32_t arg_count = 2;
   TiArgument args[arg_count] = {std::move(arg0), std::move(arg1)};
 
-  ti_launch_kernel(runtime, k_run, arg_count, &args[0]);
+  ti_cmd_launch_kernel(runtime, k_run, arg_count, &args[0]);
+
+  ti_submit(runtime);
+  ti_wait(runtime);
 
   // Check Results
   auto *data = reinterpret_cast<int32_t *>(ti_map_memory(runtime, memory));

--- a/c_api/tests/c_api_aot_test.cpp
+++ b/c_api/tests/c_api_aot_test.cpp
@@ -45,6 +45,9 @@ void kernel_aot_test(TiArch arch) {
 
   ti_cmd_launch_kernel(runtime, k_run, arg_count, &args[0]);
 
+  ti_submit(runtime);
+  ti_wait(runtime);
+
   // Check Results
   auto *data = reinterpret_cast<int32_t *>(ti_map_memory(runtime, memory));
 

--- a/c_api/tests/c_api_cgraph_test.cpp
+++ b/c_api/tests/c_api_cgraph_test.cpp
@@ -65,9 +65,6 @@ void graph_aot_test(TiArch arch) {
 
   ti_cmd_launch_compute_graph(runtime, run_graph, arg_count, &named_args[0]);
 
-  ti_submit(runtime);
-  ti_wait(runtime);
-
   // Check Results
   auto *data = reinterpret_cast<int32_t *>(ti_map_memory(runtime, arr_memory));
 

--- a/c_api/tests/c_api_cgraph_test.cpp
+++ b/c_api/tests/c_api_cgraph_test.cpp
@@ -65,6 +65,9 @@ void graph_aot_test(TiArch arch) {
 
   ti_cmd_launch_compute_graph(runtime, run_graph, arg_count, &named_args[0]);
 
+  ti_submit(runtime);
+  ti_wait(runtime);
+
   // Check Results
   auto *data = reinterpret_cast<int32_t *>(ti_map_memory(runtime, arr_memory));
 

--- a/c_api/tests/c_api_cgraph_test.cpp
+++ b/c_api/tests/c_api_cgraph_test.cpp
@@ -63,7 +63,10 @@ void graph_aot_test(TiArch arch) {
       std::move(arr_named_arg),
   };
 
-  ti_launch_compute_graph(runtime, run_graph, arg_count, &named_args[0]);
+  ti_cmd_launch_compute_graph(runtime, run_graph, arg_count, &named_args[0]);
+
+  ti_submit(runtime);
+  ti_wait(runtime);
 
   // Check Results
   auto *data = reinterpret_cast<int32_t *>(ti_map_memory(runtime, arr_memory));

--- a/misc/taichi_json.py
+++ b/misc/taichi_json.py
@@ -110,6 +110,10 @@ class EntryBase:
                 suffix += [str(version)]
             self.version = version
 
+        if "is_device_command" in j and j["is_device_command"]:
+            self.is_device_command = True
+            prefix += ["cmd"]
+
         self.name = Name(j["name"], prefix, suffix)
         self.id = f"{clazz}.{self.name}"
 


### PR DESCRIPTION
Added a `cmd` prefix to highlight the subset of C-API that only takes effect after `submit()` to avoid confusion when more APIs are added in the future. It breaks existing prebuilt C-API libraries.