### PR TITLE
[aot] Workaround C-API build structure to export GGUI symbols in libtaichi_c_api.so

### DIFF
--- a/cmake/TaichiCAPI.cmake
+++ b/cmake/TaichiCAPI.cmake
@@ -10,6 +10,12 @@ endif()
 add_library(${TAICHI_C_API_NAME} SHARED ${C_API_SOURCE})
 target_link_libraries(${TAICHI_C_API_NAME} PRIVATE taichi_core)
 
+# [TODO] Remove the following two linkages after rewriting AOT Demos with Device APIS
+if(TI_WITH_GGUI)
+target_link_libraries(${TAICHI_C_API_NAME} PRIVATE taichi_ui_vulkan)
+target_link_libraries(${TAICHI_C_API_NAME} PRIVATE taichi_ui)
+endif()
+
 set(C_API_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 set_target_properties(${TAICHI_C_API_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${C_API_OUTPUT_DIRECTORY}


### PR DESCRIPTION
Related issue = #