### PR TITLE
[aot] C-API versioning

### DIFF
--- a/c_api/docs/taichi/taichi_core.h.md
+++ b/c_api/docs/taichi/taichi_core.h.md
@@ -269,6 +269,14 @@ Types of backend archs.
 - `enumeration.arch.vulkan`: Vulkan GPU backend.
 - `enumeration.arch.opengl`: OpenGL GPU backend.
 
+`enumeration.capability`
+
+Device capabilities.
+
+`structure.capability_level_info`
+
+An integral device capability level. It currently is not guaranteed that a higher level value is compatible with a lower level value.
+
 `enumeration.data_type`
 
 Elementary (primitive) data types. There might be vendor-specific constraints on the available data types so it's recommended to use 32-bit data types if multi-platform distribution is desired.
@@ -370,6 +378,10 @@ Dimensions of an image allocation.
 - `enumeration.image_layout.transfer_src`: Optimal layout as a data copy source.
 - `enumeration.image_layout.present_src`:  Optimal layout as a presentation source.
 
+`enumeration.format`
+
+Texture formats. The availability of texture formats depends on runtime support.
+
 `structure.image_offset`
 
 Offsets of an image in X, Y, Z, and array layers.
@@ -441,6 +453,10 @@ A named argument value to feed compute graphs.
 - `structure.named_argument.name`: Name of the argument.
 - `structure.named_argument.argument`: Argument body.
 
+`function.get_version`
+
+Get the current taichi version. It has the same value as `TI_C_API_VERSION` as defined in `taichi_core.h`.
+
 `function.get_available_archs`
 
 Gets a list of available archs on the current platform. An arch is only available if:
@@ -474,6 +490,10 @@ Creates a Taichi Runtime with the specified `enumeration.arch`.
 `function.destroy_runtime`
 
 Destroys a Taichi Runtime.
+
+`function.set_runtime_capabilities`
+
+Force override the list of available capabilities in the runtime instance.
 
 `function.get_runtime_capabilities`
 
@@ -542,6 +562,11 @@ Waits until all previously invoked device commands are executed. Any invoked com
 
 Loads a pre-compiled AOT module from the file system.
 Returns `definition.null_handle` if the runtime fails to load the AOT module from the specified path.
+
+`function.create_aot_module`
+
+Creates a pre-compiled AOT module from TCM data.
+Returns `definition.null_handle` if the runtime fails to create the AOT module from TCM data.
 
 `function.destroy_aot_module`
 

--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -226,7 +226,7 @@
 #pragma once
 
 #ifndef TI_C_API_VERSION
-#define TI_C_API_VERSION 1000002
+#define TI_C_API_VERSION 1004000
 #endif  // TI_C_API_VERSION
 
 #include <taichi/taichi.h>
@@ -371,6 +371,7 @@ typedef enum TiArch {
   TI_ARCH_AMDGPU = 11,
   // Vulkan GPU backend.
   TI_ARCH_VULKAN = 12,
+  TI_ARCH_GLES = 13,
   TI_ARCH_MAX_ENUM = 0xffffffff,
 } TiArch;
 
@@ -797,6 +798,9 @@ typedef struct TiNamedArgument {
   // Argument body.
   TiArgument argument;
 } TiNamedArgument;
+
+// Function `ti_get_version`
+TI_DLL_EXPORT uint32_t TI_API_CALL ti_get_version();
 
 // Function `ti_get_available_archs`
 //

--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -235,24 +235,24 @@
 extern "C" {
 #endif  // __cplusplus
 
-// Alias `TiBool`
+// Alias `TiBool` (1.4.0)
 //
 // A boolean value. Can be either [`TI_TRUE`](#definition-ti_true) or
 // [`TI_FALSE`](#definition-ti_false). Assignment with other values could lead
 // to undefined behavior.
 typedef uint32_t TiBool;
 
-// Definition `TI_FALSE`
+// Definition `TI_FALSE` (1.4.0)
 //
 // A condition or a predicate is not satisfied; a statement is invalid.
 #define TI_FALSE 0
 
-// Definition `TI_TRUE`
+// Definition `TI_TRUE` (1.4.0)
 //
 // A condition or a predicate is satisfied; a statement is valid.
 #define TI_TRUE 1
 
-// Alias `TiFlags`
+// Alias `TiFlags` (1.4.0)
 //
 // A bit field that can be used to represent 32 orthogonal flags. Bits
 // unspecified in the corresponding flag enum are ignored.
@@ -262,13 +262,13 @@ typedef uint32_t TiBool;
 // semantical impact and can be safely ignored.
 typedef uint32_t TiFlags;
 
-// Definition `TI_NULL_HANDLE`
+// Definition `TI_NULL_HANDLE` (1.4.0)
 //
 // A sentinal invalid handle that will never be produced from a valid call to
 // Taichi C-API.
 #define TI_NULL_HANDLE 0
 
-// Handle `TiRuntime`
+// Handle `TiRuntime` (1.4.0)
 //
 // Taichi runtime represents an instance of a logical backend and its internal
 // dynamic state. The user is responsible to synchronize any use of
@@ -276,18 +276,18 @@ typedef uint32_t TiFlags;
 // [`TiRuntime`](#handle-tiruntime)s in the same thread.
 typedef struct TiRuntime_t *TiRuntime;
 
-// Handle `TiAotModule`
+// Handle `TiAotModule` (1.4.0)
 //
 // An ahead-of-time (AOT) compiled Taichi module, which contains a collection of
 // kernels and compute graphs.
 typedef struct TiAotModule_t *TiAotModule;
 
-// Handle `TiMemory`
+// Handle `TiMemory` (1.4.0)
 //
 // A contiguous allocation of device memory.
 typedef struct TiMemory_t *TiMemory;
 
-// Handle `TiImage`
+// Handle `TiImage` (1.4.0)
 //
 // A contiguous allocation of device image.
 typedef struct TiImage_t *TiImage;
@@ -299,18 +299,18 @@ typedef struct TiImage_t *TiImage;
 // modes and address modes of default samplers depend on backend implementation.
 typedef struct TiSampler_t *TiSampler;
 
-// Handle `TiKernel`
+// Handle `TiKernel` (1.4.0)
 //
 // A Taichi kernel that can be launched on the offload target for execution.
 typedef struct TiKernel_t *TiKernel;
 
-// Handle `TiComputeGraph`
+// Handle `TiComputeGraph` (1.4.0)
 //
 // A collection of Taichi kernels (a compute graph) to launch on the offload
 // target in a predefined order.
 typedef struct TiComputeGraph_t *TiComputeGraph;
 
-// Enumeration `TiError`
+// Enumeration `TiError` (1.4.0)
 //
 // Errors reported by the Taichi C-API.
 typedef enum TiError {
@@ -349,7 +349,7 @@ typedef enum TiError {
   TI_ERROR_MAX_ENUM = 0xffffffff,
 } TiError;
 
-// Enumeration `TiArch`
+// Enumeration `TiArch` (1.4.0)
 //
 // Types of backend archs.
 typedef enum TiArch {
@@ -375,7 +375,9 @@ typedef enum TiArch {
   TI_ARCH_MAX_ENUM = 0xffffffff,
 } TiArch;
 
-// Enumeration `TiCapability`
+// Enumeration `TiCapability` (1.4.0)
+//
+// Device capabilities.
 typedef enum TiCapability {
   TI_CAPABILITY_RESERVED = 0,
   TI_CAPABILITY_SPIRV_VERSION = 1,
@@ -405,13 +407,16 @@ typedef enum TiCapability {
   TI_CAPABILITY_MAX_ENUM = 0xffffffff,
 } TiCapability;
 
-// Structure `TiCapabilityLevelInfo`
+// Structure `TiCapabilityLevelInfo` (1.4.0)
+//
+// An integral device capability level. It currently is not guaranteed that a
+// higher level value is compatible with a lower level value.
 typedef struct TiCapabilityLevelInfo {
   TiCapability capability;
   uint32_t level;
 } TiCapabilityLevelInfo;
 
-// Enumeration `TiDataType`
+// Enumeration `TiDataType` (1.4.0)
 //
 // Elementary (primitive) data types. There might be vendor-specific constraints
 // on the available data types so it's recommended to use 32-bit data types if
@@ -445,7 +450,7 @@ typedef enum TiDataType {
   TI_DATA_TYPE_MAX_ENUM = 0xffffffff,
 } TiDataType;
 
-// Enumeration `TiArgumentType`
+// Enumeration `TiArgumentType` (1.4.0)
 //
 // Types of kernel and compute graph argument.
 typedef enum TiArgumentType {
@@ -460,7 +465,7 @@ typedef enum TiArgumentType {
   TI_ARGUMENT_TYPE_MAX_ENUM = 0xffffffff,
 } TiArgumentType;
 
-// BitField `TiMemoryUsageFlags`
+// BitField `TiMemoryUsageFlags` (1.4.0)
 //
 // Usages of a memory allocation. Taichi requires kernel argument memories to be
 // allocated with `TI_MEMORY_USAGE_STORAGE_BIT`.
@@ -476,7 +481,7 @@ typedef enum TiMemoryUsageFlagBits {
 } TiMemoryUsageFlagBits;
 typedef TiFlags TiMemoryUsageFlags;
 
-// Structure `TiMemoryAllocateInfo`
+// Structure `TiMemoryAllocateInfo` (1.4.0)
 //
 // Parameters of a newly allocated memory.
 typedef struct TiMemoryAllocateInfo {
@@ -494,7 +499,7 @@ typedef struct TiMemoryAllocateInfo {
   TiMemoryUsageFlags usage;
 } TiMemoryAllocateInfo;
 
-// Structure `TiMemorySlice`
+// Structure `TiMemorySlice` (1.4.0)
 //
 // A subsection of a memory allocation. The sum of `offset` and `size` cannot
 // exceed the size of `memory`.
@@ -507,7 +512,7 @@ typedef struct TiMemorySlice {
   uint64_t size;
 } TiMemorySlice;
 
-// Structure `TiNdShape`
+// Structure `TiNdShape` (1.4.0)
 //
 // Multi-dimensional size of an ND-array. Dimension sizes after `dim_count` are
 // ignored.
@@ -518,7 +523,7 @@ typedef struct TiNdShape {
   uint32_t dims[16];
 } TiNdShape;
 
-// Structure `TiNdArray`
+// Structure `TiNdArray` (1.4.0)
 //
 // Multi-dimensional array of dense primitive data.
 typedef struct TiNdArray {
@@ -533,7 +538,7 @@ typedef struct TiNdArray {
   TiDataType elem_type;
 } TiNdArray;
 
-// BitField `TiImageUsageFlags`
+// BitField `TiImageUsageFlags` (1.4.0)
 //
 // Usages of an image allocation. Taichi requires kernel argument images to be
 // allocated with `TI_IMAGE_USAGE_STORAGE_BIT` and `TI_IMAGE_USAGE_SAMPLED_BIT`.
@@ -548,7 +553,7 @@ typedef enum TiImageUsageFlagBits {
 } TiImageUsageFlagBits;
 typedef TiFlags TiImageUsageFlags;
 
-// Enumeration `TiImageDimension`
+// Enumeration `TiImageDimension` (1.4.0)
 //
 // Dimensions of an image allocation.
 typedef enum TiImageDimension {
@@ -568,7 +573,7 @@ typedef enum TiImageDimension {
   TI_IMAGE_DIMENSION_MAX_ENUM = 0xffffffff,
 } TiImageDimension;
 
-// Enumeration `TiImageLayout`
+// Enumeration `TiImageLayout` (1.4.0)
 typedef enum TiImageLayout {
   // Undefined layout. An image in this layout does not contain any semantical
   // information.
@@ -596,7 +601,10 @@ typedef enum TiImageLayout {
   TI_IMAGE_LAYOUT_MAX_ENUM = 0xffffffff,
 } TiImageLayout;
 
-// Enumeration `TiFormat`
+// Enumeration `TiFormat` (1.4.0)
+//
+// Texture formats. The availability of texture formats depends on runtime
+// support.
 typedef enum TiFormat {
   TI_FORMAT_UNKNOWN = 0,
   TI_FORMAT_R8 = 1,
@@ -645,7 +653,7 @@ typedef enum TiFormat {
   TI_FORMAT_MAX_ENUM = 0xffffffff,
 } TiFormat;
 
-// Structure `TiImageOffset`
+// Structure `TiImageOffset` (1.4.0)
 //
 // Offsets of an image in X, Y, Z, and array layers.
 typedef struct TiImageOffset {
@@ -667,7 +675,7 @@ typedef struct TiImageOffset {
   uint32_t array_layer_offset;
 } TiImageOffset;
 
-// Structure `TiImageExtent`
+// Structure `TiImageExtent` (1.4.0)
 //
 // Extents of an image in X, Y, Z, and array layers.
 typedef struct TiImageExtent {
@@ -690,7 +698,7 @@ typedef struct TiImageExtent {
   uint32_t array_layer_count;
 } TiImageExtent;
 
-// Structure `TiImageAllocateInfo`
+// Structure `TiImageAllocateInfo` (1.4.0)
 //
 // Parameters of a newly allocated image.
 typedef struct TiImageAllocateInfo {
@@ -710,7 +718,7 @@ typedef struct TiImageAllocateInfo {
   TiImageUsageFlags usage;
 } TiImageAllocateInfo;
 
-// Structure `TiImageSlice`
+// Structure `TiImageSlice` (1.4.0)
 //
 // A subsection of a memory allocation. The sum of `offset` and `extent` in each
 // dimension cannot exceed the size of `image`.
@@ -748,7 +756,7 @@ typedef struct TiSamplerCreateInfo {
   float max_anisotropy;
 } TiSamplerCreateInfo;
 
-// Structure `TiTexture`
+// Structure `TiTexture` (1.4.0)
 //
 // Image data bound to a sampler.
 typedef struct TiTexture {
@@ -765,7 +773,7 @@ typedef struct TiTexture {
   TiFormat format;
 } TiTexture;
 
-// Union `TiArgumentValue`
+// Union `TiArgumentValue` (1.4.0)
 //
 // A scalar or structured argument value.
 typedef union TiArgumentValue {
@@ -779,7 +787,7 @@ typedef union TiArgumentValue {
   TiTexture texture;
 } TiArgumentValue;
 
-// Structure `TiArgument`
+// Structure `TiArgument` (1.4.0)
 //
 // An argument value to feed kernels.
 typedef struct TiArgument {
@@ -789,7 +797,7 @@ typedef struct TiArgument {
   TiArgumentValue value;
 } TiArgument;
 
-// Structure `TiNamedArgument`
+// Structure `TiNamedArgument` (1.4.0)
 //
 // A named argument value to feed compute graphs.
 typedef struct TiNamedArgument {
@@ -799,10 +807,13 @@ typedef struct TiNamedArgument {
   TiArgument argument;
 } TiNamedArgument;
 
-// Function `ti_get_version`
+// Function `ti_get_version` (1.4.0)
+//
+// Get the current taichi version. It has the same value as `TI_C_API_VERSION`
+// as defined in `taichi_core.h`.
 TI_DLL_EXPORT uint32_t TI_API_CALL ti_get_version();
 
-// Function `ti_get_available_archs`
+// Function `ti_get_available_archs` (1.4.0)
 //
 // Gets a list of available archs on the current platform. An arch is only
 // available if:
@@ -818,7 +829,7 @@ TI_DLL_EXPORT uint32_t TI_API_CALL ti_get_version();
 TI_DLL_EXPORT void TI_API_CALL ti_get_available_archs(uint32_t *arch_count,
                                                       TiArch *archs);
 
-// Function `ti_get_last_error`
+// Function `ti_get_last_error` (1.4.0)
 //
 // Gets the last error raised by Taichi C-API invocations. Returns the
 // semantical error code.
@@ -829,7 +840,7 @@ TI_DLL_EXPORT TiError TI_API_CALL ti_get_last_error(
     // 0.
     char *message);
 
-// Function `ti_set_last_error`
+// Function `ti_set_last_error` (1.4.0)
 //
 // Sets the provided error as the last error raised by Taichi C-API invocations.
 // It can be useful in extended validation procedures in Taichi C-API wrappers
@@ -841,7 +852,7 @@ TI_DLL_EXPORT void TI_API_CALL ti_set_last_error(
     // empty error message.
     const char *message);
 
-// Function `ti_create_runtime`
+// Function `ti_create_runtime` (1.4.0)
 //
 // Creates a Taichi Runtime with the specified [`TiArch`](#enumeration-tiarch).
 TI_DLL_EXPORT TiRuntime TI_API_CALL ti_create_runtime(
@@ -851,18 +862,20 @@ TI_DLL_EXPORT TiRuntime TI_API_CALL ti_create_runtime(
     // Runtime on.
     uint32_t device_index);
 
-// Function `ti_destroy_runtime`
+// Function `ti_destroy_runtime` (1.4.0)
 //
 // Destroys a Taichi Runtime.
 TI_DLL_EXPORT void TI_API_CALL ti_destroy_runtime(TiRuntime runtime);
 
-// Function `ti_set_runtime_capabilities_ext`
+// Function `ti_set_runtime_capabilities_ext` (1.4.0)
+//
+// Force override the list of available capabilities in the runtime instance.
 TI_DLL_EXPORT void TI_API_CALL
 ti_set_runtime_capabilities_ext(TiRuntime runtime,
                                 uint32_t capability_count,
                                 const TiCapabilityLevelInfo *capabilities);
 
-// Function `ti_get_runtime_capabilities`
+// Function `ti_get_runtime_capabilities` (1.4.0)
 //
 // Gets all capabilities available on the runtime instance.
 TI_DLL_EXPORT void TI_API_CALL
@@ -872,27 +885,27 @@ ti_get_runtime_capabilities(TiRuntime runtime,
                             // Returned capabilities.
                             TiCapabilityLevelInfo *capabilities);
 
-// Function `ti_allocate_memory`
+// Function `ti_allocate_memory` (1.4.0)
 //
 // Allocates a contiguous device memory with provided parameters.
 TI_DLL_EXPORT TiMemory TI_API_CALL
 ti_allocate_memory(TiRuntime runtime,
                    const TiMemoryAllocateInfo *allocate_info);
 
-// Function `ti_free_memory`
+// Function `ti_free_memory` (1.4.0)
 //
 // Frees a memory allocation.
 TI_DLL_EXPORT void TI_API_CALL ti_free_memory(TiRuntime runtime,
                                               TiMemory memory);
 
-// Function `ti_map_memory`
+// Function `ti_map_memory` (1.4.0)
 //
 // Maps a device memory to a host-addressable space. You *must* ensure that the
 // device is not being used by any device command before the mapping.
 TI_DLL_EXPORT void *TI_API_CALL ti_map_memory(TiRuntime runtime,
                                               TiMemory memory);
 
-// Function `ti_unmap_memory`
+// Function `ti_unmap_memory` (1.4.0)
 //
 // Unmaps a device memory and makes any host-side changes about the memory
 // visible to the device. You *must* ensure that there is no further access to
@@ -900,13 +913,13 @@ TI_DLL_EXPORT void *TI_API_CALL ti_map_memory(TiRuntime runtime,
 TI_DLL_EXPORT void TI_API_CALL ti_unmap_memory(TiRuntime runtime,
                                                TiMemory memory);
 
-// Function `ti_allocate_image`
+// Function `ti_allocate_image` (1.4.0)
 //
 // Allocates a device image with provided parameters.
 TI_DLL_EXPORT TiImage TI_API_CALL
 ti_allocate_image(TiRuntime runtime, const TiImageAllocateInfo *allocate_info);
 
-// Function `ti_free_image`
+// Function `ti_free_image` (1.4.0)
 //
 // Frees an image allocation.
 TI_DLL_EXPORT void TI_API_CALL ti_free_image(TiRuntime runtime, TiImage image);
@@ -919,7 +932,7 @@ ti_create_sampler(TiRuntime runtime, const TiSamplerCreateInfo *create_info);
 TI_DLL_EXPORT void TI_API_CALL ti_destroy_sampler(TiRuntime runtime,
                                                   TiSampler sampler);
 
-// Function `ti_copy_memory_device_to_device` (Device Command)
+// Function `ti_copy_memory_device_to_device` (Device Command) (1.4.0)
 //
 // Copies the data in a contiguous subsection of the device memory to another
 // subsection. The two subsections *must not* overlap.
@@ -937,7 +950,7 @@ ti_copy_image_device_to_device(TiRuntime runtime,
                                const TiImageSlice *dst_image,
                                const TiImageSlice *src_image);
 
-// Function `ti_track_image_ext`
+// Function `ti_track_image_ext` (1.4.0)
 //
 // Tracks the device image with the provided image layout. Because Taichi tracks
 // image layouts internally, it is *only* useful to inform Taichi that the image
@@ -946,7 +959,7 @@ TI_DLL_EXPORT void TI_API_CALL ti_track_image_ext(TiRuntime runtime,
                                                   TiImage image,
                                                   TiImageLayout layout);
 
-// Function `ti_transition_image` (Device Command)
+// Function `ti_transition_image` (Device Command) (1.4.0)
 //
 // Transitions the image to the provided image layout. Because Taichi tracks
 // image layouts internally, it is *only* useful to enforce an image layout for
@@ -955,7 +968,7 @@ TI_DLL_EXPORT void TI_API_CALL ti_transition_image(TiRuntime runtime,
                                                    TiImage image,
                                                    TiImageLayout layout);
 
-// Function `ti_launch_kernel` (Device Command)
+// Function `ti_launch_kernel` (Device Command) (1.4.0)
 //
 // Launches a Taichi kernel with the provided arguments. The arguments *must*
 // have the same count and types in the same order as in the source code.
@@ -964,7 +977,7 @@ TI_DLL_EXPORT void TI_API_CALL ti_launch_kernel(TiRuntime runtime,
                                                 uint32_t arg_count,
                                                 const TiArgument *args);
 
-// Function `ti_launch_compute_graph` (Device Command)
+// Function `ti_launch_compute_graph` (Device Command) (1.4.0)
 //
 // Launches a Taichi compute graph with provided named arguments. The named
 // arguments *must* have the same count, names, and types as in the source code.
@@ -974,19 +987,19 @@ ti_launch_compute_graph(TiRuntime runtime,
                         uint32_t arg_count,
                         const TiNamedArgument *args);
 
-// Function `ti_flush`
+// Function `ti_flush` (1.4.0)
 //
 // Submits all previously invoked device commands to the offload device for
 // execution.
 TI_DLL_EXPORT void TI_API_CALL ti_flush(TiRuntime runtime);
 
-// Function `ti_wait`
+// Function `ti_wait` (1.4.0)
 //
 // Waits until all previously invoked device commands are executed. Any invoked
 // command that has not been submitted is submitted first.
 TI_DLL_EXPORT void TI_API_CALL ti_wait(TiRuntime runtime);
 
-// Function `ti_load_aot_module`
+// Function `ti_load_aot_module` (1.4.0)
 //
 // Loads a pre-compiled AOT module from the file system.
 // Returns [`TI_NULL_HANDLE`](#definition-ti_null_handle) if the runtime fails
@@ -994,17 +1007,21 @@ TI_DLL_EXPORT void TI_API_CALL ti_wait(TiRuntime runtime);
 TI_DLL_EXPORT TiAotModule TI_API_CALL
 ti_load_aot_module(TiRuntime runtime, const char *module_path);
 
-// Function `ti_create_aot_module`
+// Function `ti_create_aot_module` (1.4.0)
+//
+// Creates a pre-compiled AOT module from TCM data.
+// Returns [`TI_NULL_HANDLE`](#definition-ti_null_handle) if the runtime fails
+// to create the AOT module from TCM data.
 TI_DLL_EXPORT TiAotModule TI_API_CALL ti_create_aot_module(TiRuntime runtime,
                                                            const void *tcm,
                                                            uint64_t size);
 
-// Function `ti_destroy_aot_module`
+// Function `ti_destroy_aot_module` (1.4.0)
 //
 // Destroys a loaded AOT module and releases all related resources.
 TI_DLL_EXPORT void TI_API_CALL ti_destroy_aot_module(TiAotModule aot_module);
 
-// Function `ti_get_aot_module_kernel`
+// Function `ti_get_aot_module_kernel` (1.4.0)
 //
 // Retrieves a pre-compiled Taichi kernel from the AOT module.
 // Returns [`TI_NULL_HANDLE`](#definition-ti_null_handle) if the module does not
@@ -1012,7 +1029,7 @@ TI_DLL_EXPORT void TI_API_CALL ti_destroy_aot_module(TiAotModule aot_module);
 TI_DLL_EXPORT TiKernel TI_API_CALL
 ti_get_aot_module_kernel(TiAotModule aot_module, const char *name);
 
-// Function `ti_get_aot_module_compute_graph`
+// Function `ti_get_aot_module_compute_graph` (1.4.0)
 //
 // Retrieves a pre-compiled compute graph from the AOT module.
 // Returns [`TI_NULL_HANDLE`](#definition-ti_null_handle) if the module does not

--- a/c_api/include/taichi/taichi_vulkan.h
+++ b/c_api/include/taichi/taichi_vulkan.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-// Structure `TiVulkanRuntimeInteropInfo`
+// Structure `TiVulkanRuntimeInteropInfo` (1.4.0)
 //
 // Necessary detail to share the same Vulkan runtime between Taichi and external
 // procedures.
@@ -44,7 +44,7 @@ typedef struct TiVulkanRuntimeInteropInfo {
   uint32_t graphics_queue_family_index;
 } TiVulkanRuntimeInteropInfo;
 
-// Structure `TiVulkanMemoryInteropInfo`
+// Structure `TiVulkanMemoryInteropInfo` (1.4.0)
 //
 // Necessary detail to share the same piece of Vulkan buffer between Taichi and
 // external procedures.
@@ -63,7 +63,7 @@ typedef struct TiVulkanMemoryInteropInfo {
   uint64_t offset;
 } TiVulkanMemoryInteropInfo;
 
-// Structure `TiVulkanImageInteropInfo`
+// Structure `TiVulkanImageInteropInfo` (1.4.0)
 //
 // Necessary detail to share the same piece of Vulkan image between Taichi and
 // external procedures.
@@ -89,7 +89,7 @@ typedef struct TiVulkanImageInteropInfo {
   VkImageUsageFlags usage;
 } TiVulkanImageInteropInfo;
 
-// Function `ti_create_vulkan_runtime_ext`
+// Function `ti_create_vulkan_runtime_ext` (1.4.0)
 //
 // Creates a Vulkan Taichi runtime with user-controlled capability settings.
 TI_DLL_EXPORT TiRuntime TI_API_CALL
@@ -99,27 +99,27 @@ ti_create_vulkan_runtime_ext(uint32_t api_version,
                              uint32_t device_extension_count,
                              const char **device_extensions);
 
-// Function `ti_import_vulkan_runtime`
+// Function `ti_import_vulkan_runtime` (1.4.0)
 //
 // Imports the Vulkan runtime owned by Taichi to external procedures.
 TI_DLL_EXPORT TiRuntime TI_API_CALL
 ti_import_vulkan_runtime(const TiVulkanRuntimeInteropInfo *interop_info);
 
-// Function `ti_export_vulkan_runtime`
+// Function `ti_export_vulkan_runtime` (1.4.0)
 //
 // Exports a Vulkan runtime from external procedures to Taichi.
 TI_DLL_EXPORT void TI_API_CALL
 ti_export_vulkan_runtime(TiRuntime runtime,
                          TiVulkanRuntimeInteropInfo *interop_info);
 
-// Function `ti_import_vulkan_memory`
+// Function `ti_import_vulkan_memory` (1.4.0)
 //
 // Imports the Vulkan buffer owned by Taichi to external procedures.
 TI_DLL_EXPORT TiMemory TI_API_CALL
 ti_import_vulkan_memory(TiRuntime runtime,
                         const TiVulkanMemoryInteropInfo *interop_info);
 
-// Function `ti_export_vulkan_memory`
+// Function `ti_export_vulkan_memory` (1.4.0)
 //
 // Exports a Vulkan buffer from external procedures to Taichi.
 TI_DLL_EXPORT void TI_API_CALL
@@ -127,7 +127,7 @@ ti_export_vulkan_memory(TiRuntime runtime,
                         TiMemory memory,
                         TiVulkanMemoryInteropInfo *interop_info);
 
-// Function `ti_import_vulkan_image`
+// Function `ti_import_vulkan_image` (1.4.0)
 //
 // Imports the Vulkan image owned by Taichi to external procedures.
 TI_DLL_EXPORT TiImage TI_API_CALL
@@ -136,7 +136,7 @@ ti_import_vulkan_image(TiRuntime runtime,
                        VkImageViewType view_type,
                        VkImageLayout layout);
 
-// Function `ti_export_vulkan_image`
+// Function `ti_export_vulkan_image` (1.4.0)
 //
 // Exports a Vulkan image from external procedures to Taichi.
 TI_DLL_EXPORT void TI_API_CALL

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -141,6 +141,10 @@ Runtime &AotModule::runtime() {
 
 // -----------------------------------------------------------------------------
 
+uint32_t ti_get_version() {
+  return TI_C_API_VERSION;
+}
+
 void ti_get_available_archs(uint32_t *arch_count, TiArch *archs) {
   if (arch_count == nullptr) {
     return;
@@ -214,6 +218,7 @@ TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
   TI_CAPI_TRY_CATCH_BEGIN();
   // FIXME: (penguinliong) Support device selection.
   TI_CAPI_NOT_SUPPORTED_IF_RV(device_index != 0);
+  TI_INFO("Taichi Runtime C-API version is: {}", TI_C_API_VERSION);
   switch (arch) {
 #ifdef TI_WITH_VULKAN
     case TI_ARCH_VULKAN: {

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -1,5 +1,4 @@
 {
-    "version": "1.0.2",
     "modules": [
         {
             "name": "taichi/taichi_platform.h",
@@ -452,6 +451,16 @@
                         },
                         {
                             "type": "structure.argument"
+                        }
+                    ]
+                },
+                {
+                    "name": "get_version",
+                    "type": "function",
+                    "parameters": [
+                        {
+                            "name": "@return",
+                            "type": "uint32_t"
                         }
                     ]
                 },

--- a/c_api/taichi.json
+++ b/c_api/taichi.json
@@ -19,46 +19,55 @@
                 {
                     "name": "bool",
                     "type": "alias",
+                    "since": "v1.4.0",
                     "alias_of": "uint32_t"
                 },
                 {
                     "name": "false",
                     "type": "definition",
+                    "since": "v1.4.0",
                     "value": "0"
                 },
                 {
                     "name": "true",
                     "type": "definition",
+                    "since": "v1.4.0",
                     "value": "1"
                 },
                 {
                     "name": "flags",
                     "type": "alias",
+                    "since": "v1.4.0",
                     "alias_of": "uint32_t"
                 },
                 {
                     "name": "null_handle",
                     "type": "definition",
+                    "since": "v1.4.0",
                     "value": "0"
                 },
                 {
                     "name": "runtime",
                     "type": "handle",
+                    "since": "v1.4.0",
                     "is_dispatchable": true
                 },
                 {
                     "name": "aot_module",
                     "type": "handle",
+                    "since": "v1.4.0",
                     "is_dispatchable": true
                 },
                 {
                     "name": "memory",
                     "type": "handle",
+                    "since": "v1.4.0",
                     "is_dispatchable": false
                 },
                 {
                     "name": "image",
                     "type": "handle",
+                    "since": "v1.4.0",
                     "is_dispatchable": false
                 },
                 {
@@ -69,16 +78,19 @@
                 {
                     "name": "kernel",
                     "type": "handle",
+                    "since": "v1.4.0",
                     "is_dispatchable": false
                 },
                 {
                     "name": "compute_graph",
                     "type": "handle",
+                    "since": "v1.4.0",
                     "is_dispatchable": false
                 },
                 {
                     "name": "error",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "cases": {
                         "success": 0,
                         "not_supported": -1,
@@ -97,16 +109,19 @@
                 {
                     "name": "arch",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "inc_cases": "PER_ARCH"
                 },
                 {
                     "name": "capability",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "inc_cases": "PER_DEVICE_CAPABILITY"
                 },
                 {
                     "name": "capability_level_info",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "type": "enumeration.capability"
@@ -120,11 +135,13 @@
                 {
                     "name": "data_type",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "inc_cases": "PER_TYPE"
                 },
                 {
                     "name": "argument_type",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "cases": {
                         "i32": 0,
                         "f32": 1,
@@ -135,6 +152,7 @@
                 {
                     "name": "memory_usage",
                     "type": "bit_field",
+                    "since": "v1.4.0",
                     "bits": {
                         "storage": 0,
                         "uniform": 1,
@@ -145,6 +163,7 @@
                 {
                     "name": "memory_allocate_info",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "size",
@@ -171,6 +190,7 @@
                 {
                     "name": "memory_slice",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "type": "handle.memory"
@@ -188,6 +208,7 @@
                 {
                     "name": "nd_shape",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "dim_count",
@@ -203,6 +224,7 @@
                 {
                     "name": "nd_array",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "memory",
@@ -225,6 +247,7 @@
                 {
                     "name": "image_usage",
                     "type": "bit_field",
+                    "since": "v1.4.0",
                     "bits": {
                         "storage": 0,
                         "sampled": 1,
@@ -234,6 +257,7 @@
                 {
                     "name": "image_dimension",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "cases": {
                         "1d": 0,
                         "2d": 1,
@@ -246,16 +270,19 @@
                 {
                     "name": "image_layout",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "inc_cases": "PER_IMAGE_LAYOUT"
                 },
                 {
                     "name": "format",
                     "type": "enumeration",
+                    "since": "v1.4.0",
                     "inc_cases": "PER_BUFFER_FORMAT"
                 },
                 {
                     "name": "image_offset",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "x",
@@ -278,6 +305,7 @@
                 {
                     "name": "image_extent",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "width",
@@ -300,6 +328,7 @@
                 {
                     "name": "image_allocate_info",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "dimension",
@@ -330,6 +359,7 @@
                 {
                     "name": "image_slice",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "type": "handle.image"
@@ -383,6 +413,7 @@
                 {
                     "name": "texture",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "image",
@@ -408,6 +439,7 @@
                 {
                     "name": "argument_value",
                     "type": "union",
+                    "since": "v1.4.0",
                     "variants": [
                         {
                             "name": "i32",
@@ -430,6 +462,7 @@
                 {
                     "name": "argument",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "type",
@@ -444,6 +477,7 @@
                 {
                     "name": "named_argument",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "name",
@@ -457,6 +491,7 @@
                 {
                     "name": "get_version",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -467,6 +502,7 @@
                 {
                     "name": "get_available_archs",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "arch_count",
@@ -484,6 +520,7 @@
                 {
                     "name": "get_last_error",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -504,6 +541,7 @@
                 {
                     "name": "set_last_error",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "enumeration.error"
@@ -517,6 +555,7 @@
                 {
                     "name": "create_runtime",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -534,6 +573,7 @@
                 {
                     "name": "destroy_runtime",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -544,6 +584,7 @@
                     "name": "set_runtime_capabilities",
                     "type": "function",
                     "is_extension": true,
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -562,6 +603,7 @@
                 {
                     "name": "get_runtime_capabilities",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -582,6 +624,7 @@
                 {
                     "name": "allocate_memory",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -600,6 +643,7 @@
                 {
                     "name": "free_memory",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -612,6 +656,7 @@
                 {
                     "name": "map_memory",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -628,6 +673,7 @@
                 {
                     "name": "unmap_memory",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -640,6 +686,7 @@
                 {
                     "name": "allocate_image",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -658,6 +705,7 @@
                 {
                     "name": "free_image",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -700,6 +748,7 @@
                 {
                     "name": "copy_memory_device_to_device",
                     "type": "function",
+                    "since": "v1.4.0",
                     "is_device_command": true,
                     "parameters": [
                         {
@@ -741,6 +790,7 @@
                     "name": "track_image",
                     "type": "function",
                     "is_extension": true,
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -757,6 +807,7 @@
                 {
                     "name": "transition_image",
                     "type": "function",
+                    "since": "v1.4.0",
                     "is_device_command": true,
                     "parameters": [
                         {
@@ -774,6 +825,7 @@
                 {
                     "name": "launch_kernel",
                     "type": "function",
+                    "since": "v1.4.0",
                     "is_device_command": true,
                     "parameters": [
                         {
@@ -796,6 +848,7 @@
                 {
                     "name": "launch_compute_graph",
                     "type": "function",
+                    "since": "v1.4.0",
                     "is_device_command": true,
                     "parameters": [
                         {
@@ -818,6 +871,7 @@
                 {
                     "name": "flush",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -827,6 +881,7 @@
                 {
                     "name": "wait",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -836,6 +891,7 @@
                 {
                     "name": "load_aot_module",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -853,6 +909,7 @@
                 {
                     "name": "create_aot_module",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -874,6 +931,7 @@
                 {
                     "name": "destroy_aot_module",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.aot_module"
@@ -883,6 +941,7 @@
                 {
                     "name": "get_aot_module_kernel",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -900,6 +959,7 @@
                 {
                     "name": "get_aot_module_compute_graph",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -1004,6 +1064,7 @@
                 {
                     "name": "vulkan_runtime_interop_info",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "get_instance_proc_addr",
@@ -1046,6 +1107,7 @@
                 {
                     "name": "vulkan_memory_interop_info",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "buffer",
@@ -1072,6 +1134,7 @@
                 {
                     "name": "vulkan_image_interop_info",
                     "type": "structure",
+                    "since": "v1.4.0",
                     "fields": [
                         {
                             "name": "image",
@@ -1115,6 +1178,7 @@
                     "name": "create_vulkan_runtime",
                     "type": "function",
                     "is_extension": true,
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -1145,6 +1209,7 @@
                 {
                     "name": "import_vulkan_runtime",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -1160,6 +1225,7 @@
                 {
                     "name": "export_vulkan_runtime",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -1174,6 +1240,7 @@
                 {
                     "name": "import_vulkan_memory",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -1192,6 +1259,7 @@
                 {
                     "name": "export_vulkan_memory",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"
@@ -1209,6 +1277,7 @@
                 {
                     "name": "import_vulkan_image",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "name": "@return",
@@ -1235,6 +1304,7 @@
                 {
                     "name": "export_vulkan_image",
                     "type": "function",
+                    "since": "v1.4.0",
                     "parameters": [
                         {
                             "type": "handle.runtime"

--- a/docs/lang/articles/c-api/taichi_core.md
+++ b/docs/lang/articles/c-api/taichi_core.md
@@ -191,6 +191,8 @@ ti_wait(runtime);
 
 ### Alias `TiBool`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // alias.bool
 typedef uint32_t TiBool;
@@ -200,6 +202,8 @@ A boolean value. Can be either [`TI_TRUE`](#definition-ti_true) or [`TI_FALSE`](
 
 ---
 ### Definition `TI_FALSE`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // definition.false
@@ -211,6 +215,8 @@ A condition or a predicate is not satisfied; a statement is invalid.
 ---
 ### Definition `TI_TRUE`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // definition.true
 #define TI_TRUE 1
@@ -220,6 +226,8 @@ A condition or a predicate is satisfied; a statement is valid.
 
 ---
 ### Alias `TiFlags`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // alias.flags
@@ -233,6 +241,8 @@ A bit field that can be used to represent 32 orthogonal flags. Bits unspecified 
 ---
 ### Definition `TI_NULL_HANDLE`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // definition.null_handle
 #define TI_NULL_HANDLE 0
@@ -242,6 +252,8 @@ A sentinal invalid handle that will never be produced from a valid call to Taich
 
 ---
 ### Handle `TiRuntime`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // handle.runtime
@@ -253,6 +265,8 @@ Taichi runtime represents an instance of a logical backend and its internal dyna
 ---
 ### Handle `TiAotModule`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // handle.aot_module
 typedef struct TiAotModule_t* TiAotModule;
@@ -262,6 +276,8 @@ An ahead-of-time (AOT) compiled Taichi module, which contains a collection of ke
 
 ---
 ### Handle `TiMemory`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // handle.memory
@@ -273,6 +289,8 @@ A contiguous allocation of device memory.
 ---
 ### Handle `TiImage`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // handle.image
 typedef struct TiImage_t* TiImage;
@@ -281,17 +299,9 @@ typedef struct TiImage_t* TiImage;
 A contiguous allocation of device image.
 
 ---
-### Handle `TiSampler`
-
-```c
-// handle.sampler
-typedef struct TiSampler_t* TiSampler;
-```
-
-An image sampler. [`TI_NULL_HANDLE`](#definition-ti_null_handle) represents a default image sampler provided by the runtime implementation. The filter modes and address modes of default samplers depend on backend implementation.
-
----
 ### Handle `TiKernel`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // handle.kernel
@@ -303,6 +313,8 @@ A Taichi kernel that can be launched on the offload target for execution.
 ---
 ### Handle `TiComputeGraph`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // handle.compute_graph
 typedef struct TiComputeGraph_t* TiComputeGraph;
@@ -312,6 +324,8 @@ A collection of Taichi kernels (a compute graph) to launch on the offload target
 
 ---
 ### Enumeration `TiError`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // enumeration.error
@@ -349,6 +363,8 @@ Errors reported by the Taichi C-API.
 ---
 ### Enumeration `TiArch`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // enumeration.arch
 typedef enum TiArch {
@@ -365,6 +381,7 @@ typedef enum TiArch {
   TI_ARCH_OPENCL = 10,
   TI_ARCH_AMDGPU = 11,
   TI_ARCH_VULKAN = 12,
+  TI_ARCH_GLES = 13,
   TI_ARCH_MAX_ENUM = 0xffffffff,
 } TiArch;
 ```
@@ -379,6 +396,8 @@ Types of backend archs.
 
 ---
 ### Enumeration `TiCapability`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // enumeration.capability
@@ -412,8 +431,12 @@ typedef enum TiCapability {
 } TiCapability;
 ```
 
+Device capabilities.
+
 ---
 ### Structure `TiCapabilityLevelInfo`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // structure.capability_level_info
@@ -423,8 +446,12 @@ typedef struct TiCapabilityLevelInfo {
 } TiCapabilityLevelInfo;
 ```
 
+An integral device capability level. It currently is not guaranteed that a higher level value is compatible with a lower level value.
+
 ---
 ### Enumeration `TiDataType`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // enumeration.data_type
@@ -464,6 +491,8 @@ Elementary (primitive) data types. There might be vendor-specific constraints on
 ---
 ### Enumeration `TiArgumentType`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // enumeration.argument_type
 typedef enum TiArgumentType {
@@ -485,6 +514,8 @@ Types of kernel and compute graph argument.
 ---
 ### BitField `TiMemoryUsageFlags`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // bit_field.memory_usage
 typedef enum TiMemoryUsageFlagBits {
@@ -505,6 +536,8 @@ Usages of a memory allocation. Taichi requires kernel argument memories to be al
 
 ---
 ### Structure `TiMemoryAllocateInfo`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // structure.memory_allocate_info
@@ -528,6 +561,8 @@ Parameters of a newly allocated memory.
 ---
 ### Structure `TiMemorySlice`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.memory_slice
 typedef struct TiMemorySlice {
@@ -546,6 +581,8 @@ A subsection of a memory allocation. The sum of `offset` and `size` cannot excee
 ---
 ### Structure `TiNdShape`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.nd_shape
 typedef struct TiNdShape {
@@ -561,6 +598,8 @@ Multi-dimensional size of an ND-array. Dimension sizes after `dim_count` are ign
 
 ---
 ### Structure `TiNdArray`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // structure.nd_array
@@ -582,6 +621,8 @@ Multi-dimensional array of dense primitive data.
 ---
 ### BitField `TiImageUsageFlags`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // bit_field.image_usage
 typedef enum TiImageUsageFlagBits {
@@ -600,6 +641,8 @@ Usages of an image allocation. Taichi requires kernel argument images to be allo
 
 ---
 ### Enumeration `TiImageDimension`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // enumeration.image_dimension
@@ -625,6 +668,8 @@ Dimensions of an image allocation.
 
 ---
 ### Enumeration `TiImageLayout`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // enumeration.image_layout
@@ -658,6 +703,8 @@ typedef enum TiImageLayout {
 
 ---
 ### Enumeration `TiFormat`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // enumeration.format
@@ -710,8 +757,12 @@ typedef enum TiFormat {
 } TiFormat;
 ```
 
+Texture formats. The availability of texture formats depends on runtime support.
+
 ---
 ### Structure `TiImageOffset`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // structure.image_offset
@@ -733,6 +784,8 @@ Offsets of an image in X, Y, Z, and array layers.
 ---
 ### Structure `TiImageExtent`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.image_extent
 typedef struct TiImageExtent {
@@ -752,6 +805,8 @@ Extents of an image in X, Y, Z, and array layers.
 
 ---
 ### Structure `TiImageAllocateInfo`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // structure.image_allocate_info
@@ -777,6 +832,8 @@ Parameters of a newly allocated image.
 ---
 ### Structure `TiImageSlice`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.image_slice
 typedef struct TiImageSlice {
@@ -795,45 +852,9 @@ A subsection of a memory allocation. The sum of `offset` and `extent` in each di
 - `mip_level`: The subsectioned mip-level.
 
 ---
-### Enumeration `TiFilter`
-
-```c
-// enumeration.filter
-typedef enum TiFilter {
-  TI_FILTER_NEAREST = 0,
-  TI_FILTER_LINEAR = 1,
-  TI_FILTER_MAX_ENUM = 0xffffffff,
-} TiFilter;
-```
-
----
-### Enumeration `TiAddressMode`
-
-```c
-// enumeration.address_mode
-typedef enum TiAddressMode {
-  TI_ADDRESS_MODE_REPEAT = 0,
-  TI_ADDRESS_MODE_MIRRORED_REPEAT = 1,
-  TI_ADDRESS_MODE_CLAMP_TO_EDGE = 2,
-  TI_ADDRESS_MODE_MAX_ENUM = 0xffffffff,
-} TiAddressMode;
-```
-
----
-### Structure `TiSamplerCreateInfo`
-
-```c
-// structure.sampler_create_info
-typedef struct TiSamplerCreateInfo {
-  TiFilter mag_filter;
-  TiFilter min_filter;
-  TiAddressMode address_mode;
-  float max_anisotropy;
-} TiSamplerCreateInfo;
-```
-
----
 ### Structure `TiTexture`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // structure.texture
@@ -857,6 +878,8 @@ Image data bound to a sampler.
 ---
 ### Union `TiArgumentValue`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // union.argument_value
 typedef union TiArgumentValue {
@@ -877,6 +900,8 @@ A scalar or structured argument value.
 ---
 ### Structure `TiArgument`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.argument
 typedef struct TiArgument {
@@ -893,6 +918,8 @@ An argument value to feed kernels.
 ---
 ### Structure `TiNamedArgument`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.named_argument
 typedef struct TiNamedArgument {
@@ -907,7 +934,22 @@ A named argument value to feed compute graphs.
 - `argument`: Argument body.
 
 ---
+### Function `ti_get_version`
+
+> Stable since Taichi version: 1.4.0
+
+```c
+// function.get_version
+TI_DLL_EXPORT uint32_t TI_API_CALL ti_get_version(
+);
+```
+
+Get the current taichi version. It has the same value as `TI_C_API_VERSION` as defined in `taichi_core.h`.
+
+---
 ### Function `ti_get_available_archs`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.get_available_archs
@@ -927,6 +969,8 @@ An available arch has at least one device available, i.e., device index 0 is alw
 ---
 ### Function `ti_get_last_error`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.get_last_error
 TI_DLL_EXPORT TiError TI_API_CALL ti_get_last_error(
@@ -942,6 +986,8 @@ Gets the last error raised by Taichi C-API invocations. Returns the semantical e
 
 ---
 ### Function `ti_set_last_error`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.set_last_error
@@ -959,6 +1005,8 @@ Sets the provided error as the last error raised by Taichi C-API invocations. It
 ---
 ### Function `ti_create_runtime`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.create_runtime
 TI_DLL_EXPORT TiRuntime TI_API_CALL ti_create_runtime(
@@ -975,6 +1023,8 @@ Creates a Taichi Runtime with the specified [`TiArch`](#enumeration-tiarch).
 ---
 ### Function `ti_destroy_runtime`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.destroy_runtime
 TI_DLL_EXPORT void TI_API_CALL ti_destroy_runtime(
@@ -987,6 +1037,8 @@ Destroys a Taichi Runtime.
 ---
 ### Function `ti_set_runtime_capabilities_ext`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.set_runtime_capabilities
 TI_DLL_EXPORT void TI_API_CALL ti_set_runtime_capabilities_ext(
@@ -996,8 +1048,12 @@ TI_DLL_EXPORT void TI_API_CALL ti_set_runtime_capabilities_ext(
 );
 ```
 
+Force override the list of available capabilities in the runtime instance.
+
 ---
 ### Function `ti_get_runtime_capabilities`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.get_runtime_capabilities
@@ -1016,6 +1072,8 @@ Gets all capabilities available on the runtime instance.
 ---
 ### Function `ti_allocate_memory`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.allocate_memory
 TI_DLL_EXPORT TiMemory TI_API_CALL ti_allocate_memory(
@@ -1028,6 +1086,8 @@ Allocates a contiguous device memory with provided parameters.
 
 ---
 ### Function `ti_free_memory`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.free_memory
@@ -1042,6 +1102,8 @@ Frees a memory allocation.
 ---
 ### Function `ti_map_memory`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.map_memory
 TI_DLL_EXPORT void* TI_API_CALL ti_map_memory(
@@ -1054,6 +1116,8 @@ Maps a device memory to a host-addressable space. You *must* ensure that the dev
 
 ---
 ### Function `ti_unmap_memory`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.unmap_memory
@@ -1068,6 +1132,8 @@ Unmaps a device memory and makes any host-side changes about the memory visible 
 ---
 ### Function `ti_allocate_image`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.allocate_image
 TI_DLL_EXPORT TiImage TI_API_CALL ti_allocate_image(
@@ -1081,6 +1147,8 @@ Allocates a device image with provided parameters.
 ---
 ### Function `ti_free_image`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.free_image
 TI_DLL_EXPORT void TI_API_CALL ti_free_image(
@@ -1092,29 +1160,9 @@ TI_DLL_EXPORT void TI_API_CALL ti_free_image(
 Frees an image allocation.
 
 ---
-### Function `ti_create_sampler`
-
-```c
-// function.create_sampler
-TI_DLL_EXPORT TiSampler TI_API_CALL ti_create_sampler(
-  TiRuntime runtime,
-  const TiSamplerCreateInfo* create_info
-);
-```
-
----
-### Function `ti_destroy_sampler`
-
-```c
-// function.destroy_sampler
-TI_DLL_EXPORT void TI_API_CALL ti_destroy_sampler(
-  TiRuntime runtime,
-  TiSampler sampler
-);
-```
-
----
 ### Function `ti_copy_memory_device_to_device` (Device Command)
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.copy_memory_device_to_device
@@ -1128,21 +1176,9 @@ TI_DLL_EXPORT void TI_API_CALL ti_copy_memory_device_to_device(
 Copies the data in a contiguous subsection of the device memory to another subsection. The two subsections *must not* overlap.
 
 ---
-### Function `ti_copy_image_device_to_device` (Device Command)
-
-```c
-// function.copy_image_device_to_device
-TI_DLL_EXPORT void TI_API_CALL ti_copy_image_device_to_device(
-  TiRuntime runtime,
-  const TiImageSlice* dst_image,
-  const TiImageSlice* src_image
-);
-```
-
-Copies the image data in a contiguous subsection of the device image to another subsection. The two subsections *must not* overlap.
-
----
 ### Function `ti_track_image_ext`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.track_image
@@ -1158,6 +1194,8 @@ Tracks the device image with the provided image layout. Because Taichi tracks im
 ---
 ### Function `ti_transition_image` (Device Command)
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.transition_image
 TI_DLL_EXPORT void TI_API_CALL ti_transition_image(
@@ -1171,6 +1209,8 @@ Transitions the image to the provided image layout. Because Taichi tracks image 
 
 ---
 ### Function `ti_launch_kernel` (Device Command)
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.launch_kernel
@@ -1187,6 +1227,8 @@ Launches a Taichi kernel with the provided arguments. The arguments *must* have 
 ---
 ### Function `ti_launch_compute_graph` (Device Command)
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.launch_compute_graph
 TI_DLL_EXPORT void TI_API_CALL ti_launch_compute_graph(
@@ -1202,6 +1244,8 @@ Launches a Taichi compute graph with provided named arguments. The named argumen
 ---
 ### Function `ti_flush`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.flush
 TI_DLL_EXPORT void TI_API_CALL ti_flush(
@@ -1214,6 +1258,8 @@ Submits all previously invoked device commands to the offload device for executi
 ---
 ### Function `ti_wait`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.wait
 TI_DLL_EXPORT void TI_API_CALL ti_wait(
@@ -1225,6 +1271,8 @@ Waits until all previously invoked device commands are executed. Any invoked com
 
 ---
 ### Function `ti_load_aot_module`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.load_aot_module
@@ -1240,6 +1288,8 @@ Returns [`TI_NULL_HANDLE`](#definition-ti_null_handle) if the runtime fails to l
 ---
 ### Function `ti_create_aot_module`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.create_aot_module
 TI_DLL_EXPORT TiAotModule TI_API_CALL ti_create_aot_module(
@@ -1249,8 +1299,13 @@ TI_DLL_EXPORT TiAotModule TI_API_CALL ti_create_aot_module(
 );
 ```
 
+Creates a pre-compiled AOT module from TCM data.
+Returns [`TI_NULL_HANDLE`](#definition-ti_null_handle) if the runtime fails to create the AOT module from TCM data.
+
 ---
 ### Function `ti_destroy_aot_module`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.destroy_aot_module
@@ -1263,6 +1318,8 @@ Destroys a loaded AOT module and releases all related resources.
 
 ---
 ### Function `ti_get_aot_module_kernel`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.get_aot_module_kernel
@@ -1277,6 +1334,8 @@ Returns [`TI_NULL_HANDLE`](#definition-ti_null_handle) if the module does not ha
 
 ---
 ### Function `ti_get_aot_module_compute_graph`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.get_aot_module_compute_graph

--- a/docs/lang/articles/c-api/taichi_vulkan.md
+++ b/docs/lang/articles/c-api/taichi_vulkan.md
@@ -207,4 +207,3 @@ TI_DLL_EXPORT void TI_API_CALL ti_export_vulkan_image(
 ```
 
 Exports a Vulkan image from external procedures to Taichi.
-

--- a/docs/lang/articles/c-api/taichi_vulkan.md
+++ b/docs/lang/articles/c-api/taichi_vulkan.md
@@ -10,6 +10,8 @@ Taichi's Vulkan API gives you further control over the Vulkan version and extens
 
 ### Structure `TiVulkanRuntimeInteropInfo`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.vulkan_runtime_interop_info
 typedef struct TiVulkanRuntimeInteropInfo {
@@ -42,6 +44,8 @@ Necessary detail to share the same Vulkan runtime between Taichi and external pr
 ---
 ### Structure `TiVulkanMemoryInteropInfo`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // structure.vulkan_memory_interop_info
 typedef struct TiVulkanMemoryInteropInfo {
@@ -63,6 +67,8 @@ Necessary detail to share the same piece of Vulkan buffer between Taichi and ext
 
 ---
 ### Structure `TiVulkanImageInteropInfo`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // structure.vulkan_image_interop_info
@@ -94,6 +100,8 @@ Necessary detail to share the same piece of Vulkan image between Taichi and exte
 ---
 ### Function `ti_create_vulkan_runtime_ext`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.create_vulkan_runtime
 TI_DLL_EXPORT TiRuntime TI_API_CALL ti_create_vulkan_runtime_ext(
@@ -110,6 +118,8 @@ Creates a Vulkan Taichi runtime with user-controlled capability settings.
 ---
 ### Function `ti_import_vulkan_runtime`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.import_vulkan_runtime
 TI_DLL_EXPORT TiRuntime TI_API_CALL ti_import_vulkan_runtime(
@@ -121,6 +131,8 @@ Imports the Vulkan runtime owned by Taichi to external procedures.
 
 ---
 ### Function `ti_export_vulkan_runtime`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.export_vulkan_runtime
@@ -135,6 +147,8 @@ Exports a Vulkan runtime from external procedures to Taichi.
 ---
 ### Function `ti_import_vulkan_memory`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.import_vulkan_memory
 TI_DLL_EXPORT TiMemory TI_API_CALL ti_import_vulkan_memory(
@@ -147,6 +161,8 @@ Imports the Vulkan buffer owned by Taichi to external procedures.
 
 ---
 ### Function `ti_export_vulkan_memory`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.export_vulkan_memory
@@ -161,6 +177,8 @@ Exports a Vulkan buffer from external procedures to Taichi.
 
 ---
 ### Function `ti_import_vulkan_image`
+
+> Stable since Taichi version: 1.4.0
 
 ```c
 // function.import_vulkan_image
@@ -177,6 +195,8 @@ Imports the Vulkan image owned by Taichi to external procedures.
 ---
 ### Function `ti_export_vulkan_image`
 
+> Stable since Taichi version: 1.4.0
+
 ```c
 // function.export_vulkan_image
 TI_DLL_EXPORT void TI_API_CALL ti_export_vulkan_image(
@@ -187,3 +207,4 @@ TI_DLL_EXPORT void TI_API_CALL ti_export_vulkan_image(
 ```
 
 Exports a Vulkan image from external procedures to Taichi.
+

--- a/misc/generate_c_api.py
+++ b/misc/generate_c_api.py
@@ -36,6 +36,8 @@ def get_field(x: Field):
 
 def get_api_ref(module: Module, x: EntryBase) -> list:
     out = [f"// {get_title(x)}"]
+    if x.since is not None:
+        out[-1] += f" ({x.since})"
     if module.doc and x.id in module.doc.api_refs:
         out += [
             f"// {resolve_inline_symbols_to_names(module, y)}"

--- a/misc/generate_c_api_docs.py
+++ b/misc/generate_c_api_docs.py
@@ -15,6 +15,12 @@ def print_module_doc(module: Module):
     for x in module.declr_reg:
         declr = module.declr_reg.resolve(x)
 
+        # Ignore interfaces with no valid publish version.
+        if declr.since is None:
+            continue
+        else:
+            assert x in module.doc.api_full_refs, f"undocumented public api is not allowed: {x}"
+
         if is_first:
             is_first = False
         else:
@@ -22,6 +28,8 @@ def print_module_doc(module: Module):
 
         out += [
             f"### {get_title(declr)}",
+            "",
+            f"> Stable since Taichi version: {declr.since}",
             "",
             "```c",
             f"// {x}",

--- a/misc/taichi_json.py
+++ b/misc/taichi_json.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List
 
+
 class Version:
     def __init__(self, ver: str) -> None:
         if ver.startswith('v'):
@@ -322,7 +323,8 @@ class Documentation:
 class Module:
     all_modules = {}
 
-    def __init__(self, version: Version, j: dict, builtin_tys: List[BuiltInType]):
+    def __init__(self, version: Version, j: dict,
+                 builtin_tys: List[BuiltInType]):
         self.name = j["name"]
         self.is_built_in = False
         self.declr_reg = DeclarationRegistry(builtin_tys)

--- a/misc/taichi_json.py
+++ b/misc/taichi_json.py
@@ -1,5 +1,6 @@
 import glob
 import json
+import os
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -355,6 +356,8 @@ class Module:
     @staticmethod
     def load_all(builtin_tys):
         def ver2int(ver: str) -> int:
+            if ver.startswith('v'):
+                ver = ver[1:]
             xs = [int(x) for x in ver.split('.')]
             assert len(xs) <= 3
             xs += ['0'] * (3 - len(xs))
@@ -368,7 +371,13 @@ class Module:
         with open("c_api/taichi.json") as f:
             j = json.load(f)
 
-        version = ver2int(j["version"])
+        version = 0
+        try:
+            with open("version.txt") as f:
+                version = ver2int(f.readline())
+        except:
+            print("faild to load c-api version")
+
         print("taichi c-api version is:", version)
 
         for k in j["modules"]:

--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -220,6 +220,10 @@ class Module:
                 DeprecationWarning)
         filepath = str(PurePosixPath(Path(filepath)))
         self._aot_builder.dump(filepath, "")
+        with open(f"{filepath}/__content__", "w") as f:
+            f.write('\n'.join(self._content))
+        with open(f"{filepath}/__version__", "w") as f:
+            f.write('.'.join(str(x) for x in taichi.__version__))
 
     def archive(self, filepath: str):
         """
@@ -238,9 +242,6 @@ class Module:
 
         # Package all artifacts into a zip archive and attach contend data.
         with ZipFile(tcm_path, "w") as z:
-            z.writestr("__content__", '\n'.join(self._content))
-            z.writestr("__version__",
-                       '.'.join(str(x) for x in taichi.__version__))
             for path in glob(f"{temp_dir}/*", recursive=True):
                 z.write(path, Path.relative_to(Path(path), temp_dir))
 


### PR DESCRIPTION
Issue: #5858

### Brief Summary

This PR introduces a versioning mechanism to the Taichi Runtime C-API. Taichi Runtime has the same version as the Python frontend. The version information can be queried from taichi header definition `TI_C_API_VERSION`, C-API `ti_get_version`, `__version__` in compiled AOT module, and log output when `ti_create_runtime` is called.

