### PR TITLE
[misc] Rename taichi::lang::llvm to taichi::lang::LLVM

### DIFF
--- a/taichi/codegen/llvm/compiled_kernel_data.cpp
+++ b/taichi/codegen/llvm/compiled_kernel_data.cpp
@@ -6,13 +6,13 @@
 namespace taichi::lang {
 
 static std::unique_ptr<CompiledKernelData> new_llvm_compiled_kernel_data() {
-  return std::make_unique<llvm::CompiledKernelData>();
+  return std::make_unique<LLVM::CompiledKernelData>();
 }
 
 CompiledKernelData::Creator *const CompiledKernelData::llvm_creator =
     new_llvm_compiled_kernel_data;
 
-namespace llvm {
+namespace LLVM {
 
 CompiledKernelData::CompiledKernelData(Arch arch, InternalData data)
     : arch_(arch), data_(std::move(data)) {
@@ -37,8 +37,8 @@ CompiledKernelData::Err CompiledKernelData::load_impl(
   } catch (const liong::json::JsonException &) {
     return Err::kParseMetadataFailed;
   }
-  ::llvm::SMDiagnostic err;
-  auto ret = ::llvm::parseAssemblyString(file.src_code(), err, llvm_ctx_);
+  llvm::SMDiagnostic err;
+  auto ret = llvm::parseAssemblyString(file.src_code(), err, llvm_ctx_);
   if (!ret) {  // File not found or Parse failed
     TI_DEBUG("Fail to parse llvm::Module from string: {}",
              err.getMessage().str());
@@ -57,7 +57,7 @@ CompiledKernelData::Err CompiledKernelData::dump_impl(
     return Err::kSerMetadataFailed;
   }
   std::string str;
-  ::llvm::raw_string_ostream oss(str);
+  llvm::raw_string_ostream oss(str);
   data_.compiled_data.module->print(oss, /*AAW=*/nullptr);
   file.set_src_code(std::move(str));
   return Err::kNoError;

--- a/taichi/codegen/llvm/compiled_kernel_data.h
+++ b/taichi/codegen/llvm/compiled_kernel_data.h
@@ -8,7 +8,7 @@
 
 namespace taichi::lang {
 
-namespace llvm {
+namespace LLVM {
 
 class CompiledKernelData : public lang::CompiledKernelData {
  public:
@@ -61,7 +61,7 @@ class CompiledKernelData : public lang::CompiledKernelData {
   Err dump_impl(CompiledKernelDataFile &file) const override;
 
  private:
-  ::llvm::LLVMContext llvm_ctx_;
+  llvm::LLVMContext llvm_ctx_;
   Arch arch_;
   InternalData data_;
 };

--- a/taichi/codegen/llvm/kernel_compiler.cpp
+++ b/taichi/codegen/llvm/kernel_compiler.cpp
@@ -6,7 +6,7 @@
 #include "taichi/codegen/llvm/compiled_kernel_data.h"
 
 namespace taichi::lang {
-namespace llvm {
+namespace LLVM {
 
 KernelCompiler::KernelCompiler(Config config) : config_(std::move(config)) {
 }
@@ -33,7 +33,7 @@ KernelCompiler::CKDPtr KernelCompiler::compile(
     const DeviceCapabilityConfig &device_caps,
     const Kernel &kernel_def,
     IRNode &chi_ir) const {
-  llvm::CompiledKernelData::InternalData data;
+  LLVM::CompiledKernelData::InternalData data;
   auto codegen = KernelCodeGen::create(compile_config, &kernel_def, &chi_ir,
                                        *config_.tlctx);
   data.compiled_data = codegen->compile_kernel_to_module();
@@ -43,7 +43,7 @@ KernelCompiler::CKDPtr KernelCompiler::compile(
   data.args_size = kernel_def.args_size;
   data.ret_type = kernel_def.ret_type;
   data.ret_size = kernel_def.ret_size;
-  return std::make_unique<llvm::CompiledKernelData>(compile_config.arch, data);
+  return std::make_unique<LLVM::CompiledKernelData>(compile_config.arch, data);
 }
 
 }  // namespace llvm

--- a/taichi/codegen/llvm/kernel_compiler.h
+++ b/taichi/codegen/llvm/kernel_compiler.h
@@ -5,7 +5,7 @@
 #include "taichi/runtime/llvm/llvm_context.h"
 
 namespace taichi::lang {
-namespace llvm {
+namespace LLVM {
 
 class KernelCompiler : public lang::KernelCompiler {
  public:

--- a/taichi/codegen/llvm/llvm_codegen_utils.h
+++ b/taichi/codegen/llvm/llvm_codegen_utils.h
@@ -210,7 +210,7 @@ class RuntimeObject {
   template <typename... Args>
   llvm::Value *call(const std::string &func_name, Args &&...args) {
     auto func = get_func(func_name);
-    auto arglist = std::vector<::llvm::Value *>({ptr, args...});
+    auto arglist = std::vector<llvm::Value *>({ptr, args...});
     check_func_call_signature(func->getFunctionType(), func->getName(), arglist,
                               builder);
     return builder->CreateCall(func, std::move(arglist));

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -80,7 +80,7 @@ FunctionType LlvmProgramImpl::compile(const CompileConfig &compile_config,
   // TODO(PGZXB): Final solution: compile -> load_or_compile + launch_kernel
   auto &mgr = get_kernel_compilation_manager();
   const auto &compiled = mgr.load_or_compile(compile_config, {}, *kernel);
-  auto &llvm_data = dynamic_cast<const llvm::CompiledKernelData &>(compiled);
+  auto &llvm_data = dynamic_cast<const LLVM::CompiledKernelData &>(compiled);
   return llvm_compiled_kernel_to_executable(
       compile_config.arch, runtime_exec_->get_llvm_context(),
       runtime_exec_.get(), kernel,
@@ -173,9 +173,9 @@ void LlvmProgramImpl::cache_field(int snode_tree_id,
 }
 
 std::unique_ptr<KernelCompiler> LlvmProgramImpl::make_kernel_compiler() {
-  lang::llvm::KernelCompiler::Config cfg;
+  lang::LLVM::KernelCompiler::Config cfg;
   cfg.tlctx = runtime_exec_->get_llvm_context();
-  return std::make_unique<lang::llvm::KernelCompiler>(std::move(cfg));
+  return std::make_unique<lang::LLVM::KernelCompiler>(std::move(cfg));
 }
 
 LlvmProgramImpl *get_llvm_program(Program *prog) {


### PR DESCRIPTION
Rename this namespace because it may introduce conflicts with `::llvm`.
