### PR TITLE
[metal] Retain Metal commandBuffers & build command buffers directly

### DIFF
--- a/cmake/TaichiCXXFlags.cmake
+++ b/cmake/TaichiCXXFlags.cmake
@@ -55,13 +55,13 @@ else()
     # [Global] CXX compilation option to enable all warnings.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ")
 
-# Due to limited CI coverage, -Werror is only turned on with Clang-compiler for now.
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    if (NOT ANDROID) # (penguinliong) Blocking builds on Android.
-        # [Global] CXX compilation option to treat all warnings as errors.
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror ")
+    # Due to limited CI coverage, -Werror is only turned on with Clang-compiler for now.
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        if (NOT ANDROID) # (penguinliong) Blocking builds on Android.
+            # [Global] CXX compilation option to treat all warnings as errors.
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror ")
+        endif()
     endif()
-endif()
 
     # [Global] By default, CXX compiler will throw a warning if it decides to ignore an attribute, for example "[[ maybe unused ]]".
     # However, this behaviour diverges across different compilers (GCC/CLANG), as well as different compiler versions.
@@ -79,15 +79,17 @@ endif()
     # However, some of these "constexpr" are debug flags and will be manually enabled upon debugging.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unneeded-internal-declaration ")
 
-    # CLANG_VERSION_MAJOR is set in check_clang_version
-    if (${CLANG_VERSION_MAJOR} VERSION_GREATER_EQUAL 15)
-      # [Global] FIXME: Newly introduced flag in clang-15
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unqualified-std-cast-call ")
-    endif()
+    # FIXME: Check why Android don't support check_cxx_compiler_flag
+    if (NOT ANDROID)
+        check_cxx_compiler_flag("-Wno-unqualified-std-cast-call" CXX_HAS_Wno_unqualified_std_cast_call)
+        if (${CXX_HAS_Wno_unqualified_std_cast_call})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unqualified-std-cast-call ")
+        endif()
 
-    if (${CLANG_VERSION_MAJOR} VERSION_GREATER_EQUAL 13)
-      # [Global] FIXME: Newly introduced flag in clang-13
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable ")
+        check_cxx_compiler_flag("-Wno-unused-but-set-variable" CXX_HAS_Wno_unused_but_set_variable)
+        if (${CXX_HAS_Wno_unused_but_set_variable})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable ")
+        endif()
     endif()
 endif ()
 

--- a/taichi/rhi/metal/metal_device.h
+++ b/taichi/rhi/metal/metal_device.h
@@ -129,7 +129,8 @@ class MetalShaderResourceSet final : public ShaderResourceSet {
 
 class MetalCommandList final : public CommandList {
  public:
-  explicit MetalCommandList(const MetalDevice &device);
+  explicit MetalCommandList(const MetalDevice &device,
+                            MTLCommandQueue_id cmd_queue);
   ~MetalCommandList() final;
 
   void bind_pipeline(Pipeline *p) noexcept final;
@@ -144,11 +145,13 @@ class MetalCommandList final : public CommandList {
   void buffer_fill(DevicePtr ptr, size_t size, uint32_t data) noexcept final;
   RhiResult dispatch(uint32_t x, uint32_t y = 1, uint32_t z = 1) noexcept final;
 
+  MTLCommandBuffer_id finalize();
+
  private:
   friend class MetalStream;
 
   const MetalDevice *device_;
-  std::vector<std::function<void(MTLCommandBuffer_id)>> pending_commands_;
+  MTLCommandBuffer_id cmdbuf_;
 
   // Non-null after `bind*` methods.
   const MetalPipeline *current_pipeline_;

--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -182,7 +182,7 @@ ShaderResourceSet &MetalShaderResourceSet::rw_buffer(uint32_t binding,
 MetalCommandList::MetalCommandList(const MetalDevice &device,
                                    MTLCommandQueue_id cmd_queue)
     : device_(&device) {
-  cmdbuf_ = [[cmd_queue commandBuffer] retain];
+  cmdbuf_ = [cmd_queue commandBuffer];
 }
 
 MetalCommandList::~MetalCommandList() { [cmdbuf_ release]; }


### PR DESCRIPTION
Issue: #

### Brief Summary

Changed the command buffer building to directly retaining a command buffer and encoding commands into it (instead of building up a list of lambda functions)
