### PR TITLE
[aot] Select any of vkGetPhysicalDeviceMemoryProperties2

### DIFF
--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -2210,9 +2210,12 @@ void VulkanDevice::create_vma_allocator() {
       table.vkGetImageMemoryRequirements2KHR;
   vk_vma_functions.vkBindBufferMemory2KHR = table.vkBindBufferMemory2KHR;
   vk_vma_functions.vkBindImageMemory2KHR = table.vkBindImageMemory2KHR;
-  vk_vma_functions.vkGetPhysicalDeviceMemoryProperties2KHR = (PFN_vkGetPhysicalDeviceMemoryProperties2KHR)(std::max(
-      vkGetInstanceProcAddr(volkGetLoadedInstance(), "vkGetPhysicalDeviceMemoryProperties2KHR"),
-      vkGetInstanceProcAddr(volkGetLoadedInstance(), "vkGetPhysicalDeviceMemoryProperties2")));
+  vk_vma_functions.vkGetPhysicalDeviceMemoryProperties2KHR =
+      (PFN_vkGetPhysicalDeviceMemoryProperties2KHR)(std::max(
+          vkGetInstanceProcAddr(volkGetLoadedInstance(),
+                                "vkGetPhysicalDeviceMemoryProperties2KHR"),
+          vkGetInstanceProcAddr(volkGetLoadedInstance(),
+                                "vkGetPhysicalDeviceMemoryProperties2")));
   vk_vma_functions.vkGetDeviceBufferMemoryRequirements =
       table.vkGetDeviceBufferMemoryRequirements;
   vk_vma_functions.vkGetDeviceImageMemoryRequirements =

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -2210,9 +2210,9 @@ void VulkanDevice::create_vma_allocator() {
       table.vkGetImageMemoryRequirements2KHR;
   vk_vma_functions.vkBindBufferMemory2KHR = table.vkBindBufferMemory2KHR;
   vk_vma_functions.vkBindImageMemory2KHR = table.vkBindImageMemory2KHR;
-  vk_vma_functions.vkGetPhysicalDeviceMemoryProperties2KHR =
-      PFN_vkGetPhysicalDeviceMemoryProperties2KHR(vkGetInstanceProcAddr(
-          volkGetLoadedInstance(), "vkGetPhysicalDeviceMemoryProperties2KHR"));
+  vk_vma_functions.vkGetPhysicalDeviceMemoryProperties2KHR = (PFN_vkGetPhysicalDeviceMemoryProperties2KHR)(std::max(
+      vkGetInstanceProcAddr(volkGetLoadedInstance(), "vkGetPhysicalDeviceMemoryProperties2KHR"),
+      vkGetInstanceProcAddr(volkGetLoadedInstance(), "vkGetPhysicalDeviceMemoryProperties2")));
   vk_vma_functions.vkGetDeviceBufferMemoryRequirements =
       table.vkGetDeviceBufferMemoryRequirements;
   vk_vma_functions.vkGetDeviceImageMemoryRequirements =


### PR DESCRIPTION
Vulkan Validation layer intercepts the function pointer getter and returns nullptr for KHR-suffixed named if such interfaces have been incorporated into a version of Vulkan Core Profile. For example, validation layer returns `nullptr` for `vkGetPhysicalDeviceMemoryProperties2KHR` with a 1.1 instance because the function has been incorporated and is renamed to `vkGetPhysicalDeviceMemoryProperties2`. But this function is required by VMA and is asserted non-null, which leads to sophisticated assertion crash in AOT demos.