### PR TITLE
[Doc] Update debugging.md

### DIFF
--- a/docs/lang/articles/debug/debugging.md
+++ b/docs/lang/articles/debug/debugging.md
@@ -76,9 +76,6 @@ To enable printing on Vulkan, please
 **Printing is not supported on the macOS Vulkan backend.**
 :::
 
-:::note
-In Graphical Python Shells like IDLE and Jupyter Notebook, `print` does not work. This is because these backends print to the console rather than the GUI.
-:::
 
 ### Comma-separated strings only
 


### PR DESCRIPTION
This PR deletes the obsolete note because:

1. Taichi will drop the support for IDLE from v1.4.0.
2. print is now supported in Jupyter notebook.