### PR TITLE
[lang] MatrixType bug fix: Avoid checks for legacy Matrix-class when real_matrix is on

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -625,12 +625,12 @@ class ASTTransformer(Builder):
                                   (MatrixType)):
 
                         # with real_matrix=True, "data" is expected to be an Expr here
-                        # Therefore we directly call "impl.expr_init_func(data)" to perform:
+                        # Therefore we simply call "impl.expr_init_func(data)" to perform:
                         #
                         # TensorType* t = alloca()
                         # assign(t, data)
                         #
-                        # Thus we created local variable "t" - a copy of the passed-in argument "data"
+                        # We created local variable "t" - a copy of the passed-in argument "data"
                         if not current_cfg().real_matrix:
                             if not isinstance(data, Matrix):
                                 raise TaichiSyntaxError(

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -623,20 +623,29 @@ class ASTTransformer(Builder):
                     # Matrix arguments are passed by value.
                     if isinstance(ctx.func.arguments[i].annotation,
                                   (MatrixType)):
-                        if not isinstance(data, Matrix):
-                            raise TaichiSyntaxError(
-                                f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is expected to be a Matrix, but got {type(data)}."
-                            )
 
-                        if data.m != ctx.func.arguments[i].annotation.m:
-                            raise TaichiSyntaxError(
-                                f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is expected to be a Matrix with m {ctx.func.arguments[i].annotation.m}, but got {data.m}."
-                            )
+                        # with real_matrix=True, "data" is expected to be an Expr here
+                        # Therefore we directly call "impl.expr_init_func(data)" to perform:
+                        #
+                        # TensorType* t = alloca()
+                        # assign(t, data)
+                        #
+                        # Thus we created local variable "t" - a copy of the passed-in argument "data"
+                        if not current_cfg().real_matrix:
+                            if not isinstance(data, Matrix):
+                                raise TaichiSyntaxError(
+                                    f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is expected to be a Matrix, but got {type(data)}."
+                                )
 
-                        if data.n != ctx.func.arguments[i].annotation.n:
-                            raise TaichiSyntaxError(
-                                f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is expected to be a Matrix with n {ctx.func.arguments[i].annotation.n}, but got {data.n}."
-                            )
+                            if data.m != ctx.func.arguments[i].annotation.m:
+                                raise TaichiSyntaxError(
+                                    f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is expected to be a Matrix with m {ctx.func.arguments[i].annotation.m}, but got {data.m}."
+                                )
+
+                            if data.n != ctx.func.arguments[i].annotation.n:
+                                raise TaichiSyntaxError(
+                                    f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is expected to be a Matrix with n {ctx.func.arguments[i].annotation.n}, but got {data.n}."
+                                )
                         ctx.create_variable(arg.arg, impl.expr_init_func(data))
                         continue
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -639,7 +639,7 @@ class ASTTransformer(Builder):
                                     f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is expected to be a Matrix, but got {type(data)}."
                                 )
 
-                            element_shape = data.ptr.get_ret_type().get_shape()
+                            element_shape = data.ptr.get_ret_type().shape()
                             if len(element_shape
                                    ) != ctx.func.arguments[i].annotation.ndim:
                                 raise TaichiSyntaxError(

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -48,8 +48,8 @@ CompileConfig::CompileConfig() {
   detect_read_only = true;
   ndarray_use_cached_allocator = true;
   use_mesh = false;
-  real_matrix = false;
-  real_matrix_scalarize = false;
+  real_matrix = true;
+  real_matrix_scalarize = true;
 
   saturating_grid_dim = 0;
   max_block_dim = 0;

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -48,8 +48,8 @@ CompileConfig::CompileConfig() {
   detect_read_only = true;
   ndarray_use_cached_allocator = true;
   use_mesh = false;
-  real_matrix = true;
-  real_matrix_scalarize = true;
+  real_matrix = false;
+  real_matrix_scalarize = false;
 
   saturating_grid_dim = 0;
   max_block_dim = 0;

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -368,8 +368,7 @@ def test_func_ndarray_arg():
         test_error(arr)
 
 
-@test_utils.test(arch=[ti.cpu, ti.gpu], debug=True)
-def test_func_matrix_arg():
+def _test_func_matrix_arg():
     vec3 = ti.types.vector(3, ti.f32)
 
     @ti.func
@@ -384,14 +383,36 @@ def test_func_matrix_arg():
 
         assert x[0] == 20
 
+    test_k()
+
+
+def _test_func_matrix_arg_with_error():
+    vec3 = ti.types.vector(3, ti.f32)
+
+    @ti.func
+    def test(a: vec3):
+        a[0] = 100
+
     @ti.kernel
     def test_error():
         x = ti.Matrix([3, 4])
         test(x)
 
-    test_k()
-
     with pytest.raises(
             ti.TaichiSyntaxError,
             match=r"is expected to be a Matrix with n 3, but got 2"):
         test_error()
+
+
+@test_utils.test(arch=[ti.cpu, ti.gpu], debug=True)
+def test_func_matrix_arg():
+    _test_func_matrix_arg()
+    _test_func_matrix_arg_with_error()
+
+
+@test_utils.test(arch=[ti.cpu, ti.gpu],
+                 debug=True,
+                 real_matrix=True,
+                 real_matrix_scalarize=True)
+def test_func_matrix_arg_real_matrix():
+    _test_func_matrix_arg()


### PR DESCRIPTION
Issue: #https://github.com/taichi-dev/taichi/issues/5819

### Brief Summary
