### PR TITLE
[lang] MatrixType bug fix: Allow indexing a matrix r-value

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -538,6 +538,11 @@ Stmt *make_tensor_access(Expression::FlattenContext *ctx,
                          std::vector<int> shape,
                          int stride) {
   flatten_lvalue(var, ctx);
+  if (!var->is_lvalue()) {
+    auto alloca_stmt = ctx->push_back<AllocaStmt>(var->ret_type);
+    ctx->push_back<LocalStoreStmt>(alloca_stmt, var->stmt);
+    var->stmt = alloca_stmt;
+  }
   bool needs_dynamic_index = false;
   for (int i = 0; i < (int)indices.size(); ++i) {
     if (!indices[i].is<ConstExpression>()) {

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -756,6 +756,16 @@ def test_local_matrix_read():
 
 
 @test_utils.test(arch=[ti.cuda, ti.cpu], real_matrix=True)
+def test_local_matrix_read_without_assign():
+    @ti.kernel
+    def local_vector_read(i: ti.i32) -> ti.i32:
+        return ti.Vector([0, 1, 2])[i]
+
+    for i in range(3):
+        assert local_vector_read(i) == i
+
+
+@test_utils.test(arch=[ti.cuda, ti.cpu], real_matrix=True)
 def test_local_matrix_indexing_in_loop():
     s = ti.field(ti.i32, shape=(3, 3))
 


### PR DESCRIPTION
Issue: #5819

### Brief Summary

It is possible that a local matrix is indexed without being assigned to a variable:
```python
@ti.kernel
def local_vector_read(i: ti.i32) -> ti.i32:
    return ti.Vector([0, 1, 2])[i]
```

In this case we need to turn it from an r-value to an l-value so that we can successfully construct the index.