### PR TITLE
[Lang] Allow augmented assign on matric slice

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -13,14 +13,13 @@ from taichi.lang._ndrange import _Ndrange, ndrange
 from taichi.lang.ast.ast_transformer_utils import (Builder, LoopStatus,
                                                    ReturnStatus)
 from taichi.lang.ast.symbol_resolver import ASTResolver
-from taichi.lang.exception import TaichiSyntaxError, TaichiTypeError
+from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.expr import Expr
 from taichi.lang.field import Field
 from taichi.lang.impl import current_cfg
-from taichi.lang.matrix import (Matrix, MatrixType, Vector, _PyScopeMatrixImpl,
-                                _TiScopeMatrixImpl, make_matrix)
+from taichi.lang.matrix import (Matrix, MatrixType, Vector)
 from taichi.lang.snode import append
-from taichi.lang.util import in_taichi_scope, is_taichi_class, to_taichi_type
+from taichi.lang.util import is_taichi_class, to_taichi_type
 from taichi.types import (annotations, ndarray_type, primitive_types,
                           texture_type)
 from taichi.types.utils import is_integral

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -114,28 +114,6 @@ class ASTTransformer(Builder):
         return None
 
     @staticmethod
-    def build_assign_slice(ctx, node_target, values, is_static_assign):
-        target = ASTTransformer.build_Subscript(ctx, node_target)
-        if current_cfg().real_matrix and isinstance(values, (list, tuple)):
-            values = make_matrix(values)
-
-        if isinstance(node_target.value.ptr, Matrix):
-            if isinstance(node_target.value.ptr._impl, _TiScopeMatrixImpl):
-                target._assign(values)
-            elif isinstance(node_target.value.ptr._impl, _PyScopeMatrixImpl):
-                if in_taichi_scope():
-                    raise TaichiTypeError(
-                        'PyScope matrix cannot be assigned in Taichi Scope')
-                node_target.ptr._assign(node_target.slice.ptr, values)
-            else:
-                raise TaichiTypeError(f'{type(target)} cannot be subscripted')
-        else:
-            ASTTransformer.build_assign_basic(ctx,
-                                              target,
-                                              values,
-                                              is_static_assign)
-
-    @staticmethod
     def build_assign_unpack(ctx, node_target, values, is_static_assign):
         """Build the unpack assignments like this: (target1, target2) = (value1, value2).
         The function should be called only if the node target is a tuple.
@@ -147,10 +125,6 @@ class ASTTransformer(Builder):
             values: A node/list representing the values.
             is_static_assign: A boolean value indicating whether this is a static assignment
         """
-        #if isinstance(node_target, ast.Subscript):
-        #    return ASTTransformer.build_assign_slice(ctx, node_target, values,
-        #                                             is_static_assign)
-
         if not isinstance(node_target, ast.Tuple):
             return ASTTransformer.build_assign_basic(ctx, node_target, values,
                                                      is_static_assign)

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -156,10 +156,7 @@ class ASTTransformer(Builder):
         return None
 
     @staticmethod
-    def build_assign_basic(ctx,
-                           target,
-                           value,
-                           is_static_assign):
+    def build_assign_basic(ctx, target, value, is_static_assign):
         """Build basic assignment like this: target = value.
 
          Args:
@@ -220,8 +217,7 @@ class ASTTransformer(Builder):
         build_stmt(ctx, node.slice)
         if not ASTTransformer.is_tuple(node.slice):
             node.slice.ptr = [node.slice.ptr]
-        node.ptr = impl.subscript(ctx.ast_builder,
-                                  node.value.ptr,
+        node.ptr = impl.subscript(ctx.ast_builder, node.value.ptr,
                                   *node.slice.ptr)
         return node.ptr
 

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -3,6 +3,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.exception import TaichiCompilationError, TaichiTypeError
+from taichi.lang.matrix import make_matrix
 from taichi.lang.util import is_taichi_class, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.primitive_types import integer_types, real_types
@@ -23,6 +24,9 @@ class Expr(TaichiOperations):
                 raise TaichiTypeError(
                     'Cannot initialize scalar expression from '
                     f'taichi class: {type(args[0])}')
+            elif isinstance(args[0], (list, tuple)):
+                assert impl.current_cfg().real_matrix
+                self.ptr = make_matrix(args[0]).ptr
             else:
                 # assume to be constant
                 arg = args[0]

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -154,8 +154,7 @@ def _calc_slice(index, default_stop):
 def subscript(ast_builder,
               value,
               *_indices,
-              skip_reordered=False,
-              get_ref=False):
+              skip_reordered=False):
     if isinstance(value, np.ndarray):
         return value.__getitem__(_indices)
 
@@ -192,7 +191,7 @@ def subscript(ast_builder,
         index_dim = indices_expr_group.size()
 
     if is_taichi_class(value):
-        return value._subscript(*indices, get_ref=get_ref)
+        return value._subscript(*indices)
     if isinstance(value, MeshElementFieldProxy):
         return value.subscript(*indices)
     if isinstance(value, MeshRelationAccessProxy):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -151,10 +151,7 @@ def _calc_slice(index, default_stop):
 
 
 @taichi_scope
-def subscript(ast_builder,
-              value,
-              *_indices,
-              skip_reordered=False):
+def subscript(ast_builder, value, *_indices, skip_reordered=False):
     if isinstance(value, np.ndarray):
         return value.__getitem__(_indices)
 

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -262,7 +262,8 @@ class _TiScopeMatrixImpl(_MatrixBaseImpl):
                 return Vector([self._subscript(is_global_mat, a) for a in i],
                               is_ref=True)
             return Matrix([[self._subscript(is_global_mat, a, b) for b in j]
-                           for a in i], is_ref=True)
+                           for a in i],
+                          is_ref=True)
 
         if self.any_array_access:
             return self.any_array_access.subscript(i, j)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -10,7 +10,7 @@ from taichi.lang import runtime_ops
 from taichi.lang._ndarray import Ndarray, NdarrayHostAccess
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.enums import Layout
-from taichi.lang.exception import (TaichiRuntimeError, TaichiSyntaxError,
+from taichi.lang.exception import (TaichiCompilationError, TaichiSyntaxError,
                                    TaichiTypeError)
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.swizzle_generator import SwizzleGenerator
@@ -81,7 +81,7 @@ def _gen_swizzles(cls):
                 @python_scope
                 def prop_setter(instance, value):
                     if len(pattern) != len(value):
-                        raise TaichiRuntimeError(
+                        raise TaichiCompilationError(
                             f'value len does not match the swizzle pattern={prop_key}'
                         )
                     checker(instance, pattern)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -10,7 +10,7 @@ from taichi.lang import runtime_ops
 from taichi.lang._ndarray import Ndarray, NdarrayHostAccess
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.enums import Layout
-from taichi.lang.exception import (TaichiCompilationError, TaichiSyntaxError,
+from taichi.lang.exception import (TaichiRuntimeError, TaichiSyntaxError,
                                    TaichiTypeError)
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.swizzle_generator import SwizzleGenerator
@@ -81,7 +81,7 @@ def _gen_swizzles(cls):
                 @python_scope
                 def prop_setter(instance, value):
                     if len(pattern) != len(value):
-                        raise TaichiCompilationError(
+                        raise TaichiRuntimeError(
                             f'value len does not match the swizzle pattern={prop_key}'
                         )
                     checker(instance, pattern)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -10,7 +10,7 @@ from taichi.lang import runtime_ops
 from taichi.lang._ndarray import Ndarray, NdarrayHostAccess
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.enums import Layout
-from taichi.lang.exception import (TaichiCompilationError, TaichiSyntaxError,
+from taichi.lang.exception import (TaichiRuntimeError, TaichiSyntaxError,
                                    TaichiTypeError)
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.swizzle_generator import SwizzleGenerator
@@ -78,17 +78,15 @@ def _gen_swizzles(cls):
                             instance._impl._get_entry(key_group.index(ch)))
                     return Vector(res, is_ref=True)
 
+                @python_scope
                 def prop_setter(instance, value):
                     if len(pattern) != len(value):
-                        raise TaichiCompilationError(
+                        raise TaichiRuntimeError(
                             f'value len does not match the swizzle pattern={prop_key}'
                         )
                     checker(instance, pattern)
                     for ch, val in zip(pattern, value):
-                        if in_python_scope():
-                            instance[key_group.index(ch)] = val
-                        else:
-                            instance(key_group.index(ch))._assign(val)
+                        instance[key_group.index(ch)] = val
 
                 prop = property(prop_getter, prop_setter)
                 return prop_key, prop
@@ -243,7 +241,7 @@ class _TiScopeMatrixImpl(_MatrixBaseImpl):
         self.dynamic_index_stride = dynamic_index_stride
 
     @taichi_scope
-    def _subscript(self, is_global_mat, *indices, get_ref=False):
+    def _subscript(self, is_global_mat, *indices):
         assert len(indices) in [1, 2]
         i = indices[0]
         j = 0 if len(indices) == 1 else indices[1]
@@ -262,10 +260,9 @@ class _TiScopeMatrixImpl(_MatrixBaseImpl):
                 j = [j]
             if len(indices) == 1:
                 return Vector([self._subscript(is_global_mat, a) for a in i],
-                              is_ref=get_ref)
+                              is_ref=True)
             return Matrix([[self._subscript(is_global_mat, a, b) for b in j]
-                           for a in i],
-                          is_ref=get_ref)
+                           for a in i], is_ref=True)
 
         if self.any_array_access:
             return self.any_array_access.subscript(i, j)
@@ -651,7 +648,7 @@ class Matrix(TaichiOperations):
         return self._impl.dynamic_index_stride
 
     @taichi_scope
-    def _subscript(self, *indices, get_ref=False):
+    def _subscript(self, *indices):
         assert len(
             indices
         ) == self.ndim, f"Expected {self.ndim} indices, got {len(indices)}"
@@ -661,7 +658,7 @@ class Matrix(TaichiOperations):
             # 2. Taichi kernel directlly uses a matrix (global variable) created in the Python scope.
             return self._impl.subscript_scope_ignored(indices)
         is_global_mat = isinstance(self, _MatrixFieldElement)
-        return self._impl._subscript(is_global_mat, *indices, get_ref=get_ref)
+        return self._impl._subscript(is_global_mat, *indices)
 
     def to_list(self):
         """Return this matrix as a 1D `list`.

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -611,44 +611,6 @@ def test_python_scope_inplace_operator():
 
 
 @test_utils.test()
-def test_slice_assign_basic():
-    @ti.kernel
-    def foo():
-        m = ti.Matrix([[0., 0., 0., 0.] for _ in range(3)])
-        vec = ti.Vector([1., 2., 3., 4.])
-        m[0, :] = vec.transpose()
-        ref = ti.Matrix([[1., 2., 3., 4.], [0., 0., 0., 0.], [0., 0., 0., 0.]])
-        assert all(m == ref)
-
-        m[1, 1:3] = ti.Vector([1., 2.]).transpose()
-        ref = ti.Matrix([[1., 2., 3., 4.], [0., 1., 2., 0.], [0., 0., 0., 0.]])
-        assert all(m == ref)
-
-        m1 = ti.Matrix([[1., 1., 1., 1.] for _ in range(2)])
-        m[:2, :] = m1
-        ref = ti.Matrix([[1., 1., 1., 1.], [1., 1., 1., 1.], [0., 0., 0., 0.]])
-        assert all(m == ref)
-
-    foo()
-
-
-@test_utils.test(dynamic_index=True)
-def test_slice_assign_dynamic_index():
-    @ti.kernel
-    def foo(i: ti.i32, ref: ti.template()):
-        m = ti.Matrix([[0., 0., 0., 0.] for _ in range(3)])
-        vec = ti.Vector([1., 2., 3., 4.])
-        m[i, :] = vec.transpose()
-        assert all(m == ref)
-
-    for i in range(3):
-        foo(
-            i,
-            ti.Matrix([[1., 2., 3., 4.] if j == i else [0., 0., 0., 0.]
-                       for j in range(3)]))
-
-
-@test_utils.test()
 def test_indexing():
     @ti.kernel
     def foo():

--- a/tests/python/test_matrix_slice.py
+++ b/tests/python/test_matrix_slice.py
@@ -91,3 +91,41 @@ def test_matrix_slice_with_variable_invalid():
             r'Or turn on ti.init\(..., dynamic_index=True\) to support indexing with variables!'
     ):
         test_one_col_slice()
+
+
+@test_utils.test(debug=True)
+def test_matrix_slice_write():
+    @ti.kernel
+    def foo():
+        m = ti.Matrix([[0., 0., 0., 0.] for _ in range(3)])
+        vec = ti.Vector([1., 2., 3., 4.])
+        m[0, :] = vec.transpose()
+        ref = ti.Matrix([[1., 2., 3., 4.], [0., 0., 0., 0.], [0., 0., 0., 0.]])
+        assert all(m == ref)
+
+        m[1, 1:3] = ti.Vector([1., 2.]).transpose()
+        ref = ti.Matrix([[1., 2., 3., 4.], [0., 1., 2., 0.], [0., 0., 0., 0.]])
+        assert all(m == ref)
+
+        m1 = ti.Matrix([[1., 1., 1., 1.] for _ in range(2)])
+        m[:2, :] += m1
+        ref = ti.Matrix([[2., 3., 4., 5.], [1., 2., 3., 1.], [0., 0., 0., 0.]])
+        assert all(m == ref)
+
+    foo()
+
+
+@test_utils.test(debug=True, dynamic_index=True)
+def test_matrix_slice_write_dynamic_index():
+    @ti.kernel
+    def foo(i: ti.i32, ref: ti.template()):
+        m = ti.Matrix([[0., 0., 0., 0.] for _ in range(3)])
+        vec = ti.Vector([1., 2., 3., 4.])
+        m[i, :] = vec.transpose()
+        assert all(m == ref)
+
+    for i in range(3):
+        foo(
+            i,
+            ti.Matrix([[1., 2., 3., 4.] if j == i else [0., 0., 0., 0.]
+                       for j in range(3)]))

--- a/tests/python/test_vector_swizzle.py
+++ b/tests/python/test_vector_swizzle.py
@@ -108,7 +108,7 @@ def test_vector_invalid_swizzle_patterns():
                 "vec2 only has attributes=('x', 'y'), got=('x', 'y', 'z')")):
         a.xyz = [1, 2, 3]
 
-    with pytest.raises(ti.TaichiCompilationError,
+    with pytest.raises(ti.TaichiRuntimeError,
                        match=re.escape(
                            "value len does not match the swizzle pattern=xy")):
         a.xy = [1, 2, 3]


### PR DESCRIPTION
Issue: #4677, #5819

### Brief Summary

Previous implementation of matrix slice only supports assign. This PR adds support for augmented assign (e.g. +=) by following the implementation of vector swizzle - always getting reference to selected matrix elements.