### PR TITLE
[rhi] Update compute CommandList APIs (except dispatch)

### DIFF
--- a/misc/prtags.json
+++ b/misc/prtags.json
@@ -17,6 +17,7 @@
   "dx12"            : "DirectX 12 backend",
   "spirv"           : "SPIR-V common codegen",
   "gfx"             : "Common graphics runtime",
+  "rhi"             : "Unified Device API",
   "wasm"            : "WebAssembly backend",
   "misc"            : "Miscellaneous",
   "std"             : "Standard library",

--- a/taichi/rhi/amdgpu/amdgpu_device.h
+++ b/taichi/rhi/amdgpu/amdgpu_device.h
@@ -17,17 +17,20 @@ class AmdgpuCommandList : public CommandList {
   ~AmdgpuCommandList() override {
   }
 
-  void bind_pipeline(Pipeline *p) override{TI_NOT_IMPLEMENTED};
+  void bind_pipeline(Pipeline *p) noexcept final{TI_NOT_IMPLEMENTED};
   RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                  int set_index = 0) final{TI_NOT_IMPLEMENTED};
-  RhiResult bind_raster_resources(RasterResources *res) final{
+                                  int set_index = 0) noexcept final{
       TI_NOT_IMPLEMENTED};
-  void buffer_barrier(DevicePtr ptr, size_t size) override{TI_NOT_IMPLEMENTED};
-  void buffer_barrier(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
-  void memory_barrier() override{TI_NOT_IMPLEMENTED};
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override{
+  RhiResult bind_raster_resources(RasterResources *res) noexcept final{
       TI_NOT_IMPLEMENTED};
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override{
+  void buffer_barrier(DevicePtr ptr,
+                      size_t size) noexcept final{TI_NOT_IMPLEMENTED};
+  void buffer_barrier(DeviceAllocation alloc) noexcept final{
+      TI_NOT_IMPLEMENTED};
+  void memory_barrier() noexcept final{TI_NOT_IMPLEMENTED};
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) noexcept final{
+      TI_NOT_IMPLEMENTED};
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept final{
       TI_NOT_IMPLEMENTED};
   void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override{
       TI_NOT_IMPLEMENTED};

--- a/taichi/rhi/cpu/cpu_device.h
+++ b/taichi/rhi/cpu/cpu_device.h
@@ -22,18 +22,20 @@ class CpuCommandList : public CommandList {
   ~CpuCommandList() override {
   }
 
-  void bind_pipeline(Pipeline *p) override{TI_NOT_IMPLEMENTED};
+  void bind_pipeline(Pipeline *p) noexcept override{TI_NOT_IMPLEMENTED};
   RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                  int set_index = 0) override{
+                                  int set_index = 0) noexcept override{
       TI_NOT_IMPLEMENTED};
-  RhiResult bind_raster_resources(RasterResources *res) override{
+  RhiResult bind_raster_resources(RasterResources *res) noexcept override{
       TI_NOT_IMPLEMENTED};
-  void buffer_barrier(DevicePtr ptr, size_t size) override{TI_NOT_IMPLEMENTED};
-  void buffer_barrier(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
-  void memory_barrier() override{TI_NOT_IMPLEMENTED};
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override{
+  void buffer_barrier(DevicePtr ptr,
+                      size_t size) noexcept override{TI_NOT_IMPLEMENTED};
+  void buffer_barrier(DeviceAllocation alloc) noexcept override{
       TI_NOT_IMPLEMENTED};
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override{
+  void memory_barrier() noexcept override{TI_NOT_IMPLEMENTED};
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) noexcept override{
+      TI_NOT_IMPLEMENTED};
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept override{
       TI_NOT_IMPLEMENTED};
   void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override{
       TI_NOT_IMPLEMENTED};

--- a/taichi/rhi/cuda/cuda_device.h
+++ b/taichi/rhi/cuda/cuda_device.h
@@ -22,17 +22,20 @@ class CudaCommandList : public CommandList {
   ~CudaCommandList() override {
   }
 
-  void bind_pipeline(Pipeline *p) override{TI_NOT_IMPLEMENTED};
+  void bind_pipeline(Pipeline *p) noexcept override{TI_NOT_IMPLEMENTED};
   RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                  int set_index = 0) final{TI_NOT_IMPLEMENTED};
-  RhiResult bind_raster_resources(RasterResources *res) final{
+                                  int set_index = 0) noexcept final{
       TI_NOT_IMPLEMENTED};
-  void buffer_barrier(DevicePtr ptr, size_t size) override{TI_NOT_IMPLEMENTED};
-  void buffer_barrier(DeviceAllocation alloc) override{TI_NOT_IMPLEMENTED};
-  void memory_barrier() override{TI_NOT_IMPLEMENTED};
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override{
+  RhiResult bind_raster_resources(RasterResources *res) noexcept final{
       TI_NOT_IMPLEMENTED};
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override{
+  void buffer_barrier(DevicePtr ptr,
+                      size_t size) noexcept override{TI_NOT_IMPLEMENTED};
+  void buffer_barrier(DeviceAllocation alloc) noexcept override{
+      TI_NOT_IMPLEMENTED};
+  void memory_barrier() noexcept override{TI_NOT_IMPLEMENTED};
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) noexcept override{
+      TI_NOT_IMPLEMENTED};
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept override{
       TI_NOT_IMPLEMENTED};
   void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override{
       TI_NOT_IMPLEMENTED};

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -367,7 +367,7 @@ class TI_DLL_EXPORT CommandList {
   virtual void buffer_fill(DevicePtr ptr,
                            size_t size,
                            uint32_t data) noexcept = 0;
-  
+
   virtual void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) = 0;
 
   struct ComputeSize {

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -20,7 +20,7 @@ enum class RhiResult {
   out_of_memory = -4,
 };
 
-constexpr size_t kBufferSizeEntireSize = size_t(-1);
+constexpr size_t kBufferSizeEntireSize = std::numeric_limits<size_t>::max();
 
 #define MAKE_ENUM_FLAGS(name)                  \
   inline name operator|(name a, name b) {      \
@@ -278,7 +278,7 @@ class TI_DLL_EXPORT CommandList {
    * Doing so resets all bound resources.
    * @params[in] pipeline The pipeline to be bound
    */
-  virtual void bind_pipeline(Pipeline *p) = 0;
+  virtual void bind_pipeline(Pipeline *p) noexcept = 0;
 
   /**
    * Bind a ShaderResourceSet to a set index.
@@ -296,7 +296,7 @@ class TI_DLL_EXPORT CommandList {
    *         `error` If binding failed due to other reasons
    */
   virtual RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                          int set_index = 0) = 0;
+                                          int set_index = 0) noexcept = 0;
 
   /**
    * Bind RasterResources to the command list.
@@ -308,13 +308,66 @@ class TI_DLL_EXPORT CommandList {
    *         `not_supported` If some bindings are not supported by the backend
    *         `error` If binding failed due to other reasons
    */
-  virtual RhiResult bind_raster_resources(RasterResources *res) = 0;
+  virtual RhiResult bind_raster_resources(RasterResources *res) noexcept = 0;
 
-  virtual void buffer_barrier(DevicePtr ptr, size_t size) = 0;
-  virtual void buffer_barrier(DeviceAllocation alloc) = 0;
-  virtual void memory_barrier() = 0;
-  virtual void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) = 0;
-  virtual void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) = 0;
+  /**
+   * Insert a memory barrier into the command list.
+   * The barrier affects a continous region of memory.
+   * Changes to memory before the barrier will be visible to accesses after the
+   * barrier (API command ordering). i.e. Command later to this barrier will see
+   * the changes made by commands before this barrier.
+   * This barrier is limited in scope to the Stream that the command list is
+   * submitted to. Other Streams or Devices may not observe this barrier.
+   * @params[in] ptr The pointer to the start of the region
+   * @params[in] size The size of the memory region.
+   *                  Size is clamped to the underlying buffer size.
+   */
+  virtual void buffer_barrier(DevicePtr ptr, size_t size) noexcept = 0;
+
+  /**
+   * Insert a memory barrier into the command list.
+   * The barrier affects an entire buffer.
+   * Behaviour is the same as `buffer_barrier(DevicePtr, size_t)`
+   * @params[in] alloc The memory allocation of this barrier
+   */
+  virtual void buffer_barrier(DeviceAllocation alloc) noexcept = 0;
+
+  /**
+   * Insert a memory barrier into the command list.
+   * The barrier affects all global memory.
+   * Behaviour is the same as `buffer_barrier(DevicePtr, size_t)`
+   * @params[in] alloc The memory allocation of this barrier
+   */
+  virtual void memory_barrier() noexcept = 0;
+
+  /**
+   * Insert a buffer copy operation into the command list.
+   * @params[in] src The source Device Pointer
+   * @params[in] dst The destination Device Pointer
+   * @params[in] size The size of the region to be copied.
+   *                  The size will be clamped to the minimum between
+   *                  `dst.size - dst.offset` and `src.size - src.offset`
+   */
+  virtual void buffer_copy(DevicePtr dst,
+                           DevicePtr src,
+                           size_t size) noexcept = 0;
+
+  /**
+   * Insert a memory region fill operation into the command list
+   * The memory region will be filled with the given (bit precise) value.
+   * - (Encouraged behavior) If the `data` is 0, the underlying API might
+   *   provide a faster code path.
+   * - (Encouraged behavior) If the `size` is -1 (max of size_t) the underlying
+   *   API might provide a faster code path.
+   * @params[in] ptr The start of the memory region.
+   *                 ptr.offset will be aligned down to a multiple of 4 bytes.
+   * @params[in] size The size of the region.
+   *                  The size will be clamped to the underlying buffer's size.
+   */
+  virtual void buffer_fill(DevicePtr ptr,
+                           size_t size,
+                           uint32_t data) noexcept = 0;
+  
   virtual void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) = 0;
 
   struct ComputeSize {

--- a/taichi/rhi/dx/dx_device.cpp
+++ b/taichi/rhi/dx/dx_device.cpp
@@ -192,7 +192,6 @@ void Dx11CommandList::buffer_fill(DevicePtr ptr,
   // Align to 4 bytes
   ptr.offset = ptr.offset & size_t(-4);
 
-
   // Check for overflow
   if (ptr.offset > desc.ByteWidth) {
     return;

--- a/taichi/rhi/dx/dx_device.h
+++ b/taichi/rhi/dx/dx_device.h
@@ -112,15 +112,15 @@ class Dx11CommandList : public CommandList {
   Dx11CommandList(Dx11Device *ti_device);
   ~Dx11CommandList() override;
 
-  void bind_pipeline(Pipeline *p) override;
+  void bind_pipeline(Pipeline *p) noexcept final;
   RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                  int set_index = 0) final;
-  RhiResult bind_raster_resources(RasterResources *res) final;
-  void buffer_barrier(DevicePtr ptr, size_t size) override;
-  void buffer_barrier(DeviceAllocation alloc) override;
-  void memory_barrier() override;
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override;
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override;
+                                  int set_index = 0) noexcept final;
+  RhiResult bind_raster_resources(RasterResources *res) noexcept final;
+  void buffer_barrier(DevicePtr ptr, size_t size) noexcept final;
+  void buffer_barrier(DeviceAllocation alloc) noexcept final;
+  void memory_barrier() noexcept final;
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) noexcept final;
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept final;
   void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override;
 
   // These are not implemented in compute only device

--- a/taichi/rhi/impl_support.h
+++ b/taichi/rhi/impl_support.h
@@ -5,6 +5,7 @@
 #include <forward_list>
 #include <unordered_set>
 #include <mutex>
+#include <type_traits>
 
 namespace taichi::lang {
 
@@ -39,6 +40,25 @@ void disabled_function([[maybe_unused]] Ts... C) {
 #endif
 
 #define RHI_ASSERT(cond) assert(cond);
+
+template <typename T>
+constexpr auto saturate_uadd(T a, T b) {
+  static_assert(std::is_unsigned<T>::value);
+  const T c = a + b;
+  if (c < a) {
+    return std::numeric_limits<T>::max();
+  }
+  return c;
+}
+
+template <typename T>
+constexpr auto saturate_usub(T x, T y) {
+  static_assert(std::is_unsigned<T>::value);
+  T res = x - y;
+  res &= -(res <= x);
+
+  return res;
+}
 
 // Wrapped return-code & object tuple for simplicity
 // Easier to read then std::pair

--- a/taichi/rhi/metal/device.cpp
+++ b/taichi/rhi/metal/device.cpp
@@ -102,33 +102,33 @@ class CommandListImpl : public CommandList {
     inflight_label_ = label;
   }
 
-  void bind_pipeline(Pipeline *p) override {
+  void bind_pipeline(Pipeline *p) noexcept final {
     get_or_make_compute_builder()->pipeline =
         static_cast<PipelineImpl *>(p)->mtl_pipeline_state();
   }
 
   RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                  int set_index = 0) final {
+                                  int set_index = 0) noexcept final {
     get_or_make_compute_builder()->binding_map =
         static_cast<ShaderResourceSetImpl *>(res)->binding_map();
     return RhiResult::success;
   }
 
-  RhiResult bind_raster_resources(RasterResources *res) final {
+  RhiResult bind_raster_resources(RasterResources *res) noexcept final {
     TI_NOT_IMPLEMENTED;
   }
 
-  void buffer_barrier(DevicePtr ptr, size_t size) override {
+  void buffer_barrier(DevicePtr ptr, size_t size) noexcept final {
     TI_NOT_IMPLEMENTED;
   }
-  void buffer_barrier(DeviceAllocation alloc) override {
+  void buffer_barrier(DeviceAllocation alloc) noexcept final {
     TI_NOT_IMPLEMENTED;
   }
-  void memory_barrier() override {
+  void memory_barrier() noexcept final {
     TI_NOT_IMPLEMENTED;
   }
 
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override {
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) noexcept final {
     TI_ERROR_IF(dst.device != src.device,
                 "dst and src must be from the same MTLDevice");
     TI_ERROR_IF(inflight_compute_builder_.has_value(), "Inflight compute");
@@ -146,7 +146,7 @@ class CommandListImpl : public CommandList {
     finish_encoder(encoder.get());
   }
 
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override {
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept final {
     TI_ERROR_IF(inflight_compute_builder_.has_value(), "Inflight compute");
     if ((data & 0xff) != data) {
       // TODO: Maybe create a shader just for this filling purpose?

--- a/taichi/rhi/opengl/opengl_device.cpp
+++ b/taichi/rhi/opengl/opengl_device.cpp
@@ -305,7 +305,7 @@ GLPipeline::~GLPipeline() {
 GLCommandList::~GLCommandList() {
 }
 
-void GLCommandList::bind_pipeline(Pipeline *p) {
+void GLCommandList::bind_pipeline(Pipeline *p) noexcept {
   GLPipeline *pipeline = static_cast<GLPipeline *>(p);
   auto cmd = std::make_unique<CmdBindPipeline>();
   cmd->program = pipeline->get_program();
@@ -313,7 +313,7 @@ void GLCommandList::bind_pipeline(Pipeline *p) {
 }
 
 RhiResult GLCommandList::bind_shader_resources(ShaderResourceSet *res,
-                                               int set_index) {
+                                               int set_index) noexcept {
   GLResourceSet *set = static_cast<GLResourceSet *>(res);
   for (auto &[binding, buffer] : set->ssbo_binding_map()) {
     auto cmd = std::make_unique<CmdBindBufferToIndex>();
@@ -343,23 +343,25 @@ RhiResult GLCommandList::bind_shader_resources(ShaderResourceSet *res,
   return RhiResult::success;
 }
 
-RhiResult GLCommandList::bind_raster_resources(RasterResources *res) {
+RhiResult GLCommandList::bind_raster_resources(RasterResources *res) noexcept {
   TI_NOT_IMPLEMENTED;
 }
 
-void GLCommandList::buffer_barrier(DevicePtr ptr, size_t size) {
+void GLCommandList::buffer_barrier(DevicePtr ptr, size_t size) noexcept {
   recorded_commands_.push_back(std::make_unique<CmdBufferBarrier>());
 }
 
-void GLCommandList::buffer_barrier(DeviceAllocation alloc) {
+void GLCommandList::buffer_barrier(DeviceAllocation alloc) noexcept {
   recorded_commands_.push_back(std::make_unique<CmdBufferBarrier>());
 }
 
-void GLCommandList::memory_barrier() {
+void GLCommandList::memory_barrier() noexcept {
   recorded_commands_.push_back(std::make_unique<CmdBufferBarrier>());
 }
 
-void GLCommandList::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
+void GLCommandList::buffer_copy(DevicePtr dst,
+                                DevicePtr src,
+                                size_t size) noexcept {
   auto cmd = std::make_unique<CmdBufferCopy>();
   cmd->src = src.alloc_id;
   cmd->dst = dst.alloc_id;
@@ -369,7 +371,9 @@ void GLCommandList::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
   recorded_commands_.push_back(std::move(cmd));
 }
 
-void GLCommandList::buffer_fill(DevicePtr ptr, size_t size, uint32_t data) {
+void GLCommandList::buffer_fill(DevicePtr ptr,
+                                size_t size,
+                                uint32_t data) noexcept {
   auto cmd = std::make_unique<CmdBufferFill>();
   cmd->buffer = ptr.alloc_id;
   cmd->offset = ptr.offset;

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -75,15 +75,15 @@ class GLCommandList : public CommandList {
   }
   ~GLCommandList() override;
 
-  void bind_pipeline(Pipeline *p) override;
+  void bind_pipeline(Pipeline *p) noexcept final;
   RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                  int set_index = 0) final;
-  RhiResult bind_raster_resources(RasterResources *res) final;
-  void buffer_barrier(DevicePtr ptr, size_t size) override;
-  void buffer_barrier(DeviceAllocation alloc) override;
-  void memory_barrier() override;
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override;
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override;
+                                  int set_index = 0) noexcept final;
+  RhiResult bind_raster_resources(RasterResources *res) noexcept final;
+  void buffer_barrier(DevicePtr ptr, size_t size) noexcept final;
+  void buffer_barrier(DeviceAllocation alloc) noexcept final;
+  void memory_barrier() noexcept final;
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) noexcept final;
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept final;
   void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override;
 
   // These are not implemented in compute only device

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -966,7 +966,7 @@ void VulkanCommandList::buffer_barrier(DevicePtr ptr, size_t size) noexcept {
     return;
   }
 
-  if (saturate_uadd(ptr.offset, size) > buffer_size) {
+  if (saturate_uadd<size_t>(ptr.offset, size) > buffer_size) {
     size = VK_WHOLE_SIZE;
   }
 
@@ -1034,11 +1034,11 @@ void VulkanCommandList::buffer_copy(DevicePtr dst,
   size_t dst_size = ti_device_->get_vkbuffer_size(dst);
 
   // Clamp to minimum available size
-  if (saturate_uadd(src.offset, size) > src_size) {
-    size = saturate_usub(src_size, src.offset);
+  if (saturate_uadd<size_t>(src.offset, size) > src_size) {
+    size = saturate_usub<size_t>(src_size, src.offset);
   }
-  if (saturate_uadd(dst.offset, size) > dst_size) {
-    size = saturate_usub(dst_size, dst.offset);
+  if (saturate_uadd<size_t>(dst.offset, size) > dst_size) {
+    size = saturate_usub<size_t>(dst_size, dst.offset);
   }
 
   if (size == 0) {
@@ -1072,7 +1072,7 @@ void VulkanCommandList::buffer_fill(DevicePtr ptr,
     return;
   }
 
-  if (saturate_uadd(ptr.offset, size) > buffer_size) {
+  if (saturate_uadd<size_t>(ptr.offset, size) > buffer_size) {
     size = VK_WHOLE_SIZE;
   }
 

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -832,7 +832,7 @@ VulkanCommandList::VulkanCommandList(VulkanDevice *ti_device,
 VulkanCommandList::~VulkanCommandList() {
 }
 
-void VulkanCommandList::bind_pipeline(Pipeline *p) {
+void VulkanCommandList::bind_pipeline(Pipeline *p) noexcept {
   auto pipeline = static_cast<VulkanPipeline *>(p);
 
   if (current_pipeline_ == pipeline)
@@ -873,7 +873,7 @@ void VulkanCommandList::bind_pipeline(Pipeline *p) {
 }
 
 RhiResult VulkanCommandList::bind_shader_resources(ShaderResourceSet *res,
-                                                   int set_index) {
+                                                   int set_index) noexcept {
   VulkanResourceSet *set = static_cast<VulkanResourceSet *>(res);
   if (set->get_bindings().size() <= 0) {
     return RhiResult::success;
@@ -927,7 +927,8 @@ RhiResult VulkanCommandList::bind_shader_resources(ShaderResourceSet *res,
   return RhiResult::success;
 }
 
-RhiResult VulkanCommandList::bind_raster_resources(RasterResources *_res) {
+RhiResult VulkanCommandList::bind_raster_resources(
+    RasterResources *_res) noexcept {
   VulkanRasterResources *res = static_cast<VulkanRasterResources *>(_res);
 
   if (!current_pipeline_->is_graphics()) {
@@ -956,11 +957,19 @@ RhiResult VulkanCommandList::bind_raster_resources(RasterResources *_res) {
   return RhiResult::success;
 }
 
-void VulkanCommandList::buffer_barrier(DevicePtr ptr, size_t size) {
-  RHI_ASSERT(ptr.device == ti_device_);
-
+void VulkanCommandList::buffer_barrier(DevicePtr ptr, size_t size) noexcept {
   auto buffer = ti_device_->get_vkbuffer(ptr);
+  size_t buffer_size = ti_device_->get_vkbuffer_size(ptr);
+ 
+  // Clamp to buffer size
+  if (ptr.offset > buffer_size) {
+    return;
+  }
 
+  if (saturate_uadd(ptr.offset, size) > buffer_size) {
+    size = VK_WHOLE_SIZE;
+  }
+  
   VkBufferMemoryBarrier barrier{};
   barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
   barrier.pNext = nullptr;
@@ -990,11 +999,11 @@ void VulkanCommandList::buffer_barrier(DevicePtr ptr, size_t size) {
   buffer_->refs.push_back(buffer);
 }
 
-void VulkanCommandList::buffer_barrier(DeviceAllocation alloc) {
-  buffer_barrier(DevicePtr{alloc, 0}, VK_WHOLE_SIZE);
+void VulkanCommandList::buffer_barrier(DeviceAllocation alloc) noexcept {
+  buffer_barrier(DevicePtr{alloc, 0}, std::numeric_limits<size_t>::max());
 }
 
-void VulkanCommandList::memory_barrier() {
+void VulkanCommandList::memory_barrier() noexcept {
   VkMemoryBarrier barrier{};
   barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
   barrier.pNext = nullptr;
@@ -1018,23 +1027,57 @@ void VulkanCommandList::memory_barrier() {
       /*pImageMemoryBarriers=*/nullptr);
 }
 
-void VulkanCommandList::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
+void VulkanCommandList::buffer_copy(DevicePtr dst,
+                                    DevicePtr src,
+                                    size_t size) noexcept {
+  size_t src_size = ti_device_->get_vkbuffer_size(src);
+  size_t dst_size = ti_device_->get_vkbuffer_size(dst);
+  
+  // Clamp to minimum available size
+  if (saturate_uadd(src.offset, size) > src_size) {
+    size = saturate_usub(src_size, src.offset);
+  }
+  if (saturate_uadd(dst.offset, size) > dst_size) {
+    size = saturate_usub(dst_size, dst.offset);
+  }
+
+  if (size == 0) {
+    return;
+  }
+
   VkBufferCopy copy_region{};
   copy_region.srcOffset = src.offset;
   copy_region.dstOffset = dst.offset;
   copy_region.size = size;
+
   auto src_buffer = ti_device_->get_vkbuffer(src);
   auto dst_buffer = ti_device_->get_vkbuffer(dst);
+  size_t src_remain_size = ti_device_->get_vkbuffer_size(src) - src.offset;
   vkCmdCopyBuffer(buffer_->buffer, src_buffer->buffer, dst_buffer->buffer,
                   /*regionCount=*/1, &copy_region);
   buffer_->refs.push_back(src_buffer);
   buffer_->refs.push_back(dst_buffer);
 }
 
-void VulkanCommandList::buffer_fill(DevicePtr ptr, size_t size, uint32_t data) {
+void VulkanCommandList::buffer_fill(DevicePtr ptr,
+                                    size_t size,
+                                    uint32_t data) noexcept {
+  // Align to 4 bytes
+  ptr.offset = ptr.offset & size_t(-4);
+  
   auto buffer = ti_device_->get_vkbuffer(ptr);
-  vkCmdFillBuffer(buffer_->buffer, buffer->buffer, ptr.offset,
-                  (size == kBufferSizeEntireSize) ? VK_WHOLE_SIZE : size, data);
+  size_t buffer_size = ti_device_->get_vkbuffer_size(ptr);
+
+  // Check for overflow
+  if (ptr.offset > buffer_size) {
+    return;
+  }
+
+  if (saturate_uadd(ptr.offset, size) > buffer_size) {
+    size = VK_WHOLE_SIZE;
+  }
+
+  vkCmdFillBuffer(buffer_->buffer, buffer->buffer, ptr.offset, size, data);
   buffer_->refs.push_back(buffer);
 }
 
@@ -1955,6 +1998,12 @@ vkapi::IVkBuffer VulkanDevice::get_vkbuffer(
   const AllocationInternal &alloc_int = get_alloc_internal(alloc);
 
   return alloc_int.buffer;
+}
+
+size_t VulkanDevice::get_vkbuffer_size(const DeviceAllocation &alloc) const {
+  const AllocationInternal &alloc_int = get_alloc_internal(alloc);
+
+  return alloc_int.alloc_info.size;
 }
 
 std::tuple<vkapi::IVkImage, vkapi::IVkImageView, VkFormat>

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -960,7 +960,7 @@ RhiResult VulkanCommandList::bind_raster_resources(
 void VulkanCommandList::buffer_barrier(DevicePtr ptr, size_t size) noexcept {
   auto buffer = ti_device_->get_vkbuffer(ptr);
   size_t buffer_size = ti_device_->get_vkbuffer_size(ptr);
- 
+
   // Clamp to buffer size
   if (ptr.offset > buffer_size) {
     return;
@@ -969,7 +969,7 @@ void VulkanCommandList::buffer_barrier(DevicePtr ptr, size_t size) noexcept {
   if (saturate_uadd(ptr.offset, size) > buffer_size) {
     size = VK_WHOLE_SIZE;
   }
-  
+
   VkBufferMemoryBarrier barrier{};
   barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
   barrier.pNext = nullptr;
@@ -1032,7 +1032,7 @@ void VulkanCommandList::buffer_copy(DevicePtr dst,
                                     size_t size) noexcept {
   size_t src_size = ti_device_->get_vkbuffer_size(src);
   size_t dst_size = ti_device_->get_vkbuffer_size(dst);
-  
+
   // Clamp to minimum available size
   if (saturate_uadd(src.offset, size) > src_size) {
     size = saturate_usub(src_size, src.offset);
@@ -1063,7 +1063,7 @@ void VulkanCommandList::buffer_fill(DevicePtr ptr,
                                     uint32_t data) noexcept {
   // Align to 4 bytes
   ptr.offset = ptr.offset & size_t(-4);
-  
+
   auto buffer = ti_device_->get_vkbuffer(ptr);
   size_t buffer_size = ti_device_->get_vkbuffer_size(ptr);
 

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -1052,7 +1052,6 @@ void VulkanCommandList::buffer_copy(DevicePtr dst,
 
   auto src_buffer = ti_device_->get_vkbuffer(src);
   auto dst_buffer = ti_device_->get_vkbuffer(dst);
-  size_t src_remain_size = ti_device_->get_vkbuffer_size(src) - src.offset;
   vkCmdCopyBuffer(buffer_->buffer, src_buffer->buffer, dst_buffer->buffer,
                   /*regionCount=*/1, &copy_region);
   buffer_->refs.push_back(src_buffer);

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -390,15 +390,15 @@ class VulkanCommandList : public CommandList {
                     vkapi::IVkCommandBuffer buffer);
   ~VulkanCommandList() override;
 
-  void bind_pipeline(Pipeline *p) override;
+  void bind_pipeline(Pipeline *p) noexcept final;
   RhiResult bind_shader_resources(ShaderResourceSet *res,
-                                  int set_index = 0) final;
-  RhiResult bind_raster_resources(RasterResources *res) final;
-  void buffer_barrier(DevicePtr ptr, size_t size) override;
-  void buffer_barrier(DeviceAllocation alloc) override;
-  void memory_barrier() override;
-  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) override;
-  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) override;
+                                  int set_index = 0) noexcept final;
+  RhiResult bind_raster_resources(RasterResources *res) noexcept final;
+  void buffer_barrier(DevicePtr ptr, size_t size) noexcept final;
+  void buffer_barrier(DeviceAllocation alloc) noexcept final;
+  void memory_barrier() noexcept final;
+  void buffer_copy(DevicePtr dst, DevicePtr src, size_t size) noexcept final;
+  void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept final;
   void dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) override;
   void begin_renderpass(int x0,
                         int y0,
@@ -680,6 +680,8 @@ class TI_DLL_EXPORT VulkanDevice : public GraphicsDevice {
       const DeviceAllocation &alloc) const;
 
   vkapi::IVkBuffer get_vkbuffer(const DeviceAllocation &alloc) const;
+
+  size_t get_vkbuffer_size(const DeviceAllocation &alloc) const;
 
   std::tuple<vkapi::IVkImage, vkapi::IVkImageView, VkFormat> get_vk_image(
       const DeviceAllocation &alloc) const;


### PR DESCRIPTION
Issue: #6832

### Brief Summary

Compute-only CommandList APIs other than dispatch has been changed to use `noexcept`, and the behavior specifications has been added, and relevant checks are now in place for Vulkan and partially for DX11.