### PR TITLE
[bug] Fix asserting failed when registering kernels with same name on Metal

### DIFF
--- a/taichi/runtime/metal/kernel_manager.cpp
+++ b/taichi/runtime/metal/kernel_manager.cpp
@@ -727,8 +727,10 @@ class KernelManager::Impl {
   }
 
   void register_taichi_kernel(const CompiledKernelData &compiled_kernel) {
-    TI_ASSERT(compiled_taichi_kernels_.find(compiled_kernel.kernel_name) ==
-              compiled_taichi_kernels_.end());
+    if (compiled_taichi_kernels_.find(compiled_kernel.kernel_name) !=
+              compiled_taichi_kernels_.end()) {
+      return;
+    }
 
     if (config_->print_kernel_llvm_ir) {
       // If users have enabled |print_kernel_llvm_ir|, it probably means that

--- a/taichi/runtime/metal/kernel_manager.cpp
+++ b/taichi/runtime/metal/kernel_manager.cpp
@@ -728,7 +728,7 @@ class KernelManager::Impl {
 
   void register_taichi_kernel(const CompiledKernelData &compiled_kernel) {
     if (compiled_taichi_kernels_.find(compiled_kernel.kernel_name) !=
-              compiled_taichi_kernels_.end()) {
+        compiled_taichi_kernels_.end()) {
       return;
     }
 


### PR DESCRIPTION
Issue: #6263 
Ignoring kernels which have been registered is required by `metal::CacheManager`.
Bug reported by `TI_WIP_OFFLINE_CACHE=1 python3 run_tests.py -a metal -vr2 --with-offline-cache --rerun-with-offline-cache 1 compare cast numpy`