### PR TITLE
[misc] Remove unnecessary functions of gfx::AotModuleBuilderImpl

### DIFF
--- a/taichi/runtime/gfx/aot_module_builder_impl.h
+++ b/taichi/runtime/gfx/aot_module_builder_impl.h
@@ -23,11 +23,6 @@ class AotModuleBuilderImpl : public AotModuleBuilder {
   void dump(const std::string &output_dir,
             const std::string &filename) const override;
 
-  void mangle_aot_data();
-  void merge_with_old_meta_data(const std::string &path);
-  std::optional<GfxRuntime::RegisterParams> try_get_kernel_register_params(
-      const std::string &kernel_name) const;
-
  private:
   void add_per_backend(const std::string &identifier, Kernel *kernel) override;
 


### PR DESCRIPTION
Issue: #7002

### Brief Summary
The functions were used by old implementation of offline cache, which are unnecessary now.