### PR TITLE
[ci] Use make_changelog.py to generate the full changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,5 +383,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: CHANGELOG.md
-          generate_release_notes: true
           tag_name: ${{ github.event.inputs.version }}

--- a/misc/make_changelog.py
+++ b/misc/make_changelog.py
@@ -43,6 +43,7 @@ def main(ver=None, repo_dir='.'):
         return f'{c.summary} (by **{c.author}**)'
 
     notable_changes = {}
+    all_changes = []
 
     details = load_pr_tags()
 
@@ -73,12 +74,17 @@ def main(ver=None, repo_dir='.'):
                 print(
                     f'** Warning: tag {tag.lower()} undefined in the "details" dict. Please include the tag into "details", unless the tag is a typo.'
                 )
+        all_changes.append(format(c))
 
     res = 'Highlights:\n'
     for tag in sorted(notable_changes.keys()):
         res += f'   - **{details[tag]}**\n'
         for item in notable_changes[tag]:
             res += f'      - {item}\n'
+
+    res += '\nFull changelog:\n'
+    for c in all_changes:
+        res += f'   - {c}\n'
 
     return res
 


### PR DESCRIPTION
Issue: #6114

### Brief Summary
The changelog automatically generated by GitHub only shows the PR list related to the branch, and the cherry-picked commits are not inside the list. So we should use our commit-based `make_changelog.py` to generate the full changelog.