### PR TITLE
[cuda] Use CUDA primary context to work with PyTorch and Numba.

### DIFF
--- a/taichi/rhi/cuda/cuda_context.cpp
+++ b/taichi/rhi/cuda/cuda_context.cpp
@@ -33,7 +33,8 @@ CUDAContext::CUDAContext()
       &cc_minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device_);
 
   TI_TRACE("CUDA Device Compute Capability: {}.{}", cc_major, cc_minor);
-  driver_.context_create(&context_, 0, device_);
+  driver_.primary_context_retain(&context_, 0);
+  driver_.context_set_current(context_);
 
   const auto GB = std::pow(1024.0, 3.0);
   TI_TRACE("Total memory {:.2f} GB; free memory {:.2f} GB",

--- a/taichi/rhi/cuda/cuda_driver_functions.inc.h
+++ b/taichi/rhi/cuda/cuda_driver_functions.inc.h
@@ -14,7 +14,7 @@ PER_CUDA_FUNCTION(device_get_attribute, cuDeviceGetAttribute, int *, uint32, voi
 PER_CUDA_FUNCTION(context_create, cuCtxCreate_v2, void*, int, void *);
 PER_CUDA_FUNCTION(context_set_current, cuCtxSetCurrent, void *);
 PER_CUDA_FUNCTION(context_get_current, cuCtxGetCurrent, void **);
-PER_CUDA_FUNCTION(context_pop_current, cuCtxPopCurrent, void **);
+PER_CUDA_FUNCTION(primary_context_retain, cuDevicePrimaryCtxRetain, void **, int);
 
 // Stream management
 PER_CUDA_FUNCTION(stream_create, cuStreamCreate, void **, uint32);

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -176,7 +176,6 @@ void LlvmRuntimeExecutor::print_list_manager_info(void *list_manager,
 void LlvmRuntimeExecutor::synchronize() {
   if (config_->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-    CUDAContext::get_instance().make_current();
     CUDADriver::get_instance().stream_synchronize(nullptr);
 #else
     TI_ERROR("No CUDA support");
@@ -191,7 +190,6 @@ uint64 LlvmRuntimeExecutor::fetch_result_uint64(int i, uint64 *result_buffer) {
   uint64 ret;
   if (config_->arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
-    CUDAContext::get_instance().make_current();
     CUDADriver::get_instance().memcpy_device_to_host(&ret, result_buffer + i,
                                                      sizeof(uint64));
 #else
@@ -612,11 +610,6 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
         "LLVMRuntime_set_profiler_stop", llvm_runtime_,
         (void *)&KernelProfilerBase::profiler_stop);
   }
-#if defined(TI_WITH_CUDA)
-  if (config_->arch == Arch::cuda) {
-    CUDADriver::get_instance().context_pop_current(nullptr);
-  }
-#endif
 }
 
 void LlvmRuntimeExecutor::destroy_snode_tree(SNodeTree *snode_tree) {


### PR DESCRIPTION
Related issue = #5502

PR #5891 solved the problem but the fix is fragile. Using primary context instead of `cuCtxCreate` could also work with PyTorch and Numba. The context management code are no longer needed and reverted.