### PR TITLE
[bug] Fix ndarray arg with shape=(1,) in cgraph

### DIFF
--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -70,7 +70,8 @@ def produce_injected_args(kernel, symbolic_args=None):
                     f' Arg {arg.name}\'s dtype {dtype.to_string()} doesn\'t match kernel\'s annotated dtype={anno.dtype.to_string()}'
                 )
 
-            if element_dim is None or element_dim == 0:
+            if element_dim is None or element_dim == 0 or element_shape == (
+                    1, ):
                 injected_args.append(ScalarNdarray(dtype, (2, ) * field_dim))
             elif element_dim == 1:
                 injected_args.append(

--- a/tests/cpp/aot/llvm/utils.py
+++ b/tests/cpp/aot/llvm/utils.py
@@ -153,17 +153,17 @@ def compile_graph_aot(arch):
     @ti.kernel
     def run0(base: int, arr: ti.types.ndarray(field_dim=1, dtype=ti.i32)):
         for i in arr:
-            arr[i] += [base + i]
+            arr[i] += base + i
 
     @ti.kernel
     def run1(base: int, arr: ti.types.ndarray(field_dim=1, dtype=ti.i32)):
         for i in arr:
-            arr[i] += [base + i]
+            arr[i] += base + i
 
     @ti.kernel
     def run2(base: int, arr: ti.types.ndarray(field_dim=1, dtype=ti.i32)):
         for i in arr:
-            arr[i] += [base + i]
+            arr[i] += base + i
 
     arr = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                        'arr',

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -35,6 +35,23 @@ def test_ndarray_int():
 
 
 @test_utils.test(arch=ti.vulkan)
+def test_ndarray_1dim_scalar():
+    @ti.kernel
+    def ti_test_debug(arr: ti.types.ndarray(field_dim=1)):
+        arr[0] = 0
+
+    debug_arr = ti.ndarray(ti.i32, shape=5)
+    sym_debug_arr = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
+                                 'debug_arr',
+                                 ti.i32,
+                                 field_dim=1,
+                                 element_shape=(1, ))
+
+    g_builder = ti.graph.GraphBuilder()
+    g_builder.dispatch(ti_test_debug, sym_debug_arr)
+
+
+@test_utils.test(arch=ti.vulkan)
 def test_ndarray_0dim():
     @ti.kernel
     def test(pos: ti.types.ndarray(dtype=ti.i32, field_dim=0)):


### PR DESCRIPTION
fixes #5663 
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
