### PR TITLE
[lang] Fixed compilation

### DIFF
--- a/taichi/util/offline_cache.h
+++ b/taichi/util/offline_cache.h
@@ -56,7 +56,7 @@ struct KernelMetadata {
 };
 
 struct Metadata {
-  using KernelMetadata = struct KernelMetadata;
+  using KernelMetadata = KernelMetadata;
 
   Version version{};
   std::size_t size{0};  // byte


### PR DESCRIPTION
`KernelMetadata` is recognized by NDK compiler as a nested class in `Metadata`.