### PR TITLE
[Bug] Fix caching same loop invariant global vars inside nested fors

### DIFF
--- a/taichi/transforms/cache_loop_invariant_global_vars.cpp
+++ b/taichi/transforms/cache_loop_invariant_global_vars.cpp
@@ -16,7 +16,7 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
 
   typedef std::unordered_map<Stmt *, std::pair<CacheStatus, AllocaStmt *>>
       CacheMap;
-  std::stack<CacheMap> cached_maps;
+  std::vector<CacheMap> cached_maps;
 
   DelayedIRModifier modifier;
   std::unordered_map<const SNode *, GlobalPtrStmt *> loop_unique_ptr_;
@@ -87,33 +87,33 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
   }
 
   void visit_loop(Block *body) override {
-    cached_maps.emplace();
+    cached_maps.emplace_back();
     LoopInvariantDetector::visit_loop(body);
-    cached_maps.pop();
+    cached_maps.pop_back();
   }
 
-  void add_writeback(AllocaStmt *alloca_stmt, Stmt *global_var) {
+  void add_writeback(AllocaStmt *alloca_stmt, Stmt *global_var, int depth) {
     auto final_value = std::make_unique<LocalLoadStmt>(alloca_stmt);
     auto global_store =
         std::make_unique<GlobalStoreStmt>(global_var, final_value.get());
-    modifier.insert_after(current_loop_stmt(), std::move(global_store));
-    modifier.insert_after(current_loop_stmt(), std::move(final_value));
+    modifier.insert_after(get_loop_stmt(depth), std::move(global_store));
+    modifier.insert_after(get_loop_stmt(depth), std::move(final_value));
   }
 
-  void set_init_value(AllocaStmt *alloca_stmt, Stmt *global_var) {
+  void set_init_value(AllocaStmt *alloca_stmt, Stmt *global_var, int depth) {
     auto new_global_load = std::make_unique<GlobalLoadStmt>(global_var);
     auto local_store =
         std::make_unique<LocalStoreStmt>(alloca_stmt, new_global_load.get());
-    modifier.insert_before(current_loop_stmt(), std::move(new_global_load));
-    modifier.insert_before(current_loop_stmt(), std::move(local_store));
+    modifier.insert_before(get_loop_stmt(depth), std::move(new_global_load));
+    modifier.insert_before(get_loop_stmt(depth), std::move(local_store));
   }
 
-  AllocaStmt *cache_global_to_local(Stmt *dest, CacheStatus status) {
-    if (auto &[cached_status, alloca_stmt] = cached_maps.top()[dest];
+  AllocaStmt *cache_global_to_local(Stmt *dest, CacheStatus status, int depth) {
+    if (auto &[cached_status, alloca_stmt] = cached_maps[depth][dest];
         cached_status != CacheStatus::None) {
       // The global variable has already been cached.
       if (cached_status == CacheStatus::Read && status == CacheStatus::Write) {
-        add_writeback(alloca_stmt, dest);
+        add_writeback(alloca_stmt, dest, depth);
         cached_status = CacheStatus::ReadWrite;
       }
       return alloca_stmt;
@@ -121,19 +121,35 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
     auto alloca_unique =
         std::make_unique<AllocaStmt>(dest->ret_type.ptr_removed());
     auto alloca_stmt = alloca_unique.get();
-    modifier.insert_before(current_loop_stmt(), std::move(alloca_unique));
-    set_init_value(alloca_stmt, dest);
+    modifier.insert_before(get_loop_stmt(depth), std::move(alloca_unique));
+    set_init_value(alloca_stmt, dest, depth);
     if (status == CacheStatus::Write) {
-      add_writeback(alloca_stmt, dest);
+      add_writeback(alloca_stmt, dest, depth);
     }
-    cached_maps.top()[dest] = {status, alloca_stmt};
+    cached_maps[depth][dest] = {status, alloca_stmt};
     return alloca_stmt;
   }
 
+  std::optional<int> find_cache_place_if_cacheable(Stmt *operand,
+                                                   Block *current_scope) {
+    if (!is_offload_unique(operand)) {
+      return std::nullopt;
+    }
+    std::optional<int> place;
+    for (int n = loop_blocks.size() - 1; n > 0; n--) {
+      if (is_operand_loop_invariant(operand, current_scope, n)) {
+        place = n;
+      } else {
+        break;
+      }
+    }
+    return place;
+  }
+
   void visit(GlobalLoadStmt *stmt) override {
-    if (is_offload_unique(stmt->src) &&
-        is_operand_loop_invariant(stmt->src, stmt->parent)) {
-      auto alloca_stmt = cache_global_to_local(stmt->src, CacheStatus::Read);
+    if (auto place = find_cache_place_if_cacheable(stmt->src, stmt->parent)) {
+      auto alloca_stmt =
+          cache_global_to_local(stmt->src, CacheStatus::Read, place.value());
       auto local_load = std::make_unique<LocalLoadStmt>(alloca_stmt);
       stmt->replace_usages_with(local_load.get());
       modifier.insert_before(stmt, std::move(local_load));
@@ -142,9 +158,9 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
   }
 
   void visit(GlobalStoreStmt *stmt) override {
-    if (is_offload_unique(stmt->dest) &&
-        is_operand_loop_invariant(stmt->dest, stmt->parent)) {
-      auto alloca_stmt = cache_global_to_local(stmt->dest, CacheStatus::Write);
+    if (auto place = find_cache_place_if_cacheable(stmt->dest, stmt->parent)) {
+      auto alloca_stmt =
+          cache_global_to_local(stmt->dest, CacheStatus::Write, place.value());
       auto local_store =
           std::make_unique<LocalStoreStmt>(alloca_stmt, stmt->val);
       stmt->replace_usages_with(local_store.get());

--- a/taichi/transforms/loop_invariant_detector.h
+++ b/taichi/transforms/loop_invariant_detector.h
@@ -12,7 +12,7 @@ class LoopInvariantDetector : public BasicStmtVisitor {
  public:
   using BasicStmtVisitor::visit;
 
-  std::stack<Block *> loop_blocks;
+  std::vector<Block *> loop_blocks;
 
   const CompileConfig &config;
 
@@ -20,13 +20,18 @@ class LoopInvariantDetector : public BasicStmtVisitor {
     allow_undefined_visitor = true;
   }
 
-  bool is_operand_loop_invariant_impl(Stmt *operand, Block *current_scope) {
+  bool is_operand_loop_invariant_impl(Stmt *operand,
+                                      Block *current_scope,
+                                      Block *loop_block = nullptr) {
+    if (!loop_block) {
+      loop_block = loop_blocks.back();
+    }
     if (operand->parent == current_scope) {
       // This statement has an operand that is in the current scope,
       // so it can not be moved out of the scope.
       return false;
     }
-    if (current_scope != loop_blocks.top()) {
+    if (current_scope != loop_block) {
       // If we enable moving code from a nested if block, we need to check
       // visibility. Example:
       // for i in range(10):
@@ -43,7 +48,7 @@ class LoopInvariantDetector : public BasicStmtVisitor {
         // If the one of the current_scope of the operand is the top loop
         // scope Then it will not be visible if we move it outside the top
         // loop scope
-        if (operand_parent == loop_blocks.top()->parent_stmt) {
+        if (operand_parent == loop_block->parent_stmt) {
           return false;
         }
       }
@@ -51,15 +56,21 @@ class LoopInvariantDetector : public BasicStmtVisitor {
     return true;
   }
 
-  bool is_operand_loop_invariant(Stmt *operand, Block *current_scope) {
-    if (loop_blocks.size() <= 1)
+  bool is_operand_loop_invariant(Stmt *operand,
+                                 Block *current_scope,
+                                 int depth = -1) {
+    if (depth == -1) {
+      depth = loop_blocks.size() - 1;
+    }
+    if (depth <= 0)
       return false;
-    return is_operand_loop_invariant_impl(operand, current_scope);
+    return is_operand_loop_invariant_impl(operand, current_scope,
+                                          loop_blocks[depth]);
   }
 
   bool is_loop_invariant(Stmt *stmt, Block *current_scope) {
     if (loop_blocks.size() <= 1 || (!config.move_loop_invariant_outside_if &&
-                                    current_scope != loop_blocks.top()))
+                                    current_scope != loop_blocks.back()))
       return false;
 
     bool is_invariant = true;
@@ -73,21 +84,24 @@ class LoopInvariantDetector : public BasicStmtVisitor {
     return is_invariant;
   }
 
-  Stmt *current_loop_stmt() {
-    return loop_blocks.top()->parent_stmt;
+  Stmt *get_loop_stmt(int depth) {
+    return loop_blocks[depth]->parent_stmt;
   }
 
+  Stmt *current_loop_stmt() {
+    return get_loop_stmt(loop_blocks.size() - 1);
+  }
   void visit(Block *stmt_list) override {
     for (auto &stmt : stmt_list->statements)
       stmt->accept(this);
   }
 
   virtual void visit_loop(Block *body) {
-    loop_blocks.push(body);
+    loop_blocks.push_back(body);
 
     body->accept(this);
 
-    loop_blocks.pop();
+    loop_blocks.pop_back();
   }
 
   void visit(RangeForStmt *stmt) override {

--- a/tests/python/test_loops.py
+++ b/tests/python/test_loops.py
@@ -187,3 +187,19 @@ def test_break_in_outermost_for_not_in_outermost_scope():
         return a
 
     assert foo() == 100
+
+
+@test_utils.test()
+def test_cache_loop_invariant_global_var_in_nested_loops():
+    p = ti.field(float, 1)
+
+    @ti.kernel
+    def k():
+        for n in range(1):
+            for t in range(2):
+                for m in range(1):
+                    p[n] = p[n] + 1.0
+                p[n] = p[n] + 1.0
+
+    k()
+    assert p[0] == 4.0


### PR DESCRIPTION
Issue: fixes #7263

### Brief Summary
The bug is caused by caching a same global variable in two different local vars in two nested loops. To avoid this, for a cache-able global var, we find the outermost loop that it can be moved out of instead of just moving out of the innermost loop.