### PR TITLE
[ir] Separate LaunchContextBuilder from Kernel

### DIFF
--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -30,7 +30,7 @@ void CompiledGraph::jit_run(
     // Compile & Run (JIT): The compilation result will be cached, so don't
     // worry that the kernels dispatched by this cgraph will be compiled
     // repeatedly.
-    lang::Kernel::LaunchContextBuilder launch_ctx(dispatch.ti_kernel, &ctx);
+    lang::LaunchContextBuilder launch_ctx(dispatch.ti_kernel, &ctx);
     (*dispatch.ti_kernel)(compile_config, launch_ctx);
   }
 }

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -9,12 +9,8 @@ class Program;
 class IRNode;
 class FrontendContext;
 
-class TI_DLL_EXPORT Callable {
+class TI_DLL_EXPORT CallableBase {
  public:
-  Program *program{nullptr};
-  std::unique_ptr<IRNode> ir{nullptr};
-  std::unique_ptr<FrontendContext> context{nullptr};
-
   struct Parameter {
     bool is_array{
         false};  // This is true for both ndarray and external array args.
@@ -97,6 +93,16 @@ class TI_DLL_EXPORT Callable {
 
   const StructType *args_type = nullptr;
   size_t args_size{0};
+
+  Arch arch;
+  std::string name;
+};
+
+class TI_DLL_EXPORT Callable : public CallableBase {
+ public:
+  Program *program{nullptr};
+  std::unique_ptr<IRNode> ir{nullptr};
+  std::unique_ptr<FrontendContext> context{nullptr};
 
   Callable();
   virtual ~Callable();

--- a/taichi/program/function.cpp
+++ b/taichi/program/function.cpp
@@ -8,6 +8,7 @@ namespace taichi::lang {
 Function::Function(Program *program, const FunctionKey &func_key)
     : func_key(func_key) {
   this->program = program;
+  arch = program->compile_config().arch;
 }
 
 void Function::set_function_body(const std::function<void()> &func) {

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -8,6 +8,7 @@
 #include "taichi/program/ndarray.h"
 #include "taichi/program/texture.h"
 #include "taichi/aot/graph_data.h"
+#include "taichi/program/launch_context_builder.h"
 
 namespace taichi::lang {
 
@@ -15,64 +16,11 @@ class Program;
 
 class TI_DLL_EXPORT Kernel : public Callable {
  public:
-  std::string name;
   std::vector<SNode *> no_activate;
 
   bool is_accessor{false};
   bool is_evaluator{false};
   AutodiffMode autodiff_mode{AutodiffMode::kNone};
-
-  class LaunchContextBuilder {
-   public:
-    LaunchContextBuilder(Kernel *kernel, RuntimeContext *ctx);
-    explicit LaunchContextBuilder(Kernel *kernel);
-
-    LaunchContextBuilder(LaunchContextBuilder &&) = default;
-    LaunchContextBuilder &operator=(LaunchContextBuilder &&) = default;
-    LaunchContextBuilder(const LaunchContextBuilder &) = delete;
-    LaunchContextBuilder &operator=(const LaunchContextBuilder &) = delete;
-
-    void set_arg_float(int arg_id, float64 d);
-
-    // Created signed and unsigned version for argument range check of pybind
-    void set_arg_int(int arg_id, int64 d);
-    void set_arg_uint(int arg_id, uint64 d);
-
-    void set_extra_arg_int(int i, int j, int32 d);
-
-    void set_arg_external_array_with_shape(int arg_id,
-                                           uintptr_t ptr,
-                                           uint64 size,
-                                           const std::vector<int64> &shape);
-
-    void set_arg_ndarray(int arg_id, const Ndarray &arr);
-    void set_arg_ndarray_with_grad(int arg_id,
-                                   const Ndarray &arr,
-                                   const Ndarray &arr_grad);
-
-    void set_arg_texture(int arg_id, const Texture &tex);
-    void set_arg_rw_texture(int arg_id, const Texture &tex);
-
-    // Sets the |arg_id|-th arg in the context to the bits stored in |d|.
-    // This ignores the underlying kernel's |arg_id|-th arg type.
-    void set_arg_raw(int arg_id, uint64 d);
-    TypedConstant fetch_ret(const std::vector<int> &index);
-    float64 get_struct_ret_float(const std::vector<int> &index);
-    int64 get_struct_ret_int(const std::vector<int> &index);
-    uint64 get_struct_ret_uint(const std::vector<int> &index);
-
-    RuntimeContext &get_context();
-
-   private:
-    Kernel *kernel_;
-    std::unique_ptr<RuntimeContext> owned_ctx_;
-    // |ctx_| *almost* always points to |owned_ctx_|. However, it is possible
-    // that the caller passes a RuntimeContext pointer externally. In that case,
-    // |owned_ctx_| will be nullptr.
-    // Invariant: |ctx_| will never be nullptr.
-    RuntimeContext *ctx_;
-    std::unique_ptr<char[]> result_buffer_;
-  };
 
   Kernel(Program &program,
          const std::function<void()> &func,
@@ -117,12 +65,6 @@ class TI_DLL_EXPORT Kernel : public Callable {
   std::vector<int64> get_ret_int_tensor(int i);
   std::vector<uint64> get_ret_uint_tensor(int i);
   std::vector<float64> get_ret_float_tensor(int i);
-
-  TypedConstant fetch_ret(const std::vector<int> &index);
-
-  float64 get_struct_ret_float(const std::vector<int> &index);
-  int64 get_struct_ret_int(const std::vector<int> &index);
-  uint64 get_struct_ret_uint(const std::vector<int> &index);
 
   uint64 get_next_task_id() {
     return task_counter_++;

--- a/taichi/program/launch_context_builder.cpp
+++ b/taichi/program/launch_context_builder.cpp
@@ -1,0 +1,223 @@
+#include <taichi/program/launch_context_builder.h>
+#define TI_RUNTIME_HOST
+#include <taichi/program/context.h>
+#undef TI_RUNTIME_HOST
+#include "taichi/util/action_recorder.h"
+
+namespace taichi::lang {
+LaunchContextBuilder::LaunchContextBuilder(CallableBase *kernel,
+                                           RuntimeContext *ctx)
+    : kernel_(kernel),
+      owned_ctx_(nullptr),
+      ctx_(ctx),
+      result_buffer_(std::make_unique<char[]>(
+          arch_uses_llvm(kernel->arch)
+              ? kernel->ret_size
+              : sizeof(uint64) * taichi_result_buffer_entries)) {
+  ctx_->result_buffer = (uint64 *)result_buffer_.get();
+  ctx_->result_buffer_size = kernel->ret_size;
+}
+
+LaunchContextBuilder::LaunchContextBuilder(CallableBase *kernel)
+    : kernel_(kernel),
+      owned_ctx_(std::make_unique<RuntimeContext>()),
+      ctx_(owned_ctx_.get()),
+      result_buffer_(std::make_unique<char[]>(
+          arch_uses_llvm(kernel->arch)
+              ? kernel->ret_size
+              : sizeof(uint64) * taichi_result_buffer_entries)),
+      ret_type_(kernel->ret_type) {
+  ctx_->result_buffer = (uint64 *)result_buffer_.get();
+  ctx_->result_buffer_size = kernel->ret_size;
+}
+
+void LaunchContextBuilder::set_arg_float(int arg_id, float64 d) {
+  TI_ASSERT_INFO(!kernel_->parameter_list[arg_id].is_array,
+                 "Assigning scalar value to external (numpy) array argument is "
+                 "not allowed.");
+
+  ActionRecorder::get_instance().record(
+      "set_kernel_arg_float64",
+      {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", arg_id),
+       ActionArg("val", d)});
+
+  auto dt = kernel_->parameter_list[arg_id].get_dtype();
+  if (dt->is_primitive(PrimitiveTypeID::f32)) {
+    ctx_->set_arg(arg_id, (float32)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
+    ctx_->set_arg(arg_id, (float64)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
+    ctx_->set_arg(arg_id, (int32)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
+    ctx_->set_arg(arg_id, (int64)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
+    ctx_->set_arg(arg_id, (int8)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
+    ctx_->set_arg(arg_id, (int16)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
+    ctx_->set_arg(arg_id, (uint8)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
+    ctx_->set_arg(arg_id, (uint16)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
+    ctx_->set_arg(arg_id, (uint32)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
+    ctx_->set_arg(arg_id, (uint64)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::f16)) {
+    // use f32 to interact with python
+    ctx_->set_arg(arg_id, (float32)d);
+  } else {
+    TI_NOT_IMPLEMENTED
+  }
+}
+
+void LaunchContextBuilder::set_arg_int(int arg_id, int64 d) {
+  TI_ASSERT_INFO(!kernel_->parameter_list[arg_id].is_array,
+                 "Assigning scalar value to external (numpy) array argument is "
+                 "not allowed.");
+
+  ActionRecorder::get_instance().record(
+      "set_kernel_arg_integer",
+      {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", arg_id),
+       ActionArg("val", d)});
+
+  auto dt = kernel_->parameter_list[arg_id].get_dtype();
+  if (dt->is_primitive(PrimitiveTypeID::i32)) {
+    ctx_->set_arg(arg_id, (int32)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
+    ctx_->set_arg(arg_id, (int64)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::i8)) {
+    ctx_->set_arg(arg_id, (int8)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
+    ctx_->set_arg(arg_id, (int16)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
+    ctx_->set_arg(arg_id, (uint8)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
+    ctx_->set_arg(arg_id, (uint16)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
+    ctx_->set_arg(arg_id, (uint32)d);
+  } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
+    ctx_->set_arg(arg_id, (uint64)d);
+  } else {
+    TI_INFO(dt->to_string());
+    TI_NOT_IMPLEMENTED
+  }
+}
+
+void LaunchContextBuilder::set_arg_uint(int arg_id, uint64 d) {
+  set_arg_int(arg_id, d);
+}
+
+void LaunchContextBuilder::set_extra_arg_int(int i, int j, int32 d) {
+  ctx_->extra_args[i][j] = d;
+}
+
+void LaunchContextBuilder::set_arg_external_array_with_shape(
+    int arg_id,
+    uintptr_t ptr,
+    uint64 size,
+    const std::vector<int64> &shape) {
+  TI_ASSERT_INFO(
+      kernel_->parameter_list[arg_id].is_array,
+      "Assigning external (numpy) array to scalar argument is not allowed.");
+
+  ActionRecorder::get_instance().record(
+      "set_kernel_arg_ext_ptr",
+      {ActionArg("kernel_name", kernel_->name), ActionArg("arg_id", arg_id),
+       ActionArg("address", fmt::format("0x{:x}", ptr)),
+       ActionArg("array_size_in_bytes", (int64)size)});
+
+  TI_ASSERT_INFO(shape.size() <= taichi_max_num_indices,
+                 "External array cannot have > {max_num_indices} indices");
+  ctx_->set_arg_external_array(arg_id, ptr, size, shape);
+}
+
+void LaunchContextBuilder::set_arg_ndarray(int arg_id, const Ndarray &arr) {
+  intptr_t ptr = arr.get_device_allocation_ptr_as_int();
+  TI_ASSERT_INFO(arr.shape.size() <= taichi_max_num_indices,
+                 "External array cannot have > {max_num_indices} indices");
+  ctx_->set_arg_ndarray(arg_id, ptr, arr.shape);
+}
+
+void LaunchContextBuilder::set_arg_ndarray_with_grad(int arg_id,
+                                                     const Ndarray &arr,
+                                                     const Ndarray &arr_grad) {
+  intptr_t ptr = arr.get_device_allocation_ptr_as_int();
+  intptr_t ptr_grad = arr_grad.get_device_allocation_ptr_as_int();
+  TI_ASSERT_INFO(arr.shape.size() <= taichi_max_num_indices,
+                 "External array cannot have > {max_num_indices} indices");
+  ctx_->set_arg_ndarray(arg_id, ptr, arr.shape, true, ptr_grad);
+}
+
+void LaunchContextBuilder::set_arg_texture(int arg_id, const Texture &tex) {
+  intptr_t ptr = tex.get_device_allocation_ptr_as_int();
+  ctx_->set_arg_texture(arg_id, ptr);
+}
+
+void LaunchContextBuilder::set_arg_rw_texture(int arg_id, const Texture &tex) {
+  intptr_t ptr = tex.get_device_allocation_ptr_as_int();
+  ctx_->set_arg_rw_texture(arg_id, ptr, tex.get_size());
+}
+
+void LaunchContextBuilder::set_arg_raw(int arg_id, uint64 d) {
+  TI_ASSERT_INFO(!kernel_->parameter_list[arg_id].is_array,
+                 "Assigning scalar value to external (numpy) array argument is "
+                 "not allowed.");
+
+  ctx_->set_arg<uint64>(arg_id, d);
+}
+
+RuntimeContext &LaunchContextBuilder::get_context() {
+  return *ctx_;
+}
+
+TypedConstant LaunchContextBuilder::fetch_ret(const std::vector<int> &index) {
+  const Type *dt = ret_type_->get_element_type(index);
+  int offset = ret_type_->get_element_offset(index);
+  return fetch_ret_impl(offset, dt);
+}
+
+float64 LaunchContextBuilder::get_struct_ret_float(
+    const std::vector<int> &index) {
+  return fetch_ret(index).val_float();
+}
+
+int64 LaunchContextBuilder::get_struct_ret_int(const std::vector<int> &index) {
+  return fetch_ret(index).val_int();
+}
+
+uint64 LaunchContextBuilder::get_struct_ret_uint(
+    const std::vector<int> &index) {
+  return fetch_ret(index).val_uint();
+}
+
+TypedConstant LaunchContextBuilder::fetch_ret_impl(int offset, const Type *dt) {
+  TI_ASSERT(dt->is<PrimitiveType>());
+  auto primitive_type = dt->as<PrimitiveType>();
+  char *ptr = result_buffer_.get() + offset;
+  switch (primitive_type->type) {
+#define RETURN_PRIMITIVE(type, ctype) \
+  case PrimitiveTypeID::type:         \
+    return TypedConstant(*(ctype *)ptr);
+
+    RETURN_PRIMITIVE(f32, float32);
+    RETURN_PRIMITIVE(f64, float64);
+    RETURN_PRIMITIVE(i8, int8);
+    RETURN_PRIMITIVE(i16, int16);
+    RETURN_PRIMITIVE(i32, int32);
+    RETURN_PRIMITIVE(i64, int64);
+    RETURN_PRIMITIVE(u8, uint8);
+    RETURN_PRIMITIVE(u16, uint16);
+    RETURN_PRIMITIVE(u32, uint32);
+    RETURN_PRIMITIVE(u64, uint64);
+#undef RETURN_PRIMITIVE
+    case PrimitiveTypeID::f16: {
+      // first fetch the data as u16, and then convert it to f32
+      uint16 half = *(uint16 *)ptr;
+      return TypedConstant(bit::half_to_float(half));
+    }
+    default:
+      TI_NOT_IMPLEMENTED
+  }
+}
+
+}  // namespace taichi::lang

--- a/taichi/program/launch_context_builder.h
+++ b/taichi/program/launch_context_builder.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <taichi/program/callable.h>
+#include "taichi/program/ndarray.h"
+#include "taichi/program/texture.h"
+
+namespace taichi::lang {
+
+class LaunchContextBuilder {
+ public:
+  LaunchContextBuilder(CallableBase *kernel, RuntimeContext *ctx);
+  explicit LaunchContextBuilder(CallableBase *kernel);
+
+  LaunchContextBuilder(LaunchContextBuilder &&) = default;
+  LaunchContextBuilder &operator=(LaunchContextBuilder &&) = default;
+  LaunchContextBuilder(const LaunchContextBuilder &) = delete;
+  LaunchContextBuilder &operator=(const LaunchContextBuilder &) = delete;
+
+  void set_arg_float(int arg_id, float64 d);
+
+  // Created signed and unsigned version for argument range check of pybind
+  void set_arg_int(int arg_id, int64 d);
+  void set_arg_uint(int arg_id, uint64 d);
+
+  void set_extra_arg_int(int i, int j, int32 d);
+
+  void set_arg_external_array_with_shape(int arg_id,
+                                         uintptr_t ptr,
+                                         uint64 size,
+                                         const std::vector<int64> &shape);
+
+  void set_arg_ndarray(int arg_id, const Ndarray &arr);
+  void set_arg_ndarray_with_grad(int arg_id,
+                                 const Ndarray &arr,
+                                 const Ndarray &arr_grad);
+
+  void set_arg_texture(int arg_id, const Texture &tex);
+  void set_arg_rw_texture(int arg_id, const Texture &tex);
+
+  // Sets the |arg_id|-th arg in the context to the bits stored in |d|.
+  // This ignores the underlying kernel's |arg_id|-th arg type.
+  void set_arg_raw(int arg_id, uint64 d);
+  TypedConstant fetch_ret(const std::vector<int> &index);
+  float64 get_struct_ret_float(const std::vector<int> &index);
+  int64 get_struct_ret_int(const std::vector<int> &index);
+  uint64 get_struct_ret_uint(const std::vector<int> &index);
+
+  RuntimeContext &get_context();
+
+ private:
+  TypedConstant fetch_ret_impl(int offset, const Type *dt);
+  CallableBase *kernel_;
+  std::unique_ptr<RuntimeContext> owned_ctx_;
+  // |ctx_| *almost* always points to |owned_ctx_|. However, it is possible
+  // that the caller passes a RuntimeContext pointer externally. In that case,
+  // |owned_ctx_| will be nullptr.
+  // Invariant: |ctx_| will never be nullptr.
+  RuntimeContext *ctx_;
+  std::unique_ptr<char[]> result_buffer_;
+  const StructType *ret_type_;
+};
+
+}  // namespace taichi::lang

--- a/taichi/program/snode_rw_accessors_bank.cpp
+++ b/taichi/program/snode_rw_accessors_bank.cpp
@@ -7,7 +7,7 @@ namespace taichi::lang {
 namespace {
 void set_kernel_args(const std::vector<int> &I,
                      int num_active_indices,
-                     Kernel::LaunchContextBuilder *launch_ctx) {
+                     LaunchContextBuilder *launch_ctx) {
   for (int i = 0; i < num_active_indices; i++) {
     launch_ctx->set_arg_int(i, I[i]);
   }

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -702,32 +702,26 @@ void export_lang(py::module &m) {
             return &self->context->builder();
           },
           py::return_value_policy::reference)
-      .def("__call__",
-           [](Kernel *kernel, Kernel::LaunchContextBuilder &launch_ctx) {
-             py::gil_scoped_release release;
-             kernel->operator()(kernel->program->compile_config(), launch_ctx);
-           });
+      .def("__call__", [](Kernel *kernel, LaunchContextBuilder &launch_ctx) {
+        py::gil_scoped_release release;
+        kernel->operator()(kernel->program->compile_config(), launch_ctx);
+      });
 
-  py::class_<Kernel::LaunchContextBuilder>(m, "KernelLaunchContext")
-      .def("set_arg_int", &Kernel::LaunchContextBuilder::set_arg_int)
-      .def("set_arg_uint", &Kernel::LaunchContextBuilder::set_arg_uint)
-      .def("set_arg_float", &Kernel::LaunchContextBuilder::set_arg_float)
+  py::class_<LaunchContextBuilder>(m, "KernelLaunchContext")
+      .def("set_arg_int", &LaunchContextBuilder::set_arg_int)
+      .def("set_arg_uint", &LaunchContextBuilder::set_arg_uint)
+      .def("set_arg_float", &LaunchContextBuilder::set_arg_float)
       .def("set_arg_external_array_with_shape",
-           &Kernel::LaunchContextBuilder::set_arg_external_array_with_shape)
-      .def("set_arg_ndarray", &Kernel::LaunchContextBuilder::set_arg_ndarray)
+           &LaunchContextBuilder::set_arg_external_array_with_shape)
+      .def("set_arg_ndarray", &LaunchContextBuilder::set_arg_ndarray)
       .def("set_arg_ndarray_with_grad",
-           &Kernel::LaunchContextBuilder::set_arg_ndarray_with_grad)
-      .def("set_arg_texture", &Kernel::LaunchContextBuilder::set_arg_texture)
-      .def("set_arg_rw_texture",
-           &Kernel::LaunchContextBuilder::set_arg_rw_texture)
-      .def("set_extra_arg_int",
-           &Kernel::LaunchContextBuilder::set_extra_arg_int)
-      .def("get_struct_ret_int",
-           &Kernel::LaunchContextBuilder::get_struct_ret_int)
-      .def("get_struct_ret_uint",
-           &Kernel::LaunchContextBuilder::get_struct_ret_uint)
-      .def("get_struct_ret_float",
-           &Kernel::LaunchContextBuilder::get_struct_ret_float);
+           &LaunchContextBuilder::set_arg_ndarray_with_grad)
+      .def("set_arg_texture", &LaunchContextBuilder::set_arg_texture)
+      .def("set_arg_rw_texture", &LaunchContextBuilder::set_arg_rw_texture)
+      .def("set_extra_arg_int", &LaunchContextBuilder::set_extra_arg_int)
+      .def("get_struct_ret_int", &LaunchContextBuilder::get_struct_ret_int)
+      .def("get_struct_ret_uint", &LaunchContextBuilder::get_struct_ret_uint)
+      .def("get_struct_ret_float", &LaunchContextBuilder::get_struct_ret_float);
 
   py::class_<Function>(m, "Function")
       .def("insert_scalar_param", &Function::insert_scalar_param)


### PR DESCRIPTION
This PR separates `LaunchContextBuilder` from `Kernel`, in order to let `LaunchContextBuilder` able to be used in AOT.

This PR also extracts a class `CallableBase` from `Callable`, and let `Callable` inherit `CallableBase`. `CallableBase` contains information sufficient for the `LaunchContextBuilder` to construct arguments and read return values, and it does not contain any runtime information (like `program`) and things related to compiling (like `ir`). In this way, `CallableBase` will be able to be used in AOT.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7441
* #7504
* #7489
* __->__ #7494

