### PR TITLE
[aot] Workaround build structure to export GGUI symbols in libt…

### DIFF
--- a/cmake/TaichiExportCore.cmake
+++ b/cmake/TaichiExportCore.cmake
@@ -10,6 +10,12 @@ set_target_properties(${TAICHI_EXPORT_CORE_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 
+# [TODO] Remove the following two linkages after rewriting AOT Demos with Device APIS
+if(TI_WITH_GGUI)
+    target_link_libraries(${TAICHI_EXPORT_CORE_NAME} PRIVATE taichi_ui_vulkan)
+    target_link_libraries(${TAICHI_EXPORT_CORE_NAME} PRIVATE taichi_ui)
+endif()
+
 target_include_directories(${TAICHI_EXPORT_CORE_NAME}
     PUBLIC
         # Used when building the library:


### PR DESCRIPTION
…export_core.so

Porting this to libtaichi_export_core.so temporarily since we need to
migrate our texture demo to c-api after it's ready. Let's work
around it for now.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
