### PR TITLE
[vulkan] Enable shared array support for vulkan backend

### DIFF
--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -16,6 +16,10 @@ def mem_sync():
     elif impl.get_runtime().prog.config.arch == _ti_core.vulkan:
         return impl.call_internal("workgroupMemoryBarrier", with_runtime_context=False)
 
+def thread_idx():
+    if impl.get_runtime().prog.config.arch == _ti_core.vulkan:
+        return impl.call_internal("localInvocationId", with_runtime_context=False)
+
 def global_thread_idx():
     if impl.get_runtime().prog.config.arch == _ti_core.vulkan:
         return impl.call_internal("vkGlobalThreadIdx", with_runtime_context=False)

--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -1,9 +1,24 @@
 from taichi.lang import impl
 from taichi.lang.util import taichi_scope
+from taichi._lib import core as _ti_core
 
 
 def sync():
-    return impl.call_internal("block_barrier", with_runtime_context=False)
+    if impl.get_runtime().prog.config.arch == _ti_core.cuda:
+        return impl.call_internal("block_barrier", with_runtime_context=False)
+    elif impl.get_runtime().prog.config.arch == _ti_core.vulkan:
+        print("CALLING VULKAN SYNC")
+        return impl.call_internal("workgroupBarrier", with_runtime_context=False)
+
+def mem_sync():
+    if impl.get_runtime().prog.config.arch == _ti_core.cuda:
+        return impl.call_internal("block_barrier", with_runtime_context=False)
+    elif impl.get_runtime().prog.config.arch == _ti_core.vulkan:
+        return impl.call_internal("workgroupMemoryBarrier", with_runtime_context=False)
+
+def global_thread_idx():
+    if impl.get_runtime().prog.config.arch == _ti_core.vulkan:
+        return impl.call_internal("vkGlobalThreadIdx", with_runtime_context=False)
 
 
 class SharedArray:

--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -1,28 +1,46 @@
+from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.util import taichi_scope
-from taichi._lib import core as _ti_core
 
 
 def sync():
-    if impl.get_runtime().prog.config.arch == _ti_core.cuda:
+    arch = impl.get_runtime().prog.config.arch
+    if arch == _ti_core.cuda:
         return impl.call_internal("block_barrier", with_runtime_context=False)
-    elif impl.get_runtime().prog.config.arch == _ti_core.vulkan:
-        print("CALLING VULKAN SYNC")
-        return impl.call_internal("workgroupBarrier", with_runtime_context=False)
+    if arch == _ti_core.vulkan:
+        return impl.call_internal("workgroupBarrier",
+                                  with_runtime_context=False)
+    raise ValueError(f'ti.block.shared_array is not supported for arch {arch}')
+
 
 def mem_sync():
-    if impl.get_runtime().prog.config.arch == _ti_core.cuda:
+    arch = impl.get_runtime().prog.config.arch
+    if arch == _ti_core.cuda:
         return impl.call_internal("block_barrier", with_runtime_context=False)
-    elif impl.get_runtime().prog.config.arch == _ti_core.vulkan:
-        return impl.call_internal("workgroupMemoryBarrier", with_runtime_context=False)
+    if arch == _ti_core.vulkan:
+        return impl.call_internal("workgroupMemoryBarrier",
+                                  with_runtime_context=False)
+    raise ValueError(f'ti.block.mem_sync is not supported for arch {arch}')
+
 
 def thread_idx():
-    if impl.get_runtime().prog.config.arch == _ti_core.vulkan:
-        return impl.call_internal("localInvocationId", with_runtime_context=False)
+    arch = impl.get_runtime().prog.config.arch
+    if arch is _ti_core.vulkan:
+        return impl.call_internal("localInvocationId",
+                                  with_runtime_context=False)
+    raise ValueError(f'ti.block.thread_idx is not supported for arch {arch}')
+
 
 def global_thread_idx():
+    arch = impl.get_runtime().prog.config.arch
+    if arch == _ti_core.cuda:
+        return impl.get_runtime().prog.current_ast_builder(
+        ).insert_thread_idx_expr()
     if impl.get_runtime().prog.config.arch == _ti_core.vulkan:
-        return impl.call_internal("vkGlobalThreadIdx", with_runtime_context=False)
+        return impl.call_internal("vkGlobalThreadIdx",
+                                  with_runtime_context=False)
+    raise ValueError(
+        f'ti.block.global_thread_idx is not supported for arch {arch}')
 
 
 class SharedArray:

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1104,10 +1104,12 @@ class TaskCodegen : public IRVisitor {
           spv::OpControlBarrier,
           ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
           ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
-          ir_->int_immediate_number(ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask | spv::MemorySemanticsAcquireReleaseMask));
+          ir_->int_immediate_number(ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask | spv::MemorySemanticsAcquireReleaseMask | spv::MemorySemanticsSequentiallyConsistentMask));
       val = ir_->const_i32_zero_;
+    } else if (stmt->func_name == "localInvocationId") {
+      val = ir_->cast(ir_->i32_type(), ir_->get_local_invocation_id(0));
     } else if (stmt->func_name == "vkGlobalThreadIdx") {
-      val = ir_->get_global_invocation_id(0);
+      val = ir_->cast(ir_->i32_type(), ir_->get_global_invocation_id(0));
     } else if (stmt->func_name == "workgroupMemoryBarrier") {
       ir_->make_inst(
           spv::OpMemoryBarrier,

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -198,14 +198,15 @@ class TaskCodegen : public IRVisitor {
     if (alloca->ret_type->is<TensorType>()) {
       // Alloca for shared memory / workgroup memory
       if (!alloca->is_shared) {
-        TI_ERROR("Tensor type for dyanmic index is not yet supported on Vulkan.");
+        TI_ERROR(
+            "Tensor type for dyanmic index is not yet supported on Vulkan.");
       }
       auto tensor_type = alloca->ret_type->cast<TensorType>();
       auto elem_num = tensor_type->get_num_elements();
-      spirv::SType elem_type = ir_->get_primitive_type(tensor_type->get_element_type());
+      spirv::SType elem_type =
+          ir_->get_primitive_type(tensor_type->get_element_type());
 
       spirv::SType arr_type = ir_->get_array_type(elem_type, elem_num);
-      // spirv::Value ptr_val = ir_->alloca_variable(arr_type, spv::StorageClassWorkgroup);
       spirv::Value ptr_val = ir_->alloca_workgroup_array(arr_type);
       ir_->register_value(alloca->raw_name(), ptr_val);
     } else {
@@ -218,11 +219,14 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(PtrOffsetStmt *stmt) override {
-    spirv::SType data_type = ir_->get_primitive_type(stmt->element_type().ptr_removed());
-    spirv::SType ptr_type = ir_->get_pointer_type(data_type, spv::StorageClassWorkgroup);
+    spirv::SType data_type =
+        ir_->get_primitive_type(stmt->element_type().ptr_removed());
+    spirv::SType ptr_type =
+        ir_->get_pointer_type(data_type, spv::StorageClassWorkgroup);
     auto origin_val = ir_->query_value(stmt->origin->raw_name());
     auto offset_val = ir_->query_value(stmt->offset->raw_name());
-    Value offset_ptr = ir_->make_value(spv::OpAccessChain, ptr_type, origin_val, offset_val);
+    Value offset_ptr =
+        ir_->make_value(spv::OpAccessChain, ptr_type, origin_val, offset_val);
     ir_->register_value(stmt->raw_name(), offset_ptr);
   }
 
@@ -1104,7 +1108,9 @@ class TaskCodegen : public IRVisitor {
           spv::OpControlBarrier,
           ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
           ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
-          ir_->int_immediate_number(ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask | spv::MemorySemanticsAcquireReleaseMask | spv::MemorySemanticsSequentiallyConsistentMask));
+          ir_->int_immediate_number(
+              ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask |
+                                   spv::MemorySemanticsAcquireReleaseMask));
       val = ir_->const_i32_zero_;
     } else if (stmt->func_name == "localInvocationId") {
       val = ir_->cast(ir_->i32_type(), ir_->get_local_invocation_id(0));
@@ -1114,7 +1120,9 @@ class TaskCodegen : public IRVisitor {
       ir_->make_inst(
           spv::OpMemoryBarrier,
           ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
-          ir_->int_immediate_number(ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask | spv::MemorySemanticsAcquireReleaseMask));
+          ir_->int_immediate_number(
+              ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask |
+                                   spv::MemorySemanticsAcquireReleaseMask));
       val = ir_->const_i32_zero_;
     } else if (stmt->func_name == "subgroupElect") {
       val = ir_->make_value(
@@ -2349,7 +2357,7 @@ void KernelCodegen::run(TaichiKernelAttributes &kernel_attribs,
              task_res.spirv_code.size(), optimized_spv.size());
 
     // Enable to dump SPIR-V assembly of kernels
-#if 1
+#if 0
     std::string spirv_asm;
     spirv_tools_->Disassemble(optimized_spv, &spirv_asm);
     auto kernel_name = tp.ti_kernel_name;

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -195,10 +195,35 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(AllocaStmt *alloca) override {
-    spirv::SType src_type = ir_->get_primitive_type(alloca->element_type());
-    spirv::Value ptr_val = ir_->alloca_variable(src_type);
-    ir_->store_variable(ptr_val, ir_->get_zero(src_type));
-    ir_->register_value(alloca->raw_name(), ptr_val);
+    if (alloca->ret_type->is<TensorType>()) {
+      // Alloca for shared memory / workgroup memory
+      if (!alloca->is_shared) {
+        TI_ERROR("Tensor type for dyanmic index is not yet supported on Vulkan.");
+      }
+      auto tensor_type = alloca->ret_type->cast<TensorType>();
+      auto elem_num = tensor_type->get_num_elements();
+      spirv::SType elem_type = ir_->get_primitive_type(tensor_type->get_element_type());
+
+      spirv::SType arr_type = ir_->get_array_type(elem_type, elem_num);
+      // spirv::Value ptr_val = ir_->alloca_variable(arr_type, spv::StorageClassWorkgroup);
+      spirv::Value ptr_val = ir_->alloca_workgroup_array(arr_type);
+      ir_->register_value(alloca->raw_name(), ptr_val);
+    } else {
+      // Alloca for a single variable
+      spirv::SType src_type = ir_->get_primitive_type(alloca->element_type());
+      spirv::Value ptr_val = ir_->alloca_variable(src_type);
+      ir_->store_variable(ptr_val, ir_->get_zero(src_type));
+      ir_->register_value(alloca->raw_name(), ptr_val);
+    }
+  }
+
+  void visit(PtrOffsetStmt *stmt) override {
+    spirv::SType data_type = ir_->get_primitive_type(stmt->element_type().ptr_removed());
+    spirv::SType ptr_type = ir_->get_pointer_type(data_type, spv::StorageClassWorkgroup);
+    auto origin_val = ir_->query_value(stmt->origin->raw_name());
+    auto offset_val = ir_->query_value(stmt->offset->raw_name());
+    Value offset_ptr = ir_->make_value(spv::OpAccessChain, ptr_type, origin_val, offset_val);
+    ir_->register_value(stmt->raw_name(), offset_ptr);
   }
 
   void visit(LocalLoadStmt *stmt) override {
@@ -1074,7 +1099,22 @@ class TaskCodegen : public IRVisitor {
         "subgroupInclusiveMax", "subgroupInclusiveAnd", "subgroupInclusiveOr",
         "subgroupInclusiveXor"};
 
-    if (stmt->func_name == "subgroupElect") {
+    if (stmt->func_name == "workgroupBarrier") {
+      ir_->make_inst(
+          spv::OpControlBarrier,
+          ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
+          ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
+          ir_->int_immediate_number(ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask | spv::MemorySemanticsAcquireReleaseMask));
+      val = ir_->const_i32_zero_;
+    } else if (stmt->func_name == "vkGlobalThreadIdx") {
+      val = ir_->get_global_invocation_id(0);
+    } else if (stmt->func_name == "workgroupMemoryBarrier") {
+      ir_->make_inst(
+          spv::OpMemoryBarrier,
+          ir_->int_immediate_number(ir_->i32_type(), spv::ScopeWorkgroup),
+          ir_->int_immediate_number(ir_->i32_type(), spv::MemorySemanticsWorkgroupMemoryMask | spv::MemorySemanticsAcquireReleaseMask));
+      val = ir_->const_i32_zero_;
+    } else if (stmt->func_name == "subgroupElect") {
       val = ir_->make_value(
           spv::OpGroupNonUniformElect, ir_->bool_type(),
           ir_->int_immediate_number(ir_->i32_type(), spv::ScopeSubgroup));
@@ -2307,7 +2347,7 @@ void KernelCodegen::run(TaichiKernelAttributes &kernel_attribs,
              task_res.spirv_code.size(), optimized_spv.size());
 
     // Enable to dump SPIR-V assembly of kernels
-#if 0
+#if 1
     std::string spirv_asm;
     spirv_tools_->Disassemble(optimized_spv, &spirv_asm);
     auto kernel_name = tp.ti_kernel_name;

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1120,6 +1120,19 @@ Value IRBuilder::alloca_variable(const SType &type) {
   return ret;
 }
 
+Value IRBuilder::alloca_workgroup_array(const SType &arr_type) {
+  Value arr_ret = new_value(arr_type, ValueKind::kVariablePtr);
+  ib_.begin(spv::OpVariable)
+      .add_seq(arr_type, arr_ret, spv::StorageClassWorkgroup)
+      .commit(&global_);
+  SType ptr_type = get_pointer_type(arr_type, spv::StorageClassWorkgroup);
+  Value ret = new_value(ptr_type, ValueKind::kVariablePtr);
+  ib_.begin(spv::OpVariable)
+      .add_seq(ptr_type, ret, spv::StorageClassWorkgroup)
+      .commit(&global_);
+  return ret;
+}
+
 Value IRBuilder::load_variable(Value pointer, const SType &res_type) {
   TI_ASSERT(pointer.flag == ValueKind::kVariablePtr ||
             pointer.flag == ValueKind::kStructArrayPtr ||

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -461,6 +461,7 @@ class IRBuilder {
 
   // Local allocate, load, store methods
   Value alloca_variable(const SType &type);
+  Value alloca_workgroup_array(const SType &type);
   Value load_variable(Value pointer, const SType &res_type);
   void store_variable(Value pointer, Value value);
 

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -427,6 +427,7 @@ class IRBuilder {
   void set_work_group_size(const std::array<int, 3> group_size);
   Value get_work_group_size(uint32_t dim_index);
   Value get_num_work_groups(uint32_t dim_index);
+  Value get_local_invocation_id(uint32_t dim_index);
   Value get_global_invocation_id(uint32_t dim_index);
   Value get_subgroup_invocation_id();
   Value get_subgroup_size();
@@ -572,6 +573,7 @@ class IRBuilder {
   SType t_v3_fp32_;
   SType t_v2_fp32_;
   Value gl_global_invocation_id_;
+  Value gl_local_invocation_id_;
   Value gl_num_work_groups_;
   Value gl_work_group_size_;
   Value subgroup_local_invocation_id_;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -913,7 +913,7 @@ class ASTBuilder {
   }
 
   void block_dim(int v) {
-    if (arch_ == Arch::cuda) {
+    if (arch_ == Arch::cuda || arch_ == Arch::vulkan) {
       TI_ASSERT((v % 32 == 0) || bit::is_power_of_two(v));
     } else {
       TI_ASSERT(bit::is_power_of_two(v));

--- a/tests/python/test_shared_array.py
+++ b/tests/python/test_shared_array.py
@@ -1,27 +1,48 @@
+import numpy as np
+
 import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(arch=ti.cuda)
-def test_shared_array_save():
+@test_utils.test(arch=[ti.cuda, ti.vulkan], vk_api_version="1.0")
+def test_shared_array_nested_loop():
     block_dim = 128
-    pad_num = 16
-    a = ti.field(dtype=ti.f32, shape=(block_dim * pad_num, ))
+    nBlocks = 64
+    N = nBlocks * block_dim
+    v_arr = np.random.randn(N).astype(np.float32)
+    d_arr = np.random.randn(N).astype(np.float32)
+    a_arr = np.zeros(N).astype(np.float32)
+    reference = np.zeros(N).astype(np.float32)
 
     @ti.kernel
-    def func():
-        ti.loop_config(block_dim=block_dim)
-        for i in range(block_dim * pad_num):
-            g_tid = ti.global_thread_idx()
-            tid = g_tid % block_dim
-            pad = ti.simt.block.SharedArray((block_dim, ), ti.f32)
-            pad[tid] = tid * 2.0
-            ti.simt.block.sync()
-            a[i] = pad[tid]
-            ti.simt.block.sync()
+    def calc(v: ti.types.ndarray(field_dim=1),
+             d: ti.types.ndarray(field_dim=1),
+             a: ti.types.ndarray(field_dim=1)):
+        for i in range(N):
+            acc = 0.0
+            v_val = v[i]
+            for j in range(N):
+                acc += v_val * d[j]
+            a[i] = acc
 
-    func()
-    for i in range(pad_num):
-        assert a[i * block_dim + 7] == 14.0
-        assert a[i * block_dim + 29] == 58.0
-        assert a[i * block_dim + 127] == 254.0
+    @ti.kernel
+    def calc_shared_array(v: ti.types.ndarray(field_dim=1),
+                          d: ti.types.ndarray(field_dim=1),
+                          a: ti.types.ndarray(field_dim=1)):
+        ti.loop_config(block_dim=block_dim)
+        for i in range(nBlocks * block_dim):
+            tid = i % block_dim
+            pad = ti.simt.block.SharedArray((block_dim, ), ti.f32)
+            acc = 0.0
+            v_val = v[i]
+            for k in range(nBlocks):
+                pad[tid] = d[k * block_dim + tid]
+                ti.simt.block.sync()
+                for j in range(block_dim):
+                    acc += v_val * pad[j]
+                ti.simt.block.sync()
+            a[i] = acc
+
+    calc(v_arr, d_arr, reference)
+    calc_shared_array(v_arr, d_arr, a_arr)
+    assert np.allclose(reference, a_arr)


### PR DESCRIPTION
closes #5338

This PR enables shared array support for vulkan backend but is only stable with `vk_api_version="1.0"` due to a memory barrier problem.

Will open another issue to fix the problem.