### PR TITLE
[aot] [ci] Change taichi-aot-demo branch back to master

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -104,7 +104,7 @@ function build-and-test-headless-demo {
     popd
 
     rm -rf taichi-aot-demo
-    git clone --recursive --depth=1 -b add_test_script https://github.com/taichi-dev/taichi-aot-demo
+    git clone --recursive --depth=1 https://github.com/taichi-dev/taichi-aot-demo
     cd taichi-aot-demo
 
     . $(pwd)/ci/test_utils.sh
@@ -138,8 +138,6 @@ function build-and-test-headless-demo {
     # Pull output images and compare with groundtruth
     rm -rf output
     mkdir output
-
-    adb shell "ls /data/local/tmp/output"
 
     adb pull /data/local/tmp/output .
     compare_to_groundtruth android


### PR DESCRIPTION
Issue: #6559 

### Brief Summary
This is a followup PR to revert CI back to use master since https://github.com/taichi-dev/taichi-aot-demo/pull/66 is merged. 