### PR TITLE
[lang] Fixed double release of Metal command buffer

### DIFF
--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -240,7 +240,10 @@ ShaderResourceSet &MetalShaderResourceSet::rw_image(uint32_t binding,
 MetalCommandList::MetalCommandList(const MetalDevice &device,
                                    MTLCommandQueue_id cmd_queue)
     : device_(&device) {
-  cmdbuf_ = [cmd_queue commandBuffer];
+  @autoreleasepool {
+    cmdbuf_ = [cmd_queue commandBuffer];
+    [cmdbuf_ retain];
+  }
 }
 
 MetalCommandList::~MetalCommandList() { [cmdbuf_ release]; }


### PR DESCRIPTION
Issue: #

### Brief Summary

It leads to a crash when there is an outer `autoreleasepool` attempting to release the command buffer. Note the command buffer is already released in the destructor, and the `autoreleasepool` will attempt to release it again because the command buffer is assigned to it.