### PR TITLE
[bug] Fix crashing on printing FrontendFuncCallStmt with no return value

### DIFF
--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -319,7 +319,8 @@ class IRPrinter : public IRVisitor {
       args += expr_to_string(stmt->args.exprs[i]);
     }
     print("{}${} = call \"{}\", args = ({}), ret = {}", stmt->type_hint(),
-          stmt->id, stmt->func->get_name(), args, stmt->ident->name());
+          stmt->id, stmt->func->get_name(), args,
+          stmt->ident.has_value() ? stmt->ident->name() : "none");
   }
 
   void visit(FuncCallStmt *stmt) override {


### PR DESCRIPTION
Taichi crashes when printing FrontendFuncCallStmt with no return value because `stmt->ident` (which is the identifier of its return value) is null when it does not have a return value. This PR fixes this bug.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7550
* #7441
* __->__ #7561
* #7560
* #7558
* #7548
* #7547
* #7546

