### PR TITLE
[cpu] Remove atomics demotion for single-thread CPU targets.

### DIFF
--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -29,10 +29,6 @@ class DemoteAtomics : public BasicStmtVisitor {
     bool demote = false;
     bool is_local = false;
     if (current_offloaded) {
-      if (arch_is_cpu(current_offloaded->device) &&
-          current_offloaded->num_cpu_threads == 1) {
-        demote = true;
-      }
       if (stmt->dest->is<ThreadLocalPtrStmt>()) {
         demote = true;
       }


### PR DESCRIPTION
Issue: #7442

Remove the single thread CPU atomic demotion, so that LLVM could do auto-reduction for better performance.

Performance on Apple M1 CPU, single thread:
1273 -> 5122 MFlops
