### PR TITLE
[example] Fix ti gallery close warning

### DIFF
--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -209,7 +209,8 @@ class TaichiMain:
             console.print(content)
             self._exec_python_file(script)
 
-        while gui.running:
+        index = None
+        while not gui.get_event(ti.GUI.ESCAPE, ti.GUI.EXIT):
             gui.set_image(gallery_image)
             mou_x, mou_y = gui.get_cursor_pos()
             gui.get_event(ti.GUI.PRESS)
@@ -223,7 +224,8 @@ class TaichiMain:
 
             gui.show()
 
-        on_mouse_click_callback(examples[index])
+        if index is not None:
+            on_mouse_click_callback(examples[index])
 
     @register
     def example(self, arguments: list = sys.argv[2:]):


### PR DESCRIPTION
The terminal will report an error when users run the command `ti gallery` but close the window without choosing any example. This PR fixes this problem.