### PR TITLE
[bug] Fix get_error_string ret type typo

### DIFF
--- a/taichi/rhi/amdgpu/amdgpu_driver.h
+++ b/taichi/rhi/amdgpu/amdgpu_driver.h
@@ -95,9 +95,9 @@ class AMDGPUDriver : protected AMDGPUDriverBase {
 #include "taichi/rhi/amdgpu/amdgpu_driver_functions.inc.h"
 #undef PER_AMDGPU_FUNCTION
 
-  char (*get_error_name)(uint32);
+  char* (*get_error_name)(uint32);
 
-  char (*get_error_string)(uint32);
+  char* (*get_error_string)(uint32);
 
   void (*driver_get_version)(int *);
 

--- a/taichi/rhi/amdgpu/amdgpu_driver.h
+++ b/taichi/rhi/amdgpu/amdgpu_driver.h
@@ -95,9 +95,9 @@ class AMDGPUDriver : protected AMDGPUDriverBase {
 #include "taichi/rhi/amdgpu/amdgpu_driver_functions.inc.h"
 #undef PER_AMDGPU_FUNCTION
 
-  char* (*get_error_name)(uint32);
+  char *(*get_error_name)(uint32);
 
-  char* (*get_error_string)(uint32);
+  char *(*get_error_string)(uint32);
 
   void (*driver_get_version)(int *);
 


### PR DESCRIPTION
Issue: #

### Brief Summary
Typos
Previously
![image](https://user-images.githubusercontent.com/47965866/220520966-5d789494-e6e4-43e2-b127-cc32a6cf68d6.png)
Update:
![image](https://user-images.githubusercontent.com/47965866/220521005-645656a0-1362-4b41-bef0-153aa413cbb0.png)
