### PR TITLE
[spirv] [bug] Fix invalid CFG error when simulated atomic is present

### DIFF
--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1217,7 +1217,7 @@ Value IRBuilder::float_atomic(AtomicOpType op_type,
     Label exit = new_label();
 
     make_inst(spv::OpBranch, head);
-    make_inst(spv::OpLabel, head);
+    start_label(head);
     make_inst(spv::OpLoopMerge, branch_true, merge, 0);
     make_inst(spv::OpBranch, body);
     make_inst(spv::OpLabel, body);
@@ -1261,7 +1261,7 @@ Value IRBuilder::float_atomic(AtomicOpType op_type,
       make_inst(spv::OpLabel, merge);
       make_inst(spv::OpBranch, head);
     }
-    make_inst(spv::OpLabel, exit);
+    start_label(exit);
 
     return make_value(spv::OpBitcast, t_fp32_,
                       load_variable(ret_val_int, t_uint32_));

--- a/tests/python/test_basics.py
+++ b/tests/python/test_basics.py
@@ -126,3 +126,17 @@ def test_datatype_string():
             ti.f64
     ]:
         assert ty.to_string() == str(ty)
+
+
+@test_utils.test()
+def test_nested_for_with_atomic():
+    x = ti.field(dtype=ti.f32, shape=())
+
+    @ti.kernel
+    def nested_loops():
+        for i in range(2):
+            x[None] += 1
+            for j in range(1):
+                x[None] += 2
+
+    nested_loops()


### PR DESCRIPTION
Fixes #5555

The root cause for the issue above is the input spirv code is invalid so
it errors out when running condtional constant propagation pass in
spirv_opt.

Running `spirv-val` with the generated spirv gives the following error:
```
line:131: OpPhi's incoming basic block <id> 39[%39] is not a predecessor
of <id> 81[%81].
  %tmp11_i32 = OpPhi %int %tmp4_i32 %39 %90 %83
```

The bug happens when a simulated atomic ops is followed by a range-for loop where `curr_label_` isn't set properly.
So when we query `spirv::Label init_label = ir_->current_label();` in
the `RangeForStmt` codegen we get the wrong label to use as incoming
block.

It doesn't error out in vulkan backend since we enable float atomic
extension in vulkan backend when it's available by default so that
simulated atomics codepath was never exercised there.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
