### PR TITLE
[bug] Fix taichi_ngp starting from ti example

### DIFF
--- a/python/taichi/examples/rendering/taichi_ngp.py
+++ b/python/taichi/examples/rendering/taichi_ngp.py
@@ -1106,4 +1106,5 @@ if __name__ == '__main__':
     parser.add_argument('--model_path', type=str, default=None)
     parser.add_argument('--gui', action='store_true', default=False)
     parser.add_argument('--print_profile', action='store_true', default=False)
-    main(parser.parse_args())
+    cmd_args, _ = parser.parse_known_args()
+    main(cmd_args)


### PR DESCRIPTION
If you start `ti example` and type `66` (taichi_ngp) it crashes and complains about unknown arg `example`. This PR fixes it.

Issue: #

### Brief Summary
