### PR TITLE
[Lang] Add deprecation warning for the removal of the packed switch

### DIFF
--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -358,11 +358,14 @@ def init(arch=None,
 
     if "packed" in kwargs:
         if kwargs["packed"] is True:
-            warnings.warn("Currently packed=True is the default setting and the switch will be removed in v1.4.0.",
-                          DeprecationWarning)
+            warnings.warn(
+                "Currently packed=True is the default setting and the switch will be removed in v1.4.0.",
+                DeprecationWarning)
         else:
-            warnings.warn("The automatic padding mode (packed=False) will no longer exist in v1.4.0. The switch will "
-                          "also be removed then. Make sure your code doesn't rely on it.", DeprecationWarning)
+            warnings.warn(
+                "The automatic padding mode (packed=False) will no longer exist in v1.4.0. The switch will "
+                "also be removed then. Make sure your code doesn't rely on it.",
+                DeprecationWarning)
 
     if "default_up" in kwargs:
         raise KeyError(

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -356,6 +356,14 @@ def init(arch=None,
     if require_version is not None:
         check_require_version(require_version)
 
+    if "packed" in kwargs:
+        if kwargs["packed"] is True:
+            warnings.warn("Currently packed=True is the default setting and the switch will be removed in v1.4.0.",
+                          DeprecationWarning)
+        else:
+            warnings.warn("The automatic padding mode (packed=False) will no longer exist in v1.4.0. The switch will "
+                          "also be removed then. Make sure your code doesn't rely on it.", DeprecationWarning)
+
     if "default_up" in kwargs:
         raise KeyError(
             "'default_up' is always the unsigned type of 'default_ip'. Please set 'default_ip' instead."

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -64,11 +64,9 @@ SNode &SNode::create_node(std::vector<Axis> axes,
     } else {
       TI_WARN_IF(
           packed && !bit::is_power_of_two(sizes[i]),
-          "Non-first division of an axis on a SNodeTree path should be a power "
-          "of two to achieve best performance:\n{} We plan to turn this "
-          "warning into an error at v1.4.0. If you do have a use case that "
-          "needs to violate this rule, please submit an issue to notify us.",
-          tb);
+          "Shape {} is detected on non-first division of axis {}:\n{} For "
+          "best performance, we recommend that you set it to a power of two.",
+          sizes[i], char('i' + ind), tb);
     }
     new_node.extractors[ind].activate(
         bit::log2int(bit::least_pot_bound(sizes[i])));

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -108,6 +108,5 @@ def test_deprecated_packed_false():
             DeprecationWarning,
             match=
             r"The automatic padding mode \(packed=False\) will no longer exist in v1.4.0. The switch will "
-            "also be removed then. Make sure your code doesn't rely on it."
-    ):
+            "also be removed then. Make sure your code doesn't rely on it."):
         ti.init(packed=False)

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -92,3 +92,22 @@ def test_deprecate_metal_sparse():
             "Dynamic SNode on metal backend is deprecated and removed in this release."
     ):
         ti.root.dynamic(ti.i, 10)
+
+
+def test_deprecated_packed_true():
+    with pytest.warns(
+            DeprecationWarning,
+            match=
+            "Currently packed=True is the default setting and the switch will be removed in v1.4.0."
+    ):
+        ti.init(packed=True)
+
+
+def test_deprecated_packed_false():
+    with pytest.warns(
+            DeprecationWarning,
+            match=
+            r"The automatic padding mode \(packed=False\) will no longer exist in v1.4.0. The switch will "
+            "also be removed then. Make sure your code doesn't rely on it."
+    ):
+        ti.init(packed=False)


### PR DESCRIPTION
Issue: #6660

### Brief Summary

Apart from the deprecated warning, the previously added limitation that "non-first division on an axis must be a power of two" is now made purely a warning because it can already let users learn the best practice.