### PR TITLE
[gui] GGUI scene APIs are broken

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -25,8 +25,8 @@ from taichi.lang.snode import SNode
 from taichi.lang.struct import Struct, StructField, _IntermediateStruct
 from taichi.lang.util import (cook_dtype, get_traceback, is_taichi_class,
                               python_scope, taichi_scope, warning)
-from taichi.types.primitive_types import (all_types, f16, f32, f64, i32, i64, u8,
-                                          u32, u64)
+from taichi.types.primitive_types import (all_types, f16, f32, f64, i32, i64,
+                                          u8, u32, u64)
 
 
 @taichi_scope

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -121,4 +121,6 @@ class Canvas:
         Args:
             scene (:class:`~taichi.ui.Scene`): an instance of :class:`~taichi.ui.Scene`.
         """
+        # FIXME: (penguinliong) Add a point light to ensure the allocation of light source SSBO.
+        scene.point_light(ti.Vector([0.0, 0.0, 0.0]), ti.Vector([0.0, 0.0, 0.0]))
         self.canvas.scene(scene.scene)

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -122,6 +122,5 @@ class Canvas:
             scene (:class:`~taichi.ui.Scene`): an instance of :class:`~taichi.ui.Scene`.
         """
         # FIXME: (penguinliong) Add a point light to ensure the allocation of light source SSBO.
-        scene.point_light((0.0, 0.0, 0.0),
-                          (0.0, 0.0, 0.0))
+        scene.point_light((0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
         self.canvas.scene(scene.scene)

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -122,6 +122,6 @@ class Canvas:
             scene (:class:`~taichi.ui.Scene`): an instance of :class:`~taichi.ui.Scene`.
         """
         # FIXME: (penguinliong) Add a point light to ensure the allocation of light source SSBO.
-        scene.point_light(ti.Vector([0.0, 0.0, 0.0]),
-                          ti.Vector([0.0, 0.0, 0.0]))
+        scene.point_light((0.0, 0.0, 0.0),
+                          (0.0, 0.0, 0.0))
         self.canvas.scene(scene.scene)

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -122,5 +122,6 @@ class Canvas:
             scene (:class:`~taichi.ui.Scene`): an instance of :class:`~taichi.ui.Scene`.
         """
         # FIXME: (penguinliong) Add a point light to ensure the allocation of light source SSBO.
-        scene.point_light(ti.Vector([0.0, 0.0, 0.0]), ti.Vector([0.0, 0.0, 0.0]))
+        scene.point_light(ti.Vector([0.0, 0.0, 0.0]),
+                          ti.Vector([0.0, 0.0, 0.0]))
         self.canvas.scene(scene.scene)

--- a/python/taichi/ui/scene.py
+++ b/python/taichi/ui/scene.py
@@ -372,4 +372,4 @@ class Scene:
             >>> scene = ti.ui.Scene()
             >>> scene.ambient_light([0.2, 0.2, 0.2])
         """
-        self.scene.ambient_light(color)
+        self.scene.ambient_light(tuple(color))

--- a/python/taichi/ui/scene.py
+++ b/python/taichi/ui/scene.py
@@ -362,7 +362,7 @@ class Scene:
             color (list, tuple, :class:`~taichi.types.vector(3, float)`):
                 (r, g, b) triple for the color of the light, in the range [0, 1].
         """
-        self.scene.point_light(pos, color)
+        self.scene.point_light(tuple(pos), tuple(color))
 
     def ambient_light(self, color):
         """Set the ambient color of this scene.


### PR DESCRIPTION
The `ambient_light` example is broken:

```python
scene = ti.ui.Scene()
scene.ambient_light([0.2, 0.2, 0.2])
```

which gives:

```log
ambient_light(): incompatible function arguments. The following argument types are supported:
    1. (self: taichi._lib.core.taichi_python.PyScene, arg0: tuple) -> None

Invoked with: <taichi._lib.core.taichi_python.PyScene object at 0x7f7c810ad7b0>, [0.2, 0.2, 0.2]
```

`point_light` has a similar issue.

Also note that if a scene doesn't have any lighting except for the ambient light, no lighting SSBO will be allocated and `Canvas.scene` will crash attempting to map this SSBO. Tried not to map when `point_lights.size() == 0` but it doesn't work. So workaround atm.