### PR TITLE
[refactor] Replace make_current with cuda context guard in jit cuda

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -588,12 +588,6 @@ class Kernel:
                 host_v = v.to(device='cpu', copy=True)
                 tmp = host_v
                 callbacks.append(get_call_back(v, host_v))
-        else:
-            # External tensor on cpu
-            if taichi_arch == _ti_core.Arch.cuda:
-                gpu_v = v.cuda()
-                tmp = gpu_v
-                callbacks.append(get_call_back(v, gpu_v))
         return tmp, callbacks
 
     def get_paddle_callbacks(self, v, has_pp):

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1666,6 +1666,7 @@ class MatrixField(Field):
                           device=device)
         from taichi._kernels import matrix_to_ext_arr  # pylint: disable=C0415
         matrix_to_ext_arr(self, arr, as_vector)
+        print('before sync in python')
         runtime_ops.sync()
         return arr
 

--- a/repro.py
+++ b/repro.py
@@ -1,0 +1,25 @@
+import numpy as np
+import torch
+
+import taichi as ti
+
+ti.init(ti.cuda, log_level=ti.TRACE)
+
+
+def test_shape_vector():
+    n = 3
+    x = ti.Vector.field(3, ti.f32, shape=(n, n))
+    print('============first time begin============', flush=True)
+    X = x.to_torch()
+    print('============first time done============', flush=True)
+
+    X1 = x.to_torch()
+    print('============second time done============', flush=True)
+
+    # print(x.to_numpy())
+    print(X1)
+
+    assert (X == X1).all()
+
+
+test_shape_vector()

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -735,7 +735,6 @@ FunctionType CUDAModuleToFunctionConverter::convert(
 
   return [cuda_modules, kernel_name, args, offloaded_tasks,
           executor = this->executor_](RuntimeContext &context) {
-    // CUDAContext::get_instance().make_current();
     std::vector<void *> arg_buffers(args.size(), nullptr);
     std::vector<void *> device_buffers(args.size(), nullptr);
 
@@ -794,6 +793,7 @@ FunctionType CUDAModuleToFunctionConverter::convert(
         }
       }
     }
+
     if (transferred) {
       auto context_guard = CUDAContext::get_instance().get_guard();
       CUDADriver::get_instance().stream_synchronize(nullptr);

--- a/taichi/rhi/cuda/cuda_context.cpp
+++ b/taichi/rhi/cuda/cuda_context.cpp
@@ -51,6 +51,11 @@ CUDAContext::CUDAContext()
   mcpu_ = fmt::format("sm_{}", compute_capability_);
 
   TI_TRACE("Emitting CUDA code for {}", mcpu_);
+
+  driver_.context_pop_current(nullptr);
+  void *curr_ctx_ = nullptr;
+  driver_.context_get_current(&curr_ctx_);
+  std::cout << "created " << curr_ctx_ << std::endl;
 }
 
 std::size_t CUDAContext::get_total_memory() {
@@ -121,6 +126,7 @@ void CUDAContext::launch(void *func,
     profiler_->stop(task_handle);
 
   if (debug_) {
+    auto guard = CUDAContext::get_instance().get_guard();
     driver_.stream_synchronize(nullptr);
   }
 }

--- a/taichi/rhi/cuda/cuda_context.h
+++ b/taichi/rhi/cuda/cuda_context.h
@@ -83,12 +83,16 @@ class CUDAContext {
       CUDADriver::get_instance().context_get_current(&old_ctx_);
       if (old_ctx_ != new_ctx_)
         new_ctx->make_current();
+      std::cout << "creating guard with " << old_ctx_ << " " << new_ctx_
+                << std::endl;
     }
 
     ~ContextGuard() {
       if (old_ctx_ != new_ctx_) {
         CUDADriver::get_instance().context_set_current(old_ctx_);
       }
+      std::cout << "destructing guard with " << old_ctx_ << " " << new_ctx_
+                << std::endl;
     }
   };
 

--- a/taichi/rhi/cuda/cuda_device.cpp
+++ b/taichi/rhi/cuda/cuda_device.cpp
@@ -43,6 +43,7 @@ DeviceAllocation CudaDevice::allocate_memory_runtime(
       caching_allocator_ = std::make_unique<CudaCachingAllocator>(this);
     }
     info.ptr = caching_allocator_->allocate(params);
+    auto context_guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().memset((void *)info.ptr, 0, info.size);
   } else {
     info.ptr = allocate_llvm_runtime_memory_jit(params);
@@ -117,6 +118,7 @@ DeviceAllocation CudaDevice::import_memory(void *ptr, size_t size) {
 }
 
 uint64 CudaDevice::fetch_result_uint64(int i, uint64 *result_buffer) {
+  auto context_guard = CUDAContext::get_instance().get_guard();
   CUDADriver::get_instance().stream_synchronize(nullptr);
   uint64 ret;
   CUDADriver::get_instance().memcpy_device_to_host(&ret, result_buffer + i,

--- a/taichi/runtime/cuda/jit_cuda.cpp
+++ b/taichi/runtime/cuda/jit_cuda.cpp
@@ -13,9 +13,7 @@ JITModule *JITSessionCUDA ::add_module(std::unique_ptr<llvm::Module> M,
                                      "module NVPTX");
     writer.write(ptx);
   }
-  // TODO: figure out why using the guard leads to wrong tests results
-  // auto context_guard = CUDAContext::get_instance().get_guard();
-  CUDAContext::get_instance().make_current();
+  auto context_guard = CUDAContext::get_instance().get_guard();
   // Create module for object
   void *cuda_module;
   TI_TRACE("PTX size: {:.2f}KB", ptx.size() / 1024.0);

--- a/taichi/runtime/cuda/jit_cuda.h
+++ b/taichi/runtime/cuda/jit_cuda.h
@@ -47,9 +47,7 @@ class JITModuleCUDA : public JITModule {
   }
 
   void *lookup_function(const std::string &name) override {
-    // TODO: figure out why using the guard leads to wrong tests results
-    // auto context_guard = CUDAContext::get_instance().get_guard();
-    CUDAContext::get_instance().make_current();
+    auto context_guard = CUDAContext::get_instance().get_guard();
     void *func = nullptr;
     auto t = Time::get_time();
     auto err = CUDADriver::get_instance().module_get_function.call_with_warning(

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -476,6 +476,7 @@ void LlvmRuntimeExecutor::fill_ndarray(const DeviceAllocation &alloc,
   auto ptr = get_ndarray_alloc_info_ptr(alloc);
   if (config_->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
+    auto context_guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().memsetd32((void *)ptr, data, size);
 #else
     TI_NOT_IMPLEMENTED

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -176,7 +176,7 @@ void LlvmRuntimeExecutor::print_list_manager_info(void *list_manager,
 void LlvmRuntimeExecutor::synchronize() {
   if (config_->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-    CUDAContext::get_instance().make_current();
+    auto guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().stream_synchronize(nullptr);
 #else
     TI_ERROR("No CUDA support");
@@ -191,7 +191,7 @@ uint64 LlvmRuntimeExecutor::fetch_result_uint64(int i, uint64 *result_buffer) {
   uint64 ret;
   if (config_->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-    CUDAContext::get_instance().make_current();
+    auto guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().memcpy_device_to_host(&ret, result_buffer + i,
                                                      sizeof(uint64));
 #else
@@ -373,6 +373,7 @@ void LlvmRuntimeExecutor::initialize_llvm_runtime_snodes(
       result_buffer);
   if (config_->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
+    auto guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);
 #else
     TI_NOT_IMPLEMENTED
@@ -516,6 +517,7 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
   TaichiLLVMContext *tlctx = nullptr;
   if (config_->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
+    auto context_guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().malloc(
         (void **)result_buffer_ptr,
         sizeof(uint64) * taichi_result_buffer_entries);
@@ -614,9 +616,9 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
         (void *)&KernelProfilerBase::profiler_stop);
   }
 #if defined(TI_WITH_CUDA)
-  if (config_->arch == Arch::cuda) {
-    CUDADriver::get_instance().context_pop_current(nullptr);
-  }
+  // if (config_->arch == Arch::cuda) {
+  //   CUDADriver::get_instance().context_pop_current(nullptr);
+  // }
 #endif
 }
 

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -56,6 +56,7 @@ T MemoryPool::fetch(volatile void *ptr) {
   T ret;
   if (use_cuda_stream && arch_ == Arch::cuda) {
 #if TI_WITH_CUDA
+    auto context_guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().stream_synchronize(cuda_stream);
     CUDADriver::get_instance().memcpy_device_to_host_async(
         &ret, (void *)ptr, sizeof(T), cuda_stream);
@@ -73,6 +74,7 @@ template <typename T>
 void MemoryPool::push(volatile T *dest, const T &val) {
   if (use_cuda_stream && arch_ == Arch::cuda) {
 #if TI_WITH_CUDA
+    auto context_guard = CUDAContext::get_instance().get_guard();
     CUDADriver::get_instance().memcpy_host_to_device_async(
         (void *)(dest), (void *)&val, sizeof(T), cuda_stream);
     CUDADriver::get_instance().stream_synchronize(cuda_stream);


### PR DESCRIPTION
session

Main goal is to get rid of the to-do in comment as it's fixed #5891

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
