### PR TITLE
[Error] Add error message when the number of the loop variables does not match the dimension of the ndrange

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1024,6 +1024,8 @@ class ASTTransformer(Builder):
                                                      ndrange_end.ptr)
             I = impl.expr_init(ndrange_loop_var)
             targets = ASTTransformer.get_for_loop_targets(node)
+            if len(targets) != len(ndrange_var.dimensions):
+                raise TaichiSyntaxError("The number of the loop variables does not match the dimension of the ndrange.")
             for i, target in enumerate(targets):
                 if i + 1 < len(targets):
                     target_tmp = impl.expr_init(

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1025,7 +1025,9 @@ class ASTTransformer(Builder):
             I = impl.expr_init(ndrange_loop_var)
             targets = ASTTransformer.get_for_loop_targets(node)
             if len(targets) != len(ndrange_var.dimensions):
-                raise TaichiSyntaxError("The number of the loop variables does not match the dimension of the ndrange.")
+                raise TaichiSyntaxError(
+                    "The number of the loop variables does not match the dimension of the ndrange."
+                )
             for i, target in enumerate(targets):
                 if i + 1 < len(targets):
                     target_tmp = impl.expr_init(

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -315,3 +315,13 @@ def test_static_ndrange_should_accept_numpy_integer():
             pass
 
     example()
+
+@test_utils.test()
+def test_n_loop_var_neq_dimension():
+    @ti.kernel
+    def iter():
+        for i in ti.ndrange(1, 4):
+            print(i)
+
+    with pytest.raises(ti.TaichiSyntaxError, match="The number of the loop variables does not match the dimension of the ndrange."):
+        iter()

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -316,6 +316,7 @@ def test_static_ndrange_should_accept_numpy_integer():
 
     example()
 
+
 @test_utils.test()
 def test_n_loop_var_neq_dimension():
     @ti.kernel
@@ -323,5 +324,9 @@ def test_n_loop_var_neq_dimension():
         for i in ti.ndrange(1, 4):
             print(i)
 
-    with pytest.raises(ti.TaichiSyntaxError, match="The number of the loop variables does not match the dimension of the ndrange."):
+    with pytest.raises(
+            ti.TaichiSyntaxError,
+            match=
+            "The number of the loop variables does not match the dimension of the ndrange."
+    ):
         iter()


### PR DESCRIPTION
Issue: #6351 

### Brief Summary
