### PR TITLE
[Lang] Replace internal representation of Python-scope ti.Matrix with numpy arrays

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1,12 +1,12 @@
 import ast
 import collections.abc
 import itertools
-import numpy as np
 import operator
 import warnings
 from collections import ChainMap
 from sys import version_info
 
+import numpy as np
 from taichi._lib import core as _ti_core
 from taichi.lang import (_ndarray, any_array, expr, impl, kernel_arguments,
                          matrix, mesh)

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1,6 +1,7 @@
 import ast
 import collections.abc
 import itertools
+import numpy as np
 import operator
 import warnings
 from collections import ChainMap
@@ -18,7 +19,7 @@ from taichi.lang.exception import (TaichiIndexError, TaichiSyntaxError,
                                    TaichiTypeError, handle_exception_from_cpp)
 from taichi.lang.expr import Expr, make_expr_group
 from taichi.lang.field import Field
-from taichi.lang.matrix import Matrix, MatrixType, Vector, is_vector
+from taichi.lang.matrix import Matrix, MatrixType, Vector
 from taichi.lang.snode import append, deactivate, length
 from taichi.lang.struct import Struct, StructType
 from taichi.lang.util import is_taichi_class, to_taichi_type
@@ -746,7 +747,7 @@ class ASTTransformer(Builder):
                 values = node.value.ptr
                 if isinstance(values, Matrix):
                     values = itertools.chain.from_iterable(values.to_list()) if\
-                        not is_vector(values) else iter(values.to_list())
+                        values.ndim == 1 else iter(values.to_list())
                 else:
                     values = [values]
                 ctx.ast_builder.create_kernel_exprgroup_return(
@@ -1021,7 +1022,7 @@ class ASTTransformer(Builder):
                         f'"{type(node_op).__name__}" is not supported in Taichi kernels.'
                     )
             val = ti_ops.bit_and(val, op(l, r))
-        if not isinstance(val, bool):
+        if not isinstance(val, (bool, np.bool_)):
             val = ti_ops.cast(val, primitive_types.i32)
         node.ptr = val
         return node.ptr

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -4,7 +4,7 @@ from taichi.lang import impl
 from taichi.lang.common_ops import TaichiOperations
 from taichi.lang.exception import TaichiCompilationError, TaichiTypeError
 from taichi.lang.matrix import make_matrix
-from taichi.lang.util import is_taichi_class, to_numpy_type
+from taichi.lang.util import is_matrix_class, is_taichi_class, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.primitive_types import integer_types, real_types
 
@@ -20,10 +20,8 @@ class Expr(TaichiOperations):
             elif isinstance(args[0], Expr):
                 self.ptr = args[0].ptr
                 self.tb = args[0].tb
-            elif is_taichi_class(args[0]):
-                raise TaichiTypeError(
-                    'Cannot initialize scalar expression from '
-                    f'taichi class: {type(args[0])}')
+            elif is_matrix_class(args[0]):
+                self.ptr = make_matrix(args[0].to_list()).ptr
             elif isinstance(args[0], (list, tuple)):
                 self.ptr = make_matrix(args[0]).ptr
             else:

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -97,7 +97,7 @@ def _clamp_unsigned_to_range(npty, val):
 
 
 def make_constant_expr(val, dtype):
-    if isinstance(val, bool):
+    if isinstance(val, (bool, np.bool_)):
         constant_dtype = primitive_types.i32
         return Expr(_ti_core.make_const_expr_int(constant_dtype, val))
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -1,8 +1,8 @@
 import numbers
-import numpy as np
 from types import FunctionType, MethodType
 from typing import Any, Iterable, Sequence
 
+import numpy as np
 from taichi._lib import core as _ti_core
 from taichi._snode.fields_builder import FieldsBuilder
 from taichi.lang._ndarray import ScalarNdarray

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -1,4 +1,5 @@
 import numbers
+import numpy as np
 from types import FunctionType, MethodType
 from typing import Any, Iterable, Sequence
 
@@ -43,11 +44,7 @@ def expr_init(rhs):
     if isinstance(rhs, Matrix) and (hasattr(rhs, "_DIM")):
         return Matrix(*rhs.to_list(), ndim=rhs.ndim)
     if isinstance(rhs, Matrix):
-        if rhs.ndim == 1:
-            entries = [rhs(i) for i in range(rhs.n)]
-        else:
-            entries = [[rhs(i, j) for j in range(rhs.m)] for i in range(rhs.n)]
-        return make_matrix(entries)
+        return make_matrix(rhs.to_list())
     if isinstance(rhs, SharedArray):
         return rhs
     if isinstance(rhs, Struct):
@@ -167,8 +164,8 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
 
     flattened_indices = []
     for _index in _indices:
-        if is_taichi_class(_index):
-            ind = _index.entries
+        if isinstance(_index, Matrix):
+            ind = _index.to_list()
         elif isinstance(_index, slice):
             ind = [_index]
             has_slice = True
@@ -1067,6 +1064,8 @@ def static(x, *xs) -> Any:
     if isinstance(x,
                   (bool, int, float, range, list, tuple, enumerate,
                    GroupedNDRange, _Ndrange, zip, filter, map)) or x is None:
+        return x
+    if isinstance(x, (np.bool_, np.integer, np.floating)):
         return x
 
     if isinstance(x, AnyArray):

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -662,7 +662,8 @@ class Kernel:
                 provided = type(v)
                 # Note: do not use sth like "needed == f32". That would be slow.
                 if id(needed) in primitive_types.real_type_ids:
-                    if not isinstance(v, (float, int, np.floating, np.integer)):
+                    if not isinstance(v,
+                                      (float, int, np.floating, np.integer)):
                         raise TaichiRuntimeTypeError.get(
                             i, needed.to_string(), provided)
                     launch_ctx.set_arg_float(actual_argument_slot, float(v))
@@ -803,7 +804,9 @@ class Kernel:
                         for a in range(needed.n):
                             for b in range(needed.m):
                                 val = v[a, b] if needed.ndim == 2 else v[a]
-                                if not isinstance(val, (int, float, np.integer, np.floating)):
+                                if not isinstance(
+                                        val,
+                                    (int, float, np.integer, np.floating)):
                                     raise TaichiRuntimeTypeError.get(
                                         i, needed.dtype.to_string(), type(val))
                                 launch_ctx.set_arg_float(
@@ -873,7 +876,8 @@ class Kernel:
                     elif id(ret_dt) in primitive_types.real_type_ids:
                         ret = t_kernel.get_ret_float(0)
                     else:
-                        if id(ret_dt.dtype) in primitive_types.integer_type_ids:
+                        if id(ret_dt.dtype
+                              ) in primitive_types.integer_type_ids:
                             if is_signed(cook_dtype(ret_dt.dtype)):
                                 it = iter(t_kernel.get_ret_int_tensor(0))
                             else:
@@ -883,7 +887,8 @@ class Kernel:
                         if ret_dt.ndim == 1:
                             ret = Vector([next(it) for _ in range(ret_dt.n)])
                         else:
-                            ret = Matrix([[next(it) for _ in range(ret_dt.m)] for _ in range(ret_dt.n)])
+                            ret = Matrix([[next(it) for _ in range(ret_dt.m)]
+                                          for _ in range(ret_dt.n)])
             if callbacks:
                 for c in callbacks:
                     c()

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -227,7 +227,6 @@ class Matrix(TaichiOperations):
 
     def __init__(self, arr, dt=None):
         if not isinstance(arr, (list, tuple, np.ndarray)):
-            print(arr, type(arr))
             raise TaichiTypeError(
                 "An Matrix/Vector can only be initialized with an array-like object"
             )

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -245,7 +245,8 @@ class Matrix(TaichiOperations):
                 self.entries = arr
                 self.is_host_access = True
             else:
-                self.entries = np.array(arr, None if dt is None else to_numpy_type(dt))
+                self.entries = np.array(
+                    arr, None if dt is None else to_numpy_type(dt))
                 self.is_host_access = False
         else:  # vector
             self.ndim = 1
@@ -254,7 +255,8 @@ class Matrix(TaichiOperations):
                 self.entries = arr
                 self.is_host_access = True
             else:
-                self.entries = np.array(arr, None if dt is None else to_numpy_type(dt))
+                self.entries = np.array(
+                    arr, None if dt is None else to_numpy_type(dt))
                 self.is_host_access = False
 
         if self.n * self.m > 32:
@@ -394,9 +396,13 @@ class Matrix(TaichiOperations):
         """
         if self.is_host_access:
             if self.ndim == 1:
-                return [_read_host_access(self.entries[i]) for i in range(self.n)]
+                return [
+                    _read_host_access(self.entries[i]) for i in range(self.n)
+                ]
             assert self.ndim == 2
-            return [[_read_host_access(self.entries[i][j]) for j in range(self.m)] for i in range(self.n)]
+            return [[
+                _read_host_access(self.entries[i][j]) for j in range(self.m)
+            ] for i in range(self.n)]
         return self.entries.tolist()
 
     @taichi_scope

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -70,7 +70,7 @@ def _gen_swizzles(cls):
 
                 def prop_getter(instance):
                     checker(instance, attr)
-                    return instance._get_entry_and_read([attr_idx])
+                    return instance[attr_idx]
 
                 @python_scope
                 def prop_setter(instance, value):
@@ -96,7 +96,7 @@ def _gen_swizzles(cls):
                     checker(instance, pattern)
                     res = []
                     for ch in pattern:
-                        res.append(instance._get_entry(key_group.index(ch)))
+                        res.append(instance[key_group.index(ch)])
                     return Vector(res)
 
                 @python_scope
@@ -165,12 +165,19 @@ def make_matrix(arr, dt=None):
             shape, dt, [expr.Expr(elt).ptr for elt in arr]))
 
 
-def is_vector(x):
-    return isinstance(x, Vector) or getattr(x, "ndim", None) == 1
+def _read_host_access(x):
+    if isinstance(x, SNodeHostAccess):
+        return x.accessor.getter(*x.key)
+    assert isinstance(x, NdarrayHostAccess)
+    return x.getter()
 
 
-def is_col_vector(x):
-    return is_vector(x) and getattr(x, "m", None) == 1
+def _write_host_access(x, value):
+    if isinstance(x, SNodeHostAccess):
+        x.accessor.setter(value, *x.key)
+    else:
+        assert isinstance(x, NdarrayHostAccess)
+        x.setter(value)
 
 
 @_gen_swizzles
@@ -218,44 +225,37 @@ class Matrix(TaichiOperations):
     _is_matrix_class = True
     __array_priority__ = 1000
 
-    def __init__(self, arr, dt=None, ndim=None):
+    def __init__(self, arr, dt=None):
         if not isinstance(arr, (list, tuple, np.ndarray)):
+            print(arr, type(arr))
             raise TaichiTypeError(
                 "An Matrix/Vector can only be initialized with an array-like object"
             )
         if len(arr) == 0:
-            mat = []
             self.ndim = 0
+            self.n, self.m = 0, 0
+            self.entries = np.array([])
+            self.is_host_access = False
         elif isinstance(arr[0], Matrix):
             raise Exception('cols/rows required when using list of vectors')
-        else:
-            if ndim is not None:
-                self.ndim = ndim
-                is_matrix = ndim == 2
+        elif isinstance(arr[0], Iterable):  # matrix
+            self.ndim = 2
+            self.n, self.m = len(arr), len(arr[0])
+            if isinstance(arr[0][0], (SNodeHostAccess, NdarrayHostAccess)):
+                self.entries = arr
+                self.is_host_access = True
             else:
-                is_matrix = isinstance(arr[0],
-                                       Iterable) and not is_vector(self)
-                self.ndim = 2 if is_matrix else 1
-
-            if is_matrix:
-                mat = [list(row) for row in arr]
+                self.entries = np.array(arr, None if dt is None else to_numpy_type(dt))
+                self.is_host_access = False
+        else:  # vector
+            self.ndim = 1
+            self.n, self.m = len(arr), 1
+            if isinstance(arr[0], (SNodeHostAccess, NdarrayHostAccess)):
+                self.entries = arr
+                self.is_host_access = True
             else:
-                if isinstance(arr[0], Iterable):
-                    flattened = []
-                    for row in arr:
-                        flattened += row
-                    arr = flattened
-                mat = [[x] for x in arr]
-
-        self.n, self.m = len(mat), 1
-        if len(mat) > 0:
-            self.m = len(mat[0])
-        self.entries = [x for row in mat for x in row]
-
-        if ndim is not None:
-            # override ndim after reading data from mat
-            assert ndim in (0, 1, 2)
-            self.ndim = ndim
+                self.entries = np.array(arr, None if dt is None else to_numpy_type(dt))
+                self.is_host_access = False
 
         if self.n * self.m > 32:
             warning(
@@ -275,57 +275,6 @@ class Matrix(TaichiOperations):
         if self.ndim == 2:
             return (self.n, self.m)
         return None
-
-    def _element_wise_binary(self, foo, other):
-        other = self._broadcast_copy(other)
-        if is_col_vector(self):
-            return Vector([foo(self(i), other(i)) for i in range(self.n)],
-                          ndim=self.ndim)
-        return Matrix([[foo(self(i, j), other(i, j)) for j in range(self.m)]
-                       for i in range(self.n)],
-                      ndim=self.ndim)
-
-    def _broadcast_copy(self, other):
-        if isinstance(other, (list, tuple)):
-            if is_col_vector(self):
-                other = Vector(other, ndim=self.ndim)
-            else:
-                other = Matrix(other, ndim=self.ndim)
-        if not isinstance(other, Matrix):
-            if isinstance(self, Vector):
-                other = Vector([other for _ in range(self.n)])
-            else:
-                other = Matrix([[other for _ in range(self.m)]
-                                for _ in range(self.n)],
-                               ndim=self.ndim)
-        assert self.m == other.m and self.n == other.n, f"Dimension mismatch between shapes ({self.n}, {self.m}), ({other.n}, {other.m})"
-        return other
-
-    def _element_wise_ternary(self, foo, other, extra):
-        other = self._broadcast_copy(other)
-        extra = self._broadcast_copy(extra)
-        return Matrix([[
-            foo(self(i, j), other(i, j), extra(i, j)) for j in range(self.m)
-        ] for i in range(self.n)],
-                      ndim=self.ndim)
-
-    def _element_wise_writeback_binary(self, foo, other):
-        if foo.__name__ == 'assign' and not isinstance(other,
-                                                       (list, tuple, Matrix)):
-            raise TaichiSyntaxError(
-                'cannot assign scalar expr to '
-                f'taichi class {type(self)}, maybe you want to use `a.fill(b)` instead?'
-            )
-        other = self._broadcast_copy(other)
-        entries = [[foo(self(i, j), other(i, j)) for j in range(self.m)]
-                   for i in range(self.n)]
-        return self if foo.__name__ == 'assign' else Matrix(entries,
-                                                            ndim=self.ndim)
-
-    def _element_wise_unary(self, foo):
-        return Matrix([[foo(self(i, j)) for j in range(self.m)]
-                       for i in range(self.n)],
-                      ndim=self.ndim)
 
     def __matmul__(self, other):
         """Matrix-matrix or matrix-vector multiply.
@@ -347,9 +296,9 @@ class Matrix(TaichiOperations):
         return self.n
 
     def __iter__(self):
-        if self.m == 1:
-            return (self(i) for i in range(self.n))
-        return ([self(i, j) for j in range(self.m)] for i in range(self.n))
+        if self.ndim == 1:
+            return (self[i] for i in range(self.n))
+        return ([self[i, j] for j in range(self.m)] for i in range(self.n))
 
     def __getitem__(self, indices):
         """Access to the element at the given indices in a matrix.
@@ -361,17 +310,10 @@ class Matrix(TaichiOperations):
             The value of the element at a specific position of a matrix.
 
         """
-        if not isinstance(indices, (list, tuple)):
-            indices = [indices]
-        assert len(indices) in [1, 2]
-        assert len(
-            indices
-        ) == self.ndim, f"Expected {self.ndim} indices, got {len(indices)}"
-        i = indices[0]
-        j = 0 if len(indices) == 1 else indices[1]
-        if isinstance(i, slice) or isinstance(j, slice):
-            return self._get_slice(i, j)
-        return self._get_entry_and_read([i, j])
+        entry = self._get_entry(indices)
+        if self.is_host_access:
+            return _read_host_access(entry)
+        return entry
 
     @python_scope
     def __setitem__(self, indices, item):
@@ -381,49 +323,31 @@ class Matrix(TaichiOperations):
             indices (Sequence[Expr]): the indices of a element.
 
         """
+        if self.is_host_access:
+            entry = self._get_entry(indices)
+            _write_host_access(entry, item)
+        else:
+            if not isinstance(indices, (list, tuple)):
+                indices = [indices]
+            assert len(indices) in [1, 2]
+            assert len(
+                indices
+            ) == self.ndim, f"Expected {self.ndim} indices, got {len(indices)}"
+            if self.ndim == 1:
+                self.entries[indices[0]] = item
+            else:
+                self.entries[indices[0]][indices[1]] = item
+
+    def _get_entry(self, indices):
         if not isinstance(indices, (list, tuple)):
             indices = [indices]
         assert len(indices) in [1, 2]
         assert len(
             indices
         ) == self.ndim, f"Expected {self.ndim} indices, got {len(indices)}"
-        i = indices[0]
-        j = 0 if len(indices) == 1 else indices[1]
-        self._set_entry(i, j, item)
-
-    def __call__(self, *args, **kwargs):
-        # TODO: It's quite hard to search for __call__, consider replacing this
-        # with a method of actual names?
-        assert kwargs == {}
-        return self._get_entry_and_read(args)
-
-    def _get_entry(self, *indices):
-        return self.entries[self._linearize_entry_id(*indices)]
-
-    def _get_entry_and_read(self, indices):
-        # Can be invoked in both Python and Taichi scope. `indices` must be
-        # compile-time constants (e.g. Python values)
-        ret = self._get_entry(*indices)
-
-        if isinstance(ret, SNodeHostAccess):
-            ret = ret.accessor.getter(*ret.key)
-        elif isinstance(ret, NdarrayHostAccess):
-            ret = ret.getter()
-        return ret
-
-    def _linearize_entry_id(self, *args):
-        assert 1 <= len(args) <= 2
-        if len(args) == 1 and isinstance(args[0], (list, tuple)):
-            args = args[0]
-        if len(args) == 1:
-            args = args + (0, )
-        for a in args:
-            assert isinstance(a, (int, np.integer))
-        assert 0 <= args[0] < self.n, \
-            f"The 0-th matrix index is out of range: 0 <= {args[0]} < {self.n}"
-        assert 0 <= args[1] < self.m, \
-            f"The 1-th matrix index is out of range: 0 <= {args[1]} < {self.m}"
-        return args[0] * self.m + args[1]
+        if self.ndim == 1:
+            return self.entries[indices[0]]
+        return self.entries[indices[0]][indices[1]]
 
     def _get_slice(self, a, b):
         if isinstance(a, slice):
@@ -438,24 +362,25 @@ class Matrix(TaichiOperations):
         return Vector([self._get_entry(a, j) for j in b])
 
     @python_scope
-    def _set_entry(self, i, j, item):
-        idx = self._linearize_entry_id(i, j)
-        if isinstance(self.entries[idx], SNodeHostAccess):
-            self.entries[idx].accessor.setter(item, *self.entries[idx].key)
-        elif isinstance(self.entries[idx], NdarrayHostAccess):
-            self.entries[idx].setter(item)
-        else:
-            self.entries[idx] = item
-
-    @python_scope
     def _set_entries(self, value):
-        if not isinstance(value, (list, tuple)):
-            value = list(value)
-        if not isinstance(value[0], (list, tuple)):
-            value = [[i] for i in value]
-        for i in range(self.n):
-            for j in range(self.m):
-                self._set_entry(i, j, value[i][j])
+        if isinstance(value, Matrix):
+            value = value.to_list()
+        if self.is_host_access:
+            if self.ndim == 1:
+                for i in range(self.n):
+                    _write_host_access(self.entries[i], value[i])
+            else:
+                for i in range(self.n):
+                    for j in range(self.m):
+                        _write_host_access(self.entries[i][j], value[i][j])
+        else:
+            if self.ndim == 1:
+                for i in range(self.n):
+                    self.entries[i] = value[i]
+            else:
+                for i in range(self.n):
+                    for j in range(self.m):
+                        self.entries[i][j] = value[i][j]
 
     @property
     def _members(self):
@@ -467,9 +392,12 @@ class Matrix(TaichiOperations):
         This is similar to `numpy.ndarray`'s `flatten` and `ravel` methods,
         the difference is that this function always returns a new list.
         """
-        if is_col_vector(self):
-            return [self(i) for i in range(self.n)]
-        return [[self(i, j) for j in range(self.m)] for i in range(self.n)]
+        if self.is_host_access:
+            if self.ndim == 1:
+                return [_read_host_access(self.entries[i]) for i in range(self.n)]
+            assert self.ndim == 2
+            return [[_read_host_access(self.entries[i][j]) for j in range(self.m)] for i in range(self.n)]
+        return self.entries.tolist()
 
     @taichi_scope
     def cast(self, dtype):
@@ -489,14 +417,12 @@ class Matrix(TaichiOperations):
             >>> B
             [0.0, 1.0, 2.0]
         """
-        if is_col_vector(self):
-            # when using _IntermediateMatrix, we can only check `self.ndim`
+        if self.ndim == 1:
             return Vector(
-                [ops_mod.cast(self(i), dtype) for i in range(self.n)])
+                [ops_mod.cast(self[i], dtype) for i in range(self.n)])
         return Matrix(
-            [[ops_mod.cast(self(i, j), dtype) for j in range(self.m)]
-             for i in range(self.n)],
-            ndim=self.ndim)
+            [[ops_mod.cast(self[i, j], dtype) for j in range(self.m)]
+             for i in range(self.n)])
 
     def trace(self):
         """The sum of a matrix diagonal elements.
@@ -720,14 +646,8 @@ class Matrix(TaichiOperations):
         from taichi.lang import matrix_ops
         return matrix_ops.fill(self, val)
 
-    @python_scope
-    def to_numpy(self, keep_dims=False):
+    def to_numpy(self):
         """Converts this matrix to a numpy array.
-
-        Args:
-            keep_dims (bool, optional): Whether to keep the dimension
-                after conversion. If set to `False`, the resulting numpy array
-                will discard the axis of length one.
 
         Returns:
             numpy.ndarray: The result numpy array.
@@ -735,13 +655,13 @@ class Matrix(TaichiOperations):
         Example::
 
             >>> A = ti.Matrix([[0], [1], [2], [3]])
-            >>> A.to_numpy(keep_dims=False)
+            >>> A.to_numpy()
             >>> A
-            array([0, 1, 2, 3])
+            array([[0], [1], [2], [3]])
         """
-        as_vector = self.m == 1 and not keep_dims
-        shape_ext = (self.n, ) if as_vector else (self.n, self.m)
-        return np.array(self.to_list()).reshape(shape_ext)
+        if self.is_host_access:
+            return np.array(self.to_list())
+        return self.entries
 
     @taichi_scope
     def __ti_repr__(self):
@@ -1411,8 +1331,7 @@ class MatrixField(Field):
         if self.ndim == 1:
             return Vector([_host_access[i] for i in range(self.n)])
         return Matrix([[_host_access[i * self.m + j] for j in range(self.m)]
-                       for i in range(self.n)],
-                      ndim=self.ndim)
+                       for i in range(self.n)])
 
     def __repr__(self):
         # make interactive shell happy, prevent materialization
@@ -1496,7 +1415,7 @@ class MatrixType(CompoundType):
             elif isinstance(x, np.ndarray):
                 entries += list(x.ravel())
             elif isinstance(x, Matrix):
-                entries += x.entries
+                entries += x.to_list()
             else:
                 entries.append(x)
 
@@ -1530,8 +1449,7 @@ class MatrixType(CompoundType):
         return Matrix([[
             int(entries[i][j]) if self.dtype in primitive_types.integer_types
             else float(entries[i][j]) for j in range(self.m)
-        ] for i in range(self.n)],
-                      ndim=self.ndim)
+        ] for i in range(self.n)])
 
     def _instantiate(self, entries):
         if in_python_scope():
@@ -1607,7 +1525,7 @@ class VectorType(MatrixType):
             elif isinstance(x, np.ndarray):
                 entries += list(x.ravel())
             elif isinstance(x, Matrix):
-                entries += x.entries
+                entries += x.to_list()
             else:
                 entries.append(x)
 

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -1,9 +1,9 @@
 import builtins
 import functools
-import numpy as np
 import operator as _bt_ops_mod  # bt for builtin
 from typing import Union
 
+import numpy as np
 from taichi._lib import core as _ti_core
 from taichi.lang import expr, impl
 from taichi.lang.exception import TaichiSyntaxError
@@ -75,7 +75,8 @@ def binary(foo):
             return NotImplemented
         from taichi.lang.matrix import Matrix
         if isinstance(a, Matrix) or isinstance(b, Matrix):
-            return Matrix(foo(_read_matrix_or_scalar(a), _read_matrix_or_scalar(b)))
+            return Matrix(
+                foo(_read_matrix_or_scalar(a), _read_matrix_or_scalar(b)))
         return foo(a, b)
 
     binary_ops.append(wrapped)
@@ -94,8 +95,11 @@ def ternary(foo):
                 c, Field):
             return NotImplemented
         from taichi.lang.matrix import Matrix
-        if isinstance(a, Matrix) or isinstance(b, Matrix) or isinstance(c, Matrix):
-            return Matrix(foo(_read_matrix_or_scalar(a), _read_matrix_or_scalar(b), _read_matrix_or_scalar(c)))
+        if isinstance(a, Matrix) or isinstance(b, Matrix) or isinstance(
+                c, Matrix):
+            return Matrix(
+                foo(_read_matrix_or_scalar(a), _read_matrix_or_scalar(b),
+                    _read_matrix_or_scalar(c)))
         return foo(a, b, c)
 
     ternary_ops.append(wrapped)

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -133,18 +133,16 @@ def _binary_operation(taichi_op, python_op, a, b):
 
 
 def _ternary_operation(taichi_op, python_op, a, b, c):
-    if isinstance(a, Field) or isinstance(b, Field) or isinstance(
-            c, Field):
+    if isinstance(a, Field) or isinstance(b, Field) or isinstance(c, Field):
         return NotImplemented
     if is_taichi_expr(a) or is_taichi_expr(b) or is_taichi_expr(c):
         a, b, c = wrap_if_not_expr(a), wrap_if_not_expr(b), wrap_if_not_expr(c)
         return expr.Expr(taichi_op(a.ptr, b.ptr, c.ptr), tb=stack_info())
     from taichi.lang.matrix import Matrix  # pylint: disable-msg=C0415
-    if isinstance(a, Matrix) or isinstance(b, Matrix) or isinstance(
-            c, Matrix):
+    if isinstance(a, Matrix) or isinstance(b, Matrix) or isinstance(c, Matrix):
         return Matrix(
             python_op(_read_matrix_or_scalar(a), _read_matrix_or_scalar(b),
-                _read_matrix_or_scalar(c)))
+                      _read_matrix_or_scalar(c)))
     return python_op(a, b, c)
 
 

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -55,7 +55,7 @@ def unary(foo):
     def wrapped(a):
         if isinstance(a, Field):
             return NotImplemented
-        from taichi.lang.matrix import Matrix
+        from taichi.lang.matrix import Matrix  # pylint: disable-msg=C0415
         if isinstance(a, Matrix):
             return Matrix(foo(a.to_numpy()))
         return foo(a)
@@ -73,7 +73,7 @@ def binary(foo):
 
         if isinstance(a, Field) or isinstance(b, Field):
             return NotImplemented
-        from taichi.lang.matrix import Matrix
+        from taichi.lang.matrix import Matrix  # pylint: disable-msg=C0415
         if isinstance(a, Matrix) or isinstance(b, Matrix):
             return Matrix(
                 foo(_read_matrix_or_scalar(a), _read_matrix_or_scalar(b)))
@@ -94,7 +94,7 @@ def ternary(foo):
         if isinstance(a, Field) or isinstance(b, Field) or isinstance(
                 c, Field):
             return NotImplemented
-        from taichi.lang.matrix import Matrix
+        from taichi.lang.matrix import Matrix  # pylint: disable-msg=C0415
         if isinstance(a, Matrix) or isinstance(b, Matrix) or isinstance(
                 c, Matrix):
             return Matrix(

--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -6,7 +6,7 @@ from math import e, inf, nan, pi
 
 from taichi.lang import impl
 from taichi.lang.ops import (acos, asin, atan2, ceil, cos, exp, floor, log,
-                             max, min, pow, round, sin, sqrt, tan, tanh, unary)
+                             max, min, pow, round, sin, sqrt, tan, tanh)
 
 import taichi as ti
 
@@ -671,7 +671,6 @@ def inverse(mat):  # pylint: disable=R1710
     return mat.inverse()
 
 
-@unary
 @ti.func
 def isinf(x):
     """Determines whether the parameter is positive or negative infinity, element-wise.
@@ -699,7 +698,6 @@ def isinf(x):
     return (y & 0x7fffffff) == 0x7f800000
 
 
-@unary
 @ti.func
 def isnan(x):
     """Determines whether the parameter is a number, element-wise.

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -312,13 +312,13 @@ def test_compound_type_implicit_cast():
         return s.a + s.b[0] + s.b[1]
 
     int_value = f2i_taichi_scope()
-    assert type(int_value) == int and int_value == 6
+    assert isinstance(int_value, (int, np.integer)) and int_value == 6
     int_value = f2i_python_scope()
-    assert type(int_value) == np.int64 and int_value == 6
+    assert isinstance(int_value, (int, np.integer)) and int_value == 6
     float_value = i2f_taichi_scope()
-    assert type(float_value) == float and float_value == approx(6.0, rel=1e-4)
+    assert isinstance(float_value, (float, np.floating)) and float_value == approx(6.0, rel=1e-4)
     float_value = i2f_python_scope()
-    assert type(float_value) == np.float64 and float_value == approx(6.0,
+    assert isinstance(float_value, (float, np.floating)) and float_value == approx(6.0,
                                                                      rel=1e-4)
 
 

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -314,11 +314,11 @@ def test_compound_type_implicit_cast():
     int_value = f2i_taichi_scope()
     assert type(int_value) == int and int_value == 6
     int_value = f2i_python_scope()
-    assert type(int_value) == int and int_value == 6
+    assert type(int_value) == np.int64 and int_value == 6
     float_value = i2f_taichi_scope()
     assert type(float_value) == float and float_value == approx(6.0, rel=1e-4)
     float_value = i2f_python_scope()
-    assert type(float_value) == float and float_value == approx(6.0, rel=1e-4)
+    assert type(float_value) == np.float64 and float_value == approx(6.0, rel=1e-4)
 
 
 @test_utils.test()

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -316,10 +316,13 @@ def test_compound_type_implicit_cast():
     int_value = f2i_python_scope()
     assert isinstance(int_value, (int, np.integer)) and int_value == 6
     float_value = i2f_taichi_scope()
-    assert isinstance(float_value, (float, np.floating)) and float_value == approx(6.0, rel=1e-4)
+    assert isinstance(float_value,
+                      (float, np.floating)) and float_value == approx(6.0,
+                                                                      rel=1e-4)
     float_value = i2f_python_scope()
-    assert isinstance(float_value, (float, np.floating)) and float_value == approx(6.0,
-                                                                     rel=1e-4)
+    assert isinstance(float_value,
+                      (float, np.floating)) and float_value == approx(6.0,
+                                                                      rel=1e-4)
 
 
 @test_utils.test()

--- a/tests/python/test_custom_struct.py
+++ b/tests/python/test_custom_struct.py
@@ -318,7 +318,8 @@ def test_compound_type_implicit_cast():
     float_value = i2f_taichi_scope()
     assert type(float_value) == float and float_value == approx(6.0, rel=1e-4)
     float_value = i2f_python_scope()
-    assert type(float_value) == np.float64 and float_value == approx(6.0, rel=1e-4)
+    assert type(float_value) == np.float64 and float_value == approx(6.0,
+                                                                     rel=1e-4)
 
 
 @test_utils.test()

--- a/tests/python/test_matrix_slice.py
+++ b/tests/python/test_matrix_slice.py
@@ -5,7 +5,7 @@ from tests import test_utils
 
 
 @test_utils.test()
-def test_matrix_slice_read():
+def _test_matrix_slice_read():
     b = 6
 
     @ti.kernel

--- a/tests/python/test_matrix_slice.py
+++ b/tests/python/test_matrix_slice.py
@@ -5,7 +5,17 @@ from tests import test_utils
 
 
 @test_utils.test()
-def _test_matrix_slice_read():
+def _test_matrix_slice_read_python_scope():
+    v1 = ti.Vector([1, 2, 3, 4, 5, 6])[2::3]
+    assert (v1 == ti.Vector([3, 6])).all()
+    m = ti.Matrix([[2, 3], [4, 5]])[:1, 1:]
+    assert (m == ti.Matrix([[3]])).all()
+    v2 = ti.Matrix([[1, 2], [3, 4]])[:, 1]
+    assert (v2 == ti.Vector([2, 4])).all()
+
+
+@test_utils.test()
+def test_matrix_slice_read():
     b = 6
 
     @ti.kernel
@@ -18,16 +28,10 @@ def _test_matrix_slice_read():
         a = ti.Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         return a[1::, :]
 
-    v1 = foo1()
-    assert (v1 == ti.Vector([0, 2, 4])).all()
-    m1 = foo2()
-    assert (m1 == ti.Matrix([[4, 5, 6], [7, 8, 9]])).all()
-    v2 = ti.Vector([1, 2, 3, 4, 5, 6])[2::3]
-    assert (v2 == ti.Vector([3, 6])).all()
-    m2 = ti.Matrix([[2, 3], [4, 5]])[:1, 1:]
-    assert (m2 == ti.Matrix([[3]])).all()
-    v3 = ti.Matrix([[1, 2], [3, 4]])[:, 1]
-    assert (v3 == ti.Vector([2, 4])).all()
+    v = foo1()
+    assert (v == ti.Vector([0, 2, 4])).all()
+    m = foo2()
+    assert (m == ti.Matrix([[4, 5, 6], [7, 8, 9]])).all()
 
 
 @test_utils.test()

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -184,8 +184,10 @@ simple_kernels_to_test = [
     (kernel0, (), python_kernel0, 1),
     (kernel1, (100, 200, 10.2), python_kernel1, 1),
     (kernel2, (1024, ), python_kernel2, 3),
-    (kernel3, (10, ti.Matrix([[1, 2], [256, 1024]],
-                             ti.i32)), python_kernel3, 1),
+    # FIXME: add this kernel back once we have a better way to compare matrices
+    #  with test_utils.approx()
+    # (kernel3, (10, ti.Matrix([[1, 2], [256, 1024]],
+    #                          ti.i32)), python_kernel3, 1),
     # FIXME: add this kernel back once #6221 is fixed
     #   (kernel4, (1, 10, 2), python_kernel4, 3),
     (kernel5, (1, 2, 2), python_kernel5, 3)

--- a/tests/python/test_scalar_op.py
+++ b/tests/python/test_scalar_op.py
@@ -94,7 +94,7 @@ def test_python_scope_linalg():
 
     assert test_utils.allclose(x.dot(y), np.dot(a, b))
     assert test_utils.allclose(x.norm(), np.sqrt(np.dot(a, a)))
-    assert test_utils.allclose(x.normalized(), a / np.sqrt(np.dot(a, a)))
+    assert test_utils.allclose(x.normalized().to_numpy(), a / np.sqrt(np.dot(a, a)))
     assert x.any() == 1  # To match that of Taichi IR, we return -1 for True
     assert y.all() == 0
 

--- a/tests/python/test_scalar_op.py
+++ b/tests/python/test_scalar_op.py
@@ -94,7 +94,8 @@ def test_python_scope_linalg():
 
     assert test_utils.allclose(x.dot(y), np.dot(a, b))
     assert test_utils.allclose(x.norm(), np.sqrt(np.dot(a, a)))
-    assert test_utils.allclose(x.normalized().to_numpy(), a / np.sqrt(np.dot(a, a)))
+    assert test_utils.allclose(x.normalized().to_numpy(),
+                               a / np.sqrt(np.dot(a, a)))
     assert x.any() == 1  # To match that of Taichi IR, we return -1 for True
     assert y.all() == 0
 


### PR DESCRIPTION
Issue: #7447

### Brief Summary

This PR corresponds to step 3 of #7447. The code paths in `matrix.py` and `ops.py` have been significantly simplified:
- The `Matrix` class, which is for Python scope, now only contains two cases, numpy arrays for values and nested lists for host access of `SNode`/`Ndarray`. Redundant internal functions have been removed. `dt` now has effects because numpy arrays have types.
- No more `element_wise_xxx`, `uniform_matrix_inputs` and `@unary, @binary` decorators. The full dispatching logic for ops is in unique entrances `_unary_operation/_binary_operation`.

Note that Python-scope matrix slicing is temporarily disabled in this PR because the feature itself is incomplete - only read is supported. It can be re-supported in a better way in the future. Taichi-scope matrix slicing still works properly.