### PR TITLE
[ci] Delete windows llvm10 ci job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -267,10 +267,6 @@ jobs:
         include:
           - os: windows-2019
             llvmVer : '15'
-            archs: "cpu,cuda"
-            runsOn: [self-hosted, windows, cuda]
-          - os: windows-2019
-            llvmVer : '10'
             archs: "cpu,cuda,opengl"
             runsOn: [self-hosted, windows, cuda, OpenGL]
     runs-on: ${{ matrix.runsOn }}


### PR DESCRIPTION
Issue: #6447

### Brief Summary
Deleting this job first since we're almost there, deleting this one can make the windows queue shorter.