### PR TITLE
[lang] Texture format for better expressiveness

### DIFF
--- a/python/taichi/examples/graph/texture_graph.py
+++ b/python/taichi/examples/graph/texture_graph.py
@@ -8,7 +8,7 @@ res = (512, 512)
 img = ti.Vector.field(4, dtype=float, shape=res)
 pixels_arr = ti.Vector.ndarray(4, dtype=float, shape=res)
 
-texture = ti.Texture(ti.f32, 1, (128, 128))
+texture = ti.Texture(ti.Format.r32f, (128, 128))
 
 
 @ti.kernel

--- a/python/taichi/examples/rendering/simple_texture.py
+++ b/python/taichi/examples/rendering/simple_texture.py
@@ -8,7 +8,7 @@ res = (512, 512)
 pixels = ti.Vector.field(3, dtype=float, shape=res)
 
 k = 256
-texture = ti.Texture(ti.f32, 1, (k, k))
+texture = ti.Texture(ti.Format.r32f, (k, k))
 
 
 @ti.kernel

--- a/python/taichi/lang/__init__.py
+++ b/python/taichi/lang/__init__.py
@@ -2,7 +2,7 @@ from taichi.lang import impl, simt
 from taichi.lang._ndarray import *
 from taichi.lang._ndrange import ndrange
 from taichi.lang._texture import Texture
-from taichi.lang.enums import Layout
+from taichi.lang.enums import Format, Layout
 from taichi.lang.exception import *
 from taichi.lang.field import *
 from taichi.lang.impl import *

--- a/python/taichi/lang/_texture.py
+++ b/python/taichi/lang/_texture.py
@@ -2,9 +2,10 @@ import numpy as np
 from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.expr import Expr
+from taichi.lang.enums import Format
 from taichi.lang.util import taichi_scope
 from taichi.types import vector
-from taichi.types.primitive_types import f32, u8
+from taichi.types.primitive_types import f16, f32, i8, i16, i32, u8, u16, u32
 
 
 class TextureSampler:
@@ -137,6 +138,47 @@ class RWTextureAccessor:
         return self.ptr_expr
 
 
+FORMAT2TY_CH = {
+    Format.r8: (u8, 1),
+    Format.r8u: (u8, 1),
+    Format.r8i: (i8, 1),
+    Format.rg8: (u8, 2),
+    Format.rg8u: (u8, 2),
+    Format.rg8i: (i8, 2),
+    Format.rgba8: (u8, 4),
+    Format.rgba8u: (u8, 4),
+    Format.rgba8i: (i8, 4),
+    Format.r16: (u16, 1),
+    Format.r16u: (u16, 1),
+    Format.r16i: (i16, 1),
+    Format.r16f: (f16, 1),
+    Format.rg16: (u16, 2),
+    Format.rg16u: (u16, 2),
+    Format.rg16i: (i16, 2),
+    Format.rg16f: (f16, 2),
+    Format.rgb16: (u16, 3),
+    Format.rgb16u: (u16, 3),
+    Format.rgb16i: (i16, 3),
+    Format.rgb16f: (f16, 3),
+    Format.rgba16: (u16, 4),
+    Format.rgba16u: (u16, 4),
+    Format.rgba16i: (i16, 4),
+    Format.rgba16f: (f16, 4),
+    Format.r32u: (u32, 1),
+    Format.r32i: (i32, 1),
+    Format.r32f: (f32, 1),
+    Format.rg32u: (u32, 2),
+    Format.rg32i: (i32, 2),
+    Format.rg32f: (f32, 2),
+    Format.rgb32u: (u32, 3),
+    Format.rgb32i: (i32, 3),
+    Format.rgb32f: (f32, 3),
+    Format.rgba32u: (u32, 4),
+    Format.rgba32i: (i32, 4),
+    Format.rgba32f: (f32, 4),
+}
+
+
 class Texture:
     """Taichi Texture class.
 
@@ -145,9 +187,11 @@ class Texture:
         num_channels (int): Number of channels in texture
         shape (Tuple[int]): Shape of the Texture.
     """
-    def __init__(self, dtype, num_channels, arr_shape):
+    def __init__(self, fmt, arr_shape):
+        dtype, num_channels = FORMAT2TY_CH[fmt]
         self.tex = impl.get_runtime().prog.create_texture(
             dtype, num_channels, arr_shape)
+        self.fmt = fmt
         self.dtype = dtype
         self.num_channels = num_channels
         self.num_dims = len(arr_shape)

--- a/python/taichi/lang/_texture.py
+++ b/python/taichi/lang/_texture.py
@@ -1,8 +1,8 @@
 import numpy as np
 from taichi._lib import core as _ti_core
 from taichi.lang import impl
-from taichi.lang.expr import Expr
 from taichi.lang.enums import Format
+from taichi.lang.expr import Expr
 from taichi.lang.util import taichi_scope
 from taichi.types import vector
 from taichi.types.primitive_types import f16, f32, i8, i16, i32, u8, u16, u32

--- a/python/taichi/lang/enums.py
+++ b/python/taichi/lang/enums.py
@@ -3,5 +3,6 @@ from taichi._lib import core as _ti_core
 Layout = _ti_core.Layout
 AutodiffMode = _ti_core.AutodiffMode
 SNodeGradType = _ti_core.SNodeGradType
+Format = _ti_core.Format
 
-__all__ = ['Layout', 'AutodiffMode', 'SNodeGradType']
+__all__ = ['Layout', 'AutodiffMode', 'SNodeGradType', 'Format']

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -587,6 +587,12 @@ void export_lang(py::module &m) {
       .def_readonly("dtype", &Ndarray::dtype)
       .def_readonly("shape", &Ndarray::shape);
 
+  py::enum_<BufferFormat>(m, "Format")
+#define PER_BUFFER_FORMAT(x) .value(#x, BufferFormat::x)
+#include "taichi/inc/rhi_constants.inc.h"
+#undef PER_EXTENSION
+      ;
+
   py::class_<Texture>(m, "Texture")
       .def("device_allocation_ptr", &Texture::get_device_allocation_ptr_as_int)
       .def("from_ndarray", &Texture::from_ndarray)

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -63,9 +63,9 @@ def _get_expected_matrix_apis():
 user_api = {}
 user_api[ti] = [
     'BitpackedFields', 'CRITICAL', 'DEBUG', 'ERROR', 'Field', 'FieldsBuilder',
-    'GUI', 'INFO', 'Layout', 'Matrix', 'MatrixField', 'MatrixNdarray', 'Mesh',
-    'MeshInstance', 'Ndarray', 'SNode', 'ScalarField', 'ScalarNdarray',
-    'Struct', 'StructField', 'TRACE', 'TaichiAssertionError',
+    'Format', 'GUI', 'INFO', 'Layout', 'Matrix', 'MatrixField',
+    'MatrixNdarray', 'Mesh', 'MeshInstance', 'Ndarray', 'SNode', 'ScalarField',
+    'ScalarNdarray', 'Struct', 'StructField', 'TRACE', 'TaichiAssertionError',
     'TaichiCompilationError', 'TaichiNameError', 'TaichiRuntimeError',
     'TaichiRuntimeTypeError', 'TaichiSyntaxError', 'TaichiTypeError',
     'Texture', 'Vector', 'VectorNdarray', 'WARN', 'abs', 'acos', 'activate',

--- a/tests/python/test_ggui.py
+++ b/tests/python/test_ggui.py
@@ -278,7 +278,7 @@ def test_set_image_with_texture():
     window = ti.ui.Window('test', (640, 480), show_window=False)
     canvas = window.get_canvas()
 
-    img = ti.Texture(ti.f32, 4, (512, 512))
+    img = ti.Texture(ti.Format.rgba32f, (512, 512))
 
     @ti.kernel
     def init_img(img: ti.types.rw_texture(num_dimensions=2,

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -400,7 +400,7 @@ def test_texture():
     g = g_builder.compile()
 
     pixels_arr = ti.Vector.ndarray(4, dtype=float, shape=res)
-    texture = ti.Texture(ti.f32, 1, (128, 128))
+    texture = ti.Texture(ti.Format.r32f, (128, 128))
     t = 1
 
     g.run({

--- a/tests/python/test_texture.py
+++ b/tests/python/test_texture.py
@@ -156,7 +156,7 @@ def test_from_to_image():
 @test_utils.test(arch=supported_archs_texture)
 def test_rw_texture_2d_struct_for():
     res = (128, 128)
-    tex = ti.Texture(ti.f32, 1, res)
+    tex = ti.Texture(ti.r32f, res)
     arr = ti.ndarray(ti.f32, res)
 
     @ti.kernel
@@ -179,7 +179,7 @@ def test_rw_texture_2d_struct_for():
 
 @test_utils.test(arch=supported_archs_texture)
 def test_rw_texture_2d_struct_for_dim_check():
-    tex = ti.Texture(ti.f32, 1, (32, 32, 32))
+    tex = ti.Texture(ti.r32f, (32, 32, 32))
 
     @ti.kernel
     def write(tex: ti.types.rw_texture(num_dimensions=2,

--- a/tests/python/test_texture.py
+++ b/tests/python/test_texture.py
@@ -85,9 +85,9 @@ def test_texture_compiled_functions():
             pixels[i, j] = [c.r, c.r, c.r]
 
     n1 = 128
-    texture1 = ti.Texture(ti.f32, 1, (n1, n1))
+    texture1 = ti.Texture(ti.Format.r32f, (n1, n1))
     n2 = 256
-    texture2 = ti.Texture(ti.f32, 1, (n2, n2))
+    texture2 = ti.Texture(ti.Format.r32f, (n2, n2))
 
     make_texture_2d(texture1, n1)
     assert impl.get_runtime().get_num_compiled_functions() == 1
@@ -106,7 +106,7 @@ def test_texture_compiled_functions():
 def test_texture_from_field():
     res = (128, 128)
     f = ti.Vector.field(2, ti.f32, res)
-    tex = ti.Texture(ti.f32, 1, res)
+    tex = ti.Texture(ti.Format.r32f, res)
 
     @ti.kernel
     def init_taichi_logo_field():
@@ -121,7 +121,7 @@ def test_texture_from_field():
 def test_texture_from_ndarray():
     res = (128, 128)
     f = ti.Vector.ndarray(2, ti.f32, res)
-    tex = ti.Texture(ti.f32, 1, res)
+    tex = ti.Texture(ti.Format.r32f, res)
 
     @ti.kernel
     def init_taichi_logo_ndarray(f: ti.types.ndarray(field_dim=2)):
@@ -135,7 +135,7 @@ def test_texture_from_ndarray():
 @test_utils.test(arch=supported_archs_texture)
 def test_texture_3d():
     res = (32, 32, 32)
-    tex = ti.Texture(ti.f32, 1, res)
+    tex = ti.Texture(ti.Format.r32f, res)
 
     make_texture_3d(tex, res[0])
 
@@ -145,7 +145,7 @@ def test_from_to_image():
     url = 'https://github.com/taichi-dev/taichi/blob/master/misc/logo.png?raw=true'
     response = requests.get(url)
     img = Image.open(BytesIO(response.content))
-    tex = ti.Texture(ti.u8, 4, img.size)
+    tex = ti.Texture(ti.Format.rgba8, img.size)
 
     tex.from_image(img)
     out = tex.to_image()

--- a/tests/python/test_texture.py
+++ b/tests/python/test_texture.py
@@ -156,7 +156,7 @@ def test_from_to_image():
 @test_utils.test(arch=supported_archs_texture)
 def test_rw_texture_2d_struct_for():
     res = (128, 128)
-    tex = ti.Texture(ti.r32f, res)
+    tex = ti.Texture(ti.Format.r32f, res)
     arr = ti.ndarray(ti.f32, res)
 
     @ti.kernel
@@ -179,7 +179,7 @@ def test_rw_texture_2d_struct_for():
 
 @test_utils.test(arch=supported_archs_texture)
 def test_rw_texture_2d_struct_for_dim_check():
-    tex = ti.Texture(ti.r32f, (32, 32, 32))
+    tex = ti.Texture(ti.Format.r32f, (32, 32, 32))
 
     @ti.kernel
     def write(tex: ti.types.rw_texture(num_dimensions=2,


### PR DESCRIPTION
Take texel format and translate the formats into datatype and channel counts internally for better expressiveness (to tolerate formats like `r11_g11_b10`). 