### PR TITLE
[Lang] Deprecate the dynamic_index switch

### DIFF
--- a/python/taichi/examples/simulation/implicit_fem.py
+++ b/python/taichi/examples/simulation/implicit_fem.py
@@ -18,7 +18,7 @@ parser.add_argument('-s',
 parser.add_argument('place_holder', nargs='*')
 args = parser.parse_args()
 
-ti.init(arch=ti.cuda, dynamic_index=True)
+ti.init(arch=ti.cuda)
 
 if args.gui == 'auto':
     if _ti_core.GGUI_AVAILABLE and ti.lang.impl.current_cfg().arch == ti.cuda:

--- a/python/taichi/examples/simulation/snow_phaseField.py
+++ b/python/taichi/examples/simulation/snow_phaseField.py
@@ -215,5 +215,5 @@ class Dendrite:
 
 
 if __name__ == "__main__":
-    ti.init(arch=ti.cuda, dynamic_index=True, default_fp=ti.f64)
+    ti.init(arch=ti.cuda, default_fp=ti.f64)
     Dendrite().getDendritic(steps=10000)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -395,20 +395,8 @@ class Matrix(TaichiOperations):
             args = args[0]
         if len(args) == 1:
             args = args + (0, )
-        # TODO(#1004): See if it's possible to support indexing at runtime
-        for i, a in enumerate(args):
-            if not isinstance(a, (int, np.integer)):
-                raise TaichiSyntaxError(
-                    f'The {i}-th index of a Matrix/Vector must be a compile-time constant '
-                    f'integer, got {type(a)}.\n'
-                    'This is because matrix operations will be **unrolled** at compile-time '
-                    'for performance reason.\n'
-                    'If you want to *iterate through matrix elements*, use a static range:\n'
-                    '  for i in ti.static(range(3)):\n'
-                    '    print(i, "-th component is", vec[i])\n'
-                    'See https://docs.taichi-lang.org/docs/meta#when-to-use-tistatic-with-for-loops for more details.'
-                    'Or turn on ti.init(..., dynamic_index=True) to support indexing with variables!'
-                )
+        for a in args:
+            assert isinstance(a, (int, np.integer))
         assert 0 <= args[0] < self.n, \
             f"The 0-th matrix index is out of range: 0 <= {args[0]} < {self.n}"
         assert 0 <= args[1] < self.m, \

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -372,6 +372,11 @@ def init(arch=None,
                 "also be removed then. Make sure your code doesn't rely on it.",
                 DeprecationWarning)
 
+    if "dynamic_index" in kwargs:
+        warnings.warn(
+            "Dynamic index is supported by default and the switch will be removed in v1.5.0.",
+            DeprecationWarning)
+
     if "default_up" in kwargs:
         raise KeyError(
             "'default_up' is always the unsigned type of 'default_ip'. Please set 'default_ip' instead."

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -38,7 +38,7 @@ CompileConfig::CompileConfig() {
   gpu_max_reg = 0;  // 0 means using the default value from the CUDA driver.
   verbose = true;
   fast_math = true;
-  dynamic_index = false;
+  dynamic_index = true;
   flatten_if = false;
   make_thread_local = true;
   make_block_local = true;

--- a/tests/python/test_ad_dynamic_index.py
+++ b/tests/python/test_ad_dynamic_index.py
@@ -2,9 +2,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(require=ti.extension.dynamic_index,
-                 dynamic_index=True,
-                 debug=True)
+@test_utils.test()
 def test_matrix_non_constant_index():
     m = ti.Matrix.field(2, 2, ti.f32, 5, needs_grad=True)
     n = ti.Matrix.field(2, 2, ti.f32, 5, needs_grad=True)

--- a/tests/python/test_ad_if.py
+++ b/tests/python/test_ad_if.py
@@ -244,9 +244,7 @@ def test_stack():
     func()
 
 
-# FIXME: There is no tensor constant (brought by dynamic index) until the whole mat/vec refactor is done, which will potentially break the adstack.
-# Temporially disable the dynamic index, will make workaround to handle tensor constant in other PRs
-@test_utils.test(dynamic_index=False)
+@test_utils.test()
 def test_if_condition_depend_on_for_loop_index():
     scalar = lambda: ti.field(dtype=ti.f32)
     vec = lambda: ti.Vector.field(3, dtype=ti.f32)

--- a/tests/python/test_ad_math_func.py
+++ b/tests/python/test_ad_math_func.py
@@ -2,7 +2,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(require=ti.extension.adstack, dynamic_index=True)
+@test_utils.test(require=ti.extension.adstack)
 def test_polar_decompose_2D():
     # `polar_decompose3d` in current Taichi version (v1.1) does not support autodiff,
     # becasue it mixed usage of for-loops and statements without looping.

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -186,3 +186,13 @@ def test_deprecated_source_inspect():
             pass
 
         print(getsourcelines(func))
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_deprecated_dynamic_index(value):
+    with pytest.warns(
+            DeprecationWarning,
+            match=
+            "Dynamic index is supported by default and the switch will be removed in v1.5.0."
+    ):
+        ti.init(dynamic_index=value)

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -187,7 +187,7 @@ def _test_local_matrix_non_constant_index():
             assert func2(i, j, 10) == 10 * (i + j + 1)
 
 
-@test_utils.test(require=ti.extension.dynamic_index, dynamic_index=True)
+@test_utils.test()
 def test_local_matrix_non_constant_index():
     _test_local_matrix_non_constant_index()
 
@@ -226,7 +226,7 @@ def test_matrix_ndarray_non_constant_index():
     assert v[3][9] == 9
 
 
-@test_utils.test(require=ti.extension.dynamic_index)
+@test_utils.test()
 def test_matrix_field_non_constant_index():
     m = ti.Matrix.field(2, 2, ti.i32, 5)
     v = ti.Vector.field(10, ti.i32, 5)
@@ -377,7 +377,7 @@ def test_copy_matrix_in_taichi_scope():
     test()
 
 
-@test_utils.test(arch=[ti.cpu, ti.cuda], dynamic_index=True, debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
 def test_matrix_field_dynamic_index_stride():
     # placeholders
     temp_a = ti.field(ti.f32)
@@ -429,7 +429,7 @@ def test_matrix_field_dynamic_index_stride():
             assert v[i][j] == i * j
 
 
-@test_utils.test(require=ti.extension.dynamic_index)
+@test_utils.test()
 def test_matrix_field_dynamic_index_different_path_length():
     v = ti.Vector.field(2, ti.i32)
     x = v.get_scalar_field(0)
@@ -442,7 +442,7 @@ def test_matrix_field_dynamic_index_different_path_length():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test(require=ti.extension.dynamic_index)
+@test_utils.test()
 def test_matrix_field_dynamic_index_not_pure_dense():
     v = ti.Vector.field(2, ti.i32)
     x = v.get_scalar_field(0)
@@ -455,7 +455,7 @@ def test_matrix_field_dynamic_index_not_pure_dense():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test(require=ti.extension.dynamic_index)
+@test_utils.test()
 def test_matrix_field_dynamic_index_different_cell_size_bytes():
     temp = ti.field(ti.f32)
 
@@ -470,7 +470,7 @@ def test_matrix_field_dynamic_index_different_cell_size_bytes():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test(require=ti.extension.dynamic_index)
+@test_utils.test()
 def test_matrix_field_dynamic_index_different_offset_bytes_in_parent_cell():
     temp_a = ti.field(ti.f32)
     temp_b = ti.field(ti.f32)
@@ -486,7 +486,7 @@ def test_matrix_field_dynamic_index_different_offset_bytes_in_parent_cell():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test(require=ti.extension.dynamic_index)
+@test_utils.test()
 def test_matrix_field_dynamic_index_different_stride():
     temp = ti.field(ti.f32)
 
@@ -501,7 +501,7 @@ def test_matrix_field_dynamic_index_different_stride():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test(require=ti.extension.dynamic_index, dynamic_index=True)
+@test_utils.test()
 def test_matrix_field_dynamic_index_multiple_materialize():
     @ti.kernel
     def empty():
@@ -523,9 +523,7 @@ def test_matrix_field_dynamic_index_multiple_materialize():
             assert a[i][j] == (i if j == i % 3 else 0)
 
 
-@test_utils.test(require=ti.extension.dynamic_index,
-                 dynamic_index=True,
-                 debug=True)
+@test_utils.test(debug=True)
 def test_local_vector_initialized_in_a_loop():
     @ti.kernel
     def foo():
@@ -1157,9 +1155,7 @@ def test_cross_scope_matrix_atomic_ops():
     assert (x[1, 3] == [100, 10, 1]).all()
 
 
-@test_utils.test(require=ti.extension.dynamic_index,
-                 dynamic_index=True,
-                 debug=True)
+@test_utils.test(debug=True)
 def test_global_tmp_overwrite():
     # https://github.com/taichi-dev/taichi/issues/6663
     @ti.kernel

--- a/tests/python/test_matrix_slice.py
+++ b/tests/python/test_matrix_slice.py
@@ -49,7 +49,7 @@ def test_matrix_slice_invalid():
         foo2()
 
 
-@test_utils.test(require=ti.extension.dynamic_index, dynamic_index=True)
+@test_utils.test()
 def test_matrix_slice_with_variable():
     @ti.kernel
     def test_one_row_slice(
@@ -99,7 +99,7 @@ def test_matrix_slice_write():
                                            [1, 1, 1, 1]])).all()
 
 
-@test_utils.test(dynamic_index=True)
+@test_utils.test()
 def test_matrix_slice_write_dynamic_index():
     @ti.kernel
     def foo(i: ti.i32) -> ti.types.matrix(3, 4, ti.i32):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -192,14 +192,10 @@ class TestParam:
 
 if os.environ.get('TI_LITE_TEST', ''):
     _test_features = {
-        "dynamic_index": [TestParam(True, [])],
     }
 else:
     _test_features = {
-        #"packed":
-        # [TestValue(True, []),
-        #  TestValue(False, [])],
-        "dynamic_index": [TestParam(True, [])]
+        # "dynamic_index": [TestParam(True, [])]
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,8 +191,7 @@ class TestParam:
 
 
 if os.environ.get('TI_LITE_TEST', ''):
-    _test_features = {
-    }
+    _test_features = {}
 else:
     _test_features = {
         # "dynamic_index": [TestParam(True, [])]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -192,16 +192,14 @@ class TestParam:
 
 if os.environ.get('TI_LITE_TEST', ''):
     _test_features = {
-        "dynamic_index": [TestParam(False, [])],
+        "dynamic_index": [TestParam(True, [])],
     }
 else:
     _test_features = {
         #"packed":
         # [TestValue(True, []),
         #  TestValue(False, [])],
-        "dynamic_index":
-        [TestParam(True, [ti.extension.dynamic_index]),
-         TestParam(False, [])]
+        "dynamic_index": [TestParam(True, [])]
     }
 
 


### PR DESCRIPTION
Issue: #2590

### Brief Summary

Dynamic indexing is now automatically supported and no switch is needed.