### PR TITLE
[bug] Fix recompilation of filling a matrix field with the same matrix

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1334,12 +1334,13 @@ class MatrixField(Field):
             else:
                 assert self.ndim == 1
                 val = tuple(val for _ in range(self.n))
-        elif isinstance(val, Matrix) or (isinstance(val, expr.Expr)
-                                         and val.is_tensor()):
+        elif isinstance(val, expr.Expr) and val.is_tensor():
             assert val.n == self.n
             if self.ndim != 1:
                 assert val.m == self.m
         else:
+            if isinstance(val, Matrix):
+                val = val.to_list()
             assert isinstance(val, (list, tuple))
             val = tuple(tuple(x) if isinstance(x, list) else x for x in val)
             assert len(val) == self.n

--- a/tests/python/test_fill.py
+++ b/tests/python/test_fill.py
@@ -1,3 +1,5 @@
+from taichi.lang import impl
+
 import taichi as ti
 from tests import test_utils
 
@@ -65,3 +67,11 @@ def test_fill_matrix_field_with_matrix():
     for i in range(n):
         for j in range(m):
             assert (val[i, j] == mat).all()
+
+
+@test_utils.test()
+def test_fill_vector_field_recompile():
+    a = ti.Vector.field(2, ti.i32, shape=3)
+    for i in range(2):
+        a.fill(ti.Vector([0, 0]))
+    assert impl.get_runtime().get_num_compiled_functions() == 1


### PR DESCRIPTION
Issue: fix #6950

### Brief Summary

The change to `fill()` in #6892 (skips turning a `ti.Matrix` into a tuple) accidentally disallows compilation caching when the argument is a `ti.Matrix`, which causes #6950. This PR puts that behavior back.