### PR TITLE
[aot] Ship runtime *.bc files with C-API for LLVM AOT

### DIFF
--- a/cmake/TaichiCAPI.cmake
+++ b/cmake/TaichiCAPI.cmake
@@ -110,3 +110,10 @@ install(DIRECTORY
     PATTERN *.h
     PATTERN *.hpp
     )
+
+if(TI_WITH_LLVM)
+# Install runtime .bc files for LLVM backend
+install(DIRECTORY
+      ${INSTALL_LIB_DIR}/runtime
+      DESTINATION c_api)
+endif()


### PR DESCRIPTION
Issue: #

LLVM AOT rely on *.bc files (`runtime_cuda.bc`, ...) at runtime, thus we have to ship those runtime files together with C-API once TI_WITH_LLVM is enabled.

Under installed directory `{install_dir}/taichi-xxxx.egg/c_api/`:

Before:
```
include
lib/libtaichi_c_api.so
lib/cmake
```

After:
```
include
lib/libtaichi_c_api.so
lib/cmake
lib/runtime/*.bc
```