### PR TITLE
[bug] Allow StructType as type hint to ti.func

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -334,6 +334,8 @@ class Func:
                     pass
                 elif isinstance(annotation, MatrixType):
                     pass
+                elif isinstance(annotation, StructType):
+                    pass
                 elif id(annotation) in primitive_types.type_ids:
                     pass
                 elif isinstance(annotation, template):

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -431,6 +431,24 @@ def test_func_matrix_arg_with_error():
         test_error()
 
 
+@test_utils.test(debug=True)
+def test_func_struct_arg():
+    @ti.dataclass
+    class C:
+        i: int
+
+    @ti.func
+    def f(c: C):
+        return c.i
+
+    @ti.kernel
+    def k():
+        c = C(i=2)
+        assert f(c) == 2
+
+    k()
+
+
 @test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_real_func_matrix_arg():
     @ti.experimental.real_func


### PR DESCRIPTION
Issue: fix #6855

### Brief Summary

Note that this PR is a quick hack to allow the type hint but doesn't check invalid cases. We would like to wait for the upcoming new struct type representation to officially support struct type as kernel/func parameters.