### PR TITLE
[build] Enable google-explicit-constructor check in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks:  '-*,
          bugprone-unused-raii,
          bugprone-use-after-move,
          google-build-explicit-make-pair,
+         google-explicit-constructor,
          modernize-use-override,
          performance-inefficient-string-concatenation,
          readability-identifier-naming'

--- a/taichi/analysis/constexpr_propagation.cpp
+++ b/taichi/analysis/constexpr_propagation.cpp
@@ -15,7 +15,7 @@ class ConstExprPropagation : public IRVisitor {
  public:
   using is_const_seed_func = std::function<bool(Stmt *)>;
 
-  ConstExprPropagation(const is_const_seed_func &is_const_seed)
+  explicit ConstExprPropagation(const is_const_seed_func &is_const_seed)
       : is_const_seed_(is_const_seed) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;

--- a/taichi/analysis/detect_fors_with_break.cpp
+++ b/taichi/analysis/detect_fors_with_break.cpp
@@ -15,7 +15,7 @@ class DetectForsWithBreak : public BasicStmtVisitor {
   std::unordered_set<Stmt *> fors_with_break;
   IRNode *root;
 
-  DetectForsWithBreak(IRNode *root) : root(root) {
+  explicit DetectForsWithBreak(IRNode *root) : root(root) {
   }
 
   void visit(FrontendBreakStmt *stmt) override {

--- a/taichi/analysis/gather_deactivations.cpp
+++ b/taichi/analysis/gather_deactivations.cpp
@@ -12,7 +12,7 @@ class GatherDeactivations : public BasicStmtVisitor {
   std::unordered_set<SNode *> snodes;
   IRNode *root;
 
-  GatherDeactivations(IRNode *root) : root(root) {
+  explicit GatherDeactivations(IRNode *root) : root(root) {
   }
 
   void visit(SNodeOpStmt *stmt) override {

--- a/taichi/analysis/gather_statements.cpp
+++ b/taichi/analysis/gather_statements.cpp
@@ -12,7 +12,7 @@ class StmtSearcher : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
 
-  StmtSearcher(std::function<bool(Stmt *)> test) : test_(test) {
+  explicit StmtSearcher(std::function<bool(Stmt *)> test) : test_(test) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
   }

--- a/taichi/analysis/gen_offline_cache_key.cpp
+++ b/taichi/analysis/gen_offline_cache_key.cpp
@@ -344,7 +344,7 @@ class ASTSerializer : public IRVisitor, public ExpressionVisitor {
     for (const auto &c : stmt->contents) {
       emit(static_cast<std::uint8_t>(c.index()));
       if (std::holds_alternative<Expr>(c)) {
-        emit(std::get<Expr>(c).expr);
+        emit(std::get<Expr>(c));
       } else {
         emit(std::get<std::string>(c));
       }

--- a/taichi/analysis/mesh_bls_analyzer.h
+++ b/taichi/analysis/mesh_bls_analyzer.h
@@ -27,7 +27,7 @@ class MeshBLSCache {
 
   MeshBLSCache() = default;
 
-  MeshBLSCache(SNode *snode) : snode(snode) {
+  explicit MeshBLSCache(SNode *snode) : snode(snode) {
     total_flags = AccessFlag(0);
     initialized = false;
     finalized = false;

--- a/taichi/aot/module_loader.h
+++ b/taichi/aot/module_loader.h
@@ -119,7 +119,7 @@ class TI_DLL_EXPORT Module {
 // Only responsible for reporting device capabilities
 class TargetDevice : public Device {
  public:
-  TargetDevice(Arch arch) {
+  explicit TargetDevice(Arch arch) {
     // TODO: make this configurable
     set_default_caps(arch);
   }

--- a/taichi/cache/gfx/cache_manager.h
+++ b/taichi/cache/gfx/cache_manager.h
@@ -30,7 +30,7 @@ class CacheManager {
     const std::vector<spirv::CompiledSNodeStructs> *compiled_structs;
   };
 
-  CacheManager(Params &&init_params);
+  explicit CacheManager(Params &&init_params);
 
   CompiledKernelData load_or_compile(CompileConfig *config, Kernel *kernel);
   void dump_with_merging() const;

--- a/taichi/cache/metal/cache_manager.h
+++ b/taichi/cache/metal/cache_manager.h
@@ -36,7 +36,7 @@ class CacheManager {
     const std::vector<CompiledStructs> *compiled_snode_trees_{nullptr};
   };
 
-  CacheManager(Params &&init_params);
+  explicit CacheManager(Params &&init_params);
 
   // Load from memory || Load from disk || (Compile && Cache the result in
   // memory)

--- a/taichi/codegen/cc/cc_layout.h
+++ b/taichi/codegen/cc/cc_layout.h
@@ -9,7 +9,8 @@ namespace cccp {
 
 class CCLayout {
  public:
-  CCLayout(CCProgramImpl *cc_program_impl) : cc_program_impl_(cc_program_impl) {
+  explicit CCLayout(CCProgramImpl *cc_program_impl)
+      : cc_program_impl_(cc_program_impl) {
   }
 
   std::string get_object() {

--- a/taichi/codegen/cpu/codegen_cpu.h
+++ b/taichi/codegen/cpu/codegen_cpu.h
@@ -11,7 +11,7 @@ namespace taichi::lang {
 
 class KernelCodeGenCPU : public KernelCodeGen {
  public:
-  KernelCodeGenCPU(Kernel *kernel, IRNode *ir = nullptr)
+  explicit KernelCodeGenCPU(Kernel *kernel, IRNode *ir = nullptr)
       : KernelCodeGen(kernel, ir) {
   }
 

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -30,7 +30,7 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
  public:
   using IRVisitor::visit;
 
-  TaskCodeGenCUDA(Kernel *kernel, IRNode *ir = nullptr)
+  explicit TaskCodeGenCUDA(Kernel *kernel, IRNode *ir = nullptr)
       : TaskCodeGenLLVM(kernel, ir) {
   }
 

--- a/taichi/codegen/cuda/codegen_cuda.h
+++ b/taichi/codegen/cuda/codegen_cuda.h
@@ -9,7 +9,7 @@ namespace taichi::lang {
 
 class KernelCodeGenCUDA : public KernelCodeGen {
  public:
-  KernelCodeGenCUDA(Kernel *kernel, IRNode *ir = nullptr)
+  explicit KernelCodeGenCUDA(Kernel *kernel, IRNode *ir = nullptr)
       : KernelCodeGen(kernel, ir) {
   }
 

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -67,9 +67,9 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   using IRVisitor::visit;
   using LLVMModuleBuilder::call;
 
-  TaskCodeGenLLVM(Kernel *kernel,
-                  IRNode *ir = nullptr,
-                  std::unique_ptr<llvm::Module> &&module = nullptr);
+  explicit TaskCodeGenLLVM(Kernel *kernel,
+                           IRNode *ir = nullptr,
+                           std::unique_ptr<llvm::Module> &&module = nullptr);
 
   Arch current_arch() {
     return kernel->arch;

--- a/taichi/codegen/llvm/llvm_compiled_data.h
+++ b/taichi/codegen/llvm/llvm_compiled_data.h
@@ -13,9 +13,9 @@ class OffloadedTask {
   int block_dim{0};
   int grid_dim{0};
 
-  OffloadedTask(const std::string &name = "",
-                int block_dim = 0,
-                int grid_dim = 0)
+  explicit OffloadedTask(const std::string &name = "",
+                         int block_dim = 0,
+                         int grid_dim = 0)
       : name(name), block_dim(block_dim), grid_dim(grid_dim){};
   TI_IO_DEF(name, block_dim, grid_dim);
 };

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -28,6 +28,7 @@ struct TaskAttributes {
 
     BufferInfo() = default;
 
+    // NOLINTNEXTLINE(google-explicit-constructor)
     BufferInfo(BufferType buffer_type) : type(buffer_type) {
     }
 

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -204,7 +204,7 @@ class InstrBuilder {
 // Builder to build up a single SPIR-V module
 class IRBuilder {
  public:
-  IRBuilder(const Device *device) : device_(device) {
+  explicit IRBuilder(const Device *device) : device_(device) {
   }
 
   template <typename... Args>

--- a/taichi/codegen/spirv/spirv_types.cpp
+++ b/taichi/codegen/spirv/spirv_types.cpp
@@ -290,7 +290,7 @@ class TypeReducer : public TypeVisitor {
   std::unique_ptr<tinyir::Block> copy{nullptr};
   std::unordered_map<const tinyir::Type *, const tinyir::Type *> &oldptr2newptr;
 
-  TypeReducer(
+  explicit TypeReducer(
       std::unordered_map<const tinyir::Type *, const tinyir::Type *> &old2new)
       : oldptr2newptr(old2new) {
     copy = std::make_unique<tinyir::Block>();

--- a/taichi/codegen/spirv/spirv_types.h
+++ b/taichi/codegen/spirv/spirv_types.h
@@ -44,7 +44,7 @@ class IntType : public tinyir::Type, public tinyir::MemRefElementTypeInterface {
 class FloatType : public tinyir::Type,
                   public tinyir::MemRefElementTypeInterface {
  public:
-  FloatType(int num_bits) : num_bits_(num_bits) {
+  explicit FloatType(int num_bits) : num_bits_(num_bits) {
   }
 
   int num_bits() const {
@@ -71,7 +71,7 @@ class FloatType : public tinyir::Type,
 class PhysicalPointerType : public IntType,
                             public tinyir::PointerTypeInterface {
  public:
-  PhysicalPointerType(const tinyir::Type *pointed_type)
+  explicit PhysicalPointerType(const tinyir::Type *pointed_type)
       : IntType(/*num_bits=*/64, /*is_signed=*/false),
         pointed_type_(pointed_type) {
   }
@@ -94,7 +94,7 @@ class StructType : public tinyir::Type,
                    public tinyir::AggregateTypeInterface,
                    public tinyir::MemRefAggregateTypeInterface {
  public:
-  StructType(std::vector<const tinyir::Type *> &elements)
+  explicit StructType(std::vector<const tinyir::Type *> &elements)
       : elements_(elements) {
   }
 

--- a/taichi/codegen/wasm/codegen_wasm.h
+++ b/taichi/codegen/wasm/codegen_wasm.h
@@ -12,7 +12,7 @@ namespace taichi::lang {
 
 class KernelCodeGenWASM : public KernelCodeGen {
  public:
-  KernelCodeGenWASM(Kernel *kernel, IRNode *ir = nullptr)
+  explicit KernelCodeGenWASM(Kernel *kernel, IRNode *ir = nullptr)
       : KernelCodeGen(kernel, ir) {
   }
 

--- a/taichi/common/core.h
+++ b/taichi/common/core.h
@@ -290,7 +290,7 @@ class DeferedExecution {
   std::function<void(void)> statement_;
 
  public:
-  DeferedExecution(const std::function<void(void)> &statement)
+  explicit DeferedExecution(const std::function<void(void)> &statement)
       : statement_(statement) {
   }
 

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -8,7 +8,7 @@ class TaichiExceptionImpl : public std::exception {
   std::string msg_;
 
  public:
-  TaichiExceptionImpl(const std::string msg) : msg_(msg) {
+  explicit TaichiExceptionImpl(const std::string msg) : msg_(msg) {
   }
   const char *what() const throw() override {
     return msg_.c_str();

--- a/taichi/common/interface.h
+++ b/taichi/common/interface.h
@@ -117,7 +117,7 @@ class InterfaceHolder {
   class TI_IMPLEMENTATION_HOLDER_NAME(T) final                                \
       : public ImplementationHolderBase {                                     \
    public:                                                                    \
-    TI_IMPLEMENTATION_HOLDER_NAME(T)(const std::string &name) {               \
+    explicit TI_IMPLEMENTATION_HOLDER_NAME(T)(const std::string &name) {      \
       this->name = name;                                                      \
     }                                                                         \
     using FactoryMethod = std::function<std::shared_ptr<T>()>;                \

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -32,7 +32,7 @@ class Expr {
 
   explicit Expr(float64 x);
 
-  Expr(std::shared_ptr<Expression> expr) : Expr() {
+  explicit Expr(std::shared_ptr<Expression> expr) : Expr() {
     this->expr = expr;
   }
 
@@ -53,6 +53,7 @@ class Expr {
     expr = o.expr;
   }
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator bool() const {
     return expr.get() != nullptr;
   }

--- a/taichi/ir/expression.h
+++ b/taichi/ir/expression.h
@@ -62,7 +62,7 @@ class ExprGroup {
   ExprGroup() {
   }
 
-  ExprGroup(const Expr &a) {
+  explicit ExprGroup(const Expr &a) {
     exprs.emplace_back(a);
   }
 
@@ -119,8 +119,8 @@ inline ExprGroup operator,(const ExprGroup &a, const Expr &b) {
 
 class ExpressionVisitor {
  public:
-  ExpressionVisitor(bool allow_undefined_visitor = false,
-                    bool invoke_default_visitor = false)
+  explicit ExpressionVisitor(bool allow_undefined_visitor = false,
+                             bool invoke_default_visitor = false)
       : allow_undefined_visitor_(allow_undefined_visitor),
         invoke_default_visitor_(invoke_default_visitor) {
   }

--- a/taichi/ir/expression_printer.h
+++ b/taichi/ir/expression_printer.h
@@ -10,7 +10,7 @@ namespace taichi::lang {
 
 class ExpressionPrinter : public ExpressionVisitor {
  public:
-  ExpressionPrinter(std::ostream *os = nullptr) : os_(os) {
+  explicit ExpressionPrinter(std::ostream *os = nullptr) : os_(os) {
   }
 
   void set_ostream(std::ostream *os) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1289,7 +1289,7 @@ void ASTBuilder::begin_frontend_mesh_for(
       "ti.loop_config(serialize=True) does not have effect on the mesh for. "
       "The execution order is not guaranteed.");
   auto stmt_unique = std::make_unique<FrontendForStmt>(
-      i, mesh_ptr, element_type, arch_, for_loop_dec_.config);
+      ExprGroup(i), mesh_ptr, element_type, arch_, for_loop_dec_.config);
   for_loop_dec_.reset();
   auto stmt = stmt_unique.get();
   this->insert(std::move(stmt_unique));

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -53,7 +53,7 @@ class FrontendExprStmt : public Stmt {
  public:
   Expr val;
 
-  FrontendExprStmt(const Expr &val) : val(val) {
+  explicit FrontendExprStmt(const Expr &val) : val(val) {
   }
 
   TI_DEFINE_ACCEPT
@@ -132,7 +132,7 @@ class FrontendIfStmt : public Stmt {
   Expr condition;
   std::unique_ptr<Block> true_statements, false_statements;
 
-  FrontendIfStmt(const Expr &condition) : condition(condition) {
+  explicit FrontendIfStmt(const Expr &condition) : condition(condition) {
   }
 
   bool is_container_statement() const override {
@@ -147,7 +147,7 @@ class FrontendPrintStmt : public Stmt {
   using EntryType = std::variant<Expr, std::string>;
   std::vector<EntryType> contents;
 
-  FrontendPrintStmt(const std::vector<EntryType> &contents_) {
+  explicit FrontendPrintStmt(const std::vector<EntryType> &contents_) {
     for (const auto &c : contents_) {
       if (std::holds_alternative<Expr>(c))
         contents.push_back(std::get<Expr>(c));
@@ -215,7 +215,7 @@ class FrontendFuncDefStmt : public Stmt {
   std::string funcid;
   std::unique_ptr<Block> body;
 
-  FrontendFuncDefStmt(const std::string &funcid) : funcid(funcid) {
+  explicit FrontendFuncDefStmt(const std::string &funcid) : funcid(funcid) {
   }
 
   bool is_container_statement() const override {
@@ -253,7 +253,7 @@ class FrontendWhileStmt : public Stmt {
   Expr cond;
   std::unique_ptr<Block> body;
 
-  FrontendWhileStmt(const Expr &cond) : cond(cond) {
+  explicit FrontendWhileStmt(const Expr &cond) : cond(cond) {
   }
 
   bool is_container_statement() const override {
@@ -267,7 +267,7 @@ class FrontendReturnStmt : public Stmt {
  public:
   ExprGroup values;
 
-  FrontendReturnStmt(const ExprGroup &group) : values(group) {
+  explicit FrontendReturnStmt(const ExprGroup &group) : values(group) {
   }
 
   bool is_container_statement() const override {
@@ -313,7 +313,7 @@ class TexturePtrExpression : public Expression {
   DataType channel_format{PrimitiveType::f32};
   int lod{0};
 
-  TexturePtrExpression(int arg_id, int num_dims = 2)
+  explicit TexturePtrExpression(int arg_id, int num_dims = 2)
       : arg_id(arg_id), num_dims(num_dims) {
   }
 
@@ -341,7 +341,7 @@ class RandExpression : public Expression {
  public:
   DataType dt;
 
-  RandExpression(DataType dt) : dt(dt) {
+  explicit RandExpression(DataType dt) : dt(dt) {
   }
 
   void type_check(CompileConfig *config) override;
@@ -677,7 +677,7 @@ class IdExpression : public Expression {
  public:
   Identifier id;
 
-  IdExpression(const Identifier &id) : id(id) {
+  explicit IdExpression(const Identifier &id) : id(id) {
   }
 
   void type_check(CompileConfig *config) override {
@@ -762,7 +762,7 @@ class ConstExpression : public Expression {
   TypedConstant val;
 
   template <typename T>
-  ConstExpression(const T &x) : val(x) {
+  explicit ConstExpression(const T &x) : val(x) {
     ret_type = val.dt;
   }
   template <typename T>
@@ -879,7 +879,7 @@ class ReferenceExpression : public Expression {
   Expr var;
   void type_check(CompileConfig *config) override;
 
-  ReferenceExpression(const Expr &expr) : var(expr) {
+  explicit ReferenceExpression(const Expr &expr) : var(expr) {
   }
 
   void flatten(FlattenContext *ctx) override;
@@ -1024,7 +1024,7 @@ class FrontendContext {
   std::unique_ptr<Block> root_node_;
 
  public:
-  FrontendContext(Arch arch) {
+  explicit FrontendContext(Arch arch) {
     root_node_ = std::make_unique<Block>();
     current_builder_ = std::make_unique<ASTBuilder>(root_node_.get(), arch);
   }

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -83,7 +83,8 @@ class Identifier {
   // Identifier() = default;
 
   // Multiple identifiers can share the same name but must have different id's
-  Identifier(int id, const std::string &name = "") : name_(name), id(id) {
+  explicit Identifier(int id, const std::string &name = "")
+      : name_(name), id(id) {
   }
 
   std::string raw_name() const;
@@ -114,6 +115,7 @@ class VecStatement {
   VecStatement() {
   }
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   VecStatement(pStmt &&stmt) {
     push_back(std::move(stmt));
   }
@@ -122,6 +124,7 @@ class VecStatement {
     stmts = std::move(o.stmts);
   }
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   VecStatement(stmt_vector &&other_stmts) {
     stmts = std::move(other_stmts);
   }
@@ -331,7 +334,7 @@ class StmtFieldManager {
  public:
   std::vector<std::unique_ptr<StmtField>> fields;
 
-  StmtFieldManager(Stmt *stmt) : stmt_(stmt) {
+  explicit StmtFieldManager(Stmt *stmt) : stmt_(stmt) {
   }
 
   template <typename T>

--- a/taichi/ir/mesh.h
+++ b/taichi/ir/mesh.h
@@ -57,7 +57,7 @@ struct MeshLocalRelation {
     fixed = false;
   }
 
-  MeshLocalRelation(SNode *value_) : value(value_) {
+  explicit MeshLocalRelation(SNode *value_) : value(value_) {
     fixed = true;
   }
 

--- a/taichi/ir/scratch_pad.h
+++ b/taichi/ir/scratch_pad.h
@@ -61,7 +61,7 @@ class ScratchPad {
 
   ScratchPad() = default;
 
-  ScratchPad(SNode *snode) : snode(snode) {
+  explicit ScratchPad(SNode *snode) : snode(snode) {
     TI_ASSERT(snode != nullptr);
     dim = snode->num_active_indices;
     coefficients.resize(dim);

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -24,7 +24,7 @@ class Axis {
   Axis() {
     value = 0;
   }
-  Axis(int value) : value(value) {
+  explicit Axis(int value) : value(value) {
     TI_ERROR_UNLESS(0 <= value && value < taichi_max_num_indices,
                     "Too many dimensions. The maximum dimensionality is {}",
                     taichi_max_num_indices);
@@ -144,8 +144,8 @@ class SNode {
   // Whether the path from root to |this| contains only `dense` SNodes.
   bool is_path_all_dense{true};
 
-  SNode(SNodeFieldMap *snode_to_fields = nullptr,
-        SNodeRwAccessorsBank *snode_rw_accessors_bank = nullptr);
+  explicit SNode(SNodeFieldMap *snode_to_fields = nullptr,
+                 SNodeRwAccessorsBank *snode_rw_accessors_bank = nullptr);
 
   SNode(int depth,
         SNodeType t,

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -17,7 +17,7 @@ class Function;
  */
 class AllocaStmt : public Stmt {
  public:
-  AllocaStmt(DataType type) : is_shared(false) {
+  explicit AllocaStmt(DataType type) : is_shared(false) {
     ret_type = type;
     TI_STMT_REG_FIELDS;
   }
@@ -206,7 +206,7 @@ class ArgLoadStmt : public Stmt {
  */
 class RandStmt : public Stmt {
  public:
-  RandStmt(const DataType &dt) {
+  explicit RandStmt(const DataType &dt) {
     ret_type = dt;
     TI_STMT_REG_FIELDS;
   }
@@ -740,18 +740,19 @@ class PrintStmt : public Stmt {
   using EntryType = std::variant<Stmt *, std::string>;
   std::vector<EntryType> contents;
 
-  PrintStmt(const std::vector<EntryType> &contents_) : contents(contents_) {
+  explicit PrintStmt(const std::vector<EntryType> &contents_)
+      : contents(contents_) {
     TI_STMT_REG_FIELDS;
   }
 
   template <typename... Args>
-  PrintStmt(Stmt *t, Args &&...args)
+  explicit PrintStmt(Stmt *t, Args &&...args)
       : contents(make_entries(t, std::forward<Args>(args)...)) {
     TI_STMT_REG_FIELDS;
   }
 
   template <typename... Args>
-  PrintStmt(const std::string &str, Args &&...args)
+  explicit PrintStmt(const std::string &str, Args &&...args)
       : contents(make_entries(str, std::forward<Args>(args)...)) {
     TI_STMT_REG_FIELDS;
   }
@@ -950,7 +951,7 @@ class ReferenceStmt : public Stmt {
   Stmt *var;
   bool global_side_effect{false};
 
-  ReferenceStmt(Stmt *var) : var(var) {
+  explicit ReferenceStmt(Stmt *var) : var(var) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -1089,7 +1090,7 @@ class BitExtractStmt : public Stmt {
  */
 class GetRootStmt : public Stmt {
  public:
-  GetRootStmt(SNode *root = nullptr) : root_(root) {
+  explicit GetRootStmt(SNode *root = nullptr) : root_(root) {
     if (this->root_ != nullptr) {
       while (this->root_->parent) {
         this->root_ = this->root_->parent;
@@ -1831,7 +1832,7 @@ class MatrixInitStmt : public Stmt {
  public:
   std::vector<Stmt *> values;
 
-  MatrixInitStmt(const std::vector<Stmt *> &values) : values(values) {
+  explicit MatrixInitStmt(const std::vector<Stmt *> &values) : values(values) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -55,6 +55,7 @@ class TI_DLL_EXPORT DataType {
  public:
   DataType();
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   DataType(Type *ptr) : ptr_(ptr) {
   }
 
@@ -75,10 +76,12 @@ class TI_DLL_EXPORT DataType {
     return ptr_->to_string();
   };
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator const Type *() const {
     return ptr_;
   }
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator Type *() {
     return ptr_;
   }
@@ -120,7 +123,7 @@ class TI_DLL_EXPORT PrimitiveType : public Type {
   // TODO(type): make 'type' private and add a const getter
   PrimitiveTypeID type;
 
-  PrimitiveType(PrimitiveTypeID type) : type(type) {
+  explicit PrimitiveType(PrimitiveTypeID type) : type(type) {
   }
 
   std::string to_string() const override;
@@ -383,41 +386,41 @@ class TypedConstant {
   TypedConstant() : dt(PrimitiveType::unknown) {
   }
 
-  TypedConstant(DataType dt) : dt(dt) {
+  explicit TypedConstant(DataType dt) : dt(dt) {
     TI_ASSERT_INFO(dt->is<PrimitiveType>(),
                    "TypedConstant can only be PrimitiveType, got {}",
                    dt->to_string());
     value_bits = 0;
   }
 
-  TypedConstant(int32 x) : dt(PrimitiveType::i32), val_i32(x) {
+  explicit TypedConstant(int32 x) : dt(PrimitiveType::i32), val_i32(x) {
   }
 
-  TypedConstant(float32 x) : dt(PrimitiveType::f32), val_f32(x) {
+  explicit TypedConstant(float32 x) : dt(PrimitiveType::f32), val_f32(x) {
   }
 
-  TypedConstant(int64 x) : dt(PrimitiveType::i64), val_i64(x) {
+  explicit TypedConstant(int64 x) : dt(PrimitiveType::i64), val_i64(x) {
   }
 
-  TypedConstant(float64 x) : dt(PrimitiveType::f64), val_f64(x) {
+  explicit TypedConstant(float64 x) : dt(PrimitiveType::f64), val_f64(x) {
   }
 
-  TypedConstant(int8 x) : dt(PrimitiveType::i8), val_i8(x) {
+  explicit TypedConstant(int8 x) : dt(PrimitiveType::i8), val_i8(x) {
   }
 
-  TypedConstant(int16 x) : dt(PrimitiveType::i16), val_i16(x) {
+  explicit TypedConstant(int16 x) : dt(PrimitiveType::i16), val_i16(x) {
   }
 
-  TypedConstant(uint8 x) : dt(PrimitiveType::u8), val_u8(x) {
+  explicit TypedConstant(uint8 x) : dt(PrimitiveType::u8), val_u8(x) {
   }
 
-  TypedConstant(uint16 x) : dt(PrimitiveType::u16), val_u16(x) {
+  explicit TypedConstant(uint16 x) : dt(PrimitiveType::u16), val_u16(x) {
   }
 
-  TypedConstant(uint32 x) : dt(PrimitiveType::u32), val_u32(x) {
+  explicit TypedConstant(uint32 x) : dt(PrimitiveType::u32), val_u32(x) {
   }
 
-  TypedConstant(uint64 x) : dt(PrimitiveType::u64), val_u64(x) {
+  explicit TypedConstant(uint64 x) : dt(PrimitiveType::u64), val_u64(x) {
   }
 
   template <typename T>

--- a/taichi/math/array_2d.h
+++ b/taichi/math/array_2d.h
@@ -226,9 +226,9 @@ class ArrayND<2, T> {
     return region;
   }
 
-  ArrayND(const Vector2i &res,
-          T init = T(0),
-          Vector2 storage_offset = Vector2(0.5f)) {
+  explicit ArrayND(const Vector2i &res,
+                   T init = T(0),
+                   Vector2 storage_offset = Vector2(0.5f)) {
     initialize(res, init, storage_offset);
   }
 
@@ -730,7 +730,7 @@ class ArrayND<2, T> {
     return true;
   }
 
-  ArrayND(const std::string &filename) {
+  explicit ArrayND(const std::string &filename) {
     load_image(filename);
   }
 

--- a/taichi/math/linalg.h
+++ b/taichi/math/linalg.h
@@ -121,7 +121,7 @@ struct VectorND : public VectorNDBase<dim__, T, ISE> {
 
   template <typename T_ = T,
             typename std::enable_if_t<std::is_same<T_, int>::value, int> = 0>
-  VectorND(const TIndex<dim> &ind);
+  explicit VectorND(const TIndex<dim> &ind);
 
   // Vector initialization
   template <typename F,
@@ -524,7 +524,7 @@ struct VectorND : public VectorNDBase<dim__, T, ISE> {
     }
   }
 
-  TI_FORCE_INLINE operator std::array<T, dim>() const {
+  TI_FORCE_INLINE explicit operator std::array<T, dim>() const {
     std::array<T, dim> arr;
     for (int i = 0; i < dim; i++) {
       arr[i] = d[i];
@@ -639,7 +639,7 @@ struct MatrixND {
     }
   }
 
-  TI_FORCE_INLINE MatrixND(T v) : MatrixND() {
+  TI_FORCE_INLINE explicit MatrixND(T v) : MatrixND() {
     for (int i = 0; i < dim; i++) {
       d[i][i] = v;
     }

--- a/taichi/program/kernel_profiler.h
+++ b/taichi/program/kernel_profiler.h
@@ -33,7 +33,7 @@ struct KernelProfileStatisticalResult {
   double max;
   double total;
 
-  KernelProfileStatisticalResult(const std::string &name)
+  explicit KernelProfileStatisticalResult(const std::string &name)
       : name(name), counter(0), min(0), max(0), total(0) {
   }
 

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -30,7 +30,7 @@ class ProgramImpl {
   CompileConfig *config;
 
  public:
-  ProgramImpl(CompileConfig &config);
+  explicit ProgramImpl(CompileConfig &config);
 
   /**
    * Codegen to specific backend

--- a/taichi/program/sparse_matrix.h
+++ b/taichi/program/sparse_matrix.h
@@ -112,11 +112,11 @@ class EigenSparseMatrix : public SparseMatrix {
   explicit EigenSparseMatrix(int rows, int cols, DataType dt)
       : SparseMatrix(rows, cols, dt), matrix_(rows, cols) {
   }
-  explicit EigenSparseMatrix(EigenSparseMatrix &sm)
+  EigenSparseMatrix(EigenSparseMatrix &sm)
       : SparseMatrix(sm.num_rows(), sm.num_cols(), sm.dtype_),
         matrix_(sm.matrix_) {
   }
-  explicit EigenSparseMatrix(EigenSparseMatrix &&sm)
+  EigenSparseMatrix(EigenSparseMatrix &&sm)
       : SparseMatrix(sm.num_rows(), sm.num_cols(), sm.dtype_),
         matrix_(sm.matrix_) {
   }

--- a/taichi/python/exception.h
+++ b/taichi/python/exception.h
@@ -16,7 +16,7 @@ class ExceptionForPython : public std::exception {
   std::string msg_;
 
  public:
-  ExceptionForPython(const std::string &msg) : msg_(msg) {
+  explicit ExceptionForPython(const std::string &msg) : msg_(msg) {
   }
   char const *what() const throw() override {
     return msg_.c_str();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -44,7 +44,7 @@ bool test_threading();
 namespace taichi::lang {
 
 Expr expr_index(const Expr &expr, const Expr &index) {
-  return expr[index];
+  return expr[ExprGroup(index)];
 }
 
 std::string libdevice_path();

--- a/taichi/python/interfaces_registry.cpp
+++ b/taichi/python/interfaces_registry.cpp
@@ -11,7 +11,7 @@ namespace taichi {
                                                                               \
   class InterfaceInjector_##class_name {                                      \
    public:                                                                    \
-    InterfaceInjector_##class_name(const std::string &name) {                 \
+    explicit InterfaceInjector_##class_name(const std::string &name) {        \
       InterfaceHolder::get_instance()->register_registration_method(          \
           base_alias, [&](void *m) {                                          \
             ((pybind11::module *)m)                                           \

--- a/taichi/rhi/cuda/cuda_caching_allocator.h
+++ b/taichi/rhi/cuda/cuda_caching_allocator.h
@@ -11,7 +11,7 @@ namespace cuda {
 
 class CudaCachingAllocator {
  public:
-  CudaCachingAllocator(LlvmDevice *device);
+  explicit CudaCachingAllocator(LlvmDevice *device);
 
   uint64_t *allocate(const LlvmDevice::LlvmRuntimeAllocParams &params);
   void release(size_t sz, uint64_t *ptr);

--- a/taichi/rhi/cuda/cuda_context.h
+++ b/taichi/rhi/cuda/cuda_context.h
@@ -78,7 +78,7 @@ class CUDAContext {
     void *new_ctx_;
 
    public:
-    ContextGuard(CUDAContext *new_ctx)
+    explicit ContextGuard(CUDAContext *new_ctx)
         : old_ctx_(nullptr), new_ctx_(new_ctx->context_) {
       CUDADriver::get_instance().context_get_current(&old_ctx_);
       if (old_ctx_ != new_ctx_)

--- a/taichi/rhi/cuda/cuda_profiler.h
+++ b/taichi/rhi/cuda/cuda_profiler.h
@@ -22,7 +22,7 @@ class EventToolkit;
 // A CUDA kernel profiler
 class KernelProfilerCUDA : public KernelProfilerBase {
  public:
-  KernelProfilerCUDA(bool enable);
+  explicit KernelProfilerCUDA(bool enable);
 
   std::string get_device_name() override;
 

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -72,7 +72,8 @@ struct TI_DLL_EXPORT DeviceAllocation {
 };
 
 struct TI_DLL_EXPORT DeviceAllocationGuard : public DeviceAllocation {
-  DeviceAllocationGuard(DeviceAllocation alloc) : DeviceAllocation(alloc) {
+  explicit DeviceAllocationGuard(DeviceAllocation alloc)
+      : DeviceAllocation(alloc) {
   }
   DeviceAllocationGuard(const DeviceAllocationGuard &) = delete;
   ~DeviceAllocationGuard();

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -45,7 +45,7 @@ class CompiledTaichiKernel {
     DeviceAllocation *listgen_buffer{nullptr};
   };
 
-  CompiledTaichiKernel(const Params &ti_params);
+  explicit CompiledTaichiKernel(const Params &ti_params);
 
   const TaichiKernelAttributes &ti_kernel_attribs() const;
 

--- a/taichi/runtime/llvm/llvm_context.h
+++ b/taichi/runtime/llvm/llvm_context.h
@@ -31,7 +31,7 @@ class TaichiLLVMContext {
     llvm::LLVMContext *llvm_context{nullptr};
     std::unique_ptr<llvm::Module> runtime_module{nullptr};
     std::unordered_map<int, std::unique_ptr<llvm::Module>> struct_modules;
-    ThreadLocalData(std::unique_ptr<llvm::orc::ThreadSafeContext> ctx);
+    explicit ThreadLocalData(std::unique_ptr<llvm::orc::ThreadSafeContext> ctx);
     ~ThreadLocalData();
   };
   CompileConfig *config_;

--- a/taichi/runtime/llvm/snode_tree_buffer_manager.h
+++ b/taichi/runtime/llvm/snode_tree_buffer_manager.h
@@ -14,7 +14,7 @@ class LlvmRuntimeExecutor;
 
 class SNodeTreeBufferManager {
  public:
-  SNodeTreeBufferManager(LlvmRuntimeExecutor *runtime_exec);
+  explicit SNodeTreeBufferManager(LlvmRuntimeExecutor *runtime_exec);
 
   void merge_and_insert(Ptr ptr, std::size_t size);
 

--- a/taichi/runtime/program_impls/metal/metal_program.h
+++ b/taichi/runtime/program_impls/metal/metal_program.h
@@ -18,7 +18,7 @@ namespace taichi::lang {
 
 class MetalProgramImpl : public ProgramImpl {
  public:
-  MetalProgramImpl(CompileConfig &config);
+  explicit MetalProgramImpl(CompileConfig &config);
 
   FunctionType compile(Kernel *kernel, OffloadedStmt *offloaded) override;
 

--- a/taichi/runtime/program_impls/opengl/opengl_program.h
+++ b/taichi/runtime/program_impls/opengl/opengl_program.h
@@ -9,7 +9,7 @@ namespace taichi::lang {
 
 class OpenglProgramImpl : public ProgramImpl {
  public:
-  OpenglProgramImpl(CompileConfig &config);
+  explicit OpenglProgramImpl(CompileConfig &config);
   FunctionType compile(Kernel *kernel, OffloadedStmt *offloaded) override;
 
   std::size_t get_snode_num_dynamically_allocated(

--- a/taichi/system/profiler.cpp
+++ b/taichi/system/profiler.cpp
@@ -62,7 +62,7 @@ class ProfilerRecords {
   int current_depth;
   bool enabled;
 
-  ProfilerRecords(const std::string &name) {
+  explicit ProfilerRecords(const std::string &name) {
     root = std::make_unique<ProfilerRecordNode>(
         fmt::format("[Profiler {}]", name), nullptr);
     current_node = root.get();

--- a/taichi/system/profiler.h
+++ b/taichi/system/profiler.h
@@ -22,7 +22,7 @@ class ProfilerRecords;
 // profiler instance
 class ScopedProfiler {
  public:
-  ScopedProfiler(std::string name, uint64 elements = -1);
+  explicit ScopedProfiler(std::string name, uint64 elements = -1);
 
   void stop();
 

--- a/taichi/system/threading.h
+++ b/taichi/system/threading.h
@@ -39,7 +39,7 @@ class ThreadPool {
                                  // taichi::lang::Context.
   int thread_counter;
 
-  ThreadPool(int max_num_threads);
+  explicit ThreadPool(int max_num_threads);
 
   void run(int splits,
            int desired_num_threads,

--- a/taichi/system/timeline.h
+++ b/taichi/system/timeline.h
@@ -41,7 +41,7 @@ class Timeline {
 
   class Guard {
    public:
-    Guard(const std::string &name);
+    explicit Guard(const std::string &name);
 
     ~Guard();
 

--- a/taichi/system/timer.h
+++ b/taichi/system/timer.h
@@ -57,7 +57,7 @@ class TI_DLL_EXPORT Time {
     bool have_output;
 
    public:
-    Timer(std::string name);
+    explicit Timer(std::string name);
 
     Timer() {
     }
@@ -76,7 +76,7 @@ class TI_DLL_EXPORT Time {
                       double average) override;
 
    public:
-    TickTimer(std::string name);
+    explicit TickTimer(std::string name);
 
     ~TickTimer() override {
       output();

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -239,7 +239,7 @@ class IdentifyIndependentBlocks : public BasicStmtVisitor {
 class PromoteSSA2LocalVar : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
 
-  PromoteSSA2LocalVar(Block *block) {
+  explicit PromoteSSA2LocalVar(Block *block) {
     alloca_block_ = block;
     invoke_default_visitor = true;
     execute_once_ = true;
@@ -436,7 +436,7 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
       auto stack_alloca = Stmt::make<AdStackAllocaStmt>(dtype, ad_stack_size);
       auto stack_alloca_ptr = stack_alloca.get();
 
-      alloc->replace_with(std::move(stack_alloca));
+      alloc->replace_with(VecStatement(std::move(stack_alloca)));
 
       // Note that unlike AllocaStmt, AdStackAllocaStmt does NOT have an 0 as
       // initial value. Therefore here we push an initial 0 value.
@@ -462,7 +462,8 @@ class ReverseOuterLoops : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
 
  private:
-  ReverseOuterLoops(const std::set<Block *> &IB) : loop_depth_(0), ib_(IB) {
+  explicit ReverseOuterLoops(const std::set<Block *> &IB)
+      : loop_depth_(0), ib_(IB) {
   }
 
   bool is_ib(Block *block) const {
@@ -675,7 +676,7 @@ class MakeAdjoint : public ADTransform {
   Block *forward_backup;
   std::map<Stmt *, Stmt *> adjoint_stmt;
 
-  MakeAdjoint(Block *block) {
+  explicit MakeAdjoint(Block *block) {
     current_block = nullptr;
     alloca_block = block;
     forward_backup = block;
@@ -1101,7 +1102,7 @@ class MakeDual : public ADTransform {
   Block *alloca_block;
   std::map<Stmt *, Stmt *> dual_stmt;
 
-  MakeDual(Block *block) {
+  explicit MakeDual(Block *block) {
     current_stmt = nullptr;
     alloca_block = block;
     current_block = block;
@@ -1412,7 +1413,8 @@ class BackupSSA : public BasicStmtVisitor {
   Block *independent_block;
   std::map<Stmt *, Stmt *> backup_alloca;
 
-  BackupSSA(Block *independent_block) : independent_block(independent_block) {
+  explicit BackupSSA(Block *independent_block)
+      : independent_block(independent_block) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
   }

--- a/taichi/transforms/demote_mesh_statements.cpp
+++ b/taichi/transforms/demote_mesh_statements.cpp
@@ -24,7 +24,7 @@ class ReplaceIndexConversion : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
 
-  ReplaceIndexConversion(OffloadedStmt *node) {
+  explicit ReplaceIndexConversion(OffloadedStmt *node) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
 

--- a/taichi/transforms/demote_operations.cpp
+++ b/taichi/transforms/demote_operations.cpp
@@ -233,7 +233,8 @@ class DemoteOperations : public BasicStmtVisitor {
       }
       auto final_result = builder.create_local_load(result);
       stmt->replace_usages_with(final_result);
-      modifier.insert_before(stmt, std::move(builder.extract_ir()->statements));
+      modifier.insert_before(
+          stmt, VecStatement(std::move(builder.extract_ir()->statements)));
       modifier.erase(stmt);
     }
   }

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -29,7 +29,8 @@ class ExternalPtrAccessVisitor : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
 
-  ExternalPtrAccessVisitor(std::unordered_map<int, ExternalPtrAccess> &map)
+  explicit ExternalPtrAccessVisitor(
+      std::unordered_map<int, ExternalPtrAccess> &map)
       : BasicStmtVisitor(), map_(map) {
   }
 

--- a/taichi/transforms/die.cpp
+++ b/taichi/transforms/die.cpp
@@ -18,7 +18,7 @@ class DIE : public IRVisitor {
   DelayedIRModifier modifier;
   bool modified_ir;
 
-  DIE(IRNode *node) {
+  explicit DIE(IRNode *node) {
     allow_undefined_visitor = true;
     invoke_default_visitor = true;
     modified_ir = false;

--- a/taichi/transforms/flag_access.cpp
+++ b/taichi/transforms/flag_access.cpp
@@ -9,7 +9,7 @@ namespace taichi::lang {
 // Flag accesses to be either weak (non-activating) or strong (activating)
 class FlagAccess : public IRVisitor {
  public:
-  FlagAccess(IRNode *node) {
+  explicit FlagAccess(IRNode *node) {
     allow_undefined_visitor = true;
     invoke_default_visitor = false;
     node->accept(this);
@@ -85,7 +85,7 @@ class WeakenAccess : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
 
-  WeakenAccess(IRNode *node) {
+  explicit WeakenAccess(IRNode *node) {
     allow_undefined_visitor = true;
     invoke_default_visitor = false;
     current_struct_for_ = nullptr;

--- a/taichi/transforms/inlining.cpp
+++ b/taichi/transforms/inlining.cpp
@@ -31,8 +31,8 @@ class Inliner : public BasicStmtVisitor {
           [&](Stmt *s) { return stmt->args[s->as<ArgLoadStmt>()->arg_id]; });
     }
     if (func->rets.empty()) {
-      modifier_.replace_with(stmt,
-                             std::move(inlined_ir->as<Block>()->statements));
+      modifier_.replace_with(
+          stmt, VecStatement(std::move(inlined_ir->as<Block>()->statements)));
     } else {
       if (irpass::analysis::gather_statements(inlined_ir.get(), [&](Stmt *s) {
             return s->is<ReturnStmt>();

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -44,8 +44,8 @@ class IRPrinter : public IRVisitor {
   std::string *output{nullptr};
   std::stringstream ss;
 
-  IRPrinter(ExpressionPrinter *expr_printer = nullptr,
-            std::string *output = nullptr)
+  explicit IRPrinter(ExpressionPrinter *expr_printer = nullptr,
+                     std::string *output = nullptr)
       : expr_printer_(expr_printer), output(output) {
   }
 

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -11,7 +11,7 @@ class Scalarize : public BasicStmtVisitor {
  public:
   DelayedIRModifier modifier_;
 
-  Scalarize(IRNode *node) {
+  explicit Scalarize(IRNode *node) {
     node->accept(this);
 
     modifier_.modify_ir();
@@ -286,7 +286,7 @@ class ScalarizePointers : public BasicStmtVisitor {
   // { original_alloca_stmt : [scalarized_alloca_stmt0, ...] }
   std::unordered_map<Stmt *, std::vector<Stmt *>> scalarized_local_tensor_map_;
 
-  ScalarizePointers(IRNode *node) {
+  explicit ScalarizePointers(IRNode *node) {
     node->accept(this);
 
     modifier_.modify_ir();

--- a/taichi/ui/gui/gui.h
+++ b/taichi/ui/gui/gui.h
@@ -84,7 +84,7 @@ class TI_DLL_EXPORT Canvas {
     bool finished;
     static Vector2 vertices[128];  // TODO: ...
 
-    TI_FORCE_INLINE Line(Canvas &canvas)
+    TI_FORCE_INLINE explicit Line(Canvas &canvas)
         : canvas(canvas),
           _color(canvas.context._color),
           _radius(canvas.context._radius) {
@@ -297,7 +297,7 @@ class TI_DLL_EXPORT Canvas {
   Array2D<Vector4> &img;
   Matrix3 transform_matrix;
 
-  Canvas(Array2D<Vector4> &img) : img(img) {
+  explicit Canvas(Array2D<Vector4> &img) : img(img) {
     transform_matrix = Matrix3(Vector3(img.get_res().cast<real>(), 1.0_f));
   }
 
@@ -566,7 +566,7 @@ class TI_DLL_EXPORT GUI : public GUIBase {
       hover = false;
     }
 
-    Widget(Rect rect) : Widget() {
+    explicit Widget(Rect rect) : Widget() {
       this->rect = rect;
     }
 

--- a/taichi/util/bit.h
+++ b/taichi/util/bit.h
@@ -38,7 +38,7 @@ struct Bits {
   }
 
   // Uninitialized
-  Bits(void *) {
+  explicit Bits(void *) {
   }
 
   template <int start, int bits = 1>
@@ -159,7 +159,7 @@ class Bitset {
   class reference {
    public:
     reference(std::vector<value_t> &vec, int x);
-    operator bool() const;
+    explicit operator bool() const;
     bool operator~() const;
     reference &operator=(bool x);
     reference &operator=(const reference &other);

--- a/tests/cpp/transforms/scalar_pointer_lowerer_test.cpp
+++ b/tests/cpp/transforms/scalar_pointer_lowerer_test.cpp
@@ -93,12 +93,12 @@ TEST_F(ScalarPointerLowererTest, Basic) {
       code_region.end = lowerer.linears[kPointerLevel];
       auto res_opt = ai.evaluate(code_region, init_ctx);
       ASSERT_TRUE(res_opt.has_value());
-      EXPECT_EQ(res_opt.value(), i);
+      EXPECT_EQ(res_opt.value().val_int(), i);
 
       code_region.end = lowerer.linears[kDenseLevel];
       res_opt = ai.evaluate(code_region, init_ctx);
       ASSERT_TRUE(res_opt.has_value());
-      EXPECT_EQ(res_opt.value(), j);
+      EXPECT_EQ(res_opt.value().val_int(), j);
     }
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6335
* __->__ #6334
* #6333
* #6332
* #6331
* #6330

Note that we have to skip the check for a few widely used constructors
to keep the size of this PR reasonable, will fix those in separate PRs.