### PR TITLE
[gui] Fixed GGUI scene mesh memory leak

### DIFF
--- a/taichi/ui/backends/vulkan/renderables/mesh.cpp
+++ b/taichi/ui/backends/vulkan/renderables/mesh.cpp
@@ -12,6 +12,10 @@ using namespace taichi::lang;
 Mesh::Mesh(AppContext *app_context, VertexAttributes vbo_attrs) {
   init_mesh(app_context, /*vertices_count=*/3, /*indices_count*/ 3, vbo_attrs);
 }
+void Mesh::cleanup() {
+  Renderable::cleanup();
+  destroy_mesh_storage_buffers();
+}
 
 void Mesh::update_ubo(const MeshInfo &info, const Scene &scene) {
   UniformBufferObject ubo;

--- a/taichi/ui/backends/vulkan/renderables/mesh.h
+++ b/taichi/ui/backends/vulkan/renderables/mesh.h
@@ -29,6 +29,8 @@ class Mesh final : public Renderable {
  public:
   Mesh(AppContext *app_context, VertexAttributes vbo_attrs);
 
+  virtual void cleanup() override;
+
   void update_data(const MeshInfo &info, const Scene &scene);
 
   virtual void record_this_frame_commands(


### PR DESCRIPTION
Usually `Renderable` allocations are released automatically by itself, but `Mesh` has an extra storage buffer that is never released in the current impl.