### PR TITLE
[Bug] [lang] Fix printing i8/u8

### DIFF
--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -87,6 +87,14 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
           value_type = tlctx->get_data_type(PrimitiveType::f64);
           value = builder->CreateFPExt(value, value_type);
         }
+        if (arg_stmt->ret_type->is_primitive(PrimitiveTypeID::i8)) {
+          value_type = tlctx->get_data_type(PrimitiveType::i16);
+          value = builder->CreateSExt(value, value_type);
+        }
+        if (arg_stmt->ret_type->is_primitive(PrimitiveTypeID::u8)) {
+          value_type = tlctx->get_data_type(PrimitiveType::u16);
+          value = builder->CreateZExt(value, value_type);
+        }
 
         types.push_back(value_type);
         values.push_back(value);

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -813,6 +813,10 @@ void TaskCodeGenLLVM::visit(PrintStmt *stmt) {
         dtype->is_primitive(PrimitiveTypeID::f16))
       return this->builder->CreateFPExt(
           to_print, this->tlctx->get_data_type(PrimitiveType::f64));
+    if (dtype->is_primitive(PrimitiveTypeID::i8))
+      return builder->CreateSExt(to_print, tlctx->get_data_type(PrimitiveType::i16));
+    if (dtype->is_primitive(PrimitiveTypeID::u8))
+      return builder->CreateZExt(to_print, tlctx->get_data_type(PrimitiveType::u16));
     return to_print;
   };
   for (auto const &content : stmt->contents) {

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -814,9 +814,11 @@ void TaskCodeGenLLVM::visit(PrintStmt *stmt) {
       return this->builder->CreateFPExt(
           to_print, this->tlctx->get_data_type(PrimitiveType::f64));
     if (dtype->is_primitive(PrimitiveTypeID::i8))
-      return builder->CreateSExt(to_print, tlctx->get_data_type(PrimitiveType::i16));
+      return builder->CreateSExt(to_print,
+                                 tlctx->get_data_type(PrimitiveType::i16));
     if (dtype->is_primitive(PrimitiveTypeID::u8))
-      return builder->CreateZExt(to_print, tlctx->get_data_type(PrimitiveType::u16));
+      return builder->CreateZExt(to_print,
+                                 tlctx->get_data_type(PrimitiveType::u16));
     return to_print;
   };
   for (auto const &content : stmt->contents) {

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -84,7 +84,11 @@ std::string tensor_type_format(DataType t) {
 }
 
 std::string data_type_format(DataType dt) {
-  if (dt->is_primitive(PrimitiveTypeID::i16)) {
+  if (dt->is_primitive(PrimitiveTypeID::i8)) {
+    return "%hhd";
+  } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
+    return "%hhu";
+  } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
     return "%hd";
   } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
     return "%hu";

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -85,9 +85,11 @@ std::string tensor_type_format(DataType t) {
 
 std::string data_type_format(DataType dt) {
   if (dt->is_primitive(PrimitiveTypeID::i8)) {
-    return "%hhd";
+    // i8/u8 is converted to i16/u16 before printing, because CUDA doesn't
+    // support the "%hhd"/"%hhu" specifiers.
+    return "%hd";
   } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
-    return "%hhu";
+    return "%hu";
   } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
     return "%hd";
   } else if (dt->is_primitive(PrimitiveTypeID::u16)) {

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -8,10 +8,7 @@ from tests import test_utils
 # Just making sure it does not crash
 # Metal doesn't support print() or 64-bit data
 # While OpenGL does support print, but not 64-bit data
-@pytest.mark.parametrize('dt', [
-    ti.i8, ti.u8, ti.i16, ti.u16, ti.i32, ti.u32, ti.i64, ti.u64, ti.f16,
-    ti.f32, ti.f64
-])
+@pytest.mark.parametrize('dt', ti.types.primitive_types.all_types)
 @test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_print(dt):
     @ti.kernel

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -13,7 +13,7 @@ from tests import test_utils
 def test_print(dt):
     @ti.kernel
     def func():
-        print(ti.cast(1234.5, dt))
+        print(ti.cast(123.4, dt))
 
     func()
     # Discussion: https://github.com/taichi-dev/taichi/issues/1063#issuecomment-636421904

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -8,7 +8,10 @@ from tests import test_utils
 # Just making sure it does not crash
 # Metal doesn't support print() or 64-bit data
 # While OpenGL does support print, but not 64-bit data
-@pytest.mark.parametrize('dt', [ti.i8, ti.u8, ti.i16, ti.u16, ti.i32, ti.u32, ti.i64, ti.u64, ti.f16, ti.f32, ti.f64])
+@pytest.mark.parametrize('dt', [
+    ti.i8, ti.u8, ti.i16, ti.u16, ti.i32, ti.u32, ti.i64, ti.u64, ti.f16,
+    ti.f32, ti.f64
+])
 @test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_print(dt):
     @ti.kernel

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -8,8 +8,8 @@ from tests import test_utils
 # Just making sure it does not crash
 # Metal doesn't support print() or 64-bit data
 # While OpenGL does support print, but not 64-bit data
-@pytest.mark.parametrize('dt', [ti.i32, ti.f32, ti.i64, ti.f64])
-@test_utils.test(exclude=[ti.metal, ti.opengl, ti.vulkan])
+@pytest.mark.parametrize('dt', [ti.i8, ti.u8, ti.i16, ti.u16, ti.i32, ti.u32, ti.i64, ti.u64, ti.f16, ti.f32, ti.f64])
+@test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_print(dt):
     @ti.kernel
     def func():


### PR DESCRIPTION
Related issue = fix #5842

`i8/u8` will be converted to `i16/u16` during printing because CUDA doesn't support `%hhd`/`%hhu` specifers (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#format-specifiers).

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
