### PR TITLE
[example] Making gravity option used in stable_fluid_ggui.py

### DIFF
--- a/python/taichi/examples/ggui_examples/stable_fluid_ggui.py
+++ b/python/taichi/examples/ggui_examples/stable_fluid_ggui.py
@@ -98,7 +98,8 @@ def advect(vf: ti.template(), qf: ti.template(), new_qf: ti.template()):
 @ti.kernel
 def apply_impulse(vf: ti.template(), dyef: ti.template(),
                   imp_data: ti.types.ndarray()):
-    g_dir = -ti.Vector([0, 9.8]) * 300
+    g_mag = 9.8 if gravity else 0.0
+    g_dir = -ti.Vector([0, g_mag]) * 300
     for i, j in vf:
         omx, omy = imp_data[2], imp_data[3]
         mdir = ti.Vector([imp_data[0], imp_data[1]])


### PR DESCRIPTION
Related issue = #

I was just tinkering with the stable_fluid_ggui.py example, and noticed that the `gravity = True` option wasn't being used, so I added it into the apply_impulse kernel. You can test that it works now by setting `gravity = False`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
