### PR TITLE
[ci] Install unzip in manylinux build

### DIFF
--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -12,7 +12,7 @@ if [[ $OSTYPE == "linux-"* ]]; then
     wget https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/taichi-llvm-15-linux.zip
     if ! [ -x "$(command -v unzip)" ]; then
       echo 'unzip not found, installing from apt'
-      sudo apt install unzip
+      sudo apt install unzip -y
     fi
     unzip taichi-llvm-15-linux.zip && rm taichi-llvm-15-linux.zip
     popd

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -10,6 +10,10 @@ if [[ $OSTYPE == "linux-"* ]]; then
   if [ ! -d ~/taichi-llvm-15 ]; then
     pushd ~
     wget https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/taichi-llvm-15-linux.zip
+    if ! [ -x "$(command -v unzip)" ]; then
+      echo 'unzip not found, installing from apt'
+      sudo apt install unzip
+    fi
     unzip taichi-llvm-15-linux.zip && rm taichi-llvm-15-linux.zip
     popd
   fi


### PR DESCRIPTION
Issue: #6447 

### Brief Summary
Got the following error message when building manylinux2014 wheel since the base docker image doesn't have `unzip`:
```
2022-11-18T06:14:27.6476325Z + unzip taichi-llvm-15-linux.zip
2022-11-18T06:14:27.6485595Z /home/dev/taichi/.github/workflows/scripts/unix-build.sh: line 13: unzip: command not found
```
reference log: https://pipelines.actions.githubusercontent.com/serviceHosts/ebf0abad-1193-4ff9-9c60-da990d1eacd9/_apis/pipelines/1/runs/56327/signedlogcontent/20?urlExpires=2022-11-18T06%3A42%3A59.6939664Z&urlSigningMethod=HMACV1&urlSignature=pRp%2BtWL7jg6DXBr5bfgq0r5KqUwjrJ6bAM4WAXwP5S0%3D