### PR TITLE
[Bug] [ir] Cast indices of ExternalPtrStmt to ti.i32

### DIFF
--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -423,6 +423,13 @@ class TypeCheck : public IRVisitor {
     stmt->ret_type.set_is_pointer(true);
     stmt->ret_type = TypeFactory::create_vector_or_scalar_type(
         stmt->base_ptrs.size(), stmt->base_ptrs[0]->ret_type);
+    for (int i = 0; i < stmt->indices.size(); i++) {
+      TI_ASSERT(is_integral(stmt->indices[i]->ret_type));
+      if (stmt->indices[i]->ret_type != PrimitiveType::i32) {
+        stmt->indices[i] =
+            insert_type_cast_before(stmt, stmt->indices[i], PrimitiveType::i32);
+      }
+    }
   }
 
   void visit(LoopIndexStmt *stmt) override {

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -213,3 +213,13 @@ def test_numpy_struct_for():
     func2(n)
     for i, j, k in ti.ndrange(98, 76, 54):
         assert n[i, j, k] == i + j + k
+
+
+@test_utils.test(require=ti.extension.data64)
+def test_numpy_i64_index():
+    @ti.kernel
+    def foo(a: ti.types.ndarray(), i: ti.i64) -> ti.i64:
+        return a[i]
+
+    x = np.array([1, 2, 3])
+    assert foo(x, 1) == 2


### PR DESCRIPTION
Related issue = fix #5504

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
