### PR TITLE
[autodiff] Avoid initializing Field with None

### DIFF
--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -16,6 +16,7 @@ class Field:
         vars (List[Expr]): Field members.
     """
     def __init__(self, _vars):
+        assert all(_vars)
         self.vars = _vars
         self.host_accessors = None
         self.grad = None

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -693,10 +693,13 @@ def field(dtype,
     """
     x, x_grad, x_dual = create_field_member(dtype, name, needs_grad,
                                             needs_dual)
-    x, x_grad, x_dual = ScalarField(x), ScalarField(x_grad), ScalarField(
-        x_dual)
-    x._set_grad(x_grad)
-    x._set_dual(x_dual)
+    x = ScalarField(x)
+    if x_grad:
+        x_grad = ScalarField(x_grad)
+        x._set_grad(x_grad)
+    if x_dual:
+        x_dual = ScalarField(x_dual)
+        x._set_dual(x_dual)
 
     if shape is None:
         if offset is not None:

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1181,14 +1181,13 @@ class Matrix(TaichiOperations):
                                              needs_dual=needs_dual))
         entries, entries_grad, entries_dual = zip(*entries)
 
-        entries, entries_grad, entries_dual = MatrixField(
-            entries, n, m, element_dim), MatrixField(entries_grad, n, m,
-                                                     element_dim), MatrixField(
-                                                         entries_dual, n, m,
-                                                         element_dim)
-
-        entries._set_grad(entries_grad)
-        entries._set_dual(entries_dual)
+        entries = MatrixField(entries, n, m, element_dim)
+        if all(entries_grad):
+            entries_grad = MatrixField(entries_grad, n, m, element_dim)
+            entries._set_grad(entries_grad)
+        if all(entries_dual):
+            entries_dual = MatrixField(entries_dual, n, m, element_dim)
+            entries._set_dual(entries_dual)
 
         impl.get_runtime().matrix_fields.append(entries)
 


### PR DESCRIPTION
When `x_grad` or `x_dual` is `None`, they should not be used to initialize the `Field` class.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
