### PR TITLE
[misc] Explicitly specify base tag commit when running make_changelog.py

### DIFF
--- a/.github/workflows/scripts/unix_build.sh
+++ b/.github/workflows/scripts/unix_build.sh
@@ -7,7 +7,7 @@ IN_DOCKER=$(check_in_docker)
 [[ "$IN_DOCKER" == "true" ]] && cd taichi
 
 build_taichi_wheel() {
-    git fetch origin master
+    git fetch origin master --tags
     PROJECT_TAGS=""
     EXTRA_ARGS=""
     if [ "$PROJECT_NAME" = "taichi-nightly" ]; then
@@ -21,7 +21,7 @@ build_taichi_wheel() {
             EXTRA_ARGS="-p manylinux_2_27_x86_64"
         fi
     fi
-    python3 misc/make_changelog.py origin/master ./ True
+    python3 misc/make_changelog.py --ver origin/master --repo_dir ./ --save
 
     TAICHI_CMAKE_ARGS="${TAICHI_CMAKE_ARGS} -DTI_WITH_C_API=ON"
     exec env TAICHI_CMAKE_ARGS="${TAICHI_CMAKE_ARGS}" python3 setup.py $PROJECT_TAGS bdist_wheel $EXTRA_ARGS

--- a/misc/make_changelog.py
+++ b/misc/make_changelog.py
@@ -1,7 +1,9 @@
-# Usage: make_changelog.py [v0.x.y]
+# Usage: make_changelog.py v1.0.4 --save
 
+import argparse
 import json
 import os
+import re
 import sys
 
 from git import Repo
@@ -17,9 +19,23 @@ def load_pr_tags():
     return details
 
 
+def find_latest_tag_commit(tags):
+    for tag in reversed(tags):
+        s = re.match(r'v\s*([\d.]+)', tag.name)
+        print(f'Latest version tag is: {tag.name}')
+        if s is not None:
+            return tag.commit
+
+
 def main(ver=None, repo_dir='.'):
     g = Repo(repo_dir)
-    commits_with_tags = set([tag.commit for tag in g.tags])
+    g.tags.sort(key=lambda x: x.commit.committed_date, reverse=True)
+
+    # We need to find out the latest common commit among base and ver,
+    # everything after this commit should be listed in the changelog.
+
+    base_commit = find_latest_tag_commit(g.tags)
+    commits_in_base_tag = list(g.iter_commits(base_commit, max_count=200))
     commits = list(g.iter_commits(ver, max_count=200))
     begin, end = -1, 0
 
@@ -33,7 +49,7 @@ def main(ver=None, repo_dir='.'):
 
     for i, c in enumerate(commits):
         s = format(c)
-        if c in commits_with_tags and i > 0:
+        if c in commits_in_base_tag and i > 0:
             break
 
         tags = []
@@ -75,11 +91,13 @@ def main(ver=None, repo_dir='.'):
 
 
 if __name__ == '__main__':
-    ver = sys.argv[1] if len(sys.argv) > 1 else None
-    repo = sys.argv[2] if len(sys.argv) > 2 else '.'
-    save = sys.argv[3] if len(sys.argv) > 3 else False
-    res = main(ver, repo)
-    if save:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ver")
+    parser.add_argument("--repo_dir", type=str, default='.')
+    parser.add_argument("--save", action="store_true", default=False)
+    args = parser.parse_args()
+    res = main(args.ver, args.repo_dir)
+    if args.save:
         with open('./python/taichi/CHANGELOG.md', 'w', encoding='utf-8') as f:
             f.write(res)
     print(res)

--- a/misc/make_changelog.py
+++ b/misc/make_changelog.py
@@ -1,4 +1,4 @@
-# Usage: make_changelog.py v1.0.4 --save
+# Usage: make_changelog.py --ver origin/master --save
 
 import argparse
 import json


### PR DESCRIPTION
Related issue = #
Previously if you have cherry-picked commits in release branches, then the tag commits won't be available in master branch history. This may result in old commits (already released in previous version) being duplicated in the changelog. This PR fixes it by sorting the tags and find out the latest tag and 200 commits before it. 
Example usage:
```
python make_changelog.py --save
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
