### PR TITLE
[bug] Fix crashing when loading old offline cache files

### DIFF
--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -20,7 +20,8 @@ file(GLOB_RECURSE TAICHI_TESTS_SOURCE
         "tests/cpp/llvm/*.cpp"
         "tests/cpp/program/*.cpp"
         "tests/cpp/struct/*.cpp"
-        "tests/cpp/transforms/*.cpp")
+        "tests/cpp/transforms/*.cpp"
+        "tests/cpp/offline_cache/*.cpp")
 
 if (TI_WITH_OPENGL OR TI_WITH_VULKAN)
     file(GLOB TAICHI_TESTS_GFX_UTILS_SOURCE

--- a/taichi/cache/gfx/cache_manager.cpp
+++ b/taichi/cache/gfx/cache_manager.cpp
@@ -96,8 +96,7 @@ struct CacheCleanerUtils<gfx::CacheManager::Metadata> {
   // To check if a file is cache file
   static bool is_valid_cache_file(const CacheCleanerConfig &config,
                                   const std::string &name) {
-    std::string postfix = filename_postfix(name);
-    return postfix == "spv";
+    return filename_extension(name) == "spv";
   }
 };
 

--- a/taichi/cache/gfx/cache_manager.cpp
+++ b/taichi/cache/gfx/cache_manager.cpp
@@ -94,7 +94,8 @@ struct CacheCleanerUtils<gfx::CacheManager::Metadata> {
   }
 
   // To check if a file is cache file
-  static bool is_valid_cache_file(const CacheCleanerConfig &config, const std::string &name) {
+  static bool is_valid_cache_file(const CacheCleanerConfig &config,
+                                  const std::string &name) {
     std::string postfix = filename_postfix(name);
     return postfix == "spv";
   }

--- a/taichi/cache/gfx/cache_manager.cpp
+++ b/taichi/cache/gfx/cache_manager.cpp
@@ -47,13 +47,6 @@ struct CacheCleanerUtils<gfx::CacheManager::Metadata> {
   using MetadataType = gfx::CacheManager::Metadata;
   using KernelMetaData = MetadataType::KernelMetadata;
 
-  // To load metadata from file
-  static bool load_metadata(const CacheCleanerConfig &config,
-                            MetadataType &result) {
-    return read_from_binary_file(
-        result, taichi::join_path(config.path, config.metadata_filename));
-  }
-
   // To save metadata as file
   static bool save_metadata(const CacheCleanerConfig &config,
                             const MetadataType &data) {
@@ -81,13 +74,6 @@ struct CacheCleanerUtils<gfx::CacheManager::Metadata> {
     return true;
   }
 
-  // To check version
-  static bool check_version(const CacheCleanerConfig &config,
-                            const Version &version) {
-    return version[0] == TI_VERSION_MAJOR && version[1] == TI_VERSION_MINOR &&
-           version[2] == TI_VERSION_PATCH;
-  }
-
   // To get cache files name
   static std::vector<std::string> get_cache_files(
       const CacheCleanerConfig &config,
@@ -105,6 +91,12 @@ struct CacheCleanerUtils<gfx::CacheManager::Metadata> {
     taichi::remove(
         taichi::join_path(config.path, kDebuggingAotMetadataFilename));
     taichi::remove(taichi::join_path(config.path, kGraphMetadataFilename));
+  }
+
+  // To check if a file is cache file
+  static bool is_valid_cache_file(const CacheCleanerConfig &config, const std::string &name) {
+    std::string postfix = filename_postfix(name);
+    return postfix == "spv";
   }
 };
 
@@ -184,10 +176,12 @@ void CacheManager::dump_with_merging() const {
       cache_builder->dump(path_, "");
 
       // Update offline_cache_metadata.tcb
+      using offline_cache::load_metadata_with_checking;
+      using Error = offline_cache::LoadMetadataError;
       Metadata old_data;
       const auto filename =
           taichi::join_path(path_, kOfflineCacheMetadataFilename);
-      if (read_from_binary_file(old_data, filename)) {
+      if (load_metadata_with_checking(old_data, filename) == Error::kNoError) {
         for (auto &[k, v] : offline_cache_metadata_.kernels) {
           auto iter = old_data.kernels.find(k);
           if (iter != old_data.kernels.end()) {  // Update

--- a/taichi/common/serialization.h
+++ b/taichi/common/serialization.h
@@ -886,9 +886,12 @@ operator<<(std::ostream &os, const T &t) {
 
 // Returns true if deserialization succeeded.
 template <typename T>
-bool read_from_binary(T &t, const void *bin, std::size_t len, bool match_all = true) {
+bool read_from_binary(T &t,
+                      const void *bin,
+                      std::size_t len,
+                      bool match_all = true) {
   BinaryInputSerializer reader;
-  reader.initialize(const_cast<void*>(bin));
+  reader.initialize(const_cast<void *>(bin));
   if (len != reader.retrieve_length()) {
     return false;
   }

--- a/taichi/common/serialization.h
+++ b/taichi/common/serialization.h
@@ -345,15 +345,20 @@ class BinarySerializer : public Serializer {
     preserved = 0;
   }
 
+  template <bool writing_ = writing>
+  typename std::enable_if<!writing_, std::size_t>::type retrieve_length() {
+    return *reinterpret_cast<std::size_t *>(c_data);
+  }
+
   void finalize() {
-    if (writing) {
+    if constexpr (writing) {
       if (c_data) {
         *reinterpret_cast<std::size_t *>(&c_data[0]) = head;
       } else {
         *reinterpret_cast<std::size_t *>(&data[0]) = head;
       }
     } else {
-      assert(head == *reinterpret_cast<std::size_t *>(c_data));
+      assert(head == retrieve_length());
     }
   }
 
@@ -880,6 +885,18 @@ operator<<(std::ostream &os, const T &t) {
 }
 
 // Returns true if deserialization succeeded.
+template <typename T>
+bool read_from_binary(T &t, const void *bin, std::size_t len, bool match_all = true) {
+  BinaryInputSerializer reader;
+  reader.initialize(const_cast<void*>(bin));
+  if (len != reader.retrieve_length()) {
+    return false;
+  }
+  reader(t);
+  auto head = reader.head;
+  return match_all ? head == len : head <= len;
+}
+
 template <typename T>
 bool read_from_binary_file(T &t, const std::string &file_name) {
   BinaryInputSerializer reader;

--- a/taichi/runtime/llvm/llvm_offline_cache.cpp
+++ b/taichi/runtime/llvm/llvm_offline_cache.cpp
@@ -88,7 +88,8 @@ struct CacheCleanerUtils<LlvmOfflineCache> {
   }
 
   // To check if a file is cache file
-  static bool is_valid_cache_file(const CacheCleanerConfig &config, const std::string &name) {
+  static bool is_valid_cache_file(const CacheCleanerConfig &config,
+                                  const std::string &name) {
     std::string postfix = filename_postfix(name);
     return postfix == "ll" || postfix == "bc";
   }

--- a/taichi/runtime/llvm/llvm_offline_cache.cpp
+++ b/taichi/runtime/llvm/llvm_offline_cache.cpp
@@ -90,8 +90,8 @@ struct CacheCleanerUtils<LlvmOfflineCache> {
   // To check if a file is cache file
   static bool is_valid_cache_file(const CacheCleanerConfig &config,
                                   const std::string &name) {
-    std::string postfix = filename_postfix(name);
-    return postfix == "ll" || postfix == "bc";
+    std::string ext = filename_extension(name);
+    return ext == "ll" || ext == "bc";
   }
 };
 

--- a/taichi/runtime/llvm/llvm_offline_cache.cpp
+++ b/taichi/runtime/llvm/llvm_offline_cache.cpp
@@ -27,13 +27,6 @@ using Format = LlvmOfflineCache::Format;
 constexpr char kMetadataFilename[] = "metadata";
 constexpr char kMetadataFileLockName[] = "metadata.lock";
 
-static bool is_current_llvm_cache_version(
-    const LlvmOfflineCache::Version &ver) {
-  // TODO(PGZXB): Do more detailed checking
-  return ver[0] == TI_VERSION_MAJOR && ver[1] == TI_VERSION_MINOR &&
-         ver[2] == TI_VERSION_PATCH;
-}
-
 static std::string get_llvm_cache_metadata_file_path(const std::string &dir) {
   return taichi::join_path(dir, std::string(kMetadataFilename) + ".tcb");
 }
@@ -60,13 +53,6 @@ struct CacheCleanerUtils<LlvmOfflineCache> {
   using MetadataType = LlvmOfflineCache;
   using KernelMetaData = typename MetadataType::KernelMetadata;
 
-  // To load metadata from file
-  static bool load_metadata(const CacheCleanerConfig &config,
-                            MetadataType &result) {
-    return read_from_binary_file(
-        result, taichi::join_path(config.path, config.metadata_filename));
-  }
-
   // To save metadata as file
   static bool save_metadata(const CacheCleanerConfig &config,
                             const MetadataType &data) {
@@ -84,12 +70,6 @@ struct CacheCleanerUtils<LlvmOfflineCache> {
     return true;
   }
 
-  // To check version
-  static bool check_version(const CacheCleanerConfig &config,
-                            const Version &version) {
-    return is_current_llvm_cache_version(version);
-  }
-
   // To get cache files name
   static std::vector<std::string> get_cache_files(
       const CacheCleanerConfig &config,
@@ -105,6 +85,12 @@ struct CacheCleanerUtils<LlvmOfflineCache> {
   // To remove other files except cache files and offline cache metadta files
   static void remove_other_files(const CacheCleanerConfig &config) {
     // Do nothing
+  }
+
+  // To check if a file is cache file
+  static bool is_valid_cache_file(const CacheCleanerConfig &config, const std::string &name) {
+    std::string postfix = filename_postfix(name);
+    return postfix == "ll" || postfix == "bc";
   }
 };
 
@@ -126,20 +112,12 @@ bool LlvmOfflineCacheFileReader::load_meta_data(
     LlvmOfflineCache &data,
     const std::string &cache_file_path,
     bool with_lock) {
+  using offline_cache::load_metadata_with_checking;
+  using Error = offline_cache::LoadMetadataError;
   const auto tcb_path = get_llvm_cache_metadata_file_path(cache_file_path);
-  {
-    // No the best way to check for filepath existence, but whatever... See
-    // https://stackoverflow.com/questions/12774207/fastest-way-to-check-if-a-file-exists-using-standard-c-c11-14-17-c
-    std::ifstream fs(tcb_path, std::ios::in | std::ios::binary);
-    if (!fs.good()) {
-      TI_DEBUG("LLVM cache {} does not exist", cache_file_path);
-      return false;
-    }
-  }
 
   if (!with_lock) {
-    read_from_binary_file(data, tcb_path);
-    return true;
+    return Error::kNoError == load_metadata_with_checking(data, tcb_path);
   }
 
   std::string lock_path =
@@ -150,8 +128,7 @@ bool LlvmOfflineCacheFileReader::load_meta_data(
         TI_WARN("Unlock {} failed", lock_path);
       }
     });
-    read_from_binary_file(data, tcb_path);
-    return true;
+    return Error::kNoError == load_metadata_with_checking(data, tcb_path);
   }
   TI_WARN("Lock {} failed", lock_path);
   return false;
@@ -389,10 +366,6 @@ void LlvmOfflineCacheFileWriter::mangle_offloaded_task_name(
     for (auto &offload : compiled_data.tasks) {
       std::string mangled_name =
           offline_cache::mangle_name(offload.name, kernel_key);
-      TI_DEBUG(
-          "Mangle offloaded-task from internal name '{}' to offline cache "
-          "key '{}'",
-          offload.name, mangled_name);
       auto func = compiled_data.module->getFunction(offload.name);
       TI_ASSERT(func != nullptr);
       func->setName(mangled_name);

--- a/taichi/runtime/llvm/llvm_offline_cache.h
+++ b/taichi/runtime/llvm/llvm_offline_cache.h
@@ -100,6 +100,7 @@ struct LlvmOfflineCache {
   std::unordered_map<std::string, KernelCacheData>
       kernels;  // key = kernel_name
 
+  // NOTE: The "version" must be the first field to be serialized
   TI_IO_DEF(version, size, fields, kernels);
 };
 

--- a/taichi/util/io.h
+++ b/taichi/util/io.h
@@ -15,7 +15,10 @@
 #if defined(TI_PLATFORM_WINDOWS)
 #include <filesystem>
 #else  // POSIX
+#include <unistd.h>
 #include <dirent.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #endif
 
 TI_NAMESPACE_BEGIN
@@ -67,7 +70,21 @@ inline bool traverse_directory(const std::string &dir, Visitor v) {
   }
   return true;
 #else  // POSIX
-  TI_NOT_IMPLEMENTED;
+  struct dirent *f = nullptr;
+  DIR *directory = ::opendir(dir.c_str());
+  if (!directory) {
+    return false;
+  }
+  while (f = ::readdir(directory)) {
+    struct stat *stat_buf = nullptr;
+    auto fullpath = join_path(dir, f->d_name);
+    auto ret = ::stat(fullpath.c_str(), stat_buf);
+    TI_ASSERT(ret == 0);
+    v(f->d_name, S_ISDIR(stat_buf->st_mode));
+  }
+  auto ret = ::closedir(directory);
+  TI_ASSERT(ret == 0);
+  return true;
 #endif
 }
 

--- a/taichi/util/io.h
+++ b/taichi/util/io.h
@@ -14,6 +14,8 @@
 
 #if defined(TI_PLATFORM_WINDOWS)
 #include <filesystem>
+#else  // POSIX
+#include <dirent.h>
 #endif
 
 TI_NAMESPACE_BEGIN
@@ -49,6 +51,33 @@ inline std::string join_path(First &&path, Path &&...others) {
 
 inline bool remove(const std::string &path) {
   return std::remove(path.c_str()) == 0;
+}
+
+template <typename Visitor>  // void(const std::string &name, bool is_dir)
+inline bool traverse_directory(const std::string &dir, Visitor v) {
+#if defined(TI_PLATFORM_WINDOWS)
+  namespace fs = std::filesystem;
+  std::error_code ec{};
+  auto iter = fs::directory_iterator(dir, ec);
+  if (ec) {
+    return false;
+  }
+  for (auto &f : iter) {
+    v(f.path().filename().string(), f.is_directory());
+  }
+  return true;
+#else  // POSIX
+  TI_NOT_IMPLEMENTED;
+#endif
+}
+
+inline std::string filename_postfix(const std::string &filename) {
+  std::string postfix;
+  auto pos = filename.find_last_of('.');
+  if (pos != std::string::npos) {
+    postfix = filename.substr(pos + 1);
+  }
+  return postfix;
 }
 
 template <typename T>

--- a/taichi/util/io.h
+++ b/taichi/util/io.h
@@ -75,7 +75,7 @@ inline bool traverse_directory(const std::string &dir, Visitor v) {
   if (!directory) {
     return false;
   }
-  while (f = ::readdir(directory)) {
+  while ((f = ::readdir(directory))) {
     struct stat *stat_buf = nullptr;
     auto fullpath = join_path(dir, f->d_name);
     auto ret = ::stat(fullpath.c_str(), stat_buf);

--- a/taichi/util/io.h
+++ b/taichi/util/io.h
@@ -88,7 +88,7 @@ inline bool traverse_directory(const std::string &dir, Visitor v) {
 #endif
 }
 
-inline std::string filename_postfix(const std::string &filename) {
+inline std::string filename_extension(const std::string &filename) {
   std::string postfix;
   auto pos = filename.find_last_of('.');
   if (pos != std::string::npos) {

--- a/taichi/util/offline_cache.h
+++ b/taichi/util/offline_cache.h
@@ -61,6 +61,7 @@ struct Metadata {
   std::size_t size{0};  // byte
   std::unordered_map<std::string, KernelMetadata> kernels;
 
+  // NOTE: The "version" must be the first field to be serialized
   TI_IO_DEF(version, size, kernels);
 };
 

--- a/taichi/util/offline_cache.h
+++ b/taichi/util/offline_cache.h
@@ -73,13 +73,17 @@ enum class LoadMetadataError {
 };
 
 template <typename MetadataType>
-inline LoadMetadataError load_metadata_with_checking(MetadataType &result, const std::string &filepath) {
+inline LoadMetadataError load_metadata_with_checking(
+    MetadataType &result,
+    const std::string &filepath) {
   if (!taichi::path_exists(filepath)) {
     TI_DEBUG("Offline cache metadata file {} not found", filepath);
     return LoadMetadataError::kFileNotFound;
   }
 
-  static_assert(std::is_same_v<std::remove_reference_t<decltype(result.version)>, Version>);
+  static_assert(
+      std::is_same_v<std::remove_reference_t<decltype(result.version)>,
+                     Version>);
   constexpr auto sizeof_version = sizeof(result.version);
   const std::vector<uint8> bytes = read_data_from_file(filepath);
   if (bytes.size() < sizeof_version) {
@@ -90,14 +94,16 @@ inline LoadMetadataError load_metadata_with_checking(MetadataType &result, const
   if (!read_from_binary(ver, bytes.data(), bytes.size(), false)) {
     return LoadMetadataError::kCorrupted;
   }
-  if (ver[0] != TI_VERSION_MAJOR || ver[1] != TI_VERSION_MINOR || ver[2] != TI_VERSION_PATCH) {
-    TI_DEBUG("The offline cache metadata file {} is old (version={}.{}.{})", filepath, ver[0], ver[1], ver[2]);
+  if (ver[0] != TI_VERSION_MAJOR || ver[1] != TI_VERSION_MINOR ||
+      ver[2] != TI_VERSION_PATCH) {
+    TI_DEBUG("The offline cache metadata file {} is old (version={}.{}.{})",
+             filepath, ver[0], ver[1], ver[2]);
     return LoadMetadataError::kVersionNotMatched;
   }
 
-  return !read_from_binary(result, bytes.data(), bytes.size()) ? 
-      LoadMetadataError::kCorrupted : 
-      LoadMetadataError::kNoError;
+  return !read_from_binary(result, bytes.data(), bytes.size())
+             ? LoadMetadataError::kCorrupted
+             : LoadMetadataError::kNoError;
 }
 
 struct CacheCleanerConfig {
@@ -138,7 +144,8 @@ struct CacheCleanerUtils {
   }
 
   // To check if a file is cache file
-  static bool is_valid_cache_file(const CacheCleanerConfig &config, const std::string &name) {
+  static bool is_valid_cache_file(const CacheCleanerConfig &config,
+                                  const std::string &name) {
     TI_NOT_IMPLEMENTED;
   }
 };
@@ -192,14 +199,16 @@ class CacheCleaner {
       Error error = load_metadata_with_checking(cache_data, metadata_file);
       if (error == Error::kFileNotFound) {
         return;
-      } else if (error == Error::kCorrupted || error == Error::kVersionNotMatched) {
-        if (policy & CleanOldVersion) { // Remove cache files and metadata files
+      } else if (error == Error::kCorrupted ||
+                 error == Error::kVersionNotMatched) {
+        if (policy &
+            CleanOldVersion) {  // Remove cache files and metadata files
           TI_DEBUG("Removing all cache files");
           if (taichi::remove(metadata_file)) {
             taichi::remove(debugging_metadata_file);
             Utils::remove_other_files(config);
-            bool success = taichi::traverse_directory(config.path,
-                [&config](const std::string &name, bool is_dir) {
+            bool success = taichi::traverse_directory(
+                config.path, [&config](const std::string &name, bool is_dir) {
                   if (!is_dir && Utils::is_valid_cache_file(config, name)) {
                     taichi::remove(taichi::join_path(config.path, name));
                   }

--- a/taichi/util/offline_cache.h
+++ b/taichi/util/offline_cache.h
@@ -81,16 +81,11 @@ inline LoadMetadataError load_metadata_with_checking(
     return LoadMetadataError::kFileNotFound;
   }
 
-  static_assert(
-      std::is_same_v<std::remove_reference_t<decltype(result.version)>,
-                     Version>);
-  constexpr auto sizeof_version = sizeof(result.version);
+  using VerType = std::remove_reference_t<decltype(result.version)>;
+  static_assert(std::is_same_v<VerType, Version>);
   const std::vector<uint8> bytes = read_data_from_file(filepath);
-  if (bytes.size() < sizeof_version) {
-    return LoadMetadataError::kCorrupted;
-  }
 
-  Version ver{};
+  VerType ver{};
   if (!read_from_binary(ver, bytes.data(), bytes.size(), false)) {
     return LoadMetadataError::kCorrupted;
   }

--- a/tests/cpp/offline_cache/load_metadata_test.cpp
+++ b/tests/cpp/offline_cache/load_metadata_test.cpp
@@ -4,7 +4,7 @@
 
 #ifdef TI_WITH_LLVM
 #include "taichi/runtime/llvm/llvm_offline_cache.h"
-#endif // TI_WITH_LLVM
+#endif  // TI_WITH_LLVM
 
 namespace taichi {
 namespace lang {
@@ -21,7 +21,7 @@ inline void gen_old_version(oc::Version &ver) {
 }
 
 template <typename MetadataType>
-MetadataType gen_metadata(const oc::Version & ver) {
+MetadataType gen_metadata(const oc::Version &ver) {
   MetadataType result;
   result.size = 1024;
   std::copy(std::begin(ver), std::end(ver), std::begin(result.version));
@@ -56,7 +56,8 @@ void load_metadata_test() {
   write_to_binary_file(gen_old_metadata<MetadataType>(), old_file);
   // Generate corrupted metadata file
   write_to_binary_file(gen_correct_metadata<MetadataType>(), corrupted_file);
-  std::ofstream(corrupted_file, std::ios::app | std::ios::binary) << "I-AM-BAD-BYTES" << std::flush;
+  std::ofstream(corrupted_file, std::ios::app | std::ios::binary)
+      << "I-AM-BAD-BYTES" << std::flush;
 
   using Error = oc::LoadMetadataError;
   Error error = Error::kNoError;
@@ -103,7 +104,7 @@ void load_metadata_test() {
 TEST(OfflineCache, LoadMetadata) {
 #ifdef TI_WITH_LLVM
   load_metadata_test<LlvmOfflineCache>();
-#endif // TI_WITH_LLVM
+#endif  // TI_WITH_LLVM
   load_metadata_test<oc::Metadata>();
 }
 

--- a/tests/cpp/offline_cache/load_metadata_test.cpp
+++ b/tests/cpp/offline_cache/load_metadata_test.cpp
@@ -1,0 +1,111 @@
+#include "gtest/gtest.h"
+#include "taichi/common/version.h"
+#include "taichi/util/offline_cache.h"
+
+#ifdef TI_WITH_LLVM
+#include "taichi/runtime/llvm/llvm_offline_cache.h"
+#endif // TI_WITH_LLVM
+
+namespace taichi {
+namespace lang {
+
+namespace {
+
+namespace oc = offline_cache;
+
+inline void gen_old_version(oc::Version &ver) {
+  auto &[major, minor, patch] = ver;
+  major = std::max(TI_VERSION_MAJOR - 1, 0);
+  minor = std::max(TI_VERSION_MINOR - 1, 0);
+  patch = std::max(TI_VERSION_PATCH - 1, 0);
+}
+
+template <typename MetadataType>
+MetadataType gen_metadata(const oc::Version & ver) {
+  MetadataType result;
+  result.size = 1024;
+  std::copy(std::begin(ver), std::end(ver), std::begin(result.version));
+  result.kernels["1"] = {};
+  result.kernels["2"] = {};
+  return result;
+}
+
+template <typename MetadataType>
+MetadataType gen_old_metadata() {
+  oc::Version old_ver{};
+  gen_old_version(old_ver);
+  return gen_metadata<MetadataType>(old_ver);
+}
+
+template <typename MetadataType>
+MetadataType gen_correct_metadata() {
+  oc::Version ver{TI_VERSION_MAJOR, TI_VERSION_MINOR, TI_VERSION_PATCH};
+  return gen_metadata<MetadataType>(ver);
+}
+
+template <typename MetadataType>
+void load_metadata_test() {
+  std::string fake_file = fmt::format("{}.tcb", std::tmpnam(nullptr));
+  std::string old_file = fmt::format("{}.tcb", std::tmpnam(nullptr));
+  std::string corrupted_file = fmt::format("{}.tcb", std::tmpnam(nullptr));
+  std::string true_file = fmt::format("{}.tcb", std::tmpnam(nullptr));
+
+  // Generate metadata & Save as file
+  write_to_binary_file(gen_correct_metadata<MetadataType>(), true_file);
+  // Generate old metadata & Save as file
+  write_to_binary_file(gen_old_metadata<MetadataType>(), old_file);
+  // Generate corrupted metadata file
+  write_to_binary_file(gen_correct_metadata<MetadataType>(), corrupted_file);
+  std::ofstream(corrupted_file, std::ios::app | std::ios::binary) << "I-AM-BAD-BYTES" << std::flush;
+
+  using Error = oc::LoadMetadataError;
+  Error error = Error::kNoError;
+
+  // Load a non-existing metadata file
+  {
+    MetadataType data;
+    error = oc::load_metadata_with_checking(data, fake_file);
+    EXPECT_EQ(error, Error::kFileNotFound);
+  }
+  // Load a old metadata file
+  {
+    MetadataType data;
+    error = oc::load_metadata_with_checking(data, old_file);
+    EXPECT_EQ(error, Error::kVersionNotMatched);
+  }
+  // Load a corrupted metadata file
+  {
+    MetadataType data;
+    error = oc::load_metadata_with_checking(data, corrupted_file);
+    EXPECT_EQ(error, Error::kCorrupted);
+  }
+  // Load a correct metadata file
+  {
+    MetadataType data;
+    error = oc::load_metadata_with_checking(data, true_file);
+    auto [major, minor, patch] = data.version;
+    EXPECT_EQ(error, Error::kNoError);
+    EXPECT_EQ(major, TI_VERSION_MAJOR);
+    EXPECT_EQ(minor, TI_VERSION_MINOR);
+    EXPECT_EQ(patch, TI_VERSION_PATCH);
+    EXPECT_EQ(data.size, 1024);
+    EXPECT_TRUE(data.kernels.count("1"));
+    EXPECT_TRUE(data.kernels.count("2"));
+  }
+
+  taichi::remove(old_file);
+  taichi::remove(corrupted_file);
+  taichi::remove(true_file);
+}
+
+}  // namespace
+
+TEST(OfflineCache, LoadMetadata) {
+#ifdef TI_WITH_LLVM
+  load_metadata_test<LlvmOfflineCache>();
+#endif // TI_WITH_LLVM
+  load_metadata_test<oc::Metadata>();
+}
+
+}  // namespace lang
+}  // namespace taichi


### PR DESCRIPTION
Issue: #4401, fixes #6081

In future, if necessary, we should maintain a version number for offline cache instead of using the Taichi version directly.