### PR TITLE
[aot] Remove duplicate submodules in AOT demos

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -5,8 +5,8 @@ export TI_SKIP_VERSION_CHECK=ON
 export TI_CI=1
 
 # IF YOU PIN THIS TO A COMMIT/BRANCH, YOU'RE RESPONSIBLE TO REVERT IT BACK TO MASTER ONCE MERGED.
-export TAICHI_AOT_DEMO_URL=https://github.com/taichi-dev/taichi-aot-demo
-export TAICHI_AOT_DEMO_BRANCH=master
+export TAICHI_AOT_DEMO_URL=https://github.com/PENGUINLIONG/taichi-aot-demo
+export TAICHI_AOT_DEMO_BRANCH=rm-deps
 
 export TAICHI_UNITY2_URL=https://github.com/taichi-dev/taichi-unity2
 export TAICHI_UNITY2_BRANCH=main


### PR DESCRIPTION
See https://github.com/taichi-dev/taichi-aot-demo/pull/117.

Removed duplicate submodules in AOT demos. This should save some CI time.
