### PR TITLE
[ci] Fix missing c_api.so in linux nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_C_API:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Previous hack to add enable capi build in unix-build.sh (#6479) is gone so this PR tries to add it back.

Issue: #

### Brief Summary
