### PR TITLE
[bug] Serialize missing fields of metal::TaichiKernelAttributes and metal::KernelAttributes

### DIFF
--- a/taichi/codegen/metal/codegen_metal.cpp
+++ b/taichi/codegen/metal/codegen_metal.cpp
@@ -1409,7 +1409,8 @@ class KernelCodegenImpl : public IRVisitor {
                   BufferDescriptor::context()};
 
     ka.runtime_list_op_attribs = KernelAttributes::RuntimeListOpAttributes();
-    ka.runtime_list_op_attribs->snode = sn;
+    ka.runtime_list_op_attribs->parent_snode_id = sn->parent->id;
+    ka.runtime_list_op_attribs->snode_id = sn->id;
     current_kernel_attribs_ = nullptr;
 
     mtl_kernels_attribs()->push_back(ka);
@@ -1425,7 +1426,7 @@ class KernelCodegenImpl : public IRVisitor {
     KernelAttributes ka;
     ka.task_type = OffloadedTaskType::gc;
     ka.gc_op_attribs = KernelAttributes::GcOpAttributes();
-    ka.gc_op_attribs->snode = sn;
+    ka.gc_op_attribs->snode_id = sn->id;
     ka.buffers = {BufferDescriptor::runtime(), BufferDescriptor::context()};
     current_kernel_attribs_ = nullptr;
     // stage 1 specific

--- a/taichi/runtime/metal/kernel_manager.cpp
+++ b/taichi/runtime/metal/kernel_manager.cpp
@@ -233,9 +233,6 @@ class SparseRuntimeMtlKernelBase : public CompiledMtlKernelBase {
 class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
  public:
   struct Params : public SparseRuntimeMtlKernelBase::Params {
-    const SNode *snode() const {
-      return kernel_attribs->runtime_list_op_attribs->snode;
-    }
   };
 
   explicit ListgenOpMtlKernel(Params &params)
@@ -245,8 +242,8 @@ class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
     // args[1] = child_snode_id
     // Note that this args buffer has nothing to do with the one passed to
     // Taichi kernel. See taichi/rhi/metal/shaders/runtime_kernels.metal.h
-    const int parent_snode_id = params.snode()->parent->id;
-    const int child_snode_id = params.snode()->id;
+    const int parent_snode_id = params.kernel_attribs->runtime_list_op_attribs->parent_snode_id;
+    const int child_snode_id = params.kernel_attribs->runtime_list_op_attribs->snode_id;
     auto *mem = reinterpret_cast<int32_t *>(args_mem_->ptr());
     mem[0] = parent_snode_id;
     mem[1] = child_snode_id;
@@ -263,14 +260,11 @@ class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
 class GcOpMtlKernel : public SparseRuntimeMtlKernelBase {
  public:
   struct Params : public SparseRuntimeMtlKernelBase::Params {
-    const SNode *snode() const {
-      return kernel_attribs->gc_op_attribs->snode;
-    }
   };
 
   explicit GcOpMtlKernel(Params &params)
       : SparseRuntimeMtlKernelBase(params, /*args_size=*/sizeof(int32_t)) {
-    const int snode_id = params.snode()->id;
+    const int snode_id = params.kernel_attribs->gc_op_attribs->snode_id;
     auto *mem = reinterpret_cast<int32_t *>(args_mem_->ptr());
     mem[0] = snode_id;
     TI_DEBUG("Registered GcOpMtlKernel: name={} num_threads={} snode_id={}",

--- a/taichi/runtime/metal/kernel_manager.cpp
+++ b/taichi/runtime/metal/kernel_manager.cpp
@@ -232,8 +232,7 @@ class SparseRuntimeMtlKernelBase : public CompiledMtlKernelBase {
 
 class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
  public:
-  struct Params : public SparseRuntimeMtlKernelBase::Params {
-  };
+  struct Params : public SparseRuntimeMtlKernelBase::Params {};
 
   explicit ListgenOpMtlKernel(Params &params)
       : SparseRuntimeMtlKernelBase(params, /*args_size=*/sizeof(int32_t) * 2) {
@@ -242,8 +241,10 @@ class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
     // args[1] = child_snode_id
     // Note that this args buffer has nothing to do with the one passed to
     // Taichi kernel. See taichi/rhi/metal/shaders/runtime_kernels.metal.h
-    const int parent_snode_id = params.kernel_attribs->runtime_list_op_attribs->parent_snode_id;
-    const int child_snode_id = params.kernel_attribs->runtime_list_op_attribs->snode_id;
+    const int parent_snode_id =
+        params.kernel_attribs->runtime_list_op_attribs->parent_snode_id;
+    const int child_snode_id =
+        params.kernel_attribs->runtime_list_op_attribs->snode_id;
     auto *mem = reinterpret_cast<int32_t *>(args_mem_->ptr());
     mem[0] = parent_snode_id;
     mem[1] = child_snode_id;
@@ -259,8 +260,7 @@ class ListgenOpMtlKernel : public SparseRuntimeMtlKernelBase {
 
 class GcOpMtlKernel : public SparseRuntimeMtlKernelBase {
  public:
-  struct Params : public SparseRuntimeMtlKernelBase::Params {
-  };
+  struct Params : public SparseRuntimeMtlKernelBase::Params {};
 
   explicit GcOpMtlKernel(Params &params)
       : SparseRuntimeMtlKernelBase(params, /*args_size=*/sizeof(int32_t)) {

--- a/taichi/runtime/metal/kernel_utils.cpp
+++ b/taichi/runtime/metal/kernel_utils.cpp
@@ -66,9 +66,9 @@ std::string KernelAttributes::debug_string() const {
   result += "]";  // closes |buffers|
   // TODO(k-ye): show range_for
   if (task_type == OffloadedTaskType::listgen) {
-    result += fmt::format(" snode={}", runtime_list_op_attribs->snode->id);
+    result += fmt::format(" snode={}", runtime_list_op_attribs->snode_id);
   } else if (task_type == OffloadedTaskType::gc) {
-    result += fmt::format(" snode={}", gc_op_attribs->snode->id);
+    result += fmt::format(" snode={}", gc_op_attribs->snode_id);
   }
   result += ">";
   return result;

--- a/taichi/runtime/metal/kernel_utils.h
+++ b/taichi/runtime/metal/kernel_utils.h
@@ -143,10 +143,15 @@ struct KernelAttributes {
   };
 
   struct RuntimeListOpAttributes {
-    const SNode *snode = nullptr;
+    int parent_snode_id{-1};
+    int snode_id{-1};
+
+    TI_IO_DEF(parent_snode_id, snode_id);
   };
   struct GcOpAttributes {
-    const SNode *snode = nullptr;
+    int snode_id{-1};
+
+    TI_IO_DEF(snode_id);
   };
   std::vector<BufferDescriptor> buffers;
   std::unordered_map<int, int> arr_args_to_binding_indices;
@@ -161,9 +166,12 @@ struct KernelAttributes {
 
   TI_IO_DEF(name,
             advisory_total_num_threads,
+            advisory_num_threads_per_group,
             task_type,
             buffers,
-            range_for_attribs);
+            range_for_attribs,
+            runtime_list_op_attribs,
+            gc_op_attribs);
 };
 
 // Groups all the Metal kernels generated from a single ti.kernel

--- a/taichi/runtime/metal/kernel_utils.h
+++ b/taichi/runtime/metal/kernel_utils.h
@@ -178,6 +178,8 @@ struct TaichiKernelAttributes {
     // Whether [[thread_index_in_simdgroup]] is used. This is only supported
     // since MSL 2.1
     bool simdgroup = false;
+
+    TI_IO_DEF(print, assertion, sparse, simdgroup);
   };
   std::string name;
   // Is this kernel for evaluating the constant fold result?
@@ -186,7 +188,7 @@ struct TaichiKernelAttributes {
   std::vector<KernelAttributes> mtl_kernels_attribs;
   UsedFeatures used_features;
 
-  TI_IO_DEF(name, mtl_kernels_attribs);
+  TI_IO_DEF(name, is_jit_evaluator, mtl_kernels_attribs, used_features);
 };
 
 // This class contains the attributes descriptors for both the input args and


### PR DESCRIPTION
Issue: #6263 
Fix bug reported by `TI_WIP_OFFLINE_CACHE=1 python3 run_tests.py -a metal -vr2 --with-offline-cache --rerun-with-offline-cache 1 debug  ast_refactor assert sparse_deactivate sparse_parallel`