### PR TITLE
[gui] Fixed GGUI crash fetching depth buffer data

### DIFF
--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -96,7 +96,7 @@ Window::~Window() {
 }
 
 std::pair<uint32_t, uint32_t> Window::get_window_shape() {
-  return {config_.width, config_.height};
+  return {renderer_->swap_chain().width(), renderer_->swap_chain().height()};
 }
 
 void Window::write_image(const std::string &filename) {


### PR DESCRIPTION
The current implementation attempts to create ND-array with the Window config shape. But the window config shape is not necesarily the shape of the OS-allocated swapchain image size. Leading to the following assertion failure:

```log
[E 08/15/22 11:09:00.350 4032256] [window.cpp:copy_depth_buffer_to_ndarray@127] Size of Depth-Ndarray not matched with the window!


Traceback (most recent call last):
  File "/Users/penguinliong/Repositories/taichi-screen-space/x.py", line 58, in <module>
    window.get_depth_buffer(zbuf)
  File "/Users/penguinliong/Repositories/taichi/python/taichi/ui/window.py", line 172, in get_depth_buffer
    self.window.copy_depth_buffer_to_ndarray(tmp_depth.arr)
RuntimeError: [window.cpp:copy_depth_buffer_to_ndarray@127] Size of Depth-Ndarray not matched with the window!
```