### PR TITLE
[Bug] Fix memory leak in SPIRV module

### DIFF
--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -300,6 +300,7 @@ void VulkanPipeline::create_descriptor_set_layout(const Params &params) {
                 graphics_pipeline_template_->blend_attachments.end(),
                 default_state);
     }
+    spvReflectDestroyShaderModule(&module);
   }
 
   for (uint32_t set : sets_used) {


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/6448

### Brief Summary

We need to explicitly destroy the SPIRV module