### PR TITLE
[Bug] [type] Fix wrong type cast in codegen of storing quant floats

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm_quant.cpp
+++ b/taichi/codegen/llvm/codegen_llvm_quant.cpp
@@ -221,7 +221,7 @@ void TaskCodeGenLLVM::visit(BitStructStoreStmt *stmt) {
           create_call("max_i32", {exponent_bits, tlctx->get_constant(0)});
 
       // Compute the bit pointer of the exponent bits.
-      val = builder->CreateBitCast(exponent_bits, physical_type);
+      val = builder->CreateIntCast(exponent_bits, physical_type, false);
       val = builder->CreateShl(val, bit_struct->get_member_bit_offset(exp));
 
       if (bit_struct_val == nullptr) {
@@ -238,7 +238,7 @@ void TaskCodeGenLLVM::visit(BitStructStoreStmt *stmt) {
                               tlctx->get_constant(0));
       val = builder->CreateSelect(exp_non_zero, digit_bits,
                                   tlctx->get_constant(0));
-      val = builder->CreateBitCast(val, physical_type);
+      val = builder->CreateIntCast(val, physical_type, false);
       val = builder->CreateShl(val, bit_struct->get_member_bit_offset(ch_id));
     } else {
       val = quant_int_or_quant_fixed_to_bits(val, dtype, physical_type);

--- a/tests/python/test_quant_float.py
+++ b/tests/python/test_quant_float.py
@@ -6,12 +6,13 @@ import taichi as ti
 from tests import test_utils
 
 
+@pytest.mark.parametrize('max_num_bits', [32, 64])
 @test_utils.test(require=ti.extension.quant)
-def test_quant_float_unsigned():
+def test_quant_float_unsigned(max_num_bits):
     qflt = ti.types.quant.float(exp=6, frac=13, signed=False)
     x = ti.field(dtype=qflt)
 
-    bitpack = ti.BitpackedFields(max_num_bits=32)
+    bitpack = ti.BitpackedFields(max_num_bits=max_num_bits)
     bitpack.place(x)
     ti.root.place(bitpack)
 


### PR DESCRIPTION
Related issue = #4857, fix #5817

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
