### PR TITLE
[Lang] Add better error message for dynamic snode

### DIFF
--- a/python/taichi/_snode/fields_builder.py
+++ b/python/taichi/_snode/fields_builder.py
@@ -98,10 +98,12 @@ class FieldsBuilder:
 
         if dimension >= 2**31:
             raise TaichiRuntimeError(
-                "The maximum dimension of a dynamic SNode cannot exceed the maximum value of a 32-bit signed integer: Got {dimension} > 2**31-1")
+                "The maximum dimension of a dynamic SNode cannot exceed the maximum value of a 32-bit signed integer: Got {dimension} > 2**31-1"
+            )
         if chunk_size >= 2**31:
             raise TaichiRuntimeError(
-                "Chunk size cannot exceed the maximum value of a 32-bit signed integer: Got {chunk_size} > 2**31-1")
+                "Chunk size cannot exceed the maximum value of a 32-bit signed integer: Got {chunk_size} > 2**31-1"
+            )
 
         self._check_not_finalized()
         self.empty = False

--- a/python/taichi/_snode/fields_builder.py
+++ b/python/taichi/_snode/fields_builder.py
@@ -98,11 +98,11 @@ class FieldsBuilder:
 
         if dimension >= 2**31:
             raise TaichiRuntimeError(
-                "The maximum dimension of a dynamic SNode cannot exceed the maximum value of a 32-bit signed integer: Got {dimension} > 2**31-1"
+                f"The maximum dimension of a dynamic SNode cannot exceed the maximum value of a 32-bit signed integer: Got {dimension} > 2**31-1"
             )
         if chunk_size >= 2**31:
             raise TaichiRuntimeError(
-                "Chunk size cannot exceed the maximum value of a 32-bit signed integer: Got {chunk_size} > 2**31-1"
+                f"Chunk size cannot exceed the maximum value of a 32-bit signed integer: Got {chunk_size} > 2**31-1"
             )
 
         self._check_not_finalized()

--- a/python/taichi/_snode/fields_builder.py
+++ b/python/taichi/_snode/fields_builder.py
@@ -100,7 +100,7 @@ class FieldsBuilder:
             raise TaichiRuntimeError(
                 f"The maximum dimension of a dynamic SNode cannot exceed the maximum value of a 32-bit signed integer: Got {dimension} > 2**31-1"
             )
-        if chunk_size >= 2**31:
+        if chunk_size is not None and chunk_size >= 2**31:
             raise TaichiRuntimeError(
                 f"Chunk size cannot exceed the maximum value of a 32-bit signed integer: Got {chunk_size} > 2**31-1"
             )

--- a/python/taichi/_snode/fields_builder.py
+++ b/python/taichi/_snode/fields_builder.py
@@ -95,6 +95,14 @@ class FieldsBuilder:
                                                _ti_core.Extension.sparse):
             raise TaichiRuntimeError(
                 "Dynamic SNode is not supported on this backend.")
+
+        if dimension >= 2**31:
+            raise TaichiRuntimeError(
+                "The maximum dimension of a dynamic SNode cannot exceed the maximum value of a 32-bit signed integer: Got {dimension} > 2**31-1")
+        if chunk_size >= 2**31:
+            raise TaichiRuntimeError(
+                "Chunk size cannot exceed the maximum value of a 32-bit signed integer: Got {chunk_size} > 2**31-1")
+
         self._check_not_finalized()
         self.empty = False
         return self.root.dynamic(index, dimension, chunk_size)


### PR DESCRIPTION
Why this PR:

Currently, when users allocate dynamic SNodes of dimension >=  2**31, the error message is not easy to understand:
```
   self.ptr.dynamic(axis[0], dimension, chunk_size, get_traceback()))
TypeError: dynamic(): incompatible function arguments. The following argument types are supported:
    1. (self: taichi._lib.core.taichi_python.SNode, arg0: taichi._lib.core.taichi_python.Axis, arg1: int, arg2: int, arg3: str) -> taichi._lib.core.taichi_python.SNode
```

This PR makes the error clear.