### PR TITLE
[aot] [opengl] Add GL interop so that we can export GL memory

### DIFF
--- a/c_api/include/taichi/taichi.h
+++ b/c_api/include/taichi/taichi.h
@@ -8,3 +8,7 @@
 #define VK_NO_PROTOTYPES 1
 #include "taichi/taichi_vulkan.h"
 #endif  // TI_WITH_VULKAN
+
+#if TI_WITH_OPENGL
+#include "taichi/taichi_opengl.h"
+#endif

--- a/c_api/include/taichi/taichi_opengl.h
+++ b/c_api/include/taichi/taichi_opengl.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <taichi/taichi_core.h>
+#include <glad/gl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// structure.opengl_memory_interop_info
+typedef struct TiOpenglMemoryInteropInfo {
+  GLuint buffer;
+  uint64_t size;
+} TiOpenglMemoryInteropInfo;
+
+// function.export_opengl_memory
+TI_DLL_EXPORT void TI_API_CALL
+ti_export_opengl_memory(TiRuntime runtime,
+                        TiMemory memory,
+                        TiOpenglMemoryInteropInfo *interop_info);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/c_api/src/taichi_opengl_impl.cpp
+++ b/c_api/src/taichi_opengl_impl.cpp
@@ -14,3 +14,17 @@ taichi::lang::Device &OpenglRuntime::get() {
 taichi::lang::gfx::GfxRuntime &OpenglRuntime::get_gfx_runtime() {
   return gfx_runtime_;
 }
+
+void ti_export_opengl_memory(TiRuntime runtime,
+                             TiMemory memory,
+                             TiOpenglMemoryInteropInfo *interop_info) {
+  TI_CAPI_ARGUMENT_NULL(runtime);
+  TI_CAPI_ARGUMENT_NULL(memory);
+  TI_CAPI_ARGUMENT_NULL(interop_info);
+  TI_CAPI_INVALID_INTEROP_ARCH(((Runtime *)runtime)->arch, opengl);
+
+  OpenglRuntime *runtime2 = static_cast<OpenglRuntime *>((Runtime *)runtime);
+  taichi::lang::DeviceAllocation devalloc = devmem2devalloc(*runtime2, memory);
+  interop_info->buffer = devalloc.alloc_id;
+  interop_info->size = runtime2->get_gl().get_devalloc_size(devalloc);
+}

--- a/c_api/src/taichi_opengl_impl.h
+++ b/c_api/src/taichi_opengl_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "taichi_gfx_impl.h"
+#include "taichi/taichi_opengl.h"
 #include "taichi/rhi/opengl/opengl_device.h"
 
 class OpenglRuntime : public GfxRuntime {
@@ -11,4 +12,7 @@ class OpenglRuntime : public GfxRuntime {
   OpenglRuntime();
   virtual taichi::lang::Device &get() override final;
   virtual taichi::lang::gfx::GfxRuntime &get_gfx_runtime() override final;
+  taichi::lang::opengl::GLDevice &get_gl() {
+    return device_;
+  }
 };

--- a/cmake/TaichiCAPITests.cmake
+++ b/cmake/TaichiCAPITests.cmake
@@ -24,6 +24,7 @@ target_include_directories(${C_API_TESTS_NAME}
     ${PROJECT_SOURCE_DIR}/c_api/include
     ${PROJECT_SOURCE_DIR}/c_api/src
     ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/external/glad/include
   )
 
 add_test(NAME ${C_API_TESTS_NAME} COMMAND ${C_API_TESTS_NAME})

--- a/taichi/rhi/opengl/opengl_device.cpp
+++ b/taichi/rhi/opengl/opengl_device.cpp
@@ -552,6 +552,7 @@ GLint GLDevice::get_devalloc_size(DeviceAllocation handle) {
   glGetBufferParameteriv(GL_ARRAY_BUFFER, GL_BUFFER_SIZE, &size);
   check_opengl_error("glGetBufferParameteriv");
   return size;
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 std::unique_ptr<Pipeline> GLDevice::create_pipeline(

--- a/taichi/rhi/opengl/opengl_device.cpp
+++ b/taichi/rhi/opengl/opengl_device.cpp
@@ -545,6 +545,15 @@ void GLDevice::dealloc_memory(DeviceAllocation handle) {
   check_opengl_error("glDeleteBuffers");
 }
 
+GLint GLDevice::get_devalloc_size(DeviceAllocation handle) {
+  glBindBuffer(GL_ARRAY_BUFFER, handle.alloc_id);
+  check_opengl_error("glBindBuffer");
+  GLint size = 0;
+  glGetBufferParameteriv(GL_ARRAY_BUFFER, GL_BUFFER_SIZE, &size);
+  check_opengl_error("glGetBufferParameteriv");
+  return size;
+}
+
 std::unique_ptr<Pipeline> GLDevice::create_pipeline(
     const PipelineSourceDesc &src,
     std::string name) {

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -245,6 +245,8 @@ class GLDevice : public GraphicsDevice {
   DeviceAllocation allocate_memory(const AllocParams &params) override;
   void dealloc_memory(DeviceAllocation handle) override;
 
+  GLint get_devalloc_size(DeviceAllocation handle);
+
   std::unique_ptr<Pipeline> create_pipeline(
       const PipelineSourceDesc &src,
       std::string name = "Pipeline") override;


### PR DESCRIPTION
See an example usage in:
https://github.com/ailzhang/taichi-aot-demo/blob/gl_demo/mpm88_gl/mpm88.cpp#L158-L159

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
