### PR TITLE
[test] Add test to make sure ndarrays are initialized as zero

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -225,7 +225,7 @@ class ScalarNdarray(Ndarray):
         super().__init__()
         self.dtype = cook_dtype(dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
-            self.dtype, arr_shape)
+            self.dtype, arr_shape, Layout.NULL, True)
         self.shape = tuple(self.arr.shape)
         self.element_type = dtype
 

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -455,8 +455,20 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 
 Ndarray *Program::create_ndarray(const DataType type,
                                  const std::vector<int> &shape,
-                                 ExternalArrayLayout layout) {
-  ndarrays_.emplace_back(std::make_unique<Ndarray>(this, type, shape, layout));
+                                 ExternalArrayLayout layout, bool zero_fill) {
+  auto arr = std::make_unique<Ndarray>(this, type, shape, layout);
+  if (zero_fill) {
+    Arch arch = this_thread_config().arch;
+    if (arch_is_cpu(arch) || arch == Arch::cuda) {
+      fill_ndarray_fast_u32(arr.get(), /*data=*/0);
+    } else {
+      Stream *stream = program_impl_->get_compute_device()->get_compute_stream();
+      auto cmdlist = stream->new_command_list();
+      cmdlist->buffer_fill(arr->ndarray_alloc_.get_ptr(0), arr->get_element_size() * arr->get_nelement(), /*data=*/0);
+      stream->submit_synced(cmdlist.get());
+    }
+  }
+  ndarrays_.emplace_back(std::move(arr));
   return ndarrays_.back().get();
 }
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -330,7 +330,8 @@ class TI_DLL_EXPORT Program {
   Ndarray *create_ndarray(
       const DataType type,
       const std::vector<int> &shape,
-      ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+      ExternalArrayLayout layout = ExternalArrayLayout::kNull,
+      bool zero_fill = false);
 
   Texture *create_texture(const DataType type,
                           int num_channels,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -456,11 +456,12 @@ void export_lang(py::module &m) {
           "create_ndarray",
           [&](Program *program, const DataType &dt,
               const std::vector<int> &shape,
-              ExternalArrayLayout layout) -> Ndarray * {
-            return program->create_ndarray(dt, shape, layout);
+              ExternalArrayLayout layout, bool zero_fill) -> Ndarray * {
+            return program->create_ndarray(dt, shape, layout, zero_fill);
           },
           py::arg("dt"), py::arg("shape"),
           py::arg("layout") = ExternalArrayLayout::kNull,
+          py::arg("zero_fill") = false,
           py::return_value_policy::reference)
       .def(
           "create_texture",

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -693,3 +693,9 @@ def test_ndarray_python_scope_read_64bit(dtype):
     run(a)
     for i in range(n):
         assert a[i] == i + 2**40
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_init_as_zero():
+    a = ti.ndarray(dtype=ti.f32, shape=(6, 10))
+    v = np.zeros((6, 10), dtype=np.float32)
+    assert test_utils.allclose(a.to_numpy(), v)


### PR DESCRIPTION
Issue: #6438 

### Brief Summary
This PR only enables zero fill for ndarrays created from Python frontend so it doesn't affect performance of ndarray created from C-API. 
In the future we may provide an option for python users to skip the zero fill as needed but that will be a separate PR.