### PR TITLE
[build] Integrate backward_cpp to test targets for enabling C++ stack trace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,6 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
-            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3
@@ -150,7 +149,6 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=OFF
             -DTI_BUILD_TESTS:BOOL=ON
-            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3
@@ -203,7 +201,6 @@ jobs:
             -DTI_WITH_OPENGL:BOOL=OFF
             -DTI_WITH_CC:BOOL=OFF
             -DTI_BUILD_TESTS:BOOL=ON
-            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3
@@ -253,7 +250,6 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
-            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3
@@ -149,6 +150,7 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=OFF
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3
@@ -201,6 +203,7 @@ jobs:
             -DTI_WITH_OPENGL:BOOL=OFF
             -DTI_WITH_CC:BOOL=OFF
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3
@@ -250,6 +253,7 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_BACKTRACE:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -103,7 +103,7 @@ jobs:
           docker exec --user dev check_clang_tidy /home/dev/taichi/.github/workflows/scripts/check_clang_tidy.sh "$CI_SETUP_CMAKE_ARGS"
         env:
           CR_PAT: ${{ secrets.GITHUB_TOKEN }}
-          CI_SETUP_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTI_WITH_OPENGL:BOOL=ON -DTI_WITH_CC:BOOL=ON -DTI_WITH_VULKAN:BOOL=ON -DTI_BUILD_TESTS:BOOL=ON
+          CI_SETUP_CMAKE_ARGS: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DTI_WITH_OPENGL:BOOL=ON -DTI_WITH_CC:BOOL=ON -DTI_WITH_VULKAN:BOOL=ON -DTI_BUILD_TESTS:BOOL=ON -DTI_WITH_BACKTRACE:BOOL=ON
 
   build_and_test_cpu_mac:
     name: Build and Test macos (CPU)
@@ -148,6 +148,7 @@ jobs:
             -DTI_WITH_CC:BOOL=${{ matrix.with_cc }}
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_WITH_C_API=ON
+            -DTI_WITH_BACKTRACE:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=${{ matrix.with_cpp_tests }}
 
       # [DEBUG] Copy this step around to enable debugging inside Github Action instances.
@@ -211,6 +212,7 @@ jobs:
             -DTI_WITH_OPENGL:BOOL=ON
             -DTI_WITH_CC:BOOL=ON
             -DTI_WITH_VULKAN:BOOL=ON
+            -DTI_WITH_BACKTRACE:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
             -DTI_WITH_C_API=ON
 
@@ -293,6 +295,7 @@ jobs:
             -DTI_WITH_DX12:BOOL=ON
             -DTI_WITH_CC:BOOL=OFF
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_BACKTRACE=ON
             -DTI_WITH_C_API=ON
 
       - name: Test
@@ -353,6 +356,7 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_BACKTRACE:BOOL=ON
             -DTI_WITH_C_API=ON
 
       - name: Test

--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 [submodule "external/DirectX-Headers"]
 	path = external/DirectX-Headers
 	url = https://github.com/microsoft/DirectX-Headers.git
+[submodule "external/backward_cpp"]
+	path = external/backward_cpp
+	url = https://github.com/bombela/backward-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,11 @@ if(CCACHE_PROGRAM)
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()
 
+# This compiles all the libraries with -fPIC, which is critical to link a static
+# library into a shared lib.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+
 option(USE_LLD "Use lld (from llvm) linker" OFF)
 option(USE_MOLD "Use mold (A Modern Linker)" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,13 +122,18 @@ option(TI_WITH_PYTHON "Build with Python language binding" ON)
 if (TI_WITH_PYTHON AND NOT ANDROID)
     include(cmake/PythonNumpyPybind11.cmake)
 endif()
+
+if (TI_BUILD_TESTS)
+  add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
+  add_subdirectory(external/backward_cpp)
+endif()
+
 include(cmake/TaichiCXXFlags.cmake)
 include(cmake/TaichiCore.cmake)
 
 option(TI_BUILD_TESTS "Build the CPP tests" OFF)
 
 if (TI_BUILD_TESTS)
-  add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
   include(cmake/TaichiTests.cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(USE_LLD "Use lld (from llvm) linker" OFF)
 option(USE_MOLD "Use mold (A Modern Linker)" OFF)
+option(TI_WITH_BACKTRACE "Use backward-cpp to print out C++ stack trace upon failure" OFF)
 
 if (USE_LLD)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
@@ -128,8 +129,7 @@ if (TI_WITH_PYTHON AND NOT ANDROID)
     include(cmake/PythonNumpyPybind11.cmake)
 endif()
 
-if (TI_BUILD_TESTS)
-  add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
+if (TI_WITH_BACKTRACE)
   add_subdirectory(external/backward_cpp)
 endif()
 
@@ -139,6 +139,7 @@ include(cmake/TaichiCore.cmake)
 option(TI_BUILD_TESTS "Build the CPP tests" OFF)
 
 if (TI_BUILD_TESTS)
+  add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
   include(cmake/TaichiTests.cmake)
 endif()
 

--- a/cmake/TaichiCAPITests.cmake
+++ b/cmake/TaichiCAPITests.cmake
@@ -25,6 +25,7 @@ if (WIN32)
 endif()
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE taichi_c_api)
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE gtest_main)
+target_link_libraries(${C_API_TESTS_NAME} PUBLIC ${BACKWARD_ENABLE})
 
 target_include_directories(${C_API_TESTS_NAME}
   PRIVATE

--- a/cmake/TaichiCAPITests.cmake
+++ b/cmake/TaichiCAPITests.cmake
@@ -25,7 +25,7 @@ if (WIN32)
 endif()
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE taichi_c_api)
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE gtest_main)
-target_link_libraries(${C_API_TESTS_NAME} PUBLIC ${BACKWARD_ENABLE})
+target_link_libraries(${C_API_TESTS_NAME} PRIVATE ${BACKWARD_ENABLE})
 
 target_include_directories(${C_API_TESTS_NAME}
   PRIVATE

--- a/cmake/TaichiCAPITests.cmake
+++ b/cmake/TaichiCAPITests.cmake
@@ -25,7 +25,10 @@ if (WIN32)
 endif()
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE taichi_c_api)
 target_link_libraries(${C_API_TESTS_NAME} PRIVATE gtest_main)
-target_link_libraries(${C_API_TESTS_NAME} PRIVATE ${BACKWARD_ENABLE})
+
+if (TI_WITH_BACKTRACE)
+    target_link_libraries(${C_API_TESTS_NAME} PRIVATE ${BACKWARD_ENABLE})
+endif()
 
 target_include_directories(${C_API_TESTS_NAME}
   PRIVATE

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -432,6 +432,13 @@ if(TI_WITH_PYTHON)
         target_link_options(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
     endif()
 
+    if (TI_BUILD_TESTS)
+        # Defined by external/backward-cpp:
+        # This will add libraries, definitions and include directories needed by backward
+        # by setting each property on the target.
+        target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC ${BACKWARD_ENABLE})
+    endif()
+
     if(TI_WITH_GGUI)
         target_compile_definitions(${CORE_WITH_PYBIND_LIBRARY_NAME} PRIVATE -DTI_WITH_GGUI)
         target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PRIVATE taichi_ui_vulkan)

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -428,7 +428,7 @@ if(TI_WITH_PYTHON)
         target_link_options(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC -Wl,--exclude-libs=ALL)
     endif()
 
-    if (TI_BUILD_TESTS)
+    if (TI_WITH_BACKTRACE)
         # Defined by external/backward-cpp:
         # This will add libraries, definitions and include directories needed by backward
         # by setting each property on the target.

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -119,10 +119,6 @@ if (TI_WITH_CC)
   list(APPEND TAICHI_CORE_SOURCE ${TAICHI_CC_SOURCE})
 endif()
 
-# This compiles all the libraries with -fPIC, which is critical to link a static
-# library into a shared lib.
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 set(CORE_LIBRARY_NAME taichi_core)
 add_library(${CORE_LIBRARY_NAME} OBJECT ${TAICHI_CORE_SOURCE})
 

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -436,7 +436,7 @@ if(TI_WITH_PYTHON)
         # Defined by external/backward-cpp:
         # This will add libraries, definitions and include directories needed by backward
         # by setting each property on the target.
-        target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PUBLIC ${BACKWARD_ENABLE})
+        target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PRIVATE ${BACKWARD_ENABLE})
     endif()
 
     if(TI_WITH_GGUI)

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -59,7 +59,7 @@ if (WIN32)
 endif()
 target_link_libraries(${TESTS_NAME} PRIVATE taichi_core)
 target_link_libraries(${TESTS_NAME} PRIVATE gtest_main)
-target_link_libraries(${TESTS_NAME} PUBLIC ${BACKWARD_ENABLE})
+target_link_libraries(${TESTS_NAME} PRIVATE ${BACKWARD_ENABLE})
 
 if (TI_WITH_OPENGL OR TI_WITH_VULKAN)
   target_link_libraries(${TESTS_NAME} PRIVATE gfx_runtime)

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -59,7 +59,10 @@ if (WIN32)
 endif()
 target_link_libraries(${TESTS_NAME} PRIVATE taichi_core)
 target_link_libraries(${TESTS_NAME} PRIVATE gtest_main)
-target_link_libraries(${TESTS_NAME} PRIVATE ${BACKWARD_ENABLE})
+
+if (TI_WITH_BACKTRACE)
+    target_link_libraries(${TESTS_NAME} PRIVATE ${BACKWARD_ENABLE})
+endif()
 
 if (TI_WITH_OPENGL OR TI_WITH_VULKAN)
   target_link_libraries(${TESTS_NAME} PRIVATE gfx_runtime)

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -59,6 +59,7 @@ if (WIN32)
 endif()
 target_link_libraries(${TESTS_NAME} PRIVATE taichi_core)
 target_link_libraries(${TESTS_NAME} PRIVATE gtest_main)
+target_link_libraries(${TESTS_NAME} PUBLIC ${BACKWARD_ENABLE})
 
 if (TI_WITH_OPENGL OR TI_WITH_VULKAN)
   target_link_libraries(${TESTS_NAME} PRIVATE gfx_runtime)


### PR DESCRIPTION
Issue: #

### Brief Summary
When building with `-DTI_BUILD_TESTS=ON`, `taichi_cpp_tests`,`taichi_c_api_tests`, `taichi_python.so` will link to an external library: https://github.com/bombela/backward-cpp, which enables C++ stack trace upon test failures.

## Segfault with python tests 
`python3 test.py`

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/22334008/203220070-7f295889-9144-44c9-9f49-0f83e4cf0805.png">

## Segfault with cpp tests
`./build/taichi_cpp_tests`

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/22334008/203220383-c268120c-05ff-4fcc-b9c0-2c1c4326fe35.png">

## Segfault with c_api tests
`./build/taichi_c_api_tests`

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/22334008/203220536-dc4e5aa0-6e73-4cd6-8057-3ff8253a72bf.png">
