### PR TITLE
[bug] Fix run_tests.py --with-offline-cache

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -228,9 +228,14 @@ def test():
 
             size = size_of_dir(tmp_cache_file_path)
             stat = {}
-            for subdir in os.listdir(tmp_cache_file_path):
-                stat[subdir] = len(
-                    os.listdir(os.path.join(tmp_cache_file_path, subdir)))
+            countof_tic = 0
+            for p in os.listdir(tmp_cache_file_path):
+                subdir_path = os.path.join(tmp_cache_file_path, p)
+                if os.path.isdir(subdir_path):
+                    stat[p] = len(os.listdir(subdir_path))
+                elif p.endswith('.tic'):
+                    countof_tic += 1
+            stat['*.tic'] = countof_tic
             shutil.rmtree(tmp_cache_file_path)
             print('Summary of testing the offline cache:')
             print(f'    Simple statistics: {stat}')


### PR DESCRIPTION
Issue: #7002 

### Brief Summary
#### Fixed bug reported by https://github.com/taichi-dev/taichi/actions/runs/4346468687/jobs/7592576659 :
```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "tests/run_tests.py", line 233, in print_and_remove
    os.listdir(os.path.join(tmp_cache_file_path, subdir)))
NotADirectoryError: [Errno 20] Not a directory: '/var/folders/1r/fk_r0s1d4ss8m19rg11bq1j80000gp/T/tmpcnyh7mz1/Tbdbfefe5b5fe6db167e250d15bb1c4cc797b2beee4fa7a09be9a6cff8c060101-metal.tic'
```
#### Quick repro on master:
`python run_tests.py -v -t4 -a vulkan,cpu abs --with-offline-cache`
```
...
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "..\taichi\tests\run_tests.py", line 233, in print_and_remove
    os.listdir(os.path.join(tmp_cache_file_path, subdir)))
NotADirectoryError: [WinError 267] The directory name is invalid. : 'C:\\Users\\xxx\\AppData\\Local\\Temp\\tmpcs7z9cpq\\T1571a996babd2f9b7a24eeba9d8450fd767cf939b8d717941f629550302d6408-vulkan.tic'
```
#### On this branch (fixed the bug):
`python run_tests.py -v -t4 -a vulkan,cpu abs --with-offline-cache`
```
...
Summary of testing the offline cache:
    Simple statistics: {'llvm': 19, '*.tic': 18}
    Size of cache files: 646.04 KB
```