### PR TITLE
[autodiff] Add grad check feature and related test

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -91,11 +91,13 @@ class GradChecker:
             self.result[i] = check_pass
 
             if not check_pass:
-                print("variable", i, "has relative error", re_range)
+                print("variable", i, "has relative error", min(re_range),
+                      ", expected relative error 0.01")
             else:
                 print("variable", i, "passes grad check")
 
-        assert all(self.result), "Not all variables pass grad check"
+        assert all(self.result
+                   ), "Grad check failed: Not all variables pass grad check"
 
         restore_all_fields(self.all_fields, self.backups)
         for func, args in self.calls:

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -25,9 +25,7 @@ class Tape:
                  loss=None,
                  clear_gradients=True,
                  validation=False,
-                 grad_check=None,
-                 watch=None,
-                 eps_range=2.**np.arange(-3, -30, -1).astype(np.float64)):
+                 grad_check=None):
         """A context manager for reverse mode autodiff :class:`~taichi.ad.Tape`. The
         context manager would catching all of the callings of functions that
         decorated by :func:`~taichi.lang.kernel_impl.kernel` or
@@ -68,8 +66,7 @@ class Tape:
         self.loss = loss
         self.grad_check = grad_check
         if self.grad_check:
-            self.watch = watch
-            self.eps_range = eps_range
+            self.eps_range = 2.**np.arange(-3, -30, -1).astype(np.float64)
             self.result = [None] * len(self.grad_check)
             self.reset(mode="save")
 
@@ -102,7 +99,6 @@ class Tape:
             self.grad()
 
     def insert(self, func, args):
-        # print("insert!")
         self.calls.append((func, args))
 
     def grad(self):
@@ -162,8 +158,6 @@ class Tape:
 
                 ip_autodiff = np.sum(x_grad_np * tangent_np)
                 err = abs(ip_autodiff - ip_numerical)
-                # print("autodiff:", ip_autodiff)
-                # print("numerical:", ip_numerical)
                 if ip_numerical != 0:
                     re = err / abs(ip_autodiff)
                 else:
@@ -177,7 +171,7 @@ class Tape:
             self.result[i] = check_pass
 
             if not check_pass:
-                print(i, "relative error:", min(re_range))
+                print(i, "relative error:", re_range)
             else:
                 print(i, "grad check pass")
 

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -7,14 +7,11 @@ import warnings
 from copy import deepcopy
 from functools import reduce
 
-import matplotlib.pyplot as plt
 import numpy as np
 import taichi.types.primitive_types as types
 from taichi.lang import impl
-
 from taichi.lang.enums import SNodeGradType
 from taichi.lang.expr import Expr
-
 from taichi.lang.field import ScalarField
 from taichi.lang.kernel_impl import kernel
 from taichi.lang.snode import SNode
@@ -131,8 +128,6 @@ class Tape:
             for I in impl.grouped(x):
                 x[I] -= eps * tangent_np[I]
 
-        plt.figure()
-
         for i, x in enumerate(self.grad_check):
             if x is self.loss:
                 self.result[i] = True
@@ -180,10 +175,6 @@ class Tape:
                     break
 
             self.result[i] = check_pass
-            plt.loglog(np.array(self.eps_range[:len(re_range)]),
-                       np.array(re_range),
-                       "-*",
-                       label="variable " + str(i))
 
             if not check_pass:
                 print(i, "relative error:", min(re_range))
@@ -192,12 +183,6 @@ class Tape:
 
         if all(self.result):
             print("all grad check pass")
-        else:
-            plt.xlabel("finite difference step size")
-            plt.ylabel("relative error")
-            plt.title("Grad check Error Convergence")
-            plt.legend()
-            plt.show()
 
         self.reset(mode="restore")
         for func, args in self.calls:

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -31,7 +31,7 @@ class Tape:
                  grad_check=None,
                  watch=None,
                  eps_range=2.**np.arange(-3, -30, -1).astype(np.float64),
-                 show_gui=False):
+                 test_mode=False):
         """A context manager for reverse mode autodiff :class:`~taichi.ad.Tape`. The
         context manager would catching all of the callings of functions that
         decorated by :func:`~taichi.lang.kernel_impl.kernel` or
@@ -75,6 +75,7 @@ class Tape:
             self.watch = watch
             self.eps_range = eps_range
             self.reset(mode="save")
+            self.test_mode = test_mode
 
     def __enter__(self):
         assert not self.entered, "Tape can be entered only once."
@@ -186,6 +187,9 @@ class Tape:
                        np.array(re_range),
                        "-*",
                        label="variable " + str(i))
+
+            if self.test_mode:
+                assert check_pass is True
 
             if not check_pass:
                 print(i, "relative error:", min(re_range))

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -84,7 +84,7 @@ class GradChecker:
                     re = err / (abs(ip_autodiff) + 1e-20)
                 re_range.append(re)
 
-                if err * 100 < abs(ip_autodiff):
+                if err * 100 <= abs(ip_autodiff):
                     check_pass = True
                     break
 

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -379,9 +379,10 @@ class SNodeHostAccessor:
                 assert len(key) == _ti_core.get_max_num_indices()
                 snode.write_float(key, value)
                 if impl.get_runtime().target_tape and impl.get_runtime(
-                ).target_tape.grad_check and not impl.get_runtime(
+                ).target_tape.grad_checker and not impl.get_runtime(
                 ).grad_replaced:
-                    for x in impl.get_runtime().target_tape.grad_check:
+                    for x in impl.get_runtime(
+                    ).target_tape.grad_checker.to_check:
                         assert snode != x.snode.ptr, "Overwritten is prohibitive when doing grad check."
                     impl.get_runtime().target_tape.insert(
                         snode.write_float, (key, value))
@@ -401,9 +402,10 @@ class SNodeHostAccessor:
                 assert len(key) == _ti_core.get_max_num_indices()
                 snode.write_int(key, value)
                 if impl.get_runtime().target_tape and impl.get_runtime(
-                ).target_tape.grad_check and not impl.get_runtime(
+                ).target_tape.grad_checker and not impl.get_runtime(
                 ).grad_replaced:
-                    for x in impl.get_runtime().target_tape.grad_check:
+                    for x in impl.get_runtime(
+                    ).target_tape.grad_checker.to_check:
                         assert snode != x.snode.ptr, "Overwritten is prohibitive when doing grad check."
                     impl.get_runtime().target_tape.insert(
                         snode.write_int, (key, value))

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -382,7 +382,7 @@ class SNodeHostAccessor:
                 ).target_tape.grad_check and not impl.get_runtime(
                 ).grad_replaced:
                     for x in impl.get_runtime().target_tape.grad_check:
-                        assert snode != x.snode.ptr, "You can not write to input field."
+                        assert snode != x.snode.ptr, "Overwritten is prohibitive when doing grad check."
                     impl.get_runtime().target_tape.insert(
                         snode.write_float, (key, value))
         else:
@@ -404,7 +404,7 @@ class SNodeHostAccessor:
                 ).target_tape.grad_check and not impl.get_runtime(
                 ).grad_replaced:
                     for x in impl.get_runtime().target_tape.grad_check:
-                        assert snode != x.snode.ptr, "You can not write to input field."
+                        assert snode != x.snode.ptr, "Overwritten is prohibitive when doing grad check."
                     impl.get_runtime().target_tape.insert(
                         snode.write_int, (key, value))
 

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -378,6 +378,7 @@ class SNodeHostAccessor:
             def setter(value, *key):
                 assert len(key) == _ti_core.get_max_num_indices()
                 snode.write_float(key, value)
+                # we only capture write kernels in tape scope with no grad_repaced
                 if impl.get_runtime().target_tape and impl.get_runtime(
                 ).target_tape.grad_checker and not impl.get_runtime(
                 ).grad_replaced:
@@ -401,6 +402,7 @@ class SNodeHostAccessor:
             def setter(value, *key):
                 assert len(key) == _ti_core.get_max_num_indices()
                 snode.write_int(key, value)
+                # same as above
                 if impl.get_runtime().target_tape and impl.get_runtime(
                 ).target_tape.grad_checker and not impl.get_runtime(
                 ).grad_replaced:

--- a/tests/python/test_ad_grad_check.py
+++ b/tests/python/test_ad_grad_check.py
@@ -5,7 +5,8 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(default_fp=ti.f64, exclude=[ti.cc, ti.vulkan, ti.opengl])
+@test_utils.test(default_fp=ti.f64,
+                 exclude=[ti.cc, ti.vulkan, ti.opengl, ti.metal])
 def test_general():
     x1 = ti.field(dtype=float, shape=(2, 2), needs_grad=True)
     y1 = ti.field(dtype=float, shape=(), needs_grad=True)
@@ -69,6 +70,7 @@ def grad_test(tifunc):
     lambda x: ti.max(0, x), lambda x: ti.max(1, x), lambda x: ti.atan2(0.4, x),
     lambda x: ti.atan2(x, 0.4), lambda x: 0.4**x, lambda x: x**0.4
 ])
-@test_utils.test(default_fp=ti.f64, exclude=[ti.cc, ti.vulkan, ti.opengl])
+@test_utils.test(default_fp=ti.f64,
+                 exclude=[ti.cc, ti.vulkan, ti.opengl, ti.metal])
 def test_basics(tifunc):
     grad_test(tifunc)

--- a/tests/python/test_ad_grad_check.py
+++ b/tests/python/test_ad_grad_check.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+import taichi as ti
+from tests import test_utils
+
+
+@test_utils.test()
+def test_grad_check():
+    ti.init(default_fp=ti.f64)
+
+    x1 = ti.field(dtype=float, shape=(2, 2), needs_grad=True)
+    y1 = ti.field(dtype=float, shape=(), needs_grad=True)
+
+    x1.from_numpy(np.array([[1, 2], [3, 4]]))
+
+    @ti.kernel
+    def compute_y1():
+        ti.loop_config(serialize=True)
+        for i, j in ti.ndrange(2, 2):
+            y1[None] += ti.cos(x1[i, j])
+
+    x2 = ti.Vector.field(n=3, dtype=float, shape=(2, 2), needs_grad=True)
+    y2 = ti.field(dtype=float, shape=(), needs_grad=True)
+    x2[0, 0] = ti.Vector([1, 2, 3])
+    x2[0, 1] = ti.Vector([4, 5, 6])
+    x2[1, 0] = ti.Vector([7, 8, 9])
+    x2[1, 1] = ti.Vector([10, 11, 12])
+
+    @ti.kernel
+    def compute_y2():
+        y2[None] += x2[0, 0][0] + x2[1, 0][1] + x2[1, 1][2]
+
+    with ti.ad.Tape(y1, grad_check=[x1], test_mode=True):
+        compute_y1()
+
+    with ti.ad.Tape(y2, grad_check=[x2], test_mode=True):
+        compute_y2()

--- a/tests/python/test_ad_grad_check.py
+++ b/tests/python/test_ad_grad_check.py
@@ -5,10 +5,8 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test()
+@test_utils.test(default_fp=ti.f64, exclude=[ti.cc, ti.vulkan])
 def test_grad_check():
-    ti.init(default_fp=ti.f64)
-
     x1 = ti.field(dtype=float, shape=(2, 2), needs_grad=True)
     y1 = ti.field(dtype=float, shape=(), needs_grad=True)
 
@@ -31,14 +29,20 @@ def test_grad_check():
     def compute_y2():
         y2[None] += x2[0, 0][0] + x2[1, 0][1] + x2[1, 1][2]
 
-    t1 = ti.ad.Tape(y1, grad_check=[x1])
-    t1.__enter__()
-    compute_y1()
-    t1.__exit__(None, None, None)
-    assert all(t1.result) is True
+    # t1 = ti.ad.Tape(y1, grad_check=[x1])
+    # t1.__enter__()
+    # compute_y1()
+    # t1.__exit__(None, None, None)
+    # assert all(t1.result) is True
 
-    t2 = ti.ad.Tape(y2, grad_check=[x2])
-    t2.__enter__()
-    compute_y2()
-    t2.__exit__(None, None, None)
-    assert all(t2.result) is True
+    # t2 = ti.ad.Tape(y2, grad_check=[x2])
+    # t2.__enter__()
+    # compute_y2()
+    # t2.__exit__(None, None, None)
+    # assert all(t2.result) is True
+
+    with ti.ad.Tape(y1, grad_check=[x1]):
+        compute_y1()
+
+    with ti.ad.Tape(y2, grad_check=[x2]):
+        compute_y2()

--- a/tests/python/test_ad_grad_check.py
+++ b/tests/python/test_ad_grad_check.py
@@ -14,7 +14,6 @@ def test_grad_check():
 
     @ti.kernel
     def compute_y1():
-        ti.loop_config(serialize=True)
         for i, j in ti.ndrange(2, 2):
             y1[None] += ti.cos(x1[i, j])
 
@@ -28,18 +27,6 @@ def test_grad_check():
     @ti.kernel
     def compute_y2():
         y2[None] += x2[0, 0][0] + x2[1, 0][1] + x2[1, 1][2]
-
-    # t1 = ti.ad.Tape(y1, grad_check=[x1])
-    # t1.__enter__()
-    # compute_y1()
-    # t1.__exit__(None, None, None)
-    # assert all(t1.result) is True
-
-    # t2 = ti.ad.Tape(y2, grad_check=[x2])
-    # t2.__enter__()
-    # compute_y2()
-    # t2.__exit__(None, None, None)
-    # assert all(t2.result) is True
 
     with ti.ad.Tape(y1, grad_check=[x1]):
         compute_y1()

--- a/tests/python/test_ad_grad_check.py
+++ b/tests/python/test_ad_grad_check.py
@@ -5,7 +5,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(default_fp=ti.f64, exclude=[ti.cc, ti.vulkan])
+@test_utils.test(default_fp=ti.f64, exclude=[ti.cc, ti.vulkan, ti.opengl])
 def test_grad_check():
     x1 = ti.field(dtype=float, shape=(2, 2), needs_grad=True)
     y1 = ti.field(dtype=float, shape=(), needs_grad=True)

--- a/tests/python/test_ad_grad_check.py
+++ b/tests/python/test_ad_grad_check.py
@@ -6,7 +6,7 @@ from tests import test_utils
 
 
 @test_utils.test(default_fp=ti.f64, exclude=[ti.cc, ti.vulkan, ti.opengl])
-def test_grad_check():
+def test_general():
     x1 = ti.field(dtype=float, shape=(2, 2), needs_grad=True)
     y1 = ti.field(dtype=float, shape=(), needs_grad=True)
 
@@ -33,3 +33,42 @@ def test_grad_check():
 
     with ti.ad.Tape(y2, grad_check=[x2]):
         compute_y2()
+
+
+def grad_test(tifunc):
+    print(
+        f'arch={ti.lang.impl.current_cfg().arch} default_fp={ti.lang.impl.current_cfg().default_fp}'
+    )
+    x = ti.field(ti.lang.impl.current_cfg().default_fp)
+    y = ti.field(ti.lang.impl.current_cfg().default_fp)
+
+    ti.root.place(x, x.grad, y, y.grad)
+
+    @ti.kernel
+    def func():
+        for i in ti.grouped(x):
+            y[i] = tifunc(x[i])
+
+    x[None] = 0.234
+
+    with ti.ad.Tape(loss=y, grad_check=[x]):
+        func()
+
+
+@pytest.mark.parametrize('tifunc', [
+    lambda x: x, lambda x: ti.abs(-x), lambda x: -x, lambda x: x * x,
+    lambda x: x**2, lambda x: x * x * x, lambda x: x * x * x * x,
+    lambda x: 0.4 * x * x - 3, lambda x: (x - 3) * (x - 1), lambda x: (x - 3) *
+    (x - 1) + x * x, lambda x: ti.tanh(x), lambda x: ti.sin(x),
+    lambda x: ti.cos(x), lambda x: ti.acos(x), lambda x: ti.asin(x),
+    lambda x: 1 / x, lambda x: (x + 1) / (x - 1), lambda x: (x + 1) * (x + 2) /
+    ((x - 1) *
+     (x + 3)), lambda x: ti.sqrt(x), lambda x: ti.exp(x), lambda x: ti.log(x),
+    lambda x: ti.min(x, 0), lambda x: ti.min(x, 1), lambda x: ti.min(0, x),
+    lambda x: ti.min(1, x), lambda x: ti.max(x, 0), lambda x: ti.max(x, 1),
+    lambda x: ti.max(0, x), lambda x: ti.max(1, x), lambda x: ti.atan2(0.4, x),
+    lambda x: ti.atan2(x, 0.4), lambda x: 0.4**x, lambda x: x**0.4
+])
+@test_utils.test(default_fp=ti.f64, exclude=[ti.cc, ti.vulkan, ti.opengl])
+def test_basics(tifunc):
+    grad_test(tifunc)

--- a/tests/python/test_ad_grad_check.py
+++ b/tests/python/test_ad_grad_check.py
@@ -31,8 +31,14 @@ def test_grad_check():
     def compute_y2():
         y2[None] += x2[0, 0][0] + x2[1, 0][1] + x2[1, 1][2]
 
-    with ti.ad.Tape(y1, grad_check=[x1], test_mode=True):
-        compute_y1()
+    t1 = ti.ad.Tape(y1, grad_check=[x1])
+    t1.__enter__()
+    compute_y1()
+    t1.__exit__(None, None, None)
+    assert all(t1.result) is True
 
-    with ti.ad.Tape(y2, grad_check=[x2], test_mode=True):
-        compute_y2()
+    t2 = ti.ad.Tape(y2, grad_check=[x2])
+    t2.__enter__()
+    compute_y2()
+    t2.__exit__(None, None, None)
+    assert all(t2.result) is True


### PR DESCRIPTION
## Motivation 
Currently Taichi uses autodiff as its differentiation system. We compute gradients of variables in a computation procedure through source code transformation, which is to add additional instructions to the IR layer. However, it's hard for users to check whether the autodiff system computes correct results. Thus, we need a grad check system to verify results given by autodiff.
## Proof of concept
We implement grad check in the python frontend, using finite difference method. Users only need to pass variables they want to check to the autodiff tape scope, and then our grad check system will automatically check whether autodiff gives the correct answer, prompting error messages if not. The API can be used in the following way.
```python
import taichi as ti
import numpy as np

ti.init(ti.gpu, default_fp=ti.f64)

# field with shape
x = ti.field(dtype=float, shape=(2, 2), needs_grad=True)
y = ti.field(dtype=float, shape=(), needs_grad=True)

x.from_numpy(np.array([[1, 2], [3, 4]]))

@ti.kernel
def compute_y():
    for i, j in ti.ndrange(2, 2):
        y[None] += ti.cos(x[i, j])

with ti.ad.Tape(y, grad_check=[x]):
    compute_y()
```
## Implementation
Here I list several key points for the implementation.
### Finite difference method
We imitate what JAX does in their grad check system.
Suppose we have a function $f$ ,  $y = f(\vec{x})$ . By math we know the following equation holds,
$$\frac{f(\vec{x}+\epsilon\vec{\delta})-f(\vec{x}-\epsilon\vec{\delta})}{2\epsilon} \approx \frac{\partial f}{\partial \vec{x}} \cdot \vec{\delta}$$
where $\epsilon$ is a small scalar, $\vec{\delta}$ is a small random vector with the same dimension as $\vec{x}$ .
We compute the left hand side by finite difference method and the right hand side by autodiff.
### Backup all variables
Unlike JAX, we often use Taichi's autodiff system by passing in some global field variables and doing in-place modifications to these variables, which means we cannot extract a pure function $f$ .
However, we need to perturb these input variables and use $f$ to get new output value in order to compute finite differences.
Therefore, we can consider the computing block inside autodiff's tape scope as a black box where input values may be modified each time we run it. The key point is that we need to backup all global field variables before we enter the tape scope. Each time we run the tape scope, we have to restore all variables to their original states. 
