### PR TITLE
[refactor] Remove _PyScopeMatrixImpl

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -80,8 +80,7 @@ def _gen_swizzles(cls):
                     checker(instance, pattern)
                     res = []
                     for ch in pattern:
-                        res.append(
-                            instance._get_entry(key_group.index(ch)))
+                        res.append(instance._get_entry(key_group.index(ch)))
                     return Vector(res)
 
                 @python_scope

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -27,7 +27,6 @@ def _get_expected_matrix_apis():
         'determinant',
         'diag',
         'dot',
-        'entries',
         'field',
         'fill',
         'identity',

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -51,7 +51,6 @@ def _get_expected_matrix_apis():
         'unit',
         'zero',
         'get_shape',
-        'element_type',
     ]
     res = base + _get_matrix_swizzle_apis()
     return sorted(res)


### PR DESCRIPTION
Issue: #5819

### Brief Summary

There is no need to wrap some methods of `Matrix` into a separate class now.