### PR TITLE
[build] Enable readability-redundant-member-init in clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,9 @@ Checks:  '-*,
          modernize-use-override,
          modernize-use-transparent-functors,
          performance-inefficient-string-concatenation,
-         readability-identifier-naming'
+         readability-identifier-naming,
+         readability-redundant-member-init,
+         '
 CheckOptions:
   - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
   - { key: readability-identifier-naming.PrivateMemberCase,      value: lower_case }

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -43,8 +43,7 @@ class AlgSimp : public BasicStmtVisitor {
   bool fast_math;
   DelayedIRModifier modifier;
 
-  explicit AlgSimp(bool fast_math_)
-      : BasicStmtVisitor(), fast_math(fast_math_) {
+  explicit AlgSimp(bool fast_math_) : fast_math(fast_math_) {
   }
 
   [[nodiscard]] bool is_redundant_cast(const DataType &first_cast,

--- a/taichi/transforms/binary_op_simplify.cpp
+++ b/taichi/transforms/binary_op_simplify.cpp
@@ -14,7 +14,7 @@ class BinaryOpSimp : public BasicStmtVisitor {
   bool operand_swapped;
 
   explicit BinaryOpSimp(bool fast_math_)
-      : BasicStmtVisitor(), fast_math(fast_math_), operand_swapped(false) {
+      : fast_math(fast_math_), operand_swapped(false) {
   }
 
   bool try_rearranging_const_rhs(BinaryOpStmt *stmt) {

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -18,7 +18,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
   std::string kernel_name;
 
   explicit CheckOutOfBound(const std::string &kernel_name)
-      : BasicStmtVisitor(), visited(), kernel_name(kernel_name) {
+      : kernel_name(kernel_name) {
   }
 
   bool is_done(Stmt *stmt) {

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -19,8 +19,7 @@ class ConstantFold : public BasicStmtVisitor {
   DelayedIRModifier modifier;
   Program *program;
 
-  explicit ConstantFold(Program *program)
-      : BasicStmtVisitor(), program(program) {
+  explicit ConstantFold(Program *program) : program(program) {
   }
 
   Kernel *get_jit_evaluator_kernel(JITEvaluatorId const &id) {

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -21,7 +21,7 @@ class DemoteAtomics : public BasicStmtVisitor {
   OffloadedStmt *current_offloaded;
   DelayedIRModifier modifier;
 
-  DemoteAtomics() : BasicStmtVisitor() {
+  DemoteAtomics() {
     current_offloaded = nullptr;
   }
 

--- a/taichi/transforms/demote_operations.cpp
+++ b/taichi/transforms/demote_operations.cpp
@@ -13,7 +13,7 @@ class DemoteOperations : public BasicStmtVisitor {
   using BasicStmtVisitor::visit;
   DelayedIRModifier modifier;
 
-  DemoteOperations() : BasicStmtVisitor() {
+  DemoteOperations() {
   }
 
   std::unique_ptr<Stmt> demote_ifloordiv(BinaryOpStmt *stmt,

--- a/taichi/transforms/detect_read_only.cpp
+++ b/taichi/transforms/detect_read_only.cpp
@@ -31,7 +31,7 @@ class ExternalPtrAccessVisitor : public BasicStmtVisitor {
 
   explicit ExternalPtrAccessVisitor(
       std::unordered_map<int, ExternalPtrAccess> &map)
-      : BasicStmtVisitor(), map_(map) {
+      : map_(map) {
   }
 
   void visit(GlobalLoadStmt *stmt) override {

--- a/taichi/transforms/inlining.cpp
+++ b/taichi/transforms/inlining.cpp
@@ -13,7 +13,7 @@ class Inliner : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
 
-  explicit Inliner() : BasicStmtVisitor() {
+  explicit Inliner() {
   }
 
   void visit(FuncCallStmt *stmt) override {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #6345
* __->__ #6344
* #6343
* #6342

