### PR TITLE
[build] Fix building with TI_WITH_OPENGL:BOOL=OFF and TI_WITH_DX11:BOOL=ON failed

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -319,6 +319,11 @@ if (TI_WITH_OPENGL OR TI_WITH_VULKAN OR TI_WITH_DX11)
   target_link_libraries(${CORE_LIBRARY_NAME} PRIVATE gfx_runtime)
 endif()
 
+if (TI_WITH_OPENGL OR TI_WITH_DX11)
+  set(SPIRV_CROSS_CLI false)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/external/SPIRV-Cross ${PROJECT_BINARY_DIR}/external/SPIRV-Cross)
+endif()
+
 # Vulkan Device API
 if (TI_WITH_VULKAN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_VULKAN")

--- a/taichi/rhi/opengl/CMakeLists.txt
+++ b/taichi/rhi/opengl/CMakeLists.txt
@@ -22,7 +22,4 @@ target_include_directories(${OPENGL_RHI}
   )
 
 target_link_libraries(opengl_rhi PRIVATE glfw)
-
-set(SPIRV_CROSS_CLI false)
-add_subdirectory(${PROJECT_SOURCE_DIR}/external/SPIRV-Cross ${PROJECT_BINARY_DIR}/external/SPIRV-Cross)
 target_link_libraries(opengl_rhi PRIVATE spirv-cross-glsl spirv-cross-core)


### PR DESCRIPTION
Building with `TI_WITH_OPENGL:BOOL=OFF` and `TI_WITH_DX11:BOOL=ON` failed:
```
# With Clang
FAILED: taichi_python.cp37-win_amd64.pyd
cmd.exe /C "cd . && D:\programming_tools_\LLVM14\bin\clang++.exe -fuse-ld=lld-link -nostartfiles -nostdlib -DTI_ISE_NONE -std=c++17 -fsized-deallocation -target x86_64-pc-windows-msvc -DTI_ARCH_x64 -march=nehalem -DTI_PASS_EXCEPTION_TO_PYTHON -DTI_INCLUDED -DTI_WITH_LLVM -DTI_WITH_CUDA -DTI_WITH_METAL -DTI_WITH_DX11 -DTI_WITH_VULKAN  -DTI_ISE_NONE -flto=thin -D_DLL -D_MT -Xclang --dependent-lib=msvcrt   -shared -o taichi_python.cp37-win_amd64.pyd  -Xlinker /MANIFEST:EMBED -Xlinker /implib:taichi_python.lib -Xlinker /pdb:taichi_python.pdb -Xlinker /version:0.0 @CMakeFiles\taichi_python.rsp  && cd ."
lld-link: error: could not open 'spirv-cross-hlsl.lib': no such file or directory
lld-link: error: could not open 'spirv-cross-core.lib': no such file or directory
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
```
# With MSVC
FAILED: taichi_python.cp37-win_amd64.pyd
cmd.exe /C "cd . && D:\programming_tools_\CMAKE\bin\cmake.exe -E vs_link_dll --intdir=CMakeFiles\taichi_python.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x86\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x86\mt.exe --manifests  -- D:\programming_tools_\VS2022\VS2022\VC\Tools\MSVC\14.31.31103\bin\Hostx86\x64\link.exe /nologo @CMakeFiles\taichi_python.rsp  /out:taichi_python.cp37-win_amd64.pyd /implib:taichi_python.lib /pdb:taichi_python.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO /DEBUG  && cd ."
LINK: command "D:\programming_tools_\VS2022\VS2022\VC\Tools\MSVC\14.31.31103\bin\Hostx86\x64\link.exe /nologo @CMakeFiles\taichi_python.rsp /out:taichi_python.cp37-win_amd64.pyd /implib:taichi_python.lib /pdb:taichi_python.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO /DEBUG /MANIFEST /MANIFESTFILE:taichi_python.cp37-win_amd64.pyd.manifest" failed (exit code 1181) with the following output:
LINK : fatal error LNK1181: cannot open input file 'spirv-cross-hlsl.lib'
```
