### PR TITLE
[example] Fix out-of-bound access in examples

### DIFF
--- a/python/taichi/examples/rendering/rasterizer.py
+++ b/python/taichi/examples/rendering/rasterizer.py
@@ -35,11 +35,11 @@ class TriangleRasterizer:
 
         # Tile-based culling
         self.block_num_triangles = ti.field(dtype=ti.i32,
-                                            shape=(width // tile_size,
-                                                   height // tile_size))
+                                            shape=((width - 1) // tile_size + 1,
+                                                   (height - 1) // tile_size + 1))
         self.block_indicies = ti.field(dtype=ti.i32,
-                                       shape=(width // tile_size,
-                                              height // tile_size, n))
+                                       shape=((width - 1) // tile_size + 1,
+                                              (height - 1) // tile_size + 1, n))
 
     def set_triangle(self, i, v0, v1, v2, c0, c1, c2):
         self.A[i] = v0

--- a/python/taichi/examples/rendering/rasterizer.py
+++ b/python/taichi/examples/rendering/rasterizer.py
@@ -34,12 +34,14 @@ class TriangleRasterizer:
         self.colors = ti.root.dense(ti.i, n).place(self.c0, self.c1, self.c2)
 
         # Tile-based culling
-        self.block_num_triangles = ti.field(dtype=ti.i32,
-                                            shape=((width - 1) // tile_size + 1,
-                                                   (height - 1) // tile_size + 1))
+        self.block_num_triangles = ti.field(
+            dtype=ti.i32,
+            shape=((width - 1) // tile_size + 1,
+                   (height - 1) // tile_size + 1))
         self.block_indicies = ti.field(dtype=ti.i32,
                                        shape=((width - 1) // tile_size + 1,
-                                              (height - 1) // tile_size + 1, n))
+                                              (height - 1) // tile_size + 1,
+                                              n))
 
     def set_triangle(self, i, v0, v1, v2, c0, c1, c2):
         self.A[i] = v0

--- a/python/taichi/examples/simulation/comet.py
+++ b/python/taichi/examples/simulation/comet.py
@@ -78,7 +78,8 @@ def render():
         img[p] = 1e-6 / (p / res - ti.Vector([sun.x, sun.y])).norm(1e-4)**3
     for i in x:
         p = int(ti.Vector([x[i].x, x[i].y]) * res)
-        img[p] += color[i]
+        if 0 <= p[0] < res and 0 <= p[1] < res:
+            img[p] += color[i]
 
 
 def main():

--- a/python/taichi/examples/simulation/game_of_life.py
+++ b/python/taichi/examples/simulation/game_of_life.py
@@ -21,10 +21,10 @@ def get_alive(i, j):
 
 @ti.func
 def get_count(i, j):
-    return (get_alive(i - 1, j) + get_alive(i + 1, j) +
-            get_alive(i, j - 1) + get_alive(i, j + 1) +
-            get_alive(i - 1, j - 1) + get_alive(i + 1, j - 1) +
-            get_alive(i - 1, j + 1) + get_alive(i + 1, j + 1))
+    return (get_alive(i - 1, j) + get_alive(i + 1, j) + get_alive(i, j - 1) +
+            get_alive(i, j + 1) + get_alive(i - 1, j - 1) +
+            get_alive(i + 1, j - 1) + get_alive(i - 1, j + 1) +
+            get_alive(i + 1, j + 1))
 
 
 # See https://www.conwaylife.com/wiki/Cellular_automaton#Rules for more rules

--- a/python/taichi/examples/simulation/game_of_life.py
+++ b/python/taichi/examples/simulation/game_of_life.py
@@ -15,10 +15,16 @@ count = ti.field(int, shape=(n, n))  # count of neighbours
 
 
 @ti.func
+def get_alive(i, j):
+    return alive[i, j] if 0 <= i < n and 0 <= j < n else 0
+
+
+@ti.func
 def get_count(i, j):
-    return (alive[i - 1, j] + alive[i + 1, j] + alive[i, j - 1] +
-            alive[i, j + 1] + alive[i - 1, j - 1] + alive[i + 1, j - 1] +
-            alive[i - 1, j + 1] + alive[i + 1, j + 1])
+    return (get_alive(i - 1, j) + get_alive(i + 1, j) +
+            get_alive(i, j - 1) + get_alive(i, j + 1) +
+            get_alive(i - 1, j - 1) + get_alive(i + 1, j - 1) +
+            get_alive(i - 1, j + 1) + get_alive(i + 1, j + 1))
 
 
 # See https://www.conwaylife.com/wiki/Cellular_automaton#Rules for more rules

--- a/python/taichi/examples/simulation/mpm_lagrangian_forces.py
+++ b/python/taichi/examples/simulation/mpm_lagrangian_forces.py
@@ -25,7 +25,7 @@ v = ti.Vector.field(dim, dtype=float, shape=n_particles)
 C = ti.Matrix.field(dim, dim, dtype=float, shape=n_particles)
 grid_v = ti.Vector.field(dim, dtype=float, shape=(n_grid, n_grid))
 grid_m = ti.field(dtype=float, shape=(n_grid, n_grid))
-restT = ti.Matrix.field(dim, dim, dtype=float, shape=n_particles)
+restT = ti.Matrix.field(dim, dim, dtype=float, shape=n_elements)
 total_energy = ti.field(dtype=float, shape=(), needs_grad=True)
 vertices = ti.field(dtype=ti.i32, shape=(n_elements, 3))
 

--- a/python/taichi/examples/simulation/two_stream_instability.py
+++ b/python/taichi/examples/simulation/two_stream_instability.py
@@ -48,11 +48,15 @@ def substep():
         base = (x[p] * inv_dx - 0.5).cast(int)
         fx = x[p] * inv_dx - 0.5 - base.cast(float)
         rho[base] += (1.0 - fx) * q * inv_dx
-        rho[base + 1] += fx * q * inv_dx
+        if base[0] < ng - 1:
+            rho[base + 1] += fx * q * inv_dx
     e.fill(0.0)
     ti.loop_config(serialize=True)
     for i in range(ng):  # compute electric fields
-        e[i] = e[i - 1] + (rho[i - 1] + rho[i]) * dx * 0.5
+        if i == 0:
+            e[i] = rho[i] * dx * 0.5
+        else:
+            e[i] = e[i - 1] + (rho[i - 1] + rho[i]) * dx * 0.5
     s = 0.0
     for i in e:
         s += e[i].x
@@ -61,8 +65,9 @@ def substep():
     for p in v:  #G2P
         base = (x[p] * inv_dx - 0.5).cast(int)
         fx = x[p] * inv_dx - 0.5 - base.cast(float)
-        a = (e[base] *
-             (1.0 - fx) + e[base + 1] * fx) * qm  # compute electric force
+        a = e[base] * (1.0 - fx) * qm
+        if base[0] < ng - 1:
+            a += e[base + 1] * fx * qm  # compute electric force
         v[p] += a * dt
 
 

--- a/python/taichi/examples/simulation/waterwave.py
+++ b/python/taichi/examples/simulation/waterwave.py
@@ -37,12 +37,10 @@ def laplacian(i, j):
 
 @ti.func
 def gradient(i, j):
-    return ti.Vector([
-        (height[i + 1, j] if i < shape[0] - 1 else 0) -
-        (height[i - 1, j] if i > 1 else 0),
-        (height[i, j + 1] if j < shape[1] - 1 else 0) -
-        (height[i, j - 1] if j > 1 else 0)
-    ]) * (0.5 / dx)
+    return ti.Vector([(height[i + 1, j] if i < shape[0] - 1 else 0) -
+                      (height[i - 1, j] if i > 1 else 0),
+                      (height[i, j + 1] if j < shape[1] - 1 else 0) -
+                      (height[i, j - 1] if j > 1 else 0)]) * (0.5 / dx)
 
 
 @ti.kernel

--- a/python/taichi/examples/simulation/waterwave.py
+++ b/python/taichi/examples/simulation/waterwave.py
@@ -38,8 +38,10 @@ def laplacian(i, j):
 @ti.func
 def gradient(i, j):
     return ti.Vector([
-        height[i + 1, j] - height[i - 1, j],
-        height[i, j + 1] - height[i, j - 1]
+        (height[i + 1, j] if i < shape[0] - 1 else 0) -
+        (height[i - 1, j] if i > 1 else 0),
+        (height[i, j + 1] if j < shape[1] - 1 else 0) -
+        (height[i, j - 1] if j > 1 else 0)
     ]) * (0.5 / dx)
 
 


### PR DESCRIPTION
### Brief Summary

Before #6485 out-of-bound accesses of SNodes were silent - through `BitExtractStmt`  they became in-bound but might not result in expected results. The optimization in #6485 removed the in-bound transition in certain cases so it was likely that an out-of-bound access would behave differently. The CI failure of #6485 (https://github.com/taichi-dev/taichi/actions/runs/3367141462/jobs/5584351541) revealed out-of-bound access in examples, which could be confirmed by turning on `ti.init(debug=True)`. This PR aims at fixing those examples.