### PR TITLE
[bug] [ir] Change the way to convert for-loop with break to while-loop

### DIFF
--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -211,7 +211,7 @@ class LowerAST : public IRVisitor {
         // transform into a structure as
         // i = begin - 1; while (1) { i += 1; if (i >= end) break; original
         // body; }
-        fctx.push_back<AllocaStmt>(PrimitiveType::u32);
+        fctx.push_back<AllocaStmt>(PrimitiveType::i32);
         auto loop_var = fctx.back_stmt();
         stmt->parent->local_var_to_stmt[stmt->loop_var_id[0]] = loop_var;
         auto const_one = fctx.push_back<ConstStmt>(TypedConstant((int32)1));

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -209,13 +209,14 @@ class LowerAST : public IRVisitor {
         fctx.push_back(std::move(new_for));
       } else {
         // transform into a structure as
-        // i = begin - 1; while (1) { i += 1; if (i >= end) break; original body; }
+        // i = begin - 1; while (1) { i += 1; if (i >= end) break; original
+        // body; }
         fctx.push_back<AllocaStmt>(PrimitiveType::u32);
         auto loop_var = fctx.back_stmt();
         stmt->parent->local_var_to_stmt[stmt->loop_var_id[0]] = loop_var;
-        auto const_one =
-            fctx.push_back<ConstStmt>(TypedConstant((int32)1));
-        auto begin_minus_one = fctx.push_back<BinaryOpStmt>(BinaryOpType::sub, begin->stmt, const_one);
+        auto const_one = fctx.push_back<ConstStmt>(TypedConstant((int32)1));
+        auto begin_minus_one = fctx.push_back<BinaryOpStmt>(
+            BinaryOpType::sub, begin->stmt, const_one);
         fctx.push_back<LocalStoreStmt>(loop_var, begin_minus_one);
         auto loop_var_addr = LaneAttribute<LocalAddress>(
             LocalAddress(loop_var->as<AllocaStmt>(), 0));
@@ -228,15 +229,14 @@ class LowerAST : public IRVisitor {
         auto cond_stmt = load_and_compare.push_back<BinaryOpStmt>(
             BinaryOpType::cmp_lt, loop_var_add_one, end->stmt);
 
-
         auto &&new_while = std::make_unique<WhileStmt>(std::move(stmt->body));
         auto mask = std::make_unique<AllocaStmt>(PrimitiveType::i32);
         new_while->mask = mask.get();
 
         // insert break
-        load_and_compare.push_back<WhileControlStmt>(new_while->mask, cond_stmt);
-        load_and_compare.push_back<LocalStoreStmt>(loop_var,
-                                                   loop_var_add_one);
+        load_and_compare.push_back<WhileControlStmt>(new_while->mask,
+                                                     cond_stmt);
+        load_and_compare.push_back<LocalStoreStmt>(loop_var, loop_var_add_one);
         auto &stmts = new_while->body;
         for (int i = 0; i < (int)load_and_compare.size(); i++) {
           stmts->insert(std::move(load_and_compare[i]), i);

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -209,41 +209,38 @@ class LowerAST : public IRVisitor {
         fctx.push_back(std::move(new_for));
       } else {
         // transform into a structure as
-        // i = begin; while (1) { if (i >= end) break; original body; i += 1; }
-        fctx.push_back<AllocaStmt>(PrimitiveType::i32);
+        // i = begin - 1; while (1) { i += 1; if (i >= end) break; original body; }
+        fctx.push_back<AllocaStmt>(PrimitiveType::u32);
         auto loop_var = fctx.back_stmt();
         stmt->parent->local_var_to_stmt[stmt->loop_var_id[0]] = loop_var;
-        fctx.push_back<LocalStoreStmt>(loop_var, begin->stmt);
+        auto const_one =
+            fctx.push_back<ConstStmt>(TypedConstant((int32)1));
+        auto begin_minus_one = fctx.push_back<BinaryOpStmt>(BinaryOpType::sub, begin->stmt, const_one);
+        fctx.push_back<LocalStoreStmt>(loop_var, begin_minus_one);
         auto loop_var_addr = LaneAttribute<LocalAddress>(
             LocalAddress(loop_var->as<AllocaStmt>(), 0));
         VecStatement load_and_compare;
         auto loop_var_load_stmt =
             load_and_compare.push_back<LocalLoadStmt>(loop_var_addr);
+        auto loop_var_add_one = load_and_compare.push_back<BinaryOpStmt>(
+            BinaryOpType::add, loop_var_load_stmt, const_one);
+
         auto cond_stmt = load_and_compare.push_back<BinaryOpStmt>(
-            BinaryOpType::cmp_lt, loop_var_load_stmt, end->stmt);
+            BinaryOpType::cmp_lt, loop_var_add_one, end->stmt);
+
 
         auto &&new_while = std::make_unique<WhileStmt>(std::move(stmt->body));
         auto mask = std::make_unique<AllocaStmt>(PrimitiveType::i32);
         new_while->mask = mask.get();
+
+        // insert break
+        load_and_compare.push_back<WhileControlStmt>(new_while->mask, cond_stmt);
+        load_and_compare.push_back<LocalStoreStmt>(loop_var,
+                                                   loop_var_add_one);
         auto &stmts = new_while->body;
         for (int i = 0; i < (int)load_and_compare.size(); i++) {
           stmts->insert(std::move(load_and_compare[i]), i);
         }
-
-        VecStatement increase_and_store;
-        auto const_one =
-            increase_and_store.push_back<ConstStmt>(TypedConstant((int32)1));
-        auto loop_var_add_one = increase_and_store.push_back<BinaryOpStmt>(
-            BinaryOpType::add, loop_var_load_stmt, const_one);
-        increase_and_store.push_back<LocalStoreStmt>(loop_var,
-                                                     loop_var_add_one);
-        for (int i = 0; i < (int)increase_and_store.size(); i++) {
-          stmts->insert(std::move(increase_and_store[i]), stmts->size());
-        }
-        // insert break
-        stmts->insert(
-            std::make_unique<WhileControlStmt>(new_while->mask, cond_stmt),
-            load_and_compare.size());
 
         stmt->insert_before_me(
             std::make_unique<AllocaStmt>(PrimitiveType::i32));

--- a/tests/python/test_for_break.py
+++ b/tests/python/test_for_break.py
@@ -92,3 +92,21 @@ def test_for_break_complex():
                 assert x[i, j] == 0
             else:
                 assert x[i, j] == 100 * i + j
+
+
+@test_utils.test()
+def test_serial_for_with_break_and_continue():
+    @ti.kernel
+    def test_kernel() -> ti.i32:
+        stop = 0
+        sum = 0
+        ti.loop_config(serialize=True)
+        for i in range(10):
+            if i % 2 == 0:
+                continue
+            sum += i
+            if stop:
+                break
+        return sum
+
+    assert test_kernel() == 25


### PR DESCRIPTION
Related issue = fixes #5562

This PR changes `i = begin; while (1) { if (i >= end) break; original body; i += 1; }` to `i = begin - 1; while (1) { i += 1; if (i >= end) break; original body; }` to avoid `continue` inside `original body` skip the last statement `i += 1`

The sample code:

```
import taichi as ti
ti.init(arch=ti.cuda)

@ti.kernel
def test_kernel():
    stop = 0
    ti.loop_config(serialize=True)
    for i in range(10):
        if i % 2 == 0:
            continue
        print(i)
        if stop:
            break

test_kernel()
```

The IR before:

```
kernel {
$0 = offloaded  
body {
  <i32> $1 = const [0]
  <i32> $2 = const [1]
  <i32> $3 = const [2]
  <i32> $4 = const [10]
  <i32> $5 = alloca
  $6 : while true {
    <i32> $7 = local load [ [$5[0]]]
    <i32> $8 = cmp_lt $7 $4
    $9 : while control nullptr, $8
    <i32> $10 = local load [ [$5[0]]]
    <i32> $11 = div $10 $3
    <i32> $12 = cmp_lt $10 $1
    <i32> $13 = bit_shl $11 $2
    <i32> $14 = cmp_ne $12 $1
    <i32> $15 = cmp_ne $10 $1
    <i32> $16 = cmp_ne $13 $10
    <i32> $17 = bit_and $14 $15
    <i32> $18 = bit_and $17 $16
    <i32> $19 = add $11 $18
    <i32> $20 = bit_shl $19 $2
    <i32> $21 = sub $10 $20
    <i32> $22 = cmp_eq $21 $1
    <i32> $23 = bit_and $22 $2
    $24 : if $23 {
      $25 continue (scope=$6)
    }
    <i32> $26 = local load [ [$5[0]]]
    print $26, "\n"
    <i32> $28 = add $7 $2
    <i32> $29 : local store [$5 <- $28]
  }
}
}
```

The IR after this PR:

```
kernel {
$0 = offloaded  
body {
  <i32> $1 = const [0]
  <i32> $2 = const [2]
  <i32> $3 = const [1]
  <i32> $4 = const [-1]
  <i32> $5 = const [10]
  <i32> $6 = alloca
  <i32> $7 : local store [$6 <- $4]
  $8 : while true {
    <i32> $9 = local load [ [$6[0]]]
    <i32> $10 = add $9 $3
    <i32> $11 = cmp_lt $10 $5
    $12 : while control nullptr, $11
    <i32> $13 : local store [$6 <- $10]
    <i32> $14 = div $10 $2
    <i32> $15 = cmp_lt $10 $1
    <i32> $16 = bit_shl $14 $3
    <i32> $17 = cmp_ne $15 $1
    <i32> $18 = cmp_ne $10 $1
    <i32> $19 = cmp_ne $16 $10
    <i32> $20 = bit_and $17 $18
    <i32> $21 = bit_and $20 $19
    <i32> $22 = add $14 $21
    <i32> $23 = bit_shl $22 $3
    <i32> $24 = sub $10 $23
    <i32> $25 = cmp_eq $24 $1
    <i32> $26 = bit_and $25 $3
    $27 : if $26 {
      $28 continue (scope=$8)
    }
    print $10, "\n"
  }
}
}
```