### PR TITLE
[bug] Remove unnecessary lower() in AotModuleBuilder::add

### DIFF
--- a/taichi/aot/module_builder.cpp
+++ b/taichi/aot/module_builder.cpp
@@ -5,9 +5,6 @@ namespace taichi {
 namespace lang {
 
 void AotModuleBuilder::add(const std::string &identifier, Kernel *kernel) {
-  if (!kernel->lowered() && Kernel::supports_lowering(kernel->arch)) {
-    kernel->lower(/*to_executable=*/!arch_uses_llvm(kernel->arch));
-  }
   add_per_backend(identifier, kernel);
 }
 
@@ -25,9 +22,6 @@ void AotModuleBuilder::add_field(const std::string &identifier,
 void AotModuleBuilder::add_kernel_template(const std::string &identifier,
                                            const std::string &key,
                                            Kernel *kernel) {
-  if (!kernel->lowered() && Kernel::supports_lowering(kernel->arch)) {
-    kernel->lower();
-  }
   add_per_backend_tmpl(identifier, key, kernel);
 }
 


### PR DESCRIPTION
Related issue = #4401 
Run `python run_tests.py --cpp --with-offline-cache` failed, reported by https://github.com/taichi-dev/taichi/actions/runs/3055000542. Reason: Generate AST key ([1]) after lowering ([2]).

[1]
https://github.com/taichi-dev/taichi/blob/72804ae992212ddee5357bae8b27d6e3f2148831/taichi/codegen/codegen.cpp#L92


[2]
https://github.com/taichi-dev/taichi/blob/72804ae992212ddee5357bae8b27d6e3f2148831/taichi/aot/module_builder.cpp#L8-L10