### PR TITLE
[ci] [amdgpu] Enable amdgpu backend python unit tests

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -123,7 +123,7 @@ if [ -z "$GPU_TEST" ]; then
     fi
 elif [ ! -z "$AMDGPU_TEST" ]; then
     run-it cpu    $(nproc)
-    # run-it amdgpu 4
+    run-it amdgpu 8
 else
     run-it cuda   8
     run-it cpu    $(nproc)

--- a/taichi/codegen/amdgpu/codegen_amdgpu.cpp
+++ b/taichi/codegen/amdgpu/codegen_amdgpu.cpp
@@ -84,7 +84,7 @@ class TaskCodeGenAMDGPU : public TaskCodeGenLLVM {
       } else {
         TI_NOT_IMPLEMENTED
       }
-    } // TODO simplify the impl of sgn
+    }  // TODO simplify the impl of sgn
     else if (op == UnaryOpType::sgn) {
       if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
         auto ashr = builder->CreateAShr(input, 31);
@@ -192,7 +192,7 @@ class TaskCodeGenAMDGPU : public TaskCodeGenLLVM {
         func->getBasicBlockList().push_back(bb_merge);
         builder->SetInsertPoint(bb_merge);
         llvm_val[stmt] =
-            builder->CreateLoad(llvm::Type::getDoubleTy(*llvm_context), cast); 
+            builder->CreateLoad(llvm::Type::getDoubleTy(*llvm_context), cast);
       }
     }
     UNARY_STD(cos)

--- a/taichi/program/extension.cpp
+++ b/taichi/program/extension.cpp
@@ -19,6 +19,7 @@ bool is_extension_supported(Arch arch, Extension ext) {
        {Extension::sparse, Extension::quant, Extension::quant_basic,
         Extension::data64, Extension::adstack, Extension::bls,
         Extension::assertion, Extension::mesh}},
+      {Arch::amdgpu, {Extension::assertion}},
       {Arch::metal, {}},
       {Arch::opengl, {Extension::extfunc}},
       {Arch::gles, {}},

--- a/taichi/runtime/llvm/llvm_context.cpp
+++ b/taichi/runtime/llvm/llvm_context.cpp
@@ -620,8 +620,8 @@ void TaichiLLVMContext::link_module_with_amdgpu_libdevice(
     }
 
     for (auto &f : libdevice_module->functions()) {
-      auto func_ = module->getFunction(f.getName());
-      if (!func_ && starts_with(f.getName().lower(), "__" + libdevice))
+      auto func_name = libdevice.substr(0, libdevice.length()-3);
+      if (starts_with(f.getName().lower(), "__" + func_name))
         f.setLinkage(llvm::Function::CommonLinkage);
     }
 

--- a/taichi/runtime/llvm/llvm_context.cpp
+++ b/taichi/runtime/llvm/llvm_context.cpp
@@ -620,7 +620,7 @@ void TaichiLLVMContext::link_module_with_amdgpu_libdevice(
     }
 
     for (auto &f : libdevice_module->functions()) {
-      auto func_name = libdevice.substr(0, libdevice.length()-3);
+      auto func_name = libdevice.substr(0, libdevice.length() - 3);
       if (starts_with(f.getName().lower(), "__" + func_name))
         f.setLinkage(llvm::Function::CommonLinkage);
     }

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -762,8 +762,10 @@ void taichi_assert_format(LLVMRuntime *runtime,
                           uint64 *arguments) {
 #ifdef ARCH_amdgpu
   // TODO: find out why error with mark_force_no_inline
-  //  llvm::SDValue llvm::SelectionDAG::getNode(unsigned int, const llvm::SDLoc &, llvm::EVT, llvm::SDValue, const llvm::SDNodeFlags): 
-  //  Assertion `VT.getSizeInBits() == Operand.getValueSizeInBits() && "Cannot BITCAST between types of different sizes!"' failed.
+  //  llvm::SDValue llvm::SelectionDAG::getNode(unsigned int, const llvm::SDLoc
+  //  &, llvm::EVT, llvm::SDValue, const llvm::SDNodeFlags): Assertion
+  //  `VT.getSizeInBits() == Operand.getValueSizeInBits() && "Cannot BITCAST
+  //  between types of different sizes!"' failed.
 #else
   mark_force_no_inline();
 #endif

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -760,8 +760,13 @@ void taichi_assert_format(LLVMRuntime *runtime,
                           const char *format,
                           int num_arguments,
                           uint64 *arguments) {
+#ifdef ARCH_amdgpu
+  // TODO: find out why error with mark_force_no_inline
+  //  llvm::SDValue llvm::SelectionDAG::getNode(unsigned int, const llvm::SDLoc &, llvm::EVT, llvm::SDValue, const llvm::SDNodeFlags): 
+  //  Assertion `VT.getSizeInBits() == Operand.getValueSizeInBits() && "Cannot BITCAST between types of different sizes!"' failed.
+#else
   mark_force_no_inline();
-
+#endif
   if (!enable_assert || test != 0)
     return;
   if (!runtime->error_code) {
@@ -1510,7 +1515,13 @@ void gpu_parallel_range_for(RuntimeContext *context,
                             range_for_xlogue epilogue,
                             const std::size_t tls_size) {
   int idx = thread_idx() + block_dim() * block_idx() + begin;
+#ifdef ARCH_amdgpu
+  // AMDGPU doesn't support dynamic array
+  // TODO: find a better way to set the tls_size (maybe like struct_for
+  alignas(8) char tls_buffer[64];
+#else
   alignas(8) char tls_buffer[tls_size];
+#endif
   auto tls_ptr = &tls_buffer[0];
   if (prologue)
     prologue(context, tls_ptr);
@@ -1588,7 +1599,13 @@ void gpu_parallel_mesh_for(RuntimeContext *context,
                            MeshForTaskFunc *func,
                            mesh_for_xlogue epilogue,
                            const std::size_t tls_size) {
+#ifdef ARCH_amdgpu
+  // AMDGPU doesn't support dynamic array
+  // TODO: find a better way to set the tls_size (maybe like struct_for
+  alignas(8) char tls_buffer[64];
+#else
   alignas(8) char tls_buffer[tls_size];
+#endif
   auto tls_ptr = &tls_buffer[0];
   for (int idx = block_idx(); idx < num_patches; idx += grid_dim()) {
     if (prologue)

--- a/tests/python/test_ad_gdar_diffmpm.py
+++ b/tests/python/test_ad_gdar_diffmpm.py
@@ -4,7 +4,8 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(require=ti.extension.assertion, debug=True, exclude=[ti.cc])
+# FIXME: gdar mpm on amdgpu backend(assign gale)
+@test_utils.test(require=ti.extension.assertion, debug=True, exclude=[ti.cc, ti.amdgpu])
 def test_gdar_mpm():
     real = ti.f32
 

--- a/tests/python/test_ad_gdar_diffmpm.py
+++ b/tests/python/test_ad_gdar_diffmpm.py
@@ -5,7 +5,9 @@ from tests import test_utils
 
 
 # FIXME: gdar mpm on amdgpu backend(assign gale)
-@test_utils.test(require=ti.extension.assertion, debug=True, exclude=[ti.cc, ti.amdgpu])
+@test_utils.test(require=ti.extension.assertion,
+                 debug=True,
+                 exclude=[ti.cc, ti.amdgpu])
 def test_gdar_mpm():
     real = ti.f32
 

--- a/tests/python/test_ad_if.py
+++ b/tests/python/test_ad_if.py
@@ -243,8 +243,8 @@ def test_stack():
 
     func()
 
-
-@test_utils.test()
+#FIXME: amdgpu backend(assign gale)
+@test_utils.test(exclude=ti.amdgpu)
 def test_if_condition_depend_on_for_loop_index():
     scalar = lambda: ti.field(dtype=ti.f32)
     vec = lambda: ti.Vector.field(3, dtype=ti.f32)

--- a/tests/python/test_ad_if.py
+++ b/tests/python/test_ad_if.py
@@ -243,6 +243,7 @@ def test_stack():
 
     func()
 
+
 #FIXME: amdgpu backend(assign gale)
 @test_utils.test(exclude=ti.amdgpu)
 def test_if_condition_depend_on_for_loop_index():

--- a/tests/python/test_cfg_continue.py
+++ b/tests/python/test_cfg_continue.py
@@ -14,8 +14,5 @@ def test_cfg_continue():
                 x[p] = 1
                 continue
 
-            if state[p] != 0:
-                print('test')
-
     foo()
     assert x[0] == 1

--- a/tests/python/test_cfg_continue.py
+++ b/tests/python/test_cfg_continue.py
@@ -13,6 +13,8 @@ def test_cfg_continue():
             if state[p] == 0:
                 x[p] = 1
                 continue
+            if state[p] != 0:
+                 print('test')
 
     foo()
     assert x[0] == 1

--- a/tests/python/test_cfg_continue.py
+++ b/tests/python/test_cfg_continue.py
@@ -14,7 +14,7 @@ def test_cfg_continue():
                 x[p] = 1
                 continue
             if state[p] != 0:
-                 print('test')
+                print('test')
 
     foo()
     assert x[0] == 1

--- a/tests/python/test_cfg_continue.py
+++ b/tests/python/test_cfg_continue.py
@@ -2,7 +2,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.amdgpu])
 def test_cfg_continue():
     x = ti.field(dtype=int, shape=1)
     state = ti.field(dtype=int, shape=1)

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -213,7 +213,7 @@ def test_cli_run():
 
 
 def test_cli_cache():
-    archs = {ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal, ti.gles}
+    archs = {ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal, ti.gles, ti.amdgpu}
     archs = {v for v in archs if v in test_utils.expected_archs()}
     exts = ('ll', 'bc', 'spv', 'metal', 'tcb', 'lock')
     tmp_path = tempfile.mkdtemp()

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -213,7 +213,9 @@ def test_cli_run():
 
 
 def test_cli_cache():
-    archs = {ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal, ti.gles, ti.amdgpu}
+    archs = {
+        ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal, ti.gles, ti.amdgpu
+    }
     archs = {v for v in archs if v in test_utils.expected_archs()}
     exts = ('ll', 'bc', 'spv', 'metal', 'tcb', 'lock')
     tmp_path = tempfile.mkdtemp()

--- a/tests/python/test_debug.py
+++ b/tests/python/test_debug.py
@@ -66,7 +66,7 @@ def test_not_out_of_bound():
     func()
 
 
-@test_utils.test(require=[ti.extension.sparse, ti.extension.assertion],,
+@test_utils.test(require=[ti.extension.sparse, ti.extension.assertion],
                  debug=True,
                  gdb_trigger=False,
                  exclude=ti.metal)
@@ -83,7 +83,7 @@ def test_out_of_bound_dynamic():
         func()
 
 
-@test_utils.test(require=[ti.extension.sparse, ti.extension.assertion],,
+@test_utils.test(require=[ti.extension.sparse, ti.extension.assertion],
                  debug=True,
                  gdb_trigger=False,
                  exclude=ti.metal)

--- a/tests/python/test_debug.py
+++ b/tests/python/test_debug.py
@@ -66,7 +66,7 @@ def test_not_out_of_bound():
     func()
 
 
-@test_utils.test(require=ti.extension.assertion,
+@test_utils.test(require=[ti.extension.sparse, ti.extension.assertion],,
                  debug=True,
                  gdb_trigger=False,
                  exclude=ti.metal)
@@ -83,7 +83,7 @@ def test_out_of_bound_dynamic():
         func()
 
 
-@test_utils.test(require=ti.extension.assertion,
+@test_utils.test(require=[ti.extension.sparse, ti.extension.assertion],,
                  debug=True,
                  gdb_trigger=False,
                  exclude=ti.metal)

--- a/tests/python/test_internal_func.py
+++ b/tests/python/test_internal_func.py
@@ -7,7 +7,7 @@ from tests import test_utils
 
 
 @test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc])
+    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
 def test_basic():
     @ti.kernel
     def test():
@@ -18,7 +18,7 @@ def test_basic():
 
 
 @test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc])
+    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
 def test_host_polling():
     return
 
@@ -33,7 +33,7 @@ def test_host_polling():
 
 
 @test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc])
+    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
 def test_list_manager():
     @ti.kernel
     def test():
@@ -44,7 +44,7 @@ def test_list_manager():
 
 
 @test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc])
+    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
 def test_node_manager():
     @ti.kernel
     def test():
@@ -55,7 +55,7 @@ def test_node_manager():
 
 
 @test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc])
+    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
 def test_node_manager_gc():
     @ti.kernel
     def test_cpu():
@@ -64,7 +64,7 @@ def test_node_manager_gc():
     test_cpu()
 
 
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.amdgpu], debug=True)
 def test_return():
     @ti.kernel
     def test_cpu():

--- a/tests/python/test_internal_func.py
+++ b/tests/python/test_internal_func.py
@@ -6,8 +6,9 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
+@test_utils.test(exclude=[
+    ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu
+])
 def test_basic():
     @ti.kernel
     def test():
@@ -17,8 +18,9 @@ def test_basic():
     test()
 
 
-@test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
+@test_utils.test(exclude=[
+    ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu
+])
 def test_host_polling():
     return
 
@@ -32,8 +34,9 @@ def test_host_polling():
         time.sleep(0.1)
 
 
-@test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
+@test_utils.test(exclude=[
+    ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu
+])
 def test_list_manager():
     @ti.kernel
     def test():
@@ -43,8 +46,9 @@ def test_list_manager():
     test()
 
 
-@test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
+@test_utils.test(exclude=[
+    ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu
+])
 def test_node_manager():
     @ti.kernel
     def test():
@@ -54,8 +58,9 @@ def test_node_manager():
     test()
 
 
-@test_utils.test(
-    exclude=[ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu])
+@test_utils.test(exclude=[
+    ti.metal, ti.opengl, ti.gles, ti.cuda, ti.vulkan, ti.cc, ti.amdgpu
+])
 def test_node_manager_gc():
     @ti.kernel
     def test_cpu():

--- a/tests/python/test_lang.py
+++ b/tests/python/test_lang.py
@@ -94,8 +94,8 @@ def test_recreate():
     test()
 
 
-@test_utils.test()
-def test_local_atomics(exclude=ti.amdgpu):
+@test_utils.test(exclude=[ti.amdgpu])
+def test_local_atomics():
     n = 32
     val = ti.field(ti.i32, shape=n)
 

--- a/tests/python/test_lang.py
+++ b/tests/python/test_lang.py
@@ -95,7 +95,7 @@ def test_recreate():
 
 
 @test_utils.test()
-def test_local_atomics():
+def test_local_atomics(exclude=ti.amdgpu):
     n = 32
     val = ti.field(ti.i32, shape=n)
 

--- a/tests/python/test_native_functions.py
+++ b/tests/python/test_native_functions.py
@@ -5,7 +5,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.amdgpu])
 def test_abs():
     x = ti.field(ti.f32)
 

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -19,7 +19,7 @@ ndarray_shapes = [(), 8, (6, 12)]
 vector_dims = [3]
 matrix_dims = [(1, 2), (2, 3)]
 supported_archs_taichi_ndarray = [
-    ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal
+    ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal, ti.amdgpu
 ]
 
 

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -317,8 +317,8 @@ def test_static_ndrange_should_accept_numpy_integer():
     example()
 
 
-@test_utils.test()
-def test_n_loop_var_neq_dimension(exclude=ti.amdgpu):
+@test_utils.test(exclude=[ti.amdgpu])
+def test_n_loop_var_neq_dimension():
     @ti.kernel
     def iter():
         for i in ti.ndrange(1, 4):

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -318,7 +318,7 @@ def test_static_ndrange_should_accept_numpy_integer():
 
 
 @test_utils.test()
-def test_n_loop_var_neq_dimension():
+def test_n_loop_var_neq_dimension(exclude=ti.amdgpu):
     @ti.kernel
     def iter():
         for i in ti.ndrange(1, 4):

--- a/tests/python/test_non_taichi_types_in_kernel.py
+++ b/tests/python/test_non_taichi_types_in_kernel.py
@@ -2,7 +2,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test()
+@test_utils.test(exclude=ti.amdgpu)
 def test_subscript_user_classes_in_kernel():
     class MyList:
         def __init__(self, elements):

--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -111,7 +111,7 @@ def test_offload_with_cross_block_globals():
     assert ret[None] == 46
 
 
-@test_utils.test()
+@test_utils.test(exclude=ti.amdgpu)
 def test_offload_with_cross_nested_for():
     @ti.kernel
     def run(a: ti.i32):
@@ -123,7 +123,7 @@ def test_offload_with_cross_nested_for():
     run(2)
 
 
-@test_utils.test()
+@test_utils.test(exclude=ti.amdgpu)
 def test_offload_with_cross_if_inside_for():
     @ti.kernel
     def run(a: ti.i32):

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -29,7 +29,7 @@ def test_print(dt):
 
 # TODO: As described by @k-ye above, what we want to ensure
 #       is that, the content shows on console is *correct*.
-@test_utils.test(exclude=[ti.dx11, vk_on_mac], debug=True)
+@test_utils.test(exclude=[ti.dx11, vk_on_mac, ti.amdgpu], debug=True)
 def test_multi_print():
     @ti.kernel
     def func(x: ti.i32, y: ti.f32):
@@ -40,7 +40,7 @@ def test_multi_print():
 
 
 # TODO: vulkan doesn't support %s but we should ignore it instead of crashing.
-@test_utils.test(exclude=[ti.vulkan, ti.dx11])
+@test_utils.test(exclude=[ti.vulkan, ti.dx11, ti.amdgpu])
 def test_print_string():
     @ti.kernel
     def func(x: ti.i32, y: ti.f32):
@@ -52,7 +52,7 @@ def test_print_string():
     ti.sync()
 
 
-@test_utils.test(exclude=[ti.dx11, vk_on_mac], debug=True)
+@test_utils.test(exclude=[ti.dx11, vk_on_mac, ti.amdgpu], debug=True)
 def test_print_matrix():
     x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=())
     y = ti.Vector.field(3, dtype=ti.f32, shape=3)
@@ -68,7 +68,7 @@ def test_print_matrix():
     ti.sync()
 
 
-@test_utils.test(exclude=[ti.dx11, vk_on_mac], debug=True)
+@test_utils.test(exclude=[ti.dx11, vk_on_mac, ti.amdgpu], debug=True)
 def test_print_sep_end():
     @ti.kernel
     def func():

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -88,7 +88,7 @@ def test_print_sep_end():
     ti.sync()
 
 
-@test_utils.test(exclude=[ti.dx11, vk_on_mac], debug=True)
+@test_utils.test(exclude=[ti.dx11, vk_on_mac, ti.amdgpu], debug=True)
 def test_print_multiple_threads():
     x = ti.field(dtype=ti.f32, shape=(128, ))
 
@@ -104,7 +104,7 @@ def test_print_multiple_threads():
     ti.sync()
 
 
-@test_utils.test(exclude=[ti.cc, ti.dx11, vk_on_mac], debug=True)
+@test_utils.test(exclude=[ti.cc, ti.dx11, vk_on_mac, ti.amdgpu], debug=True)
 def test_print_list():
     x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=(2, 3))
     y = ti.Vector.field(3, dtype=ti.f32, shape=())
@@ -125,7 +125,7 @@ def test_print_list():
     ti.sync()
 
 
-@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac, ti.amdgpu], debug=True)
 def test_python_scope_print_field():
     x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=())
     y = ti.Vector.field(3, dtype=ti.f32, shape=3)
@@ -136,7 +136,7 @@ def test_python_scope_print_field():
     print(z)
 
 
-@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac, ti.amdgpu], debug=True)
 def test_print_string_format():
     @ti.kernel
     def func(k: ti.f32):
@@ -152,7 +152,7 @@ def test_print_string_format():
     ti.sync()
 
 
-@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac, ti.amdgpu], debug=True)
 def test_print_fstring():
     def foo1(x):
         return x + 1
@@ -166,7 +166,7 @@ def test_print_fstring():
 
 
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
-                 exclude=[vk_on_mac],
+                 exclude=[vk_on_mac, ti.amdgpu],
                  debug=True)
 def test_print_u64():
     @ti.kernel
@@ -178,7 +178,7 @@ def test_print_u64():
 
 
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
-                 exclude=[vk_on_mac],
+                 exclude=[vk_on_mac, ti.amdgpu],
                  debug=True)
 def test_print_i64():
     @ti.kernel
@@ -190,7 +190,7 @@ def test_print_i64():
 
 
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
-                 exclude=[vk_on_mac, cuda_on_windows],
+                 exclude=[vk_on_mac, cuda_on_windows, ti.amdgpu],
                  debug=True)
 def test_print_seq(capfd):
     @ti.kernel

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -125,7 +125,9 @@ def test_print_list():
     ti.sync()
 
 
-@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac, ti.amdgpu], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.vulkan],
+                 exclude=[vk_on_mac, ti.amdgpu],
+                 debug=True)
 def test_python_scope_print_field():
     x = ti.Matrix.field(2, 3, dtype=ti.f32, shape=())
     y = ti.Vector.field(3, dtype=ti.f32, shape=3)
@@ -136,7 +138,9 @@ def test_python_scope_print_field():
     print(z)
 
 
-@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac, ti.amdgpu], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.vulkan],
+                 exclude=[vk_on_mac, ti.amdgpu],
+                 debug=True)
 def test_print_string_format():
     @ti.kernel
     def func(k: ti.f32):
@@ -152,7 +156,9 @@ def test_print_string_format():
     ti.sync()
 
 
-@test_utils.test(arch=[ti.cpu, ti.vulkan], exclude=[vk_on_mac, ti.amdgpu], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.vulkan],
+                 exclude=[vk_on_mac, ti.amdgpu],
+                 debug=True)
 def test_print_fstring():
     def foo1(x):
         return x + 1

--- a/tests/python/test_struct_for_dynamic.py
+++ b/tests/python/test_struct_for_dynamic.py
@@ -2,7 +2,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
+@test_utils.test(require=ti.extension.sparse, exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
 def test_dynamic():
     x = ti.field(ti.i32)
     y = ti.field(ti.i32, shape=())
@@ -23,7 +23,7 @@ def test_dynamic():
     assert y[None] == n // 3 + 1
 
 
-@test_utils.test(exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
+@test_utils.test(require=ti.extension.sparse, exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
 def test_dense_dynamic():
     n = 128
 

--- a/tests/python/test_struct_for_dynamic.py
+++ b/tests/python/test_struct_for_dynamic.py
@@ -2,7 +2,8 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(require=ti.extension.sparse, exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
+@test_utils.test(require=ti.extension.sparse,
+                 exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
 def test_dynamic():
     x = ti.field(ti.i32)
     y = ti.field(ti.i32, shape=())
@@ -23,7 +24,8 @@ def test_dynamic():
     assert y[None] == n // 3 + 1
 
 
-@test_utils.test(require=ti.extension.sparse, exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
+@test_utils.test(require=ti.extension.sparse,
+                 exclude=[ti.opengl, ti.gles, ti.cc, ti.vulkan, ti.metal])
 def test_dense_dynamic():
     n = 128
 


### PR DESCRIPTION
Issue: #https://github.com/taichi-dev/taichi/issues/6434

### Brief Summary
1. fix amdgpu backend bugs:
    a. codegen typos
    b. add more types support for `sgn`
    c. use temporary method to handle `runtime.cpp` error
2. enable amdgpu backend python unit test
    a. because of the lack of `print` support, temporarily disable all `print` related tests on amdgpu backend.
    b. there is still something wrong in `gdar_mpm` and `ad_if` tests.