### PR TITLE
[refactor] [ir] Remove legacy LocalAddress / VectorElement / create_vector_or_scalar_type()

### DIFF
--- a/taichi/analysis/data_source_analysis.cpp
+++ b/taichi/analysis/data_source_analysis.cpp
@@ -9,7 +9,7 @@ namespace irpass::analysis {
 std::vector<Stmt *> get_load_pointers(Stmt *load_stmt) {
   // If load_stmt loads some variables or a stack, return the pointers of them.
   if (auto local_load = load_stmt->cast<LocalLoadStmt>()) {
-    return std::vector<Stmt *>(1, local_load->src.var);
+    return std::vector<Stmt *>(1, local_load->src);
   } else if (auto global_load = load_stmt->cast<GlobalLoadStmt>()) {
     return std::vector<Stmt *>(1, global_load->src);
   } else if (auto atomic = load_stmt->cast<AtomicOpStmt>()) {

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -104,8 +104,8 @@ class IRVerifier : public BasicStmtVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     basic_verify(stmt);
-    TI_ASSERT(stmt->src.var->is<AllocaStmt>() ||
-              stmt->src.var->is<PtrOffsetStmt>());
+    TI_ASSERT(stmt->src->is<AllocaStmt>() ||
+              stmt->src->is<PtrOffsetStmt>());
   }
 
   void visit(LocalStoreStmt *stmt) override {

--- a/taichi/analysis/verify.cpp
+++ b/taichi/analysis/verify.cpp
@@ -104,8 +104,7 @@ class IRVerifier : public BasicStmtVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     basic_verify(stmt);
-    TI_ASSERT(stmt->src->is<AllocaStmt>() ||
-              stmt->src->is<PtrOffsetStmt>());
+    TI_ASSERT(stmt->src->is<AllocaStmt>() || stmt->src->is<PtrOffsetStmt>());
   }
 
   void visit(LocalStoreStmt *stmt) override {

--- a/taichi/codegen/cc/codegen_cc.cpp
+++ b/taichi/codegen/cc/codegen_cc.cpp
@@ -217,7 +217,7 @@ class CCTransformer : public IRVisitor {
   void visit(LocalLoadStmt *stmt) override {
     auto var =
         define_var(cc_data_type_name(stmt->element_type()), stmt->raw_name());
-    emit("{} = {};", var, stmt->src.var->raw_name());
+    emit("{} = {};", var, stmt->src->raw_name());
   }
 
   void visit(LocalStoreStmt *stmt) override {

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1889,7 +1889,7 @@ std::tuple<llvm::Value *, llvm::Value *> TaskCodeGenLLVM::get_range_for_bounds(
   } else {
     auto begin_stmt = Stmt::make<GlobalTemporaryStmt>(
         stmt->begin_offset,
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+        PrimitiveType::i32);
     begin_stmt->accept(this);
     begin = builder->CreateLoad(
 #ifdef TI_LLVM_15
@@ -1902,7 +1902,7 @@ std::tuple<llvm::Value *, llvm::Value *> TaskCodeGenLLVM::get_range_for_bounds(
   } else {
     auto end_stmt = Stmt::make<GlobalTemporaryStmt>(
         stmt->end_offset,
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+        PrimitiveType::i32);
     end_stmt->accept(this);
     end = builder->CreateLoad(
 #ifdef TI_LLVM_15

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1887,9 +1887,8 @@ std::tuple<llvm::Value *, llvm::Value *> TaskCodeGenLLVM::get_range_for_bounds(
   if (stmt->const_begin) {
     begin = tlctx->get_constant(stmt->begin_value);
   } else {
-    auto begin_stmt = Stmt::make<GlobalTemporaryStmt>(
-        stmt->begin_offset,
-        PrimitiveType::i32);
+    auto begin_stmt =
+        Stmt::make<GlobalTemporaryStmt>(stmt->begin_offset, PrimitiveType::i32);
     begin_stmt->accept(this);
     begin = builder->CreateLoad(
 #ifdef TI_LLVM_15
@@ -1900,9 +1899,8 @@ std::tuple<llvm::Value *, llvm::Value *> TaskCodeGenLLVM::get_range_for_bounds(
   if (stmt->const_end) {
     end = tlctx->get_constant(stmt->end_value);
   } else {
-    auto end_stmt = Stmt::make<GlobalTemporaryStmt>(
-        stmt->end_offset,
-        PrimitiveType::i32);
+    auto end_stmt =
+        Stmt::make<GlobalTemporaryStmt>(stmt->end_offset, PrimitiveType::i32);
     end_stmt->accept(this);
     end = builder->CreateLoad(
 #ifdef TI_LLVM_15

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1191,16 +1191,16 @@ void TaskCodeGenLLVM::visit(LocalLoadStmt *stmt) {
 #ifdef TI_LLVM_15
   // FIXME: get ptr_ty from taichi instead of llvm.
   llvm::Type *ptr_ty = nullptr;
-  auto *val = llvm_val[stmt->src.var];
+  auto *val = llvm_val[stmt->src];
   if (auto *alloc = llvm::dyn_cast<llvm::AllocaInst>(val))
     ptr_ty = alloc->getAllocatedType();
-  if (!ptr_ty && stmt->src.var->element_type().is_pointer()) {
-    ptr_ty = llvm_type(stmt->src.var->element_type().ptr_removed());
+  if (!ptr_ty && stmt->src->element_type().is_pointer()) {
+    ptr_ty = llvm_type(stmt->src->element_type().ptr_removed());
   }
   TI_ASSERT(ptr_ty);
-  llvm_val[stmt] = builder->CreateLoad(ptr_ty, llvm_val[stmt->src.var]);
+  llvm_val[stmt] = builder->CreateLoad(ptr_ty, llvm_val[stmt->src]);
 #else
-  llvm_val[stmt] = builder->CreateLoad(llvm_val[stmt->src.var]);
+  llvm_val[stmt] = builder->CreateLoad(llvm_val[stmt->src]);
 #endif
 }
 

--- a/taichi/codegen/metal/codegen_metal.cpp
+++ b/taichi/codegen/metal/codegen_metal.cpp
@@ -1475,11 +1475,10 @@ class KernelCodegenImpl : public IRVisitor {
 
   std::string inject_load_global_tmp(int offset,
                                      DataType dt = PrimitiveType::i32) {
-    const auto vt = TypeFactory::create_vector_or_scalar_type(1, dt);
-    auto gtmp = Stmt::make<GlobalTemporaryStmt>(offset, vt);
+    auto gtmp = Stmt::make<GlobalTemporaryStmt>(offset, dt);
     gtmp->accept(this);
     auto gload = Stmt::make<GlobalLoadStmt>(gtmp.get());
-    gload->ret_type = vt;
+    gload->ret_type = dt;
     gload->accept(this);
     return gload->raw_name();
   }

--- a/taichi/codegen/metal/codegen_metal.cpp
+++ b/taichi/codegen/metal/codegen_metal.cpp
@@ -260,7 +260,7 @@ class KernelCodegenImpl : public IRVisitor {
   }
 
   void visit(LocalLoadStmt *stmt) override {
-    auto ptr = stmt->src.var;
+    auto ptr = stmt->src;
     emit("const {} {}({});", metal_data_type_name(stmt->element_type()),
          stmt->raw_name(), ptr->raw_name());
   }

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -234,7 +234,7 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(LocalLoadStmt *stmt) override {
-    auto ptr = stmt->src.var;
+    auto ptr = stmt->src;
     spirv::Value ptr_val = ir_->query_value(ptr->raw_name());
     spirv::Value val = ir_->load_variable(
         ptr_val, ir_->get_primitive_type(stmt->element_type()));

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -262,7 +262,7 @@ bool CFGNode::store_to_load_forwarding(bool after_lower_access,
     auto stmt = block->statements[i].get();
     Stmt *result = nullptr;
     if (auto local_load = stmt->cast<LocalLoadStmt>()) {
-      result = get_store_forwarding_data(local_load->src.var, i);
+      result = get_store_forwarding_data(local_load->src, i);
     } else if (auto global_load = stmt->cast<GlobalLoadStmt>()) {
       if (!after_lower_access && !autodiff_enabled) {
         result = get_store_forwarding_data(global_load->src, i);
@@ -431,7 +431,7 @@ bool CFGNode::dead_store_elimination(bool after_lower_access) {
           // Weaken the atomic operation to a load.
           if (atomic->dest->is<AllocaStmt>()) {
             auto local_load =
-                Stmt::make<LocalLoadStmt>(LocalAddress(atomic->dest, 0));
+                Stmt::make<LocalLoadStmt>(atomic->dest);
             local_load->ret_type = atomic->ret_type;
             // Notice that we have a load here
             // (the return value of AtomicOpStmt).

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -430,8 +430,7 @@ bool CFGNode::dead_store_elimination(bool after_lower_access) {
           auto atomic = stmt->cast<AtomicOpStmt>();
           // Weaken the atomic operation to a load.
           if (atomic->dest->is<AllocaStmt>()) {
-            auto local_load =
-                Stmt::make<LocalLoadStmt>(atomic->dest);
+            auto local_load = Stmt::make<LocalLoadStmt>(atomic->dest);
             local_load->ret_type = atomic->ret_type;
             // Notice that we have a load here
             // (the return value of AtomicOpStmt).

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -242,7 +242,7 @@ void BinaryOpExpression::flatten(FlattenContext *ctx) {
   if (binary_is_logical(type)) {
     auto result = ctx->push_back<AllocaStmt>(ret_type);
     ctx->push_back<LocalStoreStmt>(result, lhs->stmt);
-    auto cond = ctx->push_back<LocalLoadStmt>(LocalAddress(result, 0));
+    auto cond = ctx->push_back<LocalLoadStmt>(result);
     auto if_stmt = ctx->push_back<IfStmt>(cond);
 
     FlattenContext rctx;
@@ -262,7 +262,7 @@ void BinaryOpExpression::flatten(FlattenContext *ctx) {
     }
     if_stmt->set_false_statements(std::move(false_block));
 
-    auto ret = ctx->push_back<LocalLoadStmt>(LocalAddress(result, 0));
+    auto ret = ctx->push_back<LocalLoadStmt>(result);
     ret->tb = tb;
     stmt = ret;
     return;
@@ -300,7 +300,7 @@ void make_ifte(Expression::FlattenContext *ctx,
   false_block->set_statements(std::move(rctx.stmts));
   if_stmt->set_false_statements(std::move(false_block));
 
-  ctx->push_back<LocalLoadStmt>(LocalAddress(result, 0));
+  ctx->push_back<LocalLoadStmt>(result);
   return;
 }
 
@@ -1153,7 +1153,7 @@ void flatten_global_load(Expr ptr, Expression::FlattenContext *ctx) {
 }
 
 void flatten_local_load(Expr ptr, Expression::FlattenContext *ctx) {
-  ctx->push_back<LocalLoadStmt>(LocalAddress(ptr->stmt, 0));
+  ctx->push_back<LocalLoadStmt>(ptr->stmt);
   ptr->stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -65,7 +65,7 @@ class FrontendAllocaStmt : public Stmt {
 
   FrontendAllocaStmt(const Identifier &lhs, DataType type)
       : ident(lhs), is_shared(false) {
-    ret_type = TypeFactory::create_vector_or_scalar_type(1, type);
+    ret_type = type;
   }
 
   FrontendAllocaStmt(const Identifier &lhs,

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -496,9 +496,5 @@ void DelayedIRModifier::mark_as_modified() {
   modified_ = true;
 }
 
-LocalAddress::LocalAddress(Stmt *var, int offset) : var(var), offset(offset) {
-  TI_ASSERT(var->is<AllocaStmt>() || var->is<PtrOffsetStmt>());
-}
-
 }  // namespace lang
 }  // namespace taichi

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -573,25 +573,6 @@ class DelayedIRModifier {
   void mark_as_modified();
 };
 
-struct LocalAddress {
-  Stmt *var;
-  int offset;
-
-  LocalAddress(Stmt *var, int offset);
-};
-
-class VectorElement {
- public:
-  Stmt *stmt;
-  int index;
-
-  VectorElement() : stmt(nullptr), index(0) {
-  }
-
-  VectorElement(Stmt *stmt, int index) : stmt(stmt), index(index) {
-  }
-};
-
 template <typename T>
 inline void StmtFieldManager::operator()(const char *key, T &&value) {
   using decay_T = typename std::decay<T>::type;
@@ -612,14 +593,6 @@ inline void StmtFieldManager::operator()(const char *key, T &&value) {
     }
   } else if constexpr (std::is_same<decay_T, Stmt *>::value) {
     stmt_->register_operand(const_cast<Stmt *&>(value));
-  } else if constexpr (std::is_same<decay_T, LocalAddress>::value) {
-    stmt_->register_operand(const_cast<Stmt *&>(value.var));
-    stmt_->field_manager.fields.emplace_back(
-        std::make_unique<StmtFieldNumeric<int>>(value.offset));
-  } else if constexpr (std::is_same<decay_T, VectorElement>::value) {
-    stmt_->register_operand(const_cast<Stmt *&>(value.stmt));
-    stmt_->field_manager.fields.emplace_back(
-        std::make_unique<StmtFieldNumeric<int>>(value.index));
   } else if constexpr (std::is_same<decay_T, SNode *>::value) {
     stmt_->field_manager.fields.emplace_back(
         std::make_unique<StmtFieldSNode>(value));

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -405,7 +405,7 @@ AllocaStmt *IRBuilder::create_local_var(DataType dt) {
 }
 
 LocalLoadStmt *IRBuilder::create_local_load(AllocaStmt *ptr) {
-  return insert(Stmt::make_typed<LocalLoadStmt>(LocalAddress(ptr, 0)));
+  return insert(Stmt::make_typed<LocalLoadStmt>(ptr));
 }
 
 void IRBuilder::create_local_store(AllocaStmt *ptr, Stmt *data) {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -593,9 +593,9 @@ class GlobalStoreStmt : public Stmt {
  */
 class LocalLoadStmt : public Stmt {
  public:
-  LocalAddress src;
+  Stmt *src;
 
-  explicit LocalLoadStmt(const LocalAddress &src) : src(src) {
+  explicit LocalLoadStmt(Stmt *src) : src(src) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -19,7 +19,7 @@ class Function;
 class AllocaStmt : public Stmt {
  public:
   AllocaStmt(DataType type) : is_shared(false) {
-    ret_type = TypeFactory::create_vector_or_scalar_type(1, type);
+    ret_type = type;
     TI_STMT_REG_FIELDS;
   }
 
@@ -164,7 +164,7 @@ class ArgLoadStmt : public Stmt {
 
   ArgLoadStmt(int arg_id, const DataType &dt, bool is_ptr = false)
       : arg_id(arg_id) {
-    this->ret_type = TypeFactory::create_vector_or_scalar_type(1, dt);
+    this->ret_type = dt;
     this->is_ptr = is_ptr;
     TI_STMT_REG_FIELDS;
   }
@@ -1389,8 +1389,7 @@ class InternalFuncStmt : public Stmt {
         args(args),
         with_runtime_context(with_runtime_context) {
     if (ret_type == nullptr) {
-      this->ret_type =
-          TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
+      this->ret_type = PrimitiveType::i32;
     } else {
       this->ret_type = ret_type;
     }

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -23,11 +23,6 @@ class AllocaStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  AllocaStmt(int width, DataType type) : is_shared(false) {
-    ret_type = TypeFactory::create_vector_or_scalar_type(width, type);
-    TI_STMT_REG_FIELDS;
-  }
-
   AllocaStmt(const std::vector<int> &shape,
              DataType type,
              bool is_shared = false)

--- a/taichi/ir/type_factory.cpp
+++ b/taichi/ir/type_factory.cpp
@@ -131,17 +131,6 @@ PrimitiveType *TypeFactory::get_primitive_real_type(int bits) {
   return real_type->cast<PrimitiveType>();
 }
 
-DataType TypeFactory::create_vector_or_scalar_type(int width,
-                                                   DataType element,
-                                                   bool element_is_pointer) {
-  TI_ASSERT(width == 1);
-  if (element_is_pointer) {
-    return TypeFactory::get_instance().get_pointer_type(element);
-  } else {
-    return element;
-  }
-}
-
 DataType TypeFactory::create_tensor_type(std::vector<int> shape,
                                          DataType element) {
   return TypeFactory::get_instance().get_tensor_type(shape, element);

--- a/taichi/ir/type_factory.h
+++ b/taichi/ir/type_factory.h
@@ -44,10 +44,6 @@ class TypeFactory {
                              Type *element_type,
                              int num_elements);
 
-  static DataType create_vector_or_scalar_type(int width,
-                                               DataType element,
-                                               bool element_is_pointer = false);
-
   static DataType create_tensor_type(std::vector<int> shape, DataType element);
 
  private:

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -258,7 +258,7 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
 
     if (stmt->is<AllocaStmt>()) {
       // Create a new alloc at the top of an ib to replace the old alloca
-      auto alloc = Stmt::make<AllocaStmt>(1, stmt->ret_type);
+      auto alloc = Stmt::make<AllocaStmt>(stmt->ret_type);
       auto alloc_ptr = alloc.get();
       TI_ASSERT(alloca_block_);
       alloca_block_->insert(std::move(alloc), 0);
@@ -276,7 +276,7 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
       stmt->parent->erase(stmt);
     } else {
       // Create a alloc
-      auto alloc = Stmt::make<AllocaStmt>(1, stmt->ret_type);
+      auto alloc = Stmt::make<AllocaStmt>(stmt->ret_type);
       auto alloc_ptr = alloc.get();
       TI_ASSERT(alloca_block_);
       alloca_block_->insert(std::move(alloc), 0);
@@ -720,9 +720,9 @@ class MakeAdjoint : public ADTransform {
 
       // create the alloca
       // auto alloca =
-      //    Stmt::make<AllocaStmt>(1, get_current_program().config.gradient_dt);
+      //    Stmt::make<AllocaStmt>(get_current_program().config.gradient_dt);
       // maybe it's better to use the statement data type than the default type
-      auto alloca = Stmt::make<AllocaStmt>(1, stmt->ret_type);
+      auto alloca = Stmt::make<AllocaStmt>(stmt->ret_type);
       adjoint_stmt[stmt] = alloca.get();
 
       // We need to insert the alloca in the block of GlobalLoadStmt when the
@@ -1137,9 +1137,9 @@ class MakeDual : public ADTransform {
 
       // create the alloca
       // auto alloca =
-      //    Stmt::make<AllocaStmt>(1, get_current_program().config.gradient_dt);
+      //    Stmt::make<AllocaStmt>(get_current_program().config.gradient_dt);
       // maybe it's better to use the statement data type than the default type
-      auto alloca = Stmt::make<AllocaStmt>(1, stmt->ret_type);
+      auto alloca = Stmt::make<AllocaStmt>(stmt->ret_type);
       dual_stmt[stmt] = alloca.get();
 
       // TODO: check whether there are any edge cases for the alloca_block
@@ -1405,7 +1405,7 @@ class BackupSSA : public BasicStmtVisitor {
 
   Stmt *load(Stmt *stmt) {
     if (backup_alloca.find(stmt) == backup_alloca.end()) {
-      auto alloca = Stmt::make<AllocaStmt>(1, stmt->ret_type);
+      auto alloca = Stmt::make<AllocaStmt>(stmt->ret_type);
       auto alloca_ptr = alloca.get();
       independent_block->insert(std::move(alloca), 0);
       auto local_store = Stmt::make<LocalStoreStmt>(alloca_ptr, stmt);

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -14,8 +14,7 @@ class IndependentBlocksJudger : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
 
   void visit(LocalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->src->is<AllocaStmt>() ||
-              stmt->src->is<PtrOffsetStmt>());
+    TI_ASSERT(stmt->src->is<AllocaStmt>() || stmt->src->is<PtrOffsetStmt>());
     touched_allocas_.insert(stmt->src);
   }
 
@@ -280,8 +279,7 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
       auto alloc_ptr = alloc.get();
       TI_ASSERT(alloca_block_);
       alloca_block_->insert(std::move(alloc), 0);
-      auto load = stmt->insert_after_me(
-          Stmt::make<LocalLoadStmt>(alloc_ptr));
+      auto load = stmt->insert_after_me(Stmt::make<LocalLoadStmt>(alloc_ptr));
       irpass::replace_all_usages_with(stmt->parent, stmt, load);
       // Create the load first so that the operand of the store won't get
       // replaced
@@ -1453,8 +1451,8 @@ class BackupSSA : public BasicStmtVisitor {
           }
         } else {
           auto alloca = load(op);
-          stmt->set_operand(i, stmt->insert_before_me(Stmt::make<LocalLoadStmt>(
-                                   alloca)));
+          stmt->set_operand(
+              i, stmt->insert_before_me(Stmt::make<LocalLoadStmt>(alloca)));
         }
       }
     }

--- a/taichi/transforms/bit_loop_vectorize.cpp
+++ b/taichi/transforms/bit_loop_vectorize.cpp
@@ -197,7 +197,7 @@ class BitLoopVectorize : public IRVisitor {
           }
         } else if (auto lhs = stmt->lhs->cast<LocalLoadStmt>()) {
           // case 1: lhs is a local load from a local adder structure
-          auto it = transformed_atomics.find(lhs->src.var);
+          auto it = transformed_atomics.find(lhs->src);
           if (it != transformed_atomics.end()) {
             int32 rhs_val = get_constant_value(stmt->rhs);
             // TODO: we limit 2 and 3 for now, the other case should be
@@ -207,9 +207,9 @@ class BitLoopVectorize : public IRVisitor {
             auto &buffer_vec = it->second;
             Stmt *a = buffer_vec[0], *b = buffer_vec[1], *c = buffer_vec[2];
             // load all three buffers
-            auto load_a = std::make_unique<LocalLoadStmt>(LocalAddress(a, 0));
-            auto load_b = std::make_unique<LocalLoadStmt>(LocalAddress(b, 0));
-            auto load_c = std::make_unique<LocalLoadStmt>(LocalAddress(c, 0));
+            auto load_a = std::make_unique<LocalLoadStmt>(a);
+            auto load_b = std::make_unique<LocalLoadStmt>(b);
+            auto load_c = std::make_unique<LocalLoadStmt>(c);
             // compute not_a first
             auto not_a = std::make_unique<UnaryOpStmt>(UnaryOpType::bit_not,
                                                        load_a.get());
@@ -283,12 +283,12 @@ class BitLoopVectorize : public IRVisitor {
     // bit To add *d* to the subarray, we do bit_xor and bit_and to compute the
     // sum and the carry
     Stmt *a = buffer_vec[0], *b = buffer_vec[1], *c = buffer_vec[2];
-    auto load_c = std::make_unique<LocalLoadStmt>(LocalAddress(c, 0));
+    auto load_c = std::make_unique<LocalLoadStmt>(c);
     auto carry_c = std::make_unique<BinaryOpStmt>(BinaryOpType::bit_and,
                                                   load_c.get(), stmt->val);
     auto sum_c =
         std::make_unique<AtomicOpStmt>(AtomicOpType::bit_xor, c, stmt->val);
-    auto load_b = std::make_unique<LocalLoadStmt>(LocalAddress(b, 0));
+    auto load_b = std::make_unique<LocalLoadStmt>(b);
     auto carry_b = std::make_unique<BinaryOpStmt>(BinaryOpType::bit_and,
                                                   load_b.get(), carry_c.get());
     auto sum_b =

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -118,7 +118,7 @@ class DemoteAtomics : public BasicStmtVisitor {
       auto new_stmts = VecStatement();
       Stmt *load;
       if (is_local) {
-        load = new_stmts.push_back<LocalLoadStmt>(LocalAddress(ptr, 0));
+        load = new_stmts.push_back<LocalLoadStmt>(ptr);
         auto bin = new_stmts.push_back<BinaryOpStmt>(bin_type, load, val);
         new_stmts.push_back<LocalStoreStmt>(ptr, bin);
       } else {

--- a/taichi/transforms/inlining.cpp
+++ b/taichi/transforms/inlining.cpp
@@ -58,8 +58,7 @@ class Inliner : public BasicStmtVisitor {
       modifier_.insert_before(stmt,
                               std::move(inlined_ir->as<Block>()->statements));
       // Load the return value here
-      modifier_.replace_with(
-          stmt, Stmt::make<LocalLoadStmt>(return_address));
+      modifier_.replace_with(stmt, Stmt::make<LocalLoadStmt>(return_address));
     }
   }
 

--- a/taichi/transforms/inlining.cpp
+++ b/taichi/transforms/inlining.cpp
@@ -59,7 +59,7 @@ class Inliner : public BasicStmtVisitor {
                               std::move(inlined_ir->as<Block>()->statements));
       // Load the return value here
       modifier_.replace_with(
-          stmt, Stmt::make<LocalLoadStmt>(LocalAddress(return_address, 0)));
+          stmt, Stmt::make<LocalLoadStmt>(return_address));
     }
   }
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -433,7 +433,7 @@ class IRPrinter : public IRVisitor {
 
   void visit(LocalLoadStmt *stmt) override {
     print("{}{} = local load [{}]", stmt->type_hint(), stmt->name(),
-          stmt->src.var->name());
+          stmt->src->name());
   }
 
   void visit(LocalStoreStmt *stmt) override {

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -218,7 +218,7 @@ class LowerAST : public IRVisitor {
         auto begin_minus_one = fctx.push_back<BinaryOpStmt>(
             BinaryOpType::sub, begin->stmt, const_one);
         fctx.push_back<LocalStoreStmt>(loop_var, begin_minus_one);
-        auto loop_var_addr = LocalAddress(loop_var->as<AllocaStmt>(), 0);
+        auto loop_var_addr = loop_var->as<AllocaStmt>();
         VecStatement load_and_compare;
         auto loop_var_load_stmt =
             load_and_compare.push_back<LocalLoadStmt>(loop_var_addr);

--- a/taichi/transforms/make_block_local.cpp
+++ b/taichi/transforms/make_block_local.cpp
@@ -203,7 +203,7 @@ void make_block_local_offload(OffloadedStmt *offload,
             }
             auto bls_ptr = element_block->push_back<BlockLocalPtrStmt>(
                 bls_element_offset_bytes,
-                TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+                TypeFactory::get_instance().get_pointer_type(data_type));
             element_block->push_back<GlobalStoreStmt>(bls_ptr, value);
           });
     }
@@ -300,7 +300,7 @@ void make_block_local_offload(OffloadedStmt *offload,
 
         bls.push_back<BlockLocalPtrStmt>(
             bls_element_offset,
-            TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+            TypeFactory::get_instance().get_pointer_type(data_type));
         global_ptr->replace_with(std::move(bls));
       }
     }
@@ -315,7 +315,7 @@ void make_block_local_offload(OffloadedStmt *offload,
             // Store/accumulate from BLS to global
             auto bls_ptr = element_block->push_back<BlockLocalPtrStmt>(
                 bls_element_offset_bytes,
-                TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+                TypeFactory::get_instance().get_pointer_type(data_type));
             auto bls_val = element_block->push_back<GlobalLoadStmt>(bls_ptr);
 
             auto global_pointer =

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -172,7 +172,7 @@ Stmt *MakeMeshBlockLocal::create_xlogue(
 
   std::unique_ptr<Block> body = std::make_unique<Block>();
   {
-    Stmt *idx_val = body->push_back<LocalLoadStmt>(LocalAddress{idx, 0});
+    Stmt *idx_val = body->push_back<LocalLoadStmt>(idx);
     Stmt *cond =
         body->push_back<BinaryOpStmt>(BinaryOpType::cmp_lt, idx_val, end_val);
     body->push_back<WhileControlStmt>(nullptr, cond);
@@ -183,7 +183,7 @@ Stmt *MakeMeshBlockLocal::create_xlogue(
         body->push_back<LocalStoreStmt>(idx, idx_val_);
   }
   block_->push_back<WhileStmt>(std::move(body));
-  Stmt *idx_val = block_->push_back<LocalLoadStmt>(LocalAddress{idx, 0});
+  Stmt *idx_val = block_->push_back<LocalLoadStmt>(idx);
   return idx_val;
 }
 

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -85,7 +85,8 @@ void MakeMeshBlockLocal::replace_conv_statements() {
     Stmt *offset = bls.push_back<BinaryOpStmt>(
         BinaryOpType::add, bls_element_offset_bytes, idx_byte);
     Stmt *bls_ptr = bls.push_back<BlockLocalPtrStmt>(
-        offset, TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
+        offset,
+        TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
     [[maybe_unused]] Stmt *bls_load = bls.push_back<GlobalLoadStmt>(bls_ptr);
     stmt->replace_with(std::move(bls));
   }
@@ -205,7 +206,8 @@ Stmt *MakeMeshBlockLocal::create_cache_mapping(
     Stmt *offset = body->push_back<BinaryOpStmt>(
         BinaryOpType::add, bls_element_offset_bytes, idx_val_byte);
     Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
-        offset, TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
+        offset,
+        TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
     [[maybe_unused]] Stmt *bls_store =
         body->push_back<GlobalStoreStmt>(bls_ptr, global_val(body, idx_val));
   });
@@ -568,7 +570,8 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
             Stmt *offset = body->push_back<BinaryOpStmt>(
                 BinaryOpType::add, bls_element_offset_bytes, idx_byte);
             Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
-                offset, TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
+                offset, TypeFactory::get_instance().get_pointer_type(
+                            mapping_data_type_));
             Stmt *global_val = body->push_back<GlobalLoadStmt>(bls_ptr);
             this->push_attr_to_global(body, idx_val, global_val);
           });

--- a/taichi/transforms/make_mesh_block_local.cpp
+++ b/taichi/transforms/make_mesh_block_local.cpp
@@ -85,8 +85,7 @@ void MakeMeshBlockLocal::replace_conv_statements() {
     Stmt *offset = bls.push_back<BinaryOpStmt>(
         BinaryOpType::add, bls_element_offset_bytes, idx_byte);
     Stmt *bls_ptr = bls.push_back<BlockLocalPtrStmt>(
-        offset,
-        TypeFactory::create_vector_or_scalar_type(1, mapping_data_type_, true));
+        offset, TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
     [[maybe_unused]] Stmt *bls_load = bls.push_back<GlobalLoadStmt>(bls_ptr);
     stmt->replace_with(std::move(bls));
   }
@@ -120,7 +119,7 @@ void MakeMeshBlockLocal::replace_global_ptrs(SNode *snode) {
     Stmt *index =
         bls.push_back<BinaryOpStmt>(BinaryOpType::add, offset, local_idx_byte);
     [[maybe_unused]] Stmt *bls_ptr = bls.push_back<BlockLocalPtrStmt>(
-        index, TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+        index, TypeFactory::get_instance().get_pointer_type(data_type));
     global_ptr->replace_with(std::move(bls));
   }
 
@@ -206,8 +205,7 @@ Stmt *MakeMeshBlockLocal::create_cache_mapping(
     Stmt *offset = body->push_back<BinaryOpStmt>(
         BinaryOpType::add, bls_element_offset_bytes, idx_val_byte);
     Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
-        offset,
-        TypeFactory::create_vector_or_scalar_type(1, mapping_data_type_, true));
+        offset, TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
     [[maybe_unused]] Stmt *bls_store =
         body->push_back<GlobalStoreStmt>(bls_ptr, global_val(body, idx_val));
   });
@@ -267,7 +265,7 @@ void MakeMeshBlockLocal::fetch_attr_to_bls(Block *body,
     Stmt *index =
         body->push_back<BinaryOpStmt>(BinaryOpType::add, offset, idx_val_byte);
     Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
-        index, TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+        index, TypeFactory::get_instance().get_pointer_type(data_type));
     body->push_back<GlobalStoreStmt>(bls_ptr, value);
 
     // Step 3-2-1:
@@ -303,7 +301,7 @@ void MakeMeshBlockLocal::push_attr_to_global(Block *body,
     Stmt *index =
         body->push_back<BinaryOpStmt>(BinaryOpType::add, offset, idx_val_byte);
     Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
-        index, TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+        index, TypeFactory::get_instance().get_pointer_type(data_type));
     Stmt *bls_val = body->push_back<GlobalLoadStmt>(bls_ptr);
 
     Stmt *global_ptr =
@@ -570,8 +568,7 @@ MakeMeshBlockLocal::MakeMeshBlockLocal(OffloadedStmt *offload,
             Stmt *offset = body->push_back<BinaryOpStmt>(
                 BinaryOpType::add, bls_element_offset_bytes, idx_byte);
             Stmt *bls_ptr = body->push_back<BlockLocalPtrStmt>(
-                offset, TypeFactory::create_vector_or_scalar_type(
-                            1, mapping_data_type_, true));
+                offset, TypeFactory::get_instance().get_pointer_type(mapping_data_type_));
             Stmt *global_val = body->push_back<GlobalLoadStmt>(bls_ptr);
             this->push_attr_to_global(body, idx_val, global_val);
           });

--- a/taichi/transforms/make_mesh_thread_local.cpp
+++ b/taichi/transforms/make_mesh_thread_local.cpp
@@ -62,11 +62,9 @@ void make_mesh_thread_local_offload(OffloadedStmt *offload,
         {
           auto offset_ptr =
               offload->tls_prologue->push_back<ThreadLocalPtrStmt>(
-                  offset_tls_offset, TypeFactory::create_vector_or_scalar_type(
-                                         1, data_type, true));
+                  offset_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
           auto num_ptr = offload->tls_prologue->push_back<ThreadLocalPtrStmt>(
-              num_tls_offset,
-              TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+              num_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
 
           const auto offset_snode = offset_.find(element_type);
           TI_ASSERT(offset_snode != offset_.end());
@@ -98,13 +96,11 @@ void make_mesh_thread_local_offload(OffloadedStmt *offload,
         {
           auto offset_ptr =
               offload->mesh_prologue->push_back<ThreadLocalPtrStmt>(
-                  offset_tls_offset, TypeFactory::create_vector_or_scalar_type(
-                                         1, data_type, true));
+                  offset_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
           auto offset_val =
               offload->mesh_prologue->push_back<GlobalLoadStmt>(offset_ptr);
           auto num_ptr = offload->mesh_prologue->push_back<ThreadLocalPtrStmt>(
-              num_tls_offset,
-              TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+              num_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
           auto num_val =
               offload->mesh_prologue->push_back<GlobalLoadStmt>(num_ptr);
 

--- a/taichi/transforms/make_mesh_thread_local.cpp
+++ b/taichi/transforms/make_mesh_thread_local.cpp
@@ -62,9 +62,11 @@ void make_mesh_thread_local_offload(OffloadedStmt *offload,
         {
           auto offset_ptr =
               offload->tls_prologue->push_back<ThreadLocalPtrStmt>(
-                  offset_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
+                  offset_tls_offset,
+                  TypeFactory::get_instance().get_pointer_type(data_type));
           auto num_ptr = offload->tls_prologue->push_back<ThreadLocalPtrStmt>(
-              num_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
+              num_tls_offset,
+              TypeFactory::get_instance().get_pointer_type(data_type));
 
           const auto offset_snode = offset_.find(element_type);
           TI_ASSERT(offset_snode != offset_.end());
@@ -96,11 +98,13 @@ void make_mesh_thread_local_offload(OffloadedStmt *offload,
         {
           auto offset_ptr =
               offload->mesh_prologue->push_back<ThreadLocalPtrStmt>(
-                  offset_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
+                  offset_tls_offset,
+                  TypeFactory::get_instance().get_pointer_type(data_type));
           auto offset_val =
               offload->mesh_prologue->push_back<GlobalLoadStmt>(offset_ptr);
           auto num_ptr = offload->mesh_prologue->push_back<ThreadLocalPtrStmt>(
-              num_tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
+              num_tls_offset,
+              TypeFactory::get_instance().get_pointer_type(data_type));
           auto num_val =
               offload->mesh_prologue->push_back<GlobalLoadStmt>(num_ptr);
 

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -137,8 +137,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
       tls_offset += (dtype_size - tls_offset % dtype_size) % dtype_size;
 
       auto tls_ptr = offload->tls_prologue->push_back<ThreadLocalPtrStmt>(
-          tls_offset,
-          TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+          tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
 
       auto zero = offload->tls_prologue->insert(
           std::make_unique<ConstStmt>(
@@ -156,8 +155,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
     {
       auto tls_ptr = offload->body->insert(
           Stmt::make<ThreadLocalPtrStmt>(
-              tls_offset,
-              TypeFactory::create_vector_or_scalar_type(1, data_type, true)),
+              tls_offset, TypeFactory::get_instance().get_pointer_type(data_type)),
           0);
       dest.first->replace_usages_with(tls_ptr);
     }
@@ -170,8 +168,7 @@ void make_thread_local_offload(OffloadedStmt *offload) {
         offload->tls_epilogue->parent_stmt = offload;
       }
       auto tls_ptr = offload->tls_epilogue->push_back<ThreadLocalPtrStmt>(
-          tls_offset,
-          TypeFactory::create_vector_or_scalar_type(1, data_type, true));
+          tls_offset, TypeFactory::get_instance().get_pointer_type(data_type));
       // TODO: do not use global load from TLS.
       auto tls_load = offload->tls_epilogue->push_back<GlobalLoadStmt>(tls_ptr);
       auto global_ptr = offload->tls_epilogue->insert(

--- a/taichi/transforms/make_thread_local.cpp
+++ b/taichi/transforms/make_thread_local.cpp
@@ -155,7 +155,8 @@ void make_thread_local_offload(OffloadedStmt *offload) {
     {
       auto tls_ptr = offload->body->insert(
           Stmt::make<ThreadLocalPtrStmt>(
-              tls_offset, TypeFactory::get_instance().get_pointer_type(data_type)),
+              tls_offset,
+              TypeFactory::get_instance().get_pointer_type(data_type)),
           0);
       dest.first->replace_usages_with(tls_ptr);
     }

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -562,7 +562,7 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
   // Replace local LD/ST with global LD/ST
   void visit(LocalLoadStmt *stmt) override {
     generic_visit(stmt);
-    auto ptr = stmt->src.var;
+    auto ptr = stmt->src;
     auto top_level_ptr = SquashPtrOffset::run(ptr);
     if (top_level_ptr->is<GlobalTemporaryStmt>()) {
       VecStatement replacement;

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -422,7 +422,7 @@ class BasicBlockSimplify : public IRVisitor {
           }
           if (clause[i]->is<LocalStoreStmt>()) {
             auto store = clause[i]->as<LocalStoreStmt>();
-            auto load = Stmt::make<LocalLoadStmt>(LocalAddress(store->dest, 0));
+            auto load = Stmt::make<LocalLoadStmt>(store->dest);
             modifier.type_check(load.get(), config);
             auto select = Stmt::make<TernaryOpStmt>(
                 TernaryOpType::select, if_stmt->cond,

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -84,9 +84,9 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(LocalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->src.var->is<AllocaStmt>() ||
-              stmt->src.var->is<PtrOffsetStmt>());
-    if (auto ptr_offset_stmt = stmt->src.var->cast<PtrOffsetStmt>()) {
+    TI_ASSERT(stmt->src->is<AllocaStmt>() ||
+              stmt->src->is<PtrOffsetStmt>());
+    if (auto ptr_offset_stmt = stmt->src->cast<PtrOffsetStmt>()) {
       TI_ASSERT(ptr_offset_stmt->origin->is<AllocaStmt>() ||
                 ptr_offset_stmt->origin->is<GlobalTemporaryStmt>());
       if (auto alloca_stmt = ptr_offset_stmt->origin->cast<AllocaStmt>()) {
@@ -104,7 +104,7 @@ class TypeCheck : public IRVisitor {
         stmt->ret_type = lookup;
       }
     } else {
-      auto lookup = stmt->src.var->ret_type;
+      auto lookup = stmt->src->ret_type;
       stmt->ret_type = lookup;
     }
   }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -84,8 +84,7 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(LocalLoadStmt *stmt) override {
-    TI_ASSERT(stmt->src->is<AllocaStmt>() ||
-              stmt->src->is<PtrOffsetStmt>());
+    TI_ASSERT(stmt->src->is<AllocaStmt>() || stmt->src->is<PtrOffsetStmt>());
     if (auto ptr_offset_stmt = stmt->src->cast<PtrOffsetStmt>()) {
       TI_ASSERT(ptr_offset_stmt->origin->is<AllocaStmt>() ||
                 ptr_offset_stmt->origin->is<GlobalTemporaryStmt>());
@@ -423,7 +422,8 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(GetRootStmt *stmt) override {
-    stmt->ret_type = TypeFactory::get_instance().get_pointer_type(PrimitiveType::gen);
+    stmt->ret_type =
+        TypeFactory::get_instance().get_pointer_type(PrimitiveType::gen);
   }
 
   void visit(SNodeLookupStmt *stmt) override {
@@ -435,7 +435,8 @@ class TypeCheck : public IRVisitor {
           TypeFactory::get_instance().get_pointer_type(element_type, true);
       stmt->ret_type = pointer_type;
     } else {
-      stmt->ret_type = TypeFactory::get_instance().get_pointer_type(PrimitiveType::gen);
+      stmt->ret_type =
+          TypeFactory::get_instance().get_pointer_type(PrimitiveType::gen);
     }
   }
 

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -125,17 +125,14 @@ class TypeCheck : public IRVisitor {
 
   void visit(SNodeOpStmt *stmt) override {
     if (stmt->op_type == SNodeOpType::get_addr) {
-      stmt->ret_type =
-          TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::u64);
+      stmt->ret_type = PrimitiveType::u64;
     } else {
-      stmt->ret_type =
-          TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
+      stmt->ret_type = PrimitiveType::i32;
     }
   }
 
   void visit(ExternalTensorShapeAlongAxisStmt *stmt) override {
-    stmt->ret_type =
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
+    stmt->ret_type = PrimitiveType::i32;
   }
 
   void visit(GlobalPtrStmt *stmt) override {
@@ -177,10 +174,8 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(RangeForStmt *stmt) override {
-    mark_as_if_const(stmt->begin, TypeFactory::create_vector_or_scalar_type(
-                                      1, PrimitiveType::i32));
-    mark_as_if_const(stmt->end, TypeFactory::create_vector_or_scalar_type(
-                                    1, PrimitiveType::i32));
+    mark_as_if_const(stmt->begin, PrimitiveType::i32);
+    mark_as_if_const(stmt->end, PrimitiveType::i32);
     stmt->body->accept(this);
   }
 
@@ -416,23 +411,19 @@ class TypeCheck : public IRVisitor {
   }
 
   void visit(LoopIndexStmt *stmt) override {
-    stmt->ret_type =
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
+    stmt->ret_type = PrimitiveType::i32;
   }
 
   void visit(LoopLinearIndexStmt *stmt) override {
-    stmt->ret_type =
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
+    stmt->ret_type = PrimitiveType::i32;
   }
 
   void visit(BlockCornerIndexStmt *stmt) override {
-    stmt->ret_type =
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
+    stmt->ret_type = PrimitiveType::i32;
   }
 
   void visit(GetRootStmt *stmt) override {
-    stmt->ret_type =
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::gen, true);
+    stmt->ret_type = TypeFactory::get_instance().get_pointer_type(PrimitiveType::gen);
   }
 
   void visit(SNodeLookupStmt *stmt) override {
@@ -444,8 +435,7 @@ class TypeCheck : public IRVisitor {
           TypeFactory::get_instance().get_pointer_type(element_type, true);
       stmt->ret_type = pointer_type;
     } else {
-      stmt->ret_type = TypeFactory::create_vector_or_scalar_type(
-          1, PrimitiveType::gen, true);
+      stmt->ret_type = TypeFactory::get_instance().get_pointer_type(PrimitiveType::gen);
     }
   }
 
@@ -521,8 +511,7 @@ class TypeCheck : public IRVisitor {
 
   void visit(InternalFuncStmt *stmt) override {
     // TODO: support return type specification
-    stmt->ret_type =
-        TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32);
+    stmt->ret_type = PrimitiveType::i32;
   }
 
   void visit(BitStructStoreStmt *stmt) override {

--- a/tests/cpp/analysis/same_statements_test.cpp
+++ b/tests/cpp/analysis/same_statements_test.cpp
@@ -11,10 +11,10 @@ TEST(SameStatements, TestSameBlock) {
   auto block = std::make_unique<Block>();
 
   auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      4, PrimitiveType::i32);
   auto one = block->push_back<ConstStmt>(TypedConstant(1));
   auto if_stmt = block->push_back<IfStmt>(one)->as<IfStmt>();
 

--- a/tests/cpp/analysis/same_statements_test.cpp
+++ b/tests/cpp/analysis/same_statements_test.cpp
@@ -10,11 +10,11 @@ namespace lang {
 TEST(SameStatements, TestSameBlock) {
   auto block = std::make_unique<Block>();
 
-  auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, PrimitiveType::i32);
+  auto global_load_addr =
+      block->push_back<GlobalTemporaryStmt>(0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
-  auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, PrimitiveType::i32);
+  auto global_store_addr =
+      block->push_back<GlobalTemporaryStmt>(4, PrimitiveType::i32);
   auto one = block->push_back<ConstStmt>(TypedConstant(1));
   auto if_stmt = block->push_back<IfStmt>(one)->as<IfStmt>();
 

--- a/tests/cpp/transforms/alg_simp_test.cpp
+++ b/tests/cpp/transforms/alg_simp_test.cpp
@@ -28,13 +28,13 @@ TEST_F(AlgebraicSimplicationTest, SimplifyAddZero) {
   block->kernel = kernel.get();
 
   auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto zero = block->push_back<ConstStmt>(TypedConstant(0));
   auto add =
       block->push_back<BinaryOpStmt>(BinaryOpType::add, global_load, zero);
   auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      4, PrimitiveType::i32);
   block->push_back<GlobalStoreStmt>(global_store_addr, add);
 
   irpass::type_check(block.get(), CompileConfig());
@@ -55,7 +55,7 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyOne) {
   block->kernel = kernel.get();
 
   auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::f32));
+      0, PrimitiveType::f32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto one = block->push_back<ConstStmt>(TypedConstant(1.0f));
   auto mul1 =
@@ -65,7 +65,7 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyOne) {
   auto div = block->push_back<BinaryOpStmt>(BinaryOpType::div, zero, one);
   auto sub = block->push_back<BinaryOpStmt>(BinaryOpType::sub, mul2, div);
   auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::f32));
+      4, PrimitiveType::f32);
   [[maybe_unused]] auto global_store =
       block->push_back<GlobalStoreStmt>(global_store_addr, sub);
 
@@ -87,7 +87,7 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyZeroFastMath) {
   block->kernel = kernel.get();
 
   auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto zero = block->push_back<ConstStmt>(TypedConstant(0));
   auto mul =
@@ -95,7 +95,7 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyZeroFastMath) {
   auto one = block->push_back<ConstStmt>(TypedConstant(1));
   auto add = block->push_back<BinaryOpStmt>(BinaryOpType::add, mul, one);
   auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      4, PrimitiveType::i32);
   [[maybe_unused]] auto global_store =
       block->push_back<GlobalStoreStmt>(global_store_addr, add);
 
@@ -116,14 +116,14 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyZeroFastMath) {
   block->kernel = kernel.get();
 
   global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      8, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::f32));
+      8, PrimitiveType::f32);
   global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   zero = block->push_back<ConstStmt>(TypedConstant(0));
   mul = block->push_back<BinaryOpStmt>(BinaryOpType::mul, global_load, zero);
   one = block->push_back<ConstStmt>(TypedConstant(1));
   add = block->push_back<BinaryOpStmt>(BinaryOpType::add, mul, one);
   global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      12, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::f32));
+      12, PrimitiveType::f32);
   global_store = block->push_back<GlobalStoreStmt>(global_store_addr, add);
 
   irpass::type_check(block.get(), config_without_fast_math);  // insert 2 casts
@@ -151,13 +151,13 @@ TEST_F(AlgebraicSimplicationTest, SimplifyAndMinusOne) {
   auto block = std::make_unique<Block>();
 
   auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto minus_one = block->push_back<ConstStmt>(TypedConstant(-1));
   auto and_result = block->push_back<BinaryOpStmt>(BinaryOpType::bit_and,
                                                    minus_one, global_load);
   auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, TypeFactory::create_vector_or_scalar_type(1, PrimitiveType::i32));
+      4, PrimitiveType::i32);
   block->push_back<GlobalStoreStmt>(global_store_addr, and_result);
 
   auto func = []() {};

--- a/tests/cpp/transforms/alg_simp_test.cpp
+++ b/tests/cpp/transforms/alg_simp_test.cpp
@@ -27,14 +27,14 @@ TEST_F(AlgebraicSimplicationTest, SimplifyAddZero) {
   auto kernel = std::make_unique<Kernel>(prog(), func, "fake_kernel");
   block->kernel = kernel.get();
 
-  auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, PrimitiveType::i32);
+  auto global_load_addr =
+      block->push_back<GlobalTemporaryStmt>(0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto zero = block->push_back<ConstStmt>(TypedConstant(0));
   auto add =
       block->push_back<BinaryOpStmt>(BinaryOpType::add, global_load, zero);
-  auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, PrimitiveType::i32);
+  auto global_store_addr =
+      block->push_back<GlobalTemporaryStmt>(4, PrimitiveType::i32);
   block->push_back<GlobalStoreStmt>(global_store_addr, add);
 
   irpass::type_check(block.get(), CompileConfig());
@@ -54,8 +54,8 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyOne) {
   auto kernel = std::make_unique<Kernel>(prog(), func, "fake_kernel");
   block->kernel = kernel.get();
 
-  auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, PrimitiveType::f32);
+  auto global_load_addr =
+      block->push_back<GlobalTemporaryStmt>(0, PrimitiveType::f32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto one = block->push_back<ConstStmt>(TypedConstant(1.0f));
   auto mul1 =
@@ -64,8 +64,8 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyOne) {
   auto zero = block->push_back<ConstStmt>(TypedConstant(0.0f));
   auto div = block->push_back<BinaryOpStmt>(BinaryOpType::div, zero, one);
   auto sub = block->push_back<BinaryOpStmt>(BinaryOpType::sub, mul2, div);
-  auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, PrimitiveType::f32);
+  auto global_store_addr =
+      block->push_back<GlobalTemporaryStmt>(4, PrimitiveType::f32);
   [[maybe_unused]] auto global_store =
       block->push_back<GlobalStoreStmt>(global_store_addr, sub);
 
@@ -86,16 +86,16 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyZeroFastMath) {
   auto kernel = std::make_unique<Kernel>(prog(), func, "fake_kernel");
   block->kernel = kernel.get();
 
-  auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, PrimitiveType::i32);
+  auto global_load_addr =
+      block->push_back<GlobalTemporaryStmt>(0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto zero = block->push_back<ConstStmt>(TypedConstant(0));
   auto mul =
       block->push_back<BinaryOpStmt>(BinaryOpType::mul, global_load, zero);
   auto one = block->push_back<ConstStmt>(TypedConstant(1));
   auto add = block->push_back<BinaryOpStmt>(BinaryOpType::add, mul, one);
-  auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, PrimitiveType::i32);
+  auto global_store_addr =
+      block->push_back<GlobalTemporaryStmt>(4, PrimitiveType::i32);
   [[maybe_unused]] auto global_store =
       block->push_back<GlobalStoreStmt>(global_store_addr, add);
 
@@ -115,15 +115,15 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyZeroFastMath) {
   block = std::make_unique<Block>();
   block->kernel = kernel.get();
 
-  global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      8, PrimitiveType::f32);
+  global_load_addr =
+      block->push_back<GlobalTemporaryStmt>(8, PrimitiveType::f32);
   global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   zero = block->push_back<ConstStmt>(TypedConstant(0));
   mul = block->push_back<BinaryOpStmt>(BinaryOpType::mul, global_load, zero);
   one = block->push_back<ConstStmt>(TypedConstant(1));
   add = block->push_back<BinaryOpStmt>(BinaryOpType::add, mul, one);
-  global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      12, PrimitiveType::f32);
+  global_store_addr =
+      block->push_back<GlobalTemporaryStmt>(12, PrimitiveType::f32);
   global_store = block->push_back<GlobalStoreStmt>(global_store_addr, add);
 
   irpass::type_check(block.get(), config_without_fast_math);  // insert 2 casts
@@ -150,14 +150,14 @@ TEST_F(AlgebraicSimplicationTest, SimplifyMultiplyZeroFastMath) {
 TEST_F(AlgebraicSimplicationTest, SimplifyAndMinusOne) {
   auto block = std::make_unique<Block>();
 
-  auto global_load_addr = block->push_back<GlobalTemporaryStmt>(
-      0, PrimitiveType::i32);
+  auto global_load_addr =
+      block->push_back<GlobalTemporaryStmt>(0, PrimitiveType::i32);
   auto global_load = block->push_back<GlobalLoadStmt>(global_load_addr);
   auto minus_one = block->push_back<ConstStmt>(TypedConstant(-1));
   auto and_result = block->push_back<BinaryOpStmt>(BinaryOpType::bit_and,
                                                    minus_one, global_load);
-  auto global_store_addr = block->push_back<GlobalTemporaryStmt>(
-      4, PrimitiveType::i32);
+  auto global_store_addr =
+      block->push_back<GlobalTemporaryStmt>(4, PrimitiveType::i32);
   block->push_back<GlobalStoreStmt>(global_store_addr, and_result);
 
   auto func = []() {};


### PR DESCRIPTION
Related issue = close #4096

As far as I can see, after this PR, the legacy skeleton code for vectorization is fully removed. There might still be missing pieces but I think the codebase is already much cleaner now.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
