### PR TITLE
[Error] Do not show warning when the offline cache path does not exist

### DIFF
--- a/taichi/runtime/llvm/llvm_offline_cache.cpp
+++ b/taichi/runtime/llvm/llvm_offline_cache.cpp
@@ -376,6 +376,9 @@ void LlvmOfflineCacheFileWriter::clean_cache(const std::string &path,
   {
     std::string lock_path = taichi::join_path(path, kMetadataFileLockName);
     if (!lock_with_file(lock_path)) {
+      if (!taichi::path_exists(path)) {
+        return;
+      }
       TI_WARN("Lock {} failed", lock_path);
       return;
     }

--- a/taichi/util/io.h
+++ b/taichi/util/io.h
@@ -18,8 +18,7 @@
 
 TI_NAMESPACE_BEGIN
 
-inline bool path_exists(const std::string &dir)
-{
+inline bool path_exists(const std::string &dir) {
   struct stat buffer;
   return stat(dir.c_str(), &buffer) == 0;
 }

--- a/taichi/util/io.h
+++ b/taichi/util/io.h
@@ -10,12 +10,19 @@
 #include <vector>
 #include <cstdio>
 #include <cstdlib>
+#include <sys/stat.h>
 
 #if defined(TI_PLATFORM_WINDOWS)
 #include <filesystem>
 #endif
 
 TI_NAMESPACE_BEGIN
+
+inline bool path_exists(const std::string &dir)
+{
+  struct stat buffer;
+  return stat(dir.c_str(), &buffer) == 0;
+}
 
 // TODO: move to std::filesystem after it's nonexperimental on all platforms
 inline void create_directories(const std::string &dir) {


### PR DESCRIPTION
Related issue = #4401, fixes #5743

Taichi now raises a warning when the offline cache path does not exist as below:
```
[W 08/12/22 14:09:20.047 1879239] [llvm_offline_cache.cpp:clean_cache@382] Lock /home/lin/.cache/taichi/ticache/metadata.lock failed
```
This PR removes it if the path does not exist.
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
