### PR TITLE
[lang] MatrixType refactor: Properly raise error when dynamic_index=False

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -629,8 +629,8 @@ Stmt *make_tensor_access(Expression::FlattenContext *ctx,
   if (is_tensor(ret_type)) {
     std::vector<Stmt *> stmts;
     for (auto &indices : indices_group) {
-      stmts.push_back(
-          make_tensor_access_single_element(ctx, var, indices, shape, stride, tb));
+      stmts.push_back(make_tensor_access_single_element(ctx, var, indices,
+                                                        shape, stride, tb));
     }
     return ctx->push_back<MatrixOfMatrixPtrStmt>(stmts, ret_type);
   }
@@ -756,9 +756,9 @@ void IndexExpression::flatten(FlattenContext *ctx) {
   } else if (is_ndarray()) {
     stmt = make_ndarray_access(ctx, var, indices_group[0]);
   } else if (is_tensor()) {
-    stmt =
-        make_tensor_access(ctx, var, indices_group, ret_type,
-                           var->ret_type->cast<TensorType>()->get_shape(), 1, tb);
+    stmt = make_tensor_access(ctx, var, indices_group, ret_type,
+                              var->ret_type->cast<TensorType>()->get_shape(), 1,
+                              tb);
   } else {
     throw TaichiTypeError(
         "Invalid IndexExpression: the source is not among field, ndarray or "

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -578,7 +578,8 @@ Stmt *make_tensor_access_single_element(Expression::FlattenContext *ctx,
                                         const Expr &var,
                                         const ExprGroup &indices,
                                         const std::vector<int> &shape,
-                                        int stride) {
+                                        int stride,
+                                        const std::string &tb) {
   bool needs_dynamic_index = false;
   for (int i = 0; i < (int)indices.size(); ++i) {
     if (!indices[i].is<ConstExpression>()) {
@@ -609,7 +610,7 @@ Stmt *make_tensor_access_single_element(Expression::FlattenContext *ctx,
     offset_stmt = ctx->push_back<BinaryOpStmt>(BinaryOpType::mul, offset_stmt,
                                                stride_stmt);
   }
-  return ctx->push_back<MatrixPtrStmt>(var->stmt, offset_stmt);
+  return ctx->push_back<MatrixPtrStmt>(var->stmt, offset_stmt, tb);
 }
 
 Stmt *make_tensor_access(Expression::FlattenContext *ctx,
@@ -617,7 +618,8 @@ Stmt *make_tensor_access(Expression::FlattenContext *ctx,
                          const std::vector<ExprGroup> &indices_group,
                          DataType ret_type,
                          std::vector<int> shape,
-                         int stride) {
+                         int stride,
+                         const std::string &tb) {
   flatten_lvalue(var, ctx);
   if (!var->is_lvalue()) {
     auto alloca_stmt = ctx->push_back<AllocaStmt>(var->ret_type);
@@ -628,12 +630,12 @@ Stmt *make_tensor_access(Expression::FlattenContext *ctx,
     std::vector<Stmt *> stmts;
     for (auto &indices : indices_group) {
       stmts.push_back(
-          make_tensor_access_single_element(ctx, var, indices, shape, stride));
+          make_tensor_access_single_element(ctx, var, indices, shape, stride, tb));
     }
     return ctx->push_back<MatrixOfMatrixPtrStmt>(stmts, ret_type);
   }
   return make_tensor_access_single_element(ctx, var, indices_group[0], shape,
-                                           stride);
+                                           stride, tb);
 }
 
 void MatrixExpression::type_check(CompileConfig *config) {
@@ -756,7 +758,7 @@ void IndexExpression::flatten(FlattenContext *ctx) {
   } else if (is_tensor()) {
     stmt =
         make_tensor_access(ctx, var, indices_group, ret_type,
-                           var->ret_type->cast<TensorType>()->get_shape(), 1);
+                           var->ret_type->cast<TensorType>()->get_shape(), 1, tb);
   } else {
     throw TaichiTypeError(
         "Invalid IndexExpression: the source is not among field, ndarray or "
@@ -777,7 +779,7 @@ void StrideExpression::type_check(CompileConfig *) {
 }
 
 void StrideExpression::flatten(FlattenContext *ctx) {
-  stmt = make_tensor_access(ctx, var, {indices}, ret_type, shape, stride);
+  stmt = make_tensor_access(ctx, var, {indices}, ret_type, shape, stride, tb);
 }
 
 void RangeAssumptionExpression::type_check(CompileConfig *) {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -407,6 +407,7 @@ std::unique_ptr<Block> Block::clone() const {
 }
 
 DelayedIRModifier::~DelayedIRModifier() {
+  // TODO: destructors should not be interrupted
   TI_ASSERT(to_insert_before_.empty());
   TI_ASSERT(to_insert_after_.empty());
   TI_ASSERT(to_erase_.empty());

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -85,7 +85,9 @@ MatrixOfMatrixPtrStmt::MatrixOfMatrixPtrStmt(const std::vector<Stmt *> &stmts,
   TI_STMT_REG_FIELDS;
 }
 
-MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input, Stmt *offset_input, const std::string &tb) {
+MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
+                             Stmt *offset_input,
+                             const std::string &tb) {
   origin = origin_input;
   offset = offset_input;
   this->tb = tb;

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -85,9 +85,10 @@ MatrixOfMatrixPtrStmt::MatrixOfMatrixPtrStmt(const std::vector<Stmt *> &stmts,
   TI_STMT_REG_FIELDS;
 }
 
-MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input, Stmt *offset_input) {
+MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input, Stmt *offset_input, const std::string &tb) {
   origin = origin_input;
   offset = offset_input;
+  this->tb = tb;
   if (origin->is<AllocaStmt>() || origin->is<GlobalTemporaryStmt>() ||
       origin->is<ExternalPtrStmt>() || origin->is<MatrixOfGlobalPtrStmt>() ||
       origin->is<MatrixOfMatrixPtrStmt>()) {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -432,7 +432,7 @@ class MatrixPtrStmt : public Stmt {
   Stmt *origin{nullptr};
   Stmt *offset{nullptr};
 
-  MatrixPtrStmt(Stmt *, Stmt *);
+  MatrixPtrStmt(Stmt *, Stmt *, const std::string & = "");
 
   /* TODO(zhanlue/yi): Unify semantics of offset in MatrixPtrStmt
 

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -568,7 +568,8 @@ class ScalarizePointers : public BasicStmtVisitor {
               "See https://docs.taichi-lang.org/docs/meta#when-to-use-tistatic-"
               "with-for-loops for more details."
               "Or turn on ti.init(..., dynamic_index=True) to support indexing "
-              "with variables!", stmt->tb));
+              "with variables!",
+              stmt->tb));
         }
         int offset = stmt->offset->cast<ConstStmt>()->val.val_int32();
 

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -555,6 +555,7 @@ class ScalarizePointers : public BasicStmtVisitor {
         // TODO(zhanlue): loose this contraint once dynamic indexing is properly
         // handled
         if (!stmt->offset->is<ConstStmt>()) {
+          // Removing this line will fail TI_ASSERT in ~DelayedIRModifier()
           modifier_.modify_ir();
           throw TaichiSyntaxError(fmt::format(
               "{}The index of a Matrix/Vector must be a compile-time constant "

--- a/tests/python/test_matrix_slice.py
+++ b/tests/python/test_matrix_slice.py
@@ -116,7 +116,9 @@ def test_matrix_slice_with_variable_invalid():
     _test_matrix_slice_with_variable_invalid()
 
 
-@test_utils.test(dynamic_index=False, real_matrix=True, real_matrix_scalarize=True)
+@test_utils.test(dynamic_index=False,
+                 real_matrix=True,
+                 real_matrix_scalarize=True)
 def test_matrix_slice_with_variable_invalid_real_matrix_scalarize():
     _test_matrix_slice_with_variable_invalid()
 

--- a/tests/python/test_matrix_slice.py
+++ b/tests/python/test_matrix_slice.py
@@ -98,8 +98,7 @@ def test_matrix_slice_with_variable_real_matrix_scalarize():
     _test_matrix_slice_with_variable()
 
 
-@test_utils.test(dynamic_index=False)
-def test_matrix_slice_with_variable_invalid():
+def _test_matrix_slice_with_variable_invalid():
     @ti.kernel
     def test_one_col_slice() -> ti.types.matrix(1, 3, dtype=ti.i32):
         m = ti.Matrix([[1, 2, 3], [4, 5, 6]])
@@ -108,18 +107,18 @@ def test_matrix_slice_with_variable_invalid():
 
     with pytest.raises(
             ti.TaichiCompilationError,
-            match=
-            r'The 0-th index of a Matrix/Vector must be a compile-time constant '
-            r"integer, got <class 'taichi.lang.expr.Expr'>.\n"
-            r'This is because matrix operations will be \*\*unrolled\*\* at compile-time '
-            r'for performance reason.\n'
-            r'If you want to \*iterate through matrix elements\*, use a static range:\n'
-            r'  for i in ti.static\(range\(3\)\):\n'
-            r'    print\(i, "-th component is", vec\[i\]\)\n'
-            r'See https://docs.taichi-lang.org/docs/meta#when-to-use-tistatic-with-for-loops for more details.'
-            r'Or turn on ti.init\(..., dynamic_index=True\) to support indexing with variables!'
-    ):
+            match='index of a Matrix/Vector must be a compile-time constant'):
         test_one_col_slice()
+
+
+@test_utils.test(dynamic_index=False)
+def test_matrix_slice_with_variable_invalid():
+    _test_matrix_slice_with_variable_invalid()
+
+
+@test_utils.test(dynamic_index=False, real_matrix=True, real_matrix_scalarize=True)
+def test_matrix_slice_with_variable_invalid_real_matrix_scalarize():
+    _test_matrix_slice_with_variable_invalid()
 
 
 def _test_matrix_slice_write():


### PR DESCRIPTION
Issue: #5819

### Brief Summary

This is to match the old behavior before the existence of `MatrixType`.