### PR TITLE
[Lang] Build csr sparse matrix on GPU using coo format ndarray

### DIFF
--- a/misc/test_build_cusm_from_coo.py
+++ b/misc/test_build_cusm_from_coo.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+import taichi as ti
+
+ti.init(arch=ti.cuda)
+
+h_coo_row = np.asarray([0, 0, 0, 1, 2, 2, 2, 3, 3], dtype=np.int32)
+h_coo_col = np.asarray([0, 2, 3, 1, 0, 2, 3, 1, 3], dtype=np.int32)
+h_coo_val = np.asarray([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                       dtype=np.float32)
+h_x = np.asarray([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+h_y = np.asarray([19.0, 8.0, 51.0, 52.0], dtype=np.float32)
+
+d_coo_row = ti.ndarray(shape=9, dtype=ti.int32)
+d_coo_col = ti.ndarray(shape=9, dtype=ti.int32)
+d_coo_val = ti.ndarray(shape=9, dtype=ti.float32)
+x = ti.ndarray(shape=4, dtype=ti.float32)
+y = ti.ndarray(shape=4, dtype=ti.float32)
+
+d_coo_row.from_numpy(h_coo_row)
+d_coo_col.from_numpy(h_coo_col)
+d_coo_val.from_numpy(h_coo_val)
+x.from_numpy(h_x)
+y.fill(0.0)
+
+A = ti.linalg.SparseMatrix(n=4, m=4, dtype=ti.float32)
+A.build_coo(d_coo_val, d_coo_col, d_coo_row)
+
+A.spmv(x, y)
+
+# Check if the results are correct
+equal = True
+for i in range(4):
+    if y[i] != h_y[i]:
+        equal = False
+        break
+if equal:
+    print("Spmv Results is correct!")
+else:
+    print("Opps! Spmv Results is wrong.")

--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -198,28 +198,29 @@ class SparseMatrix:
                 'Sparse matrix only supports building from [ti.ndarray, ti.Vector.ndarray, ti.Matrix.ndarray]'
             )
 
-    def build_csr_cusparse(self, data, indices, indptr):
-        """Build a csr format sparse matrix using cuSparse where the column indices
-            for row i are stored in ``indices[indptr[i]:indptr[i+1]]``
-            and their corresponding values are stored in ``data[indptr[i]:indptr[i+1]]``.
+    def build_coo(self, data, row_idx, col_idx):
+        """Build a CSR format sparse matrix from COO format inputs.
 
         Args:
-            data (ti.ndarray): CSR format data array of the matrix.
-            indices (ti.ndarray): CSR format index array of the matrix.
-            indptr (ti.ndarray): CSR format index pointer array of the matrix.
+            data (ti.ndarray): the entries of the matrix.
+            indices (ti.ndarray): the row indices of the matrix entries.
+            indptr (ti.ndarray): the column indices of the matrix entries.
+
+        Raises:
+            TaichiRuntimeError: If the inputs are not ``ti.ndarray`` or the datatypes of the ndarray are not correct.
         """
         if not isinstance(data, Ndarray) or not isinstance(
-                indices, Ndarray) or not isinstance(indptr, Ndarray):
+                row_idx, Ndarray) or not isinstance(col_idx, Ndarray):
             raise TaichiRuntimeError(
                 'Sparse matrix only supports building from [ti.ndarray, ti.Vector.ndarray, ti.Matrix.ndarray].'
             )
-        elif data.dtype != f32 or indices.dtype != i32 or indptr.dtype != i32:
+        elif data.dtype != f32 or row_idx.dtype != i32 or col_idx.dtype != i32:
             raise TaichiRuntimeError(
                 'Sparse matrix only supports building from float32 data and int32 indices/indptr.'
             )
         else:
             get_runtime().prog.make_sparse_matrix_from_ndarray_cusparse(
-                self.matrix, indptr.arr, indices.arr, data.arr)
+                self.matrix, col_idx.arr, row_idx.arr, data.arr)
 
     def spmv(self, x, y):
         """Sparse matrix-vector multiplication using cuSparse.

--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -198,29 +198,29 @@ class SparseMatrix:
                 'Sparse matrix only supports building from [ti.ndarray, ti.Vector.ndarray, ti.Matrix.ndarray]'
             )
 
-    def build_coo(self, data, row_idx, col_idx):
+    def build_coo(self, row_indices, col_indices, data):
         """Build a CSR format sparse matrix from COO format inputs.
 
         Args:
+            row_indices (ti.ndarray): the row indices of the matrix entries.
+            col_indices (ti.ndarray): the column indices of the matrix entries.
             data (ti.ndarray): the entries of the matrix.
-            indices (ti.ndarray): the row indices of the matrix entries.
-            indptr (ti.ndarray): the column indices of the matrix entries.
 
         Raises:
             TaichiRuntimeError: If the inputs are not ``ti.ndarray`` or the datatypes of the ndarray are not correct.
         """
         if not isinstance(data, Ndarray) or not isinstance(
-                row_idx, Ndarray) or not isinstance(col_idx, Ndarray):
+                col_indices, Ndarray) or not isinstance(row_indices, Ndarray):
             raise TaichiRuntimeError(
-                'Sparse matrix only supports building from [ti.ndarray, ti.Vector.ndarray, ti.Matrix.ndarray].'
+                'Sparse matrix only supports COO format building from [ti.ndarray, ti.Vector.ndarray, ti.Matrix.ndarray].'
             )
-        elif data.dtype != f32 or row_idx.dtype != i32 or col_idx.dtype != i32:
+        elif data.dtype != f32 or col_indices.dtype != i32 or row_indices.dtype != i32:
             raise TaichiRuntimeError(
-                'Sparse matrix only supports building from float32 data and int32 indices/indptr.'
+                'Sparse matrix only supports COO fromat building from float32 data and int32 row/col indices.'
             )
         else:
             get_runtime().prog.make_sparse_matrix_from_ndarray_cusparse(
-                self.matrix, col_idx.arr, row_idx.arr, data.arr)
+                self.matrix, row_indices.arr, col_indices.arr, data.arr)
 
     def spmv(self, x, y):
         """Sparse matrix-vector multiplication using cuSparse.

--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -229,7 +229,7 @@ CuSparseMatrix::~CuSparseMatrix() {
 }
 void make_sparse_matrix_from_ndarray_cusparse(Program *prog,
                                               SparseMatrix &sm,
-                                              const Ndarray &row_offsets,
+                                              const Ndarray &row_indices,
                                               const Ndarray &col_indices,
                                               const Ndarray &values) {
 #if defined(TI_WITH_CUDA)
@@ -240,7 +240,7 @@ void make_sparse_matrix_from_ndarray_cusparse(Program *prog,
       TI_ERROR("Failed to load cusparse library!");
     }
   }
-  size_t row_coo = prog->get_ndarray_data_ptr_as_int(&row_offsets);
+  size_t row_coo = prog->get_ndarray_data_ptr_as_int(&row_indices);
   size_t col_coo = prog->get_ndarray_data_ptr_as_int(&col_indices);
   size_t values_coo = prog->get_ndarray_data_ptr_as_int(&values);
   int nnz = values.get_nelement();

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "taichi/rhi/cuda/cuda_driver.h"
 #include "taichi/common/core.h"
 #include "taichi/inc/constants.h"
 #include "taichi/ir/type_utils.h"
 #include "taichi/program/ndarray.h"
 #include "taichi/program/program.h"
+#include "taichi/rhi/cuda/cuda_driver.h"
 
 #include "Eigen/Sparse"
 
@@ -63,13 +63,12 @@ class SparseMatrix {
     TI_NOT_IMPLEMENTED;
   };
 
-  virtual void build_csr(void *csr_ptr,
-                         void *csr_indices_ptr,
-                         void *csr_values_ptr,
-                         int nnz) {
+  virtual void build_csr_from_coo(void *coo_row_ptr,
+                                  void *coo_col_ptr,
+                                  void *coo_values_ptr,
+                                  int nnz) {
     TI_NOT_IMPLEMENTED;
-  };
-
+  }
   inline const int num_rows() const {
     return rows_;
   }
@@ -206,12 +205,17 @@ class CuSparseMatrix : public SparseMatrix {
   }
 
   virtual ~CuSparseMatrix();
-  void build_csr(void *csr_ptr,
-                 void *csr_indices_ptr,
-                 void *csr_values_ptr,
-                 int nnz) override;
-
+  void build_csr_from_coo(void *coo_row_ptr,
+                          void *coo_col_ptr,
+                          void *coo_values_ptr,
+                          int nnz) override;
   void spmv(Program *prog, const Ndarray &x, Ndarray &y);
+
+  const void *get_matrix() const override {
+    return &matrix_;
+  };
+
+  void print_info();
 
  private:
   cusparseSpMatDescr_t matrix_;

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -235,7 +235,7 @@ void make_sparse_matrix_from_ndarray(Program *prog,
                                      const Ndarray &ndarray);
 void make_sparse_matrix_from_ndarray_cusparse(Program *prog,
                                               SparseMatrix &sm,
-                                              const Ndarray &row_offsets,
+                                              const Ndarray &row_indices,
                                               const Ndarray &col_indices,
                                               const Ndarray &values);
 }  // namespace lang

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -403,13 +403,13 @@ void export_lang(py::module &m) {
              return make_sparse_matrix_from_ndarray(program, sm, ndarray);
            })
       .def("make_sparse_matrix_from_ndarray_cusparse",
-           [](Program *program, CuSparseMatrix &sm, const Ndarray &row_csr,
-              const Ndarray &col_csr, const Ndarray &val_csr) {
+           [](Program *program, CuSparseMatrix &sm, const Ndarray &row_coo,
+              const Ndarray &col_coo, const Ndarray &val_coo) {
              TI_ERROR_IF(
                  !arch_is_cuda(program->config.arch),
                  "SparseMatrix based on GPU only supports CUDA for now.");
              return make_sparse_matrix_from_ndarray_cusparse(
-                 program, sm, row_csr, col_csr, val_csr);
+                 program, sm, row_coo, col_coo, val_coo);
            })
       .def("no_activate",
            [](Program *program, SNode *snode) {

--- a/taichi/rhi/cuda/cusparse_functions.inc.h
+++ b/taichi/rhi/cuda/cusparse_functions.inc.h
@@ -7,6 +7,7 @@ PER_CUSPARSE_FUNCTION(cpDestroy, cusparseDestroy, cusparseHandle_t);
 // cusparse sparse matrix description
 PER_CUSPARSE_FUNCTION(cpCreateCoo, cusparseCreateCoo, cusparseSpMatDescr_t*, int, int, int,void*, void*, void*,cusparseIndexType_t, cusparseIndexBase_t,cudaDataType );
 PER_CUSPARSE_FUNCTION(cpCreateCsr, cusparseCreateCsr, cusparseSpMatDescr_t*, int, int, int,void*, void*, void*,cusparseIndexType_t, cusparseIndexType_t, cusparseIndexBase_t,cudaDataType );
+PER_CUSPARSE_FUNCTION(cpCoo2Csr, cusparseXcoo2csr, cusparseHandle_t ,const void*, int, int,void*, cusparseIndexBase_t );
 PER_CUSPARSE_FUNCTION(cpDestroySpMat, cusparseDestroySpMat, cusparseSpMatDescr_t);
 
 // cusparse dense vector description

--- a/tests/python/test_sparse_matrix.py
+++ b/tests/python/test_sparse_matrix.py
@@ -408,7 +408,7 @@ def test_gpu_sparse_matrix():
     A = ti.linalg.SparseMatrix(n=4, m=4, dtype=ti.f32)
 
     # Build the CSR matrix A with Taichi ndarray
-    A.build_coo(d_coo_val, d_coo_col, d_coo_row)
+    A.build_coo(d_coo_row, d_coo_col, d_coo_val)
 
     # Compute Y = A @ X
     A.spmv(X, Y)

--- a/tests/python/test_sparse_matrix.py
+++ b/tests/python/test_sparse_matrix.py
@@ -379,28 +379,28 @@ def test_sparse_matrix_nonsymmetric_multiplication(dtype, storage_format):
 
 @test_utils.test(arch=ti.cuda)
 def test_gpu_sparse_matrix():
-    h_row_csr = np.asarray([0, 3, 4, 7, 9], dtype=np.int32)
-    h_col_csr = np.asarray([0, 2, 3, 1, 0, 2, 3, 1, 3], dtype=np.int32)
-    h_value_csr = np.asarray([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-                             dtype=np.float32)
+    h_coo_row = np.asarray([0, 0, 0, 1, 2, 2, 2, 3, 3], dtype=np.int32)
+    h_coo_col = np.asarray([0, 2, 3, 1, 0, 2, 3, 1, 3], dtype=np.int32)
+    h_coo_val = np.asarray([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                           dtype=np.float32)
     h_X = np.asarray([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
     h_Y = np.asarray([19.0, 8.0, 51.0, 52.0], dtype=np.float32)
 
     # Data structure for building the CSR matrix A using Taichi Sparse Matrix
     idx_dt = ti.int32
     val_dt = ti.f32
-    row_csr = ti.ndarray(shape=5, dtype=idx_dt)
-    col_csr = ti.ndarray(shape=9, dtype=idx_dt)
-    value_csr = ti.ndarray(shape=9, dtype=val_dt)
+    d_coo_row = ti.ndarray(shape=9, dtype=idx_dt)
+    d_coo_col = ti.ndarray(shape=9, dtype=idx_dt)
+    d_coo_val = ti.ndarray(shape=9, dtype=val_dt)
     # Dense vector x
     X = ti.ndarray(shape=4, dtype=val_dt)
     # Results for A @ x
     Y = ti.ndarray(shape=4, dtype=val_dt)
 
     # Initialize the CSR matrix and vectors with numpy array
-    row_csr.from_numpy(h_row_csr)
-    col_csr.from_numpy(h_col_csr)
-    value_csr.from_numpy(h_value_csr)
+    d_coo_row.from_numpy(h_coo_row)
+    d_coo_col.from_numpy(h_coo_col)
+    d_coo_val.from_numpy(h_coo_val)
     X.from_numpy(h_X)
     Y.fill(0.0)
 
@@ -408,7 +408,7 @@ def test_gpu_sparse_matrix():
     A = ti.linalg.SparseMatrix(n=4, m=4, dtype=ti.f32)
 
     # Build the CSR matrix A with Taichi ndarray
-    A.build_csr_cusparse(value_csr, col_csr, row_csr)
+    A.build_coo(d_coo_val, d_coo_col, d_coo_row)
 
     # Compute Y = A @ X
     A.spmv(X, Y)


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/2906

It's more convenient for the users to generate COO format sparse matrix. But it's more efficient for the computer to use CSR format sparse matrix. In this pr, we provide a API to construct a CSR format sparse matrix using COO format input ndarrays.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
