### PR TITLE
[bug] MatrixType bug fix: Fix error with quant

### DIFF
--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -226,7 +226,9 @@ class Scalarize : public BasicStmtVisitor {
   void visit(BinaryOpStmt *stmt) override {
     auto lhs_dtype = stmt->lhs->ret_type;
     auto rhs_dtype = stmt->rhs->ret_type;
-    if (lhs_dtype->is<TensorType>() && rhs_dtype->is<TensorType>()) {
+    if (lhs_dtype->is<TensorType>() || rhs_dtype->is<TensorType>()) {
+      // Make sure broadcasting has been correctly applied by BinaryOpStmt::type_check()
+      TI_ASSERT(lhs_dtype->is<TensorType>() && rhs_dtype->is<TensorType>());
       // Scalarization for LoadStmt should have already replaced both operands
       // to MatrixInitStmt
       TI_ASSERT(stmt->lhs->is<MatrixInitStmt>());
@@ -317,7 +319,9 @@ class Scalarize : public BasicStmtVisitor {
   void visit(AtomicOpStmt *stmt) override {
     auto dest_dtype = stmt->dest->ret_type.ptr_removed();
     auto val_dtype = stmt->val->ret_type;
-    if (dest_dtype->is<TensorType>() && val_dtype->is<TensorType>()) {
+    if (dest_dtype->is<TensorType>() || val_dtype->is<TensorType>()) {
+      // Make sure broadcasting has been correctly applied by AtomicOpStmt::type_check()
+      TI_ASSERT(dest_dtype->is<TensorType>() && val_dtype->is<TensorType>());
       // AtomicOpExpression::type_check() have taken care of the broadcasting,
       // but the type conversions are delayed until irpass::type_check().
       // So we only check for the shape here.

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -409,7 +409,8 @@ class Scalarize : public BasicStmtVisitor {
         op3_dtype->is<TensorType>()) {
       // Make sure broadcasting has been correctly applied by
       // TernaryOpExpression::type_check().
-      TI_ASSERT(cond_dtype->is<TensorType>() && op2_dtype->is<TensorType>() && op3_dtype->is<TensorType>());
+      TI_ASSERT(cond_dtype->is<TensorType>() && op2_dtype->is<TensorType>() &&
+                op3_dtype->is<TensorType>());
       // However, since the type conversions are delayed until
       // irpass::type_check(), we only check for the shape here.
       TI_ASSERT(cond_dtype.get_shape() == op2_dtype.get_shape());

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -227,7 +227,8 @@ class Scalarize : public BasicStmtVisitor {
     auto lhs_dtype = stmt->lhs->ret_type;
     auto rhs_dtype = stmt->rhs->ret_type;
     if (lhs_dtype->is<TensorType>() || rhs_dtype->is<TensorType>()) {
-      // Make sure broadcasting has been correctly applied by BinaryOpStmt::type_check()
+      // Make sure broadcasting has been correctly applied by
+      // BinaryOpStmt::type_check()
       TI_ASSERT(lhs_dtype->is<TensorType>() && rhs_dtype->is<TensorType>());
       // Scalarization for LoadStmt should have already replaced both operands
       // to MatrixInitStmt
@@ -320,7 +321,8 @@ class Scalarize : public BasicStmtVisitor {
     auto dest_dtype = stmt->dest->ret_type.ptr_removed();
     auto val_dtype = stmt->val->ret_type;
     if (dest_dtype->is<TensorType>() || val_dtype->is<TensorType>()) {
-      // Make sure broadcasting has been correctly applied by AtomicOpStmt::type_check()
+      // Make sure broadcasting has been correctly applied by
+      // AtomicOpStmt::type_check()
       TI_ASSERT(dest_dtype->is<TensorType>() && val_dtype->is<TensorType>());
       // AtomicOpExpression::type_check() have taken care of the broadcasting,
       // but the type conversions are delayed until irpass::type_check().

--- a/tests/python/test_quant_atomics.py
+++ b/tests/python/test_quant_atomics.py
@@ -43,9 +43,7 @@ def test_quant_int_atomics():
     assert z[None] == 3
 
 
-@test_utils.test(require=[ti.extension.quant_basic, ti.extension.data64],
-                 debug=True)
-def test_quant_int_atomics_b64():
+def _test_quant_int_atomics_b64():
     qi13 = ti.types.quant.int(13, True)
 
     x = ti.field(dtype=qi13)
@@ -68,8 +66,19 @@ def test_quant_int_atomics_b64():
     assert x[2] == 315
 
 
-@test_utils.test(require=ti.extension.quant_basic, debug=True)
-def test_quant_fixed_atomics():
+@test_utils.test(require=[ti.extension.quant_basic, ti.extension.data64],
+                 debug=True)
+def test_quant_int_atomics_b64():
+    _test_quant_int_atomics_b64()
+
+
+@test_utils.test(require=[ti.extension.quant_basic, ti.extension.data64],
+                 debug=True, real_matrix=True, real_matrix_scalarize=True)
+def test_quant_int_atomics_b64_real_matrix_scalarize():
+    _test_quant_int_atomics_b64()
+
+
+def _test_quant_fixed_atomics():
     qfxt13 = ti.types.quant.fixed(bits=13, signed=True, scale=0.1)
     qfxt19 = ti.types.quant.fixed(bits=19, signed=False, scale=0.1)
 
@@ -91,3 +100,13 @@ def test_quant_fixed_atomics():
     foo()
     assert x[None] == approx(-3.3)
     assert y[None] == approx(1124.4)
+
+
+@test_utils.test(require=ti.extension.quant_basic, debug=True)
+def test_quant_fixed_atomics():
+    _test_quant_fixed_atomics()
+
+
+@test_utils.test(require=ti.extension.quant_basic, debug=True, real_matrix=True, real_matrix_scalarize=True)
+def test_quant_fixed_atomics_real_matrix_scalarize():
+    _test_quant_fixed_atomics()

--- a/tests/python/test_quant_atomics.py
+++ b/tests/python/test_quant_atomics.py
@@ -73,7 +73,9 @@ def test_quant_int_atomics_b64():
 
 
 @test_utils.test(require=[ti.extension.quant_basic, ti.extension.data64],
-                 debug=True, real_matrix=True, real_matrix_scalarize=True)
+                 debug=True,
+                 real_matrix=True,
+                 real_matrix_scalarize=True)
 def test_quant_int_atomics_b64_real_matrix_scalarize():
     _test_quant_int_atomics_b64()
 
@@ -107,6 +109,9 @@ def test_quant_fixed_atomics():
     _test_quant_fixed_atomics()
 
 
-@test_utils.test(require=ti.extension.quant_basic, debug=True, real_matrix=True, real_matrix_scalarize=True)
+@test_utils.test(require=ti.extension.quant_basic,
+                 debug=True,
+                 real_matrix=True,
+                 real_matrix_scalarize=True)
 def test_quant_fixed_atomics_real_matrix_scalarize():
     _test_quant_fixed_atomics()


### PR DESCRIPTION
Issue: #5819

### Brief Summary

Quant types are not primitive types, so we should not make assertions that types only contain primitive types and tensor type. We just need to trigger scalarization when all the operands have `TensorType`.