### PR TITLE
[build] Enable a few bugprone related rules in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,13 @@
 ---
-Checks: '-*,
+Checks:  '-*,
+         bugprone-argument-comment,
+         bugprone-assert-side-effect,
+         bugprone-dangling-handle,
+         bugprone-inaccurate-erase,
+         bugprone-string-constructor,
+         bugprone-string-integer-assignment,
+         bugprone-unused-raii,
+         bugprone-use-after-move,
          modernize-use-override,
          performance-inefficient-string-concatenation,
          readability-identifier-naming'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -102,7 +102,7 @@ jobs:
           docker exec --user dev check_clang_tidy /home/dev/taichi/.github/workflows/scripts/check_clang_tidy.sh "$CI_SETUP_CMAKE_ARGS"
         env:
           CR_PAT: ${{ secrets.GITHUB_TOKEN }}
-          CI_SETUP_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=ON -DTI_WITH_VULKAN:BOOL=OFF -DTI_BUILD_TESTS:BOOL=OFF
+          CI_SETUP_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTI_WITH_OPENGL:BOOL=OFF -DTI_WITH_CC:BOOL=ON -DTI_WITH_VULKAN:BOOL=OFF -DTI_BUILD_TESTS:BOOL=ON
 
   build_and_test_cpu_linux:
     name: Build and Test linux (CPU)

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -414,7 +414,7 @@ void TaskCodeGenLLVM::visit(UnaryOpStmt *stmt) {
         if (!cast_type->is<TensorType>()) {
           llvm_val[stmt] = trunc_func(llvm_val[stmt], to_ty);
         } else {
-          create_elementwise_cast(stmt, to_ty, trunc_func, /*trunc_self=*/true);
+          create_elementwise_cast(stmt, to_ty, trunc_func, /*on_self=*/true);
         }
       }
     } else if (is_real(from.get_element_type()) &&

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1181,8 +1181,9 @@ class TaskCodegen : public IRVisitor {
         }
 
         int binding = binding_head_++;
-        val = ir_->storage_image_argument(/*num_channels=*/4, stmt->dimensions,
-                                          /*set=*/0, binding, format);
+        val =
+            ir_->storage_image_argument(/*num_channels=*/4, stmt->dimensions,
+                                        /*descriptor_set=*/0, binding, format);
         TextureBind bind;
         bind.arg_id = arg_id;
         bind.binding = binding;
@@ -1192,7 +1193,7 @@ class TaskCodegen : public IRVisitor {
       } else {
         int binding = binding_head_++;
         val = ir_->texture_argument(/*num_channels=*/4, stmt->dimensions,
-                                    /*set=*/0, binding);
+                                    /*descriptor_set=*/0, binding);
         TextureBind bind;
         bind.arg_id = arg_id;
         bind.binding = binding;

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -441,7 +441,7 @@ void Kernel::offload_to_executable(IRNode *stmt) {
       stmt, config, this, verbose,
       /*determine_ad_stack_size=*/autodiff_mode == AutodiffMode::kReverse,
       /*lower_global_access=*/true,
-      /*make_block_local=*/config.make_thread_local,
+      /*make_thread_local=*/config.make_thread_local,
       /*make_block_local=*/
       is_extension_supported(config.arch, Extension::bls) &&
           config.make_block_local);

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -77,7 +77,7 @@ class SparseMatrix {
   }
 
   virtual const std::string to_string() const {
-    return nullptr;
+    return "";
   }
 
   virtual const void *get_matrix() const {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -619,7 +619,7 @@ void export_lang(py::module &m) {
       .def("dtype", &aot::Arg::dtype)
       .def("channel_format", &aot::Arg::dtype);
 
-  py::class_<Node>(m, "Node");
+  py::class_<Node>(m, "Node");  // NOLINT(bugprone-unused-raii)
 
   py::class_<Sequential, Node>(m, "Sequential")
       .def(py::init<GraphBuilder *>())
@@ -810,7 +810,7 @@ void export_lang(py::module &m) {
       .def("size", [](ExprGroup *eg) { return eg->exprs.size(); })
       .def("push_back", &ExprGroup::push_back);
 
-  py::class_<Stmt>(m, "Stmt");
+  py::class_<Stmt>(m, "Stmt");  // NOLINT(bugprone-unused-raii)
 
   m.def("expr_snode_get_addr", &snode_get_addr);
   m.def("expr_snode_append", &snode_append);
@@ -1156,6 +1156,7 @@ void export_lang(py::module &m) {
   m.def("get_type_factory_instance", TypeFactory::get_instance,
         py::return_value_policy::reference);
 
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<BitStructType>(m, "BitStructType");
   py::class_<BitStructTypeBuilder>(m, "BitStructTypeBuilder")
       .def(py::init<int>())
@@ -1294,8 +1295,8 @@ void export_lang(py::module &m) {
       .value("g2r", mesh::ConvType::g2r)
       .export_values();
 
-  py::class_<mesh::Mesh>(m, "Mesh");
-  py::class_<mesh::MeshPtr>(m, "MeshPtr");
+  py::class_<mesh::Mesh>(m, "Mesh");        // NOLINT(bugprone-unused-raii)
+  py::class_<mesh::MeshPtr>(m, "MeshPtr");  // NOLINT(bugprone-unused-raii)
 
   m.def("element_order", mesh::element_order);
   m.def("from_end_element_order", mesh::from_end_element_order);

--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -70,7 +70,7 @@ void print_all_units() {
 }
 
 void export_misc(py::module &m) {
-  py::class_<Config>(m, "Config");
+  py::class_<Config>(m, "Config");  // NOLINT(bugprone-unused-raii)
   py::register_exception_translator([](std::exception_ptr p) {
     try {
       if (p)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6335
* #6334
* #6333
* __->__ #6332
* #6331
* #6330

- bugprone-argument-comment
- bugprone-assert-side-effect
- bugprone-dangling-handle
- bugprone-inaccurate-erase
- bugprone-string-integer-assignment
- bugprone-use-after-move
- bugprone-string-constructor
- bugprone-unused-raii