### PR TITLE
[aot] Remove support for depth24stencil8 format on Metal

### DIFF
--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -602,7 +602,7 @@ MTLPixelFormat format2mtl(BufferFormat format) {
       {BufferFormat::rgb32f, MTLPixelFormatInvalid},
       {BufferFormat::rgba32f, MTLPixelFormatRGBA32Float},
       {BufferFormat::depth16, MTLPixelFormatDepth16Unorm},
-      {BufferFormat::depth24stencil8, MTLPixelFormatDepth24Unorm_Stencil8},
+      {BufferFormat::depth24stencil8, MTLPixelFormatInvalid},
       {BufferFormat::depth32f, MTLPixelFormatDepth32Float},
   };
   auto it = map.find(format);


### PR DESCRIPTION
Issue: #

### Brief Summary

It's not supported by iOS and it even doesn't compile.
