### PR TITLE
[refactor] Separate texture args from scalar arg declaration

### DIFF
--- a/cpp_examples/autograd.cpp
+++ b/cpp_examples/autograd.cpp
@@ -176,9 +176,9 @@ void autograd() {
     }
 
     kernel_ext = std::make_unique<Kernel>(program, builder.extract_ir(), "ext");
-    kernel_ext->insert_arg(get_data_type<int>(), true);
-    kernel_ext->insert_arg(get_data_type<int>(), true);
-    kernel_ext->insert_arg(get_data_type<int>(), true);
+    kernel_ext->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {n});
+    kernel_ext->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {n});
+    kernel_ext->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {n});
   }
 
   auto ctx_init = kernel_init->make_launch_context();

--- a/cpp_examples/run_snode.cpp
+++ b/cpp_examples/run_snode.cpp
@@ -123,7 +123,6 @@ void run_snode() {
 
     kernel_ext = std::make_unique<Kernel>(program, builder.extract_ir(), "ext");
     kernel_ext->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {n});
-    ;
   }
 
   auto ctx_init = kernel_init->make_launch_context();

--- a/cpp_examples/run_snode.cpp
+++ b/cpp_examples/run_snode.cpp
@@ -122,7 +122,8 @@ void run_snode() {
     }
 
     kernel_ext = std::make_unique<Kernel>(program, builder.extract_ir(), "ext");
-    kernel_ext->insert_arg(get_data_type<int>(), true);
+    kernel_ext->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {n});
+    ;
   }
 
   auto ctx_init = kernel_init->make_launch_context();

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -53,7 +53,7 @@ def decl_scalar_arg(dtype):
         is_ref = True
         dtype = dtype.tp
     dtype = cook_dtype(dtype)
-    arg_id = impl.get_runtime().prog.decl_arg(dtype, False)
+    arg_id = impl.get_runtime().prog.decl_scalar_arg(dtype)
     return Expr(_ti_core.make_arg_load_expr(arg_id, dtype, is_ref))
 
 
@@ -68,7 +68,7 @@ def decl_sparse_matrix(dtype):
     value_type = cook_dtype(dtype)
     ptr_type = cook_dtype(u64)
     # Treat the sparse matrix argument as a scalar since we only need to pass in the base pointer
-    arg_id = impl.get_runtime().prog.decl_arg(ptr_type, False)
+    arg_id = impl.get_runtime().prog.decl_scalar_arg(ptr_type)
     return SparseMatrixProxy(
         _ti_core.make_arg_load_expr(arg_id, ptr_type, False), value_type)
 
@@ -86,13 +86,15 @@ def decl_ndarray_arg(dtype, dim, element_shape, layout):
 
 
 def decl_texture_arg(num_dimensions):
-    arg_id = impl.get_runtime().prog.decl_arg(f32, True)
+    # FIXME: texture_arg doesn't have element_shape so better separate them
+    arg_id = impl.get_runtime().prog.decl_texture_arg(f32)
     return TextureSampler(
         _ti_core.make_texture_ptr_expr(arg_id, num_dimensions), num_dimensions)
 
 
 def decl_rw_texture_arg(num_dimensions, num_channels, channel_format, lod):
-    arg_id = impl.get_runtime().prog.decl_arg(f32, True)
+    # FIXME: texture_arg doesn't have element_shape so better separate them
+    arg_id = impl.get_runtime().prog.decl_texture_arg(f32)
     return RWTextureAccessor(
         _ti_core.make_rw_texture_ptr_expr(arg_id, num_dimensions, num_channels,
                                           channel_format, lod), num_dimensions)

--- a/taichi/program/callable.cpp
+++ b/taichi/program/callable.cpp
@@ -8,8 +8,8 @@ Callable::Callable() = default;
 
 Callable::~Callable() = default;
 
-int Callable::insert_arg(const DataType &dt, bool is_array) {
-  args.emplace_back(dt->get_compute_type(), is_array);
+int Callable::insert_scalar_arg(const DataType &dt) {
+  args.emplace_back(dt->get_compute_type(), /*is_array=*/false);
   return (int)args.size() - 1;
 }
 
@@ -17,11 +17,18 @@ int Callable::insert_ret(const DataType &dt) {
   rets.emplace_back(dt->get_compute_type());
   return (int)rets.size() - 1;
 }
+
 int Callable::insert_arr_arg(const DataType &dt,
                              int total_dim,
                              std::vector<int> element_shape) {
   args.emplace_back(dt->get_compute_type(), /*is_array=*/true, /*size=*/0,
                     total_dim, element_shape);
+  return (int)args.size() - 1;
+}
+
+int Callable::insert_texture_arg(const DataType &dt) {
+  // FIXME: we shouldn't abuse is_array for texture args
+  args.emplace_back(dt->get_compute_type(), /*is_array=*/true);
   return (int)args.size() - 1;
 }
 

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -47,11 +47,12 @@ class TI_DLL_EXPORT Callable {
   Callable();
   virtual ~Callable();
 
-  int insert_arg(const DataType &dt, bool is_array);
+  int insert_scalar_arg(const DataType &dt);
 
   int insert_arr_arg(const DataType &dt,
                      int total_dim,
                      std::vector<int> element_shape);
+  int insert_texture_arg(const DataType &dt);
 
   int insert_ret(const DataType &dt);
 

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -351,7 +351,7 @@ Kernel &Program::get_snode_reader(SNode *snode) {
   ker.name = kernel_name;
   ker.is_accessor = true;
   for (int i = 0; i < snode->num_active_indices; i++)
-    ker.insert_arg(PrimitiveType::i32, false);
+    ker.insert_scalar_arg(PrimitiveType::i32);
   ker.insert_ret(snode->dt);
   return ker;
 }
@@ -373,8 +373,8 @@ Kernel &Program::get_snode_writer(SNode *snode) {
   ker.name = kernel_name;
   ker.is_accessor = true;
   for (int i = 0; i < snode->num_active_indices; i++)
-    ker.insert_arg(PrimitiveType::i32, false);
-  ker.insert_arg(snode->dt, false);
+    ker.insert_scalar_arg(PrimitiveType::i32);
+  ker.insert_scalar_arg(snode->dt);
   return ker;
 }
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -425,15 +425,19 @@ void export_lang(py::module &m) {
              TI_ASSERT(kernel);
              kernel->no_activate.push_back(snode);
            })
-      .def("decl_arg",
-           [&](Program *program, const DataType &dt, bool is_array) {
-             return program->current_callable->insert_arg(dt, is_array);
+      .def("decl_scalar_arg",
+           [&](Program *program, const DataType &dt) {
+             return program->current_callable->insert_scalar_arg(dt);
            })
       .def("decl_arr_arg",
            [&](Program *program, const DataType &dt, int total_dim,
                std::vector<int> shape) {
              return program->current_callable->insert_arr_arg(dt, total_dim,
                                                               shape);
+           })
+      .def("decl_texture_arg",
+           [&](Program *program, const DataType &dt) {
+             return program->current_callable->insert_texture_arg(dt);
            })
       .def("decl_ret",
            [&](Program *program, const DataType &dt) {

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -58,9 +58,9 @@ class ConstantFold : public BasicStmtVisitor {
 
     auto ker = std::make_unique<Kernel>(*program, func, kernel_name);
     ker->insert_ret(id.ret);
-    ker->insert_arg(id.lhs, false);
+    ker->insert_scalar_arg(id.lhs);
     if (id.is_binary)
-      ker->insert_arg(id.rhs, false);
+      ker->insert_scalar_arg(id.rhs);
     ker->is_evaluator = true;
 
     auto *ker_ptr = ker.get();

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -112,7 +112,7 @@ TEST(IRBuilder, ExternalPtr) {
   builder.create_global_store(a2ptr, a0plusa2);  // a[2] = a[0] + a[2]
   auto block = builder.extract_ir();
   auto ker = std::make_unique<Kernel>(*test_prog.prog(), std::move(block));
-  ker->insert_arg(get_data_type<int>(), /*is_array=*/true);
+  ker->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {1});
   auto launch_ctx = ker->make_launch_context();
   launch_ctx.set_arg_external_array_with_shape(
       /*arg_id=*/0, (uint64)array.get(), size, {size});

--- a/tests/cpp/ir/ndarray_kernel.cpp
+++ b/tests/cpp/ir/ndarray_kernel.cpp
@@ -22,7 +22,8 @@ std::unique_ptr<Kernel> setup_kernel1(Program *prog) {
   }
   auto block = builder1.extract_ir();
   auto ker1 = std::make_unique<Kernel>(*prog, std::move(block), "ker1");
-  ker1->insert_arg(get_data_type<int>(), /*is_array=*/true);
+  ker1->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {1});
+  ;
   return ker1;
 }
 
@@ -40,8 +41,9 @@ std::unique_ptr<Kernel> setup_kernel2(Program *prog) {
   }
   auto block2 = builder2.extract_ir();
   auto ker2 = std::make_unique<Kernel>(*prog, std::move(block2), "ker2");
-  ker2->insert_arg(get_data_type<int>(), /*is_array=*/true);
-  ker2->insert_arg(get_data_type<int>(), /*is_array=*/false);
+  ker2->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {1});
+  ;
+  ker2->insert_scalar_arg(get_data_type<int>());
   return ker2;
 }
 }  // namespace lang

--- a/tests/cpp/ir/ndarray_kernel.cpp
+++ b/tests/cpp/ir/ndarray_kernel.cpp
@@ -23,7 +23,6 @@ std::unique_ptr<Kernel> setup_kernel1(Program *prog) {
   auto block = builder1.extract_ir();
   auto ker1 = std::make_unique<Kernel>(*prog, std::move(block), "ker1");
   ker1->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {1});
-  ;
   return ker1;
 }
 
@@ -42,7 +41,6 @@ std::unique_ptr<Kernel> setup_kernel2(Program *prog) {
   auto block2 = builder2.extract_ir();
   auto ker2 = std::make_unique<Kernel>(*prog, std::move(block2), "ker2");
   ker2->insert_arr_arg(get_data_type<int>(), /*total_dim=*/1, {1});
-  ;
   ker2->insert_scalar_arg(get_data_type<int>());
   return ker2;
 }

--- a/tests/cpp/transforms/inlining_test.cpp
+++ b/tests/cpp/transforms/inlining_test.cpp
@@ -34,7 +34,7 @@ TEST_F(InliningTest, ArgLoadOfArgLoad) {
 
   auto *func = prog_->create_function(
       FunctionKey("test_func", /*func_id=*/0, /*instance_id=*/0));
-  func->insert_arg(get_data_type<int>(), /*is_array=*/false);
+  func->insert_scalar_arg(get_data_type<int>());
   func->insert_ret(get_data_type<int>());
   func->set_function_body(std::move(func_body));
 


### PR DESCRIPTION
But texture arg declaration is still hacky as it abuses `is_array`.
That should be fixed in the followup PRs.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
