### PR TITLE
[ir] MatrixField refactor 1/n: Make a GlobalVariableExpression solely represent a field

### DIFF
--- a/python/taichi/lang/any_array.py
+++ b/python/taichi/lang/any_array.py
@@ -58,8 +58,6 @@ class AnyArray:
     def _loop_range(self):
         """Gets the corresponding taichi_python.Expr to serve as loop range.
 
-        This is not in use now because struct fors on AnyArrays are not supported yet.
-
         Returns:
             taichi_python.Expr: See above.
         """

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -87,12 +87,12 @@ class Field:
         return self.vars
 
     def _loop_range(self):
-        """Gets representative field member for loop range info.
+        """Gets SNode of representative field member for loop range info.
 
         Returns:
-            taichi_python.Expr: Representative (first) field member.
+            taichi_python.SNode: SNode of representative (first) field member.
         """
-        return self.vars[0].ptr
+        return self.vars[0].ptr.snode()
 
     def _set_grad(self, grad):
         """Sets corresponding grad field (reverse mode).

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -111,9 +111,11 @@ def begin_frontend_struct_for(ast_builder, group, loop_range):
             'use "for I in ti.grouped(x)" to group all indices into a single vector I?'
         )
     if isinstance(loop_range, AnyArray):
-        ast_builder.begin_frontend_struct_for_on_external_tensor(group, loop_range._loop_range())
+        ast_builder.begin_frontend_struct_for_on_external_tensor(
+            group, loop_range._loop_range())
     else:
-        ast_builder.begin_frontend_struct_for_on_snode(group, loop_range._loop_range())
+        ast_builder.begin_frontend_struct_for_on_snode(
+            group, loop_range._loop_range())
 
 
 def begin_frontend_if(ast_builder, cond):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -110,7 +110,10 @@ def begin_frontend_struct_for(ast_builder, group, loop_range):
             f'({group.size()} != {len(loop_range.shape)}). Maybe you wanted to '
             'use "for I in ti.grouped(x)" to group all indices into a single vector I?'
         )
-    ast_builder.begin_frontend_struct_for(group, loop_range._loop_range())
+    if isinstance(loop_range, AnyArray):
+        ast_builder.begin_frontend_struct_for_on_external_tensor(group, loop_range._loop_range())
+    else:
+        ast_builder.begin_frontend_struct_for_on_snode(group, loop_range._loop_range())
 
 
 def begin_frontend_if(ast_builder, cond):

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -234,12 +234,12 @@ class SNode:
         return ret
 
     def _loop_range(self):
-        """Gets the taichi_python.Expr wrapping the taichi_python.GlobalVariableExpression corresponding to `self` to serve as loop range.
+        """Gets the taichi_python.SNode to serve as loop range.
 
         Returns:
-            taichi_python.Expr: See above.
+            taichi_python.SNode: See above.
         """
-        return impl.get_runtime().prog.global_var_expr_from_snode(self.ptr)
+        return self.ptr
 
     @property
     def _name(self):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -510,10 +510,10 @@ class StructField(Field):
         return self._members[0]._snode
 
     def _loop_range(self):
-        """Gets representative field member for loop range info.
+        """Gets SNode of representative field member for loop range info.
 
         Returns:
-            taichi_python.Expr: Representative (first) field member.
+            taichi_python.SNode: SNode of representative (first) field member.
         """
         return self._members[0]._loop_range()
 

--- a/taichi/analysis/gen_offline_cache_key.cpp
+++ b/taichi/analysis/gen_offline_cache_key.cpp
@@ -31,9 +31,10 @@ enum class StmtOpCode : std::uint8_t {
 };
 
 enum class ForLoopType : std::uint8_t {
-  RangeFor,
-  StructFor,
+  StructForOnSNode,
+  StructForOnExternalTensor,
   MeshFor,
+  RangeFor
 };
 
 enum class ExternalFuncType : std::uint8_t {
@@ -357,20 +358,22 @@ class ASTSerializer : public IRVisitor, public ExpressionVisitor {
 
   void visit(FrontendForStmt *stmt) override {
     emit(StmtOpCode::FrontendForStmt);
-    if (stmt->is_ranged()) {
-      emit(ForLoopType::RangeFor);
-      emit(stmt->loop_var_id);
-      emit(stmt->begin);
-      emit(stmt->end);
-    } else if (stmt->mesh_for) {
+    if (stmt->snode) {
+      emit(ForLoopType::StructForOnSNode);
+      emit(stmt->snode);
+    } else if (stmt->external_tensor) {
+      emit(ForLoopType::StructForOnExternalTensor);
+      emit(stmt->external_tensor);
+    } else if (stmt->mesh) {
       emit(ForLoopType::MeshFor);
       emit(stmt->element_type);
       emit(stmt->mesh);
     } else {
-      emit(ForLoopType::StructFor);
-      emit(stmt->loop_var_id);
-      emit(stmt->global_var);
+      emit(ForLoopType::RangeFor);
+      emit(stmt->begin);
+      emit(stmt->end);
     }
+    emit(stmt->loop_var_ids);
     emit(stmt->is_bit_vectorized);
     emit(stmt->num_cpu_threads);
     emit(stmt->strictly_serialized);

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -78,7 +78,7 @@ void FrontendForStmt::init_config(Arch arch, const ForLoopConfig &config) {
   if (arch == Arch::cuda) {
     num_cpu_threads = 1;
     TI_ASSERT(block_dim <= taichi_max_gpu_block_dim);
-  } else { // cpu
+  } else {  // cpu
     if (config.num_cpu_threads == 0) {
       num_cpu_threads = std::thread::hardware_concurrency();
     } else {
@@ -1082,14 +1082,15 @@ void ASTBuilder::begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars,
   this->create_scope(stmt->body, For);
 }
 
-void ASTBuilder::begin_frontend_struct_for_on_external_tensor(const ExprGroup &loop_vars,
-                                           const Expr &external_tensor) {
+void ASTBuilder::begin_frontend_struct_for_on_external_tensor(
+    const ExprGroup &loop_vars,
+    const Expr &external_tensor) {
   TI_WARN_IF(
       for_loop_dec_.config.strictly_serialized,
       "ti.loop_config(serialize=True) does not have effect on the struct for. "
       "The execution order is not guaranteed.");
-  auto stmt_unique = std::make_unique<FrontendForStmt>(loop_vars, external_tensor, arch_,
-                                                       for_loop_dec_.config);
+  auto stmt_unique = std::make_unique<FrontendForStmt>(
+      loop_vars, external_tensor, arch_, for_loop_dec_.config);
   for_loop_dec_.reset();
   auto stmt = stmt_unique.get();
   this->insert(std::move(stmt_unique));

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -928,8 +928,11 @@ class ASTBuilder {
                           const std::string &msg,
                           const std::vector<Expr> &args);
   void begin_frontend_range_for(const Expr &i, const Expr &s, const Expr &e);
-  void begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars, SNode *snode);
-  void begin_frontend_struct_for_on_external_tensor(const ExprGroup &loop_vars, const Expr &external_tensor);
+  void begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars,
+                                          SNode *snode);
+  void begin_frontend_struct_for_on_external_tensor(
+      const ExprGroup &loop_vars,
+      const Expr &external_tensor);
   void begin_frontend_mesh_for(const Expr &i,
                                const mesh::MeshPtr &mesh_ptr,
                                const mesh::MeshElementType &element_type);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -161,34 +161,30 @@ class FrontendPrintStmt : public Stmt {
 
 class FrontendForStmt : public Stmt {
  public:
+  SNode *snode{nullptr};
+  Expr external_tensor;
+  mesh::Mesh *mesh{nullptr};
+  mesh::MeshElementType element_type;
   Expr begin, end;
-  Expr global_var;
   std::unique_ptr<Block> body;
-  std::vector<Identifier> loop_var_id;
+  std::vector<Identifier> loop_var_ids;
   bool is_bit_vectorized;
   int num_cpu_threads;
   bool strictly_serialized;
   MemoryAccessOptions mem_access_opt;
   int block_dim;
 
-  bool mesh_for = false;
-  mesh::Mesh *mesh;
-  mesh::MeshElementType element_type;
-
-  bool is_ranged() const {
-    if (global_var.expr == nullptr && !mesh_for) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  FrontendForStmt(const ExprGroup &loop_var,
-                  const Expr &global_var,
+  FrontendForStmt(const ExprGroup &loop_vars,
+                  SNode *snode,
                   Arch arch,
                   const ForLoopConfig &config);
 
-  FrontendForStmt(const ExprGroup &loop_var,
+  FrontendForStmt(const ExprGroup &loop_vars,
+                  const Expr &external_tensor,
+                  Arch arch,
+                  const ForLoopConfig &config);
+
+  FrontendForStmt(const ExprGroup &loop_vars,
                   const mesh::MeshPtr &mesh,
                   const mesh::MeshElementType &element_type,
                   Arch arch,
@@ -205,6 +201,13 @@ class FrontendForStmt : public Stmt {
   }
 
   TI_DEFINE_ACCEPT
+
+ private:
+  void init_config(Arch arch, const ForLoopConfig &config);
+
+  void init_loop_vars(const ExprGroup &loop_vars);
+
+  void add_loop_var(const Expr &loop_var);
 };
 
 class FrontendFuncDefStmt : public Stmt {
@@ -497,10 +500,6 @@ class GlobalVariableExpression : public Expression {
 
   GlobalVariableExpression(DataType dt, const Identifier &ident)
       : ident(ident), dt(dt) {
-  }
-
-  GlobalVariableExpression(SNode *snode, const Identifier &ident)
-      : ident(ident), dt(snode->dt), snode(snode) {
   }
 
   void type_check(CompileConfig *config) override {
@@ -929,8 +928,8 @@ class ASTBuilder {
                           const std::string &msg,
                           const std::vector<Expr> &args);
   void begin_frontend_range_for(const Expr &i, const Expr &s, const Expr &e);
-  void begin_frontend_struct_for(const ExprGroup &loop_vars,
-                                 const Expr &global);
+  void begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars, SNode *snode);
+  void begin_frontend_struct_for_on_external_tensor(const ExprGroup &loop_vars, const Expr &external_tensor);
   void begin_frontend_mesh_for(const Expr &i,
                                const mesh::MeshPtr &mesh_ptr,
                                const mesh::MeshElementType &element_type);
@@ -984,13 +983,14 @@ class FrontendContext {
   std::unique_ptr<Block> root_node_;
 
  public:
-  FrontendContext(Arch arch);
+  FrontendContext(Arch arch) {
+    root_node_ = std::make_unique<Block>();
+    current_builder_ = std::make_unique<ASTBuilder>(root_node_.get(), arch);
+  }
 
   ASTBuilder &builder() {
     return *current_builder_;
   }
-
-  IRNode *root();
 
   std::unique_ptr<Block> get_root() {
     return std::move(root_node_);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -301,8 +301,10 @@ void export_lang(py::module &m) {
       .def("expr_assign", &ASTBuilder::expr_assign)
       .def("begin_frontend_range_for", &ASTBuilder::begin_frontend_range_for)
       .def("end_frontend_range_for", &ASTBuilder::pop_scope)
-      .def("begin_frontend_struct_for_on_snode", &ASTBuilder::begin_frontend_struct_for_on_snode)
-      .def("begin_frontend_struct_for_on_external_tensor", &ASTBuilder::begin_frontend_struct_for_on_external_tensor)
+      .def("begin_frontend_struct_for_on_snode",
+           &ASTBuilder::begin_frontend_struct_for_on_snode)
+      .def("begin_frontend_struct_for_on_external_tensor",
+           &ASTBuilder::begin_frontend_struct_for_on_external_tensor)
       .def("end_frontend_struct_for", &ASTBuilder::pop_scope)
       .def("begin_frontend_mesh_for", &ASTBuilder::begin_frontend_mesh_for)
       .def("end_frontend_mesh_for", &ASTBuilder::pop_scope)
@@ -484,10 +486,9 @@ void export_lang(py::module &m) {
              program->fill_ndarray_fast(ndarray,
                                         reinterpret_cast<int32_t &>(val));
            })
-      .def("fill_uint",
-           [](Program *program, Ndarray *ndarray, uint32_t val) {
-             program->fill_ndarray_fast(ndarray, val);
-           });
+      .def("fill_uint", [](Program *program, Ndarray *ndarray, uint32_t val) {
+        program->fill_ndarray_fast(ndarray, val);
+      });
 
   py::class_<AotModuleBuilder>(m, "AotModuleBuilder")
       .def("add_field", &AotModuleBuilder::add_field)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -301,7 +301,8 @@ void export_lang(py::module &m) {
       .def("expr_assign", &ASTBuilder::expr_assign)
       .def("begin_frontend_range_for", &ASTBuilder::begin_frontend_range_for)
       .def("end_frontend_range_for", &ASTBuilder::pop_scope)
-      .def("begin_frontend_struct_for", &ASTBuilder::begin_frontend_struct_for)
+      .def("begin_frontend_struct_for_on_snode", &ASTBuilder::begin_frontend_struct_for_on_snode)
+      .def("begin_frontend_struct_for_on_external_tensor", &ASTBuilder::begin_frontend_struct_for_on_external_tensor)
       .def("end_frontend_struct_for", &ASTBuilder::pop_scope)
       .def("begin_frontend_mesh_for", &ASTBuilder::begin_frontend_mesh_for)
       .def("end_frontend_mesh_for", &ASTBuilder::pop_scope)
@@ -486,11 +487,7 @@ void export_lang(py::module &m) {
       .def("fill_uint",
            [](Program *program, Ndarray *ndarray, uint32_t val) {
              program->fill_ndarray_fast(ndarray, val);
-           })
-      .def("global_var_expr_from_snode", [](Program *program, SNode *snode) {
-        return Expr::make<GlobalVariableExpression>(
-            snode, program->get_next_global_id());
-      });
+           });
 
   py::class_<AotModuleBuilder>(m, "AotModuleBuilder")
       .def("add_field", &AotModuleBuilder::add_field)

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -187,15 +187,103 @@ class LowerAST : public IRVisitor {
 
   void visit(FrontendForStmt *stmt) override {
     auto fctx = make_flatten_ctx();
-    if (stmt->is_ranged()) {
-      TI_ASSERT(stmt->loop_var_id.size() == 1);
+    if (stmt->snode) {
+      auto snode = stmt->snode;
+      std::vector<int> offsets;
+      if (snode->type == SNodeType::place) {
+        /* Note:
+         * for i in x:
+         *   x[i] = 0
+         *
+         * has the same effect as
+         *
+         * for i in x.parent():
+         *   x[i] = 0
+         *
+         * (unless x has index offsets)*/
+        offsets = snode->index_offsets;
+        snode = snode->parent;
+      }
+
+      // Climb up one more level if inside bit_struct.
+      // Note that when looping over bit_structs, we generate
+      // struct for on their parent node instead of itself for
+      // higher performance.
+      if (snode->type == SNodeType::bit_struct)
+        snode = snode->parent;
+
+      auto &&new_for = std::make_unique<StructForStmt>(
+          snode, std::move(stmt->body), stmt->is_bit_vectorized,
+          stmt->num_cpu_threads, stmt->block_dim);
+      new_for->index_offsets = offsets;
+      VecStatement new_statements;
+      for (int i = 0; i < (int)stmt->loop_var_ids.size(); i++) {
+        Stmt *loop_index = new_statements.push_back<LoopIndexStmt>(
+            new_for.get(), snode->physical_index_position[i]);
+        if ((int)offsets.size() > i && offsets[i] != 0) {
+          auto offset_const =
+              new_statements.push_back<ConstStmt>(TypedConstant(offsets[i]));
+          auto result = new_statements.push_back<BinaryOpStmt>(
+              BinaryOpType::add, loop_index, offset_const);
+          loop_index = result;
+        }
+        new_for->body->local_var_to_stmt[stmt->loop_var_ids[i]] = loop_index;
+      }
+      new_for->body->insert(std::move(new_statements), 0);
+      new_for->mem_access_opt = stmt->mem_access_opt;
+      fctx.push_back(std::move(new_for));
+    } else if (stmt->external_tensor) {
+      auto tensor = stmt->external_tensor.cast<ExternalTensorExpression>();
+      std::vector<Stmt *> shape;
+      for (int i = 0; i < tensor->dim - abs(tensor->element_dim); i++) {
+        shape.push_back(fctx.push_back<ExternalTensorShapeAlongAxisStmt>(
+            i, tensor->arg_id));
+      }
+      Stmt *begin = fctx.push_back<ConstStmt>(TypedConstant(0));
+      Stmt *end = fctx.push_back<ConstStmt>(TypedConstant(1));
+      for (int i = 0; i < (int)shape.size(); i++) {
+        end = fctx.push_back<BinaryOpStmt>(BinaryOpType::mul, end, shape[i]);
+      }
+      // TODO: add a note explaining why shape might be empty.
+      auto &&new_for = std::make_unique<RangeForStmt>(
+          begin, end, std::move(stmt->body), stmt->is_bit_vectorized,
+          stmt->num_cpu_threads, stmt->block_dim, stmt->strictly_serialized,
+          /*range_hint=*/fmt::format("arg {}", tensor->arg_id));
+      VecStatement new_statements;
+      Stmt *loop_index =
+          new_statements.push_back<LoopIndexStmt>(new_for.get(), 0);
+      for (int i = (int)shape.size() - 1; i >= 0; i--) {
+        Stmt *loop_var = new_statements.push_back<BinaryOpStmt>(
+            BinaryOpType::mod, loop_index, shape[i]);
+        new_for->body->local_var_to_stmt[stmt->loop_var_ids[i]] = loop_var;
+        std::vector<uint32_t> decoration = {
+            uint32_t(DecorationStmt::Decoration::kLoopUnique), uint32_t(i)};
+        new_statements.push_back<DecorationStmt>(loop_var, decoration);
+        loop_index = new_statements.push_back<BinaryOpStmt>(
+            BinaryOpType::div, loop_index, shape[i]);
+      }
+      new_for->body->insert(std::move(new_statements), 0);
+      fctx.push_back(std::move(new_for));
+    } else if (stmt->mesh) {
+      auto &&new_for = std::make_unique<MeshForStmt>(
+          stmt->mesh, stmt->element_type, std::move(stmt->body),
+          stmt->is_bit_vectorized, stmt->num_cpu_threads, stmt->block_dim);
+      new_for->body->insert(std::make_unique<LoopIndexStmt>(new_for.get(), 0),
+                            0);
+      new_for->body->local_var_to_stmt[stmt->loop_var_ids[0]] =
+          new_for->body->statements[0].get();
+      new_for->mem_access_opt = stmt->mem_access_opt;
+      new_for->fields_registered = true;
+      fctx.push_back(std::move(new_for));
+    } else {
+      TI_ASSERT(stmt->loop_var_ids.size() == 1);
       auto begin = stmt->begin;
       auto end = stmt->end;
       flatten_rvalue(begin, &fctx);
       flatten_rvalue(end, &fctx);
       bool is_good_range_for = detected_fors_with_break_.find(stmt) ==
                                detected_fors_with_break_.end();
-      // #578: a good range for is a range for that doesn't contains a break
+      // #578: a good range for is a range for that doesn't contain a break
       // statement
       if (is_good_range_for) {
         auto &&new_for = std::make_unique<RangeForStmt>(
@@ -204,7 +292,7 @@ class LowerAST : public IRVisitor {
             stmt->strictly_serialized);
         new_for->body->insert(std::make_unique<LoopIndexStmt>(new_for.get(), 0),
                               0);
-        new_for->body->local_var_to_stmt[stmt->loop_var_id[0]] =
+        new_for->body->local_var_to_stmt[stmt->loop_var_ids[0]] =
             new_for->body->statements[0].get();
         fctx.push_back(std::move(new_for));
       } else {
@@ -213,7 +301,7 @@ class LowerAST : public IRVisitor {
         // body; }
         fctx.push_back<AllocaStmt>(PrimitiveType::i32);
         auto loop_var = fctx.back_stmt();
-        stmt->parent->local_var_to_stmt[stmt->loop_var_id[0]] = loop_var;
+        stmt->parent->local_var_to_stmt[stmt->loop_var_ids[0]] = loop_var;
         auto const_one = fctx.push_back<ConstStmt>(TypedConstant((int32)1));
         auto begin_minus_one = fctx.push_back<BinaryOpStmt>(
             BinaryOpType::sub, begin->stmt, const_one);
@@ -252,94 +340,6 @@ class LowerAST : public IRVisitor {
             std::make_unique<LocalStoreStmt>(new_while->mask, const_stmt_ptr));
         fctx.push_back(std::move(new_while));
       }
-    } else if (stmt->mesh_for) {
-      auto &&new_for = std::make_unique<MeshForStmt>(
-          stmt->mesh, stmt->element_type, std::move(stmt->body),
-          stmt->is_bit_vectorized, stmt->num_cpu_threads, stmt->block_dim);
-      new_for->body->insert(std::make_unique<LoopIndexStmt>(new_for.get(), 0),
-                            0);
-      new_for->body->local_var_to_stmt[stmt->loop_var_id[0]] =
-          new_for->body->statements[0].get();
-      new_for->mem_access_opt = stmt->mem_access_opt;
-      new_for->fields_registered = true;
-      fctx.push_back(std::move(new_for));
-    } else if (stmt->global_var.is<GlobalVariableExpression>()) {
-      auto snode = stmt->global_var.cast<GlobalVariableExpression>()->snode;
-      std::vector<int> offsets;
-      if (snode->type == SNodeType::place) {
-        /* Note:
-         * for i in x:
-         *   x[i] = 0
-         *
-         * has the same effect as
-         *
-         * for i in x.parent():
-         *   x[i] = 0
-         *
-         * (unless x has index offsets)*/
-        offsets = snode->index_offsets;
-        snode = snode->parent;
-      }
-
-      // Climb up one more level if inside bit_struct.
-      // Note that when looping over bit_structs, we generate
-      // struct for on their parent node instead of itself for
-      // higher performance.
-      if (snode->type == SNodeType::bit_struct)
-        snode = snode->parent;
-
-      auto &&new_for = std::make_unique<StructForStmt>(
-          snode, std::move(stmt->body), stmt->is_bit_vectorized,
-          stmt->num_cpu_threads, stmt->block_dim);
-      new_for->index_offsets = offsets;
-      VecStatement new_statements;
-      for (int i = 0; i < (int)stmt->loop_var_id.size(); i++) {
-        Stmt *loop_index = new_statements.push_back<LoopIndexStmt>(
-            new_for.get(), snode->physical_index_position[i]);
-        if ((int)offsets.size() > i && offsets[i] != 0) {
-          auto offset_const =
-              new_statements.push_back<ConstStmt>(TypedConstant(offsets[i]));
-          auto result = new_statements.push_back<BinaryOpStmt>(
-              BinaryOpType::add, loop_index, offset_const);
-          loop_index = result;
-        }
-        new_for->body->local_var_to_stmt[stmt->loop_var_id[i]] = loop_index;
-      }
-      new_for->body->insert(std::move(new_statements), 0);
-      new_for->mem_access_opt = stmt->mem_access_opt;
-      fctx.push_back(std::move(new_for));
-    } else {
-      auto tensor = stmt->global_var.cast<ExternalTensorExpression>();
-      std::vector<Stmt *> shape;
-      for (int i = 0; i < tensor->dim - abs(tensor->element_dim); i++) {
-        shape.push_back(fctx.push_back<ExternalTensorShapeAlongAxisStmt>(
-            i, tensor->arg_id));
-      }
-      Stmt *begin = fctx.push_back<ConstStmt>(TypedConstant(0));
-      Stmt *end = fctx.push_back<ConstStmt>(TypedConstant(1));
-      for (int i = 0; i < (int)shape.size(); i++) {
-        end = fctx.push_back<BinaryOpStmt>(BinaryOpType::mul, end, shape[i]);
-      }
-      // TODO: add a note explaining why shape might be empty.
-      auto &&new_for = std::make_unique<RangeForStmt>(
-          begin, end, std::move(stmt->body), stmt->is_bit_vectorized,
-          stmt->num_cpu_threads, stmt->block_dim, stmt->strictly_serialized,
-          /*range_hint=*/fmt::format("arg {}", tensor->arg_id));
-      VecStatement new_statements;
-      Stmt *loop_index =
-          new_statements.push_back<LoopIndexStmt>(new_for.get(), 0);
-      for (int i = (int)shape.size() - 1; i >= 0; i--) {
-        Stmt *loop_var = new_statements.push_back<BinaryOpStmt>(
-            BinaryOpType::mod, loop_index, shape[i]);
-        new_for->body->local_var_to_stmt[stmt->loop_var_id[i]] = loop_var;
-        std::vector<uint32_t> decoration = {
-            uint32_t(DecorationStmt::Decoration::kLoopUnique), uint32_t(i)};
-        new_statements.push_back<DecorationStmt>(loop_var, decoration);
-        loop_index = new_statements.push_back<BinaryOpStmt>(
-            BinaryOpType::div, loop_index, shape[i]);
-      }
-      new_for->body->insert(std::move(new_statements), 0);
-      fctx.push_back(std::move(new_for));
     }
     auto pfor = fctx.stmts.back().get();
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -81,10 +81,8 @@ TEST(FrontendTypeInference, TernaryOp) {
 }
 
 TEST(FrontendTypeInference, GlobalPtr_GlobalVariable) {
-  auto snode = std::make_unique<SNode>(0, SNodeType::root);
-  snode->dt = PrimitiveType::u8;
   auto global_var =
-      Expr::make<GlobalVariableExpression>(snode.get(), Identifier(0));
+      Expr::make<GlobalVariableExpression>(PrimitiveType::u8, Identifier(0));
   auto index = value<int32>(2);
   index->type_check(nullptr);
   auto global_ptr = global_var[ExprGroup(index)];


### PR DESCRIPTION
Related issue = #5959

Previously, a `GlobalVariableExpression` serves two purposes:
- representing a field;
- being a wrapper of a (maybe intermediate) SNode so that no matter a `FrontendForStmt` is actually a struct for on a SNode or an external tensor, it can always be constructed by passing an `Expr`.

However, the second purpose doesn't make sense - a struct for on a SNode and a struct for on an external tensor are handled differently everywhere (`lower_ast`, `ir_printer`, ...), so it's natural to split the constructors as well.

This PR clearly and consistently distinguishes different types of `FrontendForStmt`:
- a struct for on a SNode (`snode != nullptr`);
- a struct for on an external tensor (`external_tensor != nullptr`);
- a mesh for (`mesh != nullptr`);
- a range for (other).

As a result, the second purpose is eliminated and a `GlobalVariableExpression` serves solely for a field.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
