### PR TITLE
[Lang] Remove sourceinspect deprecation warning message

### DIFF
--- a/python/taichi/lang/_wrap_inspect.py
+++ b/python/taichi/lang/_wrap_inspect.py
@@ -4,14 +4,8 @@ import os
 import tempfile
 import warnings
 
-import sourceinspect
-
 _builtin_getfile = inspect.getfile
 _builtin_findsource = inspect.findsource
-
-
-def check_use_sourceinspect():
-    return int(os.getenv('USE_SOURCEINSPECT', 0)) == 1
 
 
 def _find_source_with_custom_getfile_func(func, obj):
@@ -130,29 +124,18 @@ class _InspectContextManager:
 
 
 def getsourcelines(obj):
-    if check_use_sourceinspect():
-        warnings.warn('Sourceinspect is deprecated since v1.4.0',
-                      DeprecationWarning)
-        return sourceinspect.getsourcelines(obj)
-
     try:
         with _InspectContextManager():
             return inspect.getsourcelines(obj)
     except:
         raise IOError(f"Cannot get the source lines of {obj}. \
-            You can try setting `USE_SOURCEINSPECT=1` in the enrionment variables \
-                or insert the lines `os.environ['USE_SOURCEINSPECT'] = 1` \
-                    at the beginning of the source file. Please report an issue to help us \
-                        fix the problem: https://github.com/taichi-dev/taichi/issues if you see this message"
+            This is possibly because of you are running Taichi in an environment \
+                in which Taichi's own inspect module cannot find the source file. \
+                    Please report an issue to help us fix this problem: https://github.com/taichi-dev/taichi/issues"
                       )
 
 
 def getsourcefile(obj):
-    if check_use_sourceinspect():
-        warnings.warn('Sourceinspect is deprecated since v1.4.0',
-                      DeprecationWarning)
-        return sourceinspect.getsourcefile(obj)
-
     try:
         with _InspectContextManager():
             ret = inspect.getsourcefile(obj)
@@ -161,11 +144,10 @@ def getsourcefile(obj):
             return ret
     except:
         raise IOError(f"Cannot get the source file of {obj}. \
-            You can try setting `USE_SOURCEINSPECT=1` in the enrionment variables \
-                or insert the lines `os.environ['USE_SOURCEINSPECT'] = 1` \
-                    at the beginning of the source file. Please report an issue to help us \
-                        fix the problem: https://github.com/taichi-dev/taichi/issues if you see this message"
-                      )
+            This is possibly because of you are running Taichi in an environment \
+                in which Taichi's own inspect module cannot find the source file. \
+                    Please report an issue to help us fix this problem: https://github.com/taichi-dev/taichi/issues"
+                    )
 
 
 __all__ = ['getsourcelines', 'getsourcefile']

--- a/python/taichi/lang/_wrap_inspect.py
+++ b/python/taichi/lang/_wrap_inspect.py
@@ -2,7 +2,6 @@ import atexit
 import inspect
 import os
 import tempfile
-import warnings
 
 _builtin_getfile = inspect.getfile
 _builtin_findsource = inspect.findsource

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -111,9 +111,7 @@ class Canvas:
         Args:
             centers: a taichi 2D Vector field, where each element indicate the \
                 3D location of a vertex.
-            radius (Union[float, numpy.array]): radius of the circles in pixels. \
-                Can be either a single number, which will be applied to all circles, or a 1D NumPy array of the same length as `centers`.\
-                The `i-th` item in the array will be the radius for the `i-th` circle in `centers`.
+            radius (Number): radius of the circles in pixels.
             color: a global color for the triangles as 3 floats representing \
                 RGB values. If `per_vertex_color` is provided, this is ignored.
             per_vertex_color (Tuple[float]): a taichi 3D vector field, where \

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,6 @@ pybind11
 GitPython
 yapf
 distro
-sourceinspect
 isort
 pylint
 requests==2.26

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ setup(name=project_name,
       url='https://github.com/taichi-dev/taichi',
       python_requires=">=3.6,<3.11",
       install_requires=[
-          'numpy', 'sourceinspect>=0.0.4', 'colorama', 'rich',
+          'numpy', 'colorama', 'rich',
           'astunparse;python_version<"3.9"'
       ],
       data_files=[(os.path.join('_lib', 'runtime'), data_files)],

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -174,20 +174,6 @@ def test_incomplete_info_rwtexture():
                 tex.store(ti.Vector([i, j]), ti.Vector([ret, 0.0, 0.0, 0.0]))
 
 
-def test_deprecated_source_inspect():
-    with pytest.warns(DeprecationWarning,
-                      match="Sourceinspect is deprecated since v1.4.0"):
-        import os
-        os.environ['USE_SOURCEINSPECT'] = '1'
-        from taichi.lang._wrap_inspect import getsourcelines
-
-        @ti.kernel
-        def func():
-            pass
-
-        print(getsourcelines(func))
-
-
 @pytest.mark.parametrize("value", [True, False])
 def test_deprecated_dynamic_index(value):
     with pytest.warns(


### PR DESCRIPTION
This PR removes the deprecation warning message for the `sourceinspect` dependency.