### PR TITLE
[bug] [test] Run C-API tests correctly on Windows

### DIFF
--- a/cmake/TaichiCAPITests.cmake
+++ b/cmake/TaichiCAPITests.cmake
@@ -14,7 +14,15 @@ file(GLOB_RECURSE TAICHI_C_API_TESTS_SOURCE
         "c_api/tests/*.cpp")
 
 add_executable(${C_API_TESTS_NAME} ${TAICHI_C_API_TESTS_SOURCE})
-
+if (WIN32)
+    # Output the executable to build/ instead of build/Debug/...
+    set(C_API_TESTS_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build")
+    set_target_properties(${C_API_TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${C_API_TESTS_OUTPUT_DIR})
+    set_target_properties(${C_API_TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG ${C_API_TESTS_OUTPUT_DIR})
+    set_target_properties(${C_API_TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE ${C_API_TESTS_OUTPUT_DIR})
+    set_target_properties(${C_API_TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${C_API_TESTS_OUTPUT_DIR})
+    set_target_properties(${C_API_TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${C_API_TESTS_OUTPUT_DIR})
+endif()
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE taichi_c_api)
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE gtest_main)
 

--- a/cmake/TaichiExamples.cmake
+++ b/cmake/TaichiExamples.cmake
@@ -11,8 +11,8 @@ file(GLOB_RECURSE TAICHI_EXAMPLES_SOURCE
 
 add_executable(${EXAMPLES_NAME} ${TAICHI_EXAMPLES_SOURCE})
 if (WIN32)
-    # Output the executable to bin/ instead of build/Debug/...
-    set(EXAMPLES_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+    # Output the executable to build/ instead of build/Debug/...
+    set(EXAMPLES_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build")
     set_target_properties(${EXAMPLES_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${EXAMPLES_OUTPUT_DIR})
     set_target_properties(${EXAMPLES_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG ${EXAMPLES_OUTPUT_DIR})
     set_target_properties(${EXAMPLES_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE ${EXAMPLES_OUTPUT_DIR})

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -40,8 +40,8 @@ endif()
 
 add_executable(${TESTS_NAME} ${TAICHI_TESTS_SOURCE})
 if (WIN32)
-    # Output the executable to bin/ instead of build/Debug/...
-    set(TESTS_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+    # Output the executable to build/ instead of build/Debug/...
+    set(TESTS_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build")
     set_target_properties(${TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TESTS_OUTPUT_DIR})
     set_target_properties(${TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG ${TESTS_OUTPUT_DIR})
     set_target_properties(${TESTS_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE ${TESTS_OUTPUT_DIR})

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -63,26 +63,30 @@ def _test_cpp_aot(test_filename, build_dir, test_info):
 
 def _test_cpp():
     curr_dir = os.path.dirname(os.path.abspath(__file__))
-    if platform.system() == "Windows":
-        cpp_test_filename = 'taichi_cpp_tests.exe'
-        capi_test_filename = 'taichi_c_api_tests.exe'
-        build_dir = os.path.join(curr_dir, '../bin')
+    cpp_test_filename = 'taichi_cpp_tests.exe'
+    capi_test_filename = 'taichi_c_api_tests.exe'
+    build_dir = os.path.join(curr_dir, '../build')
+
+    capi_tests_exe_path = os.path.join(build_dir, capi_test_filename)
+    cpp_tests_exe_path = os.path.join(build_dir, cpp_test_filename)
+
+    if os.path.exists(capi_tests_exe_path):
+        # Run C-API test cases
+        exclude_tests_cmd = _test_cpp_aot(capi_test_filename, build_dir,
+                                        __capi_aot_test_cases)
+        # Run rest of the C-API tests
+        _run_cpp_test(capi_test_filename, build_dir, exclude_tests_cmd)
     else:
-        cpp_test_filename = 'taichi_cpp_tests'
-        capi_test_filename = 'taichi_c_api_tests'
-        build_dir = os.path.join(curr_dir, '../build')
+        print(f'Not found {capi_tests_exe_path}, skipping...')
 
-    # Run C-API test cases
-    exclude_tests_cmd = _test_cpp_aot(capi_test_filename, build_dir,
-                                      __capi_aot_test_cases)
-    _run_cpp_test(capi_test_filename, build_dir, exclude_tests_cmd)
-
-    # Run AOT test cases
-    exclude_tests_cmd = _test_cpp_aot(cpp_test_filename, build_dir,
-                                      __aot_test_cases)
-
-    # Run rest of the cpp tests
-    _run_cpp_test(cpp_test_filename, build_dir, exclude_tests_cmd)
+    if os.path.exists(cpp_tests_exe_path):
+        # Run AOT test cases
+        exclude_tests_cmd = _test_cpp_aot(cpp_test_filename, build_dir,
+                                        __aot_test_cases)
+        # Run rest of the cpp tests
+        _run_cpp_test(cpp_test_filename, build_dir, exclude_tests_cmd)
+    else:
+        print(f'Not found {cpp_tests_exe_path}, skipping...')
 
 
 def _test_python(args):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -63,9 +63,12 @@ def _test_cpp_aot(test_filename, build_dir, test_info):
 
 def _test_cpp():
     curr_dir = os.path.dirname(os.path.abspath(__file__))
-    cpp_test_filename = 'taichi_cpp_tests.exe'
-    capi_test_filename = 'taichi_c_api_tests.exe'
     build_dir = os.path.join(curr_dir, '../build')
+    cpp_test_filename = 'taichi_cpp_tests'
+    capi_test_filename = 'taichi_c_api_tests'
+    if platform.system() == "Windows":
+        cpp_test_filename += ".exe"
+        capi_test_filename += ".exe"
 
     capi_tests_exe_path = os.path.join(build_dir, capi_test_filename)
     cpp_tests_exe_path = os.path.join(build_dir, cpp_test_filename)


### PR DESCRIPTION
Related issue = #

Output all exes to build/

> This PR moves it to bin\, which is in the PATH and we can run taichi_cpp_tests everywhere.
>    --from https://github.com/taichi-dev/taichi/pull/2515#issue-941918398

IMO, we should run cpp/capi tests by running `python run_tests.py --cpp` instead of launching `taichi_cpp_tests(.exe)` manually

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
