### PR TITLE
[bug] Fix flaky mass_spring_game_ggui.py on Mac M1 by setting up default values for VulkanCapabilities

### DIFF
--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -562,12 +562,12 @@ class VulkanStream : public Stream {
 };
 
 struct VulkanCapabilities {
-  uint32_t vk_api_version;
-  bool physical_device_features2;
-  bool external_memory;
-  bool wide_line;
-  bool surface;
-  bool present;
+  uint32_t vk_api_version = 0;
+  bool physical_device_features2 = false;
+  bool external_memory = false;
+  bool wide_line = false;
+  bool surface = false;
+  bool present = false;
 };
 
 class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -562,12 +562,12 @@ class VulkanStream : public Stream {
 };
 
 struct VulkanCapabilities {
-  uint32_t vk_api_version {0};
-  bool physical_device_features2 {false};
-  bool external_memory {false};
-  bool wide_line {false};
-  bool surface {false};
-  bool present {false};
+  uint32_t vk_api_version{0};
+  bool physical_device_features2{false};
+  bool external_memory{false};
+  bool wide_line{false};
+  bool surface{false};
+  bool present{false};
 };
 
 class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -562,12 +562,12 @@ class VulkanStream : public Stream {
 };
 
 struct VulkanCapabilities {
-  uint32_t vk_api_version = 0;
-  bool physical_device_features2 = false;
-  bool external_memory = false;
-  bool wide_line = false;
-  bool surface = false;
-  bool present = false;
+  uint32_t vk_api_version {0};
+  bool physical_device_features2 {false};
+  bool external_memory {false};
+  bool wide_line {false};
+  bool surface {false};
+  bool present {false};
 };
 
 class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {


### PR DESCRIPTION
Mac M1 does not support `wide_line` with Vulkan. However, device capability was initialized to random values which is why some examples are flaky on M1.

Before this PR: 
<img width="577" alt="image" src="https://user-images.githubusercontent.com/22334008/206649063-9e68b812-560b-4662-8c39-aea4dc7ef1c9.png">


<img width="302" alt="image" src="https://user-images.githubusercontent.com/22334008/206648989-ecf9ea38-5975-4e43-8db0-f32458192a82.png">

