### PR TITLE
[cuda] Decouple update from sync function in kernel profiler

### DIFF
--- a/python/taichi/profiler/kernel_profiler.py
+++ b/python/taichi/profiler/kernel_profiler.py
@@ -107,7 +107,7 @@ class KernelProfiler:
         #sync first
         impl.get_runtime().prog.sync_kernel_profiler()
         #then clear backend & frontend info
-        impl.get_runtime().prog.clear_kernel_profile_info()
+        impl.get_runtime().prog.clear_kernel_profiler()
         self._clear_frontend()
 
         return None
@@ -199,6 +199,7 @@ class KernelProfiler:
     def _update_records(self):
         """Acquires kernel records from a backend."""
         impl.get_runtime().prog.sync_kernel_profiler()
+        impl.get_runtime().prog.update_kernel_profiler()
         self._clear_frontend()
         self._traced_records = impl.get_runtime(
         ).prog.get_kernel_profiler_records()

--- a/taichi/program/kernel_profiler.cpp
+++ b/taichi/program/kernel_profiler.cpp
@@ -72,6 +72,9 @@ class DefaultProfiler : public KernelProfilerBase {
   void sync() override {
   }
 
+  void update() override {
+  }
+
   void clear() override {
     // sync(); //decoupled: trigger from the foront end
     total_time_ms_ = 0;

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -61,6 +61,8 @@ class KernelProfilerBase {
 
   virtual void sync() = 0;
 
+  virtual void update() = 0;
+
   virtual bool set_profiler_toolkit(std::string toolkit_name) {
     return false;
   }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -312,6 +312,10 @@ void export_lang(py::module &m) {
       .def_readonly("config", &Program::config)
       .def("sync_kernel_profiler",
            [](Program *program) { program->profiler->sync(); })
+      .def("update_kernel_profiler",
+           [](Program *program) { program->profiler->update(); })
+      .def("clear_kernel_profiler",
+           [](Program *program) { program->profiler->clear(); })
       .def("query_kernel_profile_info",
            [](Program *program, const std::string &name) {
              return program->query_kernel_profile_info(name);
@@ -339,7 +343,6 @@ void export_lang(py::module &m) {
            [](Program *program, const std::string toolkit_name) {
              return program->profiler->set_profiler_toolkit(toolkit_name);
            })
-      .def("clear_kernel_profile_info", &Program::clear_kernel_profile_info)
       .def("timeline_clear",
            [](Program *) { Timelines::get_instance().clear(); })
       .def("timeline_save",

--- a/taichi/rhi/cuda/cuda_profiler.cpp
+++ b/taichi/rhi/cuda/cuda_profiler.cpp
@@ -153,10 +153,10 @@ bool KernelProfilerCUDA::statistics_on_traced_records() {
 }
 
 void KernelProfilerCUDA::sync() {
-  // sync
   CUDADriver::get_instance().stream_synchronize(nullptr);
+}
 
-  // update
+void KernelProfilerCUDA::update() {
   if (tool_ == ProfilingToolkit::event) {
     event_toolkit_->update_record(records_size_after_sync_, traced_records_);
     event_toolkit_->update_timeline(traced_records_);
@@ -173,6 +173,7 @@ void KernelProfilerCUDA::sync() {
 
 void KernelProfilerCUDA::clear() {
   // sync(); //decoupled: trigger from the foront end
+  update();
   total_time_ms_ = 0;
   records_size_after_sync_ = 0;
   traced_records_.clear();
@@ -238,6 +239,9 @@ void KernelProfilerCUDA::stop(KernelProfilerBase::TaskHandle handle) {
   TI_NOT_IMPLEMENTED;
 }
 void KernelProfilerCUDA::sync() {
+  TI_NOT_IMPLEMENTED;
+}
+void KernelProfilerCUDA::update() {
   TI_NOT_IMPLEMENTED;
 }
 void KernelProfilerCUDA::clear() {

--- a/taichi/rhi/cuda/cuda_profiler.h
+++ b/taichi/rhi/cuda/cuda_profiler.h
@@ -34,6 +34,7 @@ class KernelProfilerCUDA : public KernelProfilerBase {
              uint32_t block_size,
              uint32_t dynamic_smem_size);
   void sync() override;
+  void update() override;
   void clear() override;
   void stop(KernelProfilerBase::TaskHandle handle) override;
 


### PR DESCRIPTION
Related issue = #5527 

This PR first decouples `update()` from `sync()` in cuda kernel profiler. The memory usage issue will be followed by a separate PR.

