### PR TITLE
[aot] Rename incomplete to truncated

### DIFF
--- a/c_api/docs/taichi/taichi_core.h.md
+++ b/c_api/docs/taichi/taichi_core.h.md
@@ -246,7 +246,7 @@ A collection of Taichi kernels (a compute graph) to launch on the offload target
 
 Errors reported by the Taichi C-API. Enumerants greater than or equal to zero are success states.
 
-- `enumeration.error.incomplete`: The output data is truncated because the user-provided buffer is too small.
+- `enumeration.error.truncated`: The output data is truncated because the user-provided buffer is too small.
 - `enumeration.error.success`: The Taichi C-API invocation finished gracefully.
 - `enumeration.error.not_supported`: The invoked API, or the combination of parameters is not supported by the Taichi C-API.
 - `enumeration.error.corrupted_data`: Provided data is corrupted.

--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -321,7 +321,7 @@ typedef struct TiComputeGraph_t *TiComputeGraph;
 // are success states.
 typedef enum TiError {
   // The output data is truncated because the user-provided buffer is too small.
-  TI_ERROR_INCOMPLETE = 1,
+  TI_ERROR_TRUNCATED = 1,
   // The Taichi C-API invocation finished gracefully.
   TI_ERROR_SUCCESS = 0,
   // The invoked API, or the combination of parameters is not supported by the

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -16,8 +16,8 @@ thread_local ErrorCache thread_error_cache;
 
 const char *describe_error(TiError error) {
   switch (error) {
-    case TI_ERROR_INCOMPLETE:
-      return "incomplete";
+    case TI_ERROR_TRUNCATED:
+      return "truncated";
     case TI_ERROR_SUCCESS:
       return "success";
     case TI_ERROR_NOT_SUPPORTED:
@@ -126,14 +126,6 @@ TiError ti_get_last_error(uint64_t message_size, char *message) {
 // external procedures.
 void ti_set_last_error(TiError error, const char *message) {
   TI_CAPI_TRY_CATCH_BEGIN();
-  if (error >= TI_ERROR_SUCCESS &&
-      thread_error_cache.error < TI_ERROR_SUCCESS) {
-    TI_WARN(
-        "Overriding C-API error: ({}) with ({}) is forbidden thus rejected.",
-        describe_error(thread_error_cache.error), describe_error(error));
-    return;
-  }
-
   if (error < TI_ERROR_SUCCESS) {
     TI_WARN("C-API error: ({}) {}", describe_error(error), message);
     if (message != nullptr) {

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -86,7 +86,7 @@
                     "name": "error",
                     "type": "enumeration",
                     "cases": {
-                        "incomplete": 1,
+                        "truncated": 1,
                         "success": 0,
                         "not_supported": -1,
                         "corrupted_data": -2,

--- a/docs/lang/articles/c-api/taichi_core.md
+++ b/docs/lang/articles/c-api/taichi_core.md
@@ -325,7 +325,7 @@ A collection of Taichi kernels (a compute graph) to launch on the offload target
 ```c
 // enumeration.error
 typedef enum TiError {
-  TI_ERROR_INCOMPLETE = 1,
+  TI_ERROR_TRUNCATED = 1,
   TI_ERROR_SUCCESS = 0,
   TI_ERROR_NOT_SUPPORTED = -1,
   TI_ERROR_CORRUPTED_DATA = -2,
@@ -342,7 +342,7 @@ typedef enum TiError {
 
 Errors reported by the Taichi C-API. Enumerants greater than or equal to zero are success states.
 
-- `TI_ERROR_INCOMPLETE`: The output data is truncated because the user-provided buffer is too small.
+- `TI_ERROR_TRUNCATED`: The output data is truncated because the user-provided buffer is too small.
 - `TI_ERROR_SUCCESS`: The Taichi C-API invocation finished gracefully.
 - `TI_ERROR_NOT_SUPPORTED`: The invoked API, or the combination of parameters is not supported by the Taichi C-API.
 - `TI_ERROR_CORRUPTED_DATA`: Provided data is corrupted.

--- a/misc/generate_c_api.py
+++ b/misc/generate_c_api.py
@@ -1,10 +1,9 @@
 import re
+from os import system
 
 from taichi_json import (Alias, BitField, BuiltInType, Definition, EntryBase,
                          Enumeration, Field, Function, Handle, Module,
                          Structure, Union)
-
-from os import system
 
 
 def get_type_name(x: EntryBase):

--- a/misc/generate_c_api.py
+++ b/misc/generate_c_api.py
@@ -4,7 +4,7 @@ from taichi_json import (Alias, BitField, BuiltInType, Definition, EntryBase,
                          Enumeration, Field, Function, Handle, Module,
                          Structure, Union)
 
-#from os import system
+from os import system
 
 
 def get_type_name(x: EntryBase):
@@ -53,7 +53,7 @@ def get_api_field_ref(module: Module, x: EntryBase, field_sym: str) -> list:
 
 
 def get_declr(module: Module, x: EntryBase, with_docs=False):
-    out = [""]
+    out = []
     if with_docs:
         out += get_api_ref(module, x)
 
@@ -274,7 +274,7 @@ def print_module_header(module: Module):
 
     for x in module.declr_reg:
         declr = module.declr_reg.resolve(x)
-        out += [get_declr(module, declr, True)]
+        out += ["", get_declr(module, declr, True)]
 
     out += [
         "",
@@ -296,7 +296,7 @@ def generate_module_header(module):
     with open(path, "w") as f:
         f.write(print_module_header(module))
 
-    #system(f"clang-format {path} -i")
+    system(f"clang-format {path} -i")
 
 
 if __name__ == "__main__":

--- a/misc/generate_c_api_docs.py
+++ b/misc/generate_c_api_docs.py
@@ -25,16 +25,17 @@ def print_module_doc(module: Module):
             "",
             "```c",
             f"// {x}",
-            get_declr(declr),
+            get_declr(module, declr),
             "```",
         ]
 
-        if x in module.doc.api_refs:
-            for line in module.doc.api_refs[x]:
+        if x in module.doc.api_full_refs:
+            for line in module.doc.api_full_refs[x]:
                 out += [resolve_inline_symbols_to_names(module, line)]
         else:
             print(f"WARNING: `{x}` is not documented")
-        out += [""]
+            out += [""]
+    out += [""]
 
     return '\n'.join(out)
 

--- a/misc/taichi_json.py
+++ b/misc/taichi_json.py
@@ -252,6 +252,7 @@ class Documentation:
             SYM_PATTERN = r"\`(\w+\.\w+)\`"
             FIELD_PATTERN = r"-\s+\`(\w+\.\w+\.\w+)\`:\s*(.*)$"
             cur_sym = None
+            api_full_refs = defaultdict(list)
             api_refs = defaultdict(list)
             api_field_refs = defaultdict(str)
             for line in templ[i:]:
@@ -269,6 +270,8 @@ class Documentation:
                     cur_sym = m[1]
                     continue
 
+                api_full_refs[cur_sym] += [line]
+
                 m = re.match(FIELD_PATTERN, line)
                 if m:
                     api_field_refs[m[1]] = m[2]
@@ -278,7 +281,12 @@ class Documentation:
 
             self.markdown_metadata = markdown_metadata
             self.module_doc = module_doc
+            # Full references including all lines for symbol specification and
+            # field specification.
+            self.api_full_refs = api_full_refs
+            # Symbol specifications without the field specifications.
             self.api_refs = api_refs
+            # Field specifications keyed by field symbol triplets.
             self.api_field_refs = api_field_refs
 
 


### PR DESCRIPTION
The error code `TI_ERROR_INCOMPLETE` is confusing because it actually means that Taichi has successfully done its work while the data is truncated because the user provided buffer is too short.

Also note that `set_last_error` with >0 error codes ("harmless errors") is allowed by designed. There must be a way to allow users to erase existing errors, otherwise the users can never suppressed those errors even they has successfully recovered from them. The restriction on overriding "hard errors" is thus removed.