### PR TITLE
[build] Delete all llvm10 code and TI_LLVM_15 macro

### DIFF
--- a/.github/workflows/scripts/win_build.ps1
+++ b/.github/workflows/scripts/win_build.ps1
@@ -65,7 +65,6 @@ if ($llvmVer -eq "10") {
     $env:LLVM_DIR = "$libsDir\taichi_llvm_15"
 	$env:TAICHI_CMAKE_ARGS += " -DCLANG_EXECUTABLE=$($libsDir -replace "\\", "\\")\\taichi_clang_15\\bin\\clang++.exe"
 	$env:TAICHI_CMAKE_ARGS += " -DLLVM_AS_EXECUTABLE=$($libsDir -replace "\\", "\\")\\taichi_llvm_15\\bin\\llvm-as.exe"
-    $env:TAICHI_CMAKE_ARGS += " -DTI_LLVM_15:BOOL=ON"
 } else {
     throw "Unsupported LLVM version"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,12 +77,6 @@ if (WIN32)
   # MSVC in `Debug` config because MSVC would try to fill uninitialize memory
   # with `0xCC` but it too breaks `LLVMTableGen` which is depended on by almost
   # every component in LLVM.
-  #
-  # FIXME: (penguinliong) This is fixed in later releases of LLVM so maybe
-  # someday we can distribute `Debug` libraries, if it's ever needed.
-  if (NOT TI_LLVM_15)
-    SET(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
-  endif()
   message("CMAKE_MSVC_RUNTIME_LIBRARY: ${CMAKE_MSVC_RUNTIME_LIBRARY}")
 endif()
 

--- a/ci/windows/win_build_test.ps1
+++ b/ci/windows/win_build_test.ps1
@@ -68,7 +68,6 @@ if (!$llvmVer.CompareTo("10")) {
 } else {
     $env:TAICHI_CMAKE_ARGS += " -DCLANG_EXECUTABLE=C:\\taichi_clang_15\\bin\\clang++.exe"
 	$env:TAICHI_CMAKE_ARGS += " -DLLVM_AS_EXECUTABLE=C:\\taichi_llvm_15\\bin\\llvm-as.exe"
-	$env:TAICHI_CMAKE_ARGS += " -DTI_LLVM_15:BOOL=ON"
     $env:TAICHI_CMAKE_ARGS += " -DTI_WITH_DX12:BOOL=ON"
 }
 

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -1,6 +1,5 @@
 option(USE_STDCPP "Use -stdlib=libc++" OFF)
 option(TI_WITH_LLVM "Build with LLVM backends" ON)
-option(TI_LLVM_15 "Switch to LLVM 15" ON)
 option(TI_WITH_METAL "Build with the Metal backend" ON)
 option(TI_WITH_CUDA "Build with the CUDA backend" ON)
 option(TI_WITH_CUDA_TOOLKIT "Build with the CUDA toolkit" OFF)
@@ -96,12 +95,6 @@ file(GLOB TAICHI_CORE_SOURCE
 
 if(TI_WITH_LLVM)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_WITH_LLVM")
-endif()
-
-if (TI_LLVM_15)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTI_LLVM_15")
-else()
-    set(TI_WITH_DX12 OFF)
 endif()
 
 ## This version var is only used to locate slim_libdevice.10.bc

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -103,12 +103,8 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
 
       {
         builder->SetInsertPoint(loop_test_bb);
-#ifdef TI_LLVM_15
         auto *loop_index_load =
             builder->CreateLoad(builder->getInt32Ty(), loop_index);
-#else
-        auto *loop_index_load = builder->CreateLoad(loop_index);
-#endif
         auto cond = builder->CreateICmp(
             llvm::CmpInst::Predicate::ICMP_SLT, loop_index_load,
             llvm_val[stmt->owned_num_local.find(stmt->major_from_type)
@@ -123,12 +119,8 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
           auto &s = stmt->body->statements[i];
           s->accept(this);
         }
-#ifdef TI_LLVM_15
         auto *loop_index_load =
             builder->CreateLoad(builder->getInt32Ty(), loop_index);
-#else
-        auto *loop_index_load = builder->CreateLoad(loop_index);
-#endif
         builder->CreateStore(
             builder->CreateAdd(loop_index_load, tlctx->get_constant(1)),
             loop_index);

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -53,10 +53,7 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     auto value_arr = builder->CreateAlloca(stype);
     for (int i = 0; i < values.size(); i++) {
       auto value_ptr = builder->CreateGEP(
-#ifdef TI_LLVM_15
-          stype,
-#endif
-          value_arr, {tlctx->get_constant(0), tlctx->get_constant(i)});
+          stype, value_arr, {tlctx->get_constant(0), tlctx->get_constant(i)});
       builder->CreateStore(values[i], value_ptr);
     }
     return LLVMModuleBuilder::call(
@@ -259,156 +256,6 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
                 llvm_val[stmt->val]);
   }
 
-  // LLVM15 already support f16 atomic in
-  // https://github.com/llvm/llvm-project/commit/0cb08e448af7167ada767e0526aa44980e72ad08
-  // the review is at https://reviews.llvm.org/D52416
-  // Limit the f16 hack to LLVM10 build.
-#ifndef TI_LLVM_15
-  // A huge hack for supporting f16 atomic add/max/min! Borrowed from
-  // https://github.com/tensorflow/tensorflow/blob/470d58a83470f8ede3beaa584e6992bc71b7baa6/tensorflow/compiler/xla/service/gpu/ir_emitter.cc#L378-L490
-  // The reason is that LLVM10 does not support generating atomicCAS for f16 on
-  // NVPTX backend.
-  //
-  // Implements atomic binary operations using atomic compare-and-swap
-  // (atomicCAS) as follows:
-  //   1. Reads the value from the memory pointed to by output_address and
-  //     records it as old_output.
-  //   2. Uses old_output as one of the source operand to perform the binary
-  //     operation and stores the result in new_output.
-  //   3. Calls atomicCAS which implements compare-and-swap as an atomic
-  //     operation. In particular, atomicCAS reads the value from the memory
-  //     pointed to by output_address, and compares the value with old_output.
-  //     If the two values equal, new_output is written to the same memory
-  //     location and true is returned to indicate that the atomic operation
-  //     succeeds. Otherwise, the new value read from the memory is returned. In
-  //     this case, the new value is copied to old_output, and steps 2. and 3.
-  //     are repeated until atomicCAS succeeds.
-  //
-  // int32 is used for the atomicCAS operation. So atomicCAS reads and writes 32
-  // bit values from the memory, which is larger than the memory size required
-  // by the original atomic binary operation. We mask off the last two bits of
-  // the output_address and use the result as an address to read the 32 bit
-  // values from the memory.
-  //
-  // This can avoid out of bound memory accesses, based on the assumption:
-  // All buffers are 4 byte aligned and have a size of 4N.
-  //
-  // The pseudo code is shown below.
-  //
-  //   cas_new_output_address = alloca(32);
-  //   cas_old_output_address = alloca(32);
-  //   atomic_address = output_address & ((int64)(-4));
-  //   new_output_address = cas_new_output_address + (output_address & 3);
-  //
-  //   *cas_old_output_address = *atomic_address;
-  //   do {
-  //     *cas_new_output_address = *cas_old_output_address;
-  //     *new_output_address = operation(*new_output_address, *source_address);
-  //     (*cas_old_output_address, success) =
-  //       atomicCAS(atomic_address, *cas_old_output_address,
-  //       *cas_new_output_address);
-  //   } while (!success);
-  //
-
-  llvm::Value *atomic_op_using_cas(
-      llvm::Value *output_address,
-      llvm::Value *val,
-      std::function<llvm::Value *(llvm::Value *, llvm::Value *)> op) override {
-    llvm::PointerType *output_address_type =
-        llvm::dyn_cast<llvm::PointerType>(output_address->getType());
-    TI_ASSERT(output_address_type != nullptr);
-
-    // element_type is the data type for the binary operation.
-    llvm::Type *element_type = output_address_type->getPointerElementType();
-    llvm::Type *element_address_type = element_type->getPointerTo();
-
-    int atomic_size = 32;
-    llvm::Type *atomic_type = builder->getIntNTy(atomic_size);
-    llvm::Type *atomic_address_type = atomic_type->getPointerTo(
-        output_address_type->getPointerAddressSpace());
-
-    // cas_old_output_address and cas_new_output_address point to the scratch
-    // memory where we store the old and new values for the repeated atomicCAS
-    // operations.
-    llvm::Value *cas_old_output_address =
-        builder->CreateAlloca(atomic_type, nullptr);
-    llvm::Value *cas_new_output_address =
-        builder->CreateAlloca(atomic_type, nullptr);
-
-    llvm::Value *atomic_memory_address;
-    // binop_output_address points to the scratch memory that stores the
-    // result of the binary operation.
-    llvm::Value *binop_output_address;
-
-    // Calculate bin_output_address output_address
-    llvm::Type *address_int_type =
-        module->getDataLayout().getIntPtrType(output_address_type);
-    atomic_memory_address =
-        builder->CreatePtrToInt(output_address, address_int_type);
-    llvm::Value *mask = llvm::ConstantInt::get(address_int_type, 3);
-    llvm::Value *offset = builder->CreateAnd(atomic_memory_address, mask);
-    mask = llvm::ConstantInt::get(address_int_type, -4);
-    atomic_memory_address = builder->CreateAnd(atomic_memory_address, mask);
-    atomic_memory_address =
-        builder->CreateIntToPtr(atomic_memory_address, atomic_address_type);
-    binop_output_address = builder->CreateAdd(
-        builder->CreatePtrToInt(cas_new_output_address, address_int_type),
-        offset);
-    binop_output_address =
-        builder->CreateIntToPtr(binop_output_address, element_address_type);
-
-    // Use the value from the memory that atomicCAS operates on to initialize
-    // cas_old_output.
-    llvm::Value *cas_old_output =
-        builder->CreateLoad(atomic_memory_address, "cas_old_output");
-    builder->CreateStore(cas_old_output, cas_old_output_address);
-
-    llvm::BasicBlock *loop_body_bb =
-        BasicBlock::Create(*llvm_context, "atomic_op_loop_body", func);
-    llvm::BasicBlock *loop_exit_bb =
-        BasicBlock::Create(*llvm_context, "loop_exit_bb", func);
-    builder->CreateBr(loop_body_bb);
-    builder->SetInsertPoint(loop_body_bb);
-
-    // loop body for one atomicCAS
-    {
-      // Use cas_old_output to initialize cas_new_output.
-      cas_old_output =
-          builder->CreateLoad(cas_old_output_address, "cas_old_output");
-      builder->CreateStore(cas_old_output, cas_new_output_address);
-
-      auto binop_output = op(builder->CreateLoad(binop_output_address), val);
-      builder->CreateStore(binop_output, binop_output_address);
-
-      llvm::Value *cas_new_output =
-          builder->CreateLoad(cas_new_output_address, "cas_new_output");
-
-      // Emit code to perform the atomicCAS operation
-      // (cas_old_output, success) = atomicCAS(memory_address, cas_old_output,
-      //                                       cas_new_output);
-      llvm::Value *ret_value = builder->CreateAtomicCmpXchg(
-          atomic_memory_address, cas_old_output, cas_new_output,
-          llvm::AtomicOrdering::SequentiallyConsistent,
-          llvm::AtomicOrdering::SequentiallyConsistent);
-
-      // Extract the memory value returned from atomicCAS and store it as
-      // cas_old_output.
-      builder->CreateStore(
-          builder->CreateExtractValue(ret_value, 0, "cas_old_output"),
-          cas_old_output_address);
-      // Extract the success bit returned from atomicCAS and generate a
-      // conditional branch on the success bit.
-      builder->CreateCondBr(
-          builder->CreateExtractValue(ret_value, 1, "success"), loop_exit_bb,
-          loop_body_bb);
-    }
-
-    builder->SetInsertPoint(loop_exit_bb);
-
-    return output_address;
-  }
-#endif
-
   void visit(RangeForStmt *for_stmt) override {
     create_naive_range_for(for_stmt);
   }
@@ -475,11 +322,7 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
         builder->SetInsertPoint(loop_test_bb);
         auto cond = builder->CreateICmp(
             llvm::CmpInst::Predicate::ICMP_SLT,
-            builder->CreateLoad(
-#ifdef TI_LLVM_15
-                i32_ty,
-#endif
-                loop_index),
+            builder->CreateLoad(i32_ty, loop_index),
             llvm_val[stmt->owned_num_local.find(stmt->major_from_type)
                          ->second]);
         builder->CreateCondBr(cond, loop_body_bb, func_exit);
@@ -492,13 +335,10 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
           auto &s = stmt->body->statements[i];
           s->accept(this);
         }
-        builder->CreateStore(builder->CreateAdd(builder->CreateLoad(
-#ifdef TI_LLVM_15
-                                                    i32_ty,
-#endif
-                                                    loop_index),
-                                                block_dim),
-                             loop_index);
+        builder->CreateStore(
+            builder->CreateAdd(builder->CreateLoad(i32_ty, loop_index),
+                               block_dim),
+            loop_index);
         builder->CreateBr(loop_test_bb);
         builder->SetInsertPoint(func_exit);
       }

--- a/taichi/codegen/dx12/codegen_dx12.cpp
+++ b/taichi/codegen/dx12/codegen_dx12.cpp
@@ -91,11 +91,7 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
         builder->SetInsertPoint(loop_test_bb);
         auto cond = builder->CreateICmp(
             llvm::CmpInst::Predicate::ICMP_SLT,
-            builder->CreateLoad(
-#ifdef TI_LLVM_15
-                i32_ty,
-#endif
-                loop_index),
+            builder->CreateLoad(i32_ty, loop_index),
             llvm_val[stmt->owned_num_local.find(stmt->major_from_type)
                          ->second]);
         builder->CreateCondBr(cond, loop_body_bb, func_exit);
@@ -108,13 +104,10 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
           auto &s = stmt->body->statements[i];
           s->accept(this);
         }
-        builder->CreateStore(builder->CreateAdd(builder->CreateLoad(
-#ifdef TI_LLVM_15
-                                                    i32_ty,
-#endif
-                                                    loop_index),
-                                                block_dim),
-                             loop_index);
+        builder->CreateStore(
+            builder->CreateAdd(builder->CreateLoad(i32_ty, loop_index),
+                               block_dim),
+            loop_index);
         builder->CreateBr(loop_test_bb);
         builder->SetInsertPoint(func_exit);
       }

--- a/taichi/codegen/llvm/llvm_codegen_utils.h
+++ b/taichi/codegen/llvm/llvm_codegen_utils.h
@@ -71,11 +71,7 @@ class LLVMModuleBuilder {
     builder->SetInsertPoint(entry_block);
     auto alloca = builder->CreateAlloca(type, (unsigned)0, array_size);
     if (alignment != 0) {
-#ifdef TI_LLVM_15
       alloca->setAlignment(llvm::Align(alignment));
-#else
-      alloca->setAlignment(llvm::MaybeAlign(alignment));
-#endif
     }
     return alloca;
   }

--- a/taichi/codegen/llvm/struct_llvm.cpp
+++ b/taichi/codegen/llvm/struct_llvm.cpp
@@ -238,18 +238,11 @@ void StructCompilerLLVM::generate_child_accessors(SNode &snode) {
       args.push_back(&arg);
     }
     llvm::Value *ret;
-#ifdef TI_LLVM_15
     ret = builder.CreateGEP(get_llvm_element_type(module.get(), parent),
                             builder.CreateBitCast(args[0], inp_type),
                             {tlctx_->get_constant(0),
                              tlctx_->get_constant(parent->child_id(&snode))},
                             "getch");
-#else
-    ret = builder.CreateGEP(builder.CreateBitCast(args[0], inp_type),
-                            {tlctx_->get_constant(0),
-                             tlctx_->get_constant(parent->child_id(&snode))},
-                            "getch");
-#endif
 
     builder.CreateRet(
         builder.CreateBitCast(ret, llvm::Type::getInt8PtrTy(*llvm_ctx_)));
@@ -299,12 +292,8 @@ llvm::Type *StructCompilerLLVM::get_stub(llvm::Module *module,
                                          uint32 index) {
   TI_ASSERT(module);
   TI_ASSERT(snode);
-#ifdef TI_LLVM_15
   auto stub = llvm::StructType::getTypeByName(module->getContext(),
                                               type_stub_name(snode));
-#else
-  auto stub = module->getTypeByName(type_stub_name(snode));
-#endif
   TI_ASSERT(stub);
   TI_ASSERT(stub->getStructNumElements() == 4);
   TI_ASSERT(0 <= index && index < 4);

--- a/taichi/codegen/wasm/codegen_wasm.cpp
+++ b/taichi/codegen/wasm/codegen_wasm.cpp
@@ -63,11 +63,7 @@ class TaskCodeGenWASM : public TaskCodeGenLLVM {
       // test block
       builder->SetInsertPoint(loop_test);
       llvm::Value *cond;
-#ifdef TI_LLVM_15
       auto *loop_var_load = builder->CreateLoad(begin->getType(), loop_var);
-#else
-      auto *loop_var_load = builder->CreateLoad(loop_var);
-#endif
       if (!stmt->reversed) {
         cond = builder->CreateICmp(llvm::CmpInst::Predicate::ICMP_SLT,
                                    loop_var_load, end);

--- a/taichi/runtime/cuda/jit_cuda.cpp
+++ b/taichi/runtime/cuda/jit_cuda.cpp
@@ -103,10 +103,6 @@ std::string JITSessionCUDA::compile_module_to_ptx(
   TI_ERROR_UNLESS(target, err_str);
 
   TargetOptions options;
-#ifndef TI_LLVM_15
-  // PrintMachineCode is removed in https://reviews.llvm.org/D83275.
-  options.PrintMachineCode = 0;
-#endif
   if (this->config_->fast_math) {
     options.AllowFPOpFusion = FPOpFusion::Fast;
     // See NVPTXISelLowering.cpp
@@ -124,10 +120,6 @@ std::string JITSessionCUDA::compile_module_to_ptx(
   options.HonorSignDependentRoundingFPMathOption = 0;
   options.NoZerosInBSS = 0;
   options.GuaranteedTailCallOpt = 0;
-#ifndef TI_LLVM_15
-  // StackAlignmentOverride is removed in https://reviews.llvm.org/D103048.
-  options.StackAlignmentOverride = 0;
-#endif
 
   std::unique_ptr<TargetMachine> target_machine(target->createTargetMachine(
       triple.str(), CUDAContext::get_instance().get_mcpu(), cuda_mattrs(),

--- a/taichi/runtime/cuda/jit_cuda.h
+++ b/taichi/runtime/cuda/jit_cuda.h
@@ -15,11 +15,7 @@
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
-#ifdef TI_LLVM_15
 #include "llvm/MC/TargetRegistry.h"
-#else
-#include "llvm/Support/TargetRegistry.h"
-#endif
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 

--- a/taichi/runtime/llvm/llvm_context.cpp
+++ b/taichi/runtime/llvm/llvm_context.cpp
@@ -20,11 +20,7 @@
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Support/TargetSelect.h"
-#ifdef TI_LLVM_15
 #include "llvm/Support/FileSystem.h"
-#else
-#include "llvm/Support/TargetRegistry.h"
-#endif
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar.h"
@@ -70,15 +66,9 @@ TaichiLLVMContext::TaichiLLVMContext(CompileConfig *config, Arch arch)
   main_thread_data_ = get_this_thread_data();
   llvm::remove_fatal_error_handler();
   llvm::install_fatal_error_handler(
-#ifdef TI_LLVM_15
       [](void *user_data, const char *reason, bool gen_crash_diag) {
         TI_ERROR("LLVM Fatal Error: {}", reason);
       },
-#else
-      [](void *user_data, const std::string &reason, bool gen_crash_diag) {
-        TI_ERROR("LLVM Fatal Error: {}", reason);
-      },
-#endif
       nullptr);
 
   if (arch_is_cpu(arch)) {
@@ -388,14 +378,9 @@ std::unique_ptr<llvm::Module> TaichiLLVMContext::module_from_file(
       std::vector<llvm::Value *> args;
       for (auto &arg : func->args())
         args.push_back(&arg);
-#ifdef TI_LLVM_15
       builder.CreateRet(builder.CreateAtomicRMW(
           op, args[0], args[1], llvm::MaybeAlign(0),
           llvm::AtomicOrdering::SequentiallyConsistent));
-#else
-      builder.CreateRet(builder.CreateAtomicRMW(
-          op, args[0], args[1], llvm::AtomicOrdering::SequentiallyConsistent));
-#endif
       TaichiLLVMContext::mark_inline(func);
     };
 
@@ -626,18 +611,9 @@ void TaichiLLVMContext::mark_inline(llvm::Function *f) {
         }
       }
     }
-#ifdef TI_LLVM_15
   f->removeFnAttr(llvm::Attribute::OptimizeNone);
   f->removeFnAttr(llvm::Attribute::NoInline);
   f->addFnAttr(llvm::Attribute::AlwaysInline);
-#else
-  f->removeAttribute(llvm::AttributeList::FunctionIndex,
-                     llvm::Attribute::OptimizeNone);
-  f->removeAttribute(llvm::AttributeList::FunctionIndex,
-                     llvm::Attribute::NoInline);
-  f->addAttribute(llvm::AttributeList::FunctionIndex,
-                  llvm::Attribute::AlwaysInline);
-#endif
 }
 
 int TaichiLLVMContext::num_instructions(llvm::Function *func) {
@@ -788,11 +764,7 @@ auto make_slim_libdevice = [](const std::vector<std::string> &args) {
 
   std::error_code ec;
   auto output_fn = "slim_" + args[0];
-#ifdef TI_LLVM_15
   llvm::raw_fd_ostream os(output_fn, ec, llvm::sys::fs::OF_None);
-#else
-  llvm::raw_fd_ostream os(output_fn, ec, llvm::sys::fs::F_None);
-#endif
   llvm::WriteBitcodeToFile(*libdevice_module, os);
   os.flush();
   TI_INFO("Slimmed libdevice written to {}", output_fn);
@@ -861,12 +833,8 @@ llvm::Function *TaichiLLVMContext::get_struct_function(const std::string &name,
 }
 
 llvm::Type *TaichiLLVMContext::get_runtime_type(const std::string &name) {
-#ifdef TI_LLVM_15
   auto ty = llvm::StructType::getTypeByName(
       get_this_thread_runtime_module()->getContext(), ("struct." + name));
-#else
-  auto ty = get_this_thread_runtime_module()->getTypeByName("struct." + name);
-#endif
   if (!ty) {
     TI_ERROR("LLVMRuntime type {} not found.", name);
   }
@@ -963,13 +931,7 @@ void TaichiLLVMContext::add_struct_for_func(llvm::Module *module,
   for (auto &bb : *patched_struct_for_func) {
     for (llvm::Instruction &inst : bb) {
       auto now_alloca = llvm::dyn_cast<AllocaInst>(&inst);
-      if (!now_alloca ||
-#ifdef TI_LLVM_15
-          now_alloca->getAlign().value() != 8
-#else
-          now_alloca->getAlignment() != 8
-#endif
-      )
+      if (!now_alloca || now_alloca->getAlign().value() != 8)
         continue;
       auto alloca_type = now_alloca->getAllocatedType();
       // Allocated type should be array [1 x i8]

--- a/tests/cpp/llvm/llvm_offline_cache_test.cpp
+++ b/tests/cpp/llvm/llvm_offline_cache_test.cpp
@@ -93,9 +93,7 @@ TEST_P(LlvmOfflineCacheTest, ReadWrite) {
   {
     auto llvm_ctx = std::make_unique<llvm::LLVMContext>();
 
-#ifdef TI_LLVM_15
     llvm_ctx->setOpaquePointers(false);
-#endif
     LlvmOfflineCache::KernelCacheData kcache;
     kcache.created_at = 1;
     kcache.last_used_at = 1;


### PR DESCRIPTION
Issue: #6447

### Brief Summary
LLVM10 is dead in taichi codebase, long live LLVM15!

I wanna mention that a lot of hard work in this upgrade was done by our OSS contributor @python3kgae , thanks a ton!!! 