### PR TITLE
[bug] [llvm] Fix is_same_type when the suffix of a type is the prefix of the suffix of the other type

### DIFF
--- a/taichi/codegen/llvm/llvm_codegen_utils.cpp
+++ b/taichi/codegen/llvm/llvm_codegen_utils.cpp
@@ -65,38 +65,37 @@ bool is_same_type(llvm::Type *a, llvm::Type *b) {
     }
     len_same++;
   }
-  if (len_same != a_name.size()) {
-    // a is xxx.yyy, and b is xxx.zzz, yyy and zzz are numbers
-    if (len_same == 0) {
-      return false;
-    }
-    int dot_pos = len_same - 1;
-    while (dot_pos && a_name[dot_pos] != '.') {
-      dot_pos--;
-    }
-    if (!dot_pos) {
-      return false;
-    }
-    for (int i = dot_pos + 1; i < a_name.size(); i++) {
-      if (!std::isdigit(a_name[i])) {
-        return false;
-      }
-    }
-    for (int i = dot_pos + 1; i < b_name.size(); i++) {
-      if (!std::isdigit(b_name[i])) {
-        return false;
-      }
-    }
-  } else {
-    // a is xxx, and b is xxx.yyy, yyy is a number
+  if (len_same == a_name.size())  {
     TI_ASSERT(len_same != b_name.size());
-    if (b_name[len_same] != '.') {
+    if (b_name[len_same] == '.') {
+      // a is xxx, and b is xxx.yyy, yyy is a number
+      for (int i = len_same + 1; i < b_name.size(); i++) {
+        if (!std::isdigit(b_name[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+  // a is xxx.yyy, and b is xxx.zzz, yyy and zzz are numbers
+  if (len_same == 0) {
+    return false;
+  }
+  int dot_pos = len_same - 1;
+  while (dot_pos && a_name[dot_pos] != '.') {
+    dot_pos--;
+  }
+  if (!dot_pos) {
+    return false;
+  }
+  for (int i = dot_pos + 1; i < a_name.size(); i++) {
+    if (!std::isdigit(a_name[i])) {
       return false;
     }
-    for (int i = len_same + 1; i < b_name.size(); i++) {
-      if (!std::isdigit(b_name[i])) {
-        return false;
-      }
+  }
+  for (int i = dot_pos + 1; i < b_name.size(); i++) {
+    if (!std::isdigit(b_name[i])) {
+      return false;
     }
   }
   return true;

--- a/taichi/codegen/llvm/llvm_codegen_utils.cpp
+++ b/taichi/codegen/llvm/llvm_codegen_utils.cpp
@@ -65,7 +65,7 @@ bool is_same_type(llvm::Type *a, llvm::Type *b) {
     }
     len_same++;
   }
-  if (len_same == a_name.size())  {
+  if (len_same == a_name.size()) {
     TI_ASSERT(len_same != b_name.size());
     if (b_name[len_same] == '.') {
       // a is xxx, and b is xxx.yyy, yyy is a number

--- a/taichi/codegen/llvm/llvm_codegen_utils.h
+++ b/taichi/codegen/llvm/llvm_codegen_utils.h
@@ -43,6 +43,8 @@ inline constexpr char kLLVMPhysicalCoordinatesName[] = "PhysicalCoordinates";
 
 std::string type_name(llvm::Type *type);
 
+bool is_same_type(llvm::Type *a, llvm::Type *b);
+
 void check_func_call_signature(llvm::FunctionType *func_type,
                                llvm::StringRef func_name,
                                std::vector<llvm::Value *> &arglist,

--- a/tests/cpp/llvm/is_same_type_test.cpp
+++ b/tests/cpp/llvm/is_same_type_test.cpp
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Type.h"
+#include "taichi/codegen/llvm/llvm_codegen_utils.h"
+
+
+TEST(IsSameTypeTest, IsSameType) {
+  llvm::LLVMContext ctx;
+  auto integer = llvm::Type::getInt32Ty(ctx);
+  auto structtype = llvm::StructType::create({integer, integer}, "structtype");
+  auto structtype1 = llvm::StructType::create({integer, integer}, "structtype.1");
+  auto structtype2 = llvm::StructType::create({integer, integer}, "structtype.2");
+  auto structtype11 = llvm::StructType::create({integer, integer}, "structtype.11");
+  auto structtype12 = llvm::StructType::create({integer, integer}, "structtype.12");
+  std::vector<llvm::Type *> types = {structtype, structtype1, structtype2, structtype11, structtype12};
+  for (auto t1: types) {
+    for (auto t2: types) {
+      ASSERT_TRUE(taichi::lang::is_same_type(t1, t2));
+      ASSERT_TRUE(taichi::lang::is_same_type(llvm::PointerType::get(t1, 0), llvm::PointerType::get(t2, 0)));
+    }
+  }
+  auto func1 = llvm::FunctionType::get(structtype, {structtype1, structtype2, structtype11, structtype12}, false);
+  auto func2 = llvm::FunctionType::get(structtype12, {structtype11, structtype1, structtype2, structtype}, false);
+  ASSERT_TRUE(taichi::lang::is_same_type(func1, func2));
+}

--- a/tests/cpp/llvm/is_same_type_test.cpp
+++ b/tests/cpp/llvm/is_same_type_test.cpp
@@ -3,23 +3,32 @@
 #include "llvm/IR/Type.h"
 #include "taichi/codegen/llvm/llvm_codegen_utils.h"
 
-
 TEST(IsSameTypeTest, IsSameType) {
   llvm::LLVMContext ctx;
   auto integer = llvm::Type::getInt32Ty(ctx);
   auto structtype = llvm::StructType::create({integer, integer}, "structtype");
-  auto structtype1 = llvm::StructType::create({integer, integer}, "structtype.1");
-  auto structtype2 = llvm::StructType::create({integer, integer}, "structtype.2");
-  auto structtype11 = llvm::StructType::create({integer, integer}, "structtype.11");
-  auto structtype12 = llvm::StructType::create({integer, integer}, "structtype.12");
-  std::vector<llvm::Type *> types = {structtype, structtype1, structtype2, structtype11, structtype12};
-  for (auto t1: types) {
-    for (auto t2: types) {
+  auto structtype1 =
+      llvm::StructType::create({integer, integer}, "structtype.1");
+  auto structtype2 =
+      llvm::StructType::create({integer, integer}, "structtype.2");
+  auto structtype11 =
+      llvm::StructType::create({integer, integer}, "structtype.11");
+  auto structtype12 =
+      llvm::StructType::create({integer, integer}, "structtype.12");
+  std::vector<llvm::Type *> types = {structtype, structtype1, structtype2,
+                                     structtype11, structtype12};
+  for (auto t1 : types) {
+    for (auto t2 : types) {
       ASSERT_TRUE(taichi::lang::is_same_type(t1, t2));
-      ASSERT_TRUE(taichi::lang::is_same_type(llvm::PointerType::get(t1, 0), llvm::PointerType::get(t2, 0)));
+      ASSERT_TRUE(taichi::lang::is_same_type(llvm::PointerType::get(t1, 0),
+                                             llvm::PointerType::get(t2, 0)));
     }
   }
-  auto func1 = llvm::FunctionType::get(structtype, {structtype1, structtype2, structtype11, structtype12}, false);
-  auto func2 = llvm::FunctionType::get(structtype12, {structtype11, structtype1, structtype2, structtype}, false);
+  auto func1 = llvm::FunctionType::get(
+      structtype, {structtype1, structtype2, structtype11, structtype12},
+      false);
+  auto func2 = llvm::FunctionType::get(
+      structtype12, {structtype11, structtype1, structtype2, structtype},
+      false);
   ASSERT_TRUE(taichi::lang::is_same_type(func1, func2));
 }


### PR DESCRIPTION
Issue: #5511

### Brief Summary
is_same_type fails when it encounters comparison between `%struct.PhysicalCoordinates.1` and `%struct.PhysicalCoordinates.11` where `1` is the prefix of `11`.

This bug does not affect 1.1.3 because parallel compilation is turned off in 1.1.3.