### PR TITLE
[AOT] [llvm] Let AOT kernel inherit CallableBase and use LaunchContextBuilder

### DIFF
--- a/taichi/aot/graph_data.cpp
+++ b/taichi/aot/graph_data.cpp
@@ -14,6 +14,7 @@ void CompiledGraph::run(
   for (const auto &dispatch : dispatches) {
     RuntimeContext ctx = ctx_;
     TI_ASSERT(dispatch.compiled_kernel);
+    LaunchContextBuilder launch_ctx(dispatch.compiled_kernel, &ctx);
     init_runtime_context(dispatch.symbolic_args, args, ctx);
     // Run cgraph loaded from AOT module
     dispatch.compiled_kernel->launch(&ctx);
@@ -26,11 +27,11 @@ void CompiledGraph::jit_run(
   for (const auto &dispatch : dispatches) {
     RuntimeContext ctx = ctx_;
     TI_ASSERT(dispatch.ti_kernel);
+    LaunchContextBuilder launch_ctx(dispatch.ti_kernel, &ctx);
     init_runtime_context(dispatch.symbolic_args, args, ctx);
     // Compile & Run (JIT): The compilation result will be cached, so don't
     // worry that the kernels dispatched by this cgraph will be compiled
     // repeatedly.
-    lang::LaunchContextBuilder launch_ctx(dispatch.ti_kernel, &ctx);
     (*dispatch.ti_kernel)(compile_config, launch_ctx);
   }
 }

--- a/taichi/aot/graph_data.h
+++ b/taichi/aot/graph_data.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <unordered_map>
 #include "taichi/ir/type.h"
+#include "taichi/program/callable.h"
 #include "taichi/aot/module_data.h"
 #include "taichi/program/compile_config.h"
 #define TI_RUNTIME_HOST
@@ -127,7 +128,7 @@ struct TI_DLL_EXPORT IValue {
   }
 };
 
-class TI_DLL_EXPORT Kernel {
+class TI_DLL_EXPORT Kernel : public CallableBase {
  public:
   // Rule of 5 to make MSVC happy
   Kernel() = default;

--- a/taichi/program/launch_context_builder.cpp
+++ b/taichi/program/launch_context_builder.cpp
@@ -14,8 +14,10 @@ LaunchContextBuilder::LaunchContextBuilder(CallableBase *kernel,
           arch_uses_llvm(kernel->arch)
               ? kernel->ret_size
               : sizeof(uint64) * taichi_result_buffer_entries)) {
-  ctx_->result_buffer = (uint64 *)result_buffer_.get();
-  ctx_->result_buffer_size = kernel->ret_size;
+  if (arch_uses_llvm(kernel->arch)) {
+    ctx_->result_buffer = (uint64 *)result_buffer_.get();
+    ctx_->result_buffer_size = kernel->ret_size;
+  }
 }
 
 LaunchContextBuilder::LaunchContextBuilder(CallableBase *kernel)

--- a/taichi/runtime/gfx/aot_graph_data.h
+++ b/taichi/runtime/gfx/aot_graph_data.h
@@ -8,6 +8,10 @@ class KernelImpl : public aot::Kernel {
   explicit KernelImpl(GfxRuntime *runtime, GfxRuntime::RegisterParams &&params)
       : runtime_(runtime), params_(std::move(params)) {
     handle_ = runtime_->register_taichi_kernel(params_);
+    arch = Arch::vulkan;  // Only for letting the launch context builder know
+                          // the arch does not use LLVM.
+                          // TODO: remove arch after the refactoring of
+                          //  SPIR-V based backends completes.
   }
 
   void launch(RuntimeContext *ctx) override {

--- a/taichi/runtime/llvm/aot_graph_data.h
+++ b/taichi/runtime/llvm/aot_graph_data.h
@@ -11,6 +11,17 @@ class KernelImpl : public aot::Kernel {
   explicit KernelImpl(FunctionType fn,
                       LlvmOfflineCache::KernelCacheData &&kernel_data)
       : kernel_data_(std::move(kernel_data)), fn_(fn) {
+    rets = kernel_data_.rets;
+    ret_type = kernel_data_.ret_type;
+    ret_size = kernel_data_.ret_size;
+    parameter_list = kernel_data_.args;
+    args_type = kernel_data_.args_type;
+    args_size = kernel_data_.args_size;
+    arch = Arch::x64;  // Only for letting the launch context builder know
+                       // the arch uses LLVM.
+                       // TODO: remove arch after the refactoring of
+                       //  SPIR-V based backends completes.
+    name = kernel_data_.kernel_key;
   }
 
   void launch(RuntimeContext *ctx) override {

--- a/taichi/runtime/llvm/llvm_aot_module_loader.cpp
+++ b/taichi/runtime/llvm/llvm_aot_module_loader.cpp
@@ -16,9 +16,9 @@ LlvmOfflineCache::KernelCacheData LlvmAotModule::load_kernel_from_cache(
 
 std::unique_ptr<aot::Kernel> LlvmAotModule::make_new_kernel(
     const std::string &name) {
-  auto fn = convert_module_to_function(name, load_kernel_from_cache(name));
-  return std::make_unique<llvm_aot::KernelImpl>(
-      fn, LlvmOfflineCache::KernelCacheData());
+  auto kernel_cache = load_kernel_from_cache(name);
+  auto fn = convert_module_to_function(name, kernel_cache.clone());
+  return std::make_unique<llvm_aot::KernelImpl>(fn, std::move(kernel_cache));
 }
 
 std::unique_ptr<aot::Field> LlvmAotModule::make_new_field(

--- a/tests/cpp/aot/llvm/dynamic_aot_test.cpp
+++ b/tests/cpp/aot/llvm/dynamic_aot_test.cpp
@@ -35,14 +35,16 @@ static void run_dynamic_tests(aot::Module *mod,
   /* -------- Test Case 1 ------ */
   // Kernel: activate()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_activate);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_activate->launch(&ctx);
   }
 
   // Kernel: check_value_0()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_check_value_0);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_check_value_0->launch(&ctx);
   }
@@ -50,13 +52,15 @@ static void run_dynamic_tests(aot::Module *mod,
   /* -------- Test Case 2 ------ */
   // Kernel: deactivate()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_deactivate);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_deactivate->launch(&ctx);
   }
   // Kernel: check_value_1()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_check_value_1);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_check_value_1->launch(&ctx);
   }

--- a/tests/cpp/aot/llvm/field_aot_test.cpp
+++ b/tests/cpp/aot/llvm/field_aot_test.cpp
@@ -45,7 +45,8 @@ static void run_field_tests(aot::Module *mod,
   /* -------- Test Case 1 ------ */
   // Kernel: init_fields(int)
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_init_fields);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     ctx.set_arg(0, base_value);
     k_init_fields->launch(&ctx);
@@ -53,14 +54,16 @@ static void run_field_tests(aot::Module *mod,
 
   // Kernel: check_init_x(int)
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_check_init_x);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     ctx.set_arg(0, base_value);
     k_check_init_x->launch(&ctx);
   }
   // Kernel: check_init_y()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_check_init_y);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_check_init_y->launch(&ctx);
   }
@@ -68,13 +71,15 @@ static void run_field_tests(aot::Module *mod,
   /* -------- Test Case 2 ------ */
   // Kernel: deactivate_pointer_fields()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_deactivate_pointer_fields);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_deactivate_pointer_fields->launch(&ctx);
   }
   // Kernel: check_deactivate_pointer_fields()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_check_deactivate_pointer_fields);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_check_deactivate_pointer_fields->launch(&ctx);
   }
@@ -82,13 +87,15 @@ static void run_field_tests(aot::Module *mod,
   /* -------- Test Case 3 ------ */
   // Kernel: activate_pointer_fields()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_activate_pointer_fields);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_activate_pointer_fields->launch(&ctx);
   }
   // Kernel: check_activate_pointer_fields()
   {
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_check_activate_pointer_fields);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec->get_llvm_runtime();
     k_check_activate_pointer_fields->launch(&ctx);
   }

--- a/tests/cpp/aot/llvm/kernel_aot_test.cpp
+++ b/tests/cpp/aot/llvm/kernel_aot_test.cpp
@@ -47,7 +47,8 @@ TEST(LlvmAotTest, CpuKernel) {
   auto mod = cpu::make_aot_module(aot_params);
   auto *k_run = mod->get_kernel("run");
 
-  RuntimeContext ctx;
+  LaunchContextBuilder builder(k_run);
+  RuntimeContext &ctx = builder.get_context();
   ctx.runtime = exec.get_llvm_runtime();
   ctx.set_arg(0, /*v=*/0);
   ctx.set_arg_ndarray(/*arg_id=*/1, arr.get_device_allocation_ptr_as_int(),
@@ -92,7 +93,8 @@ TEST(LlvmAotTest, CudaKernel) {
     aot_params.executor_ = &exec;
     auto mod = cuda::make_aot_module(aot_params);
     auto *k_run = mod->get_kernel("run");
-    RuntimeContext ctx;
+    LaunchContextBuilder builder(k_run);
+    RuntimeContext &ctx = builder.get_context();
     ctx.runtime = exec.get_llvm_runtime();
     ctx.set_arg(0, /*v=*/0);
     ctx.set_arg_ndarray(/*arg_id=*/1, arr.get_device_allocation_ptr_as_int(),

--- a/tests/cpp/aot/python_scripts/kernel_return_aot_test_.py
+++ b/tests/cpp/aot/python_scripts/kernel_return_aot_test_.py
@@ -1,0 +1,35 @@
+import argparse
+import os
+
+import taichi as ti
+
+
+def compile_kernel_return_aot(arch):
+    ti.init(arch=arch)
+
+    s = ti.types.struct(a=ti.i32, b=ti.math.vec3)
+
+    @ti.kernel
+    def test_ret() -> s:
+        return s(1, ti.math.vec3([2, 3, 4]))
+
+    assert "TAICHI_AOT_FOLDER_PATH" in os.environ.keys()
+    dir_name = str(os.environ["TAICHI_AOT_FOLDER_PATH"])
+
+    m = ti.aot.Module()
+
+    m.add_kernel(test_ret, template_args={})
+
+    m.save(dir_name)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--arch", type=str)
+    args = parser.parse_args()
+    if args.arch == "cpu":
+        compile_kernel_return_aot(arch=ti.cpu)
+    elif args.arch == "cuda":
+        compile_kernel_return_aot(arch=ti.cuda)
+    else:
+        assert False

--- a/tests/cpp/cpptests.yaml
+++ b/tests/cpp/cpptests.yaml
@@ -11,6 +11,12 @@
   - test: LlvmAotTest.DX12Kernel
     script: aot/python_scripts/kernel_aot_test1.py
     args: --arch=dx12
+  - test: LlvmAotTest.CpuReturn
+    script: aot/python_scripts/kernel_return_aot_test_.py
+    args: --arch=cpu
+  - test: LlvmAotTest.CudaReturn
+    script: aot/python_scripts/kernel_return_aot_test_.py
+    args: --arch=cuda
   - test: LlvmAotTest.CpuField
     script: aot/python_scripts/field_aot_test_.py
     args: --arch=cpu


### PR DESCRIPTION
After this PR the AOT kernel also have information about the types of the arguments and the return values. 

As a result, AOT kernels of LLVM-based backends can have return values now.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7441
* __->__ #7504
* #7489
* #7494

