### PR TITLE
[ci] Run test when pushing to rc branches

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [master]
+    branches:
+      - master
+      - rc-*
   schedule:
     - cron: '0 18 * * *'  # For testing the offline cache, GMT 18 == GMT+8 02
 


### PR DESCRIPTION
We should directly push the cherry-picks to the rc branches instead of merging it using PRs.

### Brief Summary
