### PR TITLE
[metal] Disable a kernel test in offline cache to unblock CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -414,7 +414,7 @@ jobs:
       run:
         # https://github.com/actions/runner/issues/805#issuecomment-844426478
         shell: '/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}'
-    runs-on: [self-hosted, ventura]
+    runs-on: [self-hosted, m1]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -414,7 +414,7 @@ jobs:
       run:
         # https://github.com/actions/runner/issues/805#issuecomment-844426478
         shell: '/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}'
-    runs-on: [self-hosted, m1]
+    runs-on: [self-hosted, ventura]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -180,14 +180,16 @@ def python_kernel5(lo: ti.i32, hi: ti.i32, n: ti.i32):
     return res
 
 
-simple_kernels_to_test = [(kernel0, (), python_kernel0, 1),
-                          (kernel1, (100, 200, 10.2), python_kernel1, 1),
-                          (kernel2, (1024, ), python_kernel2, 3),
-                          (kernel3, (10,
-                                     ti.Matrix([[1, 2], [256, 1024]],
-                                               ti.i32)), python_kernel3, 1),
-                          (kernel4, (1, 10, 2), python_kernel4, 3),
-                          (kernel5, (1, 2, 2), python_kernel5, 3)]
+simple_kernels_to_test = [
+    (kernel0, (), python_kernel0, 1),
+    (kernel1, (100, 200, 10.2), python_kernel1, 1),
+    (kernel2, (1024, ), python_kernel2, 3),
+    (kernel3, (10, ti.Matrix([[1, 2], [256, 1024]],
+                             ti.i32)), python_kernel3, 1),
+    # FIXME: add this kernel back once #6221 is fixed
+    #   (kernel4, (1, 10, 2), python_kernel4, 3),
+    (kernel5, (1, 2, 2), python_kernel5, 3)
+]
 
 
 def _test_offline_cache_dec(func):


### PR DESCRIPTION
Issue: #6221 

### Brief Summary

`kernel4` in `test_offline_cache.py` triggers a weird LLVM internal error on metal backend for macos12+. After moving metal runtime to gfxruntime by @PENGUINLIONG  and #7201, this is now the only blocker for us to run full CI on macos ventura. As discussed with @PENGUINLIONG and @feisuzhu offline, let's disable this test to unblock CI and add it back once the issue is fixed. 
