### PR TITLE
[Bug] [opt] Remove wrong optimization: Float x // 1 -> x

### DIFF
--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -154,7 +154,8 @@ class AlgSimp : public BasicStmtVisitor {
     auto rhs = stmt->rhs->cast<ConstStmt>();
     TI_ASSERT(stmt->op_type == BinaryOpType::div ||
               stmt->op_type == BinaryOpType::floordiv);
-    if (alg_is_one(rhs) && !(is_real(stmt->lhs->ret_type) && stmt->op_type == BinaryOpType::floordiv)) {
+    if (alg_is_one(rhs) && !(is_real(stmt->lhs->ret_type) &&
+                             stmt->op_type == BinaryOpType::floordiv)) {
       // a / 1 -> a
       stmt->replace_usages_with(stmt->lhs);
       modifier.erase(stmt);

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -154,7 +154,7 @@ class AlgSimp : public BasicStmtVisitor {
     auto rhs = stmt->rhs->cast<ConstStmt>();
     TI_ASSERT(stmt->op_type == BinaryOpType::div ||
               stmt->op_type == BinaryOpType::floordiv);
-    if (alg_is_one(rhs)) {
+    if (alg_is_one(rhs) && !(is_real(stmt->lhs->ret_type) && stmt->op_type == BinaryOpType::floordiv)) {
       // a / 1 -> a
       stmt->replace_usages_with(stmt->lhs);
       modifier.erase(stmt);

--- a/tests/python/test_div.py
+++ b/tests/python/test_div.py
@@ -82,3 +82,13 @@ def test_floor_div_pythonic():
             if j != 0:
                 func(i, j)
                 assert z[None] == i // j
+
+
+@test_utils.test()
+def test_float_floordiv_one():
+    @ti.kernel
+    def func() -> ti.f32:
+        a = 0.5
+        return a % 1
+
+    assert func() == 0.5

--- a/tests/python/test_div.py
+++ b/tests/python/test_div.py
@@ -82,13 +82,3 @@ def test_floor_div_pythonic():
             if j != 0:
                 func(i, j)
                 assert z[None] == i // j
-
-
-@test_utils.test()
-def test_float_floordiv_one():
-    @ti.kernel
-    def func() -> ti.f32:
-        a = 0.5
-        return a % 1
-
-    assert func() == 0.5

--- a/tests/python/test_mod.py
+++ b/tests/python/test_mod.py
@@ -60,3 +60,13 @@ def test_mod_scan():
                 func(i, j)
                 assert z[None] == i % j
                 assert w[None] == _c_mod(i, j)
+
+
+@test_utils.test()
+def test_py_style_float_const_mod_one():
+    @ti.kernel
+    def func() -> ti.f32:
+        a = 0.5
+        return a % 1
+
+    assert func() == 0.5


### PR DESCRIPTION
Related issue = fix #5635

Obviously `0.5 // 1` is `0` instead of `0.5`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
