### PR TITLE
[llvm] Disable f16 atomic hack for llvm 15.

### DIFF
--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -218,6 +218,10 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
                        {llvm_val[stmt->dest], llvm_val[stmt->val]});
   }
 
+  // LLVM15 already support f16 atomic in
+  // https://github.com/llvm/llvm-project/commit/0cb08e448af7167ada767e0526aa44980e72ad08
+  // the review is at https://reviews.llvm.org/D52416
+  // Limit the f16 hack to LLVM10 build.
 #ifndef TI_LLVM_15
   // A huge hack for supporting f16 atomic add/max/min! Borrowed from
   // https://github.com/tensorflow/tensorflow/blob/470d58a83470f8ede3beaa584e6992bc71b7baa6/tensorflow/compiler/xla/service/gpu/ir_emitter.cc#L378-L490
@@ -264,8 +268,6 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
   //       *cas_new_output_address);
   //   } while (!success);
   //
-  // TODO(sjwsl): Try to rewrite this after upgrading LLVM or supporting raw
-  // NVPTX
 
   llvm::Value *atomic_op_using_cas(
       llvm::Value *output_address,

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -318,8 +318,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 
     // Use the value from the memory that atomicCAS operates on to initialize
     // cas_old_output.
-    llvm::Value *cas_old_output = builder->CreateLoad(
-        atomic_memory_address, "cas_old_output");
+    llvm::Value *cas_old_output =
+        builder->CreateLoad(atomic_memory_address, "cas_old_output");
     builder->CreateStore(cas_old_output, cas_old_output_address);
 
     llvm::BasicBlock *loop_body_bb =
@@ -332,17 +332,15 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     // loop body for one atomicCAS
     {
       // Use cas_old_output to initialize cas_new_output.
-      cas_old_output = builder->CreateLoad(
-          cas_old_output_address, "cas_old_output");
+      cas_old_output =
+          builder->CreateLoad(cas_old_output_address, "cas_old_output");
       builder->CreateStore(cas_old_output, cas_new_output_address);
 
-      auto binop_output = op(builder->CreateLoad(
-                                 binop_output_address),
-                             val);
+      auto binop_output = op(builder->CreateLoad(binop_output_address), val);
       builder->CreateStore(binop_output, binop_output_address);
 
-      llvm::Value *cas_new_output = builder->CreateLoad(
-          cas_new_output_address, "cas_new_output");
+      llvm::Value *cas_new_output =
+          builder->CreateLoad(cas_new_output_address, "cas_new_output");
 
       // Emit code to perform the atomicCAS operation
       // (cas_old_output, success) = atomicCAS(memory_address, cas_old_output,


### PR DESCRIPTION
Limit TaskCodeGenCUDA::atomic_op_using_cas to llvm 10 build.

Related issue = #5276 
