### PR TITLE
[llvm] Remove unused argument 'arch' in LlvmProgramImpl::get_llvm_context

### DIFF
--- a/taichi/codegen/amdgpu/codegen_amdgpu.cpp
+++ b/taichi/codegen/amdgpu/codegen_amdgpu.cpp
@@ -407,8 +407,7 @@ LLVMCompiledTask KernelCodeGenAMDGPU::compile_task(
 
 FunctionType KernelCodeGenAMDGPU::compile_to_function() {
   auto *llvm_prog = get_llvm_program(prog);
-  const auto &config = get_compile_config();
-  auto *tlctx = llvm_prog->get_llvm_context(config.arch);
+  auto *tlctx = llvm_prog->get_llvm_context();
 
   AMDGPUModuleToFunctionConverter converter{tlctx,
                                             llvm_prog->get_runtime_executor()};

--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -68,7 +68,7 @@ KernelCodeGen::maybe_read_compilation_from_cache(
   }
 
   LlvmOfflineCache::KernelCacheData cache_data;
-  auto *tlctx = llvm_prog->get_llvm_context(compile_config_.arch);
+  auto *tlctx = llvm_prog->get_llvm_context();
   auto &llvm_ctx = *tlctx->get_this_thread_context();
 
   if (!reader->get_kernel_cache(cache_data, kernel_key, llvm_ctx)) {
@@ -85,7 +85,7 @@ void KernelCodeGen::cache_kernel(const std::string &kernel_key,
 
 LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   auto *llvm_prog = get_llvm_program(prog);
-  auto *tlctx = llvm_prog->get_llvm_context(compile_config_.arch);
+  auto *tlctx = llvm_prog->get_llvm_context();
   std::string kernel_key =
       get_hashed_offline_cache_key(compile_config_, kernel);
   kernel->set_kernel_key_for_cache(kernel_key);

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -274,8 +274,7 @@ LLVMCompiledTask KernelCodeGenCPU::compile_task(
 FunctionType KernelCodeGenCPU::compile_to_function() {
   TI_AUTO_PROF;
   auto *llvm_prog = get_llvm_program(prog);
-  const auto &config = get_compile_config();
-  auto *tlctx = llvm_prog->get_llvm_context(config.arch);
+  auto *tlctx = llvm_prog->get_llvm_context();
 
   CPUModuleToFunctionConverter converter(
       tlctx, get_llvm_program(prog)->get_runtime_executor());

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -597,8 +597,7 @@ LLVMCompiledTask KernelCodeGenCUDA::compile_task(
 FunctionType KernelCodeGenCUDA::compile_to_function() {
   TI_AUTO_PROF
   auto *llvm_prog = get_llvm_program(prog);
-  const auto &config = get_compile_config();
-  auto *tlctx = llvm_prog->get_llvm_context(config.arch);
+  auto *tlctx = llvm_prog->get_llvm_context();
 
   CUDAModuleToFunctionConverter converter{tlctx,
                                           llvm_prog->get_runtime_executor()};

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -308,13 +308,11 @@ TaskCodeGenLLVM::TaskCodeGenLLVM(const CompileConfig &compile_config,
                                  IRNode *ir,
                                  std::unique_ptr<llvm::Module> &&module)
     // TODO: simplify LLVMModuleBuilder ctor input
-    : LLVMModuleBuilder(module == nullptr
-                            ? get_llvm_program(kernel->program)
-                                  ->get_llvm_context(compile_config.arch)
-                                  ->new_module("kernel")
-                            : std::move(module),
-                        get_llvm_program(kernel->program)
-                            ->get_llvm_context(compile_config.arch)),
+    : LLVMModuleBuilder(module == nullptr ? get_llvm_program(kernel->program)
+                                                ->get_llvm_context()
+                                                ->new_module("kernel")
+                                          : std::move(module),
+                        get_llvm_program(kernel->program)->get_llvm_context()),
       compile_config(compile_config),
       kernel(kernel),
       ir(ir),
@@ -2551,7 +2549,7 @@ FunctionCreationGuard TaskCodeGenLLVM::get_function_creation_guard(
 }
 
 void TaskCodeGenLLVM::initialize_context() {
-  tlctx = get_llvm_program(prog)->get_llvm_context(compile_config.arch);
+  tlctx = get_llvm_program(prog)->get_llvm_context();
   llvm_context = tlctx->get_this_thread_context();
   builder = std::make_unique<llvm::IRBuilder<>>(*llvm_context);
 }

--- a/taichi/codegen/llvm/struct_llvm.cpp
+++ b/taichi/codegen/llvm/struct_llvm.cpp
@@ -28,7 +28,7 @@ StructCompilerLLVM::StructCompilerLLVM(Arch arch,
                                        int snode_tree_id)
     : StructCompilerLLVM(arch,
                          *prog->config,
-                         prog->get_llvm_context(arch),
+                         prog->get_llvm_context(),
                          std::move(module),
                          snode_tree_id) {
 }

--- a/taichi/codegen/wasm/codegen_wasm.cpp
+++ b/taichi/codegen/wasm/codegen_wasm.cpp
@@ -239,8 +239,7 @@ class TaskCodeGenWASM : public TaskCodeGenLLVM {
 FunctionType KernelCodeGenWASM::compile_to_function() {
   TI_AUTO_PROF
   auto linked = compile_kernel_to_module();
-  auto *tlctx =
-      get_llvm_program(prog)->get_llvm_context(get_compile_config().arch);
+  auto *tlctx = get_llvm_program(prog)->get_llvm_context();
   tlctx->create_jit_module(std::move(linked.module));
   auto kernel_symbol = tlctx->lookup_function_pointer(linked.tasks[0].name);
   return [=](RuntimeContext &context) {
@@ -279,7 +278,7 @@ LLVMCompiledTask KernelCodeGenWASM::compile_task(
 
 LLVMCompiledKernel KernelCodeGenWASM::compile_kernel_to_module() {
   const auto &config = get_compile_config();
-  auto *tlctx = get_llvm_program(prog)->get_llvm_context(config.arch);
+  auto *tlctx = get_llvm_program(prog)->get_llvm_context();
   irpass::ast_to_ir(config, *kernel, true);
 
   auto res = compile_task(config);

--- a/taichi/runtime/program_impls/llvm/llvm_program.h
+++ b/taichi/runtime/program_impls/llvm/llvm_program.h
@@ -172,7 +172,7 @@ class LlvmProgramImpl : public ProgramImpl {
     runtime_exec_->print_memory_profiler_info(snode_trees_, result_buffer);
   }
 
-  TaichiLLVMContext *get_llvm_context(Arch arch) {
+  TaichiLLVMContext *get_llvm_context() {
     return runtime_exec_->get_llvm_context();
   }
 

--- a/tests/cpp/codegen/refine_coordinates_test.cpp
+++ b/tests/cpp/codegen/refine_coordinates_test.cpp
@@ -113,7 +113,7 @@ class RefineCoordinatesTest : public ::testing::Test {
     config_.print_kernel_llvm_ir = false;
     prog_ = std::make_unique<Program>(arch_);
     auto *llvm_prog_ = get_llvm_program(prog_.get());
-    tlctx_ = llvm_prog_->get_llvm_context(arch_);
+    tlctx_ = llvm_prog_->get_llvm_context();
 
     root_snode_ = std::make_unique<SNode>(/*depth=*/0, /*t=*/SNodeType::root);
     const std::vector<Axis> axes = {Axis{0}};

--- a/tests/cpp/llvm/llvm_offline_cache_test.cpp
+++ b/tests/cpp/llvm/llvm_offline_cache_test.cpp
@@ -45,7 +45,7 @@ class LlvmOfflineCacheTest : public testing::TestWithParam<Format> {
     config_.print_kernel_llvm_ir = false;
     prog_ = std::make_unique<Program>(arch);
     auto *llvm_prog_ = get_llvm_program(prog_.get());
-    tlctx_ = llvm_prog_->get_llvm_context(arch);
+    tlctx_ = llvm_prog_->get_llvm_context();
   }
 
   static std::unique_ptr<llvm::Module> make_module(


### PR DESCRIPTION
Issue: #7251

### Brief Summary
