### PR TITLE
[misc] Remove usage of deprecated num_channels/channel_format type hint in rw_texture in codebase

### DIFF
--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -2,6 +2,7 @@ from taichi._funcs import field_fill_taichi_scope
 from taichi._lib.utils import get_os_name
 from taichi.lang import ops
 from taichi.lang._ndrange import ndrange
+from taichi.lang.enums import Format
 from taichi.lang.expr import Expr
 from taichi.lang.field import ScalarField
 from taichi.lang.impl import grouped, static, static_assert
@@ -256,8 +257,7 @@ def snode_deactivate_dynamic(b: template()):
 
 @kernel
 def load_texture_from_numpy(tex: texture_type.rw_texture(num_dimensions=2,
-                                                         num_channels=4,
-                                                         channel_format=u8,
+                                                         fmt=Format.rgba8u,
                                                          lod=0),
                             img: ndarray_type.ndarray(dtype=vec3, ndim=2)):
     for i, j in img:
@@ -269,8 +269,7 @@ def load_texture_from_numpy(tex: texture_type.rw_texture(num_dimensions=2,
 
 @kernel
 def save_texture_to_numpy(tex: texture_type.rw_texture(num_dimensions=2,
-                                                       num_channels=4,
-                                                       channel_format=u8,
+                                                       fmt=Format.rgba8u,
                                                        lod=0),
                           img: ndarray_type.ndarray(dtype=vec3, ndim=2)):
     for i, j in img:

--- a/python/taichi/examples/graph/texture_graph.py
+++ b/python/taichi/examples/graph/texture_graph.py
@@ -13,8 +13,7 @@ texture = ti.Texture(ti.Format.r32f, (128, 128))
 
 @ti.kernel
 def make_texture(tex: ti.types.rw_texture(num_dimensions=2,
-                                          num_channels=1,
-                                          channel_format=ti.f32,
+                                          fmt=ti.Format.r32f,
                                           lod=0)):
     for i, j in ti.ndrange(128, 128):
         ret = ti.cast(taichi_logo(ti.Vector([i, j]) / 128), ti.f32)

--- a/python/taichi/examples/rendering/simple_texture.py
+++ b/python/taichi/examples/rendering/simple_texture.py
@@ -13,8 +13,7 @@ texture = ti.Texture(ti.Format.r32f, (k, k))
 
 @ti.kernel
 def make_texture(tex: ti.types.rw_texture(
-    num_dimensions=2, num_channels=1, channel_format=ti.f32, lod=0), n: ti.i32
-                 ):
+    num_dimensions=2, fmt=ti.Format.r32f, lod=0), n: ti.i32):
     for i, j in ti.ndrange(n, n):
         ret = ti.cast(taichi_logo(ti.Vector([i, j]) / n), ti.f32)
         tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))


### PR DESCRIPTION

Issue: discovered by #6630, thanks @neozhaoliang !

### Brief Summary
`num_channels/channel_format` will be deprecated in #6782  so let's remove them in the user facing codebase to suppress warnings. 