### PR TITLE
[metal] Update Metal RHI impl & add support for shared arrays

### DIFF
--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -3,12 +3,14 @@ from taichi.lang import impl
 from taichi.lang.expr import make_expr_group
 from taichi.lang.util import taichi_scope
 
+def arch_uses_spv(arch):
+    return arch == _ti_core.vulkan or arch == _ti_core.metal or arch == _ti_core.opengl or arch == _ti_core.dx11
 
 def sync():
     arch = impl.get_runtime().prog.config().arch
     if arch == _ti_core.cuda:
         return impl.call_internal("block_barrier", with_runtime_context=False)
-    if arch == _ti_core.vulkan:
+    if arch_uses_spv(arch):
         return impl.call_internal("workgroupBarrier",
                                   with_runtime_context=False)
     raise ValueError(f'ti.block.shared_array is not supported for arch {arch}')
@@ -18,7 +20,7 @@ def mem_sync():
     arch = impl.get_runtime().prog.config().arch
     if arch == _ti_core.cuda:
         return impl.call_internal("block_barrier", with_runtime_context=False)
-    if arch == _ti_core.vulkan:
+    if arch_uses_spv(arch):
         return impl.call_internal("workgroupMemoryBarrier",
                                   with_runtime_context=False)
     raise ValueError(f'ti.block.mem_sync is not supported for arch {arch}')
@@ -26,7 +28,7 @@ def mem_sync():
 
 def thread_idx():
     arch = impl.get_runtime().prog.config().arch
-    if arch is _ti_core.vulkan:
+    if arch_uses_spv(arch):
         return impl.call_internal("localInvocationId",
                                   with_runtime_context=False)
     raise ValueError(f'ti.block.thread_idx is not supported for arch {arch}')
@@ -37,8 +39,8 @@ def global_thread_idx():
     if arch == _ti_core.cuda:
         return impl.get_runtime().compiling_callable.ast_builder(
         ).insert_thread_idx_expr()
-    if impl.get_runtime().prog.config().arch == _ti_core.vulkan:
-        return impl.call_internal("vkGlobalThreadIdx",
+    if arch_uses_spv(arch):
+        return impl.call_internal("globalInvocationId",
                                   with_runtime_context=False)
     raise ValueError(
         f'ti.block.global_thread_idx is not supported for arch {arch}')

--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -3,8 +3,10 @@ from taichi.lang import impl
 from taichi.lang.expr import make_expr_group
 from taichi.lang.util import taichi_scope
 
+
 def arch_uses_spv(arch):
     return arch == _ti_core.vulkan or arch == _ti_core.metal or arch == _ti_core.opengl or arch == _ti_core.dx11
+
 
 def sync():
     arch = impl.get_runtime().prog.config().arch

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1294,7 +1294,7 @@ class TaskCodegen : public IRVisitor {
       val = ir_->const_i32_zero_;
     } else if (stmt->func_name == "localInvocationId") {
       val = ir_->cast(ir_->i32_type(), ir_->get_local_invocation_id(0));
-    } else if (stmt->func_name == "vkGlobalThreadIdx") {
+    } else if (stmt->func_name == "globalInvocationId") {
       val = ir_->cast(ir_->i32_type(), ir_->get_global_invocation_id(0));
     } else if (stmt->func_name == "workgroupMemoryBarrier") {
       ir_->make_inst(

--- a/taichi/rhi/metal/metal_device.h
+++ b/taichi/rhi/metal/metal_device.h
@@ -2,6 +2,7 @@
 #include <memory>
 #include "taichi/rhi/device.h"
 #include "taichi/rhi/metal/metal_api.h"
+#include "taichi/rhi/impl_support.h"
 
 #if defined(__APPLE__) && defined(__OBJC__)
 #import <Foundation/Foundation.h>
@@ -203,7 +204,9 @@ class MetalDevice final : public Device {
 
   DeviceAllocation allocate_memory(const AllocParams &params) override;
   void dealloc_memory(DeviceAllocation handle) override;
+
   const MetalMemory &get_memory(DeviceAllocationId alloc_id) const;
+  MetalMemory &get_memory(DeviceAllocationId alloc_id);
 
   RhiResult map_range(DevicePtr ptr, uint64_t size, void **mapped_ptr) override;
   RhiResult map(DeviceAllocation alloc, void **mapped_ptr) override;
@@ -221,7 +224,7 @@ class MetalDevice final : public Device {
 
  private:
   MTLDevice_id mtl_device_;
-  std::map<DeviceAllocationId, std::unique_ptr<MetalMemory>> memory_allocs_;
+  rhi_impl::SyncedPtrStableObjectList<MetalMemory> memory_allocs_;
   std::unique_ptr<MetalStream> compute_stream_;
 
   bool is_destroyed_{false};

--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -52,7 +52,9 @@ MetalPipeline *MetalPipeline::create(const MetalDevice &device,
     if (mtl_library == nil) {
       if (err != nil) {
         std::array<char, 4096> msgbuf;
-        snprintf(msgbuf.data(), msgbuf.size(), "cannot compile metal library from source: %s (code=%d)", err.localizedDescription.UTF8String, (int)err.code);
+        snprintf(msgbuf.data(), msgbuf.size(),
+                 "cannot compile metal library from source: %s (code=%d)",
+                 err.localizedDescription.UTF8String, (int)err.code);
         RHI_LOG_ERROR(msgbuf.data());
       }
       return nullptr;
@@ -66,7 +68,8 @@ MetalPipeline *MetalPipeline::create(const MetalDevice &device,
     if (mtl_library == nil) {
       // FIXME: (penguinliong) Specify the actual entry name after we compile
       // directly to MSL in codegen.
-      RHI_LOG_ERROR("cannot extract entry point function 'main' from shader library");
+      RHI_LOG_ERROR(
+          "cannot extract entry point function 'main' from shader library");
     }
   }
 
@@ -80,7 +83,9 @@ MetalPipeline *MetalPipeline::create(const MetalDevice &device,
     if (mtl_compute_pipeline_state == nil) {
       if (err != nil) {
         std::array<char, 4096> msgbuf;
-        snprintf(msgbuf.data(), msgbuf.size(), "cannot create compute pipeline state: %s (code=%d)", err.localizedDescription.UTF8String, (int)err.code);
+        snprintf(msgbuf.data(), msgbuf.size(),
+                 "cannot create compute pipeline state: %s (code=%d)",
+                 err.localizedDescription.UTF8String, (int)err.code);
         RHI_LOG_ERROR(msgbuf.data());
       }
       return nullptr;
@@ -433,9 +438,9 @@ DeviceAllocation MetalDevice::allocate_memory(const AllocParams &params) {
 
   MTLBuffer_id buffer = [mtl_device_ newBufferWithLength:params.size
                                                  options:resource_options];
-  
+
   MetalMemory &alloc = memory_allocs_.acquire(buffer);
-  
+
   DeviceAllocation out{};
   out.device = this;
   out.alloc_id = reinterpret_cast<uint64_t>(&alloc);

--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -33,8 +33,8 @@ MetalPipeline::~MetalPipeline() { destroy(); }
 MetalPipeline *MetalPipeline::create(const MetalDevice &device,
                                      const uint32_t *spv_data,
                                      size_t spv_size) {
-  TI_ASSERT((size_t)spv_data % sizeof(uint32_t) == 0);
-  TI_ASSERT(spv_size % sizeof(uint32_t) == 0);
+  RHI_ASSERT((size_t)spv_data % sizeof(uint32_t) == 0);
+  RHI_ASSERT(spv_size % sizeof(uint32_t) == 0);
   spirv_cross::CompilerMSL compiler(spv_data, spv_size / sizeof(uint32_t));
   spirv_cross::CompilerMSL::Options options{};
   options.enable_decoration_binding = true;
@@ -50,9 +50,11 @@ MetalPipeline *MetalPipeline::create(const MetalDevice &device,
                                                       error:&err];
 
     if (mtl_library == nil) {
-      TI_WARN_IF(err != nil,
-                 "cannot compile metal library from source: {} (code={})",
-                 err.localizedDescription.UTF8String, (uint32_t)err.code);
+      if (err != nil) {
+        std::array<char, 4096> msgbuf;
+        snprintf(msgbuf.data(), msgbuf.size(), "cannot compile metal library from source: %s (code=%d)", err.localizedDescription.UTF8String, (int)err.code);
+        RHI_LOG_ERROR(msgbuf.data());
+      }
       return nullptr;
     }
   }
@@ -64,8 +66,7 @@ MetalPipeline *MetalPipeline::create(const MetalDevice &device,
     if (mtl_library == nil) {
       // FIXME: (penguinliong) Specify the actual entry name after we compile
       // directly to MSL in codegen.
-      TI_WARN("cannot extract entry point function '{}' from shader library",
-              "main");
+      RHI_LOG_ERROR("cannot extract entry point function 'main' from shader library");
     }
   }
 
@@ -77,9 +78,11 @@ MetalPipeline *MetalPipeline::create(const MetalDevice &device,
                                                            error:&err];
 
     if (mtl_compute_pipeline_state == nil) {
-      TI_WARN_IF(err != nil,
-                 "cannot create compute pipeline state: {} (code={})",
-                 err.localizedDescription.UTF8String, (uint32_t)err.code);
+      if (err != nil) {
+        std::array<char, 4096> msgbuf;
+        snprintf(msgbuf.data(), msgbuf.size(), "cannot create compute pipeline state: %s (code=%d)", err.localizedDescription.UTF8String, (int)err.code);
+        RHI_LOG_ERROR(msgbuf.data());
+      }
       return nullptr;
     }
   }
@@ -110,7 +113,7 @@ MetalShaderResourceSet::~MetalShaderResourceSet() {}
 
 ShaderResourceSet &MetalShaderResourceSet::buffer(uint32_t binding,
                                                   DevicePtr ptr, size_t size) {
-  TI_ASSERT(ptr.device == (Device *)device_);
+  RHI_ASSERT(ptr.device == (Device *)device_);
   const MetalMemory &memory = device_->get_memory(ptr.alloc_id);
 
   MetalShaderResource rsc{};
@@ -125,7 +128,7 @@ ShaderResourceSet &MetalShaderResourceSet::buffer(uint32_t binding,
 }
 ShaderResourceSet &MetalShaderResourceSet::buffer(uint32_t binding,
                                                   DeviceAllocation alloc) {
-  TI_ASSERT(alloc.device == (Device *)device_);
+  RHI_ASSERT(alloc.device == (Device *)device_);
   const MetalMemory &memory = device_->get_memory(alloc.alloc_id);
 
   MetalShaderResource rsc{};
@@ -142,7 +145,7 @@ ShaderResourceSet &MetalShaderResourceSet::buffer(uint32_t binding,
 ShaderResourceSet &MetalShaderResourceSet::rw_buffer(uint32_t binding,
                                                      DevicePtr ptr,
                                                      size_t size) {
-  TI_ASSERT(ptr.device == (Device *)device_);
+  RHI_ASSERT(ptr.device == (Device *)device_);
   const MetalMemory &memory = device_->get_memory(ptr.alloc_id);
 
   MetalShaderResource rsc{};
@@ -157,7 +160,7 @@ ShaderResourceSet &MetalShaderResourceSet::rw_buffer(uint32_t binding,
 }
 ShaderResourceSet &MetalShaderResourceSet::rw_buffer(uint32_t binding,
                                                      DeviceAllocation alloc) {
-  TI_ASSERT(alloc.device == (Device *)device_);
+  RHI_ASSERT(alloc.device == (Device *)device_);
   const MetalMemory &memory = device_->get_memory(alloc.alloc_id);
 
   MetalShaderResource rsc{};
@@ -176,13 +179,13 @@ MetalCommandList::MetalCommandList(const MetalDevice &device)
 MetalCommandList::~MetalCommandList() {}
 
 void MetalCommandList::bind_pipeline(Pipeline *p) noexcept {
-  TI_ASSERT(p != nullptr);
+  RHI_ASSERT(p != nullptr);
   current_pipeline_ = (MetalPipeline *)p;
 }
 RhiResult MetalCommandList::bind_shader_resources(ShaderResourceSet *res,
                                                   int set_index) noexcept {
-  TI_ASSERT(res != nullptr);
-  TI_ASSERT(set_index == 0);
+  RHI_ASSERT(res != nullptr);
+  RHI_ASSERT(set_index == 0);
   current_shader_resource_set_ = (MetalShaderResourceSet *)res;
   return RhiResult::success;
 }
@@ -208,7 +211,7 @@ void MetalCommandList::buffer_copy(DevicePtr dst, DevicePtr src,
   if (size == kBufferSizeEntireSize) {
     size_t src_size = src_memory.size();
     size_t dst_size = dst_memory.size();
-    TI_ASSERT(src_size == dst_size);
+    RHI_ASSERT(src_size == dst_size);
     size = src_size;
   }
 
@@ -228,7 +231,7 @@ void MetalCommandList::buffer_copy(DevicePtr dst, DevicePtr src,
 }
 void MetalCommandList::buffer_fill(DevicePtr ptr, size_t size,
                                    uint32_t data) noexcept {
-  TI_ASSERT(data == 0);
+  RHI_ASSERT(data == 0);
 
   const MetalMemory &memory = device_->get_memory(ptr.alloc_id);
 
@@ -250,8 +253,8 @@ void MetalCommandList::buffer_fill(DevicePtr ptr, size_t size,
 
 RhiResult MetalCommandList::dispatch(uint32_t x, uint32_t y,
                                      uint32_t z) noexcept {
-  TI_ASSERT(current_pipeline_);
-  TI_ASSERT(current_shader_resource_set_);
+  RHI_ASSERT(current_pipeline_);
+  RHI_ASSERT(current_shader_resource_set_);
 
   MTLComputePipelineState_id mtl_compute_pipeline_state =
       current_pipeline_->mtl_compute_pipeline_state();
@@ -276,7 +279,7 @@ RhiResult MetalCommandList::dispatch(uint32_t x, uint32_t y,
         break;
       }
       default:
-        TI_ASSERT(false);
+        RHI_ASSERT(false);
       }
     }
 
@@ -404,9 +407,6 @@ MetalDevice *MetalDevice::create() {
 void MetalDevice::destroy() {
   if (!is_destroyed_) {
     compute_stream_.reset();
-    TI_WARN_IF(memory_allocs_.size() != 0,
-               "metal device memory leaked: {} unreleased memory allocations",
-               memory_allocs_.size());
     memory_allocs_.clear();
     [mtl_device_ release];
     is_destroyed_ = true;
@@ -414,7 +414,9 @@ void MetalDevice::destroy() {
 }
 
 DeviceAllocation MetalDevice::allocate_memory(const AllocParams &params) {
-  TI_WARN_IF(params.export_sharing, "export sharing is not available in metal");
+  if (params.export_sharing) {
+    RHI_LOG_ERROR("export sharing is not available in metal");
+  }
 
   bool can_map = params.host_read || params.host_write;
 
@@ -431,39 +433,41 @@ DeviceAllocation MetalDevice::allocate_memory(const AllocParams &params) {
 
   MTLBuffer_id buffer = [mtl_device_ newBufferWithLength:params.size
                                                  options:resource_options];
-
-  std::unique_ptr<MetalMemory> memory = std::make_unique<MetalMemory>(buffer);
-
-  DeviceAllocationId alloc_id = (uint64_t)(size_t)memory.get();
-  memory_allocs_[alloc_id] = std::move(memory);
-
+  
+  MetalMemory &alloc = memory_allocs_.acquire(buffer);
+  
   DeviceAllocation out{};
   out.device = this;
-  out.alloc_id = alloc_id;
+  out.alloc_id = reinterpret_cast<uint64_t>(&alloc);
   return out;
 }
+
 void MetalDevice::dealloc_memory(DeviceAllocation handle) {
-  TI_ASSERT(handle.device == this);
-  auto it = memory_allocs_.find(handle.alloc_id);
-  memory_allocs_.erase(it);
+  RHI_ASSERT(handle.device == this);
+  memory_allocs_.release(&get_memory(handle.alloc_id));
 }
+
 const MetalMemory &MetalDevice::get_memory(DeviceAllocationId alloc_id) const {
-  return *memory_allocs_.at(alloc_id);
+  return *reinterpret_cast<MetalMemory *>(alloc_id);
+}
+
+MetalMemory &MetalDevice::get_memory(DeviceAllocationId alloc_id) {
+  return *reinterpret_cast<MetalMemory *>(alloc_id);
 }
 
 RhiResult MetalDevice::map_range(DevicePtr ptr, uint64_t size,
                                  void **mapped_ptr) {
-  const MetalMemory &memory = *memory_allocs_.at(ptr.alloc_id);
+  const MetalMemory &memory = get_memory(ptr.alloc_id);
 
   size_t offset = (size_t)ptr.offset;
-  TI_ASSERT(offset + size <= memory.size());
+  RHI_ASSERT(offset + size <= memory.size());
 
   RhiResult result = map(ptr, mapped_ptr);
   *(const uint8_t **)mapped_ptr += offset;
   return result;
 }
 RhiResult MetalDevice::map(DeviceAllocation alloc, void **mapped_ptr) {
-  const MetalMemory &memory = *memory_allocs_.at(alloc.alloc_id);
+  const MetalMemory &memory = get_memory(alloc.alloc_id);
   return memory.mapped_ptr(mapped_ptr);
 }
 void MetalDevice::unmap(DevicePtr ptr) {}
@@ -471,7 +475,7 @@ void MetalDevice::unmap(DeviceAllocation ptr) {}
 
 std::unique_ptr<Pipeline>
 MetalDevice::create_pipeline(const PipelineSourceDesc &src, std::string name) {
-  TI_ASSERT(src.type == PipelineSourceType::spirv_binary);
+  RHI_ASSERT(src.type == PipelineSourceType::spirv_binary);
   Pipeline *out =
       MetalPipeline::create(*this, (const uint32_t *)src.data, src.size);
   return std::unique_ptr<Pipeline>(out);
@@ -486,7 +490,7 @@ void MetalDevice::wait_idle() { compute_stream_->command_sync(); }
 void MetalDevice::memcpy_internal(DevicePtr dst, DevicePtr src, uint64_t size) {
   Stream *stream = get_compute_stream();
   auto [cmd, res] = stream->new_command_list_unique();
-  TI_ASSERT(res == RhiResult::success);
+  RHI_ASSERT(res == RhiResult::success);
   cmd->buffer_copy(dst, src, size);
   stream->submit_synced(cmd.get());
 }


### PR DESCRIPTION
1. Remove most of the `TI_XXX` macros from Metal RHI impl
2. Utilize some features from `impl_support.h`
3. Enable shared array support on all SPIR-V backends