### PR TITLE
[amdgpu] Enable llvm FpOpFusion option on AMDGPU backend

### DIFF
--- a/taichi/runtime/amdgpu/jit_amdgpu.cpp
+++ b/taichi/runtime/amdgpu/jit_amdgpu.cpp
@@ -1,10 +1,10 @@
 #include "taichi/runtime/amdgpu/jit_amdgpu.h"
 #include "taichi/runtime/llvm/llvm_context.h"
 #include "taichi/runtime/llvm/llvm_context_pass.h"
+#include "llvm/CodeGen/CommandFlags.h"
 
 namespace taichi {
 namespace lang {
-
 #if defined(TI_WITH_AMDGPU)
 JITModule *JITSessionAMDGPU ::add_module(std::unique_ptr<llvm::Module> M,
                                          int max_reg) {
@@ -44,7 +44,24 @@ std::string JITSessionAMDGPU::compile_module_to_hsaco(
   auto triple_str = llvm_module->getTargetTriple();
   std::string error_str;
   auto target = llvm::TargetRegistry::lookupTarget(triple_str, error_str);
+
   llvm::TargetOptions options;
+  options.MCOptions.AsmVerbose = false;
+  if (this->config_.fast_math) {
+    options.AllowFPOpFusion = FPOpFusion::Fast;
+    options.UnsafeFPMath = 1;
+    options.NoInfsFPMath = 1;
+    options.NoNaNsFPMath = 1;
+  } else {
+    options.AllowFPOpFusion = FPOpFusion::Strict;
+    options.UnsafeFPMath = 0;
+    options.NoInfsFPMath = 0;
+    options.NoNaNsFPMath = 0;
+  }
+  options.HonorSignDependentRoundingFPMathOption = 0;
+  options.NoZerosInBSS = 0;
+  options.GuaranteedTailCallOpt = 0;
+
   std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(
       triple_str, AMDGPUContext::get_instance().get_mcpu(), "", options,
       llvm::Reloc::PIC_, llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive));

--- a/taichi/runtime/amdgpu/jit_amdgpu.cpp
+++ b/taichi/runtime/amdgpu/jit_amdgpu.cpp
@@ -1,7 +1,6 @@
 #include "taichi/runtime/amdgpu/jit_amdgpu.h"
 #include "taichi/runtime/llvm/llvm_context.h"
 #include "taichi/runtime/llvm/llvm_context_pass.h"
-#include "llvm/CodeGen/CommandFlags.h"
 
 namespace taichi {
 namespace lang {


### PR DESCRIPTION
### Brief Summary
1. Enable the FpOpFusion option. If not, it will cut `saxpy` performance in half

- a. Turn off

  performance:
  <img width="634" alt="image" src="https://user-images.githubusercontent.com/47965866/219954146-1e54a0e7-ffa7-441e-ad09-20aeba0f7954.png">

- b. Turn on

  performance:
  <img width="604" alt="image" src="https://user-images.githubusercontent.com/47965866/219954180-0730fc4a-7711-4f26-b752-ef441fc87aab.png">
2. Disable AsmVerbose in machine option. Thus we will get pure LLVM-IR after module and function passes. Or there will be some instructions for target in the module.



