### PR TITLE
[lang] Add support for struct on Dynamic SNode

### DIFF
--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -371,7 +371,8 @@ def append(node, indices, val):
         val (:mod:`~taichi.types.primitive_types`): the scalar data to be appended, only i32 value is support for now.
     """
     if isinstance(val, matrix.Matrix):
-        raise ValueError("ti.append only supports appending a scalar value or a struct")
+        raise ValueError(
+            "ti.append only supports appending a scalar value or a struct")
     ptrs = []
     if isinstance(val, struct.Struct):
         for item in val._members:
@@ -380,8 +381,7 @@ def append(node, indices, val):
         ptrs = [expr.Expr(val).ptr]
     a = impl.expr_init(
         _ti_core.expr_snode_append(node._snode.ptr,
-                                   expr.make_expr_group(indices),
-                                   ptrs))
+                                   expr.make_expr_group(indices), ptrs))
     return a
 
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -1,7 +1,7 @@
 import numbers
 
 from taichi._lib import core as _ti_core
-from taichi.lang import expr, impl, matrix
+from taichi.lang import expr, impl, matrix, struct
 from taichi.lang.field import BitpackedFields, Field
 
 
@@ -371,11 +371,17 @@ def append(node, indices, val):
         val (:mod:`~taichi.types.primitive_types`): the scalar data to be appended, only i32 value is support for now.
     """
     if isinstance(val, matrix.Matrix):
-        raise ValueError("ti.append only supports appending a scalar value")
+        raise ValueError("ti.append only supports appending a scalar value or a struct")
+    ptrs = []
+    if isinstance(val, struct.Struct):
+        for item in val._members:
+            ptrs.append(expr.Expr(item).ptr)
+    else:
+        ptrs = [expr.Expr(val).ptr]
     a = impl.expr_init(
         _ti_core.expr_snode_append(node._snode.ptr,
                                    expr.make_expr_group(indices),
-                                   expr.Expr(val).ptr))
+                                   ptrs))
     return a
 
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -379,9 +379,9 @@ def append(node, indices, val):
             ptrs.append(expr.Expr(item).ptr)
     else:
         ptrs = [expr.Expr(val).ptr]
-    a = impl.expr_init(
-        _ti_core.expr_snode_append(node._snode.ptr,
-                                   expr.make_expr_group(indices), ptrs))
+    append_expr = expr.Expr(_ti_core.expr_snode_append(node._snode.ptr,
+                                   expr.make_expr_group(indices), ptrs), tb=impl.get_runtime().get_current_src_info())
+    a = impl.expr_init(append_expr)
     return a
 
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -379,8 +379,9 @@ def append(node, indices, val):
             ptrs.append(expr.Expr(item).ptr)
     else:
         ptrs = [expr.Expr(val).ptr]
-    append_expr = expr.Expr(_ti_core.expr_snode_append(node._snode.ptr,
-                                   expr.make_expr_group(indices), ptrs), tb=impl.get_runtime().get_current_src_info())
+    append_expr = expr.Expr(_ti_core.expr_snode_append(
+        node._snode.ptr, expr.make_expr_group(indices), ptrs),
+                            tb=impl.get_runtime().get_current_src_info())
     a = impl.expr_init(append_expr)
     return a
 

--- a/taichi/analysis/gen_offline_cache_key.cpp
+++ b/taichi/analysis/gen_offline_cache_key.cpp
@@ -222,7 +222,7 @@ class ASTSerializer : public IRVisitor, public ExpressionVisitor {
     emit(expr->op_type);
     emit(expr->snode);
     emit(expr->indices.exprs);
-    emit(expr->value);
+    emit(expr->values);
   }
 
   void visit(ConstExpression *expr) override {

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -83,7 +83,9 @@ Expr expr_rand(DataType dt) {
   return Expr::make<RandExpression>(dt);
 }
 
-Expr snode_append(SNode *snode, const ExprGroup &indices, const std::vector<Expr> &val) {
+Expr snode_append(SNode *snode,
+                  const ExprGroup &indices,
+                  const std::vector<Expr> &val) {
   return Expr::make<SNodeOpExpression>(snode, SNodeOpType::append, indices,
                                        val);
 }

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -85,9 +85,9 @@ Expr expr_rand(DataType dt) {
 
 Expr snode_append(SNode *snode,
                   const ExprGroup &indices,
-                  const std::vector<Expr> &val) {
+                  const std::vector<Expr> &vals) {
   return Expr::make<SNodeOpExpression>(snode, SNodeOpType::append, indices,
-                                       val);
+                                       vals);
 }
 
 Expr snode_is_active(SNode *snode, const ExprGroup &indices) {

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -83,7 +83,7 @@ Expr expr_rand(DataType dt) {
   return Expr::make<RandExpression>(dt);
 }
 
-Expr snode_append(SNode *snode, const ExprGroup &indices, const Expr &val) {
+Expr snode_append(SNode *snode, const ExprGroup &indices, const std::vector<Expr> &val) {
   return Expr::make<SNodeOpExpression>(snode, SNodeOpType::append, indices,
                                        val);
 }

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -133,9 +133,18 @@ Expr expr_rand() {
   return taichi::lang::expr_rand(get_data_type<T>());
 }
 
+/*
+ * This function allocates the space for a new item (a struct or a scalar)
+ * in the Dynamic SNode, and assigns values to the elements inside it.
+ *
+ * When appending a struct, the size of vals must be equal to
+ * the number of elements in the struct. When appending a scalar,
+ * the size of vals must be one.
+ */
+
 Expr snode_append(SNode *snode,
                   const ExprGroup &indices,
-                  const std::vector<Expr> &val);
+                  const std::vector<Expr> &vals);
 
 Expr snode_is_active(SNode *snode, const ExprGroup &indices);
 

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -133,7 +133,9 @@ Expr expr_rand() {
   return taichi::lang::expr_rand(get_data_type<T>());
 }
 
-Expr snode_append(SNode *snode, const ExprGroup &indices, const std::vector<Expr> &val);
+Expr snode_append(SNode *snode,
+                  const ExprGroup &indices,
+                  const std::vector<Expr> &val);
 
 Expr snode_is_active(SNode *snode, const ExprGroup &indices);
 

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -133,7 +133,7 @@ Expr expr_rand() {
   return taichi::lang::expr_rand(get_data_type<T>());
 }
 
-Expr snode_append(SNode *snode, const ExprGroup &indices, const Expr &val);
+Expr snode_append(SNode *snode, const ExprGroup &indices, const std::vector<Expr> &val);
 
 Expr snode_is_active(SNode *snode, const ExprGroup &indices);
 

--- a/taichi/ir/expression_printer.h
+++ b/taichi/ir/expression_printer.h
@@ -202,9 +202,9 @@ class ExpressionHumanFriendlyPrinter : public ExpressionPrinter {
     emit('(', expr->snode->get_node_type_name_hinted(), ", [");
     emit_vector(expr->indices.exprs);
     emit("]");
-    if (expr->value.expr) {
+    if (!expr->values.empty()) {
       emit(' ');
-      expr->value->accept(this);
+      emit_vector(expr->values);
     }
     emit(')');
   }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -909,8 +909,7 @@ void SNodeOpExpression::type_check(CompileConfig *config) {
       auto promoted = promoted_type(dst_type, values[i]->ret_type);
       if (dst_type != promoted) {
         TI_WARN("Append may lose precision: {} <- {}\n{}",
-                dst_type->to_string(), values[i]->ret_type->to_string(),
-                tb);
+                dst_type->to_string(), values[i]->ret_type->to_string(), tb);
       }
       values[i] = cast(values[i], dst_type);
       values[i]->type_check(config);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -730,7 +730,7 @@ class SNodeOpExpression : public Expression {
   SNode *snode;
   SNodeOpType op_type;
   ExprGroup indices;
-  Expr value;
+  std::vector<Expr> values;
 
   SNodeOpExpression(SNode *snode, SNodeOpType op_type, const ExprGroup &indices)
       : snode(snode), op_type(op_type), indices(indices) {
@@ -739,8 +739,8 @@ class SNodeOpExpression : public Expression {
   SNodeOpExpression(SNode *snode,
                     SNodeOpType op_type,
                     const ExprGroup &indices,
-                    const Expr &value)
-      : snode(snode), op_type(op_type), indices(indices), value(value) {
+                    const std::vector<Expr> &values)
+      : snode(snode), op_type(op_type), indices(indices), values(values) {
   }
 
   void type_check(CompileConfig *config) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -730,7 +730,7 @@ class SNodeOpExpression : public Expression {
   SNode *snode;
   SNodeOpType op_type;
   ExprGroup indices;
-  std::vector<Expr> values;
+  std::vector<Expr> values; // Only for op_type==append
 
   SNodeOpExpression(SNode *snode, SNodeOpType op_type, const ExprGroup &indices)
       : snode(snode), op_type(op_type), indices(indices) {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -730,7 +730,7 @@ class SNodeOpExpression : public Expression {
   SNode *snode;
   SNodeOpType op_type;
   ExprGroup indices;
-  std::vector<Expr> values; // Only for op_type==append
+  std::vector<Expr> values;  // Only for op_type==append
 
   SNodeOpExpression(SNode *snode, SNodeOpType op_type, const ExprGroup &indices)
       : snode(snode), op_type(op_type), indices(indices) {

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -278,7 +278,9 @@ def test_append_struct():
     def make_list():
         for i in range(10):
             for j in range(20):
-                x[i].append(struct(i * j * 10, i * j * 10000, i * j * 100000000, i * j * ti.u64(10000000000)))
+                x[i].append(
+                    struct(i * j * 10, i * j * 10000, i * j * 100000000,
+                           i * j * ti.u64(10000000000)))
 
     make_list()
 

--- a/tests/python/test_dynamic.py
+++ b/tests/python/test_dynamic.py
@@ -265,3 +265,26 @@ def test_append_u64():
 
     for i in range(20):
         assert x[i] == i * i * i * 10000000000
+
+
+@test_utils.test(require=ti.extension.sparse, exclude=[ti.metal])
+def test_append_struct():
+    struct = ti.types.struct(a=ti.u8, b=ti.u16, c=ti.u32, d=ti.u64)
+    x = struct.field()
+    pixel = ti.root.dense(ti.i, 10).dynamic(ti.j, 20, 5)
+    pixel.place(x)
+
+    @ti.kernel
+    def make_list():
+        for i in range(10):
+            for j in range(20):
+                x[i].append(struct(i * j * 10, i * j * 10000, i * j * 100000000, i * j * ti.u64(10000000000)))
+
+    make_list()
+
+    for i in range(10):
+        for j in range(20):
+            assert x[i, j].a == i * j * 10 % 256
+            assert x[i, j].b == i * j * 10000 % 65536
+            assert x[i, j].c == i * j * 100000000 % 4294967296
+            assert x[i, j].d == i * j * 10000000000


### PR DESCRIPTION
Issue: #5420

### Brief Summary
This PR lets `SNodeOpExpression` store `vector<Expr> values` instead of `Expr value`, and enables passing a struct to `ti.append`.