### PR TITLE
[lang] Migrate TensorType expansion for FuncCallExpression from Python code to Frontend IR

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -248,6 +248,7 @@ class Func:
 
     def func_call_rvalue(self, key, args):
         # Skip the template args, e.g., |self|
+        ast_builder = impl.get_runtime().prog.current_ast_builder()
         assert self.is_real_function
         non_template_args = []
         for i, kernel_arg in enumerate(self.arguments):
@@ -258,18 +259,12 @@ class Func:
                 elif isinstance(anno, primitive_types.RefType):
                     non_template_args.append(
                         _ti_core.make_reference(args[i].ptr))
-                elif isinstance(args[i],
-                                impl.Expr) and args[i].ptr.is_tensor():
-                    non_template_args.extend([
-                        Expr(x) for x in impl.get_runtime().prog.
-                        current_ast_builder().expand_expr([args[i].ptr])
-                    ])
                 else:
                     non_template_args.append(args[i])
         non_template_args = impl.make_expr_group(non_template_args,
                                                  real_func_arg=True)
         func_call = Expr(
-            _ti_core.make_func_call_expr(
+            ast_builder.insert_func_call_expr(
                 self.taichi_functions[key.instance_id], non_template_args))
         impl.get_runtime().prog.current_ast_builder().insert_expr_stmt(
             func_call.ptr)

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -35,6 +35,13 @@ FrontendSNodeOpStmt::FrontendSNodeOpStmt(ASTBuilder *builder,
   }
 }
 
+FuncCallExpression::FuncCallExpression(ASTBuilder *builder,
+                                       Function *func,
+                                       const ExprGroup &args)
+    : func(func), args(args) {
+  this->args.exprs = builder->expand_expr(args.exprs);
+}
+
 FrontendAssignStmt::FrontendAssignStmt(const Expr &lhs, const Expr &rhs)
     : lhs(lhs), rhs(rhs) {
   TI_ASSERT(lhs->is_lvalue());
@@ -1474,6 +1481,10 @@ Expr ASTBuilder::snode_length(SNode *snode, const ExprGroup &indices) {
 Expr ASTBuilder::snode_get_addr(SNode *snode, const ExprGroup &indices) {
   return Expr::make<SNodeOpExpression>(this, snode, SNodeOpType::get_addr,
                                        indices);
+}
+
+Expr ASTBuilder::insert_func_call_expr(Function *func, const ExprGroup &args) {
+  return Expr::make<FuncCallExpression>(this, func, args);
 }
 
 std::vector<Expr> ASTBuilder::expand_expr(const std::vector<Expr> &exprs) {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -787,9 +787,9 @@ class FuncCallExpression : public Expression {
 
   void type_check(CompileConfig *config) override;
 
-  FuncCallExpression(Function *func, const ExprGroup &args)
-      : func(func), args(args) {
-  }
+  FuncCallExpression(ASTBuilder *builder,
+                     Function *func,
+                     const ExprGroup &args);
 
   void flatten(FlattenContext *ctx) override;
 
@@ -978,6 +978,7 @@ class ASTBuilder {
   void insert_expr_stmt(const Expr &val);
   void insert_snode_activate(SNode *snode, const ExprGroup &expr_group);
   void insert_snode_deactivate(SNode *snode, const ExprGroup &expr_group);
+  Expr insert_func_call_expr(Function *func, const ExprGroup &args);
 
   /*
    * This function allocates the space for a new item (a struct or a scalar)

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -317,6 +317,7 @@ void export_lang(py::module &m) {
       .def("insert_thread_idx_expr", &ASTBuilder::insert_thread_idx_expr)
       .def("insert_patch_idx_expr", &ASTBuilder::insert_patch_idx_expr)
       .def("expand_expr", &ASTBuilder::expand_expr)
+      .def("insert_func_call_expr", &ASTBuilder::insert_func_call_expr)
       .def("sifakis_svd_f32", sifakis_svd_export<float32, int32>)
       .def("sifakis_svd_f64", sifakis_svd_export<float64, int64>)
       .def("expr_var", &ASTBuilder::make_var)
@@ -820,9 +821,6 @@ void export_lang(py::module &m) {
           return Expr::make<InternalFuncCallExpression>(func_name, args.exprs,
                                                         with_runtime_context);
         });
-
-  m.def("make_func_call_expr",
-        Expr::make<FuncCallExpression, Function *, const ExprGroup &>);
 
   m.def("make_get_element_expr",
         Expr::make<GetElementExpression, const Expr &, int>);


### PR DESCRIPTION


Issue: https://github.com/taichi-dev/taichi/issues/5819

### Brief Summary
