### PR TITLE
[misc] Remove unused Program::jit_evaluator_id

### DIFF
--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -108,7 +108,6 @@ class TI_DLL_EXPORT Program {
   std::unordered_map<JITEvaluatorId, std::unique_ptr<Kernel>>
       jit_evaluator_cache;
   std::mutex jit_evaluator_cache_mut;
-  std::atomic<uint32_t> jit_evaluator_id{0};
 
   // Note: for now we let all Programs share a single TypeFactory for smooth
   // migration. In the future each program should have its own copy.


### PR DESCRIPTION
Issue: #

### Brief Summary
The `Program::jit_evaluator_id` is not used.
