### PR TITLE
[autodiff] second order derivative forward-over-forward mode

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -570,6 +570,7 @@ def create_field_member(dtype, name, needs_grad, needs_dual):
     x_dual = None
     # The x_grad_checkbit is used for global data access rule checker
     x_grad_checkbit = None
+    x_dual_dual = None
     if _ti_core.is_real(dtype):
         # adjoint
         x_grad = Expr(get_runtime().prog.make_id_expr(""))
@@ -599,6 +600,14 @@ def create_field_member(dtype, name, needs_grad, needs_dual):
         x_dual.ptr.set_name(name + ".dual")
         x_dual.ptr.set_grad_type(SNodeGradType.DUAL)
         x.ptr.set_dual(x_dual.ptr)
+
+        # dual_dual
+        x_dual_dual = Expr(get_runtime().prog.make_id_expr(""))
+        x_dual_dual.ptr = _ti_core.global_new(x_dual_dual.ptr, dtype)
+        x_dual_dual.ptr.set_name(name + ".dual")
+        x_dual_dual.ptr.set_grad_type(SNodeGradType.DUAL)
+        x_dual.ptr.set_dual(x_dual_dual.ptr)
+
         if needs_dual:
             pytaichi.dual_vars.append(x_dual)
     elif needs_grad or needs_dual:
@@ -606,7 +615,7 @@ def create_field_member(dtype, name, needs_grad, needs_dual):
             f'{dtype} is not supported for field with `needs_grad=True` or `needs_dual=True`.'
         )
 
-    return x, x_grad, x_dual
+    return x, x_grad, x_dual, x_dual_dual
 
 
 @python_scope
@@ -652,12 +661,13 @@ def field(dtype,
             >>> ti.root.dense(ti.j, shape=8).dense(ti.i, shape=16).place(x4)
 
     """
-    x, x_grad, x_dual = create_field_member(dtype, name, needs_grad,
-                                            needs_dual)
-    x, x_grad, x_dual = ScalarField(x), ScalarField(x_grad), ScalarField(
-        x_dual)
+    x, x_grad, x_dual, x_dual_dual = create_field_member(
+        dtype, name, needs_grad, needs_dual)
+    x, x_grad, x_dual, x_dual_dual = ScalarField(x), ScalarField(
+        x_grad), ScalarField(x_dual), ScalarField(x_dual_dual)
     x._set_grad(x_grad)
     x._set_dual(x_dual)
+    x_dual._set_dual(x_dual_dual)
 
     if shape is None:
         if offset is not None:

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -298,8 +298,7 @@ void SNode::lazy_dual() {
   make_lazy_place(
       this, snode_to_glb_var_exprs_,
       [this](std::unique_ptr<SNode> &c, std::vector<Expr> &new_duals) {
-        if (c->type == SNodeType::place && c->is_primal() && is_real(c->dt) &&
-            !c->has_dual()) {
+        if (c->type == SNodeType::place && is_real(c->dt) && !c->has_dual()) {
           new_duals.push_back(snode_to_glb_var_exprs_->at(c.get())->dual);
         }
       });
@@ -336,7 +335,7 @@ bool SNode::has_adjoint_checkbit() const {
 }
 
 bool SNode::has_dual() const {
-  return is_primal() && (grad_info->dual_snode() != nullptr);
+  return (grad_info->dual_snode() != nullptr);
 }
 
 SNode *SNode::get_adjoint() const {

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -558,10 +558,13 @@ class ADTransform : public IRVisitor {
 
  public:
   virtual Stmt *insert_grad_stmt(std::unique_ptr<Stmt> &&stmt) = 0;
+  std::set<Stmt *> new_inserted_statements;
 
   template <typename T, typename... Args>
   Stmt *insert(Args &&...args) {
-    return insert_grad_stmt(Stmt::make<T>(args...));
+    auto stmt = insert_grad_stmt(Stmt::make<T>(args...));
+    new_inserted_statements.insert(stmt);
+    return stmt;
   }
 
   void visit(AllocaStmt *alloca) override {
@@ -1096,6 +1099,9 @@ class MakeAdjoint : public ADTransform {
 
 // Forward mode autodiff
 class MakeDual : public ADTransform {
+ private:
+  std::set<Stmt *> statements_to_visit_;
+
  public:
   using ADTransform::visit;
   Stmt *current_stmt;
@@ -1103,15 +1109,38 @@ class MakeDual : public ADTransform {
   Block *alloca_block;
   std::map<Stmt *, Stmt *> dual_stmt;
 
-  MakeDual(Block *block) {
+  MakeDual(Block *block,
+           const std::set<Stmt *> &statements_to_visit,
+           const std::map<Stmt *, Stmt *> &dual_stmt_backup) {
     current_stmt = nullptr;
     alloca_block = block;
     current_block = block;
+    copy_backup_statements(statements_to_visit_, statements_to_visit, dual_stmt,
+                           dual_stmt_backup);
   }
 
-  static void run(Block *block) {
-    auto p = MakeDual(block);
+  static void copy_backup_statements(
+      std::set<Stmt *> &statements_to_visit_dst,
+      const std::set<Stmt *> &statements_to_visit_src,
+      std::map<Stmt *, Stmt *> &dual_stmt_dst,
+      const std::map<Stmt *, Stmt *> &dual_stmt_src) {
+    statements_to_visit_dst.clear();
+    for (auto const &item : statements_to_visit_src) {
+      statements_to_visit_dst.insert(item);
+    }
+    dual_stmt_dst.clear();
+    for (auto const &item : dual_stmt_src) {
+      dual_stmt_dst[item.first] = item.second;
+    }
+  }
+
+  static void run(Block *block,
+                  std::set<Stmt *> &statements_to_visit,
+                  std::map<Stmt *, Stmt *> &dual_stmt_backup) {
+    auto p = MakeDual(block, statements_to_visit, dual_stmt_backup);
     block->accept(&p);
+    copy_backup_statements(statements_to_visit, p.new_inserted_statements,
+                           dual_stmt_backup, p.dual_stmt);
   }
 
   Stmt *insert_grad_stmt(std::unique_ptr<Stmt> &&stmt) override {
@@ -1120,11 +1149,21 @@ class MakeDual : public ADTransform {
     return ptr;
   }
 
+  // The statements which are additional inserted in previous pass needs to be
+  // transformed at this pass.
+  bool needs_transform(Stmt *stmt) {
+    return statements_to_visit_.empty() || stmt->is<RangeForStmt>() ||
+           stmt->is<IfStmt>() || stmt->is<StructForStmt>() ||
+           (statements_to_visit_.find(stmt) != statements_to_visit_.end());
+  }
+
   void visit(Block *block) override {
     std::vector<Stmt *> statements;
     // always make a copy since the list can be modified.
     for (auto &stmt : block->statements) {
-      statements.push_back(stmt.get());
+      if (needs_transform(stmt.get())) {
+        statements.push_back(stmt.get());
+      }
     }
     for (auto stmt : statements) {
       current_stmt = stmt;
@@ -1158,6 +1197,9 @@ class MakeDual : public ADTransform {
       // maybe it's better to use the statement data type than the default type
       auto alloca = Stmt::make<AllocaStmt>(1, stmt->ret_type);
       dual_stmt[stmt] = alloca.get();
+
+      // Store the alloca of dual for next pass use
+      new_inserted_statements.insert(alloca.get());
 
       // TODO: check whether there are any edge cases for the alloca_block
       alloca_block->insert(std::move(alloca), 0);
@@ -1269,7 +1311,9 @@ class MakeDual : public ADTransform {
     if (if_stmt->true_statements) {
       std::vector<Stmt *> true_statements;
       for (auto &stmt : if_stmt->true_statements->statements) {
-        true_statements.push_back(stmt.get());
+        if (needs_transform(stmt.get())) {
+          true_statements.push_back(stmt.get());
+        }
       }
 
       for (auto stmt : true_statements) {
@@ -1280,7 +1324,9 @@ class MakeDual : public ADTransform {
     if (if_stmt->false_statements) {
       std::vector<Stmt *> false_statements;
       for (auto &stmt : if_stmt->false_statements->statements) {
-        false_statements.push_back(stmt.get());
+        if (needs_transform(stmt.get())) {
+          false_statements.push_back(stmt.get());
+        }
       }
 
       for (auto stmt : false_statements) {
@@ -1294,7 +1340,9 @@ class MakeDual : public ADTransform {
     std::vector<Stmt *> statements;
     // always make a copy since the list can be modified.
     for (auto &stmt : for_stmt->body->statements) {
-      statements.push_back(stmt.get());
+      if (needs_transform(stmt.get())) {
+        statements.push_back(stmt.get());
+      }
     }
     auto previous_alloca_block = alloca_block;
     alloca_block = for_stmt->body.get();
@@ -1306,8 +1354,10 @@ class MakeDual : public ADTransform {
   }
 
   void visit(StructForStmt *for_stmt) override {
+    auto previous_alloca_block = alloca_block;
     alloca_block = for_stmt->body.get();
     for_stmt->body->accept(this);
+    alloca_block = previous_alloca_block;
   }
 
   void visit(LocalLoadStmt *stmt) override {
@@ -1342,10 +1392,11 @@ class MakeDual : public ADTransform {
     }
     TI_ASSERT(src->width() == 1);
     auto snodes = src->snodes;
-    if (!snodes[0]->has_dual()) {
-      // No dual SNode. Do nothing
-      return;
-    }
+    // if (!snodes[0]->has_dual()) {
+    //   // No dual SNode. Do nothing
+    //   return;
+    // }
+    TI_ASSERT(snodes[0]->has_dual());
     if (gradients_stopped(stmt, snodes[0])) {
       // gradients stopped, do nothing.
       return;
@@ -1371,10 +1422,11 @@ class MakeDual : public ADTransform {
     }
     TI_ASSERT(dest->width() == 1);
     auto snodes = dest->snodes;
-    if (!snodes[0]->has_dual()) {
-      // no gradient (likely integer types)
-      return;
-    }
+    // if (!snodes[0]->has_dual()) {
+    //   // no gradient (likely integer types)
+    //   return;
+    // }
+    TI_ASSERT(snodes[0]->has_dual());
     TI_ASSERT(snodes[0]->get_dual() != nullptr);
     snodes[0] = snodes[0]->get_dual();
     auto dual_ptr = insert<GlobalPtrStmt>(snodes, dest->indices);
@@ -1382,7 +1434,8 @@ class MakeDual : public ADTransform {
       dual_ptr = insert<PtrOffsetStmt>(dual_ptr,
                                        stmt->dest->as<PtrOffsetStmt>()->offset);
     }
-    insert<AtomicOpStmt>(AtomicOpType::add, dual_ptr, load(dual(stmt->val)));
+    // insert<AtomicOpStmt>(AtomicOpType::add, dual_ptr, load(dual(stmt->val)));
+    insert<GlobalStoreStmt>(dual_ptr, load(dual(stmt->val)));
   }
 
   void visit(AtomicOpStmt *stmt) override {
@@ -1396,10 +1449,11 @@ class MakeDual : public ADTransform {
     }
     TI_ASSERT(dest->width() == 1);
     auto snodes = dest->snodes;
-    if (!snodes[0]->has_dual()) {
-      // no gradient (likely integer types)
-      return;
-    }
+    // if (!snodes[0]->has_dual()) {
+    //   // no gradient (likely integer types)
+    //   return;
+    // }
+    TI_ASSERT(snodes[0]->has_dual());
     TI_ASSERT(snodes[0]->get_dual() != nullptr);
     snodes[0] = snodes[0]->get_dual();
     auto dual_ptr = insert<GlobalPtrStmt>(snodes, dest->indices);
@@ -1529,36 +1583,41 @@ void auto_diff(IRNode *root,
                AutodiffMode autodiff_mode,
                bool use_stack) {
   TI_AUTO_PROF;
-  if (autodiff_mode == AutodiffMode::kReverse) {
-    if (use_stack) {
-      auto IB = IdentifyIndependentBlocks::run(root);
-      ReverseOuterLoops::run(root, IB);
+  int order = 2;
+  std::set<Stmt *> statements_to_visited;
+  std::map<Stmt *, Stmt *> dual_stmt_backup;
+  for (int i = 0; i < order; i++) {
+    if (autodiff_mode == AutodiffMode::kReverse) {
+      if (use_stack) {
+        auto IB = IdentifyIndependentBlocks::run(root);
+        ReverseOuterLoops::run(root, IB);
 
-      for (auto ib : IB) {
-        PromoteSSA2LocalVar::run(ib);
-        ReplaceLocalVarWithStacks replace(config.ad_stack_size);
-        ib->accept(&replace);
+        for (auto ib : IB) {
+          PromoteSSA2LocalVar::run(ib);
+          ReplaceLocalVarWithStacks replace(config.ad_stack_size);
+          ib->accept(&replace);
+          type_check(root, config);
+          MakeAdjoint::run(ib);
+          type_check(root, config);
+          BackupSSA::run(ib);
+          irpass::analysis::verify(root);
+        }
+      } else {
+        auto IB = IdentifyIndependentBlocks::run(root);
+        ReverseOuterLoops::run(root, IB);
         type_check(root, config);
-        MakeAdjoint::run(ib);
-        type_check(root, config);
-        BackupSSA::run(ib);
-        irpass::analysis::verify(root);
+        for (auto ib : IB) {
+          MakeAdjoint::run(ib);
+        }
       }
-    } else {
-      auto IB = IdentifyIndependentBlocks::run(root);
-      ReverseOuterLoops::run(root, IB);
-      type_check(root, config);
-      for (auto ib : IB) {
-        MakeAdjoint::run(ib);
-      }
+    } else if (autodiff_mode == AutodiffMode::kForward) {
+      // Forward mode autodiff
+      Block *block = root->as<Block>();
+      MakeDual::run(block, statements_to_visited, dual_stmt_backup);
     }
-  } else if (autodiff_mode == AutodiffMode::kForward) {
-    // Forward mode autodiff
-    Block *block = root->as<Block>();
-    MakeDual::run(block);
+    type_check(root, config);
+    irpass::analysis::verify(root);
   }
-  type_check(root, config);
-  irpass::analysis::verify(root);
 }
 
 class GloablDataAccessRuleChecker : public BasicStmtVisitor {


### PR DESCRIPTION
Example
```py
import taichi as ti
ti.init(print_ir=False, offline_cache=False)

x = ti.field(dtype=ti.f32, shape=())
y = ti.field(dtype=ti.f32, shape=5)

ti.root.lazy_dual()
ti.root.lazy_dual()

x[None] = 1.0
@ti.kernel
def compute_y():
    for i in range(5):
        y[i] = i * x[None] ** 2

with ti.ad.FwdMode(loss=y, param=x):
    compute_y()

print('dy/dx =', y.dual, "dy^2/dx^2= ", y.dual.dual, ' at x =', x[None])
```

```
[Taichi] version 1.1.3, llvm 10.0.0, commit 743c5204, linux, python 3.8.10
[Taichi] Starting on arch=x64
dy/dx = [0. 2. 4. 6. 8.] dy^2/dx^2=  [0. 2. 4. 6. 8.]  at x = 1.0
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
