### PR TITLE
[Lang] Deprecate sourceinspect dependency

### DIFF
--- a/python/taichi/lang/_wrap_inspect.py
+++ b/python/taichi/lang/_wrap_inspect.py
@@ -1,0 +1,168 @@
+import atexit
+import inspect
+import os
+import tempfile
+import warnings
+
+import sourceinspect
+
+_builtin_getfile = inspect.getfile
+_builtin_findsource = inspect.findsource
+
+def check_use_sourceinspect():
+    return int(os.getenv('USE_SOURCEINSPECT', 0)) == 1
+
+
+def _find_source_with_custom_getfile_func(func, obj):
+    inspect.getfile = func  # replace with our custom func
+    source = inspect.findsource(obj)
+    inspect.getfile = _builtin_getfile  # restore
+    return source
+
+
+def _blender_get_text_name(filename: str):
+    if filename.startswith(os.path.sep) and filename.count(os.path.sep) == 1:
+        return filename[1:]  # "/Text.001" --> "Text.001"
+
+    index = filename.rfind('.blend' + os.path.sep)
+    if index != -1:
+        return filename[index + 7:]  # "hello.blend/test.py" --> "test.py"
+
+    return None
+
+
+def _blender_findsource(obj):
+    try:
+        import bpy  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        raise IOError('Not in Blender environment!')
+
+    filename = _builtin_getfile(obj)
+    text_name = _blender_get_text_name(filename)
+    if text_name is None:
+        raise IOError(
+            'Object `{obj.__name__}` is not defined in a .blend file!')
+
+    lines = bpy.data.texts[text_name].as_string()
+    # Now we have found the filename and code lines.
+    # We first check if they are already cached, to avoid file io in each query.
+    try:
+        filename = _blender_findsource._saved_inspect_cache[lines]  # pylint: disable=no-member
+    except KeyError:
+        fd, filename = tempfile.mkstemp(prefix='_Blender_',
+                                        suffix=f'_{text_name}.py')
+        os.close(fd)
+
+        with open(filename, 'w') as f:
+            f.write(lines)
+
+        _blender_findsource._saved_inspect_cache[lines] = filename  # pylint: disable=no-member
+        atexit.register(os.unlink, filename)  # Remove file when program exits
+
+    def wrapped_getfile(ob):
+        if id(ob) == id(obj):
+            return filename
+
+        return _builtin_getfile(ob)
+
+    return _find_source_with_custom_getfile_func(wrapped_getfile, obj)
+
+
+_blender_findsource._saved_inspect_cache = {}
+
+
+def _Python_IPython_findsource(obj):
+    try:
+        # In Python and IPython the builtin findsource would suffice in most cases
+        return _builtin_findsource(obj)
+    except IOError:
+        # Except that the cell has a magic command like %%time or %%timeit
+        # In this case the filename returned by getfile is wrong
+        filename = _builtin_getfile(obj)
+        if (filename in {"<timed exec>", "<magic-timeit>"}):
+            try:
+                ip = get_ipython()
+                if ip is not None:
+                    session_id = ip.history_manager.get_last_session_id()
+                    fd, filename = tempfile.mkstemp(prefix='_IPython_',
+                                                    suffix=f'_{session_id}.py')
+                    os.close(fd)
+                    # The latest lines of code are stored in this file
+                    lines = ip.history_manager._i00
+
+                    # Remove the magic command (and spaces/sep around it) before saving to a file
+                    index = lines.find("%time")
+                    lines_stripped = lines[index:]
+                    lines_stripped = lines_stripped.split(maxsplit=1)[1]
+
+                    with open(filename, 'w') as f:
+                        f.write(lines_stripped)
+
+                    atexit.register(
+                        os.unlink,
+                        filename)  # Remove the file after the program exits
+                    func = lambda obj: filename
+                    return _find_source_with_custom_getfile_func(func, obj)
+
+            except:
+                pass
+        raise IOError(f"Cannot find source code for Object: {obj}")
+
+
+def _custom_findsource(obj):
+    try:
+        return _Python_IPython_findsource(obj)
+    except IOError:
+        try:
+            return _blender_findsource(obj)
+        except:
+            raise IOError(f"Cannot find source code for Object: {obj} ")
+
+
+class _InspectContextManager:
+    def __enter__(self):
+        inspect.findsource = _custom_findsource
+        return self
+
+    def __exit__(self, *_):
+        inspect.findsource = _builtin_findsource
+
+
+def getsourcelines(obj):
+    if check_use_sourceinspect():
+        warnings.warn('Sourceinspect is deprecated since v1.4.0', DeprecationWarning)
+        return sourceinspect.getsourcelines(obj)
+
+    try:
+        with _InspectContextManager():
+            return inspect.getsourcelines(obj)
+    except:
+        raise IOError(f"Cannot get the source lines of {obj}. \
+            You can try setting `USE_SOURCEINSPECT=1` in the enrionment variables \
+                or insert the lines `os.environ['USE_SOURCEINSPECT'] = 1` \
+                    at the beginning of the source file. Please report an issue to help us \
+                        fix the problem: https://github.com/taichi-dev/taichi/issues if you see this message"
+                      )
+
+
+def getsourcefile(obj):
+    if check_use_sourceinspect():
+        warnings.warn('Sourceinspect is deprecated since v1.4.0', DeprecationWarning)
+        return sourceinspect.getsourcefile(obj)
+
+    try:
+        with _InspectContextManager():
+            ret = inspect.getsourcefile(obj)
+            if ret is None:
+                ret = inspect.getfile(obj)
+            return ret
+    except:
+        raise IOError(f"Cannot get the source file of {obj}. \
+            You can try setting `USE_SOURCEINSPECT=1` in the enrionment variables \
+                or insert the lines `os.environ['USE_SOURCEINSPECT'] = 1` \
+                    at the beginning of the source file. Please report an issue to help us \
+                        fix the problem: https://github.com/taichi-dev/taichi/issues if you see this message"
+                      )
+
+
+__all__ = ['getsourcelines', 'getsourcefile']

--- a/python/taichi/lang/_wrap_inspect.py
+++ b/python/taichi/lang/_wrap_inspect.py
@@ -9,6 +9,7 @@ import sourceinspect
 _builtin_getfile = inspect.getfile
 _builtin_findsource = inspect.findsource
 
+
 def check_use_sourceinspect():
     return int(os.getenv('USE_SOURCEINSPECT', 0)) == 1
 
@@ -130,7 +131,8 @@ class _InspectContextManager:
 
 def getsourcelines(obj):
     if check_use_sourceinspect():
-        warnings.warn('Sourceinspect is deprecated since v1.4.0', DeprecationWarning)
+        warnings.warn('Sourceinspect is deprecated since v1.4.0',
+                      DeprecationWarning)
         return sourceinspect.getsourcelines(obj)
 
     try:
@@ -147,7 +149,8 @@ def getsourcelines(obj):
 
 def getsourcefile(obj):
     if check_use_sourceinspect():
-        warnings.warn('Sourceinspect is deprecated since v1.4.0', DeprecationWarning)
+        warnings.warn('Sourceinspect is deprecated since v1.4.0',
+                      DeprecationWarning)
         return sourceinspect.getsourcefile(obj)
 
     try:

--- a/python/taichi/lang/ast/checkers.py
+++ b/python/taichi/lang/ast/checkers.py
@@ -1,7 +1,7 @@
 import ast
 
-from taichi.lang.exception import TaichiSyntaxError
 from taichi.lang._wrap_inspect import getsourcefile, getsourcelines
+from taichi.lang.exception import TaichiSyntaxError
 
 
 class KernelSimplicityASTChecker(ast.NodeVisitor):

--- a/python/taichi/lang/ast/checkers.py
+++ b/python/taichi/lang/ast/checkers.py
@@ -1,7 +1,7 @@
 import ast
 
 from taichi.lang.exception import TaichiSyntaxError
-from taichi.lang.shell import oinspect
+from taichi.lang._wrap_inspect import getsourcefile, getsourcelines
 
 
 class KernelSimplicityASTChecker(ast.NodeVisitor):
@@ -34,8 +34,8 @@ class KernelSimplicityASTChecker(ast.NodeVisitor):
 
     def __init__(self, func):
         super().__init__()
-        self._func_file = oinspect.getsourcefile(func)
-        self._func_lineno = oinspect.getsourcelines(func)[1]
+        self._func_file = getsourcefile(func)
+        self._func_lineno = getsourcelines(func)[1]
         self._func_name = func.__name__
         self._scope_guards = []
 

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -12,6 +12,7 @@ import numpy as np
 import taichi.lang
 from taichi._lib import core as _ti_core
 from taichi.lang import impl, ops, runtime_ops
+from taichi.lang._wrap_inspect import getsourcefile, getsourcelines
 from taichi.lang.ast import (ASTTransformerContext, KernelSimplicityASTChecker,
                              transform_tree)
 from taichi.lang.ast.ast_transformer_utils import ReturnStatus
@@ -22,7 +23,7 @@ from taichi.lang.exception import (TaichiCompilationError, TaichiRuntimeError,
 from taichi.lang.expr import Expr
 from taichi.lang.kernel_arguments import KernelArgument
 from taichi.lang.matrix import Matrix, MatrixType
-from taichi.lang.shell import _shell_pop_print, oinspect
+from taichi.lang.shell import _shell_pop_print
 from taichi.lang.struct import StructType
 from taichi.lang.util import (cook_dtype, has_paddle, has_pytorch,
                               to_taichi_type)
@@ -115,8 +116,8 @@ def _get_tree_and_ctx(self,
                       args=None,
                       ast_builder=None,
                       is_real_function=False):
-    file = oinspect.getsourcefile(self.func)
-    src, start_lineno = oinspect.getsourcelines(self.func)
+    file = getsourcefile(self.func)
+    src, start_lineno = getsourcelines(self.func)
     src = [textwrap.fill(line, tabsize=4, width=9999) for line in src]
     tree = ast.parse(textwrap.dedent("\n".join(src)))
 

--- a/python/taichi/lang/shell.py
+++ b/python/taichi/lang/shell.py
@@ -3,17 +3,7 @@ import os
 import sys
 
 from taichi._lib import core as _ti_core
-from taichi._logging import info, warn
-
-try:
-    import sourceinspect as oinspect  # pylint: disable=unused-import
-except ImportError:
-    warn('`sourceinspect` not installed!')
-    warn(
-        'Without this package Taichi may not function well in Python IDLE interactive shell, '
-        'Blender scripting module and Python native shell.')
-    warn('Please run `python3 -m pip install sourceinspect` to install.')
-    import inspect as oinspect  # pylint: disable=unused-import
+from taichi._logging import info
 
 pybuf_enabled = False
 _env_enable_pybuf = os.environ.get('TI_ENABLE_PYBUF', '1')

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -175,11 +175,8 @@ def test_incomplete_info_rwtexture():
 
 
 def test_deprecated_source_inspect():
-    with pytest.warns(
-            DeprecationWarning,
-            match=
-            "Sourceinspect is deprecated since v1.4.0"
-    ):
+    with pytest.warns(DeprecationWarning,
+                      match="Sourceinspect is deprecated since v1.4.0"):
         import os
         os.environ['USE_SOURCEINSPECT'] = '1'
         from taichi.lang._wrap_inspect import getsourcelines

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -172,3 +172,20 @@ def test_incomplete_info_rwtexture():
             for i, j in ti.ndrange(n, n):
                 ret = ti.cast(1, ti.f32)
                 tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))
+
+
+def test_deprecated_source_inspect():
+    with pytest.warns(
+            DeprecationWarning,
+            match=
+            "Sourceinspect is deprecated since v1.4.0"
+    ):
+        import os
+        os.environ['USE_SOURCEINSPECT'] = '1'
+        from taichi.lang._wrap_inspect import getsourcelines
+
+        @ti.kernel
+        def func():
+            pass
+
+        print(getsourcelines(func))


### PR DESCRIPTION
This PR replaces #6630 (now closed)

It deprecates, and also fixes a bug in the sourceinpect module (cannot use cell magics %%time and %%timeit in jupyter notebooks). The dependency on sourceinspect is reserved and will be removed in future releases (if the current fix works fine)

Also added test in `test_deprecation.py`.