### PR TITLE
[aot] Fixed vulkan texture usage export

### DIFF
--- a/taichi/rhi/vulkan/vulkan_api.cpp
+++ b/taichi/rhi/vulkan/vulkan_api.cpp
@@ -417,7 +417,7 @@ IVkImage create_image(VkDevice device,
   image->depth = image_info->extent.depth;
   image->mip_levels = image_info->mipLevels;
   image->array_layers = image_info->arrayLayers;
-  image->usage = alloc_info->usage;
+  image->usage = image_info->usage;
 
   VkResult res = vmaCreateImage(allocator, image_info, alloc_info,
                                 &image->image, &image->allocation, nullptr);


### PR DESCRIPTION
`alloc_info.usage` is the usage of memory allocation, to inform VMA how we gonna use the memory (for example, is it host accessible?) While `image_info.usage` is the one that should be exported.