### PR TITLE
[ci] Update slack message to include workflow_url instead of head commit

### DIFF
--- a/.github/workflows/notify_on_failure.yml
+++ b/.github/workflows/notify_on_failure.yml
@@ -35,7 +35,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ toJSON(github.event.workflow_run.head_commit.message) }}
+                    "text": ${{ toJSON(github.event.workflow_run.workflow_url) }}
                   }
                 }
               ]


### PR DESCRIPTION
I found an example of payload in
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run

Issue: #

### Brief Summary
