### PR TITLE
[aot] Device capability refactorization

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -34,8 +34,6 @@ function build-and-smoke-test-android-aot-demo {
     python implicit_fem.py --aot
     popd
 
-    ls taichi-aot-demo/implicit_fem/android/app/src/main/assets/shaders/aot/implicit_fem
-
     mkdir -p $JNI_PATH
     cp taichi/build/libtaichi_export_core.so $JNI_PATH
     cd $ANDROID_APP_ROOT

--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -21,7 +21,7 @@ function build-and-smoke-test-android-aot-demo {
     # Normally we checkout the master's commit Id: https://github.com/taichi-dev/taichi-aot-demo/commit/master
     # As for why we need this explicit commit Id here, refer to: https://docs.taichi-lang.org/docs/master/contributor_guide#handle-special-ci-failures
     pushd taichi-aot-demo
-    git checkout ed5bb27b600920d6fbb2942c5315242baba57944
+    git checkout 6b8d22f2c38318cf7a7333dc17cff4ae7ee5e607
     popd
 
     APP_ROOT=taichi-aot-demo/implicit_fem

--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -21,7 +21,7 @@ function build-and-smoke-test-android-aot-demo {
     # Normally we checkout the master's commit Id: https://github.com/taichi-dev/taichi-aot-demo/commit/master
     # As for why we need this explicit commit Id here, refer to: https://docs.taichi-lang.org/docs/master/contributor_guide#handle-special-ci-failures
     pushd taichi-aot-demo
-    git checkout bd8fb7bf30a3494f4ecc671cd4d017b926afed10
+    git checkout ed5bb27b600920d6fbb2942c5315242baba57944
     popd
 
     APP_ROOT=taichi-aot-demo/implicit_fem
@@ -33,6 +33,8 @@ function build-and-smoke-test-android-aot-demo {
     sudo chmod 0777 $HOME/.cache
     python implicit_fem.py --aot
     popd
+
+    ls taichi-aot-demo/implicit_fem/android/app/src/main/assets/shaders/aot/implicit_fem
 
     mkdir -p $JNI_PATH
     cp taichi/build/libtaichi_export_core.so $JNI_PATH
@@ -49,7 +51,7 @@ function prepare-unity-build-env {
     cd taichi
 
     # Dependencies
-    git clone --reference-if-able /var/lib/git-cache -b upgrade-modules1 https://github.com/taichi-dev/Taichi-UnityExample
+    git clone --reference-if-able /var/lib/git-cache -b upgrade-modules2 https://github.com/taichi-dev/Taichi-UnityExample
 
     python misc/generate_unity_language_binding.py
     cp c_api/unity/*.cs Taichi-UnityExample/Assets/Taichi/Generated

--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -103,7 +103,7 @@ function build-and-test-headless-demo {
     popd
 
     rm -rf taichi-aot-demo
-    git clone --recursive --depth=1 https://github.com/taichi-dev/taichi-aot-demo
+    git clone --recursive --depth=1 https://github.com/taichi-dev/taichi-aot-demo -b update-aot-module1
     cd taichi-aot-demo
     mkdir build
     pushd build

--- a/c_api/src/taichi_opengl_impl.cpp
+++ b/c_api/src/taichi_opengl_impl.cpp
@@ -5,9 +5,11 @@ OpenglRuntime::OpenglRuntime()
     : GfxRuntime(taichi::Arch::opengl),
       gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{
           host_result_buffer_.data(), &device_}) {
-  device_.set_cap(taichi::lang::DeviceCapability::spirv_has_int64, true);
-  device_.set_cap(taichi::lang::DeviceCapability::spirv_has_float64, true);
-  device_.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10300);
+  taichi::lang::DeviceCapabilityConfig caps{};
+  caps.set(taichi::lang::DeviceCapability::spirv_has_int64, true);
+  caps.set(taichi::lang::DeviceCapability::spirv_has_float64, true);
+  caps.set(taichi::lang::DeviceCapability::spirv_version, 0x10300);
+  get_gl().set_current_caps(std::move(caps));
 }
 taichi::lang::Device &OpenglRuntime::get() {
   return static_cast<taichi::lang::Device &>(device_);

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -25,22 +25,24 @@ VulkanRuntimeImported::Workaround::Workaround(
   }
   taichi::lang::vulkan::VulkanLoader::instance().load_instance(params.instance);
   taichi::lang::vulkan::VulkanLoader::instance().load_device(params.device);
-  vk_device.set_cap(taichi::lang::DeviceCapability::vk_api_version,
-                    api_version);
+  vk_device.vk_caps().vk_api_version = api_version;
 
-  vk_device.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10000);
+  taichi::lang::DeviceCapabilityConfig caps{};
+
   if (api_version >= VK_API_VERSION_1_2) {
-    vk_device.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10500);
+    caps.set(taichi::lang::DeviceCapability::spirv_version, 0x10500);
   } else if (api_version >= VK_API_VERSION_1_1) {
-    vk_device.set_cap(taichi::lang::DeviceCapability::spirv_version, 0x10300);
+    caps.set(taichi::lang::DeviceCapability::spirv_version, 0x10300);
+  } else {
+    caps.set(taichi::lang::DeviceCapability::spirv_version, 0x10000);
   }
 
   if (api_version > VK_API_VERSION_1_0) {
-    vk_device.set_cap(
-        taichi::lang::DeviceCapability::spirv_has_physical_storage_buffer,
-        true);
+    caps.set(taichi::lang::DeviceCapability::spirv_has_physical_storage_buffer,
+             true);
   }
 
+  vk_device.set_current_caps(std::move(caps));
   vk_device.init_vulkan_structs(
       const_cast<taichi::lang::vulkan::VulkanDevice::Params &>(params));
 }
@@ -188,8 +190,7 @@ void ti_export_vulkan_runtime(TiRuntime runtime,
   taichi::lang::vulkan::VulkanDevice &vk_device =
       static_cast<VulkanRuntime *>(runtime2)->get_vk();
   interop_info->get_instance_proc_addr = vkGetInstanceProcAddr;
-  interop_info->api_version =
-      vk_device.get_cap(taichi::lang::DeviceCapability::vk_api_version);
+  interop_info->api_version = vk_device.vk_caps().vk_api_version;
   interop_info->instance = vk_device.vk_instance();
   interop_info->physical_device = vk_device.vk_physical_device();
   interop_info->device = vk_device.vk_device();

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -105,6 +105,24 @@
                     "inc_cases": "PER_ARCH"
                 },
                 {
+                    "name": "capability",
+                    "type": "enumeration",
+                    "inc_cases": "PER_DEVICE_CAPABILITY"
+                },
+                {
+                    "name": "capability_level_info",
+                    "type": "structure",
+                    "fields": [
+                        {
+                            "type": "enumeration.capability"
+                        },
+                        {
+                            "name": "level",
+                            "type": "uint32_t"
+                        }
+                    ]
+                },
+                {
                     "name": "data_type",
                     "type": "enumeration",
                     "inc_cases": "PER_TYPE"
@@ -493,6 +511,25 @@
                     "parameters": [
                         {
                             "type": "handle.runtime"
+                        }
+                    ]
+                },
+                {
+                    "name": "set_runtime_capabilities",
+                    "type": "function",
+                    "is_extension": true,
+                    "parameters": [
+                        {
+                            "type": "handle.runtime"
+                        },
+                        {
+                            "name": "capability_count",
+                            "type": "uint32_t"
+                        },
+                        {
+                            "name": "capabilities",
+                            "type": "enumeration.capability",
+                            "count": "capability_count"
                         }
                     ]
                 },

--- a/cpp_examples/aot_save.cpp
+++ b/cpp_examples/aot_save.cpp
@@ -18,7 +18,7 @@ void aot_save(taichi::Arch arch) {
   place->dt = PrimitiveType::i32;
   program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/true);
 
-  auto aot_builder = program.make_aot_module_builder(arch);
+  auto aot_builder = program.make_aot_module_builder(arch, {});
 
   std::unique_ptr<Kernel> kernel_init, kernel_ret;
 

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -81,19 +81,20 @@ class Module:
         # Now the module file '/path/to/module' contains the Metal kernels
         # for running ``foo`` and ``bar``.
     """
-    def __init__(self, arch):
+    def __init__(self, arch, caps=[]):
         """Creates a new AOT module instance
 
         Args:
-          arch: Target backend architecture. This is ignored for now. The AOT
-            backend still uses the one specified in :func:`~taichi.lang.init`.
+          arch: Target backend architecture. This must match the one specified
+            in :func:`~taichi.lang.init`.
+          caps (List[str]): Enabled device capabilities.
         """
         self._arch = arch
         self._kernels = []
         self._fields = {}
         rtm = impl.get_runtime()
         rtm._finalize_root_fb_for_aot()
-        self._aot_builder = rtm.prog.make_aot_module_builder(arch)
+        self._aot_builder = rtm.prog.make_aot_module_builder(arch, caps)
         self._content = []
 
     def add_field(self, name, field):

--- a/python/taichi/examples/simulation/fractal.py
+++ b/python/taichi/examples/simulation/fractal.py
@@ -1,6 +1,6 @@
 import taichi as ti
 
-ti.init(arch=ti.vulkan)
+ti.init(arch=ti.gpu)
 
 n = 320
 pixels = ti.field(dtype=float, shape=(n * 2, n))

--- a/python/taichi/examples/simulation/fractal.py
+++ b/python/taichi/examples/simulation/fractal.py
@@ -1,6 +1,6 @@
 import taichi as ti
 
-ti.init(arch=ti.gpu)
+ti.init(arch=ti.vulkan)
 
 n = 320
 pixels = ti.field(dtype=float, shape=(n * 2, n))

--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -120,7 +120,7 @@ struct ModuleData {
   std::unordered_map<std::string, CompiledTaichiKernel> kernels;
   std::unordered_map<std::string, CompiledTaichiKernel> kernel_tmpls;
   std::vector<aot::CompiledFieldData> fields;
-  std::map<DeviceCapability, uint32_t> required_caps;
+  std::map<std::string, uint32_t> required_caps;
 
   size_t root_buffer_size;
 

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -116,53 +116,5 @@ class TI_DLL_EXPORT Module {
   std::unordered_map<std::string, std::unique_ptr<Field>> loaded_fields_;
 };
 
-// Only responsible for reporting device capabilities
-class TargetDevice : public Device {
- public:
-  explicit TargetDevice(Arch arch) {
-    // TODO: make this configurable
-    set_default_caps(arch);
-  }
-
-  void set_default_caps(Arch arch) {
-    if (arch == Arch::vulkan || arch == Arch::opengl) {
-      set_cap(DeviceCapability::spirv_version, 0x10300);
-    }
-  }
-
-  DeviceAllocation allocate_memory(const AllocParams &params) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void dealloc_memory(DeviceAllocation handle) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  std::unique_ptr<Pipeline> create_pipeline(
-      const PipelineSourceDesc &src,
-      std::string name = "Pipeline") override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void *map_range(DevicePtr ptr, uint64_t size) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void *map(DeviceAllocation alloc) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void unmap(DevicePtr ptr) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void unmap(DeviceAllocation alloc) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) override {
-    TI_NOT_IMPLEMENTED;
-  }
-  Stream *get_compute_stream() override {
-    TI_NOT_IMPLEMENTED;
-  }
-  void wait_idle() override {
-    TI_NOT_IMPLEMENTED;
-  }
-};
-
 }  // namespace aot
 }  // namespace taichi::lang

--- a/taichi/cache/gfx/cache_manager.h
+++ b/taichi/cache/gfx/cache_manager.h
@@ -26,7 +26,7 @@ class CacheManager {
     Mode mode{MemCache};
     std::string cache_path;
     GfxRuntime *runtime{nullptr};
-    std::unique_ptr<aot::TargetDevice> target_device;
+    DeviceCapabilityConfig caps{};
     const std::vector<spirv::CompiledSNodeStructs> *compiled_structs;
   };
 

--- a/taichi/codegen/cc/cc_program.h
+++ b/taichi/codegen/cc/cc_program.h
@@ -47,7 +47,7 @@ class CCProgramImpl : public ProgramImpl {
     // Not implemented yet.
   }
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override {
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) override {
     // Not implemented yet.
     return nullptr;
   }

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -47,8 +47,9 @@ std::string TaskAttributes::BufferBind::debug_string() const {
                      TaskAttributes::buffers_name(buffer), binding);
 }
 
-KernelContextAttributes::KernelContextAttributes(const Kernel &kernel,
-                                                 Device *device)
+KernelContextAttributes::KernelContextAttributes(
+    const Kernel &kernel,
+    const DeviceCapabilityConfig *caps)
     : args_bytes_(0),
       rets_bytes_(0),
       extra_args_bytes_(RuntimeContext::extra_args_size) {
@@ -114,7 +115,7 @@ KernelContextAttributes::KernelContextAttributes(const Kernel &kernel,
   TI_TRACE("args:");
   args_bytes_ = arange_args(
       &arg_attribs_vec_, 0, false,
-      device->get_cap(DeviceCapability::spirv_has_physical_storage_buffer));
+      caps->get(DeviceCapability::spirv_has_physical_storage_buffer));
   // Align to extra args
   args_bytes_ = (args_bytes_ + 4 - 1) / 4 * 4;
 

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -177,7 +177,8 @@ class KernelContextAttributes {
   struct RetAttributes : public AttribsBase {};
 
   KernelContextAttributes() = default;
-  explicit KernelContextAttributes(const Kernel &kernel, Device *device);
+  explicit KernelContextAttributes(const Kernel &kernel,
+                                   const DeviceCapabilityConfig *caps);
 
   /**
    * Whether this kernel has any argument

--- a/taichi/codegen/spirv/spirv_codegen.h
+++ b/taichi/codegen/spirv/spirv_codegen.h
@@ -22,7 +22,8 @@ class KernelCodegen {
     std::string ti_kernel_name;
     Kernel *kernel;
     std::vector<CompiledSNodeStructs> compiled_structs;
-    Device *device;
+    Arch arch;
+    DeviceCapabilityConfig caps;
     bool enable_spv_opt{true};
   };
 

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -11,9 +11,9 @@ void IRBuilder::init_header() {
   TI_ASSERT(header_.size() == 0U);
   header_.push_back(spv::MagicNumber);
 
-  header_.push_back(device_->get_cap(cap::spirv_version));
+  header_.push_back(caps_->get(cap::spirv_version));
 
-  TI_TRACE("SPIR-V Version {}", device_->get_cap(cap::spirv_version));
+  TI_TRACE("SPIR-V Version {}", caps_->get(cap::spirv_version));
 
   // generator: set to 0, unknown
   header_.push_back(0U);
@@ -25,25 +25,25 @@ void IRBuilder::init_header() {
   // capability
   ib_.begin(spv::OpCapability).add(spv::CapabilityShader).commit(&header_);
 
-  if (device_->get_cap(cap::spirv_has_atomic_float64_add)) {
+  if (caps_->get(cap::spirv_has_atomic_float64_add)) {
     ib_.begin(spv::OpCapability)
         .add(spv::CapabilityAtomicFloat64AddEXT)
         .commit(&header_);
   }
 
-  if (device_->get_cap(cap::spirv_has_atomic_float_add)) {
+  if (caps_->get(cap::spirv_has_atomic_float_add)) {
     ib_.begin(spv::OpCapability)
         .add(spv::CapabilityAtomicFloat32AddEXT)
         .commit(&header_);
   }
 
-  if (device_->get_cap(cap::spirv_has_atomic_float_minmax)) {
+  if (caps_->get(cap::spirv_has_atomic_float_minmax)) {
     ib_.begin(spv::OpCapability)
         .add(spv::CapabilityAtomicFloat32MinMaxEXT)
         .commit(&header_);
   }
 
-  if (device_->get_cap(cap::spirv_has_variable_ptr)) {
+  if (caps_->get(cap::spirv_has_variable_ptr)) {
     /*
     ib_.begin(spv::OpCapability)
         .add(spv::CapabilityVariablePointers)
@@ -54,22 +54,22 @@ void IRBuilder::init_header() {
         */
   }
 
-  if (device_->get_cap(cap::spirv_has_int8)) {
+  if (caps_->get(cap::spirv_has_int8)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt8).commit(&header_);
   }
-  if (device_->get_cap(cap::spirv_has_int16)) {
+  if (caps_->get(cap::spirv_has_int16)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt16).commit(&header_);
   }
-  if (device_->get_cap(cap::spirv_has_int64)) {
+  if (caps_->get(cap::spirv_has_int64)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityInt64).commit(&header_);
   }
-  if (device_->get_cap(cap::spirv_has_float16)) {
+  if (caps_->get(cap::spirv_has_float16)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityFloat16).commit(&header_);
   }
-  if (device_->get_cap(cap::spirv_has_float64)) {
+  if (caps_->get(cap::spirv_has_float64)) {
     ib_.begin(spv::OpCapability).add(spv::CapabilityFloat64).commit(&header_);
   }
-  if (device_->get_cap(cap::spirv_has_physical_storage_buffer)) {
+  if (caps_->get(cap::spirv_has_physical_storage_buffer)) {
     ib_.begin(spv::OpCapability)
         .add(spv::CapabilityPhysicalStorageBufferAddresses)
         .commit(&header_);
@@ -79,31 +79,31 @@ void IRBuilder::init_header() {
       .add("SPV_KHR_storage_buffer_storage_class")
       .commit(&header_);
 
-  if (device_->get_cap(cap::spirv_has_non_semantic_info)) {
+  if (caps_->get(cap::spirv_has_non_semantic_info)) {
     ib_.begin(spv::OpExtension)
         .add("SPV_KHR_non_semantic_info")
         .commit(&header_);
   }
 
-  if (device_->get_cap(cap::spirv_has_variable_ptr)) {
+  if (caps_->get(cap::spirv_has_variable_ptr)) {
     ib_.begin(spv::OpExtension)
         .add("SPV_KHR_variable_pointers")
         .commit(&header_);
   }
 
-  if (device_->get_cap(cap::spirv_has_atomic_float_add)) {
+  if (caps_->get(cap::spirv_has_atomic_float_add)) {
     ib_.begin(spv::OpExtension)
         .add("SPV_EXT_shader_atomic_float_add")
         .commit(&header_);
   }
 
-  if (device_->get_cap(cap::spirv_has_atomic_float_minmax)) {
+  if (caps_->get(cap::spirv_has_atomic_float_minmax)) {
     ib_.begin(spv::OpExtension)
         .add("SPV_EXT_shader_atomic_float_min_max")
         .commit(&header_);
   }
 
-  if (device_->get_cap(cap::spirv_has_physical_storage_buffer)) {
+  if (caps_->get(cap::spirv_has_physical_storage_buffer)) {
     ib_.begin(spv::OpExtension)
         .add("SPV_KHR_physical_storage_buffer")
         .commit(&header_);
@@ -141,30 +141,30 @@ std::vector<uint32_t> IRBuilder::finalize() {
 
 void IRBuilder::init_pre_defs() {
   ext_glsl450_ = ext_inst_import("GLSL.std.450");
-  if (device_->get_cap(cap::spirv_has_non_semantic_info)) {
+  if (caps_->get(cap::spirv_has_non_semantic_info)) {
     debug_printf_ = ext_inst_import("NonSemantic.DebugPrintf");
   }
 
   t_bool_ = declare_primitive_type(get_data_type<bool>());
-  if (device_->get_cap(cap::spirv_has_int8)) {
+  if (caps_->get(cap::spirv_has_int8)) {
     t_int8_ = declare_primitive_type(get_data_type<int8>());
     t_uint8_ = declare_primitive_type(get_data_type<uint8>());
   }
-  if (device_->get_cap(cap::spirv_has_int16)) {
+  if (caps_->get(cap::spirv_has_int16)) {
     t_int16_ = declare_primitive_type(get_data_type<int16>());
     t_uint16_ = declare_primitive_type(get_data_type<uint16>());
   }
   t_int32_ = declare_primitive_type(get_data_type<int32>());
   t_uint32_ = declare_primitive_type(get_data_type<uint32>());
-  if (device_->get_cap(cap::spirv_has_int64)) {
+  if (caps_->get(cap::spirv_has_int64)) {
     t_int64_ = declare_primitive_type(get_data_type<int64>());
     t_uint64_ = declare_primitive_type(get_data_type<uint64>());
   }
   t_fp32_ = declare_primitive_type(get_data_type<float32>());
-  if (device_->get_cap(cap::spirv_has_float16)) {
+  if (caps_->get(cap::spirv_has_float16)) {
     t_fp16_ = declare_primitive_type(PrimitiveType::f16);
   }
-  if (device_->get_cap(cap::spirv_has_float64)) {
+  if (caps_->get(cap::spirv_has_float64)) {
     t_fp64_ = declare_primitive_type(get_data_type<float64>());
   }
   // declare void, and void functions
@@ -280,41 +280,41 @@ SType IRBuilder::get_primitive_type(const DataType &dt) const {
   if (dt->is_primitive(PrimitiveTypeID::u1)) {
     return t_bool_;
   } else if (dt->is_primitive(PrimitiveTypeID::f16)) {
-    if (!device_->get_cap(cap::spirv_has_float16))
+    if (!caps_->get(cap::spirv_has_float16))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_fp16_;
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
     return t_fp32_;
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
-    if (!device_->get_cap(cap::spirv_has_float64))
+    if (!caps_->get(cap::spirv_has_float64))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_fp64_;
   } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
-    if (!device_->get_cap(cap::spirv_has_int8))
+    if (!caps_->get(cap::spirv_has_int8))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_int8_;
   } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
-    if (!device_->get_cap(cap::spirv_has_int16))
+    if (!caps_->get(cap::spirv_has_int16))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_int16_;
   } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
     return t_int32_;
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
-    if (!device_->get_cap(cap::spirv_has_int64))
+    if (!caps_->get(cap::spirv_has_int64))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_int64_;
   } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
-    if (!device_->get_cap(cap::spirv_has_int8))
+    if (!caps_->get(cap::spirv_has_int8))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_uint8_;
   } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
-    if (!device_->get_cap(cap::spirv_has_int16))
+    if (!caps_->get(cap::spirv_has_int16))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_uint16_;
   } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
     return t_uint32_;
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    if (!device_->get_cap(cap::spirv_has_int64))
+    if (!caps_->get(cap::spirv_has_int64))
       TI_ERROR("Type {} not supported.", dt->to_string());
     return t_uint64_;
   } else {
@@ -493,7 +493,7 @@ SType IRBuilder::get_storage_image_type(BufferFormat format,
 
 SType IRBuilder::get_storage_pointer_type(const SType &value_type) {
   spv::StorageClass storage_class;
-  if (device_->get_cap(cap::spirv_version) < 0x10300) {
+  if (caps_->get(cap::spirv_version) < 0x10300) {
     storage_class = spv::StorageClassUniform;
   } else {
     storage_class = spv::StorageClassStorageBuffer;
@@ -559,7 +559,7 @@ SType IRBuilder::get_struct_array_type(const SType &value_type,
       .add_seq(struct_type, 0, spv::DecorationOffset, 0)
       .commit(&decorate_);
 
-  if (device_->get_cap(cap::spirv_version) < 0x10300) {
+  if (caps_->get(cap::spirv_version) < 0x10300) {
     // NOTE: BufferBlock was deprecated in SPIRV 1.3
     // use StorageClassStorageBuffer instead.
     // runtime array are always decorated as BufferBlock(shader storage buffer)
@@ -605,7 +605,7 @@ Value IRBuilder::buffer_struct_argument(const SType &struct_type,
   // NOTE: BufferBlock was deprecated in SPIRV 1.3
   // use StorageClassStorageBuffer instead.
   spv::StorageClass storage_class;
-  if (device_->get_cap(cap::spirv_version) < 0x10300) {
+  if (caps_->get(cap::spirv_version) < 0x10300) {
     storage_class = spv::StorageClassUniform;
   } else {
     storage_class = spv::StorageClassStorageBuffer;
@@ -613,7 +613,7 @@ Value IRBuilder::buffer_struct_argument(const SType &struct_type,
 
   this->debug_name(spv::OpName, struct_type, name + "_t");
 
-  if (device_->get_cap(cap::spirv_version) < 0x10300) {
+  if (caps_->get(cap::spirv_version) < 0x10300) {
     // NOTE: BufferBlock was deprecated in SPIRV 1.3
     // use StorageClassStorageBuffer instead.
     // runtime array are always decorated as BufferBlock(shader storage buffer)
@@ -675,7 +675,7 @@ Value IRBuilder::buffer_argument(const SType &value_type,
   // NOTE: BufferBlock was deprecated in SPIRV 1.3
   // use StorageClassStorageBuffer instead.
   spv::StorageClass storage_class;
-  if (device_->get_cap(cap::spirv_version) < 0x10300) {
+  if (caps_->get(cap::spirv_version) < 0x10300) {
     storage_class = spv::StorageClassUniform;
   } else {
     storage_class = spv::StorageClassStorageBuffer;
@@ -711,7 +711,7 @@ Value IRBuilder::struct_array_access(const SType &res_type,
   TI_ASSERT(res_type.flag == TypeKind::kPrimitive);
 
   spv::StorageClass storage_class;
-  if (device_->get_cap(cap::spirv_version) < 0x10300) {
+  if (caps_->get(cap::spirv_version) < 0x10300) {
     storage_class = spv::StorageClassUniform;
   } else {
     storage_class = spv::StorageClassStorageBuffer;
@@ -1534,7 +1534,7 @@ void IRBuilder::init_random_function(Value global_tmp_) {
 
 // use atomic increment for DX API to avoid error X3694
 #ifdef TI_WITH_DX11
-  if (dynamic_cast<const taichi::lang::directx11::Dx11Device *>(device_)) {
+  if (arch_ == Arch::dx11) {
     use_atomic_increment = true;
   }
 #endif

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -204,7 +204,8 @@ class InstrBuilder {
 // Builder to build up a single SPIR-V module
 class IRBuilder {
  public:
-  explicit IRBuilder(const Device *device) : device_(device) {
+  IRBuilder(Arch arch, const DeviceCapabilityConfig *caps)
+      : arch_(arch), caps_(caps) {
   }
 
   template <typename... Args>
@@ -394,7 +395,7 @@ class IRBuilder {
     for (const auto &arg : args) {
       ib_.add(arg);
     }
-    if (device_->get_cap(DeviceCapability::spirv_version) >= 0x10400) {
+    if (caps_->get(DeviceCapability::spirv_version) >= 0x10400) {
       for (const auto &v : global_values) {
         ib_.add(v);
       }
@@ -553,7 +554,8 @@ class IRBuilder {
 
   void init_random_function(Value global_tmp_);
 
-  const Device *device_;
+  Arch arch_;
+  const DeviceCapabilityConfig *caps_;
 
   // internal instruction builder
   InstrBuilder ib_;

--- a/taichi/inc/rhi_constants.inc.h
+++ b/taichi/inc/rhi_constants.inc.h
@@ -1,10 +1,11 @@
+// (penguinliong) Device capability is a shared intelligence between the runtime
+// environment and the code generator. It's only about the program executed
+// on-device rather than any platform specific capability provided by some
+// graphics APIs like Vulkan or CUDA. For example, DirectX shader model, CUDA
+// compute capability and Vulkan physical device features can be listed here as
+// device capabilities, yet things like Vulkan API version and GLFW version
+// should not.
 #ifdef PER_DEVICE_CAPABILITY
-// Vulkan Caps
-PER_DEVICE_CAPABILITY(vk_api_version)
-PER_DEVICE_CAPABILITY(vk_has_physical_features2)
-PER_DEVICE_CAPABILITY(vk_has_external_memory)
-PER_DEVICE_CAPABILITY(vk_has_surface)
-PER_DEVICE_CAPABILITY(vk_has_presentation)
 // SPIR-V Caps
 PER_DEVICE_CAPABILITY(spirv_version)
 PER_DEVICE_CAPABILITY(spirv_has_int8)
@@ -29,8 +30,6 @@ PER_DEVICE_CAPABILITY(spirv_has_subgroup_vote)
 PER_DEVICE_CAPABILITY(spirv_has_subgroup_arithmetic)
 PER_DEVICE_CAPABILITY(spirv_has_subgroup_ballot)
 PER_DEVICE_CAPABILITY(spirv_has_non_semantic_info)
-// Graphics Caps
-PER_DEVICE_CAPABILITY(wide_lines)
 #endif
 
 #ifdef PER_BUFFER_FORMAT

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -293,7 +293,9 @@ class TI_DLL_EXPORT Program {
    */
   SNode *get_snode_root(int tree_id);
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(Arch arch);
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(
+      Arch arch,
+      const std::vector<std::string>& caps);
 
   size_t get_field_in_tree_offset(int tree_id, const SNode *child) {
     return program_impl_->get_field_in_tree_offset(tree_id, child);

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -75,7 +75,7 @@ class ProgramImpl {
   /**
    * Make a AotModulerBuilder, currently only supported by metal and wasm.
    */
-  virtual std::unique_ptr<AotModuleBuilder> make_aot_module_builder() = 0;
+  virtual std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) = 0;
 
   /**
    * Compile a taichi::lang::Kernel to taichi::lang::aot::Kernel.

--- a/taichi/rhi/device.cpp
+++ b/taichi/rhi/device.cpp
@@ -302,13 +302,6 @@ const std::string to_string(DeviceCapability c) {
 #undef PER_DEVICE_CAPABILITY
 }
 
-void Device::print_all_cap() const {
-  for (auto &pair : caps_) {
-    TI_TRACE("DeviceCapability::{} ({}) = {}", to_string(pair.first),
-             int(pair.first), pair.second);
-  }
-}
-
 void GraphicsDevice::image_transition(DeviceAllocation img,
                                       ImageLayout old_layout,
                                       ImageLayout new_layout) {

--- a/taichi/rhi/device.cpp
+++ b/taichi/rhi/device.cpp
@@ -288,6 +288,14 @@ void Device::memcpy_via_host(DevicePtr dst,
   TI_NOT_IMPLEMENTED;
 }
 
+DeviceCapability str2devcap(const std::string_view& name) {
+#define PER_DEVICE_CAPABILITY(x) \
+  if (#x == name) return DeviceCapability::x;
+#include "taichi/inc/rhi_constants.inc.h"
+#undef PER_DEVICE_CAPABILITY
+  TI_ERROR("unexpected device capability name {}", name);
+}
+
 const std::string to_string(DeviceCapability c) {
 #define PER_DEVICE_CAPABILITY(name) \
   case DeviceCapability::name:      \

--- a/taichi/rhi/device_capability.h
+++ b/taichi/rhi/device_capability.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <string>
+#include <map>
+#include <cstdint>
+
+namespace taichi::lang {
+
+// For backend dependent code (e.g. codegen)
+// Or the backend runtime itself
+// Capabilities are per-device
+enum class DeviceCapability : uint32_t {
+#define PER_DEVICE_CAPABILITY(name) name,
+#include "taichi/inc/rhi_constants.inc.h"
+#undef PER_DEVICE_CAPABILITY
+};
+const std::string to_string(DeviceCapability c);
+
+// A collection of device capability.
+struct DeviceCapabilityConfig {
+ private:
+  std::map<DeviceCapability, uint32_t> inner_;
+
+ public:
+  inline uint32_t get(DeviceCapability cap) const {
+    auto it = inner_.find(cap);
+    if (it != inner_.end()) {
+      return it->second;
+    }
+    return 0;
+  }
+  inline void set(DeviceCapability cap, uint32_t level) {
+    inner_[cap] = level;
+  }
+  inline void dbg_print_all() const {
+    for (auto &pair : inner_) {
+      TI_TRACE("DeviceCapability::{} ({}) = {}", to_string(pair.first),
+               int(pair.first), pair.second);
+    }
+  }
+  inline const std::map<DeviceCapability, uint32_t> &to_inner() const {
+    return inner_;
+  }
+};
+
+}  // namespace taichi::lang

--- a/taichi/rhi/device_capability.h
+++ b/taichi/rhi/device_capability.h
@@ -13,6 +13,7 @@ enum class DeviceCapability : uint32_t {
 #include "taichi/inc/rhi_constants.inc.h"
 #undef PER_DEVICE_CAPABILITY
 };
+DeviceCapability str2devcap(const std::string_view& name);
 const std::string to_string(DeviceCapability c);
 
 // A collection of device capability.
@@ -21,6 +22,10 @@ struct DeviceCapabilityConfig {
   std::map<DeviceCapability, uint32_t> inner_;
 
  public:
+  inline uint32_t contains(DeviceCapability cap) const {
+    auto it = inner_.find(cap);
+    return it != inner_.end();
+  }
   inline uint32_t get(DeviceCapability cap) const {
     auto it = inner_.find(cap);
     if (it != inner_.end()) {

--- a/taichi/rhi/dx/dx_device.cpp
+++ b/taichi/rhi/dx/dx_device.cpp
@@ -515,7 +515,7 @@ Dx11Device::Dx11Device() {
   if (kD3d11DebugEnabled) {
     info_queue_ = std::make_unique<Dx11InfoQueue>(device_);
   }
-  set_cap(DeviceCapability::spirv_version, 0x10300);
+  caps_.set(DeviceCapability::spirv_version, 0x10300);
 
   stream_ = std::make_unique<Dx11Stream>(this);
 }

--- a/taichi/rhi/dx/dx_device.h
+++ b/taichi/rhi/dx/dx_device.h
@@ -296,8 +296,7 @@ class Dx11Device : public GraphicsDevice {
                                        ID3D11Device *device);
   };
 
-  const DeviceCapabilityConfig &get_current_caps()
-      const override final {
+  const DeviceCapabilityConfig &get_current_caps() const override final {
     return caps_;
   }
 

--- a/taichi/rhi/dx/dx_device.h
+++ b/taichi/rhi/dx/dx_device.h
@@ -171,7 +171,7 @@ class Dx11Device : public GraphicsDevice {
   Dx11Device();
   ~Dx11Device() override;
 
-  virtual Arch arch() const override final {
+  Arch arch() const override {
     return Arch::dx11;
   }
 
@@ -296,7 +296,7 @@ class Dx11Device : public GraphicsDevice {
                                        ID3D11Device *device);
   };
 
-  virtual const DeviceCapabilityConfig &get_current_caps()
+  const DeviceCapabilityConfig &get_current_caps()
       const override final {
     return caps_;
   }

--- a/taichi/rhi/dx/dx_device.h
+++ b/taichi/rhi/dx/dx_device.h
@@ -171,6 +171,10 @@ class Dx11Device : public GraphicsDevice {
   Dx11Device();
   ~Dx11Device() override;
 
+  virtual Arch arch() const override final {
+    return Arch::dx11;
+  }
+
   DeviceAllocation allocate_memory(const AllocParams &params) override;
   void dealloc_memory(DeviceAllocation handle) override;
   std::unique_ptr<Pipeline> create_pipeline(
@@ -236,6 +240,8 @@ class Dx11Device : public GraphicsDevice {
  private:
   void create_dx11_device();
   void destroy_dx11_device();
+
+  DeviceCapabilityConfig caps_{};
   ID3D11Device *device_{nullptr};
   ID3D11DeviceContext *context_{nullptr};
   std::unique_ptr<Dx11InfoQueue> info_queue_{nullptr};
@@ -289,6 +295,11 @@ class Dx11Device : public GraphicsDevice {
     ID3D11UnorderedAccessView *get_uav(ID3D11DeviceContext *context,
                                        ID3D11Device *device);
   };
+
+  virtual const DeviceCapabilityConfig &get_current_caps()
+      const override final {
+    return caps_;
+  }
 
   std::unordered_map<uint32_t, BufferTuple> alloc_id_to_buffer_;
   int alloc_serial_{0};

--- a/taichi/rhi/dx/dx_device.h
+++ b/taichi/rhi/dx/dx_device.h
@@ -296,7 +296,7 @@ class Dx11Device : public GraphicsDevice {
                                        ID3D11Device *device);
   };
 
-  const DeviceCapabilityConfig &get_current_caps() const override final {
+  const DeviceCapabilityConfig &get_current_caps() const override {
     return caps_;
   }
 

--- a/taichi/rhi/llvm/llvm_device.h
+++ b/taichi/rhi/llvm/llvm_device.h
@@ -13,7 +13,7 @@ class LlvmDevice : public Device {
     uint64 *result_buffer{nullptr};
   };
 
-  virtual Arch arch() const override final {
+  Arch arch() const override {
     TI_NOT_IMPLEMENTED
   }
 

--- a/taichi/rhi/llvm/llvm_device.h
+++ b/taichi/rhi/llvm/llvm_device.h
@@ -13,6 +13,10 @@ class LlvmDevice : public Device {
     uint64 *result_buffer{nullptr};
   };
 
+  virtual Arch arch() const override final {
+    TI_NOT_IMPLEMENTED
+  }
+
   virtual DeviceAllocation allocate_memory_runtime(
       const LlvmRuntimeAllocParams &params) {
     TI_NOT_IMPLEMENTED;

--- a/taichi/rhi/metal/device.cpp
+++ b/taichi/rhi/metal/device.cpp
@@ -286,7 +286,7 @@ class DeviceImpl : public Device, public AllocToMTLBufferMapper {
     TI_ASSERT(stream_ != nullptr);
   }
 
-  virtual Arch arch() const override final {
+  Arch arch() const override {
     return Arch::metal;
   }
 

--- a/taichi/rhi/metal/device.cpp
+++ b/taichi/rhi/metal/device.cpp
@@ -286,6 +286,10 @@ class DeviceImpl : public Device, public AllocToMTLBufferMapper {
     TI_ASSERT(stream_ != nullptr);
   }
 
+  virtual Arch arch() const override final {
+    return Arch::metal;
+  }
+
   DeviceAllocation allocate_memory(const AllocParams &params) override {
     DeviceAllocation res;
     res.device = this;

--- a/taichi/rhi/opengl/opengl_api.cpp
+++ b/taichi/rhi/opengl/opengl_api.cpp
@@ -207,12 +207,6 @@ bool is_gles() {
 
 std::shared_ptr<Device> make_opengl_device() {
   std::shared_ptr<Device> dev = std::make_shared<GLDevice>();
-  if (!is_gles()) {
-    // 64bit isn't supported in ES profile
-    dev->set_cap(DeviceCapability::spirv_has_int64, true);
-    dev->set_cap(DeviceCapability::spirv_has_float64, true);
-  }
-  dev->set_cap(DeviceCapability::spirv_version, 0x10300);
   return dev;
 }
 

--- a/taichi/rhi/opengl/opengl_device.cpp
+++ b/taichi/rhi/opengl/opengl_device.cpp
@@ -517,6 +517,12 @@ void GLStream::command_sync() {
 }
 
 GLDevice::GLDevice() : stream_(this) {
+  if (!is_gles()) {
+    // 64bit isn't supported in ES profile
+    caps_.set(DeviceCapability::spirv_has_int64, true);
+    caps_.set(DeviceCapability::spirv_has_float64, true);
+  }
+  caps_.set(DeviceCapability::spirv_version, 0x10300);
 }
 
 GLDevice::~GLDevice() {

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -302,8 +302,7 @@ class GLDevice : public GraphicsDevice {
     return image_to_int_format_.at(image);
   }
 
-  const DeviceCapabilityConfig &get_current_caps()
-      const override final {
+  const DeviceCapabilityConfig &get_current_caps() const override final {
     return caps_;
   }
 

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -241,7 +241,7 @@ class GLDevice : public GraphicsDevice {
   GLDevice();
   ~GLDevice() override;
 
-  virtual Arch arch() const override final {
+  Arch arch() const override {
     return Arch::opengl;
   }
 
@@ -302,7 +302,7 @@ class GLDevice : public GraphicsDevice {
     return image_to_int_format_.at(image);
   }
 
-  virtual const DeviceCapabilityConfig &get_current_caps()
+  const DeviceCapabilityConfig &get_current_caps()
       const override final {
     return caps_;
   }

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -302,7 +302,7 @@ class GLDevice : public GraphicsDevice {
     return image_to_int_format_.at(image);
   }
 
-  const DeviceCapabilityConfig &get_current_caps() const override final {
+  const DeviceCapabilityConfig &get_current_caps() const override {
     return caps_;
   }
 

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -241,6 +241,10 @@ class GLDevice : public GraphicsDevice {
   GLDevice();
   ~GLDevice() override;
 
+  virtual Arch arch() const override final {
+    return Arch::opengl;
+  }
+
   DeviceAllocation allocate_memory(const AllocParams &params) override;
   void dealloc_memory(DeviceAllocation handle) override;
 
@@ -298,7 +302,18 @@ class GLDevice : public GraphicsDevice {
     return image_to_int_format_.at(image);
   }
 
+  virtual const DeviceCapabilityConfig &get_current_caps()
+      const override final {
+    return caps_;
+  }
+
+  void set_current_caps(DeviceCapabilityConfig &&caps) {
+    caps_ = caps;
+  }
+
  private:
+  DeviceCapabilityConfig caps_;
+
   GLStream stream_;
   std::unordered_map<GLuint, GLbitfield> buffer_to_access_;
   std::unordered_map<GLuint, GLuint> image_to_dims_;

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1300,7 +1300,7 @@ void VulkanCommandList::wait_event(DeviceEvent *event) {
 }
 
 void VulkanCommandList::set_line_width(float width) {
-  if (ti_device_->get_cap(DeviceCapability::wide_lines)) {
+  if (ti_device_->vk_caps().wide_line) {
     vkCmdSetLineWidth(buffer_->buffer, width);
   }
 }
@@ -1329,6 +1329,7 @@ struct VulkanDevice::ThreadLocalStreams {
 VulkanDevice::VulkanDevice()
     : compute_streams_(std::make_unique<ThreadLocalStreams>()),
       graphics_streams_(std::make_unique<ThreadLocalStreams>()) {
+  caps_.set(DeviceCapability::spirv_version, 0x10000);
 }
 
 void VulkanDevice::init_vulkan_structs(Params &params) {
@@ -1380,6 +1381,8 @@ std::unique_ptr<Pipeline> VulkanDevice::create_pipeline(
     std::string name) {
   TI_ASSERT(src.type == PipelineSourceType::spirv_binary &&
             src.stage == PipelineStageType::compute);
+  TI_ERROR_IF(src.data == nullptr || src.size == 0,
+              "pipeline source cannot be empty");
 
   SpirvCodeView code;
   code.data = (uint32_t *)src.data;
@@ -1454,8 +1457,7 @@ DeviceAllocation VulkanDevice::allocate_memory(const AllocParams &params) {
       VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
 #endif
 
-  bool export_sharing = params.export_sharing &&
-                        this->get_cap(DeviceCapability::vk_has_external_memory);
+  bool export_sharing = params.export_sharing && vk_caps_.external_memory;
 
   VmaAllocationCreateInfo alloc_info{};
   if (export_sharing) {
@@ -1487,7 +1489,7 @@ DeviceAllocation VulkanDevice::allocate_memory(const AllocParams &params) {
     alloc_info.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
   }
 
-  if (get_cap(DeviceCapability::spirv_has_physical_storage_buffer)) {
+  if (caps_.get(DeviceCapability::spirv_has_physical_storage_buffer)) {
     buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
   }
 
@@ -1502,7 +1504,7 @@ DeviceAllocation VulkanDevice::allocate_memory(const AllocParams &params) {
            handle.alloc_id);
 #endif
 
-  if (get_cap(DeviceCapability::spirv_has_physical_storage_buffer)) {
+  if (caps_.get(DeviceCapability::spirv_has_physical_storage_buffer)) {
     VkBufferDeviceAddressInfoKHR info{};
     info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR;
     info.buffer = alloc.buffer->buffer;
@@ -1838,7 +1840,7 @@ DeviceAllocation VulkanDevice::import_vkbuffer(vkapi::IVkBuffer buffer) {
   alloc_int.external = true;
   alloc_int.buffer = buffer;
   alloc_int.mapped = nullptr;
-  if (get_cap(DeviceCapability::spirv_has_physical_storage_buffer)) {
+  if (caps_.get(DeviceCapability::spirv_has_physical_storage_buffer)) {
     VkBufferDeviceAddressInfoKHR info{};
     info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
     info.buffer = buffer->buffer;
@@ -1950,8 +1952,7 @@ DeviceAllocation VulkanDevice::create_image(const ImageParams &params) {
     image_info.pQueueFamilyIndices = queue_family_indices;
   }
 
-  bool export_sharing = params.export_sharing &&
-                        this->get_cap(DeviceCapability::vk_has_external_memory);
+  bool export_sharing = params.export_sharing && vk_caps_.external_memory;
 
   VkExternalMemoryImageCreateInfo external_mem_image_create_info = {};
   if (export_sharing) {
@@ -2160,8 +2161,7 @@ vkapi::IVkDescriptorSet VulkanDevice::alloc_desc_set(
 
 void VulkanDevice::create_vma_allocator() {
   VmaAllocatorCreateInfo allocatorInfo = {};
-  allocatorInfo.vulkanApiVersion =
-      this->get_cap(DeviceCapability::vk_api_version);
+  allocatorInfo.vulkanApiVersion = vk_caps_.vk_api_version;
   allocatorInfo.physicalDevice = physical_device_;
   allocatorInfo.device = device_;
   allocatorInfo.instance = instance_;
@@ -2210,7 +2210,7 @@ void VulkanDevice::create_vma_allocator() {
 
   allocatorInfo.pVulkanFunctions = &vk_vma_functions;
 
-  if (get_cap(DeviceCapability::spirv_has_physical_storage_buffer)) {
+  if (caps_.get(DeviceCapability::spirv_has_physical_storage_buffer)) {
     allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
   }
 

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -587,7 +587,7 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
   void init_vulkan_structs(Params &params);
   ~VulkanDevice() override;
 
-  virtual Arch arch() const override final {
+  Arch arch() const override {
     return Arch::vulkan;
   }
 
@@ -687,7 +687,7 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
   inline void set_current_caps(DeviceCapabilityConfig &&caps) {
     caps_ = std::move(caps);
   }
-  virtual const DeviceCapabilityConfig &get_current_caps()
+  const DeviceCapabilityConfig &get_current_caps()
       const override final {
     return caps_;
   }

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -687,8 +687,7 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
   inline void set_current_caps(DeviceCapabilityConfig &&caps) {
     caps_ = std::move(caps);
   }
-  const DeviceCapabilityConfig &get_current_caps()
-      const override final {
+  const DeviceCapabilityConfig &get_current_caps() const override final {
     return caps_;
   }
 

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -687,7 +687,7 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
   inline void set_current_caps(DeviceCapabilityConfig &&caps) {
     caps_ = std::move(caps);
   }
-  const DeviceCapabilityConfig &get_current_caps() const override final {
+  const DeviceCapabilityConfig &get_current_caps() const override {
     return caps_;
   }
 

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -561,6 +561,15 @@ class VulkanStream : public Stream {
   double device_time_elapsed_us_;
 };
 
+struct VulkanCapabilities {
+  uint32_t vk_api_version;
+  bool physical_device_features2;
+  bool external_memory;
+  bool wide_line;
+  bool surface;
+  bool present;
+};
+
 class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
  public:
   struct Params {
@@ -577,6 +586,10 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
   VulkanDevice();
   void init_vulkan_structs(Params &params);
   ~VulkanDevice() override;
+
+  virtual Arch arch() const override final {
+    return Arch::vulkan;
+  }
 
   std::unique_ptr<Pipeline> create_pipeline(
       const PipelineSourceDesc &src,
@@ -671,11 +684,29 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
       VulkanResourceBinder::Set &set);
   vkapi::IVkDescriptorSet alloc_desc_set(vkapi::IVkDescriptorSetLayout layout);
 
+  inline void set_current_caps(DeviceCapabilityConfig &&caps) {
+    caps_ = std::move(caps);
+  }
+  virtual const DeviceCapabilityConfig &get_current_caps()
+      const override final {
+    return caps_;
+  }
+
+  constexpr VulkanCapabilities &vk_caps() {
+    return vk_caps_;
+  }
+  constexpr const VulkanCapabilities &vk_caps() const {
+    return vk_caps_;
+  }
+
  private:
   friend VulkanSurface;
 
   void create_vma_allocator();
   void new_descriptor_pool();
+
+  DeviceCapabilityConfig caps_;
+  VulkanCapabilities vk_caps_;
 
   VkInstance instance_;
   VkDevice device_;

--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -201,21 +201,22 @@ VulkanDeviceCreator::VulkanDeviceCreator(
   }
 
   ti_device_ = std::make_unique<VulkanDevice>();
+  uint32_t vk_api_version;
   bool manual_create;
   if (params_.api_version.has_value()) {
     // The version client specified to use
     //
     // If the user provided an API version then the device creation process is
     // totally directed by the information provided externally.
-    api_version_ = params_.api_version.value();
+    vk_api_version = params_.api_version.value();
     manual_create = true;
   } else {
     // The highest version designed to use
-    api_version_ = VulkanEnvSettings::k_api_version();
+    vk_api_version = VulkanEnvSettings::k_api_version();
     manual_create = false;
   }
 
-  create_instance(manual_create);
+  create_instance(vk_api_version, manual_create);
   setup_debug_messenger();
   if (params_.is_for_ui) {
     create_surface();
@@ -251,7 +252,8 @@ VulkanDeviceCreator::~VulkanDeviceCreator() {
   vkDestroyInstance(instance_, kNoVkAllocCallbacks);
 }
 
-void VulkanDeviceCreator::create_instance(bool manual_create) {
+void VulkanDeviceCreator::create_instance(uint32_t vk_api_version,
+                                          bool manual_create) {
   VkApplicationInfo app_info{};
   app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
   app_info.pApplicationName = "Taichi Vulkan Backend";
@@ -320,10 +322,10 @@ void VulkanDeviceCreator::create_instance(bool manual_create) {
     std::string name = ext.extensionName;
     if (name == VK_KHR_SURFACE_EXTENSION_NAME) {
       extensions.insert(name);
-      ti_device_->set_cap(DeviceCapability::vk_has_surface, true);
+      ti_device_->vk_caps().surface = true;
     } else if (name == VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) {
       extensions.insert(name);
-      ti_device_->set_cap(DeviceCapability::vk_has_physical_features2, true);
+      ti_device_->vk_caps().physical_device_features2 = true;
     } else if (name == VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME) {
       extensions.insert(name);
     } else if (name == VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME) {
@@ -349,9 +351,12 @@ void VulkanDeviceCreator::create_instance(bool manual_create) {
     // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkApplicationInfo.html
     // Vulkan 1.0 implementation will return this when api version is not 1.0
     // Vulkan 1.1+ implementation will work with maximum version set
-    api_version_ = app_info.apiVersion = VK_API_VERSION_1_0;
+    ti_device_->vk_caps().vk_api_version = VK_API_VERSION_1_0;
+    app_info.apiVersion = VK_API_VERSION_1_0;
 
     res = vkCreateInstance(&create_info, kNoVkAllocCallbacks, &instance_);
+  } else {
+    ti_device_->vk_caps().vk_api_version = vk_api_version;
   }
 
   if (res != VK_SUCCESS) {
@@ -426,6 +431,8 @@ void VulkanDeviceCreator::pick_physical_device() {
 }
 
 void VulkanDeviceCreator::create_logical_device(bool manual_create) {
+  DeviceCapabilityConfig caps{};
+
   std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
   std::unordered_set<uint32_t> unique_families;
 
@@ -461,25 +468,19 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
           VK_API_VERSION_MINOR(physical_device_properties.apiVersion),
           VK_API_VERSION_PATCH(physical_device_properties.apiVersion));
 
-  if (manual_create) {
-    TI_INFO("User decided to create Vulkan {} Device version {}.{}.{}",
-            VK_API_VERSION_VARIANT(api_version_),
-            VK_API_VERSION_MAJOR(api_version_),
-            VK_API_VERSION_MINOR(api_version_),
-            VK_API_VERSION_PATCH(api_version_));
+  // (penguinliong) The actual logical device is created with lastest version of
+  // Vulkan but we use the device like it has a lower version (if the user
+  // wanted a lower version device).
+  uint32_t vk_api_version = physical_device_properties.apiVersion;
+  ti_device_->vk_caps().vk_api_version = vk_api_version;
+  if (vk_api_version >= VK_API_VERSION_1_3) {
+    caps.set(DeviceCapability::spirv_version, 0x10500);
+  } else if (vk_api_version >= VK_API_VERSION_1_2) {
+    caps.set(DeviceCapability::spirv_version, 0x10500);
+  } else if (vk_api_version >= VK_API_VERSION_1_1) {
+    caps.set(DeviceCapability::spirv_version, 0x10300);
   } else {
-    api_version_ = physical_device_properties.apiVersion;
-  }
-
-  ti_device_->set_cap(DeviceCapability::vk_api_version, api_version_);
-  ti_device_->set_cap(DeviceCapability::spirv_version, 0x10000);
-
-  if (api_version_ >= VK_API_VERSION_1_3) {
-    ti_device_->set_cap(DeviceCapability::spirv_version, 0x10500);
-  } else if (api_version_ >= VK_API_VERSION_1_2) {
-    ti_device_->set_cap(DeviceCapability::spirv_version, 0x10500);
-  } else if (api_version_ >= VK_API_VERSION_1_1) {
-    ti_device_->set_cap(DeviceCapability::spirv_version, 0x10300);
+    caps.set(DeviceCapability::spirv_version, 0x10000);
   }
 
   // Detect extensions
@@ -521,13 +522,13 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
     } else if (name == VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME) {
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_SPIRV_1_4_EXTENSION_NAME) {
-      if (ti_device_->get_cap(DeviceCapability::spirv_version) < 0x10400) {
-        ti_device_->set_cap(DeviceCapability::spirv_version, 0x10400);
+      if (caps.get(DeviceCapability::spirv_version) < 0x10400) {
+        caps.set(DeviceCapability::spirv_version, 0x10400);
         enabled_extensions.push_back(ext.extensionName);
       }
     } else if (name == VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME ||
                name == VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) {
-      ti_device_->set_cap(DeviceCapability::vk_has_external_memory, true);
+      ti_device_->vk_caps().external_memory = true;
       enabled_extensions.push_back(ext.extensionName);
     } else if (name == VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME) {
       enabled_extensions.push_back(ext.extensionName);
@@ -545,7 +546,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
                params_.enable_validation_layer) {
       // VK_KHR_shader_non_semantic_info isn't supported on molten-vk.
       // Tracking issue: https://github.com/KhronosGroup/MoltenVK/issues/1214
-      ti_device_->set_cap(DeviceCapability::spirv_has_non_semantic_info, true);
+      caps.set(DeviceCapability::spirv_has_non_semantic_info, true);
       enabled_extensions.push_back(ext.extensionName);
     } else if (std::find(params_.additional_device_extensions.begin(),
                          params_.additional_device_extensions.end(),
@@ -555,7 +556,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
   }
 
   if (has_swapchain) {
-    ti_device_->set_cap(DeviceCapability::vk_has_presentation, true);
+    ti_device_->vk_caps().present = true;
   }
 
   VkPhysicalDeviceFeatures device_features{};
@@ -565,25 +566,25 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
 
   if (device_supported_features.shaderInt16) {
     device_features.shaderInt16 = true;
-    ti_device_->set_cap(DeviceCapability::spirv_has_int16, true);
+    caps.set(DeviceCapability::spirv_has_int16, true);
   }
   if (device_supported_features.shaderInt64) {
     device_features.shaderInt64 = true;
-    ti_device_->set_cap(DeviceCapability::spirv_has_int64, true);
+    caps.set(DeviceCapability::spirv_has_int64, true);
   }
   if (device_supported_features.shaderFloat64) {
     device_features.shaderFloat64 = true;
-    ti_device_->set_cap(DeviceCapability::spirv_has_float64, true);
+    caps.set(DeviceCapability::spirv_has_float64, true);
   }
   if (device_supported_features.wideLines) {
     device_features.wideLines = true;
-    ti_device_->set_cap(DeviceCapability::wide_lines, true);
+    ti_device_->vk_caps().wide_line = true;
   } else if (params_.is_for_ui) {
     TI_WARN_IF(!device_features.wideLines,
                "Taichi GPU GUI requires wide lines support");
   }
 
-  if (api_version_ >= VK_API_VERSION_1_1) {
+  if (ti_device_->vk_caps().vk_api_version >= VK_API_VERSION_1_1) {
     VkPhysicalDeviceSubgroupProperties subgroup_properties{};
     subgroup_properties.sType =
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES;
@@ -599,20 +600,19 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
 
     if (subgroup_properties.supportedOperations &
         VK_SUBGROUP_FEATURE_BASIC_BIT) {
-      ti_device_->set_cap(DeviceCapability::spirv_has_subgroup_basic, true);
+      caps.set(DeviceCapability::spirv_has_subgroup_basic, true);
     }
     if (subgroup_properties.supportedOperations &
         VK_SUBGROUP_FEATURE_VOTE_BIT) {
-      ti_device_->set_cap(DeviceCapability::spirv_has_subgroup_vote, true);
+      caps.set(DeviceCapability::spirv_has_subgroup_vote, true);
     }
     if (subgroup_properties.supportedOperations &
         VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) {
-      ti_device_->set_cap(DeviceCapability::spirv_has_subgroup_arithmetic,
-                          true);
+      caps.set(DeviceCapability::spirv_has_subgroup_arithmetic, true);
     }
     if (subgroup_properties.supportedOperations &
         VK_SUBGROUP_FEATURE_BALLOT_BIT) {
-      ti_device_->set_cap(DeviceCapability::spirv_has_subgroup_ballot, true);
+      caps.set(DeviceCapability::spirv_has_subgroup_ballot, true);
     }
   }
 
@@ -640,7 +640,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
   buffer_device_address_feature.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR;
 
-  if (ti_device_->get_cap(DeviceCapability::vk_has_physical_features2)) {
+  if (ti_device_->vk_caps().physical_device_features2) {
     VkPhysicalDeviceFeatures2KHR features2{};
     features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 
@@ -649,8 +649,9 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
                [=](const char *o) { return strcmp(ext, o) == 0; }) != \
       enabled_extensions.end()
 
+    uint32_t vk_api_version = ti_device_->vk_caps().vk_api_version;
 #define CHECK_VERSION(major, minor) \
-  api_version_ >= VK_MAKE_API_VERSION(0, major, minor, 0)
+  vk_api_version >= VK_MAKE_API_VERSION(0, major, minor, 0)
 
     // Variable ptr
     if (CHECK_VERSION(1, 1) ||
@@ -660,7 +661,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
 
       if (variable_ptr_feature.variablePointers &&
           variable_ptr_feature.variablePointersStorageBuffer) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_variable_ptr, true);
+        caps.set(DeviceCapability::spirv_has_variable_ptr, true);
       }
       *pNextEnd = &variable_ptr_feature;
       pNextEnd = &variable_ptr_feature.pNext;
@@ -671,17 +672,16 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       features2.pNext = &shader_atomic_float_feature;
       vkGetPhysicalDeviceFeatures2KHR(physical_device_, &features2);
       if (shader_atomic_float_feature.shaderBufferFloat32AtomicAdd) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float_add, true);
+        caps.set(DeviceCapability::spirv_has_atomic_float_add, true);
       }
       if (shader_atomic_float_feature.shaderBufferFloat64AtomicAdd) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float64_add,
-                            true);
+        caps.set(DeviceCapability::spirv_has_atomic_float64_add, true);
       }
       if (shader_atomic_float_feature.shaderBufferFloat32Atomics) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float, true);
+        caps.set(DeviceCapability::spirv_has_atomic_float, true);
       }
       if (shader_atomic_float_feature.shaderBufferFloat64Atomics) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float64, true);
+        caps.set(DeviceCapability::spirv_has_atomic_float64, true);
       }
       *pNextEnd = &shader_atomic_float_feature;
       pNextEnd = &shader_atomic_float_feature.pNext;
@@ -692,22 +692,19 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       features2.pNext = &shader_atomic_float_2_feature;
       vkGetPhysicalDeviceFeatures2KHR(physical_device_, &features2);
       if (shader_atomic_float_2_feature.shaderBufferFloat16AtomicAdd) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float_add, true);
+        caps.set(DeviceCapability::spirv_has_atomic_float_add, true);
       }
       if (shader_atomic_float_2_feature.shaderBufferFloat16AtomicMinMax) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float16_minmax,
-                            true);
+        caps.set(DeviceCapability::spirv_has_atomic_float16_minmax, true);
       }
       if (shader_atomic_float_2_feature.shaderBufferFloat16Atomics) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float16, true);
+        caps.set(DeviceCapability::spirv_has_atomic_float16, true);
       }
       if (shader_atomic_float_2_feature.shaderBufferFloat32AtomicMinMax) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float_minmax,
-                            true);
+        caps.set(DeviceCapability::spirv_has_atomic_float_minmax, true);
       }
       if (shader_atomic_float_2_feature.shaderBufferFloat64AtomicMinMax) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_atomic_float64_minmax,
-                            true);
+        caps.set(DeviceCapability::spirv_has_atomic_float64_minmax, true);
       }
       *pNextEnd = &shader_atomic_float_2_feature;
       pNextEnd = &shader_atomic_float_2_feature.pNext;
@@ -720,10 +717,10 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       vkGetPhysicalDeviceFeatures2KHR(physical_device_, &features2);
 
       if (shader_f16_i8_feature.shaderFloat16) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_float16, true);
+        caps.set(DeviceCapability::spirv_has_float16, true);
       }
       if (shader_f16_i8_feature.shaderInt8) {
-        ti_device_->set_cap(DeviceCapability::spirv_has_int8, true);
+        caps.set(DeviceCapability::spirv_has_int8, true);
       }
       *pNextEnd = &shader_f16_i8_feature;
       pNextEnd = &shader_f16_i8_feature.pNext;
@@ -738,8 +735,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
       if (CHECK_VERSION(1, 3) ||
           buffer_device_address_feature.bufferDeviceAddress) {
         if (device_supported_features.shaderInt64) {
-          ti_device_->set_cap(
-              DeviceCapability::spirv_has_physical_storage_buffer, true);
+          caps.set(DeviceCapability::spirv_has_physical_storage_buffer, true);
         }
       }
       *pNextEnd = &buffer_device_address_feature;
@@ -770,7 +766,8 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
   }
 
   // Dump capabilities
-  ti_device_->print_all_cap();
+  caps.dbg_print_all();
+  ti_device_->set_current_caps(std::move(caps));
 }
 
 }  // namespace vulkan

--- a/taichi/rhi/vulkan/vulkan_device_creator.h
+++ b/taichi/rhi/vulkan/vulkan_device_creator.h
@@ -74,13 +74,12 @@ class TI_DLL_EXPORT VulkanDeviceCreator {
   }
 
  private:
-  void create_instance(bool manual_create);
+  void create_instance(uint32_t vk_api_version, bool manual_create);
   void setup_debug_messenger();
   void create_surface();
   void pick_physical_device();
   void create_logical_device(bool manual_create);
 
-  uint32_t api_version_{VK_API_VERSION_1_0};
   VkInstance instance_{VK_NULL_HANDLE};
   VkDebugUtilsMessengerEXT debug_messenger_{VK_NULL_HANDLE};
   VkPhysicalDevice physical_device_{VK_NULL_HANDLE};

--- a/taichi/runtime/gfx/aot_module_builder_impl.cpp
+++ b/taichi/runtime/gfx/aot_module_builder_impl.cpp
@@ -104,13 +104,13 @@ class AotDataConverter {
 AotModuleBuilderImpl::AotModuleBuilderImpl(
     const std::vector<CompiledSNodeStructs> &compiled_structs,
     Arch device_api_backend,
-    std::unique_ptr<Device> &&target_device)
+    const DeviceCapabilityConfig &caps)
     : compiled_structs_(compiled_structs),
-      device_api_backend_(device_api_backend) {
-  aot_target_device_ =
-      target_device ? std::move(target_device)
-                    : std::make_unique<aot::TargetDevice>(device_api_backend_);
-  aot_target_device_->clone_caps(ti_aot_data_.required_caps);
+      device_api_backend_(device_api_backend),
+      caps_(caps) {
+  for (const auto &pair : caps.to_inner()) {
+    ti_aot_data_.required_caps[to_string(pair.first)] = pair.second;
+  }
   if (!compiled_structs.empty()) {
     ti_aot_data_.root_buffer_size = compiled_structs[0].root_size;
   }
@@ -199,7 +199,7 @@ void AotModuleBuilderImpl::add_per_backend(const std::string &identifier,
                                            Kernel *kernel) {
   spirv::lower(kernel);
   auto compiled =
-      run_codegen(kernel, aot_target_device_.get(), compiled_structs_);
+      run_codegen(kernel, this->device_api_backend_, caps_, compiled_structs_);
   compiled.kernel_attribs.name = identifier;
   ti_aot_data_.kernels.push_back(compiled.kernel_attribs);
   ti_aot_data_.spirv_codes.push_back(compiled.task_spirv_source_codes);
@@ -251,7 +251,7 @@ void AotModuleBuilderImpl::add_per_backend_tmpl(const std::string &identifier,
                                                 Kernel *kernel) {
   spirv::lower(kernel);
   auto compiled =
-      run_codegen(kernel, aot_target_device_.get(), compiled_structs_);
+      run_codegen(kernel, device_api_backend_, caps_, compiled_structs_);
 
   compiled.kernel_attribs.name = identifier + "|" + key;
   ti_aot_data_.kernels.push_back(compiled.kernel_attribs);

--- a/taichi/runtime/gfx/aot_module_builder_impl.h
+++ b/taichi/runtime/gfx/aot_module_builder_impl.h
@@ -17,7 +17,7 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
   explicit AotModuleBuilderImpl(
       const std::vector<CompiledSNodeStructs> &compiled_structs,
       Arch device_api_backend,
-      std::unique_ptr<Device> &&target_device = nullptr);
+      const DeviceCapabilityConfig &caps);
 
   void dump(const std::string &output_dir,
             const std::string &filename) const override;
@@ -51,9 +51,9 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
 
   const std::vector<CompiledSNodeStructs> &compiled_structs_;
   TaichiAotData ti_aot_data_;
-  std::unique_ptr<Device> aot_target_device_;
 
   Arch device_api_backend_;
+  DeviceCapabilityConfig caps_;
 };
 
 }  // namespace gfx

--- a/taichi/runtime/gfx/aot_utils.h
+++ b/taichi/runtime/gfx/aot_utils.h
@@ -17,7 +17,7 @@ struct TaichiAotData {
   std::vector<std::vector<std::vector<uint32_t>>> spirv_codes;
   std::vector<spirv::TaichiKernelAttributes> kernels;
   std::vector<aot::CompiledFieldData> fields;
-  std::map<DeviceCapability, uint32_t> required_caps;
+  std::map<std::string, uint32_t> required_caps;
   size_t root_buffer_size{0};
 
   TI_IO_DEF(kernels, fields, required_caps, root_buffer_size);

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -73,13 +73,14 @@ class HostDeviceContextBlitter {
               device_->unmap(buffer);
             }
           }
-          // Substitute in the device address if supported
+          // Substitute in the device address.
+
+          // (penguinliong) We don't check the availability of physical pointer
+          // here. It should be done before you need this class.
           if ((host_ctx_->device_allocation_type[i] ==
                    RuntimeContext::DevAllocType::kNone ||
                host_ctx_->device_allocation_type[i] ==
-                   RuntimeContext::DevAllocType::kNdarray) &&
-              device_->get_cap(
-                  DeviceCapability::spirv_has_physical_storage_buffer)) {
+                   RuntimeContext::DevAllocType::kNdarray)) {
             uint64_t addr =
                 device_->get_memory_physical_pointer(ext_arrays.at(i));
             reinterpret_cast<uint64 *>(device_ptr)[0] = addr;
@@ -87,30 +88,23 @@ class HostDeviceContextBlitter {
           // We should not process the rest
           break;
         }
-        if (device_->get_cap(DeviceCapability::spirv_has_int8)) {
-          TO_DEVICE(i8, int8)
-          TO_DEVICE(u8, uint8)
-        }
-        if (device_->get_cap(DeviceCapability::spirv_has_int16)) {
-          TO_DEVICE(i16, int16)
-          TO_DEVICE(u16, uint16)
-        }
+        // (penguinliong) Same. The availability of short/long int types depends
+        // on the kernels and compute graphs and the check should already be
+        // done during module loads.
+        TO_DEVICE(i8, int8)
+        TO_DEVICE(u8, uint8)
+        TO_DEVICE(i16, int16)
+        TO_DEVICE(u16, uint16)
         TO_DEVICE(i32, int32)
         TO_DEVICE(u32, uint32)
         TO_DEVICE(f32, float32)
-        if (device_->get_cap(DeviceCapability::spirv_has_int64)) {
-          TO_DEVICE(i64, int64)
-          TO_DEVICE(u64, uint64)
-        }
-        if (device_->get_cap(DeviceCapability::spirv_has_float64)) {
-          TO_DEVICE(f64, float64)
-        }
-        if (device_->get_cap(DeviceCapability::spirv_has_float16)) {
-          if (arg.dtype == PrimitiveTypeID::f16) {
-            auto d = fp16_ieee_from_fp32_value(host_ctx_->get_arg<float>(i));
-            reinterpret_cast<uint16 *>(device_ptr)[0] = d;
-            break;
-          }
+        TO_DEVICE(i64, int64)
+        TO_DEVICE(u64, uint64)
+        TO_DEVICE(f64, float64)
+        if (arg.dtype == PrimitiveTypeID::f16) {
+          auto d = fp16_ieee_from_fp32_value(host_ctx_->get_arg<float>(i));
+          reinterpret_cast<uint16 *>(device_ptr)[0] = d;
+          break;
         }
         TI_ERROR("Device does not support arg type={}",
                  PrimitiveType::get(arg.dtype).to_string());
@@ -196,32 +190,24 @@ class HostDeviceContextBlitter {
       const auto dt = PrimitiveType::get(ret.dtype);
       const auto num = ret.stride / data_type_size(dt);
       for (int j = 0; j < num; ++j) {
-        if (device_->get_cap(DeviceCapability::spirv_has_int8)) {
-          TO_HOST(i8, int8, j)
-          TO_HOST(u8, uint8, j)
-        }
-        if (device_->get_cap(DeviceCapability::spirv_has_int16)) {
-          TO_HOST(i16, int16, j)
-          TO_HOST(u16, uint16, j)
-        }
+        // (penguinliong) Again, it's the module loader's responsibility to
+        // check the data type availability.
+        TO_HOST(i8, int8, j)
+        TO_HOST(u8, uint8, j)
+        TO_HOST(i16, int16, j)
+        TO_HOST(u16, uint16, j)
         TO_HOST(i32, int32, j)
         TO_HOST(u32, uint32, j)
         TO_HOST(f32, float32, j)
-        if (device_->get_cap(DeviceCapability::spirv_has_int64)) {
-          TO_HOST(i64, int64, j)
-          TO_HOST(u64, uint64, j)
-        }
-        if (device_->get_cap(DeviceCapability::spirv_has_float64)) {
-          TO_HOST(f64, float64, j)
-        }
-        if (device_->get_cap(DeviceCapability::spirv_has_float16)) {
-          if (dt->is_primitive(PrimitiveTypeID::f16)) {
-            const float d = fp16_ieee_to_fp32_value(
-                *reinterpret_cast<uint16 *>(device_ptr) + j);
-            host_result_buffer_[j] =
-                taichi_union_cast_with_different_sizes<uint64>(d);
-            continue;
-          }
+        TO_HOST(i64, int64, j)
+        TO_HOST(u64, uint64, j)
+        TO_HOST(f64, float64, j)
+        if (dt->is_primitive(PrimitiveTypeID::f16)) {
+          const float d = fp16_ieee_to_fp32_value(
+              *reinterpret_cast<uint16 *>(device_ptr) + j);
+          host_result_buffer_[j] =
+              taichi_union_cast_with_different_sizes<uint64>(d);
+          continue;
         }
         TI_ERROR("Device does not support return value type={}",
                  data_type_name(PrimitiveType::get(ret.dtype)));
@@ -728,7 +714,8 @@ void GfxRuntime::enqueue_compute_op_lambda(
 
 GfxRuntime::RegisterParams run_codegen(
     Kernel *kernel,
-    Device *device,
+    Arch arch,
+    const DeviceCapabilityConfig &caps,
     const std::vector<CompiledSNodeStructs> &compiled_structs) {
   const auto id = Program::get_kernel_id();
   const auto taichi_kernel_name(fmt::format("{}_k{:04d}_vk", kernel->name, id));
@@ -737,7 +724,8 @@ GfxRuntime::RegisterParams run_codegen(
   params.ti_kernel_name = taichi_kernel_name;
   params.kernel = kernel;
   params.compiled_structs = compiled_structs;
-  params.device = device;
+  params.arch = arch;
+  params.caps = caps;
   params.enable_spv_opt =
       kernel->program->this_thread_config().external_optimization_level > 0;
   spirv::KernelCodegen codegen(params);

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -159,7 +159,8 @@ class TI_DLL_EXPORT GfxRuntime {
 
 GfxRuntime::RegisterParams run_codegen(
     Kernel *kernel,
-    Device *device,
+    Arch arch,
+    const DeviceCapabilityConfig &caps,
     const std::vector<CompiledSNodeStructs> &compiled_structs);
 
 }  // namespace gfx

--- a/taichi/runtime/program_impls/dx/dx_program.cpp
+++ b/taichi/runtime/program_impls/dx/dx_program.cpp
@@ -67,7 +67,8 @@ std::unique_ptr<AotModuleBuilder> Dx11ProgramImpl::make_aot_module_builder(
     const DeviceCapabilityConfig &caps) {
   if (runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::dx11, caps);
+        snode_tree_mgr_->get_compiled_structs(), Arch::dx11,
+        runtime_->get_ti_device()->get_current_caps());
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
         aot_compiled_snode_structs_, Arch::dx11, caps);

--- a/taichi/runtime/program_impls/dx/dx_program.cpp
+++ b/taichi/runtime/program_impls/dx/dx_program.cpp
@@ -63,15 +63,13 @@ void Dx11ProgramImpl::materialize_snode_tree(SNodeTree *tree,
   snode_tree_mgr_->materialize_snode_tree(tree);
 }
 
-std::unique_ptr<AotModuleBuilder> Dx11ProgramImpl::make_aot_module_builder() {
+std::unique_ptr<AotModuleBuilder> Dx11ProgramImpl::make_aot_module_builder(const DeviceCapabilityConfig& caps) {
   if (runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::dx11,
-        runtime_->get_ti_device()->get_current_caps());
+        snode_tree_mgr_->get_compiled_structs(), Arch::dx11, caps);
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        aot_compiled_snode_structs_, Arch::dx11,
-        runtime_->get_ti_device()->get_current_caps());
+        aot_compiled_snode_structs_, Arch::dx11, caps);
   }
 }
 

--- a/taichi/runtime/program_impls/dx/dx_program.cpp
+++ b/taichi/runtime/program_impls/dx/dx_program.cpp
@@ -67,8 +67,7 @@ std::unique_ptr<AotModuleBuilder> Dx11ProgramImpl::make_aot_module_builder(
     const DeviceCapabilityConfig &caps) {
   if (runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::dx11,
-        runtime_->get_ti_device()->get_current_caps());
+        snode_tree_mgr_->get_compiled_structs(), Arch::dx11, caps);
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
         aot_compiled_snode_structs_, Arch::dx11, caps);

--- a/taichi/runtime/program_impls/dx/dx_program.h
+++ b/taichi/runtime/program_impls/dx/dx_program.h
@@ -35,7 +35,7 @@ class Dx11ProgramImpl : public ProgramImpl {
     return runtime_->flush();
   }
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) override;
 
   void destroy_snode_tree(SNodeTree *snode_tree) override {
     TI_ASSERT(snode_tree_mgr_ != nullptr);

--- a/taichi/runtime/program_impls/dx12/dx12_program.cpp
+++ b/taichi/runtime/program_impls/dx12/dx12_program.cpp
@@ -11,7 +11,7 @@ Dx12ProgramImpl::Dx12ProgramImpl(CompileConfig &config)
     : LlvmProgramImpl(config, nullptr) {
 }
 
-std::unique_ptr<AotModuleBuilder> Dx12ProgramImpl::make_aot_module_builder() {
+std::unique_ptr<AotModuleBuilder> Dx12ProgramImpl::make_aot_module_builder(const DeviceCapabilityConfig& caps) {
   return std::make_unique<directx12::AotModuleBuilderImpl>(this);
 }
 

--- a/taichi/runtime/program_impls/dx12/dx12_program.h
+++ b/taichi/runtime/program_impls/dx12/dx12_program.h
@@ -11,7 +11,7 @@ class Dx12ProgramImpl : public LlvmProgramImpl {
  public:
   Dx12ProgramImpl(CompileConfig &config);
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) override;
 };
 
 }  // namespace lang

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -87,7 +87,7 @@ void LlvmProgramImpl::materialize_snode_tree(SNodeTree *tree,
                                  result_buffer);
 }
 
-std::unique_ptr<AotModuleBuilder> LlvmProgramImpl::make_aot_module_builder() {
+std::unique_ptr<AotModuleBuilder> LlvmProgramImpl::make_aot_module_builder(const DeviceCapabilityConfig& caps) {
   if (config->arch == Arch::x64 || config->arch == Arch::arm64) {
     return std::make_unique<cpu::AotModuleBuilderImpl>(this);
   }

--- a/taichi/runtime/program_impls/llvm/llvm_program.h
+++ b/taichi/runtime/program_impls/llvm/llvm_program.h
@@ -70,7 +70,7 @@ class LlvmProgramImpl : public ProgramImpl {
 
   std::unique_ptr<aot::Kernel> make_aot_kernel(Kernel &kernel) override;
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) override;
 
   void dump_cache_data_to_disk() override;
 

--- a/taichi/runtime/program_impls/metal/metal_program.cpp
+++ b/taichi/runtime/program_impls/metal/metal_program.cpp
@@ -88,7 +88,7 @@ void MetalProgramImpl::materialize_snode_tree(SNodeTree *tree,
   metal_kernel_mgr_->add_compiled_snode_tree(csnode_tree);
 }
 
-std::unique_ptr<AotModuleBuilder> MetalProgramImpl::make_aot_module_builder() {
+std::unique_ptr<AotModuleBuilder> MetalProgramImpl::make_aot_module_builder(const DeviceCapabilityConfig& caps) {
   TI_ERROR_IF(compiled_snode_trees_.size() > 1,
               "AOT: only supports one SNodeTree");
   const auto fields =

--- a/taichi/runtime/program_impls/metal/metal_program.h
+++ b/taichi/runtime/program_impls/metal/metal_program.h
@@ -42,7 +42,7 @@ class MetalProgramImpl : public ProgramImpl {
     TI_NOT_IMPLEMENTED;
   }
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) override;
 
   DeviceAllocation allocate_memory_ndarray(std::size_t alloc_size,
                                            uint64 *result_buffer) override;

--- a/taichi/runtime/program_impls/opengl/opengl_program.cpp
+++ b/taichi/runtime/program_impls/opengl/opengl_program.cpp
@@ -64,7 +64,8 @@ std::unique_ptr<AotModuleBuilder> OpenglProgramImpl::make_aot_module_builder(
     const DeviceCapabilityConfig &caps) {
   if (runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::opengl, caps);
+        snode_tree_mgr_->get_compiled_structs(), Arch::opengl,
+        runtime_->get_ti_device()->get_current_caps());
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
         aot_compiled_snode_structs_, Arch::opengl, caps);

--- a/taichi/runtime/program_impls/opengl/opengl_program.cpp
+++ b/taichi/runtime/program_impls/opengl/opengl_program.cpp
@@ -63,10 +63,12 @@ void OpenglProgramImpl::materialize_snode_tree(SNodeTree *tree,
 std::unique_ptr<AotModuleBuilder> OpenglProgramImpl::make_aot_module_builder() {
   if (runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::opengl);
+        snode_tree_mgr_->get_compiled_structs(), Arch::opengl,
+        runtime_->get_ti_device()->get_current_caps());
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        aot_compiled_snode_structs_, Arch::opengl);
+        aot_compiled_snode_structs_, Arch::opengl,
+        runtime_->get_ti_device()->get_current_caps());
   }
 }
 
@@ -101,15 +103,13 @@ const std::unique_ptr<gfx::CacheManager>
     &OpenglProgramImpl::get_cache_manager() {
   if (!cache_manager_) {
     TI_ASSERT(runtime_ && snode_tree_mgr_ && device_);
-    auto target_device = std::make_unique<aot::TargetDevice>(config->arch);
-    device_->clone_caps(*target_device);
     using Mgr = gfx::CacheManager;
     Mgr::Params params;
     params.arch = config->arch;
     params.mode = config->offline_cache ? Mgr::MemAndDiskCache : Mgr::MemCache;
     params.cache_path = config->offline_cache_file_path;
     params.runtime = runtime_.get();
-    params.target_device = std::move(target_device);
+    params.caps = device_->get_current_caps();
     params.compiled_structs = &snode_tree_mgr_->get_compiled_structs();
     cache_manager_ = std::make_unique<gfx::CacheManager>(std::move(params));
   }

--- a/taichi/runtime/program_impls/opengl/opengl_program.cpp
+++ b/taichi/runtime/program_impls/opengl/opengl_program.cpp
@@ -60,15 +60,13 @@ void OpenglProgramImpl::materialize_snode_tree(SNodeTree *tree,
   snode_tree_mgr_->materialize_snode_tree(tree);
 }
 
-std::unique_ptr<AotModuleBuilder> OpenglProgramImpl::make_aot_module_builder() {
+std::unique_ptr<AotModuleBuilder> OpenglProgramImpl::make_aot_module_builder(const DeviceCapabilityConfig& caps) {
   if (runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::opengl,
-        runtime_->get_ti_device()->get_current_caps());
+        snode_tree_mgr_->get_compiled_structs(), Arch::opengl, caps);
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        aot_compiled_snode_structs_, Arch::opengl,
-        runtime_->get_ti_device()->get_current_caps());
+        aot_compiled_snode_structs_, Arch::opengl, caps);
   }
 }
 

--- a/taichi/runtime/program_impls/opengl/opengl_program.cpp
+++ b/taichi/runtime/program_impls/opengl/opengl_program.cpp
@@ -64,8 +64,7 @@ std::unique_ptr<AotModuleBuilder> OpenglProgramImpl::make_aot_module_builder(
     const DeviceCapabilityConfig &caps) {
   if (runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::opengl,
-        runtime_->get_ti_device()->get_current_caps());
+        snode_tree_mgr_->get_compiled_structs(), Arch::opengl, caps);
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
         aot_compiled_snode_structs_, Arch::opengl, caps);

--- a/taichi/runtime/program_impls/opengl/opengl_program.h
+++ b/taichi/runtime/program_impls/opengl/opengl_program.h
@@ -34,7 +34,7 @@ class OpenglProgramImpl : public ProgramImpl {
     return runtime_->flush();
   }
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) override;
 
   void destroy_snode_tree(SNodeTree *snode_tree) override {
     TI_ASSERT(snode_tree_mgr_ != nullptr);

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -185,8 +185,7 @@ std::unique_ptr<AotModuleBuilder> VulkanProgramImpl::make_aot_module_builder(
     const DeviceCapabilityConfig &caps) {
   if (vulkan_runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::vulkan,
-        vulkan_runtime_->get_ti_device()->get_current_caps());
+        snode_tree_mgr_->get_compiled_structs(), Arch::vulkan, caps);
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
         aot_compiled_snode_structs_, Arch::vulkan, caps);

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -182,12 +182,14 @@ void VulkanProgramImpl::materialize_snode_tree(SNodeTree *tree,
 }
 
 std::unique_ptr<AotModuleBuilder> VulkanProgramImpl::make_aot_module_builder() {
+  const DeviceCapabilityConfig &caps =
+      embedded_device_->device()->get_current_caps();
   if (vulkan_runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::vulkan);
+        snode_tree_mgr_->get_compiled_structs(), Arch::vulkan, caps);
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        aot_compiled_snode_structs_, Arch::vulkan);
+        aot_compiled_snode_structs_, Arch::vulkan, caps);
   }
 }
 
@@ -230,15 +232,13 @@ const std::unique_ptr<gfx::CacheManager>
     &VulkanProgramImpl::get_cache_manager() {
   if (!cache_manager_) {
     TI_ASSERT(vulkan_runtime_ && snode_tree_mgr_ && embedded_device_);
-    auto target_device = std::make_unique<aot::TargetDevice>(config->arch);
-    embedded_device_->device()->clone_caps(*target_device);
     using Mgr = gfx::CacheManager;
     Mgr::Params params;
     params.arch = config->arch;
     params.mode = config->offline_cache ? Mgr::MemAndDiskCache : Mgr::MemCache;
     params.cache_path = config->offline_cache_file_path;
     params.runtime = vulkan_runtime_.get();
-    params.target_device = std::move(target_device);
+    params.caps = embedded_device_->device()->get_current_caps();
     params.compiled_structs = &snode_tree_mgr_->get_compiled_structs();
     cache_manager_ = std::make_unique<gfx::CacheManager>(std::move(params));
   }

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -181,9 +181,10 @@ void VulkanProgramImpl::materialize_snode_tree(SNodeTree *tree,
   snode_tree_mgr_->materialize_snode_tree(tree);
 }
 
-std::unique_ptr<AotModuleBuilder> VulkanProgramImpl::make_aot_module_builder() {
-  const DeviceCapabilityConfig &caps =
-      embedded_device_->device()->get_current_caps();
+
+
+std::unique_ptr<AotModuleBuilder> VulkanProgramImpl::make_aot_module_builder(
+    const DeviceCapabilityConfig& caps) {
   if (vulkan_runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
         snode_tree_mgr_->get_compiled_structs(), Arch::vulkan, caps);

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -185,7 +185,8 @@ std::unique_ptr<AotModuleBuilder> VulkanProgramImpl::make_aot_module_builder(
     const DeviceCapabilityConfig &caps) {
   if (vulkan_runtime_) {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
-        snode_tree_mgr_->get_compiled_structs(), Arch::vulkan, caps);
+        snode_tree_mgr_->get_compiled_structs(), Arch::vulkan,
+        vulkan_runtime_->get_ti_device()->get_current_caps());
   } else {
     return std::make_unique<gfx::AotModuleBuilderImpl>(
         aot_compiled_snode_structs_, Arch::vulkan, caps);

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.h
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.h
@@ -57,7 +57,7 @@ class VulkanProgramImpl : public ProgramImpl {
     return vulkan_runtime_->flush();
   }
 
-  std::unique_ptr<AotModuleBuilder> make_aot_module_builder() override;
+  std::unique_ptr<AotModuleBuilder> make_aot_module_builder(const DeviceCapabilityConfig& caps) override;
 
   void destroy_snode_tree(SNodeTree *snode_tree) override {
     TI_ASSERT(snode_tree_mgr_ != nullptr);

--- a/tests/cpp/aot/dx12/aot_save_load_test.cpp
+++ b/tests/cpp/aot/dx12/aot_save_load_test.cpp
@@ -28,7 +28,7 @@ namespace fs = std::filesystem;
   place->dt = PrimitiveType::i32;
   program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/true);
 
-  auto aot_builder = program.make_aot_module_builder(Arch::dx12);
+  auto aot_builder = program.make_aot_module_builder(Arch::dx12, {});
 
   std::unique_ptr<Kernel> kernel_init, kernel_ret, kernel_simple_ret;
 

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -89,18 +89,21 @@ def test_numpy_2d_transpose():
     def test_numpy(arr: ti.types.ndarray()):
         for i in ti.grouped(val):
             val[i] = arr[i]
+            arr[i] = 1
 
     a = np.empty(shape=(n, m), dtype=np.int32)
+    b = a.transpose()
 
     for i in range(n):
         for j in range(m):
             a[i, j] = i * j + i * 4
 
-    test_numpy(a.transpose())
+    test_numpy(b)
 
     for i in range(n):
         for j in range(m):
             assert val[i, j] == i * j + j * 4
+            assert a[i][j] == 1
 
 
 @test_utils.test()
@@ -234,3 +237,15 @@ def test_numpy_op_with_matrix():
         assert all(y == [1.0, 2.0])
 
     test()
+
+
+@test_utils.test()
+def test_numpy_view():
+    @ti.kernel
+    def fill(img: ti.types.ndarray()):
+        img[0] = 1
+
+    a = np.zeros(shape=(2, 2))[:, 0]
+    with pytest.raises(ValueError,
+                       match='Non contiguous numpy arrays are not supported'):
+        fill(a)


### PR DESCRIPTION
This PR refactorized `DeviceCapability` control logics in Taichi. `DeviceCapability` controls the compilation of kernels and the execution behavior on device. The current implementation collect capabilities from the device interface but it blocks extension of AOT code generation because it depends on the currently attached compute device whether to enable a set of feature during compilation. AOT users, however, demands an interface to control the availability of `DeviceCapability`.

This PR does several things and it seems large:
- Removed runtime capability form the list of caps, see code comments for details of design decisions;
- Encapsulate the capability settings in `Device` in `DeviceCapabilityConfig`;
- Replace any reference to `Device` with `DeviceCapabilityConfig` in codegens;
- Removed `TargetDevice` for in the SPIR-V codegen;
- Adapt backends (basically gfx backends) to this change.

Python and C-API users will be able to configure `DeviceCapability`s in future PRs.