### PR TITLE
Revert "[spirv] Fixed OpLoad with physical address"

### DIFF
--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1169,16 +1169,7 @@ Value IRBuilder::load_variable(Value pointer, const SType &res_type) {
             pointer.flag == ValueKind::kStructArrayPtr ||
             pointer.flag == ValueKind::kPhysicalPtr);
   Value ret = new_value(res_type, ValueKind::kNormal);
-  if (pointer.flag == ValueKind::kPhysicalPtr) {
-    Value alignment =
-        uint_immediate_number(t_uint32_, get_primitive_type_size(res_type.dt));
-    ib_.begin(spv::OpLoad)
-        .add_seq(res_type, ret, pointer, spv::MemoryAccessAlignedMask,
-                 alignment)
-        .commit(&function_);
-  } else {
-    ib_.begin(spv::OpLoad).add_seq(res_type, ret, pointer).commit(&function_);
-  }
+  ib_.begin(spv::OpLoad).add_seq(res_type, ret, pointer).commit(&function_);
   return ret;
 }
 void IRBuilder::store_variable(Value pointer, Value value) {


### PR DESCRIPTION
Reverts taichi-dev/taichi#5212

PR #5212 fixes a warning on Vulkan validation layer, but it introduces performance regression to Vulkan backend.