### PR TITLE
[Error] Remove deprecated a.atomic_op(b) in Taichi v1.6.0

### DIFF
--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -19,7 +19,7 @@ class TaichiOperations:
     def __getattr__(self, item):
         if item in TaichiOperations.__deprecated_atomic_ops__:
             warnings.warn(
-                f"a.{item}(b) is deprecated. Please use ti.{item}(a, b) instead.",
+                f"a.{item}(b) is deprecated, and it will be removed in Taichi v1.6.0. Please use ti.{item}(a, b) instead.",
                 DeprecationWarning)
             return getattr(self,
                            TaichiOperations.__deprecated_atomic_ops__[item])

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -8,6 +8,22 @@ from tests import test_utils
 
 
 @test_utils.test()
+def test_deprecate_a_atomic_b():
+    with pytest.warns(
+            DeprecationWarning,
+            match=
+            r"a\.atomic_add\(b\) is deprecated, and it will be removed in Taichi v1.6.0."
+    ):
+
+        @ti.kernel
+        def func():
+            a = 1
+            a.atomic_add(2)
+
+        func()
+
+
+@test_utils.test()
 def test_deprecate_element_shape_ndarray_annotation():
     with pytest.warns(
             DeprecationWarning,


### PR DESCRIPTION
Issue: #7189 

### Brief Summary
