### PR TITLE
[aot] Disable physical storage buffer in runtime

### DIFF
--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -37,10 +37,13 @@ VulkanRuntimeImported::Workaround::Workaround(
     caps.set(taichi::lang::DeviceCapability::spirv_version, 0x10000);
   }
 
+  // (penguinliong) Will bring it back after devcap.
+  /*
   if (api_version > VK_API_VERSION_1_0) {
     caps.set(taichi::lang::DeviceCapability::spirv_has_physical_storage_buffer,
              true);
   }
+  */
 
   vk_device.set_current_caps(std::move(caps));
   vk_device.init_vulkan_structs(

--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -738,7 +738,7 @@ void VulkanDeviceCreator::create_logical_device(bool manual_create) {
         if (device_supported_features.shaderInt64) {
 // Temporarily disable it on macOS:
 // https://github.com/taichi-dev/taichi/issues/6295
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && false
           caps.set(DeviceCapability::spirv_has_physical_storage_buffer, true);
 #endif
         }


### PR DESCRIPTION
The physical storage buffer codegen was disabled but the runtime can still use them. This is an attempt to disable psb at runtime. Will bring it back after devcap.