### PR TITLE
[autodiff] Skip gradient kernel compilation for validation kernel

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -109,7 +109,8 @@ void compile_to_offloads(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
-  if (autodiff_mode != AutodiffMode::kNone) {
+  if (autodiff_mode == AutodiffMode::kReverse ||
+      autodiff_mode == AutodiffMode::kForward) {
     // Remove local atomics here so that we don't have to handle their gradients
     irpass::demote_atomics(ir, config);
 


### PR DESCRIPTION
Issue: #6239 
Skip gradient kernel compilation for validation kernel
