### PR TITLE
[aot] Temporarily allow Vulkan extensions to be automatically enabled in C-API runtimes

### DIFF
--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -285,10 +285,9 @@ void VulkanDeviceCreator::create_instance(bool manual_create) {
   }
 
   uint32_t num_instance_extensions = 0;
-  if (!manual_create) {
-    vkEnumerateInstanceExtensionProperties(nullptr, &num_instance_extensions,
-                                           nullptr);
-  }
+  // FIXME: (penguinliong) This was NOT called when `manual_create` is true.
+  vkEnumerateInstanceExtensionProperties(nullptr, &num_instance_extensions,
+                                          nullptr);
   std::vector<VkExtensionProperties> supported_extensions(
       num_instance_extensions);
   vkEnumerateInstanceExtensionProperties(nullptr, &num_instance_extensions,
@@ -464,10 +463,9 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
   std::vector<const char *> enabled_extensions;
 
   uint32_t extension_count = 0;
-  if (!manual_create) {
-    vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
-                                         &extension_count, nullptr);
-  }
+  // FIXME: (penguinliong) This was NOT called when `manual_create` is true.
+  vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
+                                        &extension_count, nullptr);
   std::vector<VkExtensionProperties> extension_properties(extension_count);
   vkEnumerateDeviceExtensionProperties(
       physical_device_, nullptr, &extension_count, extension_properties.data());

--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -287,7 +287,7 @@ void VulkanDeviceCreator::create_instance(bool manual_create) {
   uint32_t num_instance_extensions = 0;
   // FIXME: (penguinliong) This was NOT called when `manual_create` is true.
   vkEnumerateInstanceExtensionProperties(nullptr, &num_instance_extensions,
-                                          nullptr);
+                                         nullptr);
   std::vector<VkExtensionProperties> supported_extensions(
       num_instance_extensions);
   vkEnumerateInstanceExtensionProperties(nullptr, &num_instance_extensions,
@@ -465,7 +465,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
   uint32_t extension_count = 0;
   // FIXME: (penguinliong) This was NOT called when `manual_create` is true.
   vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
-                                        &extension_count, nullptr);
+                                       &extension_count, nullptr);
   std::vector<VkExtensionProperties> extension_properties(extension_count);
   vkEnumerateDeviceExtensionProperties(
       physical_device_, nullptr, &extension_count, extension_properties.data());


### PR DESCRIPTION
This PR temprarily allows extensions to be enabled based on device-capability in the C-API. This workaround should be replaced by a more formal device capability mechanism before the next major release.