### PR TITLE
[ci] Prevent using the offline cache of previous jobs

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -11,12 +11,6 @@ export TI_IN_DOCKER=$(check_in_docker)
 export LD_LIBRARY_PATH=$PWD/build/:$LD_LIBRARY_PATH
 export TI_OFFLINE_CACHE_FILE_PATH=$PWD/.cache/taichi
 
-[ -d $TI_OFFLINE_CACHE_FILE_PATH ] && echo "Directory $TI_OFFLINE_CACHE_FILE_PATH exists."
-
-[ ! -d $TI_OFFLINE_CACHE_FILE_PATH ] && echo "Directory $TI_OFFLINE_CACHE_FILE_PATH DOES NOT exists."
-
-rm -rf $TI_OFFLINE_CACHE_FILE_PATH
-
 if [[ "$TI_IN_DOCKER" == "true" ]]; then
     source $HOME/miniconda/etc/profile.d/conda.sh
     conda activate "$PY"

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -9,6 +9,8 @@ export TI_SKIP_VERSION_CHECK=ON
 export TI_CI=1
 export TI_IN_DOCKER=$(check_in_docker)
 export LD_LIBRARY_PATH=$PWD/build/:$LD_LIBRARY_PATH
+export TI_OFFLINE_CACHE_FILE_PATH=$PWD/.cache/taichi
+rm -rf $TI_OFFLINE_CACHE_FILE_PATH
 
 if [[ "$TI_IN_DOCKER" == "true" ]]; then
     source $HOME/miniconda/etc/profile.d/conda.sh

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -10,6 +10,11 @@ export TI_CI=1
 export TI_IN_DOCKER=$(check_in_docker)
 export LD_LIBRARY_PATH=$PWD/build/:$LD_LIBRARY_PATH
 export TI_OFFLINE_CACHE_FILE_PATH=$PWD/.cache/taichi
+
+[ -d $TI_OFFLINE_CACHE_FILE_PATH ] && echo "Directory $TI_OFFLINE_CACHE_FILE_PATH exists."
+
+[ ! -d $TI_OFFLINE_CACHE_FILE_PATH ] && echo "Directory $TI_OFFLINE_CACHE_FILE_PATH DOES NOT exists."
+
 rm -rf $TI_OFFLINE_CACHE_FILE_PATH
 
 if [[ "$TI_IN_DOCKER" == "true" ]]; then

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -2,6 +2,13 @@ $ErrorActionPreference = "Stop"
 
 $env:PYTHONUNBUFFERED = 1
 $env:TI_CI = 1
+$env:TI_OFFLINE_CACHE_FILE_PATH = Join-Path -Path $pwd -ChildPath ".cache\taichi"
+if (Test-Path $env:TI_OFFLINE_CACHE_FILE_PATH) {
+    echo "Deleting old offline cache"
+    Remove-Item -Path $env:TI_OFFLINE_CACHE_FILE_PATH -Force -Recurse
+} else {
+    echo "Old offline cache does not exist"
+}
 
 . venv\Scripts\activate.ps1
 python -c "import taichi"

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -3,12 +3,6 @@ $ErrorActionPreference = "Stop"
 $env:PYTHONUNBUFFERED = 1
 $env:TI_CI = 1
 $env:TI_OFFLINE_CACHE_FILE_PATH = Join-Path -Path $pwd -ChildPath ".cache\taichi"
-if (Test-Path $env:TI_OFFLINE_CACHE_FILE_PATH) {
-    echo "Deleting old offline cache"
-    Remove-Item -Path $env:TI_OFFLINE_CACHE_FILE_PATH -Force -Recurse
-} else {
-    echo "Old offline cache does not exist"
-}
 
 . venv\Scripts\activate.ps1
 python -c "import taichi"


### PR DESCRIPTION
Related issue = #4401 
The release test seems to be using the offline cache of previous jobs on Windows and M1.
Moving the offline cache directory into the repository directory solves this because the repository is deleted after the job finishes.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
