### PR TITLE
[vulkan] Make sure kernel recompiles when texture dtype changes

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -385,7 +385,7 @@ class TaichiCallableTemplateMapper:
             # [Primitive arguments] Return the value
             return arg
         if isinstance(anno, texture_type.TextureType):
-            return arg.num_dims,
+            return arg.num_dims, arg.dtype
         if isinstance(anno, texture_type.RWTextureType):
             # (penguinliong) '0' is the assumed LOD level. We currently don't
             # support mip-mapping.

--- a/tests/python/test_texture.py
+++ b/tests/python/test_texture.py
@@ -88,6 +88,7 @@ def test_texture_compiled_functions():
     texture1 = ti.Texture(ti.Format.r32f, (n1, n1))
     n2 = 256
     texture2 = ti.Texture(ti.Format.r32f, (n2, n2))
+    texture3 = ti.Texture(ti.Format.r8, (n1, n1))
 
     make_texture_2d(texture1, n1)
     assert impl.get_runtime().get_num_compiled_functions() == 1
@@ -95,11 +96,17 @@ def test_texture_compiled_functions():
     make_texture_2d(texture2, n2)
     assert impl.get_runtime().get_num_compiled_functions() == 1
 
-    paint(0.1, texture1, n1)
+    make_texture_2d(texture3, n1)
     assert impl.get_runtime().get_num_compiled_functions() == 2
 
+    paint(0.1, texture1, n1)
+    assert impl.get_runtime().get_num_compiled_functions() == 3
+
     paint(0.2, texture2, n2)
-    assert impl.get_runtime().get_num_compiled_functions() == 2
+    assert impl.get_runtime().get_num_compiled_functions() == 3
+
+    paint(0.3, texture3, n1)
+    assert impl.get_runtime().get_num_compiled_functions() == 4
 
 
 @test_utils.test(arch=supported_archs_texture_excluding_load_store)


### PR DESCRIPTION
Issue: #

### Brief Summary
As discussed with @PENGUINLIONG offline, kernel should recompile when `dtype & num_dimension` changes. Note currently `rwtexture` also recompiles if `num_channels` change, I didn't remove that in this PR.