### PR TITLE
[bug] [test] Fix patch_os_environ_helper

### DIFF
--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -41,7 +41,7 @@ def patch_os_environ_helper(custom_environ: dict, excludes: dict):
         environ[key] = custom_environ[key]
     try:
         cached_environ = os.environ
-        os.environ = custom_environ
+        os.environ = environ
         yield os.environ
     finally:
         os.environ = cached_environ


### PR DESCRIPTION
Related PR = #6002
In #6002, `test_init_arg` and `test_init_arch` fails on Windows. The failure is caused by reading outdated offline cache format. However, we have set offline cache to off and set the offline cache directory to a new directory in the environment variables in `run_tests.py`, so this should not happen. Then, I discovered that function `patch_os_environ_helper` which intends to remove only a few specified environment variables (`excludes`) accidentally removes all the environment variables, and replaced them with `custom_environ`. This PR fixes the bug and lets it work as expected.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
