### PR TITLE
[bug] Fix incorrect autodiff_mode information in offline cache key

### DIFF
--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -161,7 +161,8 @@ std::string get_hashed_offline_cache_key(CompileConfig *config,
     compile_config_key = get_offline_cache_key_of_compile_config(config);
   }
 
-  std::string autodiff_mode = std::to_string(static_cast<std::size_t>(kernel->autodiff_mode));
+  std::string autodiff_mode =
+      std::to_string(static_cast<std::size_t>(kernel->autodiff_mode));
   picosha2::hash256_one_by_one hasher;
   hasher.process(compile_config_key.begin(), compile_config_key.end());
   hasher.process(kernel_ast_string.begin(), kernel_ast_string.end());
@@ -169,7 +170,7 @@ std::string get_hashed_offline_cache_key(CompileConfig *config,
   hasher.finish();
 
   auto res = picosha2::get_hash_hex_string(hasher);
-  res.insert(res.begin(), 'T'); // The key must start with a letter
+  res.insert(res.begin(), 'T');  // The key must start with a letter
   return res;
 }
 

--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -161,14 +161,15 @@ std::string get_hashed_offline_cache_key(CompileConfig *config,
     compile_config_key = get_offline_cache_key_of_compile_config(config);
   }
 
+  std::string autodiff_mode = std::to_string(static_cast<std::size_t>(kernel->autodiff_mode));
   picosha2::hash256_one_by_one hasher;
   hasher.process(compile_config_key.begin(), compile_config_key.end());
   hasher.process(kernel_ast_string.begin(), kernel_ast_string.end());
+  hasher.process(autodiff_mode.begin(), autodiff_mode.end());
   hasher.finish();
 
   auto res = picosha2::get_hash_hex_string(hasher);
-  res.insert(res.begin(),
-             kernel->autodiff_mode != AutodiffMode::kNone ? 'g' : 'n');
+  res.insert(res.begin(), 'T'); // The key must start with a letter
   return res;
 }
 


### PR DESCRIPTION
Related issue = #

reported by `ti example jacobian`

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
