### PR TITLE
[ci] Run Meshtaichi tests only on cuda machine

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -113,13 +113,9 @@ else
 fi
 
 # meshtaichi end-to-end test
-if [[ $OSTYPE == "linux-"* && ($TI_WANTED_ARCHS == *"cuda"* || $TI_WANTED_ARCHS == *"cpu"*) ]]; then
+if [[ $OSTYPE == "linux-"* && $TI_WANTED_ARCHS == *"cuda"* ]]; then
     python3 -m pip install meshtaichi_patcher --upgrade
     git clone https://github.com/taichi-dev/meshtaichi.git
-    if [[ $TI_WANTED_ARCHS == *"cuda"* ]]; then
-        python3 meshtaichi/ci/run_test.py --arch cuda
-    fi
-    if [[ $TI_WANTED_ARCHS == *"cpu"* ]]; then
-        python3 meshtaichi/ci/run_test.py --arch cpu
-    fi
+    python3 meshtaichi/ci/run_test.py --arch cuda
+    python3 meshtaichi/ci/run_test.py --arch cpu
 fi


### PR DESCRIPTION
related: #6453

Github CI machine sometimes gives results with large numerical error on Meshtaichi tests.
This pr tries running both cuda and CPU tests on cuda machine.