### PR TITLE
[build] Initial distributed compiling support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,4 +213,3 @@ if (TI_WITH_GRAPHVIZ)
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,10 @@ if (TI_WITH_BACKTRACE)
   add_subdirectory(external/backward_cpp)
 endif()
 
-include(cmake/Distributed.cmake)
+if (TI_DISTRIBUTED_COMPILE)
+    include(cmake/Distributed.cmake)
+endif()
+
 include(cmake/TaichiCXXFlags.cmake)
 include(cmake/TaichiCore.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ if (TI_WITH_BACKTRACE)
   add_subdirectory(external/backward_cpp)
 endif()
 
+include(cmake/Distributed.cmake)
 include(cmake/TaichiCXXFlags.cmake)
 include(cmake/TaichiCore.cmake)
 
@@ -212,3 +213,4 @@ if (TI_WITH_GRAPHVIZ)
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
 endif()
+

--- a/cmake/Distributed.cmake
+++ b/cmake/Distributed.cmake
@@ -1,0 +1,27 @@
+if (DISTRIBUTED_COMPILE)
+
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "Distruted compiling only supports Clang for now." )
+endif()
+
+message("Enabling distributed compiling quirks")
+
+execute_process(
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND ${CMAKE_CXX_COMPILER} -print-target-triple
+  OUTPUT_VARIABLE TRIPLET
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Essentially cross compiling
+add_compile_options(--target=${TRIPLET})
+
+# False alarm caused by macro expansion
+# if(LSB_SET(x)) => if((x & 1))
+add_compile_options(-Wno-parentheses-equality)
+
+# False alarm caused by macro expansion
+# taichi/python/export_lang.cpp:1241
+# MAKE_SPARSE_MATRIX(32, ColMajor, f)
+add_compile_options(-Wno-self-assign-overloaded)
+
+endif()  # DISTRIBUTED_COMPILE

--- a/cmake/Distributed.cmake
+++ b/cmake/Distributed.cmake
@@ -1,10 +1,8 @@
-if (DISTRIBUTED_COMPILE)
-
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    message(FATAL_ERROR "Distruted compiling only supports Clang for now." )
+    message(FATAL_ERROR "Distributed compiling only supports Clang for now." )
 endif()
 
-message("Enabling distributed compiling quirks")
+message(WARNING "Enabling distributed compiling support, this is experimental and only tested in Taichi's internal CI/CD system, use at your own risk.")
 
 execute_process(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -23,5 +21,3 @@ add_compile_options(-Wno-parentheses-equality)
 # taichi/python/export_lang.cpp:1241
 # MAKE_SPARSE_MATRIX(32, ColMajor, f)
 add_compile_options(-Wno-self-assign-overloaded)
-
-endif()  # DISTRIBUTED_COMPILE


### PR DESCRIPTION
Issue: #6445

### Brief Summary

This PR addresses quirks in `sccache` distributed compiling:

1.  `sccache` would run preprocessing locally (`clang -E`) first and then send the expanded code to remote build server. This can trigger false warnings not present when compiling locally.
2.  Compile host and target can be different, `--target=` must be send to remote build server.