### PR TITLE
[ci] Fix nightly build failure, and minor improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,13 +289,21 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Build
-        shell: pwsh
         if: ${{ needs.check_files.outputs.run_job != 'false' }}
+        shell: cmd
         run: |
-          .\.github\workflows\scripts\win_build.ps1 -llvmVer 15 -installVulkan -libsDir "$env:LocalAppData/buildbot"
+          python .\.github\workflows\scripts\build.py
         env:
           PY: ${{ matrix.python }}
           PROJECT_NAME: ${{ matrix.name }}
+          TAICHI_CMAKE_ARGS: >-
+            -DTI_WITH_OPENGL:BOOL=ON
+            -DTI_WITH_VULKAN:BOOL=ON
+            -DTI_WITH_DX11:BOOL=ON
+            -DTI_WITH_DX12:BOOL=ON
+            -DTI_WITH_CC:BOOL=OFF
+            -DTI_BUILD_TESTS:BOOL=ON
+            -DTI_WITH_C_API=ON
 
       - name: Archive Wheel Artifacts
         uses: actions/upload-artifact@v3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 Pillow
 pytest
-git+https://github.com/taichi-dev/pytest-xdist@e3e1ccf517#egg=pytest-xdist
+git+https://github.com/taichi-dev/pytest-xdist@a3b5ad3038#egg=pytest-xdist
 pytest-rerunfailures
 pytest-cov
 numpy

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -74,7 +74,7 @@ def _test_python(args, default_dir='python'):
         )
     else:
         if int(threads) > 1:
-            pytest_args += ['-n', str(threads)]
+            pytest_args += ['-n', str(threads), '--dist=worksteal']
     import pytest  # pylint: disable=C0415
     return int(pytest.main(pytest_args))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,9 +141,11 @@ def expected_archs():
     Returns:
         List[taichi_python.Arch]: All expected archs on the machine.
     """
-    archs = set([cpu, cuda, metal, vulkan, opengl, cc, gles])
-    # TODO: now expected_archs is not called per test so we cannot test it
-    archs = set(filter(is_arch_supported, archs))
+    def get_archs():
+        archs = set([cpu, cuda, metal, vulkan, opengl, cc, gles])
+        # TODO: now expected_archs is not called per test so we cannot test it
+        archs = set(filter(is_arch_supported, archs))
+        return archs
 
     wanted_archs = os.environ.get('TI_WANTED_ARCHS', '')
     want_exclude = wanted_archs.startswith('^')
@@ -162,9 +164,9 @@ def expected_archs():
         else:
             expanded_wanted_archs.add(_ti_core.arch_from_name(arch))
     if len(expanded_wanted_archs) == 0:
-        return list(archs)
+        return list(get_archs())
     if want_exclude:
-        expected = archs - expanded_wanted_archs
+        expected = get_archs() - expanded_wanted_archs
     else:
         expected = expanded_wanted_archs
     return list(expected)


### PR DESCRIPTION
1. Update `pytest-xdist` and enable work stealing scheduler
2. Use `build.py` to build Windows wheels in nightly builds
3. Defer obtaining available architectures in `expected_archs` to resolve Windows CPU tests getting stuck issue.