### PR TITLE
[aot] Fixed compilation on Linux distros

### DIFF
--- a/c_api/include/taichi/cpp/taichi.hpp
+++ b/c_api/include/taichi/cpp/taichi.hpp
@@ -3,6 +3,7 @@
 #include <list>
 #include <vector>
 #include <string>
+#include <utility>
 #include "taichi/taichi.h"
 
 namespace ti {


### PR DESCRIPTION
Follow up of #5994. Clang follows a strict separation between C++ headers so fundamental utilities like `std::exchange` is not implicitly included in other `std` headers.