### PR TITLE
[vulkan] Support texture type args in aot add_kernel

### DIFF
--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -665,3 +665,20 @@ def test_save_kernel_with_rwtexture():
     m.add_kernel(write)
     with tempfile.TemporaryDirectory() as tmpdir:
         m.save(tmpdir)
+
+
+@test_utils.test(arch=[ti.vulkan])
+def test_read_kernel_with_texture():
+    @ti.kernel
+    def read(tex: ti.types.texture(num_dimensions=2), arr: ti.types.ndarray()):
+        for i, j in arr:
+            arr[i, j] = tex.fetch(ti.Vector([i, j]), 0).x
+
+    res = (128, 128)
+    tex = ti.Texture(ti.Format.r32f, res)
+    arr = ti.ndarray(ti.f32, res)
+
+    m = ti.aot.Module()
+    m.add_kernel(read, template_args={"tex": tex, "arr": arr})
+    with tempfile.TemporaryDirectory() as tmpdir:
+        m.save(tmpdir)


### PR DESCRIPTION
Issue: #

### Brief Summary
`ti.types.texture` has been a template type so I didn't change that in this PR. But in the future `TextureType` may support args other than `num_dimensions` so that users can provide all necessary info in the type hint. But that's out of scope for this PR.

This PR just added support for texture type args in aot `add_kernel` so that it can be used in AOT without cgraph, and it worth noticing that you're currently required to provide a template_args for texture type. But since we require enough info in rw_texture type annotation, you don't need to provide any template_args for rw_texture type. 