### PR TITLE
[Vulkan] Fixed depth texture validation error

### DIFF
--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1845,13 +1845,14 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   image_info.format = buffer_format_ti_to_vk(params.format);
   image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
   image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-  image_info.usage =
-      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-      VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+  image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT |
+                     VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                     VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
   if (is_depth) {
     image_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
   } else {
-    image_info.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+    image_info.usage |=
+        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
   }
   image_info.samples = VK_SAMPLE_COUNT_1_BIT;
 

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1847,11 +1847,11 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
   image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
   image_info.usage =
       VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-      VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+      VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
   if (is_depth) {
     image_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
   } else {
-    image_info.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    image_info.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
   }
   image_info.samples = VK_SAMPLE_COUNT_1_BIT;
 


### PR DESCRIPTION
This PR fixed a trivial validation error that storage usage of depth image is not allowed.