### PR TITLE
[lang] Support matrix args on real function

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -128,7 +128,7 @@ def make_var_list(size, ast_builder=None):
     return exprs
 
 
-def make_expr_group(*exprs):
+def make_expr_group(*exprs, real_func_arg=False):
     from taichi.lang.matrix import Matrix  # pylint: disable=C0415
     if len(exprs) == 1:
         if isinstance(exprs[0], (list, tuple)):
@@ -140,8 +140,12 @@ def make_expr_group(*exprs):
     expr_group = _ti_core.ExprGroup()
     for i in exprs:
         if isinstance(i, Matrix):
-            assert i.local_tensor_proxy is not None
-            expr_group.push_back(i.local_tensor_proxy)
+            if real_func_arg:
+                for item in i.entries:
+                    expr_group.push_back(Expr(item).ptr)
+            else:
+                assert i.local_tensor_proxy is not None
+                expr_group.push_back(i.local_tensor_proxy)
         else:
             expr_group.push_back(Expr(i).ptr)
     return expr_group

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -253,7 +253,8 @@ class Func:
                         _ti_core.make_reference(args[i].ptr))
                 else:
                     non_template_args.append(args[i])
-        non_template_args = impl.make_expr_group(non_template_args, real_func_arg=True)
+        non_template_args = impl.make_expr_group(non_template_args,
+                                                 real_func_arg=True)
         return Expr(
             _ti_core.make_func_call_expr(
                 self.taichi_functions[key.instance_id], non_template_args))

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -253,7 +253,7 @@ class Func:
                         _ti_core.make_reference(args[i].ptr))
                 else:
                     non_template_args.append(args[i])
-        non_template_args = impl.make_expr_group(non_template_args)
+        non_template_args = impl.make_expr_group(non_template_args, real_func_arg=True)
         return Expr(
             _ti_core.make_func_call_expr(
                 self.taichi_functions[key.instance_id], non_template_args))

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -444,6 +444,7 @@ def test_func_matrix_arg():
 def test_func_matrix_arg_real_matrix():
     _test_func_matrix_arg()
 
+
 @test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_real_func_matrix_arg():
     @ti.experimental.real_func
@@ -451,7 +452,7 @@ def test_real_func_matrix_arg():
         return a[0, 0] + a[0, 1] + a[1, 0] + a[1, 1]
 
     @ti.kernel
-    def foo()->float:
+    def foo() -> float:
         a = ti.math.mat2(1, 2, 3, 4)
         return mat_arg(a)
 

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -443,3 +443,16 @@ def test_func_matrix_arg():
                  real_matrix_scalarize=True)
 def test_func_matrix_arg_real_matrix():
     _test_func_matrix_arg()
+
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_real_func_matrix_arg():
+    @ti.experimental.real_func
+    def mat_arg(a: ti.math.mat2) -> float:
+        return a[0, 0] + a[0, 1] + a[1, 0] + a[1, 1]
+
+    @ti.kernel
+    def foo()->float:
+        a = ti.math.mat2(1, 2, 3, 4)
+        return mat_arg(a)
+
+    assert foo() == pytest.approx(10)


### PR DESCRIPTION
Issue: #602

### Brief Summary
We only need to disassemble the arguments and pass them to the real function one by one just as we pass matrix arguments to the kernel.

It does not support local matrix and element of matrix field as argument when real_matrix=True yet.