### PR TITLE
[Lang] Matrix lib: Stop changing dimension in transpose()

### DIFF
--- a/python/taichi/_funcs.py
+++ b/python/taichi/_funcs.py
@@ -50,21 +50,6 @@ def randn(dt=None):
 
 
 @pyfunc
-def _matrix_transpose(mat):
-    """Permute the first two axes of the matrix.
-
-    Args:
-        mat (:class:`~taichi.lang.matrix.Matrix`): Input matrix.
-
-    Returns:
-        Transpose of the input matrix.
-    """
-    return matrix.Matrix([[mat(i, j) for i in range(mat.n)]
-                          for j in range(mat.m)],
-                         ndim=mat.ndim)
-
-
-@pyfunc
 def _matrix_cross3d(self, other):
     return matrix.Matrix([
         self[1] * other[2] - self[2] * other[1],

--- a/python/taichi/lang/matrix_ops.py
+++ b/python/taichi/lang/matrix_ops.py
@@ -123,36 +123,13 @@ def determinant(x):
     return None
 
 
-def _vector_transpose(v):
-    shape = v.get_shape()
-    if isinstance(v, Vector):
-
-        @pyfunc
-        def _transpose():
-            return Matrix([[v[i] for i in static(range(shape[0]))]], ndim=1)
-
-        return _transpose()
-    if isinstance(v, Matrix):
-
-        @pyfunc
-        def _transpose():
-            return Vector([v[i, 0] for i in static(range(shape[0]))])
-
-        return _transpose()
-    return v
-
-
 @preconditions(assert_tensor)
-@func
-def transpose(m):
-    shape = static(m.get_shape())
+@pyfunc
+def transpose(mat: template()):
+    shape = static(mat.get_shape())
     if static(len(shape) == 1):
-        return _vector_transpose(m)
-    result = _init_matrix((shape[1], shape[0]), dt=m.element_type())
-    for i in static(range(shape[0])):
-        for j in static(range(shape[1])):
-            result[j, i] = m[i, j]
-    return result
+        return Vector([mat[i] for i in static(range(shape[0]))])
+    return Matrix([[mat[i, j] for i in static(range(shape[0]))] for j in static(range(shape[1]))])
 
 
 @preconditions(arg_at(0, is_int_const),

--- a/python/taichi/lang/matrix_ops.py
+++ b/python/taichi/lang/matrix_ops.py
@@ -129,7 +129,8 @@ def transpose(mat: template()):
     shape = static(mat.get_shape())
     if static(len(shape) == 1):
         return Vector([mat[i] for i in static(range(shape[0]))])
-    return Matrix([[mat[i, j] for i in static(range(shape[0]))] for j in static(range(shape[1]))])
+    return Matrix([[mat[i, j] for i in static(range(shape[0]))]
+                   for j in static(range(shape[1]))])
 
 
 @preconditions(arg_at(0, is_int_const),

--- a/python/taichi/lang/matrix_ops.py
+++ b/python/taichi/lang/matrix_ops.py
@@ -125,7 +125,7 @@ def determinant(x):
 
 @preconditions(assert_tensor)
 @pyfunc
-def transpose(mat: template()):
+def transpose(mat):
     shape = static(mat.get_shape())
     if static(len(shape) == 1):
         return Vector([mat[i] for i in static(range(shape[0]))])


### PR DESCRIPTION
Issue: #5819

### Brief Summary

This PR enforces that `vector.transpose()` returns a vector while `matrix.transpose()` returns a matrix, which mimics the behavior of numpy.