### PR TITLE
[lang] Free ndarray memory when it's GC-ed in Python

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -231,6 +231,11 @@ class ScalarNdarray(Ndarray):
         self.shape = tuple(self.arr.shape)
         self.element_type = dtype
 
+    def __del__(self):
+        if impl is not None and impl.get_runtime(
+        ) is not None and impl.get_runtime().prog is not None:
+            impl.get_runtime().prog.delete_ndarray(self.arr)
+
     @property
     def element_shape(self):
         return ()

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -454,8 +454,26 @@ Ndarray *Program::create_ndarray(const DataType type,
       stream->submit_synced(cmdlist.get());
     }
   }
-  ndarrays_.emplace_back(std::move(arr));
-  return ndarrays_.back().get();
+  auto arr_ptr = arr.get();
+  ndarrays_.insert({arr_ptr, std::move(arr)});
+  return arr_ptr;
+}
+
+void Program::delete_ndarray(Ndarray *ndarray) {
+  // [Note] Ndarray memory deallocation
+  // Ndarray's memory allocation is managed by Taichi and Python can control this via Taichi indirectly.
+  // For example, when an ndarray is GC-ed in Python, it signals Taichi to free its memory allocation. 
+  // But Taichi will make sure **no pending kernels to be executed needs the ndarray** before it actually 
+  // frees the memory.
+  // When `ti.reset()` is called, all ndarrays allocated in this program should be gone and no longer valid
+  // in Python.
+  // This isn't the best implementation, ndarrays should be managed by taichi runtime instead of this giant program
+  // and it should be freed when:
+  // - Python GC signals taichi that it's no longer useful
+  // - All kernels using it are executed.
+  if (ndarrays_.count(ndarray) && !program_impl_->used_in_kernel(ndarray->ndarray_alloc_.alloc_id)) {
+    ndarrays_.erase(ndarray);
+  }
 }
 
 Texture *Program::create_texture(const DataType type,

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -461,17 +461,18 @@ Ndarray *Program::create_ndarray(const DataType type,
 
 void Program::delete_ndarray(Ndarray *ndarray) {
   // [Note] Ndarray memory deallocation
-  // Ndarray's memory allocation is managed by Taichi and Python can control this via Taichi indirectly.
-  // For example, when an ndarray is GC-ed in Python, it signals Taichi to free its memory allocation. 
-  // But Taichi will make sure **no pending kernels to be executed needs the ndarray** before it actually 
-  // frees the memory.
-  // When `ti.reset()` is called, all ndarrays allocated in this program should be gone and no longer valid
-  // in Python.
-  // This isn't the best implementation, ndarrays should be managed by taichi runtime instead of this giant program
-  // and it should be freed when:
+  // Ndarray's memory allocation is managed by Taichi and Python can control
+  // this via Taichi indirectly. For example, when an ndarray is GC-ed in
+  // Python, it signals Taichi to free its memory allocation. But Taichi will
+  // make sure **no pending kernels to be executed needs the ndarray** before it
+  // actually frees the memory. When `ti.reset()` is called, all ndarrays
+  // allocated in this program should be gone and no longer valid in Python.
+  // This isn't the best implementation, ndarrays should be managed by taichi
+  // runtime instead of this giant program and it should be freed when:
   // - Python GC signals taichi that it's no longer useful
   // - All kernels using it are executed.
-  if (ndarrays_.count(ndarray) && !program_impl_->used_in_kernel(ndarray->ndarray_alloc_.alloc_id)) {
+  if (ndarrays_.count(ndarray) &&
+      !program_impl_->used_in_kernel(ndarray->ndarray_alloc_.alloc_id)) {
     ndarrays_.erase(ndarray);
   }
 }

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -320,6 +320,8 @@ class TI_DLL_EXPORT Program {
       ExternalArrayLayout layout = ExternalArrayLayout::kNull,
       bool zero_fill = false);
 
+  void delete_ndarray(Ndarray *ndarray);
+
   Texture *create_texture(const DataType type,
                           int num_channels,
                           const std::vector<int> &shape);
@@ -386,7 +388,8 @@ class TI_DLL_EXPORT Program {
   bool finalized_{false};
 
   std::unique_ptr<MemoryPool> memory_pool_{nullptr};
-  std::vector<std::unique_ptr<Ndarray>> ndarrays_;
+  // TODO: Move ndarrays_ and textures_ to be managed by runtime
+  std::unordered_map<void *, std::unique_ptr<Ndarray>> ndarrays_;
   std::vector<std::unique_ptr<Texture>> textures_;
   std::shared_mutex config_map_mut;
 };

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -105,6 +105,10 @@ class ProgramImpl {
     return kDeviceNullAllocation;
   }
 
+  virtual bool used_in_kernel(DeviceAllocationId) {
+    return false;
+  }
+
   virtual DeviceAllocation allocate_texture(const ImageParams &params) {
     return kDeviceNullAllocation;
   }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -432,8 +432,7 @@ void export_lang(py::module &m) {
           },
           py::arg("dt"), py::arg("shape"),
           py::arg("layout") = ExternalArrayLayout::kNull,
-          py::arg("zero_fill") = false, py::return_value_policy::reference,
-          py::return_value_policy::reference)
+          py::arg("zero_fill") = false, py::return_value_policy::reference)
       .def("delete_ndarray", &Program::delete_ndarray)
       .def(
           "create_texture",

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -432,7 +432,9 @@ void export_lang(py::module &m) {
           },
           py::arg("dt"), py::arg("shape"),
           py::arg("layout") = ExternalArrayLayout::kNull,
-          py::arg("zero_fill") = false, py::return_value_policy::reference)
+          py::arg("zero_fill") = false, py::return_value_policy::reference,
+          py::return_value_policy::reference)
+      .def("delete_ndarray", &Program::delete_ndarray)
       .def(
           "create_texture",
           [&](Program *program, const DataType &dt, int num_channels,

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -414,6 +414,7 @@ void GfxRuntime::launch_kernel(KernelHandle handle, RuntimeContext *host_ctx) {
           if (host_ctx->device_allocation_type[i] ==
               RuntimeContext::DevAllocType::kNdarray) {
             any_arrays[i] = devalloc;
+            ndarrays_in_use_.insert(devalloc.alloc_id);
           } else if (host_ctx->device_allocation_type[i] ==
                      RuntimeContext::DevAllocType::kTexture) {
             textures[i] = devalloc;
@@ -588,6 +589,7 @@ void GfxRuntime::synchronize() {
   flush();
   device_->wait_idle();
   ctx_buffers_.clear();
+  ndarrays_in_use_.clear();
   fflush(stdout);
 }
 

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -156,9 +156,10 @@ class TI_DLL_EXPORT GfxRuntime {
   std::unordered_map<DeviceAllocation *, size_t> root_buffers_size_map_;
   std::unordered_map<DeviceAllocationId, ImageLayout> last_image_layouts_;
   // [Note] Why do we need to track ndarrays that are in use?
-  // Since we separate cmdlist is async, taichi needs a way to know whether ndarrays are still used by
-  // pending kernels to be executed. So we use ndarray_in_use_ to track this so that we can free
-  // memory allocated for ndarray whenever it's safe to do so.
+  // Since we separate cmdlist is async, taichi needs a way to know whether
+  // ndarrays are still used by pending kernels to be executed. So we use
+  // ndarray_in_use_ to track this so that we can free memory allocated for
+  // ndarray whenever it's safe to do so.
   std::unordered_set<DeviceAllocationId> ndarrays_in_use_;
 };
 

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -126,6 +126,10 @@ class TI_DLL_EXPORT GfxRuntime {
       std::function<void(Device *device, CommandList *cmdlist)> op,
       const std::vector<ComputeOpImageRef> &image_refs);
 
+  bool used_in_kernel(DeviceAllocationId id) {
+    return ndarrays_in_use_.count(id) > 0;
+  }
+
  private:
   friend class taichi::lang::gfx::SNodeTreeManager;
 
@@ -151,6 +155,11 @@ class TI_DLL_EXPORT GfxRuntime {
 
   std::unordered_map<DeviceAllocation *, size_t> root_buffers_size_map_;
   std::unordered_map<DeviceAllocationId, ImageLayout> last_image_layouts_;
+  // [Note] Why do we need to track ndarrays that are in use?
+  // Since we separate cmdlist is async, taichi needs a way to know whether ndarrays are still used by
+  // pending kernels to be executed. So we use ndarray_in_use_ to track this so that we can free
+  // memory allocated for ndarray whenever it's safe to do so.
+  std::unordered_set<DeviceAllocationId> ndarrays_in_use_;
 };
 
 GfxRuntime::RegisterParams run_codegen(

--- a/taichi/runtime/program_impls/metal/metal_program.h
+++ b/taichi/runtime/program_impls/metal/metal_program.h
@@ -59,6 +59,10 @@ class MetalProgramImpl : public ProgramImpl {
                                            uint64 *result_buffer) override;
   DeviceAllocation allocate_texture(const ImageParams &params) override;
 
+  bool used_in_kernel(DeviceAllocationId id) override {
+     return gfx_runtime_->used_in_kernel(id);
+  }
+
   Device *get_compute_device() override {
     if (embedded_device_) {
       return embedded_device_.get();

--- a/taichi/runtime/program_impls/metal/metal_program.h
+++ b/taichi/runtime/program_impls/metal/metal_program.h
@@ -60,7 +60,7 @@ class MetalProgramImpl : public ProgramImpl {
   DeviceAllocation allocate_texture(const ImageParams &params) override;
 
   bool used_in_kernel(DeviceAllocationId id) override {
-     return gfx_runtime_->used_in_kernel(id);
+    return gfx_runtime_->used_in_kernel(id);
   }
 
   Device *get_compute_device() override {

--- a/taichi/runtime/program_impls/opengl/opengl_program.h
+++ b/taichi/runtime/program_impls/opengl/opengl_program.h
@@ -47,6 +47,11 @@ class OpenglProgramImpl : public ProgramImpl {
 
   DeviceAllocation allocate_memory_ndarray(std::size_t alloc_size,
                                            uint64 *result_buffer) override;
+
+  bool used_in_kernel(DeviceAllocationId id) override {
+    return runtime_->used_in_kernel(id);
+  }
+
   DeviceAllocation allocate_texture(const ImageParams &params) override;
 
   Device *get_compute_device() override {

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.h
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.h
@@ -67,6 +67,9 @@ class VulkanProgramImpl : public ProgramImpl {
 
   DeviceAllocation allocate_memory_ndarray(std::size_t alloc_size,
                                            uint64 *result_buffer) override;
+  bool used_in_kernel(DeviceAllocationId id) override {
+    return vulkan_runtime_->used_in_kernel(id);
+  }
   DeviceAllocation allocate_texture(const ImageParams &params) override;
 
   Device *get_compute_device() override {

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -711,12 +711,15 @@ def test_ndarray_reset():
     ti.reset()
 
 
-@test_utils.test(arch=supported_archs_taichi_ndarray)
+# FIXME[#7119]: enable this test on CPU backend once caching allocator is used.
+@pytest.mark.run_in_serial
+@test_utils.test(arch=supported_archs_taichi_ndarray, exclude=ti.cpu)
 def test_ndarray_in_python_func():
     def test():
-        z = ti.ndarray(float, (8192))
+        z = ti.ndarray(float, (8192, 8192))
 
-    test()
+    for i in range(300):
+        test()
 
 
 @test_utils.test(arch=supported_archs_taichi_ndarray)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -701,6 +701,7 @@ def test_ndarray_init_as_zero():
     v = np.zeros((6, 10), dtype=np.float32)
     assert test_utils.allclose(a.to_numpy(), v)
 
+
 @test_utils.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_reset():
     n = 8

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -720,8 +720,3 @@ def test_ndarray_in_python_func():
 
     for i in range(300):
         test()
-
-
-@test_utils.test(arch=supported_archs_taichi_ndarray)
-def test_ndarray_simple_alloc():
-    z = ti.ndarray(float, (8192))

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -700,3 +700,24 @@ def test_ndarray_init_as_zero():
     a = ti.ndarray(dtype=ti.f32, shape=(6, 10))
     v = np.zeros((6, 10), dtype=np.float32)
     assert test_utils.allclose(a.to_numpy(), v)
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_reset():
+    n = 8
+    c = ti.Matrix.ndarray(4, 4, ti.f32, shape=(n))
+    del c
+    d = ti.Matrix.ndarray(4, 4, ti.f32, shape=(n))
+    ti.reset()
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_in_python_func():
+    def test():
+        z = ti.ndarray(float, (8192))
+
+    test()
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_simple_alloc():
+    z = ti.ndarray(float, (8192))


### PR DESCRIPTION
Issue: fixes #5048 

### Brief Summary
  Ndarray's memory allocation is managed by Taichi and Python can control this via Taichi indirectly.
  For example, when an ndarray is GC-ed in Python, it signals Taichi to free its memory allocation. 
  But Taichi will make sure **no pending kernels to be executed needs the ndarray** before it actually 
  frees the memory.