### PR TITLE
[Lang] MatrixField refactor 5/n: Lower access of matrix field element into CHI IR

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -204,6 +204,10 @@ def subscript(value, *_indices, skip_reordered=False, get_ref=False):
                 f'Field with dim {field_dim} accessed with indices of dim {index_dim}'
             )
         if isinstance(value, MatrixField):
+            if current_cfg().real_matrix:
+                return Expr(
+                    _ti_core.subscript(value.ptr, indices_expr_group,
+                                       get_runtime().get_current_src_info()))
             return _MatrixFieldElement(value, indices_expr_group)
         if isinstance(value, StructField):
             entries = {k: subscript(v, *_indices) for k, v in value._items}

--- a/taichi/inc/statements.inc.h
+++ b/taichi/inc/statements.inc.h
@@ -59,6 +59,7 @@ PER_STATEMENT(GetChStmt)
 // With per-lane attributes
 PER_STATEMENT(LocalLoadStmt)
 PER_STATEMENT(GlobalPtrStmt)
+PER_STATEMENT(MatrixOfGlobalPtrStmt)
 
 // Offloaded
 PER_STATEMENT(OffloadedStmt)

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -27,13 +27,8 @@ Expr bit_cast(const Expr &input, DataType dt) {
 }
 
 Expr Expr::operator[](const ExprGroup &indices) const {
-  if (is<IndexExpression>()) {
-    // Allow indexing IndexExpression with ret_type = TensorType
-    TI_ASSERT(is_tensor(expr->ret_type));
-  } else {
-    TI_ASSERT(is<FieldExpression>() || is<MatrixFieldExpression>() ||
-              is<ExternalTensorExpression>() || is<IdExpression>());
-  }
+  TI_ASSERT(is<FieldExpression>() || is<MatrixFieldExpression>() ||
+            is<ExternalTensorExpression>() || is_tensor(expr->ret_type));
   return Expr::make<IndexExpression>(*this, indices);
 }
 

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -31,8 +31,8 @@ Expr Expr::operator[](const ExprGroup &indices) const {
     // Allow indexing IndexExpression with ret_type = TensorType
     TI_ASSERT(is_tensor(expr->ret_type));
   } else {
-    TI_ASSERT(is<FieldExpression>() || is<ExternalTensorExpression>() ||
-              is<IdExpression>());
+    TI_ASSERT(is<FieldExpression>() || is<MatrixFieldExpression>() ||
+              is<ExternalTensorExpression>() || is<IdExpression>());
   }
   return Expr::make<IndexExpression>(*this, indices);
 }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -576,7 +576,8 @@ void IndexExpression::flatten(FlattenContext *ctx) {
   if (is_field()) {
     stmt = make_field_access(ctx, *var.cast<FieldExpression>(), indices);
   } else if (is_matrix_field()) {
-    stmt = make_matrix_field_access(ctx, *var.cast<MatrixFieldExpression>(), indices, ret_type);
+    stmt = make_matrix_field_access(ctx, *var.cast<MatrixFieldExpression>(),
+                                    indices, ret_type);
   } else if (is_ndarray()) {
     stmt = make_ndarray_access(ctx, var, indices);
   } else if (is_tensor()) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -386,7 +386,9 @@ void FieldExpression::flatten(FlattenContext *ctx) {
   ctx->push_back(std::move(ptr));
 }
 
-std::vector<Stmt *> make_index_stmts(Expression::FlattenContext *ctx, const ExprGroup &indices, const std::vector<int> &offsets) {
+std::vector<Stmt *> make_index_stmts(Expression::FlattenContext *ctx,
+                                     const ExprGroup &indices,
+                                     const std::vector<int> &offsets) {
   std::vector<Stmt *> index_stmts;
   for (int i = 0; i < (int)indices.size(); i++) {
     flatten_rvalue(indices.exprs[i], ctx);
@@ -404,7 +406,8 @@ Stmt *make_field_access(Expression::FlattenContext *ctx,
                         Expr var,
                         ExprGroup indices) {
   SNode *snode = var.cast<FieldExpression>()->snode;
-  return ctx->push_back(std::make_unique<GlobalPtrStmt>(snode, make_index_stmts(ctx, indices, snode->index_offsets)));
+  return ctx->push_back(std::make_unique<GlobalPtrStmt>(
+      snode, make_index_stmts(ctx, indices, snode->index_offsets)));
 }
 
 Stmt *make_matrix_field_access(Expression::FlattenContext *ctx,
@@ -416,7 +419,10 @@ Stmt *make_matrix_field_access(Expression::FlattenContext *ctx,
   for (auto &field : matrix_field->fields) {
     snodes.push_back(field.cast<FieldExpression>()->snode);
   }
-  return ctx->push_back(std::make_unique<MatrixOfGlobalPtrStmt>(snodes, make_index_stmts(ctx, indices, snodes[0]->index_offsets), matrix_field->dynamic_indexable, matrix_field->dynamic_index_stride, ret_type));
+  return ctx->push_back(std::make_unique<MatrixOfGlobalPtrStmt>(
+      snodes, make_index_stmts(ctx, indices, snodes[0]->index_offsets),
+      matrix_field->dynamic_indexable, matrix_field->dynamic_index_stride,
+      ret_type));
 }
 
 Stmt *make_ndarray_access(Expression::FlattenContext *ctx,
@@ -463,7 +469,8 @@ Stmt *make_tensor_access(Expression::FlattenContext *ctx,
   } else {
     int offset = 0;
     for (int i = 0; i < (int)indices.size(); ++i) {
-      offset = offset * shape[i] + indices[i].cast<ConstExpression>()->val.val_int();
+      offset =
+          offset * shape[i] + indices[i].cast<ConstExpression>()->val.val_int();
     }
     offset_stmt = ctx->push_back<ConstStmt>(TypedConstant(offset));
   }
@@ -518,7 +525,8 @@ bool IndexExpression::is_global() const {
   // Special case: Indexing into TensorType-element of ExternalPtrStmt
   // or GlobalPtrStmt should be treated as global ptrs
   if (var.is<IndexExpression>()) {
-    TI_ASSERT(var.cast<IndexExpression>()->is_matrix_field() || var.cast<IndexExpression>()->is_ndarray());
+    TI_ASSERT(var.cast<IndexExpression>()->is_matrix_field() ||
+              var.cast<IndexExpression>()->is_ndarray());
     return true;
   }
 
@@ -533,7 +541,10 @@ void IndexExpression::type_check(CompileConfig *) {
     ret_type = var.cast<FieldExpression>()->dt->get_compute_type();
   } else if (is_matrix_field()) {
     auto matrix_field_expr = var.cast<MatrixFieldExpression>();
-    ret_type = TypeFactory::create_tensor_type(matrix_field_expr->element_shape, matrix_field_expr->fields[0].cast<FieldExpression>()->dt->get_compute_type());
+    ret_type = TypeFactory::create_tensor_type(matrix_field_expr->element_shape,
+                                               matrix_field_expr->fields[0]
+                                                   .cast<FieldExpression>()
+                                                   ->dt->get_compute_type());
   } else if (is_ndarray()) {  // ndarray
     auto external_tensor_expr = var.cast<ExternalTensorExpression>();
     int total_dim = external_tensor_expr->dim;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -577,8 +577,8 @@ class MatrixExpression : public Expression {
 
 class IndexExpression : public Expression {
  public:
-  // `var` is one of FieldExpression, ExternalTensorExpression,
-  // IdExpression
+  // `var` is one of FieldExpression, MatrixFieldExpression,
+  // ExternalTensorExpression, IdExpression
   Expr var;
   ExprGroup indices;
 
@@ -606,6 +606,7 @@ class IndexExpression : public Expression {
 
  private:
   bool is_field() const;
+  bool is_matrix_field() const;
   bool is_ndarray() const;
   bool is_tensor() const;
 };

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -516,8 +516,6 @@ class FieldExpression : public Expression {
     this->snode = snode;
   }
 
-  void flatten(FlattenContext *ctx) override;
-
   TI_DEFINE_ACCEPT_FOR_EXPRESSION
 };
 

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -67,7 +67,10 @@ MatrixOfGlobalPtrStmt::MatrixOfGlobalPtrStmt(const std::vector<SNode *> &snodes,
                                              int dynamic_index_stride,
                                              DataType dt,
                                              bool activate)
-    : snodes(snodes), indices(indices), dynamic_indexable(dynamic_indexable), dynamic_index_stride(dynamic_index_stride) {
+    : snodes(snodes),
+      indices(indices),
+      dynamic_indexable(dynamic_indexable),
+      dynamic_index_stride(dynamic_index_stride) {
   ret_type = dt;
   TI_STMT_REG_FIELDS;
 }
@@ -75,7 +78,8 @@ MatrixOfGlobalPtrStmt::MatrixOfGlobalPtrStmt(const std::vector<SNode *> &snodes,
 PtrOffsetStmt::PtrOffsetStmt(Stmt *origin_input, Stmt *offset_input) {
   origin = origin_input;
   offset = offset_input;
-  if (origin->is<AllocaStmt>() || origin->is<GlobalTemporaryStmt>() || origin->is<ExternalPtrStmt>() || origin->is<MatrixOfGlobalPtrStmt>()) {
+  if (origin->is<AllocaStmt>() || origin->is<GlobalTemporaryStmt>() ||
+      origin->is<ExternalPtrStmt>() || origin->is<MatrixOfGlobalPtrStmt>()) {
     auto tensor_type = origin->ret_type.ptr_removed()->cast<TensorType>();
     TI_ASSERT(tensor_type != nullptr);
     element_type() = tensor_type->get_element_type();
@@ -85,7 +89,8 @@ PtrOffsetStmt::PtrOffsetStmt(Stmt *origin_input, Stmt *offset_input) {
   } else {
     TI_ERROR(
         "PtrOffsetStmt must be used for AllocaStmt / GlobalTemporaryStmt "
-        "(locally) or GlobalPtrStmt / MatrixOfGlobalPtrStmt / ExternalPtrStmt (globally).")
+        "(locally) or GlobalPtrStmt / MatrixOfGlobalPtrStmt / ExternalPtrStmt "
+        "(globally).")
   }
   TI_STMT_REG_FIELDS;
 }

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -70,7 +70,8 @@ MatrixOfGlobalPtrStmt::MatrixOfGlobalPtrStmt(const std::vector<SNode *> &snodes,
     : snodes(snodes),
       indices(indices),
       dynamic_indexable(dynamic_indexable),
-      dynamic_index_stride(dynamic_index_stride) {
+      dynamic_index_stride(dynamic_index_stride),
+      activate(activate) {
   ret_type = dt;
   TI_STMT_REG_FIELDS;
 }

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -61,37 +61,31 @@ GlobalPtrStmt::GlobalPtrStmt(SNode *snode,
   TI_STMT_REG_FIELDS;
 }
 
+MatrixOfGlobalPtrStmt::MatrixOfGlobalPtrStmt(const std::vector<SNode *> &snodes,
+                                             const std::vector<Stmt *> &indices,
+                                             bool dynamic_indexable,
+                                             int dynamic_index_stride,
+                                             DataType dt,
+                                             bool activate)
+    : snodes(snodes), indices(indices), dynamic_indexable(dynamic_indexable), dynamic_index_stride(dynamic_index_stride) {
+  ret_type = dt;
+  TI_STMT_REG_FIELDS;
+}
+
 PtrOffsetStmt::PtrOffsetStmt(Stmt *origin_input, Stmt *offset_input) {
   origin = origin_input;
   offset = offset_input;
-  if (origin->is<AllocaStmt>()) {
-    TI_ASSERT(
-        origin->cast<AllocaStmt>()->ret_type.ptr_removed()->is<TensorType>());
-    auto tensor_type =
-        origin->cast<AllocaStmt>()->ret_type.ptr_removed()->cast<TensorType>();
-    element_type() = tensor_type->get_element_type();
-    element_type().set_is_pointer(true);
-  } else if (origin->is<GlobalTemporaryStmt>()) {
-    TI_ASSERT(origin->cast<GlobalTemporaryStmt>()->ret_type->is<TensorType>());
-    auto tensor_type =
-        origin->cast<GlobalTemporaryStmt>()->ret_type->cast<TensorType>();
+  if (origin->is<AllocaStmt>() || origin->is<GlobalTemporaryStmt>() || origin->is<ExternalPtrStmt>() || origin->is<MatrixOfGlobalPtrStmt>()) {
+    auto tensor_type = origin->ret_type.ptr_removed()->cast<TensorType>();
+    TI_ASSERT(tensor_type != nullptr);
     element_type() = tensor_type->get_element_type();
     element_type().set_is_pointer(true);
   } else if (origin->is<GlobalPtrStmt>()) {
     element_type() = origin->cast<GlobalPtrStmt>()->ret_type;
-  } else if (origin->is<ExternalPtrStmt>()) {
-    TI_ASSERT(origin->cast<ExternalPtrStmt>()
-                  ->ret_type.ptr_removed()
-                  ->is<TensorType>());
-    auto tensor_type = origin->cast<ExternalPtrStmt>()
-                           ->ret_type.ptr_removed()
-                           ->cast<TensorType>();
-    element_type() = tensor_type->get_element_type();
-    element_type().set_is_pointer(true);
   } else {
     TI_ERROR(
         "PtrOffsetStmt must be used for AllocaStmt / GlobalTemporaryStmt "
-        "(locally) or GlobalPtrStmt (globally).")
+        "(locally) or GlobalPtrStmt / MatrixOfGlobalPtrStmt / ExternalPtrStmt (globally).")
   }
   TI_STMT_REG_FIELDS;
 }

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -348,9 +348,9 @@ class GlobalPtrStmt : public Stmt {
 /**
  * An "abstract" pointer for an element of a MatrixField, which logically
  * contains a matrix of GlobalPtrStmts. Upon construction, only snodes, indices,
- * dynamic_indexable, and dynamic_index_stride are initialized. After the
- * lower_matrix_ptr pass, this stmt will either be eliminated (constant index)
- * or have ptr_base initialized (dynamic index or whole-matrix access).
+ * dynamic_indexable, dynamic_index_stride and activate are initialized. After
+ * the lower_matrix_ptr pass, this stmt will either be eliminated (constant
+ * index) or have ptr_base initialized (dynamic index or whole-matrix access).
  */
 class MatrixOfGlobalPtrStmt : public Stmt {
  public:

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -376,7 +376,13 @@ class MatrixOfGlobalPtrStmt : public Stmt {
     return true;
   }
 
-  TI_STMT_DEF_FIELDS(ret_type, snodes, indices, ptr_base, dynamic_indexable, dynamic_index_stride, activate);
+  TI_STMT_DEF_FIELDS(ret_type,
+                     snodes,
+                     indices,
+                     ptr_base,
+                     dynamic_indexable,
+                     dynamic_index_stride,
+                     activate);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -346,6 +346,41 @@ class GlobalPtrStmt : public Stmt {
 };
 
 /**
+ * An "abstract" pointer for an element of a MatrixField, which logically
+ * contains a matrix of GlobalPtrStmts. Upon construction, only snodes, indices,
+ * dynamic_indexable, and dynamic_index_stride are initialized. After the
+ * lower_matrix_ptr pass, this stmt will either be eliminated (constant index)
+ * or have ptr_base initialized (dynamic index or whole-matrix access).
+ */
+class MatrixOfGlobalPtrStmt : public Stmt {
+ public:
+  std::vector<SNode *> snodes;
+  std::vector<Stmt *> indices;
+  Stmt *ptr_base{nullptr};
+  bool dynamic_indexable{false};
+  int dynamic_index_stride{0};
+  bool activate{true};
+
+  MatrixOfGlobalPtrStmt(const std::vector<SNode *> &snodes,
+                        const std::vector<Stmt *> &indices,
+                        bool dynamic_indexable,
+                        int dynamic_index_stride,
+                        DataType dt,
+                        bool activate = true);
+
+  bool has_global_side_effect() const override {
+    return activate;
+  }
+
+  bool common_statement_eliminable() const override {
+    return true;
+  }
+
+  TI_STMT_DEF_FIELDS(ret_type, snodes, indices, ptr_base, dynamic_indexable, dynamic_index_stride, activate);
+  TI_DEFINE_ACCEPT_AND_CLONE
+};
+
+/**
  * An accessing tensor element operation.
  */
 class PtrOffsetStmt : public Stmt {

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -30,6 +30,7 @@ namespace irpass {
 void re_id(IRNode *root);
 void flag_access(IRNode *root);
 void scalarize(IRNode *root);
+void lower_matrix_ptr(IRNode *root);
 bool die(IRNode *root);
 bool simplify(IRNode *root, const CompileConfig &config);
 bool cfg_optimization(

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -57,6 +57,9 @@ void compile_to_offloads(IRNode *ir,
     print("Scalarized");
   }
 
+  irpass::lower_matrix_ptr(ir);
+  print("Matrix ptr lowered");
+
   irpass::type_check(ir, config);
   print("Typechecked");
   irpass::analysis::verify(ir);

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -377,6 +377,30 @@ class IRPrinter : public IRVisitor {
     print("}}");
   }
 
+  void visit(MatrixOfGlobalPtrStmt *stmt) override {
+    std::string s =
+        fmt::format("{}{} = matrix of global ptr [", stmt->type_hint(), stmt->name());
+
+    for (int i = 0; i < (int)stmt->snodes.size(); i++) {
+      s += fmt::format("{}", stmt->snodes[i]->get_node_type_name_hinted());
+      if (i + 1 < (int)stmt->snodes.size()) {
+        s += ", ";
+      }
+    }
+    s += "], index [";
+    for (int i = 0; i < (int)stmt->indices.size(); i++) {
+      s += fmt::format("{}", stmt->indices[i]->name());
+      if (i + 1 < (int)stmt->indices.size()) {
+        s += ", ";
+      }
+    }
+    s += "]";
+
+    s += " activate=" + std::string(stmt->activate ? "true" : "false");
+
+    print_raw(s);
+  }
+
   void visit(GlobalPtrStmt *stmt) override {
     std::string s =
         fmt::format("{}{} = global ptr [", stmt->type_hint(), stmt->name());

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -378,8 +378,8 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(MatrixOfGlobalPtrStmt *stmt) override {
-    std::string s =
-        fmt::format("{}{} = matrix of global ptr [", stmt->type_hint(), stmt->name());
+    std::string s = fmt::format("{}{} = matrix of global ptr [",
+                                stmt->type_hint(), stmt->name());
 
     for (int i = 0; i < (int)stmt->snodes.size(); i++) {
       s += fmt::format("{}", stmt->snodes[i]->get_node_type_name_hinted());

--- a/taichi/transforms/lower_matrix_ptr.cpp
+++ b/taichi/transforms/lower_matrix_ptr.cpp
@@ -1,0 +1,59 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/ir/visitors.h"
+#include "taichi/system/profiler.h"
+
+TLANG_NAMESPACE_BEGIN
+
+class LowerMatrixPtr : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
+  DelayedIRModifier modifier;
+
+  void visit(PtrOffsetStmt *stmt) override {
+    if (stmt->origin->is<MatrixOfGlobalPtrStmt>()) {
+      TI_ASSERT(stmt->offset->is<ConstStmt>());
+      auto origin = stmt->origin->as<MatrixOfGlobalPtrStmt>();
+      auto offset = stmt->offset->as<ConstStmt>();
+      auto lowered = std::make_unique<GlobalPtrStmt>(origin->snodes[offset->val.val_int()], origin->indices);
+      stmt->replace_usages_with(lowered.get());
+      modifier.insert_before(stmt, std::move(lowered));
+      modifier.erase(stmt);
+    }
+  }
+
+  static void run(IRNode *node) {
+    LowerMatrixPtr pass;
+    node->accept(&pass);
+    pass.modifier.modify_ir();
+  }
+};
+
+class RemoveMatrixOfGlobalPtr : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
+  DelayedIRModifier modifier;
+
+  void visit(MatrixOfGlobalPtrStmt *stmt) override {
+    modifier.erase(stmt);
+  }
+
+  static void run(IRNode *node) {
+    RemoveMatrixOfGlobalPtr pass;
+    node->accept(&pass);
+    pass.modifier.modify_ir();
+  }
+};
+
+namespace irpass {
+
+void lower_matrix_ptr(IRNode *root) {
+  TI_AUTO_PROF;
+  LowerMatrixPtr::run(root);
+  RemoveMatrixOfGlobalPtr::run(root);
+}
+
+}  // namespace irpass
+
+TLANG_NAMESPACE_END

--- a/taichi/transforms/lower_matrix_ptr.cpp
+++ b/taichi/transforms/lower_matrix_ptr.cpp
@@ -16,7 +16,8 @@ class LowerMatrixPtr : public BasicStmtVisitor {
       TI_ASSERT(stmt->offset->is<ConstStmt>());
       auto origin = stmt->origin->as<MatrixOfGlobalPtrStmt>();
       auto offset = stmt->offset->as<ConstStmt>();
-      auto lowered = std::make_unique<GlobalPtrStmt>(origin->snodes[offset->val.val_int()], origin->indices);
+      auto lowered = std::make_unique<GlobalPtrStmt>(
+          origin->snodes[offset->val.val_int()], origin->indices);
       stmt->replace_usages_with(lowered.get());
       modifier.insert_before(stmt, std::move(lowered));
       modifier.erase(stmt);

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -248,8 +248,7 @@ def test_matrix_non_constant_index():
     func4(10)
 
 
-@test_utils.test(arch=ti.cpu)
-def test_matrix_constant_index():
+def _test_matrix_constant_index():
     m = ti.Matrix.field(2, 2, ti.i32, 5)
 
     @ti.kernel
@@ -261,6 +260,16 @@ def test_matrix_constant_index():
     func()
 
     assert np.allclose(m.to_numpy(), np.ones((5, 2, 2), np.int32) * 12)
+
+
+@test_utils.test()
+def test_matrix_constant_index():
+    _test_matrix_constant_index()
+
+
+@test_utils.test(real_matrix=True)
+def test_matrix_constant_index_real_matrix():
+    _test_matrix_constant_index()
 
 
 @test_utils.test(arch=ti.cpu)


### PR DESCRIPTION
Issue: #5959

### Brief Summary

This PR lowers access of matrix field element into CHI IR. To verify its functionality, this PR also makes the following path of #5959 running end-to-end (currently only enabled when `real_matrix=True`):

![MatrixField_Part5](https://user-images.githubusercontent.com/3251060/191258468-d3b0237f-6e0e-47ce-844f-5516103d05de.png)

Key steps:
- Python: when running into subscript of `MatrixField`, create `IndexExpression` in C++ instead of building `_MatrixFieldElement` in Python
- Frontend IR: allow `IndexExpression` to take `MatrixFieldExpression`
- CHI IR: add `MatrixOfGlobalPtrStmt`; add `lower_matrix_ptr` pass, which demotes `PtrOffsetStmt(MatrixOfGlobalPtrStmt)` into `GlobalPtrStmt` in the case of constant index - this is incomplete and only aims at supporting the above path