### PR TITLE
[build] Add commit id to taichi-aot-demo for Build-Andriod-Demos CI pipeline

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -15,6 +15,7 @@ function build-and-smoke-test-android-aot-demo {
     export TAICHI_REPO_DIR=$(pwd)/taichi
 
     git clone https://github.com/taichi-dev/taichi-aot-demo
+    git checkout c3348e1e3fc9a2bdef70b947c24510f2da29ea13
     APP_ROOT=taichi-aot-demo/implicit_fem
     ANDROID_APP_ROOT=$APP_ROOT/android
     JNI_PATH=$ANDROID_APP_ROOT/app/src/main/jniLibs/arm64-v8a/

--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -15,7 +15,7 @@ function build-and-smoke-test-android-aot-demo {
     export TAICHI_REPO_DIR=$(pwd)/taichi
 
     git clone https://github.com/taichi-dev/taichi-aot-demo
-    git checkout c3348e1e3fc9a2bdef70b947c24510f2da29ea13
+    cd taichi-aot-demo && git checkout c3348e1e3fc9a2bdef70b947c24510f2da29ea13 && cd -
     APP_ROOT=taichi-aot-demo/implicit_fem
     ANDROID_APP_ROOT=$APP_ROOT/android
     JNI_PATH=$ANDROID_APP_ROOT/app/src/main/jniLibs/arm64-v8a/

--- a/docs/lang/articles/contribution/contributor_guide.md
+++ b/docs/lang/articles/contribution/contributor_guide.md
@@ -386,6 +386,17 @@ Wrap the lines of interest with the following two macros; then warnings are igno
 #endif
 ```
 
+## Handle special CI failures
+Taichi's CI system was implemented using the [Github Actions](https://github.com/features/actions), the entrance of which lies in [testing.yaml](https://github.com/taichi-dev/taichi/blob/master/.github/workflows/testing.yml). Depending on the CI pipeline, this `testing.yml` will execute one of the corresponding test script under [here](https://github.com/taichi-dev/taichi/tree/master/.github/workflows/scripts)
+
+### CI pipeline - Build Android Demos
+`Build Andriod Demos` works slightly different from other CI pipelines. It builds both [taichi-repo](https://github.com/taichi-dev/taichi) with your PR and an external [taichi-aot-demo](https://github.com/taichi-dev/taichi-aot-demo) repo. After that, it attempts to execute the demos from `taichi-aot-demo` with the compiled `taichi-repo`.
+
+If your PR to `taichi-repo` contains changes to the public interface, you may want to also adjust the codes in `taichi-aot-demo` to avoid breaking the demos. To achieve that, please follow these steps:
+1. File your PR to `taichi-repo`. If this PR contains changes to some public interfaces, then it probably breaks the demos thus fail the `Build Android Demos` CI pipeline (Don't panic, this is expected).
+2. Update the demo codes in `taichi-aot-demo` to make it work with the above mentioned PR, then file a separate PR to `taichi-aot-demo` repo and have it merged.
+3. In the original PR to `taichi-repo`, update the commit id for `taichi-aot-demo` in [aot-demo.sh](https://github.com/taichi-dev/taichi/blob/master/.github/workflows/scripts/aot-demo.sh). This time your PR is expected to pass `Build Android Demos`.
+
 ##  Still have issues?
 
 If you encounter any issue that is not covered here, feel free to ask us on GitHub discussions or [open an issue on GitHub](https://github.com/taichi-dev/taichi/issues/new?labels=potential+bug&template=bug_report.md) with all the details attached. We are always there to help!

--- a/docs/lang/articles/contribution/contributor_guide.md
+++ b/docs/lang/articles/contribution/contributor_guide.md
@@ -387,13 +387,15 @@ Wrap the lines of interest with the following two macros; then warnings are igno
 ```
 
 ## Handle special CI failures
-Taichi's CI system was implemented using the [Github Actions](https://github.com/features/actions), the entrance of which lies in [testing.yaml](https://github.com/taichi-dev/taichi/blob/master/.github/workflows/testing.yml). Depending on the CI pipeline, this `testing.yml` will execute one of the corresponding test script under [here](https://github.com/taichi-dev/taichi/tree/master/.github/workflows/scripts)
+Taichi's CI system is implemented using the [Github Actions](https://github.com/features/actions), the entrance of which lies in [testing.yaml](https://github.com/taichi-dev/taichi/blob/master/.github/workflows/testing.yml). Depending on the CI pipeline, `testing.yml` will execute one of the corresponding test scripts under [this directory](https://github.com/taichi-dev/taichi/tree/master/.github/workflows/scripts)
+
+There are a few CI pipelines that work slightly different from the standard CI pipeline:
 
 ### CI pipeline - Build Android Demos
-`Build Andriod Demos` works slightly different from other CI pipelines. It builds both [taichi-repo](https://github.com/taichi-dev/taichi) with your PR and an external [taichi-aot-demo](https://github.com/taichi-dev/taichi-aot-demo) repo. After that, it attempts to execute the demos from `taichi-aot-demo` with the compiled `taichi-repo`.
+`Build Andriod Demos` builds both [taichi-repo](https://github.com/taichi-dev/taichi) with your PR applied and an external [taichi-aot-demo](https://github.com/taichi-dev/taichi-aot-demo) repo. After that, it executes the demos from `taichi-aot-demo` with the just-compiled Taichi program and libraries.
 
-If your PR to `taichi-repo` contains changes to the public interface, you may want to also adjust the codes in `taichi-aot-demo` to avoid breaking the demos. To achieve that, please follow these steps:
-1. File your PR to `taichi-repo`. If this PR contains changes to some public interfaces, then it probably breaks the demos thus fail the `Build Android Demos` CI pipeline (Don't panic, this is expected).
+If your PR to `taichi-repo` contains changes to some public interface, you may need to adjust the codes in `taichi-aot-demo` to avoid breaking the demos. To achieve that, please follow these steps:
+1. File your PR to `taichi-repo`. If this PR changes the public interface, then it probably breaks the demos thus fail the `Build Android Demos` CI pipeline - Don't panic, this is expected.
 2. Update the demo codes in `taichi-aot-demo` to make it work with the above mentioned PR, then file a separate PR to `taichi-aot-demo` repo and have it merged.
 3. In the original PR to `taichi-repo`, update the commit id for `taichi-aot-demo` in [aot-demo.sh](https://github.com/taichi-dev/taichi/blob/master/.github/workflows/scripts/aot-demo.sh). This time your PR is expected to pass `Build Android Demos`.
 


### PR DESCRIPTION
Related issue = #

Preview shortcut: https://deploy-preview-5693--docsite-preview.netlify.app/docs/master/contributor_guide#handle-special-ci-failures