### PR TITLE
[llvm] [refactor] Set the llvm runtime when executing

### DIFF
--- a/c_api/src/taichi_llvm_impl.cpp
+++ b/c_api/src/taichi_llvm_impl.cpp
@@ -118,8 +118,6 @@ TiAotModule LlvmRuntime::load_aot_module(const char *module_path) {
                                                this->result_buffer);
   }
 
-  // Insert LLVMRuntime to RuntimeContext
-  executor_->prepare_runtime_context(&this->runtime_context_);
   return (TiAotModule)(new AotModule(*this, std::move(aot_module)));
 }
 

--- a/taichi/codegen/amdgpu/codegen_amdgpu.cpp
+++ b/taichi/codegen/amdgpu/codegen_amdgpu.cpp
@@ -511,6 +511,7 @@ FunctionType AMDGPUModuleToFunctionConverter::convert(
   return [amdgpu_module, kernel_name, args, offloaded_tasks = tasks,
           executor = this->executor_](RuntimeContext &context) {
     AMDGPUContext::get_instance().make_current();
+    context.runtime = executor->get_llvm_runtime();
     std::vector<void *> arg_buffers(args.size(), nullptr);
     std::vector<void *> device_buffers(args.size(), nullptr);
     char *device_result_buffer{nullptr};

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -243,6 +243,7 @@ FunctionType CPUModuleToFunctionConverter::convert(
   return [executor = this->executor_, args, kernel_name,
           task_funcs](RuntimeContext &context) {
     TI_TRACE("Launching kernel {}", kernel_name);
+    context.runtime = executor->get_llvm_runtime();
     // For taichi ndarrays, context.args saves pointer to its
     // |DeviceAllocation|, CPU backend actually want to use the raw ptr here.
     for (int i = 0; i < (int)args.size(); i++) {

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -722,6 +722,7 @@ FunctionType CUDAModuleToFunctionConverter::convert(
     CUDADriver::get_instance().malloc_async(
         (void **)&device_result_buffer,
         std::max(context.result_buffer_size, sizeof(uint64)), nullptr);
+    context.runtime = executor->get_llvm_runtime();
 
     bool transferred = false;
     for (int i = 0; i < (int)args.size(); i++) {

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -64,7 +64,6 @@ void Kernel::operator()(const CompileConfig &compile_config,
   }
 
   auto &context = ctx_builder.get_context();
-  program->prepare_runtime_context(&context);
   compiled_(context);
 
   const auto arch = compile_config.arch;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -499,10 +499,6 @@ int Program::allocate_snode_tree_id() {
   }
 }
 
-void Program::prepare_runtime_context(RuntimeContext *ctx) {
-  program_impl_->prepare_runtime_context(ctx);
-}
-
 void Program::enqueue_compute_op_lambda(
     std::function<void(Device *device, CommandList *cmdlist)> op,
     const std::vector<ComputeOpImageRef> &image_refs) {

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -329,8 +329,6 @@ class TI_DLL_EXPORT Program {
     return Identifier(global_id_counter_++, name);
   }
 
-  void prepare_runtime_context(RuntimeContext *ctx);
-
   /** Enqueue a custom compute op to the current program execution flow.
    *
    *  @params op The lambda that is invoked to construct the custom compute Op

--- a/taichi/program/program_impl.h
+++ b/taichi/program/program_impl.h
@@ -132,10 +132,6 @@ class ProgramImpl {
     TI_ERROR("fill_ndarray() not implemented on the current backend");
   }
 
-  // TODO: Move to Runtime Object
-  virtual void prepare_runtime_context(RuntimeContext *ctx) {
-  }
-
   virtual void enqueue_compute_op_lambda(
       std::function<void(Device *device, CommandList *cmdlist)> op,
       const std::vector<ComputeOpImageRef> &image_refs) {

--- a/taichi/runtime/llvm/llvm_aot_module_loader.cpp
+++ b/taichi/runtime/llvm/llvm_aot_module_loader.cpp
@@ -54,7 +54,6 @@ std::unique_ptr<aot::CompiledGraph> LlvmAotModule::get_graph(
   }
 
   aot::CompiledGraph graph = aot::CompiledGraph({dispatches});
-  executor_->prepare_runtime_context(&graph.ctx_);
 
   return std::make_unique<aot::CompiledGraph>(std::move(graph));
 }

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -751,10 +751,6 @@ LLVMRuntime *LlvmRuntimeExecutor::get_llvm_runtime() {
   return static_cast<LLVMRuntime *>(llvm_runtime_);
 }
 
-void LlvmRuntimeExecutor::prepare_runtime_context(RuntimeContext *ctx) {
-  ctx->runtime = get_llvm_runtime();
-}
-
 void LlvmRuntimeExecutor::init_runtime_jit_module(
     std::unique_ptr<llvm::Module> module) {
   llvm_context_->init_runtime_module(module.get());

--- a/taichi/runtime/llvm/llvm_runtime_executor.h
+++ b/taichi/runtime/llvm/llvm_runtime_executor.h
@@ -71,8 +71,6 @@ class LlvmRuntimeExecutor {
 
   LLVMRuntime *get_llvm_runtime();
 
-  void prepare_runtime_context(RuntimeContext *ctx);
-
   Device *get_compute_device();
 
   LlvmDevice *llvm_device();

--- a/taichi/runtime/program_impls/llvm/llvm_program.h
+++ b/taichi/runtime/program_impls/llvm/llvm_program.h
@@ -131,10 +131,6 @@ class LlvmProgramImpl : public ProgramImpl {
     return runtime_exec_->fill_ndarray(alloc, size, data);
   }
 
-  void prepare_runtime_context(RuntimeContext *ctx) override {
-    runtime_exec_->prepare_runtime_context(ctx);
-  }
-
   DeviceAllocation allocate_memory_ndarray(std::size_t alloc_size,
                                            uint64 *result_buffer) override {
     return runtime_exec_->allocate_memory_ndarray(alloc_size, result_buffer);


### PR DESCRIPTION
In this PR, I moved the logic of `prepare_runtime_context` which sets the llvm runtime to `RuntimeContext` to `ModuleToFunctionConverter`. After this PR, we no longer need the `prepare_runtime_context` function. We don't need to store a copy of `RuntimeContext` in CGraph and C-API as well, and I will remove them in #7576. 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7612
* #7611
* #7610
* #7608
* #7576
* __->__ #7601
* #7550

