### PR TITLE
[cpu] Reuse VirtualMemoryAllocator for CPU ndarray memory allocation

### DIFF
--- a/taichi/rhi/cpu/cpu_device.cpp
+++ b/taichi/rhi/cpu/cpu_device.cpp
@@ -28,17 +28,7 @@ DeviceAllocation CpuDevice::allocate_memory(const AllocParams &params) {
 
 DeviceAllocation CpuDevice::allocate_memory_runtime(
     const LlvmRuntimeAllocParams &params) {
-  AllocInfo info;
-  info.ptr = allocate_llvm_runtime_memory_jit(params);
-  // TODO: Add caching allocator
-  info.size = params.size;
-  info.use_cached = params.use_cached;
-  DeviceAllocation alloc;
-  alloc.alloc_id = allocations_.size();
-  alloc.device = this;
-
-  allocations_.push_back(info);
-  return alloc;
+  return allocate_memory(params);
 }
 
 void CpuDevice::dealloc_memory(DeviceAllocation handle) {

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -711,9 +711,8 @@ def test_ndarray_reset():
     ti.reset()
 
 
-# FIXME[#7119]: enable this test on CPU backend once caching allocator is used.
 @pytest.mark.run_in_serial
-@test_utils.test(arch=supported_archs_taichi_ndarray, exclude=ti.cpu)
+@test_utils.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_in_python_func():
     def test():
         z = ti.ndarray(float, (8192, 8192))


### PR DESCRIPTION
Fixes #7119

### Brief Summary
It seems unnecessary for CPU to use runtime jit memory allocation for ndarray, let's see if anything breaks... 