### PR TITLE
[lang] Implement experimental CG(Conjugate Gradient) solver in Taichi-lang

### DIFF
--- a/python/taichi/linalg/__init__.py
+++ b/python/taichi/linalg/__init__.py
@@ -3,3 +3,4 @@
 from taichi.linalg.cg import CG
 from taichi.linalg.sparse_matrix import *
 from taichi.linalg.sparse_solver import SparseSolver
+from taichi.linalg.taichi_cg import *

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -92,7 +92,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
             update_p()
             old_rTr = new_rTr
             if not quiet:
-                print(f'>>> Iter = {i+1:4}, Residual = {(new_rTr):e}')
+                print(f'>>> Iter = {i+1:4}, Residual = {sqrt(new_rTr):e}')
 
     solve()
     vector_fields_snode_tree.destroy()

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -1,7 +1,9 @@
 from math import sqrt
 
-import taichi as ti
 from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
+
+import taichi as ti
+
 
 @ti.data_oriented
 class LinearOperator:
@@ -25,7 +27,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
         raise TaichiTypeError("Not supported dtype:", b.dtype)
     if b.shape != x.shape:
         raise TaichiRuntimeError("Dimension mismatch b.shape != x.shape.")
-    
+
     size = b.shape
     vector_fields_builder = ti.FieldsBuilder()
     p = ti.field(dtype=solver_dtype)

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -1,7 +1,5 @@
 from math import sqrt
-
 from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
-
 import taichi as ti
 
 
@@ -12,21 +10,24 @@ class LinearOperator:
 
     def matvec(self, x, Ax):
         if x.shape != Ax.shape:
-            raise TaichiRuntimeError("Dimension mismatch x.shape != Ax.shape.")
+            raise TaichiRuntimeError(
+                f"Dimension mismatch x.shape{x.shape} != Ax.shape{Ax.shape}.")
         self._matvec(x, Ax)
 
 
 def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     if b.dtype != x.dtype:
-        raise TaichiTypeError("Dtype mismatch b.dtype != x.dtype.")
+        raise TaichiTypeError(
+            f"Dtype mismatch b.dtype({b.dtype}) != x.dtype({x.dtype}).")
     if str(b.dtype) == 'f32':
         solver_dtype = ti.f32
     elif str(b.dtype) == 'f64':
         solver_dtype = ti.f64
     else:
-        raise TaichiTypeError(f"Not supported dtype:{b.dtype}")
+        raise TaichiTypeError(f"Not supported dtype: {b.dtype}")
     if b.shape != x.shape:
-        raise TaichiRuntimeError("Dimension mismatch b.shape != x.shape.")
+        raise TaichiRuntimeError(
+            f"Dimension mismatch b.shape{b.shape} != x.shape{x.shape}.")
 
     size = b.shape
     vector_fields_builder = ti.FieldsBuilder()
@@ -75,7 +76,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
         init()
         initial_rTr = reduce(r, r)
         if not quiet:
-            print(">>> Initial residual =", (initial_rTr))
+            print(f'>>> Initial residual = {initial_rTr:e}')
         old_rTr = initial_rTr
         update_p()
         # -- Main loop --
@@ -89,7 +90,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
             if sqrt(new_rTr) < tol:
                 if not quiet:
                     print('>>> Conjugate Gradient method converged.')
-                    print('>>> #iterations', i)
+                    print(f'>>> #iterations {i}')
                 break
             beta[None] = new_rTr / old_rTr
             update_p()

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -1,5 +1,7 @@
 from math import sqrt
+
 from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
+
 import taichi as ti
 
 

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -1,5 +1,7 @@
-import taichi as ti
 from math import sqrt
+
+import taichi as ti
+
 
 @ti.data_oriented
 class LinearOperator:
@@ -10,6 +12,7 @@ class LinearOperator:
         assert x.shape == Ax.shape, "Dimension mismatch x.shape != Ax.shape."
         self._matvec(x, Ax)
 
+
 def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     assert b.dtype == x.dtype, "Dtype mismatch b.dtype != x.dtype."
     if str(b.dtype) == 'f32':
@@ -19,10 +22,10 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     else:
         print("Not supported dtype:", b.dtype)
         exit()
-        
+
     assert b.shape == x.shape, "Dimension mismatch b.shape != x.shape."
     size = b.shape
-    
+
     vector_fields_builder = ti.FieldsBuilder()
     p = ti.field(dtype=solver_dtype)
     r = ti.field(dtype=solver_dtype)
@@ -42,7 +45,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
             r[I] = b[I]
             p[I] = 0.0
             Ap[I] = 0.0
-            
+
     @ti.kernel
     def reduce(p: ti.template(), q: ti.template()) -> solver_dtype:
         result = 0.0
@@ -54,7 +57,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     def update_x():
         for I in ti.grouped(x):
             x[I] += alpha[None] * p[I]
-            
+
     @ti.kernel
     def update_r():
         for I in ti.grouped(r):
@@ -90,7 +93,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
             old_rTr = new_rTr
             if not quiet:
                 print(f'>>> Iter = {i+1:4}, Residual = {(new_rTr):e}')
-        
+
     solve()
     vector_fields_snode_tree.destroy()
     scalar_snode_tree.destroy()

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -1,7 +1,7 @@
 from math import sqrt
 
 import taichi as ti
-
+from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
 
 @ti.data_oriented
 class LinearOperator:
@@ -9,23 +9,24 @@ class LinearOperator:
         self._matvec = matvec_kernel
 
     def matvec(self, x, Ax):
-        assert x.shape == Ax.shape, "Dimension mismatch x.shape != Ax.shape."
+        if x.shape != Ax.shape:
+            raise TaichiRuntimeError("Dimension mismatch x.shape != Ax.shape.")
         self._matvec(x, Ax)
 
 
 def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
-    assert b.dtype == x.dtype, "Dtype mismatch b.dtype != x.dtype."
+    if b.dtype != x.dtype:
+        raise TaichiTypeError("Dtype mismatch b.dtype != x.dtype.")
     if str(b.dtype) == 'f32':
         solver_dtype = ti.f32
     elif str(b.dtype) == 'f64':
         solver_dtype = ti.f64
     else:
-        print("Not supported dtype:", b.dtype)
-        exit()
-
-    assert b.shape == x.shape, "Dimension mismatch b.shape != x.shape."
+        raise TaichiTypeError("Not supported dtype:", b.dtype)
+    if b.shape != x.shape:
+        raise TaichiRuntimeError("Dimension mismatch b.shape != x.shape.")
+    
     size = b.shape
-
     vector_fields_builder = ti.FieldsBuilder()
     p = ti.field(dtype=solver_dtype)
     r = ti.field(dtype=solver_dtype)

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -3,7 +3,7 @@ from math import sqrt
 from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
 
 import taichi as ti
-from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
+
 
 @ti.data_oriented
 class LinearOperator:
@@ -27,7 +27,7 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
         raise TaichiTypeError(f"Not supported dtype:{b.dtype}")
     if b.shape != x.shape:
         raise TaichiRuntimeError("Dimension mismatch b.shape != x.shape.")
-    
+
     size = b.shape
     vector_fields_builder = ti.FieldsBuilder()
     p = ti.field(dtype=solver_dtype)

--- a/python/taichi/linalg/taichi_cg.py
+++ b/python/taichi/linalg/taichi_cg.py
@@ -3,7 +3,7 @@ from math import sqrt
 from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
 
 import taichi as ti
-
+from taichi.lang.exception import TaichiRuntimeError, TaichiTypeError
 
 @ti.data_oriented
 class LinearOperator:
@@ -24,10 +24,10 @@ def taichi_cg_solver(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     elif str(b.dtype) == 'f64':
         solver_dtype = ti.f64
     else:
-        raise TaichiTypeError("Not supported dtype:", b.dtype)
+        raise TaichiTypeError(f"Not supported dtype:{b.dtype}")
     if b.shape != x.shape:
         raise TaichiRuntimeError("Dimension mismatch b.shape != x.shape.")
-
+    
     size = b.shape
     vector_fields_builder = ti.FieldsBuilder()
     p = ti.field(dtype=solver_dtype)

--- a/tests/python/test_taichi_cg.py
+++ b/tests/python/test_taichi_cg.py
@@ -1,7 +1,9 @@
-import taichi as ti
 import math
+
 import pytest
-from taichi.linalg import taichi_cg_solver, LinearOperator
+from taichi.linalg import LinearOperator, taichi_cg_solver
+
+import taichi as ti
 from tests import test_utils
 
 
@@ -28,7 +30,7 @@ def test_taichi_cg(ti_dtype):
             r = v[i + 1, j] if i + 1 <= GRID - 1 else 0.0
             t = v[i, j + 1] if j + 1 <= GRID - 1 else 0.0
             b = v[i, j - 1] if j - 1 >= 0 else 0.0
-            # Avoid ill-conditioned matrix A            
+            # Avoid ill-conditioned matrix A
             mv[i, j] = 20 * v[i, j] - l - r - t - b
 
     @ti.kernel

--- a/tests/python/test_taichi_cg.py
+++ b/tests/python/test_taichi_cg.py
@@ -7,8 +7,11 @@ import taichi as ti
 from tests import test_utils
 
 
+vk_on_mac = (ti.vulkan, 'Darwin')
+
 @pytest.mark.parametrize("ti_dtype", [ti.f32, ti.f64])
-@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan])
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
+                 exclude=[vk_on_mac])
 def test_taichi_cg(ti_dtype):
     GRID = 32
     Ax = ti.field(dtype=ti_dtype, shape=(GRID, GRID))

--- a/tests/python/test_taichi_cg.py
+++ b/tests/python/test_taichi_cg.py
@@ -6,12 +6,11 @@ from taichi.linalg import LinearOperator, taichi_cg_solver
 import taichi as ti
 from tests import test_utils
 
-
 vk_on_mac = (ti.vulkan, 'Darwin')
 
+
 @pytest.mark.parametrize("ti_dtype", [ti.f32, ti.f64])
-@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
-                 exclude=[vk_on_mac])
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan], exclude=[vk_on_mac])
 def test_taichi_cg(ti_dtype):
     GRID = 32
     Ax = ti.field(dtype=ti_dtype, shape=(GRID, GRID))

--- a/tests/python/test_taichi_cg.py
+++ b/tests/python/test_taichi_cg.py
@@ -1,0 +1,53 @@
+import taichi as ti
+import math
+import pytest
+from taichi.linalg import taichi_cg_solver, LinearOperator
+from tests import test_utils
+
+
+@pytest.mark.parametrize("ti_dtype", [ti.f32, ti.f64])
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_taichi_cg(ti_dtype):
+    GRID = 32
+    Ax = ti.field(dtype=ti_dtype, shape=(GRID, GRID))
+    x = ti.field(dtype=ti_dtype, shape=(GRID, GRID))
+    b = ti.field(dtype=ti_dtype, shape=(GRID, GRID))
+
+    @ti.kernel
+    def init():
+        for i, j in ti.ndrange(GRID, GRID):
+            xl = i / (GRID - 1)
+            yl = j / (GRID - 1)
+            b[i, j] = ti.sin(2 * math.pi * xl) * ti.sin(2 * math.pi * yl)
+            x[i, j] = 0.0
+
+    @ti.kernel
+    def compute_Ax(v: ti.template(), mv: ti.template()):
+        for i, j in v:
+            l = v[i - 1, j] if i - 1 >= 0 else 0.0
+            r = v[i + 1, j] if i + 1 <= GRID - 1 else 0.0
+            t = v[i, j + 1] if j + 1 <= GRID - 1 else 0.0
+            b = v[i, j - 1] if j - 1 >= 0 else 0.0
+            # Avoid ill-conditioned matrix A            
+            mv[i, j] = 20 * v[i, j] - l - r - t - b
+
+    @ti.kernel
+    def check_solution(sol: ti.template(), ans: ti.template(),
+                       tol: ti_dtype) -> bool:
+        exit_code = True
+        for i, j in ti.ndrange(GRID, GRID):
+            if ti.abs(ans[i, j] - sol[i, j]) < tol:
+                pass
+            else:
+                exit_code = False
+        return exit_code
+
+    A = LinearOperator(compute_Ax)
+    init()
+    taichi_cg_solver(A, b, x, maxiter=10 * GRID * GRID, tol=1e-18, quiet=True)
+    compute_Ax(x, Ax)
+    # `tol` can't be < 1e-6 for ti.f32 because of accumulating round-off error;
+    # see https://en.wikipedia.org/wiki/Conjugate_gradient_method#cite_note-6
+    # for more details.
+    result = check_solution(Ax, b, tol=1e-6)
+    assert result

--- a/tests/python/test_taichi_cg.py
+++ b/tests/python/test_taichi_cg.py
@@ -8,7 +8,7 @@ from tests import test_utils
 
 
 @pytest.mark.parametrize("ti_dtype", [ti.f32, ti.f64])
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan])
 def test_taichi_cg(ti_dtype):
     GRID = 32
     Ax = ti.field(dtype=ti_dtype, shape=(GRID, GRID))


### PR DESCRIPTION
Issue: #7634 

### Brief Summary
This PR implements a matrix-free CG (Conjugate-Gradient) solver in Taichi. The solver targets to solve the linear equation system:

$$ Ax = b$$

where $A$ is implicitly represented as a `LinearOperator` instead of a explicitly stored matrix, hence the name "matrix-free".