### PR TITLE
[misc] Add dynamic_index to offline cache key

### DIFF
--- a/taichi/analysis/offline_cache_util.cpp
+++ b/taichi/analysis/offline_cache_util.cpp
@@ -64,6 +64,7 @@ static std::vector<std::uint8_t> get_offline_cache_key_of_compile_config(
   serializer(config->demote_no_access_mesh_fors);
   serializer(config->experimental_auto_mesh_local);
   serializer(config->auto_mesh_local_default_occupacy);
+  serializer(config->dynamic_index);
   serializer(config->real_matrix);
   serializer(config->real_matrix_scalarize);
   serializer.finalize();

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -511,9 +511,7 @@ def test_offline_cache_cleaning(curr_arch, factor, policy):
         only_init(max_size)
         for kernel, args, get_res, num_offloads in simple_kernels_to_test:
             assert kernel(*args) == test_utils.approx(get_res(*args))
-            if curr_arch in [ti.vulkan]:
-                sleep(
-                    1)  # make sure the kernels are not used in the same second
+            sleep(1)  # make sure the kernels are not used in the same second
 
     kernel_count = len(simple_kernels_to_test)
     count_of_cache_file = cache_files_cnt(curr_arch)

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -511,7 +511,8 @@ def test_offline_cache_cleaning(curr_arch, factor, policy):
         only_init(max_size)
         for kernel, args, get_res, num_offloads in simple_kernels_to_test:
             assert kernel(*args) == test_utils.approx(get_res(*args))
-            sleep(1)  # make sure the kernels are not used in the same second
+            # The timestamp used by cache cleaning is at second precision, so we should make sure the kernels are not used in the same second
+            sleep(1)
 
     kernel_count = len(simple_kernels_to_test)
     count_of_cache_file = cache_files_cnt(curr_arch)


### PR DESCRIPTION
Fixed bug reported by https://github.com/taichi-dev/taichi/actions/runs/3396038407/jobs/5646653663
Repro: `python tests/run_tests.py -v -t1 -a cpu,cuda matrix_slice --with-offline-cache`