### PR TITLE
[ci] Update macos runner version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
     needs: matrix_prep
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix_osx) }}
     runs-on: [self-hosted, macos-10.15]
     env:
       PY: ${{ matrix.python }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -208,14 +208,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-10.15
+          - os: [[self-hosted, macos-10.15], macos-latest]
             python: 3.7
             with_cc: OFF
             with_cpp_tests: ON
             wanted_archs: 'cpu'
-    runs-on:
-    - self-hosted
-    - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     env:
       PY: ${{ matrix.python }}
     steps:


### PR DESCRIPTION
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

Note: the `CI_PLATFORM` env variable is used to download the prebuilt version of LLVM, and setting it to `macos` is completely ok.