### PR TITLE
[autodiff] Fix mode capture for validation kernels

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -218,7 +218,7 @@ class Tape:
     def insert(self, func, args):
         # Kernels with mode `AutodiffMode.NONE` and `AutodiffMode.VALIDATION` are all forward kernels.
         # The difference is there are `assert` for global data access rule check in VALIDATION kernels.
-        assert func.autodiff_mode == AutodiffMode.NONE or func.autodiff_mode == AutodiffMode.VALIDATION, "Inserted funcs should be forward kernels."
+        assert func.autodiff_mode in (AutodiffMode.NONE, AutodiffMode.VALIDATION), "Inserted funcs should be forward kernels."
         self.modes.append(func.autodiff_mode)
         if self.validation:
             func.autodiff_mode = AutodiffMode.VALIDATION

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -218,7 +218,9 @@ class Tape:
     def insert(self, func, args):
         # Kernels with mode `AutodiffMode.NONE` and `AutodiffMode.VALIDATION` are all forward kernels.
         # The difference is there are `assert` for global data access rule check in VALIDATION kernels.
-        assert func.autodiff_mode in (AutodiffMode.NONE, AutodiffMode.VALIDATION), "Inserted funcs should be forward kernels."
+        assert func.autodiff_mode in (
+            AutodiffMode.NONE, AutodiffMode.VALIDATION
+        ), "Inserted funcs should be forward kernels."
         self.modes.append(func.autodiff_mode)
         if self.validation:
             func.autodiff_mode = AutodiffMode.VALIDATION

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -216,6 +216,8 @@ class Tape:
             calls[0].autodiff_mode = mode
 
     def insert(self, func, args):
+        # Kernels with mode `AutodiffMode.NONE` and `AutodiffMode.VALIDATION` are all forward kernels.
+        # The difference is there are `assert` for global data access rule check in VALIDATION kernels.
         assert func.autodiff_mode == AutodiffMode.NONE or func.autodiff_mode == AutodiffMode.VALIDATION, "Inserted funcs should be forward kernels."
         self.modes.append(func.autodiff_mode)
         if self.validation:

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -216,7 +216,7 @@ class Tape:
             calls[0].autodiff_mode = mode
 
     def insert(self, func, args):
-        assert func.autodiff_mode == AutodiffMode.NONE, "Inserted funcs should be forward kernels."
+        assert func.autodiff_mode == AutodiffMode.NONE or func.autodiff_mode == AutodiffMode.VALIDATION, "Inserted funcs should be forward kernels."
         self.modes.append(func.autodiff_mode)
         if self.validation:
             func.autodiff_mode = AutodiffMode.VALIDATION

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -847,8 +847,8 @@ class Kernel:
         # In both cases, |self.grad| is another Kernel instance that computes the
         # gradient. For class kernels, args[0] is always the kernel owner.
 
-        # No need to capture grad kernels because they are already binded with their primal kernels
-        if self.autodiff_mode != AutodiffMode.REVERSE and self.runtime.target_tape and not self.runtime.grad_replaced:
+        # No need to capture grad kernels because they are already bound with their primal kernels
+        if self.autodiff_mode in (AutodiffMode.NONE, AutodiffMode.VALIDATION) and self.runtime.target_tape and not self.runtime.grad_replaced:
             self.runtime.target_tape.insert(self, args)
 
         if self.autodiff_mode != AutodiffMode.NONE and impl.current_cfg(

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -848,7 +848,9 @@ class Kernel:
         # gradient. For class kernels, args[0] is always the kernel owner.
 
         # No need to capture grad kernels because they are already bound with their primal kernels
-        if self.autodiff_mode in (AutodiffMode.NONE, AutodiffMode.VALIDATION) and self.runtime.target_tape and not self.runtime.grad_replaced:
+        if self.autodiff_mode in (
+                AutodiffMode.NONE, AutodiffMode.VALIDATION
+        ) and self.runtime.target_tape and not self.runtime.grad_replaced:
             self.runtime.target_tape.insert(self, args)
 
         if self.autodiff_mode != AutodiffMode.NONE and impl.current_cfg(

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -522,6 +522,8 @@ class Kernel:
             grad_suffix = "_forward_grad"
         elif self.autodiff_mode == AutodiffMode.REVERSE:
             grad_suffix = "_reverse_grad"
+        elif self.autodiff_mode == AutodiffMode.VALIDATION:
+            grad_suffix = "_validate_grad"
         kernel_name = f"{self.func.__name__}_c{self.kernel_counter}_{key[1]}{grad_suffix}"
         _logging.trace(f"Compiling kernel {kernel_name}...")
 
@@ -844,7 +846,7 @@ class Kernel:
         # Both the class kernels and the plain-function kernels are unified now.
         # In both cases, |self.grad| is another Kernel instance that computes the
         # gradient. For class kernels, args[0] is always the kernel owner.
-        if self.autodiff_mode == AutodiffMode.NONE and self.runtime.target_tape and not self.runtime.grad_replaced:
+        if self.autodiff_mode != AutodiffMode.REVERSE and self.runtime.target_tape and not self.runtime.grad_replaced:
             self.runtime.target_tape.insert(self, args)
 
         if self.autodiff_mode != AutodiffMode.NONE and impl.current_cfg(

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -846,6 +846,8 @@ class Kernel:
         # Both the class kernels and the plain-function kernels are unified now.
         # In both cases, |self.grad| is another Kernel instance that computes the
         # gradient. For class kernels, args[0] is always the kernel owner.
+
+        # No need to capture grad kernels because they are already binded with their primal kernels
         if self.autodiff_mode != AutodiffMode.REVERSE and self.runtime.target_tape and not self.runtime.grad_replaced:
             self.runtime.target_tape.insert(self, args)
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -404,9 +404,10 @@ void Kernel::init(Program &program,
 
   this->arch = program.this_thread_config().arch;
 
-  if (autodiff_mode == AutodiffMode::kNone ||
-      autodiff_mode == AutodiffMode::kCheckAutodiffValid) {
+  if (autodiff_mode == AutodiffMode::kNone) {
     name = primal_name;
+  } else if (autodiff_mode == AutodiffMode::kCheckAutodiffValid) {
+    name = primal_name + "_validate_grad";
   } else if (autodiff_mode == AutodiffMode::kForward) {
     name = primal_name + "_forward_grad";
   } else if (autodiff_mode == AutodiffMode::kReverse) {

--- a/tests/python/test_ad_global_data_access_rule_checker.py
+++ b/tests/python/test_ad_global_data_access_rule_checker.py
@@ -161,3 +161,35 @@ def test_autodiff_mode_recovered():
         func_calls = t.calls
     for f, _ in func_calls:
         assert f.autodiff_mode == AutodiffMode.NONE
+
+
+@test_utils.test(require=ti.extension.assertion, exclude=[ti.cc], debug=True)
+def test_validation_kernel_capture():
+    N = 16
+    T = 8
+    x = ti.field(dtype=ti.f32, shape=N, needs_grad=True)
+    loss = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
+    b = ti.field(dtype=ti.f32, shape=(), needs_grad=True)
+
+    @ti.kernel
+    def kernel_1():
+        loss[None] = x[1] * b[None]
+
+    @ti.kernel
+    def kernel_2():
+        loss[None] = x[1] * b[None]
+
+    def forward(T):
+        for t in range(T):
+            kernel_1()
+            kernel_2()
+
+    for i in range(N):
+        x[i] = i
+
+    b[None] = 10
+    loss.grad[None] = 1
+
+    with ti.ad.Tape(loss=loss, validation=True) as t:
+        forward(T)
+        assert len(t.calls) == 2 * T and len(t.modes) == 2 * T


### PR DESCRIPTION
Issue: #6240 

Handle cases that there are loops inside the `ti.ad.tape`. In these cases, the `autodiff_mode` has not been recovered to `AutodiffMode.NONE` since `__exit__` of the tape has not been reached.   
