### PR TITLE
[ci] Reenable AMDGPU CI, disable OpenGL tests in AMDGPU task

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -17,7 +17,7 @@ function build-and-smoke-test-android-aot-demo {
 
     rm -rf taichi-aot-demo
     # IF YOU PIN THIS TO A COMMIT/BRANCH, YOU'RE RESPONSIBLE TO REVERT IT BACK TO MASTER ONCE MERGED.
-    git clone https://github.com/bobcao3/taichi-aot-demo
+    git clone https://github.com/taichi-dev/taichi-aot-demo
 
     APP_ROOT=taichi-aot-demo/implicit_fem
     ANDROID_APP_ROOT=$APP_ROOT/android

--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -172,7 +172,6 @@ function ci-docker-run-amdgpu {
         --device=/dev/dri \
         --device=/dev/vga_arbiter \
         --group-add=video \
-        --group-add=render \
         -e DISPLAY=:$i \
         -e GPU_TEST=ON \
         -e AMDGPU_TEST=ON \

--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -168,6 +168,7 @@ function ci-docker-run-amdgpu {
     fi
 
     ci-docker-run \
+        --priviledged \
         --device=/dev/kfd \
         --device=/dev/dri \
         --group-add=video \

--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -168,10 +168,11 @@ function ci-docker-run-amdgpu {
     fi
 
     ci-docker-run \
-        --priviledged \
         --device=/dev/kfd \
         --device=/dev/dri \
+        --device=/dev/vga_arbiter \
         --group-add=video \
+        --group-add=render \
         -e DISPLAY=:$i \
         -e GPU_TEST=ON \
         -e AMDGPU_TEST=ON \

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -268,6 +268,75 @@ jobs:
           path: taichi-release-tests/bad-compare/*
           retention-days: 7
 
+  build_and_test_amdgpu_linux:
+    name: Build and Test (AMDGPU)
+    needs: check_files
+    timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
+
+    runs-on: [self-hosted, amdgpu]
+
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: '0'
+
+      - name: Prepare Environment
+        run: |
+          . .github/workflows/scripts/common-utils.sh
+          prepare-build-cache
+          echo CI_DOCKER_RUN_EXTRA_ARGS="-v $(pwd):/home/dev/taichi" >> $GITHUB_ENV
+
+      - name: Build & Install
+        run: |
+          [[ ${{needs.check_files.outputs.run_job}} == false ]] && exit 0
+          . .github/workflows/scripts/common-utils.sh
+
+          ci-docker-run-amdgpu --name taichi-build \
+            registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.3 \
+            /home/dev/taichi/.github/workflows/scripts/unix-build.sh
+
+        env:
+          PY: py38
+          PROJECT_NAME: taichi
+          TAICHI_CMAKE_ARGS: >-
+            -DTI_WITH_VULKAN:BOOL=OFF
+            -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_CUDA:BOOL=OFF
+
+      - name: Test
+        id: test
+        run: |
+          [[ ${{needs.check_files.outputs.run_job}} == false ]] && exit 0
+          . .github/workflows/scripts/common-utils.sh
+
+          ci-docker-run-amdgpu --name taichi-test \
+             registry.taichigraphics.com/taichidev-ubuntu18.04.amdgpu:v0.0.3 \
+             /home/dev/taichi/.github/workflows/scripts/unix_test.sh
+        env:
+          PY: py38
+          TI_WANTED_ARCHS: 'cpu,amdgpu'
+          TI_DEVICE_MEMORY_GB: '1'
+          TI_RUN_RELEASE_TESTS: '0'
+
+      - name: Save wheel if test failed
+        if: failure() && steps.test.conclusion == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          name: broken-wheel
+          path: dist/*
+          retention-days: 7
+
+      - name: Save Bad Captures
+        if: failure() && steps.test.conclusion == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          name: bad-captures
+          path: taichi-release-tests/bad-compare/*
+          retention-days: 7
+
+
   build_and_test_windows:
     name: Build and Test Windows
     needs: check_files

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -272,10 +272,7 @@ jobs:
     name: Build and Test (AMDGPU)
     needs: check_files
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
-
     runs-on: [self-hosted, amdgpu]
-
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -301,9 +298,10 @@ jobs:
           PY: py38
           PROJECT_NAME: taichi
           TAICHI_CMAKE_ARGS: >-
-            -DTI_WITH_VULKAN:BOOL=OFF
-            -DTI_BUILD_TESTS:BOOL=ON
             -DTI_WITH_CUDA:BOOL=OFF
+            -DTI_WITH_VULKAN:BOOL=OFF
+            -DTI_WITH_OPENGL:BOOL=OFF
+            -DTI_BUILD_TESTS:BOOL=ON
 
       - name: Test
         id: test


### PR DESCRIPTION
AMDGPU node is back.
And I couldn't make OpenGL work in container (probably because of mesa version / other user space AMDGPU driver), disabling for now.