### PR TITLE
[refactor] Remove dependencies on LlvmProgramImpl::get_llvm_context() in TaskCodeGenLLVM

### DIFF
--- a/taichi/codegen/amdgpu/codegen_amdgpu.cpp
+++ b/taichi/codegen/amdgpu/codegen_amdgpu.cpp
@@ -28,9 +28,10 @@ class TaskCodeGenAMDGPU : public TaskCodeGenLLVM {
  public:
   using IRVisitor::visit;
   TaskCodeGenAMDGPU(const CompileConfig &config,
+                    TaichiLLVMContext &tlctx,
                     Kernel *kernel,
                     IRNode *ir = nullptr)
-      : TaskCodeGenLLVM(config, kernel, ir) {
+      : TaskCodeGenLLVM(config, tlctx, kernel, ir) {
   }
 
   llvm::Value *create_print(std::string tag,
@@ -485,7 +486,7 @@ LLVMCompiledTask KernelCodeGenAMDGPU::compile_task(
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenAMDGPU gen(config, kernel, stmt);
+  TaskCodeGenAMDGPU gen(config, get_taichi_llvm_context(), kernel, stmt);
   return gen.run_compilation();
 }
 

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -18,8 +18,11 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
  public:
   using IRVisitor::visit;
 
-  TaskCodeGenCPU(const CompileConfig &config, Kernel *kernel, IRNode *ir)
-      : TaskCodeGenLLVM(config, kernel, ir, nullptr) {
+  TaskCodeGenCPU(const CompileConfig &config,
+                 TaichiLLVMContext &tlctx,
+                 Kernel *kernel,
+                 IRNode *ir)
+      : TaskCodeGenLLVM(config, tlctx, kernel, ir, nullptr) {
     TI_AUTO_PROF
   }
 
@@ -273,7 +276,7 @@ LLVMCompiledTask KernelCodeGenCPU::compile_task(
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenCPU gen(config, kernel, stmt);
+  TaskCodeGenCPU gen(config, get_taichi_llvm_context(), kernel, stmt);
   return gen.run_compilation();
 }
 #endif  // TI_WITH_LLVM

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -31,9 +31,10 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
   using IRVisitor::visit;
 
   explicit TaskCodeGenCUDA(const CompileConfig &config,
+                           TaichiLLVMContext &tlctx,
                            Kernel *kernel,
                            IRNode *ir = nullptr)
-      : TaskCodeGenLLVM(config, kernel, ir) {
+      : TaskCodeGenLLVM(config, tlctx, kernel, ir) {
   }
 
   llvm::Value *create_print(std::string tag,
@@ -599,7 +600,7 @@ LLVMCompiledTask KernelCodeGenCUDA::compile_task(
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenCUDA gen(config, kernel, stmt);
+  TaskCodeGenCUDA gen(config, get_taichi_llvm_context(), kernel, stmt);
   return gen.run_compilation();
 }
 

--- a/taichi/codegen/dx12/codegen_dx12.cpp
+++ b/taichi/codegen/dx12/codegen_dx12.cpp
@@ -21,8 +21,11 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
  public:
   using IRVisitor::visit;
 
-  TaskCodeGenLLVMDX12(const CompileConfig &config, Kernel *kernel, IRNode *ir)
-      : TaskCodeGenLLVM(config, kernel, ir, nullptr) {
+  TaskCodeGenLLVMDX12(const CompileConfig &config,
+                      TaichiLLVMContext &tlctx,
+                      Kernel *kernel,
+                      IRNode *ir)
+      : TaskCodeGenLLVM(config, tlctx, kernel, ir, nullptr) {
     TI_AUTO_PROF
   }
 
@@ -262,7 +265,7 @@ LLVMCompiledTask KernelCodeGenDX12::compile_task(
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenLLVMDX12 gen(config, kernel, stmt);
+  TaskCodeGenLLVMDX12 gen(config, get_taichi_llvm_context(), kernel, stmt);
   return gen.run_compilation();
 }
 #endif  // TI_WITH_LLVM

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -304,15 +304,14 @@ void TaskCodeGenLLVM::emit_struct_meta_base(const std::string &name,
 }
 
 TaskCodeGenLLVM::TaskCodeGenLLVM(const CompileConfig &compile_config,
+                                 TaichiLLVMContext &tlctx,
                                  Kernel *kernel,
                                  IRNode *ir,
                                  std::unique_ptr<llvm::Module> &&module)
     // TODO: simplify LLVMModuleBuilder ctor input
-    : LLVMModuleBuilder(module == nullptr ? get_llvm_program(kernel->program)
-                                                ->get_llvm_context()
-                                                ->new_module("kernel")
-                                          : std::move(module),
-                        get_llvm_program(kernel->program)->get_llvm_context()),
+    : LLVMModuleBuilder(
+          module == nullptr ? tlctx.new_module("kernel") : std::move(module),
+          &tlctx),
       compile_config(compile_config),
       kernel(kernel),
       ir(ir),
@@ -2535,7 +2534,7 @@ FunctionCreationGuard TaskCodeGenLLVM::get_function_creation_guard(
 }
 
 void TaskCodeGenLLVM::initialize_context() {
-  tlctx = get_llvm_program(prog)->get_llvm_context();
+  TI_ASSERT(tlctx != nullptr);
   llvm_context = tlctx->get_this_thread_context();
   builder = std::make_unique<llvm::IRBuilder<>>(*llvm_context);
 }

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -71,6 +71,7 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   using LLVMModuleBuilder::call;
 
   explicit TaskCodeGenLLVM(const CompileConfig &config,
+                           TaichiLLVMContext &tlctx,
                            Kernel *kernel,
                            IRNode *ir = nullptr,
                            std::unique_ptr<llvm::Module> &&module = nullptr);

--- a/taichi/codegen/wasm/codegen_wasm.cpp
+++ b/taichi/codegen/wasm/codegen_wasm.cpp
@@ -24,10 +24,11 @@ class TaskCodeGenWASM : public TaskCodeGenLLVM {
   using IRVisitor::visit;
 
   TaskCodeGenWASM(const CompileConfig &config,
+                  TaichiLLVMContext &tlctx,
                   Kernel *kernel,
                   IRNode *ir,
                   std::unique_ptr<llvm::Module> &&M = nullptr)
-      : TaskCodeGenLLVM(config, kernel, ir, std::move(M)) {
+      : TaskCodeGenLLVM(config, tlctx, kernel, ir, std::move(M)) {
     TI_AUTO_PROF
   }
 
@@ -260,8 +261,8 @@ LLVMCompiledTask KernelCodeGenWASM::compile_task(
     OffloadedStmt *stmt) {
   bool init_flag = module == nullptr;
   std::vector<OffloadedTask> name_list;
-  auto gen =
-      std::make_unique<TaskCodeGenWASM>(config, kernel, ir, std::move(module));
+  auto gen = std::make_unique<TaskCodeGenWASM>(
+      config, get_taichi_llvm_context(), kernel, ir, std::move(module));
 
   name_list.emplace_back(nullptr);
   name_list[0].name = gen->init_taichi_kernel_function();


### PR DESCRIPTION
Issue: #7286 
* This PR: Part of removing `TaskCodeGenLLVM::prog`
* removing `TaskCodeGenLLVM::prog`: Part of #7286 
* #7286: Part of #7002