### PR TITLE
[Error] Return NotImplemented for operations between field and Expr/Matrix/Struct

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -806,7 +806,7 @@ class ASTTransformer(Builder):
         try:
             node.ptr = op(node.left.ptr, node.right.ptr)
         except TypeError as e:
-            raise TaichiTypeError(str(e))
+            raise TaichiTypeError(str(e)) from None
         return node.ptr
 
     @staticmethod

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -6,8 +6,8 @@ import operator as _bt_ops_mod  # bt for builtin
 from taichi._lib import core as _ti_core
 from taichi.lang import expr, impl
 from taichi.lang.exception import TaichiSyntaxError
-from taichi.lang.util import cook_dtype, is_taichi_class, taichi_scope
 from taichi.lang.field import Field
+from taichi.lang.util import cook_dtype, is_taichi_class, taichi_scope
 
 unary_ops = []
 
@@ -82,7 +82,8 @@ def ternary(foo):
 
     @functools.wraps(foo)
     def wrapped(a, b, c):
-        if isinstance(a, Field) or isinstance(b, Field) or isinstance(c, Field):
+        if isinstance(a, Field) or isinstance(b, Field) or isinstance(
+                c, Field):
             return NotImplemented
         if is_taichi_class(a):
             return a._element_wise_ternary(abc_foo, b, c)

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -7,6 +7,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang import expr, impl
 from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang.util import cook_dtype, is_taichi_class, taichi_scope
+from taichi.lang.field import Field
 
 unary_ops = []
 
@@ -51,6 +52,8 @@ def binary(foo):
 
     @functools.wraps(foo)
     def wrapped(a, b):
+        if isinstance(a, Field) or isinstance(b, Field):
+            return NotImplemented
         if is_taichi_class(a):
             return a._element_wise_binary(imp_foo, b)
         if is_taichi_class(b):
@@ -79,6 +82,8 @@ def ternary(foo):
 
     @functools.wraps(foo)
     def wrapped(a, b, c):
+        if isinstance(a, Field) or isinstance(b, Field) or isinstance(c, Field):
+            return NotImplemented
         if is_taichi_class(a):
             return a._element_wise_ternary(abc_foo, b, c)
         if is_taichi_class(b):
@@ -101,6 +106,8 @@ def writeback_binary(foo):
 
     @functools.wraps(foo)
     def wrapped(a, b):
+        if isinstance(a, Field) or isinstance(b, Field):
+            return NotImplemented
         if is_taichi_class(a):
             return a._element_wise_writeback_binary(imp_foo, b)
         if is_taichi_class(b):

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -317,8 +317,10 @@ def test_python_for_in():
 def test_matrix_mult_field():
     x = ti.field(int, shape=())
     with pytest.raises(ti.TaichiTypeError, match="unsupported operand type"):
+
         @ti.kernel
         def foo():
             a = ti.Vector([1, 1, 1])
             b = a * x
+
         foo()

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -311,3 +311,14 @@ def test_python_for_in():
                        match="Struct for is only available in Taichi scope"):
         for i in x:
             pass
+
+
+@test_utils.test()
+def test_matrix_mult_field():
+    x = ti.field(int, shape=())
+    with pytest.raises(ti.TaichiTypeError, match="unsupported operand type"):
+        @ti.kernel
+        def foo():
+            a = ti.Vector([1, 1, 1])
+            b = a * x
+        foo()


### PR DESCRIPTION
Issue: #6472 

### Brief Summary
Traceback of #6472 before #6474, #6475 and #6477:
```
Traceback (most recent call last):
  File "/home/lin/test/ant.py", line 21, in <module>
    myclass.do_something()
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 1022, in __call__
    return self._primal(self._kernel_owner, *args, **kwargs)
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 888, in __call__
    key = self.ensure_compiled(*args)
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 855, in ensure_compiled
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 566, in materialize
    taichi_kernel = impl.get_runtime().prog.create_kernel(
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 556, in taichi_ast_generator
    transform_tree(tree, ctx)
  File "/home/lin/taichi/python/taichi/lang/ast/transform.py", line 6, in transform_tree
    ASTTransformer()(ctx, tree)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer_utils.py", line 28, in __call__
    raise e.with_traceback(None)
taichi.lang.exception.TaichiCompilationError: File "/home/lin/test/ant.py", line 16, in do_something:
            NEE_contrib = brdf * self.light_weight * self.light_color[None]
                          ^^^^^^^^^^^^^^^^^^^^^^^^
Traceback (most recent call last):
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer_utils.py", line 25, in __call__
    return method(ctx, node)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer.py", line 800, in build_BinOp
    node.ptr = op(node.left.ptr, node.right.ptr)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer.py", line 788, in <lambda>
    ast.Mult: lambda l, r: l * r,
  File "/home/lin/taichi/python/taichi/lang/common_ops.py", line 47, in __mul__
    return ops.mul(self, other)
  File "/home/lin/taichi/python/taichi/lang/ops.py", line 55, in wrapped
    return a._element_wise_binary(imp_foo, b)
  File "/home/lin/taichi/python/taichi/lang/matrix.py", line 491, in _element_wise_binary
    other = self._broadcast_copy(other)
  File "/home/lin/taichi/python/taichi/lang/matrix.py", line 507, in _broadcast_copy
    other = Vector([other for _ in range(self.n)])
  File "/home/lin/taichi/python/taichi/lang/matrix.py", line 1465, in __init__
    super().__init__(arr, dt=dt, **kwargs)
  File "/home/lin/taichi/python/taichi/lang/matrix.py", line 433, in __init__
    flattened += row
  File "/home/lin/taichi/python/taichi/lang/field.py", line 264, in __iter__
    raise NotImplementedError(
NotImplementedError: Struct for is only available in Taichi scope.
```

Traceback after #6474: 
```
Traceback (most recent call last):
  File "/home/lin/test/ant.py", line 21, in <module>
    myclass.do_something()
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 1022, in __call__
    return self._primal(self._kernel_owner, *args, **kwargs)
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 888, in __call__
    key = self.ensure_compiled(*args)
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 855, in ensure_compiled
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 566, in materialize
    taichi_kernel = impl.get_runtime().prog.create_kernel(
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 556, in taichi_ast_generator
    transform_tree(tree, ctx)
  File "/home/lin/taichi/python/taichi/lang/ast/transform.py", line 6, in transform_tree
    ASTTransformer()(ctx, tree)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer_utils.py", line 28, in __call__
    raise e.with_traceback(None)
taichi.lang.exception.TaichiCompilationError: File "/home/lin/test/ant.py", line 16, in do_something:
            NEE_contrib = brdf * self.light_weight * self.light_color[None]
                          ^^^^^^^^^^^^^^^^^^^^^^^^
Traceback (most recent call last):
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer_utils.py", line 25, in __call__
    return method(ctx, node)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer.py", line 800, in build_BinOp
    node.ptr = op(node.left.ptr, node.right.ptr)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer.py", line 788, in <lambda>
    ast.Mult: lambda l, r: l * r,
TypeError: unsupported operand type(s) for *: 'Vector' and 'ScalarField'
```

Traceback after #6474 and #6475: 
```
Traceback (most recent call last):
  File "/home/lin/test/ant.py", line 21, in <module>
    myclass.do_something()
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 1025, in __call__
    raise type(e)('\n' + str(e)) from None
taichi.lang.exception.TaichiCompilationError: 
File "/home/lin/test/ant.py", line 16, in do_something:
            NEE_contrib = brdf * self.light_weight * self.light_color[None]
                          ^^^^^^^^^^^^^^^^^^^^^^^^
Traceback (most recent call last):
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer_utils.py", line 25, in __call__
    return method(ctx, node)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer.py", line 800, in build_BinOp
    node.ptr = op(node.left.ptr, node.right.ptr)
  File "/home/lin/taichi/python/taichi/lang/ast/ast_transformer.py", line 788, in <lambda>
    ast.Mult: lambda l, r: l * r,
TypeError: unsupported operand type(s) for *: 'Vector' and 'ScalarField'
```
Traceback after #6474, #6475 and #6477: 
```
Traceback (most recent call last):
  File "/home/lin/test/ant.py", line 21, in <module>
    myclass.do_something()
  File "/home/lin/taichi/python/taichi/lang/kernel_impl.py", line 1025, in __call__
    raise type(e)('\n' + str(e)) from None
taichi.lang.exception.TaichiTypeError: 
File "/home/lin/test/ant.py", line 16, in do_something:
            NEE_contrib = brdf * self.light_weight * self.light_color[None]
                          ^^^^^^^^^^^^^^^^^^^^^^^^
unsupported operand type(s) for *: 'Vector' and 'ScalarField'
```