### PR TITLE
[Lang] Fix pylance types warning

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -6,7 +6,7 @@ from taichi._lib.utils import warn_restricted_version
 from taichi._logging import *
 from taichi._snode import *
 from taichi.lang import *  # pylint: disable=W0622 # TODO(archibate): It's `taichi.lang.core` overriding `taichi.core`
-import taichi.types as types
+from taichi import types
 from taichi.types.annotations import *
 # Provide a shortcut to types since they're commonly used.
 from taichi.types.primitive_types import *

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -1,6 +1,5 @@
 import sys
 
-import taichi.types as types
 from taichi._funcs import *
 from taichi._lib import core as _ti_core
 from taichi._lib.utils import warn_restricted_version

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -6,6 +6,7 @@ from taichi._lib.utils import warn_restricted_version
 from taichi._logging import *
 from taichi._snode import *
 from taichi.lang import *  # pylint: disable=W0622 # TODO(archibate): It's `taichi.lang.core` overriding `taichi.core`
+import taichi.types as types
 from taichi.types.annotations import *
 # Provide a shortcut to types since they're commonly used.
 from taichi.types.primitive_types import *


### PR DESCRIPTION
This PR fixes the warning message "xxx is not a known member of None" raised by Pylance, when using the syntax `ti.types.xxx`.