### PR TITLE
[aot] Support texture and rwtexture in cgraph

### DIFF
--- a/python/taichi/examples/graph/texture_graph.py
+++ b/python/taichi/examples/graph/texture_graph.py
@@ -1,0 +1,93 @@
+from taichi.examples.patterns import taichi_logo
+
+import taichi as ti
+
+ti.init(arch=ti.vulkan)
+
+res = (512, 512)
+img = ti.Vector.field(4, dtype=float, shape=res)
+pixels_arr = ti.Vector.ndarray(4, dtype=float, shape=res)
+
+texture = ti.Texture(ti.f32, 1, (128, 128))
+
+
+@ti.kernel
+def make_texture(tex: ti.types.rw_texture(num_dimensions=2,
+                                          num_channels=1,
+                                          channel_format=ti.f32,
+                                          lod=0)):
+    for i, j in ti.ndrange(128, 128):
+        ret = ti.cast(taichi_logo(ti.Vector([i, j]) / 128), ti.f32)
+        tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))
+
+
+@ti.kernel
+def paint(t: ti.f32, pixels: ti.types.ndarray(field_dim=2),
+          tex: ti.types.texture(num_dimensions=2)):
+    for i, j in pixels:
+        uv = ti.Vector([i / res[0], j / res[1]])
+        warp_uv = uv + ti.Vector(
+            [ti.cos(t + uv.x * 5.0),
+             ti.sin(t + uv.y * 5.0)]) * 0.1
+        c = ti.math.vec4(0.0)
+        if uv.x > 0.5:
+            c = tex.sample_lod(warp_uv, 0.0)
+        else:
+            c = tex.fetch(ti.cast(warp_uv * 128, ti.i32), 0)
+        pixels[i, j] = [c.r, c.r, c.r, 1.0]
+
+
+@ti.kernel
+def copy_to_field(pixels: ti.types.ndarray(field_dim=2)):
+    for I in ti.grouped(pixels):
+        img[I] = pixels[I]
+
+
+def main():
+    _t = ti.graph.Arg(ti.graph.ArgKind.SCALAR, 't', ti.f32)
+    _pixels_arr = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                               'pixels_arr',
+                               ti.f32,
+                               field_dim=2,
+                               element_shape=(4, ))
+
+    _rw_tex = ti.graph.Arg(ti.graph.ArgKind.RWTEXTURE,
+                           'rw_tex',
+                           channel_format=ti.f32,
+                           shape=(128, 128),
+                           num_channels=1)
+    g_init_builder = ti.graph.GraphBuilder()
+    g_init_builder.dispatch(make_texture, _rw_tex)
+    g_init = g_init_builder.compile()
+
+    g_init.run({'rw_tex': texture})
+    _tex = ti.graph.Arg(ti.graph.ArgKind.TEXTURE,
+                        'tex',
+                        channel_format=ti.f32,
+                        shape=(128, 128),
+                        num_channels=1)
+    g_builder = ti.graph.GraphBuilder()
+    g_builder.dispatch(paint, _t, _pixels_arr, _tex)
+    g = g_builder.compile()
+
+    aot = False
+    if aot:
+        tmpdir = 'shaders'
+        mod = ti.aot.Module(ti.vulkan)
+        mod.add_graph('g', g)
+        mod.add_graph('g_init', g_init)
+        mod.save(tmpdir, '')
+    else:
+        t = 0.0
+        window = ti.ui.Window('UV', res)
+        canvas = window.get_canvas()
+        while window.running:
+            g.run({'t': t, 'pixels_arr': pixels_arr, 'tex': texture})
+            copy_to_field(pixels_arr)
+            canvas.set_image(img)
+            window.show()
+            t += 0.03
+
+
+if __name__ == '__main__':
+    main()

--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -1,5 +1,6 @@
 #include "taichi/aot/graph_data.h"
 #include "taichi/program/ndarray.h"
+#include "taichi/program/texture.h"
 
 namespace taichi {
 namespace lang {
@@ -39,6 +40,12 @@ void CompiledGraph::run(
         set_runtime_ctx_ndarray(&ctx, i, arr);
       } else if (ival.tag == aot::ArgKind::kScalar) {
         ctx.set_arg(i, ival.val);
+      } else if (ival.tag == aot::ArgKind::kTexture) {
+        Texture *tex = reinterpret_cast<Texture *>(ival.val);
+        ctx.set_arg_texture(i, tex->get_device_allocation_ptr_as_int());
+      } else if (ival.tag == aot::ArgKind::kRWTexture) {
+        Texture *tex = reinterpret_cast<Texture *>(ival.val);
+        ctx.set_arg_rw_texture(i, tex->get_device_allocation_ptr_as_int());
       } else {
         TI_ERROR("Error in compiled graph: unknown tag {}", ival.tag);
       }

--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -44,6 +44,14 @@ struct BufferBind {
   TI_IO_DEF(buffer, binding);
 };
 
+struct TextureBind {
+  int arg_id;
+  int binding;
+  bool is_storage;
+
+  TI_IO_DEF(arg_id, binding, is_storage);
+};
+
 struct CompiledOffloadedTask {
   std::string type;
   std::string range_hint;
@@ -53,8 +61,15 @@ struct CompiledOffloadedTask {
   int gpu_block_size{0};
 
   std::vector<BufferBind> buffer_binds;
+  std::vector<TextureBind> texture_binds;
 
-  TI_IO_DEF(type, range_hint, name, source_path, gpu_block_size, buffer_binds);
+  TI_IO_DEF(type,
+            range_hint,
+            name,
+            source_path,
+            gpu_block_size,
+            buffer_binds,
+            texture_binds);
 };
 
 struct ScalarArg {

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -72,6 +72,8 @@ struct TaskAttributes {
     int arg_id{0};
     int binding{0};
     bool is_storage{false};
+
+    TI_IO_DEF(arg_id, binding, is_storage);
   };
 
   std::string name;
@@ -115,6 +117,7 @@ struct TaskAttributes {
             advisory_num_threads_per_group,
             task_type,
             buffer_binds,
+            texture_binds,
             range_for_attribs);
 };
 

--- a/taichi/program/context.h
+++ b/taichi/program/context.h
@@ -78,13 +78,13 @@ struct RuntimeContext {
     return taichi_union_cast_with_different_sizes<T>(result_buffer[i]);
   }
 
-  void set_arg_texture(int arg_id, DeviceAllocation &alloc) {
-    args[arg_id] = taichi_union_cast_with_different_sizes<uint64>(&alloc);
+  void set_arg_texture(int arg_id, intptr_t alloc_ptr) {
+    args[arg_id] = taichi_union_cast_with_different_sizes<uint64>(alloc_ptr);
     set_array_device_allocation_type(arg_id, DevAllocType::kTexture);
   }
 
-  void set_arg_rw_texture(int arg_id, DeviceAllocation &alloc) {
-    args[arg_id] = taichi_union_cast_with_different_sizes<uint64>(&alloc);
+  void set_arg_rw_texture(int arg_id, intptr_t alloc_ptr) {
+    args[arg_id] = taichi_union_cast_with_different_sizes<uint64>(alloc_ptr);
     set_array_device_allocation_type(arg_id, DevAllocType::kRWTexture);
   }
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -592,6 +592,8 @@ void export_lang(py::module &m) {
       // Using this MATRIX as Scalar alias, we can move to native matrix type
       // when supported
       .value("MATRIX", aot::ArgKind::kMatrix)
+      .value("TEXTURE", aot::ArgKind::kTexture)
+      .value("RWTEXTURE", aot::ArgKind::kRWTexture)
       .export_values();
 
   py::class_<aot::Arg>(m, "Arg")
@@ -599,10 +601,17 @@ void export_lang(py::module &m) {
                     std::vector<int>>(),
            py::arg("tag"), py::arg("name"), py::arg("dtype"),
            py::arg("field_dim"), py::arg("element_shape"))
+      .def(py::init<aot::ArgKind, std::string, DataType &, size_t,
+                    std::vector<int>>(),
+           py::arg("tag"), py::arg("name"), py::arg("channel_format"),
+           py::arg("num_channels"), py::arg("shape"))
       .def_readonly("name", &aot::Arg::name)
       .def_readonly("element_shape", &aot::Arg::element_shape)
+      .def_readonly("texture_shape", &aot::Arg::element_shape)
       .def_readonly("field_dim", &aot::Arg::field_dim)
-      .def("dtype", &aot::Arg::dtype);
+      .def_readonly("num_channels", &aot::Arg::num_channels)
+      .def("dtype", &aot::Arg::dtype)
+      .def("channel_format", &aot::Arg::dtype);
 
   py::class_<Node>(m, "Node");
 
@@ -629,6 +638,12 @@ void export_lang(py::module &m) {
             auto &val = it.second.cast<Ndarray &>();
             args.insert(
                 {py::cast<std::string>(it.first), aot::IValue::create(val)});
+          } else if (tag == aot::ArgKind::kTexture ||
+                     tag == aot::ArgKind::kRWTexture) {
+            auto &val = it.second.cast<Texture &>();
+            args.insert(
+                {py::cast<std::string>(it.first), aot::IValue::create(val)});
+
           } else if (tag == aot::ArgKind::kScalar ||
                      tag == aot::ArgKind::kMatrix) {
             std::string arg_name = py::cast<std::string>(it.first);

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -199,7 +199,7 @@ enum class PolygonMode : int {
   Point = 2,
 };
 
-enum class BufferFormat : uint32_t {
+enum class TI_DLL_EXPORT BufferFormat : uint32_t {
   r8,
   rg8,
   rgba8,
@@ -254,9 +254,9 @@ class Pipeline {
   virtual ResourceBinder *resource_binder() = 0;
 };
 
-enum class ImageDimension { d1D, d2D, d3D };
+enum class TI_DLL_EXPORT ImageDimension { d1D, d2D, d3D };
 
-enum class ImageLayout {
+enum class TI_DLL_EXPORT ImageLayout {
   undefined,
   shader_read,
   shader_write,
@@ -580,7 +580,7 @@ struct SurfaceConfig {
   uint32_t height{1};
 };
 
-struct ImageParams {
+struct TI_DLL_EXPORT ImageParams {
   ImageDimension dimension;
   BufferFormat format;
   ImageLayout initial_layout;

--- a/taichi/runtime/gfx/aot_module_builder_impl.cpp
+++ b/taichi/runtime/gfx/aot_module_builder_impl.cpp
@@ -91,6 +91,11 @@ class AotDataConverter {
              buffer_bind.binding});
       }
     }
+
+    for (auto &texture_bind : in.texture_binds) {
+      res.texture_binds.push_back(
+          {texture_bind.arg_id, texture_bind.binding, texture_bind.is_storage});
+    }
     return res;
   }
 };


### PR DESCRIPTION
This PR works as a proof of concept for texture support in cgraph and
there might be a few adjustments and C++ tests to be added in the
followup PRs.

Run `ti example texture_graph` to see an example running cgraph with
texture arguments.

A demo in C++ that loads the saved cgraph module and run it without
python can be found in
https://github.com/ailzhang/taichi-aot-demo/blob/master/texture/desktop/texture.cpp

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
