### PR TITLE
[aot] Make arch an optional argument in ti.aot.Module

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -82,16 +82,24 @@ class Module:
         # Now the module file '/path/to/module' contains the Metal kernels
         # for running ``foo`` and ``bar``.
     """
-    def __init__(self, arch, caps=None):
+    def __init__(self, arch=None, caps=None):
         """Creates a new AOT module instance
 
         Args:
-          arch: Target backend architecture. This must match the one specified
-            in :func:`~taichi.lang.init`.
+          arch: Target backend architecture. Default to the one initialized in :func:`~taichi.lang.init` if not specified.
           caps (List[str]): Enabled device capabilities.
         """
         if caps is None:
             caps = []
+        curr_arch = impl.current_cfg().arch
+        if arch is None:
+            arch = curr_arch
+        elif arch != curr_arch:
+            # TODO: we'll support this eventually but not yet...
+            warnings.warn(
+                f"AOT compilation to a different arch than the current one is not yet supported, switching to {curr_arch}"
+            )
+            arch = curr_arch
 
         self._arch = arch
         self._kernels = []

--- a/tests/cpp/aot/python_scripts/bitmasked_aot_test.py
+++ b/tests/cpp/aot/python_scripts/bitmasked_aot_test.py
@@ -60,7 +60,7 @@ def compile_bitmasked_aot(arch):
     assert "TAICHI_AOT_FOLDER_PATH" in os.environ.keys()
     dir_name = str(os.environ["TAICHI_AOT_FOLDER_PATH"])
 
-    m = ti.aot.Module(arch)
+    m = ti.aot.Module()
 
     m.add_kernel(activate, template_args={})
     m.add_kernel(check_value_0, template_args={})

--- a/tests/cpp/aot/python_scripts/comet_aot.py
+++ b/tests/cpp/aot/python_scripts/comet_aot.py
@@ -121,7 +121,7 @@ def initialize():
 
 
 def save_kernels(arch):
-    mod = ti.aot.Module(arch)
+    mod = ti.aot.Module()
 
     # Initialize
     g_init_builder = ti.graph.GraphBuilder()

--- a/tests/cpp/aot/python_scripts/dense_field_aot_test.py
+++ b/tests/cpp/aot/python_scripts/dense_field_aot_test.py
@@ -33,7 +33,7 @@ def compile_dense_field_aot_test(arch):
     assert "TAICHI_AOT_FOLDER_PATH" in os.environ.keys()
     dir_name = str(os.environ["TAICHI_AOT_FOLDER_PATH"])
 
-    m = ti.aot.Module(arch)
+    m = ti.aot.Module()
     m.add_kernel(simple_return)
     m.add_kernel(init)
     m.add_kernel(ret)

--- a/tests/cpp/aot/python_scripts/dynamic_aot_test.py
+++ b/tests/cpp/aot/python_scripts/dynamic_aot_test.py
@@ -59,7 +59,7 @@ def compile_dynamic_aot(arch):
         assert x[2, 0] == 9
         assert x[3, 0] == 12
 
-    m = ti.aot.Module(arch)
+    m = ti.aot.Module()
 
     m.add_kernel(activate, template_args={})
     m.add_kernel(check_value_0, template_args={})

--- a/tests/cpp/aot/python_scripts/field_aot_test.py
+++ b/tests/cpp/aot/python_scripts/field_aot_test.py
@@ -104,7 +104,7 @@ def compile_field_aot(arch, compile_for_cgraph=False):
 
         run_graph = g_builder.compile()
 
-        m = ti.aot.Module(arch)
+        m = ti.aot.Module()
 
         m.add_field("x", x)
         m.add_field("y", y)
@@ -112,7 +112,7 @@ def compile_field_aot(arch, compile_for_cgraph=False):
         m.add_graph('run_graph', run_graph)
         m.save(dir_name, '')
     else:
-        m = ti.aot.Module(arch)
+        m = ti.aot.Module()
 
         m.add_kernel(init_fields, template_args={})
         m.add_kernel(check_init_x, template_args={})

--- a/tests/cpp/aot/python_scripts/graph_aot_test.py
+++ b/tests/cpp/aot/python_scripts/graph_aot_test.py
@@ -48,7 +48,7 @@ def compile_graph_aot(arch):
     assert "TAICHI_AOT_FOLDER_PATH" in os.environ.keys()
     tmpdir = str(os.environ["TAICHI_AOT_FOLDER_PATH"])
 
-    mod = ti.aot.Module(arch)
+    mod = ti.aot.Module()
     mod.add_graph('run_graph', run_graph)
     mod.save(tmpdir, '')
 

--- a/tests/cpp/aot/python_scripts/kernel_aot_test1.py
+++ b/tests/cpp/aot/python_scripts/kernel_aot_test1.py
@@ -20,7 +20,7 @@ def compile_kernel_aot_test1(arch):
     assert "TAICHI_AOT_FOLDER_PATH" in os.environ.keys()
     dir_name = str(os.environ["TAICHI_AOT_FOLDER_PATH"])
 
-    m = ti.aot.Module(arch)
+    m = ti.aot.Module()
     m.add_kernel(run, template_args={'arr': arr})
     m.save(dir_name, 'whatever')
 

--- a/tests/cpp/aot/python_scripts/kernel_aot_test2.py
+++ b/tests/cpp/aot/python_scripts/kernel_aot_test2.py
@@ -22,7 +22,7 @@ def compile_kernel_aot_test2(arch, save_compute_graph):
     assert "TAICHI_AOT_FOLDER_PATH" in os.environ.keys()
     dir_name = str(os.environ["TAICHI_AOT_FOLDER_PATH"])
 
-    m = ti.aot.Module(arch)
+    m = ti.aot.Module()
     if save_compute_graph:
         sym_arr = ti.graph.Arg(ti.graph.ArgKind.NDARRAY,
                                'arr',

--- a/tests/cpp/aot/python_scripts/mpm88_graph_aot.py
+++ b/tests/cpp/aot/python_scripts/mpm88_graph_aot.py
@@ -181,7 +181,7 @@ def compile_mpm88(arch, save_compute_graph):
         grid_v = ti.Vector.ndarray(2, ti.f32, shape=(n_grid, n_grid))
         grid_m = ti.ndarray(ti.f32, shape=(n_grid, n_grid))
 
-        mod = ti.aot.Module(arch)
+        mod = ti.aot.Module()
         mod.add_graph('init', g_init)
         mod.add_graph('update', g_update)
         mod.save(tmpdir, '')
@@ -195,7 +195,7 @@ def compile_mpm88(arch, save_compute_graph):
         grid_v = ti.Vector.ndarray(2, ti.f32, shape=(n_grid, n_grid))
         grid_m = ti.ndarray(ti.f32, shape=(n_grid, n_grid))
 
-        mod = ti.aot.Module(arch)
+        mod = ti.aot.Module()
         mod.add_kernel(init_particles, template_args={'x': x, 'v': v, 'J': J})
         mod.add_kernel(substep_reset_grid,
                        template_args={

--- a/tests/cpp/aot/python_scripts/sph_aot.py
+++ b/tests/cpp/aot/python_scripts/sph_aot.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
     print('running in graph mode')
 
     # Serialize!
-    mod = ti.aot.Module(arch)
+    mod = ti.aot.Module()
 
     mod.add_kernel(initialize,
                    template_args={

--- a/tests/cpp/aot/python_scripts/taichi_sparse_test.py
+++ b/tests/cpp/aot/python_scripts/taichi_sparse_test.py
@@ -72,7 +72,7 @@ def paint():
 
 
 def save_kernels(arch):
-    m = ti.aot.Module(arch)
+    m = ti.aot.Module()
 
     m.add_kernel(fill_img, template_args={})
     m.add_kernel(block1_deactivate_all, template_args={})

--- a/tests/cpp/aot/python_scripts/texture_aot_test.py
+++ b/tests/cpp/aot/python_scripts/texture_aot_test.py
@@ -74,7 +74,7 @@ def compile_graph_aot(arch):
     assert "TAICHI_AOT_FOLDER_PATH" in os.environ.keys()
     tmpdir = str(os.environ["TAICHI_AOT_FOLDER_PATH"])
 
-    mod = ti.aot.Module(arch)
+    mod = ti.aot.Module()
     mod.add_graph('run_graph', run_graph)
     mod.save(tmpdir, '')
 

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -11,7 +11,7 @@ def test_deprecated_aot_save_filename():
     density = ti.field(float, shape=(4, 4))
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        m = ti.aot.Module(ti.lang.impl.current_cfg().arch)
+        m = ti.aot.Module()
         m.add_field('density', density)
         with pytest.warns(
                 DeprecationWarning,


### PR DESCRIPTION

Fixes #5859

### Brief Summary
We haven't supported compiling to a target different from the initialized arch and it won't be available in the short term. So let's make this an optional argument and default to the current arch to save users from some typing work.
