### PR TITLE
[refactor] Change print statement to warnings.warn in taichi.lang.util.warning

### DIFF
--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import traceback
+import warnings
 
 import numpy as np
 from colorama import Fore, Style
@@ -318,16 +319,15 @@ def warning(msg, warning_type=UserWarning, stacklevel=1, print_stack=True):
 
     Args:
         msg (str): message to print.
-        warning_type (Warning): type of warning.
+        warning_type (Type[Warning]): type of warning.
         stacklevel (int): warning stack level from the caller.
         print_stack (bool): whether to print the stack
     """
     if not is_logging_effective('warn'):
         return
-    msg = f'{warning_type.__name__}: {msg}'
     if print_stack:
         msg += f'\n{get_traceback(stacklevel)}'
-    print(Fore.YELLOW + Style.BRIGHT + msg + Style.RESET_ALL)
+    warnings.warn(Fore.YELLOW + Style.BRIGHT + msg + Style.RESET_ALL, warning_type)
 
 
 def get_traceback(stacklevel=1):

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -327,7 +327,8 @@ def warning(msg, warning_type=UserWarning, stacklevel=1, print_stack=True):
         return
     if print_stack:
         msg += f'\n{get_traceback(stacklevel)}'
-    warnings.warn(Fore.YELLOW + Style.BRIGHT + msg + Style.RESET_ALL, warning_type)
+    warnings.warn(Fore.YELLOW + Style.BRIGHT + msg + Style.RESET_ALL,
+                  warning_type)
 
 
 def get_traceback(stacklevel=1):


### PR DESCRIPTION
Issue: #4543

### Brief Summary
Changed print statement in `taichi.lang.util.warning` to `warnings.warn` to respect stdlib warnings filters