### PR TITLE
[vulkan] Remove GLFW from Vulkan rhi dependency

### DIFF
--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -5,6 +5,8 @@
 #ifdef ANDROID
 #define VK_KHR_android_surface 1
 #include "vulkan/vulkan_android.h"
+#else
+#include "GLFW/glfw3.h"
 #endif  // ANDROID
 
 VulkanRuntime::VulkanRuntime() : GfxRuntime(taichi::Arch::vulkan) {

--- a/cpp_examples/rhi_examples/common.h
+++ b/cpp_examples/rhi_examples/common.h
@@ -89,7 +89,6 @@ class App {
 
     {
       SurfaceConfig config;
-      config.window_handle = glfw_window;
       config.native_surface_handle = device_creator->get_surface();
 
       surface = device->create_surface(config);

--- a/cpp_examples/rhi_examples/common.h
+++ b/cpp_examples/rhi_examples/common.h
@@ -88,8 +88,15 @@ class App {
     }
 
     {
+      VkSurfaceKHR vk_surf = VK_NULL_HANDLE;
+
+      if (glfwCreateWindowSurface(device_creator->device()->vk_instance(), glfw_window, nullptr, &vk_surf) !=
+          VK_SUCCESS) {
+        TI_ERROR("failed to create window surface!");
+      }
+
       SurfaceConfig config;
-      config.native_surface_handle = device_creator->get_surface();
+      config.native_surface_handle = vk_surf;
 
       surface = device->create_surface(config);
     }

--- a/taichi/rhi/device.h
+++ b/taichi/rhi/device.h
@@ -885,7 +885,6 @@ struct SurfaceConfig {
   //   waiting, a tearing may appear, reduces overall latency
   bool vsync{false};
   bool adaptive{true};
-  void *window_handle{nullptr};
   uint32_t width{1};
   uint32_t height{1};
   void *native_surface_handle{nullptr};

--- a/taichi/rhi/vulkan/CMakeLists.txt
+++ b/taichi/rhi/vulkan/CMakeLists.txt
@@ -24,7 +24,6 @@ target_include_directories(${VULKAN_RHI}
   PUBLIC
     ${PROJECT_SOURCE_DIR}/external/volk
     ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include
-    ${PROJECT_SOURCE_DIR}/external/glfw/include
   )
 
 # By specifying SYSTEM, we suppressed the warnings from third-party headers.

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -2777,7 +2777,6 @@ VulkanSurface::~VulkanSurface() {
   if (config_.native_surface_handle) {
     destroy_swap_chain();
     image_available_ = nullptr;
-    vkDestroySurfaceKHR(device_->vk_instance(), surface_, nullptr);
   } else {
     for (auto &img : swapchain_images_) {
       device_->destroy_image(img);

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -2680,7 +2680,7 @@ void VulkanSurface::create_swap_chain() {
   VkPresentModeKHR present_mode =
       choose_swap_present_mode(present_modes, config_.vsync, config_.adaptive);
 
-  VkExtent2D extent = {uint32_t(width_), uint32_t(width_)};
+  VkExtent2D extent = {uint32_t(width_), uint32_t(height_)};
   extent.width =
       std::max(capabilities.minImageExtent.width,
                std::min(capabilities.maxImageExtent.width, extent.width));

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -2608,32 +2608,11 @@ VkPresentModeKHR choose_swap_present_mode(
 
 VulkanSurface::VulkanSurface(VulkanDevice *device, const SurfaceConfig &config)
     : config_(config), device_(device) {
-#ifdef ANDROID
-  window_ = (ANativeWindow *)config.window_handle;
-#else
-  window_ = (GLFWwindow *)config.window_handle;
-#endif
-  if (window_) {
-    if (config.native_surface_handle) {
-      surface_ = (VkSurfaceKHR)config.native_surface_handle;
-    } else {
-#ifdef ANDROID
-      VkAndroidSurfaceCreateInfoKHR createInfo{
-          .sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR,
-          .pNext = nullptr,
-          .flags = 0,
-          .window = window_};
+  width_ = config.width;
+  height_ = config.height;
 
-      vkCreateAndroidSurfaceKHR(device->vk_instance(), &createInfo, nullptr,
-                                &surface_);
-#else
-      glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-      BAIL_ON_VK_BAD_RESULT_NO_RETURN(
-          glfwCreateWindowSurface(device->vk_instance(), window_, nullptr,
-                                  &surface_),
-          "Failed to create window surface ({})");
-#endif
-    }
+  if (config.native_surface_handle) {
+    surface_ = (VkSurfaceKHR)config.native_surface_handle;
 
     create_swap_chain();
 
@@ -2649,8 +2628,6 @@ VulkanSurface::VulkanSurface(VulkanDevice *device, const SurfaceConfig &config)
     // screenshot_image_ = device->create_image(params);
     swapchain_images_.push_back(device->create_image(params));
     swapchain_images_.push_back(device->create_image(params));
-    width_ = config.width;
-    height_ = config.height;
   }
 }
 
@@ -2703,15 +2680,7 @@ void VulkanSurface::create_swap_chain() {
   VkPresentModeKHR present_mode =
       choose_swap_present_mode(present_modes, config_.vsync, config_.adaptive);
 
-  int width, height;
-#ifdef ANDROID
-  width = ANativeWindow_getWidth(window_);
-  height = ANativeWindow_getHeight(window_);
-#else
-  glfwGetFramebufferSize(window_, &width, &height);
-#endif
-
-  VkExtent2D extent = {uint32_t(width), uint32_t(height)};
+  VkExtent2D extent = {uint32_t(width_), uint32_t(width_)};
   extent.width =
       std::max(capabilities.minImageExtent.width,
                std::min(capabilities.maxImageExtent.width, extent.width));
@@ -2770,7 +2739,7 @@ void VulkanSurface::create_swap_chain() {
   for (VkImage img : swapchain_images) {
     vkapi::IVkImage image = vkapi::create_image(
         device_->vk_device(), img, surface_format.format, VK_IMAGE_TYPE_2D,
-        VkExtent3D{uint32_t(width), uint32_t(height), 1}, 1u, 1u, usage);
+        VkExtent3D{uint32_t(width_), uint32_t(height_), 1}, 1u, 1u, usage);
 
     VkImageViewCreateInfo create_info{};
     create_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -2805,7 +2774,7 @@ int VulkanSurface::get_image_count() {
 }
 
 VulkanSurface::~VulkanSurface() {
-  if (config_.window_handle) {
+  if (config_.native_surface_handle) {
     destroy_swap_chain();
     image_available_ = nullptr;
     vkDestroySurfaceKHR(device_->vk_instance(), surface_, nullptr);
@@ -2827,7 +2796,7 @@ std::pair<uint32_t, uint32_t> VulkanSurface::get_size() {
 }
 
 StreamSemaphore VulkanSurface::acquire_next_image() {
-  if (!config_.window_handle) {
+  if (!config_.native_surface_handle) {
     image_index_ = (image_index_ + 1) % uint32_t(swapchain_images_.size());
     return nullptr;
   } else {
@@ -2910,38 +2879,12 @@ DeviceAllocation VulkanSurface::get_image_data() {
   auto [w, h] = get_size();
   size_t size_bytes = size_t(w * h) * sizeof(uint8_t) * 4;
 
-  /*
-  if (screenshot_image_ == kDeviceNullAllocation) {
-    ImageParams params = {ImageDimension::d2D,
-                          BufferFormat::rgba8,
-                          ImageLayout::transfer_dst,
-                          w,
-                          h,
-                          1,
-                          false};
-    screenshot_image_ = device_->create_image(params);
-  }
-  */
-
   if (!screenshot_buffer_) {
     Device::AllocParams params{size_bytes, /*host_wrtie*/ false,
                                /*host_read*/ true, /*export_sharing*/ false,
                                AllocUsage::Uniform};
     screenshot_buffer_ = device_->allocate_memory_unique(params);
   }
-
-  /*
-  if (config_.window_handle) {
-    // TODO: check if blit is supported, and use copy_image if not
-    cmd_list = stream->new_command_list();
-    cmd_list->blit_image(screenshot_image_, img_alloc,
-                         ImageLayout::transfer_dst, ImageLayout::transfer_src,
-                         {w, h, 1});
-    cmd_list->image_transition(screenshot_image_, ImageLayout::transfer_dst,
-                               ImageLayout::transfer_src);
-    stream->submit_synced(cmd_list.get());
-  }
-  */
 
   BufferImageCopyParams copy_params;
   copy_params.image_extent.x = w;
@@ -2956,12 +2899,6 @@ DeviceAllocation VulkanSurface::get_image_data() {
                             ImageLayout::transfer_src, copy_params);
   cmd_list->image_transition(img_alloc, ImageLayout::transfer_src,
                              ImageLayout::present_src);
-  /*
-  if (config_.window_handle) {
-    cmd_list->image_transition(screenshot_image_, ImageLayout::transfer_src,
-                               ImageLayout::transfer_dst);
-  }
-  */
   stream->submit_synced(cmd_list.get());
 
   return *screenshot_buffer_;

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -7,12 +7,6 @@
 
 #include "vk_mem_alloc.h"
 
-#ifdef ANDROID
-#include <android/native_window_jni.h>
-#else
-#include <GLFW/glfw3.h>
-#endif
-
 #include <memory>
 #include <optional>
 #include <list>
@@ -524,11 +518,6 @@ class VulkanSurface : public Surface {
   VkSurfaceKHR surface_{VK_NULL_HANDLE};
   VkSwapchainKHR swapchain_{VK_NULL_HANDLE};
   vkapi::IVkSemaphore image_available_{nullptr};
-#ifdef ANDROID
-  ANativeWindow *window_{nullptr};
-#else
-  GLFWwindow *window_{nullptr};
-#endif
   BufferFormat image_format_{BufferFormat::unknown};
 
   uint32_t image_index_{0};

--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -248,10 +248,12 @@ VulkanDeviceCreator::VulkanDeviceCreator(
 
   create_instance(vk_api_version, manual_create);
   setup_debug_messenger();
+  VkSurfaceKHR test_surface = VK_NULL_HANDLE;
   if (params_.is_for_ui) {
-    create_surface();
+    test_surface = params_.surface_creator(instance_);
+    RHI_ASSERT((test_surface != VK_NULL_HANDLE) && "failed to create window surface!");
   }
-  pick_physical_device();
+  pick_physical_device(test_surface);
   create_logical_device(manual_create);
 
   {
@@ -267,13 +269,14 @@ VulkanDeviceCreator::VulkanDeviceCreator(
         queue_family_indices_.graphics_family.value();
     ti_device_->init_vulkan_structs(params);
   }
+
+  if (params_.is_for_ui) {
+    vkDestroySurfaceKHR(instance_, test_surface, kNoVkAllocCallbacks);
+  }
 }
 
 VulkanDeviceCreator::~VulkanDeviceCreator() {
   ti_device_.reset();
-  if (surface_ != VK_NULL_HANDLE) {
-    vkDestroySurfaceKHR(instance_, surface_, kNoVkAllocCallbacks);
-  }
   if (params_.enable_validation_layer) {
     destroy_debug_utils_messenger_ext(instance_, debug_messenger_,
                                       kNoVkAllocCallbacks);
@@ -409,12 +412,7 @@ void VulkanDeviceCreator::setup_debug_messenger() {
       "failed to set up debug messenger");
 }
 
-void VulkanDeviceCreator::create_surface() {
-  surface_ = params_.surface_creator(instance_);
-  RHI_ASSERT(surface_ && "failed to create window surface!");
-}
-
-void VulkanDeviceCreator::pick_physical_device() {
+void VulkanDeviceCreator::pick_physical_device(VkSurfaceKHR test_surface) {
   uint32_t device_count = 0;
   vkEnumeratePhysicalDevices(instance_, &device_count, nullptr);
   RHI_ASSERT(device_count > 0 && "failed to find GPUs with Vulkan support");
@@ -443,7 +441,7 @@ void VulkanDeviceCreator::pick_physical_device() {
                "TI_VISIBLE_DEVICE=%d is not valid, found %d devices available",
                id, device_count);
       RHI_LOG_ERROR(msg_buf);
-    } else if (get_device_score(devices[id], surface_)) {
+    } else if (get_device_score(devices[id], test_surface)) {
       physical_device_ = devices[id];
       has_visible_device = true;
     }
@@ -453,7 +451,7 @@ void VulkanDeviceCreator::pick_physical_device() {
     // could not find a user defined visible device, use the first one suitable
     size_t max_score = 0;
     for (const auto &device : devices) {
-      size_t score = get_device_score(device, surface_);
+      size_t score = get_device_score(device, test_surface);
       if (score > max_score) {
         physical_device_ = device;
         max_score = score;
@@ -463,7 +461,7 @@ void VulkanDeviceCreator::pick_physical_device() {
   RHI_ASSERT(physical_device_ != VK_NULL_HANDLE &&
              "failed to find a suitable GPU");
 
-  queue_family_indices_ = find_queue_families(physical_device_, surface_);
+  queue_family_indices_ = find_queue_families(physical_device_, test_surface);
 }
 
 void VulkanDeviceCreator::create_logical_device(bool manual_create) {

--- a/taichi/rhi/vulkan/vulkan_device_creator.h
+++ b/taichi/rhi/vulkan/vulkan_device_creator.h
@@ -70,15 +70,10 @@ class TI_DLL_EXPORT VulkanDeviceCreator {
     return ti_device_.get();
   }
 
-  VkSurfaceKHR get_surface() {
-    return surface_;
-  }
-
  private:
   void create_instance(uint32_t vk_api_version, bool manual_create);
   void setup_debug_messenger();
-  void create_surface();
-  void pick_physical_device();
+  void pick_physical_device(VkSurfaceKHR test_surface);
   void create_logical_device(bool manual_create);
 
   VkInstance instance_{VK_NULL_HANDLE};
@@ -89,8 +84,6 @@ class TI_DLL_EXPORT VulkanDeviceCreator {
 
   VkQueue compute_queue_{VK_NULL_HANDLE};
   VkQueue graphics_queue_{VK_NULL_HANDLE};
-
-  VkSurfaceKHR surface_{VK_NULL_HANDLE};
 
   std::unique_ptr<VulkanDevice> ti_device_{nullptr};
 

--- a/taichi/rhi/vulkan/vulkan_loader.cpp
+++ b/taichi/rhi/vulkan/vulkan_loader.cpp
@@ -6,8 +6,6 @@
 #ifdef __APPLE__
 // For `runtime_lib_dir()`
 #include "taichi/util/lang_util.h"
-// For `glfwInitVulkanLoader`
-#include "GLFW/glfw3.h"
 #endif
 
 namespace taichi::lang {
@@ -17,10 +15,6 @@ VulkanLoader::VulkanLoader() {
 }
 
 bool VulkanLoader::check_vulkan_device() {
-#ifdef __APPLE__
-  glfwInitVulkanLoader(vkGetInstanceProcAddr);
-#endif
-
   bool found_device_with_compute = false;
 
   // We create an temporary Vulkan instance to probe the Vulkan devices.

--- a/taichi/rhi/window_system.cpp
+++ b/taichi/rhi/window_system.cpp
@@ -1,3 +1,8 @@
+#ifdef TI_WITH_VULKAN
+// NOTE: This must be included before `GLFW/glfw3.h` is included
+#include "taichi/rhi/vulkan/vulkan_common.h"
+#endif
+
 #include "window_system.h"
 #include "taichi/rhi/impl_support.h"
 
@@ -24,6 +29,13 @@ static void glfw_error_callback(int code, const char *description) {
 bool glfw_context_acquire() {
   std::lock_guard lg(glfw_state.mutex);
   if (glfw_state.glfw_ref_count == 0) {
+#ifdef TI_WITH_VULKAN
+    // This must be done before glfwInit() on macOS
+    // Ref: https://github.com/taichi-dev/taichi/pull/4813
+    // Here the `vkGetInstanceProcAddr` comes from Volk
+    glfwInitVulkanLoader(vkGetInstanceProcAddr);
+#endif
+
     auto res = glfwInit();
     if (res != GLFW_TRUE) {
       return false;

--- a/taichi/rhi/window_system.cpp
+++ b/taichi/rhi/window_system.cpp
@@ -1,6 +1,7 @@
 #ifdef TI_WITH_VULKAN
 // NOTE: This must be included before `GLFW/glfw3.h` is included
 #include "taichi/rhi/vulkan/vulkan_common.h"
+#include "taichi/rhi/vulkan/vulkan_loader.h"
 #endif
 
 #include "window_system.h"
@@ -33,7 +34,9 @@ bool glfw_context_acquire() {
     // This must be done before glfwInit() on macOS
     // Ref: https://github.com/taichi-dev/taichi/pull/4813
     // Here the `vkGetInstanceProcAddr` comes from Volk
-    glfwInitVulkanLoader(vkGetInstanceProcAddr);
+    if (vulkan::is_vulkan_api_available()) {
+      glfwInitVulkanLoader(vkGetInstanceProcAddr);
+    }
 #endif
 
     auto res = glfwInit();

--- a/taichi/runtime/program_impls/vulkan/CMakeLists.txt
+++ b/taichi/runtime/program_impls/vulkan/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(vulkan_program_impl
     ${PROJECT_SOURCE_DIR}/external/eigen
     ${PROJECT_SOURCE_DIR}/external/spdlog/include
     ${PROJECT_SOURCE_DIR}/external/SPIRV-Tools/include
+    ${PROJECT_SOURCE_DIR}/external/glfw/include
     ${LLVM_INCLUDE_DIRS}
   )
 

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -96,10 +96,6 @@ void VulkanProgramImpl::materialize_runtime(MemoryPool *memory_pool,
   GLFWwindow *glfw_window = nullptr;
 
   if (window_system::glfw_context_acquire()) {
-#ifdef __APPLE__
-    glfwInitVulkanLoader(vkGetInstanceProcAddr);
-#endif
-
     // glfw init success
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -96,6 +96,10 @@ void VulkanProgramImpl::materialize_runtime(MemoryPool *memory_pool,
   GLFWwindow *glfw_window = nullptr;
 
   if (window_system::glfw_context_acquire()) {
+#ifdef __APPLE__
+    glfwInitVulkanLoader(vkGetInstanceProcAddr);
+#endif
+
     // glfw init success
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);

--- a/taichi/ui/backends/vulkan/app_context.cpp
+++ b/taichi/ui/backends/vulkan/app_context.cpp
@@ -127,6 +127,12 @@ const taichi::lang::vulkan::VulkanDevice &AppContext::device() const {
 }
 
 AppContext::~AppContext() {
+  if (!embedded_vulkan_device_) {
+    // If `embedded_vulkan_device_` then surface is provided by device creator
+    // Otherwise we need to manage it
+    vkDestroySurfaceKHR(vulkan_device_->vk_instance(), native_surface_,
+                        nullptr);
+  }
 }
 
 bool AppContext::requires_export_sharing() const {

--- a/taichi/ui/backends/vulkan/app_context.cpp
+++ b/taichi/ui/backends/vulkan/app_context.cpp
@@ -71,16 +71,7 @@ void AppContext::init(Program *prog,
   prog_ = prog;
   this->config = config;
 
-  // Create a Vulkan device if the original configuration is not for Vulkan or
-  // there is no active current program (usage from external library for AOT
-  // modules for example).
-  if (config.ti_arch != Arch::vulkan || prog == nullptr) {
-    taichi::lang::vulkan::VulkanDeviceCreator::Params evd_params{};
-    evd_params.additional_instance_extensions =
-        get_required_instance_extensions();
-    evd_params.additional_device_extensions = get_required_device_extensions();
-    evd_params.is_for_ui = config.show_window;
-    evd_params.surface_creator = [&](VkInstance instance) -> VkSurfaceKHR {
+  auto make_vk_surface = [&](VkInstance instance) -> VkSurfaceKHR {
       VkSurfaceKHR surface = VK_NULL_HANDLE;
 #ifdef ANDROID
       VkAndroidSurfaceCreateInfoKHR createInfo{
@@ -100,11 +91,24 @@ void AppContext::init(Program *prog,
 #endif
       return surface;
     };
+
+  // Create a Vulkan device if the original configuration is not for Vulkan or
+  // there is no active current program (usage from external library for AOT
+  // modules for example).
+  if (config.ti_arch != Arch::vulkan || prog == nullptr) {
+    taichi::lang::vulkan::VulkanDeviceCreator::Params evd_params{};
+    evd_params.additional_instance_extensions =
+        get_required_instance_extensions();
+    evd_params.additional_device_extensions = get_required_device_extensions();
+    evd_params.is_for_ui = config.show_window;
+    evd_params.surface_creator = make_vk_surface;
     embedded_vulkan_device_ =
         std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
+    native_surface_ = embedded_vulkan_device_->get_surface();
   } else {
     vulkan_device_ = static_cast<taichi::lang::vulkan::VulkanDevice *>(
         prog->get_graphics_device());
+    native_surface_ = make_vk_surface(vulkan_device_->vk_instance());
   }
 }
 

--- a/taichi/ui/backends/vulkan/app_context.cpp
+++ b/taichi/ui/backends/vulkan/app_context.cpp
@@ -104,11 +104,15 @@ void AppContext::init(Program *prog,
     evd_params.surface_creator = make_vk_surface;
     embedded_vulkan_device_ =
         std::make_unique<taichi::lang::vulkan::VulkanDeviceCreator>(evd_params);
-    native_surface_ = embedded_vulkan_device_->get_surface();
+    if (config.show_window) {
+      native_surface_ = embedded_vulkan_device_->get_surface();
+    }
   } else {
     vulkan_device_ = static_cast<taichi::lang::vulkan::VulkanDevice *>(
         prog->get_graphics_device());
-    native_surface_ = make_vk_surface(vulkan_device_->vk_instance());
+    if (config.show_window) {
+      native_surface_ = make_vk_surface(vulkan_device_->vk_instance());
+    }
   }
 }
 
@@ -127,7 +131,7 @@ const taichi::lang::vulkan::VulkanDevice &AppContext::device() const {
 }
 
 AppContext::~AppContext() {
-  if (!embedded_vulkan_device_) {
+  if (!embedded_vulkan_device_ && native_surface_ != VK_NULL_HANDLE) {
     // If `embedded_vulkan_device_` then surface is provided by device creator
     // Otherwise we need to manage it
     vkDestroySurfaceKHR(vulkan_device_->vk_instance(), native_surface_,

--- a/taichi/ui/backends/vulkan/app_context.h
+++ b/taichi/ui/backends/vulkan/app_context.h
@@ -68,9 +68,15 @@ class TI_DLL_EXPORT AppContext {
   // - This function will cache the pipeline for future use
   taichi::lang::Pipeline *get_compute_pipeline(const std::string &shader_path);
 
+  VkSurfaceKHR get_native_surface() const {
+    return native_surface_;
+  }
+
  private:
   std::unique_ptr<taichi::lang::vulkan::VulkanDeviceCreator>
       embedded_vulkan_device_{nullptr};
+
+  VkSurfaceKHR native_surface_{VK_NULL_HANDLE};
 
   // not owned
   taichi::lang::vulkan::VulkanDevice *vulkan_device_{nullptr};

--- a/taichi/ui/backends/vulkan/app_context.h
+++ b/taichi/ui/backends/vulkan/app_context.h
@@ -78,10 +78,10 @@ class TI_DLL_EXPORT AppContext {
 
   VkSurfaceKHR native_surface_{VK_NULL_HANDLE};
 
+  std::unordered_map<std::string, taichi::lang::UPipeline> pipelines_;
+
   // not owned
   taichi::lang::vulkan::VulkanDevice *vulkan_device_{nullptr};
-
-  std::unordered_map<std::string, taichi::lang::UPipeline> pipelines_;
 
   TaichiWindow *taichi_window_{nullptr};
 

--- a/taichi/ui/backends/vulkan/swap_chain.cpp
+++ b/taichi/ui/backends/vulkan/swap_chain.cpp
@@ -14,7 +14,7 @@ void SwapChain::init(class AppContext *app_context) {
   app_context_ = app_context;
   SurfaceConfig config;
   config.vsync = app_context_->config.vsync;
-  config.window_handle = app_context_->taichi_window();
+  config.native_surface_handle = app_context_->get_native_surface();
   config.width = app_context_->config.width;
   config.height = app_context_->config.height;
   surface_ = app_context_->device().create_surface(config);

--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -75,10 +75,6 @@ inline GLFWwindow *create_glfw_window_(const std::string &name,
     exit(EXIT_FAILURE);
   }
 
-  if (glfwVulkanSupported() != GLFW_TRUE) {
-    printf("GLFW reports no Vulkan support\n");
-  }
-
   // Reset the window hints to default
   glfwDefaultWindowHints();
 

--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -66,7 +66,6 @@ inline GLFWwindow *create_glfw_window_(const std::string &name,
 
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-  glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
 
   window = glfwCreateWindow(screenWidth, screenHeight, name.c_str(), nullptr,
                             nullptr);

--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -66,6 +66,7 @@ inline GLFWwindow *create_glfw_window_(const std::string &name,
 
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
   glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+  glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
 
   window = glfwCreateWindow(screenWidth, screenHeight, name.c_str(), nullptr,
                             nullptr);


### PR DESCRIPTION
Issue: #

### Brief Summary

This moves native surface handle construction explicitly out of the Vulkan RHI and is now managed by the user (i.e. GGUI, or example application).
