### PR TITLE
[vulkan] Support rw_texture in aot add_kernel

### DIFF
--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -89,7 +89,11 @@ def produce_injected_args(kernel, symbolic_args=None):
                                   shape=(2, ) * ndim))
             else:
                 raise RuntimeError('')
-        elif isinstance(anno, (TextureType, RWTextureType)):
+        elif isinstance(anno, RWTextureType):
+            texture_shape = (2, ) * anno.num_dimensions
+            fmt = anno.fmt
+            injected_args.append(Texture(fmt, texture_shape))
+        elif isinstance(anno, TextureType):
             if symbolic_args is None:
                 raise RuntimeError(
                     'Texture type annotation doesn\'t have enough information for aot. Please either specify the channel_format, shape and num_channels in the graph arg declaration.'

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -650,3 +650,18 @@ def test_module_arch_fallback():
             r'AOT compilation to a different arch than the current one is not yet supported, switching'
     ):
         m = ti.aot.Module(ti.cpu)
+
+
+@test_utils.test(arch=[ti.vulkan])
+def test_save_kernel_with_rwtexture():
+    @ti.kernel
+    def write(tex: ti.types.rw_texture(num_dimensions=2,
+                                       fmt=ti.Format.r32f,
+                                       lod=0)):
+        for i, j in tex:
+            tex.store(ti.Vector([i, j]), ti.Vector([1.0, 0.0, 0.0, 0.0]))
+
+    m = ti.aot.Module()
+    m.add_kernel(write)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        m.save(tmpdir)

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -130,3 +130,45 @@ def test_deprecated_rwtexture_type():
             for i, j in ti.ndrange(n, n):
                 ret = ti.cast(1, ti.f32)
                 tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))
+
+
+@test_utils.test(arch=ti.vulkan)
+def test_incomplete_info_rwtexture():
+    n = 128
+
+    with pytest.raises(
+            ti.TaichiCompilationError,
+            match=r"Incomplete type info for rw_texture, please specify its fmt"
+    ):
+
+        @ti.kernel
+        def ker(tex: ti.types.rw_texture(num_dimensions=2,
+                                         channel_format=ti.f32,
+                                         lod=0)):
+            for i, j in ti.ndrange(n, n):
+                ret = ti.cast(1, ti.f32)
+                tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))
+
+    with pytest.raises(
+            ti.TaichiCompilationError,
+            match=r"Incomplete type info for rw_texture, please specify its fmt"
+    ):
+
+        @ti.kernel
+        def ker(tex: ti.types.rw_texture(num_dimensions=2,
+                                         num_channels=2,
+                                         lod=0)):
+            for i, j in ti.ndrange(n, n):
+                ret = ti.cast(1, ti.f32)
+                tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))
+
+    with pytest.raises(
+            ti.TaichiCompilationError,
+            match=r"Incomplete type info for rw_texture, please specify its fmt"
+    ):
+
+        @ti.kernel
+        def ker(tex: ti.types.rw_texture(num_dimensions=2, lod=0)):
+            for i, j in ti.ndrange(n, n):
+                ret = ti.cast(1, ti.f32)
+                tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))


### PR DESCRIPTION
Issue: #

### Brief Summary
https://github.com/taichi-dev/taichi/pull/6782 accidentally makes `channel_format/num_channels` optional and this PR fixes it by throwing an error if none of
`channel_format/num_channels/fmt` is specified.

Note `rw_texture` isn't a template type (yet) so it's okay to just compile it directly with its type hint.

TODO: support `ti.types.texture()` in add_kernel