### PR TITLE
[bug] Prevent ti.kernel from directly caching the passed-in arguments to avoid memory leak

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -353,6 +353,11 @@ class TaichiCallableTemplateMapper:
                 # [Composite arguments] Return weak reference to the object
                 # Taichi kernel will cache the extracted arguments, thus we can't simply return the original argument.
                 # Instead, a weak reference to the original value is returned to avoid memory leak.
+
+                # TODO(zhanlue): replacing "tuple(args)" with "hash of argument values"
+                # This can resolve the following issues:
+                # 1. Invalid weak-ref will leave a dead(dangling) entry in both caches: "self.mapping" and "self.compiled_functions"
+                # 2. Different argument instances with same type and same value, will get templatized into seperate kernels.
                 return weakref.ref(arg)
 
             # [Primitive arguments] Return the value

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -351,8 +351,8 @@ class TaichiCallableTemplateMapper:
             if isinstance(arg, (list, tuple, dict, set)) or hasattr(
                     arg, '__class__'):
                 # [Composite arguments] Return weak reference to the object
-                # Taichi kernel will cache extracted arguments, therefore we can't return the original argument.
-                # Instead, we return a weak reference to the original value to avoid memory leak.
+                # Taichi kernel will cache the extracted arguments, thus we can't simply return the original argument.
+                # Instead, a weak reference to the original value is returned to avoid memory leak.
                 return weakref.ref(arg)
 
             # [Primitive arguments] Return the value

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -349,7 +349,7 @@ class TaichiCallableTemplateMapper:
                 )
 
             if isinstance(arg, (list, tuple, dict, set)) or hasattr(
-                    arg, '__class__'):
+                    arg, '_data_oriented'):
                 # [Composite arguments] Return weak reference to the object
                 # Taichi kernel will cache the extracted arguments, thus we can't simply return the original argument.
                 # Instead, a weak reference to the original value is returned to avoid memory leak.

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -347,9 +347,16 @@ class TaichiCallableTemplateMapper:
                 raise TaichiRuntimeTypeError(
                     'Ndarray shouldn\'t be passed in via `ti.template()`, please annotate your kernel using `ti.types.ndarray(...)` instead'
                 )
-            # Taichi kernel will cache extracted arguments, therefore we can't return the original argument.
-            # Instead, we return a weak reference to the original value to avoid memory leak.
-            return weakref.ref(arg)
+
+            if isinstance(arg, (list, tuple, dict, set)) or hasattr(
+                    arg, '__class__'):
+                # [Composite arguments] Return weak reference to the object
+                # Taichi kernel will cache extracted arguments, therefore we can't return the original argument.
+                # Instead, we return a weak reference to the original value to avoid memory leak.
+                return weakref.ref(arg)
+
+            # [Primitive arguments] Return the value
+            return arg
         if isinstance(anno, texture_type.TextureType):
             return '#'
         if isinstance(anno, ndarray_type.NdarrayType):


### PR DESCRIPTION
Issue: #6133