### PR TITLE
[Lang] Support abs(i64)

### DIFF
--- a/taichi/codegen/cc/runtime/base.h
+++ b/taichi/codegen/cc/runtime/base.h
@@ -65,6 +65,10 @@ static inline Ti_f64 Ti_rsqrt(Ti_f64 x) {
   return 1 / sqrt(x);
 }
 
+static inline Ti_i64 Ti_llabs(Ti_i64 x) {
+  return x >= 0 ? x : -x;
+}
+
 ) "\n" STR(
 
 static inline Ti_i32 Ti_rand_i32(void) {

--- a/taichi/codegen/cc/runtime/base.h
+++ b/taichi/codegen/cc/runtime/base.h
@@ -64,7 +64,6 @@ static inline Ti_f32 Ti_rsqrtf(Ti_f32 x) {
 static inline Ti_f64 Ti_rsqrt(Ti_f64 x) {
   return 1 / sqrt(x);
 }
-
 static inline Ti_i64 Ti_llabs(Ti_i64 x) {
   return x >= 0 ? x : -x;
 }

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -148,6 +148,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
         llvm_val[stmt] = create_call("__nv_fabs", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
         llvm_val[stmt] = create_call("__nv_abs", input);
+      } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i64)) {
+        llvm_val[stmt] = create_call("__nv_llabs", input);
       } else {
         TI_NOT_IMPLEMENTED
       }

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -209,6 +209,8 @@ void TaskCodeGenLLVM::emit_extra_unary(UnaryOpStmt *stmt) {
       llvm_val[stmt] = create_call(#x "_f64", input);                   \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) { \
       llvm_val[stmt] = create_call(#x "_i32", input);                   \
+    } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i64)) { \
+      llvm_val[stmt] = create_call(#x "_i64", input);                   \
     } else {                                                            \
       TI_NOT_IMPLEMENTED                                                \
     }                                                                   \

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -221,12 +221,12 @@ DEFINE_UNARY_REAL_FUNC(sin)
 DEFINE_FAST_POW(i32)
 DEFINE_FAST_POW(i64)
 
-int abs_i32(int a) {
-  if (a > 0) {
-    return a;
-  } else {
-    return -a;
-  }
+i32 abs_i32(i32 a) {
+  return a >= 0 ? a : -a;
+}
+
+i64 abs_i64(i64 a) {
+  return a >= 0 ? a : -a;
 }
 
 i32 floordiv_i32(i32 a, i32 b) {

--- a/tests/python/test_abs.py
+++ b/tests/python/test_abs.py
@@ -68,3 +68,13 @@ def test_abs_fwd():
     for i in range(N):
         assert x[i] == abs(y[i])
         assert x.dual[i] == sgn(y[i])
+
+
+@test_utils.test(require=ti.extension.data64)
+def test_abs_i64():
+    @ti.kernel
+    def foo(x: ti.i64) -> ti.i64:
+        return abs(x)
+
+    for x in [-2**40, 0, 2**40]:
+        assert foo(x) == abs(x)


### PR DESCRIPTION
I found that `abs(i64)` was not supported while fixing #5915. This PR adds support for that.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
