### PR TITLE
[Lang] MatrixNdarray refactor part10: Remove redundant MatrixInitStmt generated from scalarization

### DIFF
--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1814,6 +1814,10 @@ class MatrixInitStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
+  bool has_global_side_effect() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, values);
   TI_DEFINE_ACCEPT_AND_CLONE
 };

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -54,6 +54,9 @@ void compile_to_offloads(IRNode *ir,
 
   if (config.real_matrix && config.real_matrix_scalarize) {
     irpass::scalarize(ir);
+
+    // Remove redundant MatrixInitStmt inserted during scalarization
+    irpass::die(ir);
     print("Scalarized");
   }
 

--- a/taichi/transforms/die.cpp
+++ b/taichi/transforms/die.cpp
@@ -108,13 +108,6 @@ class DIE : public IRVisitor {
     }
     stmt->all_blocks_accept(this, true);
   }
-
-  void visit(MatrixInitStmt *stmt) override {
-    register_usage(stmt);
-    for (auto &elts : stmt->values) {
-      elts->accept(this);
-    }
-  }
 };
 
 namespace irpass {

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -382,11 +382,6 @@ void scalarize(IRNode *root) {
   TI_AUTO_PROF;
   Scalarize scalarize_pass(root);
   ScalarizePointers scalarize_pointers_pass(root);
-
-  /* TODO(zhanlue): Remove redundant MatrixInitStmt
-    Scalarize pass will generate temporary MatrixInitStmts, which are only used
-    as rvalues. Remove these MatrixInitStmts since it's no longer needed.
-  */
 }
 
 }  // namespace irpass


### PR DESCRIPTION
Related issue = https://github.com/taichi-dev/taichi/issues/5873, https://github.com/taichi-dev/taichi/issues/5819

This PR is working "Part ④" in https://github.com/taichi-dev/taichi/issues/5873.