### PR TITLE
[ci] Disable show_env job on forked repo

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   show_environ:
     name: Show Environment Variables
+    # Disable this workflow on forks
+    if: github.repository_owner == 'taichi-dev'
     runs-on: [self-hosted, Linux]
     steps:
     - name: Environment Variables


### PR DESCRIPTION
Let's disable this job on all forked repos to save some resources.