### PR TITLE
[Bug] Avoid overwriting global tmp with dynamic_index=True

### DIFF
--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -535,7 +535,8 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
       auto const_zero_stmt = replacement.push_back<ConstStmt>(zero);
       stmt_to_offloaded_[const_zero_stmt] = offloaded;
       for (int i = 0; i < tensor_type->get_num_elements(); ++i) {
-        auto const_offset_stmt = replacement.push_back<ConstStmt>(TypedConstant(i));
+        auto const_offset_stmt =
+            replacement.push_back<ConstStmt>(TypedConstant(i));
         auto ptr_offset_stmt =
             replacement.push_back<MatrixPtrStmt>(ptr, const_offset_stmt);
         auto global_store_stmt = replacement.push_back<GlobalStoreStmt>(

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -535,9 +535,7 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
       auto const_zero_stmt = replacement.push_back<ConstStmt>(zero);
       stmt_to_offloaded_[const_zero_stmt] = offloaded;
       for (int i = 0; i < tensor_type->get_num_elements(); ++i) {
-        TypedConstant offset(i *
-                             data_type_size(tensor_type->get_element_type()));
-        auto const_offset_stmt = replacement.push_back<ConstStmt>(offset);
+        auto const_offset_stmt = replacement.push_back<ConstStmt>(TypedConstant(i));
         auto ptr_offset_stmt =
             replacement.push_back<MatrixPtrStmt>(ptr, const_offset_stmt);
         auto global_store_stmt = replacement.push_back<GlobalStoreStmt>(

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -1211,7 +1211,9 @@ def test_vector_transpose():
         foo()
 
 
-@test_utils.test(require=ti.extension.dynamic_index, dynamic_index=True, debug=True)
+@test_utils.test(require=ti.extension.dynamic_index,
+                 dynamic_index=True,
+                 debug=True)
 def test_global_tmp_overwrite():
     # https://github.com/taichi-dev/taichi/issues/6663
     @ti.kernel

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -1217,7 +1217,7 @@ def test_vector_transpose():
 def test_global_tmp_overwrite():
     # https://github.com/taichi-dev/taichi/issues/6663
     @ti.kernel
-    def foo():
+    def foo() -> ti.i32:
         p = ti.Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
         loop = 1
         sig = ti.Vector([0, 0, 0, 0])
@@ -1228,6 +1228,6 @@ def test_global_tmp_overwrite():
             p[0, 0] = -1
         for i in range(1):
             sig[i] = 2
-        print(sig, p)
+        return sig.sum() + p.sum()
 
-    foo()
+    assert foo() == 4

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -1209,3 +1209,23 @@ def test_vector_transpose():
             r"`transpose\(\)` cannot apply to a vector. If you want something like `a @ b.transpose\(\)`, write `a.outer_product\(b\)` instead."
     ):
         foo()
+
+
+@test_utils.test(require=ti.extension.dynamic_index, dynamic_index=True, debug=True)
+def test_global_tmp_overwrite():
+    # https://github.com/taichi-dev/taichi/issues/6663
+    @ti.kernel
+    def foo():
+        p = ti.Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+        loop = 1
+        sig = ti.Vector([0, 0, 0, 0])
+        assert p[0, 0] == 1
+        while loop == 1:
+            assert p[0, 0] == 1
+            loop = 0
+            p[0, 0] = -1
+        for i in range(1):
+            sig[i] = 2
+        print(sig, p)
+
+    foo()


### PR DESCRIPTION
Issue: fix #6663

### Brief Summary

In `MatrixPtrStmt`, when `origin` is `GlobalTemporaryStmt`, the semantics of `offset` has changed from the number of bytes to the number of elements. This PR fixes the outdated usage which may overwrite the global tmp buffer.