### PR TITLE
[doc] Update deprecated function call "ti.ui.make_camera()" to "ti.ui.Camera()"

### DIFF
--- a/docs/lang/articles/get-started/cloth_simulation.md
+++ b/docs/lang/articles/get-started/cloth_simulation.md
@@ -463,7 +463,7 @@ window = ti.ui.Window("Taichi Cloth Simulation on GGUI", (1024, 1024),
 canvas = window.get_canvas()
 canvas.set_background_color((1, 1, 1))
 scene = ti.ui.Scene()
-camera = ti.ui.make_camera()
+camera = ti.ui.Camera()
 
 current_t = 0.0
 initialize_mass_points()

--- a/docs/lang/articles/visualization/ggui.md
+++ b/docs/lang/articles/visualization/ggui.md
@@ -135,7 +135,7 @@ init_points_pos(points_pos)
 window = ti.ui.Window("Test for Drawing 3d-lines", (768, 768))
 canvas = window.get_canvas()
 scene = ti.ui.Scene()
-camera = ti.ui.make_camera()
+camera = ti.ui.Camera()
 camera.position(5, 2, 2)
 
 while window.running:
@@ -226,7 +226,7 @@ init_points_indices(points_indices)
 window = ti.ui.Window("Test for Drawing 3d-lines", (768, 768))
 canvas = window.get_canvas()
 scene = ti.ui.Scene()
-camera = ti.ui.make_camera()
+camera = ti.ui.Camera()
 camera.position(5, 2, 2)
 
 while window.running:
@@ -287,7 +287,7 @@ scene.mesh_instance(vertices, indices, transforms = m_transforms, instance_offse
 window = ti.ui.Window("Display Mesh", (1024, 1024), vsync=True)
 canvas = window.get_canvas()
 scene = ti.ui.Scene()
-camera = ti.ui.make_camera()
+camera = ti.ui.Camera()
 
 # slider_int usage
 some_int_type_value = 0
@@ -367,7 +367,7 @@ window_shape = (720, 1080)
 window = ti.ui.Window("Test for copy depth data", window_shape)
 canvas = window.get_canvas()
 scene = ti.ui.Scene()
-camera = ti.ui.make_camera()
+camera = ti.ui.Camera()
 
 # Get the shape of the window
 w, h = window.get_window_shape()


### PR DESCRIPTION
Issue: #

### Brief Summary

I copied the code from the [document](https://docs.taichi-lang.cn/docs/cloth_simulation) to run, but when running, it output:
```
[Taichi] version 1.2.2, llvm 10.0.0, commit 608e4b57, osx, python 3.10.8
venv/lib/python3.10/site-packages/taichi/ui/ui.py:22: DeprecationWarning: `ti.ui.make_camera()` is deprecated, please use `ti.ui.Camera()` instead
```

After I updated it, running no longer outputs warnings.