### PR TITLE
[Error] Deprecate ndrange with number of the loop variables != the dimension of the ndrange

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1011,8 +1011,11 @@ class ASTTransformer(Builder):
                     'Ndrange for loop with number of the loop variables not equal to '
                     'the dimension of the ndrange is deprecated. '
                     'Please check if the number of arguments of ti.ndrange() is equal to '
-                    'the number of the loop variables.', DeprecationWarning,
-                    ctx.file, node.lineno + ctx.lineno_offset, module="taichi")
+                    'the number of the loop variables.',
+                    DeprecationWarning,
+                    ctx.file,
+                    node.lineno + ctx.lineno_offset,
+                    module="taichi")
             for i, target in enumerate(targets):
                 if i + 1 < len(targets):
                     target_tmp = impl.expr_init(

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1007,9 +1007,12 @@ class ASTTransformer(Builder):
             I = impl.expr_init(ndrange_loop_var)
             targets = ASTTransformer.get_for_loop_targets(node)
             if len(targets) != len(ndrange_var.dimensions):
-                raise TaichiSyntaxError(
-                    "The number of the loop variables does not match the dimension of the ndrange."
-                )
+                warnings.warn_explicit(
+                    'Ndrange for loop with number of the loop variables not equal to '
+                    'the dimension of the ndrange is deprecated. '
+                    'Please check if the number of arguments of ti.ndrange() is equal to '
+                    'the number of the loop variables.', DeprecationWarning,
+                    ctx.file, node.lineno + ctx.lineno_offset)
             for i, target in enumerate(targets):
                 if i + 1 < len(targets):
                     target_tmp = impl.expr_init(

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1012,7 +1012,7 @@ class ASTTransformer(Builder):
                     'the dimension of the ndrange is deprecated. '
                     'Please check if the number of arguments of ti.ndrange() is equal to '
                     'the number of the loop variables.', DeprecationWarning,
-                    ctx.file, node.lineno + ctx.lineno_offset)
+                    ctx.file, node.lineno + ctx.lineno_offset, module="taichi")
             for i, target in enumerate(targets):
                 if i + 1 < len(targets):
                     target_tmp = impl.expr_init(

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -327,6 +327,5 @@ def test_n_loop_var_neq_dimension():
     with pytest.warns(
             DeprecationWarning,
             match=
-            "Ndrange for loop with number of the loop variables not equal to"
-    ):
+            "Ndrange for loop with number of the loop variables not equal to"):
         iter()

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -324,9 +324,9 @@ def test_n_loop_var_neq_dimension():
         for i in ti.ndrange(1, 4):
             print(i)
 
-    with pytest.raises(
-            ti.TaichiSyntaxError,
+    with pytest.warns(
+            DeprecationWarning,
             match=
-            "The number of the loop variables does not match the dimension of the ndrange."
+            "Ndrange for loop with number of the loop variables not equal to"
     ):
         iter()


### PR DESCRIPTION
Issue: fixes #6351 

### Brief Summary
