### PR TITLE
[Lang] Remove deprecated ti.Matrix.rotation2d()

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -836,25 +836,6 @@ class Matrix(TaichiOperations):
         from taichi.lang import matrix_ops  # pylint: disable=C0415
         return matrix_ops._identity_matrix(n, dt)
 
-    @staticmethod
-    def rotation2d(alpha):
-        """Returns the matrix representation of the 2D
-        anti-clockwise rotation of angle `alpha`. The angle `alpha`
-        is in radians.
-
-        Example::
-
-            >>> import math
-            >>> ti.Matrix.rotation2d(math.pi/4)
-            [[ 0.70710678 -0.70710678]
-             [ 0.70710678  0.70710678]]
-        """
-        warnings.warn(
-            "`ti.Matrix.rotation2d()` will be removed in release v1.4.0. Use `ti.math.rotation2d()` instead.",
-            DeprecationWarning)
-        from taichi.lang import matrix_ops  # pylint: disable=C0415
-        return matrix_ops._rotation2d_matrix(alpha)
-
     @classmethod
     @python_scope
     def field(cls,

--- a/python/taichi/lang/matrix_ops.py
+++ b/python/taichi/lang/matrix_ops.py
@@ -51,12 +51,6 @@ def _identity_matrix(n: template(), dtype: template()):
                    for i in static(range(n))], dtype)
 
 
-@pyfunc
-def _rotation2d_matrix(alpha):
-    return Matrix([[ops_mod.cos(alpha), -ops_mod.sin(alpha)],
-                   [ops_mod.sin(alpha), ops_mod.cos(alpha)]])
-
-
 @preconditions(
     arg_at(0, lambda xs: same_shapes(*xs)),
     arg_foreach_check(

--- a/tests/cpp/aot/python_scripts/taichi_sparse_test.py
+++ b/tests/cpp/aot/python_scripts/taichi_sparse_test.py
@@ -47,7 +47,7 @@ def block1_deactivate_all():
 def activate(t: ti.f32):
     for i, j in ti.ndrange(n, n):
         p = ti.Vector([i, j]) / n
-        p = ti.Matrix.rotation2d(ti.sin(t)) @ (p - 0.5) + 0.5
+        p = ti.math.rotation2d(ti.sin(t)) @ (p - 0.5) + 0.5
 
         if taichi_logo(p) == 0:
             x[i, j] = 1

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -40,7 +40,6 @@ def _get_expected_matrix_apis():
         'normalized',
         'one',
         'outer_product',
-        'rotation2d',
         'rows',
         'sum',
         'to_list',

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -23,16 +23,6 @@ def test_deprecated_aot_save_filename():
 
 
 @test_utils.test()
-def test_deprecated_matrix_rotation2d():
-    with pytest.warns(
-            DeprecationWarning,
-            match=
-            r'`ti.Matrix.rotation2d\(\)` will be removed in release v1.4.0. Use `ti.math.rotation2d\(\)` instead.'
-    ):
-        a = ti.Matrix.rotation2d(math.pi / 2)
-
-
-@test_utils.test()
 def test_deprecate_element_shape_ndarray_annotation():
     with pytest.warns(
             DeprecationWarning,

--- a/tests/python/test_linalg.py
+++ b/tests/python/test_linalg.py
@@ -251,7 +251,7 @@ def test_matrix_factories():
     @ti.kernel
     def fill():
         b[0] = ti.Matrix.identity(ti.f32, 2)
-        b[1] = ti.Matrix.rotation2d(math.pi / 3)
+        b[1] = ti.math.rotation2d(math.pi / 3)
         c[0] = ti.Matrix.zero(ti.f32, 2, 3)
         c[1] = ti.Matrix.one(ti.f32, 2, 3)
         for i in ti.static(range(3)):


### PR DESCRIPTION
### Brief Summary

`ti.Matrix.rotation2d()` should be removed according to the [deprecation notice](https://github.com/taichi-dev/taichi/releases/tag/v1.3.0).