### PR TITLE
[aot] Fix validation warning: OpImageFetch should operate on OpImage instead of OpSampledImage

### DIFF
--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -392,6 +392,14 @@ SType IRBuilder::get_pointer_type(const SType &value_type,
   return t;
 }
 
+SType IRBuilder::get_underlying_image_type(const SType &primitive_type,
+                                           int num_dimensions) {
+  auto key = std::make_pair(primitive_type.id, num_dimensions);
+  TI_ASSERT(sampled_image_underlying_image_type_.find(key) !=
+            sampled_image_underlying_image_type_.end());
+  return sampled_image_underlying_image_type_[key];
+}
+
 SType IRBuilder::get_sampled_image_type(const SType &primitive_type,
                                         int num_dimensions) {
   auto key = std::make_pair(primitive_type.id, num_dimensions);
@@ -415,6 +423,7 @@ SType IRBuilder::get_sampled_image_type(const SType &primitive_type,
                /*Depth=*/0, /*Arrayed=*/0, /*MS=*/0, /*Sampled=*/1,
                spv::ImageFormatUnknown)
       .commit(&global_);
+
   SType sampled_t;
   sampled_t.id = id_counter_++;
   sampled_t.flag = TypeKind::kImage;
@@ -422,6 +431,12 @@ SType IRBuilder::get_sampled_image_type(const SType &primitive_type,
       .add_seq(sampled_t, img_id)
       .commit(&global_);
   sampled_image_ptr_tbl_[key] = sampled_t;
+
+  SType image_type;
+  image_type.id = img_id;
+  image_type.flag = TypeKind::kImage;
+  sampled_image_underlying_image_type_[key] = image_type;
+
   return sampled_t;
 }
 
@@ -806,8 +821,18 @@ Value IRBuilder::sample_texture(Value texture_var,
 Value IRBuilder::fetch_texel(Value texture_var,
                              const std::vector<Value> &args,
                              Value lod) {
-  auto image = this->load_variable(
+  auto sampled_image = this->load_variable(
       texture_var, this->get_sampled_image_type(f32_type(), args.size()));
+
+  // OpImageFetch requires operand with OpImageType
+  // We have to extract the underlying OpImage from OpSampledImage here
+  SType image_type = get_underlying_image_type(f32_type(), args.size());
+  Value image_val = new_value(image_type, ValueKind::kNormal);
+
+  ib_.begin(spv::OpImage)
+      .add_seq(image_type, image_val, sampled_image)
+      .commit(&function_);
+
   Value uv;
   if (args.size() == 1) {
     uv = args[0];
@@ -820,8 +845,8 @@ Value IRBuilder::fetch_texel(Value texture_var,
     TI_ERROR("Unsupported number of texture coordinates");
   }
   uint32_t lod_operand = 0x2;
-  auto res_vec4 =
-      make_value(spv::OpImageFetch, t_v4_fp32_, image, uv, lod_operand, lod);
+  auto res_vec4 = make_value(spv::OpImageFetch, t_v4_fp32_, image_val, uv,
+                             lod_operand, lod);
   return res_vec4;
 }
 

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -330,6 +330,8 @@ class IRBuilder {
                          spv::StorageClass storage_class);
   // Get an image type
   SType get_sampled_image_type(const SType &primitive_type, int num_dimensions);
+  SType get_underlying_image_type(const SType &primitive_type,
+                                  int num_dimensions);
   SType get_storage_image_type(BufferFormat format, int num_dimensions);
   // Get a value_type[num_elems] type
   SType get_array_type(const SType &value_type, uint32_t num_elems);
@@ -608,6 +610,9 @@ class IRBuilder {
   // map from value to its pointer type
   std::map<std::pair<uint32_t, spv::StorageClass>, SType> pointer_type_tbl_;
   std::map<std::pair<uint32_t, int>, SType> sampled_image_ptr_tbl_;
+  std::map<std::pair<uint32_t, int>, SType>
+      sampled_image_underlying_image_type_;
+
   std::map<std::pair<BufferFormat, int>, SType> storage_image_ptr_tbl_;
 
   // map from constant int to its value


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/6807

### Brief Summary
`spv::OpImageFetch` should take `OpImage` instead of `OpSampledImage` as operand. Therefore we extract the underlying `OpImage` during code generation for `TextureOpStmt("fetch")`