### PR TITLE
[aot] Properly handle texture attributes

### DIFF
--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -1,12 +1,13 @@
 from taichi.lang._ndarray import ScalarNdarray
 from taichi.lang._texture import Texture
+from taichi.lang.enums import Format
 from taichi.lang.exception import TaichiCompilationError
 from taichi.lang.matrix import (Matrix, MatrixNdarray, MatrixType,
                                 VectorNdarray, VectorType)
 from taichi.lang.util import cook_dtype
 from taichi.types.annotations import template
 from taichi.types.ndarray_type import NdarrayType
-from taichi.types.texture_type import TY_CH2FORMAT, RWTextureType, TextureType
+from taichi.types.texture_type import RWTextureType, TextureType
 
 template_types = (NdarrayType, TextureType, template)
 
@@ -97,14 +98,8 @@ def produce_injected_args(kernel, symbolic_args=None):
             fmt = anno.fmt
             injected_args.append(Texture(fmt, texture_shape))
         elif isinstance(anno, TextureType):
-            if symbolic_args is None:
-                raise RuntimeError(
-                    'Texture type annotation doesn\'t have enough information for aot. Please either specify the channel_format, shape and num_channels in the graph arg declaration.'
-                )
-            texture_shape = tuple(symbolic_args[i].texture_shape)
-            fmt = TY_CH2FORMAT[(symbolic_args[i].channel_format(),
-                                symbolic_args[i].num_channels)]
-            injected_args.append(Texture(fmt, texture_shape))
+            texture_shape = (2, ) * anno.num_dimensions
+            injected_args.append(Texture(Format.rgba8, texture_shape))
         elif isinstance(anno, MatrixType):
             if not isinstance(symbolic_args[i], list):
                 raise RuntimeError('Expected a symbolic arg with Matrix type.')

--- a/python/taichi/lang/_texture.py
+++ b/python/taichi/lang/_texture.py
@@ -5,8 +5,7 @@ from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.matrix import Matrix
 from taichi.lang.util import taichi_scope
 from taichi.types import vector
-from taichi.types.primitive_types import f32, u8
-from taichi.types.texture_type import FORMAT2TY_CH
+from taichi.types.primitive_types import f32
 
 
 def _get_entries(mat):
@@ -130,12 +129,8 @@ class Texture:
         shape (Tuple[int]): Shape of the Texture.
     """
     def __init__(self, fmt, arr_shape):
-        dtype, num_channels = FORMAT2TY_CH[fmt]
-        self.tex = impl.get_runtime().prog.create_texture(
-            dtype, num_channels, arr_shape)
+        self.tex = impl.get_runtime().prog.create_texture(fmt, arr_shape)
         self.fmt = fmt
-        self.dtype = dtype
-        self.num_channels = num_channels
         self.num_dims = len(arr_shape)
         self.shape = arr_shape
 
@@ -172,8 +167,6 @@ class Texture:
         assert image.size == tuple(self.shape)
 
         assert self.num_dims == 2
-        assert self.dtype == u8
-        assert self.num_channels == 4
         # Don't use transpose method since its enums are too new
         image = image.rotate(90, expand=True)
         arr = np.asarray(image)
@@ -188,8 +181,6 @@ class Texture:
             img (PIL.Image.Image): a PIL image in RGB mode, with the same size as source texture.
         """
         assert self.num_dims == 2
-        assert self.dtype == u8
-        assert self.num_channels == 4
         from PIL import Image  # pylint: disable=import-outside-toplevel
         res = np.zeros(self.shape + (3, ), np.uint8)
         from taichi._kernels import \

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -608,7 +608,7 @@ class ASTTransformer(Builder):
                         arg.arg,
                         kernel_arguments.decl_rw_texture_arg(
                             ctx.arg_features[i][0], ctx.arg_features[i][1],
-                            ctx.arg_features[i][2], ctx.arg_features[i][3]))
+                            ctx.arg_features[i][2]))
                 elif isinstance(ctx.func.arguments[i].annotation, MatrixType):
                     ctx.create_variable(
                         arg.arg,

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -10,7 +10,7 @@ from taichi.lang.expr import Expr
 from taichi.lang.matrix import MatrixType, VectorType, make_matrix
 from taichi.lang.struct import StructType
 from taichi.lang.util import cook_dtype
-from taichi.types.primitive_types import RefType, f32, u64
+from taichi.types.primitive_types import RefType, u64
 
 
 class KernelArgument:
@@ -91,17 +91,19 @@ def decl_ndarray_arg(dtype, dim, element_shape, layout):
 
 def decl_texture_arg(num_dimensions):
     # FIXME: texture_arg doesn't have element_shape so better separate them
-    arg_id = impl.get_runtime().compiling_callable.insert_texture_param(f32)
+    arg_id = impl.get_runtime().compiling_callable.insert_texture_param(
+        num_dimensions)
     return TextureSampler(
         _ti_core.make_texture_ptr_expr(arg_id, num_dimensions), num_dimensions)
 
 
-def decl_rw_texture_arg(num_dimensions, num_channels, channel_format, lod):
+def decl_rw_texture_arg(num_dimensions, buffer_format, lod):
     # FIXME: texture_arg doesn't have element_shape so better separate them
-    arg_id = impl.get_runtime().compiling_callable.insert_texture_param(f32)
+    arg_id = impl.get_runtime().compiling_callable.insert_rw_texture_param(
+        num_dimensions, buffer_format)
     return RWTextureAccessor(
-        _ti_core.make_rw_texture_ptr_expr(arg_id, num_dimensions, num_channels,
-                                          channel_format, lod), num_dimensions)
+        _ti_core.make_rw_texture_ptr_expr(arg_id, num_dimensions,
+                                          buffer_format, lod), num_dimensions)
 
 
 def decl_ret(dtype, real_func=False):

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -387,11 +387,11 @@ class TaichiCallableTemplateMapper:
             # [Primitive arguments] Return the value
             return arg
         if isinstance(anno, texture_type.TextureType):
-            return arg.num_dims, arg.dtype
+            return (arg.num_dims, )
         if isinstance(anno, texture_type.RWTextureType):
             # (penguinliong) '0' is the assumed LOD level. We currently don't
             # support mip-mapping.
-            return arg.num_dims, arg.num_channels, arg.dtype, 0
+            return arg.num_dims, arg.fmt, 0
         if isinstance(anno, ndarray_type.NdarrayType):
             if isinstance(arg, taichi.lang._ndarray.ScalarNdarray):
                 anno.check_matched(arg.get_type())

--- a/python/taichi/types/texture_type.py
+++ b/python/taichi/types/texture_type.py
@@ -69,7 +69,6 @@ class RWTextureType:
         if fmt is None:
             raise TaichiCompilationError("fmt is required for rw_texture type")
         else:
-            self.channel_format, self.num_channels = FORMAT2TY_CH[fmt]
             self.fmt = fmt
         self.lod = lod
 

--- a/taichi/analysis/gen_offline_cache_key.cpp
+++ b/taichi/analysis/gen_offline_cache_key.cpp
@@ -89,8 +89,11 @@ class ASTSerializer : public IRVisitor, public ExpressionVisitor {
     emit(expr->arg_id);
     emit(expr->num_dims);
     emit(expr->is_storage);
-    emit(expr->num_channels);
-    emit(expr->channel_format);
+    // FIXME (penguinliong): ?? What happens here?
+    auto [channel_format, num_channels] =
+        buffer_format2type_channels(expr->format);
+    emit((int)num_channels);
+    emit(channel_format);
     emit(expr->lod);
   }
 

--- a/taichi/aot/module_data.h
+++ b/taichi/aot/module_data.h
@@ -89,12 +89,14 @@ struct ArrayArg {
   std::size_t shape_offset_in_args_buf{0};
   // For Vulkan/OpenGL/Metal, this is the binding index
   int bind_index{0};
+  BufferFormat format{BufferFormat::unknown};
 
   TI_IO_DEF(dtype_name,
             field_dim,
             element_shape,
             shape_offset_in_args_buf,
-            bind_index);
+            bind_index,
+            format);
 };
 
 struct CompiledTaichiKernel {

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -68,6 +68,7 @@ KernelContextAttributes::KernelContextAttributes(
     }
     aa.stride = dt_bytes;
     aa.index = arg_attribs_vec_.size();
+    aa.format = ka.format;
     arg_attribs_vec_.push_back(aa);
   }
   for (const auto &kr : kernel.rets) {

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -155,6 +155,9 @@ class KernelContextAttributes {
     bool is_array{false};
     std::vector<int> element_shape;
     std::size_t field_dim{0};
+    // Only used with textures. Sampled textures always have unknown format;
+    // while RW textures always have a valid format.
+    BufferFormat format{BufferFormat::unknown};
 
     TI_IO_DEF(stride,
               offset_in_mem,
@@ -162,7 +165,8 @@ class KernelContextAttributes {
               dtype,
               is_array,
               element_shape,
-              field_dim);
+              field_dim,
+              format);
   };
 
  public:

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1123,45 +1123,7 @@ class TaskCodegen : public IRVisitor {
       val = argid_to_tex_value_.at(arg_id);
     } else {
       if (stmt->is_storage) {
-        BufferFormat format = BufferFormat::unknown;
-
-        if (stmt->num_channels == 1) {
-          if (stmt->channel_format == PrimitiveType::u8 ||
-              stmt->channel_format == PrimitiveType::i8) {
-            format = BufferFormat::r8;
-          } else if (stmt->channel_format == PrimitiveType::u16 ||
-                     stmt->channel_format == PrimitiveType::i16) {
-            format = BufferFormat::r16;
-          } else if (stmt->channel_format == PrimitiveType::f16) {
-            format = BufferFormat::r16f;
-          } else if (stmt->channel_format == PrimitiveType::f32) {
-            format = BufferFormat::r32f;
-          }
-        } else if (stmt->num_channels == 2) {
-          if (stmt->channel_format == PrimitiveType::u8 ||
-              stmt->channel_format == PrimitiveType::i8) {
-            format = BufferFormat::rg8;
-          } else if (stmt->channel_format == PrimitiveType::u16 ||
-                     stmt->channel_format == PrimitiveType::i16) {
-            format = BufferFormat::rg16;
-          } else if (stmt->channel_format == PrimitiveType::f16) {
-            format = BufferFormat::rg16f;
-          } else if (stmt->channel_format == PrimitiveType::f32) {
-            format = BufferFormat::rg32f;
-          }
-        } else if (stmt->num_channels == 4) {
-          if (stmt->channel_format == PrimitiveType::u8 ||
-              stmt->channel_format == PrimitiveType::i8) {
-            format = BufferFormat::rgba8;
-          } else if (stmt->channel_format == PrimitiveType::u16 ||
-                     stmt->channel_format == PrimitiveType::i16) {
-            format = BufferFormat::rgba16;
-          } else if (stmt->channel_format == PrimitiveType::f16) {
-            format = BufferFormat::rgba16f;
-          } else if (stmt->channel_format == PrimitiveType::f32) {
-            format = BufferFormat::rgba32f;
-          }
-        }
+        BufferFormat format = stmt->format;
 
         int binding = binding_head_++;
         val =

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -155,8 +155,8 @@ void TexturePtrExpression::type_check(const CompileConfig *config) {
 
 void TexturePtrExpression::flatten(FlattenContext *ctx) {
   ctx->push_back<ArgLoadStmt>(arg_id, PrimitiveType::f32, true);
-  ctx->push_back<TexturePtrStmt>(ctx->back_stmt(), num_dims, is_storage,
-                                 num_channels, channel_format, lod);
+  ctx->push_back<TexturePtrStmt>(ctx->back_stmt(), num_dims, is_storage, format,
+                                 lod);
   stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -342,24 +342,18 @@ class TexturePtrExpression : public Expression {
   bool is_storage{false};
 
   // Optional, for storage textures
-  int num_channels{0};
-  DataType channel_format{PrimitiveType::f32};
+  BufferFormat format{BufferFormat::unknown};
   int lod{0};
 
   explicit TexturePtrExpression(int arg_id, int num_dims)
       : arg_id(arg_id), num_dims(num_dims) {
   }
 
-  TexturePtrExpression(int arg_id,
-                       int num_dims,
-                       int num_channels,
-                       DataType channel_format,
-                       int lod)
+  TexturePtrExpression(int arg_id, int num_dims, BufferFormat format, int lod)
       : arg_id(arg_id),
         num_dims(num_dims),
         is_storage(true),
-        num_channels(num_channels),
-        channel_format(channel_format),
+        format(format),
         lod(lod) {
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -4,6 +4,7 @@
 #include "taichi/ir/offloaded_task_type.h"
 #include "taichi/ir/stmt_op_types.h"
 #include "taichi/rhi/arch.h"
+#include "taichi/rhi/device.h"
 #include "taichi/ir/mesh.h"
 
 #include <optional>
@@ -1591,21 +1592,18 @@ class TexturePtrStmt : public Stmt {
   bool is_storage{false};
 
   // Optional, for storage textures
-  int num_channels{0};
-  DataType channel_format{PrimitiveType::f32};
+  BufferFormat format{0};
   int lod{0};
 
   explicit TexturePtrStmt(Stmt *stmt,
                           int dimensions,
                           bool is_storage,
-                          int num_channels,
-                          DataType channel_format,
+                          BufferFormat format,
                           int lod)
       : arg_load_stmt(stmt),
         dimensions(dimensions),
         is_storage(is_storage),
-        num_channels(num_channels),
-        channel_format(channel_format),
+        format(format),
         lod(lod) {
     TI_STMT_REG_FIELDS;
   }
@@ -1615,12 +1613,7 @@ class TexturePtrStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  TI_STMT_DEF_FIELDS(arg_load_stmt,
-                     dimensions,
-                     is_storage,
-                     num_channels,
-                     channel_format,
-                     lod);
+  TI_STMT_DEF_FIELDS(arg_load_stmt, dimensions, is_storage, format, lod);
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 

--- a/taichi/program/callable.cpp
+++ b/taichi/program/callable.cpp
@@ -1,4 +1,5 @@
 #include "taichi/program/callable.h"
+#include "taichi/ir/type.h"
 #include "taichi/program/program.h"
 
 namespace taichi::lang {
@@ -25,9 +26,17 @@ int Callable::insert_arr_param(const DataType &dt,
   return (int)parameter_list.size() - 1;
 }
 
-int Callable::insert_texture_param(const DataType &dt) {
+int Callable::insert_texture_param(int total_dim) {
   // FIXME: we shouldn't abuse is_array for texture parameters
-  parameter_list.emplace_back(dt->get_compute_type(), /*is_array=*/true);
+  parameter_list.emplace_back(PrimitiveType::f32, /*is_array=*/true, 0,
+                              total_dim, std::vector<int>{});
+  return (int)parameter_list.size() - 1;
+}
+
+int Callable::insert_rw_texture_param(int total_dim, BufferFormat format) {
+  // FIXME: we shouldn't abuse is_array for texture parameters
+  parameter_list.emplace_back(PrimitiveType::f32, /*is_array=*/true, 0,
+                              total_dim, std::vector<int>{}, format);
   return (int)parameter_list.size() - 1;
 }
 

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "taichi/rhi/device.h"
 #include "taichi/util/lang_util.h"
 
 namespace taichi::lang {
@@ -18,6 +19,7 @@ class TI_DLL_EXPORT Callable {
     bool is_array{
         false};  // This is true for both ndarray and external array args.
     std::size_t total_dim{0};  // total dim of array
+    BufferFormat format{BufferFormat::unknown};
 
     /* [arguments with TensorType]
 
@@ -36,7 +38,8 @@ class TI_DLL_EXPORT Callable {
                        bool is_array = false,
                        std::size_t size_unused = 0,
                        int total_dim = 0,
-                       std::vector<int> element_shape = {}) {
+                       std::vector<int> element_shape = {},
+                       BufferFormat format = BufferFormat::unknown) {
       if (dt->is<PrimitiveType>() && element_shape.size() > 0) {
         this->dt_ =
             taichi::lang::TypeFactory::get_instance().create_tensor_type(
@@ -47,6 +50,7 @@ class TI_DLL_EXPORT Callable {
 
       this->is_array = is_array;
       this->total_dim = total_dim;
+      this->format = format;
     }
 
     std::vector<int> get_element_shape() const {
@@ -89,7 +93,8 @@ class TI_DLL_EXPORT Callable {
   int insert_arr_param(const DataType &dt,
                        int total_dim,
                        std::vector<int> element_shape);
-  int insert_texture_param(const DataType &dt);
+  int insert_texture_param(int total_dim);
+  int insert_rw_texture_param(int total_dim, BufferFormat format);
 
   int insert_ret(const DataType &dt);
 

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -388,10 +388,8 @@ void Program::delete_ndarray(Ndarray *ndarray) {
   }
 }
 
-Texture *Program::create_texture(const DataType type,
-                                 int num_channels,
+Texture *Program::create_texture(BufferFormat buffer_format,
                                  const std::vector<int> &shape) {
-  BufferFormat buffer_format = type_channels2buffer_format(type, num_channels);
   if (shape.size() == 1) {
     textures_.push_back(
         std::make_unique<Texture>(this, buffer_format, shape[0], 1, 1));

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -316,8 +316,7 @@ class TI_DLL_EXPORT Program {
 
   void delete_ndarray(Ndarray *ndarray);
 
-  Texture *create_texture(const DataType type,
-                          int num_channels,
+  Texture *create_texture(BufferFormat buffer_format,
                           const std::vector<int> &shape);
 
   intptr_t get_ndarray_data_ptr_as_int(const Ndarray *ndarray);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -430,12 +430,10 @@ void export_lang(py::module &m) {
       .def("delete_ndarray", &Program::delete_ndarray)
       .def(
           "create_texture",
-          [&](Program *program, const DataType &dt, int num_channels,
-              const std::vector<int> &shape) -> Texture * {
-            return program->create_texture(dt, num_channels, shape);
-          },
-          py::arg("dt"), py::arg("num_channels"),
-          py::arg("shape") = py::tuple(), py::return_value_policy::reference)
+          [&](Program *program, BufferFormat fmt, const std::vector<int> &shape)
+              -> Texture * { return program->create_texture(fmt, shape); },
+          py::arg("fmt"), py::arg("shape") = py::tuple(),
+          py::return_value_policy::reference)
       .def("get_ndarray_data_ptr_as_int",
            [](Program *program, Ndarray *ndarray) {
              return program->get_ndarray_data_ptr_as_int(ndarray);
@@ -686,6 +684,7 @@ void export_lang(py::module &m) {
       .def("insert_scalar_param", &Kernel::insert_scalar_param)
       .def("insert_arr_param", &Kernel::insert_arr_param)
       .def("insert_texture_param", &Kernel::insert_texture_param)
+      .def("insert_rw_texture_param", &Kernel::insert_rw_texture_param)
       .def("insert_ret", &Kernel::insert_ret)
       .def("finalize_rets", &Kernel::finalize_rets)
       .def("get_ret_int", &Kernel::get_ret_int)
@@ -729,6 +728,7 @@ void export_lang(py::module &m) {
       .def("insert_scalar_param", &Function::insert_scalar_param)
       .def("insert_arr_param", &Function::insert_arr_param)
       .def("insert_texture_param", &Function::insert_texture_param)
+      .def("insert_rw_texture_param", &Function::insert_rw_texture_param)
       .def("insert_ret", &Function::insert_ret)
       .def("set_function_body",
            py::overload_cast<const std::function<void()> &>(
@@ -948,7 +948,7 @@ void export_lang(py::module &m) {
 
   m.def("make_texture_ptr_expr", Expr::make<TexturePtrExpression, int, int>);
   m.def("make_rw_texture_ptr_expr",
-        Expr::make<TexturePtrExpression, int, int, int, const DataType &, int>);
+        Expr::make<TexturePtrExpression, int, int, const BufferFormat &, int>);
 
   auto &&texture =
       py::enum_<TextureOpType>(m, "TextureOpType", py::arithmetic());

--- a/taichi/runtime/gfx/aot_module_builder_impl.cpp
+++ b/taichi/runtime/gfx/aot_module_builder_impl.cpp
@@ -55,6 +55,7 @@ class AotDataConverter {
         arr_arg.dtype_name = PrimitiveType::get(arg.dtype).to_string();
         arr_arg.field_dim = arg.field_dim;
         arr_arg.element_shape = arg.element_shape;
+        arr_arg.format = arg.format;
         arr_arg.shape_offset_in_args_buf = arg.index * sizeof(int32_t);
         res.arr_args[arg.index] = arr_arg;
       }

--- a/tests/python/test_texture.py
+++ b/tests/python/test_texture.py
@@ -103,8 +103,10 @@ def test_texture_compiled_functions():
     paint(0.2, texture2, n2)
     assert impl.get_runtime().get_num_compiled_functions() == 3
 
+    # (penguinliong) Remember that non-RW textures don't enforce a format so
+    # it's the same as the first call to `paint`.
     paint(0.3, texture3, n1)
-    assert impl.get_runtime().get_num_compiled_functions() == 4
+    assert impl.get_runtime().get_num_compiled_functions() == 3
 
 
 @test_utils.test(arch=supported_archs_texture_excluding_load_store)


### PR DESCRIPTION
Issue: #

### Brief Summary

Provide enough information to double check user arguments at runtime. Also to remove the chain of `format -> (dtype, num_channels) -> format` conversion.
