### PR TITLE
[build] Fix compile error on gcc

### DIFF
--- a/taichi/util/offline_cache.h
+++ b/taichi/util/offline_cache.h
@@ -56,7 +56,7 @@ struct KernelMetadata {
 };
 
 struct Metadata {
-  using KernelMetadata = KernelMetadata;
+  using KernelMetadata = taichi::lang::offline_cache::KernelMetadata;
 
   Version version{};
   std::size_t size{0};  // byte

--- a/taichi/util/offline_cache.h
+++ b/taichi/util/offline_cache.h
@@ -45,18 +45,16 @@ inline CleanCachePolicy string_to_clean_cache_policy(const std::string &str) {
   return Never;
 }
 
-struct KernelMetadata {
-  std::string kernel_key;
-  std::size_t size{0};          // byte
-  std::time_t created_at{0};    // sec
-  std::time_t last_used_at{0};  // sec
-  std::size_t num_files{0};
-
-  TI_IO_DEF(kernel_key, size, created_at, last_used_at, num_files);
-};
-
 struct Metadata {
-  using KernelMetadata = taichi::lang::offline_cache::KernelMetadata;
+  struct KernelMetadata {
+    std::string kernel_key;
+    std::size_t size{0};          // byte
+    std::time_t created_at{0};    // sec
+    std::time_t last_used_at{0};  // sec
+    std::size_t num_files{0};
+
+    TI_IO_DEF(kernel_key, size, created_at, last_used_at, num_files);
+  };
 
   Version version{};
   std::size_t size{0};  // byte


### PR DESCRIPTION
Related issue = #

```
/home/yc/taichi/taichi/util/offline_cache.h:59:9: error: declaration of 'using KernelMetadata = struct taichi::lang::offline_cache::KernelMetadata' changes meaning of 'KernelMetadata' [-fpermissive]
   59 |   using KernelMetadata = KernelMetadata;
      |         ^~~~~~~~~~~~~~
```

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
