### PR TITLE
[ci] More Windows git hacks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,11 @@ jobs:
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     runs-on: [self-hosted, windows, cuda, OpenGL]
     steps:
+      - name: Workaround checkout Needed single revision issue
+        run: |
+          git config --system core.longpaths true
+          git submodule foreach 'git rev-parse HEAD > /dev/null 2>&1 || rm -rf $PWD'
+
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -351,6 +351,7 @@ jobs:
     steps:
       - name: Workaround checkout Needed single revision issue
         run: |
+          git config --system core.longpaths true
           git submodule foreach 'git rev-parse HEAD > /dev/null 2>&1 || rm -rf $PWD'
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
Issue: #

### Brief Summary

Sometimes we can see `filename too long` errors in `actions/checkout` step, with the added `core.longpaths=true` we can (hopefully) solve this.

Still didn't figure out the exact reason why checked-out repos go corrupt, but this seems a reasonable candidate.

![2023-01-09-151745_1951x428_scrot](https://user-images.githubusercontent.com/857880/211257397-2447a941-84ce-4e3c-87c5-0efdc4ec40d8.png)


