### PR TITLE
[misc] Remove the default potential_bug label on bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug Report
 about: Create a report to help us improve
 title: ''
-labels: potential bug
 assignees: ''
 
 ---


### PR DESCRIPTION
Issue: #

### Brief Summary
Unlike other issue templates, bug report issues can be very diverse and `potential bug` label isn't that helpful. We'd rather assign a proper label manually or make it more automatic in the future. 