### PR TITLE
[opengl] Fix target device for opengl aot

### DIFF
--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -117,7 +117,7 @@ class TargetDevice : public Device {
   }
 
   void set_default_caps(Arch arch) {
-    if (arch == Arch::vulkan) {
+    if (arch == Arch::vulkan || arch == Arch::opengl) {
       set_cap(DeviceCapability::spirv_version, 0x10300);
     }
   }

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -2352,7 +2352,7 @@ void KernelCodegen::run(TaichiKernelAttributes &kernel_attribs,
     do {
       last_size = optimized_spv.size();
       bool result = false;
-      TI_WARN_IF(
+      TI_ERROR_IF(
           (result = !spirv_opt_->Run(optimized_spv.data(), optimized_spv.size(),
                                      &optimized_spv, spirv_opt_options_)),
           "SPIRV optimization failed");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #5775
* #5774
* __->__ #5773

Note we used to generate invalid spirv shaders during opengl aot and
failed to run spirv-opt passes. But it only generated a warning instead
of an error so we didn't catch this in tests.

This was the second bug triggered by invalid spirv shaders. We
probably should just throw when spirv-opt fails. Alternatively we can
run spirv-val separately if we really want to ignore spirv-opt failures.

Note we don't properly handle gles target device yet, will do that in a
followup PR.