### PR TITLE
[llvm] Fix PtrOffset address for shared array in llvm 15.

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -128,12 +128,11 @@ void TaskCodeGenLLVM::visit(AllocaStmt *stmt) {
     auto array_size = tlctx->get_constant(tensor_type->get_num_elements());
     // Return type is [array_size x type]*.
     if (stmt->is_shared) {
-      auto array_type = llvm::ArrayType::get(
-          type, tensor_type->get_num_elements());
+      auto array_type =
+          llvm::ArrayType::get(type, tensor_type->get_num_elements());
       auto base = new llvm::GlobalVariable(
           *module, array_type, false, llvm::GlobalValue::ExternalLinkage,
-          nullptr,
-          fmt::format("shared_array_{}", stmt->id), nullptr,
+          nullptr, fmt::format("shared_array_{}", stmt->id), nullptr,
           llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
       base->setAlignment(llvm::MaybeAlign(8));
       // FIXME: create GEP manually instead of using builder->CreateGEP for

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -128,8 +128,6 @@ void TaskCodeGenLLVM::visit(AllocaStmt *stmt) {
     auto array_size = tlctx->get_constant(tensor_type->get_num_elements());
     // Return type is [array_size x type]*.
     if (stmt->is_shared) {
-      size_t data_element_size = tlctx->get_type_size(
-          tlctx->get_data_type(tensor_type->get_element_type()));
       auto array_type = llvm::ArrayType::get(
           type, tensor_type->get_num_elements());
       auto base = new llvm::GlobalVariable(

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -130,23 +130,34 @@ void TaskCodeGenLLVM::visit(AllocaStmt *stmt) {
     if (stmt->is_shared) {
       size_t data_element_size = tlctx->get_type_size(
           tlctx->get_data_type(tensor_type->get_element_type()));
-      auto type = llvm::ArrayType::get(
-          llvm::Type::getInt8Ty(*llvm_context),
-          data_element_size * tensor_type->get_num_elements());
+      auto array_type = llvm::ArrayType::get(
+          type, tensor_type->get_num_elements());
       auto base = new llvm::GlobalVariable(
-          *module, type, false, llvm::GlobalValue::ExternalLinkage, nullptr,
+          *module, array_type, false, llvm::GlobalValue::ExternalLinkage,
+          nullptr,
           fmt::format("shared_array_{}", stmt->id), nullptr,
           llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
       base->setAlignment(llvm::MaybeAlign(8));
-
-      auto ptr = builder->CreateGEP(
+      // FIXME: create GEP manually instead of using builder->CreateGEP for
+      // opaque ptr in llvm 15.
+      // If using builder->CreateGEP, it will just return base because all zero
+      // idx.
+      // When opaque ptr is enabled, the CreatePointerCast will only create
+      // address space case instead of bitcast and address space cast. The type
+      // which was kept in bitcast will be lost.
+      // The manually created GEP is usded to keep the type.
+      // Later when lower PtrOffsetStmt, the type should be element type instead
+      // of array_type.
+      // Once llvm type is converted from taichi ir directly when lower
+      // PtrOffsetStmt, we can switch back to builder->CreateGEP.
+      auto *gep = llvm::GetElementPtrInst::CreateInBounds(
 #ifdef TI_LLVM_15
-          base->getValueType(),
+          array_type,
 #endif
           base, {tlctx->get_constant(0), tlctx->get_constant(0)});
-      auto ptr_type = llvm::PointerType::get(
-          tlctx->get_data_type(tensor_type->get_element_type()), 0);
-      llvm_val[stmt] = builder->CreatePointerCast(ptr, ptr_type);
+      builder->Insert(gep);
+      auto ptr_type = llvm::PointerType::get(type, 0);
+      llvm_val[stmt] = builder->CreatePointerCast(gep, ptr_type);
     } else {
       llvm_val[stmt] = create_entry_block_alloca(type, 0, array_size);
     }
@@ -1720,6 +1731,8 @@ void TaskCodeGenLLVM::visit(PtrOffsetStmt *stmt) {
       ptr_ty = alloc->getAllocatedType();
     else if (auto *gv = llvm::dyn_cast<llvm::GlobalVariable>(val))
       ptr_ty = gv->getValueType();
+    else if (auto *gep = llvm::dyn_cast<llvm::GEPOperator>(val))
+      ptr_ty = gep->getResultElementType();
     else if (stmt->origin->is<GlobalTemporaryStmt>()) {
       auto *tmpo_stmt = stmt->origin->cast<GlobalTemporaryStmt>();
       if (tmpo_stmt->ret_type->is<TensorType>()) {


### PR DESCRIPTION
Create GEP manually instead of using builder->CreateGEP to keep element type.
If use builder->CreateGEP, PtrOffset lower function will use array type of the shared array instead of element type.
And cause crash for out of bound access.

Related issue = #5276 

