### PR TITLE
[ci] Add AMDGPU relected ci

### DIFF
--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -155,6 +155,28 @@ function ci-docker-run-gpu {
         $@
 }
 
+function ci-docker-run-amdgpu {
+    for i in {0..9}; do
+        if xset -display ":$i" -q >/dev/null 2>&1; then
+            break
+        fi
+    done
+
+    if [ $? -ne 0 ]; then
+        echo "No display!"
+        exit 1
+    fi
+
+    ci-docker-run \
+        
+        # 注释说明一下
+        -e DISPLAY=:$i \
+        -e GPU_BUILD=ON \
+        -e GPU_TEST=ON \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        $@
+}
+
 function setup-android-ndk-env {
     export ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-/android-sdk/ndk-bundle}
     export ANDROID_CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=29 -DANDROID_ABI=arm64-v8a"

--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -168,8 +168,9 @@ function ci-docker-run-amdgpu {
     fi
 
     ci-docker-run \
-        
-        # 注释说明一下
+        --device=/dev/kfd \
+        --device=/dev/dri \
+        --group-add=video \
         -e DISPLAY=:$i \
         -e GPU_BUILD=ON \
         -e GPU_TEST=ON \

--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -172,8 +172,8 @@ function ci-docker-run-amdgpu {
         --device=/dev/dri \
         --group-add=video \
         -e DISPLAY=:$i \
-        -e GPU_BUILD=ON \
         -e GPU_TEST=ON \
+        -e AMDGPU_TEST=ON \
         -v /tmp/.X11-unix:/tmp/.X11-unix \
         $@
 }

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -68,6 +68,10 @@ build_taichi_wheel() {
             EXTRA_ARGS="-p manylinux_2_27_x86_64"
         fi
     fi
+
+    if ["$AMDGPU_TEST"]; then
+      TAICHI_CMAKE_ARGS="$TAICHI_CMAKE_ARGS -DTI_WITH_CUDA:BOOL=OFF"
+    fi
     python3 misc/make_changelog.py --ver origin/master --repo_dir ./ --save
 
     python3 setup.py $PROJECT_TAGS bdist_wheel $EXTRA_ARGS

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -7,7 +7,12 @@ set -ex
 [[ "$IN_DOCKER" == "true" ]] && cd taichi
 
 if [[ $OSTYPE == "linux-"* ]]; then
-  if [ -z "$AMDGPU_TEST"]; then
+  if ["$AMDGPU_TEST"]; then
+    sudo ln -s /usr/bin/clang++-10 /usr/bin/clang++
+    sudo ln -s /usr/bin/clang-10 /usr/bin/clang
+    sudo ln -s /usr/bin/ld.lld-10 /usr/bin/ld.lld
+    export LLVM_DIR="/taichi-llvm-15.0.0-linux"
+  else
     if [ ! -d ~/taichi-llvm-15 ]; then
       pushd ~
       if [ -f /etc/centos-release ] ; then
@@ -20,11 +25,6 @@ if [[ $OSTYPE == "linux-"* ]]; then
       popd
     fi
     export LLVM_DIR="$HOME/taichi-llvm-15"
-  else
-    sudo ln -s /usr/bin/clang++-10 /usr/bin/clang++
-    sudo ln -s /usr/bin/clang-10 /usr/bin/clang
-    sudo ln -s /usr/bin/ld.lld-10 /usr/bin/ld.lld
-    export LLVM_DIR="/taichi-llvm-15.0.0-linux"
   fi
 
     

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -7,7 +7,7 @@ set -ex
 [[ "$IN_DOCKER" == "true" ]] && cd taichi
 
 if [[ $OSTYPE == "linux-"* ]]; then
-  if ["$AMDGPU_TEST"]; then
+  if [ ! -z "$AMDGPU_TEST" ]; then
     sudo ln -s /usr/bin/clang++-10 /usr/bin/clang++
     sudo ln -s /usr/bin/clang-10 /usr/bin/clang
     sudo ln -s /usr/bin/ld.lld-10 /usr/bin/ld.lld

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -68,10 +68,6 @@ build_taichi_wheel() {
             EXTRA_ARGS="-p manylinux_2_27_x86_64"
         fi
     fi
-
-    if ["$AMDGPU_TEST"]; then
-      TAICHI_CMAKE_ARGS="$TAICHI_CMAKE_ARGS -DTI_WITH_CUDA:BOOL=OFF"
-    fi
     python3 misc/make_changelog.py --ver origin/master --repo_dir ./ --save
 
     python3 setup.py $PROJECT_TAGS bdist_wheel $EXTRA_ARGS

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -27,7 +27,6 @@ if [[ $OSTYPE == "linux-"* ]]; then
     export LLVM_DIR="$HOME/taichi-llvm-15"
   fi
 
-    
 elif [ "$(uname -s):$(uname -m)" == "Darwin:arm64" ]; then
   # The following commands are done manually to save time.
   if [ ! -d ~/taichi-llvm-15-m1 ]; then

--- a/.github/workflows/scripts/unix-build.sh
+++ b/.github/workflows/scripts/unix-build.sh
@@ -7,19 +7,27 @@ set -ex
 [[ "$IN_DOCKER" == "true" ]] && cd taichi
 
 if [[ $OSTYPE == "linux-"* ]]; then
-  if [ ! -d ~/taichi-llvm-15 ]; then
-    pushd ~
-    if [ -f /etc/centos-release ] ; then
-      # FIXIME: prebuilt llvm15 on ubuntu didn't work on manylinux image of centos. Once that's fixed, remove this hack.
-      wget https://github.com/ailzhang/torchhub_example/releases/download/0.3/taichi-llvm-15-linux.zip
-    else
-      wget https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/taichi-llvm-15-linux.zip
+  if [ -z "$AMDGPU_TEST"]; then
+    if [ ! -d ~/taichi-llvm-15 ]; then
+      pushd ~
+      if [ -f /etc/centos-release ] ; then
+        # FIXIME: prebuilt llvm15 on ubuntu didn't work on manylinux image of centos. Once that's fixed, remove this hack.
+        wget https://github.com/ailzhang/torchhub_example/releases/download/0.3/taichi-llvm-15-linux.zip
+      else
+        wget https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/taichi-llvm-15-linux.zip
+      fi
+      unzip taichi-llvm-15-linux.zip && rm taichi-llvm-15-linux.zip
+      popd
     fi
-    unzip taichi-llvm-15-linux.zip && rm taichi-llvm-15-linux.zip
-    popd
+    export LLVM_DIR="$HOME/taichi-llvm-15"
+  else
+    sudo ln -s /usr/bin/clang++-10 /usr/bin/clang++
+    sudo ln -s /usr/bin/clang-10 /usr/bin/clang
+    sudo ln -s /usr/bin/ld.lld-10 /usr/bin/ld.lld
+    export LLVM_DIR="/taichi-llvm-15.0.0-linux"
   fi
 
-  export LLVM_DIR="$HOME/taichi-llvm-15"
+    
 elif [ "$(uname -s):$(uname -m)" == "Darwin:arm64" ]; then
   # The following commands are done manually to save time.
   if [ ! -d ~/taichi-llvm-15-m1 ]; then

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -14,6 +14,11 @@ setup_python
 
 [[ "$IN_DOCKER" == "true" ]] && cd taichi
 
+if ["$AMDGPU_TEST"]; then
+    sudo chmod 666 /dev/kfd
+    sudo chmod 666 /dev/dri/*
+fi
+
 python3 -m pip install dist/*.whl
 if [ -z "$GPU_TEST" ]; then
     python3 -m pip install -r requirements_test.txt
@@ -103,6 +108,9 @@ if [ -z "$GPU_TEST" ]; then
         fi
         python3 tests/run_tests.py -vr2 -t4 -k "not paddle" -a "$TI_WANTED_ARCHS"
     fi
+elif ["$AMDGPU_TEST"]; then
+    run-it cpu    $(nproc)
+    # run-it amdgpu 4
 else
     run-it cuda   8
     run-it cpu    $(nproc)

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -14,7 +14,7 @@ setup_python
 
 [[ "$IN_DOCKER" == "true" ]] && cd taichi
 
-if ["$AMDGPU_TEST"]; then
+if [ ! -z "$AMDGPU_TEST" ]; then
     sudo chmod 666 /dev/kfd
     sudo chmod 666 /dev/dri/*
 fi
@@ -108,7 +108,7 @@ if [ -z "$GPU_TEST" ]; then
         fi
         python3 tests/run_tests.py -vr2 -t4 -k "not paddle" -a "$TI_WANTED_ARCHS"
     fi
-elif ["$AMDGPU_TEST"]; then
+elif [ ! -z "$AMDGPU_TEST" ]; then
     run-it cpu    $(nproc)
     # run-it amdgpu 4
 else

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -272,10 +272,9 @@ jobs:
     name: Build and Test (AMDGPU)
     needs: check_files
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
-    strategy:
-      matrix:
-        tags:
-          - [self-hosted, amdgpu]
+
+    runs-on: [self-hosted, amdgpu]
+
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -305,6 +305,7 @@ jobs:
           TAICHI_CMAKE_ARGS: >-
             -DTI_WITH_VULKAN:BOOL=OFF
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_CUDA:BOOL=OFF
 
       - name: Test
         id: test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -301,7 +301,7 @@ jobs:
           . .github/workflows/scripts/common-utils.sh
 
           ci-docker-run-amdgpu --name taichi-build \
-            registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.2 \
+            registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.3 \
             /home/dev/taichi/.github/workflows/scripts/unix-build.sh
 
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -291,6 +291,9 @@ jobs:
           echo CI_DOCKER_RUN_EXTRA_ARGS="-v $(pwd):/home/dev/taichi" >> $GITHUB_ENV
           sudo chmod 666 /dev/kfd
           sudo chmod 666 /dev/dri/*
+          ln -s /usr/bin/clang++-10 /usr/bin/clang++
+          ln -s /usr/bin/clang-10 /usr/bin/clang
+          ln -s /usr/bin/lld-10 /usr/bin/lld
 
       - name: Build & Install
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -277,7 +277,6 @@ jobs:
         tags:
           - [self-hosted, amdgpu]
 
-    runs-on: ${{ matrix.tags }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -318,7 +317,7 @@ jobs:
              /home/dev/taichi/.github/workflows/scripts/unix_test.sh
         env:
           PY: py38
-          TI_WANTED_ARCHS: 'cc,cpu,amdgpu'
+          TI_WANTED_ARCHS: 'cpu,amdgpu'
           TI_DEVICE_MEMORY_GB: '1'
           TI_RUN_RELEASE_TESTS: '0'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -268,6 +268,77 @@ jobs:
           path: taichi-release-tests/bad-compare/*
           retention-days: 7
 
+  build_and_test_amdgpu_linux:
+    name: Build and Test (AMDGPU)
+    needs: check_files
+    timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
+    strategy:
+      matrix:
+        tags:
+          - [self-hosted, amdgpu]
+
+    runs-on: ${{ matrix.tags }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: '0'
+
+      - name: Prepare Environment
+        run: |
+          . .github/workflows/scripts/common-utils.sh
+          prepare-build-cache
+          echo CI_DOCKER_RUN_EXTRA_ARGS="-v $(pwd):/home/dev/taichi" >> $GITHUB_ENV
+          sudo chmod 666 /dev/kfd
+          sudo chmod 666 /dev/dri/*
+
+      - name: Build & Install
+        run: |
+          [[ ${{needs.check_files.outputs.run_job}} == false ]] && exit 0
+          . .github/workflows/scripts/common-utils.sh
+
+          ci-docker-run-amdgpu --name taichi-build \
+            registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.2 \
+            /home/dev/taichi/.github/workflows/scripts/unix-build.sh
+
+        env:
+          PY: py38
+          PROJECT_NAME: taichi
+          TAICHI_CMAKE_ARGS: >-
+            -DTI_WITH_VULKAN:BOOL=OFF
+            -DTI_BUILD_TESTS:BOOL=ON
+
+      - name: Test
+        id: test
+        run: |
+          [[ ${{needs.check_files.outputs.run_job}} == false ]] && exit 0
+          . .github/workflows/scripts/common-utils.sh
+
+          ci-docker-run-amdgpu --name taichi-test \
+             registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.2 \
+             /home/dev/taichi/.github/workflows/scripts/unix_test.sh
+        env:
+          PY: py38
+          TI_WANTED_ARCHS: 'cc,cpu,amdgpu'
+          TI_DEVICE_MEMORY_GB: '1'
+          TI_RUN_RELEASE_TESTS: '1'
+
+      - name: Save wheel if test failed
+        if: failure() && steps.test.conclusion == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          name: broken-wheel
+          path: dist/*
+          retention-days: 7
+
+      - name: Save Bad Captures
+        if: failure() && steps.test.conclusion == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          name: bad-captures
+          path: taichi-release-tests/bad-compare/*
+          retention-days: 7
+
 
   build_and_test_windows:
     name: Build and Test Windows

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -298,11 +298,6 @@ jobs:
           ci-docker-run-amdgpu --name taichi-build \
             registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.3 \
             /home/dev/taichi/.github/workflows/scripts/unix-build.sh
-          sudo chmod 666 /dev/dri/*
-          sudo chmod 666 /dev/kfd
-          sudo ln -s /usr/bin/clang++-10 /usr/bin/clang++
-          sudo ln -s /usr/bin/clang-10 /usr/bin/clang
-          sudo ln -s /usr/bin/lld-10 /usr/bin/lld
 
         env:
           PY: py38
@@ -318,7 +313,7 @@ jobs:
           . .github/workflows/scripts/common-utils.sh
 
           ci-docker-run-amdgpu --name taichi-test \
-             registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.2 \
+             registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.3 \
              /home/dev/taichi/.github/workflows/scripts/unix_test.sh
         env:
           PY: py38

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -320,7 +320,7 @@ jobs:
           PY: py38
           TI_WANTED_ARCHS: 'cc,cpu,amdgpu'
           TI_DEVICE_MEMORY_GB: '1'
-          TI_RUN_RELEASE_TESTS: '1'
+          TI_RUN_RELEASE_TESTS: '0'
 
       - name: Save wheel if test failed
         if: failure() && steps.test.conclusion == 'failure'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -289,11 +289,6 @@ jobs:
           . .github/workflows/scripts/common-utils.sh
           prepare-build-cache
           echo CI_DOCKER_RUN_EXTRA_ARGS="-v $(pwd):/home/dev/taichi" >> $GITHUB_ENV
-          sudo chmod 666 /dev/kfd
-          sudo chmod 666 /dev/dri/*
-          ln -s /usr/bin/clang++-10 /usr/bin/clang++
-          ln -s /usr/bin/clang-10 /usr/bin/clang
-          ln -s /usr/bin/lld-10 /usr/bin/lld
 
       - name: Build & Install
         run: |
@@ -303,6 +298,11 @@ jobs:
           ci-docker-run-amdgpu --name taichi-build \
             registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.3 \
             /home/dev/taichi/.github/workflows/scripts/unix-build.sh
+          sudo chmod 666 /dev/dri/*
+          sudo chmod 666 /dev/kfd
+          sudo ln -s /usr/bin/clang++-10 /usr/bin/clang++
+          sudo ln -s /usr/bin/clang-10 /usr/bin/clang
+          sudo ln -s /usr/bin/lld-10 /usr/bin/lld
 
         env:
           PY: py38

--- a/ci/Dockerfile.ubuntu.18.04.amdgpu
+++ b/ci/Dockerfile.ubuntu.18.04.amdgpu
@@ -47,7 +47,7 @@ RUN apt-get update && \
 # Install LLVM 15
 WORKDIR /
 # Make sure this URL gets updated each time there is a new prebuilt bin release
-RUN wget https://github.com/GaleSeLee/assets/releases/download/v0.0.1/taichi-llvm-15.0.0-linux.zip
+RUN wget https://github.com/GaleSeLee/assets/releases/download/v0.0.2/taichi-llvm-15.0.0-linux.zip
 RUN unzip taichi-llvm-15.0.0-linux.zip && \
     rm taichi-llvm-15.0.0-linux.zip
 ENV PATH="/taichi-llvm-15.0.0-linux/bin:$PATH"
@@ -57,9 +57,7 @@ ENV CXX="clang++-10"
 
 # Create non-root user for running the container
 RUN useradd -m -s /bin/bash dev && \
-    usermod -a -G video dev && \
-    chmod 666 /dev/kfd && \
-    chmod 666 /dev/dri/*
+    usermod -a -G video dev
 WORKDIR /home/dev
 USER dev
 

--- a/ci/Dockerfile.ubuntu.20.04.amdgpu
+++ b/ci/Dockerfile.ubuntu.20.04.amdgpu
@@ -41,7 +41,7 @@ RUN apt-get update && \
 # Install LLVM 15
 WORKDIR /
 # Make sure this URL gets updated each time there is a new prebuilt bin release
-RUN wget https://github.com/GaleSeLee/assets/releases/download/v0.0.1/taichi-llvm-15.0.0-linux.zip
+RUN wget https://github.com/GaleSeLee/assets/releases/download/v0.0.2/taichi-llvm-15.0.0-linux.zip
 RUN unzip taichi-llvm-15.0.0-linux.zip && \
     rm taichi-llvm-15.0.0-linux.zip
 ENV PATH="/taichi-llvm-15.0.0-linux/bin:$PATH"

--- a/ci/Dockerfile.ubuntu.20.04.amdgpu
+++ b/ci/Dockerfile.ubuntu.20.04.amdgpu
@@ -1,3 +1,6 @@
+// clang++-10 -> clang++ etc
+// assets llvm v0.0.1 -> v0.0.2
+// apt install lld-10
 # Taichi Dockerfile for development
 FROM rocm/dev-ubuntu-20.04:5.2
 


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/6434

### Brief Summary
Add the logic of docker for AMDGPU ci
1. The llvm used which only contains AMDGPU and X86 targets is from docker image
2. Using AMDGPU in docker requires that `/dev/kfd` and the directory `/dev/dri` be mounted on. For `dev` user, there is no permission to access these character devices by default.
3. `TI_WITH_CUDA=OFF`
4. `TI_RUN_RELEASE_TESTS=OFF`
5. Currently only run cpu-relected test
