### PR TITLE
[example] Remove cv2, cairo dependency

### DIFF
--- a/python/taichi/examples/algorithm/circle-packing/circle_packing_image.py
+++ b/python/taichi/examples/algorithm/circle-packing/circle_packing_image.py
@@ -2,11 +2,11 @@
 Given an input image, redraw it with circle packings.
 """
 try:
-    import cairocffi as cairo
+    import cairo
     import cv2
 except:
     raise ImportError(
-        "This example depends on opencv and cairocffi, please run 'pip install opencv-python cairocffi' to install."
+        "This example depends on opencv and cairo, please run 'pip install opencv-python pycairo' to install."
     )
 
 import os

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,5 +16,3 @@ pre-commit
 scikit-build
 numpy
 ninja; platform_system != 'Windows'
-cairocffi
-opencv-python


### PR DESCRIPTION
This PR removes the `cv2` and `cairocffi` dependency in `requirements_dev.txt`.