### PR TITLE
[lang] Reformat source indicator in Python convention

### DIFF
--- a/docs/lang/articles/debug/debugging.md
+++ b/docs/lang/articles/debug/debugging.md
@@ -293,7 +293,7 @@ Traceback (most recent call last):
     build_stmt(ctx, node.value)
   File "/Users/lanhaidong/taichi/taichi/python/taichi/lang/ast/ast_transformer_utils.py", line 32, in __call__
     raise TaichiCompilationError(msg)
-taichi.lang.exception.TaichiCompilationError: On line 10 of file "misc/demo_traceback.py":
+taichi.lang.exception.TaichiCompilationError: File "misc/demo_traceback.py", line 10:
     ti.static_assert(1 + 1 == 3)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 AssertionError:
@@ -319,7 +319,7 @@ AssertionError
 
 During handling of the above exception, another exception occurred:
 
-taichi.lang.exception.TaichiCompilationError: On line 10 of file "misc/demo_traceback.py":
+taichi.lang.exception.TaichiCompilationError: File "misc/demo_traceback.py", line 10:
     ti.static_assert(1 + 1 == 3)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 AssertionError:

--- a/python/taichi/lang/ast/ast_transformer_utils.py
+++ b/python/taichi/lang/ast/ast_transformer_utils.py
@@ -251,7 +251,7 @@ class ASTTransformerContext:
             raise TaichiNameError(f'Name "{name}" is not defined')
 
     def get_pos_info(self, node):
-        msg = f'On line {node.lineno + self.lineno_offset} of file "{self.file}", in {self.func.func.__name__}:\n'
+        msg = f'File "{self.file}", line {node.lineno + self.lineno_offset}, in {self.func.func.__name__}:\n'
         if version_info < (3, 8):
             msg += self.src[node.lineno - 1] + "\n"
             return msg

--- a/tests/python/test_exception.py
+++ b/tests/python/test_exception.py
@@ -23,11 +23,11 @@ def test_exception_multiline():
 
     if version_info < (3, 8):
         msg = f"""
-On line {frameinfo.lineno + 5} of file "{frameinfo.filename}", in foo:
+File "{frameinfo.filename}", line {frameinfo.lineno + 5}, in foo:
             aaaa(111,"""
     else:
         msg = f"""
-On line {frameinfo.lineno + 5} of file "{frameinfo.filename}", in foo:
+File "{frameinfo.filename}", line {frameinfo.lineno + 5}, in foo:
             aaaa(111,
             ^^^^"""
     print(e.value.args[0])
@@ -56,21 +56,21 @@ def test_exception_from_func():
     file = frameinfo.filename
     if version_info < (3, 8):
         msg = f"""
-On line {lineno + 13} of file "{file}", in foo:
+File "{file}", line {lineno + 13}, in foo:
             bar()
-On line {lineno + 9} of file "{file}", in bar:
+File "{file}", line {lineno + 9}, in bar:
             baz()
-On line {lineno + 5} of file "{file}", in baz:
+File "{file}", line {lineno + 5}, in baz:
             t()"""
     else:
         msg = f"""
-On line {lineno + 13} of file "{file}", in foo:
+File "{file}", line {lineno + 13}, in foo:
             bar()
             ^^^^^
-On line {lineno + 9} of file "{file}", in bar:
+File "{file}", line {lineno + 9}, in bar:
             baz()
             ^^^^^
-On line {lineno + 5} of file "{file}", in baz:
+File "{file}", line {lineno + 5}, in baz:
             t()
             ^"""
     print(e.value.args[0])
@@ -91,11 +91,11 @@ def test_tab():
     file = frameinfo.filename
     if version_info < (3, 8):
         msg = f"""
-On line {lineno + 5} of file "{file}", in foo:
+File "{file}", line {lineno + 5}, in foo:
             a(11,   22, 3)"""
     else:
         msg = f"""
-On line {lineno + 5} of file "{file}", in foo:
+File "{file}", line {lineno + 5}, in foo:
             a(11,   22, 3)
             ^"""
     print(e.value.args[0])
@@ -116,12 +116,12 @@ def test_super_long_line():
     file = frameinfo.filename
     if version_info < (3, 8):
         msg = f"""
-On line {lineno + 5} of file "{file}", in foo:
+File "{file}", line {lineno + 5}, in foo:
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(111)
 """
     else:
         msg = f"""
-On line {lineno + 5} of file "{file}", in foo:
+File "{file}", line {lineno + 5}, in foo:
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaa
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -149,7 +149,7 @@ def test_exception_in_node_with_body():
     lineno = frameinfo.lineno
     file = frameinfo.filename
     msg = f"""
-On line {lineno + 3} of file "{file}", in foo:
+File "{file}", line {lineno + 3}, in foo:
         for i in range(1, 2, 3):
         ^^^^^^^^^^^^^^^^^^^^^^^^
 Range should have 1 or 2 arguments, found 3"""


### PR DESCRIPTION
Follow the Python stacktrace convention to support click-jump to the exact line of compiler error in VS Code.
<img width="663" alt="Image" src="https://user-images.githubusercontent.com/1487605/190040352-daa32d39-9506-49ad-a416-7edcfd203d1b.png">
