### PR TITLE
[Lang] MatrixNdarray refactor part0: Support direct TensorType construction in Ndarray and refactor use of element_shape

### DIFF
--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -558,8 +558,12 @@ void ti_launch_compute_graph(TiRuntime runtime,
           }
         }
 
-        ndarrays.emplace_back(
-            taichi::lang::Ndarray(devalloc, *prim_ty, shape, elem_shape));
+        taichi::lang::DataType dtype = *prim_ty;
+        if (elem_shape.size() > 0) {
+          dtype = taichi::lang::TypeFactory::get_instance().get_tensor_type(
+              elem_shape, dtype);
+        }
+        ndarrays.emplace_back(taichi::lang::Ndarray(devalloc, dtype, shape));
         arg_map.emplace(std::make_pair(
             arg.name, taichi::lang::aot::IValue::create(ndarrays.back())));
         break;

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -265,7 +265,8 @@ class ScalarNdarray(Ndarray):
 
 class NdarrayHostAccessor:
     def __init__(self, ndarray):
-        if _ti_core.is_real(ndarray.dtype):
+        dtype = ndarray.element_data_type()
+        if _ti_core.is_real(dtype):
 
             def getter(*key):
                 return ndarray.read_float(key)
@@ -273,7 +274,7 @@ class NdarrayHostAccessor:
             def setter(value, *key):
                 ndarray.write_float(key, value)
         else:
-            if _ti_core.is_signed(ndarray.dtype):
+            if _ti_core.is_signed(dtype):
 
                 def getter(*key):
                     return ndarray.read_int(key)

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -5,7 +5,7 @@ from taichi.lang.enums import Layout
 from taichi.lang.util import cook_dtype, python_scope, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.ndarray_type import NdarrayTypeMetadata
-from taichi.types.utils import is_real
+from taichi.types.utils import is_real, is_signed
 
 
 class Ndarray:
@@ -275,7 +275,7 @@ class NdarrayHostAccessor:
             def setter(value, *key):
                 ndarray.write_float(key, value)
         else:
-            if _ti_core.is_signed(dtype):
+            if is_signed(dtype):
 
                 def getter(*key):
                     return ndarray.read_int(key)

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -5,6 +5,7 @@ from taichi.lang.enums import Layout
 from taichi.lang.util import cook_dtype, python_scope, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.ndarray_type import NdarrayTypeMetadata
+from taichi.types.utils import is_real
 
 
 class Ndarray:
@@ -266,7 +267,7 @@ class ScalarNdarray(Ndarray):
 class NdarrayHostAccessor:
     def __init__(self, ndarray):
         dtype = ndarray.element_data_type()
-        if _ti_core.is_real(dtype):
+        if is_real(dtype):
 
             def getter(*key):
                 return ndarray.read_float(key)

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -100,7 +100,8 @@ def decl_rw_texture_arg(num_dimensions, num_channels, channel_format, lod):
 
 def decl_ret(dtype):
     if isinstance(dtype, MatrixType):
-        dtype = _ti_core.get_tensor_type([dtype.n, dtype.m], dtype.dtype)
+        dtype = _ti_core.get_type_factory_instance().get_tensor_type(
+            [dtype.n, dtype.m], dtype.dtype)
     else:
         dtype = cook_dtype(dtype)
     return impl.get_runtime().prog.decl_ret(dtype)

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -100,7 +100,7 @@ def decl_rw_texture_arg(num_dimensions, num_channels, channel_format, lod):
 
 def decl_ret(dtype):
     if isinstance(dtype, MatrixType):
-        dtype = _ti_core.decl_tensor_type([dtype.n, dtype.m], dtype.dtype)
+        dtype = _ti_core.get_tensor_type([dtype.n, dtype.m], dtype.dtype)
     else:
         dtype = cook_dtype(dtype)
     return impl.get_runtime().prog.decl_ret(dtype)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -2002,7 +2002,7 @@ class VectorNdarray(Ndarray):
 
         self.layout = layout
         self.shape = tuple(shape)
-        self.element_type = TensorType((n, ), dtype)
+        self.element_type = TensorType((n, ), self.dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
             cook_dtype(self.element_type.ptr), shape, layout)
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1895,13 +1895,15 @@ class MatrixNdarray(Ndarray):
         self.n = n
         self.m = m
         super().__init__()
+        # TODO(zhanlue): remove self.dtype and migrate its usages to element_type
         self.dtype = cook_dtype(dtype)
+
         self.layout = layout
         self.shape = tuple(shape)
         self.element_type = TensorType((self.n, self.m), self.dtype)
         # TODO: we should pass in element_type, shape, layout instead.
         self.arr = impl.get_runtime().prog.create_ndarray(
-            self.element_type.dtype, shape, self.element_type.shape, layout)
+            self.element_type, shape, layout)
 
     @property
     def element_shape(self):
@@ -1995,13 +1997,14 @@ class VectorNdarray(Ndarray):
     def __init__(self, n, dtype, shape, layout):
         self.n = n
         super().__init__()
+        # TODO(zhanlue): remove self.dtype and migrate its usages to element_type
         self.dtype = cook_dtype(dtype)
         self.layout = layout
         self.shape = tuple(shape)
         self.element_type = TensorType((n, ), self.dtype)
         # TODO: pass in element_type, shape, layout directly
         self.arr = impl.get_runtime().prog.create_ndarray(
-            self.element_type.dtype, shape, self.element_type.shape, layout)
+            self.element_type, shape, layout)
 
     @property
     def element_shape(self):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1900,10 +1900,10 @@ class MatrixNdarray(Ndarray):
 
         self.layout = layout
         self.shape = tuple(shape)
-        self.element_type = TensorType((self.n, self.m), self.dtype)
+        self.element_type = TensorType((self.n, self.m), dtype)
         # TODO: we should pass in element_type, shape, layout instead.
         self.arr = impl.get_runtime().prog.create_ndarray(
-            self.element_type, shape, layout)
+            cook_dtype(self.element_type.ptr), shape, layout)
 
     @property
     def element_shape(self):
@@ -1915,7 +1915,7 @@ class MatrixNdarray(Ndarray):
             >>> arr.element_shape
             (2, 2)
         """
-        return tuple(self.arr.element_shape)
+        return tuple(self.arr.element_shape())
 
     @python_scope
     def __setitem__(self, key, value):
@@ -1999,12 +1999,12 @@ class VectorNdarray(Ndarray):
         super().__init__()
         # TODO(zhanlue): remove self.dtype and migrate its usages to element_type
         self.dtype = cook_dtype(dtype)
+
         self.layout = layout
         self.shape = tuple(shape)
-        self.element_type = TensorType((n, ), self.dtype)
-        # TODO: pass in element_type, shape, layout directly
+        self.element_type = TensorType((n, ), dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
-            self.element_type, shape, layout)
+            cook_dtype(self.element_type.ptr), shape, layout)
 
     @property
     def element_shape(self):
@@ -2016,7 +2016,7 @@ class VectorNdarray(Ndarray):
             >>> a.element_shape
             (3,)
         """
-        return tuple(self.arr.element_shape)
+        return tuple(self.arr.element_shape())
 
     @python_scope
     def __setitem__(self, key, value):

--- a/python/taichi/types/compound_types.py
+++ b/python/taichi/types/compound_types.py
@@ -14,14 +14,12 @@ class TensorType(CompoundType):
         if isinstance(dtype, _ti_python_core.DataType):
             dtype = dtype.get_ptr()
         self.ptr = _type_factory.get_tensor_type(shape, dtype)
-        self.shape = self.get_shape()
-        self.dtype = self.get_element_type()
 
     def get_shape(self):
-        return self.ptr.get_element_shape()
+        return tuple(self.ptr.get_element_shape())
 
     def get_element_type(self):
-        return self.ptr.get_element_type()
+        return _ti_python_core.DataType(self.ptr.get_element_type())
 
 
 # TODO: maybe move MatrixType, StructType here to avoid the circular import?

--- a/python/taichi/types/compound_types.py
+++ b/python/taichi/types/compound_types.py
@@ -14,7 +14,7 @@ class TensorType(CompoundType):
         self.ptr = _type_factory.get_tensor_type(shape, dtype)
 
     def get_shape(self):
-        return tuple(self.ptr.get_element_shape())
+        return tuple(self.ptr.get_shape())
 
     def get_element_type(self):
         return self.ptr.get_element_type()

--- a/python/taichi/types/compound_types.py
+++ b/python/taichi/types/compound_types.py
@@ -11,15 +11,13 @@ class CompoundType:
 
 class TensorType(CompoundType):
     def __init__(self, shape, dtype):
-        if isinstance(dtype, _ti_python_core.DataType):
-            dtype = dtype.get_ptr()
         self.ptr = _type_factory.get_tensor_type(shape, dtype)
 
     def get_shape(self):
         return tuple(self.ptr.get_element_shape())
 
     def get_element_type(self):
-        return _ti_python_core.DataType(self.ptr.get_element_type())
+        return self.ptr.get_element_type()
 
 
 # TODO: maybe move MatrixType, StructType here to avoid the circular import?

--- a/python/taichi/types/compound_types.py
+++ b/python/taichi/types/compound_types.py
@@ -1,4 +1,8 @@
+from taichi._lib.utils import ti_python_core as _ti_python_core
+
 import taichi
+
+_type_factory = _ti_python_core.get_type_factory_instance()
 
 
 class CompoundType:
@@ -7,8 +11,17 @@ class CompoundType:
 
 class TensorType(CompoundType):
     def __init__(self, shape, dtype):
-        self.dtype = dtype
-        self.shape = shape
+        if isinstance(dtype, _ti_python_core.DataType):
+            dtype = dtype.get_ptr()
+        self.ptr = _type_factory.get_tensor_type(shape, dtype)
+        self.shape = self.get_shape()
+        self.dtype = self.get_element_type()
+
+    def get_shape(self):
+        return self.ptr.get_element_shape()
+
+    def get_element_type(self):
+        return self.ptr.get_element_type()
 
 
 # TODO: maybe move MatrixType, StructType here to avoid the circular import?

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -49,9 +49,9 @@ class NdarrayType:
                 raise TypeError(
                     f"Expect TensorType element for Ndarray with element_dim: {self.element_dim} > 0"
                 )
-            if self.element_dim != len(ndarray_type.element_type.shape):
+            if self.element_dim != len(ndarray_type.element_type.get_shape()):
                 raise ValueError(
-                    f"Invalid argument into ti.types.ndarray() - required element_dim={self.element_dim}, but {len(ndarray_type.element_type.shape)} is provided"
+                    f"Invalid argument into ti.types.ndarray() - required element_dim={self.element_dim}, but {len(ndarray_type.element_type.get_shape())} is provided"
                 )
 
         if self.element_shape is not None and len(self.element_shape) > 0:
@@ -60,9 +60,9 @@ class NdarrayType:
                     f"Expect TensorType element for Ndarray with element_shape: {self.element_shape}"
                 )
 
-            if self.element_shape != ndarray_type.element_type.shape:
+            if self.element_shape != ndarray_type.element_type.get_shape():
                 raise ValueError(
-                    f"Invalid argument into ti.types.ndarray() - required element_shape={self.element_shape}, but {ndarray_type.element_type.shape} is provided"
+                    f"Invalid argument into ti.types.ndarray() - required element_shape={self.element_shape}, but {ndarray_type.element_type.get_shape()} is provided"
                 )
 
         if self.layout is not None and self.layout != ndarray_type.layout:

--- a/python/taichi/types/utils.py
+++ b/python/taichi/types/utils.py
@@ -4,4 +4,6 @@ is_signed = ti_python_core.is_signed
 
 is_integral = ti_python_core.is_integral
 
-__all__ = ['is_signed', 'is_integral']
+is_real = ti_python_core.is_real
+
+__all__ = ['is_signed', 'is_integral', 'is_real']

--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -35,6 +35,17 @@ void CompiledGraph::run(
                     symbolic_arg.name, symbolic_arg.field_dim,
                     arr->shape.size());
 
+        // CGraph uses aot::Arg as symbolic argument, which represents
+        // TensorType via combination of element_shape and PrimitiveTypeID
+        // Therefore we only check for element_type for now.
+        //
+        // TODO(zhanlue): Replace all "element_shape + PrimitiveType" use cases
+        // with direct use of "TensorType",
+        //                In the end, "element_shape" should only appear inside
+        //                TensorType and nowhere else.
+        //
+        //                This refactor includes aot::Arg, kernel::Arg,
+        //                MetalDataType, and more...
         DataType symbolic_arg_primitive_dtype = symbolic_arg.dtype();
         if (symbolic_arg.dtype()->is<TensorType>()) {
           symbolic_arg_primitive_dtype =

--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -25,6 +25,7 @@ void CompiledGraph::run(
       const aot::IValue &ival = found->second;
       if (ival.tag == aot::ArgKind::kNdarray) {
         Ndarray *arr = reinterpret_cast<Ndarray *>(ival.val);
+
         TI_ERROR_IF(arr->get_element_shape() != symbolic_arg.element_shape,
                     "Mismatched shape information for argument {}",
                     symbolic_arg.name);
@@ -33,12 +34,24 @@ void CompiledGraph::run(
                     "field_dim={} but got an ndarray with field_dim={}",
                     symbolic_arg.name, symbolic_arg.field_dim,
                     arr->shape.size());
-        TI_ERROR_IF(arr->dtype != symbolic_arg.dtype(),
+
+        DataType symbolic_arg_primitive_dtype = symbolic_arg.dtype();
+        if (symbolic_arg.dtype()->is<TensorType>()) {
+          symbolic_arg_primitive_dtype =
+              symbolic_arg.dtype()->cast<TensorType>()->get_element_type();
+        }
+
+        DataType arr_primitive_dtype = arr->dtype;
+        if (arr->dtype->is<TensorType>()) {
+          arr_primitive_dtype =
+              arr->dtype->cast<TensorType>()->get_element_type();
+        }
+
+        TI_ERROR_IF(arr_primitive_dtype != symbolic_arg_primitive_dtype,
                     "Dispatch node is compiled for argument {} with "
                     "dtype={} but got an ndarray with dtype={}",
-                    symbolic_arg.name, symbolic_arg.dtype().to_string(),
-                    arr->dtype.to_string());
-
+                    symbolic_arg.name, symbolic_arg_primitive_dtype.to_string(),
+                    arr_primitive_dtype.to_string());
         ctx.set_arg_ndarray(i, arr->get_device_allocation_ptr_as_int(),
                             arr->shape);
       } else if (ival.tag == aot::ArgKind::kScalar) {

--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -25,7 +25,7 @@ void CompiledGraph::run(
       const aot::IValue &ival = found->second;
       if (ival.tag == aot::ArgKind::kNdarray) {
         Ndarray *arr = reinterpret_cast<Ndarray *>(ival.val);
-        TI_ERROR_IF(arr->element_shape != symbolic_arg.element_shape,
+        TI_ERROR_IF(arr->get_element_shape() != symbolic_arg.element_shape,
                     "Mismatched shape information for argument {}",
                     symbolic_arg.name);
         TI_ERROR_IF(arr->shape.size() != symbolic_arg.field_dim,

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -64,7 +64,7 @@ DataType DataType::ptr_removed() const {
   }
 }
 
-std::vector<int> DataType::get_element_shape() const {
+std::vector<int> DataType::get_shape() const {
   if (ptr_->is<TensorType>()) {
     return ptr_->as<TensorType>()->get_shape();
   }

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -64,6 +64,22 @@ DataType DataType::ptr_removed() const {
   }
 }
 
+std::vector<int> DataType::get_element_shape() const {
+  if (ptr_->is<TensorType>()) {
+    return ptr_->as<TensorType>()->get_shape();
+  }
+
+  return {};
+}
+
+DataType DataType::get_element_type() const {
+  if (ptr_->is<TensorType>()) {
+    return ptr_->as<TensorType>()->get_element_type();
+  }
+
+  return *this;
+}
+
 std::string PrimitiveType::to_string() const {
   return data_type_name(DataType(const_cast<PrimitiveType *>(this)));
 }

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -42,6 +42,14 @@ class TI_DLL_EXPORT Type {
 
   bool is_primitive(PrimitiveTypeID type) const;
 
+  virtual std::vector<int> get_shape() const {
+    return {};
+  }
+
+  virtual Type *get_element_type() const {
+    return nullptr;
+  }
+
   virtual Type *get_compute_type() {
     TI_NOT_IMPLEMENTED;
   }
@@ -160,7 +168,7 @@ class TensorType : public Type {
       : shape_(std::move(shape)), element_(element) {
   }
 
-  Type *get_element_type() const {
+  Type *get_element_type() const override {
     return element_;
   }
 
@@ -171,7 +179,7 @@ class TensorType : public Type {
     return num_elements;
   }
 
-  std::vector<int> get_shape() const {
+  std::vector<int> get_shape() const override {
     return shape_;
   }
 
@@ -339,7 +347,7 @@ class QuantArrayType : public Type {
     return physical_type_;
   }
 
-  Type *get_element_type() const {
+  Type *get_element_type() const override {
     return element_type_;
   }
 

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -103,7 +103,7 @@ class TI_DLL_EXPORT DataType {
 
   DataType ptr_removed() const;
 
-  std::vector<int> get_element_shape() const;
+  std::vector<int> get_shape() const;
 
   DataType get_element_type() const;
 

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -5,6 +5,8 @@
 
 TLANG_NAMESPACE_BEGIN
 
+class TensorType;
+
 enum class PrimitiveTypeID : int {
 #define PER_TYPE(x) x,
 #include "taichi/inc/data_type.inc.h"
@@ -41,14 +43,6 @@ class TI_DLL_EXPORT Type {
   int vector_width() const;
 
   bool is_primitive(PrimitiveTypeID type) const;
-
-  virtual std::vector<int> get_shape() const {
-    return {};
-  }
-
-  virtual Type *get_element_type() const {
-    return nullptr;
-  }
 
   virtual Type *get_compute_type() {
     TI_NOT_IMPLEMENTED;
@@ -109,6 +103,10 @@ class TI_DLL_EXPORT DataType {
 
   DataType ptr_removed() const;
 
+  std::vector<int> get_element_shape() const;
+
+  DataType get_element_type() const;
+
  private:
   Type *ptr_;
 };
@@ -168,7 +166,7 @@ class TensorType : public Type {
       : shape_(std::move(shape)), element_(element) {
   }
 
-  Type *get_element_type() const override {
+  Type *get_element_type() const {
     return element_;
   }
 
@@ -179,7 +177,7 @@ class TensorType : public Type {
     return num_elements;
   }
 
-  std::vector<int> get_shape() const override {
+  std::vector<int> get_shape() const {
     return shape_;
   }
 
@@ -347,7 +345,7 @@ class QuantArrayType : public Type {
     return physical_type_;
   }
 
-  Type *get_element_type() const override {
+  Type *get_element_type() const {
     return element_type_;
   }
 

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -19,6 +19,15 @@ std::string data_type_name(DataType t) {
     TI_NOT_IMPLEMENTED
 }
 
+std::vector<int> data_type_shape(DataType t) {
+  if (t->is<TensorType>()) {
+    auto tensor_type = t->cast<TensorType>();
+    return tensor_type->get_shape();
+  }
+
+  return {};
+}
+
 int data_type_size(DataType t) {
   // TODO:
   //  1. Ensure in the old code, pointer attributes of t are correct (by
@@ -32,6 +41,13 @@ int data_type_size(DataType t) {
     return 0;
   else if (t->is_primitive(PrimitiveTypeID::unknown))
     return -1;
+
+  if (t->is<TensorType>()) {
+    auto tensor_type = t->cast<TensorType>();
+    TI_ASSERT(tensor_type->get_element_type());
+    return tensor_type->get_num_elements() *
+           data_type_size(tensor_type->get_element_type());
+  }
 
 #define REGISTER_DATA_TYPE(i, j) \
   else if (t->is_primitive(PrimitiveTypeID::i)) return sizeof(j)

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -6,6 +6,8 @@
 namespace taichi {
 namespace lang {
 
+std::vector<int> data_type_shape(DataType t);
+
 TI_DLL_EXPORT std::string data_type_name(DataType t);
 
 TI_DLL_EXPORT int data_type_size(DataType t);

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -27,28 +27,24 @@ size_t flatten_index(const std::vector<int> &shapes,
   }
 }
 }  // namespace
+
 Ndarray::Ndarray(Program *prog,
                  const DataType type,
                  const std::vector<int> &shape_,
-                 const std::vector<int> &element_shape_,
                  ExternalArrayLayout layout_)
     : dtype(type),
-      element_shape(element_shape_),
       shape(shape_),
       layout(layout_),
       nelement_(std::accumulate(std::begin(shape_),
                                 std::end(shape_),
                                 1,
                                 std::multiplies<>())),
-      element_size_(data_type_size(dtype) *
-                    std::accumulate(std::begin(element_shape),
-                                    std::end(element_shape),
-                                    1,
-                                    std::multiplies<>())),
+      element_size_(data_type_size(dtype)),
       prog_(prog) {
   // Now that we have two shapes which may be concatenated differently
   // depending on layout, total_shape_ comes handy.
   total_shape_ = shape;
+  auto element_shape = data_type_shape(dtype);
   if (layout == ExternalArrayLayout::kAOS) {
     total_shape_.insert(total_shape_.end(), element_shape.begin(),
                         element_shape.end());
@@ -64,23 +60,18 @@ Ndarray::Ndarray(Program *prog,
 Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
-                 const std::vector<int> &element_shape,
                  ExternalArrayLayout layout)
     : ndarray_alloc_(devalloc),
       dtype(type),
-      element_shape(element_shape),
       shape(shape),
       layout(layout),
       nelement_(std::accumulate(std::begin(shape),
                                 std::end(shape),
                                 1,
                                 std::multiplies<>())),
-      element_size_(data_type_size(dtype) *
-                    std::accumulate(std::begin(element_shape),
-                                    std::end(element_shape),
-                                    1,
-                                    std::multiplies<>())) {
+      element_size_(data_type_size(dtype)) {
   // When element_shape is specified but layout is not, default layout is AOS.
+  auto element_shape = data_type_shape(dtype);
   if (!element_shape.empty() && layout == ExternalArrayLayout::kNull) {
     layout = ExternalArrayLayout::kAOS;
   }
@@ -96,6 +87,16 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
   }
 }
 
+Ndarray::Ndarray(DeviceAllocation &devalloc,
+                 const DataType type,
+                 const std::vector<int> &shape,
+                 const std::vector<int> &element_shape,
+                 ExternalArrayLayout layout) {
+  TI_ASSERT(type->is<PrimitiveType>());
+  auto tensor_type = TypeFactory::create_tensor_type(element_shape, type);
+  Ndarray(devalloc, tensor_type, shape, layout);
+}
+
 Ndarray::~Ndarray() {
   if (prog_) {
     // prog_->flush();
@@ -108,6 +109,10 @@ intptr_t Ndarray::get_device_allocation_ptr_as_int() const {
   // specified device. Note that torch-based ndarray's ptr is a raw ptr but
   // we'll get rid of it soon.
   return reinterpret_cast<intptr_t>(&ndarray_alloc_);
+}
+
+std::vector<int> Ndarray::get_element_shape() const {
+  return data_type_shape(dtype);
 }
 
 std::size_t Ndarray::get_element_size() const {

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -91,10 +91,11 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
                  const std::vector<int> &element_shape,
-                 ExternalArrayLayout layout) {
-  TI_ASSERT(type->is<PrimitiveType>());
-  auto tensor_type = TypeFactory::create_tensor_type(element_shape, type);
-  Ndarray(devalloc, tensor_type, shape, layout);
+                 ExternalArrayLayout layout)
+    : Ndarray(devalloc,
+              TypeFactory::create_tensor_type(element_shape, type),
+              shape,
+              layout) {
 }
 
 Ndarray::~Ndarray() {

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -116,6 +116,13 @@ std::vector<int> Ndarray::get_element_shape() const {
   return data_type_shape(dtype);
 }
 
+DataType Ndarray::get_element_data_type() const {
+  if (dtype->is<TensorType>()) {
+    return dtype->cast<TensorType>()->get_element_type();
+  }
+  return dtype;
+}
+
 std::size_t Ndarray::get_element_size() const {
   return element_size_;
 }

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -96,6 +96,7 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
               TypeFactory::create_tensor_type(element_shape, type),
               shape,
               layout) {
+  TI_ASSERT(type->is<PrimitiveType>());
 }
 
 Ndarray::~Ndarray() {

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -34,6 +34,10 @@ class TI_DLL_EXPORT Ndarray {
                    const std::vector<int> &shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull);
 
+  /* Constructs a Ndarray from an existing DeviceAllocation.
+   * This is an overloaded constructor for constructing Ndarray with TensorType
+   * elements "type" is expected to be PrimitiveType
+   */
   explicit Ndarray(DeviceAllocation &devalloc,
                    const DataType type,
                    const std::vector<int> &shape,

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -22,29 +22,33 @@ class TI_DLL_EXPORT Ndarray {
   explicit Ndarray(Program *prog,
                    const DataType type,
                    const std::vector<int> &shape,
-                   const std::vector<int> &element_shape = {},
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull);
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * It doesn't handle the allocation and deallocation.
    * You can see a Ndarray as a view or interpretation of DeviceAllocation
-   * with specified element_shape & dtype & layout.
+   * with specified dtype & layout.
    */
   explicit Ndarray(DeviceAllocation &devalloc,
                    const DataType type,
                    const std::vector<int> &shape,
-                   const std::vector<int> &element_shape = {},
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+
+  explicit Ndarray(DeviceAllocation &devalloc,
+                   const DataType type,
+                   const std::vector<int> &shape,
+                   const std::vector<int> &element_shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull);
 
   DeviceAllocation ndarray_alloc_{kDeviceNullAllocation};
   DataType dtype;
-  std::vector<int> element_shape;
   // Invariant: Since ndarray indices are flattened for vector/matrix, this is
   // always true:
   //   num_active_indices = shape.size()
   std::vector<int> shape;
   ExternalArrayLayout layout{ExternalArrayLayout::kNull};
 
+  std::vector<int> get_element_shape() const;
   intptr_t get_data_ptr_as_int() const;
   intptr_t get_device_allocation_ptr_as_int() const;
   std::size_t get_element_size() const;

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -49,6 +49,7 @@ class TI_DLL_EXPORT Ndarray {
   ExternalArrayLayout layout{ExternalArrayLayout::kNull};
 
   std::vector<int> get_element_shape() const;
+  DataType get_element_data_type() const;
   intptr_t get_data_ptr_as_int() const;
   intptr_t get_device_allocation_ptr_as_int() const;
   std::size_t get_element_size() const;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -458,10 +458,8 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 
 Ndarray *Program::create_ndarray(const DataType type,
                                  const std::vector<int> &shape,
-                                 const std::vector<int> &element_shape,
                                  ExternalArrayLayout layout) {
-  ndarrays_.emplace_back(
-      std::make_unique<Ndarray>(this, type, shape, element_shape, layout));
+  ndarrays_.emplace_back(std::make_unique<Ndarray>(this, type, shape, layout));
   return ndarrays_.back().get();
 }
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -311,7 +311,6 @@ class TI_DLL_EXPORT Program {
   Ndarray *create_ndarray(
       const DataType type,
       const std::vector<int> &shape,
-      const std::vector<int> &element_shape = {},
       ExternalArrayLayout layout = ExternalArrayLayout::kNull);
 
   Texture *create_texture(const DataType type,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -573,6 +573,7 @@ void export_lang(py::module &m) {
       .def("write_float", &Ndarray::write_float)
       .def("total_shape", &Ndarray::total_shape)
       .def("element_shape", &Ndarray::get_element_shape)
+      .def("element_data_type", &Ndarray::get_element_data_type)
       .def_readonly("dtype", &Ndarray::dtype)
       .def_readonly("shape", &Ndarray::shape);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1090,7 +1090,10 @@ void export_lang(py::module &m) {
 
   // Type system
 
-  py::class_<Type>(m, "Type").def("to_string", &Type::to_string);
+  py::class_<Type>(m, "Type")
+      .def("to_string", &Type::to_string)
+      .def("get_element_shape", &Type::get_shape)
+      .def("get_element_type", &Type::get_element_type);
 
   // Note that it is important to specify py::return_value_policy::reference for
   // the factory methods, otherwise pybind11 will delete the Types owned by
@@ -1104,7 +1107,9 @@ void export_lang(py::module &m) {
            py::return_value_policy::reference)
       .def("get_quant_float_type", &TypeFactory::get_quant_float_type,
            py::arg("digits_type"), py::arg("exponent_type"),
-           py::arg("compute_type"), py::return_value_policy::reference);
+           py::arg("compute_type"), py::return_value_policy::reference)
+      .def("get_tensor_type", &TypeFactory::get_tensor_type, py::arg("shape"),
+           py::arg("element_type"), py::return_value_policy::reference);
 
   m.def("get_type_factory_instance", TypeFactory::get_instance,
         py::return_value_policy::reference);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -112,7 +112,7 @@ void export_lang(py::module &m) {
       .def("__hash__", &DataType::hash)
       .def("to_string", &DataType::to_string)
       .def("__str__", &DataType::to_string)
-      .def("get_element_shape", &DataType::get_element_shape)
+      .def("get_shape", &DataType::get_shape)
       .def("get_element_type", &DataType::get_element_type)
       .def(
           "get_ptr", [](DataType *dtype) -> Type * { return *dtype; },

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -447,12 +447,10 @@ void export_lang(py::module &m) {
           "create_ndarray",
           [&](Program *program, const DataType &dt,
               const std::vector<int> &shape,
-              const std::vector<int> &element_shape,
               ExternalArrayLayout layout) -> Ndarray * {
-            return program->create_ndarray(dt, shape, element_shape, layout);
+            return program->create_ndarray(dt, shape, layout);
           },
           py::arg("dt"), py::arg("shape"),
-          py::arg("element_shape") = py::tuple(),
           py::arg("layout") = ExternalArrayLayout::kNull,
           py::return_value_policy::reference)
       .def(
@@ -574,8 +572,8 @@ void export_lang(py::module &m) {
       .def("write_int", &Ndarray::write_int)
       .def("write_float", &Ndarray::write_float)
       .def("total_shape", &Ndarray::total_shape)
+      .def("element_shape", &Ndarray::get_element_shape)
       .def_readonly("dtype", &Ndarray::dtype)
-      .def_readonly("element_shape", &Ndarray::element_shape)
       .def_readonly("shape", &Ndarray::shape);
 
   py::class_<Texture>(m, "Texture")

--- a/tests/cpp/aot/gfx_utils.cpp
+++ b/tests/cpp/aot/gfx_utils.cpp
@@ -33,13 +33,13 @@ void view_devalloc_as_ndarray(Device *device_) {
 
   std::vector<int> element_shape = {4};
   auto arr1 = Ndarray(devalloc_arr_, PrimitiveType::i32, {10}, element_shape);
-  EXPECT_TRUE(arr1.element_shape == element_shape);
+  EXPECT_TRUE(arr1.get_element_shape() == element_shape);
   EXPECT_EQ(arr1.total_shape()[0], 10);
   EXPECT_EQ(arr1.total_shape()[1], 4);
 
   auto arr2 = Ndarray(devalloc_arr_, PrimitiveType::i32, {10}, element_shape,
                       ExternalArrayLayout::kSOA);
-  EXPECT_TRUE(arr2.element_shape == element_shape);
+  EXPECT_TRUE(arr2.get_element_shape() == element_shape);
   EXPECT_EQ(arr2.total_shape()[0], 4);
   EXPECT_EQ(arr2.total_shape()[1], 10);
 

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -174,15 +174,15 @@ def test_ndarray_compound_element():
     b = ti.ndarray(vec3, shape=(n, n))
     assert isinstance(b, ti.MatrixNdarray)
     assert b.shape == (n, n)
-    assert b.element_type.dtype == ti.i32
-    assert b.element_type.shape == (3, 1)
+    assert b.element_type.get_element_type() == ti.i32
+    assert b.element_type.get_shape() == (3, 1)
 
     matrix34 = ti.types.matrix(3, 4, float)
     c = ti.ndarray(matrix34, shape=(n, n + 1), layout=ti.Layout.SOA)
     assert isinstance(c, ti.MatrixNdarray)
     assert c.shape == (n, n + 1)
-    assert c.element_type.dtype == ti.f32
-    assert c.element_type.shape == (3, 4)
+    assert c.element_type.get_element_type() == ti.f32
+    assert c.element_type.get_shape() == (3, 4)
     assert c.layout == ti.Layout.SOA
 
 


### PR DESCRIPTION
Related issue = #5873, #5819

This PR belongs to "Part ②" in #5873, which also covers Part ①.

[Major change]
1. Refactored python-scope `TensorType` to construct & keep a `ptr` with C++ TensorType.
2. Refactored C++ Ndarray to represent matrix-element with `TensorType` instead of the `PrimitiveType + element_shape` combination.
3. Adjust python-scope class `MatrixNdarray` and `VectorNdarray` to adopt refactored `TensorType` and `Ndarray`