### PR TITLE
[example] Re-implement the Cornell Box demo with shorter lines of code

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -66,7 +66,7 @@ if [ "$TI_RUN_RELEASE_TESTS" == "1" ]; then
     python3 -m pip install PyYAML
     git clone https://github.com/taichi-dev/taichi-release-tests
     pushd taichi-release-tests
-    git checkout 20221230
+    git checkout 20230130
     mkdir -p repos/taichi/python/taichi
     EXAMPLES=$(cat <<EOF | python3 | tail -n 1
 import taichi.examples

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -72,7 +72,7 @@ if ("$env:TI_RUN_RELEASE_TESTS" -eq "1") {
     Invoke pip install PyYAML
     Invoke git clone https://github.com/taichi-dev/taichi-release-tests
     Push-Location taichi-release-tests
-    Invoke git checkout 20221230
+    Invoke git checkout 20230130
     mkdir -p repos/taichi/python/taichi
     $EXAMPLES = & python -c 'import taichi.examples as e; print(e.__path__._path[0])' | Select-Object -Last 1
     Push-Location repos

--- a/python/taichi/examples/rendering/cornell_box.py
+++ b/python/taichi/examples/rendering/cornell_box.py
@@ -1,132 +1,115 @@
-import taichi as ti  # of course, we need taichi
-from taichi.math import *  # need common mathematical operations
+# pylint: disable=W0622,W0621,W0401
+import taichi as ti
+from taichi.math import *
 
-ti.init(arch=ti.gpu, default_ip=ti.i32,
-        default_fp=ti.f32)  # initialize, use GPU, set default ip and fp
+ti.init(arch=ti.gpu, default_ip=ti.i32, default_fp=ti.f32)
 
-image_resolution = (512, 512)  # resolution of the image, not too large
-image_buffer = ti.Vector.field(
-    4, float,
-    image_resolution)  # image buffer field for recording sample counts
-image_pixels = ti.Vector.field(
-    3, float, image_resolution)  # for output display pixels to the screen
+image_resolution = (512, 512)
+image_buffer = ti.Vector.field(4, float, image_resolution)
+image_pixels = ti.Vector.field(3, float, image_resolution)
 
-Ray = ti.types.struct(origin=vec3, direction=vec3,
-                      color=vec3)  # the struct representing camera light ray
-Material = ti.types.struct(
-    albedo=vec3, emission=vec3)  # Cornell Box need only albedo and emission
-Transform = ti.types.struct(position=vec3, rotation=vec3,
-                            scale=vec3)  # Transformation of SDF objects
+Ray = ti.types.struct(origin=vec3, direction=vec3, color=vec3)
+Material = ti.types.struct(albedo=vec3, emission=vec3)
+Transform = ti.types.struct(position=vec3,
+                            rotation=vec3,
+                            scale=vec3,
+                            matrix=mat3)
 SDFObject = ti.types.struct(distance=float,
                             transform=Transform,
-                            material=Material)  # SDF objects
-HitRecord = ti.types.struct(object=SDFObject,
-                            position=vec3,
-                            distance=float,
-                            hit=bool)  # for ray-hit-surface
+                            material=Material)
 
-objects = SDFObject.field(
-    shape=8)  # field for storing SDF objects with 8 objects
+objects = SDFObject.field(shape=8)
 objects[0] = SDFObject(transform=Transform(vec3(0, 0, -1), vec3(0, 0, 0),
                                            vec3(1, 1, 0.2)),
-                       material=Material(vec3(1, 1, 1) * 0.4,
-                                         vec3(1)))  # wall 1
+                       material=Material(vec3(1, 1, 1) * 0.4, vec3(1)))
 objects[1] = SDFObject(transform=Transform(vec3(0, 1, 0), vec3(90, 0, 0),
                                            vec3(1, 1, 0.2)),
-                       material=Material(vec3(1, 1, 1) * 0.4,
-                                         vec3(1)))  # wall 2
+                       material=Material(vec3(1, 1, 1) * 0.4, vec3(1)))
 objects[2] = SDFObject(transform=Transform(vec3(0, -1, 0), vec3(90, 0, 0),
                                            vec3(1, 1, 0.2)),
-                       material=Material(vec3(1, 1, 1) * 0.4,
-                                         vec3(1)))  # wall 3
+                       material=Material(vec3(1, 1, 1) * 0.4, vec3(1)))
 objects[3] = SDFObject(transform=Transform(vec3(-1, 0, 0), vec3(0, 90, 0),
                                            vec3(1, 1, 0.2)),
-                       material=Material(vec3(1, 0, 0) * 0.5,
-                                         vec3(1)))  # wall 4
+                       material=Material(vec3(1, 0, 0) * 0.5, vec3(1)))
 objects[4] = SDFObject(transform=Transform(vec3(1, 0, 0), vec3(0, 90, 0),
                                            vec3(1, 1, 0.2)),
-                       material=Material(vec3(0, 1, 0) * 0.5,
-                                         vec3(1)))  # wall 5
+                       material=Material(vec3(0, 1, 0) * 0.5, vec3(1)))
 objects[5] = SDFObject(transform=Transform(vec3(-0.275, -0.3, -0.2),
                                            vec3(0, 112, 0),
                                            vec3(0.25, 0.5, 0.25)),
-                       material=Material(vec3(1, 1, 1) * 0.4,
-                                         vec3(1)))  # taller box
+                       material=Material(vec3(1, 1, 1) * 0.4, vec3(1)))
 objects[6] = SDFObject(transform=Transform(vec3(0.275, -0.55, 0.2),
                                            vec3(0, -197, 0),
                                            vec3(0.25, 0.25, 0.25)),
-                       material=Material(vec3(1, 1, 1) * 0.4, vec3(1)))  # box
+                       material=Material(vec3(1, 1, 1) * 0.4, vec3(1)))
 objects[7] = SDFObject(transform=Transform(vec3(0, 0.809, 0), vec3(90, 0, 0),
                                            vec3(0.2, 0.2, 0.01)),
-                       material=Material(vec3(1, 1, 1) * 1,
-                                         vec3(100)))  # light
+                       material=Material(vec3(1, 1, 1) * 1, vec3(100)))
 
 
 @ti.func
-def angle(a: vec3) -> mat3:  # convert Euler angles to rotation matrix
-    s, c = sin(a), cos(a)  # first calculate the two axial projections
-    return mat3(c.z, s.z, 0, -s.z, c.z, 0, 0, 0, 1) @ \
-           mat3(c.y, 0, -s.y, 0, 1, 0, s.y, 0, c.y) @ \
-           mat3(1, 0, 0, 0, c.x, s.x, 0, -s.x, c.x)      # convert to rotation matrix in XYZ and multiply left
+def rotate(a: vec3) -> mat3:
+    s, c = sin(a), cos(a)
+    return \
+        mat3(c.z, s.z, 0, -s.z, c.z, 0, 0, 0, 1) @ \
+        mat3(c.y, 0, -s.y, 0, 1, 0, s.y, 0, c.y) @ \
+        mat3(1, 0, 0, 0, c.x, s.x, 0, -s.x, c.x)
 
 
 @ti.func
-def signed_distance(
-        obj: SDFObject,
-        pos: vec3) -> float:  # calc the signed distance from pos to SDF object
-    p = angle(radians(obj.transform.rotation)) @ (
-        pos - obj.transform.position)  # translate and then rotate
+def signed_distance(obj: SDFObject, pos: vec3) -> float:
+    p = obj.transform.matrix @ (pos - obj.transform.position)
     q = abs(p) - obj.transform.scale
-    return length(max(q, 0)) + min(max(q.x, max(q.y, q.z)),
-                                   0)  # return the sdf value of the box
+    return length(max(q, 0)) + min(max(q.x, max(q.y, q.z)), 0)
 
 
 @ti.func
-def nearest_object(p: vec3) -> SDFObject:  # find the nearest sdf object
-    o = objects[0]
-    o.distance = abs(signed_distance(o, p))  # we start with the first object
-    for i in range(1, 8):  # for all 8 objects
-        oi = objects[i]
-        oi.distance = abs(signed_distance(
-            oi, p))  # handling the interior of SDF with abs
-        if oi.distance < o.distance:
-            o = oi  # we need the nearest object to step into the ray
-    return o  # this can also be seen as a concatenation of the SDF
+def nearest_object(p: vec3):
+    index, min_dis = 0, 1e32
+    for i in range(8):
+        dis = abs(signed_distance(objects[i], p))
+        if dis < min_dis:
+            min_dis, index = dis, i
+    return index, min_dis
 
 
 @ti.func
-def calc_normal(
-    obj: SDFObject, p: vec3
-) -> vec3:  # representing the surface normal by the gradient of the SDF
-    e = vec2(
-        1, -1
-    ) * 0.5773 * 0.005  # calculation of gradients using the Tetrahedron technique
-    return normalize(e.xyy * signed_distance(obj, p + e.xyy) + \
-                     e.yyx * signed_distance(obj, p + e.yyx) + \
-                     e.yxy * signed_distance(obj, p + e.yxy) + \
-                     e.xxx * signed_distance(obj, p + e.xxx) )
+def calc_normal(obj: SDFObject, p: vec3) -> vec3:
+    e = vec2(1, -1) * 0.5773 * 0.005
+    return normalize(e.xyy * signed_distance(obj, p + e.xyy) +
+                     e.yyx * signed_distance(obj, p + e.yyx) +
+                     e.yxy * signed_distance(obj, p + e.yxy) +
+                     e.xxx * signed_distance(obj, p + e.xxx))
 
 
 @ti.func
-def raycast(
-    ray: Ray
-) -> HitRecord:  # ray marching to obtain the intersection with the surface
-    record = HitRecord(distance=0.0005)  # step a little off the surface first
-    for _ in range(256):  # need a maximum number of steps
-        record.position = ray.origin + record.distance * ray.direction
-        record.object = nearest_object(
-            record.position)  # according to the nearest distance ray marching
-        record.distance += record.object.distance  # sphere tracing
-        record.hit = record.object.distance < 0.00001  # less than the surface thickness is a hit
-        if record.distance > 2000.0 or record.hit:
-            break  # no need to continue stepping
-    return record
+def raycast(ray: Ray):
+    w, s, d, cerr = 1.6, 0.0, 0.0, 1e32
+    index, t, position, hit = 0, 0.005, vec3(0), False
+    for _ in range(64):
+        position = ray.origin + ray.direction * t
+        index, distance = nearest_object(position)
+
+        ld, d = d, distance
+        if w > 1.0 and ld + d < s:
+            s -= w * s
+            t += s
+            w = 1.0
+            continue
+        err = d / t
+        if err < cerr:
+            cerr = err
+
+        s = w * d
+        t += s
+        hit = err < 0.001
+        if t > 10.0 or hit:
+            break
+    return objects[index], position, hit
 
 
 @ti.func
-def hemispheric_sampling(
-    normal: vec3
-) -> vec3:  # choose a random direction in the normal hemisphere
+def hemispheric_sampling(normal: vec3) -> vec3:
     z = 2.0 * ti.random() - 1.0
     a = ti.random() * 2.0 * pi
     xy = sqrt(1.0 - z * z) * vec2(sin(a), cos(a))
@@ -134,93 +117,74 @@ def hemispheric_sampling(
 
 
 @ti.func
-def raytrace(ray: Ray) -> Ray:  # Path Tracing
-    for i in range(
-            3
-    ):  # 3 times is already enough to bring Global Illumination to the scene
-        inv_pdf = exp(float(i) / 128.0)
-        roulette_prob = 1.0 - (
-            1.0 / inv_pdf
-        )  # Russian Roulette for spreading the computation between frames
-        if ti.random() < roulette_prob:
-            ray.color *= roulette_prob
-            break  # end of tracing
-
-        record = raycast(
-            ray)  # calculate the intersection of the ray with the scene
-        if not record.hit:
+def raytrace(ray: Ray) -> Ray:
+    for _ in range(3):
+        object, position, hit = raycast(ray)
+        if not hit:
             ray.color = vec3(0)
-            break  # not hitting the light source
+            break
 
-        normal = calc_normal(
-            record.object,
-            record.position)  # calc the normal of the intersection points
-        ray.direction = hemispheric_sampling(
-            normal)  # approximate diffuse reflection direction
-        ray.color *= record.object.material.albedo  # ray needs to be multiplied by the albedo
-        ray.origin = record.position  # update light departure position
+        normal = calc_normal(object, position)
+        ray.direction = hemispheric_sampling(normal)
+        ray.color *= object.material.albedo
+        ray.origin = position
 
-        intensity = dot(ray.color,
-                        vec3(0.299, 0.587,
-                             0.114))  # calculating the intensity of ray
-        ray.color *= record.object.material.emission  # multiplying the emission
-        visible = dot(ray.color, vec3(0.299, 0.587, 0.114))  # new brightness
+        intensity = dot(ray.color, vec3(0.299, 0.587, 0.114))
+        ray.color *= object.material.emission
+        visible = dot(ray.color, vec3(0.299, 0.587, 0.114))
         if intensity < visible or visible < 0.000001:
-            break  # too dark or arrive at the light source
+            break
     return ray
 
 
 @ti.kernel
-def render(camera_position: vec3, camera_lookat: vec3, camera_up: vec3):
-    for i, j in image_pixels:  # iterate through all pixels in parallel
-        buffer = image_buffer[i, j]  # current buffer color
+def build_scene():
+    for i in objects:
+        rotation = objects[i].transform.rotation
+        objects[i].transform.matrix = rotate(radians(rotation))
 
+
+@ti.kernel
+def render(camera_position: vec3, camera_lookat: vec3, camera_up: vec3):
+    for i, j in image_pixels:
         z = normalize(camera_position - camera_lookat)
-        x = normalize(cross(camera_up,
-                            z))  # calculating the camera coordinate system
+        x = normalize(cross(camera_up, z))
         y = cross(z, x)
 
-        half_width = half_height = tan(
-            radians(35) * 0.5)  # calculate camera frame position and size
+        half_width = half_height = tan(radians(35) * 0.5)
         lower_left_corner = camera_position - half_width * x - half_height * y - z
         horizontal = 2.0 * half_width * x
         vertical = 2.0 * half_height * y
 
-        uv = (vec2(i, j) + vec2(ti.random(), ti.random())) / vec2(
-            image_resolution)  # oversampling
+        uv = (vec2(i, j) + vec2(ti.random(), ti.random())) / \
+            vec2(image_resolution)
         po = lower_left_corner + uv.x * horizontal + uv.y * vertical
-        rd = normalize(
-            po - camera_position)  # calculation of ray direction by camera
+        rd = normalize(po - camera_position)
 
-        ray = raytrace(Ray(camera_position, rd, vec3(1)))  # Path Tracing
-        buffer += vec4(
-            ray.color,
-            1.0)  # accumulate colors and record the number of accumulations
-        image_buffer[i, j] = buffer  # updating the buffer
+        ray = raytrace(Ray(camera_position, rd, vec3(1)))
+        buffer = image_buffer[i, j]
+        buffer += vec4(ray.color, 1.0)
+        image_buffer[i, j] = buffer
 
-        color = buffer.rgb / buffer.a  # calculate the average value of colors
-        color = pow(color, vec3(
-            1.0 / 2.2))  # Gamma correction, then use ACES tone mapping
+        color = buffer.rgb / buffer.a
+        color = pow(color, vec3(1.0 / 2.2))
         color = mat3(0.597190, 0.35458, 0.04823, 0.07600, 0.90834, 0.01566,
                      0.02840, 0.13383, 0.83777) @ color
-        color = (color * (color + 0.024578) -
-                 0.0000905) / (color *
-                               (0.983729 * color + 0.4329510) + 0.238081)
+        color = (color * (color + 0.024578) - 0.0000905) / \
+            (color * (0.983729 * color + 0.4329510) + 0.238081)
         color = mat3(1.60475, -0.531, -0.0736, -0.102, 1.10813, -0.00605,
                      -0.00327, -0.07276, 1.07602) @ color
-        image_pixels[i, j] = clamp(
-            color, 0,
-            1)  # write pixels, clamp the brightness that cannot be displayed
+        image_pixels[i, j] = clamp(color, 0, 1)
 
 
 def main():
-    window = ti.ui.Window("Cornell Box", image_resolution)  # create window
+    window = ti.ui.Window("Cornell Box", image_resolution)
     canvas = window.get_canvas()
-    while window.running:  # main loop of the window
-        render(vec3(0, 0, 3.5), vec3(0, 0, -1),
-               vec3(0, 1, 0))  # set the camera parameters, then render
-        canvas.set_image(image_pixels)  # writing pixels to canvas
-        window.show()  # continue to show window
+    build_scene()
+    while window.running:
+        render(vec3(0, 0, 3.5), vec3(0, 0, -1), vec3(0, 1, 0))
+        canvas.set_image(image_pixels)
+        window.show()
 
 
 if __name__ == '__main__':

--- a/python/taichi/examples/rendering/cornell_box.py
+++ b/python/taichi/examples/rendering/cornell_box.py
@@ -1,513 +1,140 @@
-import time
+import taichi as ti                                                                # of course, we need taichi
+from taichi.math import *                                                # need common mathematical operations
 
-import numpy as np
+ti.init(arch=ti.gpu, default_ip=ti.i32, default_fp=ti.f32)        # initialize, use GPU, set default ip and fp
 
-import taichi as ti
+image_resolution = (512, 512)                                         # resolution of the image, not too large
+image_buffer = ti.Vector.field(4, float, image_resolution)    # image buffer field for recording sample counts
+image_pixels = ti.Vector.field(3, float, image_resolution)           # for output display pixels to the screen
 
-ti.init(arch=ti.gpu)
-res = (800, 800)
-color_buffer = ti.Vector.field(3, dtype=ti.f32, shape=res)
-count_var = ti.field(ti.i32, shape=(1, ))
-tonemapped_buffer = ti.Vector.field(3, dtype=ti.f32, shape=res)
+Ray = ti.types.struct(origin=vec3, direction=vec3, color=vec3)      # the struct representing camera light ray
+Material = ti.types.struct(albedo=vec3, emission=vec3)             # Cornell Box need only albedo and emission
+Transform = ti.types.struct(position=vec3, rotation=vec3, scale=vec3)          # Transformation of SDF objects
+SDFObject = ti.types.struct(distance=float, transform=Transform, material=Material)              # SDF objects
+HitRecord = ti.types.struct(object=SDFObject, position=vec3, distance=float, hit=bool)   # for ray-hit-surface
 
-max_ray_depth = 10
-eps = 1e-4
-inf = 1e10
-fov = 0.8
-
-camera_pos = ti.Vector([0.0, 0.6, 3.0])
-
-mat_none = 0
-mat_lambertian = 1
-mat_specular = 2
-mat_glass = 3
-mat_light = 4
-
-light_y_pos = 2.0 - eps
-light_x_min_pos = -0.25
-light_x_range = 0.5
-light_z_min_pos = 1.0
-light_z_range = 0.12
-light_area = light_x_range * light_z_range
-light_min_pos = ti.Vector([light_x_min_pos, light_y_pos, light_z_min_pos])
-light_max_pos = ti.Vector([
-    light_x_min_pos + light_x_range, light_y_pos,
-    light_z_min_pos + light_z_range
-])
-light_color = ti.Vector(list(np.array([0.9, 0.85, 0.7])))
-light_normal = ti.Vector([0.0, -1.0, 0.0])
-
-# No absorption, integrates over a unit hemisphere
-lambertian_brdf = 1.0 / np.pi
-# diamond!
-refr_idx = 2.4
-
-# right sphere
-sp1_center = ti.Vector([0.4, 0.225, 1.75])
-sp1_radius = 0.22
-
-
-def make_box_transform_matrices():
-    rad = np.pi / 8.0
-    c, s = np.cos(rad), np.sin(rad)
-    rot = np.array([[c, 0, s, 0], [0, 1, 0, 0], [-s, 0, c, 0], [0, 0, 0, 1]])
-    translate = np.array([
-        [1, 0, 0, -0.7],
-        [0, 1, 0, 0],
-        [0, 0, 1, 0.7],
-        [0, 0, 0, 1],
-    ])
-    m = translate @ rot
-    m_inv = np.linalg.inv(m)
-    m_inv_t = np.transpose(m_inv)
-    return ti.Matrix(m_inv), ti.Matrix(m_inv_t)
-
-
-# left box
-BOX_MIN = ti.Vector([0.0, 0.0, 0.0])
-BOX_MAX = ti.Vector([0.55, 1.1, 0.55])
-BOX_M_INV, BOX_M_INV_T = make_box_transform_matrices()
-
+objects    = SDFObject.field(shape=8)                           # field for storing SDF objects with 8 objects
+objects[0] = SDFObject(transform=Transform(vec3(0, 0, -1), vec3(0, 0, 0), vec3(1, 1, 0.2)),
+                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                        # wall 1
+objects[1] = SDFObject(transform=Transform(vec3(0, 1, 0), vec3(90, 0, 0), vec3(1, 1, 0.2)),
+                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                        # wall 2
+objects[2] = SDFObject(transform=Transform(vec3(0, -1, 0), vec3(90, 0, 0), vec3(1, 1, 0.2)),
+                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                        # wall 3
+objects[3] = SDFObject(transform=Transform(vec3(-1, 0, 0), vec3(0, 90, 0), vec3(1, 1, 0.2)),
+                material=Material(vec3(1, 0, 0)*0.5, vec3(1)))                                        # wall 4
+objects[4] = SDFObject(transform=Transform(vec3(1, 0, 0), vec3(0, 90, 0), vec3(1, 1, 0.2)),
+                material=Material(vec3(0, 1, 0)*0.5, vec3(1)))                                        # wall 5
+objects[5] = SDFObject(transform=Transform(vec3(-0.275, -0.3, -0.2), vec3(0, 112, 0), vec3(0.25, 0.5, 0.25)),
+                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                    # taller box
+objects[6] = SDFObject(transform=Transform(vec3(0.275,-0.55, 0.2), vec3(0, -197, 0), vec3(0.25, 0.25, 0.25)),
+                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                           # box
+objects[7] = SDFObject(transform=Transform(vec3(0, 0.809, 0), vec3(90, 0, 0), vec3(0.2, 0.2, 0.01)),
+                material=Material(vec3(1, 1, 1)*1, vec3(100)))                                         # light
 
 @ti.func
-def reflect(d, n):
-    # Assuming |d| and |n| are normalized
-    return d - 2.0 * d.dot(n) * n
-
-
-@ti.func
-def refract(d, n, ni_over_nt):
-    # Assuming |d| and |n| are normalized
-    has_r, rd = 0, d
-    dt = d.dot(n)
-    discr = 1.0 - ni_over_nt * ni_over_nt * (1.0 - dt * dt)
-    if discr > 0.0:
-        has_r = 1
-        rd = (ni_over_nt * (d - n * dt) - n * ti.sqrt(discr)).normalized()
-    else:
-        rd *= 0.0
-    return has_r, rd
-
+def angle(a: vec3) -> mat3:                                          # convert Euler angles to rotation matrix
+    s, c = sin(a), cos(a)                                          # first calculate the two axial projections
+    return mat3(c.z, s.z, 0, -s.z, c.z, 0, 0, 0, 1) @ \
+           mat3(c.y, 0, -s.y, 0, 1, 0, s.y, 0, c.y) @ \
+           mat3(1, 0, 0, 0, c.x, s.x, 0, -s.x, c.x)      # convert to rotation matrix in XYZ and multiply left
 
 @ti.func
-def mat_mul_point(m, p):
-    hp = ti.Vector([p[0], p[1], p[2], 1.0])
-    hp = m @ hp
-    hp /= hp[3]
-    return ti.Vector([hp[0], hp[1], hp[2]])
-
+def signed_distance(obj: SDFObject, pos: vec3) -> float:     # calc the signed distance from pos to SDF object
+    p = angle(radians(obj.transform.rotation)) @ (pos - obj.transform.position)    # translate and then rotate
+    q = abs(p) - obj.transform.scale
+    return length(max(q, 0)) + min(max(q.x, max(q.y, q.z)), 0)               # return the sdf value of the box
 
 @ti.func
-def mat_mul_vec(m, v):
-    hv = ti.Vector([v[0], v[1], v[2], 0.0])
-    hv = m @ hv
-    return ti.Vector([hv[0], hv[1], hv[2]])
-
-
-@ti.func
-def intersect_sphere(pos, d, center, radius):
-    T = pos - center
-    A = 1.0
-    B = 2.0 * T.dot(d)
-    C = T.dot(T) - radius * radius
-    delta = B * B - 4.0 * A * C
-    dist = inf
-    hit_pos = ti.Vector([0.0, 0.0, 0.0])
-
-    if delta > -1e-4:
-        delta = ti.max(delta, 0)
-        sdelta = ti.sqrt(delta)
-        ratio = 0.5 / A
-        ret1 = ratio * (-B - sdelta)
-        dist = ret1
-        if dist < inf:
-            # refinement
-            old_dist = dist
-            new_pos = pos + d * dist
-            T = new_pos - center
-            A = 1.0
-            B = 2.0 * T.dot(d)
-            C = T.dot(T) - radius * radius
-            delta = B * B - 4 * A * C
-            if delta > 0:
-                sdelta = ti.sqrt(delta)
-                ratio = 0.5 / A
-                ret1 = ratio * (-B - sdelta) + old_dist
-                if ret1 > 0:
-                    dist = ret1
-                    hit_pos = new_pos + ratio * (-B - sdelta) * d
-            else:
-                dist = inf
-
-    return dist, hit_pos
-
+def nearest_object(p: vec3) -> SDFObject:                                        # find the nearest sdf object
+    o = objects[0]; o.distance = abs(signed_distance(o, p))                   # we start with the first object
+    for i in range(1, 8):                                                                  # for all 8 objects
+        oi = objects[i]; oi.distance = abs(signed_distance(oi, p))     # handling the interior of SDF with abs
+        if oi.distance < o.distance: o = oi                  # we need the nearest object to step into the ray
+    return o                                             # this can also be seen as a concatenation of the SDF
 
 @ti.func
-def intersect_plane(pos, d, pt_on_plane, norm):
-    dist = inf
-    hit_pos = ti.Vector([0.0, 0.0, 0.0])
-    denom = d.dot(norm)
-    if abs(denom) > eps:
-        dist = norm.dot(pt_on_plane - pos) / denom
-        hit_pos = pos + d * dist
-    return dist, hit_pos
-
+def calc_normal(obj: SDFObject, p: vec3) -> vec3: # representing the surface normal by the gradient of the SDF
+    e = vec2(1, -1) * 0.5773 * 0.005                # calculation of gradients using the Tetrahedron technique
+    return normalize(e.xyy * signed_distance(obj, p + e.xyy) + \
+                     e.yyx * signed_distance(obj, p + e.yyx) + \
+                     e.yxy * signed_distance(obj, p + e.yxy) + \
+                     e.xxx * signed_distance(obj, p + e.xxx) )
 
 @ti.func
-def intersect_aabb(box_min, box_max, o, d):
-    intersect = 1
-
-    near_t = -inf
-    far_t = inf
-    near_face = 0
-    near_is_max = 0
-
-    for i in ti.static(range(3)):
-        if d[i] == 0:
-            if o[i] < box_min[i] or o[i] > box_max[i]:
-                intersect = 0
-        else:
-            i1 = (box_min[i] - o[i]) / d[i]
-            i2 = (box_max[i] - o[i]) / d[i]
-
-            new_far_t = ti.max(i1, i2)
-            new_near_t = ti.min(i1, i2)
-            new_near_is_max = i2 < i1
-
-            far_t = ti.min(new_far_t, far_t)
-            if new_near_t > near_t:
-                near_t = new_near_t
-                near_face = int(i)
-                near_is_max = new_near_is_max
-
-    near_norm = ti.Vector([0.0, 0.0, 0.0])
-    if near_t > far_t:
-        intersect = 0
-    if intersect:
-        for i in ti.static(range(2)):
-            if near_face == i:
-                near_norm[i] = -1 + near_is_max * 2
-    return intersect, near_t, far_t, near_norm
-
+def raycast(ray: Ray) -> HitRecord:                 # ray marching to obtain the intersection with the surface
+    record = HitRecord(distance=0.0005)                                  # step a little off the surface first
+    for _ in range(256):                                                      # need a maximum number of steps
+        record.position  = ray.origin + record.distance * ray.direction
+        record.object    = nearest_object(record.position)    # according to the nearest distance ray marching
+        record.distance += record.object.distance                                             # sphere tracing
+        record.hit       = record.object.distance < 0.00001         # less than the surface thickness is a hit
+        if record.distance > 2000.0 or record.hit: break                        # no need to continue stepping
+    return record
 
 @ti.func
-def intersect_aabb_transformed(box_min, box_max, o, d):
-    # Transform the ray to the box's local space
-    obj_o = mat_mul_point(BOX_M_INV, o)
-    obj_d = mat_mul_vec(BOX_M_INV, d)
-    intersect, near_t, _, near_norm = intersect_aabb(box_min, box_max, obj_o,
-                                                     obj_d)
-    if intersect and 0 < near_t:
-        # Transform the normal in the box's local space to world space
-        near_norm = mat_mul_vec(BOX_M_INV_T, near_norm)
-    else:
-        intersect = 0
-    return intersect, near_t, near_norm
-
+def hemispheric_sampling(normal: vec3) -> vec3:           # choose a random direction in the normal hemisphere
+    z = 2.0 * ti.random() - 1.0
+    a = ti.random() * 2.0 * pi
+    xy = sqrt(1.0 - z*z) * vec2(sin(a), cos(a))
+    return normalize(normal + vec3(xy, z))
 
 @ti.func
-def intersect_light(pos, d, tmax):
-    hit, t, far_t, near_norm = intersect_aabb(light_min_pos, light_max_pos,
-                                              pos, d)
-    if hit and 0 < t < tmax:
-        hit = 1
-    else:
-        hit = 0
-        t = inf
-    return hit, t
+def raytrace(ray: Ray) -> Ray:                                                                  # Path Tracing
+    for i in range(3):                   # 3 times is already enough to bring Global Illumination to the scene
+        inv_pdf = exp(float(i) / 128.0)
+        roulette_prob = 1.0 - (1.0 / inv_pdf)  # Russian Roulette for spreading the computation between frames
+        if ti.random() < roulette_prob: ray.color *= roulette_prob; break                     # end of tracing
 
+        record = raycast(ray)                           # calculate the intersection of the ray with the scene
+        if not record.hit: ray.color = vec3(0); break                           # not hitting the light source
 
-@ti.func
-def intersect_scene(pos, ray_dir):
-    closest, normal = inf, ti.Vector.zero(ti.f32, 3)
-    c, mat = ti.Vector.zero(ti.f32, 3), mat_none
+        normal  = calc_normal(record.object, record.position)     # calc the normal of the intersection points
+        ray.direction = hemispheric_sampling(normal)                # approximate diffuse reflection direction
+        ray.color *= record.object.material.albedo                  # ray needs to be multiplied by the albedo
+        ray.origin = record.position                                         # update light departure position
 
-    # right near sphere
-    cur_dist, hit_pos = intersect_sphere(pos, ray_dir, sp1_center, sp1_radius)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = (hit_pos - sp1_center).normalized()
-        c, mat = ti.Vector([1.0, 1.0, 1.0]), mat_glass
-    # left box
-    hit, cur_dist, pnorm = intersect_aabb_transformed(BOX_MIN, BOX_MAX, pos,
-                                                      ray_dir)
-    if hit and 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([0.8, 0.5, 0.4]), mat_specular
-
-    # left
-    pnorm = ti.Vector([1.0, 0.0, 0.0])
-    cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([-1.1, 0.0, 0.0]),
-                                  pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([0.65, 0.05, 0.05]), mat_lambertian
-    # right
-    pnorm = ti.Vector([-1.0, 0.0, 0.0])
-    cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([1.1, 0.0, 0.0]),
-                                  pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = ti.Vector([0.12, 0.45, 0.15]), mat_lambertian
-    # bottom
-    gray = ti.Vector([0.93, 0.93, 0.93])
-    pnorm = ti.Vector([0.0, 1.0, 0.0])
-    cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([0.0, 0.0, 0.0]),
-                                  pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = gray, mat_lambertian
-    # top
-    pnorm = ti.Vector([0.0, -1.0, 0.0])
-    cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([0.0, 2.0, 0.0]),
-                                  pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = gray, mat_lambertian
-    # far
-    pnorm = ti.Vector([0.0, 0.0, 1.0])
-    cur_dist, _ = intersect_plane(pos, ray_dir, ti.Vector([0.0, 0.0, 0.0]),
-                                  pnorm)
-    if 0 < cur_dist < closest:
-        closest = cur_dist
-        normal = pnorm
-        c, mat = gray, mat_lambertian
-    # light
-    hit_l, cur_dist = intersect_light(pos, ray_dir, closest)
-    if hit_l and 0 < cur_dist < closest:
-        # technically speaking, no need to check the second term
-        closest = cur_dist
-        normal = light_normal
-        c, mat = light_color, mat_light
-
-    return closest, normal, c, mat
-
-
-@ti.func
-def visible_to_light(pos, ray_dir):
-    # eps*ray_dir is easy way to prevent rounding error
-    # here is best way to check the float precision:
-    # http://www.pbr-book.org/3ed-2018/Shapes/Managing_Rounding_Error.html
-    a, b, c, mat = intersect_scene(pos + eps * ray_dir, ray_dir)
-    return mat == mat_light
-
-
-@ti.func
-def dot_or_zero(n, l):
-    return ti.max(0.0, n.dot(l))
-
-
-@ti.func
-def mis_power_heuristic(pf, pg):
-    # Assume 1 sample for each distribution
-    f = pf**2
-    g = pg**2
-    return f / (f + g)
-
-
-@ti.func
-def compute_area_light_pdf(pos, ray_dir):
-    hit_l, t = intersect_light(pos, ray_dir, inf)
-    pdf = 0.0
-    if hit_l:
-        l_cos = light_normal.dot(-ray_dir)
-        if l_cos > eps:
-            tmp = ray_dir * t
-            dist_sqr = tmp.dot(tmp)
-            pdf = dist_sqr / (light_area * l_cos)
-    return pdf
-
-
-@ti.func
-def compute_brdf_pdf(normal, sample_dir):
-    return dot_or_zero(normal, sample_dir) / np.pi
-
-
-@ti.func
-def sample_area_light(hit_pos, pos_normal):
-    # sampling inside the light area
-    x = ti.random() * light_x_range + light_x_min_pos
-    z = ti.random() * light_z_range + light_z_min_pos
-    on_light_pos = ti.Vector([x, light_y_pos, z])
-    return (on_light_pos - hit_pos).normalized()
-
-
-@ti.func
-def sample_brdf(normal):
-    # cosine hemisphere sampling
-    # Uniformly sample on a disk using concentric sampling(r, theta)
-    # https://www.pbr-book.org/3ed-2018/Monte_Carlo_Integration/2D_Sampling_with_Multidimensional_Transformations#CosineSampleHemisphere
-    r, theta = 0.0, 0.0
-    sx = ti.random() * 2.0 - 1.0
-    sy = ti.random() * 2.0 - 1.0
-    if sx != 0 or sy != 0:
-        if abs(sx) > abs(sy):
-            r = sx
-            theta = np.pi / 4 * (sy / sx)
-        else:
-            r = sy
-            theta = np.pi / 4 * (2 - sx / sy)
-    # Apply Malley's method to project disk to hemisphere
-    u = ti.Vector([1.0, 0.0, 0.0])
-    if abs(normal[1]) < 1 - eps:
-        u = normal.cross(ti.Vector([0.0, 1.0, 0.0]))
-    v = normal.cross(u)
-    costt, sintt = ti.cos(theta), ti.sin(theta)
-    xy = (u * costt + v * sintt) * r
-    zlen = ti.sqrt(ti.max(0.0, 1.0 - xy.dot(xy)))
-    return xy + zlen * normal
-
-
-@ti.func
-def sample_direct_light(hit_pos, hit_normal, hit_color):
-    direct_li = ti.Vector([0.0, 0.0, 0.0])
-    fl = lambertian_brdf * hit_color * light_color
-    light_pdf, brdf_pdf = 0.0, 0.0
-
-    # sample area light
-    to_light_dir = sample_area_light(hit_pos, hit_normal)
-    if to_light_dir.dot(hit_normal) > 0:
-        light_pdf = compute_area_light_pdf(hit_pos, to_light_dir)
-        brdf_pdf = compute_brdf_pdf(hit_normal, to_light_dir)
-        if light_pdf > 0 and brdf_pdf > 0:
-            l_visible = visible_to_light(hit_pos, to_light_dir)
-            if l_visible:
-                w = mis_power_heuristic(light_pdf, brdf_pdf)
-                nl = dot_or_zero(to_light_dir, hit_normal)
-                direct_li += fl * w * nl / light_pdf
-
-    # sample brdf
-    brdf_dir = sample_brdf(hit_normal)
-    brdf_pdf = compute_brdf_pdf(hit_normal, brdf_dir)
-    if brdf_pdf > 0:
-        light_pdf = compute_area_light_pdf(hit_pos, brdf_dir)
-        if light_pdf > 0:
-            l_visible = visible_to_light(hit_pos, brdf_dir)
-            if l_visible:
-                w = mis_power_heuristic(brdf_pdf, light_pdf)
-                nl = dot_or_zero(brdf_dir, hit_normal)
-                direct_li += fl * w * nl / brdf_pdf
-
-    return direct_li
-
-
-@ti.func
-def schlick(cos, eta):
-    r0 = (1.0 - eta) / (1.0 + eta)
-    r0 = r0 * r0
-    return r0 + (1 - r0) * ((1.0 - cos)**5)
-
-
-@ti.func
-def sample_ray_dir(indir, normal, hit_pos, mat):
-    u = ti.Vector([0.0, 0.0, 0.0])
-    pdf = 1.0
-    if mat == mat_lambertian:
-        u = sample_brdf(normal)
-        pdf = ti.max(eps, compute_brdf_pdf(normal, u))
-    elif mat == mat_specular:
-        u = reflect(indir, normal)
-    elif mat == mat_glass:
-        cos = indir.dot(normal)
-        ni_over_nt = refr_idx
-        outn = normal
-        if cos > 0.0:
-            outn = -normal
-            cos = refr_idx * cos
-        else:
-            ni_over_nt = 1.0 / refr_idx
-            cos = -cos
-        has_refr, refr_dir = refract(indir, outn, ni_over_nt)
-        refl_prob = 1.0
-        if has_refr:
-            refl_prob = schlick(cos, refr_idx)
-        if ti.random() < refl_prob:
-            u = reflect(indir, normal)
-        else:
-            u = refr_dir
-    return u.normalized(), pdf
-
-
-stratify_res = 5
-inv_stratify = 1.0 / 5.0
-
+        intensity  = dot(ray.color, vec3(0.299, 0.587, 0.114))              # calculating the intensity of ray
+        ray.color *= record.object.material.emission                                # multiplying the emission
+        visible    = dot(ray.color, vec3(0.299, 0.587, 0.114))                                # new brightness
+        if intensity < visible or visible < 0.000001: break           # too dark or arrive at the light source
+    return ray
 
 @ti.kernel
-def render():
-    for u, v in color_buffer:
-        aspect_ratio = res[0] / res[1]
-        pos = camera_pos
-        cur_iter = count_var[0]
-        str_x, str_y = (cur_iter / stratify_res), (cur_iter % stratify_res)
-        ray_dir = ti.Vector([
-            (2 * fov * (u + (str_x + ti.random()) * inv_stratify) / res[1] -
-             fov * aspect_ratio - 1e-5),
-            (2 * fov * (v + (str_y + ti.random()) * inv_stratify) / res[1] -
-             fov - 1e-5),
-            -1.0,
-        ])
-        ray_dir = ray_dir.normalized()
+def render(camera_position: vec3, camera_lookat: vec3, camera_up: vec3):
+    for i, j in image_pixels:                                         # iterate through all pixels in parallel
+        buffer = image_buffer[i, j]                                                     # current buffer color
 
-        acc_color = ti.Vector([0.0, 0.0, 0.0])
-        throughput = ti.Vector([1.0, 1.0, 1.0])
+        z = normalize(camera_position - camera_lookat)
+        x = normalize(cross(camera_up, z))                          # calculating the camera coordinate system
+        y = cross(z, x)
+        
+        half_width = half_height = tan(radians(35) * 0.5)           # calculate camera frame position and size
+        lower_left_corner = camera_position - half_width * x - half_height * y - z
+        horizontal = 2.0 * half_width  * x
+        vertical   = 2.0 * half_height * y
 
-        depth = 0
-        while depth < max_ray_depth:
-            closest, hit_normal, hit_color, mat = intersect_scene(pos, ray_dir)
-            if mat == mat_none:
-                break
+        uv = (vec2(i, j) + vec2(ti.random(), ti.random())) / vec2(image_resolution)             # oversampling
+        po = lower_left_corner + uv.x * horizontal + uv.y * vertical
+        rd = normalize(po - camera_position)                          # calculation of ray direction by camera
 
-            hit_pos = pos + closest * ray_dir
-            hit_light = (mat == mat_light)
-            if hit_light:
-                acc_color += throughput * light_color
-                break
-            elif mat == mat_lambertian:
-                acc_color += throughput * sample_direct_light(
-                    hit_pos, hit_normal, hit_color)
+        ray = raytrace(Ray(camera_position, rd, vec3(1)))                                       # Path Tracing
+        buffer += vec4(ray.color, 1.0)              # accumulate colors and record the number of accumulations
+        image_buffer[i, j] = buffer                                                      # updating the buffer
 
-            depth += 1
-            ray_dir, pdf = sample_ray_dir(ray_dir, hit_normal, hit_pos, mat)
-            pos = hit_pos + 1e-4 * ray_dir
-            if mat == mat_lambertian:
-                throughput *= lambertian_brdf * hit_color * dot_or_zero(
-                    hit_normal, ray_dir) / pdf
-            else:
-                throughput *= hit_color
-        color_buffer[u, v] += acc_color
-    count_var[0] = (count_var[0] + 1) % (stratify_res * stratify_res)
-
-
-@ti.kernel
-def tonemap(accumulated: ti.f32):
-    for i, j in tonemapped_buffer:
-        tonemapped_buffer[i, j] = ti.sqrt(color_buffer[i, j] / accumulated *
-                                          100.0)
-
+        color = buffer.rgb / buffer.a                                  # calculate the average value of colors
+        color = pow(color, vec3(1.0 / 2.2))                     # Gamma correction, then use ACES tone mapping
+        color = mat3(0.597190, 0.35458, 0.04823, 0.07600, 0.90834, 0.01566, 0.02840, 0.13383, 0.83777) @ color
+        color = (color * (color + 0.024578) - 0.0000905) / (color * (0.983729 * color + 0.4329510) + 0.238081)
+        color = mat3(1.60475, -0.531, -0.0736, -0.102, 1.10813, -0.00605, -0.00327, -0.07276, 1.07602) @ color
+        image_pixels[i, j] = clamp(color, 0, 1)  # write pixels, clamp the brightness that cannot be displayed
 
 def main():
-    gui = ti.GUI('Cornell Box', res, fast_gui=True)
-    gui.fps_limit = 300
-    last_t = time.time()
-    i = 0
-    while gui.running:
-        render()
-        interval = 10
-        if i % interval == 0:
-            tonemap(i)
-            print(
-                f"{interval / (time.time() - last_t):.2f} samples/s ({i} iters)"
-            )
-            last_t = time.time()
-            gui.set_image(tonemapped_buffer)
-            gui.show()
-        i += 1
-
+    window = ti.ui.Window("Cornell Box", image_resolution)                                     # create window
+    canvas = window.get_canvas()
+    while window.running:                                                            # main loop of the window
+        render(vec3(0, 0, 3.5), vec3(0, 0, -1), vec3(0, 1, 0))        # set the camera parameters, then render
+        canvas.set_image(image_pixels)                                              # writing pixels to canvas
+        window.show()                                                                # continue to show window
 
 if __name__ == '__main__':
     main()

--- a/python/taichi/examples/rendering/cornell_box.py
+++ b/python/taichi/examples/rendering/cornell_box.py
@@ -66,8 +66,8 @@ def signed_distance(obj: SDFObject, pos: vec3) -> float:
 @ti.func
 def nearest_object(p: vec3):
     index, min_dis = 0, 1e32
-    for i in range(8):
-        dis = abs(signed_distance(objects[i], p))
+    for i in ti.static(range(8)):
+        dis = signed_distance(objects[i], p)
         if dis < min_dis:
             min_dis, index = dis, i
     return index, min_dis
@@ -103,7 +103,7 @@ def raycast(ray: Ray):
         s = w * d
         t += s
         hit = err < 0.001
-        if t > 10.0 or hit:
+        if t > 5.0 or hit:
             break
     return objects[index], position, hit
 
@@ -140,8 +140,8 @@ def raytrace(ray: Ray) -> Ray:
 @ti.kernel
 def build_scene():
     for i in objects:
-        rotation = objects[i].transform.rotation
-        objects[i].transform.matrix = rotate(radians(rotation))
+        rotation = radians(objects[i].transform.rotation)
+        objects[i].transform.matrix = rotate(rotation)
 
 
 @ti.kernel

--- a/python/taichi/examples/rendering/cornell_box.py
+++ b/python/taichi/examples/rendering/cornell_box.py
@@ -91,10 +91,11 @@ def raycast(ray: Ray):
         index, distance = nearest_object(position)
 
         ld, d = d, distance
-        if w > 1.0 and ld + d < s:
+        if ld + d < s:
             s -= w * s
             t += s
-            w = 1.0
+            w *= 0.5
+            w += 0.5
             continue
         err = d / t
         if err < cerr:

--- a/python/taichi/examples/rendering/cornell_box.py
+++ b/python/taichi/examples/rendering/cornell_box.py
@@ -1,140 +1,227 @@
-import taichi as ti                                                                # of course, we need taichi
-from taichi.math import *                                                # need common mathematical operations
+import taichi as ti  # of course, we need taichi
+from taichi.math import *  # need common mathematical operations
 
-ti.init(arch=ti.gpu, default_ip=ti.i32, default_fp=ti.f32)        # initialize, use GPU, set default ip and fp
+ti.init(arch=ti.gpu, default_ip=ti.i32,
+        default_fp=ti.f32)  # initialize, use GPU, set default ip and fp
 
-image_resolution = (512, 512)                                         # resolution of the image, not too large
-image_buffer = ti.Vector.field(4, float, image_resolution)    # image buffer field for recording sample counts
-image_pixels = ti.Vector.field(3, float, image_resolution)           # for output display pixels to the screen
+image_resolution = (512, 512)  # resolution of the image, not too large
+image_buffer = ti.Vector.field(
+    4, float,
+    image_resolution)  # image buffer field for recording sample counts
+image_pixels = ti.Vector.field(
+    3, float, image_resolution)  # for output display pixels to the screen
 
-Ray = ti.types.struct(origin=vec3, direction=vec3, color=vec3)      # the struct representing camera light ray
-Material = ti.types.struct(albedo=vec3, emission=vec3)             # Cornell Box need only albedo and emission
-Transform = ti.types.struct(position=vec3, rotation=vec3, scale=vec3)          # Transformation of SDF objects
-SDFObject = ti.types.struct(distance=float, transform=Transform, material=Material)              # SDF objects
-HitRecord = ti.types.struct(object=SDFObject, position=vec3, distance=float, hit=bool)   # for ray-hit-surface
+Ray = ti.types.struct(origin=vec3, direction=vec3,
+                      color=vec3)  # the struct representing camera light ray
+Material = ti.types.struct(
+    albedo=vec3, emission=vec3)  # Cornell Box need only albedo and emission
+Transform = ti.types.struct(position=vec3, rotation=vec3,
+                            scale=vec3)  # Transformation of SDF objects
+SDFObject = ti.types.struct(distance=float,
+                            transform=Transform,
+                            material=Material)  # SDF objects
+HitRecord = ti.types.struct(object=SDFObject,
+                            position=vec3,
+                            distance=float,
+                            hit=bool)  # for ray-hit-surface
 
-objects    = SDFObject.field(shape=8)                           # field for storing SDF objects with 8 objects
-objects[0] = SDFObject(transform=Transform(vec3(0, 0, -1), vec3(0, 0, 0), vec3(1, 1, 0.2)),
-                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                        # wall 1
-objects[1] = SDFObject(transform=Transform(vec3(0, 1, 0), vec3(90, 0, 0), vec3(1, 1, 0.2)),
-                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                        # wall 2
-objects[2] = SDFObject(transform=Transform(vec3(0, -1, 0), vec3(90, 0, 0), vec3(1, 1, 0.2)),
-                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                        # wall 3
-objects[3] = SDFObject(transform=Transform(vec3(-1, 0, 0), vec3(0, 90, 0), vec3(1, 1, 0.2)),
-                material=Material(vec3(1, 0, 0)*0.5, vec3(1)))                                        # wall 4
-objects[4] = SDFObject(transform=Transform(vec3(1, 0, 0), vec3(0, 90, 0), vec3(1, 1, 0.2)),
-                material=Material(vec3(0, 1, 0)*0.5, vec3(1)))                                        # wall 5
-objects[5] = SDFObject(transform=Transform(vec3(-0.275, -0.3, -0.2), vec3(0, 112, 0), vec3(0.25, 0.5, 0.25)),
-                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                    # taller box
-objects[6] = SDFObject(transform=Transform(vec3(0.275,-0.55, 0.2), vec3(0, -197, 0), vec3(0.25, 0.25, 0.25)),
-                material=Material(vec3(1, 1, 1)*0.4, vec3(1)))                                           # box
-objects[7] = SDFObject(transform=Transform(vec3(0, 0.809, 0), vec3(90, 0, 0), vec3(0.2, 0.2, 0.01)),
-                material=Material(vec3(1, 1, 1)*1, vec3(100)))                                         # light
+objects = SDFObject.field(
+    shape=8)  # field for storing SDF objects with 8 objects
+objects[0] = SDFObject(transform=Transform(vec3(0, 0, -1), vec3(0, 0, 0),
+                                           vec3(1, 1, 0.2)),
+                       material=Material(vec3(1, 1, 1) * 0.4,
+                                         vec3(1)))  # wall 1
+objects[1] = SDFObject(transform=Transform(vec3(0, 1, 0), vec3(90, 0, 0),
+                                           vec3(1, 1, 0.2)),
+                       material=Material(vec3(1, 1, 1) * 0.4,
+                                         vec3(1)))  # wall 2
+objects[2] = SDFObject(transform=Transform(vec3(0, -1, 0), vec3(90, 0, 0),
+                                           vec3(1, 1, 0.2)),
+                       material=Material(vec3(1, 1, 1) * 0.4,
+                                         vec3(1)))  # wall 3
+objects[3] = SDFObject(transform=Transform(vec3(-1, 0, 0), vec3(0, 90, 0),
+                                           vec3(1, 1, 0.2)),
+                       material=Material(vec3(1, 0, 0) * 0.5,
+                                         vec3(1)))  # wall 4
+objects[4] = SDFObject(transform=Transform(vec3(1, 0, 0), vec3(0, 90, 0),
+                                           vec3(1, 1, 0.2)),
+                       material=Material(vec3(0, 1, 0) * 0.5,
+                                         vec3(1)))  # wall 5
+objects[5] = SDFObject(transform=Transform(vec3(-0.275, -0.3, -0.2),
+                                           vec3(0, 112, 0),
+                                           vec3(0.25, 0.5, 0.25)),
+                       material=Material(vec3(1, 1, 1) * 0.4,
+                                         vec3(1)))  # taller box
+objects[6] = SDFObject(transform=Transform(vec3(0.275, -0.55, 0.2),
+                                           vec3(0, -197, 0),
+                                           vec3(0.25, 0.25, 0.25)),
+                       material=Material(vec3(1, 1, 1) * 0.4, vec3(1)))  # box
+objects[7] = SDFObject(transform=Transform(vec3(0, 0.809, 0), vec3(90, 0, 0),
+                                           vec3(0.2, 0.2, 0.01)),
+                       material=Material(vec3(1, 1, 1) * 1,
+                                         vec3(100)))  # light
+
 
 @ti.func
-def angle(a: vec3) -> mat3:                                          # convert Euler angles to rotation matrix
-    s, c = sin(a), cos(a)                                          # first calculate the two axial projections
+def angle(a: vec3) -> mat3:  # convert Euler angles to rotation matrix
+    s, c = sin(a), cos(a)  # first calculate the two axial projections
     return mat3(c.z, s.z, 0, -s.z, c.z, 0, 0, 0, 1) @ \
            mat3(c.y, 0, -s.y, 0, 1, 0, s.y, 0, c.y) @ \
            mat3(1, 0, 0, 0, c.x, s.x, 0, -s.x, c.x)      # convert to rotation matrix in XYZ and multiply left
 
+
 @ti.func
-def signed_distance(obj: SDFObject, pos: vec3) -> float:     # calc the signed distance from pos to SDF object
-    p = angle(radians(obj.transform.rotation)) @ (pos - obj.transform.position)    # translate and then rotate
+def signed_distance(
+        obj: SDFObject,
+        pos: vec3) -> float:  # calc the signed distance from pos to SDF object
+    p = angle(radians(obj.transform.rotation)) @ (
+        pos - obj.transform.position)  # translate and then rotate
     q = abs(p) - obj.transform.scale
-    return length(max(q, 0)) + min(max(q.x, max(q.y, q.z)), 0)               # return the sdf value of the box
+    return length(max(q, 0)) + min(max(q.x, max(q.y, q.z)),
+                                   0)  # return the sdf value of the box
+
 
 @ti.func
-def nearest_object(p: vec3) -> SDFObject:                                        # find the nearest sdf object
-    o = objects[0]; o.distance = abs(signed_distance(o, p))                   # we start with the first object
-    for i in range(1, 8):                                                                  # for all 8 objects
-        oi = objects[i]; oi.distance = abs(signed_distance(oi, p))     # handling the interior of SDF with abs
-        if oi.distance < o.distance: o = oi                  # we need the nearest object to step into the ray
-    return o                                             # this can also be seen as a concatenation of the SDF
+def nearest_object(p: vec3) -> SDFObject:  # find the nearest sdf object
+    o = objects[0]
+    o.distance = abs(signed_distance(o, p))  # we start with the first object
+    for i in range(1, 8):  # for all 8 objects
+        oi = objects[i]
+        oi.distance = abs(signed_distance(
+            oi, p))  # handling the interior of SDF with abs
+        if oi.distance < o.distance:
+            o = oi  # we need the nearest object to step into the ray
+    return o  # this can also be seen as a concatenation of the SDF
+
 
 @ti.func
-def calc_normal(obj: SDFObject, p: vec3) -> vec3: # representing the surface normal by the gradient of the SDF
-    e = vec2(1, -1) * 0.5773 * 0.005                # calculation of gradients using the Tetrahedron technique
+def calc_normal(
+    obj: SDFObject, p: vec3
+) -> vec3:  # representing the surface normal by the gradient of the SDF
+    e = vec2(
+        1, -1
+    ) * 0.5773 * 0.005  # calculation of gradients using the Tetrahedron technique
     return normalize(e.xyy * signed_distance(obj, p + e.xyy) + \
                      e.yyx * signed_distance(obj, p + e.yyx) + \
                      e.yxy * signed_distance(obj, p + e.yxy) + \
                      e.xxx * signed_distance(obj, p + e.xxx) )
 
+
 @ti.func
-def raycast(ray: Ray) -> HitRecord:                 # ray marching to obtain the intersection with the surface
-    record = HitRecord(distance=0.0005)                                  # step a little off the surface first
-    for _ in range(256):                                                      # need a maximum number of steps
-        record.position  = ray.origin + record.distance * ray.direction
-        record.object    = nearest_object(record.position)    # according to the nearest distance ray marching
-        record.distance += record.object.distance                                             # sphere tracing
-        record.hit       = record.object.distance < 0.00001         # less than the surface thickness is a hit
-        if record.distance > 2000.0 or record.hit: break                        # no need to continue stepping
+def raycast(
+    ray: Ray
+) -> HitRecord:  # ray marching to obtain the intersection with the surface
+    record = HitRecord(distance=0.0005)  # step a little off the surface first
+    for _ in range(256):  # need a maximum number of steps
+        record.position = ray.origin + record.distance * ray.direction
+        record.object = nearest_object(
+            record.position)  # according to the nearest distance ray marching
+        record.distance += record.object.distance  # sphere tracing
+        record.hit = record.object.distance < 0.00001  # less than the surface thickness is a hit
+        if record.distance > 2000.0 or record.hit:
+            break  # no need to continue stepping
     return record
 
+
 @ti.func
-def hemispheric_sampling(normal: vec3) -> vec3:           # choose a random direction in the normal hemisphere
+def hemispheric_sampling(
+    normal: vec3
+) -> vec3:  # choose a random direction in the normal hemisphere
     z = 2.0 * ti.random() - 1.0
     a = ti.random() * 2.0 * pi
-    xy = sqrt(1.0 - z*z) * vec2(sin(a), cos(a))
+    xy = sqrt(1.0 - z * z) * vec2(sin(a), cos(a))
     return normalize(normal + vec3(xy, z))
 
+
 @ti.func
-def raytrace(ray: Ray) -> Ray:                                                                  # Path Tracing
-    for i in range(3):                   # 3 times is already enough to bring Global Illumination to the scene
+def raytrace(ray: Ray) -> Ray:  # Path Tracing
+    for i in range(
+            3
+    ):  # 3 times is already enough to bring Global Illumination to the scene
         inv_pdf = exp(float(i) / 128.0)
-        roulette_prob = 1.0 - (1.0 / inv_pdf)  # Russian Roulette for spreading the computation between frames
-        if ti.random() < roulette_prob: ray.color *= roulette_prob; break                     # end of tracing
+        roulette_prob = 1.0 - (
+            1.0 / inv_pdf
+        )  # Russian Roulette for spreading the computation between frames
+        if ti.random() < roulette_prob:
+            ray.color *= roulette_prob
+            break  # end of tracing
 
-        record = raycast(ray)                           # calculate the intersection of the ray with the scene
-        if not record.hit: ray.color = vec3(0); break                           # not hitting the light source
+        record = raycast(
+            ray)  # calculate the intersection of the ray with the scene
+        if not record.hit:
+            ray.color = vec3(0)
+            break  # not hitting the light source
 
-        normal  = calc_normal(record.object, record.position)     # calc the normal of the intersection points
-        ray.direction = hemispheric_sampling(normal)                # approximate diffuse reflection direction
-        ray.color *= record.object.material.albedo                  # ray needs to be multiplied by the albedo
-        ray.origin = record.position                                         # update light departure position
+        normal = calc_normal(
+            record.object,
+            record.position)  # calc the normal of the intersection points
+        ray.direction = hemispheric_sampling(
+            normal)  # approximate diffuse reflection direction
+        ray.color *= record.object.material.albedo  # ray needs to be multiplied by the albedo
+        ray.origin = record.position  # update light departure position
 
-        intensity  = dot(ray.color, vec3(0.299, 0.587, 0.114))              # calculating the intensity of ray
-        ray.color *= record.object.material.emission                                # multiplying the emission
-        visible    = dot(ray.color, vec3(0.299, 0.587, 0.114))                                # new brightness
-        if intensity < visible or visible < 0.000001: break           # too dark or arrive at the light source
+        intensity = dot(ray.color,
+                        vec3(0.299, 0.587,
+                             0.114))  # calculating the intensity of ray
+        ray.color *= record.object.material.emission  # multiplying the emission
+        visible = dot(ray.color, vec3(0.299, 0.587, 0.114))  # new brightness
+        if intensity < visible or visible < 0.000001:
+            break  # too dark or arrive at the light source
     return ray
+
 
 @ti.kernel
 def render(camera_position: vec3, camera_lookat: vec3, camera_up: vec3):
-    for i, j in image_pixels:                                         # iterate through all pixels in parallel
-        buffer = image_buffer[i, j]                                                     # current buffer color
+    for i, j in image_pixels:  # iterate through all pixels in parallel
+        buffer = image_buffer[i, j]  # current buffer color
 
         z = normalize(camera_position - camera_lookat)
-        x = normalize(cross(camera_up, z))                          # calculating the camera coordinate system
+        x = normalize(cross(camera_up,
+                            z))  # calculating the camera coordinate system
         y = cross(z, x)
-        
-        half_width = half_height = tan(radians(35) * 0.5)           # calculate camera frame position and size
+
+        half_width = half_height = tan(
+            radians(35) * 0.5)  # calculate camera frame position and size
         lower_left_corner = camera_position - half_width * x - half_height * y - z
-        horizontal = 2.0 * half_width  * x
-        vertical   = 2.0 * half_height * y
+        horizontal = 2.0 * half_width * x
+        vertical = 2.0 * half_height * y
 
-        uv = (vec2(i, j) + vec2(ti.random(), ti.random())) / vec2(image_resolution)             # oversampling
+        uv = (vec2(i, j) + vec2(ti.random(), ti.random())) / vec2(
+            image_resolution)  # oversampling
         po = lower_left_corner + uv.x * horizontal + uv.y * vertical
-        rd = normalize(po - camera_position)                          # calculation of ray direction by camera
+        rd = normalize(
+            po - camera_position)  # calculation of ray direction by camera
 
-        ray = raytrace(Ray(camera_position, rd, vec3(1)))                                       # Path Tracing
-        buffer += vec4(ray.color, 1.0)              # accumulate colors and record the number of accumulations
-        image_buffer[i, j] = buffer                                                      # updating the buffer
+        ray = raytrace(Ray(camera_position, rd, vec3(1)))  # Path Tracing
+        buffer += vec4(
+            ray.color,
+            1.0)  # accumulate colors and record the number of accumulations
+        image_buffer[i, j] = buffer  # updating the buffer
 
-        color = buffer.rgb / buffer.a                                  # calculate the average value of colors
-        color = pow(color, vec3(1.0 / 2.2))                     # Gamma correction, then use ACES tone mapping
-        color = mat3(0.597190, 0.35458, 0.04823, 0.07600, 0.90834, 0.01566, 0.02840, 0.13383, 0.83777) @ color
-        color = (color * (color + 0.024578) - 0.0000905) / (color * (0.983729 * color + 0.4329510) + 0.238081)
-        color = mat3(1.60475, -0.531, -0.0736, -0.102, 1.10813, -0.00605, -0.00327, -0.07276, 1.07602) @ color
-        image_pixels[i, j] = clamp(color, 0, 1)  # write pixels, clamp the brightness that cannot be displayed
+        color = buffer.rgb / buffer.a  # calculate the average value of colors
+        color = pow(color, vec3(
+            1.0 / 2.2))  # Gamma correction, then use ACES tone mapping
+        color = mat3(0.597190, 0.35458, 0.04823, 0.07600, 0.90834, 0.01566,
+                     0.02840, 0.13383, 0.83777) @ color
+        color = (color * (color + 0.024578) -
+                 0.0000905) / (color *
+                               (0.983729 * color + 0.4329510) + 0.238081)
+        color = mat3(1.60475, -0.531, -0.0736, -0.102, 1.10813, -0.00605,
+                     -0.00327, -0.07276, 1.07602) @ color
+        image_pixels[i, j] = clamp(
+            color, 0,
+            1)  # write pixels, clamp the brightness that cannot be displayed
+
 
 def main():
-    window = ti.ui.Window("Cornell Box", image_resolution)                                     # create window
+    window = ti.ui.Window("Cornell Box", image_resolution)  # create window
     canvas = window.get_canvas()
-    while window.running:                                                            # main loop of the window
-        render(vec3(0, 0, 3.5), vec3(0, 0, -1), vec3(0, 1, 0))        # set the camera parameters, then render
-        canvas.set_image(image_pixels)                                              # writing pixels to canvas
-        window.show()                                                                # continue to show window
+    while window.running:  # main loop of the window
+        render(vec3(0, 0, 3.5), vec3(0, 0, -1),
+               vec3(0, 1, 0))  # set the camera parameters, then render
+        canvas.set_image(image_pixels)  # writing pixels to canvas
+        window.show()  # continue to show window
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Using the updated taichi writing style and a more simplified implementation that includes comments.

It runs fine on: 
- Window11 AMD Ryzen 7 6800H with Radeon Graphics CPUs and GPUs
- macOS 12.5.1 Intel Core i7 and AMD Radeon Pro 5500XT CPUs and GPUs

Performance (updated: `2023/02/10`, https://github.com/taichi-dev/taichi/pull/7252/commits/97da1b398bd46b5270d3dde66bcec8393479979c): 
- AMD 6800H 680M Radeon Graphics about 200 fps
- Intel Core i7&Radeon Pro 5500XT about 250 fps

This requires a change in the test sample, can anyone assist me?
- https://github.com/taichi-dev/taichi-release-tests/pull/6

Results: 
- Look in the forum: https://forum.taichi-lang.cn/t/topic/3837