### PR TITLE
[bug] Let the arguments in ti.init override the environment variables

### DIFF
--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -384,7 +384,7 @@ def init(arch=None,
             _ti_core.warn(
                 f'Environment variable TI_DEFAULT_IP={env_default_ip} overridden by ti.init argument "default_ip"'
             )
-        if env_default_ip == '32':
+        elif env_default_ip == '32':
             default_ip = i32
         elif env_default_ip == '64':
             default_ip = i64

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -228,16 +228,15 @@ class _EnvironmentConfigurator:
         # TI_ASYNC=1  : True
         name = 'TI_' + key.upper()
         value = os.environ.get(name, '')
-        if len(value):
-            self[key] = _cast(value)
-            if key in self.kwargs:
-                _ti_core.warn(
-                    f'ti.init argument "{key}" overridden by environment variable {name}={value}'
-                )
-                del self.kwargs[key]  # mark as recognized
-        elif key in self.kwargs:
+        if key in self.kwargs:
             self[key] = self.kwargs[key]
+            if value:
+                _ti_core.warn(
+                    f'Environment variable {name}={value} overridden by ti.init argument "{key}"'
+                )
             del self.kwargs[key]  # mark as recognized
+        elif value:
+            self[key] = _cast(value)
 
     def __getitem__(self, key):
         return getattr(self.cfg, key)
@@ -369,9 +368,9 @@ def init(arch=None,
     if env_default_fp:
         if default_fp is not None:
             _ti_core.warn(
-                f'ti.init argument "default_fp" overridden by environment variable TI_DEFAULT_FP={env_default_fp}'
+                f'Environment variable TI_DEFAULT_FP={env_default_fp} overridden by ti.init argument "default_fp"'
             )
-        if env_default_fp == '32':
+        elif env_default_fp == '32':
             default_fp = f32
         elif env_default_fp == '64':
             default_fp = f64
@@ -383,7 +382,7 @@ def init(arch=None,
     if env_default_ip:
         if default_ip is not None:
             _ti_core.warn(
-                f'ti.init argument "default_ip" overridden by environment variable TI_DEFAULT_IP={env_default_ip}'
+                f'Environment variable TI_DEFAULT_IP={env_default_ip} overridden by ti.init argument "default_ip"'
             )
         if env_default_ip == '32':
             default_ip = i32

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -160,6 +160,7 @@ def _test_closing_offline_cache_for_a_kernel(curr_arch, kernel, args, result):
 
     ti.init(arch=curr_arch,
             enable_fallback=False,
+            offline_cache=False,
             offline_cache_file_path=tmp_offline_cache_file_path())
     res1 = kernel(*args)
     assert len(listdir(tmp_offline_cache_file_path())
@@ -167,6 +168,7 @@ def _test_closing_offline_cache_for_a_kernel(curr_arch, kernel, args, result):
 
     ti.init(arch=curr_arch,
             enable_fallback=False,
+            offline_cache=False,
             offline_cache_file_path=tmp_offline_cache_file_path())
     assert len(listdir(tmp_offline_cache_file_path())
                ) - count_of_cache_file == get_expected_num_cache_files()


### PR DESCRIPTION
Related issue = #4401, close #5496

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
