### PR TITLE
[bug] Fix potential bug of lang::Program that could be double finalized

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -381,6 +381,9 @@ uint64 Program::fetch_result_uint64(int i) {
 }
 
 void Program::finalize() {
+  if (finalized_) {
+    return;
+  }
   synchronize();
 
   TI_TRACE("Program finalizing...");
@@ -498,8 +501,7 @@ void Program::fill_ndarray_fast(Ndarray *ndarray, uint32_t val) {
 }
 
 Program::~Program() {
-  if (!finalized_)
-    finalize();
+  finalize();
 }
 
 std::unique_ptr<AotModuleBuilder> Program::make_aot_module_builder(Arch arch) {


### PR DESCRIPTION
Related issue = #4401, #5524 

### The bug is reflected in:
* https://github.com/taichi-dev/taichi/runs/7540400411?check_suite_focus=true DeviceAllocation, double deallocated
* https://github.com/taichi-dev/taichi/runs/7539283313?check_suite_focus=true Program::num_instances_ == -1, double finalized
* https://github.com/taichi-dev/taichi/runs/7538198742?check_suite_focus=true MemoryPool, double terminated

### **BUT I DON'T KNOW WHY AND WHEN `Program::finalize` WILL BE DOUBLE CALLED.**
(Only when tests are run on **multi-thread** (and with offline_cache=True) is the bug triggered.

cc: @k-ye @strongoier @lin-hitonami 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
