### PR TITLE
[autodiff] Clear adjoint after global store

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -235,6 +235,7 @@ class Tape:
             # since we insert write_int and write_float kernels to self.calls
             # e.g. x[None] = 0.0, this func has no grad attribute
             if hasattr(func, 'grad'):
+                self.loss.fill(1.0)
                 func.grad(*args)
 
         self.gradient_evaluated = True

--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -235,7 +235,7 @@ class Tape:
             # since we insert write_int and write_float kernels to self.calls
             # e.g. x[None] = 0.0, this func has no grad attribute
             if hasattr(func, 'grad'):
-                self.loss.fill(1.0)
+                self.loss.grad.fill(1.0)
                 func.grad(*args)
 
         self.gradient_evaluated = True

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1061,6 +1061,12 @@ class MakeAdjoint : public ADTransform {
           adjoint_ptr, stmt->dest->as<MatrixPtrStmt>()->offset);
     }
     accumulate(stmt->val, insert<GlobalLoadStmt>(adjoint_ptr));
+
+    // Clear the gradient after accumulation finished.
+    auto zero = insert<ConstStmt>(
+        TypedConstant(adjoint_ptr->ret_type.ptr_removed(), 0));
+    insert<GlobalStoreStmt>(adjoint_ptr, zero);
+
     stmt->parent->erase(stmt);
   }
 

--- a/tests/python/test_ad_basics.py
+++ b/tests/python/test_ad_basics.py
@@ -504,7 +504,7 @@ def test_ad_global_store_forwarding():
     with ti.ad.Tape(loss=e):
         func()
     assert x.grad[None] == 120.0
-    assert a.grad[None] == 120.0
-    assert b.grad[None] == 60.0
-    assert c.grad[None] == 20.0
-    assert d.grad[None] == 5.0
+    assert a.grad[None] == 0.0
+    assert b.grad[None] == 0.0
+    assert c.grad[None] == 0.0
+    assert d.grad[None] == 0.0

--- a/tests/python/test_loop_grad.py
+++ b/tests/python/test_loop_grad.py
@@ -27,8 +27,8 @@ def test_loop_grad():
     func.grad()
 
     for k in range(n):
-    # The grad of fields on left-hand sides of assignments (GlobalStoreStmt) need to be reset to zero after the corresponding adjoint assignments.
-    # Therefore, only the grad of the element with index 0 at second dimension is preserved here.
+        # The grad of fields on left-hand sides of assignments (GlobalStoreStmt) need to be reset to zero after the corresponding adjoint assignments.
+        # Therefore, only the grad of the element with index 0 at second dimension is preserved here.
         assert x[k, 0] == 2**0 * k
         assert x.grad[k, 0] == 2**(m - 1 - 0)
 

--- a/tests/python/test_loop_grad.py
+++ b/tests/python/test_loop_grad.py
@@ -27,9 +27,8 @@ def test_loop_grad():
     func.grad()
 
     for k in range(n):
-        for i in range(m):
-            assert x[k, i] == 2**i * k
-            assert x.grad[k, i] == 2**(m - 1 - i)
+        assert x[k, 0] == 2**0 * k
+        assert x.grad[k, 0] == 2**(m - 1 - 0)
 
 
 @test_utils.test(exclude=[ti.vulkan, ti.dx11])

--- a/tests/python/test_loop_grad.py
+++ b/tests/python/test_loop_grad.py
@@ -27,6 +27,8 @@ def test_loop_grad():
     func.grad()
 
     for k in range(n):
+    # The grad of fields on left-hand sides of assignments (GlobalStoreStmt) need to be reset to zero after the corresponding adjoint assignments.
+    # Therefore, only the grad of the element with index 0 at second dimension is preserved here.
         assert x[k, 0] == 2**0 * k
         assert x.grad[k, 0] == 2**(m - 1 - 0)
 

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -327,12 +327,12 @@ def test_multiple_ib_with_offline_cache(curr_arch):
             enable_fallback=False,
             **current_thread_ext_options())
     assert added_files(curr_arch) == expected_num_cache_files(
-        curr_arch, [1] * 8)
+        curr_arch, [1] * 9)
     helper()
 
     ti.reset()
     assert added_files(curr_arch) == expected_num_cache_files(
-        curr_arch, [1] * 8)
+        curr_arch, [1] * 9)
 
 
 @pytest.mark.parametrize('curr_arch', supported_archs_offline_cache)


### PR DESCRIPTION
To avoid invalid grad accumulation, adjoints of fields on left-hand sides of assignments (GlobalStoreStmt) need to be reset to zero after the corresponding adjoint assignments.