### PR TITLE
[bug] Unify error message matching with/without validation layers for CapiTest.FailMapDeviceOnlyMemory

### DIFF
--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -399,8 +399,8 @@ void *ti_map_memory(TiRuntime runtime, TiMemory devmem) {
   Runtime *runtime2 = (Runtime *)runtime;
   TI_ASSERT(runtime2->get().map(devmem2devalloc(*runtime2, devmem), &out) ==
                 taichi::lang::RhiResult::success &&
-            "RHI map memory failed: Mapping Memory without "
-            "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT set");
+            "RHI map memory failed: "
+            "Mapping Memory without VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT set");
   TI_CAPI_TRY_CATCH_END();
   return out;
 }

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -399,7 +399,8 @@ void *ti_map_memory(TiRuntime runtime, TiMemory devmem) {
   Runtime *runtime2 = (Runtime *)runtime;
   TI_ASSERT(runtime2->get().map(devmem2devalloc(*runtime2, devmem), &out) ==
                 taichi::lang::RhiResult::success &&
-            "RHI map memory failed");
+            "RHI map memory failed: Mapping Memory without "
+            "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT set");
   TI_CAPI_TRY_CATCH_END();
   return out;
 }

--- a/c_api/tests/c_api_interface_test.cpp
+++ b/c_api/tests/c_api_interface_test.cpp
@@ -136,18 +136,10 @@ TEST_F(CapiTest, FailMapDeviceOnlyMemory) {
     ti::Memory mem = runtime.allocate_memory(100);
     mem.map();
 
-#ifdef __APPLE__
-    // Vulkan Validation aren't supported on MacOS platform
-    EXPECT_TAICHI_ERROR(TI_ERROR_INVALID_STATE, "Assertion failure",
-                        /*reset_error=*/false);
-    EXPECT_TAICHI_ERROR(TI_ERROR_INVALID_STATE, "RHI map memory failed",
-                        /*reset_error=*/true);
-#else
     EXPECT_TAICHI_ERROR(
         TI_ERROR_INVALID_STATE,
         "Mapping Memory without VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT set",
         /*reset_error=*/true);
-#endif
   }
 }
 


### PR DESCRIPTION
Issue: #

### Brief Summary
