### PR TITLE
[ci] Adaptively laying off test workers on CUDA OOM, 2nd try

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -104,7 +104,7 @@ if [ -z "$GPU_TEST" ]; then
         python3 tests/run_tests.py -vr2 -t4 -k "not paddle" -a "$TI_WANTED_ARCHS"
     fi
 else
-    run-it cuda   6
+    run-it cuda   8
     run-it cpu    $(nproc)
     run-it vulkan 8
     run-it opengl 4

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -58,7 +58,7 @@ if ("$env:TI_WANTED_ARCHS".Contains("cpu")) {
 if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
   # TODO relax this when torch supports 3.10
   Invoke pip install "torch==1.10.1+cu113; python_version < '3.10'" -f https://download.pytorch.org/whl/cu113/torch_stable.html
-  RunIt cuda 6
+  RunIt cuda 8
 }
 
 RunIt opengl 4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 Pillow
 pytest
-pytest-xdist
+git+https://github.com/taichi-dev/pytest-xdist@c686d0dd#egg=pytest-xdist
 pytest-rerunfailures
 pytest-cov
 numpy

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 Pillow
 pytest
-git+https://github.com/taichi-dev/pytest-xdist@c686d0dd#egg=pytest-xdist
+git+https://github.com/taichi-dev/pytest-xdist@e3e1ccf517#egg=pytest-xdist
 pytest-rerunfailures
 pytest-cov
 numpy

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,4 +1,4 @@
-import os
+import sys
 
 import pytest
 
@@ -36,18 +36,12 @@ def pytest_generate_tests(metafunc):
                              ids=['none'])
 
 
-IS_WORKER = False
-
-
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "run_in_serial: mark test to run serially(usually for resource intensive tests)."
     )
-
-    global IS_WORKER
-    IS_WORKER = hasattr(config, "workerinput")
 
 
 @pytest.hookimpl(trylast=True)
@@ -57,10 +51,21 @@ def pytest_runtest_logreport(report):
     This is to avoid the failing test leaving a corrupted GPU state for the
     following tests.
     '''
-    if not IS_WORKER:
+
+    interactor = getattr(sys, 'xdist_interactor', None)
+    if not interactor:
+        # not running under xdist, or xdist is not active,
+        # or using stock xdist (we need a customized version)
         return
 
     if report.outcome not in ('rerun', 'error', 'failed'):
         return
 
-    os._exit(0)
+    layoff = False
+
+    for _, loc, _ in report.longrepr.chain:
+        if 'CUDA_ERROR_OUT_OF_MEMORY' in loc.message:
+            layoff = True
+            break
+
+    interactor.retire(layoff=layoff)

--- a/tests/python/test_mpm88.py
+++ b/tests/python/test_mpm88.py
@@ -103,12 +103,14 @@ def run_mpm88_test():
 
 
 @pytest.mark.skipif(os.environ.get('TI_LITE_TEST') or '0', reason='Lite test')
+@pytest.mark.run_in_serial
 @test_utils.test()
 def test_mpm88():
     run_mpm88_test()
 
 
 @pytest.mark.skipif(os.environ.get('TI_LITE_TEST') or '0', reason='Lite test')
+@pytest.mark.run_in_serial
 @test_utils.test(real_matrix=True, real_matrix_scalarize=True)
 def test_mpm88_real_matrix_scalarize():
     run_mpm88_test()
@@ -121,6 +123,7 @@ def _is_appveyor():
 
 
 @pytest.mark.skipif(os.environ.get('TI_LITE_TEST') or '0', reason='Lite test')
+@pytest.mark.run_in_serial
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.opengl])
 def test_mpm88_numpy_and_ndarray():
     import numpy as np

--- a/tests/python/test_mpm_particle_list.py
+++ b/tests/python/test_mpm_particle_list.py
@@ -1,5 +1,7 @@
 import random
 
+import pytest
+
 import taichi as ti
 from tests import test_utils
 
@@ -44,6 +46,7 @@ class MPMSolver:
             self.build_pid()
 
 
+@pytest.mark.run_in_serial
 @test_utils.test(require=ti.extension.sparse,
                  exclude=[ti.metal],
                  device_memory_GB=1.0)
@@ -53,6 +56,7 @@ def test_mpm_particle_list_no_leakage():
     mpm.step()
 
 
+@pytest.mark.run_in_serial
 @test_utils.test(require=[ti.extension.sparse, ti.extension.packed],
                  exclude=[ti.metal],
                  device_memory_GB=1.0,


### PR DESCRIPTION
Issue: #

### Brief Summary

Actual `pytest-xdist` fix: https://github.com/taichi-dev/pytest-xdist/commit/e3e1ccf5178ff53e5c9fa01adea18a2019cb764d

nothing is changed compared to last PR except the git commit hash in `requirements_test.txt`
