### PR TITLE
[opengl] Fix GLFW global context issue

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -159,7 +159,7 @@ if (TI_WITH_OPENGL OR TI_WITH_VULKAN AND NOT ANDROID)
   endif()
 
   message("Building with GLFW")
-  target_compile_definitions(${CORE_LIBRARY_NAME} PRIVATE TI_WITH_GLFW)
+  add_compile_definitions(TI_WITH_GLFW)
   add_subdirectory(external/glfw)
   target_link_libraries(${CORE_LIBRARY_NAME} PRIVATE glfw)
   target_include_directories(${CORE_LIBRARY_NAME} PUBLIC external/glfw/include)

--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -159,6 +159,7 @@ if (TI_WITH_OPENGL OR TI_WITH_VULKAN AND NOT ANDROID)
   endif()
 
   message("Building with GLFW")
+  target_compile_definitions(${CORE_LIBRARY_NAME} PRIVATE TI_WITH_GLFW)
   add_subdirectory(external/glfw)
   target_link_libraries(${CORE_LIBRARY_NAME} PRIVATE glfw)
   target_include_directories(${CORE_LIBRARY_NAME} PUBLIC external/glfw/include)

--- a/taichi/rhi/opengl/opengl_api.cpp
+++ b/taichi/rhi/opengl/opengl_api.cpp
@@ -4,10 +4,9 @@
 
 #include "glad/gl.h"
 #include "glad/egl.h"
-#ifndef ANDROID
-#include "GLFW/glfw3.h"
-#endif  // ANDROID
 #include "taichi/rhi/opengl/opengl_device.h"
+
+#include "taichi/rhi/window_system.h"
 
 namespace taichi::lang {
 namespace opengl {
@@ -28,12 +27,6 @@ static bool kUseGles = false;
 static std::optional<bool> supported;  // std::nullopt
 void *kGetOpenglProcAddr;
 
-#ifndef ANDROID
-static void glfw_error_callback(int code, const char *description) {
-  TI_WARN("GLFW Error {}: {}", code, description);
-}
-#endif  // ANDROID
-
 bool initialize_opengl(bool use_gles, bool error_tolerance) {
   TI_TRACE("initialize_opengl({}, {}) called", use_gles, error_tolerance);
 
@@ -52,8 +45,7 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
   void *get_proc_addr = nullptr;
 
 #ifndef ANDROID
-  if (glfwInit()) {
-    glfwSetErrorCallback(glfw_error_callback);
+  if (window_system::glfwContextAcquire()) {
     // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
     if (use_gles) {
       glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
@@ -220,7 +212,7 @@ void reset_opengl() {
   supported = std::nullopt;
   kUseGles = false;
 #ifndef ANDROID
-  glfwTerminate();
+  window_system::glfwContextRelease();
 #endif
 }
 

--- a/taichi/rhi/opengl/opengl_api.cpp
+++ b/taichi/rhi/opengl/opengl_api.cpp
@@ -45,7 +45,7 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
   void *get_proc_addr = nullptr;
 
 #ifndef ANDROID
-  if (window_system::glfwContextAcquire()) {
+  if (window_system::glfw_context_acquire()) {
     // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
     if (use_gles) {
       glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
@@ -212,7 +212,7 @@ void reset_opengl() {
   supported = std::nullopt;
   kUseGles = false;
 #ifndef ANDROID
-  window_system::glfwContextRelease();
+  window_system::glfw_context_release();
 #endif
 }
 

--- a/taichi/rhi/window_system.cpp
+++ b/taichi/rhi/window_system.cpp
@@ -21,7 +21,7 @@ static void glfw_error_callback(int code, const char *description) {
   RHI_LOG_ERROR(buf.data());
 }
 
-bool glfwContextAcquire() {
+bool glfw_context_acquire() {
   std::lock_guard lg(glfw_state.mutex);
   if (glfw_state.glfw_ref_count == 0) {
     auto res = glfwInit();
@@ -35,7 +35,7 @@ bool glfwContextAcquire() {
   return true;
 }
 
-void glfwContextRelease() {
+void glfw_context_release() {
   std::lock_guard lg(glfw_state.mutex);
   glfw_state.glfw_ref_count--;
   if (glfw_state.glfw_ref_count == 0) {
@@ -47,11 +47,11 @@ void glfwContextRelease() {
 
 #else
 
-bool glfwContextAcquire() {
+bool glfw_context_acquire() {
   return false;
 }
 
-void glfwContextRelease() {
+void glfw_context_release() {
   return;
 }
 

--- a/taichi/rhi/window_system.cpp
+++ b/taichi/rhi/window_system.cpp
@@ -1,0 +1,61 @@
+#include "window_system.h"
+#include "taichi/rhi/impl_support.h"
+
+#include <mutex>
+#include <array>
+#include <iostream>
+
+namespace taichi::lang::window_system {
+
+#ifndef ANDROID
+struct GLFWState {
+  std::mutex mutex;
+  int glfw_ref_count = 0;
+};
+
+static GLFWState glfw_state;
+
+static void glfw_error_callback(int code, const char *description) {
+  std::array<char, 1024> buf;
+  snprintf(buf.data(), buf.size(), "GLFW Error %d: %s", code, description);
+  RHI_LOG_ERROR(buf.data());
+}
+
+bool glfwContextAcquire() {
+  std::lock_guard lg(glfw_state.mutex);
+  if (glfw_state.glfw_ref_count == 0) {
+    auto res = glfwInit();
+    if (res != GLFW_TRUE) {
+      return false;
+    }
+    
+    glfwSetErrorCallback(glfw_error_callback);
+  }
+  glfw_state.glfw_ref_count++;
+  return true;
+}
+
+void glfwContextRelease() {
+  std::lock_guard lg(glfw_state.mutex);
+  glfw_state.glfw_ref_count--;
+  if (glfw_state.glfw_ref_count == 0) {
+    glfwTerminate();
+  } else if (glfw_state.glfw_ref_count < 0) {
+    assert(false && "GLFW context double release?");
+  }
+}
+
+#else
+
+bool glfwContextAcquire() {
+  return false;
+}
+
+void glfwContextRelease() {
+  return;
+}
+
+#endif  // ANDROID
+
+
+}

--- a/taichi/rhi/window_system.cpp
+++ b/taichi/rhi/window_system.cpp
@@ -7,7 +7,7 @@
 
 namespace taichi::lang::window_system {
 
-#ifndef ANDROID
+#ifdef TI_WITH_GLFW
 struct GLFWState {
   std::mutex mutex;
   int glfw_ref_count = 0;
@@ -55,7 +55,7 @@ void glfw_context_release() {
   return;
 }
 
-#endif  // ANDROID
+#endif  // TI_WITH_GLFW
 
 
 }

--- a/taichi/rhi/window_system.h
+++ b/taichi/rhi/window_system.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#ifndef ANDROID
+#ifdef TI_WITH_GLFW
 #include "GLFW/glfw3.h"
-#endif  // ANDROID
+#endif  // TI_WITH_GLFW
 
 namespace taichi::lang::window_system {
 

--- a/taichi/rhi/window_system.h
+++ b/taichi/rhi/window_system.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifndef ANDROID
+#include "GLFW/glfw3.h"
+#endif  // ANDROID
+
+namespace taichi::lang::window_system {
+
+bool glfwContextAcquire();
+void glfwContextRelease();
+
+}

--- a/taichi/rhi/window_system.h
+++ b/taichi/rhi/window_system.h
@@ -6,7 +6,7 @@
 
 namespace taichi::lang::window_system {
 
-bool glfwContextAcquire();
-void glfwContextRelease();
+bool glfw_context_acquire();
+void glfw_context_release();
 
 }

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -7,9 +7,7 @@
 #include "taichi/runtime/gfx/aot_module_loader_impl.h"
 #include "taichi/util/offline_cache.h"
 
-#if !defined(ANDROID)
-#include "GLFW/glfw3.h"
-#endif
+#include "taichi/rhi/window_system.h"
 
 using namespace taichi::lang::vulkan;
 
@@ -85,10 +83,6 @@ FunctionType VulkanProgramImpl::compile(const CompileConfig &compile_config,
       vulkan_runtime_.get());
 }
 
-static void glfw_error_callback(int code, const char *description) {
-  TI_WARN("GLFW Error {}: {}", code, description);
-}
-
 void VulkanProgramImpl::materialize_runtime(MemoryPool *memory_pool,
                                             KernelProfilerBase *profiler,
                                             uint64 **result_buffer_ptr) {
@@ -101,9 +95,7 @@ void VulkanProgramImpl::materialize_runtime(MemoryPool *memory_pool,
 #ifndef ANDROID
   GLFWwindow *glfw_window = nullptr;
 
-  if (glfwInit()) {
-    glfwSetErrorCallback(glfw_error_callback);
-
+  if (window_system::glfwContextAcquire()) {
     // glfw init success
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -95,7 +95,7 @@ void VulkanProgramImpl::materialize_runtime(MemoryPool *memory_pool,
 #ifndef ANDROID
   GLFWwindow *glfw_window = nullptr;
 
-  if (window_system::glfwContextAcquire()) {
+  if (window_system::glfw_context_acquire()) {
     // glfw init success
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);

--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -92,7 +92,7 @@ Window::~Window() {
   gui_.reset();
   renderer_.reset();
   if (config_.show_window) {
-    taichi::lang::window_system::glfwContextRelease();
+    taichi::lang::window_system::glfw_context_release();
   }
 }
 

--- a/taichi/ui/backends/vulkan/window.cpp
+++ b/taichi/ui/backends/vulkan/window.cpp
@@ -3,6 +3,7 @@
 
 #include "taichi/program/program.h"
 #include "taichi/ui/utils/utils.h"
+#include "taichi/rhi/window_system.h"
 
 using taichi::lang::Program;
 
@@ -91,7 +92,7 @@ Window::~Window() {
   gui_.reset();
   renderer_.reset();
   if (config_.show_window) {
-    glfwTerminate();
+    taichi::lang::window_system::glfwContextRelease();
   }
 }
 

--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -44,7 +44,7 @@
 
 namespace taichi::ui {
 
-#if !defined(ANDROID)
+#ifdef TI_WITH_GLFW
 inline GLFWwindow *create_glfw_window_(const std::string &name,
                                        int screenWidth,
                                        int screenHeight,

--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -51,7 +51,7 @@ inline GLFWwindow *create_glfw_window_(const std::string &name,
                                        int window_pos_x,
                                        int window_pos_y,
                                        bool vsync) {
-  if (!taichi::lang::window_system::glfwContextAcquire()) {
+  if (!taichi::lang::window_system::glfw_context_acquire()) {
     printf("cannot initialize GLFW\n");
     exit(EXIT_FAILURE);
   }
@@ -64,7 +64,7 @@ inline GLFWwindow *create_glfw_window_(const std::string &name,
                             nullptr);
 
   if (!window) {
-    taichi::lang::window_system::glfwContextRelease();
+    taichi::lang::window_system::glfw_context_release();
     exit(EXIT_FAILURE);
   }
 

--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -33,9 +33,7 @@
 #endif
 
 #include "taichi/rhi/vulkan/vulkan_common.h"
-#if !defined(ANDROID)
-#include <GLFW/glfw3.h>
-#endif
+#include "taichi/rhi/window_system.h"
 
 #include <stdarg.h>
 
@@ -47,27 +45,17 @@
 namespace taichi::ui {
 
 #if !defined(ANDROID)
-inline void initGLFW() {
-  if (!glfwInit()) {
-    printf("cannot initialize GLFW\n");
-    exit(EXIT_FAILURE);
-  }
-}
-
-static void glfw_error_callback(int code, const char *description) {
-  printf("GLFW Error %d: %s\n", code, description);
-}
-
 inline GLFWwindow *create_glfw_window_(const std::string &name,
                                        int screenWidth,
                                        int screenHeight,
                                        int window_pos_x,
                                        int window_pos_y,
                                        bool vsync) {
-  initGLFW();
+  if (!taichi::lang::window_system::glfwContextAcquire()) {
+    printf("cannot initialize GLFW\n");
+    exit(EXIT_FAILURE);
+  }
   GLFWwindow *window;
-
-  glfwSetErrorCallback(glfw_error_callback);
 
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
@@ -76,7 +64,7 @@ inline GLFWwindow *create_glfw_window_(const std::string &name,
                             nullptr);
 
   if (!window) {
-    glfwTerminate();
+    taichi::lang::window_system::glfwContextRelease();
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
Related: #7218

Without this GGUI will mess with the OpenGL backend because both tries to initialize & destroy GLFW.

There is an issue tho with dependency. Which target should `rhi/window_system` belong to? Maybe we need a device API target that collects all the specific backends and generate a static lib with all backends and optional dependencies like GLFW? (Anyways, that will be a TODO for another PR)
