### PR TITLE
[opengl] Fix with_opengl when TI_WITH_OPENGL is off

### DIFF
--- a/taichi/python/export_misc.cpp
+++ b/taichi/python/export_misc.cpp
@@ -153,7 +153,7 @@ void export_misc(py::module &m) {
   m.def("with_opengl", taichi::lang::opengl::is_opengl_api_available,
         py::arg("use_gles") = false);
 #else
-  m.def("with_opengl", []() { return false; });
+  m.def("with_opengl", [](bool use_gles) { return false; });
 #endif
 #ifdef TI_WITH_VULKAN
   m.def("with_vulkan", taichi::lang::vulkan::is_vulkan_api_available);


### PR DESCRIPTION
This fixes the following error when opengl build is turned off:

```
Invoked with: False' occurred when detecting opengl, consider adding `TI_ENABLE_OPENGL=0`  to environment variables to suppress this warning message.
[W 10/17/22 21:43:05.396 46857808] TypeError: 'with_opengl(): incompatible function arguments. The following argument types are supported:
    1. () -> bool
```

Issue: #

### Brief Summary
