### PR TITLE
[lang] MatrixType refactor: Simplify reduction ops

### DIFF
--- a/python/taichi/lang/matrix_ops_utils.py
+++ b/python/taichi/lang/matrix_ops_utils.py
@@ -100,7 +100,7 @@ def same_shapes(xs):
 def square_matrix(x):
     assert_tensor(x)
     shape = x.get_shape()
-    if shape[0] != shape[1]:
+    if len(shape) != 2 or shape[0] != shape[1]:
         return False, f'not a square matrix: {shape}'
     return True, None
 


### PR DESCRIPTION
Issue: #5819

### Brief Summary

The use of atomic ops in #6425 is unnecessary. This PR removes those usage and simplifies logic around reduction ops.