### PR TITLE
[Doc] Remove packed mode in doc

### DIFF
--- a/docs/lang/articles/reference/global_settings.md
+++ b/docs/lang/articles/reference/global_settings.md
@@ -70,9 +70,6 @@ Following are some frequently-used configurations in `ti.init()`:
     offline_cache_file_path: str
         Set a directory for holding the offline cached files.
 
-    packed: bool
-        Enable/disable the packed memory layout.
-
     random_seed: int
         Set a custom seed for the random number generator.
 
@@ -174,7 +171,6 @@ If you want to use CUDA and Taichi's GGUI system at the same time on a machine w
 - To set a custom seed for the random number generator used by `ti.random()`: `ti.init(random_seed=seed)`. `seed` should be an integer. An example: `ti.init(random_seed=int(time.time()))`.
 - To set the default precision of floating-point numbers of Taichi runtime to `ti.f64`: `ti.init(default_fp=ti.i64)`.
 - To set the default precision of floating-point numbers of Taichi runtime to `ti.i32`: `ti.init(default_ip=ti.i32)`.
-- To enable the packed mode for memory layout: `ti.init(packed=True)`. See the [Packed mode](../basic/layout.md#packed-mode) for more information.
 - To disable the offline cache of compiled kernels: `ti.init(offline_cache=False)`. See the [Offline cache](../performance_tuning/performance.md#offline-cache) for more information.
 - To enable the use of variables as indices to access vector/matrix elements in the Taichi scope: `ti.init(dynamic_index=True)`.
 - To turn on kernel profiling: `ti.init(kernel_profiler=True)`. See the [Profiler](../performance_tuning/profiler.md#kernelprofiler) for more information.

--- a/docs/lang/articles/reference/global_settings.md
+++ b/docs/lang/articles/reference/global_settings.md
@@ -178,7 +178,7 @@ If you want to use CUDA and Taichi's GGUI system at the same time on a machine w
 
 ## Logging
 
-- To set the logging level: `ti.init(log_level=ti.TRACE)` or  `ti.set_logging_level(ti.TRACE)` enables the TRACE level. The environment variable `TI_LOG_LEVEL` serves the same purpose.
+- To set the logging level: `ti.init(log_level=ti.TRACE)` or `ti.set_logging_level(ti.TRACE)` enables the TRACE level. The environment variable `TI_LOG_LEVEL` serves the same purpose.
 - To eliminate verbose outputs: `ti.init(verbose=False)`.
 
 ## Develop


### PR DESCRIPTION
This PR removes the `packed` option in `ti.init` according to the changes in v1.4.0.
