### PR TITLE
[bug] Fix false overflow alarm in struct fors under packed mode

### DIFF
--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -91,8 +91,8 @@ SNode &SNode::create_node(std::vector<Axis> axes,
   }
   if (acc_shape > std::numeric_limits<int>::max()) {
     TI_WARN(
-        "Snode index might be out of int32 boundary but int64 indexing is not "
-        "supported yet.");
+        "SNode index might be out of int32 boundary but int64 indexing is not "
+        "supported yet. Struct fors might not work either.");
   }
   new_node.num_cells_per_container = acc_shape;
   // infer extractors (only for POT)

--- a/taichi/transforms/demote_dense_struct_fors.cpp
+++ b/taichi/transforms/demote_dense_struct_fors.cpp
@@ -26,7 +26,6 @@ void convert_to_range_for(OffloadedStmt *offloaded, bool packed) {
     snode = snode->parent;
   }
   std::reverse(snodes.begin(), snodes.end());
-  TI_ASSERT(total_bits <= 30);
 
   // general shape calculation - no dependence on POT
   int64 total_n = 1;
@@ -38,6 +37,7 @@ void convert_to_range_for(OffloadedStmt *offloaded, bool packed) {
     }
     total_n *= s->num_cells_per_container;
   }
+  TI_ASSERT(total_n <= std::numeric_limits<int>::max());
 
   offloaded->const_begin = true;
   offloaded->const_end = true;

--- a/tests/python/test_struct_for_non_pot.py
+++ b/tests/python/test_struct_for_non_pot.py
@@ -68,9 +68,9 @@ def test_2d_packed():
     _test_2d()
 
 
-@test_utils.test(packed=True)
+@test_utils.test(require=ti.extension.packed, packed=True)
 def test_2d_overflow_if_not_packed():
-    n, m = 40000000, 50
+    n, m = 2**25 + 1, 2**5 + 1
     arr = ti.field(ti.u8, (n, m))
 
     @ti.kernel

--- a/tests/python/test_struct_for_non_pot.py
+++ b/tests/python/test_struct_for_non_pot.py
@@ -70,8 +70,8 @@ def test_2d_packed():
 
 @test_utils.test(require=ti.extension.packed, packed=True)
 def test_2d_overflow_if_not_packed():
-    n, m = 2**25 + 1, 2**5 + 1
-    arr = ti.field(ti.u8, (n, m))
+    n, m, p = 2**9 + 1, 2**9 + 1, 2**10 + 1
+    arr = ti.field(ti.u8, (n, m, p))
 
     @ti.kernel
     def count() -> ti.i32:
@@ -80,4 +80,4 @@ def test_2d_overflow_if_not_packed():
             res += 1
         return res
 
-    assert count() == n * m
+    assert count() == n * m * p

--- a/tests/python/test_struct_for_non_pot.py
+++ b/tests/python/test_struct_for_non_pot.py
@@ -66,3 +66,18 @@ def test_2d():
 @test_utils.test(require=ti.extension.packed, packed=True)
 def test_2d_packed():
     _test_2d()
+
+
+@test_utils.test(packed=True)
+def test_2d_overflow_if_not_packed():
+    n, m = 40000000, 50
+    arr = ti.field(ti.u8, (n, m))
+
+    @ti.kernel
+    def count() -> ti.i32:
+        res = 0
+        for _ in ti.grouped(arr):
+            res += 1
+        return res
+
+    assert count() == n * m


### PR DESCRIPTION
Issue: fix #6258

### Brief Summary

For the script in #6258, which causes overflow only in non-packed mode, an error will be raised even if `packed=True`. The PR fixes the false alarm.