### PR TITLE
[llvm] [refactor] Merge create_call and call

### DIFF
--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -66,9 +66,8 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
       stmt->block_dim = std::min(1024, std::max(512, items_per_thread));
     }
 
-    call(
-        "cpu_parallel_range_for",
-        get_arg(0), tlctx->get_constant(stmt->num_cpu_threads), begin, end,
+    call("cpu_parallel_range_for", get_arg(0),
+         tlctx->get_constant(stmt->num_cpu_threads), begin, end,
          tlctx->get_constant(step), tlctx->get_constant(stmt->block_dim),
          tls_prologue, body, epilogue, tlctx->get_constant(stmt->tls_size));
   }
@@ -147,11 +146,11 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
 
     llvm::Value *epilogue = create_mesh_xlogue(stmt->tls_epilogue);
 
-    call("cpu_parallel_mesh_for",
-                get_arg(0), tlctx->get_constant(stmt->num_cpu_threads),
-                 tlctx->get_constant(stmt->mesh->num_patches),
-                 tlctx->get_constant(stmt->block_dim), tls_prologue, body,
-                 epilogue, tlctx->get_constant(stmt->tls_size));
+    call("cpu_parallel_mesh_for", get_arg(0),
+         tlctx->get_constant(stmt->num_cpu_threads),
+         tlctx->get_constant(stmt->mesh->num_patches),
+         tlctx->get_constant(stmt->block_dim), tls_prologue, body, epilogue,
+         tlctx->get_constant(stmt->tls_size));
   }
 
   void create_bls_buffer(OffloadedStmt *stmt) {
@@ -179,9 +178,8 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
     auto offloaded_task_name = init_offloaded_task_function(stmt);
     if (prog->this_thread_config().kernel_profiler &&
         arch_is_cpu(prog->this_thread_config().arch)) {
-      call(
-          "LLVMRuntime_profiler_start",
-          get_runtime(), builder->CreateGlobalStringPtr(offloaded_task_name));
+      call("LLVMRuntime_profiler_start", get_runtime(),
+           builder->CreateGlobalStringPtr(offloaded_task_name));
     }
     if (stmt->task_type == Type::serial) {
       stmt->body->accept(this);

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -66,11 +66,11 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
       stmt->block_dim = std::min(1024, std::max(512, items_per_thread));
     }
 
-    create_call(
+    call(
         "cpu_parallel_range_for",
-        {get_arg(0), tlctx->get_constant(stmt->num_cpu_threads), begin, end,
+        get_arg(0), tlctx->get_constant(stmt->num_cpu_threads), begin, end,
          tlctx->get_constant(step), tlctx->get_constant(stmt->block_dim),
-         tls_prologue, body, epilogue, tlctx->get_constant(stmt->tls_size)});
+         tls_prologue, body, epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void create_offload_mesh_for(OffloadedStmt *stmt) override {
@@ -147,11 +147,11 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
 
     llvm::Value *epilogue = create_mesh_xlogue(stmt->tls_epilogue);
 
-    create_call("cpu_parallel_mesh_for",
-                {get_arg(0), tlctx->get_constant(stmt->num_cpu_threads),
+    call("cpu_parallel_mesh_for",
+                get_arg(0), tlctx->get_constant(stmt->num_cpu_threads),
                  tlctx->get_constant(stmt->mesh->num_patches),
                  tlctx->get_constant(stmt->block_dim), tls_prologue, body,
-                 epilogue, tlctx->get_constant(stmt->tls_size)});
+                 epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void create_bls_buffer(OffloadedStmt *stmt) {
@@ -180,8 +180,8 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
     if (prog->this_thread_config().kernel_profiler &&
         arch_is_cpu(prog->this_thread_config().arch)) {
       call(
-          builder.get(), "LLVMRuntime_profiler_start",
-          {get_runtime(), builder->CreateGlobalStringPtr(offloaded_task_name)});
+          "LLVMRuntime_profiler_start",
+          get_runtime(), builder->CreateGlobalStringPtr(offloaded_task_name));
     }
     if (stmt->task_type == Type::serial) {
       stmt->body->accept(this);
@@ -204,7 +204,7 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
         arch_is_cpu(prog->this_thread_config().arch)) {
       llvm::IRBuilderBase::InsertPointGuard guard(*builder);
       builder->SetInsertPoint(final_block);
-      call(builder.get(), "LLVMRuntime_profiler_stop", {get_runtime()});
+      call("LLVMRuntime_profiler_stop", get_runtime());
     }
     finalize_offloaded_task_function();
     offloaded_tasks.push_back(*current_task);

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -156,11 +156,11 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 #define UNARY_STD(x)                                                    \
   else if (op == UnaryOpType::x) {                                      \
     if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {        \
-      llvm_val[stmt] = call("__nv_" #x "f", input);              \
+      llvm_val[stmt] = call("__nv_" #x "f", input);                     \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) { \
-      llvm_val[stmt] = call("__nv_" #x, input);                  \
+      llvm_val[stmt] = call("__nv_" #x, input);                         \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) { \
-      llvm_val[stmt] = call(#x, input);                          \
+      llvm_val[stmt] = call(#x, input);                                 \
     } else {                                                            \
       TI_NOT_IMPLEMENTED                                                \
     }                                                                   \
@@ -247,8 +247,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     }
     TI_ASSERT(fast_reductions.at(prim_type).find(op) !=
               fast_reductions.at(prim_type).end());
-    return call(fast_reductions.at(prim_type).at(op),
-                       llvm_val[stmt->dest], llvm_val[stmt->val]);
+    return call(fast_reductions.at(prim_type).at(op), llvm_val[stmt->dest],
+                llvm_val[stmt->val]);
   }
 
   // LLVM15 already support f16 atomic in
@@ -425,9 +425,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     auto epilogue = create_xlogue(stmt->tls_epilogue);
 
     auto [begin, end] = get_range_for_bounds(stmt);
-    call("gpu_parallel_range_for",
-                get_arg(0), begin, end, tls_prologue, body, epilogue,
-                 tlctx->get_constant(stmt->tls_size));
+    call("gpu_parallel_range_for", get_arg(0), begin, end, tls_prologue, body,
+         epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void create_offload_mesh_for(OffloadedStmt *stmt) override {
@@ -506,10 +505,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 
     auto tls_epilogue = create_mesh_xlogue(stmt->tls_epilogue);
 
-    call(
-        "gpu_parallel_mesh_for",
-        get_arg(0), tlctx->get_constant(stmt->mesh->num_patches), tls_prologue,
-         body, tls_epilogue, tlctx->get_constant(stmt->tls_size));
+    call("gpu_parallel_mesh_for", get_arg(0),
+         tlctx->get_constant(stmt->mesh->num_patches), tls_prologue, body,
+         tls_epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void emit_cuda_gc(OffloadedStmt *stmt) {
@@ -648,9 +646,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
   void visit(ExternalTensorShapeAlongAxisStmt *stmt) override {
     const auto arg_id = stmt->arg_id;
     const auto axis = stmt->axis;
-    llvm_val[stmt] = call("RuntimeContext_get_extra_args",
-                                 get_context(), tlctx->get_constant(arg_id),
-                                  tlctx->get_constant(axis));
+    llvm_val[stmt] =
+        call("RuntimeContext_get_extra_args", get_context(),
+             tlctx->get_constant(arg_id), tlctx->get_constant(axis));
   }
 
   void visit(BinaryOpStmt *stmt) override {

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -156,38 +156,38 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 #define UNARY_STD(x)                                                    \
   else if (op == UnaryOpType::x) {                                      \
     if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {        \
-      llvm_val[stmt] = create_call("__nv_" #x "f", input);              \
+      llvm_val[stmt] = call("__nv_" #x "f", input);              \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) { \
-      llvm_val[stmt] = create_call("__nv_" #x, input);                  \
+      llvm_val[stmt] = call("__nv_" #x, input);                  \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) { \
-      llvm_val[stmt] = create_call(#x, input);                          \
+      llvm_val[stmt] = call(#x, input);                          \
     } else {                                                            \
       TI_NOT_IMPLEMENTED                                                \
     }                                                                   \
   }
     if (op == UnaryOpType::abs) {
       if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {
-        llvm_val[stmt] = create_call("__nv_fabsf", input);
+        llvm_val[stmt] = call("__nv_fabsf", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) {
-        llvm_val[stmt] = create_call("__nv_fabs", input);
+        llvm_val[stmt] = call("__nv_fabs", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
-        llvm_val[stmt] = create_call("__nv_abs", input);
+        llvm_val[stmt] = call("__nv_abs", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i64)) {
-        llvm_val[stmt] = create_call("__nv_llabs", input);
+        llvm_val[stmt] = call("__nv_llabs", input);
       } else {
         TI_NOT_IMPLEMENTED
       }
     } else if (op == UnaryOpType::sqrt) {
       if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {
-        llvm_val[stmt] = create_call("__nv_sqrtf", input);
+        llvm_val[stmt] = call("__nv_sqrtf", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) {
-        llvm_val[stmt] = create_call("__nv_sqrt", input);
+        llvm_val[stmt] = call("__nv_sqrt", input);
       } else {
         TI_NOT_IMPLEMENTED
       }
     } else if (op == UnaryOpType::logic_not) {
       if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
-        llvm_val[stmt] = create_call("logic_not_i32", input);
+        llvm_val[stmt] = call("logic_not_i32", input);
       } else {
         TI_NOT_IMPLEMENTED
       }
@@ -247,8 +247,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     }
     TI_ASSERT(fast_reductions.at(prim_type).find(op) !=
               fast_reductions.at(prim_type).end());
-    return create_call(fast_reductions.at(prim_type).at(op),
-                       {llvm_val[stmt->dest], llvm_val[stmt->val]});
+    return call(fast_reductions.at(prim_type).at(op),
+                       llvm_val[stmt->dest], llvm_val[stmt->val]);
   }
 
   // LLVM15 already support f16 atomic in
@@ -425,9 +425,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     auto epilogue = create_xlogue(stmt->tls_epilogue);
 
     auto [begin, end] = get_range_for_bounds(stmt);
-    create_call("gpu_parallel_range_for",
-                {get_arg(0), begin, end, tls_prologue, body, epilogue,
-                 tlctx->get_constant(stmt->tls_size)});
+    call("gpu_parallel_range_for",
+                get_arg(0), begin, end, tls_prologue, body, epilogue,
+                 tlctx->get_constant(stmt->tls_size));
   }
 
   void create_offload_mesh_for(OffloadedStmt *stmt) override {
@@ -506,10 +506,10 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 
     auto tls_epilogue = create_mesh_xlogue(stmt->tls_epilogue);
 
-    create_call(
+    call(
         "gpu_parallel_mesh_for",
-        {get_arg(0), tlctx->get_constant(stmt->mesh->num_patches), tls_prologue,
-         body, tls_epilogue, tlctx->get_constant(stmt->tls_size)});
+        get_arg(0), tlctx->get_constant(stmt->mesh->num_patches), tls_prologue,
+         body, tls_epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void emit_cuda_gc(OffloadedStmt *stmt) {
@@ -648,9 +648,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
   void visit(ExternalTensorShapeAlongAxisStmt *stmt) override {
     const auto arg_id = stmt->arg_id;
     const auto axis = stmt->axis;
-    llvm_val[stmt] = create_call("RuntimeContext_get_extra_args",
-                                 {get_context(), tlctx->get_constant(arg_id),
-                                  tlctx->get_constant(axis)});
+    llvm_val[stmt] = call("RuntimeContext_get_extra_args",
+                                 get_context(), tlctx->get_constant(arg_id),
+                                  tlctx->get_constant(axis));
   }
 
   void visit(BinaryOpStmt *stmt) override {
@@ -679,9 +679,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 
     if (op == BinaryOpType::atan2) {
       if (ret_type->is_primitive(PrimitiveTypeID::f32)) {
-        llvm_val[stmt] = create_call("__nv_atan2f", {lhs, rhs});
+        llvm_val[stmt] = call("__nv_atan2f", lhs, rhs);
       } else if (ret_type->is_primitive(PrimitiveTypeID::f64)) {
-        llvm_val[stmt] = create_call("__nv_atan2", {lhs, rhs});
+        llvm_val[stmt] = call("__nv_atan2", lhs, rhs);
       } else {
         TI_P(data_type_name(ret_type));
         TI_NOT_IMPLEMENTED
@@ -690,9 +690,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
       // Note that ret_type here cannot be integral because pow with an
       // integral exponent has been demoted in the demote_operations pass
       if (ret_type->is_primitive(PrimitiveTypeID::f32)) {
-        llvm_val[stmt] = create_call("__nv_powf", {lhs, rhs});
+        llvm_val[stmt] = call("__nv_powf", lhs, rhs);
       } else if (ret_type->is_primitive(PrimitiveTypeID::f64)) {
-        llvm_val[stmt] = create_call("__nv_pow", {lhs, rhs});
+        llvm_val[stmt] = call("__nv_pow", lhs, rhs);
       } else {
         TI_P(data_type_name(ret_type));
         TI_NOT_IMPLEMENTED

--- a/taichi/codegen/dx12/codegen_dx12.cpp
+++ b/taichi/codegen/dx12/codegen_dx12.cpp
@@ -47,9 +47,9 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
     auto epilogue = create_xlogue(stmt->tls_epilogue);
 
     auto [begin, end] = get_range_for_bounds(stmt);
-    create_call("gpu_parallel_range_for",
-                {get_arg(0), begin, end, tls_prologue, body, epilogue,
-                 tlctx->get_constant(stmt->tls_size)});
+    call("gpu_parallel_range_for",
+                get_arg(0), begin, end, tls_prologue, body, epilogue,
+                 tlctx->get_constant(stmt->tls_size));
   }
 
   void create_offload_mesh_for(OffloadedStmt *stmt) override {
@@ -131,10 +131,10 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
 
     auto tls_epilogue = create_mesh_xlogue(stmt->tls_epilogue);
 
-    create_call(
+    call(
         "gpu_parallel_mesh_for",
-        {get_arg(0), tlctx->get_constant(stmt->mesh->num_patches), tls_prologue,
-         body, tls_epilogue, tlctx->get_constant(stmt->tls_size)});
+        get_arg(0), tlctx->get_constant(stmt->mesh->num_patches), tls_prologue,
+         body, tls_epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void create_bls_buffer(OffloadedStmt *stmt) {

--- a/taichi/codegen/dx12/codegen_dx12.cpp
+++ b/taichi/codegen/dx12/codegen_dx12.cpp
@@ -47,9 +47,8 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
     auto epilogue = create_xlogue(stmt->tls_epilogue);
 
     auto [begin, end] = get_range_for_bounds(stmt);
-    call("gpu_parallel_range_for",
-                get_arg(0), begin, end, tls_prologue, body, epilogue,
-                 tlctx->get_constant(stmt->tls_size));
+    call("gpu_parallel_range_for", get_arg(0), begin, end, tls_prologue, body,
+         epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void create_offload_mesh_for(OffloadedStmt *stmt) override {
@@ -131,10 +130,9 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
 
     auto tls_epilogue = create_mesh_xlogue(stmt->tls_epilogue);
 
-    call(
-        "gpu_parallel_mesh_for",
-        get_arg(0), tlctx->get_constant(stmt->mesh->num_patches), tls_prologue,
-         body, tls_epilogue, tlctx->get_constant(stmt->tls_size));
+    call("gpu_parallel_mesh_for", get_arg(0),
+         tlctx->get_constant(stmt->mesh->num_patches), tls_prologue, body,
+         tls_epilogue, tlctx->get_constant(stmt->tls_size));
   }
 
   void create_bls_buffer(OffloadedStmt *stmt) {

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -153,9 +153,8 @@ void TaskCodeGenLLVM::visit(RandStmt *stmt) {
     llvm_val[stmt] =
         builder->CreateFPTrunc(val_f32, llvm::Type::getHalfTy(*llvm_context));
   } else {
-    llvm_val[stmt] =
-        call(fmt::format("rand_{}", data_type_name(stmt->ret_type)),
-                    get_context());
+    llvm_val[stmt] = call(
+        fmt::format("rand_{}", data_type_name(stmt->ret_type)), get_context());
   }
 }
 
@@ -175,13 +174,13 @@ void TaskCodeGenLLVM::emit_extra_unary(UnaryOpStmt *stmt) {
 #define UNARY_STD(x)                                                    \
   else if (op == UnaryOpType::x) {                                      \
     if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {        \
-      llvm_val[stmt] = call(#x "_f32", input);                   \
+      llvm_val[stmt] = call(#x "_f32", input);                          \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) { \
-      llvm_val[stmt] = call(#x "_f64", input);                   \
+      llvm_val[stmt] = call(#x "_f64", input);                          \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) { \
-      llvm_val[stmt] = call(#x "_i32", input);                   \
+      llvm_val[stmt] = call(#x "_i32", input);                          \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i64)) { \
-      llvm_val[stmt] = call(#x "_i64", input);                   \
+      llvm_val[stmt] = call(#x "_i64", input);                          \
     } else {                                                            \
       TI_NOT_IMPLEMENTED                                                \
     }                                                                   \
@@ -642,9 +641,9 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
           builder->CreateLShr(llvm_val[stmt->lhs], llvm_val[stmt->rhs]);
     }
   } else if (op == BinaryOpType::max) {
-#define BINARYOP_MAX(x)                                                     \
-  else if (ret_type->is_primitive(PrimitiveTypeID::x)) {                    \
-    llvm_val[stmt] =                                                        \
+#define BINARYOP_MAX(x)                                            \
+  else if (ret_type->is_primitive(PrimitiveTypeID::x)) {           \
+    llvm_val[stmt] =                                               \
         call("max_" #x, llvm_val[stmt->lhs], llvm_val[stmt->rhs]); \
   }
 
@@ -679,9 +678,9 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
       }
     }
   } else if (op == BinaryOpType::min) {
-#define BINARYOP_MIN(x)                                                     \
-  else if (ret_type->is_primitive(PrimitiveTypeID::x)) {                    \
-    llvm_val[stmt] =                                                        \
+#define BINARYOP_MIN(x)                                            \
+  else if (ret_type->is_primitive(PrimitiveTypeID::x)) {           \
+    llvm_val[stmt] =                                               \
         call("min_" #x, llvm_val[stmt->lhs], llvm_val[stmt->rhs]); \
   }
 
@@ -899,7 +898,8 @@ llvm::Value *TaskCodeGenLLVM::create_print(std::string tag,
   args.push_back(value);
 
   auto func_type_func = get_runtime_function("get_func_type_host_printf");
-  return call(runtime_printf, func_type_func->getFunctionType(), std::move(args));
+  return call(runtime_printf, func_type_func->getFunctionType(),
+              std::move(args));
 }
 
 llvm::Value *TaskCodeGenLLVM::create_print(std::string tag,
@@ -1275,9 +1275,8 @@ void TaskCodeGenLLVM::visit(ReturnStmt *stmt) {
     TI_ASSERT(stmt->values.size() <= taichi_max_num_ret_value);
     int idx{0};
     for (auto &value : stmt->values) {
-      call(
-          "RuntimeContext_store_result",
-          get_context(), bitcast_to_u64(llvm_val[value], value->ret_type),
+      call("RuntimeContext_store_result", get_context(),
+           bitcast_to_u64(llvm_val[value], value->ret_type),
            tlctx->get_constant<int32>(idx++));
     }
   }
@@ -1522,8 +1521,8 @@ llvm::Value *TaskCodeGenLLVM::real_type_atomic(AtomicOpStmt *stmt) {
   atomics[PrimitiveTypeID::f64][AtomicOpType::max] = "atomic_max_f64";
   TI_ASSERT(atomics.find(prim_type) != atomics.end());
   TI_ASSERT(atomics.at(prim_type).find(op) != atomics.at(prim_type).end());
-  return call(atomics.at(prim_type).at(op),
-                     llvm_val[stmt->dest], llvm_val[stmt->val]);
+  return call(atomics.at(prim_type).at(op), llvm_val[stmt->dest],
+              llvm_val[stmt->val]);
 }
 
 void TaskCodeGenLLVM::visit(AtomicOpStmt *stmt) {
@@ -1900,9 +1899,8 @@ void TaskCodeGenLLVM::visit(ExternalPtrStmt *stmt) {
       (layout == ExternalArrayLayout::kAOS) ? num_array_args : 0;
 
   for (int i = 0; i < num_array_args; i++) {
-    auto raw_arg = call(
-        "RuntimeContext_get_extra_args",
-        get_context(), tlctx->get_constant(arg_id), tlctx->get_constant(i));
+    auto raw_arg = call("RuntimeContext_get_extra_args", get_context(),
+                        tlctx->get_constant(arg_id), tlctx->get_constant(i));
     sizes[i] = raw_arg;
   }
 
@@ -1973,9 +1971,8 @@ void TaskCodeGenLLVM::visit(ExternalPtrStmt *stmt) {
 void TaskCodeGenLLVM::visit(ExternalTensorShapeAlongAxisStmt *stmt) {
   const auto arg_id = stmt->arg_id;
   const auto axis = stmt->axis;
-  llvm_val[stmt] = call(
-      "RuntimeContext_get_extra_args",
-      get_context(), tlctx->get_constant(arg_id), tlctx->get_constant(axis));
+  llvm_val[stmt] = call("RuntimeContext_get_extra_args", get_context(),
+                        tlctx->get_constant(arg_id), tlctx->get_constant(axis));
 }
 
 std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt,
@@ -2159,7 +2156,7 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     // cell within that block, and is the same for all the cells within that
     // block.
     call(refine, parent_coordinates, block_corner_coordinates,
-                         tlctx->get_constant(0));
+         tlctx->get_constant(0));
 
     if (stmt->tls_prologue) {
       stmt->tls_prologue->accept(this);
@@ -2223,11 +2220,11 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     auto new_coordinates = create_entry_block_alloca(physical_coordinate_ty);
 
     call(refine, parent_coordinates, new_coordinates,
-                         builder->CreateLoad(
+         builder->CreateLoad(
 #ifdef TI_LLVM_15
-                             loop_index_ty,
+             loop_index_ty,
 #endif
-                             loop_index));
+             loop_index));
 
     // For a bit-vectorized loop over a quant array, one more refine step is
     // needed to make final coordinates non-consecutive, since each thread will
@@ -2235,8 +2232,7 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     if (stmt->is_bit_vectorized) {
       refine = get_struct_function(stmt->snode->refine_coordinates_func_name(),
                                    stmt->snode->get_snode_tree_id());
-      call(refine,
-                  new_coordinates, new_coordinates, tlctx->get_constant(0));
+      call(refine, new_coordinates, new_coordinates, tlctx->get_constant(0));
     }
 
     current_coordinates = new_coordinates;
@@ -2331,9 +2327,7 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     struct_for_tls_sizes.insert(stmt->tls_size);
   }
   // Loop over nodes in the element list, in parallel
-  call(
-      struct_for_func,
-      get_context(), tlctx->get_constant(leaf_block->id),
+  call(struct_for_func, get_context(), tlctx->get_constant(leaf_block->id),
        tlctx->get_constant(list_element_size), tlctx->get_constant(num_splits),
        body, tlctx->get_constant(stmt->tls_size),
        tlctx->get_constant(stmt->num_cpu_threads));
@@ -2698,8 +2692,8 @@ llvm::Type *TaskCodeGenLLVM::get_mesh_xlogue_function_type() {
 }
 
 llvm::Value *TaskCodeGenLLVM::get_root(int snode_tree_id) {
-  return call("LLVMRuntime_get_roots",
-                     get_runtime(), tlctx->get_constant(snode_tree_id));
+  return call("LLVMRuntime_get_roots", get_runtime(),
+              tlctx->get_constant(snode_tree_id));
 }
 
 llvm::Value *TaskCodeGenLLVM::get_runtime() {

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -149,13 +149,13 @@ void TaskCodeGenLLVM::visit(AllocaStmt *stmt) {
 void TaskCodeGenLLVM::visit(RandStmt *stmt) {
   if (stmt->ret_type->is_primitive(PrimitiveTypeID::f16)) {
     // Promoting to f32 since there's no rand_f16 support in runtime.cpp.
-    auto val_f32 = create_call("rand_f32", {get_context()});
+    auto val_f32 = call("rand_f32", get_context());
     llvm_val[stmt] =
         builder->CreateFPTrunc(val_f32, llvm::Type::getHalfTy(*llvm_context));
   } else {
     llvm_val[stmt] =
-        create_call(fmt::format("rand_{}", data_type_name(stmt->ret_type)),
-                    {get_context()});
+        call(fmt::format("rand_{}", data_type_name(stmt->ret_type)),
+                    get_context());
   }
 }
 
@@ -175,13 +175,13 @@ void TaskCodeGenLLVM::emit_extra_unary(UnaryOpStmt *stmt) {
 #define UNARY_STD(x)                                                    \
   else if (op == UnaryOpType::x) {                                      \
     if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {        \
-      llvm_val[stmt] = create_call(#x "_f32", input);                   \
+      llvm_val[stmt] = call(#x "_f32", input);                   \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) { \
-      llvm_val[stmt] = create_call(#x "_f64", input);                   \
+      llvm_val[stmt] = call(#x "_f64", input);                   \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) { \
-      llvm_val[stmt] = create_call(#x "_i32", input);                   \
+      llvm_val[stmt] = call(#x "_i32", input);                   \
     } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i64)) { \
-      llvm_val[stmt] = create_call(#x "_i64", input);                   \
+      llvm_val[stmt] = call(#x "_i64", input);                   \
     } else {                                                            \
       TI_NOT_IMPLEMENTED                                                \
     }                                                                   \
@@ -645,7 +645,7 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
 #define BINARYOP_MAX(x)                                                     \
   else if (ret_type->is_primitive(PrimitiveTypeID::x)) {                    \
     llvm_val[stmt] =                                                        \
-        create_call("max_" #x, {llvm_val[stmt->lhs], llvm_val[stmt->rhs]}); \
+        call("max_" #x, llvm_val[stmt->lhs], llvm_val[stmt->rhs]); \
   }
 
     if (is_real(ret_type.get_element_type())) {
@@ -670,7 +670,7 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
         auto dtype_name = data_type_name(elt_ty);
         auto binary_max = [this, &dtype_name](llvm::Value *lhs,
                                               llvm::Value *rhs) {
-          return create_call("max_" + dtype_name, {lhs, rhs});
+          return call("max_" + dtype_name, lhs, rhs);
         };
         create_elementwise_binary(stmt, binary_max);
       } else {
@@ -682,7 +682,7 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
 #define BINARYOP_MIN(x)                                                     \
   else if (ret_type->is_primitive(PrimitiveTypeID::x)) {                    \
     llvm_val[stmt] =                                                        \
-        create_call("min_" #x, {llvm_val[stmt->lhs], llvm_val[stmt->rhs]}); \
+        call("min_" #x, llvm_val[stmt->lhs], llvm_val[stmt->rhs]); \
   }
 
     if (is_real(ret_type.get_element_type())) {
@@ -707,7 +707,7 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
         auto dtype_name = data_type_name(elt_ty);
         auto binary_min = [this, &dtype_name](llvm::Value *lhs,
                                               llvm::Value *rhs) {
-          return create_call("min_" + dtype_name, {lhs, rhs});
+          return call("min_" + dtype_name, lhs, rhs);
         };
         create_elementwise_binary(stmt, binary_min);
       } else {
@@ -802,9 +802,9 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
     if (op == BinaryOpType::atan2) {
       if (arch_is_cpu(current_arch())) {
         if (ret_type->is_primitive(PrimitiveTypeID::f32)) {
-          llvm_val[stmt] = create_call("atan2_f32", {lhs, rhs});
+          llvm_val[stmt] = call("atan2_f32", lhs, rhs);
         } else if (ret_type->is_primitive(PrimitiveTypeID::f64)) {
-          llvm_val[stmt] = create_call("atan2_f64", {lhs, rhs});
+          llvm_val[stmt] = call("atan2_f64", lhs, rhs);
         } else {
           TI_P(data_type_name(ret_type));
           TI_NOT_IMPLEMENTED
@@ -817,9 +817,9 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
         // Note that ret_type here cannot be integral because pow with an
         // integral exponent has been demoted in the demote_operations pass
         if (ret_type->is_primitive(PrimitiveTypeID::f32)) {
-          llvm_val[stmt] = create_call("pow_f32", {lhs, rhs});
+          llvm_val[stmt] = call("pow_f32", lhs, rhs);
         } else if (ret_type->is_primitive(PrimitiveTypeID::f64)) {
-          llvm_val[stmt] = create_call("pow_f64", {lhs, rhs});
+          llvm_val[stmt] = call("pow_f64", lhs, rhs);
         } else {
           TI_P(data_type_name(ret_type));
           TI_NOT_IMPLEMENTED
@@ -899,7 +899,7 @@ llvm::Value *TaskCodeGenLLVM::create_print(std::string tag,
   args.push_back(value);
 
   auto func_type_func = get_runtime_function("get_func_type_host_printf");
-  return create_call(runtime_printf, func_type_func->getFunctionType(), args);
+  return call(runtime_printf, func_type_func->getFunctionType(), std::move(args));
 }
 
 llvm::Value *TaskCodeGenLLVM::create_print(std::string tag,
@@ -979,7 +979,7 @@ void TaskCodeGenLLVM::visit(PrintStmt *stmt) {
               builder->CreateGlobalStringPtr(formats.c_str(), "format_string"));
   auto func_type_func = get_runtime_function("get_func_type_host_printf");
   llvm_val[stmt] =
-      create_call(runtime_printf, func_type_func->getFunctionType(), args);
+      call(runtime_printf, func_type_func->getFunctionType(), std::move(args));
 }
 
 void TaskCodeGenLLVM::visit(ConstStmt *stmt) {
@@ -1107,30 +1107,6 @@ void TaskCodeGenLLVM::emit_list_gen(OffloadedStmt *listgen) {
 void TaskCodeGenLLVM::emit_gc(OffloadedStmt *stmt) {
   auto snode = stmt->snode->id;
   call("node_gc", get_runtime(), tlctx->get_constant(snode));
-}
-
-llvm::Value *TaskCodeGenLLVM::create_call(llvm::Function *func,
-                                          llvm::ArrayRef<llvm::Value *> args) {
-  return create_call(func, func->getFunctionType(), args);
-}
-
-llvm::Value *TaskCodeGenLLVM::create_call(
-    llvm::Value *func,
-    llvm::FunctionType *func_ty,
-    llvm::ArrayRef<llvm::Value *> args_arr) {
-  std::vector<llvm::Value *> args = args_arr;
-  check_func_call_signature(func_ty, func->getName(), args, builder.get());
-#ifdef TI_LLVM_15
-  return builder->CreateCall(func_ty, func, args);
-#else
-  return builder->CreateCall(func, args);
-#endif
-}
-
-llvm::Value *TaskCodeGenLLVM::create_call(std::string func_name,
-                                          llvm::ArrayRef<llvm::Value *> args) {
-  auto func = get_runtime_function(func_name);
-  return create_call(func, args);
 }
 
 void TaskCodeGenLLVM::create_increment(llvm::Value *ptr, llvm::Value *value) {
@@ -1299,10 +1275,10 @@ void TaskCodeGenLLVM::visit(ReturnStmt *stmt) {
     TI_ASSERT(stmt->values.size() <= taichi_max_num_ret_value);
     int idx{0};
     for (auto &value : stmt->values) {
-      create_call(
+      call(
           "RuntimeContext_store_result",
-          {get_context(), bitcast_to_u64(llvm_val[value], value->ret_type),
-           tlctx->get_constant<int32>(idx++)});
+          get_context(), bitcast_to_u64(llvm_val[value], value->ret_type),
+           tlctx->get_constant<int32>(idx++));
     }
   }
   builder->CreateBr(final_block);
@@ -1374,7 +1350,7 @@ void TaskCodeGenLLVM::visit(AssertStmt *stmt) {
 #endif
       arguments, {tlctx->get_constant(0), tlctx->get_constant(0)}));
 
-  llvm_val[stmt] = create_call("taichi_assert_format", args);
+  llvm_val[stmt] = call("taichi_assert_format", args);
 }
 
 void TaskCodeGenLLVM::visit(SNodeOpStmt *stmt) {
@@ -1546,8 +1522,8 @@ llvm::Value *TaskCodeGenLLVM::real_type_atomic(AtomicOpStmt *stmt) {
   atomics[PrimitiveTypeID::f64][AtomicOpType::max] = "atomic_max_f64";
   TI_ASSERT(atomics.find(prim_type) != atomics.end());
   TI_ASSERT(atomics.at(prim_type).find(op) != atomics.at(prim_type).end());
-  return create_call(atomics.at(prim_type).at(op),
-                     {llvm_val[stmt->dest], llvm_val[stmt->val]});
+  return call(atomics.at(prim_type).at(op),
+                     llvm_val[stmt->dest], llvm_val[stmt->val]);
 }
 
 void TaskCodeGenLLVM::visit(AtomicOpStmt *stmt) {
@@ -1691,7 +1667,7 @@ llvm::Value *TaskCodeGenLLVM::call(
   func_arguments.insert(func_arguments.end(), arguments.begin(),
                         arguments.end());
 
-  return call(builder.get(), prefix + "_" + method, func_arguments);
+  return call(prefix + "_" + method, func_arguments);
 }
 
 llvm::Function *TaskCodeGenLLVM::get_struct_function(const std::string &name,
@@ -1924,9 +1900,9 @@ void TaskCodeGenLLVM::visit(ExternalPtrStmt *stmt) {
       (layout == ExternalArrayLayout::kAOS) ? num_array_args : 0;
 
   for (int i = 0; i < num_array_args; i++) {
-    auto raw_arg = create_call(
+    auto raw_arg = call(
         "RuntimeContext_get_extra_args",
-        {get_context(), tlctx->get_constant(arg_id), tlctx->get_constant(i)});
+        get_context(), tlctx->get_constant(arg_id), tlctx->get_constant(i));
     sizes[i] = raw_arg;
   }
 
@@ -1997,9 +1973,9 @@ void TaskCodeGenLLVM::visit(ExternalPtrStmt *stmt) {
 void TaskCodeGenLLVM::visit(ExternalTensorShapeAlongAxisStmt *stmt) {
   const auto arg_id = stmt->arg_id;
   const auto axis = stmt->axis;
-  llvm_val[stmt] = create_call(
+  llvm_val[stmt] = call(
       "RuntimeContext_get_extra_args",
-      {get_context(), tlctx->get_constant(arg_id), tlctx->get_constant(axis)});
+      get_context(), tlctx->get_constant(arg_id), tlctx->get_constant(axis));
 }
 
 std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt,
@@ -2182,8 +2158,8 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     // A block corner is the global coordinate/index of the lower-left corner
     // cell within that block, and is the same for all the cells within that
     // block.
-    create_call(refine, {parent_coordinates, block_corner_coordinates,
-                         tlctx->get_constant(0)});
+    call(refine, parent_coordinates, block_corner_coordinates,
+                         tlctx->get_constant(0));
 
     if (stmt->tls_prologue) {
       stmt->tls_prologue->accept(this);
@@ -2246,12 +2222,12 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     // initialize the coordinates
     auto new_coordinates = create_entry_block_alloca(physical_coordinate_ty);
 
-    create_call(refine, {parent_coordinates, new_coordinates,
+    call(refine, parent_coordinates, new_coordinates,
                          builder->CreateLoad(
 #ifdef TI_LLVM_15
                              loop_index_ty,
 #endif
-                             loop_index)});
+                             loop_index));
 
     // For a bit-vectorized loop over a quant array, one more refine step is
     // needed to make final coordinates non-consecutive, since each thread will
@@ -2259,8 +2235,8 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     if (stmt->is_bit_vectorized) {
       refine = get_struct_function(stmt->snode->refine_coordinates_func_name(),
                                    stmt->snode->get_snode_tree_id());
-      create_call(refine,
-                  {new_coordinates, new_coordinates, tlctx->get_constant(0)});
+      call(refine,
+                  new_coordinates, new_coordinates, tlctx->get_constant(0));
     }
 
     current_coordinates = new_coordinates;
@@ -2355,12 +2331,12 @@ void TaskCodeGenLLVM::create_offload_struct_for(OffloadedStmt *stmt,
     struct_for_tls_sizes.insert(stmt->tls_size);
   }
   // Loop over nodes in the element list, in parallel
-  create_call(
+  call(
       struct_for_func,
-      {get_context(), tlctx->get_constant(leaf_block->id),
+      get_context(), tlctx->get_constant(leaf_block->id),
        tlctx->get_constant(list_element_size), tlctx->get_constant(num_splits),
        body, tlctx->get_constant(stmt->tls_size),
-       tlctx->get_constant(stmt->num_cpu_threads)});
+       tlctx->get_constant(stmt->num_cpu_threads));
   // TODO: why do we need num_cpu_threads on GPUs?
 
   current_coordinates = nullptr;
@@ -2407,7 +2383,7 @@ void TaskCodeGenLLVM::visit(LoopLinearIndexStmt *stmt) {
            OffloadedStmt::TaskType::struct_for ||
        stmt->loop->as<OffloadedStmt>()->task_type ==
            OffloadedStmt::TaskType::mesh_for)) {
-    llvm_val[stmt] = create_call("thread_idx");
+    llvm_val[stmt] = call("thread_idx");
   } else {
     TI_NOT_IMPLEMENTED;
   }
@@ -2499,7 +2475,7 @@ void TaskCodeGenLLVM::visit(InternalFuncStmt *stmt) {
   for (auto s : stmt->args) {
     args.push_back(llvm_val[s]);
   }
-  llvm_val[stmt] = create_call(stmt->func_name, args);
+  llvm_val[stmt] = call(stmt->func_name, args);
 }
 
 void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {
@@ -2612,7 +2588,7 @@ void TaskCodeGenLLVM::visit_call_bitcode(ExternalFuncCallStmt *stmt) {
     arg_values[i] =
         builder->CreatePointerCast(tmp_value, func_ptr->getArg(i)->getType());
   }
-  create_call(func_ptr, arg_values);
+  call(func_ptr, arg_values);
 }
 
 void TaskCodeGenLLVM::visit_call_shared_object(ExternalFuncCallStmt *stmt) {
@@ -2638,7 +2614,7 @@ void TaskCodeGenLLVM::visit_call_shared_object(ExternalFuncCallStmt *stmt) {
 
   auto addr = tlctx->get_constant((std::size_t)stmt->so_func);
   auto func = builder->CreateIntToPtr(addr, func_ptr_type);
-  create_call(func, func_type, arg_values);
+  call(func, func_type, arg_values);
 }
 
 void TaskCodeGenLLVM::visit(ExternalFuncCallStmt *stmt) {
@@ -2722,12 +2698,12 @@ llvm::Type *TaskCodeGenLLVM::get_mesh_xlogue_function_type() {
 }
 
 llvm::Value *TaskCodeGenLLVM::get_root(int snode_tree_id) {
-  return create_call("LLVMRuntime_get_roots",
-                     {get_runtime(), tlctx->get_constant(snode_tree_id)});
+  return call("LLVMRuntime_get_roots",
+                     get_runtime(), tlctx->get_constant(snode_tree_id));
 }
 
 llvm::Value *TaskCodeGenLLVM::get_runtime() {
-  auto runtime_ptr = create_call("RuntimeContext_get_runtime", {get_context()});
+  auto runtime_ptr = call("RuntimeContext_get_runtime", get_context());
   return builder->CreateBitCast(
       runtime_ptr, llvm::PointerType::get(get_runtime_type("LLVMRuntime"), 0));
 }
@@ -2816,7 +2792,7 @@ void TaskCodeGenLLVM::visit(FuncCallStmt *stmt) {
       !stmt->ret_type->is_primitive(PrimitiveTypeID::unknown)) {
     result_buffer = builder->CreateAlloca(tlctx->get_data_type<uint64>());
     call("RuntimeContext_set_result_buffer", new_ctx, result_buffer);
-    create_call(llvm_func, {new_ctx});
+    call(llvm_func, new_ctx);
     auto *ret_val_u64 = builder->CreateLoad(
 #ifdef TI_LLVM_15
         builder->getInt64Ty(),
@@ -2824,7 +2800,7 @@ void TaskCodeGenLLVM::visit(FuncCallStmt *stmt) {
         result_buffer);
     llvm_val[stmt] = bitcast_from_u64(ret_val_u64, stmt->ret_type);
   } else {
-    create_call(llvm_func, {new_ctx});
+    call(llvm_func, new_ctx);
   }
 }
 

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1350,7 +1350,7 @@ void TaskCodeGenLLVM::visit(AssertStmt *stmt) {
 #endif
       arguments, {tlctx->get_constant(0), tlctx->get_constant(0)}));
 
-  llvm_val[stmt] = call("taichi_assert_format", args);
+  llvm_val[stmt] = call("taichi_assert_format", std::move(args));
 }
 
 void TaskCodeGenLLVM::visit(SNodeOpStmt *stmt) {
@@ -1667,7 +1667,7 @@ llvm::Value *TaskCodeGenLLVM::call(
   func_arguments.insert(func_arguments.end(), arguments.begin(),
                         arguments.end());
 
-  return call(prefix + "_" + method, func_arguments);
+  return call(prefix + "_" + method, std::move(func_arguments));
 }
 
 llvm::Function *TaskCodeGenLLVM::get_struct_function(const std::string &name,
@@ -2475,7 +2475,7 @@ void TaskCodeGenLLVM::visit(InternalFuncStmt *stmt) {
   for (auto s : stmt->args) {
     args.push_back(llvm_val[s]);
   }
-  llvm_val[stmt] = call(stmt->func_name, args);
+  llvm_val[stmt] = call(stmt->func_name, std::move(args));
 }
 
 void TaskCodeGenLLVM::visit(AdStackAllocaStmt *stmt) {

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -142,15 +142,6 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   void emit_gc(OffloadedStmt *stmt);
 
-  llvm::Value *create_call(llvm::Function *func,
-                           llvm::ArrayRef<llvm::Value *> args = {});
-
-  llvm::Value *create_call(llvm::Value *func,
-                           llvm::FunctionType *func_ty,
-                           llvm::ArrayRef<llvm::Value *> args = {});
-
-  llvm::Value *create_call(std::string func_name,
-                           llvm::ArrayRef<llvm::Value *> args = {});
   llvm::Value *call(SNode *snode,
                     llvm::Value *node_ptr,
                     const std::string &method,

--- a/taichi/codegen/llvm/codegen_llvm_quant.cpp
+++ b/taichi/codegen/llvm/codegen_llvm_quant.cpp
@@ -21,11 +21,11 @@ llvm::Value *TaskCodeGenLLVM::atomic_add_quant_int(llvm::Value *ptr,
                                                    llvm::Value *value,
                                                    bool value_is_signed) {
   auto [byte_ptr, bit_offset] = load_bit_ptr(ptr);
-  return create_call(
+  return call(
       fmt::format("atomic_add_partial_bits_b{}",
                   physical_type->getIntegerBitWidth()),
-      {byte_ptr, bit_offset, tlctx->get_constant(qit->get_num_bits()),
-       builder->CreateIntCast(value, physical_type, value_is_signed)});
+      byte_ptr, bit_offset, tlctx->get_constant(qit->get_num_bits()),
+       builder->CreateIntCast(value, physical_type, value_is_signed));
 }
 
 llvm::Value *TaskCodeGenLLVM::atomic_add_quant_fixed(llvm::Value *ptr,
@@ -36,10 +36,10 @@ llvm::Value *TaskCodeGenLLVM::atomic_add_quant_fixed(llvm::Value *ptr,
   auto qit = qfxt->get_digits_type()->as<QuantIntType>();
   auto val_store = to_quant_fixed(value, qfxt);
   val_store = builder->CreateSExt(val_store, physical_type);
-  return create_call(fmt::format("atomic_add_partial_bits_b{}",
+  return call(fmt::format("atomic_add_partial_bits_b{}",
                                  physical_type->getIntegerBitWidth()),
-                     {byte_ptr, bit_offset,
-                      tlctx->get_constant(qit->get_num_bits()), val_store});
+                     byte_ptr, bit_offset,
+                      tlctx->get_constant(qit->get_num_bits()), val_store);
 }
 
 llvm::Value *TaskCodeGenLLVM::to_quant_fixed(llvm::Value *real,
@@ -53,9 +53,9 @@ llvm::Value *TaskCodeGenLLVM::to_quant_fixed(llvm::Value *real,
   auto scaled = builder->CreateFMul(input_real, s);
 
   // Add/minus the 0.5 offset for rounding
-  scaled = create_call(
+  scaled = call(
       fmt::format("rounding_prepare_f{}", data_type_bits(compute_type)),
-      {scaled});
+      scaled);
 
   auto qit = qfxt->get_digits_type()->as<QuantIntType>();
   if (qit->get_is_signed()) {
@@ -75,10 +75,10 @@ void TaskCodeGenLLVM::store_quant_int(llvm::Value *ptr,
   auto [byte_ptr, bit_offset] = load_bit_ptr(ptr);
   // TODO(type): CUDA only supports atomicCAS on 32- and 64-bit integers.
   // Try to support 8/16-bit physical types.
-  create_call(fmt::format("{}set_partial_bits_b{}", atomic ? "atomic_" : "",
+  call(fmt::format("{}set_partial_bits_b{}", atomic ? "atomic_" : "",
                           physical_type->getIntegerBitWidth()),
-              {byte_ptr, bit_offset, tlctx->get_constant(qit->get_num_bits()),
-               builder->CreateIntCast(value, physical_type, false)});
+              byte_ptr, bit_offset, tlctx->get_constant(qit->get_num_bits()),
+               builder->CreateIntCast(value, physical_type, false));
 }
 
 void TaskCodeGenLLVM::store_quant_fixed(llvm::Value *ptr,
@@ -106,10 +106,10 @@ void TaskCodeGenLLVM::store_masked(llvm::Value *ptr,
     builder->CreateStore(value, ptr);
     return;
   }
-  create_call(fmt::format("{}set_mask_b{}", atomic ? "atomic_" : "",
+  call(fmt::format("{}set_mask_b{}", atomic ? "atomic_" : "",
                           ty->getIntegerBitWidth()),
-              {ptr, tlctx->get_constant(mask),
-               builder->CreateIntCast(value, ty, false)});
+              ptr, tlctx->get_constant(mask),
+               builder->CreateIntCast(value, ty, false));
 }
 
 llvm::Value *TaskCodeGenLLVM::get_exponent_offset(llvm::Value *exponent,
@@ -221,7 +221,7 @@ void TaskCodeGenLLVM::visit(BitStructStoreStmt *stmt) {
       auto exponent_offset = get_exponent_offset(exponent_bits, qflt);
       exponent_bits = builder->CreateSub(exponent_bits, exponent_offset);
       exponent_bits =
-          create_call("max_i32", {exponent_bits, tlctx->get_constant(0)});
+          call("max_i32", exponent_bits, tlctx->get_constant(0));
 
       // Compute the bit pointer of the exponent bits.
       val = builder->CreateIntCast(exponent_bits, physical_type, false);
@@ -318,7 +318,7 @@ void TaskCodeGenLLVM::store_quant_floats_with_shared_exponents(
       // TODO: we only support f32 here.
       auto exp_bits = extract_exponent_from_f32(f);
       if (max_exp_bits) {
-        max_exp_bits = create_call("max_u32", {max_exp_bits, exp_bits});
+        max_exp_bits = call("max_u32", max_exp_bits, exp_bits);
       } else {
         max_exp_bits = exp_bits;
       }
@@ -332,7 +332,7 @@ void TaskCodeGenLLVM::store_quant_floats_with_shared_exponents(
         builder->CreateSub(max_exp_bits, exponent_offset);
 
     max_exp_bits_to_store =
-        create_call("max_i32", {max_exp_bits_to_store, tlctx->get_constant(0)});
+        call("max_i32", max_exp_bits_to_store, tlctx->get_constant(0));
 
     // store the exponent
     auto bit_offset = bit_struct->get_member_bit_offset(i);
@@ -361,7 +361,7 @@ void TaskCodeGenLLVM::store_quant_floats_with_shared_exponents(
           digits, tlctx->get_constant(1 << (right_shift_bits - 1)));
       // do not allow overflowing
       digits =
-          create_call("min_u32", {digits, tlctx->get_constant((1u << 24) - 1)});
+          call("min_u32", digits, tlctx->get_constant((1u << 24) - 1));
 
       // Compress f32 digits to qflt digits.
       // Note that we need to keep the leading 1 bit so 24 instead of 23 in the
@@ -427,7 +427,7 @@ llvm::Value *TaskCodeGenLLVM::extract_digits_from_f32_with_shared_exponent(
 
   auto digits = extract_digits_from_f32(f, true);
   digits = builder->CreateOr(digits, implicit_bit);
-  exp_offset = create_call("min_u32", {exp_offset, tlctx->get_constant(31)});
+  exp_offset = call("min_u32", exp_offset, tlctx->get_constant(31));
   return builder->CreateLShr(digits, exp_offset);
 }
 

--- a/taichi/codegen/llvm/llvm_codegen_utils.h
+++ b/taichi/codegen/llvm/llvm_codegen_utils.h
@@ -112,22 +112,19 @@ class LLVMModuleBuilder {
     return builder->CreateCall(func_ty, func, std::move(args));
   }
 
-  llvm::Value *call(
-      llvm::Value *func,
-      llvm::FunctionType *func_ty,
-      std::vector<llvm::Value *> args) {
+  llvm::Value *call(llvm::Value *func,
+                    llvm::FunctionType *func_ty,
+                    std::vector<llvm::Value *> args) {
     return call(builder.get(), func, func_ty, std::move(args));
   }
 
   llvm::Value *call(llvm::IRBuilder<> *builder,
-      llvm::Function *func,
-      std::vector<llvm::Value *> args) {
+                    llvm::Function *func,
+                    std::vector<llvm::Value *> args) {
     return call(builder, func, func->getFunctionType(), std::move(args));
   }
 
-  llvm::Value *call(
-      llvm::Function *func,
-      std::vector<llvm::Value *> args) {
+  llvm::Value *call(llvm::Function *func, std::vector<llvm::Value *> args) {
     return call(builder.get(), func, std::move(args));
   }
 
@@ -143,16 +140,15 @@ class LLVMModuleBuilder {
     return call(builder.get(), func_name, std::move(args));
   }
 
-  template<typename... Args>
+  template <typename... Args>
   llvm::Value *call(llvm::IRBuilder<> *builder,
                     llvm::Function *func,
                     Args *...args) {
     return call(builder, func, {args...});
   }
 
-  template<typename... Args>
-  llvm::Value *call(llvm::Function *func,
-                    Args &&...args) {
+  template <typename... Args>
+  llvm::Value *call(llvm::Function *func, Args &&...args) {
     return call(builder.get(), func, std::forward<Args>(args)...);
   }
 

--- a/taichi/codegen/llvm/llvm_codegen_utils.h
+++ b/taichi/codegen/llvm/llvm_codegen_utils.h
@@ -109,7 +109,7 @@ class LLVMModuleBuilder {
                     llvm::FunctionType *func_ty,
                     std::vector<llvm::Value *> args) {
     check_func_call_signature(func_ty, func->getName(), args, builder);
-    return builder->CreateCall(func_ty, func, args);
+    return builder->CreateCall(func_ty, func, std::move(args));
   }
 
   llvm::Value *call(


### PR DESCRIPTION
Issue: #3382
Currently `create_call` in `TaskCodeGenLLVM` and `call` in `LLVMModuleBuilder` do the same thing so they should be merged.
### Brief Summary
