### PR TITLE
[gui] Eliminate redundant compilation of fill_vbo kernel in GGUI

### DIFF
--- a/python/taichi/ui/staging_buffer.py
+++ b/python/taichi/ui/staging_buffer.py
@@ -41,7 +41,7 @@ def copy_to_vbo(vbo: template(), src: template(), offset: template(),
 
 
 @kernel
-def fill_vbo(vbo: template(), value: template(), offset: template(),
+def fill_vbo(vbo: template(), value: f32, offset: template(),
              num_components: template()):
     for i in vbo:
         for c in ti.static(range(num_components)):
@@ -88,7 +88,7 @@ def copy_colors_to_vbo(vbo, colors):
         raise Exception('colors can only be 3D/4D vector fields')
     copy_to_vbo(vbo, colors, 8, colors.n)
     if colors.n == 3:
-        fill_vbo(vbo, ti.cast(1.0, ti.f32), 11, 1)
+        fill_vbo(vbo, 1.0, 11, 1)
 
 
 @ti.kernel


### PR DESCRIPTION
Fix #5598

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
