### PR TITLE
[lang] Sign python library for Apple M1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,9 +177,8 @@ def sign_development_for_apple_m1():
         try:
             for path in glob.glob("python/taichi/_lib/core/*.so"):
                 print(f"signing {path}..")
-                subprocess.check_call([
-                    'codesign', '--force', '--deep', '--sign', '-', path
-                ])
+                subprocess.check_call(
+                    ['codesign', '--force', '--deep', '--sign', '-', path])
         except:
             print("cannot sign python shared library for macos arm64 build")
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import multiprocessing
 import os
 import platform
 import shutil
+import subprocess
 import sys
 from distutils.command.clean import clean
 from distutils.dir_util import remove_tree
@@ -166,6 +167,19 @@ def cmake_install_manifest_filter(manifest_files):
     ]
 
 
+def sign_development_for_apple_m1():
+    """
+    Apple enforces codesigning for arm64 targets even for local development
+    builds. See discussion here:
+        https://github.com/supercollider/supercollider/issues/5603
+    """
+    if sys.platform == "darwin" and platform.machine() == "arm64":
+        try:
+            subprocess.check_call(['codesign', '--force', '--deep', '--sign', '-', 'python/taichi/_lib/core/taichi_python.cpython-310-darwin.so'])
+        except:
+            print("cannot sign python shared library for macos arm64 build")
+
+
 copy_assets()
 setup(name=project_name,
       packages=packages,
@@ -197,3 +211,5 @@ setup(name=project_name,
           'clean': Clean
       },
       has_ext_modules=lambda: True)
+
+sign_development_for_apple_m1()

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,10 @@ def sign_development_for_apple_m1():
     """
     if sys.platform == "darwin" and platform.machine() == "arm64":
         try:
-            subprocess.check_call(['codesign', '--force', '--deep', '--sign', '-', 'python/taichi/_lib/core/taichi_python.cpython-310-darwin.so'])
+            subprocess.check_call([
+                'codesign', '--force', '--deep', '--sign', '-',
+                'python/taichi/_lib/core/taichi_python.cpython-310-darwin.so'
+            ])
         except:
             print("cannot sign python shared library for macos arm64 build")
 

--- a/setup.py
+++ b/setup.py
@@ -175,10 +175,11 @@ def sign_development_for_apple_m1():
     """
     if sys.platform == "darwin" and platform.machine() == "arm64":
         try:
-            subprocess.check_call([
-                'codesign', '--force', '--deep', '--sign', '-',
-                'python/taichi/_lib/core/taichi_python.cpython-310-darwin.so'
-            ])
+            for path in glob.glob("python/taichi/_lib/core/*.so"):
+                print(f"signing {path}..")
+                subprocess.check_call([
+                    'codesign', '--force', '--deep', '--sign', '-', path
+                ])
         except:
             print("cannot sign python shared library for macos arm64 build")
 


### PR DESCRIPTION
Apple requires any shared library built for Apple Silicon to be codesigned with a local development certificate. This certificate is generated by Xcode automatically.