### PR TITLE
[autodiff] Basic demo of autodiff for ndarray

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -601,6 +601,7 @@ class TapeNdarray:
             self.grad_checker.add_calls(self.calls)
             self.grad_checker.check_grad()
 
+
 __all__ = [
     'FwdMode', 'Tape', 'clear_all_gradients', 'grad_for', 'grad_replaced',
     'no_grad', 'TapeNdarray'

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -213,7 +213,7 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
 
 }  // namespace
 
-#ifdef TI_WITH_LLVM
+// #ifdef TI_WITH_LLVM
 FunctionType CPUModuleToFunctionConverter::convert(
     const std::string &kernel_name,
     const std::vector<LlvmLaunchArgInfo> &args,
@@ -269,7 +269,7 @@ LLVMCompiledTask KernelCodeGenCPU::compile_task(
   TaskCodeGenCPU gen(config, kernel, stmt);
   return gen.run_compilation();
 }
-#endif  // TI_WITH_LLVM
+// #endif  // TI_WITH_LLVM
 
 FunctionType KernelCodeGenCPU::compile_to_function() {
   TI_AUTO_PROF;

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -213,7 +213,7 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
 
 }  // namespace
 
-// #ifdef TI_WITH_LLVM
+#ifdef TI_WITH_LLVM
 FunctionType CPUModuleToFunctionConverter::convert(
     const std::string &kernel_name,
     const std::vector<LlvmLaunchArgInfo> &args,
@@ -269,7 +269,7 @@ LLVMCompiledTask KernelCodeGenCPU::compile_task(
   TaskCodeGenCPU gen(config, kernel, stmt);
   return gen.run_compilation();
 }
-// #endif  // TI_WITH_LLVM
+#endif  // TI_WITH_LLVM
 
 FunctionType KernelCodeGenCPU::compile_to_function() {
   TI_AUTO_PROF;

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1620,11 +1620,7 @@ void auto_diff(IRNode *root,
         ReplaceLocalVarWithStacks replace(config.ad_stack_size);
         ib->accept(&replace);
         type_check(root, config);
-        std::cout << "Before MakeAdjoint" << std::endl;
-        irpass::print(ib);
         MakeAdjoint::run(ib);
-        std::cout << "After MakeAdjoint" << std::endl;
-        irpass::print(ib);
         type_check(root, config);
         BackupSSA::run(ib);
         irpass::analysis::verify(root);

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1045,8 +1045,8 @@ class MakeAdjoint : public ADTransform {
       if (arg->is_grad) {
         return;
       }
-      auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
-                                         arg->is_ptr, true);
+      auto adj_arg =
+          insert<ArgLoadStmt>(arg->arg_id, arg->ret_type, arg->is_ptr, true);
       auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, src->indices);
       insert<AtomicOpStmt>(AtomicOpType::add, adj_ptr, load(adjoint(stmt)));
     } else {
@@ -1087,13 +1087,13 @@ class MakeAdjoint : public ADTransform {
       if (arg->is_grad) {
         return;
       }
-      auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
-                                         arg->is_ptr, true);
+      auto adj_arg =
+          insert<ArgLoadStmt>(arg->arg_id, arg->ret_type, arg->is_ptr, true);
       auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, dest->indices);
       accumulate(stmt->val, insert<GlobalLoadStmt>(adj_ptr));
       // Clear the gradient after accumulation finished.
-      auto zero = insert<ConstStmt>(
-          TypedConstant(dest->ret_type.ptr_removed(), 0));
+      auto zero =
+          insert<ConstStmt>(TypedConstant(dest->ret_type.ptr_removed(), 0));
       insert<GlobalStoreStmt>(adj_ptr, zero);
 
       stmt->parent->erase(stmt);
@@ -1138,8 +1138,8 @@ class MakeAdjoint : public ADTransform {
       if (arg->is_grad) {
         return;
       }
-      auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
-                                         arg->is_ptr, true);
+      auto adj_arg =
+          insert<ArgLoadStmt>(arg->arg_id, arg->ret_type, arg->is_ptr, true);
       auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, dest->indices);
       accumulate(stmt->val, insert<GlobalLoadStmt>(adj_ptr));
       stmt->parent->erase(stmt);

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1044,10 +1044,10 @@ class MakeAdjoint : public ADTransform {
     if (stmt->src->is<ExternalPtrStmt>()) {
       ExternalPtrStmt *src = stmt->src->as<ExternalPtrStmt>();
       ArgLoadStmt *arg = src->base_ptr->as<ArgLoadStmt>();
-      // how to judge if it has a grad?
-      // if (!arg->is_grad) {
-      //   return;
-      // }
+      // use is_grad to judge if it has a grad
+      if (arg->is_grad) {
+        return;
+      }
       auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
                                          arg->is_ptr, true);
       auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, src->indices);
@@ -1087,9 +1087,9 @@ class MakeAdjoint : public ADTransform {
     if (stmt->dest->is<ExternalPtrStmt>()) {
       ExternalPtrStmt *dest = stmt->dest->as<ExternalPtrStmt>();
       ArgLoadStmt *arg = dest->base_ptr->as<ArgLoadStmt>();
-      // if (!arg->is_grad) {
-      //   return;
-      // }
+      if (arg->is_grad) {
+        return;
+      }
       auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
                                          arg->is_ptr, true);
       auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, dest->indices);
@@ -1138,9 +1138,9 @@ class MakeAdjoint : public ADTransform {
     if (stmt->dest->is<ExternalPtrStmt>()) {
       ExternalPtrStmt *dest = stmt->dest->as<ExternalPtrStmt>();
       ArgLoadStmt *arg = dest->base_ptr->as<ArgLoadStmt>();
-      // if (!arg->is_grad) {
-      //   return;
-      // }
+      if (arg->is_grad) {
+        return;
+      }
       auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
                                          arg->is_ptr, true);
       auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, dest->indices);

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -635,6 +635,10 @@ class ADTransform : public IRVisitor {
     // do nothing
   }
 
+  void visit(ExternalPtrStmt *stmt) override {
+    // do nothing
+  }
+
   void visit(WhileControlStmt *stmt) override {
     TI_NOT_IMPLEMENTED
   }
@@ -715,6 +719,7 @@ class MakeAdjoint : public ADTransform {
   }
 
   static void run(Block *block) {
+    std::cout << "MakeAdjoint::run" << std::endl;
     auto p = MakeAdjoint(block);
     block->accept(&p);
   }
@@ -729,6 +734,8 @@ class MakeAdjoint : public ADTransform {
     }
     std::reverse(statements.begin(), statements.end());  // reverse-mode AD...
     for (auto stmt : statements) {
+      std::cout << "MakeAdjoint::visit(Block) stmt: " << stmt->name()
+                << std::endl;
       current_block = block;
       stmt->accept(this);
     }
@@ -1035,104 +1042,136 @@ class MakeAdjoint : public ADTransform {
   void visit(GlobalLoadStmt *stmt) override {
     // issue global store to adjoint
     if (stmt->src->is<ExternalPtrStmt>()) {
-      TI_ERROR(
-          "Importing data from external array (such as numpy array) not "
-          "supported in AutoDiff for now")
-    }
-
-    GlobalPtrStmt *src = nullptr;
-    bool is_ptr_offset = false;
-    if (stmt->src->is<MatrixPtrStmt>()) {
-      is_ptr_offset = true;
-      src = stmt->src->as<MatrixPtrStmt>()->origin->as<GlobalPtrStmt>();
+      ExternalPtrStmt *src = stmt->src->as<ExternalPtrStmt>();
+      ArgLoadStmt *arg = src->base_ptr->as<ArgLoadStmt>();
+      // how to judge if it has a grad?
+      // if (!arg->is_grad) {
+      //   return;
+      // }
+      auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
+                                         arg->is_ptr, true);
+      auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, src->indices);
+      insert<AtomicOpStmt>(AtomicOpType::add, adj_ptr, load(adjoint(stmt)));
     } else {
-      src = stmt->src->as<GlobalPtrStmt>();
-    }
+      GlobalPtrStmt *src = nullptr;
+      bool is_ptr_offset = false;
+      if (stmt->src->is<MatrixPtrStmt>()) {
+        is_ptr_offset = true;
+        src = stmt->src->as<MatrixPtrStmt>()->origin->as<GlobalPtrStmt>();
+      } else {
+        src = stmt->src->as<GlobalPtrStmt>();
+      }
 
-    auto snode = src->snode;
-    if (!snode->has_adjoint()) {
-      // No adjoint SNode. Do nothing
-      return;
+      auto snode = src->snode;
+      if (!snode->has_adjoint()) {
+        // No adjoint SNode. Do nothing
+        return;
+      }
+      if (gradients_stopped(stmt, snode)) {
+        // gradients stopped, do nothing.
+        return;
+      }
+      TI_ASSERT(snode->get_adjoint() != nullptr);
+      snode = snode->get_adjoint();
+      auto adj_ptr = insert<GlobalPtrStmt>(snode, src->indices);
+      if (is_ptr_offset) {
+        adj_ptr = insert<MatrixPtrStmt>(adj_ptr,
+                                        stmt->src->as<MatrixPtrStmt>()->offset);
+      }
+      insert<AtomicOpStmt>(AtomicOpType::add, adj_ptr, load(adjoint(stmt)));
     }
-    if (gradients_stopped(stmt, snode)) {
-      // gradients stopped, do nothing.
-      return;
-    }
-    TI_ASSERT(snode->get_adjoint() != nullptr);
-    snode = snode->get_adjoint();
-    auto adj_ptr = insert<GlobalPtrStmt>(snode, src->indices);
-    if (is_ptr_offset) {
-      adj_ptr = insert<MatrixPtrStmt>(adj_ptr,
-                                      stmt->src->as<MatrixPtrStmt>()->offset);
-    }
-    insert<AtomicOpStmt>(AtomicOpType::add, adj_ptr, load(adjoint(stmt)));
   }
 
   void visit(GlobalStoreStmt *stmt) override {
     // erase and replace with global load adjoint
     if (stmt->dest->is<ExternalPtrStmt>()) {
-      TI_ERROR(
-          "Exporting data to external array (such as numpy array) not "
-          "supported in AutoDiff for now")
-    }
+      ExternalPtrStmt *dest = stmt->dest->as<ExternalPtrStmt>();
+      ArgLoadStmt *arg = dest->base_ptr->as<ArgLoadStmt>();
+      // if (!arg->is_grad) {
+      //   return;
+      // }
+      auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
+                                         arg->is_ptr, true);
+      auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, dest->indices);
+      accumulate(stmt->val, insert<GlobalLoadStmt>(adj_ptr));
+      // Clear the gradient after accumulation finished.
+      auto zero = insert<ConstStmt>(
+          TypedConstant(dest->ret_type.ptr_removed(), 0));
+      insert<GlobalStoreStmt>(adj_ptr, zero);
 
-    GlobalPtrStmt *dest = nullptr;
-    bool is_ptr_offset = false;
-    if (stmt->dest->is<MatrixPtrStmt>()) {
-      is_ptr_offset = true;
-      dest = stmt->dest->as<MatrixPtrStmt>()->origin->as<GlobalPtrStmt>();
+      stmt->parent->erase(stmt);
     } else {
-      dest = stmt->dest->as<GlobalPtrStmt>();
-    }
+      GlobalPtrStmt *dest = nullptr;
+      bool is_ptr_offset = false;
+      if (stmt->dest->is<MatrixPtrStmt>()) {
+        is_ptr_offset = true;
+        dest = stmt->dest->as<MatrixPtrStmt>()->origin->as<GlobalPtrStmt>();
+      } else {
+        dest = stmt->dest->as<GlobalPtrStmt>();
+      }
 
-    auto snode = dest->snode;
-    if (!snode->has_adjoint()) {
-      // no gradient (likely integer types)
-      return;
-    }
-    TI_ASSERT(snode->get_adjoint() != nullptr);
-    snode = snode->get_adjoint();
-    auto adjoint_ptr = insert<GlobalPtrStmt>(snode, dest->indices);
-    if (is_ptr_offset) {
-      adjoint_ptr = insert<MatrixPtrStmt>(
-          adjoint_ptr, stmt->dest->as<MatrixPtrStmt>()->offset);
-    }
-    accumulate(stmt->val, insert<GlobalLoadStmt>(adjoint_ptr));
+      auto snode = dest->snode;
+      if (!snode->has_adjoint()) {
+        // no gradient (likely integer types)
+        return;
+      }
+      TI_ASSERT(snode->get_adjoint() != nullptr);
+      snode = snode->get_adjoint();
+      auto adjoint_ptr = insert<GlobalPtrStmt>(snode, dest->indices);
+      if (is_ptr_offset) {
+        adjoint_ptr = insert<MatrixPtrStmt>(
+            adjoint_ptr, stmt->dest->as<MatrixPtrStmt>()->offset);
+      }
+      accumulate(stmt->val, insert<GlobalLoadStmt>(adjoint_ptr));
 
-    // Clear the gradient after accumulation finished.
-    auto zero = insert<ConstStmt>(
-        TypedConstant(adjoint_ptr->ret_type.ptr_removed(), 0));
-    insert<GlobalStoreStmt>(adjoint_ptr, zero);
+      // Clear the gradient after accumulation finished.
+      auto zero = insert<ConstStmt>(
+          TypedConstant(adjoint_ptr->ret_type.ptr_removed(), 0));
+      insert<GlobalStoreStmt>(adjoint_ptr, zero);
 
-    stmt->parent->erase(stmt);
+      stmt->parent->erase(stmt);
+    }
   }
 
   void visit(AtomicOpStmt *stmt) override {
     // erase and replace with global load adjoint
-    GlobalPtrStmt *dest = nullptr;
-    bool is_ptr_offset = false;
-    if (stmt->dest->is<MatrixPtrStmt>()) {
-      is_ptr_offset = true;
-      dest = stmt->dest->as<MatrixPtrStmt>()->origin->as<GlobalPtrStmt>();
+    if (stmt->dest->is<ExternalPtrStmt>()) {
+      ExternalPtrStmt *dest = stmt->dest->as<ExternalPtrStmt>();
+      ArgLoadStmt *arg = dest->base_ptr->as<ArgLoadStmt>();
+      // if (!arg->is_grad) {
+      //   return;
+      // }
+      auto adj_arg = insert<ArgLoadStmt>(arg->arg_id, arg->ret_type,
+                                         arg->is_ptr, true);
+      auto adj_ptr = insert<ExternalPtrStmt>(adj_arg, dest->indices);
+      accumulate(stmt->val, insert<GlobalLoadStmt>(adj_ptr));
+      stmt->parent->erase(stmt);
     } else {
-      dest = stmt->dest->as<GlobalPtrStmt>();
-    }
+      GlobalPtrStmt *dest = nullptr;
+      bool is_ptr_offset = false;
+      if (stmt->dest->is<MatrixPtrStmt>()) {
+        is_ptr_offset = true;
+        dest = stmt->dest->as<MatrixPtrStmt>()->origin->as<GlobalPtrStmt>();
+      } else {
+        dest = stmt->dest->as<GlobalPtrStmt>();
+      }
 
-    auto snode = dest->snode;
-    if (!snode->has_adjoint()) {
-      // no gradient (likely integer types)
-      return;
-    }
+      auto snode = dest->snode;
+      if (!snode->has_adjoint()) {
+        // no gradient (likely integer types)
+        return;
+      }
 
-    TI_ASSERT(snode->get_adjoint() != nullptr);
-    snode = snode->get_adjoint();
-    auto adjoint_ptr = insert<GlobalPtrStmt>(snode, dest->indices);
-    if (is_ptr_offset) {
-      adjoint_ptr = insert<MatrixPtrStmt>(
-          adjoint_ptr, stmt->dest->as<MatrixPtrStmt>()->offset);
+      TI_ASSERT(snode->get_adjoint() != nullptr);
+      snode = snode->get_adjoint();
+      auto adjoint_ptr = insert<GlobalPtrStmt>(snode, dest->indices);
+      if (is_ptr_offset) {
+        adjoint_ptr = insert<MatrixPtrStmt>(
+            adjoint_ptr, stmt->dest->as<MatrixPtrStmt>()->offset);
+      }
+      accumulate(stmt->val, insert<GlobalLoadStmt>(adjoint_ptr));
+      stmt->parent->erase(stmt);
     }
-    accumulate(stmt->val, insert<GlobalLoadStmt>(adjoint_ptr));
-    stmt->parent->erase(stmt);
   }
 };
 
@@ -1581,7 +1620,11 @@ void auto_diff(IRNode *root,
         ReplaceLocalVarWithStacks replace(config.ad_stack_size);
         ib->accept(&replace);
         type_check(root, config);
+        std::cout << "Before MakeAdjoint" << std::endl;
+        irpass::print(ib);
         MakeAdjoint::run(ib);
+        std::cout << "After MakeAdjoint" << std::endl;
+        irpass::print(ib);
         type_check(root, config);
         BackupSSA::run(ib);
         irpass::analysis::verify(root);

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -719,7 +719,6 @@ class MakeAdjoint : public ADTransform {
   }
 
   static void run(Block *block) {
-    std::cout << "MakeAdjoint::run" << std::endl;
     auto p = MakeAdjoint(block);
     block->accept(&p);
   }
@@ -734,8 +733,6 @@ class MakeAdjoint : public ADTransform {
     }
     std::reverse(statements.begin(), statements.end());  // reverse-mode AD...
     for (auto stmt : statements) {
-      std::cout << "MakeAdjoint::visit(Block) stmt: " << stmt->name()
-                << std::endl;
       current_block = block;
       stmt->accept(this);
     }

--- a/tests/python/test_ad_ndarray_autodiff.py
+++ b/tests/python/test_ad_ndarray_autodiff.py
@@ -10,6 +10,7 @@ def test_ad_ndarray_autodiff():
     @ti.kernel
     def write(x: ti.types.ndarray()):
         x[None] = 3.0
+
     write(x)
 
     @ti.kernel
@@ -22,4 +23,5 @@ def test_ad_ndarray_autodiff():
     @ti.kernel
     def test(x: ti.types.ndarray()):
         assert x.grad[None] == -ti.sin(x[None])
+
     test(x)

--- a/tests/python/test_ad_ndarray_autodiff.py
+++ b/tests/python/test_ad_ndarray_autodiff.py
@@ -1,0 +1,25 @@
+import taichi as ti
+from tests import test_utils
+
+
+@test_utils.test(arch=ti.cpu)
+def test_ad_ndarray_autodiff():
+    x = ti.ndarray(ti.f32, shape=(), needs_grad=True)
+    y = ti.ndarray(ti.f32, shape=(), needs_grad=True)
+
+    @ti.kernel
+    def write(x: ti.types.ndarray()):
+        x[None] = 3.0
+    write(x)
+
+    @ti.kernel
+    def compute(x: ti.types.ndarray(), y: ti.types.ndarray()):
+        y[None] = ti.cos(x[None])
+
+    with ti.ad.TapeNdarray(loss=y):
+        compute(x, y)
+
+    @ti.kernel
+    def test(x: ti.types.ndarray()):
+        assert x.grad[None] == -ti.sin(x[None])
+    test(x)

--- a/tests/python/test_api.py
+++ b/tests/python/test_api.py
@@ -87,7 +87,7 @@ user_api[ti] = [
 ]
 user_api[ti.ad] = [
     'FwdMode', 'Tape', 'clear_all_gradients', 'grad_for', 'grad_replaced',
-    'no_grad'
+    'no_grad', 'TapeNdarray'
 ]
 user_api[ti.algorithms] = ['PrefixSumExecutor', 'parallel_sort']
 user_api[ti.Field] = [


### PR DESCRIPTION
We modify the visit functions of GlobalLoadStmt and GlobalStoreStmt in autodiff to support external_ptr. The following demo works
```python
    x = ti.ndarray(ti.f32, shape=(), needs_grad=True)
    y = ti.ndarray(ti.f32, shape=(), needs_grad=True)

    @ti.kernel
    def write(x: ti.types.ndarray()):
        x[None] = 3.0
    write(x)

    @ti.kernel
    def compute(x: ti.types.ndarray(), y: ti.types.ndarray()):
        y[None] = ti.cos(x[None])

    with ti.ad.TapeNdarray(loss=y):
        compute(x, y)

    @ti.kernel
    def test(x: ti.types.ndarray()):
        assert x.grad[None] == -ti.sin(x[None])
    test(x)
```
However, there are still several things to be done. We may need work out how to let an argloadstmt know whether it has a grad. This is important for autodiff system, since it's necessary to identify independent blocks and so on.
