### PR TITLE
[vulkan] Support printing constant strings containing %

### DIFF
--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -97,6 +97,19 @@ class TaskCodegen : public IRVisitor {
     }
   }
 
+  // Replace the wild '%' in the format string with "%%".
+  std::string sanitize_format_string(std::string const &str) {
+    std::string sanitized_str;
+    for (char c : str) {
+      if (c == '%') {
+        sanitized_str += "%%";
+      } else {
+        sanitized_str += c;
+      }
+    }
+    return sanitized_str;
+  }
+
   struct Result {
     std::vector<uint32_t> spirv_code;
     TaskAttributes task_attribs;
@@ -161,7 +174,7 @@ class TaskCodegen : public IRVisitor {
         formats += data_type_format(arg_stmt->ret_type, Arch::vulkan);
       } else {
         auto arg_str = std::get<std::string>(content);
-        formats += arg_str;
+        formats += sanitize_format_string(arg_str);
       }
     }
     ir_->call_debugprintf(formats, vals);

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -39,8 +39,7 @@ def test_multi_print():
     ti.sync()
 
 
-# TODO: vulkan doesn't support %s but we should ignore it instead of crashing.
-@test_utils.test(exclude=[ti.vulkan, ti.dx11, ti.amdgpu])
+@test_utils.test(exclude=[ti.dx11, vk_on_mac, ti.amdgpu], debug=True)
 def test_print_string():
     @ti.kernel
     def func(x: ti.i32, y: ti.f32):


### PR DESCRIPTION
Issue: #

### Brief Summary
This PR fixes an issue that crashes the vulkan backend when printing constant strings containing '%'.
It escapes all '%' in the constant strings to "%%", allowing them to be printed correctly in Vulkan's debug_printf function, since these strings and other formatting specifiers are concatenated to directly form the first parameter of the function. In other words, if a wild '%d' or '%s' is passed to printf, the function will incorrectly assume that there is a new argument to take (from the stack?), which will mess everything up and may result in type confusion and buffer overflows.
