### PR TITLE
[misc] Lazy load spirv code from disk during offline cache

### DIFF
--- a/taichi/cache/gfx/cache_manager.cpp
+++ b/taichi/cache/gfx/cache_manager.cpp
@@ -134,6 +134,7 @@ CacheManager::CacheManager(Params &&init_params)
       gfx::AotModuleParams params;
       params.module_path = path_;
       params.runtime = runtime_;
+      params.enable_lazy_loading = true;
       cached_module_ = gfx::make_aot_module(params, init_params.arch);
     }
   }

--- a/taichi/runtime/gfx/aot_module_loader_impl.cpp
+++ b/taichi/runtime/gfx/aot_module_loader_impl.cpp
@@ -24,7 +24,7 @@ class FieldImpl : public aot::Field {
 class AotModuleImpl : public aot::Module {
  public:
   explicit AotModuleImpl(const AotModuleParams &params, Arch device_api_backend)
-      : runtime_(params.runtime), device_api_backend_(device_api_backend) {
+      : module_path_(params.module_path), runtime_(params.runtime), device_api_backend_(device_api_backend) {
     const std::string bin_path =
         fmt::format("{}/metadata.tcb", params.module_path);
     if (!read_from_binary_file(ti_aot_data_, bin_path)) {
@@ -32,20 +32,21 @@ class AotModuleImpl : public aot::Module {
       return;
     }
 
-    for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
-      auto k = ti_aot_data_.kernels[i];
-
-      std::vector<std::vector<uint32_t>> spirv_sources_codes;
-      for (int j = 0; j < k.tasks_attribs.size(); ++j) {
-        std::vector<uint32_t> res =
-            read_spv_file(params.module_path, k.tasks_attribs[j]);
-        if (res.size() == 0) {
-          mark_corrupted();
-          return;
+    if (!params.enable_lazy_loading) {
+      for (int i = 0; i < ti_aot_data_.kernels.size(); ++i) {
+        auto k = ti_aot_data_.kernels[i];
+        std::vector<std::vector<uint32_t>> spirv_sources_codes;
+        for (int j = 0; j < k.tasks_attribs.size(); ++j) {
+          std::vector<uint32_t> res =
+              read_spv_file(params.module_path, k.tasks_attribs[j]);
+          if (res.size() == 0) {
+            mark_corrupted();
+            return;
+          }
+          spirv_sources_codes.push_back(res);
         }
-        spirv_sources_codes.push_back(res);
+        ti_aot_data_.spirv_codes.push_back(spirv_sources_codes);
       }
-      ti_aot_data_.spirv_codes.push_back(spirv_sources_codes);
     }
 
     const std::string graph_path =
@@ -104,6 +105,9 @@ class AotModuleImpl : public aot::Module {
       // AOT, only use the name of the function which should be the first part
       // of the struct
       if (ti_aot_data_.kernels[i].name.rfind(name, 0) == 0) {
+        if (!try_load_spv_code(i)) {
+          return false;
+        }
         kernel.kernel_attribs = ti_aot_data_.kernels[i];
         kernel.task_spirv_source_codes = ti_aot_data_.spirv_codes[i];
         // We don't have to store the number of SNodeTree in |ti_aot_data_| yet,
@@ -141,19 +145,39 @@ class AotModuleImpl : public aot::Module {
     return std::make_unique<FieldImpl>(runtime_, field);
   }
 
-  std::vector<uint32_t> read_spv_file(const std::string &output_dir,
+  bool try_load_spv_code(std::size_t index) {
+    if (index >= ti_aot_data_.spirv_codes.size() || ti_aot_data_.spirv_codes[index].empty()) {
+      ti_aot_data_.spirv_codes.resize(index + 1);
+      auto &codes = ti_aot_data_.spirv_codes[index];
+      const auto &k = ti_aot_data_.kernels[index];
+      for (const auto &t : k.tasks_attribs) {
+        auto spv = read_spv_file(module_path_, t);
+        if (spv.empty()) {
+          mark_corrupted();
+          return false;
+        }
+        codes.push_back(spv);
+      }
+    }
+    return true;
+  }
+
+  static std::vector<uint32_t> read_spv_file(const std::string &output_dir,
                                       const TaskAttributes &k) {
     const std::string spv_path = fmt::format("{}/{}.spv", output_dir, k.name);
     std::vector<uint32_t> source_code;
     std::ifstream fs(spv_path, std::ios_base::binary | std::ios::ate);
-    size_t size = fs.tellg();
-    fs.seekg(0, std::ios::beg);
-    source_code.resize(size / sizeof(uint32_t));
-    fs.read((char *)source_code.data(), size);
-    fs.close();
+    if (fs.is_open()) {
+      size_t size = fs.tellg();
+      fs.seekg(0, std::ios::beg);
+      source_code.resize(size / sizeof(uint32_t));
+      fs.read((char *)source_code.data(), size);
+      fs.close();
+    }
     return source_code;
   }
 
+  std::string module_path_;
   TaichiAotData ti_aot_data_;
   GfxRuntime *runtime_{nullptr};
   Arch device_api_backend_;

--- a/taichi/runtime/gfx/aot_module_loader_impl.cpp
+++ b/taichi/runtime/gfx/aot_module_loader_impl.cpp
@@ -24,7 +24,9 @@ class FieldImpl : public aot::Field {
 class AotModuleImpl : public aot::Module {
  public:
   explicit AotModuleImpl(const AotModuleParams &params, Arch device_api_backend)
-      : module_path_(params.module_path), runtime_(params.runtime), device_api_backend_(device_api_backend) {
+      : module_path_(params.module_path),
+        runtime_(params.runtime),
+        device_api_backend_(device_api_backend) {
     const std::string bin_path =
         fmt::format("{}/metadata.tcb", params.module_path);
     if (!read_from_binary_file(ti_aot_data_, bin_path)) {
@@ -146,7 +148,8 @@ class AotModuleImpl : public aot::Module {
   }
 
   bool try_load_spv_code(std::size_t index) {
-    if (index >= ti_aot_data_.spirv_codes.size() || ti_aot_data_.spirv_codes[index].empty()) {
+    if (index >= ti_aot_data_.spirv_codes.size() ||
+        ti_aot_data_.spirv_codes[index].empty()) {
       ti_aot_data_.spirv_codes.resize(index + 1);
       auto &codes = ti_aot_data_.spirv_codes[index];
       const auto &k = ti_aot_data_.kernels[index];
@@ -163,7 +166,7 @@ class AotModuleImpl : public aot::Module {
   }
 
   static std::vector<uint32_t> read_spv_file(const std::string &output_dir,
-                                      const TaskAttributes &k) {
+                                             const TaskAttributes &k) {
     const std::string spv_path = fmt::format("{}/{}.spv", output_dir, k.name);
     std::vector<uint32_t> source_code;
     std::ifstream fs(spv_path, std::ios_base::binary | std::ios::ate);

--- a/taichi/runtime/gfx/aot_module_loader_impl.cpp
+++ b/taichi/runtime/gfx/aot_module_loader_impl.cpp
@@ -107,7 +107,7 @@ class AotModuleImpl : public aot::Module {
       // AOT, only use the name of the function which should be the first part
       // of the struct
       if (ti_aot_data_.kernels[i].name.rfind(name, 0) == 0) {
-        if (!try_load_spv_code(i)) {
+        if (!try_load_spv_kernel(i)) {
           return false;
         }
         kernel.kernel_attribs = ti_aot_data_.kernels[i];

--- a/taichi/runtime/gfx/aot_module_loader_impl.cpp
+++ b/taichi/runtime/gfx/aot_module_loader_impl.cpp
@@ -147,7 +147,7 @@ class AotModuleImpl : public aot::Module {
     return std::make_unique<FieldImpl>(runtime_, field);
   }
 
-  bool try_load_spv_code(std::size_t index) {
+  bool try_load_spv_kernel(std::size_t index) {
     if (index >= ti_aot_data_.spirv_codes.size() ||
         ti_aot_data_.spirv_codes[index].empty()) {
       ti_aot_data_.spirv_codes.resize(index + 1);

--- a/taichi/runtime/gfx/aot_module_loader_impl.h
+++ b/taichi/runtime/gfx/aot_module_loader_impl.h
@@ -20,10 +20,11 @@ struct TI_DLL_EXPORT AotModuleParams {
   std::string module_path;
   GfxRuntime *runtime{nullptr};
   bool enable_lazy_loading{false};
-  
+
   AotModuleParams() = default;
-  
-  AotModuleParams(const std::string &path, GfxRuntime *rt) : module_path(path), runtime(rt) {
+
+  AotModuleParams(const std::string &path, GfxRuntime *rt)
+      : module_path(path), runtime(rt) {
   }
 };
 

--- a/taichi/runtime/gfx/aot_module_loader_impl.h
+++ b/taichi/runtime/gfx/aot_module_loader_impl.h
@@ -18,6 +18,7 @@ namespace gfx {
 
 struct TI_DLL_EXPORT AotModuleParams {
   std::string module_path;
+  bool enable_lazy_loading{false};
   GfxRuntime *runtime{nullptr};
 };
 

--- a/taichi/runtime/gfx/aot_module_loader_impl.h
+++ b/taichi/runtime/gfx/aot_module_loader_impl.h
@@ -18,8 +18,13 @@ namespace gfx {
 
 struct TI_DLL_EXPORT AotModuleParams {
   std::string module_path;
-  bool enable_lazy_loading{false};
   GfxRuntime *runtime{nullptr};
+  bool enable_lazy_loading{false};
+  
+  AotModuleParams() = default;
+  
+  AotModuleParams(const std::string &path, GfxRuntime *rt) : module_path(path), runtime(rt) {
+  }
 };
 
 TI_DLL_EXPORT std::unique_ptr<aot::Module> make_aot_module(


### PR DESCRIPTION
Related issue = #4401

<img src="https://user-images.githubusercontent.com/52557189/188795791-557054fc-578c-43a8-9046-402e5f4de2b5.png" width="500px">

ps: The above testing was run in an environment with **100MB+** cache files.
(100MB is the default value of `offline_cache_max_size_of_files` 
<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
