### PR TITLE
[ci] Add end-to-end CI tests for meshtaichi

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -111,3 +111,15 @@ else
     python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
     # Paddle's paddle.fluid.core.Tensor._ptr() is only available on develop branch, and CUDA version on linux will get error `Illegal Instruction`
 fi
+
+# meshtaichi end-to-end test
+if [[ $OSTYPE == "linux-"* && ($TI_WANTED_ARCHS == *"cuda"* || $TI_WANTED_ARCHS == *"cpu"*) ]]; then
+    python3 -m pip install meshtaichi_patcher --upgrade
+    # git clone git@github.com:taichi-dev/meshtaichi.git
+    if [[ $TI_WANTED_ARCHS == *"cuda"* ]]; then
+        python3 meshtaichi/ci/run_test.py --arch cuda
+    fi
+    if [[ $TI_WANTED_ARCHS == *"cpu"* ]]; then
+        python3 meshtaichi/ci/run_test.py --arch cpu
+    fi
+fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -129,6 +129,12 @@ jobs:
           fetch-depth: '0'
           submodules: 'recursive'
 
+      - uses: actions/checkout@v3
+        with:
+          repository:  taichi-dev/meshtaichi
+          path: meshtaichi
+          token: ${{ secrets.GARDENER_PAT }}
+
       - name: Get Build Cache
         uses: actions/cache@v2
         with:
@@ -356,6 +362,12 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: '0'
+
+      - uses: actions/checkout@v3
+        with:
+          repository:  taichi-dev/meshtaichi
+          path: meshtaichi
+          token: ${{ secrets.GARDENER_PAT }}
 
       - name: Prepare Environment
         run: |


### PR DESCRIPTION
Continued from #6310.
Changes of mesh.py in taichi need to be merged before this CI change.