### PR TITLE
[misc] Add an explicit error in cc backend codegen for dynamic indexing

### DIFF
--- a/taichi/codegen/cc/codegen_cc.cpp
+++ b/taichi/codegen/cc/codegen_cc.cpp
@@ -82,7 +82,9 @@ class CCTransformer : public IRVisitor {
   }
 
   void visit(MatrixPtrStmt *stmt) override {
-    TI_ERROR("[cc] Dynamic indexing is not supported on cc backend, please use a compile time constant for indexing");
+    TI_ERROR(
+        "[cc] Dynamic indexing is not supported on cc backend, please use a "
+        "compile time constant for indexing");
   }
 
   void visit(GetRootStmt *stmt) override {

--- a/taichi/codegen/cc/codegen_cc.cpp
+++ b/taichi/codegen/cc/codegen_cc.cpp
@@ -81,6 +81,10 @@ class CCTransformer : public IRVisitor {
     }
   }
 
+  void visit(MatrixPtrStmt *stmt) override {
+    TI_ERROR("[cc] Dynamic indexing is not supported on cc backend, please use a compile time constant for indexing");
+  }
+
   void visit(GetRootStmt *stmt) override {
     auto *root = kernel_->program->get_snode_root(SNodeTree::kFirstID);
     emit("{} = ti_ctx->root;",


### PR DESCRIPTION
Issue: #7443 

### Brief Summary
For backends that don't support dynamic indexing, we should raise an explicit error. 