### PR TITLE
[refactor] Remove MemoryPool daemon in LLVM runtime

### DIFF
--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -315,7 +315,6 @@ void Program::finalize() {
   TI_TRACE("Program finalizing...");
 
   synchronize();
-  memory_pool_->terminate();
   if (arch_uses_llvm(compile_config().arch)) {
     program_impl_->finalize();
   }

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -677,13 +677,6 @@ void LlvmRuntimeExecutor::materialize_runtime(MemoryPool *memory_pool,
   }
 
   if (arch_use_host_memory(config_.arch)) {
-    runtime_jit->call<void *>("runtime_get_mem_req_queue", llvm_runtime_);
-    auto mem_req_queue = fetch_result<void *>(taichi_result_buffer_ret_value_id,
-                                              *result_buffer_ptr);
-    memory_pool->set_queue((MemRequestQueue *)mem_req_queue);
-  }
-
-  if (arch_use_host_memory(config_.arch)) {
     runtime_jit->call<void *, void *, void *>(
         "LLVMRuntime_initialize_thread_pool", llvm_runtime_, thread_pool_.get(),
         (void *)ThreadPool::static_run);

--- a/taichi/runtime/llvm/runtime_module/internal_functions.h
+++ b/taichi/runtime/llvm/runtime_module/internal_functions.h
@@ -25,9 +25,6 @@ i32 do_nothing(RuntimeContext *context) {
 }
 
 i32 refresh_counter(RuntimeContext *context) {
-  auto runtime = context->runtime;
-  auto queue = runtime->mem_req_queue;
-  queue->tail++;
   return 0;
 }
 

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -860,6 +860,8 @@ Ptr LLVMRuntime::request_allocate_aligned(std::size_t size,
   if (preallocated)
     return allocate_from_buffer(size, alignment);
   else {
+    // host only
+    /*
     auto i = atomic_add_i32(&mem_req_queue->tail, 1);
     taichi_assert_runtime(this, i <= taichi_max_num_mem_requests,
                           "Too many memory allocation requests.");
@@ -874,6 +876,8 @@ Ptr LLVMRuntime::request_allocate_aligned(std::size_t size,
 #endif
     };
     return r->ptr;
+    */
+    return (Ptr)vm_allocator(memory_pool, size, alignment);
   }
 }
 

--- a/taichi/system/memory_pool.cpp
+++ b/taichi/system/memory_pool.cpp
@@ -11,10 +11,6 @@ MemoryPool::MemoryPool(Arch arch, Device *device)
     : arch_(arch), device_(device) {
   TI_TRACE("Memory pool created. Default buffer size per allocator = {} MB",
            default_allocator_size / 1024 / 1024);
-  terminating = false;
-  killed = false;
-  processed_tail = 0;
-  queue = nullptr;
 #if defined(TI_WITH_CUDA)
   // http://on-demand.gputechconf.com/gtc/2014/presentations/S4158-cuda-streams-best-practices-common-pitfalls.pdf
   // Stream 0 has special synchronization rules: Operations in stream 0 cannot
@@ -25,12 +21,6 @@ MemoryPool::MemoryPool(Arch arch, Device *device)
                                              CU_STREAM_NON_BLOCKING);
   }
 #endif
-  th = std::make_unique<std::thread>([this] { this->daemon(); });
-}
-
-void MemoryPool::set_queue(MemRequestQueue *queue) {
-  std::lock_guard<std::mutex> _(mut);
-  this->queue = queue;
 }
 
 void *MemoryPool::allocate(std::size_t size, std::size_t alignment) {
@@ -50,90 +40,7 @@ void *MemoryPool::allocate(std::size_t size, std::size_t alignment) {
   return ret;
 }
 
-template <typename T>
-T MemoryPool::fetch(volatile void *ptr) {
-  T ret;
-  if (use_cuda_stream && arch_ == Arch::cuda) {
-#if TI_WITH_CUDA
-    CUDADriver::get_instance().stream_synchronize(cuda_stream);
-    CUDADriver::get_instance().memcpy_device_to_host_async(
-        &ret, (void *)ptr, sizeof(T), cuda_stream);
-    CUDADriver::get_instance().stream_synchronize(cuda_stream);
-#else
-    TI_NOT_IMPLEMENTED
-#endif
-  } else {
-    ret = *(T *)ptr;
-  }
-  return ret;
-}
-
-template <typename T>
-void MemoryPool::push(volatile T *dest, const T &val) {
-  if (use_cuda_stream && arch_ == Arch::cuda) {
-#if TI_WITH_CUDA
-    CUDADriver::get_instance().memcpy_host_to_device_async(
-        (void *)(dest), (void *)&val, sizeof(T), cuda_stream);
-    CUDADriver::get_instance().stream_synchronize(cuda_stream);
-#else
-    TI_NOT_IMPLEMENTED
-#endif
-  } else {
-    *(T *)dest = val;
-  }
-}
-
-void MemoryPool::daemon() {
-  while (true) {
-    Time::usleep(1000);
-    std::lock_guard<std::mutex> _(mut);
-    if (terminating) {
-      killed = true;
-      break;
-    }
-    if (!queue) {
-      continue;
-    }
-
-    // poll allocation requests.
-    using tail_type = decltype(MemRequestQueue::tail);
-    auto tail = fetch<tail_type>(&queue->tail);
-    if (tail > processed_tail) {
-      // allocate new buffer
-      auto i = processed_tail;
-      TI_DEBUG("Processing memory alloc request {}", i);
-      auto req = fetch<MemRequest>(&queue->requests[i]);
-      if (req.size == 0 || req.alignment == 0) {
-        TI_DEBUG(" Incomplete memory alloc request {} fetched. Skipping", i);
-        continue;
-      }
-      TI_DEBUG("  Allocating memory {} B (alignment {}B) ", req.size,
-               req.alignment);
-      auto ptr = allocate(req.size, req.alignment);
-      TI_DEBUG("  Allocated. Ptr = {:p}", ptr);
-      push(&queue->requests[i].ptr, (uint8 *)ptr);
-      processed_tail += 1;
-    }
-  }
-}
-
-void MemoryPool::terminate() {
-  {
-    std::lock_guard<std::mutex> _(mut);
-    terminating = true;
-  }
-  th->join();
-  TI_ASSERT(killed);
-#if 0 && defined(TI_WITH_CUDA)
-  if (arch_ == Arch::cuda)
-    CUDADriver::get_instance().cudaStreamDestroy(cuda_stream);
-#endif
-}
-
 MemoryPool::~MemoryPool() {
-  if (!killed) {
-    terminate();
-  }
 }
 
 }  // namespace taichi::lang

--- a/taichi/system/memory_pool.h
+++ b/taichi/system/memory_pool.h
@@ -19,13 +19,8 @@ class TI_DLL_EXPORT MemoryPool {
   std::vector<std::unique_ptr<UnifiedAllocator>> allocators;
   static constexpr std::size_t default_allocator_size =
       1 << 30;  // 1 GB per allocator
-  bool terminating, killed;
-  std::mutex mut;
   std::mutex mut_allocators;
-  std::unique_ptr<std::thread> th;
-  int processed_tail;
 
-  MemRequestQueue *queue;
   void *cuda_stream{nullptr};
   void *amdgpu_stream{nullptr};
 
@@ -33,19 +28,7 @@ class TI_DLL_EXPORT MemoryPool {
   // so that the memory allocated from each Device can be used as-is.
   MemoryPool(Arch arch, Device *device);
 
-  template <typename T>
-  T fetch(volatile void *ptr);
-
-  template <typename T>
-  void push(volatile T *dest, const T &val);
-
   void *allocate(std::size_t size, std::size_t alignment);
-
-  void set_queue(MemRequestQueue *queue);
-
-  void daemon();
-
-  void terminate();
 
   ~MemoryPool();
 


### PR DESCRIPTION
Issue: #7599

### Brief Summary
MemoryPool used to startup a `daemon` thread and takes `MemoryRequest` to allocate for runtime memory allocations. However, this is redundant or even harmful because the runtime process still have to wait util the memory is allocated, plus some overhead preparing for the `MemoryRequest` object:

[Previous] Runtime memory allocation via `MemoryRequest`:
```
    auto i = atomic_add_i32(&mem_req_queue->tail, 1);
    taichi_assert_runtime(this, i <= taichi_max_num_mem_requests,
                          "Too many memory allocation requests.");
    auto volatile r = &mem_req_queue->requests[i];
    atomic_exchange_u64((uint64 *)&r->size, size);
    atomic_exchange_u64((uint64 *)&r->alignment, alignment);

    // wait for host to allocate
    while (r->ptr == nullptr) {
#if defined(ARCH_cuda)
      system_memfence();
#endif
    };
```

This PR simplifies the above process into a mutex-based allocation. Tested with `python/taichi/examples/algorithm/mgpcg_advanced.py` (on x64) which made use of `ti.pointer`, and observed 5% performance improvement.

```
[Before Patch] avg = 0.69s
0.686
0.678
0.676
0.688
0.701
0.705
0.704
0.685
0.702
0.679
0.677
0.699

[After Patch] avg = 0.65s
0.642
0.671
0.645
0.651
0.652
0.644
0.657
0.650
0.650
0.650
0.646

```