### PR TITLE
[aot] Hide map memory failure

### DIFF
--- a/taichi/rhi/vulkan/vulkan_device_creator.cpp
+++ b/taichi/rhi/vulkan/vulkan_device_creator.cpp
@@ -42,6 +42,9 @@ bool check_validation_layer_support() {
 static const std::unordered_set<std::string> ignored_messages = {
     "UNASSIGNED-DEBUG-PRINTF",
     "VUID_Undefined",
+    // (penguinliong): Attempting to map a non-host-visible piece of memory.
+    // `VulkanDevice::map()` returns `RhiResult::invalid_usage` in this case.
+    "VUID-vkMapMemory-memory-00682",
 };
 
 [[maybe_unused]] bool vk_ignore_validation_warning(


### PR DESCRIPTION
Issue: #

### Brief Summary

Vulkan memory mapping can fail when the memory is not visible. But this is checked by both our RHI and the validation layers. We ignore the validation message in this case to unblock the CI.
