### PR TITLE
[aot] C-API get version wrapper

### DIFF
--- a/c_api/include/taichi/cpp/taichi.hpp
+++ b/c_api/include/taichi/cpp/taichi.hpp
@@ -11,6 +11,29 @@
 
 namespace ti {
 
+struct Version {
+  uint32_t version;
+
+  inline uint32_t major() const {
+    return version / 1000000;
+  }
+  inline uint32_t minor() const {
+    return (version / 1000) % 1000;
+  }
+  inline uint32_t patch() const {
+    return version % 1000;
+  }
+
+  operator uint32_t() const {
+    return version;
+  }
+};
+inline Version get_version() {
+  Version out{};
+  out.version = ti_get_version();
+  return out;
+}
+
 inline std::vector<TiArch> get_available_archs() {
   uint32_t narch = 0;
   ti_get_available_archs(&narch, nullptr);

--- a/c_api/tests/c_api_interface_test.cpp
+++ b/c_api/tests/c_api_interface_test.cpp
@@ -3,6 +3,11 @@
 #include "taichi/cpp/taichi.hpp"
 #include "c_api/tests/gtest_fixture.h"
 
+TEST_F(CapiTest, DryRunGetVersion) {
+  ti::Version version = ti::get_version();
+  TI_ASSERT(version.major() == 1);
+}
+
 TEST_F(CapiTest, DryRunAvailableArchs) {
   std::vector<TiArch> archs = ti::get_available_archs();
 }


### PR DESCRIPTION
Issue: #

### Brief Summary

Added C++ wrapper for `ti_get_version`.
