### PR TITLE
[lang] MatrixType bug fix: Make test_mpm88 work properly

### DIFF
--- a/python/taichi/lang/matrix_ops.py
+++ b/python/taichi/lang/matrix_ops.py
@@ -303,3 +303,9 @@ def outer_product(vec_x, vec_y):
     shape_y = static(vec_y.get_shape())
     return Matrix([[vec_x[i] * vec_y[j] for j in static(range(shape_y[0]))]
                    for i in static(range(shape_x[0]))])
+
+
+@preconditions(assert_tensor)
+@func
+def cast(mat, dtype: template()):
+    return ops_mod.cast(mat, dtype)

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -885,8 +885,9 @@ void AtomicOpExpression::flatten(FlattenContext *ctx) {
   }
   // expand rhs
   flatten_rvalue(val, ctx);
+  auto src_val = val->stmt;
   flatten_lvalue(dest, ctx);
-  stmt = ctx->push_back<AtomicOpStmt>(op_type, dest->stmt, val->stmt);
+  stmt = ctx->push_back<AtomicOpStmt>(op_type, dest->stmt, src_val);
   stmt->ret_type = stmt->as<AtomicOpStmt>()->dest->ret_type;
   stmt->tb = tb;
 }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -197,6 +197,7 @@ void UnaryOpExpression::flatten(FlattenContext *ctx) {
   }
   stmt = unary.get();
   stmt->tb = tb;
+  stmt->ret_type = ret_type;
   ctx->push_back(std::move(unary));
 }
 
@@ -868,6 +869,7 @@ void AtomicOpExpression::type_check(CompileConfig *config) {
 }
 
 void AtomicOpExpression::flatten(FlattenContext *ctx) {
+  TI_ASSERT(dest.is<IdExpression>() || dest.is<IndexExpression>() || dest.is<StrideExpression>() || (dest.is<ArgLoadExpression>() && dest.cast<ArgLoadExpression>()->is_ptr));
   // replace atomic sub with negative atomic add
   if (op_type == AtomicOpType::sub) {
     if (val->ret_type != ret_type) {
@@ -880,19 +882,8 @@ void AtomicOpExpression::flatten(FlattenContext *ctx) {
   }
   // expand rhs
   flatten_rvalue(val, ctx);
-  auto src_val = val->stmt;
-  if (dest.is<IdExpression>()) {  // local variable
-    // emit local store stmt
-    auto alloca = ctx->current_block->lookup_var(dest.cast<IdExpression>()->id);
-    ctx->push_back<AtomicOpStmt>(op_type, alloca, src_val);
-  } else {
-    TI_ASSERT(dest.is<IndexExpression>() || dest.is<StrideExpression>() ||
-              (dest.is<ArgLoadExpression>() &&
-               dest.cast<ArgLoadExpression>()->is_ptr));
-    flatten_lvalue(dest, ctx);
-    ctx->push_back<AtomicOpStmt>(op_type, dest->stmt, src_val);
-  }
-  stmt = ctx->back_stmt();
+  flatten_lvalue(dest, ctx);
+  stmt = ctx->push_back<AtomicOpStmt>(op_type, dest->stmt, val->stmt);
   stmt->ret_type = stmt->as<AtomicOpStmt>()->dest->ret_type;
   stmt->tb = tb;
 }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -869,7 +869,10 @@ void AtomicOpExpression::type_check(CompileConfig *config) {
 }
 
 void AtomicOpExpression::flatten(FlattenContext *ctx) {
-  TI_ASSERT(dest.is<IdExpression>() || dest.is<IndexExpression>() || dest.is<StrideExpression>() || (dest.is<ArgLoadExpression>() && dest.cast<ArgLoadExpression>()->is_ptr));
+  TI_ASSERT(
+      dest.is<IdExpression>() || dest.is<IndexExpression>() ||
+      dest.is<StrideExpression>() ||
+      (dest.is<ArgLoadExpression>() && dest.cast<ArgLoadExpression>()->is_ptr));
   // replace atomic sub with negative atomic add
   if (op_type == AtomicOpType::sub) {
     if (val->ret_type != ret_type) {

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -171,6 +171,9 @@ class Scalarize : public BasicStmtVisitor {
       for (size_t i = 0; i < num_elements; i++) {
         auto unary_stmt = std::make_unique<UnaryOpStmt>(
             stmt->op_type, operand_matrix_init_stmt->values[i]);
+        if (stmt->is_cast()) {
+          unary_stmt->cast_type = stmt->cast_type;
+        }
         unary_stmt->ret_type = primitive_type;
         matrix_init_values.push_back(unary_stmt.get());
 

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 import taichi as ti
 from tests import test_utils
 
@@ -104,6 +102,11 @@ def run_mpm88_test():
 
 @test_utils.test()
 def test_mpm88():
+    run_mpm88_test()
+
+
+@test_utils.test(real_matrix=True, real_matrix_scalarize=True)
+def test_mpm88_real_matrix_scalarize():
     run_mpm88_test()
 
 


### PR DESCRIPTION
Issue: #5819

### Brief Summary

This PR contains 3 small fixes to make `test_mpm88` work properly:
1. Support `matrix_type_expr.cast()`;
2. Fix the flatten process of `AtomicOpExpression`;
3. Fix the scalarization process of `UnaryOpStmt`.