### PR TITLE
Revert "[ci] Fix missing c_api.so in linux nightly"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,6 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
-            -DTI_WITH_C_API:BOOL=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Reverts taichi-dev/taichi#6962
We don't want to add c_api.so to official releases *yet*, so #6969 is a better fix. :D 