### PR TITLE
[Doc] Fix docstring

### DIFF
--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -111,9 +111,7 @@ class Canvas:
         Args:
             centers: a taichi 2D Vector field, where each element indicate the \
                 3D location of a vertex.
-            radius (Union[float, numpy.array]): radius of the circles in pixels. \
-                Can be either a single number, which will be applied to all circles, or a 1D NumPy array of the same length as `centers`.\
-                The `i-th` item in the array will be the radius for the `i-th` circle in `centers`.
+            radius (Number): radius of the circles in pixels.
             color: a global color for the triangles as 3 floats representing \
                 RGB values. If `per_vertex_color` is provided, this is ignored.
             per_vertex_color (Tuple[float]): a taichi 3D vector field, where \


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/6999

GGUI's `circles` method does not allow passing NumPy array as radius; this PR fixes this error.