### PR TITLE
[Error] Remove deprecated ti.linalg.sparse_matrix_builder in 1.6.0

### DIFF
--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import reduce
 
 import numpy as np
@@ -6,7 +7,6 @@ from taichi.lang._ndarray import Ndarray, ScalarNdarray
 from taichi.lang.exception import TaichiRuntimeError
 from taichi.lang.field import Field
 from taichi.lang.impl import get_runtime
-from taichi.lang.util import warning
 from taichi.types import annotations, f32
 
 
@@ -265,8 +265,9 @@ class SparseMatrixBuilder:
 # TODO: remove this in 1.0 release
 class sparse_matrix_builder(annotations.sparse_matrix_builder):
     def __init__(self):
-        warning(
-            'ti.linalg.sparse_matrix_builder is deprecated. Please use ti.types.sparse_matrix_builder instead.',
+        warnings.warn(
+            'ti.linalg.sparse_matrix_builder is deprecated, and it will be removed in Taichi v1.6.0. '
+            'Please use ti.types.sparse_matrix_builder instead.',
             DeprecationWarning)
 
 

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -144,3 +144,13 @@ def test_deprecation_in_taichi_init_py():
             match=
             "ti.SOA is deprecated, and it will be removed in Taichi v1.6.0."):
         ti.SOA
+
+
+@test_utils.test()
+def test_deprecate_sparse_matrix_builder():
+    with pytest.warns(
+            DeprecationWarning,
+            match=
+            r"ti\.linalg\.sparse_matrix_builder is deprecated, and it will be removed in Taichi v1\.6\.0\."
+    ):
+        ti.linalg.sparse_matrix_builder()


### PR DESCRIPTION
Issue: #7189

### Brief Summary
