### PR TITLE
[bug] Add DeviceCapabilityConfig to offline cache key

### DIFF
--- a/taichi/analysis/offline_cache_util.h
+++ b/taichi/analysis/offline_cache_util.h
@@ -7,6 +7,7 @@
 namespace taichi::lang {
 
 struct CompileConfig;
+struct DeviceCapabilityConfig;
 class Program;
 class IRNode;
 class SNode;
@@ -14,6 +15,7 @@ class Kernel;
 
 std::string get_hashed_offline_cache_key_of_snode(const SNode *snode);
 std::string get_hashed_offline_cache_key(const CompileConfig &config,
+                                         const DeviceCapabilityConfig &caps,
                                          Kernel *kernel);
 void gen_offline_cache_key(IRNode *ast, std::ostream *os);
 

--- a/taichi/cache/gfx/cache_manager.cpp
+++ b/taichi/cache/gfx/cache_manager.cpp
@@ -168,7 +168,8 @@ CompiledKernelData CacheManager::load_or_compile(const CompileConfig &config,
                             runtime_->get_ti_device()->get_caps(),
                             compiled_structs_, config);
   }
-  std::string kernel_key = make_kernel_key(config, kernel);
+  std::string kernel_key =
+      make_kernel_key(config, runtime_->get_ti_device()->get_caps(), kernel);
   if (mode_ > NotCache) {
     if (auto opt = this->try_load_cached_kernel(kernel, kernel_key)) {
       return *opt;
@@ -295,13 +296,14 @@ CompiledKernelData CacheManager::compile_and_cache_kernel(
 }
 
 std::string CacheManager::make_kernel_key(const CompileConfig &config,
+                                          const DeviceCapabilityConfig &caps,
                                           Kernel *kernel) const {
   if (mode_ < MemAndDiskCache) {
     return kernel->get_name();
   }
   auto key = kernel->get_cached_kernel_key();
   if (key.empty()) {
-    key = get_hashed_offline_cache_key(config, kernel);
+    key = get_hashed_offline_cache_key(config, caps, kernel);
     kernel->set_kernel_key_for_cache(key);
   }
   return key;

--- a/taichi/cache/gfx/cache_manager.h
+++ b/taichi/cache/gfx/cache_manager.h
@@ -51,6 +51,7 @@ class CacheManager {
   CompiledKernelData compile_and_cache_kernel(const std::string &key,
                                               Kernel *kernel);
   std::string make_kernel_key(const CompileConfig &config,
+                              const DeviceCapabilityConfig &caps,
                               Kernel *kernel) const;
 
   Mode mode_{MemCache};

--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -98,7 +98,7 @@ void KernelCodeGen::cache_kernel(const std::string &kernel_key,
 
 LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   std::string kernel_key =
-      get_hashed_offline_cache_key(compile_config_, kernel);
+      get_hashed_offline_cache_key(compile_config_, {}, kernel);
   kernel->set_kernel_key_for_cache(kernel_key);
   if (compile_config_.offline_cache && this->supports_offline_cache() &&
       !kernel->is_evaluator) {

--- a/taichi/codegen/dx12/codegen_dx12.cpp
+++ b/taichi/codegen/dx12/codegen_dx12.cpp
@@ -230,7 +230,7 @@ static std::vector<uint8_t> generate_dxil_from_llvm(
 KernelCodeGenDX12::CompileResult KernelCodeGenDX12::compile() {
   TI_AUTO_PROF;
   const auto &config = get_compile_config();
-  std::string kernel_key = get_hashed_offline_cache_key(config, kernel);
+  std::string kernel_key = get_hashed_offline_cache_key(config, {}, kernel);
   kernel->set_kernel_key_for_cache(kernel_key);
 
   irpass::ast_to_ir(config, *kernel, false);


### PR DESCRIPTION
Issue: fixes #7381 

### Repro on my PC:
| `TI_VISIBLE_DEVICE` (on my PC) | `spirv_has_atomic_float_add` |
| --- | --- |
| 0 | **Y** |
| 1 | **N** |

Example program:
```Python
# t.py
import taichi as ti

ti.init(arch=ti.vulkan)

@ti.kernel
def f1() -> ti.f32:
  a = 0.0
  for i in range(1024):
    a += i / ti.f32(100.0)
  return a

print(f1())
```
On [master](https://github.com/taichi-dev/taichi/commit/4af54d49b38a40e1035ca36227ddaf342b0b15c0):
<img src="https://user-images.githubusercontent.com/52557189/219542797-add50208-6b47-4892-9ea0-1c91f4e73e43.png" width="350px">

On [this branch](https://github.com/PGZXB/taichi/tree/dev-add-dev-caps-to-offline-cache-key):
<img src="https://user-images.githubusercontent.com/52557189/219541578-0aacdd72-c871-4e20-b3dc-b815e7250e12.png" width="350px">