### PR TITLE
[ci] Disable backward_cpp on macOS

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -148,7 +148,6 @@ jobs:
             -DTI_WITH_CC:BOOL=${{ matrix.with_cc }}
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_WITH_C_API=ON
-            -DTI_WITH_BACKTRACE:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=${{ matrix.with_cpp_tests }}
 
       # [DEBUG] Copy this step around to enable debugging inside Github Action instances.
@@ -437,7 +436,6 @@ jobs:
             -DTI_WITH_CC:BOOL=OFF
             -DTI_WITH_VULKAN:BOOL=ON
             -DTI_BUILD_TESTS:BOOL=ON
-            -DTI_WITH_BACKTRACE:BOOL=ON
             -DTI_WITH_C_API=ON
 
       - name: Check C-API Export Symbols


### PR DESCRIPTION
Related Issue: #7140 

### Brief Summary

On macOS, when test worker hard fails (abort, EXC_BAD_ACCESS, etc.), backward_cpp's signal handler will re-raise the signal and catch it afterwards, make it an infinite loop, at the moment the offending process can't be terminated easily (except a SIGKILL), eat CPU cycles and blocks test runner.

```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00000001a04f0e28 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #2: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #3: 0x00000001283a0848 taichi_python.cpython-38-darwin.so`backward::SignalHandling::sig_handler(int, __siginfo*, void*) + 28
    frame #4: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #5: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #6: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #7: 0x00000001283a0848 taichi_python.cpython-38-darwin.so`backward::SignalHandling::sig_handler(int, __siginfo*, void*) + 28
    frame #8: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #9: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #10: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #11: 0x00000001283a0848 taichi_python.cpython-38-darwin.so`backward::SignalHandling::sig_handler(int, __siginfo*, void*) + 28
    frame #12: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #13: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #14: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #15: 0x00000001283a0848 taichi_python.cpython-38-darwin.so`backward::SignalHandling::sig_handler(int, __siginfo*, void*) + 28
    frame #16: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #17: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #18: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #19: 0x00000001283a0848 taichi_python.cpython-38-darwin.so`backward::SignalHandling::sig_handler(int, __siginfo*, void*) + 28
    frame #20: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #21: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #22: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #23: 0x00000001283a0848 taichi_python.cpython-38-darwin.so`backward::SignalHandling::sig_handler(int, __siginfo*, void*) + 28
    frame #24: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #25: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #26: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #27: 0x00000001283a0848 taichi_python.cpython-38-darwin.so`backward::SignalHandling::sig_handler(int, __siginfo*, void*) + 28
    frame #28: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #29: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #30: 0x00000001a0402e10 libsystem_c.dylib`raise + 32
    frame #31: 0x00000001a056ec44 libsystem_platform.dylib`_sigtramp + 56
    frame #32: 0x00000001a052343c libsystem_pthread.dylib`pthread_kill + 292
    frame #33: 0x00000001a046b454 libsystem_c.dylib`abort + 124
    frame #34: 0x0000000100194fc0 python`os_abort + 12
    frame #35: 0x00000001000758a8 python`cfunction_vectorcall_NOARGS + 324
    frame #36: 0x00000001001140f0 python`call_function + 460
    frame #37: 0x000000010011086c python`_PyEval_EvalFrameDefault + 27176
    frame #38: 0x00000001000287e4 python`function_code_fastcall + 128
    frame #39: 0x0000000100028008 python`PyVectorcall_Call + 120
    frame #40: 0x0000000100110b20 python`_PyEval_EvalFrameDefault + 27868
    frame #41: 0x000000010010982c python`_PyEval_EvalCodeWithName + 3008
    frame #42: 0x0000000100028948 python`_PyFunction_Vectorcall + 208
    frame #43: 0x0000000100028008 python`PyVectorcall_Call + 120
```
