### PR TITLE
[Lang] MatrixType refactor: Support matrix factories

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -104,6 +104,8 @@ def make_matrix(arr, dt=None):
     is_matrix = isinstance(arr[0], Iterable)
     if dt is None:
         dt = _make_entries_initializer(is_matrix).infer_dt(arr)
+    else:
+        dt = cook_dtype(dt)
     if not is_matrix:
         return impl.Expr(
             impl.make_matrix_expr([len(arr)], dt,
@@ -454,6 +456,8 @@ class Matrix(TaichiOperations):
                     )
                 if dt is None:
                     dt = initializer.infer_dt(arr)
+                else:
+                    dt = cook_dtype(dt)
                 local_tensor_proxy, mat = initializer.with_dynamic_index(
                     arr, dt)
         self.n, self.m = len(mat), 1
@@ -1039,10 +1043,10 @@ class Matrix(TaichiOperations):
             :class:`~taichi.lang.matrix.Matrix`: A :class:`~taichi.lang.matrix.Matrix` instance filled with zeros.
 
         """
+        from taichi.lang import matrix_ops  # pylint: disable=C0415
         if m is None:
-            return Vector([ops_mod.cast(0, dt) for _ in range(n)])
-        return Matrix([[ops_mod.cast(0, dt) for _ in range(m)]
-                       for _ in range(n)])
+            return matrix_ops._filled_vector(n, dt, 0)
+        return matrix_ops._filled_matrix(n, m, dt, 0)
 
     @staticmethod
     @taichi_scope
@@ -1058,10 +1062,10 @@ class Matrix(TaichiOperations):
             :class:`~taichi.lang.matrix.Matrix`: A :class:`~taichi.lang.matrix.Matrix` instance filled with ones.
 
         """
+        from taichi.lang import matrix_ops  # pylint: disable=C0415
         if m is None:
-            return Vector([ops_mod.cast(1, dt) for _ in range(n)])
-        return Matrix([[ops_mod.cast(1, dt) for _ in range(m)]
-                       for _ in range(n)])
+            return matrix_ops._filled_vector(n, dt, 1)
+        return matrix_ops._filled_matrix(n, m, dt, 1)
 
     @staticmethod
     @taichi_scope
@@ -1083,10 +1087,11 @@ class Matrix(TaichiOperations):
             >>> A
             [0, 1, 0]
         """
+        from taichi.lang import matrix_ops  # pylint: disable=C0415
         if dt is None:
             dt = int
         assert 0 <= i < n
-        return Vector([ops_mod.cast(int(j == i), dt) for j in range(n)])
+        return matrix_ops._unit_vector(n, i, dt)
 
     @staticmethod
     @taichi_scope
@@ -1100,8 +1105,8 @@ class Matrix(TaichiOperations):
         Returns:
             :class:`~taichi.Matrix`: An `n x n` identity matrix.
         """
-        return Matrix([[ops_mod.cast(int(i == j), dt) for j in range(n)]
-                       for i in range(n)])
+        from taichi.lang import matrix_ops  # pylint: disable=C0415
+        return matrix_ops._identity_matrix(n, dt)
 
     @staticmethod
     def rotation2d(alpha):
@@ -1117,11 +1122,10 @@ class Matrix(TaichiOperations):
              [ 0.70710678  0.70710678]]
         """
         warnings.warn(
-            "`ti.Matrix.rotation2d(alpha)` is renamed to `ti.Math.rotation2d(ang)`",
+            "`ti.Matrix.rotation2d()` will be removed in release v1.4.0. Use `ti.math.rotation2d()` instead.",
             DeprecationWarning)
-        return Matrix([[ops_mod.cos(alpha), -ops_mod.sin(alpha)],
-                       [ops_mod.sin(alpha),
-                        ops_mod.cos(alpha)]])
+        from taichi.lang import matrix_ops  # pylint: disable=C0415
+        return matrix_ops._rotation2d_matrix(alpha)
 
     @classmethod
     @python_scope

--- a/python/taichi/lang/matrix_ops.py
+++ b/python/taichi/lang/matrix_ops.py
@@ -55,8 +55,10 @@ def _filled_vector(n: template(), dtype: template(), val: template()):
 
 
 @func
-def _filled_matrix(n: template(), m: template(), dtype: template(), val: template()):
-    return Matrix([[val for _ in static(range(m))] for _ in static(range(n))], dtype)
+def _filled_matrix(n: template(), m: template(), dtype: template(),
+                   val: template()):
+    return Matrix([[val for _ in static(range(m))] for _ in static(range(n))],
+                  dtype)
 
 
 @func
@@ -66,7 +68,8 @@ def _unit_vector(n: template(), i: template(), dtype: template()):
 
 @func
 def _identity_matrix(n: template(), dtype: template()):
-    return Matrix([[i == j for j in static(range(n))] for i in static(range(n))], dtype)
+    return Matrix([[i == j for j in static(range(n))]
+                   for i in static(range(n))], dtype)
 
 
 @pyfunc

--- a/python/taichi/lang/matrix_ops.py
+++ b/python/taichi/lang/matrix_ops.py
@@ -49,6 +49,32 @@ def _reduce(mat, fun: template()):
     return result
 
 
+@func
+def _filled_vector(n: template(), dtype: template(), val: template()):
+    return Vector([val for _ in static(range(n))], dtype)
+
+
+@func
+def _filled_matrix(n: template(), m: template(), dtype: template(), val: template()):
+    return Matrix([[val for _ in static(range(m))] for _ in static(range(n))], dtype)
+
+
+@func
+def _unit_vector(n: template(), i: template(), dtype: template()):
+    return Vector([i == j for j in static(range(n))], dtype)
+
+
+@func
+def _identity_matrix(n: template(), dtype: template()):
+    return Matrix([[i == j for j in static(range(n))] for i in static(range(n))], dtype)
+
+
+@pyfunc
+def _rotation2d_matrix(alpha):
+    return Matrix([[ops_mod.cos(alpha), -ops_mod.sin(alpha)],
+                   [ops_mod.sin(alpha), ops_mod.cos(alpha)]])
+
+
 @preconditions(
     arg_at(
         0,

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -26,6 +26,7 @@ def test_deprecated_aot_save_filename():
 def test_deprecated_matrix_rotation2d():
     with pytest.warns(
             DeprecationWarning,
-            match=r'`ti.Matrix.rotation2d\(\)` will be removed in release v1.4.0. Use `ti.math.rotation2d\(\)` instead.'
+            match=
+            r'`ti.Matrix.rotation2d\(\)` will be removed in release v1.4.0. Use `ti.math.rotation2d\(\)` instead.'
     ):
         a = ti.Matrix.rotation2d(math.pi / 2)

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -1,3 +1,4 @@
+import math
 import tempfile
 
 import pytest
@@ -19,3 +20,12 @@ def test_deprecated_aot_save_filename():
                 r'Specifying filename is no-op and will be removed in release v1.4.0'
         ):
             m.save(tmpdir, 'filename')
+
+
+@test_utils.test()
+def test_deprecated_matrix_rotation2d():
+    with pytest.warns(
+            DeprecationWarning,
+            match=r'`ti.Matrix.rotation2d\(\)` will be removed in release v1.4.0. Use `ti.math.rotation2d\(\)` instead.'
+    ):
+        a = ti.Matrix.rotation2d(math.pi / 2)

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -269,8 +269,7 @@ def test_mat_inverse_size(n):
     np.testing.assert_almost_equal(m_np, np.linalg.inv(M))
 
 
-@test_utils.test()
-def test_matrix_factories():
+def _test_matrix_factories():
     a = ti.Vector.field(3, dtype=ti.i32, shape=3)
     b = ti.Matrix.field(2, 2, dtype=ti.f32, shape=2)
     c = ti.Matrix.field(2, 3, dtype=ti.f32, shape=2)
@@ -296,6 +295,16 @@ def test_matrix_factories():
         np.array([[0.5, -sqrt3o2], [sqrt3o2, 0.5]]))
     assert c[0].to_numpy() == test_utils.approx(np.zeros((2, 3)))
     assert c[1].to_numpy() == test_utils.approx(np.ones((2, 3)))
+
+
+@test_utils.test()
+def test_matrix_factories():
+    _test_matrix_factories()
+
+
+@test_utils.test(real_matrix=True, real_matrix_scalarize=True)
+def test_matrix_factories_real_matrix_scalarize():
+    _test_matrix_factories()
 
 
 # TODO: move codes below to test_matrix.py:


### PR DESCRIPTION
Issue: #5819

### Brief Summary

This PR includes a deprecation test of `ti.Matrix.rotation2d()` by the way.