### PR TITLE
[bug] Force CMAKE_OSX_ARCHITECTURES in sync with host processor's architecture to avoid ABI issues on Mac m1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.17)
 
+project(taichi)
+
 # Taichi does not set target architecture explicitly,
 # but rather rely on CMake to detect the host arch.
 #
@@ -13,12 +15,10 @@ cmake_minimum_required(VERSION 3.17)
 #
 # Therefore we force CMake to choose arm64 architecture on arm64 chips.
 if (APPLE)
-  if( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64" )
+  if( "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64" )
     set(CMAKE_OSX_ARCHITECTURES ${CMAKE_HOST_SYSTEM_PROCESSOR})
   endif()
 endif()
-
-project(taichi)
 
 if (NOT DEFINED TI_VERSION_MAJOR)
     message(WARNING "It seems that you are running cmake manually, which may cause issues. Please use setup.py to build taichi from source, see https://docs.taichi-lang.org/docs/dev_install for more details.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,20 @@
 
 cmake_minimum_required(VERSION 3.17)
 
+# Taichi does not set target architecture explicitly,
+# but rather rely on CMake to detect the host arch.
+#
+# However on Mac m1, there are two available architectures namely x86_64 and arm64.
+# On some combination of "OSX version", CMake will use x86_64 as default architecture even if it's on m1 chip.
+# This causes conflicts with the precompiled LLVM/Clang binaries downloaded from Taichi's repo (pre-built for arm64)
+#
+# Therefore we force CMake to choose arm64 architecture on arm64 chips.
+if (APPLE)
+  if( ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64" )
+    set(CMAKE_OSX_ARCHITECTURES ${CMAKE_HOST_SYSTEM_PROCESSOR})
+  endif()
+endif()
+
 project(taichi)
 
 if (NOT DEFINED TI_VERSION_MAJOR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.17)
 # but rather rely on CMake to detect the host arch.
 #
 # However on Mac m1, there are two available architectures namely x86_64 and arm64.
-# On some combination of "OSX version", CMake will use x86_64 as default architecture even if it's on m1 chip.
+# On some combination of "OSX version" and "CMake version", CMake will use x86_64 as default architecture even if it's on m1 chip.
 # This causes conflicts with the precompiled LLVM/Clang binaries downloaded from Taichi's repo (pre-built for arm64)
 #
 # Therefore we force CMake to choose arm64 architecture on arm64 chips.


### PR DESCRIPTION
Related issue = #

@Morcki  can you help verify if Taichi builds on your Mac with this PR?