### PR TITLE
[Lang] Warn users if ndarray size is out of int32 boundary

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -655,8 +655,11 @@ class Kernel:
                     # so that it only holds "real" array shapes.
                     is_soa = needed.layout == Layout.SOA
                     array_shape = v.shape
-                    if functools.reduce(operator.mul, array_shape) > np.iinfo(np.int32).max:
-                        warnings.warn("Ndarray index might be out of int32 boundary but int64 indexing is not supported yet.")
+                    if functools.reduce(operator.mul, array_shape) > np.iinfo(
+                            np.int32).max:
+                        warnings.warn(
+                            "Ndarray index might be out of int32 boundary but int64 indexing is not supported yet."
+                        )
                     if needed.dtype is None or id(
                             needed.dtype) in primitive_types.type_ids:
                         element_dim = 0

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -655,8 +655,8 @@ class Kernel:
                     # so that it only holds "real" array shapes.
                     is_soa = needed.layout == Layout.SOA
                     array_shape = v.shape
-                    if functools.reduce(operator.mul, array_shape, 1) > np.iinfo(
-                            np.int32).max:
+                    if functools.reduce(operator.mul, array_shape,
+                                        1) > np.iinfo(np.int32).max:
                         warnings.warn(
                             "Ndarray index might be out of int32 boundary but int64 indexing is not supported yet."
                         )

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -1,9 +1,11 @@
 import ast
 import functools
 import inspect
+import operator
 import re
 import sys
 import textwrap
+import warnings
 import weakref
 
 import numpy as np
@@ -653,6 +655,8 @@ class Kernel:
                     # so that it only holds "real" array shapes.
                     is_soa = needed.layout == Layout.SOA
                     array_shape = v.shape
+                    if functools.reduce(operator.mul, array_shape) > np.iinfo(np.int32).max:
+                        warnings.warn("Ndarray index might be out of int32 boundary but int64 indexing is not supported yet.")
                     if needed.dtype is None or id(
                             needed.dtype) in primitive_types.type_ids:
                         element_dim = 0

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -655,7 +655,7 @@ class Kernel:
                     # so that it only holds "real" array shapes.
                     is_soa = needed.layout == Layout.SOA
                     array_shape = v.shape
-                    if functools.reduce(operator.mul, array_shape) > np.iinfo(
+                    if functools.reduce(operator.mul, array_shape, 1) > np.iinfo(
                             np.int32).max:
                         warnings.warn(
                             "Ndarray index might be out of int32 boundary but int64 indexing is not supported yet."

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -51,7 +51,10 @@ Ndarray::Ndarray(Program *prog,
     total_shape_.insert(total_shape_.begin(), element_shape.begin(),
                         element_shape.end());
   }
-
+  auto total_num_scalar = std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL, std::multiplies<>());
+  if (total_num_scalar > std::numeric_limits<int>::max()) {
+    TI_WARN("Ndarray index might be out of int32 boundary but int64 indexing is not supported yet.");
+  }
   ndarray_alloc_ = prog->allocate_memory_ndarray(nelement_ * element_size_,
                                                  prog->result_buffer);
 }
@@ -83,6 +86,10 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
   } else if (layout == ExternalArrayLayout::kSOA) {
     total_shape_.insert(total_shape_.begin(), element_shape.begin(),
                         element_shape.end());
+  }
+  auto total_num_scalar = std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL, std::multiplies<>());
+  if (total_num_scalar > std::numeric_limits<int>::max()) {
+    TI_WARN("Ndarray index might be out of int32 boundary but int64 indexing is not supported yet.");
   }
 }
 

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -51,9 +51,13 @@ Ndarray::Ndarray(Program *prog,
     total_shape_.insert(total_shape_.begin(), element_shape.begin(),
                         element_shape.end());
   }
-  auto total_num_scalar = std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL, std::multiplies<>());
+  auto total_num_scalar =
+      std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL,
+                      std::multiplies<>());
   if (total_num_scalar > std::numeric_limits<int>::max()) {
-    TI_WARN("Ndarray index might be out of int32 boundary but int64 indexing is not supported yet.");
+    TI_WARN(
+        "Ndarray index might be out of int32 boundary but int64 indexing is "
+        "not supported yet.");
   }
   ndarray_alloc_ = prog->allocate_memory_ndarray(nelement_ * element_size_,
                                                  prog->result_buffer);
@@ -87,9 +91,13 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
     total_shape_.insert(total_shape_.begin(), element_shape.begin(),
                         element_shape.end());
   }
-  auto total_num_scalar = std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL, std::multiplies<>());
+  auto total_num_scalar =
+      std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL,
+                      std::multiplies<>());
   if (total_num_scalar > std::numeric_limits<int>::max()) {
-    TI_WARN("Ndarray index might be out of int32 boundary but int64 indexing is not supported yet.");
+    TI_WARN(
+        "Ndarray index might be out of int32 boundary but int64 indexing is "
+        "not supported yet.");
   }
 }
 


### PR DESCRIPTION
Issue: fix #6758

### Brief Summary

This PR adds a boundary check for ndarray similar to https://github.com/taichi-dev/taichi/blob/a87b98fd40fc93dbe1bdf8c4e3932a6078379fa3/taichi/ir/snode.cpp#L89-L93