### PR TITLE
[doc] Fix docs and docs sidebar conflict issue

### DIFF
--- a/docs/lang/articles/type/_category_.json
+++ b/docs/lang/articles/type/_category_.json
@@ -1,4 +1,5 @@
 {
   "label": "Type System",
+  "id": "type-system",
   "position": 3
 }

--- a/docs/lang/articles/type/_category_.json
+++ b/docs/lang/articles/type/_category_.json
@@ -1,5 +1,10 @@
 {
   "label": "Type System",
-  "id": "type-system",
+  "collapsible": true,
+  "collapsed": true,
+  "link" : {
+    "type": "doc",
+    "id": "type-system"
+  },
   "position": 3
 }


### PR DESCRIPTION
Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->

- [x] Fix the issue that docs sidebar cannot expand when folder and doc have the exact same name, by explicitly giving the folder a id.
