### PR TITLE
[test] Exclude the cc backend from tests that involve dynamic indexing

### DIFF
--- a/tests/python/test_ad_dynamic_index.py
+++ b/tests/python/test_ad_dynamic_index.py
@@ -2,7 +2,7 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_non_constant_index():
     m = ti.Matrix.field(2, 2, ti.f32, 5, needs_grad=True)
     n = ti.Matrix.field(2, 2, ti.f32, 5, needs_grad=True)

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -187,7 +187,7 @@ def _test_local_matrix_non_constant_index():
             assert func2(i, j, 10) == 10 * (i + j + 1)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_local_matrix_non_constant_index():
     _test_local_matrix_non_constant_index()
 
@@ -523,7 +523,7 @@ def test_matrix_field_dynamic_index_multiple_materialize():
             assert a[i][j] == (i if j == i % 3 else 0)
 
 
-@test_utils.test(debug=True)
+@test_utils.test(exclude=[ti.cc], debug=True)
 def test_local_vector_initialized_in_a_loop():
     @ti.kernel
     def foo():
@@ -1189,7 +1189,7 @@ def test_cross_scope_matrix_atomic_ops():
 
 
 @test_utils.test(debug=True)
-def test_global_tmp_overwrite():
+def test_global_tmp_overwrite(exclude=[ti.cc]):
     # https://github.com/taichi-dev/taichi/issues/6663
     @ti.kernel
     def foo() -> ti.i32:

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -226,7 +226,7 @@ def test_matrix_ndarray_non_constant_index():
     assert v[3][9] == 9
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_field_non_constant_index():
     m = ti.Matrix.field(2, 2, ti.i32, 5)
     v = ti.Vector.field(10, ti.i32, 5)
@@ -455,7 +455,7 @@ def test_matrix_field_dynamic_index_not_pure_dense():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_field_dynamic_index_different_cell_size_bytes():
     temp = ti.field(ti.f32)
 
@@ -470,7 +470,7 @@ def test_matrix_field_dynamic_index_different_cell_size_bytes():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_field_dynamic_index_different_offset_bytes_in_parent_cell():
     temp_a = ti.field(ti.f32)
     temp_b = ti.field(ti.f32)
@@ -486,7 +486,7 @@ def test_matrix_field_dynamic_index_different_offset_bytes_in_parent_cell():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_field_dynamic_index_different_stride():
     temp = ti.field(ti.f32)
 
@@ -501,7 +501,7 @@ def test_matrix_field_dynamic_index_different_stride():
     assert v._get_dynamic_index_stride() is None
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_field_dynamic_index_multiple_materialize():
     @ti.kernel
     def empty():
@@ -1188,8 +1188,8 @@ def test_cross_scope_matrix_atomic_ops():
     assert (x[1, 3] == [100, 10, 1]).all()
 
 
-@test_utils.test(debug=True)
-def test_global_tmp_overwrite(exclude=[ti.cc]):
+@test_utils.test(exclude=[ti.cc], debug=True)
+def test_global_tmp_overwrite():
     # https://github.com/taichi-dev/taichi/issues/6663
     @ti.kernel
     def foo() -> ti.i32:

--- a/tests/python/test_matrix_slice.py
+++ b/tests/python/test_matrix_slice.py
@@ -55,7 +55,7 @@ def test_matrix_slice_invalid():
         foo2()
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_slice_with_variable():
     @ti.kernel
     def test_one_row_slice(index: ti.i32) -> ti.types.vector(2, dtype=ti.i32):
@@ -103,7 +103,7 @@ def test_matrix_slice_write():
                                            [1, 1, 1, 1]])).all()
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_matrix_slice_write_dynamic_index():
     @ti.kernel
     def foo(i: ti.i32) -> ti.types.matrix(3, 4, ti.i32):


### PR DESCRIPTION
Issue: #

### Brief Summary
I'm still encountering failures in these unit tests and have no idea how to resolve them.
```
FAILED tests/python/test_numpy.py::test_numpy_i32[arch=cc]
FAILED tests/python/test_abs.py::test_abs_fwd[arch=cc]
FAILED tests/python/test_div.py::test_floor_div[arch=cc-arg14--10-arg24-3-arg34--4] - assert -2.0 == -4
FAILED tests/python/test_get_external_tensor_shape.py::test_get_external_tensor_shape_sum_numpy[arch=cc-size0]
FAILED tests/python/test_div.py::test_floor_div[arch=cc-arg18-10-arg28--3-arg38--4] - assert -2.0 == -4
FAILED tests/python/test_matrix.py::test_store_scalarize[arch=cc]
FAILED tests/python/test_random.py::test_random_independent_product[arch=cc]
FAILED tests/python/test_div.py::test_floor_div_pythonic[arch=cc] - assert -2 == (-10 // 3)
FAILED tests/python/test_numpy.py::test_numpy_i64[arch=cc]
FAILED tests/python/test_eig.py::test_eig2x2_f32[arch=cc-_test_eig2x2_real]
FAILED tests/python/test_numpy.py::test_numpy_2d[arch=cc]
FAILED tests/python/test_eig.py::test_eig2x2_f32[arch=cc-_test_eig2x2_complex]
FAILED tests/python/test_parallel_range_for.py::test_parallel_range_for[arch=cc]
FAILED tests/python/test_ndrange.py::test_field_init_eye[arch=cc]
FAILED tests/python/test_eig.py::test_sym_eig3x3_f32[arch=cc-4]
FAILED tests/python/test_parallel_range_for.py::test_loop_config_parallel_range_for[arch=cc]
FAILED tests/python/test_ad_basics_fwd.py::test_ad_fwd_add[arch=cc]
FAILED tests/python/test_ndrange.py::test_2d_loop_over_ndarray[arch=cc]
FAILED tests/python/test_svd.py::test_svd_f32[arch=cc-2]
FAILED tests/python/test_arg_load.py::test_ndarray[arch=cc]
FAILED tests/python/test_eig.py::test_sym_eig3x3_f32[arch=cc-5]
FAILED tests/python/test_ad_atomic_fwd.py::test_ad_reduce_fwd[arch=cc]
FAILED tests/python/test_atomic.py::test_atomic_add_global_i32[arch=cc]
FAILED tests/python/test_atomic.py::test_atomic_add_global_f32[arch=cc]
FAILED tests/python/test_numpy.py::test_numpy_multiple_external_arrays[arch=cc]
FAILED tests/python/test_numpy.py::test_numpy_f32[arch=cc]
FAILED tests/python/test_torch_ad.py::test_torch_ad[arch=cc]
FAILED tests/python/test_field.py::test_field_copy_from[dtype0-shape0-arch=cc]
FAILED tests/python/test_svd.py::test_svd_f32[arch=cc-3]
FAILED tests/python/test_ad_basics.py::test_select_fwd[arch=cc]
FAILED tests/python/test_linalg.py::test_mat_inverse_size[arch=cc-1]
FAILED tests/python/test_svd.py::test_svd_f64[arch=cc-2]
FAILED tests/python/test_torch_ad.py::test_torch_ad_gpu[arch=cc]
FAILED tests/python/test_numpy.py::test_numpy_2d_transpose[arch=cc]
FAILED tests/python/test_matrix.py::test_matrix_field_constant_index[arch=cc]
FAILED tests/python/test_eig.py::test_eig2x2_f64[arch=cc-_test_eig2x2_real]
FAILED tests/python/test_numpy.py::test_numpy_3d[arch=cc]
FAILED tests/python/test_matrix.py::test_load_store_scalarize[arch=cc]
FAILED tests/python/test_cli.py::test_cli_cache[none] - assert False
FAILED tests/python/test_continue.py::test_for_continue[arch=cc]
FAILED tests/python/test_types.py::test_uint_max[arch=cc-dt0-4294967295]
FAILED tests/python/test_mod.py::test_py_style_mod[arch=cc--10-3] - assert -4 == (-10 % 3)
FAILED tests/python/test_mod.py::test_py_style_mod[arch=cc-10--3] - assert 4 == (10 % -3)
FAILED tests/python/test_mod.py::test_mod_scan[arch=cc] - assert -4 == (-10 % 3)
FAILED tests/python/test_mpm88.py::test_mpm88[arch=cc]
```