### PR TITLE
[misc] Enable offline cache in frontend instead of C++ Side

### DIFF
--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -348,6 +348,7 @@ def init(arch=None,
     current_dir = os.getcwd()
 
     cfg = impl.default_cfg()
+    cfg.offline_cache = True  # Enable offline cache by default in frontend instead of C++ Side
     # Check if installed version meets the requirements.
     if require_version is not None:
         check_require_version(require_version)

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -348,7 +348,7 @@ def init(arch=None,
     current_dir = os.getcwd()
 
     cfg = impl.default_cfg()
-    cfg.offline_cache = True  # Enable offline cache by default in frontend instead of C++ Side
+    cfg.offline_cache = True  # Enable offline cache in frontend instead of C++ Side
     # Check if installed version meets the requirements.
     if require_version is not None:
         check_require_version(require_version)

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -348,7 +348,7 @@ def init(arch=None,
     current_dir = os.getcwd()
 
     cfg = impl.default_cfg()
-    cfg.offline_cache = True  # Enable offline cache in frontend instead of C++ Side
+    cfg.offline_cache = True  # Enable offline cache in frontend instead of C++ side
     # Check if installed version meets the requirements.
     if require_version is not None:
         check_require_version(require_version)

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -96,7 +96,7 @@ struct CompileConfig {
   int auto_mesh_local_default_occupacy{4};
 
   // Offline cache options
-  bool offline_cache{true};
+  bool offline_cache{false};
   std::string offline_cache_file_path{get_repo_dir() + "ticache"};
   std::string offline_cache_cleaning_policy{
       "lru"};  // "never"|"version"|"lru"|"fifo"


### PR DESCRIPTION
Related issue = #4401 

Enabling offline cache in C++ Side (setting `CompileConfig::offline_cache` as `true` by default) is dangerous. The offline cache will always be enabled when running taichi_cpp_tests because the value of compile config in C++ side is not affected by env variables, which is not expected and can cause some strange bugs because it will unexpectedly load cache files that were not expected to generate.

<!--
Thank you for your contribution!

If it is your first time contributing to Taichi, please read our Contributor Guidelines:
  https://docs.taichi-lang.org/docs/contributor_guide

- Please always prepend your PR title with tags such as [CUDA], [Lang], [Doc], [Example]. For a complete list of valid PR tags, please check out https://github.com/taichi-dev/taichi/blob/master/misc/prtags.json.
- Use upper-case tags (e.g., [Metal]) for PRs that change public APIs. Otherwise, please use lower-case tags (e.g., [metal]).
- More details: https://docs.taichi-lang.org/docs/contributor_guide#pr-title-format-and-tags

- Please fill in the issue number that this PR relates to.
- If your PR fixes the issue **completely**, use the `close` or `fixes` prefix so that GitHub automatically closes the issue when the PR is merged. For example,
    Related issue = close #2345
- If the PR does not belong to any existing issue, free to leave it blank.
-->
