### PR TITLE
[ci] Windows Build: Use PowerShell 7 (pwsh)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -492,7 +492,7 @@ jobs:
     steps:
       # See also https://github.com/taichi-dev/taichi/issues/4161
       - name: Cleanup
-        shell: powershell
+        shell: pwsh
         run: |
           remove-item '${{ github.workspace }}\*' -recurse -force
 
@@ -518,7 +518,7 @@ jobs:
             ccache-win64-
 
       - name: Build
-        shell: powershell
+        shell: pwsh
         if: ${{ needs.check_files.outputs.run_job != 'false' }}
         run: |
           .\.github\workflows\scripts\win_build.ps1  -llvmVer ${{ matrix.llvmVer }} -installVulkan -install -libsDir C:\
@@ -527,7 +527,7 @@ jobs:
 
       - name: Test
         id: test
-        shell: powershell
+        shell: pwsh
         if: ${{ needs.check_files.outputs.run_job != 'false' }}
         run: |
           .\.github\workflows\scripts\win_test.ps1


### PR DESCRIPTION
While adding new Windows buildbot using Windows Server 2019, the shipped Windows PowerShell 5.x exhibit different behaviour between Windows Server and Windows 10, but PowerShell 7.x works fine.

On Windows Server 2019 build scripts will throw NativeCommandError when anything is pumped into stderr.

Didn't find any viable solution or configuration difference, giving up, just use PowerShell 7.x.


<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
