### PR TITLE
[autodiff] Fix adjoint checkbit type in gdar checker

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1550,11 +1550,12 @@ class GloablDataAccessRuleChecker : public BasicStmtVisitor {
     }
     TI_ASSERT(snode->get_adjoint_checkbit() != nullptr);
     snode = snode->get_adjoint_checkbit();
-    auto gloabl_ptr =
+    auto global_ptr =
         stmt->insert_after_me(Stmt::make<GlobalPtrStmt>(snode, src->indices));
-    auto one =
-        gloabl_ptr->insert_after_me(Stmt::make<ConstStmt>(TypedConstant(1)));
-    one->insert_after_me(Stmt::make<GlobalStoreStmt>(gloabl_ptr, one));
+    auto dtype = global_ptr->ret_type;
+    auto one = global_ptr->insert_after_me(
+        Stmt::make<ConstStmt>(TypedConstant(dtype, 1)));
+    one->insert_after_me(Stmt::make<GlobalStoreStmt>(global_ptr, one));
   }
 
   void visit_gloabl_store_stmt_and_atomic_add(Stmt *stmt, GlobalPtrStmt *dest) {
@@ -1568,7 +1569,9 @@ class GloablDataAccessRuleChecker : public BasicStmtVisitor {
         stmt->insert_before_me(Stmt::make<GlobalPtrStmt>(snode, dest->indices));
     auto global_load =
         stmt->insert_before_me(Stmt::make<GlobalLoadStmt>(global_ptr));
-    auto zero = stmt->insert_before_me(Stmt::make<ConstStmt>(TypedConstant(0)));
+    auto dtype = global_ptr->ret_type;
+    auto zero =
+        stmt->insert_before_me(Stmt::make<ConstStmt>(TypedConstant(dtype, 0)));
     auto check_equal = stmt->insert_before_me(
         Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_eq, global_load, zero));
     std::string msg = fmt::format(


### PR DESCRIPTION
Make the adjoint checkbit value type consistent to the destination/source field. 

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
