### PR TITLE
[doc] Handle 2 digit minor versions correctly

### DIFF
--- a/docs/lang/articles/faqs/install.md
+++ b/docs/lang/articles/faqs/install.md
@@ -38,7 +38,7 @@ sidebar_position: 2
   - Make sure you're using Python version 3.7/3.8/3.9/3.10:
 
     ```bash
-    python3 -c "print(__import__('sys').version[:3])"
+    python3 -c "import sys;print(sys.version[:sys.version.find('.', 2)])"
     # 3.7, 3.8, 3.9, or 3.10
     ```
 


### PR DESCRIPTION
The docs previously stated to use `python3 -c "print(__import__('sys').version[:3])"` to verify the Python version you were using. This only works if the minor version is 1 digit (like 3.6), but not for two digits (like 3.10 or 3.11). I've modified it to do this correctly regardless of how many digits the minor version is. 

Incidentally, should this page also be updated to mention 3.11 is supported? I don't have a machine with Python 3.11 installed to test.
