### PR TITLE
[aot] Header generator completed

### DIFF
--- a/c_api/include/taichi/cpp/taichi.hpp
+++ b/c_api/include/taichi/cpp/taichi.hpp
@@ -210,6 +210,7 @@ class MemorySlice {
 };
 
 class Memory {
+ protected:
   TiRuntime runtime_{TI_NULL_HANDLE};
   TiMemory memory_{TI_NULL_HANDLE};
   size_t size_{0};
@@ -314,6 +315,7 @@ class Memory {
 
 template <typename T>
 class NdArray {
+ protected:
   Memory memory_{};
   TiNdArray ndarray_{};
   size_t elem_count_{};
@@ -507,6 +509,7 @@ class ImageSlice {
 };
 
 class Image {
+ protected:
   TiRuntime runtime_{TI_NULL_HANDLE};
   TiImage image_{TI_NULL_HANDLE};
   TiImageDimension dimension_{TI_IMAGE_DIMENSION_MAX_ENUM};
@@ -627,6 +630,7 @@ class Image {
 };
 
 class Texture {
+ protected:
   Image image_{};
   TiTexture texture_{};
 
@@ -748,6 +752,7 @@ class ArgumentEntry {
 };
 
 class ComputeGraph {
+ protected:
   TiRuntime runtime_{TI_NULL_HANDLE};
   TiComputeGraph compute_graph_{TI_NULL_HANDLE};
   std::list<std::string> arg_names_{};  // For stable addresses.
@@ -834,6 +839,7 @@ class ComputeGraph {
 };
 
 class Kernel {
+ protected:
   TiRuntime runtime_{TI_NULL_HANDLE};
   TiKernel kernel_{TI_NULL_HANDLE};
   std::vector<TiArgument> args_{};
@@ -915,6 +921,7 @@ class Kernel {
 };
 
 class AotModule {
+ protected:
   TiRuntime runtime_{TI_NULL_HANDLE};
   TiAotModule aot_module_{TI_NULL_HANDLE};
   bool should_destroy_{false};
@@ -1155,6 +1162,7 @@ inline CapabilityLevelConfigBuilder CapabilityLevelConfig::builder() {
 }
 
 class Runtime {
+ protected:
   TiArch arch_{TI_ARCH_MAX_ENUM};
   TiRuntime runtime_{TI_NULL_HANDLE};
   bool should_destroy_{false};

--- a/misc/Test-TaichiAotWorkflow.ps1
+++ b/misc/Test-TaichiAotWorkflow.ps1
@@ -1,0 +1,164 @@
+param (
+    # Skip Taichi installation.
+    [switch] $SkipInstall,
+    # Debug mode: Generate files in current directory and keep the generated artifacts.
+    [switch] $Debug
+)
+
+function Install-Taichi {
+    if (-not $SkipInstall) {
+        & pip install -i https://pypi.taichi.graphics/simple/ taichi-nightly
+    }
+
+    # Check Taichi (nightly) installation.
+    & ti module -h
+    if ($LASTEXITCODE -ne 0) {
+        throw "Taichi (nightly) installation failed."
+    }
+}
+
+
+function Main {
+    param (
+        [string] $Arch
+    )
+
+    # Test for `ti module build`.
+
+    Write-Host "Generating arange.py..."
+    '
+import taichi as ti
+
+ti.init(arch=ti.' + $Arch + ')
+
+@ti.aot.export
+@ti.kernel
+def arange(a: ti.types.ndarray(ti.i32, ndim=1)):
+    for i in a:
+        a[i] = i
+    ' > "arange.py"
+
+    Write-Host "Building arange_module.tcm..."
+    & ti module build "arange.py" --output "arange_module.tcm"
+
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path "arange_module.tcm")) {
+        throw "Taichi AOT module build failed."
+    }
+
+
+    # Test for `ti module cppgen`.
+
+    Write-Host "Generating arange.h from arange_module.tcm..."
+    & ti module cppgen "arange_module.tcm" --output "arange.h" --namespace "test"
+
+    Write-Host "Generating arange.cpp..."
+    '
+#include <iostream>
+#include <cstdint>
+#include <taichi/cpp/taichi.hpp>
+#include "arange.h"
+
+int main(int argc, char **argv) {
+    ti::Runtime runtime = ti::Runtime(TI_ARCH_' + $ARCH.ToUpper() + ');
+
+    ti::NdArray<int32_t> a = runtime.allocate_ndarray<int32_t>({8}, {}, true);
+
+    test::AotModule_arange_module aot_module = test::AotModule_arange_module::load(runtime, "arange_module.tcm");
+    test::Kernel_arange k_arange = aot_module.get_kernel_arange();
+    k_arange.set_a(a);
+    k_arange.launch();
+
+    runtime.wait();
+
+    std::vector<uint32_t> out(8);
+    a.read(out);
+    for (int i = 0; i < 8; i++) {
+        std::cout << i << " ";
+        if (out[i] != i) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+    ' > "main.cpp"
+
+    Write-Host "Downloading FindTaichi.cmake from Taichi repository..."
+    New-Item -ItemType Directory -Path "cmake" -Force
+    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/taichi-dev/taichi/master/c_api/cmake/FindTaichi.cmake" -OutFile "cmake/FindTaichi.cmake" -Proxy "http://127.0.0.1:1080"
+
+    Write-Host "Generating CMakeLists.txt..."
+    '
+project(TestAotWorkflow)
+cmake_minimum_required(VERSION 3.17)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+find_package(Taichi REQUIRED)
+
+add_executable(TestAotWorkflow main.cpp)
+target_link_libraries(TestAotWorkflow PRIVATE Taichi::Runtime)
+
+add_custom_command(
+    TARGET TestAotWorkflow
+    PRE_BUILD
+    COMMENT "-- Copy redistributed libraries to output directory (if different): ${Taichi_REDIST_LIBRARIES}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Taichi_REDIST_LIBRARIES} "$<TARGET_FILE_DIR:TestAotWorkflow>")
+    ' > "CMakeLists.txt"
+
+    Write-Host "Compiling and running TestAotWorkflow..."
+    & cmake -B "build" -GNinja -S "."
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "CMake generation failed."
+    }
+
+    & cmake --build "build"
+
+    $Executable = Get-ChildItem build -Recurse -File | Where-Object { $_.Name.IndexOf("TestAotWorkflow") -ge 0 } | Select-Object -First 1
+    Write-Host $Executable
+
+    if ($LASTEXITCODE -ne 0 -or -not $Executable) {
+        throw "Compilation failed."
+    }
+
+    & $Executable
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Execution failed."
+    }
+}
+
+try {
+    if ($Debug) {
+        $WorkingDir = "./$(New-Guid)"
+    } else {
+        $TempDir = $(Get-PSDrive -Name "Temp").Root
+        $WorkingDir = "$TempDir/$(New-Guid)"
+    }
+    Write-Host "Working directory: $WorkingDir"
+    New-Item -ItemType Directory -Path $WorkingDir -Force
+
+    Push-Location $WorkingDir
+
+    if ($IsMacOS) {
+        $Arch = "metal"
+    } else {
+        $Arch = "vulkan"
+    }
+
+    Install-Taichi
+
+    Main -Arch $Arch
+
+    Write-Host "Test passed."
+} catch {
+    Write-Error $_
+} finally {
+    Pop-Location
+    if (!($Debug)) {
+        Remove-Item -Path $WorkingDir -Recurse -Force
+    }
+}

--- a/python/taichi/_ti_module/cppgen.py
+++ b/python/taichi/_ti_module/cppgen.py
@@ -86,7 +86,7 @@ def generate_ndarray_assign(cls_name: str, i: int, arg_name: str,
         f"  {cls_name} &set_{arg_name}(const TiNdArray &value) {{",
     ]
 
-    out += check_arg("elem_type", arg.dtype)
+    out += check_arg("elem_type", f"TI_DATA_TYPE_{arg.dtype.name.upper()}")
     out += check_arg("shape.dim_count", arg.ndim)
     assert len(arg.element_shape) <= 16
     out += check_arg("elem_shape.dim_count", len(arg.element_shape))
@@ -218,22 +218,19 @@ def generate_module_content_repr(m: GfxRuntime140, module_name: str,
     out = []
 
     if module_name:
-        out += [
-            f"struct Module_{module_name} {{",
-        ]
+        module_name = f"Module_{module_name}"
     else:
-        out += [
-            "struct Module {",
-        ]
+        module_name = "Module"
 
     out += [
+        f"struct {module_name} {{",
         "  TiRuntime runtime;",
         "  TiAotModule aot_module;",
         "  bool should_destroy;",
         "",
-        "  explicit Module(TiRuntime runtime, TiAotModule aot_module, bool should_destroy = true) :",
+        f"  explicit {module_name}(TiRuntime runtime, TiAotModule aot_module, bool should_destroy = true) :",
         "    runtime(runtime), aot_module(aot_module), should_destroy(should_destroy) {}",
-        "  ~Module() {",
+        f"  ~{module_name}() {{",
         "    if (should_destroy) {",
         "      ti_destroy_aot_module(aot_module);",
         "    }",

--- a/python/taichi/_ti_module/cppgen.py
+++ b/python/taichi/_ti_module/cppgen.py
@@ -33,8 +33,8 @@ def check_arg(actual: str, expect: Any) -> List[str]:
 
 def get_arg_dst(i: int, is_named: bool) -> str:
     if is_named:
-        return f"args[{i}].argument"
-    return f"args[{i}]"
+        return f"args_[{i}].argument"
+    return f"args_[{i}]"
 
 
 def generate_scalar_assign(cls_name: str, i: int, arg_name: str,
@@ -50,7 +50,7 @@ def generate_scalar_assign(cls_name: str, i: int, arg_name: str,
 
     if is_named:
         out += [
-            f"    args[{i}].name = \"{arg_name}\";",
+            f"    args_[{i}].name = \"{arg_name}\";",
         ]
     if ctype == "float":
         out += [
@@ -95,7 +95,7 @@ def generate_ndarray_assign(cls_name: str, i: int, arg_name: str,
 
     if is_named:
         out += [
-            f"    args[{i}].name = \"{arg_name}\";",
+            f"    args_[{i}].name = \"{arg_name}\";",
         ]
     out += [
         f"    {get_arg_dst(i, is_named)}.type = TI_ARGUMENT_TYPE_NDARRAY;",
@@ -122,7 +122,7 @@ def generate_texture_assign(cls_name: str, i: int, arg_name: str,
 
     if is_named:
         out += [
-            f"    args[{i}].name = \"{arg_name}\";",
+            f"    args_[{i}].name = \"{arg_name}\";",
         ]
     out += [
         f"    {get_arg_dst(i, is_named)}.type = TI_ARGUMENT_TYPE_TEXTURE;",
@@ -137,21 +137,17 @@ def generate_kernel_args_builder(kernel: sr.Kernel) -> List[str]:
     out = []
 
     out += [
-        f"struct Kernel_{kernel.name} {{",
-        "  TiRuntime runtime;",
-        "  TiKernel kernel;",
-        f"  TiArgument args[{len(kernel.context.args)}];",
-        "",
+        f"struct Kernel_{kernel.name} : public ti::Kernel {{",
         f"  explicit Kernel_{kernel.name}(TiRuntime runtime, TiKernel kernel) :",
-        "    runtime(runtime), kernel(kernel) {}",
-        f"  explicit Kernel_{kernel.name}(TiRuntime runtime, TiAotModule aot_module) :",
-        f"    runtime(runtime), kernel(ti_get_aot_module_kernel(aot_module, \"{kernel.name}\")) {{}}",
+        "    ti::Kernel(runtime, kernel) {",
+        f"    args_.resize({len(kernel.context.args)});",
+        "  }",
         "",
     ]
 
     cls_name = f"Kernel_{kernel.name}"
     for i, arg in enumerate(kernel.context.args):
-        arg_name = f"arg_{i}"
+        arg_name = arg.name if arg.name else f"arg{i}"
         if isinstance(arg, sr.ArgumentScalar):
             out += generate_scalar_assign(cls_name, i, arg_name, arg, False)
         elif isinstance(arg, sr.ArgumentNdArray):
@@ -163,9 +159,6 @@ def generate_kernel_args_builder(kernel: sr.Kernel) -> List[str]:
         out += [""]
 
     out += [
-        "  void launch() const {",
-        f"    ti_launch_kernel(runtime, kernel, {len(kernel.context.args)}, args);",
-        "  }",
         "};",
         "",
     ]
@@ -176,19 +169,15 @@ def generate_graph_args_builder(graph: sr.Graph) -> List[str]:
     out = []
 
     out += [
-        f"struct Graph_{graph.name} {{",
-        "  TiRuntime runtime;",
-        "  TiComputeGraph graph;",
-        f"  TiNamedArgument args[{len(graph.args)}];",
-        "",
-        f"  explicit Graph_{graph.name}(TiRuntime runtime, TiComputeGraph graph) :",
-        "    runtime(runtime), graph(graph) {}",
-        f"  explicit Graph_{graph.name}(TiRuntime runtime, TiAotModule aot_module) :",
-        f"    runtime(runtime), graph(ti_get_aot_module_compute_graph(aot_module, \"{graph.name}\")) {{}}",
+        f"struct ComputeGraph_{graph.name} : public ti::ComputeGraph {{",
+        f"  explicit ComputeGraph_{graph.name}(TiRuntime runtime, TiComputeGraph graph) :",
+        "    ti::ComputeGraph(runtime, graph) {",
+        f"    args_.resize({len(graph.args)})",
+        "  }",
         "",
     ]
 
-    cls_name = f"Graph_{graph.name}"
+    cls_name = f"ComputeGraph_{graph.name}"
     for i, arg in enumerate(graph.args):
         arg_name = arg.name
         if isinstance(arg.arg, sr.ArgumentScalar):
@@ -204,9 +193,6 @@ def generate_graph_args_builder(graph: sr.Graph) -> List[str]:
         out += [""]
 
     out += [
-        "  void launch() const {",
-        f"    ti_launch_compute_graph(runtime, graph, {len(graph.args)}, args);",
-        "  }",
         "};",
         "",
     ]
@@ -218,22 +204,28 @@ def generate_module_content_repr(m: GfxRuntime140, module_name: str,
     out = []
 
     if module_name:
-        module_name = f"Module_{module_name}"
+        module_name = f"AotModule_{module_name}"
     else:
-        module_name = "Module"
+        module_name = "AotModule"
 
     out += [
-        f"struct {module_name} {{",
-        "  TiRuntime runtime;",
-        "  TiAotModule aot_module;",
-        "  bool should_destroy;",
-        "",
+        f"struct {module_name} : public ti::AotModule {{",
         f"  explicit {module_name}(TiRuntime runtime, TiAotModule aot_module, bool should_destroy = true) :",
-        "    runtime(runtime), aot_module(aot_module), should_destroy(should_destroy) {}",
-        f"  ~{module_name}() {{",
-        "    if (should_destroy) {",
-        "      ti_destroy_aot_module(aot_module);",
-        "    }",
+        "    ti::AotModule(runtime, aot_module, should_destroy) {}",
+        "",
+        f"  static {module_name} load(TiRuntime runtime, const char *path) {{",
+        "    TiAotModule aot_module = ti_load_aot_module(runtime, path);",
+        f"    return {module_name}(runtime, aot_module, true);",
+        "  }",
+        f"  static {module_name} load(TiRuntime runtime, const std::string &path) {{",
+        f"    return {module_name}::load(runtime, path.c_str());",
+        "  }",
+        f"  static {module_name} create(TiRuntime runtime, const void *tcm, size_t size) {{",
+        "    TiAotModule aot_module = ti_create_aot_module(runtime, tcm, size);",
+        f"    return {module_name}(runtime, aot_module, true);",
+        "  }",
+        f"  static {module_name} create(TiRuntime runtime, const std::vector<uint8_t> &tcm) {{",
+        f"    return {module_name}::create(runtime, tcm.data(), tcm.size());",
         "  }",
         "",
     ]
@@ -242,13 +234,13 @@ def generate_module_content_repr(m: GfxRuntime140, module_name: str,
             continue
         out += [
             f"  Kernel_{kernel.name} get_kernel_{kernel.name}() const {{",
-            f"    return Kernel_{kernel.name}(runtime, aot_module);",
+            f'    return Kernel_{kernel.name}(runtime_, ti_get_aot_module_kernel(aot_module(), "{kernel.name}"));',
             "  }",
         ]
     for graph in m.graphs:
         out += [
-            f"  Graph_{graph.name} get_graph_{graph.name}() const {{",
-            f"    return Graph_{graph.name}(runtime, aot_module);",
+            f"  ComputeGraph_{graph.name} get_compute_graph_{graph.name}() const {{",
+            f'    return ComputeGraph_{graph.name}(runtime_, ti_get_aot_module_compute_graph(aot_module(), "{graph.name}"));',
             "  }",
         ]
     out += [
@@ -284,7 +276,9 @@ def generate_header(m: GfxRuntime140, module_name: str,
     out += [
         "// THIS IS A GENERATED HEADER; PLEASE DO NOT MODIFY.",
         "#pragma once",
-        "#include <taichi/taichi.h>",
+        "#include <vector>",
+        "#include <string>",
+        "#include <taichi/cpp/taichi.hpp>",
         "",
     ]
 

--- a/python/taichi/aot/conventions/gfxruntime140/dr.py
+++ b/python/taichi/aot/conventions/gfxruntime140/dr.py
@@ -38,6 +38,10 @@ class ArgumentAttributes:
         is_array = j["is_array"]
         offset_in_mem = j["offset_in_mem"]
         stride = j["stride"]
+        # (penguinliong) Note that the name field is optional for kernels.
+        # Kernels are always launched by indexed arguments and this is for
+        # debugging and header generation only.
+        name = j["name"] if "name" in j and len(j["name"]) > 0 else None
 
         self.dtype: int = int(dtype)
         self.element_shape: List[int] = [int(x) for x in element_shape]
@@ -47,6 +51,7 @@ class ArgumentAttributes:
         self.is_array: bool = bool(is_array)
         self.offset_in_mem: int = int(offset_in_mem)
         self.stride: int = int(stride)
+        self.name: Optional[str] = str(name) if name is not None else None
 
 
 @json_data_model

--- a/python/taichi/aot/conventions/gfxruntime140/sr.py
+++ b/python/taichi/aot/conventions/gfxruntime140/sr.py
@@ -476,7 +476,8 @@ class Graph:
     def __init__(self, name: str, dispatches: List[Dispatch]):
         self.name = name
         self.dispatches = dispatches
-        self.args = [y for x in dispatches for y in x.args]
+        args = {y.name: y.arg for x in dispatches for y in x.args}
+        self.args: List[NamedArgument] = [NamedArgument(k, v) for k, v in args.items()]
 
 
 def from_dr_graph(meta: Metadata, j: dr.Graph) -> Graph:

--- a/python/taichi/aot/conventions/gfxruntime140/sr.py
+++ b/python/taichi/aot/conventions/gfxruntime140/sr.py
@@ -55,8 +55,8 @@ class NdArrayAccess(Enum):
 
 
 class ArgumentNdArray(Argument):
-    def __init__(self, name: Optional[str], dtype: DataType, element_shape: List[int],
-                 ndim: int, access: NdArrayAccess):
+    def __init__(self, name: Optional[str], dtype: DataType,
+                 element_shape: List[int], ndim: int, access: NdArrayAccess):
         super().__init__(name)
         self.dtype: DataType = dtype
         self.element_shape: List[int] = element_shape
@@ -247,8 +247,7 @@ def from_dr_kernel(d: dr.KernelAttributes) -> Kernel:
                 if binding_ty == OpaqueArgumentType.NdArray:
                     args += [
                         ArgumentNdArray(
-                            arg.name,
-                            DataType(arg.dtype), arg.element_shape,
+                            arg.name, DataType(arg.dtype), arg.element_shape,
                             arg.field_dim,
                             NdArrayAccess(d.ctx_attribs.arr_access[i]))
                     ]
@@ -256,7 +255,8 @@ def from_dr_kernel(d: dr.KernelAttributes) -> Kernel:
                     args += [ArgumentTexture(arg.name, arg.field_dim)]
                 elif binding_ty == OpaqueArgumentType.RwTexture:
                     args += [
-                        ArgumentRwTexture(arg.name, ti.Format(arg.format), arg.field_dim)
+                        ArgumentRwTexture(arg.name, ti.Format(arg.format),
+                                          arg.field_dim)
                     ]
                 else:
                     assert False
@@ -483,7 +483,9 @@ class Graph:
         self.name = name
         self.dispatches = dispatches
         args = {y.name: y.arg for x in dispatches for y in x.args}
-        self.args: List[NamedArgument] = [NamedArgument(k, v) for k, v in args.items()]
+        self.args: List[NamedArgument] = [
+            NamedArgument(k, v) for k, v in args.items()
+        ]
 
 
 def from_dr_graph(meta: Metadata, j: dr.Graph) -> Graph:

--- a/python/taichi/aot/conventions/gfxruntime140/sr.py
+++ b/python/taichi/aot/conventions/gfxruntime140/sr.py
@@ -36,12 +36,14 @@ def get_data_type_size(dtype: DataType) -> int:
 
 
 class Argument(ABC):
-    def __init__(self):
+    def __init__(self, name: Optional[str]):
+        self.name = name
         pass
 
 
 class ArgumentScalar(Argument):
-    def __init__(self, dtype: DataType):
+    def __init__(self, name: Optional[str], dtype: DataType):
+        super().__init__(name)
         self.dtype: DataType = dtype
 
 
@@ -53,8 +55,9 @@ class NdArrayAccess(Enum):
 
 
 class ArgumentNdArray(Argument):
-    def __init__(self, dtype: DataType, element_shape: List[int], ndim: int,
-                 access: NdArrayAccess):
+    def __init__(self, name: Optional[str], dtype: DataType, element_shape: List[int],
+                 ndim: int, access: NdArrayAccess):
+        super().__init__(name)
         self.dtype: DataType = dtype
         self.element_shape: List[int] = element_shape
         self.ndim: int = ndim
@@ -62,12 +65,14 @@ class ArgumentNdArray(Argument):
 
 
 class ArgumentTexture(Argument):
-    def __init__(self, ndim: int):
+    def __init__(self, name: Optional[str], ndim: int):
+        super().__init__(name)
         self.ndim: int = ndim
 
 
 class ArgumentRwTexture(Argument):
-    def __init__(self, fmt: ti.Format, ndim: int):
+    def __init__(self, name: Optional[str], fmt: ti.Format, ndim: int):
+        super().__init__(name)
         self.fmt: ti.Format = fmt
         self.ndim: int = ndim
 
@@ -242,20 +247,21 @@ def from_dr_kernel(d: dr.KernelAttributes) -> Kernel:
                 if binding_ty == OpaqueArgumentType.NdArray:
                     args += [
                         ArgumentNdArray(
+                            arg.name,
                             DataType(arg.dtype), arg.element_shape,
                             arg.field_dim,
                             NdArrayAccess(d.ctx_attribs.arr_access[i]))
                     ]
                 elif binding_ty == OpaqueArgumentType.Texture:
-                    args += [ArgumentTexture(arg.field_dim)]
+                    args += [ArgumentTexture(arg.name, arg.field_dim)]
                 elif binding_ty == OpaqueArgumentType.RwTexture:
                     args += [
-                        ArgumentRwTexture(ti.Format(arg.format), arg.field_dim)
+                        ArgumentRwTexture(arg.name, ti.Format(arg.format), arg.field_dim)
                     ]
                 else:
                     assert False
         else:
-            args += [ArgumentScalar(DataType(arg.dtype))]
+            args += [ArgumentScalar(arg.name, DataType(arg.dtype))]
 
     assert len(d.ctx_attribs.ret_attribs_vec_) <= 1
     if len(d.ctx_attribs.ret_attribs_vec_) != 0:

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -601,7 +601,7 @@ class ASTTransformer(Builder):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_sparse_matrix(
-                            to_taichi_type(ctx.arg_features[i])))
+                            to_taichi_type(ctx.arg_features[i]), ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation,
                                 ndarray_type.NdarrayType):
                     ctx.create_variable(
@@ -609,30 +609,30 @@ class ASTTransformer(Builder):
                         kernel_arguments.decl_ndarray_arg(
                             to_taichi_type(ctx.arg_features[i][0]),
                             ctx.arg_features[i][1], ctx.arg_features[i][2],
-                            ctx.arg_features[i][3]))
+                            ctx.arg_features[i][3], ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation,
                                 texture_type.TextureType):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_texture_arg(
-                            ctx.arg_features[i][0]))
+                            ctx.arg_features[i][0], ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation,
                                 texture_type.RWTextureType):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_rw_texture_arg(
                             ctx.arg_features[i][0], ctx.arg_features[i][1],
-                            ctx.arg_features[i][2]))
+                            ctx.arg_features[i][2], ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation, MatrixType):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_matrix_arg(
-                            ctx.func.arguments[i].annotation))
+                            ctx.func.arguments[i].annotation, ctx.func.arguments[i].name))
                 else:
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_scalar_arg(
-                            ctx.func.arguments[i].annotation))
+                            ctx.func.arguments[i].annotation, ctx.func.arguments[i].name))
             impl.get_runtime().compiling_callable.finalize_params()
             # remove original args
             node.args.args = []

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -601,7 +601,8 @@ class ASTTransformer(Builder):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_sparse_matrix(
-                            to_taichi_type(ctx.arg_features[i]), ctx.func.arguments[i].name))
+                            to_taichi_type(ctx.arg_features[i]),
+                            ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation,
                                 ndarray_type.NdarrayType):
                     ctx.create_variable(
@@ -609,30 +610,35 @@ class ASTTransformer(Builder):
                         kernel_arguments.decl_ndarray_arg(
                             to_taichi_type(ctx.arg_features[i][0]),
                             ctx.arg_features[i][1], ctx.arg_features[i][2],
-                            ctx.arg_features[i][3], ctx.func.arguments[i].name))
+                            ctx.arg_features[i][3],
+                            ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation,
                                 texture_type.TextureType):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_texture_arg(
-                            ctx.arg_features[i][0], ctx.func.arguments[i].name))
+                            ctx.arg_features[i][0],
+                            ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation,
                                 texture_type.RWTextureType):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_rw_texture_arg(
                             ctx.arg_features[i][0], ctx.arg_features[i][1],
-                            ctx.arg_features[i][2], ctx.func.arguments[i].name))
+                            ctx.arg_features[i][2],
+                            ctx.func.arguments[i].name))
                 elif isinstance(ctx.func.arguments[i].annotation, MatrixType):
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_matrix_arg(
-                            ctx.func.arguments[i].annotation, ctx.func.arguments[i].name))
+                            ctx.func.arguments[i].annotation,
+                            ctx.func.arguments[i].name))
                 else:
                     ctx.create_variable(
                         arg.arg,
                         kernel_arguments.decl_scalar_arg(
-                            ctx.func.arguments[i].annotation, ctx.func.arguments[i].name))
+                            ctx.func.arguments[i].annotation,
+                            ctx.func.arguments[i].name))
             impl.get_runtime().compiling_callable.finalize_params()
             # remove original args
             node.args.args = []

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -65,11 +65,14 @@ def decl_scalar_arg(dtype, name):
 
 def decl_matrix_arg(matrixtype, name):
     if isinstance(matrixtype, VectorType):
-        return make_matrix(
-            [decl_scalar_arg(matrixtype.dtype, f"{name}_{i}") for i in range(matrixtype.n)])
-    return make_matrix(
-        [[decl_scalar_arg(matrixtype.dtype, f"{name}_{i}_{j}") for i in range(matrixtype.m)]
-         for j in range(matrixtype.n)])
+        return make_matrix([
+            decl_scalar_arg(matrixtype.dtype, f"{name}_{i}")
+            for i in range(matrixtype.n)
+        ])
+    return make_matrix([[
+        decl_scalar_arg(matrixtype.dtype, f"{name}_{i}_{j}")
+        for i in range(matrixtype.m)
+    ] for j in range(matrixtype.n)])
 
 
 def decl_sparse_matrix(dtype, name):

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -59,6 +59,7 @@ KernelContextAttributes::KernelContextAttributes(
   // as well but let's leave that as a followup up PR.
   for (const auto &ka : kernel.parameter_list) {
     ArgAttributes aa;
+    aa.name = ka.name;
     aa.dtype = ka.get_element_type()->as<PrimitiveType>()->type;
     const size_t dt_bytes = ka.get_element_size();
     aa.is_array = ka.is_array;

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -143,6 +143,7 @@ class KernelContextAttributes {
    * Attributes that are shared by the input arg and the return value.
    */
   struct AttribsBase {
+    std::string name;
     // For scalar arg, this is max(stride(dt), 4)
     // For array arg, this is #elements * max(stride(dt), 4)
     // Unit: byte
@@ -159,7 +160,8 @@ class KernelContextAttributes {
     // while RW textures always have a valid format.
     BufferFormat format{BufferFormat::unknown};
 
-    TI_IO_DEF(stride,
+    TI_IO_DEF(name,
+              stride,
               offset_in_mem,
               index,
               dtype,

--- a/taichi/program/callable.cpp
+++ b/taichi/program/callable.cpp
@@ -29,8 +29,7 @@ int Callable::insert_arr_param(const DataType &dt,
   return (int)parameter_list.size() - 1;
 }
 
-int Callable::insert_texture_param(int total_dim,
-                                   const std::string &name) {
+int Callable::insert_texture_param(int total_dim, const std::string &name) {
   // FIXME: we shouldn't abuse is_array for texture parameters
   parameter_list.emplace_back(PrimitiveType::f32, /*is_array=*/true, 0,
                               total_dim, std::vector<int>{});

--- a/taichi/program/callable.cpp
+++ b/taichi/program/callable.cpp
@@ -8,8 +8,9 @@ Callable::Callable() = default;
 
 Callable::~Callable() = default;
 
-int Callable::insert_scalar_param(const DataType &dt) {
+int Callable::insert_scalar_param(const DataType &dt, const std::string &name) {
   parameter_list.emplace_back(dt->get_compute_type(), /*is_array=*/false);
+  parameter_list.back().name = name;
   return (int)parameter_list.size() - 1;
 }
 
@@ -20,28 +21,37 @@ int Callable::insert_ret(const DataType &dt) {
 
 int Callable::insert_arr_param(const DataType &dt,
                                int total_dim,
-                               std::vector<int> element_shape) {
+                               std::vector<int> element_shape,
+                               const std::string &name) {
   parameter_list.emplace_back(dt->get_compute_type(), /*is_array=*/true,
                               /*size=*/0, total_dim, element_shape);
+  parameter_list.back().name = name;
   return (int)parameter_list.size() - 1;
 }
 
-int Callable::insert_texture_param(int total_dim) {
+int Callable::insert_texture_param(int total_dim,
+                                   const std::string &name) {
   // FIXME: we shouldn't abuse is_array for texture parameters
   parameter_list.emplace_back(PrimitiveType::f32, /*is_array=*/true, 0,
                               total_dim, std::vector<int>{});
+  parameter_list.back().name = name;
   return (int)parameter_list.size() - 1;
 }
 
-int Callable::insert_pointer_param(const DataType &dt) {
+int Callable::insert_pointer_param(const DataType &dt,
+                                   const std::string &name) {
   parameter_list.emplace_back(dt->get_compute_type(), /*is_array=*/true);
+  parameter_list.back().name = name;
   return (int)parameter_list.size() - 1;
 }
 
-int Callable::insert_rw_texture_param(int total_dim, BufferFormat format) {
+int Callable::insert_rw_texture_param(int total_dim,
+                                      BufferFormat format,
+                                      const std::string &name) {
   // FIXME: we shouldn't abuse is_array for texture parameters
   parameter_list.emplace_back(PrimitiveType::f32, /*is_array=*/true, 0,
                               total_dim, std::vector<int>{}, format);
+  parameter_list.back().name = name;
   return (int)parameter_list.size() - 1;
 }
 

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -12,6 +12,7 @@ class FrontendContext;
 class TI_DLL_EXPORT CallableBase {
  public:
   struct Parameter {
+    std::string name;
     bool is_array{
         false};  // This is true for both ndarray and external array args.
     std::size_t total_dim{0};  // total dim of array
@@ -107,14 +108,16 @@ class TI_DLL_EXPORT Callable : public CallableBase {
   Callable();
   virtual ~Callable();
 
-  int insert_scalar_param(const DataType &dt);
-
+  int insert_scalar_param(const DataType &dt, const std::string &name = "");
   int insert_arr_param(const DataType &dt,
                        int total_dim,
-                       std::vector<int> element_shape);
-  int insert_texture_param(int total_dim);
-  int insert_pointer_param(const DataType &dt);
-  int insert_rw_texture_param(int total_dim, BufferFormat format);
+                       std::vector<int> element_shape,
+                       const std::string &name = "");
+  int insert_texture_param(int total_dim, const std::string &name = "");
+  int insert_pointer_param(const DataType &dt, const std::string &name = "");
+  int insert_rw_texture_param(int total_dim,
+                              BufferFormat format,
+                              const std::string &name = "");
 
   int insert_ret(const DataType &dt);
 


### PR DESCRIPTION
Issue: #

### Brief Summary

This PR introduces the working version of Taichi AOT module header generator and its corresponding CI script. To allow the argument fillers to assign values with meaningful function names (instead of `set_arg1` etc.), optional debug names are added to kernel arguments. Also there is a CI script to cover `ti module build` and `ti module cppgen` with test. It's written in Powershell so we only need one script to cover all the platforms.
