### PR TITLE
[ci] Add dockerfile.ubuntu-20.04.amdgpu

### DIFF
--- a/ci/Dockerfile.ubuntu.20.04.amdgpu
+++ b/ci/Dockerfile.ubuntu.20.04.amdgpu
@@ -45,10 +45,10 @@ ENV PATH="/cmake-3.20.5-linux-x86_64/bin:$PATH"
 # Install LLVM 15
 WORKDIR /
 # Make sure this URL gets updated each time there is a new prebuilt bin release
-RUN wget https://github.com/taichi-dev/taichi_assets/releases/download/llvm10_linux_patch2/taichi-llvm-10.0.0-linux.zip
-RUN unzip taichi-llvm-10.0.0-linux.zip && \
-    rm taichi-llvm-10.0.0-linux.zip
-ENV PATH="/taichi-llvm-10.0.0-linux/bin:$PATH"
+RUN wget https://github.com/GaleSeLee/assets/releases/download/v0.0.1/taichi-llvm-15.0.0-linux.zip
+RUN unzip taichi-llvm-15.0.0-linux.zip && \
+    rm taichi-llvm-15.0.0-linux.zip
+ENV PATH="/taichi-llvm-15.0.0-linux/bin:$PATH"
 # Use Clang as the default compiler
 ENV CC="clang-10"
 ENV CXX="clang++-10"

--- a/ci/Dockerfile.ubuntu.20.04.amdgpu
+++ b/ci/Dockerfile.ubuntu.20.04.amdgpu
@@ -1,0 +1,79 @@
+# Taichi Dockerfile for development
+FROM rocm/dev-ubuntu-20.04:5.2
+
+LABEL maintainer="https://github.com/taichi-dev"
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    apt-get install -y libtinfo-dev \
+                       clang-10 \
+                       wget \
+                       git \
+                       unzip \
+                       ffmpeg \
+                       libxrandr-dev \
+                       libxinerama-dev \
+                       libxcursor-dev \
+                       libxi-dev \
+                       libglu1-mesa-dev \
+                       freeglut3-dev \
+                       libssl-dev \
+                       libglm-dev \
+                       libxcb-keysyms1-dev \
+                       libxcb-dri3-dev \
+                       libxcb-randr0-dev \
+                       libxcb-ewmh-dev \
+                       libpng-dev \
+                       g++-multilib \
+                       libmirclient-dev \
+                       libwayland-dev \
+                       bison \
+                       libx11-xcb-dev \
+                       liblz4-dev \
+                       libzstd-dev \
+                       qt5-default \
+                       libglfw3 \
+                       libglfw3-dev \
+                       libjpeg-dev
+# Install the latest version of CMAKE v3.20.5 from source
+WORKDIR /
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.tar.gz
+RUN tar xf cmake-3.20.5-linux-x86_64.tar.gz && \
+    rm cmake-3.20.5-linux-x86_64.tar.gz
+ENV PATH="/cmake-3.20.5-linux-x86_64/bin:$PATH"
+
+# Install LLVM 15
+WORKDIR /
+# Make sure this URL gets updated each time there is a new prebuilt bin release
+RUN wget https://github.com/taichi-dev/taichi_assets/releases/download/llvm10_linux_patch2/taichi-llvm-10.0.0-linux.zip
+RUN unzip taichi-llvm-10.0.0-linux.zip && \
+    rm taichi-llvm-10.0.0-linux.zip
+ENV PATH="/taichi-llvm-10.0.0-linux/bin:$PATH"
+# Use Clang as the default compiler
+ENV CC="clang-10"
+ENV CXX="clang++-10"
+
+# Create non-root user for running the container
+# add user into video(&&render) group
+RUN useradd -ms /bin/bash dev
+WORKDIR /home/dev
+USER dev
+
+# Install miniconda
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -p /home/dev/miniconda -b
+ENV PATH="/home/dev/miniconda/bin:$PATH"
+
+# Set up multi-python environment
+RUN conda init bash
+RUN conda create -n py36 python=3.6 -y
+RUN conda create -n py37 python=3.7 -y
+RUN conda create -n py38 python=3.8 -y
+RUN conda create -n py39 python=3.9 -y
+
+# Load scripts for build and test
+WORKDIR /home/dev/scripts
+COPY ci/scripts/ubuntu_build_test.sh ubuntu_build_test.sh
+
+WORKDIR /home/dev
+ENV LANG="C.UTF-8"

--- a/ci/Dockerfile.ubuntu.20.04.amdgpu
+++ b/ci/Dockerfile.ubuntu.20.04.amdgpu
@@ -55,7 +55,8 @@ ENV CXX="clang++-10"
 
 # Create non-root user for running the container
 # add user into video(&&render) group
-RUN useradd -ms /bin/bash dev
+RUN useradd -ms /bin/bash dev && \
+    usermod -a -G video dev
 WORKDIR /home/dev
 USER dev
 

--- a/ci/Dockerfile.ubuntu.20.04.amdgpu
+++ b/ci/Dockerfile.ubuntu.20.04.amdgpu
@@ -35,13 +35,6 @@ RUN apt-get update && \
                        libglfw3 \
                        libglfw3-dev \
                        libjpeg-dev
-# Install the latest version of CMAKE v3.20.5 from source
-WORKDIR /
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.tar.gz
-RUN tar xf cmake-3.20.5-linux-x86_64.tar.gz && \
-    rm cmake-3.20.5-linux-x86_64.tar.gz
-ENV PATH="/cmake-3.20.5-linux-x86_64/bin:$PATH"
-
 # Install LLVM 15
 WORKDIR /
 # Make sure this URL gets updated each time there is a new prebuilt bin release


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/6434

### Brief Summary
This dockerfile refs to Dockerfile.ubuntu.20.04. The differences are following
1. based docker image
2. del python3-pip, mesa-common-dev which are already downloaded in based image.
3. remove vulkan module(amdgpu is not yet adapted to vulkan)
4. add user into video usergroup. (Some Ubuntu-20.04 versions also require render group)

