### PR TITLE
[autodiff] Move autodiff gdar checker to release

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -352,8 +352,7 @@ class PyTaichi:
             # https://github.com/taichi-dev/taichi/blob/27bb1dc3227d9273a79fcb318fdb06fd053068f5/tests/python/test_ad_basics.py#L260-L266
             return
 
-        if get_runtime().prog.config().debug and get_runtime().prog.config(
-        ).validate_autodiff:
+        if get_runtime().prog.config().debug:
             if not root.finalized:
                 root._allocate_adjoint_checkbit()
 
@@ -643,7 +642,7 @@ def create_field_member(dtype, name, needs_grad, needs_dual):
         if needs_grad:
             pytaichi.grad_vars.append(x_grad)
 
-        if prog.config().debug and prog.config().validate_autodiff:
+        if prog.config().debug:
             # adjoint checkbit
             x_grad_checkbit = Expr(get_runtime().prog.make_id_expr(""))
             dtype = u8

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -23,7 +23,6 @@ CompileConfig::CompileConfig() {
   debug = false;
   cfg_optimization = true;
   check_out_of_bound = false;
-  validate_autodiff = false;
   lazy_compilation = true;
   serial_schedule = false;
   simplify_before_lower_access = true;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -146,7 +146,6 @@ void export_lang(py::module &m) {
       .def_readwrite("debug", &CompileConfig::debug)
       .def_readwrite("cfg_optimization", &CompileConfig::cfg_optimization)
       .def_readwrite("check_out_of_bound", &CompileConfig::check_out_of_bound)
-      .def_readwrite("validate_autodiff", &CompileConfig::validate_autodiff)
       .def_readwrite("print_accessor_ir", &CompileConfig::print_accessor_ir)
       .def_readwrite("print_evaluator_ir", &CompileConfig::print_evaluator_ir)
       .def_readwrite("use_llvm", &CompileConfig::use_llvm)

--- a/tests/python/test_ad_global_data_access_rule_checker.py
+++ b/tests/python/test_ad_global_data_access_rule_checker.py
@@ -5,7 +5,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(debug=True, validate_autodiff=True, exclude=[ti.cc])
+@test_utils.test(debug=True, exclude=[ti.cc])
 def test_adjoint_checkbit_needs_grad():
     x = ti.field(float, shape=(), needs_grad=True)
 
@@ -19,7 +19,7 @@ def test_adjoint_checkbit_needs_grad():
     assert x.snode.ptr.has_adjoint_checkbit()
 
 
-@test_utils.test(debug=True, validate_autodiff=True, exclude=[ti.cc])
+@test_utils.test(debug=True, exclude=[ti.cc])
 def test_adjoint_checkbit_lazy_grad():
     x = ti.field(float, shape=())
     ti.root.lazy_grad()
@@ -34,7 +34,7 @@ def test_adjoint_checkbit_lazy_grad():
     assert x.snode.ptr.has_adjoint_checkbit()
 
 
-@test_utils.test(debug=True, validate_autodiff=True, exclude=[ti.cc])
+@test_utils.test(debug=True, exclude=[ti.cc])
 def test_adjoint_checkbit_place_grad():
     x = ti.field(float)
     y = ti.field(float)
@@ -51,7 +51,7 @@ def test_adjoint_checkbit_place_grad():
     assert not y.snode.ptr.has_adjoint_checkbit()
 
 
-@test_utils.test(debug=False, validate_autodiff=True)
+@test_utils.test(debug=False)
 def test_adjoint_checkbit_needs_grad():
     x = ti.field(float, shape=(), needs_grad=True)
 
@@ -71,10 +71,7 @@ def test_adjoint_checkbit_needs_grad():
     assert warn_raised
 
 
-@test_utils.test(require=ti.extension.assertion,
-                 exclude=[ti.cc],
-                 debug=True,
-                 validate_autodiff=True)
+@test_utils.test(require=ti.extension.assertion, exclude=[ti.cc], debug=True)
 def test_break_gdar_rule_1():
     N = 16
     x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)
@@ -97,10 +94,7 @@ def test_break_gdar_rule_1():
             func_broke_rule_1()
 
 
-@test_utils.test(require=ti.extension.assertion,
-                 exclude=[ti.cc],
-                 debug=True,
-                 validate_autodiff=True)
+@test_utils.test(require=ti.extension.assertion, exclude=[ti.cc], debug=True)
 def test_skip_grad_replaced():
     N = 16
     x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)
@@ -137,10 +131,7 @@ def test_skip_grad_replaced():
         kernel_2()
 
 
-@test_utils.test(require=ti.extension.assertion,
-                 exclude=[ti.cc],
-                 debug=True,
-                 validate_autodiff=True)
+@test_utils.test(require=ti.extension.assertion, exclude=[ti.cc], debug=True)
 def test_autodiff_mode_recovered():
     N = 16
     x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)


### PR DESCRIPTION
Issue: #6239 
Remove the `validate_autodiff` flag in `ti.init`.