### PR TITLE
[bug] Fix minor issue for CUPTI kernel profiler

### DIFF
--- a/python/taichi/profiler/kernel_metrics.py
+++ b/python/taichi/profiler/kernel_metrics.py
@@ -133,7 +133,7 @@ global_op_reduction = CuptiMetric(
 
 # Hardware Utilization Metrics
 sm_throughput = CuptiMetric(
-    name='sm__throughput.avg.pct_of_peak_sustained_elapsed',
+    name='smsp__cycles_active.avg.pct_of_peak_sustained_elapsed',
     header=' core.uti ',
     val_format=' {:6.2f} % ')
 

--- a/python/taichi/profiler/kernel_profiler.py
+++ b/python/taichi/profiler/kernel_profiler.py
@@ -319,7 +319,7 @@ class KernelProfiler:
                     record.active_blocks_per_multiprocessor
                 ]
             for idx in range(values_num):
-                formatted_str += metric_list[idx].format + '|'
+                formatted_str += metric_list[idx].val_format + '|'
                 values += [record.metric_values[idx] * metric_list[idx].scale]
             formatted_str = (formatted_str + '] ' + record.name)
             string_list.append(formatted_str.replace("|]", "]"))
@@ -524,7 +524,7 @@ def set_kernel_profiler_metrics(metric_list=default_cupti_metrics):
         >>> profiling_metrics += [global_op_atom]
 
         >>> # metrics setting will be retained until the next configuration
-        >>> ti.profiler.set_kernel_profile_metrics(profiling_metrics)
+        >>> ti.profiler.set_kernel_profiler_metrics(profiling_metrics)
         >>> for i in range(16):
         >>>     reduction()
         >>> ti.profiler.print_kernel_profiler_info('trace')


### PR DESCRIPTION
Related issue = #5627 

About SM Throughput metric, since "sm__throughput" metric cannot be found in the latest CUPTI document, please let me know if the relative modification is correct.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
