### PR TITLE
[refactor] Remove LaunchContextBuilder::set_arg_raw

### DIFF
--- a/taichi/program/launch_context_builder.cpp
+++ b/taichi/program/launch_context_builder.cpp
@@ -109,6 +109,18 @@ void LaunchContextBuilder::set_arg_uint(int arg_id, uint64 d) {
   set_arg_int(arg_id, d);
 }
 
+void LaunchContextBuilder::set_arg(int arg_id, TypedConstant d) {
+  if (is_real(d.dt)) {
+    set_arg_float(arg_id, d.val_float());
+  } else {
+    if (is_signed(d.dt)) {
+      set_arg_int(arg_id, d.val_int());
+    } else {
+      set_arg_uint(arg_id, d.val_uint());
+    }
+  }
+}
+
 void LaunchContextBuilder::set_extra_arg_int(int i, int j, int32 d) {
   ctx_->extra_args[i][j] = d;
 }
@@ -158,14 +170,6 @@ void LaunchContextBuilder::set_arg_texture(int arg_id, const Texture &tex) {
 void LaunchContextBuilder::set_arg_rw_texture(int arg_id, const Texture &tex) {
   intptr_t ptr = tex.get_device_allocation_ptr_as_int();
   ctx_->set_arg_rw_texture(arg_id, ptr, tex.get_size());
-}
-
-void LaunchContextBuilder::set_arg_raw(int arg_id, uint64 d) {
-  TI_ASSERT_INFO(!kernel_->parameter_list[arg_id].is_array,
-                 "Assigning scalar value to external (numpy) array argument is "
-                 "not allowed.");
-
-  ctx_->set_arg<uint64>(arg_id, d);
 }
 
 RuntimeContext &LaunchContextBuilder::get_context() {

--- a/taichi/program/launch_context_builder.h
+++ b/taichi/program/launch_context_builder.h
@@ -21,6 +21,8 @@ class LaunchContextBuilder {
   void set_arg_int(int arg_id, int64 d);
   void set_arg_uint(int arg_id, uint64 d);
 
+  void set_arg(int arg_id, TypedConstant d);
+
   void set_extra_arg_int(int i, int j, int32 d);
 
   void set_arg_external_array_with_shape(int arg_id,
@@ -36,9 +38,6 @@ class LaunchContextBuilder {
   void set_arg_texture(int arg_id, const Texture &tex);
   void set_arg_rw_texture(int arg_id, const Texture &tex);
 
-  // Sets the |arg_id|-th arg in the context to the bits stored in |d|.
-  // This ignores the underlying kernel's |arg_id|-th arg type.
-  void set_arg_raw(int arg_id, uint64 d);
   TypedConstant fetch_ret(const std::vector<int> &index);
   float64 get_struct_ret_float(const std::vector<int> &index);
   int64 get_struct_ret_int(const std::vector<int> &index);

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -104,8 +104,8 @@ class ConstantFold : public BasicStmtVisitor {
                       true};
     auto *ker = get_jit_evaluator_kernel(id);
     auto launch_ctx = ker->make_launch_context();
-    launch_ctx.set_arg_raw(0, lhs.val_u64);
-    launch_ctx.set_arg_raw(1, rhs.val_u64);
+    launch_ctx.set_arg(0, lhs);
+    launch_ctx.set_arg(1, rhs);
     {
       std::lock_guard<std::mutex> _(program->jit_evaluator_cache_mut);
       (*ker)(compile_config, launch_ctx);
@@ -132,7 +132,7 @@ class ConstantFold : public BasicStmtVisitor {
                       false};
     auto *ker = get_jit_evaluator_kernel(id);
     auto launch_ctx = ker->make_launch_context();
-    launch_ctx.set_arg_raw(0, operand.val_u64);
+    launch_ctx.set_arg(0, operand);
     {
       std::lock_guard<std::mutex> _(program->jit_evaluator_cache_mut);
       (*ker)(compile_config, launch_ctx);


### PR DESCRIPTION
`set_arg_raw` no longer works when the type of the arguments are not uniformly 64 bits long, so I removed it in this PR and added `set_arg(int arg_id, TypedConstant d)` to set the argument correctly.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7550
* #7441
* #7561
* __->__ #7560
* #7558
* #7548
* #7547
* #7546

