### PR TITLE
[ci] Skip match_any and match_all intrinsics for Pascal

### DIFF
--- a/tests/python/test_simt.py
+++ b/tests/python/test_simt.py
@@ -269,6 +269,9 @@ def test_shfl_down_f32():
 
 @test_utils.test(arch=ti.cuda)
 def test_match_any():
+    # Skip match_any test for Pascal
+    if ti.lang.impl.get_cuda_compute_capability() < 70:
+        return
     a = ti.field(dtype=ti.i32, shape=32)
     b = ti.field(dtype=ti.u32, shape=32)
 
@@ -292,6 +295,9 @@ def test_match_any():
 
 @test_utils.test(arch=ti.cuda)
 def test_match_all():
+    # Skip match_all test for Pascal
+    if ti.lang.impl.get_cuda_compute_capability() < 70:
+        return
     a = ti.field(dtype=ti.i32, shape=32)
     b = ti.field(dtype=ti.u32, shape=32)
     c = ti.field(dtype=ti.u32, shape=32)


### PR DESCRIPTION
We need to skip the unsupported SIMT intrinsics unit tests on Pascal.
