### PR TITLE
[refactor] Remove legacy implementation of llvm offline cache

### DIFF
--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -71,52 +71,7 @@ std::unique_ptr<KernelCodeGen> KernelCodeGen::create(
 }
 #ifdef TI_WITH_LLVM
 
-std::optional<LLVMCompiledKernel>
-KernelCodeGen::maybe_read_compilation_from_cache(
-    const std::string &kernel_key) {
-  TI_AUTO_PROF;
-  auto *llvm_prog = get_llvm_program(prog);
-  const auto &reader = llvm_prog->get_cache_reader();
-  if (!reader) {
-    return std::nullopt;
-  }
-
-  LlvmOfflineCache::KernelCacheData cache_data;
-  auto &llvm_ctx = *tlctx_.get_this_thread_context();
-
-  if (!reader->get_kernel_cache(cache_data, kernel_key, llvm_ctx)) {
-    return std::nullopt;
-  }
-  return {std::move(cache_data.compiled_data)};
-}
-
-void KernelCodeGen::cache_kernel(const std::string &kernel_key,
-                                 const LLVMCompiledKernel &data) {
-  get_llvm_program(prog)->cache_kernel(kernel_key, data, kernel);
-}
-
 LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
-  // NOTE: The code below (codegen + offline cache) is a little confusing. But
-  // don't worry, the KernelCompilationManager to be introduced to unify the
-  // implementation of the offline cache will resolve the problem.
-
-  bool enable_offline_cache = compile_config_.offline_cache &&
-                              this->supports_offline_cache() &&
-                              !kernel->is_evaluator;
-
-  // Generate offline cache key & Try loading kernel from offline cache
-  if (enable_offline_cache) {
-    std::string key = get_hashed_offline_cache_key(compile_config_, {}, kernel);
-    kernel->set_kernel_key_for_cache(key);
-    if (auto res = maybe_read_compilation_from_cache(key)) {
-      TI_DEBUG("Create kernel '{}' from cache (key='{}')", kernel->get_name(),
-               key);
-      return std::move(*res);
-    }
-  }
-
-  // Compile & Cache it
-
   irpass::ast_to_ir(compile_config_, *kernel, false);
 
   auto block = dynamic_cast<Block *>(kernel->ir.get());
@@ -143,16 +98,7 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   if (!kernel->is_evaluator) {
     worker.flush();
   }
-  auto linked = tlctx_.link_compiled_tasks(std::move(data));
-
-  if (enable_offline_cache) {
-    const auto &key = kernel->get_cached_kernel_key();
-    TI_ASSERT(!key.empty());
-    TI_DEBUG("Cache kernel '{}' (key='{}')", kernel->get_name(), key);
-    cache_kernel(key, linked);
-  }
-
-  return linked;
+  return tlctx_.link_compiled_tasks(std::move(data));
 }
 
 ModuleToFunctionConverter::ModuleToFunctionConverter(

--- a/taichi/codegen/codegen.h
+++ b/taichi/codegen/codegen.h
@@ -65,7 +65,9 @@ class KernelCodeGen {
   virtual LLVMCompiledTask compile_task(
       const CompileConfig &config,
       std::unique_ptr<llvm::Module> &&module = nullptr,
-      OffloadedStmt *stmt = nullptr){TI_NOT_IMPLEMENTED}
+      OffloadedStmt *stmt = nullptr) {
+    TI_NOT_IMPLEMENTED
+  }
 
 #endif
  protected:

--- a/taichi/codegen/codegen.h
+++ b/taichi/codegen/codegen.h
@@ -67,10 +67,6 @@ class KernelCodeGen {
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr){TI_NOT_IMPLEMENTED}
 
-  std::optional<LLVMCompiledKernel> maybe_read_compilation_from_cache(
-      const std::string &kernel_key);
-  void cache_kernel(const std::string &kernel_key,
-                    const LLVMCompiledKernel &data);
 #endif
  protected:
   const CompileConfig &get_compile_config() const {

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -32,11 +32,6 @@ LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
       compilation_workers("compile", config_.num_compile_threads) {
   runtime_exec_ = std::make_unique<LlvmRuntimeExecutor>(config_, profiler);
   cache_data_ = std::make_unique<LlvmOfflineCache>();
-  if (config_.offline_cache) {
-    cache_reader_ =
-        LlvmOfflineCacheFileReader::make(offline_cache::get_cache_path_by_arch(
-            config_.offline_cache_file_path, config->arch));
-  }
 }
 
 FunctionType LlvmProgramImpl::compile(const CompileConfig &compile_config,
@@ -102,25 +97,6 @@ std::unique_ptr<AotModuleBuilder> LlvmProgramImpl::make_aot_module_builder(
 
   TI_NOT_IMPLEMENTED;
   return nullptr;
-}
-
-void LlvmProgramImpl::cache_kernel(const std::string &kernel_key,
-                                   const LLVMCompiledKernel &data,
-                                   Kernel *kernel) {
-  if (cache_data_->kernels.find(kernel_key) != cache_data_->kernels.end()) {
-    return;
-  }
-  auto &kernel_cache = cache_data_->kernels[kernel_key];
-  kernel_cache.kernel_key = kernel_key;
-  kernel_cache.compiled_data = data.clone();
-  kernel_cache.args = kernel->parameter_list;
-  kernel_cache.rets = kernel->rets;
-  kernel_cache.args_size = kernel->args_size;
-  kernel_cache.args_type = kernel->args_type;
-  kernel_cache.ret_size = kernel->ret_size;
-  kernel_cache.ret_type = kernel->ret_type;
-  kernel_cache.created_at = std::time(nullptr);
-  kernel_cache.last_used_at = std::time(nullptr);
 }
 
 void LlvmProgramImpl::cache_field(int snode_tree_id,

--- a/taichi/runtime/program_impls/llvm/llvm_program.h
+++ b/taichi/runtime/program_impls/llvm/llvm_program.h
@@ -55,10 +55,6 @@ class LlvmProgramImpl : public ProgramImpl {
   // initialize_llvm_runtime_snodes It's a 2-in-1 interface
   void materialize_snode_tree(SNodeTree *tree, uint64 *result_buffer) override;
 
-  void cache_kernel(const std::string &kernel_key,
-                    const LLVMCompiledKernel &data,
-                    Kernel *kernel);
-
   void cache_field(int snode_tree_id,
                    int root_id,
                    const StructCompiler &struct_compiler);
@@ -278,10 +274,6 @@ class LlvmProgramImpl : public ProgramImpl {
     return runtime_exec_.get();
   }
 
-  const std::unique_ptr<LlvmOfflineCacheFileReader> &get_cache_reader() {
-    return cache_reader_;
-  }
-
   std::string get_kernel_return_data_layout() override {
     return get_llvm_context()->get_data_layout_string();
   };
@@ -332,10 +324,7 @@ class LlvmProgramImpl : public ProgramImpl {
     // 1. Destructs cache_data_
     cache_data_.reset();
 
-    // 2. Destructs cache_reader_
-    cache_reader_.reset();
-
-    // 3. Destructs runtime_exec_
+    // 2. Destructs runtime_exec_
     runtime_exec_.reset();
   }
   ParallelExecutor compilation_workers;  // parallel compilation
@@ -349,7 +338,6 @@ class LlvmProgramImpl : public ProgramImpl {
   std::size_t num_snode_trees_processed_{0};
   std::unique_ptr<LlvmRuntimeExecutor> runtime_exec_;
   std::unique_ptr<LlvmOfflineCache> cache_data_;
-  std::unique_ptr<LlvmOfflineCacheFileReader> cache_reader_;
 };
 
 LlvmProgramImpl *get_llvm_program(Program *prog);

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -212,7 +212,7 @@ def test_cli_run():
         assert args.filename == "a.py"
 
 
-def test_cli_cache():
+def _test_cli_cache():  # TODO(PGZXB): Re-enable the test
     archs = {
         ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal, ti.gles, ti.amdgpu
     }

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -18,7 +18,7 @@ from tests import test_utils
 OFFLINE_CACHE_TEMP_DIR = mkdtemp()
 atexit.register(lambda: rmdir(OFFLINE_CACHE_TEMP_DIR))
 
-supported_llvm_archs = {ti.cpu, ti.cuda}
+supported_llvm_archs = set()
 supported_gfx_archs = {ti.opengl, ti.vulkan, ti.metal}
 supported_archs_offline_cache = supported_llvm_archs | supported_gfx_archs
 supported_archs_offline_cache = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7587
* #7586
* #7585
* #7584
* #7583
* #7582
* __->__ #7581
* #7580

