### PR TITLE
[WIP] Try to enable LLVM auto vectorization.

### DIFF
--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -107,7 +107,6 @@ struct CompileConfig {
 
   size_t cuda_stack_limit{8192};
 
-
   CompileConfig();
 };
 

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -107,6 +107,7 @@ struct CompileConfig {
 
   size_t cuda_stack_limit{8192};
 
+
   CompileConfig();
 };
 

--- a/taichi/transforms/loop_invariant_detector.h
+++ b/taichi/transforms/loop_invariant_detector.h
@@ -60,8 +60,9 @@ class LoopInvariantDetector : public BasicStmtVisitor {
 
   bool is_loop_invariant(Stmt *stmt, Block *current_scope) {
     int loop_invariant_nesting_level = (arch_is_cpu(config.arch)) ? 0 : 1;
-    if (loop_blocks.size() <= loop_invariant_nesting_level || (!config.move_loop_invariant_outside_if &&
-                                    current_scope != loop_blocks.top()))
+    if (loop_blocks.size() <= loop_invariant_nesting_level ||
+        (!config.move_loop_invariant_outside_if &&
+         current_scope != loop_blocks.top()))
       return false;
 
     bool is_invariant = true;

--- a/taichi/transforms/loop_invariant_detector.h
+++ b/taichi/transforms/loop_invariant_detector.h
@@ -52,13 +52,15 @@ class LoopInvariantDetector : public BasicStmtVisitor {
   }
 
   bool is_operand_loop_invariant(Stmt *operand, Block *current_scope) {
-    if (loop_blocks.size() <= 1)
+    int loop_invariant_nesting_level = (arch_is_cpu(config.arch)) ? 0 : 1;
+    if (loop_blocks.size() <= loop_invariant_nesting_level)
       return false;
     return is_operand_loop_invariant_impl(operand, current_scope);
   }
 
   bool is_loop_invariant(Stmt *stmt, Block *current_scope) {
-    if (loop_blocks.size() <= 1 || (!config.move_loop_invariant_outside_if &&
+    int loop_invariant_nesting_level = (arch_is_cpu(config.arch)) ? 0 : 1;
+    if (loop_blocks.size() <= loop_invariant_nesting_level || (!config.move_loop_invariant_outside_if &&
                                     current_scope != loop_blocks.top()))
       return false;
 

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -89,7 +89,7 @@ class Offloader {
     for (int i = 0; i < (int)root_statements.size(); i++) {
       auto &stmt = root_statements[i];
       // Note that stmt->parent is root_block, which doesn't contain stmt now.
-      if (auto s = stmt->cast<RangeForStmt>(); s && !s->strictly_serialized) {
+      if (auto s = stmt->cast<RangeForStmt>(); s && !s->strictly_serialized && !arch_is_cpu(arch)) {
         assemble_serial_statements();
         auto offloaded = Stmt::make_typed<OffloadedStmt>(
             OffloadedStmt::TaskType::range_for, arch);

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -89,7 +89,8 @@ class Offloader {
     for (int i = 0; i < (int)root_statements.size(); i++) {
       auto &stmt = root_statements[i];
       // Note that stmt->parent is root_block, which doesn't contain stmt now.
-      if (auto s = stmt->cast<RangeForStmt>(); s && !s->strictly_serialized && !arch_is_cpu(arch)) {
+      if (auto s = stmt->cast<RangeForStmt>();
+          s && !s->strictly_serialized && !arch_is_cpu(arch)) {
         assemble_serial_statements();
         auto offloaded = Stmt::make_typed<OffloadedStmt>(
             OffloadedStmt::TaskType::range_for, arch);


### PR DESCRIPTION
Issue: #6771

This is a proof of concept that LLVM auto vectorization can be leveraged by not offloading CPU range for and re-enable loop invariant code motion pass for single-level loops.

Apparently, multithreading is disabled with this regard.

Single threaded performance on M1: 7.5GB/s -> 50GB/s

### Brief Summary
