### PR TITLE
[build] Enable a few modernize checks in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,9 +11,17 @@ Checks:  '-*,
          google-build-explicit-make-pair,
          google-explicit-constructor,
          modernize-avoid-bind,
+         modernize-make-shared,
+         modernize-make-unique,
          modernize-replace-random-shuffle,
          modernize-shrink-to-fit,
+         modernize-use-bool-literals,
+         modernize-use-equals-default
+         modernize-use-equals-delete,
+         modernize-use-noexcept,
+         modernize-use-nullptr,
          modernize-use-override,
+         modernize-use-transparent-functors,
          performance-inefficient-string-concatenation,
          readability-identifier-naming'
 CheckOptions:

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -10,7 +10,7 @@ class TaichiExceptionImpl : public std::exception {
  public:
   explicit TaichiExceptionImpl(const std::string msg) : msg_(msg) {
   }
-  const char *what() const throw() override {
+  const char *what() const noexcept override {
     return msg_.c_str();
   }
 };

--- a/taichi/program/sparse_solver.cpp
+++ b/taichi/program/sparse_solver.cpp
@@ -155,9 +155,9 @@ void CuSparseSolver::solve_cu(Program *prog,
                               const Ndarray &b,
                               Ndarray &x) {
 #ifdef TI_WITH_CUDA
-  cusparseHandle_t cusparseHandle = NULL;
+  cusparseHandle_t cusparseHandle = nullptr;
   CUSPARSEDriver::get_instance().cpCreate(&cusparseHandle);
-  cusolverSpHandle_t handle = NULL;
+  cusolverSpHandle_t handle = nullptr;
   CUSOLVERDriver::get_instance().csSpCreate(&handle);
 
   int major_version, minor_version, patch_level;
@@ -191,21 +191,21 @@ void CuSparseSolver::solve_cu(Program *prog,
   float *h_val_B = (float *)malloc(sizeof(float) * nnz);
   int *h_mapBfromA = (int *)malloc(sizeof(int) * nnz);
 
-  assert(NULL != h_z);
-  assert(NULL != h_x);
-  assert(NULL != h_b);
-  assert(NULL != h_Qb);
-  assert(NULL != h_Q);
-  assert(NULL != hrow_offsets_B);
-  assert(NULL != hcol_indices_B);
-  assert(NULL != h_val_B);
-  assert(NULL != h_mapBfromA);
+  assert(nullptr != h_z);
+  assert(nullptr != h_x);
+  assert(nullptr != h_b);
+  assert(nullptr != h_Qb);
+  assert(nullptr != h_Q);
+  assert(nullptr != hrow_offsets_B);
+  assert(nullptr != hcol_indices_B);
+  assert(nullptr != h_val_B);
+  assert(nullptr != h_mapBfromA);
 
-  int *hrow_offsets = NULL, *hcol_indices = NULL;
+  int *hrow_offsets = nullptr, *hcol_indices = nullptr;
   hrow_offsets = (int *)malloc(sizeof(int) * (nrows + 1));
   hcol_indices = (int *)malloc(sizeof(int) * nnz);
-  assert(NULL != hrow_offsets);
-  assert(NULL != hcol_indices);
+  assert(nullptr != hrow_offsets);
+  assert(nullptr != hcol_indices);
   // Attention: drow_offsets is not freed at other palces
   CUDADriver::get_instance().memcpy_device_to_host(
       (void *)hrow_offsets, drow_offsets, sizeof(int) * (nrows + 1));
@@ -213,7 +213,7 @@ void CuSparseSolver::solve_cu(Program *prog,
       (void *)hcol_indices, dcol_indices, sizeof(int) * nnz);
 
   /* configure matrix descriptor*/
-  cusparseMatDescr_t descrA = NULL;
+  cusparseMatDescr_t descrA = nullptr;
   CUSPARSEDriver::get_instance().cpCreateMatDescr(&descrA);
   CUSPARSEDriver::get_instance().cpSetMatType(descrA,
                                               CUSPARSE_MATRIX_TYPE_GENERAL);
@@ -286,31 +286,31 @@ void CuSparseSolver::solve_cu(Program *prog,
   CUSOLVERDriver::get_instance().csSpDestory(handle);
   CUSPARSEDriver::get_instance().cpDestroy(cusparseHandle);
 
-  if (hrow_offsets != NULL)
+  if (hrow_offsets != nullptr)
     free(hrow_offsets);
-  if (hcol_indices != NULL)
+  if (hcol_indices != nullptr)
     free(hcol_indices);
-  if (hrow_offsets_B != NULL)
+  if (hrow_offsets_B != nullptr)
     free(hrow_offsets_B);
-  if (hcol_indices_B != NULL)
+  if (hcol_indices_B != nullptr)
     free(hcol_indices_B);
-  if (h_Q != NULL)
+  if (h_Q != nullptr)
     free(h_Q);
-  if (h_mapBfromA != NULL)
+  if (h_mapBfromA != nullptr)
     free(h_mapBfromA);
-  if (h_z != NULL)
+  if (h_z != nullptr)
     free(h_z);
-  if (h_b != NULL)
+  if (h_b != nullptr)
     free(h_b);
-  if (h_Qb != NULL)
+  if (h_Qb != nullptr)
     free(h_Qb);
-  if (h_x != NULL)
+  if (h_x != nullptr)
     free(h_x);
-  if (buffer_cpu != NULL)
+  if (buffer_cpu != nullptr)
     free(buffer_cpu);
-  if (h_val_A != NULL)
+  if (h_val_A != nullptr)
     free(h_val_A);
-  if (h_val_B != NULL)
+  if (h_val_B != nullptr)
     free(h_val_B);
 #endif
 }

--- a/taichi/python/exception.h
+++ b/taichi/python/exception.h
@@ -18,7 +18,7 @@ class ExceptionForPython : public std::exception {
  public:
   explicit ExceptionForPython(const std::string &msg) : msg_(msg) {
   }
-  char const *what() const throw() override {
+  char const *what() const noexcept override {
     return msg_.c_str();
   }
 };

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -114,7 +114,7 @@ class HostDeviceContextBlitter {
         }
         TI_ERROR("Device does not support arg type={}",
                  PrimitiveType::get(arg.dtype).to_string());
-      } while (0);
+      } while (false);
     }
 
     char *device_ptr = device_base + ctx_attribs_->extra_args_mem_offset();

--- a/taichi/runtime/metal/shaders/print.metal.h
+++ b/taichi/runtime/metal/shaders/print.metal.h
@@ -195,7 +195,7 @@ STR(
                                                 metal::memory_order_relaxed);
       if (cur + sz >= kMetalPrintMsgsMaxQueueSize) {
         // Avoid buffer overflow
-        return (device int32_t *)0;
+        return (device int32_t *)nullptr;
       }
       device byte *data_begin = reinterpret_cast<device byte *>(pa + 1);
       device int32_t *ptr =

--- a/taichi/system/demangling.cpp
+++ b/taichi/system/demangling.cpp
@@ -18,7 +18,7 @@ std::string cpp_demangle(const std::string &mangled_name) {
   char *demangled_name;
   int status = -1;
   demangled_name =
-      abi::__cxa_demangle(mangled_name.c_str(), NULL, NULL, &status);
+      abi::__cxa_demangle(mangled_name.c_str(), nullptr, nullptr, &status);
   std::string ret(demangled_name);
   free(demangled_name);
   return ret;

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -84,7 +84,7 @@ void MemoryPool::push(volatile T *dest, const T &val) {
 }
 
 void MemoryPool::daemon() {
-  while (1) {
+  while (true) {
     Time::usleep(1000);
     std::lock_guard<std::mutex> _(mut);
     if (terminating) {

--- a/taichi/system/traceback.cpp
+++ b/taichi/system/traceback.cpp
@@ -343,7 +343,8 @@ void print_traceback() {
 
       int status = -1;
 
-      demangled_name_ = abi::__cxa_demangle(name.c_str(), NULL, NULL, &status);
+      demangled_name_ =
+          abi::__cxa_demangle(name.c_str(), nullptr, nullptr, &status);
 
       if (demangled_name_) {
         name = std::string(demangled_name_);

--- a/taichi/transforms/lower_matrix_ptr.cpp
+++ b/taichi/transforms/lower_matrix_ptr.cpp
@@ -57,9 +57,9 @@ class LowerMatrixPtr : public BasicStmtVisitor {
       // during IndexExpression::flatten() Here we need to modify the
       // element_dim and element_shape a little bit.
       int element_dim = -1;  // AOS Vector
-      std::vector<int> element_shape = {std::accumulate(
-          begin(origin->element_shape), end(origin->element_shape), 1,
-          std::multiplies<int>())};
+      std::vector<int> element_shape = {
+          std::accumulate(begin(origin->element_shape),
+                          end(origin->element_shape), 1, std::multiplies<>())};
 
       auto fused = std::make_unique<ExternalPtrStmt>(
           origin->base_ptr, indices, element_shape, element_dim);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6345
* #6344
* #6343
* __->__ #6342

- modernize-make-shared
- modernize-make-unique
- modernize-use-bool-literals
- modernize-use-equals-default
- modernize-use-equals-delete
- modernize-use-noexcept
- modernize-use-nullptr
- modernize-use-transparent-functors