### PR TITLE
[vulkan] Deprecate num_channels and channel_format args in rw_texture type annotation

### DIFF
--- a/python/taichi/lang/_texture.py
+++ b/python/taichi/lang/_texture.py
@@ -1,7 +1,6 @@
 import numpy as np
 from taichi._lib import core as _ti_core
 from taichi.lang import impl
-from taichi.lang.enums import Format
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.matrix import Matrix
 from taichi.lang.util import taichi_scope

--- a/python/taichi/lang/_texture.py
+++ b/python/taichi/lang/_texture.py
@@ -1,11 +1,11 @@
 import numpy as np
 from taichi._lib import core as _ti_core
 from taichi.lang import impl
-from taichi.lang.enums import Format
 from taichi.lang.expr import Expr
 from taichi.lang.util import taichi_scope
 from taichi.types import vector
-from taichi.types.primitive_types import f16, f32, i8, i16, i32, u8, u16, u32
+from taichi.types.primitive_types import f32, u8
+from taichi.types.texture_type import FORMAT2TY_CH
 
 
 class TextureSampler:
@@ -138,53 +138,11 @@ class RWTextureAccessor:
         return self.ptr_expr
 
 
-FORMAT2TY_CH = {
-    Format.r8: (u8, 1),
-    Format.r8u: (u8, 1),
-    Format.r8i: (i8, 1),
-    Format.rg8: (u8, 2),
-    Format.rg8u: (u8, 2),
-    Format.rg8i: (i8, 2),
-    Format.rgba8: (u8, 4),
-    Format.rgba8u: (u8, 4),
-    Format.rgba8i: (i8, 4),
-    Format.r16: (u16, 1),
-    Format.r16u: (u16, 1),
-    Format.r16i: (i16, 1),
-    Format.r16f: (f16, 1),
-    Format.rg16: (u16, 2),
-    Format.rg16u: (u16, 2),
-    Format.rg16i: (i16, 2),
-    Format.rg16f: (f16, 2),
-    Format.rgb16: (u16, 3),
-    Format.rgb16u: (u16, 3),
-    Format.rgb16i: (i16, 3),
-    Format.rgb16f: (f16, 3),
-    Format.rgba16: (u16, 4),
-    Format.rgba16u: (u16, 4),
-    Format.rgba16i: (i16, 4),
-    Format.rgba16f: (f16, 4),
-    Format.r32u: (u32, 1),
-    Format.r32i: (i32, 1),
-    Format.r32f: (f32, 1),
-    Format.rg32u: (u32, 2),
-    Format.rg32i: (i32, 2),
-    Format.rg32f: (f32, 2),
-    Format.rgb32u: (u32, 3),
-    Format.rgb32i: (i32, 3),
-    Format.rgb32f: (f32, 3),
-    Format.rgba32u: (u32, 4),
-    Format.rgba32i: (i32, 4),
-    Format.rgba32f: (f32, 4),
-}
-
-
 class Texture:
     """Taichi Texture class.
 
     Args:
-        dtype (DataType): Data type of each value.
-        num_channels (int): Number of channels in texture
+        fmt (ti.Format): Color format of the texture.
         shape (Tuple[int]): Shape of the Texture.
     """
     def __init__(self, fmt, arr_shape):

--- a/python/taichi/types/texture_type.py
+++ b/python/taichi/types/texture_type.py
@@ -1,3 +1,48 @@
+from taichi.lang.enums import Format
+from taichi.types.primitive_types import f16, f32, i8, i16, i32, u8, u16, u32
+
+FORMAT2TY_CH = {
+    Format.r8: (u8, 1),
+    Format.r8u: (u8, 1),
+    Format.r8i: (i8, 1),
+    Format.rg8: (u8, 2),
+    Format.rg8u: (u8, 2),
+    Format.rg8i: (i8, 2),
+    Format.rgba8: (u8, 4),
+    Format.rgba8u: (u8, 4),
+    Format.rgba8i: (i8, 4),
+    Format.r16: (u16, 1),
+    Format.r16u: (u16, 1),
+    Format.r16i: (i16, 1),
+    Format.r16f: (f16, 1),
+    Format.rg16: (u16, 2),
+    Format.rg16u: (u16, 2),
+    Format.rg16i: (i16, 2),
+    Format.rg16f: (f16, 2),
+    Format.rgb16: (u16, 3),
+    Format.rgb16u: (u16, 3),
+    Format.rgb16i: (i16, 3),
+    Format.rgb16f: (f16, 3),
+    Format.rgba16: (u16, 4),
+    Format.rgba16u: (u16, 4),
+    Format.rgba16i: (i16, 4),
+    Format.rgba16f: (f16, 4),
+    Format.r32u: (u32, 1),
+    Format.r32i: (i32, 1),
+    Format.r32f: (f32, 1),
+    Format.rg32u: (u32, 2),
+    Format.rg32i: (i32, 2),
+    Format.rg32f: (f32, 2),
+    Format.rgb32u: (u32, 3),
+    Format.rgb32i: (i32, 3),
+    Format.rgb32f: (f32, 3),
+    Format.rgba32u: (u32, 4),
+    Format.rgba32i: (i32, 4),
+    Format.rgba32f: (f32, 4),
+}
+import warnings
+
+
 class TextureType:
     """Type annotation for Textures.
 
@@ -15,12 +60,24 @@ class RWTextureType:
         num_dimensions (int): Number of dimensions. For examples for a 2D texture this should be `2`.
         num_channels (int): Number of channels in the texture.
         channel_format (DataType): Data type of texture
-        log (float): Specifies the explicit level-of-detail.
+        lod (float): Specifies the explicit level-of-detail.
+        fmt (ti.Format): Color format of texture
     """
-    def __init__(self, num_dimensions, num_channels, channel_format, lod):
+    def __init__(self,
+                 num_dimensions,
+                 num_channels=None,
+                 channel_format=None,
+                 lod=0,
+                 fmt=None):
         self.num_dimensions = num_dimensions
-        self.num_channels = num_channels
-        self.channel_format = channel_format
+        if fmt is None:
+            warnings.warn(
+                "Specifying num_channels and channel_format is deprecated and will be removed in v1.5.0, please specify fmt instead.",
+                DeprecationWarning)
+            self.num_channels = num_channels
+            self.channel_format = channel_format
+        else:
+            self.num_channels, self.channel_format = FORMAT2TY_CH[fmt]
         self.lod = lod
 
 

--- a/tests/cpp/aot/python_scripts/texture_aot_test.py
+++ b/tests/cpp/aot/python_scripts/texture_aot_test.py
@@ -12,8 +12,7 @@ def compile_graph_aot(arch):
 
     @ti.kernel
     def run0(rw_tex: ti.types.rw_texture(num_dimensions=2,
-                                         num_channels=1,
-                                         channel_format=ti.f32,
+                                         fmt=ti.Format.r32f,
                                          lod=0)):
         for i, j in ti.ndrange(128, 128):
             value = ti.cast((j * 129 + i) % 2, ti.f32)
@@ -22,8 +21,7 @@ def compile_graph_aot(arch):
     @ti.kernel
     def run1(tex: ti.types.texture(num_dimensions=2),
              rw_tex: ti.types.rw_texture(num_dimensions=2,
-                                         num_channels=1,
-                                         channel_format=ti.f32,
+                                         fmt=ti.Format.r32f,
                                          lod=0)):
         for i, j in ti.ndrange(128, 128):
             value = tex.fetch(ti.Vector([i, j]), 0).x

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -110,3 +110,23 @@ def test_deprecated_packed_false():
             r"The automatic padding mode \(packed=False\) will no longer exist in v1.4.0. The switch will "
             "also be removed then. Make sure your code doesn't rely on it."):
         ti.init(packed=False)
+
+
+@test_utils.test(arch=ti.vulkan)
+def test_deprecated_rwtexture_type():
+    n = 128
+
+    with pytest.warns(
+            DeprecationWarning,
+            match=
+            r"Specifying num_channels and channel_format is deprecated and will be removed in v1.5.0, please specify fmt instead"
+    ):
+
+        @ti.kernel
+        def ker(tex: ti.types.rw_texture(num_dimensions=2,
+                                         num_channels=1,
+                                         channel_format=ti.f32,
+                                         lod=0)):
+            for i, j in ti.ndrange(n, n):
+                ret = ti.cast(1, ti.f32)
+                tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))

--- a/tests/python/test_ggui.py
+++ b/tests/python/test_ggui.py
@@ -282,8 +282,7 @@ def test_set_image_with_texture():
 
     @ti.kernel
     def init_img(img: ti.types.rw_texture(num_dimensions=2,
-                                          num_channels=4,
-                                          channel_format=ti.f32,
+                                          fmt=ti.Format.rgba32f,
                                           lod=0)):
         for i, j in ti.ndrange(512, 512):
             img.store(ti.Vector([i, j]),

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -355,8 +355,7 @@ def test_texture():
 
     @ti.kernel
     def make_texture(tex: ti.types.rw_texture(num_dimensions=2,
-                                              num_channels=1,
-                                              channel_format=ti.f32,
+                                              fmt=ti.Format.r32f,
                                               lod=0)):
         for i, j in ti.ndrange(128, 128):
             tex.store(ti.Vector([i, j]), ti.Vector([0.1, 0.0, 0.0, 0.0]))
@@ -458,8 +457,7 @@ def test_texture_struct_for():
 
     @ti.kernel
     def write(tex: ti.types.rw_texture(num_dimensions=2,
-                                       num_channels=1,
-                                       channel_format=ti.f32,
+                                       fmt=ti.Format.r32f,
                                        lod=0)):
         for i, j in tex:
             tex.store(ti.Vector([i, j]), ti.Vector([1.0, 0.0, 0.0, 0.0]))

--- a/tests/python/test_texture.py
+++ b/tests/python/test_texture.py
@@ -46,8 +46,7 @@ def taichi_logo(pos: ti.template(), scale: float = 1 / 1.11):
 
 @ti.kernel
 def make_texture_2d(tex: ti.types.rw_texture(
-    num_dimensions=2, num_channels=1, channel_format=ti.f32, lod=0), n: ti.i32
-                    ):
+    num_dimensions=2, fmt=ti.Format.r32f, lod=0), n: ti.i32):
     for i, j in ti.ndrange(n, n):
         ret = ti.cast(taichi_logo(ti.Vector([i, j]) / n), ti.f32)
         tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))
@@ -55,8 +54,7 @@ def make_texture_2d(tex: ti.types.rw_texture(
 
 @ti.kernel
 def make_texture_3d(tex: ti.types.rw_texture(
-    num_dimensions=3, num_channels=1, channel_format=ti.f32, lod=0), n: ti.i32
-                    ):
+    num_dimensions=3, fmt=ti.Format.r32f, lod=0), n: ti.i32):
     for i, j, k in ti.ndrange(n, n, n):
         div = ti.cast(i / n, ti.f32)
         if div > 0.5:
@@ -168,8 +166,7 @@ def test_rw_texture_2d_struct_for():
 
     @ti.kernel
     def write(tex: ti.types.rw_texture(num_dimensions=2,
-                                       num_channels=1,
-                                       channel_format=ti.f32,
+                                       fmt=ti.Format.r32f,
                                        lod=0)):
         for i, j in tex:
             tex.store(ti.Vector([i, j]), ti.Vector([1.0, 0.0, 0.0, 0.0]))
@@ -190,8 +187,7 @@ def test_rw_texture_2d_struct_for_dim_check():
 
     @ti.kernel
     def write(tex: ti.types.rw_texture(num_dimensions=2,
-                                       num_channels=1,
-                                       channel_format=ti.f32,
+                                       fmt=ti.Format.r32f,
                                        lod=0)):
         for i, j in tex:
             tex.store(ti.Vector([i, j]), ti.Vector([1.0, 0.0, 0.0, 0.0]))


### PR DESCRIPTION

Issue: #

### Brief Summary
#6338 added a way to specify fmt (`ti.Format`) which is more expressive and easier to understand than the combo of `num_channels + channel_format` so let's deprecate them to avoid confuse users. 
