### PR TITLE
[build] Fix ssize_t type undefined errors when building with TI_WITH_LLVM=OFF on windows

### DIFF
--- a/taichi/python/export_ggui.cpp
+++ b/taichi/python/export_ggui.cpp
@@ -25,6 +25,12 @@ namespace py = pybind11;
 #include "taichi/program/ndarray.h"
 #include <memory>
 
+#ifndef TI_WITH_LLVM
+#if defined(_WIN64)
+typedef signed __int64 ssize_t;
+#endif /* _WIN64 */
+#endif /* TI_WITH_LLVM */
+
 namespace taichi::ui {
 
 using namespace taichi::lang;


### PR DESCRIPTION

Issue: #

### Brief Summary
