### PR TITLE
[opt] Move binary_jit_evaluator on host

### DIFF
--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -12,6 +12,12 @@
 #include "taichi/program/program.h"
 
 namespace taichi::lang {
+namespace {
+template <typename T>
+T sar(T value, T amount) {
+  return value < 0 ? ~(~value >> amount) : value >> amount;
+}
+}  // namespace
 
 class ConstantFold : public BasicStmtVisitor {
  public:
@@ -27,53 +33,6 @@ class ConstantFold : public BasicStmtVisitor {
     this->compile_config.external_optimization_level = 0;
   }
 
-  Kernel *get_jit_evaluator_kernel(JITEvaluatorId const &id) {
-    auto &cache = program->jit_evaluator_cache;
-    // Discussion:
-    // https://github.com/taichi-dev/taichi/pull/954#discussion_r423442606
-    std::lock_guard<std::mutex> _(program->jit_evaluator_cache_mut);
-    auto it = cache.find(id);
-    if (it != cache.end())  // cached?
-      return it->second.get();
-
-    auto kernel_name = fmt::format("jit_evaluator_{}", cache.size());
-    auto func = [&id](Kernel *kernel) {
-      auto left =
-          Expr::make<ArgLoadExpression>(/*arg_id=*/0, id.lhs, /*is_ptr=*/false);
-      auto right =
-          Expr::make<ArgLoadExpression>(/*arg_id=*/1, id.rhs, /*is_ptr=*/false);
-      Expr oper;
-      if (id.is_binary) {
-        oper = Expr::make<BinaryOpExpression>(id.binary_op(), left, right);
-        oper.set_tb(id.tb);
-      } else {
-        oper = Expr::make<UnaryOpExpression>(id.unary_op(), left);
-        if (unary_op_is_cast(id.unary_op())) {
-          oper.cast<UnaryOpExpression>()->cast_type = id.rhs;
-        }
-      }
-      auto &ast_builder = kernel->context->builder();
-      auto ret = Stmt::make<FrontendReturnStmt>(ExprGroup(oper));
-      ast_builder.insert(std::move(ret));
-    };
-
-    auto ker = std::make_unique<Kernel>(*program, func, kernel_name);
-    ker->insert_ret(id.ret);
-    ker->insert_scalar_param(id.lhs);
-    if (id.is_binary)
-      ker->insert_scalar_param(id.rhs);
-    ker->is_evaluator = true;
-    ker->finalize_params();
-    ker->finalize_rets();
-
-    auto *ker_ptr = ker.get();
-    TI_TRACE("Saving JIT evaluator cache entry id={}",
-             std::hash<JITEvaluatorId>{}(id));
-    cache[id] = std::move(ker);
-
-    return ker_ptr;
-  }
-
   static bool is_good_type(DataType dt) {
     // ConstStmt of `bad` types like `i8` is not supported by LLVM.
     // Discussion:
@@ -87,35 +46,6 @@ class ConstantFold : public BasicStmtVisitor {
       return true;
     else
       return false;
-  }
-
-  bool jit_evaluate_binary_op(TypedConstant &ret,
-                              BinaryOpStmt *stmt,
-                              const TypedConstant &lhs,
-                              const TypedConstant &rhs) {
-    if (!is_good_type(ret.dt))
-      return false;
-    JITEvaluatorId id{std::this_thread::get_id(),
-                      (int)stmt->op_type,
-                      ret.dt,
-                      lhs.dt,
-                      rhs.dt,
-                      compile_config.debug ? stmt->tb : "",
-                      true};
-    auto *ker = get_jit_evaluator_kernel(id);
-    auto launch_ctx = ker->make_launch_context();
-    launch_ctx.set_arg(0, lhs);
-    launch_ctx.set_arg(1, rhs);
-    {
-      std::lock_guard<std::mutex> _(program->jit_evaluator_cache_mut);
-      (*ker)(compile_config, launch_ctx);
-      if (arch_uses_llvm(compile_config.arch)) {
-        ret = launch_ctx.fetch_ret({0});
-      } else {
-        ret.val_i64 = program->fetch_result<int64_t>(0);
-      }
-    }
-    return true;
   }
 
   void visit(BinaryOpStmt *stmt) override {
@@ -135,8 +65,85 @@ class ConstantFold : public BasicStmtVisitor {
       }
     }
 
-    if (jit_evaluate_binary_op(new_constant, stmt, lhs->val, rhs->val)) {
-      insert_and_erase(stmt, new_constant);
+    // Type check should have been done at this point.
+    auto dt = lhs->val.dt;
+    switch (stmt->op_type) {
+#define COMMA ,
+#define HANDLE_REAL_AND_INTEGRAL_BINARY(OP_TYPE, PREFIX, OP_CPP)             \
+  case BinaryOpType::OP_TYPE: {                                              \
+    if (dt->is_primitive(PrimitiveTypeID::f32) ||                            \
+        dt->is_primitive(PrimitiveTypeID::f64)) {                            \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_cast_to_float64()                    \
+                               OP_CPP rhs->val.val_cast_to_float64()));      \
+      insert_and_erase(stmt, res);                                           \
+    } else if (dt->is_primitive(PrimitiveTypeID::i32) ||                     \
+               dt->is_primitive(PrimitiveTypeID::i64)) {                     \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_int() OP_CPP rhs->val.val_int()));   \
+      insert_and_erase(stmt, res);                                           \
+    } else if (dt->is_primitive(PrimitiveTypeID::u32) ||                     \
+               dt->is_primitive(PrimitiveTypeID::u64)) {                     \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_uint() OP_CPP rhs->val.val_uint())); \
+      insert_and_erase(stmt, res);                                           \
+    }                                                                        \
+    break;                                                                   \
+  }
+
+      HANDLE_REAL_AND_INTEGRAL_BINARY(mul, , *)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(add, , +)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(sub, , -)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(truediv, , /)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(floordiv, std::floor, /)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(div, , /)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(cmp_lt, , <)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(cmp_le, , <=)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(cmp_gt, , >)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(cmp_ge, , >=)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(cmp_eq, , ==)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(cmp_ne, , !=)
+
+      HANDLE_REAL_AND_INTEGRAL_BINARY(max, std::max, COMMA)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(min, std::min, COMMA)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(atan2, std::atan2, COMMA)
+      HANDLE_REAL_AND_INTEGRAL_BINARY(pow, std::pow, COMMA)
+#undef HANDLE_REAL_AND_INTEGRAL_BINARY
+
+#define HANDLE_INTEGRAL_BINARY(OP_TYPE, PREFIX, OP_CPP)                      \
+  case BinaryOpType::OP_TYPE: {                                              \
+    if (dt->is_primitive(PrimitiveTypeID::i32) ||                            \
+        dt->is_primitive(PrimitiveTypeID::i64)) {                            \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_int() OP_CPP rhs->val.val_int()));   \
+      insert_and_erase(stmt, res);                                           \
+    } else if (dt->is_primitive(PrimitiveTypeID::u32) ||                     \
+               dt->is_primitive(PrimitiveTypeID::u64)) {                     \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_uint() OP_CPP rhs->val.val_uint())); \
+      insert_and_erase(stmt, res);                                           \
+    }                                                                        \
+    break;                                                                   \
+  }
+
+      HANDLE_INTEGRAL_BINARY(mod, , %)
+      HANDLE_INTEGRAL_BINARY(bit_and, , &)
+      HANDLE_INTEGRAL_BINARY(bit_or, , |)
+      HANDLE_INTEGRAL_BINARY(bit_xor, , ^)
+      HANDLE_INTEGRAL_BINARY(bit_shl, , <<)
+      HANDLE_INTEGRAL_BINARY(bit_shr, , >>)
+      HANDLE_INTEGRAL_BINARY(bit_sar, sar, COMMA)
+#undef HANDLE_INTEGRAL_BINARY
+#undef COMMA
+
+      case BinaryOpType::logical_or:
+      case BinaryOpType::logical_and:
+        TI_ERROR("{} should have been lowered.",
+                 binary_op_type_name(stmt->op_type));
+        break;
+
+      default:
+        break;
     }
   }
 


### PR DESCRIPTION
Note that `logical_or` and `logical+and` are lowered in the frontend ir so constant folding shouldn't see them at all. That's why we updated the C++ test in this PR.

nit: will send out a followup PR to remove `constant_fold`'s dependency on `CompileConfig`. 