### PR TITLE
[refactor] [ir] Remove legacy ElementShuffleStmt

### DIFF
--- a/taichi/analysis/value_diff.cpp
+++ b/taichi/analysis/value_diff.cpp
@@ -80,15 +80,6 @@ class ValueDiffLoopIndex : public IRVisitor {
     }
   }
 
-  void visit(ElementShuffleStmt *stmt) override {
-    int old_lane = lane;
-    auto src = stmt->elements[lane].stmt;
-    lane = stmt->elements[lane].index;
-    src->accept(this);
-    results[stmt->instance_id] = results[src->instance_id];
-    lane = old_lane;
-  }
-
   void visit(ConstStmt *stmt) override {
     if (stmt->val[lane].dt->is_primitive(PrimitiveTypeID::i32)) {
       results[stmt->instance_id] = DiffRange(true, 0, stmt->val[lane].val_i32);

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1508,24 +1508,6 @@ void TaskCodeGenLLVM::visit(GlobalLoadStmt *stmt) {
   create_global_load(stmt, false);
 }
 
-void TaskCodeGenLLVM::visit(ElementShuffleStmt *stmt){
-    TI_NOT_IMPLEMENTED
-    /*
-    auto init = stmt->elements.serialize(
-        [](const VectorElement &elem) {
-          return fmt::format("{}[{}]", elem.stmt->raw_name(), elem.index);
-        },
-        "{");
-    if (stmt->pointer) {
-      emit("{} * const {} [{}] {};", data_type_name(stmt->ret_type),
-           stmt->raw_name(), stmt->width(), init);
-    } else {
-      emit("const {} {} ({});", stmt->ret_data_type_name(), stmt->raw_name(),
-           init);
-    }
-    */
-}
-
 std::string TaskCodeGenLLVM::get_runtime_snode_name(SNode *snode) {
   if (snode->type == SNodeType::root) {
     return "Root";

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -280,8 +280,6 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void visit(GlobalLoadStmt *stmt) override;
 
-  void visit(ElementShuffleStmt *stmt) override;
-
   void visit(GetRootStmt *stmt) override;
 
   void visit(BitExtractStmt *stmt) override;

--- a/taichi/inc/statements.inc.h
+++ b/taichi/inc/statements.inc.h
@@ -59,7 +59,6 @@ PER_STATEMENT(GetChStmt)
 // With per-lane attributes
 PER_STATEMENT(LocalLoadStmt)
 PER_STATEMENT(GlobalPtrStmt)
-PER_STATEMENT(ElementShuffleStmt)
 
 // Offloaded
 PER_STATEMENT(OffloadedStmt)

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -974,28 +974,6 @@ class WhileStmt : public Stmt {
   TI_DEFINE_ACCEPT
 };
 
-// TODO: document for this
-class ElementShuffleStmt : public Stmt {
- public:
-  LaneAttribute<VectorElement> elements;
-  bool pointer;
-
-  explicit ElementShuffleStmt(const LaneAttribute<VectorElement> &elements,
-                              bool pointer = false)
-      : elements(elements), pointer(pointer) {
-    TI_ASSERT(elements.size() == 1);  // TODO: support vectorized cases
-    ret_type = elements[0].stmt->element_type();
-    TI_STMT_REG_FIELDS;
-  }
-
-  bool has_global_side_effect() const override {
-    return false;
-  }
-
-  TI_STMT_DEF_FIELDS(ret_type, elements, pointer);
-  TI_DEFINE_ACCEPT_AND_CLONE
-};
-
 // TODO: remove this (replace with input + ConstStmt(offset))
 class IntegerOffsetStmt : public Stmt {
  public:

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -625,10 +625,6 @@ class ADTransform : public IRVisitor {
     return false;
   }
 
-  void visit(ElementShuffleStmt *stmt) override {
-    TI_NOT_IMPLEMENTED
-  }
-
   void visit(AssertStmt *stmt) override {
     // do nothing
   }

--- a/taichi/transforms/demote_operations.cpp
+++ b/taichi/transforms/demote_operations.cpp
@@ -67,7 +67,7 @@ class DemoteOperations : public BasicStmtVisitor {
                                              cond12.get(), cond3.get());
         auto real_ret =
             Stmt::make<BinaryOpStmt>(BinaryOpType::add, ret.get(), cond.get());
-
+        real_ret->ret_type = stmt->ret_type;
         stmt->replace_usages_with(real_ret.get());
         modifier.insert_before(stmt, std::move(ret));
         modifier.insert_before(stmt, std::move(zero));
@@ -89,6 +89,7 @@ class DemoteOperations : public BasicStmtVisitor {
         //     return ti.floor(r)
         auto div = Stmt::make<BinaryOpStmt>(BinaryOpType::div, lhs, rhs);
         auto floor = Stmt::make<UnaryOpStmt>(UnaryOpType::floor, div.get());
+        floor->ret_type = stmt->ret_type;
         stmt->replace_usages_with(floor.get());
         modifier.insert_before(stmt, std::move(div));
         modifier.insert_before(stmt, std::move(floor));
@@ -112,6 +113,7 @@ class DemoteOperations : public BasicStmtVisitor {
       auto signed_cast =
           Stmt::make<UnaryOpStmt>(UnaryOpType::cast_bits, shift.get());
       signed_cast->as<UnaryOpStmt>()->cast_type = lhs->element_type();
+      signed_cast->ret_type = stmt->ret_type;
       stmt->replace_usages_with(signed_cast.get());
       modifier.insert_before(stmt, std::move(unsigned_cast));
       modifier.insert_before(stmt, std::move(shift));

--- a/taichi/transforms/demote_operations.cpp
+++ b/taichi/transforms/demote_operations.cpp
@@ -29,7 +29,7 @@ class DemoteOperations : public BasicStmtVisitor {
                       (1LL << (stmt->bit_end - stmt->bit_begin)) - 1)));
     auto ret = statements.push_back<BinaryOpStmt>(BinaryOpType::bit_and,
                                                   input_sar_begin, mask);
-
+    ret->ret_type = stmt->ret_type;
     stmt->replace_usages_with(ret);
     modifier.insert_before(stmt, std::move(statements));
     modifier.erase(stmt);

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -463,13 +463,6 @@ class IRPrinter : public IRVisitor {
           stmt->dest->name(), stmt->val->name());
   }
 
-  void visit(ElementShuffleStmt *stmt) override {
-    print("{}{} = shuffle {}", stmt->type_hint(), stmt->name(),
-          stmt->elements.serialize([](const VectorElement &ve) {
-            return fmt::format("{}[{}]", ve.stmt->name(), ve.index);
-          }));
-  }
-
   void visit(RangeAssumptionStmt *stmt) override {
     print("{}{} = assume_in_range({}{:+d} <= {} < {}{:+d})", stmt->type_hint(),
           stmt->name(), stmt->base->name(), stmt->low, stmt->input->name(),

--- a/taichi/transforms/lower_access.cpp
+++ b/taichi/transforms/lower_access.cpp
@@ -91,55 +91,30 @@ class LowerAccess : public IRVisitor {
     current_struct_for = nullptr;
   }
 
-  void lower_scalar_ptr(SNode *leaf_snode,
-                        const std::vector<Stmt *> indices,
-                        const bool pointer_needs_activation,
-                        const SNodeOpType snode_op,
-                        const bool is_bit_vectorized,
-                        VecStatement *lowered) {
+  VecStatement lower_ptr(GlobalPtrStmt *ptr, bool activate,
+                         SNodeOpType snode_op = SNodeOpType::undefined) {
+    VecStatement lowered;
     if (snode_op == SNodeOpType::is_active) {
       // For ti.is_active
-      TI_ASSERT(!pointer_needs_activation);
+      TI_ASSERT(!activate);
     }
-
-    PtrLowererImpl lowerer{leaf_snode,        indices, snode_op,
-                           is_bit_vectorized, lowered, packed};
-    lowerer.set_pointer_needs_activation(pointer_needs_activation);
+    PtrLowererImpl lowerer{ptr->snodes[0], ptr->indices, snode_op,
+                           ptr->is_bit_vectorized, &lowered, packed};
+    lowerer.set_pointer_needs_activation(activate);
     lowerer.set_lower_access(this);
     lowerer.run();
-  }
-
-  VecStatement lower_vector_ptr(GlobalPtrStmt *ptr,
-                                bool activate,
-                                SNodeOpType snode_op = SNodeOpType::undefined) {
-    VecStatement lowered;
-    std::vector<Stmt *> lowered_pointers;
-    std::vector<Stmt *> indices;
-    for (int k = 0; k < (int)ptr->indices.size(); k++) {
-      auto extractor =
-          Stmt::make<ElementShuffleStmt>(VectorElement(ptr->indices[k], 0));
-      indices.push_back(extractor.get());
-      lowered.push_back(std::move(extractor));
-    }
-    lower_scalar_ptr(ptr->snodes[0], indices, activate, snode_op,
-                     ptr->is_bit_vectorized, &lowered);
     TI_ASSERT(lowered.size() > 0);
-    lowered_pointers.push_back(lowered.back().get());
-    // create shuffle
-    LaneAttribute<VectorElement> lanes;
-    lanes.push_back(VectorElement(lowered_pointers[0], 0));
-    auto merge = Stmt::make<ElementShuffleStmt>(lanes, true);
+    auto lowered_ptr = lowered.back().get();
     if (ptr->is_bit_vectorized) {
       // if the global ptr is bit vectorized, we start from the place snode
       // and find the parent quant array snode, use its physical type
       auto parent_ret_type = ptr->snodes[0]->parent->physical_type;
       auto ptr_ret_type =
           TypeFactory::get_instance().get_pointer_type(parent_ret_type);
-      merge->ret_type = DataType(ptr_ret_type);
+      lowered_ptr->ret_type = DataType(ptr_ret_type);
     } else {
-      merge->ret_type = ptr->snodes[0]->dt;
+      lowered_ptr->ret_type = ptr->snodes[0]->dt;
     }
-    lowered.push_back(std::move(merge));
     return lowered;
   }
 
@@ -147,7 +122,7 @@ class LowerAccess : public IRVisitor {
     if (!stmt->src->is<GlobalPtrStmt>())
       return;
     // No need to activate for all read accesses
-    auto lowered = lower_vector_ptr(stmt->src->as<GlobalPtrStmt>(), false);
+    auto lowered = lower_ptr(stmt->src->as<GlobalPtrStmt>(), false);
     stmt->src = lowered.back().get();
     modifier.insert_before(stmt, std::move(lowered));
   }
@@ -159,7 +134,7 @@ class LowerAccess : public IRVisitor {
     auto ptr = stmt->origin->as<GlobalPtrStmt>();
     // If ptr already has activate = false, no need to activate all the
     // generated micro-access ops. Otherwise, activate the nodes.
-    auto lowered = lower_vector_ptr(ptr, ptr->activate);
+    auto lowered = lower_ptr(ptr, ptr->activate);
     stmt->origin = lowered.back().get();
     modifier.insert_before(stmt, std::move(lowered));
   }
@@ -170,7 +145,7 @@ class LowerAccess : public IRVisitor {
     auto ptr = stmt->dest->as<GlobalPtrStmt>();
     // If ptr already has activate = false, no need to activate all the
     // generated micro-access ops. Otherwise, activate the nodes.
-    auto lowered = lower_vector_ptr(ptr, ptr->activate);
+    auto lowered = lower_ptr(ptr, ptr->activate);
     stmt->dest = lowered.back().get();
     modifier.insert_before(stmt, std::move(lowered));
   }
@@ -179,11 +154,11 @@ class LowerAccess : public IRVisitor {
     if (stmt->ptr->is<GlobalPtrStmt>()) {
       if (SNodeOpStmt::activation_related(stmt->op_type) &&
           stmt->snode->type != SNodeType::dynamic) {
-        auto lowered = lower_vector_ptr(stmt->ptr->as<GlobalPtrStmt>(), false,
-                                        stmt->op_type);
+        auto lowered =
+            lower_ptr(stmt->ptr->as<GlobalPtrStmt>(), false, stmt->op_type);
         modifier.replace_with(stmt, std::move(lowered), true);
       } else if (stmt->op_type == SNodeOpType::get_addr) {
-        auto lowered = lower_vector_ptr(stmt->ptr->as<GlobalPtrStmt>(), false);
+        auto lowered = lower_ptr(stmt->ptr->as<GlobalPtrStmt>(), false);
         auto cast = lowered.push_back<UnaryOpStmt>(UnaryOpType::cast_bits,
                                                    lowered.back().get());
         cast->cast_type = TypeFactory::get_instance().get_primitive_type(
@@ -191,9 +166,8 @@ class LowerAccess : public IRVisitor {
         stmt->ptr = lowered.back().get();
         modifier.replace_with(stmt, std::move(lowered));
       } else {
-        auto lowered =
-            lower_vector_ptr(stmt->ptr->as<GlobalPtrStmt>(),
-                             SNodeOpStmt::need_activation(stmt->op_type));
+        auto lowered = lower_ptr(stmt->ptr->as<GlobalPtrStmt>(),
+                                 SNodeOpStmt::need_activation(stmt->op_type));
         stmt->ptr = lowered.back().get();
         modifier.insert_before(stmt, std::move(lowered));
       }
@@ -204,9 +178,8 @@ class LowerAccess : public IRVisitor {
     if (!lower_atomic_ptr)
       return;
     if (stmt->dest->is<GlobalPtrStmt>()) {
-      auto lowered =
-          lower_vector_ptr(stmt->dest->as<GlobalPtrStmt>(),
-                           stmt->dest->as<GlobalPtrStmt>()->activate);
+      auto lowered = lower_ptr(stmt->dest->as<GlobalPtrStmt>(),
+                               stmt->dest->as<GlobalPtrStmt>()->activate);
       stmt->dest = lowered.back().get();
       modifier.insert_before(stmt, std::move(lowered));
     }
@@ -214,7 +187,7 @@ class LowerAccess : public IRVisitor {
 
   void visit(LocalStoreStmt *stmt) override {
     if (stmt->val->is<GlobalPtrStmt>()) {
-      auto lowered = lower_vector_ptr(stmt->val->as<GlobalPtrStmt>(), true);
+      auto lowered = lower_ptr(stmt->val->as<GlobalPtrStmt>(), true);
       stmt->val = lowered.back().get();
       modifier.insert_before(stmt, std::move(lowered));
     }

--- a/taichi/transforms/lower_access.cpp
+++ b/taichi/transforms/lower_access.cpp
@@ -91,15 +91,16 @@ class LowerAccess : public IRVisitor {
     current_struct_for = nullptr;
   }
 
-  VecStatement lower_ptr(GlobalPtrStmt *ptr, bool activate,
+  VecStatement lower_ptr(GlobalPtrStmt *ptr,
+                         bool activate,
                          SNodeOpType snode_op = SNodeOpType::undefined) {
     VecStatement lowered;
     if (snode_op == SNodeOpType::is_active) {
       // For ti.is_active
       TI_ASSERT(!activate);
     }
-    PtrLowererImpl lowerer{ptr->snodes[0], ptr->indices, snode_op,
-                           ptr->is_bit_vectorized, &lowered, packed};
+    PtrLowererImpl lowerer{ptr->snodes[0],         ptr->indices, snode_op,
+                           ptr->is_bit_vectorized, &lowered,     packed};
     lowerer.set_pointer_needs_activation(activate);
     lowerer.set_lower_access(this);
     lowerer.run();

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -69,17 +69,6 @@ class BasicBlockSimplify : public IRVisitor {
     return ir_modified;
   }
 
-  void visit(ElementShuffleStmt *stmt) override {
-    if (is_done(stmt))
-      return;
-    // is this stmt necessary?
-    // useless shuffle.
-    stmt->replace_usages_with(stmt->elements[0].stmt);
-    modifier.erase(stmt);
-
-    set_done(stmt);
-  }
-
   void visit(GlobalLoadStmt *stmt) override {
     if (is_done(stmt))
       return;

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -379,11 +379,6 @@ class TypeCheck : public IRVisitor {
     }
   }
 
-  void visit(ElementShuffleStmt *stmt) override {
-    TI_ASSERT(stmt->elements.size() != 0);
-    stmt->element_type() = stmt->elements[0].stmt->element_type();
-  }
-
   void visit(RangeAssumptionStmt *stmt) override {
     stmt->ret_type = stmt->input->ret_type;
   }


### PR DESCRIPTION
Related issue = #4096

In this PR, `lower_vector_ptr()` is rewritten and renamed to `lower_ptr()` so that the legacy `ElementShuffleStmt` can be fully removed.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
