### PR TITLE
[Vulkan] Fix repeated generation of array ranges in spirv codegen.

### DIFF
--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1782,6 +1782,14 @@ class TaskCodegen : public IRVisitor {
   }
 
   void gen_array_range(Stmt *stmt) {
+    /* Fix issue 7493
+     *
+     * Prevent repeated range generation for the same array
+     * when loop range has multiple dimensions.
+     */
+    if (ir_->check_value_existence(stmt->raw_name())) {
+      return;
+    }
     int num_operands = stmt->num_operands();
     for (int i = 0; i < num_operands; i++) {
       gen_array_range(stmt->operand(i));

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -329,3 +329,15 @@ def test_n_loop_var_neq_dimension():
             match=
             "Ndrange for loop with number of the loop variables not equal to"):
         iter()
+
+
+@test_utils.test()
+def test_2d_loop_over_ndarray():
+    @ti.kernel
+    def foo(arr: ti.types.ndarray(dtype=ti.i32, ndim=1)):
+        M = arr.shape[0]
+        for i, j in ti.ndrange(M, M):
+            verts = ti.math.vec4(arr[i], arr[i + 1], arr[j], arr[j + 1])
+
+    array = ti.ndarray(ti.i32, shape=(16, ))
+    foo(array)


### PR DESCRIPTION
Fixes #7493 