### PR TITLE
[misc] Show suggestion when locking metadata.lock fails

### DIFF
--- a/taichi/cache/gfx/cache_manager.cpp
+++ b/taichi/cache/gfx/cache_manager.cpp
@@ -124,7 +124,10 @@ CacheManager::CacheManager(Params &&init_params)
       if (exists && lock_with_file(lock_path)) {
         auto _ = make_cleanup([&lock_path]() {
           if (!unlock_with_file(lock_path)) {
-            TI_WARN("Unlock {} failed", lock_path);
+            TI_WARN(
+                "Unlock {} failed. You can remove this .lock file manually and "
+                "try again.",
+                lock_path);
           }
         });
         gfx::AotModuleParams params;
@@ -172,7 +175,10 @@ void CacheManager::dump_with_merging() const {
     if (lock_with_file(lock_path)) {
       auto _ = make_cleanup([&lock_path]() {
         if (!unlock_with_file(lock_path)) {
-          TI_WARN("Unlock {} failed", lock_path);
+          TI_WARN(
+              "Unlock {} failed. You can remove this .lock file manually and "
+              "try again.",
+              lock_path);
         }
       });
 

--- a/taichi/runtime/llvm/llvm_offline_cache.cpp
+++ b/taichi/runtime/llvm/llvm_offline_cache.cpp
@@ -130,12 +130,17 @@ bool LlvmOfflineCacheFileReader::load_meta_data(
   if (lock_with_file(lock_path)) {
     auto _ = make_cleanup([&lock_path]() {
       if (!unlock_with_file(lock_path)) {
-        TI_WARN("Unlock {} failed", lock_path);
+        TI_WARN(
+            "Unlock {} failed. You can remove this .lock file manually and try "
+            "again.",
+            lock_path);
       }
     });
     return Error::kNoError == load_metadata_with_checking(data, tcb_path);
   }
-  TI_WARN("Lock {} failed", lock_path);
+  TI_WARN(
+      "Lock {} failed. You can remove this .lock file manually and try again.",
+      lock_path);
   return false;
 }
 
@@ -313,12 +318,18 @@ void LlvmOfflineCacheFileWriter::dump(const std::string &path,
     // metadata file format to reduce overhead.
     std::string lock_path = taichi::join_path(path, kMetadataFileLockName);
     if (!lock_with_file(lock_path)) {
-      TI_WARN("Lock {} failed", lock_path);
+      TI_WARN(
+          "Lock {} failed. You can remove this .lock file manually and try "
+          "again.",
+          lock_path);
       return;
     }
     auto _ = make_cleanup([&lock_path]() {
       if (!unlock_with_file(lock_path)) {
-        TI_WARN("Unlock {} failed", lock_path);
+        TI_WARN(
+            "Unlock {} failed. You can remove this .lock file manually and try "
+            "again.",
+            lock_path);
       }
     });
 

--- a/taichi/util/lock.h
+++ b/taichi/util/lock.h
@@ -58,7 +58,10 @@ inline bool lock_with_file(const std::string &path,
 inline RaiiCleanup make_unlocker(const std::string &path) {
   return make_cleanup([&path]() {
     if (!unlock_with_file(path)) {
-      TI_WARN("Unlock {} failed", path);
+      TI_WARN(
+          "Unlock {} failed. You can remove this .lock file manually and try "
+          "again.",
+          path);
     }
   });
 }

--- a/taichi/util/offline_cache.h
+++ b/taichi/util/offline_cache.h
@@ -173,13 +173,19 @@ class CacheCleaner {
       std::string lock_path =
           taichi::join_path(path, config.metadata_lock_name);
       if (!lock_with_file(lock_path)) {
-        TI_WARN("Lock {} failed", lock_path);
+        TI_WARN(
+            "Lock {} failed. You can remove this .lock file manually and try "
+            "again.",
+            lock_path);
         return;
       }
       auto _ = make_cleanup([&lock_path]() {
         TI_DEBUG("Stop cleaning cache");
         if (!unlock_with_file(lock_path)) {
-          TI_WARN("Unlock {} failed", lock_path);
+          TI_WARN(
+              "Unlock {} failed. You can remove this .lock file manually and "
+              "try again.",
+              lock_path);
         }
       });
       TI_DEBUG("Start cleaning cache");


### PR DESCRIPTION
Issue: #4401

### Brief Summary
I found that some users' programs warn the `"[W ... Lock C:/taichi_cache/ticache/llvm/metadata.lock failed"`.
I think the crash when loading old version cache files which were generated by old version taichi-nightly could cause the warning. But I'm not sure.

Temporarily, show a message to suggest the user remove this `.lock` file manually.
And I will provide `python -m taichi clean_ticache` to allow user to clean the cache files manually. 