### PR TITLE
[lang] MatrixType bug fix: Allow dynamic_index=True when real_matrix_scalarize=True

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -29,7 +29,7 @@ namespace irpass {
 
 void re_id(IRNode *root);
 void flag_access(IRNode *root);
-void scalarize(IRNode *root);
+void scalarize(IRNode *root, const CompileConfig &config);
 void lower_matrix_ptr(IRNode *root);
 bool die(IRNode *root);
 bool simplify(IRNode *root, const CompileConfig &config);

--- a/taichi/runtime/llvm/llvm_context.cpp
+++ b/taichi/runtime/llvm/llvm_context.cpp
@@ -152,7 +152,7 @@ llvm::Type *TaichiLLVMContext::get_data_type(DataType dt) {
     auto num_elements = tensor_type->get_num_elements();
     // Return type is <element_type * num_elements> if real matrix is used,
     // otherwise [element_type * num_elements].
-    if (config_->real_matrix) {
+    if (config_->real_matrix && !config_->real_matrix_scalarize) {
       return llvm::VectorType::get(element_type, num_elements,
                                    /*scalable=*/false);
     }

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -53,7 +53,7 @@ void compile_to_offloads(IRNode *ir,
   }
 
   if (config.real_matrix && config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
+    irpass::scalarize(ir, config);
 
     // Remove redundant MatrixInitStmt inserted during scalarization
     irpass::die(ir);

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -378,10 +378,12 @@ class ScalarizePointers : public BasicStmtVisitor {
 
 namespace irpass {
 
-void scalarize(IRNode *root) {
+void scalarize(IRNode *root, const CompileConfig &config) {
   TI_AUTO_PROF;
   Scalarize scalarize_pass(root);
-  ScalarizePointers scalarize_pointers_pass(root);
+  if (!config.dynamic_index) {
+    ScalarizePointers scalarize_pointers_pass(root);
+  }
 }
 
 }  // namespace irpass

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -164,8 +164,56 @@ def test_taichi_scope_matrix_operations_with_global_matrices(ops):
     assert np.allclose(r2[None].to_numpy(), ops(a, c))
 
 
+def _test_local_matrix_non_constant_index():
+    @ti.kernel
+    def func1():
+        tmp = ti.Vector([1, 2, 3])
+        for i in range(3):
+            vec = ti.Vector([4, 5, 6])
+            for j in range(3):
+                vec[tmp[i] % 3] += vec[j]
+            tmp[i] = vec[tmp[i] % 3]
+        assert tmp[0] == 24
+        assert tmp[1] == 30
+        assert tmp[2] == 19
+
+    func1()
+
+    @ti.kernel
+    def func2(i: ti.i32, j: ti.i32, k: ti.i32):
+        tmp = ti.Matrix([[k, k * 2], [k * 2, k * 3]])
+        assert tmp[i, j] == k * (i + j + 1)
+
+    for i in range(2):
+        for j in range(2):
+            func2(i, j, 10)
+
+
+@test_utils.test(require=ti.extension.dynamic_index,
+                 dynamic_index=True,
+                 debug=True)
+def test_local_matrix_non_constant_index():
+    _test_local_matrix_non_constant_index()
+
+
+@test_utils.test(require=ti.extension.dynamic_index,
+                 real_matrix=True,
+                 debug=True)
+def test_local_matrix_non_constant_index_real_matrix():
+    _test_local_matrix_non_constant_index()
+
+
+@test_utils.test(require=ti.extension.dynamic_index,
+                 dynamic_index=True,
+                 real_matrix=True,
+                 real_matrix_scalarize=True,
+                 debug=True)
+def test_local_matrix_non_constant_index_real_matrix_scalarize():
+    _test_local_matrix_non_constant_index()
+
+
 @test_utils.test(exclude=[ti.cc])
-def test_matrix_non_constant_index_numpy():
+def test_matrix_ndarray_non_constant_index():
     @ti.kernel
     def func1(a: ti.types.ndarray(element_dim=2)):
         for i in range(5):
@@ -193,7 +241,7 @@ def test_matrix_non_constant_index_numpy():
     assert v[3][9] == 9
 
 
-def _test_matrix_non_constant_index():
+def _test_matrix_field_non_constant_index():
     m = ti.Matrix.field(2, 2, ti.i32, 5)
     v = ti.Vector.field(10, ti.i32, 5)
 
@@ -202,11 +250,11 @@ def _test_matrix_non_constant_index():
         for i in range(5):
             for j, k in ti.ndrange(2, 2):
                 m[i][j, k] = j * j + k * k
-        assert m[1][0, 1] == 1
-        assert m[2][1, 0] == 1
-        assert m[3][1, 1] == 2
 
     func1()
+    assert m[1][0, 1] == 1
+    assert m[2][1, 0] == 1
+    assert m[3][1, 1] == 2
     assert m[4][0, 1] == 1
 
     @ti.kernel
@@ -214,52 +262,27 @@ def _test_matrix_non_constant_index():
         for i in range(5):
             for j in range(4):
                 v[i][j * j] = j * j
-        assert v[1][0] == 0
-        assert v[1][1] == 1
-        assert v[1][4] == 4
 
     func2()
+    assert v[1][0] == 0
+    assert v[1][1] == 1
+    assert v[1][4] == 4
     assert v[1][9] == 9
 
-    @ti.kernel
-    def func3():
-        tmp = ti.Vector([1, 2, 3])
-        for i in range(3):
-            tmp[i] = i * i
-            vec = ti.Vector([4, 5, 6])
-            for j in range(3):
-                vec[tmp[i] % 3] += vec[j % 3]
-        assert tmp[0] == 0
-        assert tmp[1] == 1
-        assert tmp[2] == 4
 
-    func3()
-
-    @ti.kernel
-    def func4(k: ti.i32):
-        tmp = ti.Vector([k, k * 2, k * 3])
-        assert tmp[0] == k
-        assert tmp[1] == k * 2
-        assert tmp[2] == k * 3
-
-    func4(10)
+@test_utils.test(require=ti.extension.dynamic_index,
+                 dynamic_index=True)
+def test_matrix_field_non_constant_index():
+    _test_matrix_field_non_constant_index()
 
 
 @test_utils.test(require=ti.extension.dynamic_index,
-                 dynamic_index=True,
-                 debug=True)
-def test_matrix_non_constant_index():
-    _test_matrix_non_constant_index()
+                 real_matrix=True)
+def test_matrix_field_non_constant_index_real_matrix():
+    _test_matrix_field_non_constant_index()
 
 
-@test_utils.test(require=ti.extension.dynamic_index,
-                 real_matrix=True,
-                 debug=True)
-def test_matrix_non_constant_index_real_matrix():
-    _test_matrix_non_constant_index()
-
-
-def _test_matrix_constant_index():
+def _test_matrix_field_constant_index():
     m = ti.Matrix.field(2, 2, ti.i32, 5)
 
     @ti.kernel
@@ -274,13 +297,13 @@ def _test_matrix_constant_index():
 
 
 @test_utils.test()
-def test_matrix_constant_index():
-    _test_matrix_constant_index()
+def test_matrix_field_constant_index():
+    _test_matrix_field_constant_index()
 
 
 @test_utils.test(real_matrix=True)
-def test_matrix_constant_index_real_matrix():
-    _test_matrix_constant_index()
+def test_matrix_field_constant_index_real_matrix():
+    _test_matrix_field_constant_index()
 
 
 @test_utils.test(arch=ti.cpu)


### PR DESCRIPTION
Issue: #5819

### Brief Summary

Under both `real_matrix_scalarize=True` and `dynamic_index=True`, local matrix should go through the old code path for dynamic index (`ArrayType`). This PR does the fix and refactors related tests.