### PR TITLE
[lang] Get the length of dynamic SNode by x.length()

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -20,7 +20,7 @@ from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field
 from taichi.lang.impl import current_cfg
 from taichi.lang.matrix import Matrix, MatrixType, Vector, is_vector
-from taichi.lang.snode import append, deactivate
+from taichi.lang.snode import append, deactivate, length
 from taichi.lang.struct import Struct, StructType
 from taichi.lang.util import is_taichi_class, to_taichi_type
 from taichi.types import (annotations, ndarray_type, primitive_types,
@@ -781,7 +781,7 @@ class ASTTransformer(Builder):
     @staticmethod
     def build_attribute_if_is_dynamic_snode_method(ctx, node):
         is_subscript = isinstance(node.value, ast.Subscript)
-        names = ("append", "deactivate")
+        names = ("append", "deactivate", "length")
         if node.attr not in names:
             return False
         if is_subscript:
@@ -801,8 +801,10 @@ class ASTTransformer(Builder):
             return False
         if node.attr == "append":
             node.ptr = lambda val: append(x.parent(), indices, val)
-        else:
+        elif node.attr == "deactivate":
             node.ptr = lambda: deactivate(x.parent(), indices)
+        else:
+            node.ptr = lambda: length(x.parent(), indices)
         return True
 
     @staticmethod

--- a/tests/python/test_dynamic_append_length.py
+++ b/tests/python/test_dynamic_append_length.py
@@ -14,7 +14,7 @@ def _test_dynamic_append_length(dt):
             for j in range(i):
                 x[i].append(j)
         for i in range(10):
-            assert (ti.length(x.parent(), i) == i)
+            assert (x[i].length() == i)
             for j in range(i):
                 assert (x[i, j] == j)
 

--- a/tests/python/test_dynamic_attributes.py
+++ b/tests/python/test_dynamic_attributes.py
@@ -21,7 +21,7 @@ def _test_dynamic_attributes(dt):
                 x[i].append(j)
 
         for i in range(n):
-            assert (ti.length(x.parent(), i) == i)
+            assert (x[i].length() == i)
             for j in range(i):
                 assert (x[i, j] == j)
 


### PR DESCRIPTION
Issue: #5420
Just noticed that we forgot to enable getting length of dynamic SNode by `x[i].length()` along with `append` and `deactivate`
### Brief Summary
