### PR TITLE
[gui] Remove renderable reuse & make renderable immediate

### DIFF
--- a/taichi/ui/backends/vulkan/renderer.h
+++ b/taichi/ui/backends/vulkan/renderer.h
@@ -83,7 +83,7 @@ class TI_DLL_EXPORT Renderer {
   SwapChain swap_chain_;
 
   std::vector<std::unique_ptr<Renderable>> renderables_;
-  int next_renderable_;
+  std::vector<Renderable *> render_queue_;
 
   taichi::lang::StreamSemaphore render_complete_semaphore_{nullptr};
 


### PR DESCRIPTION
Removed all the renderable reusing logic and since we have added the shader factory, we can now make creation of `renderable` immediate (and release them per frame). This allows the next step of immediate data transfer (so that we can remove the host numpy array cache)