### PR TITLE
[ci] Python test minor fixes

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,14 +1,13 @@
 import sys
 
 import pytest
-
-import taichi as ti
-
-
 # rerunfailures use xdist version number to determine if it is compatible
 # but we are using a forked version of xdist(with git hash as it's version),
 # so we need to override it
 import pytest_rerunfailures
+
+import taichi as ti
+
 pytest_rerunfailures.works_with_current_xdist = lambda: True
 
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -5,6 +5,13 @@ import pytest
 import taichi as ti
 
 
+# rerunfailures use xdist version number to determine if it is compatible
+# but we are using a forked version of xdist(with git hash as it's version),
+# so we need to override it
+import pytest_rerunfailures
+pytest_rerunfailures.works_with_current_xdist = lambda: True
+
+
 @pytest.fixture(autouse=True)
 def wanted_arch(request, req_arch, req_options):
     if req_arch is not None:

--- a/tests/python/examples/rendering/test_cornell_box.py
+++ b/tests/python/examples/rendering/test_cornell_box.py
@@ -8,6 +8,7 @@ import taichi as ti
 FRAMES = 200
 
 
+@pytest.mark.run_in_serial
 @pytest.mark.skipif(os.environ.get('TI_LITE_TEST') or '0', reason='Lite test')
 def test_cornell_box():
     from taichi.examples.rendering.cornell_box import render, tonemap
@@ -18,6 +19,7 @@ def test_cornell_box():
             tonemap(i)
 
 
+@pytest.mark.run_in_serial
 @pytest.mark.skipif(os.environ.get('TI_LITE_TEST') or '0', reason='Lite test')
 def video_cornell_box(result_dir):
     from taichi.examples.rendering.cornell_box import (render, tonemap,

--- a/tests/python/examples/simulation/test_mpm99.py
+++ b/tests/python/examples/simulation/test_mpm99.py
@@ -8,6 +8,7 @@ import taichi as ti
 FRAMES = 100
 
 
+@pytest.mark.run_in_serial
 @pytest.mark.skipif(os.environ.get('TI_LITE_TEST') or '0', reason='Lite test')
 def test_mpm99():
     from taichi.examples.simulation.mpm99 import dt, initialize, substep
@@ -18,6 +19,7 @@ def test_mpm99():
             substep()
 
 
+@pytest.mark.run_in_serial
 @pytest.mark.skipif(os.environ.get('TI_LITE_TEST') or '0', reason='Lite test')
 def video_mpm99(result_dir):
     from taichi.examples.simulation.mpm99 import (dt, initialize, material,


### PR DESCRIPTION
Issue: #

### Brief Summary
1. Run `mpm99` and `cornell_box` in serial.
2. Monkey-patching `pytest_rerunfailures` version number checking, force it to treat our forked xdist 'compatible'.