### PR TITLE
[llvm] Fix broken llvm module on CUDA backend when TI_LLVM_15 is on

### DIFF
--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -116,6 +116,7 @@ function ci-docker-run {
         --user dev \
         -e PY \
         -e PROJECT_NAME \
+        -e LLVM_VERSION \
         -e TAICHI_CMAKE_ARGS \
         -e IN_DOCKER=true \
         -e TI_CI=1 \

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -7,6 +7,12 @@ set -ex
 [[ "$IN_DOCKER" == "true" ]] && cd taichi
 
 # TODO: Move llvm installation from container image to here
+if [[ "$LLVM_VERSION" == "15" ]]; then
+    wget https://github.com/ailzhang/torchhub_example/releases/download/0.2/taichi-llvm-15-linux.zip
+    unzip taichi-llvm-15-linux.zip && rm taichi-llvm-15-linux.zip
+    export PATH="$PWD/taichi-llvm-15/bin:$PATH"
+    export TAICHI_CMAKE_ARGS="$TAICHI_CMAKE_ARGS -DTI_LLVM_15:BOOL=ON"
+fi
 
 build_taichi_wheel() {
     python3 -m pip install -r requirements_dev.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -169,6 +169,7 @@ jobs:
             -DTI_WITH_VULKAN:BOOL=OFF
             -DTI_BUILD_TESTS:BOOL=ON
             -DTI_WITH_C_API=ON
+          LLVM_VERSION: 15
 
       - name: Test
         id: test

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -780,12 +780,6 @@ FunctionType CUDAModuleToFunctionConverter::convert(
   auto &mod = data.module;
   auto &tasks = data.tasks;
 #ifdef TI_WITH_CUDA
-  for (const auto &task : tasks) {
-    llvm::Function *func = mod->getFunction(task.name);
-    TI_ASSERT(func);
-    tlctx_->mark_function_as_cuda_kernel(func, task.block_dim);
-  }
-
   auto jit = tlctx_->jit.get();
   auto cuda_module =
       jit->add_module(std::move(mod), executor_->get_config()->gpu_max_reg);

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -2749,6 +2749,13 @@ LLVMCompiledTask TaskCodeGenLLVM::run_compilation() {
   emit_to_module();
   eliminate_unused_functions();
 
+  // CUDA specific metadata
+  for (const auto &task : offloaded_tasks) {
+    llvm::Function *func = module->getFunction(task.name);
+    TI_ASSERT(func);
+    tlctx->mark_function_as_cuda_kernel(func, task.block_dim);
+  }
+
   return {std::move(offloaded_tasks), std::move(module),
           std::move(used_tree_ids), std::move(struct_for_tls_sizes)};
 }

--- a/taichi/runtime/cuda/jit_cuda.cpp
+++ b/taichi/runtime/cuda/jit_cuda.cpp
@@ -77,7 +77,7 @@ std::string JITSessionCUDA::compile_module_to_ptx(
   // Part of this function is borrowed from Halide::CodeGen_PTX_Dev.cpp
   if (llvm::verifyModule(*module, &llvm::errs())) {
     module->print(llvm::errs(), nullptr);
-    TI_WARN("Module broken");
+    TI_ERROR("LLVM Module broken");
   }
 
   using namespace llvm;

--- a/tests/cpp/llvm/llvm_offline_cache_test.cpp
+++ b/tests/cpp/llvm/llvm_offline_cache_test.cpp
@@ -93,6 +93,9 @@ TEST_P(LlvmOfflineCacheTest, ReadWrite) {
   {
     auto llvm_ctx = std::make_unique<llvm::LLVMContext>();
 
+#ifdef TI_LLVM_15
+    llvm_ctx->setOpaquePointers(false);
+#endif
     LlvmOfflineCache::KernelCacheData kcache;
     kcache.created_at = 1;
     kcache.last_used_at = 1;


### PR DESCRIPTION
Issue: #

### Brief Summary
I also changed broken module from TI_WARN to TI_ERROR.... not sure if we relied on this or not, let's see.... 