### PR TITLE
[misc] Revert "Security upgrade ipython from 7.34.0 to 8.10.0 (#7341)"

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,5 +13,4 @@ scipy
 setproctitle
 nbmake
 marko
-ipython>=8.10.0 # not directly required, pinned by Snyk to avoid a vulnerability
 PyYAML


### PR DESCRIPTION
This reverts commit 4459881448107f6b737457bc9c05c715fdcfba08.

IPython 8 need python3.8, but we need to support python3.7

Issue: #

### Brief Summary
