### PR TITLE
[bug] Fix logical comparison returns -1

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -785,7 +785,7 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
       TI_NOT_IMPLEMENTED
     }
     llvm_val[stmt] =
-        builder->CreateSExt(cmp, tlctx->get_data_type(PrimitiveType::i32));
+        builder->CreateZExt(cmp, tlctx->get_data_type(PrimitiveType::i32));
   } else {
     // This branch contains atan2 and pow which use runtime.cpp function for
     // **real** type. We don't have f16 support there so promoting to f32 is

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1052,11 +1052,10 @@ class TaskCodegen : public IRVisitor {
     }
 #undef BINARY_OP_TO_SPIRV_BITWISE
 
-#define BINARY_OP_TO_SPIRV_LOGICAL(op, func)                          \
-  else if (op_type == BinaryOpType::op) {                             \
-    bin_value = ir_->func(lhs_value, rhs_value);                      \
-    bin_value = ir_->cast(dst_type, bin_value);                       \
-    bin_value = ir_->make_value(spv::OpSNegate, dst_type, bin_value); \
+#define BINARY_OP_TO_SPIRV_LOGICAL(op, func)     \
+  else if (op_type == BinaryOpType::op) {        \
+    bin_value = ir_->func(lhs_value, rhs_value); \
+    bin_value = ir_->cast(dst_type, bin_value);  \
   }
 
     BINARY_OP_TO_SPIRV_LOGICAL(cmp_lt, lt)

--- a/taichi/transforms/demote_operations.cpp
+++ b/taichi/transforms/demote_operations.cpp
@@ -38,7 +38,7 @@ class DemoteOperations : public BasicStmtVisitor {
     auto cond = Stmt::make<BinaryOpStmt>(BinaryOpType::bit_and, cond12.get(),
                                          cond3.get());
     auto real_ret =
-        Stmt::make<BinaryOpStmt>(BinaryOpType::add, ret.get(), cond.get());
+        Stmt::make<BinaryOpStmt>(BinaryOpType::sub, ret.get(), cond.get());
     modifier.insert_before(stmt, std::move(ret));
     modifier.insert_before(stmt, std::move(zero));
     modifier.insert_before(stmt, std::move(lhs_ltz));


### PR DESCRIPTION
Issue: #

### Brief Summary
We used to return -1 for comparison ops which is kinda confusing... This PR makes it return 1 for true. Note this change might have wide numerical impact on programs so we should pay additional attention when reviewing & bisecting for bugs in the future.