### PR TITLE
[bug] [vulkan] Only enable non_semantic_info cap when validation layer is on

### DIFF
--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -543,7 +543,8 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME) {
       enabled_extensions.push_back(ext.extensionName);
-    } else if (name == VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME) {
+    } else if (name == VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME &&
+               params_.enable_validation_layer) {
       // VK_KHR_shader_non_semantic_info isn't supported on molten-vk.
       // Tracking issue: https://github.com/KhronosGroup/MoltenVK/issues/1214
       ti_device_->set_cap(DeviceCapability::spirv_has_non_semantic_info, true);


### PR DESCRIPTION

related: #5350

Thanks @turbo0628 and @lin-hitonami for catching this! It turns out codegening non-semantic info spirv code isn't no-op when validation is off. It slows down the program execution so we should properly guard it.

