### PR TITLE
Revert "[ci] Add unix end-to-end CI tests for meshtaichi"

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -111,15 +111,3 @@ else
     python3 tests/run_tests.py -vr2 -t1 -k "torch" -a "$TI_WANTED_ARCHS"
     # Paddle's paddle.fluid.core.Tensor._ptr() is only available on develop branch, and CUDA version on linux will get error `Illegal Instruction`
 fi
-
-# meshtaichi end-to-end test
-if [[ $OSTYPE == "linux-"* && ($TI_WANTED_ARCHS == *"cuda"* || $TI_WANTED_ARCHS == *"cpu"*) ]]; then
-    python3 -m pip install meshtaichi_patcher --upgrade
-    git clone https://github.com/taichi-dev/meshtaichi.git
-    if [[ $TI_WANTED_ARCHS == *"cuda"* ]]; then
-        python3 meshtaichi/ci/run_test.py --arch cuda
-    fi
-    if [[ $TI_WANTED_ARCHS == *"cpu"* ]]; then
-        python3 meshtaichi/ci/run_test.py --arch cpu
-    fi
-fi


### PR DESCRIPTION
Reverts taichi-dev/taichi#6453 since it broke nightly, https://github.com/taichi-dev/taichi/actions/workflows/release.yml