### PR TITLE
[cuda] Parallelize random state initialization in ti.init()

### DIFF
--- a/taichi/jit/jit_module.h
+++ b/taichi/jit/jit_module.h
@@ -70,8 +70,7 @@ class JITModule {
               std::size_t shared_mem_bytes,
               Args... args) {
     auto arg_pointers = JITModule::get_arg_pointers(args...);
-    launch_with_arg_pointers(name, grid_dim, block_dim, shared_mem_bytes,
-                             arg_pointers);
+    launch(name, grid_dim, block_dim, shared_mem_bytes, arg_pointers);
   }
 
   virtual void launch(const std::string &name,

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -571,12 +571,12 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
 
   TI_TRACE("Launching runtime_initialize");
 
-  runtime_jit->call<void *, void *, std::size_t, void *, int, void *,
-                    void *, void *>(
-      "runtime_initialize", *result_buffer_ptr, memory_pool, prealloc_size,
-      preallocated_device_buffer_, num_rand_states,
-      (void *)&taichi_allocate_aligned, (void *)std::printf,
-      (void *)std::vsnprintf);
+  runtime_jit
+      ->call<void *, void *, std::size_t, void *, int, void *, void *, void *>(
+          "runtime_initialize", *result_buffer_ptr, memory_pool, prealloc_size,
+          preallocated_device_buffer_, num_rand_states,
+          (void *)&taichi_allocate_aligned, (void *)std::printf,
+          (void *)std::vsnprintf);
 
   TI_TRACE("LLVMRuntime initialized (excluding `root`)");
   llvm_runtime_ = fetch_result<void *>(taichi_result_buffer_ret_value_id,
@@ -585,14 +585,13 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
 
   if (config_->arch == Arch::cuda) {
     TI_TRACE("Initializing {} random states using CUDA", num_rand_states);
-    runtime_jit->launch<void *, int>("runtime_initialize_rand_states_cuda",
-                                config_->saturating_grid_dim,
-                                config_->max_block_dim,
-                                0,
-                                llvm_runtime_, starting_rand_state);
+    runtime_jit->launch<void *, int>(
+        "runtime_initialize_rand_states_cuda", config_->saturating_grid_dim,
+        config_->max_block_dim, 0, llvm_runtime_, starting_rand_state);
   } else {
     TI_TRACE("Initializing {} random states (serially)", num_rand_states);
-    runtime_jit->call<void *, int>("runtime_initialize_rand_states_serial", llvm_runtime_, starting_rand_state);
+    runtime_jit->call<void *, int>("runtime_initialize_rand_states_serial",
+                                   llvm_runtime_, starting_rand_state);
   }
 
   if (arch_use_host_memory(config_->arch)) {

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -569,12 +569,12 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
     num_rand_states = config_->cpu_max_num_threads;
   }
 
-  TI_TRACE("Allocating {} random states (used by CUDA only)", num_rand_states);
+  TI_TRACE("Launching runtime_initialize");
 
-  runtime_jit->call<void *, void *, std::size_t, void *, int, int, void *,
+  runtime_jit->call<void *, void *, std::size_t, void *, int, void *,
                     void *, void *>(
       "runtime_initialize", *result_buffer_ptr, memory_pool, prealloc_size,
-      preallocated_device_buffer_, starting_rand_state, num_rand_states,
+      preallocated_device_buffer_, num_rand_states,
       (void *)&taichi_allocate_aligned, (void *)std::printf,
       (void *)std::vsnprintf);
 
@@ -582,6 +582,18 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
   llvm_runtime_ = fetch_result<void *>(taichi_result_buffer_ret_value_id,
                                        *result_buffer_ptr);
   TI_TRACE("LLVMRuntime pointer fetched");
+
+  if (config_->arch == Arch::cuda) {
+    TI_TRACE("Initializing {} random states using CUDA", num_rand_states);
+    runtime_jit->launch<void *, int>("runtime_initialize_rand_states_cuda",
+                                config_->saturating_grid_dim,
+                                config_->max_block_dim,
+                                0,
+                                llvm_runtime_, starting_rand_state);
+  } else {
+    TI_TRACE("Initializing {} random states (serially)", num_rand_states);
+    runtime_jit->call<void *, int>("runtime_initialize_rand_states_serial", llvm_runtime_, starting_rand_state);
+  }
 
   if (arch_use_host_memory(config_->arch)) {
     runtime_jit->call<void *>("runtime_get_mem_req_queue", llvm_runtime_);

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -905,7 +905,6 @@ void runtime_initialize(
     std::size_t
         preallocated_size,  // Non-zero means use the preallocated buffer
     Ptr preallocated_buffer,
-    i32 starting_rand_state,
     i32 num_rand_states,
     void *_vm_allocator,
     void *_host_printf,
@@ -948,13 +947,22 @@ void runtime_initialize(
   runtime->num_rand_states = num_rand_states;
   runtime->rand_states = (RandState *)runtime->allocate_aligned(
       sizeof(RandState) * runtime->num_rand_states, taichi_page_size);
-  for (int i = 0; i < runtime->num_rand_states; i++)
-    initialize_rand_state(&runtime->rand_states[i], starting_rand_state + i);
 }
 
 void runtime_initialize_runtime_context_buffer(LLVMRuntime *runtime) {
   runtime->runtime_context_buffer_allocator =
       runtime->create<NodeManager>(runtime, sizeof(RuntimeContext), 4096);
+}
+
+void runtime_initialize_rand_states_cuda(LLVMRuntime *runtime, int starting_rand_state) {
+  int i = block_dim() * block_idx() + thread_idx();
+  initialize_rand_state(&runtime->rand_states[i], starting_rand_state + i);
+}
+
+void runtime_initialize_rand_states_serial(LLVMRuntime *runtime, int starting_rand_state) {
+  for (int i = 0; i < runtime->num_rand_states; i++) {
+    initialize_rand_state(&runtime->rand_states[i], starting_rand_state + i);
+  }
 }
 
 void runtime_initialize_snodes(LLVMRuntime *runtime,

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -954,12 +954,14 @@ void runtime_initialize_runtime_context_buffer(LLVMRuntime *runtime) {
       runtime->create<NodeManager>(runtime, sizeof(RuntimeContext), 4096);
 }
 
-void runtime_initialize_rand_states_cuda(LLVMRuntime *runtime, int starting_rand_state) {
+void runtime_initialize_rand_states_cuda(LLVMRuntime *runtime,
+                                         int starting_rand_state) {
   int i = block_dim() * block_idx() + thread_idx();
   initialize_rand_state(&runtime->rand_states[i], starting_rand_state + i);
 }
 
-void runtime_initialize_rand_states_serial(LLVMRuntime *runtime, int starting_rand_state) {
+void runtime_initialize_rand_states_serial(LLVMRuntime *runtime,
+                                           int starting_rand_state) {
   for (int i = 0; i < runtime->num_rand_states; i++) {
     initialize_rand_state(&runtime->rand_states[i], starting_rand_state + i);
   }


### PR DESCRIPTION
Issue: #

### Brief Summary

This PR improves `ti.init(arch=ti.cuda)` time, especially in unit test environment.

| Concurrent processes * `ti.init()` count | Master  | With this PR | Speed up |
| --------------------------- | ------- | ------------ | -------- |
| 1 Process * 1                  | 556ms   | 410ms        | 35.6%    |
| 8 Processes * 1                 | 2500ms  | 1000ms       | 150%     |
| 1 Process * 10                 | 5850ms  | 4380ms       | 33.6%    |
| 8 Processes * 10               | 15200ms | 5760ms       | 164%     |

Filling rand states cost a whopping 150ms time during `ti.init(arch=ti.cuda)` because rand states are filled serially by a for loop in `runtime_initialize` by a `<<<1, 1>>>` kernel. This PR try to utilize GPU power to fill the rand states by a  `<<<saturating_grid_dim, max_block_dim>>>` kernel.
