### PR TITLE
[bug] Let scalar arguments of the kernel be new variables

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -564,8 +564,10 @@ class ASTTransformer(Builder):
                             ctx.func.arguments[i].annotation))
                 else:
                     ctx.create_variable(
-                        arg.arg, impl.expr_init(kernel_arguments.decl_scalar_arg(
-                            ctx.func.arguments[i].annotation)))
+                        arg.arg,
+                        impl.expr_init(
+                            kernel_arguments.decl_scalar_arg(
+                                ctx.func.arguments[i].annotation)))
             # remove original args
             node.args.args = []
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -563,9 +563,9 @@ class ASTTransformer(Builder):
                         kernel_arguments.decl_scalar_arg(
                             ctx.func.arguments[i].annotation))
                 else:
-                    ctx.global_vars[
-                        arg.arg] = kernel_arguments.decl_scalar_arg(
-                            ctx.func.arguments[i].annotation)
+                    ctx.create_variable(
+                        arg.arg, impl.expr_init(kernel_arguments.decl_scalar_arg(
+                            ctx.func.arguments[i].annotation)))
             # remove original args
             node.args.args = []
 

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -181,3 +181,25 @@ def test_function_keyword_args_duplicate():
     with pytest.raises(ti.TaichiSyntaxError,
                        match="Multiple values for argument 'a'"):
         duplicate()
+
+
+@test_utils.test()
+def test_kernel_scalar_arg_mutable():
+    @ti.kernel
+    def foo(a: ti.i32) -> ti.i32:
+        for i in range(10):
+            a += i
+        return a
+
+    assert foo(10) == 55
+
+
+@test_utils.test()
+def test_kernel_scalar_arg_reassign():
+    @ti.kernel
+    def foo(a: ti.i32) -> ti.i32:
+        if True:
+            a = 1
+        return a
+
+    assert foo(10) == 1


### PR DESCRIPTION
Related issue = fixes #5619 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
