### PR TITLE
[autodiff] Move the global data access rule checker to experimental

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -361,7 +361,8 @@ class PyTaichi:
             _field._calc_dynamic_index_stride()
 
     def materialize(self):
-        if get_runtime().prog.config.debug:
+        if get_runtime().prog.config.debug and get_runtime(
+        ).prog.config.check_autodiff_valid:
             self._allocate_gradient_visited()
         self.materialize_root_fb(not self.materialized)
         self.materialized = True

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -362,7 +362,7 @@ class PyTaichi:
 
     def materialize(self):
         if get_runtime().prog.config.debug and get_runtime(
-        ).prog.config.check_autodiff_valid:
+        ).prog.config.validate_autodiff:
             self._allocate_gradient_visited()
         self.materialize_root_fb(not self.materialized)
         self.materialized = True

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -23,6 +23,7 @@ CompileConfig::CompileConfig() {
   debug = false;
   cfg_optimization = true;
   check_out_of_bound = false;
+  check_autodiff_valid = false;
   lazy_compilation = true;
   serial_schedule = false;
   simplify_before_lower_access = true;

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -23,7 +23,7 @@ CompileConfig::CompileConfig() {
   debug = false;
   cfg_optimization = true;
   check_out_of_bound = false;
-  check_autodiff_valid = false;
+  validate_autodiff = false;
   lazy_compilation = true;
   serial_schedule = false;
   simplify_before_lower_access = true;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -11,6 +11,7 @@ struct CompileConfig {
   bool debug;
   bool cfg_optimization;
   bool check_out_of_bound;
+  bool check_autodiff_valid;
   int simd_width;
   bool lazy_compilation;
   int opt_level;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -11,7 +11,7 @@ struct CompileConfig {
   bool debug;
   bool cfg_optimization;
   bool check_out_of_bound;
-  bool check_autodiff_valid;
+  bool validate_autodiff;
   int simd_width;
   bool lazy_compilation;
   int opt_level;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -137,6 +137,8 @@ void export_lang(py::module &m) {
       .def_readwrite("debug", &CompileConfig::debug)
       .def_readwrite("cfg_optimization", &CompileConfig::cfg_optimization)
       .def_readwrite("check_out_of_bound", &CompileConfig::check_out_of_bound)
+      .def_readwrite("check_autodiff_valid",
+                     &CompileConfig::check_autodiff_valid)
       .def_readwrite("print_accessor_ir", &CompileConfig::print_accessor_ir)
       .def_readwrite("print_evaluator_ir", &CompileConfig::print_evaluator_ir)
       .def_readwrite("use_llvm", &CompileConfig::use_llvm)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -137,8 +137,7 @@ void export_lang(py::module &m) {
       .def_readwrite("debug", &CompileConfig::debug)
       .def_readwrite("cfg_optimization", &CompileConfig::cfg_optimization)
       .def_readwrite("check_out_of_bound", &CompileConfig::check_out_of_bound)
-      .def_readwrite("check_autodiff_valid",
-                     &CompileConfig::check_autodiff_valid)
+      .def_readwrite("validate_autodiff", &CompileConfig::validate_autodiff)
       .def_readwrite("print_accessor_ir", &CompileConfig::print_accessor_ir)
       .def_readwrite("print_evaluator_ir", &CompileConfig::print_evaluator_ir)
       .def_readwrite("use_llvm", &CompileConfig::use_llvm)

--- a/tests/python/test_ad_global_data_access_rule_checker.py
+++ b/tests/python/test_ad_global_data_access_rule_checker.py
@@ -4,7 +4,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(debug=True, exclude=[ti.cc])
+@test_utils.test(debug=True, check_autodiff_valid=True, exclude=[ti.cc])
 def test_adjoint_visited_needs_grad():
     x = ti.field(float, shape=(), needs_grad=True)
 
@@ -18,7 +18,7 @@ def test_adjoint_visited_needs_grad():
     assert x.snode.ptr.has_adjoint_visited()
 
 
-@test_utils.test(debug=True, exclude=[ti.cc])
+@test_utils.test(debug=True, check_autodiff_valid=True, exclude=[ti.cc])
 def test_adjoint_visited_lazy_grad():
     x = ti.field(float, shape=())
     ti.root.lazy_grad()
@@ -33,7 +33,7 @@ def test_adjoint_visited_lazy_grad():
     assert x.snode.ptr.has_adjoint_visited()
 
 
-@test_utils.test(debug=True, exclude=[ti.cc])
+@test_utils.test(debug=True, check_autodiff_valid=True, exclude=[ti.cc])
 def test_adjoint_visited_place_grad():
     x = ti.field(float)
     y = ti.field(float)
@@ -50,7 +50,7 @@ def test_adjoint_visited_place_grad():
     assert not y.snode.ptr.has_adjoint_visited()
 
 
-@test_utils.test(debug=False)
+@test_utils.test(debug=False, check_autodiff_valid=True)
 def test_adjoint_visited_needs_grad():
     x = ti.field(float, shape=(), needs_grad=True)
 
@@ -70,7 +70,10 @@ def test_adjoint_visited_needs_grad():
     assert warn_raised
 
 
-@test_utils.test(require=ti.extension.assertion, exclude=[ti.cc], debug=True)
+@test_utils.test(require=ti.extension.assertion,
+                 exclude=[ti.cc],
+                 debug=True,
+                 check_autodiff_valid=True)
 def test_break_gdar_rule_1():
     N = 16
     x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)

--- a/tests/python/test_ad_global_data_access_rule_checker.py
+++ b/tests/python/test_ad_global_data_access_rule_checker.py
@@ -4,7 +4,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(debug=True, check_autodiff_valid=True, exclude=[ti.cc])
+@test_utils.test(debug=True, validate_autodiff=True, exclude=[ti.cc])
 def test_adjoint_visited_needs_grad():
     x = ti.field(float, shape=(), needs_grad=True)
 
@@ -18,7 +18,7 @@ def test_adjoint_visited_needs_grad():
     assert x.snode.ptr.has_adjoint_visited()
 
 
-@test_utils.test(debug=True, check_autodiff_valid=True, exclude=[ti.cc])
+@test_utils.test(debug=True, validate_autodiff=True, exclude=[ti.cc])
 def test_adjoint_visited_lazy_grad():
     x = ti.field(float, shape=())
     ti.root.lazy_grad()
@@ -33,7 +33,7 @@ def test_adjoint_visited_lazy_grad():
     assert x.snode.ptr.has_adjoint_visited()
 
 
-@test_utils.test(debug=True, check_autodiff_valid=True, exclude=[ti.cc])
+@test_utils.test(debug=True, validate_autodiff=True, exclude=[ti.cc])
 def test_adjoint_visited_place_grad():
     x = ti.field(float)
     y = ti.field(float)
@@ -50,7 +50,7 @@ def test_adjoint_visited_place_grad():
     assert not y.snode.ptr.has_adjoint_visited()
 
 
-@test_utils.test(debug=False, check_autodiff_valid=True)
+@test_utils.test(debug=False, validate_autodiff=True)
 def test_adjoint_visited_needs_grad():
     x = ti.field(float, shape=(), needs_grad=True)
 
@@ -73,7 +73,7 @@ def test_adjoint_visited_needs_grad():
 @test_utils.test(require=ti.extension.assertion,
                  exclude=[ti.cc],
                  debug=True,
-                 check_autodiff_valid=True)
+                 validate_autodiff=True)
 def test_break_gdar_rule_1():
     N = 16
     x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)


### PR DESCRIPTION
Related issue = #5718 
Move the global data access rule checker to experimental. 
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
