### PR TITLE
[lang] Add is_lvalue() to Expr to check writeback_binary operand

### DIFF
--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -141,7 +141,8 @@ def writeback_binary(foo):
                 f'cannot augassign taichi class {type(b)} to scalar expr')
         if not (is_taichi_expr(a) and a.ptr.is_lvalue()):
             raise TaichiSyntaxError(
-                f'cannot use a non-writable target as the first operand of \'{foo.__name__}\'')
+                f'cannot use a non-writable target as the first operand of \'{foo.__name__}\''
+            )
         else:
             return imp_foo(a, b)
 

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -1330,7 +1330,6 @@ def atomic_min(x, y):
         >>>
         >>>     ti.atomic_min(1, x)  # will raise TaichiSyntaxError
     """
-
     return impl.expr_init(
         expr.Expr(_ti_core.expr_atomic_min(x.ptr, y.ptr), tb=stack_info()))
 

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -139,6 +139,9 @@ def writeback_binary(foo):
         if is_taichi_class(b):
             raise TaichiSyntaxError(
                 f'cannot augassign taichi class {type(b)} to scalar expr')
+        if not (is_taichi_expr(a) and a.ptr.is_lvalue()):
+            raise TaichiSyntaxError(
+                f'cannot use a non-writable target as the first operand of \'{foo.__name__}\'')
         else:
             return imp_foo(a, b)
 
@@ -1326,6 +1329,7 @@ def atomic_min(x, y):
         >>>
         >>>     ti.atomic_min(1, x)  # will raise TaichiSyntaxError
     """
+
     return impl.expr_init(
         expr.Expr(_ti_core.expr_atomic_min(x.ptr, y.ptr), tb=stack_info()))
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -935,9 +935,7 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
 }
 
 void AtomicOpExpression::flatten(FlattenContext *ctx) {
-  TI_ASSERT(
-      dest.is<IdExpression>() || dest.is<IndexExpression>() ||
-      (dest.is<ArgLoadExpression>() && dest.cast<ArgLoadExpression>()->is_ptr));
+  TI_ASSERT(dest.expr->is_lvalue());
   // replace atomic sub with negative atomic add
   if (op_type == AtomicOpType::sub) {
     if (val->ret_type != ret_type) {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -752,12 +752,7 @@ void export_lang(py::module &m) {
              return expr->cast<FieldExpression>()->snode_grad_type ==
                     SNodeGradType::kPrimal;
            })
-      .def("is_lvalue",
-           [](Expr *expr) {
-             return expr->is<IdExpression>() || expr->is<IndexExpression>() ||
-                    (expr->is<ArgLoadExpression>() &&
-                     expr->cast<ArgLoadExpression>()->is_lvalue());
-           })
+      .def("is_lvalue", [](Expr *expr) { return expr->expr->is_lvalue(); })
       .def("set_tb", &Expr::set_tb)
       .def("set_name",
            [&](Expr *expr, std::string na) {

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -752,6 +752,12 @@ void export_lang(py::module &m) {
              return expr->cast<FieldExpression>()->snode_grad_type ==
                     SNodeGradType::kPrimal;
            })
+      .def("is_lvalue",
+           [](Expr *expr) {
+             return expr->is<IdExpression>() || expr->is<IndexExpression>() ||
+                    (expr->is<ArgLoadExpression>() &&
+                     expr->cast<ArgLoadExpression>()->is_lvalue());
+           })
       .def("set_tb", &Expr::set_tb)
       .def("set_name",
            [&](Expr *expr, std::string na) {

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -1,4 +1,5 @@
 import pytest
+
 import taichi as ti
 from tests import test_utils
 

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -1,3 +1,4 @@
+import pytest
 import taichi as ti
 from tests import test_utils
 
@@ -376,3 +377,18 @@ def test_atomic_xor_expr_evaled():
     func()
 
     assert c[None] == 0
+
+
+@test_utils.test()
+def test_atomic_min_rvalue_as_frist_op():
+    @ti.kernel
+    def func():
+        y = ti.Vector([1, 2, 3])
+        z = ti.atomic_min([3, 2, 1], y)
+
+    with pytest.raises(ti.TaichiSyntaxError) as e:
+        func()
+
+    assert 'atomic_min' in str(e.value)
+    assert 'cannot use a non-writable target as the first operand of' in str(
+        e.value)


### PR DESCRIPTION
Issue: #4455

### Brief Summary
Currently, the following error message appears when the user uses the constant int as the first operand of the `atomic_*()` series of functions: `AttributeError: 'int' object has no attribute 'ptr'`. To make matters worse, taichi gives an internal assertion failure when the user uses some right value expression, e.g., `-x`. 

This PR adds a helper function exposed in the Expr python class called `is_lvalue()`, which the python AST parser can use to check the validity of operands and throw an error message when a rvalue is used as a write target.