### PR TITLE
[llvm] [refactor] Rename methods in KernelCodeGen

### DIFF
--- a/taichi/codegen/codegen.h
+++ b/taichi/codegen/codegen.h
@@ -27,13 +27,13 @@ class KernelCodeGen {
                                                Kernel *kernel,
                                                Stmt *stmt = nullptr);
 
-  virtual FunctionType codegen() = 0;
+  virtual FunctionType compile_to_function() = 0;
   virtual bool supports_offline_cache() const {
     return false;
   }
 
 #ifdef TI_WITH_LLVM
-  virtual LLVMCompiledData modulegen(
+  virtual LLVMCompiledData compile_task(
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr) {
     TI_NOT_IMPLEMENTED

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -275,7 +275,7 @@ FunctionType CPUModuleToFunctionConverter::convert(
   };
 }
 
-LLVMCompiledData KernelCodeGenCPU::modulegen(
+LLVMCompiledData KernelCodeGenCPU::compile_task(
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
   TaskCodeGenCPU gen(kernel, stmt);
@@ -283,7 +283,7 @@ LLVMCompiledData KernelCodeGenCPU::modulegen(
 }
 #endif  // TI_WITH_LLVM
 
-FunctionType KernelCodeGenCPU::codegen() {
+FunctionType KernelCodeGenCPU::compile_to_function() {
   TI_AUTO_PROF;
   // TODO(PGZXB): move the offline cache part to the base class
   auto *llvm_prog = get_llvm_program(prog);
@@ -321,7 +321,7 @@ FunctionType KernelCodeGenCPU::codegen() {
       auto offload =
           irpass::analysis::clone(offloads[i].get(), offloads[i]->get_kernel());
       irpass::re_id(offload.get());
-      auto new_data = this->modulegen(nullptr, offload->as<OffloadedStmt>());
+      auto new_data = this->compile_task(nullptr, offload->as<OffloadedStmt>());
       data[i].tasks = std::move(new_data.tasks);
       data[i].module = std::move(new_data.module);
     };

--- a/taichi/codegen/cpu/codegen_cpu.h
+++ b/taichi/codegen/cpu/codegen_cpu.h
@@ -23,12 +23,12 @@ class KernelCodeGenCPU : public KernelCodeGen {
   bool supports_offline_cache() const override {
     return true;
   }
-  LLVMCompiledData modulegen(std::unique_ptr<llvm::Module> &&module = nullptr,
+  LLVMCompiledData compile_task(std::unique_ptr<llvm::Module> &&module = nullptr,
                              OffloadedStmt *stmt = nullptr) override;
 
 #endif  // TI_WITH_LLVM
 
-  FunctionType codegen() override;
+  FunctionType compile_to_function() override;
 };
 
 #ifdef TI_WITH_LLVM

--- a/taichi/codegen/cpu/codegen_cpu.h
+++ b/taichi/codegen/cpu/codegen_cpu.h
@@ -23,8 +23,9 @@ class KernelCodeGenCPU : public KernelCodeGen {
   bool supports_offline_cache() const override {
     return true;
   }
-  LLVMCompiledData compile_task(std::unique_ptr<llvm::Module> &&module = nullptr,
-                             OffloadedStmt *stmt = nullptr) override;
+  LLVMCompiledData compile_task(
+      std::unique_ptr<llvm::Module> &&module = nullptr,
+      OffloadedStmt *stmt = nullptr) override;
 
 #endif  // TI_WITH_LLVM
 

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -692,14 +692,14 @@ std::unique_ptr<TaskCodeGenLLVM> KernelCodeGenCUDA::make_codegen_llvm(
 }
 #endif  // TI_WITH_LLVM
 
-LLVMCompiledData KernelCodeGenCUDA::modulegen(
+LLVMCompiledData KernelCodeGenCUDA::compile_task(
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
   TaskCodeGenCUDA gen(kernel, stmt);
   return gen.run_compilation();
 }
 
-FunctionType KernelCodeGenCUDA::codegen() {
+FunctionType KernelCodeGenCUDA::compile_to_function() {
   TI_AUTO_PROF
   // TODO: move the offline cache part to the base class
   auto *llvm_prog = get_llvm_program(prog);
@@ -737,7 +737,7 @@ FunctionType KernelCodeGenCUDA::codegen() {
       auto offload =
           irpass::analysis::clone(offloads[i].get(), offloads[i]->get_kernel());
       irpass::re_id(offload.get());
-      auto new_data = this->modulegen(nullptr, offload->as<OffloadedStmt>());
+      auto new_data = this->compile_task(nullptr, offload->as<OffloadedStmt>());
       data[i].tasks = std::move(new_data.tasks);
       data[i].module = std::move(new_data.module);
     };

--- a/taichi/codegen/cuda/codegen_cuda.h
+++ b/taichi/codegen/cuda/codegen_cuda.h
@@ -17,8 +17,9 @@ class KernelCodeGenCUDA : public KernelCodeGen {
 #ifdef TI_WITH_LLVM
   static std::unique_ptr<TaskCodeGenLLVM> make_codegen_llvm(Kernel *kernel,
                                                             IRNode *ir);
-  LLVMCompiledData compile_task(std::unique_ptr<llvm::Module> &&module = nullptr,
-                             OffloadedStmt *stmt = nullptr) override;
+  LLVMCompiledData compile_task(
+      std::unique_ptr<llvm::Module> &&module = nullptr,
+      OffloadedStmt *stmt = nullptr) override;
 #endif  // TI_WITH_LLVM
 
   bool supports_offline_cache() const override {

--- a/taichi/codegen/cuda/codegen_cuda.h
+++ b/taichi/codegen/cuda/codegen_cuda.h
@@ -17,7 +17,7 @@ class KernelCodeGenCUDA : public KernelCodeGen {
 #ifdef TI_WITH_LLVM
   static std::unique_ptr<TaskCodeGenLLVM> make_codegen_llvm(Kernel *kernel,
                                                             IRNode *ir);
-  LLVMCompiledData modulegen(std::unique_ptr<llvm::Module> &&module = nullptr,
+  LLVMCompiledData compile_task(std::unique_ptr<llvm::Module> &&module = nullptr,
                              OffloadedStmt *stmt = nullptr) override;
 #endif  // TI_WITH_LLVM
 
@@ -25,7 +25,7 @@ class KernelCodeGenCUDA : public KernelCodeGen {
     return true;
   }
 
-  FunctionType codegen() override;
+  FunctionType compile_to_function() override;
 };
 
 class CUDAModuleToFunctionConverter : public ModuleToFunctionConverter {

--- a/taichi/codegen/wasm/codegen_wasm.cpp
+++ b/taichi/codegen/wasm/codegen_wasm.cpp
@@ -241,7 +241,7 @@ class TaskCodeGenWASM : public TaskCodeGenLLVM {
   }
 };
 
-FunctionType KernelCodeGenWASM::codegen() {
+FunctionType KernelCodeGenWASM::compile_to_function() {
   TI_AUTO_PROF
   TaskCodeGenWASM gen(kernel, ir);
   auto res = gen.run_compilation();
@@ -254,7 +254,7 @@ FunctionType KernelCodeGenWASM::codegen() {
   };
 }
 
-LLVMCompiledData KernelCodeGenWASM::modulegen(
+LLVMCompiledData KernelCodeGenWASM::compile_task(
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
   bool init_flag = module == nullptr;

--- a/taichi/codegen/wasm/codegen_wasm.h
+++ b/taichi/codegen/wasm/codegen_wasm.h
@@ -17,10 +17,10 @@ class KernelCodeGenWASM : public KernelCodeGen {
       : KernelCodeGen(kernel, ir) {
   }
 
-  FunctionType codegen() override;
+  FunctionType compile_to_function() override;
 
 #ifdef TI_WITH_LLVM
-  LLVMCompiledData modulegen(
+  LLVMCompiledData compile_task(
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr) override;  // AOT Module Gen
 #endif

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -39,7 +39,7 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
 FunctionType LlvmProgramImpl::compile(Kernel *kernel,
                                       OffloadedStmt *offloaded) {
   auto codegen = KernelCodeGen::create(kernel->arch, kernel, offloaded);
-  return codegen->codegen();
+  return codegen->compile_to_function();
 }
 
 std::unique_ptr<llvm::Module>

--- a/taichi/runtime/wasm/aot_module_builder_impl.cpp
+++ b/taichi/runtime/wasm/aot_module_builder_impl.cpp
@@ -36,7 +36,7 @@ void AotModuleBuilderImpl::dump(const std::string &output_dir,
 void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
                                            Kernel *kernel) {
   auto module_info =
-      KernelCodeGenWASM(kernel, nullptr).modulegen(std::move(module_));
+      KernelCodeGenWASM(kernel, nullptr).compile_task(std::move(module_));
   module_ = std::move(module_info.module);
 
   for (auto &task : module_info.tasks)


### PR DESCRIPTION
Related issue = #5511 
Renamed `codegen` to `compile_to_function`.
Renamed `modulegen` to `compile_task`.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
