### PR TITLE
[refactor] Turn on torch_io tests for opengl, vulkan and dx11 backend

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -573,13 +573,6 @@ class Kernel:
             )
         tmp = v
         taichi_arch = self.runtime.prog.config.arch
-        # Ndarray means its memory is allocated on the specified taichi arch.
-        # Since torch only supports CPU & CUDA, torch-base ndarray only supports
-        # taichi cpu/cuda backend as well.
-        # Note I put x64/arm64/cuda here to be more specific.
-        assert not is_ndarray or taichi_arch in (
-            _ti_core.Arch.cuda, _ti_core.Arch.x64, _ti_core.Arch.arm64
-        ), "Torch-based ndarray is only supported on taichi x64/arm64/cuda backend."
 
         if str(v.device).startswith('cuda'):
             # External tensor on cuda
@@ -588,12 +581,6 @@ class Kernel:
                 host_v = v.to(device='cpu', copy=True)
                 tmp = host_v
                 callbacks.append(get_call_back(v, host_v))
-        else:
-            # External tensor on cpu
-            if taichi_arch == _ti_core.Arch.cuda:
-                gpu_v = v.cuda()
-                tmp = gpu_v
-                callbacks.append(get_call_back(v, gpu_v))
         return tmp, callbacks
 
     def get_paddle_callbacks(self, v, has_pp):

--- a/tests/python/test_torch_ad.py
+++ b/tests/python/test_torch_ad.py
@@ -22,7 +22,7 @@ def test_torch_cuda_context():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=ti.opengl)
+@test_utils.test()
 def test_torch_ad():
     n = 32
 
@@ -63,6 +63,7 @@ def test_torch_ad():
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
 @pytest.mark.skipif(sys.platform == 'win32', reason='not working on Windows.')
+# FIXME: crashes at glCreateShader when arch=ti.opengl
 @test_utils.test(exclude=ti.opengl)
 def test_torch_ad_gpu():
     if not torch.cuda.is_available():

--- a/tests/python/test_torch_io.py
+++ b/tests/python/test_torch_io.py
@@ -11,7 +11,7 @@ if has_pytorch():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_io_devices():
     n = 32
     x = ti.field(dtype=ti.i32, shape=n)
@@ -48,7 +48,7 @@ def test_io_devices():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_io():
     n = 32
 
@@ -88,7 +88,7 @@ def test_io():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_io_2d():
     n = 32
 
@@ -112,7 +112,7 @@ def test_io_2d():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_io_3d():
     n = 16
 
@@ -138,7 +138,7 @@ def test_io_3d():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_io_simple():
     n = 32
 
@@ -165,7 +165,7 @@ def test_io_simple():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_io_zeros():
     mat = ti.Matrix.field(2, 6, dtype=ti.f32, shape=(), needs_grad=True)
     zeros = torch.zeros((2, 6))
@@ -179,7 +179,7 @@ def test_io_zeros():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_io_struct():
     n = 16
     x1 = ti.Struct.field({"a": ti.i32, "b": ti.f32}, shape=(n, ))
@@ -199,7 +199,7 @@ def test_io_struct():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_fused_kernels():
     n = 12
     X = ti.Matrix.field(3, 2, ti.f32, shape=(n, n, n))
@@ -211,7 +211,7 @@ def test_fused_kernels():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_device():
     n = 12
     X = ti.Matrix.field(3, 2, ti.f32, shape=(n, n, n))
@@ -222,7 +222,7 @@ def test_device():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_shape_matrix():
     n = 12
     x = ti.Matrix.field(3, 2, ti.f32, shape=(n, n))
@@ -242,7 +242,7 @@ def test_shape_matrix():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_shape_vector():
     n = 12
     x = ti.Vector.field(3, ti.f32, shape=(n, n))
@@ -261,7 +261,7 @@ def test_shape_vector():
 
 
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@test_utils.test(exclude=[ti.opengl, ti.vulkan, ti.dx11])
+@test_utils.test()
 def test_torch_zero():
     @ti.kernel
     def test_torch(arr: ti.types.ndarray()):


### PR DESCRIPTION
These io are through torch cpu tensors, not really the most efficient solution but should
be working at least.

Related issue = #

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
