### PR TITLE
[bug] Convert non-i32 type indices to i32 for GlobalPtrStmt

### DIFF
--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -152,9 +152,9 @@ class TypeCheck : public IRVisitor {
                stmt->snode->parent->num_active_indices, stmt->indices.size());
     }
     for (int i = 0; i < stmt->indices.size(); i++) {
-      if (!is_integral(stmt->indices[i]->ret_type)) {
+      if (!stmt->indices[i]->ret_type->is_primitive(PrimitiveTypeID::i32)) {
         TI_WARN(
-            "[{}] Field index {} not integral, casting into int32 "
+            "[{}] Field index {} not int32, casting into int32 "
             "implicitly\n{}",
             stmt->name(), i, stmt->tb);
         stmt->indices[i] =

--- a/tests/python/test_indices.py
+++ b/tests/python/test_indices.py
@@ -35,3 +35,20 @@ def test_indices():
         for j in range(32):
             assert b[i, j] == i * 10 + j
     assert get_field_addr(0, 1) + 4 == get_field_addr(1, 1)
+
+
+@test_utils.test(arch=get_host_arch_list(), default_ip=ti.i64)
+def test_indices_i64():
+    n = 1024
+    val = ti.field(dtype=ti.i64, shape=n)
+    val.fill(1)
+
+    @ti.kernel
+    def prefix_sum():
+        ti.loop_config(serialize=True)
+        for i in range(1, 1024):
+            val[i] += val[i - 1]
+
+    prefix_sum()
+    for i in range(n):
+        assert (val[i] == i + 1)


### PR DESCRIPTION
Issue: fix #6159

### Brief Summary
