### PR TITLE
[lang] Use less gpu memory when building sparse matrix

### DIFF
--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -156,7 +156,8 @@ std::unique_ptr<SparseMatrix> SparseMatrixBuilder::build_cuda() {
   built_ = true;
   auto sm = make_cu_sparse_matrix(rows_, cols_, dtype_);
 #ifdef TI_WITH_CUDA
-  num_triplets_ = ndarray_data_base_ptr_->read_int(std::vector<int>{0});
+  CUDADriver::get_instance().memcpy_device_to_host(
+      &num_triplets_, (void *)get_ndarray_data_ptr(), sizeof(int));
   auto len = 3 * num_triplets_ + 1;
   std::vector<float32> trips(len);
   CUDADriver::get_instance().memcpy_device_to_host(


### PR DESCRIPTION
Issue: #2906 

### Brief Summary
The `read_int` function of ndarray consumes more than 100M gpu memory. It's better to use `memcpy_device_to_host` function to obtain `num_triplets_`.