### PR TITLE
[vulkan] Fixed query pool invalid usage

### DIFF
--- a/c_api/src/c_api_test_utils.cpp
+++ b/c_api/src/c_api_test_utils.cpp
@@ -95,13 +95,13 @@ TiNdarrayAndMem make_ndarray(TiRuntime runtime,
     e_shape.dims[i] = element_shape[i];
   }
 
-  TiNdArray arg_array {};
+  TiNdArray arg_array{};
   arg_array.memory = res.memory_;
   arg_array.shape = shape;
   arg_array.elem_shape = e_shape;
   arg_array.elem_type = dtype;
 
-  TiArgumentValue arg_value {};
+  TiArgumentValue arg_value{};
   arg_value.ndarray = arg_array;
 
   res.arg_.type = TiArgumentType::TI_ARGUMENT_TYPE_NDARRAY;

--- a/c_api/src/c_api_test_utils.cpp
+++ b/c_api/src/c_api_test_utils.cpp
@@ -60,7 +60,7 @@ TiNdarrayAndMem make_ndarray(TiRuntime runtime,
     alloc_size = 1;
 
   } else {
-    assert(false);
+    TI_ASSERT(false);
   }
 
   for (int i = 0; i < arr_dims; i++) {
@@ -95,15 +95,17 @@ TiNdarrayAndMem make_ndarray(TiRuntime runtime,
     e_shape.dims[i] = element_shape[i];
   }
 
-  TiNdArray arg_array = {.memory = res.memory_,
-                         .shape = shape,
-                         .elem_shape = e_shape,
-                         .elem_type = dtype};
+  TiNdArray arg_array {};
+  arg_array.memory = res.memory_;
+  arg_array.shape = shape;
+  arg_array.elem_shape = e_shape;
+  arg_array.elem_type = dtype;
 
-  TiArgumentValue arg_value = {.ndarray = arg_array};
+  TiArgumentValue arg_value {};
+  arg_value.ndarray = arg_array;
 
-  res.arg_ = {.type = TiArgumentType::TI_ARGUMENT_TYPE_NDARRAY,
-              .value = arg_value};
+  res.arg_.type = TiArgumentType::TI_ARGUMENT_TYPE_NDARRAY;
+  res.arg_.value = arg_value;
 
   return res;
 }

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -140,7 +140,11 @@ void export_misc(py::module &m) {
   m.def("pop_python_print_buffer", []() { return py_cout.pop_content(); });
   m.def("toggle_python_print_buffer", [](bool opt) { py_cout.enabled = opt; });
   m.def("with_cuda", is_cuda_api_available);
+#ifdef TI_WITH_METAL
   m.def("with_metal", taichi::lang::metal::is_metal_api_available);
+#else
+  m.def("with_metal", []() { return false; });
+#endif
 #ifdef TI_WITH_OPENGL
   m.def("with_opengl", taichi::lang::opengl::is_opengl_api_available,
         py::arg("use_gles") = false);

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1722,6 +1722,7 @@ void VulkanStream::command_sync() {
     vkGetQueryPoolResults(device_.vk_device(), cmdbuf.query_pool->query_pool, 0,
                           2, sizeof(uint64_t) * 2, &t, sizeof(uint64_t),
                           VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+    vkResetQueryPool(device_.vk_device(), cmdbuf.query_pool->query_pool, 0, 2);
     double duration_us = (t[1] - t[0]) * props.limits.timestampPeriod / 1000.0;
     device_time_elapsed_us_ += duration_us;
   }

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -782,6 +782,7 @@ VulkanCommandList::VulkanCommandList(VulkanDevice *ti_device,
   info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
 
   vkBeginCommandBuffer(buffer->buffer, &info);
+  vkCmdResetQueryPool(buffer->buffer, query_pool_->query_pool, 0, 2);
   vkCmdWriteTimestamp(buffer->buffer, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                       query_pool_->query_pool, 0);
 }
@@ -1722,7 +1723,6 @@ void VulkanStream::command_sync() {
     vkGetQueryPoolResults(device_.vk_device(), cmdbuf.query_pool->query_pool, 0,
                           2, sizeof(uint64_t) * 2, &t, sizeof(uint64_t),
                           VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
-    vkResetQueryPool(device_.vk_device(), cmdbuf.query_pool->query_pool, 0, 2);
     double duration_us = (t[1] - t[0]) * props.limits.timestampPeriod / 1000.0;
     device_time_elapsed_us_ += duration_us;
   }

--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -18,7 +18,7 @@ namespace vulkan {
 namespace {
 
 // FIXME: NDEBUG is broken, so just manually enable this if necessary.
-constexpr bool kEnableValidationLayers = false;
+constexpr bool kEnableValidationLayers = true;
 
 const std::vector<const char *> kValidationLayers = {
     "VK_LAYER_KHRONOS_validation",

--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -18,7 +18,7 @@ namespace vulkan {
 namespace {
 
 // FIXME: NDEBUG is broken, so just manually enable this if necessary.
-constexpr bool kEnableValidationLayers = true;
+constexpr bool kEnableValidationLayers = false;
 
 const std::vector<const char *> kValidationLayers = {
     "VK_LAYER_KHRONOS_validation",


### PR DESCRIPTION
This PR fixed a validation issue that query pools are not correctly reset before use (for on-device execution time measurement). Also fixed a bit of compilation issue.