### PR TITLE
[autodiff] Fix validate autodiff kernel name lost

### DIFF
--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -397,7 +397,8 @@ void Kernel::init(Program &program,
 
   this->arch = program.config.arch;
 
-  if (autodiff_mode == AutodiffMode::kNone) {
+  if (autodiff_mode == AutodiffMode::kNone ||
+      autodiff_mode == AutodiffMode::kCheckAutodiffValid) {
     name = primal_name;
   } else if (autodiff_mode == AutodiffMode::kForward) {
     name = primal_name + "_forward_grad";


### PR DESCRIPTION
Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
