### PR TITLE
[Lang] Fix pylance warnings raised by ti.static

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -1,6 +1,6 @@
 import numbers
 from types import FunctionType, MethodType
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Sequence
 
 from taichi._lib import core as _ti_core
 from taichi._snode.fields_builder import FieldsBuilder
@@ -999,7 +999,7 @@ def axes(*x: Iterable[int]):
 Axis = _ti_core.Axis
 
 
-def static(x, *xs):
+def static(x, *xs) -> Any:
     """Evaluates a Taichi-scope expression at compile time.
 
     `static()` is what enables the so-called metaprogramming in Taichi. It is


### PR DESCRIPTION
This PR fixes pylance warnings raised by `ti.static`.

![图片](https://user-images.githubusercontent.com/23307174/222057474-a2e0cdb9-1eb6-47e3-ba6d-d664dff6b0a0.png)
