### PR TITLE
[bug] Add glFinish to wait_idle for opengl device

### DIFF
--- a/taichi/rhi/opengl/opengl_device.cpp
+++ b/taichi/rhi/opengl/opengl_device.cpp
@@ -622,6 +622,7 @@ Stream *GLDevice::get_graphics_stream() {
 }
 
 void GLDevice::wait_idle() {
+  glFinish();
 }
 
 std::unique_ptr<Surface> GLDevice::create_surface(const SurfaceConfig &config) {


### PR DESCRIPTION
Without it, `synchronize()` in GfxRuntime cannot work properly: 
https://github.com/taichi-dev/taichi/blob/0c464321e7ff62ce0710162d12188634dad2f50f/taichi/runtime/gfx/runtime.cpp#L582

Log time in Python code after `ti.sync()` yields wrong result. This PR fixes this.
 