### PR TITLE
[misc] Add out of bound check for ndarray

### DIFF
--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -716,3 +716,57 @@ def test_ndarray_in_python_func():
 
     for i in range(300):
         test()
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray,
+                 require=ti.extension.assertion,
+                 debug=True,
+                 check_out_of_bound=True,
+                 gdb_trigger=False)
+def test_scalar_ndarray_oob():
+    @ti.kernel
+    def access_arr(input: ti.types.ndarray(), x: ti.i32) -> ti.f32:
+        return input[x]
+
+    input = np.random.randn(4)
+
+    # Works
+    access_arr(input, 1)
+
+    with pytest.raises(AssertionError, match=r'Out of bound access'):
+        access_arr(input, 4)
+
+    with pytest.raises(AssertionError, match=r'Out of bound access'):
+        access_arr(input, -1)
+
+
+# SOA layout for ndarray is deprecated so no need to test
+@test_utils.test(arch=supported_archs_taichi_ndarray,
+                 require=ti.extension.assertion,
+                 debug=True,
+                 check_out_of_bound=True,
+                 gdb_trigger=False)
+def test_matrix_ndarray_oob():
+    @ti.kernel
+    def access_arr(input: ti.types.ndarray(), p: ti.i32, q: ti.i32, x: ti.i32,
+                   y: ti.i32) -> ti.f32:
+        return input[p, q][x, y]
+
+    input = ti.ndarray(dtype=ti.math.mat2, shape=(4, 5))
+
+    # Works
+    access_arr(input, 2, 3, 0, 1)
+
+    # element_shape
+    with pytest.raises(AssertionError, match=r'Out of bound access'):
+        access_arr(input, 2, 3, 2, 1)
+    # field_shape[0]
+    with pytest.raises(AssertionError, match=r'Out of bound access'):
+        access_arr(input, 4, 4, 0, 1)
+    with pytest.raises(AssertionError, match=r'Out of bound access'):
+        access_arr(input, -3, 4, 1, 1)
+    # field_shape[1]
+    with pytest.raises(AssertionError, match=r'Out of bound access'):
+        access_arr(input, 3, 5, 0, 1)
+    with pytest.raises(AssertionError, match=r'Out of bound access'):
+        access_arr(input, 2, -10, 1, 1)


### PR DESCRIPTION
Fixes #7430 

### Brief Summary
Note that this PR only added out of bound check for the following cases: 
- when your index is OOB for field dimension
- or when your flattened index in element is OOB for flattened element dimensions 

Here's a case that is not covered by this PR, e.g 
For an ndarray with element shape `[2, 2]` and field shape `[4, 5]`, if you index it with `[3, 4][0, 2]` if won't throw as element indices are flattened in https://github.com/taichi-dev/taichi/blob/master/taichi/transforms/lower_matrix_ptr.cpp#L56. We should find a better way to throw in that case.  