### PR TITLE
[Vulkan] Add overflow detection on vulkan when debug=True

### DIFF
--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -940,21 +940,21 @@ class TaskCodegen : public IRVisitor {
 
     bool debug = device_->get_cap(DeviceCapability::spirv_has_non_semantic_info);
 
-    if (debug && op_type == BinaryOpType::add) {
+    if (debug && op_type == BinaryOpType::add && is_integral(dst_type.dt)) {
       if (is_unsigned(dst_type.dt)) {
         bin_value = generate_uadd_overflow(lhs_value, rhs_value, bin->tb);
       } else {
         bin_value = generate_sadd_overflow(lhs_value, rhs_value, bin->tb);
       }
       bin_value = ir_->cast(dst_type, bin_value);
-    } else if (debug && op_type == BinaryOpType::sub) {
+    } else if (debug && op_type == BinaryOpType::sub && is_integral(dst_type.dt)) {
       if (is_unsigned(dst_type.dt)) {
         bin_value = generate_usub_overflow(lhs_value, rhs_value, bin->tb);
       } else {
         bin_value = generate_ssub_overflow(lhs_value, rhs_value, bin->tb);
       }
       bin_value = ir_->cast(dst_type, bin_value);
-    } else if (debug && op_type == BinaryOpType::mul) {
+    } else if (debug && op_type == BinaryOpType::mul && is_integral(dst_type.dt)) {
       if (is_unsigned(dst_type.dt)) {
         bin_value = generate_umul_overflow(lhs_value, rhs_value, bin->tb);
       } else {

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -925,12 +925,14 @@ class TaskCodegen : public IRVisitor {
     auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
     auto a_not_zero = ir_->ne(a, zero);
     auto b_not_zero = ir_->ne(b, zero);
-    auto a_b_not_zero = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_not_zero, b_not_zero);
+    auto a_b_not_zero = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(),
+                                        a_not_zero, b_not_zero);
     auto low_sign =
         ir_->make_value(spv::OpSLessThan, ir_->bool_type(), low, zero);
     auto expected_sign = ir_->make_value(spv::OpLogicalNotEqual,
                                          ir_->bool_type(), a_sign, b_sign);
-    expected_sign = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), expected_sign, a_b_not_zero);
+    expected_sign = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(),
+                                    expected_sign, a_b_not_zero);
     auto not_expected_sign = ir_->ne(low_sign, expected_sign);
     auto expected_high = ir_->select(expected_sign, minus_one, zero);
     auto not_expected_high = ir_->ne(high, expected_high);

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -794,6 +794,134 @@ class TaskCodegen : public IRVisitor {
     else {TI_NOT_IMPLEMENTED} ir_->register_value(stmt->raw_name(), val);
   }
 
+  void generate_overflow_branch(const spirv::Value &cond_v, const std::string &op, const std::string &tb) {
+    spirv::Value cond =
+        ir_->ne(cond_v, ir_->cast(cond_v.stype, ir_->const_i32_zero_));
+    spirv::Label then_label = ir_->new_label();
+    spirv::Label merge_label = ir_->new_label();
+    ir_->make_inst(spv::OpSelectionMerge, merge_label,
+                   spv::SelectionControlMaskNone);
+    ir_->make_inst(spv::OpBranchConditional, cond, then_label, merge_label);
+    // then block
+    ir_->start_label(then_label);
+    PrintStmt print_stmt({op + " overflow detected in " + tb});
+    visit(&print_stmt);
+    ir_->make_inst(spv::OpBranch, merge_label);
+    // merge label
+    ir_->start_label(merge_label);
+  }
+
+  spirv::Value generate_uadd_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    std::vector<std::tuple<spirv::SType, std::string, size_t>>
+        struct_components_;
+    struct_components_.emplace_back(a.stype, "result", 0);
+    struct_components_.emplace_back(a.stype, "carry", ir_->get_primitive_type_size( a.stype.dt));
+    auto struct_type = ir_->create_struct_type(struct_components_);
+    auto add_carry = ir_->make_value(spv::OpIAddCarry, struct_type, a, b);
+    auto result = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 0);
+    auto carry = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 1);
+    generate_overflow_branch(carry, "Addition", tb);
+    return result;
+  }
+
+  spirv::Value generate_usub_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    std::vector<std::tuple<spirv::SType, std::string, size_t>>
+        struct_components_;
+    struct_components_.emplace_back(a.stype, "result", 0);
+    struct_components_.emplace_back(a.stype, "borrow", ir_->get_primitive_type_size( a.stype.dt));
+    auto struct_type = ir_->create_struct_type(struct_components_);
+    auto add_carry = ir_->make_value(spv::OpISubBorrow, struct_type, a, b);
+    auto result = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 0);
+    auto borrow = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 1);
+    generate_overflow_branch(borrow, "Subtraction", tb);
+    return result;
+  }
+
+  spirv::Value generate_sadd_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    // overflow iff (sign(a) == sign(b)) && (sign(a) != sign(result))
+    auto result = ir_->make_value(spv::OpIAdd, a.stype, a, b);
+    auto zero = ir_->int_immediate_number(a.stype, 0);
+    auto a_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), a, zero);
+    auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
+    auto r_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), result, zero);
+    auto a_eq_b = ir_->make_value(spv::OpLogicalEqual, ir_->bool_type(), a_sign, b_sign);
+    auto a_neq_r = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, r_sign);
+    auto overflow = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_eq_b, a_neq_r);
+    generate_overflow_branch(overflow, "Addition", tb);
+    return result;
+  }
+
+  spirv::Value generate_ssub_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    // overflow iff (sign(a) != sign(b)) && (sign(a) != sign(result))
+    auto result = ir_->make_value(spv::OpISub, a.stype, a, b);
+    auto zero = ir_->int_immediate_number(a.stype, 0);
+    auto a_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), a, zero);
+    auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
+    auto r_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), result, zero);
+    auto a_neq_b = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, b_sign);
+    auto a_neq_r = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, r_sign);
+    auto overflow = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_neq_b, a_neq_r);
+    generate_overflow_branch(overflow, "Subtraction", tb);
+    return result;
+  }
+
+  spirv::Value generate_umul_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    // overflow iff high bits != 0
+    std::vector<std::tuple<spirv::SType, std::string, size_t>>
+        struct_components_;
+    struct_components_.emplace_back(a.stype, "low", 0);
+    struct_components_.emplace_back(a.stype, "high", ir_->get_primitive_type_size( a.stype.dt));
+    auto struct_type = ir_->create_struct_type(struct_components_);
+    auto mul_ext = ir_->make_value(spv::OpUMulExtended, struct_type, a, b);
+    auto low = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 0);
+    auto high = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 1);
+    generate_overflow_branch(high, "Multiplication", tb);
+    return low;
+  }
+
+  spirv::Value generate_smul_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    // overflow if high bits are not all sign bit (0 if positive, -1 if negative) or
+    // the sign bit of the low bits is not the expected sign bit.
+    std::vector<std::tuple<spirv::SType, std::string, size_t>>
+        struct_components_;
+    struct_components_.emplace_back(a.stype, "low", 0);
+    struct_components_.emplace_back(a.stype, "high", ir_->get_primitive_type_size( a.stype.dt));
+    auto struct_type = ir_->create_struct_type(struct_components_);
+    auto mul_ext = ir_->make_value(spv::OpSMulExtended, struct_type, a, b);
+    auto low = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 0);
+    auto high = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 1);
+    auto zero = ir_->int_immediate_number(a.stype, 0);
+    auto minus_one = ir_->int_immediate_number(a.stype, -1);
+    auto a_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), a, zero);
+    auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
+    auto low_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), low, zero);
+    auto expected_sign = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, b_sign);
+    auto not_expected_sign = ir_->ne(low_sign, expected_sign);
+    auto expected_high = ir_->select(expected_sign, minus_one, zero);
+    auto not_expected_high = ir_->ne(high, expected_high);
+    auto overflow = ir_->make_value(spv::OpLogicalOr, ir_->bool_type(), not_expected_high, not_expected_sign);
+    generate_overflow_branch(overflow, "Multiplication", tb);
+    return low;
+  }
+
+  spirv::Value generate_ushl_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    // overflow iff a << b >> b != a
+    auto result = ir_->make_value(spv::OpShiftLeftLogical, a.stype, a, b);
+    auto restore = ir_->make_value(spv::OpShiftRightLogical, a.stype, result, b);
+    auto overflow = ir_->ne(a, restore);
+    generate_overflow_branch(overflow, "Shift left", tb);
+    return result;
+  }
+
+  spirv::Value generate_sshl_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+    // overflow iff a << b >> b != a
+    auto result = ir_->make_value(spv::OpShiftLeftLogical, a.stype, a, b);
+    auto restore = ir_->make_value(spv::OpShiftRightArithmetic, a.stype, result, b);
+    auto overflow = ir_->ne(a, restore);
+    generate_overflow_branch(overflow, "Shift left", tb);
+    return result;
+  }
+
   void visit(BinaryOpStmt *bin) override {
     const auto lhs_name = bin->lhs->raw_name();
     const auto rhs_name = bin->rhs->raw_name();
@@ -810,7 +938,29 @@ class TaskCodegen : public IRVisitor {
                lhs_value.stype.dt->to_string(), rhs_name,
                rhs_value.stype.dt->to_string(), bin->tb);
 
-    if (false) {
+    bool debug = device_->get_cap(DeviceCapability::spirv_has_non_semantic_info);
+
+    if (debug && op_type == BinaryOpType::add) {
+      if (is_unsigned(dst_type.dt)) {
+        bin_value = generate_uadd_overflow(lhs_value, rhs_value, bin->tb);
+      } else {
+        bin_value = generate_sadd_overflow(lhs_value, rhs_value, bin->tb);
+      }
+      bin_value = ir_->cast(dst_type, bin_value);
+    } else if (debug && op_type == BinaryOpType::sub) {
+      if (is_unsigned(dst_type.dt)) {
+        bin_value = generate_usub_overflow(lhs_value, rhs_value, bin->tb);
+      } else {
+        bin_value = generate_ssub_overflow(lhs_value, rhs_value, bin->tb);
+      }
+      bin_value = ir_->cast(dst_type, bin_value);
+    } else if (debug && op_type == BinaryOpType::mul) {
+      if (is_unsigned(dst_type.dt)) {
+        bin_value = generate_umul_overflow(lhs_value, rhs_value, bin->tb);
+      } else {
+        bin_value = generate_smul_overflow(lhs_value, rhs_value, bin->tb);
+      }
+      bin_value = ir_->cast(dst_type, bin_value);
     }
 #define BINARY_OP_TO_SPIRV_ARTHIMATIC(op, func)  \
   else if (op_type == BinaryOpType::op) {        \
@@ -830,6 +980,13 @@ class TaskCodegen : public IRVisitor {
     bin_value = ir_->make_value(spv::sym, dst_type, lhs_value, rhs_value); \
   }
 
+    else if (debug && op_type == BinaryOpType::bit_shl) {
+      if (is_unsigned(dst_type.dt)) {
+        bin_value = generate_ushl_overflow(lhs_value, rhs_value, bin->tb);
+      } else {
+        bin_value = generate_sshl_overflow(lhs_value, rhs_value, bin->tb);
+      }
+    }
     BINARY_OP_TO_SPIRV_BITWISE(bit_and, OpBitwiseAnd)
     BINARY_OP_TO_SPIRV_BITWISE(bit_or, OpBitwiseOr)
     BINARY_OP_TO_SPIRV_BITWISE(bit_xor, OpBitwiseXor)

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -902,20 +902,7 @@ class TaskCodegen : public IRVisitor {
     auto mul_ext = ir_->make_value(spv::OpUMulExtended, struct_type, a, b);
     auto low = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 0);
     auto high = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 1);
-
-    auto overflow = ir_->ne(high, ir_->int_immediate_number(a.stype, 0));
-    auto overflow_int = ir_->cast(a.stype, overflow);
-    std::vector<Value> vals;
-    std::string formats;
-    auto tf = data_type_format(a.stype.dt);
-    formats += "UMul: a: " + tf + " b: " + tf + " low: " + tf + " high: " + tf + "overflow: " + tf;
-    vals.push_back(a);
-    vals.push_back(b);
-    vals.push_back(low);
-    vals.push_back(high);
-    vals.push_back(overflow_int);
-    ir_->call_debugprintf(formats, vals);
-    generate_overflow_branch(overflow, "Multiplication", tb);
+    generate_overflow_branch(high, "Multiplication", tb);
     return low;
   }
 

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -923,10 +923,14 @@ class TaskCodegen : public IRVisitor {
     auto minus_one = ir_->int_immediate_number(a.stype, -1);
     auto a_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), a, zero);
     auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
+    auto a_not_zero = ir_->ne(a, zero);
+    auto b_not_zero = ir_->ne(b, zero);
+    auto a_b_not_zero = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_not_zero, b_not_zero);
     auto low_sign =
         ir_->make_value(spv::OpSLessThan, ir_->bool_type(), low, zero);
     auto expected_sign = ir_->make_value(spv::OpLogicalNotEqual,
                                          ir_->bool_type(), a_sign, b_sign);
+    expected_sign = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), expected_sign, a_b_not_zero);
     auto not_expected_sign = ir_->ne(low_sign, expected_sign);
     auto expected_high = ir_->select(expected_sign, minus_one, zero);
     auto not_expected_high = ir_->ne(high, expected_high);

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -891,7 +891,6 @@ class TaskCodegen : public IRVisitor {
   spirv::Value generate_umul_overflow(const spirv::Value &a,
                                       const spirv::Value &b,
                                       const std::string &tb) {
-
     // overflow iff high bits != 0
     std::vector<std::tuple<spirv::SType, std::string, size_t>>
         struct_components_;

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -794,7 +794,9 @@ class TaskCodegen : public IRVisitor {
     else {TI_NOT_IMPLEMENTED} ir_->register_value(stmt->raw_name(), val);
   }
 
-  void generate_overflow_branch(const spirv::Value &cond_v, const std::string &op, const std::string &tb) {
+  void generate_overflow_branch(const spirv::Value &cond_v,
+                                const std::string &op,
+                                const std::string &tb) {
     spirv::Value cond =
         ir_->ne(cond_v, ir_->cast(cond_v.stype, ir_->const_i32_zero_));
     spirv::Label then_label = ir_->new_label();
@@ -811,66 +813,91 @@ class TaskCodegen : public IRVisitor {
     ir_->start_label(merge_label);
   }
 
-  spirv::Value generate_uadd_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+  spirv::Value generate_uadd_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
     std::vector<std::tuple<spirv::SType, std::string, size_t>>
         struct_components_;
     struct_components_.emplace_back(a.stype, "result", 0);
-    struct_components_.emplace_back(a.stype, "carry", ir_->get_primitive_type_size( a.stype.dt));
+    struct_components_.emplace_back(a.stype, "carry",
+                                    ir_->get_primitive_type_size(a.stype.dt));
     auto struct_type = ir_->create_struct_type(struct_components_);
     auto add_carry = ir_->make_value(spv::OpIAddCarry, struct_type, a, b);
-    auto result = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 0);
-    auto carry = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 1);
+    auto result =
+        ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 0);
+    auto carry =
+        ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 1);
     generate_overflow_branch(carry, "Addition", tb);
     return result;
   }
 
-  spirv::Value generate_usub_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+  spirv::Value generate_usub_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
     std::vector<std::tuple<spirv::SType, std::string, size_t>>
         struct_components_;
     struct_components_.emplace_back(a.stype, "result", 0);
-    struct_components_.emplace_back(a.stype, "borrow", ir_->get_primitive_type_size( a.stype.dt));
+    struct_components_.emplace_back(a.stype, "borrow",
+                                    ir_->get_primitive_type_size(a.stype.dt));
     auto struct_type = ir_->create_struct_type(struct_components_);
     auto add_carry = ir_->make_value(spv::OpISubBorrow, struct_type, a, b);
-    auto result = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 0);
-    auto borrow = ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 1);
+    auto result =
+        ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 0);
+    auto borrow =
+        ir_->make_value(spv::OpCompositeExtract, a.stype, add_carry, 1);
     generate_overflow_branch(borrow, "Subtraction", tb);
     return result;
   }
 
-  spirv::Value generate_sadd_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+  spirv::Value generate_sadd_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
     // overflow iff (sign(a) == sign(b)) && (sign(a) != sign(result))
     auto result = ir_->make_value(spv::OpIAdd, a.stype, a, b);
     auto zero = ir_->int_immediate_number(a.stype, 0);
     auto a_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), a, zero);
     auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
-    auto r_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), result, zero);
-    auto a_eq_b = ir_->make_value(spv::OpLogicalEqual, ir_->bool_type(), a_sign, b_sign);
-    auto a_neq_r = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, r_sign);
-    auto overflow = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_eq_b, a_neq_r);
+    auto r_sign =
+        ir_->make_value(spv::OpSLessThan, ir_->bool_type(), result, zero);
+    auto a_eq_b =
+        ir_->make_value(spv::OpLogicalEqual, ir_->bool_type(), a_sign, b_sign);
+    auto a_neq_r = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(),
+                                   a_sign, r_sign);
+    auto overflow =
+        ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_eq_b, a_neq_r);
     generate_overflow_branch(overflow, "Addition", tb);
     return result;
   }
 
-  spirv::Value generate_ssub_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+  spirv::Value generate_ssub_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
     // overflow iff (sign(a) != sign(b)) && (sign(a) != sign(result))
     auto result = ir_->make_value(spv::OpISub, a.stype, a, b);
     auto zero = ir_->int_immediate_number(a.stype, 0);
     auto a_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), a, zero);
     auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
-    auto r_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), result, zero);
-    auto a_neq_b = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, b_sign);
-    auto a_neq_r = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, r_sign);
-    auto overflow = ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_neq_b, a_neq_r);
+    auto r_sign =
+        ir_->make_value(spv::OpSLessThan, ir_->bool_type(), result, zero);
+    auto a_neq_b = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(),
+                                   a_sign, b_sign);
+    auto a_neq_r = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(),
+                                   a_sign, r_sign);
+    auto overflow =
+        ir_->make_value(spv::OpLogicalAnd, ir_->bool_type(), a_neq_b, a_neq_r);
     generate_overflow_branch(overflow, "Subtraction", tb);
     return result;
   }
 
-  spirv::Value generate_umul_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+  spirv::Value generate_umul_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
     // overflow iff high bits != 0
     std::vector<std::tuple<spirv::SType, std::string, size_t>>
         struct_components_;
     struct_components_.emplace_back(a.stype, "low", 0);
-    struct_components_.emplace_back(a.stype, "high", ir_->get_primitive_type_size( a.stype.dt));
+    struct_components_.emplace_back(a.stype, "high",
+                                    ir_->get_primitive_type_size(a.stype.dt));
     auto struct_type = ir_->create_struct_type(struct_components_);
     auto mul_ext = ir_->make_value(spv::OpUMulExtended, struct_type, a, b);
     auto low = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 0);
@@ -879,13 +906,16 @@ class TaskCodegen : public IRVisitor {
     return low;
   }
 
-  spirv::Value generate_smul_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
-    // overflow if high bits are not all sign bit (0 if positive, -1 if negative) or
-    // the sign bit of the low bits is not the expected sign bit.
+  spirv::Value generate_smul_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
+    // overflow if high bits are not all sign bit (0 if positive, -1 if
+    // negative) or the sign bit of the low bits is not the expected sign bit.
     std::vector<std::tuple<spirv::SType, std::string, size_t>>
         struct_components_;
     struct_components_.emplace_back(a.stype, "low", 0);
-    struct_components_.emplace_back(a.stype, "high", ir_->get_primitive_type_size( a.stype.dt));
+    struct_components_.emplace_back(a.stype, "high",
+                                    ir_->get_primitive_type_size(a.stype.dt));
     auto struct_type = ir_->create_struct_type(struct_components_);
     auto mul_ext = ir_->make_value(spv::OpSMulExtended, struct_type, a, b);
     auto low = ir_->make_value(spv::OpCompositeExtract, a.stype, mul_ext, 0);
@@ -894,29 +924,38 @@ class TaskCodegen : public IRVisitor {
     auto minus_one = ir_->int_immediate_number(a.stype, -1);
     auto a_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), a, zero);
     auto b_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), b, zero);
-    auto low_sign = ir_->make_value(spv::OpSLessThan, ir_->bool_type(), low, zero);
-    auto expected_sign = ir_->make_value(spv::OpLogicalNotEqual, ir_->bool_type(), a_sign, b_sign);
+    auto low_sign =
+        ir_->make_value(spv::OpSLessThan, ir_->bool_type(), low, zero);
+    auto expected_sign = ir_->make_value(spv::OpLogicalNotEqual,
+                                         ir_->bool_type(), a_sign, b_sign);
     auto not_expected_sign = ir_->ne(low_sign, expected_sign);
     auto expected_high = ir_->select(expected_sign, minus_one, zero);
     auto not_expected_high = ir_->ne(high, expected_high);
-    auto overflow = ir_->make_value(spv::OpLogicalOr, ir_->bool_type(), not_expected_high, not_expected_sign);
+    auto overflow = ir_->make_value(spv::OpLogicalOr, ir_->bool_type(),
+                                    not_expected_high, not_expected_sign);
     generate_overflow_branch(overflow, "Multiplication", tb);
     return low;
   }
 
-  spirv::Value generate_ushl_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+  spirv::Value generate_ushl_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
     // overflow iff a << b >> b != a
     auto result = ir_->make_value(spv::OpShiftLeftLogical, a.stype, a, b);
-    auto restore = ir_->make_value(spv::OpShiftRightLogical, a.stype, result, b);
+    auto restore =
+        ir_->make_value(spv::OpShiftRightLogical, a.stype, result, b);
     auto overflow = ir_->ne(a, restore);
     generate_overflow_branch(overflow, "Shift left", tb);
     return result;
   }
 
-  spirv::Value generate_sshl_overflow(const spirv::Value &a, const spirv::Value &b, const std::string &tb) {
+  spirv::Value generate_sshl_overflow(const spirv::Value &a,
+                                      const spirv::Value &b,
+                                      const std::string &tb) {
     // overflow iff a << b >> b != a
     auto result = ir_->make_value(spv::OpShiftLeftLogical, a.stype, a, b);
-    auto restore = ir_->make_value(spv::OpShiftRightArithmetic, a.stype, result, b);
+    auto restore =
+        ir_->make_value(spv::OpShiftRightArithmetic, a.stype, result, b);
     auto overflow = ir_->ne(a, restore);
     generate_overflow_branch(overflow, "Shift left", tb);
     return result;
@@ -938,7 +977,8 @@ class TaskCodegen : public IRVisitor {
                lhs_value.stype.dt->to_string(), rhs_name,
                rhs_value.stype.dt->to_string(), bin->tb);
 
-    bool debug = device_->get_cap(DeviceCapability::spirv_has_non_semantic_info);
+    bool debug =
+        device_->get_cap(DeviceCapability::spirv_has_non_semantic_info);
 
     if (debug && op_type == BinaryOpType::add && is_integral(dst_type.dt)) {
       if (is_unsigned(dst_type.dt)) {
@@ -947,14 +987,16 @@ class TaskCodegen : public IRVisitor {
         bin_value = generate_sadd_overflow(lhs_value, rhs_value, bin->tb);
       }
       bin_value = ir_->cast(dst_type, bin_value);
-    } else if (debug && op_type == BinaryOpType::sub && is_integral(dst_type.dt)) {
+    } else if (debug && op_type == BinaryOpType::sub &&
+               is_integral(dst_type.dt)) {
       if (is_unsigned(dst_type.dt)) {
         bin_value = generate_usub_overflow(lhs_value, rhs_value, bin->tb);
       } else {
         bin_value = generate_ssub_overflow(lhs_value, rhs_value, bin->tb);
       }
       bin_value = ir_->cast(dst_type, bin_value);
-    } else if (debug && op_type == BinaryOpType::mul && is_integral(dst_type.dt)) {
+    } else if (debug && op_type == BinaryOpType::mul &&
+               is_integral(dst_type.dt)) {
       if (is_unsigned(dst_type.dt)) {
         bin_value = generate_umul_overflow(lhs_value, rhs_value, bin->tb);
       } else {

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1028,6 +1028,8 @@ DEFINE_BUILDER_CMP_OP(ge, GreaterThanEqual);
     const auto &bool_type = t_bool_; /* TODO: Only scalar supported now */ \
     if (is_integral(a.stype.dt)) {                                         \
       return make_value(spv::OpI##_Op, bool_type, a, b);                   \
+    } else if (a.stype.id == bool_type.id) {                               \
+      return make_value(spv::OpLogical##_Op, bool_type, a, b);             \
     } else {                                                               \
       TI_ASSERT(is_real(a.stype.dt));                                      \
       return make_value(spv::OpFOrd##_Op, bool_type, a, b);                \

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -116,9 +116,9 @@ std::string data_type_format(DataType dt) {
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
     // Use %lld on Windows.
     // Discussion: https://github.com/taichi-dev/taichi/issues/2522
-    return "%lld";
+    return "%ld";
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    return "%llu";
+    return "%lu";
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
     return "%f";
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {

--- a/taichi/ir/type_utils.cpp
+++ b/taichi/ir/type_utils.cpp
@@ -116,9 +116,9 @@ std::string data_type_format(DataType dt) {
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
     // Use %lld on Windows.
     // Discussion: https://github.com/taichi-dev/taichi/issues/2522
-    return "%ld";
+    return "%lld";
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    return "%lu";
+    return "%llu";
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
     return "%f";
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -610,6 +610,7 @@ void GfxRuntime::synchronize() {
   flush();
   device_->wait_idle();
   ctx_buffers_.clear();
+  fflush(stdout);
 }
 
 StreamSemaphore GfxRuntime::flush() {

--- a/tests/python/test_overflow.py
+++ b/tests/python/test_overflow.py
@@ -30,10 +30,10 @@ def test_no_debug(capfd):
     assert "return a + b" not in captured
 
 
-
 def supports_overflow(arch):
     return arch != ti.vulkan or platform.system(
     ) != "Darwin"  # Vulkan on macOS do not have the validation layer.
+
 
 add_table = [
     (ti.i8, 2**6),

--- a/tests/python/test_overflow.py
+++ b/tests/python/test_overflow.py
@@ -194,7 +194,9 @@ def test_mul_overflow(capfd, ty, num1, num2):
         return
     # 64-bit Multiplication overflow detection does not function correctly on old drivers.
     # See https://github.com/taichi-dev/taichi/issues/6303
-    if ti.lang.impl.current_cfg().arch == ti.vulkan and id(ty) in [id(ti.i64), id(ti.u64)]:
+    if ti.lang.impl.current_cfg().arch == ti.vulkan and id(ty) in [
+            id(ti.i64), id(ti.u64)
+    ]:
         return
     capfd.readouterr()
 

--- a/tests/python/test_overflow.py
+++ b/tests/python/test_overflow.py
@@ -30,16 +30,10 @@ def test_no_debug(capfd):
     assert "return a + b" not in captured
 
 
-def supports_overflow(arch, ty):
-    if arch != ti.vulkan:
-        return True
-    if platform.system() != "Darwin":  # Only vulkan on macOS have problems
-        return True
-    if platform.machine() == "arm64":  # M1 does not support validation layers
-        return False
-    return id(ty) not in [id(ti.i64), id(ti.u64)
-                          ]  # macOS does not support 64-bit data types
 
+def supports_overflow(arch):
+    return arch != ti.vulkan or platform.system(
+    ) != "Darwin"  # Vulkan on macOS do not have the validation layer.
 
 add_table = [
     (ti.i8, 2**6),
@@ -56,7 +50,7 @@ add_table = [
 @pytest.mark.parametrize("ty,num", add_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_add_overflow(capfd, ty, num):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -76,7 +70,7 @@ def test_add_overflow(capfd, ty, num):
 @pytest.mark.parametrize("ty,num", add_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_add_no_overflow(capfd, ty, num):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -104,7 +98,7 @@ sub_table = [
 @pytest.mark.parametrize("ty,num", sub_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_overflow_i(capfd, ty, num):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -124,7 +118,7 @@ def test_sub_overflow_i(capfd, ty, num):
 @pytest.mark.parametrize("ty,num", sub_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_no_overflow_i(capfd, ty, num):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -144,7 +138,7 @@ def test_sub_no_overflow_i(capfd, ty, num):
 @pytest.mark.parametrize("ty", [ti.u8, ti.u16, ti.u32, ti.u64])
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_overflow_u(capfd, ty):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -164,7 +158,7 @@ def test_sub_overflow_u(capfd, ty):
 @pytest.mark.parametrize("ty", [ti.u8, ti.u16, ti.u32, ti.u64])
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_no_overflow_u(capfd, ty):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -196,7 +190,7 @@ mul_table = [
 @pytest.mark.parametrize("ty,num1,num2", mul_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_mul_overflow(capfd, ty, num1, num2):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -216,7 +210,7 @@ def test_mul_overflow(capfd, ty, num1, num2):
 @pytest.mark.parametrize("ty,num1,num2", mul_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_mul_no_overflow(capfd, ty, num1, num2):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -248,7 +242,7 @@ shl_table = [
 @pytest.mark.parametrize("ty,num", shl_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_shl_overflow(capfd, ty, num):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 
@@ -268,7 +262,7 @@ def test_shl_overflow(capfd, ty, num):
 @pytest.mark.parametrize("ty,num", shl_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_shl_no_overflow(capfd, ty, num):
-    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
     capfd.readouterr()
 

--- a/tests/python/test_overflow.py
+++ b/tests/python/test_overflow.py
@@ -192,6 +192,10 @@ mul_table = [
 def test_mul_overflow(capfd, ty, num1, num2):
     if not supports_overflow(ti.lang.impl.current_cfg().arch):
         return
+    # 64-bit Multiplication overflow detection does not function correctly on old drivers.
+    # See https://github.com/taichi-dev/taichi/issues/6303
+    if ti.lang.impl.current_cfg().arch == ti.vulkan and id(ty) in [id(ti.i64), id(ti.u64)]:
+        return
     capfd.readouterr()
 
     @ti.kernel

--- a/tests/python/test_overflow.py
+++ b/tests/python/test_overflow.py
@@ -1,7 +1,7 @@
 import os
+import platform
 
 import pytest
-import platform
 
 import taichi as ti
 from tests import test_utils
@@ -37,7 +37,8 @@ def supports_overflow(arch, ty):
         return True
     if platform.machine() == "arm64":  # M1 does not support validation layers
         return False
-    return id(ty) not in [id(ti.i64), id(ti.u64)]  # macOS does not support 64-bit data types
+    return id(ty) not in [id(ti.i64), id(ti.u64)
+                          ]  # macOS does not support 64-bit data types
 
 
 add_table = [

--- a/tests/python/test_overflow.py
+++ b/tests/python/test_overflow.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import platform
 
 import taichi as ti
 from tests import test_utils
@@ -29,6 +30,16 @@ def test_no_debug(capfd):
     assert "return a + b" not in captured
 
 
+def supports_overflow(arch, ty):
+    if arch != ti.vulkan:
+        return True
+    if platform.system() != "Darwin":  # Only vulkan on macOS have problems
+        return True
+    if platform.machine() == "arm64":  # M1 does not support validation layers
+        return False
+    return id(ty) not in [id(ti.i64), id(ti.u64)]  # macOS does not support 64-bit data types
+
+
 add_table = [
     (ti.i8, 2**6),
     (ti.u8, 2**7),
@@ -44,6 +55,8 @@ add_table = [
 @pytest.mark.parametrize("ty,num", add_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_add_overflow(capfd, ty, num):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -62,6 +75,8 @@ def test_add_overflow(capfd, ty, num):
 @pytest.mark.parametrize("ty,num", add_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_add_no_overflow(capfd, ty, num):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -88,6 +103,8 @@ sub_table = [
 @pytest.mark.parametrize("ty,num", sub_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_overflow_i(capfd, ty, num):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -106,6 +123,8 @@ def test_sub_overflow_i(capfd, ty, num):
 @pytest.mark.parametrize("ty,num", sub_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_no_overflow_i(capfd, ty, num):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -124,6 +143,8 @@ def test_sub_no_overflow_i(capfd, ty, num):
 @pytest.mark.parametrize("ty", [ti.u8, ti.u16, ti.u32, ti.u64])
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_overflow_u(capfd, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -142,6 +163,8 @@ def test_sub_overflow_u(capfd, ty):
 @pytest.mark.parametrize("ty", [ti.u8, ti.u16, ti.u32, ti.u64])
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_no_overflow_u(capfd, ty):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -172,6 +195,8 @@ mul_table = [
 @pytest.mark.parametrize("ty,num1,num2", mul_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_mul_overflow(capfd, ty, num1, num2):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -190,6 +215,8 @@ def test_mul_overflow(capfd, ty, num1, num2):
 @pytest.mark.parametrize("ty,num1,num2", mul_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_mul_no_overflow(capfd, ty, num1, num2):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -220,6 +247,8 @@ shl_table = [
 @pytest.mark.parametrize("ty,num", shl_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_shl_overflow(capfd, ty, num):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel
@@ -238,6 +267,8 @@ def test_shl_overflow(capfd, ty, num):
 @pytest.mark.parametrize("ty,num", shl_table)
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_shl_no_overflow(capfd, ty, num):
+    if not supports_overflow(ti.lang.impl.current_cfg().arch, ty):
+        return
     capfd.readouterr()
 
     @ti.kernel

--- a/tests/python/test_overflow.py
+++ b/tests/python/test_overflow.py
@@ -12,7 +12,7 @@ if os.name == 'nt':
         allow_module_level=True)
 
 
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan])
 def test_no_debug(capfd):
     capfd.readouterr()
 
@@ -42,7 +42,7 @@ add_table = [
 
 
 @pytest.mark.parametrize("ty,num", add_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_add_overflow(capfd, ty, num):
     capfd.readouterr()
 
@@ -60,7 +60,7 @@ def test_add_overflow(capfd, ty, num):
 
 
 @pytest.mark.parametrize("ty,num", add_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_add_no_overflow(capfd, ty, num):
     capfd.readouterr()
 
@@ -86,7 +86,7 @@ sub_table = [
 
 
 @pytest.mark.parametrize("ty,num", sub_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_overflow_i(capfd, ty, num):
     capfd.readouterr()
 
@@ -104,7 +104,7 @@ def test_sub_overflow_i(capfd, ty, num):
 
 
 @pytest.mark.parametrize("ty,num", sub_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_no_overflow_i(capfd, ty, num):
     capfd.readouterr()
 
@@ -122,7 +122,7 @@ def test_sub_no_overflow_i(capfd, ty, num):
 
 
 @pytest.mark.parametrize("ty", [ti.u8, ti.u16, ti.u32, ti.u64])
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_overflow_u(capfd, ty):
     capfd.readouterr()
 
@@ -140,7 +140,7 @@ def test_sub_overflow_u(capfd, ty):
 
 
 @pytest.mark.parametrize("ty", [ti.u8, ti.u16, ti.u32, ti.u64])
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_sub_no_overflow_u(capfd, ty):
     capfd.readouterr()
 
@@ -170,7 +170,7 @@ mul_table = [
 
 
 @pytest.mark.parametrize("ty,num1,num2", mul_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_mul_overflow(capfd, ty, num1, num2):
     capfd.readouterr()
 
@@ -188,7 +188,7 @@ def test_mul_overflow(capfd, ty, num1, num2):
 
 
 @pytest.mark.parametrize("ty,num1,num2", mul_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_mul_no_overflow(capfd, ty, num1, num2):
     capfd.readouterr()
 
@@ -218,7 +218,7 @@ shl_table = [
 
 
 @pytest.mark.parametrize("ty,num", shl_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_shl_overflow(capfd, ty, num):
     capfd.readouterr()
 
@@ -236,7 +236,7 @@ def test_shl_overflow(capfd, ty, num):
 
 
 @pytest.mark.parametrize("ty,num", shl_table)
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], debug=True)
 def test_shl_no_overflow(capfd, ty, num):
     capfd.readouterr()
 


### PR DESCRIPTION
Issue: #5932 

### Brief Summary
Added overflow detection of addition, subtraction, multiplication and shift left operators on Vulkan. 

Known bug: 64-bit multiplication overflow detection works on NVIDIA driver 510 with Vulkan version 1.3.194 but does not work on NVIDIA driver 470 with Vulkan version 1.2.175. See https://github.com/taichi-dev/taichi/issues/6303

TODO: Support for OpenGL should be automatically available when the print support of OpenGL is available. Add OpenGL to the test at that time.