### PR TITLE
[bug] Support indexing via np.integer in field

### DIFF
--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -352,8 +352,9 @@ class ScalarField(Field):
         # Check for potential slicing behaviour
         # for instance: x[0, :]
         padded_key = self._pad_key(key)
+        import numpy as np  # pylint: disable=C0415
         for key in padded_key:
-            if not isinstance(key, int):
+            if not isinstance(key, (int, np.integer)):
                 raise TypeError(
                     f"Detected illegal element of type: {type(key)}. "
                     f"Please be aware that slicing a ti.field is not supported so far."

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -125,7 +125,7 @@ class _MatrixBaseImpl:
             args = args + (0, )
         # TODO(#1004): See if it's possible to support indexing at runtime
         for i, a in enumerate(args):
-            if not isinstance(a, int):
+            if not isinstance(a, (int, np.integer)):
                 raise TaichiSyntaxError(
                     f'The {i}-th index of a Matrix/Vector must be a compile-time constant '
                     f'integer, got {type(a)}.\n'

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -2,6 +2,7 @@
 To test our new `ti.field` API is functional (#1500)
 '''
 
+import numpy as np
 import pytest
 from taichi.lang import impl
 from taichi.lang.misc import get_host_arch_list
@@ -280,6 +281,27 @@ def test_invalid_slicing():
     ):
         val = ti.field(ti.i32, shape=(2, 2))
         val[0, :]
+
+
+@test_utils.test()
+def test_indexing_with_np_int():
+    val = ti.field(ti.i32, shape=(2))
+    idx = np.int32(0)
+    val[idx]
+
+
+@test_utils.test()
+def test_indexing_vec_field_with_np_int():
+    val = ti.Vector.field(2, ti.i32, shape=(2))
+    idx = np.int32(0)
+    val[idx][idx]
+
+
+@test_utils.test()
+def test_indexing_mat_field_with_np_int():
+    val = ti.Matrix.field(2, 2, ti.i32, shape=(2))
+    idx = np.int32(0)
+    val[idx][idx, idx]
 
 
 @test_utils.test(exclude=[ti.cc], debug=True)


### PR DESCRIPTION
Related issue = #

This was used in difftaichi. `python examples/diffmpm.py`
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
