### PR TITLE
[misc] Allow more commits in changelog generation

### DIFF
--- a/misc/make_changelog.py
+++ b/misc/make_changelog.py
@@ -35,8 +35,8 @@ def main(ver=None, repo_dir='.'):
     # everything after this commit should be listed in the changelog.
 
     base_commit = find_latest_tag_commit(g.tags)
-    commits_in_base_tag = list(g.iter_commits(base_commit, max_count=200))
-    commits = list(g.iter_commits(ver, max_count=200))
+    commits_in_base_tag = list(g.iter_commits(base_commit, max_count=500))
+    commits = list(g.iter_commits(ver, max_count=500))
     begin, end = -1, 0
 
     def format(c):


### PR DESCRIPTION
### Brief Summary

There are more than 200 commits in v1.1.3 (https://github.com/taichi-dev/taichi/releases/tag/v1.1.3) so let's increase the number of commits for changelog generation.