### PR TITLE
[cpu] Explicitly make cpu multithreading loop for range-fors.

### DIFF
--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -58,16 +58,6 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
 
     auto [begin, end] = get_range_for_bounds(stmt);
 
-    // adaptive block_dim
-    if (compile_config.cpu_block_dim_adaptive) {
-      int num_items = (stmt->end_value - stmt->begin_value) / std::abs(step);
-      int num_threads = stmt->num_cpu_threads;
-      int items_per_thread = std::max(1, num_items / (num_threads * 32));
-      // keep each task has at least 512 items to amortize scheduler overhead
-      // also saturate the value to 1024 for better load balancing
-      stmt->block_dim = std::min(1024, std::max(512, items_per_thread));
-    }
-
     call("cpu_parallel_range_for", get_arg(0),
          tlctx->get_constant(stmt->num_cpu_threads), begin, end,
          tlctx->get_constant(step), tlctx->get_constant(stmt->block_dim),

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -72,7 +72,8 @@ std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *root);
 void make_block_local(IRNode *root,
                       const CompileConfig &config,
                       const MakeBlockLocalPass::Args &args);
-void make_cpu_multithreaded_range_for(IRNode *root, const CompileConfig &config);
+void make_cpu_multithreaded_range_for(IRNode *root,
+                                      const CompileConfig &config);
 void make_mesh_thread_local(IRNode *root,
                             const CompileConfig &config,
                             const MakeBlockLocalPass::Args &args);

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -72,6 +72,7 @@ std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *root);
 void make_block_local(IRNode *root,
                       const CompileConfig &config,
                       const MakeBlockLocalPass::Args &args);
+void make_cpu_multithreaded_range_for(IRNode *root, const CompileConfig &config);
 void make_mesh_thread_local(IRNode *root,
                             const CompileConfig &config,
                             const MakeBlockLocalPass::Args &args);

--- a/taichi/program/compile_config.cpp
+++ b/taichi/program/compile_config.cpp
@@ -46,6 +46,7 @@ CompileConfig::CompileConfig() {
   ndarray_use_cached_allocator = true;
   real_matrix_scalarize = true;
   half2_vectorization = false;
+  make_cpu_multithreading_loop = true;
 
   saturating_grid_dim = 0;
   max_block_dim = 0;

--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -41,6 +41,7 @@ struct CompileConfig {
   bool ndarray_use_cached_allocator;
   bool real_matrix_scalarize;
   bool half2_vectorization;
+  bool make_cpu_multithreading_loop;
   DataType default_fp;
   DataType default_ip;
   DataType default_up;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -200,6 +200,8 @@ void export_lang(py::module &m) {
       .def_readwrite("real_matrix_scalarize",
                      &CompileConfig::real_matrix_scalarize)
       .def_readwrite("half2_vectorization", &CompileConfig::half2_vectorization)
+      .def_readwrite("make_cpu_multithreading_loop",
+                     &CompileConfig::make_cpu_multithreading_loop)
       .def_readwrite("cc_compile_cmd", &CompileConfig::cc_compile_cmd)
       .def_readwrite("cc_link_cmd", &CompileConfig::cc_link_cmd)
       .def_readwrite("quant_opt_store_fusion",

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -218,7 +218,7 @@ void offload_to_executable(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
-  if (arch_is_cpu(config.arch)) {
+  if (config.make_cpu_multithreading_loop && arch_is_cpu(config.arch)) {
     irpass::make_cpu_multithreaded_range_for(ir, config);
     irpass::type_check(ir, config);
     print("Make CPU multithreaded range-for");

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -221,7 +221,7 @@ void offload_to_executable(IRNode *ir,
   if (arch_is_cpu(config.arch)) {
     irpass::make_cpu_multithreaded_range_for(ir, config);
     irpass::type_check(ir, config);
-    print("Make CPU multithreaded ranage-for");
+    print("Make CPU multithreaded range-for");
     irpass::analysis::verify(ir);
   }
 

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -218,6 +218,13 @@ void offload_to_executable(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
+  if (arch_is_cpu(config.arch)) {
+    irpass::make_cpu_multithreaded_range_for(ir, config);
+    irpass::type_check(ir, config);
+    print("Make CPU multithreaded ranage-for");
+    irpass::analysis::verify(ir);
+  }
+
   if (is_extension_supported(config.arch, Extension::mesh) &&
       config.demote_no_access_mesh_fors) {
     irpass::demote_no_access_mesh_fors(ir);

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -10,7 +10,8 @@ namespace {
 
 using TaskType = OffloadedStmt::TaskType;
 
-void make_multithreaded_range_for(OffloadedStmt *offloaded, const CompileConfig &config) {
+void make_multithreaded_range_for(OffloadedStmt *offloaded,
+                                  const CompileConfig &config) {
   TI_ASSERT(offloaded->task_type == TaskType::range_for);
 
   auto offloaded_body = std::make_unique<Block>();
@@ -27,24 +28,23 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded, const CompileConfig 
   // auto offloaded_body = offloaded_body.get();
   offloaded_body->insert(Stmt::make_typed<LoopIndexStmt>(offloaded, 0));
   auto thread_index = offloaded_body->back();
-  
 
   // Retrieve range-for bounds.
-  Stmt* begin_stmt;
-  Stmt* end_stmt;
+  Stmt *begin_stmt;
+  Stmt *end_stmt;
   if (offloaded->const_begin) {
     begin_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
         TypedConstant(PrimitiveType::i32, offloaded->begin_value)));
   } else {
-    begin_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(offloaded->begin_offset,
-                                                 PrimitiveType::i32));
+    begin_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
+        offloaded->begin_offset, PrimitiveType::i32));
   }
   if (offloaded->const_end) {
     end_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
         TypedConstant(PrimitiveType::i32, offloaded->end_value)));
   } else {
-    end_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(offloaded->end_offset,
-                                                 PrimitiveType::i32));
+    end_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
+        offloaded->end_offset, PrimitiveType::i32));
   }
 
   // Inner serial block range is
@@ -53,26 +53,26 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded, const CompileConfig 
       Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, end_stmt, begin_stmt));
   offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
       BinaryOpType::add, offloaded_body->back(), num_threads));
-  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub,
-                                                   offloaded_body->back(), one));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::sub, offloaded_body->back(), one));
   offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
       BinaryOpType::floordiv, offloaded_body->back(), num_threads));
-  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::max,
-                                                   offloaded_body->back(), one));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::max, offloaded_body->back(), one));
 
   // Inner loop begins at $[begin + block_range * thread_id]
   auto block_range = offloaded_body->back();
-  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::mul,
-                                                   block_range, thread_index));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::mul, block_range, thread_index));
   offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
       BinaryOpType::add, begin_stmt, offloaded_body->back()));
   auto block_begin = offloaded_body->back();
 
   // Inner loop ends at $[min(block_begin + block_range), end))]
-  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add,
-                                                   block_begin, block_range));
-  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, end_stmt,
-                                                   offloaded_body->back()));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::add, block_begin, block_range));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::min, end_stmt, offloaded_body->back()));
   auto block_end = offloaded_body->back();
 
   offloaded_body->insert(Stmt::make_typed<RangeForStmt>(
@@ -102,7 +102,8 @@ void maybe_convert(OffloadedStmt *stmt, const CompileConfig &config) {
 
 namespace irpass {
 
-void make_cpu_multithreaded_range_for(IRNode *root, const CompileConfig &config) {
+void make_cpu_multithreaded_range_for(IRNode *root,
+                                      const CompileConfig &config) {
   if (auto *block = root->cast<Block>()) {
     for (auto &s_ : block->statements) {
       if (auto *s = s_->cast<OffloadedStmt>()) {

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -35,15 +35,17 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
   } else {
     begin_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
         offloaded->begin_offset, PrimitiveType::i32));
-    begin_stmt = offloaded_body->insert(Stmt::make<GlobalLoadStmt>(offloaded_body->back()));
+    begin_stmt = offloaded_body->insert(
+        Stmt::make<GlobalLoadStmt>(offloaded_body->back()));
   }
   if (offloaded->const_end) {
     end_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
         TypedConstant(PrimitiveType::i32, offloaded->end_value)));
   } else {
-    end_stmt =  offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
+    end_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
         offloaded->end_offset, PrimitiveType::i32));
-    end_stmt = offloaded_body->insert(Stmt::make<GlobalLoadStmt>(offloaded_body->back()));
+    end_stmt = offloaded_body->insert(
+        Stmt::make<GlobalLoadStmt>(offloaded_body->back()));
   }
 
   // Inner serial block range is

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -21,7 +21,8 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
       Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 512)));
   auto num_threads = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
       TypedConstant(PrimitiveType::i32, config.cpu_max_num_threads)));
-  auto thread_index = offloaded_body->insert(Stmt::make_typed<LoopIndexStmt>(offloaded, 0));
+  auto thread_index =
+      offloaded_body->insert(Stmt::make_typed<LoopIndexStmt>(offloaded, 0));
 
   // Retrieve range-for bounds.
   Stmt *begin_stmt;
@@ -49,8 +50,8 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
       Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, end_stmt, begin_stmt));
   block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
       BinaryOpType::add, block_range, num_threads));
-  block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::sub, block_range, one));
+  block_range = offloaded_body->insert(
+      Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, block_range, one));
   block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
       BinaryOpType::floordiv, block_range, num_threads));
   block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
@@ -65,8 +66,8 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
   // Inner loop ends at $[min(block_begin + block_range), end))]
   auto block_end = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
       BinaryOpType::add, block_begin, block_range));
-  block_end = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::min, end_stmt, block_end));
+  block_end = offloaded_body->insert(
+      Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, end_stmt, block_end));
 
   // Create the serial inner loop.
   auto inner_loop = offloaded_body->insert(Stmt::make_typed<RangeForStmt>(

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -101,8 +101,8 @@ class MakeCPUMultithreadedRangeFor : public BasicStmtVisitor {
     auto saturated_total_range =
         offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
             BinaryOpType::sub,
-            Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, total_range,
-                                           num_threads),
+            offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+                BinaryOpType::add, total_range, num_threads)),
             one));
     auto block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
         BinaryOpType::floordiv, saturated_total_range, num_threads));

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -10,105 +10,115 @@ namespace {
 
 using TaskType = OffloadedStmt::TaskType;
 
-void make_multithreaded_range_for(OffloadedStmt *offloaded,
-                                  const CompileConfig &config) {
-  TI_ASSERT(offloaded->task_type == TaskType::range_for);
-
-  auto offloaded_body = std::make_unique<Block>();
-  auto one = offloaded_body->insert(
-      Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
-  auto minimal_block_range = offloaded_body->insert(
-      Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 512)));
-  auto num_threads = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
-      TypedConstant(PrimitiveType::i32, config.cpu_max_num_threads)));
-  auto thread_index =
-      offloaded_body->insert(Stmt::make_typed<LoopIndexStmt>(offloaded, 0));
-
-  // Retrieve range-for bounds.
-  Stmt *begin_stmt;
-  Stmt *end_stmt;
-  if (offloaded->const_begin) {
-    begin_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
-        TypedConstant(PrimitiveType::i32, offloaded->begin_value)));
-  } else {
-    begin_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
-        offloaded->begin_offset, PrimitiveType::i32));
-    begin_stmt = offloaded_body->insert(Stmt::make<GlobalLoadStmt>(begin_stmt));
-  }
-  if (offloaded->const_end) {
-    end_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
-        TypedConstant(PrimitiveType::i32, offloaded->end_value)));
-  } else {
-    end_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
-        offloaded->end_offset, PrimitiveType::i32));
-    end_stmt = offloaded_body->insert(Stmt::make<GlobalLoadStmt>(end_stmt));
+class MakeCPUMultithreadedRangeFor : public BasicStmtVisitor {
+ public:
+  MakeCPUMultithreadedRangeFor(const CompileConfig &config)
+      : config(config), modified(false) {
   }
 
-  // Inner serial block range is
-  // $[max(((end - begin) + (num_threads - 1)) / num_threads, 1)]
-  auto block_range = offloaded_body->insert(
-      Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, end_stmt, begin_stmt));
-  block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::add, block_range, num_threads));
-  block_range = offloaded_body->insert(
-      Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, block_range, one));
-  block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::floordiv, block_range, num_threads));
-  block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::max, block_range, minimal_block_range));
-
-  // Inner loop begins at $[begin + block_range * thread_id]
-  auto block_begin = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::mul, block_range, thread_index));
-  block_begin = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::add, begin_stmt, block_begin));
-
-  // Inner loop ends at $[min(block_begin + block_range), end))]
-  auto block_end = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::add, block_begin, block_range));
-  block_end = offloaded_body->insert(
-      Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, end_stmt, block_end));
-
-  // Create the serial inner loop.
-  auto inner_loop = offloaded_body->insert(Stmt::make_typed<RangeForStmt>(
-      block_begin, block_end, std::move(offloaded->body),
-      /*is_bit_vectorized*/ false, /*num_cpu_threads*/ 1, /*block_dim*/ 1,
-      /*strictly_serialized*/ true, offloaded->range_hint));
-
-  irpass::replace_all_usages_with(inner_loop, offloaded, inner_loop);
-
-  // Update the offloaded stmt.
-  offloaded->const_begin = true;
-  offloaded->const_end = true;
-  offloaded->begin_value = 0;
-  offloaded->end_value = config.cpu_max_num_threads;
-  offloaded->body = std::move(offloaded_body);
-  offloaded->body->parent_stmt = offloaded;
-  offloaded->block_dim = 1;
-}
-
-void maybe_convert(OffloadedStmt *stmt, const CompileConfig &config) {
-  if ((stmt->task_type == TaskType::range_for) && (!stmt->is_bit_vectorized)) {
-    make_multithreaded_range_for(stmt, config);
+  void visit(Block *block) override {
+    for (auto &s_ : block->statements) {
+      s_->accept(this);
+    }
   }
-}
 
+  void visit(OffloadedStmt *offloaded) override {
+    if (offloaded->task_type != TaskType::range_for) {
+      return;
+    }
+
+    auto offloaded_body = std::make_unique<Block>();
+    auto one = offloaded_body->insert(
+        Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
+    auto minimal_block_range = offloaded_body->insert(
+        Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 512)));
+    auto num_threads = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
+        TypedConstant(PrimitiveType::i32, config.cpu_max_num_threads)));
+    auto thread_index =
+        offloaded_body->insert(Stmt::make_typed<LoopIndexStmt>(offloaded, 0));
+
+    // Retrieve range-for bounds.
+    Stmt *begin_stmt;
+    Stmt *end_stmt;
+    if (offloaded->const_begin) {
+      begin_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
+          TypedConstant(PrimitiveType::i32, offloaded->begin_value)));
+    } else {
+      begin_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
+          offloaded->begin_offset, PrimitiveType::i32));
+      begin_stmt =
+          offloaded_body->insert(Stmt::make<GlobalLoadStmt>(begin_stmt));
+    }
+    if (offloaded->const_end) {
+      end_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
+          TypedConstant(PrimitiveType::i32, offloaded->end_value)));
+    } else {
+      end_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
+          offloaded->end_offset, PrimitiveType::i32));
+      end_stmt = offloaded_body->insert(Stmt::make<GlobalLoadStmt>(end_stmt));
+    }
+
+    // Inner serial block range is
+    // $[max(((end - begin) + (num_threads - 1)) / num_threads, 1)]
+    auto block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::sub, end_stmt, begin_stmt));
+    block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::add, block_range, num_threads));
+    block_range = offloaded_body->insert(
+        Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, block_range, one));
+    block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::floordiv, block_range, num_threads));
+    block_range = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::max, block_range, minimal_block_range));
+
+    // Inner loop begins at $[begin + block_range * thread_id]
+    auto block_begin = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::mul, block_range, thread_index));
+    block_begin = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::add, begin_stmt, block_begin));
+
+    // Inner loop ends at $[min(block_begin + block_range), end))]
+    auto block_end = offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::add, block_begin, block_range));
+    block_end = offloaded_body->insert(
+        Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, end_stmt, block_end));
+
+    // Create the serial inner loop.
+    auto inner_loop = offloaded_body->insert(Stmt::make_typed<RangeForStmt>(
+        block_begin, block_end, std::move(offloaded->body),
+        /*is_bit_vectorized*/ false, /*num_cpu_threads*/ 1, /*block_dim*/ 1,
+        /*strictly_serialized*/ true, offloaded->range_hint));
+
+    irpass::replace_all_usages_with(inner_loop, offloaded, inner_loop);
+
+    // Update the offloaded stmt.
+    offloaded->const_begin = true;
+    offloaded->const_end = true;
+    offloaded->begin_value = 0;
+    offloaded->end_value = config.cpu_max_num_threads;
+    offloaded->body = std::move(offloaded_body);
+    offloaded->body->parent_stmt = offloaded;
+    offloaded->block_dim = 1;
+    modified = true;
+  }
+
+  static bool run(IRNode *root, const CompileConfig &config) {
+    MakeCPUMultithreadedRangeFor pass(config);
+    root->accept(&pass);
+    return pass.modified;
+  }
+
+ private:
+  const CompileConfig &config;
+  bool modified{false};
+};
 }  // namespace
 
 namespace irpass {
 
 void make_cpu_multithreaded_range_for(IRNode *root,
                                       const CompileConfig &config) {
-  if (auto *block = root->cast<Block>()) {
-    for (auto &s_ : block->statements) {
-      if (auto *s = s_->cast<OffloadedStmt>()) {
-        maybe_convert(s, config);
-      }
-    }
-  } else if (auto *s = root->cast<OffloadedStmt>()) {
-    maybe_convert(s, config);
-  }
-  re_id(root);
+  MakeCPUMultithreadedRangeFor::run(root, config);
 }
 
 }  // namespace irpass

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -18,6 +18,8 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
   offloaded_body->insert(
       Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
   auto one = offloaded_body->back();
+  auto minimal_block_range = offloaded_body->insert(
+      Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 512)));
   offloaded_body->insert(Stmt::make_typed<ConstStmt>(
       TypedConstant(PrimitiveType::i32, config.cpu_max_num_threads)));
   auto num_threads = offloaded_body->back();
@@ -55,7 +57,7 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
   offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
       BinaryOpType::floordiv, offloaded_body->back(), num_threads));
   offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
-      BinaryOpType::max, offloaded_body->back(), one));
+      BinaryOpType::max, offloaded_body->back(), minimal_block_range));
 
   // Inner loop begins at $[begin + block_range * thread_id]
   auto block_range = offloaded_body->back();

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -15,17 +15,12 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
   TI_ASSERT(offloaded->task_type == TaskType::range_for);
 
   auto offloaded_body = std::make_unique<Block>();
-  // offloaded_body->insert(
-  //     Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 0)));
-  // auto zero = offloaded_body->back();
   offloaded_body->insert(
       Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
   auto one = offloaded_body->back();
   offloaded_body->insert(Stmt::make_typed<ConstStmt>(
       TypedConstant(PrimitiveType::i32, config.cpu_max_num_threads)));
   auto num_threads = offloaded_body->back();
-
-  // auto offloaded_body = offloaded_body.get();
   offloaded_body->insert(Stmt::make_typed<LoopIndexStmt>(offloaded, 0));
   auto thread_index = offloaded_body->back();
 

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -1,0 +1,120 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/ir/visitors.h"
+#include "taichi/transforms/utils.h"
+
+namespace taichi::lang {
+
+namespace {
+
+using TaskType = OffloadedStmt::TaskType;
+
+void make_multithreaded_range_for(OffloadedStmt *offloaded, const CompileConfig &config) {
+  TI_ASSERT(offloaded->task_type == TaskType::range_for);
+
+  auto offloaded_body = std::make_unique<Block>();
+  // offloaded_body->insert(
+  //     Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 0)));
+  // auto zero = offloaded_body->back();
+  offloaded_body->insert(
+      Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
+  auto one = offloaded_body->back();
+  offloaded_body->insert(Stmt::make_typed<ConstStmt>(
+      TypedConstant(PrimitiveType::i32, config.cpu_max_num_threads)));
+  auto num_threads = offloaded_body->back();
+
+  // auto offloaded_body = offloaded_body.get();
+  offloaded_body->insert(Stmt::make_typed<LoopIndexStmt>(offloaded, 0));
+  auto thread_index = offloaded_body->back();
+  
+
+  // Retrieve range-for bounds.
+  Stmt* begin_stmt;
+  Stmt* end_stmt;
+  if (offloaded->const_begin) {
+    begin_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
+        TypedConstant(PrimitiveType::i32, offloaded->begin_value)));
+  } else {
+    begin_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(offloaded->begin_offset,
+                                                 PrimitiveType::i32));
+  }
+  if (offloaded->const_end) {
+    end_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
+        TypedConstant(PrimitiveType::i32, offloaded->end_value)));
+  } else {
+    end_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(offloaded->end_offset,
+                                                 PrimitiveType::i32));
+  }
+
+  // Inner serial block range is
+  // $[max(((end - begin) + (num_threads - 1)) / num_threads, 1)]
+  offloaded_body->insert(
+      Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, end_stmt, begin_stmt));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::add, offloaded_body->back(), num_threads));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub,
+                                                   offloaded_body->back(), one));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::floordiv, offloaded_body->back(), num_threads));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::max,
+                                                   offloaded_body->back(), one));
+
+  // Inner loop begins at $[begin + block_range * thread_id]
+  auto block_range = offloaded_body->back();
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::mul,
+                                                   block_range, thread_index));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(
+      BinaryOpType::add, begin_stmt, offloaded_body->back()));
+  auto block_begin = offloaded_body->back();
+
+  // Inner loop ends at $[min(block_begin + block_range), end))]
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add,
+                                                   block_begin, block_range));
+  offloaded_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, end_stmt,
+                                                   offloaded_body->back()));
+  auto block_end = offloaded_body->back();
+
+  offloaded_body->insert(Stmt::make_typed<RangeForStmt>(
+      block_begin, block_end, std::move(offloaded->body), false, 1, 1,
+      /*strictly_serialized*/ true, offloaded->range_hint));
+  auto inner_loop = offloaded_body->back();
+
+  irpass::replace_all_usages_with(inner_loop, offloaded, inner_loop);
+
+  // Update the offloaded stmt.
+  offloaded->const_begin = true;
+  offloaded->const_end = true;
+  offloaded->begin_value = 0;
+  offloaded->end_value = config.cpu_max_num_threads;
+  offloaded->body = std::move(offloaded_body);
+  offloaded->body->parent_stmt = offloaded;
+  offloaded->block_dim = 1;
+}
+
+void maybe_convert(OffloadedStmt *stmt, const CompileConfig &config) {
+  if ((stmt->task_type == TaskType::range_for) && (!stmt->is_bit_vectorized)) {
+    make_multithreaded_range_for(stmt, config);
+  }
+}
+
+}  // namespace
+
+namespace irpass {
+
+void make_cpu_multithreaded_range_for(IRNode *root, const CompileConfig &config) {
+  if (auto *block = root->cast<Block>()) {
+    for (auto &s_ : block->statements) {
+      if (auto *s = s_->cast<OffloadedStmt>()) {
+        maybe_convert(s, config);
+      }
+    }
+  } else if (auto *s = root->cast<OffloadedStmt>()) {
+    maybe_convert(s, config);
+  }
+  re_id(root);
+}
+
+}  // namespace irpass
+
+}  // namespace taichi::lang

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -33,13 +33,15 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
   } else {
     begin_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
         offloaded->begin_offset, PrimitiveType::i32));
+    begin_stmt = offloaded_body->insert(Stmt::make<GlobalLoadStmt>(offloaded_body->back()));
   }
   if (offloaded->const_end) {
     end_stmt = offloaded_body->insert(Stmt::make_typed<ConstStmt>(
         TypedConstant(PrimitiveType::i32, offloaded->end_value)));
   } else {
-    end_stmt = offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
+    end_stmt =  offloaded_body->insert(Stmt::make<GlobalTemporaryStmt>(
         offloaded->end_offset, PrimitiveType::i32));
+    end_stmt = offloaded_body->insert(Stmt::make<GlobalLoadStmt>(offloaded_body->back()));
   }
 
   // Inner serial block range is

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -70,7 +70,8 @@ void make_multithreaded_range_for(OffloadedStmt *offloaded,
 
   // Create the serial inner loop.
   auto inner_loop = offloaded_body->insert(Stmt::make_typed<RangeForStmt>(
-      block_begin, block_end, std::move(offloaded->body), false, 1, 1,
+      block_begin, block_end, std::move(offloaded->body),
+      /*is_bit_vectorized*/ false, /*num_cpu_threads*/ 1, /*block_dim*/ 1,
       /*strictly_serialized*/ true, offloaded->range_hint));
 
   irpass::replace_all_usages_with(inner_loop, offloaded, inner_loop);

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -43,46 +43,60 @@ class MakeCPUMultithreadingLoop : public IRVisitor {
     }
     // Make constants before multithreading loop
     mt_body_ = std::make_unique<Block>();
-    mt_body_->insert(Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 0)));
+    mt_body_->insert(
+        Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 0)));
     auto zero = mt_body_->back();
-    mt_body_->insert(Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
+    mt_body_->insert(
+        Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
     auto one = mt_body_->back();
-    mt_body_->insert(Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, config_.cpu_max_num_threads)));
+    mt_body_->insert(Stmt::make_typed<ConstStmt>(
+        TypedConstant(PrimitiveType::i32, config_.cpu_max_num_threads)));
     auto num_threads = mt_body_->back();
 
     auto mt_loop = Stmt::make_typed<RangeForStmt>(
-              zero, num_threads, std::make_unique<Block>(), false, config_.cpu_max_num_threads, 1, /*strictly_serialized*/false);
-    
+        zero, num_threads, std::make_unique<Block>(), false,
+        config_.cpu_max_num_threads, 1, /*strictly_serialized*/ false);
+
     // Build serial loop with in each thread.
     auto loop_body = mt_loop->body.get();
 
     loop_body->insert(Stmt::make_typed<LoopIndexStmt>(mt_loop.get(), 0));
     auto thread_index = loop_body->back();
-    // Inner serial block range is 
+    // Inner serial block range is
     // $[max(((end - begin) + (num_threads - 1)) / num_threads, 1)]
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, stmt->end, stmt->begin));
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, loop_body->back(), num_threads));
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, loop_body->back(), one));
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::floordiv, loop_body->back(), num_threads));
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::max, loop_body->back(), one));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub,
+                                                     stmt->end, stmt->begin));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::add, loop_body->back(), num_threads));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub,
+                                                     loop_body->back(), one));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::floordiv, loop_body->back(), num_threads));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::max,
+                                                     loop_body->back(), one));
 
     // Inner loop begins at $[begin + block_range * thread_id]
     auto block_range = loop_body->back();
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::mul, block_range, thread_index));
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, stmt->begin, loop_body->back()));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::mul, block_range, thread_index));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::add, stmt->begin, loop_body->back()));
     auto block_begin = loop_body->back();
 
     // Inner loop ends at $[min(block_begin + block_range), end))]
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, block_begin, block_range));
-    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, stmt->end, loop_body->back()));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add,
+                                                     block_begin, block_range));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(
+        BinaryOpType::min, stmt->end, loop_body->back()));
     auto block_end = loop_body->back();
 
     loop_body->insert(Stmt::make_typed<RangeForStmt>(
-              block_begin, block_end, std::move(stmt->body), false, 1, 1,  /*strictly_serialized*/true, stmt->range_hint));
+        block_begin, block_end, std::move(stmt->body), false, 1, 1,
+        /*strictly_serialized*/ true, stmt->range_hint));
     auto inner_loop = loop_body->back();
 
     replace_all_usages_with(inner_loop, stmt, inner_loop);
-    
+
     mt_body_->insert(std::move(mt_loop));
   }
 

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -29,7 +29,6 @@ bool demotable_axis_load(Stmt *stmt) {
   }
   return true;
 }
-
 class SquashPtrOffset : public IRVisitor {
  public:
   SquashPtrOffset() {

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -29,6 +29,86 @@ bool demotable_axis_load(Stmt *stmt) {
   }
   return true;
 }
+
+class MakeCPUMultithreadingLoop : public IRVisitor {
+ public:
+  MakeCPUMultithreadingLoop(const CompileConfig &config) : config_(config) {
+    allow_undefined_visitor = true;
+    invoke_default_visitor = true;
+  }
+
+  void visit(RangeForStmt *stmt) override {
+    if (stmt->strictly_serialized || stmt->is_bit_vectorized) {
+      return;
+    }
+    // Make constants before multithreading loop
+    mt_body_ = std::make_unique<Block>();
+    mt_body_->insert(Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 0)));
+    auto zero = mt_body_->back();
+    mt_body_->insert(Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, 1)));
+    auto one = mt_body_->back();
+    mt_body_->insert(Stmt::make_typed<ConstStmt>(TypedConstant(PrimitiveType::i32, config_.cpu_max_num_threads)));
+    auto num_threads = mt_body_->back();
+
+    auto mt_loop = Stmt::make_typed<RangeForStmt>(
+              zero, num_threads, std::make_unique<Block>(), false, config_.cpu_max_num_threads, 1, /*strictly_serialized*/false);
+    
+    // Build serial loop with in each thread.
+    auto loop_body = mt_loop->body.get();
+
+    loop_body->insert(Stmt::make_typed<LoopIndexStmt>(mt_loop.get(), 0));
+    auto thread_index = loop_body->back();
+    // Inner serial block range is 
+    // $[max(((end - begin) + (num_threads - 1)) / num_threads, 1)]
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, stmt->end, stmt->begin));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, loop_body->back(), num_threads));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::sub, loop_body->back(), one));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::floordiv, loop_body->back(), num_threads));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::max, loop_body->back(), one));
+
+    // Inner loop begins at $[begin + block_range * thread_id]
+    auto block_range = loop_body->back();
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::mul, block_range, thread_index));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, stmt->begin, loop_body->back()));
+    auto block_begin = loop_body->back();
+
+    // Inner loop ends at $[min(block_begin + block_range), end))]
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::add, block_begin, block_range));
+    loop_body->insert(Stmt::make_typed<BinaryOpStmt>(BinaryOpType::min, stmt->end, loop_body->back()));
+    auto block_end = loop_body->back();
+
+    loop_body->insert(Stmt::make_typed<RangeForStmt>(
+              block_begin, block_end, std::move(stmt->body), false, 1, 1,  /*strictly_serialized*/true, stmt->range_hint));
+    auto inner_loop = loop_body->back();
+
+    replace_all_usages_with(inner_loop, stmt, inner_loop);
+    
+    mt_body_->insert(std::move(mt_loop));
+  }
+
+  static void run(IRNode *root, const CompileConfig &config) {
+    auto root_block = dynamic_cast<Block *>(root);
+    auto root_statements = std::move(root_block->statements);
+    root_block->statements.clear();
+
+    for (int i = 0; i < (int)root_statements.size(); i++) {
+      MakeCPUMultithreadingLoop m(config);
+      root_statements[i]->accept(&m);
+      if (m.mt_body_) {
+        for (auto &stmt : m.mt_body_->statements) {
+          root_block->insert(std::move(stmt));
+        }
+      } else {
+        root_block->insert(std::move(root_statements[i]));
+      }
+    }
+  }
+
+ private:
+  const CompileConfig &config_;
+  std::unique_ptr<Block> mt_body_;
+};
+
 class SquashPtrOffset : public IRVisitor {
  public:
   SquashPtrOffset() {
@@ -776,6 +856,9 @@ class AssociateContinueScope : public BasicStmtVisitor {
 
 void offload(IRNode *root, const CompileConfig &config) {
   TI_AUTO_PROF;
+  if (arch_is_cpu(config.arch)) {
+    MakeCPUMultithreadingLoop::run(root, config);
+  }
   auto offloaded_ranges = Offloader::run(root, config);
   type_check(root, config);
   {


### PR DESCRIPTION
Issue: #7442 

This PR explicitly breaks a single range-for into two nested loops. The outer one is for CPU multithreading and thus could help LLVM properly auto-vectorize the inner loop.

Would improve memcpy/vecadd case from 8GB/s -> 54GB/s on an Apple M1 chip. Also significantly speedup x86 CPUs.