### PR TITLE
[refactor] [ir] Remove legacy stmt width

### DIFF
--- a/taichi/analysis/alias_analysis.cpp
+++ b/taichi/analysis/alias_analysis.cpp
@@ -91,9 +91,6 @@ AliasResult alias_analysis(Stmt *var1, Stmt *var2) {
                : AliasResult::uncertain;
   }
 
-  TI_ASSERT(var1->width() == 1);
-  TI_ASSERT(var2->width() == 1);
-
   if (var1->is<ExternalPtrStmt>() || var2->is<ExternalPtrStmt>()) {
     if (!var1->is<ExternalPtrStmt>() || !var2->is<ExternalPtrStmt>())
       return AliasResult::different;

--- a/taichi/analysis/bls_analyzer.cpp
+++ b/taichi/analysis/bls_analyzer.cpp
@@ -36,58 +36,54 @@ void BLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
   if (!stmt->is<GlobalPtrStmt>())
     return;  // local alloca
   auto ptr = stmt->as<GlobalPtrStmt>();
-  for (int l = 0; l < stmt->width(); l++) {
-    auto snode = ptr->snodes[l];
-    if (!pads_->has(snode)) {
-      continue;
+  auto snode = ptr->snodes[0];
+  if (!pads_->has(snode)) {
+    return;
+  }
+  bool matching_indices = true;
+  std::vector<IndexRange> offsets;
+  std::vector<int> coeffs;
+  offsets.resize(ptr->indices.size());
+  coeffs.resize(ptr->indices.size());
+  const int num_indices = (int)ptr->indices.size();
+  for (int i = 0; i < num_indices; i++) {
+    auto diff = irpass::analysis::value_diff_loop_index(ptr->indices[i],
+                                                        for_stmt_, i);
+    if (diff.related() && diff.coeff > 0) {
+      offsets[i].low = diff.low;
+      offsets[i].high = diff.high;
+      coeffs[i] = diff.coeff;
+    } else {
+      matching_indices = false;
+      analysis_ok_ = false;
     }
-    bool matching_indices = true;
-    std::vector<IndexRange> offsets;
-    std::vector<int> coeffs;
-    offsets.resize(ptr->indices.size());
-    coeffs.resize(ptr->indices.size());
-    const int num_indices = (int)ptr->indices.size();
-    for (int i = 0; i < num_indices; i++) {
-      auto diff = irpass::analysis::value_diff_loop_index(ptr->indices[i],
-                                                          for_stmt_, i);
-      if (diff.related() && diff.coeff > 0) {
-        offsets[i].low = diff.low;
-        offsets[i].high = diff.high;
-        coeffs[i] = diff.coeff;
-      } else {
-        matching_indices = false;
-        analysis_ok_ = false;
+  }
+  if (matching_indices) {
+    auto *block = snode->parent;
+    const auto &index_bounds = block_indices_[block];
+    std::vector<int> index(num_indices, 0);
+    std::function<void(int)> visit = [&](int dimension) {
+      if (dimension == num_indices) {
+        pads_->access(snode, coeffs, index, flag);
+        return;
       }
-    }
-    if (matching_indices) {
-      auto *block = snode->parent;
-      const auto &index_bounds = block_indices_[block];
-      std::vector<int> index(num_indices, 0);
-      std::function<void(int)> visit = [&](int dimension) {
-        if (dimension == num_indices) {
-          pads_->access(snode, coeffs, index, flag);
-          return;
-        }
-        for (int i = (index_bounds[dimension].low + offsets[dimension].low);
-             i < (index_bounds[dimension].high + offsets[dimension].high);
-             i++) {
-          index[dimension] = i;
-          visit(dimension + 1);
-        }
-      };
-      visit(0);
-    }
+      for (int i = (index_bounds[dimension].low + offsets[dimension].low);
+           i < (index_bounds[dimension].high + offsets[dimension].high);
+           i++) {
+        index[dimension] = i;
+        visit(dimension + 1);
+      }
+    };
+    visit(0);
   }
 }
 
 // Do not eliminate global data access
 void BLSAnalyzer::visit(GlobalLoadStmt *stmt) {
-  TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
   record_access(stmt->src, AccessFlag::read);
 }
 
 void BLSAnalyzer::visit(GlobalStoreStmt *stmt) {
-  TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
   record_access(stmt->dest, AccessFlag::write);
 }
 

--- a/taichi/analysis/bls_analyzer.cpp
+++ b/taichi/analysis/bls_analyzer.cpp
@@ -47,8 +47,8 @@ void BLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
   coeffs.resize(ptr->indices.size());
   const int num_indices = (int)ptr->indices.size();
   for (int i = 0; i < num_indices; i++) {
-    auto diff = irpass::analysis::value_diff_loop_index(ptr->indices[i],
-                                                        for_stmt_, i);
+    auto diff =
+        irpass::analysis::value_diff_loop_index(ptr->indices[i], for_stmt_, i);
     if (diff.related() && diff.coeff > 0) {
       offsets[i].low = diff.low;
       offsets[i].high = diff.high;
@@ -68,8 +68,7 @@ void BLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
         return;
       }
       for (int i = (index_bounds[dimension].low + offsets[dimension].low);
-           i < (index_bounds[dimension].high + offsets[dimension].high);
-           i++) {
+           i < (index_bounds[dimension].high + offsets[dimension].high); i++) {
         index[dimension] = i;
         visit(dimension + 1);
       }

--- a/taichi/analysis/mesh_bls_analyzer.cpp
+++ b/taichi/analysis/mesh_bls_analyzer.cpp
@@ -35,38 +35,34 @@ void MeshBLSAnalyzer::record_access(Stmt *stmt, AccessFlag flag) {
   auto idx = conv->idx;
   if (conv_type == mesh::ConvType::g2r)
     return;
-  for (int l = 0; l < stmt->width(); l++) {
-    auto snode = ptr->snodes[l];
-    if (!caches_->has(snode)) {
-      if (auto_mesh_local_ &&
-          (flag == AccessFlag::accumulate ||
-           (flag == AccessFlag::read && config_.arch == Arch::cuda)) &&
-          (!idx->is<LoopIndexStmt>() ||
-           !idx->as<LoopIndexStmt>()->is_mesh_index())) {
-        caches_->insert(snode);
-      } else {
-        continue;
-      }
-    }
-    if (idx->is<MeshRelationAccessStmt>()) {
-      if (!caches_->access(snode, element_type, conv_type, flag,
-                           idx->as<MeshRelationAccessStmt>()->neighbor_idx)) {
-        analysis_ok_ = false;
-        break;
-      }
+  auto snode = ptr->snodes[0];
+  if (!caches_->has(snode)) {
+    if (auto_mesh_local_ &&
+        (flag == AccessFlag::accumulate ||
+         (flag == AccessFlag::read && config_.arch == Arch::cuda)) &&
+        (!idx->is<LoopIndexStmt>() ||
+         !idx->as<LoopIndexStmt>()->is_mesh_index())) {
+      caches_->insert(snode);
     } else {
-      // No optimization for front-end attribute access
+      return;
     }
+  }
+  if (idx->is<MeshRelationAccessStmt>()) {
+    if (!caches_->access(snode, element_type, conv_type, flag,
+                         idx->as<MeshRelationAccessStmt>()->neighbor_idx)) {
+      analysis_ok_ = false;
+      return;
+    }
+  } else {
+    // No optimization for front-end attribute access
   }
 }
 
 void MeshBLSAnalyzer::visit(GlobalLoadStmt *stmt) {
-  TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
   record_access(stmt->src, AccessFlag::read);
 }
 
 void MeshBLSAnalyzer::visit(GlobalStoreStmt *stmt) {
-  TI_ASSERT(stmt->width() == 1);  // TODO: support vectorization
   record_access(stmt->dest, AccessFlag::write);
 }
 

--- a/taichi/analysis/same_statements.cpp
+++ b/taichi/analysis/same_statements.cpp
@@ -137,7 +137,6 @@ class IRNodeComparator : public IRVisitor {
         // directly because that function does not support id_map.
 
         // TODO: Update this part if GlobalPtrStmt comes to have more fields
-        TI_ASSERT(stmt->width() == 1);
         if (stmt->as<GlobalPtrStmt>()->snodes[0]->id !=
             other->as<GlobalPtrStmt>()->snodes[0]->id) {
           same = false;

--- a/taichi/analysis/value_diff.cpp
+++ b/taichi/analysis/value_diff.cpp
@@ -82,7 +82,6 @@ class ValueDiffLoopIndex : public IRVisitor {
 
   void visit(ElementShuffleStmt *stmt) override {
     int old_lane = lane;
-    TI_ASSERT(stmt->width() == 1);
     auto src = stmt->elements[lane].stmt;
     lane = stmt->elements[lane].index;
     src->accept(this);
@@ -152,7 +151,6 @@ class FindDirectValueBaseAndOffset : public IRVisitor {
   }
 
   void visit(ConstStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     if (stmt->val[0].dt->is_primitive(PrimitiveTypeID::i32)) {
       result = std::make_tuple(true, nullptr, stmt->val[0].val_i32);
     }
@@ -195,7 +193,6 @@ DiffRange value_diff_loop_index(Stmt *stmt, Stmt *loop, int index_id) {
       return DiffRange(true, 1, 0);
     }
   }
-  TI_ASSERT(stmt->width() == 1);
   auto diff = ValueDiffLoopIndex(stmt, 0, loop, index_id);
   return diff.run();
 }

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -104,10 +104,8 @@ class IRVerifier : public BasicStmtVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     basic_verify(stmt);
-    for (int i = 0; i < stmt->width(); i++) {
-      TI_ASSERT(stmt->src[i].var->is<AllocaStmt>() ||
-                stmt->src[i].var->is<PtrOffsetStmt>());
-    }
+    TI_ASSERT(stmt->src[0].var->is<AllocaStmt>() ||
+              stmt->src[0].var->is<PtrOffsetStmt>());
   }
 
   void visit(LocalStoreStmt *stmt) override {

--- a/taichi/codegen/cc/codegen_cc.cpp
+++ b/taichi/codegen/cc/codegen_cc.cpp
@@ -125,19 +125,16 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(GlobalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     emit("{} = *{};",
          define_var(cc_data_type_name(stmt->element_type()), stmt->raw_name()),
          stmt->src->raw_name());
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     emit("*{} = {};", stmt->dest->raw_name(), stmt->val->raw_name());
   }
 
   void visit(GlobalTemporaryStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     auto ptr_type =
         cc_data_type_name(stmt->element_type().ptr_removed()) + " *";
     auto var = define_var(ptr_type, stmt->raw_name());
@@ -154,7 +151,6 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(ExternalPtrStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     std::string offset = "0";
     const auto *argload = stmt->base_ptrs[0]->as<ArgLoadStmt>();
     const int arg_id = argload->arg_id;
@@ -208,7 +204,6 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(ConstStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     emit("{} = {};",
          define_var(cc_data_type_name(stmt->element_type()), stmt->raw_name()),
          stmt->val[0].stringify());
@@ -226,8 +221,7 @@ class CCTransformer : public IRVisitor {
         linear_index = false;
       }
     }
-    TI_ASSERT(stmt->same_source() && linear_index &&
-              stmt->width() == stmt->src[0].var->width());
+    TI_ASSERT(stmt->same_source() && linear_index);
 
     auto var =
         define_var(cc_data_type_name(stmt->element_type()), stmt->raw_name());
@@ -334,7 +328,6 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(BinaryOpStmt *bin) override {
-    TI_ASSERT(bin->width() == 1);
     const auto dt_name = cc_data_type_name(bin->element_type());
     const auto lhs_name = bin->lhs->raw_name();
     const auto rhs_name = bin->rhs->raw_name();
@@ -371,7 +364,6 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(UnaryOpStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     const auto dt_name = cc_data_type_name(stmt->element_type());
     const auto operand_name = stmt->operand->raw_name();
     const auto dest_name = stmt->raw_name();
@@ -505,7 +497,6 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(RangeForStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     auto var = define_var("Ti_i32", stmt->raw_name());
     if (!stmt->reversed) {
       emit("for ({} = {}; {} < {}; {} += {}) {{", var, stmt->begin->raw_name(),
@@ -552,7 +543,6 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(AdStackAllocaStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     TI_ASSERT_INFO(
         stmt->max_size > 0,
         "Adaptive autodiff stack's size should have been determined.");

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -67,7 +67,6 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
   }
 
   void visit(PrintStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     TI_ASSERT_INFO(stmt->contents.size() < 32,
                    "CUDA `print()` doesn't support more than 32 entries");
 

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -151,8 +151,6 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(ConstStmt *const_stmt) override {
-    TI_ASSERT(const_stmt->width() == 1);
-
     auto get_const = [&](const TypedConstant &const_val) {
       auto dt = const_val.dt.ptr_removed();
       spirv::SType stype = ir_->get_primitive_type(dt);
@@ -243,8 +241,7 @@ class TaskCodegen : public IRVisitor {
         linear_index = false;
       }
     }
-    if (stmt->same_source() && linear_index &&
-        stmt->width() == stmt->src[0].var->width()) {
+    if (stmt->same_source() && linear_index) {
       auto ptr = stmt->src[0].var;
       spirv::Value ptr_val = ir_->query_value(ptr->raw_name());
       spirv::Value val = ir_->load_variable(
@@ -510,15 +507,12 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
-
     spirv::Value val = ir_->query_value(stmt->val->raw_name());
 
     store_buffer(stmt->dest, val);
   }
 
   void visit(GlobalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     auto dt = stmt->element_type();
 
     auto val = load_buffer(stmt->src, dt);
@@ -565,7 +559,6 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(GlobalTemporaryStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     spirv::Value val = ir_->int_immediate_number(ir_->i32_type(), stmt->offset,
                                                  false);  // Named Constant
     ir_->register_value(stmt->raw_name(), val);
@@ -594,7 +587,6 @@ class TaskCodegen : public IRVisitor {
   void visit(ExternalPtrStmt *stmt) override {
     // Used mostly for transferring data between host (e.g. numpy array) and
     // device.
-    TI_ASSERT(stmt->width() == 1);
     spirv::Value linear_offset = ir_->int_immediate_number(ir_->i32_type(), 0);
     const auto *argload = stmt->base_ptrs[0]->as<ArgLoadStmt>();
     const int arg_id = argload->arg_id;
@@ -1225,7 +1217,6 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(AtomicOpStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     const auto dt = stmt->dest->element_type().ptr_removed();
 
     spirv::Value data = ir_->query_value(stmt->val->raw_name());
@@ -1437,7 +1428,6 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(RangeForStmt *for_stmt) override {
-    TI_ASSERT(for_stmt->width() == 1);
     auto loop_var_name = for_stmt->raw_name();
     // Must get init label after making value(to make sure they are correct)
     spirv::Label init_label = ir_->current_label();

--- a/taichi/codegen/wasm/codegen_wasm.cpp
+++ b/taichi/codegen/wasm/codegen_wasm.cpp
@@ -113,7 +113,6 @@ class TaskCodeGenWASM : public TaskCodeGenLLVM {
   }
 
   void visit(PrintStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     std::vector<llvm::Value *> args;
     for (auto const &content : stmt->contents) {
       if (std::holds_alternative<Stmt *>(content)) {

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -192,7 +192,6 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
     if (!irpass::analysis::same_value(result, data)) {
       // check the special case of alloca (initialized to 0)
       if (!(result->is<AllocaStmt>() && data->is<ConstStmt>() &&
-            data->width() == 1 &&
             data->as<ConstStmt>()->val[0].equal_value(0))) {
         return false;  // return nullptr
       }
@@ -263,17 +262,7 @@ bool CFGNode::store_to_load_forwarding(bool after_lower_access,
     auto stmt = block->statements[i].get();
     Stmt *result = nullptr;
     if (auto local_load = stmt->cast<LocalLoadStmt>()) {
-      bool regular = true;
-      auto alloca = local_load->src[0].var;
-      for (int l = 0; l < stmt->width(); l++) {
-        if (local_load->src[l].offset != l ||
-            local_load->src[l].var != alloca) {
-          regular = false;
-        }
-      }
-      if (regular) {
-        result = get_store_forwarding_data(alloca, i);
-      }
+      result = get_store_forwarding_data(local_load->src[0].var, i);
     } else if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
       if (!after_lower_access && !autodiff_enabled) {
         result = get_store_forwarding_data(global_load->src, i);
@@ -284,7 +273,6 @@ bool CFGNode::store_to_load_forwarding(bool after_lower_access,
       if (result->is<AllocaStmt>()) {
         // special case of alloca (initialized to 0)
         auto zero = Stmt::make<ConstStmt>(TypedConstant(result->ret_type, 0));
-        zero->repeat(result->width());
         replace_with(i, std::move(zero), true);
       } else {
         stmt->replace_usages_with(result);
@@ -501,7 +489,7 @@ bool CFGNode::dead_store_elimination(bool after_lower_access) {
       }
     }
     auto load_ptrs = irpass::analysis::get_load_pointers(stmt);
-    if (load_ptrs.size() == 1 && store_ptrs.empty() && stmt->width() == 1) {
+    if (load_ptrs.size() == 1 && store_ptrs.empty()) {
       // Identical load elimination
       auto load_ptr = load_ptrs.front();
       if (!after_lower_access ||

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -494,10 +494,6 @@ class Stmt : public IRNode {
   Stmt();
   Stmt(const Stmt &stmt);
 
-  int width() const {
-    return ret_type->vector_width();
-  }
-
   virtual bool is_container_statement() const {
     return false;
   }
@@ -547,11 +543,6 @@ class Stmt : public IRNode {
   virtual void replace_operand_with(Stmt *old_stmt, Stmt *new_stmt);
 
   IRNode *get_parent() const override;
-
-  virtual void repeat(int factor) {
-    TI_ASSERT(factor == 1);
-    // ret_type.width *= factor;
-  }
 
   // returns the inserted stmt
   Stmt *insert_before_me(std::unique_ptr<Stmt> &&new_stmt);

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -208,11 +208,7 @@ bool LocalLoadStmt::same_source() const {
 }
 
 bool LocalLoadStmt::has_source(Stmt *alloca) const {
-  for (int i = 0; i < width(); i++) {
-    if (src[i].var == alloca)
-      return true;
-  }
-  return false;
+  return src[0].var == alloca;
 }
 
 IfStmt::IfStmt(Stmt *cond) : cond(cond) {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -744,11 +744,6 @@ class ConstStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  void repeat(int factor) override {
-    Stmt::repeat(factor);
-    val.repeat(factor);
-  }
-
   bool has_global_side_effect() const override {
     return false;
   }

--- a/taichi/ir/type.cpp
+++ b/taichi/ir/type.cpp
@@ -87,10 +87,6 @@ std::string TensorType::to_string() const {
   return s;
 }
 
-int Type::vector_width() const {
-  return 1;  // TODO: CPU vectorization
-}
-
 bool Type::is_primitive(PrimitiveTypeID type) const {
   if (auto p = cast<PrimitiveType>()) {
     return p->type == type;

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -38,8 +38,6 @@ class TI_DLL_EXPORT Type {
     return p;
   }
 
-  int vector_width() const;
-
   bool is_primitive(PrimitiveTypeID type) const;
 
   virtual Type *get_compute_type() {

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -220,9 +220,6 @@ class AlgSimp : public BasicStmtVisitor {
     }
     auto lhs = stmt->lhs->cast<ConstStmt>();
     auto rhs = stmt->rhs->cast<ConstStmt>();
-    if (stmt->width() != 1) {
-      return;
-    }
     if (stmt->op_type == BinaryOpType::mul) {
       optimize_multiplication(stmt);
     } else if (stmt->op_type == BinaryOpType::div ||
@@ -393,31 +390,31 @@ class AlgSimp : public BasicStmtVisitor {
   }
 
   static bool alg_is_zero(ConstStmt *stmt) {
-    if (!stmt || stmt->width() != 1)
+    if (!stmt)
       return false;
     return stmt->val[0].equal_value(0);
   }
 
   static bool alg_is_one(ConstStmt *stmt) {
-    if (!stmt || stmt->width() != 1)
+    if (!stmt)
       return false;
     return stmt->val[0].equal_value(1);
   }
 
   static bool alg_is_two(ConstStmt *stmt) {
-    if (!stmt || stmt->width() != 1)
+    if (!stmt)
       return false;
     return stmt->val[0].equal_value(2);
   }
 
   static bool alg_is_minus_one(ConstStmt *stmt) {
-    if (!stmt || stmt->width() != 1)
+    if (!stmt)
       return false;
     return stmt->val[0].equal_value(-1);
   }
 
   static bool alg_is_pot(ConstStmt *stmt) {
-    if (!stmt || stmt->width() != 1)
+    if (!stmt)
       return false;
     if (!is_integral(stmt->val[0].dt))
       return false;

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -253,7 +253,6 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
   void visit(Stmt *stmt) override {
     if (execute_once_)
       return;
-    TI_ASSERT(stmt->width() == 1);
     if (!(stmt->is<UnaryOpStmt>() || stmt->is<BinaryOpStmt>() ||
           stmt->is<TernaryOpStmt>() || stmt->is<BitExtractStmt>() ||
           stmt->is<GlobalLoadStmt>() || stmt->is<AllocaStmt>())) {
@@ -421,8 +420,6 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
   }
 
   void visit(AllocaStmt *alloc) override {
-    TI_ASSERT(alloc->width() == 1);
-
     bool is_stack_needed = AdStackAllocaJudger::run(alloc);
     if (is_stack_needed) {
       auto dtype = alloc->ret_type;
@@ -441,13 +438,11 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
   }
 
   void visit(LocalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     if (stmt->src[0].var->is<AdStackAllocaStmt>())
       stmt->replace_with(Stmt::make<AdStackLoadTopStmt>(stmt->src[0].var));
   }
 
   void visit(LocalStoreStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     if (stmt->dest->is<AdStackAllocaStmt>())
       stmt->replace_with(Stmt::make<AdStackPushStmt>(stmt->dest, stmt->val));
   }
@@ -719,7 +714,6 @@ class MakeAdjoint : public ADTransform {
     } else {
       TI_ASSERT(alloca_->is<AllocaStmt>());
       auto alloca = alloca_->as<AllocaStmt>();
-      TI_ASSERT(alloca->width() == 1);
       auto local_load = insert<LocalLoadStmt>(LocalAddress(alloca, 0));
       insert<LocalStoreStmt>(alloca, add(local_load, value));
     }
@@ -1011,7 +1005,6 @@ class MakeAdjoint : public ADTransform {
       src = stmt->src->as<GlobalPtrStmt>();
     }
 
-    TI_ASSERT(src->width() == 1);
     auto snodes = src->snodes;
     if (!snodes[0]->has_adjoint()) {
       // No adjoint SNode. Do nothing
@@ -1048,7 +1041,6 @@ class MakeAdjoint : public ADTransform {
       dest = stmt->dest->as<GlobalPtrStmt>();
     }
 
-    TI_ASSERT(dest->width() == 1);
     auto snodes = dest->snodes;
     if (!snodes[0]->has_adjoint()) {
       // no gradient (likely integer types)
@@ -1076,7 +1068,6 @@ class MakeAdjoint : public ADTransform {
       dest = stmt->dest->as<GlobalPtrStmt>();
     }
 
-    TI_ASSERT(dest->width() == 1);
     auto snodes = dest->snodes;
     if (!snodes[0]->has_adjoint()) {
       // no gradient (likely integer types)
@@ -1141,7 +1132,6 @@ class MakeDual : public ADTransform {
 
     TI_ASSERT(alloca_->is<AllocaStmt>());
     auto alloca = alloca_->as<AllocaStmt>();
-    TI_ASSERT(alloca->width() == 1);
     auto local_load = insert<LocalLoadStmt>(LocalAddress(alloca, 0));
     insert<LocalStoreStmt>(alloca, add(local_load, value));
   }
@@ -1341,7 +1331,6 @@ class MakeDual : public ADTransform {
     } else {
       src = stmt->src->as<GlobalPtrStmt>();
     }
-    TI_ASSERT(src->width() == 1);
     auto snodes = src->snodes;
     if (!snodes[0]->has_dual()) {
       // No dual SNode. Do nothing
@@ -1370,7 +1359,6 @@ class MakeDual : public ADTransform {
     } else {
       dest = stmt->dest->as<GlobalPtrStmt>();
     }
-    TI_ASSERT(dest->width() == 1);
     auto snodes = dest->snodes;
     if (!snodes[0]->has_dual()) {
       // no gradient (likely integer types)
@@ -1395,7 +1383,6 @@ class MakeDual : public ADTransform {
     } else {
       dest = stmt->dest->as<GlobalPtrStmt>();
     }
-    TI_ASSERT(dest->width() == 1);
     auto snodes = dest->snodes;
     if (!snodes[0]->has_dual()) {
       // no gradient (likely integer types)
@@ -1426,7 +1413,7 @@ class BackupSSA : public BasicStmtVisitor {
 
   Stmt *load(Stmt *stmt) {
     if (backup_alloca.find(stmt) == backup_alloca.end()) {
-      auto alloca = Stmt::make<AllocaStmt>(stmt->width(), stmt->ret_type);
+      auto alloca = Stmt::make<AllocaStmt>(1, stmt->ret_type);
       auto alloca_ptr = alloca.get();
       independent_block->insert(std::move(alloca), 0);
       auto local_store = Stmt::make<LocalStoreStmt>(alloca_ptr, stmt);
@@ -1474,7 +1461,6 @@ class BackupSSA : public BasicStmtVisitor {
           }
         } else {
           auto alloca = load(op);
-          TI_ASSERT(op->width() == 1);
           stmt->set_operand(i, stmt->insert_before_me(Stmt::make<LocalLoadStmt>(
                                    LocalAddress(alloca, 0))));
         }
@@ -1568,7 +1554,6 @@ class GloablDataAccessRuleChecker : public BasicStmtVisitor {
 
   void visit(GlobalLoadStmt *stmt) override {
     GlobalPtrStmt *src = stmt->src->as<GlobalPtrStmt>();
-    TI_ASSERT(src->width() == 1);
     auto snodes = src->snodes;
     if (!snodes[0]->has_adjoint_checkbit()) {
       return;
@@ -1583,7 +1568,6 @@ class GloablDataAccessRuleChecker : public BasicStmtVisitor {
   }
 
   void visit_gloabl_store_stmt_and_atomic_add(Stmt *stmt, GlobalPtrStmt *dest) {
-    TI_ASSERT(dest->width() == 1);
     auto snodes = dest->snodes;
     if (!snodes[0]->has_adjoint_checkbit()) {
       return;

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -137,8 +137,6 @@ class ConstantFold : public BasicStmtVisitor {
     auto rhs = stmt->rhs->cast<ConstStmt>();
     if (!lhs || !rhs)
       return;
-    if (stmt->width() != 1)
-      return;
     auto dst_type = stmt->ret_type;
     TypedConstant new_constant(dst_type);
 
@@ -169,9 +167,6 @@ class ConstantFold : public BasicStmtVisitor {
     auto operand = stmt->operand->cast<ConstStmt>();
     if (!operand)
       return;
-    if (stmt->width() != 1) {
-      return;
-    }
     if (stmt->is_cast()) {
       bool cast_available = true;
       TypedConstant new_constant(stmt->ret_type);
@@ -210,8 +205,6 @@ class ConstantFold : public BasicStmtVisitor {
   void visit(BitExtractStmt *stmt) override {
     auto input = stmt->input->cast<ConstStmt>();
     if (!input)
-      return;
-    if (stmt->width() != 1)
       return;
     std::unique_ptr<Stmt> result_stmt;
     if (is_signed(input->val[0].dt)) {

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -123,7 +123,6 @@ class DemoteAtomics : public BasicStmtVisitor {
       auto new_stmts = VecStatement();
       Stmt *load;
       if (is_local) {
-        TI_ASSERT(stmt->width() == 1);
         load = new_stmts.push_back<LocalLoadStmt>(LocalAddress(ptr, 0));
         auto bin = new_stmts.push_back<BinaryOpStmt>(bin_type, load, val);
         new_stmts.push_back<LocalStoreStmt>(ptr, bin);

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -391,18 +391,13 @@ class IRPrinter : public IRVisitor {
     std::string s =
         fmt::format("{}{} = global ptr [", stmt->type_hint(), stmt->name());
 
-    for (int l = 0; l < stmt->width(); l++) {
-      std::string snode_name;
-      if (stmt->snodes[l]) {
-        snode_name = stmt->snodes[l]->get_node_type_name_hinted();
-      } else {
-        snode_name = "unknown";
-      }
-      s += snode_name;
-      if (l + 1 < stmt->width()) {
-        s += ", ";
-      }
+    std::string snode_name;
+    if (stmt->snodes[0]) {
+      snode_name = stmt->snodes[0]->get_node_type_name_hinted();
+    } else {
+      snode_name = "unknown";
     }
+    s += snode_name;
     s += "], index [";
     for (int i = 0; i < (int)stmt->indices.size(); i++) {
       s += fmt::format("{}", stmt->indices[i]->name());

--- a/taichi/transforms/make_block_local.cpp
+++ b/taichi/transforms/make_block_local.cpp
@@ -216,7 +216,6 @@ void make_block_local_offload(OffloadedStmt *offload,
       // TODO: no more abuse of gather_statements...
       irpass::analysis::gather_statements(offload->body.get(), [&](Stmt *stmt) {
         if (auto global_ptr = stmt->cast<GlobalPtrStmt>()) {
-          TI_ASSERT(global_ptr->width() == 1);
           if (global_ptr->snodes[0] == snode) {
             global_ptrs.push_back(global_ptr);
           }

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -100,7 +100,6 @@ void MakeMeshBlockLocal::replace_global_ptrs(SNode *snode) {
   std::vector<GlobalPtrStmt *> global_ptrs;
   irpass::analysis::gather_statements(offload_->body.get(), [&](Stmt *stmt) {
     if (auto global_ptr = stmt->cast<GlobalPtrStmt>()) {
-      TI_ASSERT(global_ptr->width() == 1);
       if (global_ptr->snodes[0] == snode &&
           global_ptr->indices[0]->is<MeshIndexConversionStmt>()) {
         global_ptrs.push_back(global_ptr);

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -87,7 +87,6 @@ std::vector<std::pair<T *, AtomicOpType>> find_global_reduction_destinations(
           return false;  // Now we are sure the statement is not related to the
                          // destination
         });
-    TI_ASSERT(dest.first->width() == 1);
     if (related_global_mem_ops.empty() && dest_checker(dest.first)) {
       valid_reduction_values.push_back(dest);
     }

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -335,7 +335,6 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   }
 
   std::size_t allocate_global(DataType type) {
-    TI_ASSERT(type->vector_width() == 1 || type->is<TensorType>());
     auto ret = global_offset_;
     if (type->is<TensorType>()) {
       auto tensor_type = type->cast<TensorType>();
@@ -551,7 +550,7 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
       }
     } else {
       LaneAttribute<TypedConstant> zeros(std::vector<TypedConstant>(
-          stmt->width(), TypedConstant(stmt->ret_type)));
+          1, TypedConstant(stmt->ret_type)));
       auto const_zeros = replacement.push_back<ConstStmt>(zeros);
       auto global_store_stmt =
           replacement.push_back<GlobalStoreStmt>(ptr, const_zeros);
@@ -566,7 +565,6 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
   // Replace local LD/ST with global LD/ST
   void visit(LocalLoadStmt *stmt) override {
     generic_visit(stmt);
-    TI_ASSERT(stmt->width() == 1)
     auto ptr = stmt->src[0].var;
     auto top_level_ptr = SquashPtrOffset::run(ptr);
     if (top_level_ptr->is<GlobalTemporaryStmt>()) {
@@ -653,7 +651,6 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
   }
 
   void visit(Stmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1)
     generic_visit(stmt);
   }
 

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -549,8 +549,8 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
         stmt_to_offloaded_[global_store_stmt] = offloaded;
       }
     } else {
-      LaneAttribute<TypedConstant> zeros(std::vector<TypedConstant>(
-          1, TypedConstant(stmt->ret_type)));
+      LaneAttribute<TypedConstant> zeros(
+          std::vector<TypedConstant>(1, TypedConstant(stmt->ret_type)));
       auto const_zeros = replacement.push_back<ConstStmt>(zeros);
       auto global_store_stmt =
           replacement.push_back<GlobalStoreStmt>(ptr, const_zeros);

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -13,7 +13,6 @@ static_assert(
     sizeof(real) == sizeof(float32),
     "Please build the taichi compiler with single precision (TI_USE_DOUBLE=0)");
 
-// "Type" here does not include vector width
 // Var lookup and Type inference
 class TypeCheck : public IRVisitor {
  private:
@@ -78,7 +77,6 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(AtomicOpStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     // TODO(type): test_ad_for fails if we assume dest is a pointer type.
     stmt->ret_type = type_check_store(
         stmt, stmt->dest, stmt->val,
@@ -86,7 +84,6 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(LocalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->width() == 1);
     TI_ASSERT_INFO(stmt->src.size() == 1, "Vectorization has been disabled.");
     TI_ASSERT(stmt->src[0].var->is<AllocaStmt>() ||
               stmt->src[0].var->is<PtrOffsetStmt>());
@@ -171,7 +168,6 @@ class TypeCheck : public IRVisitor {
         stmt->indices[i] =
             insert_type_cast_before(stmt, stmt->indices[i], PrimitiveType::i32);
       }
-      TI_ASSERT(stmt->indices[i]->width() == stmt->snodes.size());
     }
   }
 
@@ -352,7 +348,6 @@ class TypeCheck : public IRVisitor {
       }
     }
     bool matching = true;
-    matching = matching && (stmt->lhs->width() == stmt->rhs->width());
     matching = matching && (stmt->lhs->ret_type != PrimitiveType::unknown);
     matching = matching && (stmt->rhs->ret_type != PrimitiveType::unknown);
     matching = matching && (stmt->lhs->ret_type == stmt->rhs->ret_type);
@@ -360,8 +355,7 @@ class TypeCheck : public IRVisitor {
       error();
     }
     if (is_comparison(stmt->op_type)) {
-      stmt->ret_type = TypeFactory::create_vector_or_scalar_type(
-          stmt->lhs->width(), PrimitiveType::i32);
+      stmt->ret_type = PrimitiveType::i32;
     } else {
       stmt->ret_type = stmt->lhs->ret_type;
     }
@@ -370,9 +364,7 @@ class TypeCheck : public IRVisitor {
   void visit(TernaryOpStmt *stmt) override {
     if (stmt->op_type == TernaryOpType::select) {
       auto ret_type = promoted_type(stmt->op2->ret_type, stmt->op3->ret_type);
-      TI_ASSERT(stmt->op1->ret_type->is_primitive(PrimitiveTypeID::i32))
-      TI_ASSERT(stmt->op1->width() == stmt->op2->width());
-      TI_ASSERT(stmt->op2->width() == stmt->op3->width());
+      TI_ASSERT(stmt->op1->ret_type->is_primitive(PrimitiveTypeID::i32));
       if (ret_type != stmt->op2->ret_type) {
         auto cast_stmt = insert_type_cast_before(stmt, stmt->op2, ret_type);
         stmt->op2 = cast_stmt;
@@ -381,8 +373,7 @@ class TypeCheck : public IRVisitor {
         auto cast_stmt = insert_type_cast_before(stmt, stmt->op3, ret_type);
         stmt->op3 = cast_stmt;
       }
-      stmt->ret_type = TypeFactory::create_vector_or_scalar_type(
-          stmt->op1->width(), ret_type);
+      stmt->ret_type = ret_type;
     } else {
       TI_NOT_IMPLEMENTED
     }
@@ -414,13 +405,11 @@ class TypeCheck : public IRVisitor {
     // TODO: Maybe have a type_inference() pass, which takes in the args/rets
     // defined by the kernel. After that, type_check() pass will purely do
     // verification, without modifying any types.
-    TI_ASSERT(stmt->width() == 1);
     stmt->ret_type.set_is_pointer(stmt->is_ptr);
   }
 
   void visit(ReturnStmt *stmt) override {
     // TODO: Support stmt->ret_id?
-    TI_ASSERT(stmt->width() == 1);
   }
 
   void visit(ExternalPtrStmt *stmt) override {
@@ -478,7 +467,6 @@ class TypeCheck : public IRVisitor {
       stmt->ret_type = DataType(ptr_ret_type);
       return;
     }
-    TI_ASSERT(stmt->width() == 1);
     auto element_type = stmt->output_snode->dt;
     // For bit_struct SNodes, their component SNodes must have
     // is_bit_level=true

--- a/taichi/transforms/unreachable_code_elimination.cpp
+++ b/taichi/transforms/unreachable_code_elimination.cpp
@@ -103,7 +103,7 @@ class UnreachableCodeEliminator : public BasicStmtVisitor {
   }
 
   void visit(IfStmt *if_stmt) override {
-    if (if_stmt->cond->is<ConstStmt>() && if_stmt->cond->width() == 1) {
+    if (if_stmt->cond->is<ConstStmt>()) {
       if (if_stmt->cond->as<ConstStmt>()->val[0].equal_value(0)) {
         // if (0)
         if (if_stmt->false_statements) {


### PR DESCRIPTION
Related issue = #4096

This is one step of removing legacy incomplete vectorization on CPU for better maintainability of current codebase.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
