### PR TITLE
[llvm] Add support for data types of different sizes on dynamic SNode

### DIFF
--- a/taichi/analysis/data_source_analysis.cpp
+++ b/taichi/analysis/data_source_analysis.cpp
@@ -66,8 +66,7 @@ std::vector<Stmt *> get_store_destination(Stmt *store_stmt) {
   } else if (auto snode_op = store_stmt->cast<SNodeOpStmt>()) {
     if (snode_op->op_type == SNodeOpType::allocate) {
       return {snode_op->val, snode_op->ptr};
-    }
-    else {
+    } else {
       return {};
     }
   } else if (auto external_func = store_stmt->cast<ExternalFuncCallStmt>()) {

--- a/taichi/analysis/data_source_analysis.cpp
+++ b/taichi/analysis/data_source_analysis.cpp
@@ -63,6 +63,13 @@ std::vector<Stmt *> get_store_destination(Stmt *store_stmt) {
     return std::vector<Stmt *>(1, global_store->dest);
   } else if (auto atomic = store_stmt->cast<AtomicOpStmt>()) {
     return std::vector<Stmt *>(1, atomic->dest);
+  } else if (auto snode_op = store_stmt->cast<SNodeOpStmt>()) {
+    if (snode_op->op_type == SNodeOpType::allocate) {
+      return {snode_op->val, snode_op->ptr};
+    }
+    else {
+      return {};
+    }
   } else if (auto external_func = store_stmt->cast<ExternalFuncCallStmt>()) {
     if (store_stmt->cast<ExternalFuncCallStmt>()->type ==
         ExternalFuncCallStmt::BITCODE) {

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1369,8 +1369,10 @@ void TaskCodeGenLLVM::visit(SNodeOpStmt *stmt) {
   auto snode = stmt->snode;
   if (stmt->op_type == SNodeOpType::allocate) {
     TI_ASSERT(snode->type == SNodeType::dynamic);
-    TI_ASSERT(stmt->ret_type.is_pointer() && stmt->ret_type.ptr_removed()->is_primitive(PrimitiveTypeID::gen));
-    auto ptr = call(snode, llvm_val[stmt->ptr], "allocate", {llvm_val[stmt->val]});
+    TI_ASSERT(stmt->ret_type.is_pointer() &&
+              stmt->ret_type.ptr_removed()->is_primitive(PrimitiveTypeID::gen));
+    auto ptr =
+        call(snode, llvm_val[stmt->ptr], "allocate", {llvm_val[stmt->val]});
     llvm_val[stmt] = ptr;
   } else if (stmt->op_type == SNodeOpType::length) {
     TI_ASSERT(snode->type == SNodeType::dynamic);

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1367,11 +1367,11 @@ void TaskCodeGenLLVM::visit(AssertStmt *stmt) {
 
 void TaskCodeGenLLVM::visit(SNodeOpStmt *stmt) {
   auto snode = stmt->snode;
-  if (stmt->op_type == SNodeOpType::append) {
+  if (stmt->op_type == SNodeOpType::allocate) {
     TI_ASSERT(snode->type == SNodeType::dynamic);
-    TI_ASSERT(stmt->ret_type->is_primitive(PrimitiveTypeID::i32));
-    llvm_val[stmt] =
-        call(snode, llvm_val[stmt->ptr], "append", {llvm_val[stmt->val]});
+    TI_ASSERT(stmt->ret_type.is_pointer() && stmt->ret_type.ptr_removed()->is_primitive(PrimitiveTypeID::gen));
+    auto ptr = call(snode, llvm_val[stmt->ptr], "allocate", {llvm_val[stmt->val]});
+    llvm_val[stmt] = ptr;
   } else if (stmt->op_type == SNodeOpType::length) {
     TI_ASSERT(snode->type == SNodeType::dynamic);
     llvm_val[stmt] = call(snode, llvm_val[stmt->ptr], "get_num_elements", {});

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -604,7 +604,8 @@ void ControlFlowGraph::reaching_definition_analysis(bool after_lower_access) {
           (!after_lower_access &&
            (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
             stmt->is<BlockLocalPtrStmt>() || stmt->is<ThreadLocalPtrStmt>() ||
-            stmt->is<GlobalTemporaryStmt>() || stmt->is<MatrixPtrStmt>() || stmt->is<GetChStmt>()))) {
+            stmt->is<GlobalTemporaryStmt>() || stmt->is<MatrixPtrStmt>() ||
+            stmt->is<GetChStmt>()))) {
         // TODO: unify them
         // A global pointer that may contain some data before this kernel.
         nodes[start_node]->reach_gen.insert(stmt);

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -604,7 +604,7 @@ void ControlFlowGraph::reaching_definition_analysis(bool after_lower_access) {
           (!after_lower_access &&
            (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
             stmt->is<BlockLocalPtrStmt>() || stmt->is<ThreadLocalPtrStmt>() ||
-            stmt->is<GlobalTemporaryStmt>() || stmt->is<MatrixPtrStmt>()))) {
+            stmt->is<GlobalTemporaryStmt>() || stmt->is<MatrixPtrStmt>() || stmt->is<GetChStmt>()))) {
         // TODO: unify them
         // A global pointer that may contain some data before this kernel.
         nodes[start_node]->reach_gen.insert(stmt);

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -928,7 +928,8 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
     flatten_rvalue(value, ctx);
 
     auto alloca = ctx->push_back<AllocaStmt>(PrimitiveType::i32);
-    auto addr = ctx->push_back<SNodeOpStmt>(SNodeOpType::allocate, snode, ptr, alloca);
+    auto addr =
+        ctx->push_back<SNodeOpStmt>(SNodeOpType::allocate, snode, ptr, alloca);
     auto ch_addr = ctx->push_back<GetChStmt>(addr, snode, 0);
     ctx->push_back<GlobalStoreStmt>(ch_addr, value->stmt);
     ctx->push_back<LocalLoadStmt>(alloca);

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -926,13 +926,16 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
     ctx->push_back<SNodeOpStmt>(SNodeOpType::get_addr, snode, ptr, nullptr);
   } else if (op_type == SNodeOpType::append) {
     flatten_rvalue(value, ctx);
-    ctx->push_back<SNodeOpStmt>(SNodeOpType::append, snode, ptr, value->stmt);
+
+    auto alloca = ctx->push_back<AllocaStmt>(PrimitiveType::i32);
+    auto addr = ctx->push_back<SNodeOpStmt>(SNodeOpType::allocate, snode, ptr, alloca);
+    auto ch_addr = ctx->push_back<GetChStmt>(addr, snode, 0);
+    ctx->push_back<GlobalStoreStmt>(ch_addr, value->stmt);
+    ctx->push_back<LocalLoadStmt>(alloca);
     TI_ERROR_IF(snode->type != SNodeType::dynamic,
                 "ti.append only works on dynamic nodes.");
     TI_ERROR_IF(snode->ch.size() != 1,
                 "ti.append only works on single-child dynamic nodes.");
-    TI_ERROR_IF(data_type_size(snode->ch[0]->dt) != 4,
-                "ti.append only works on i32/f32 nodes.");
   }
   stmt = ctx->back_stmt();
 }

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -121,7 +121,8 @@ bool SNodeOpStmt::activation_related(SNodeOpType op) {
 }
 
 bool SNodeOpStmt::need_activation(SNodeOpType op) {
-  return op == SNodeOpType::activate || op == SNodeOpType::append || op == SNodeOpType::allocate;
+  return op == SNodeOpType::activate || op == SNodeOpType::append ||
+         op == SNodeOpType::allocate;
 }
 
 ExternalTensorShapeAlongAxisStmt::ExternalTensorShapeAlongAxisStmt(int axis,
@@ -273,7 +274,10 @@ GetChStmt::GetChStmt(Stmt *input_ptr, int chid, bool is_bit_vectorized)
   TI_STMT_REG_FIELDS;
 }
 
-GetChStmt::GetChStmt(Stmt *input_ptr, SNode *snode, int chid, bool is_bit_vectorized)
+GetChStmt::GetChStmt(Stmt *input_ptr,
+                     SNode *snode,
+                     int chid,
+                     bool is_bit_vectorized)
     : input_ptr(input_ptr), chid(chid), is_bit_vectorized(is_bit_vectorized) {
   input_snode = snode;
   output_snode = input_snode->ch[chid].get();

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -121,7 +121,7 @@ bool SNodeOpStmt::activation_related(SNodeOpType op) {
 }
 
 bool SNodeOpStmt::need_activation(SNodeOpType op) {
-  return op == SNodeOpType::activate || op == SNodeOpType::append;
+  return op == SNodeOpType::activate || op == SNodeOpType::append || op == SNodeOpType::allocate;
 }
 
 ExternalTensorShapeAlongAxisStmt::ExternalTensorShapeAlongAxisStmt(int axis,
@@ -269,6 +269,13 @@ GetChStmt::GetChStmt(Stmt *input_ptr, int chid, bool is_bit_vectorized)
     : input_ptr(input_ptr), chid(chid), is_bit_vectorized(is_bit_vectorized) {
   TI_ASSERT(input_ptr->is<SNodeLookupStmt>());
   input_snode = input_ptr->as<SNodeLookupStmt>()->snode;
+  output_snode = input_snode->ch[chid].get();
+  TI_STMT_REG_FIELDS;
+}
+
+GetChStmt::GetChStmt(Stmt *input_ptr, SNode *snode, int chid, bool is_bit_vectorized)
+    : input_ptr(input_ptr), chid(chid), is_bit_vectorized(is_bit_vectorized) {
+  input_snode = snode;
   output_snode = input_snode->ch[chid].get();
   TI_STMT_REG_FIELDS;
 }

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1182,7 +1182,10 @@ class GetChStmt : public Stmt {
   bool is_bit_vectorized;
 
   GetChStmt(Stmt *input_ptr, int chid, bool is_bit_vectorized = false);
-  GetChStmt(Stmt *input_ptr, SNode *snode, int chid, bool is_bit_vectorized = false);
+  GetChStmt(Stmt *input_ptr,
+            SNode *snode,
+            int chid,
+            bool is_bit_vectorized = false);
 
   bool has_global_side_effect() const override {
     return false;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1182,6 +1182,7 @@ class GetChStmt : public Stmt {
   bool is_bit_vectorized;
 
   GetChStmt(Stmt *input_ptr, int chid, bool is_bit_vectorized = false);
+  GetChStmt(Stmt *input_ptr, SNode *snode, int chid, bool is_bit_vectorized = false);
 
   bool has_global_side_effect() const override {
     return false;

--- a/taichi/ir/stmt_op_types.cpp
+++ b/taichi/ir/stmt_op_types.cpp
@@ -136,6 +136,7 @@ std::string snode_op_type_name(SNodeOpType type) {
     REGISTER_TYPE(activate);
     REGISTER_TYPE(deactivate);
     REGISTER_TYPE(append);
+    REGISTER_TYPE(allocate);
     REGISTER_TYPE(clear);
     REGISTER_TYPE(undefined);
 

--- a/taichi/ir/stmt_op_types.h
+++ b/taichi/ir/stmt_op_types.h
@@ -77,6 +77,7 @@ enum class SNodeOpType : int {
   activate,
   deactivate,
   append,
+  allocate,
   clear,
   undefined
 };

--- a/taichi/runtime/llvm/runtime_module/node_dynamic.h
+++ b/taichi/runtime/llvm/runtime_module/node_dynamic.h
@@ -58,11 +58,12 @@ void Dynamic_deactivate(Ptr meta_, Ptr node_) {
   }
 }
 
-i32 Dynamic_append(Ptr meta_, Ptr node_, i32 data) {
+Ptr Dynamic_allocate(Ptr meta_, Ptr node_, i32 *len) {
   auto meta = (DynamicMeta *)(meta_);
   auto node = (DynamicNode *)(node_);
   auto chunk_size = meta->chunk_size;
   auto i = atomic_add_i32(&node->n, 1);
+  *len = i;
   int chunk_start = 0;
   auto p_chunk_ptr = &node->ptr;
   while (true) {
@@ -76,14 +77,12 @@ i32 Dynamic_append(Ptr meta_, Ptr node_, i32 data) {
       });
     }
     if (i < chunk_start + chunk_size) {
-      *(i32 *)(*p_chunk_ptr + sizeof(Ptr) +
-               (i - chunk_start) * meta->element_size) = data;
-      break;
+      return *p_chunk_ptr + sizeof(Ptr) +
+               (i - chunk_start) * meta->element_size;
     }
     p_chunk_ptr = (Ptr *)(*p_chunk_ptr);
     chunk_start += chunk_size;
   }
-  return i;
 }
 
 i32 Dynamic_is_active(Ptr meta_, Ptr node_, int i) {

--- a/taichi/runtime/llvm/runtime_module/node_dynamic.h
+++ b/taichi/runtime/llvm/runtime_module/node_dynamic.h
@@ -78,7 +78,7 @@ Ptr Dynamic_allocate(Ptr meta_, Ptr node_, i32 *len) {
     }
     if (i < chunk_start + chunk_size) {
       return *p_chunk_ptr + sizeof(Ptr) +
-               (i - chunk_start) * meta->element_size;
+             (i - chunk_start) * meta->element_size;
     }
     p_chunk_ptr = (Ptr *)(*p_chunk_ptr);
     chunk_start += chunk_size;

--- a/taichi/runtime/llvm/runtime_module/node_dynamic.h
+++ b/taichi/runtime/llvm/runtime_module/node_dynamic.h
@@ -83,6 +83,8 @@ Ptr Dynamic_allocate(Ptr meta_, Ptr node_, i32 *len) {
     p_chunk_ptr = (Ptr *)(*p_chunk_ptr);
     chunk_start += chunk_size;
   }
+  // Unreachable
+  return nullptr;
 }
 
 i32 Dynamic_is_active(Ptr meta_, Ptr node_, int i) {

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -125,7 +125,11 @@ class TypeCheck : public IRVisitor {
   void visit(SNodeOpStmt *stmt) override {
     if (stmt->op_type == SNodeOpType::get_addr) {
       stmt->ret_type = PrimitiveType::u64;
-    } else {
+    } else if (stmt->op_type == SNodeOpType::allocate) {
+      stmt->ret_type = PrimitiveType::gen;
+      stmt->ret_type.set_is_pointer(true);
+    }
+    else {
       stmt->ret_type = PrimitiveType::i32;
     }
   }

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -128,8 +128,7 @@ class TypeCheck : public IRVisitor {
     } else if (stmt->op_type == SNodeOpType::allocate) {
       stmt->ret_type = PrimitiveType::gen;
       stmt->ret_type.set_is_pointer(true);
-    }
-    else {
+    } else {
       stmt->ret_type = PrimitiveType::i32;
     }
   }

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -83,7 +83,7 @@ def test_compare_equality():
     assert not a[11]
 
 
-@test_utils.test(require=ti.extension.sparse)
+@test_utils.test(require=ti.extension.sparse, exclude=[ti.metal])
 def test_no_duplicate_eval():
     a = ti.field(ti.i32)
     ti.root.dynamic(ti.i, 256).place(a)

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -141,8 +141,8 @@ def test_dense_dynamic():
     # being that appending to Taichi's dynamic node messes up its length. See
     # https://stackoverflow.com/questions/65995357/cuda-spinlock-implementation-with-independent-thread-scheduling-supported
     # CUDA 11.2 didn't fix this bug, unfortunately.
-    # if ti.lang.impl.current_cfg().arch == ti.cuda:
-    #     pytest.skip('CUDA spinlock bug')
+    if ti.lang.impl.current_cfg().arch == ti.cuda:
+        pytest.skip('CUDA spinlock bug')
 
     n = 128
     x = ti.field(ti.i32)

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -236,6 +236,7 @@ def test_append_u8():
     x = ti.field(ti.u8)
     pixel = ti.root.dynamic(ti.j, 20)
     pixel.place(x)
+
     @ti.kernel
     def make_list():
         for i in range(20):
@@ -252,6 +253,7 @@ def test_append_u64():
     x = ti.field(ti.u64)
     pixel = ti.root.dynamic(ti.i, 20)
     pixel.place(x)
+
     @ti.kernel
     def make_list():
         for i in range(20):

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -239,6 +239,7 @@ def test_append_u8():
 
     @ti.kernel
     def make_list():
+        ti.loop_config(serialize=True)
         for i in range(20):
             x[()].append(i * i * i)
 
@@ -256,6 +257,7 @@ def test_append_u64():
 
     @ti.kernel
     def make_list():
+        ti.loop_config(serialize=True)
         for i in range(20):
             x[()].append(i * i * i * ti.u64(10000000000))
 

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -21,7 +21,7 @@ def _test_dynamic_append_length(dt):
     test()
 
 
-@test_utils.test(exclude=[ti.cc, ti.opengl, ti.vulkan],
+@test_utils.test(exclude=[ti.cc, ti.opengl, ti.vulkan, ti.metal],
                  default_fp=ti.f32,
                  debug=True)
 def test_dynamic_append_length_f32():

--- a/tests/python/test_sparse_deactivate.py
+++ b/tests/python/test_sparse_deactivate.py
@@ -170,7 +170,7 @@ def test_pointer3():
                     assert xn[i, j] == i + j
 
 
-@test_utils.test(require=ti.extension.sparse)
+@test_utils.test(require=ti.extension.sparse, exclude=[ti.metal])
 def test_dynamic():
     x = ti.field(ti.i32)
     s = ti.field(ti.i32)

--- a/tests/python/test_struct_for_dynamic.py
+++ b/tests/python/test_struct_for_dynamic.py
@@ -2,7 +2,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(exclude=[ti.opengl, ti.cc, ti.vulkan])
+@test_utils.test(exclude=[ti.opengl, ti.cc, ti.vulkan, ti.metal])
 def test_dynamic():
     x = ti.field(ti.i32)
     y = ti.field(ti.i32, shape=())
@@ -23,7 +23,7 @@ def test_dynamic():
     assert y[None] == n // 3 + 1
 
 
-@test_utils.test(exclude=[ti.opengl, ti.cc, ti.vulkan])
+@test_utils.test(exclude=[ti.opengl, ti.cc, ti.vulkan, ti.metal])
 def test_dense_dynamic():
     n = 128
 


### PR DESCRIPTION
Issue: #5420

### Brief Summary
This PR splits `append` operation of Dynamic SNode to two steps:
1. Allocate the space for the new element, increase the length by one, and return the address (void *) to the first byte of the new element.
2. Use `GetChStmt` to get the pointer of the element (of the right type) from the address returned in step 1, and use `GlobalStoreStmt` to store the value into the address.

**This PR breaks Dynamic SNode on Metal**