### PR TITLE
[bug] Switch the gallery image used by README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If you wish to try our our experimental features or build Taichi Lang for your o
 
 Kudos to all of our amazing contributors! Taichi Lang thrives through open-source. In that spirit, we welcome all kinds of contributions from the community. If you would like to participate, check out the [Contribution Guidelines](CONTRIBUTING.md) first.
 
-<a href="https://github.com/taichi-dev/taichi/graphs/contributors"><img src="https://raw.githubusercontent.com/taichi-dev/public_files/rex/bugfix/fix-issue-that-blank-avatars-are-generated/taichi/contributors_taichi-dev_taichi_18.png" width="800px"></a>
+<a href="https://github.com/taichi-dev/taichi/graphs/contributors"><img src="https://raw.githubusercontent.com/taichi-dev/public_files/master/taichi/contributors_taichi-dev_taichi_18.png" width="800px"></a>
 
 *Contributor avatars are randomly shuffled.*
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If you wish to try our our experimental features or build Taichi Lang for your o
 
 Kudos to all of our amazing contributors! Taichi Lang thrives through open-source. In that spirit, we welcome all kinds of contributions from the community. If you would like to participate, check out the [Contribution Guidelines](CONTRIBUTING.md) first.
 
-<a href="https://github.com/taichi-dev/taichi/graphs/contributors"><img src="https://raw.githubusercontent.com/taichi-dev/public_files/master/taichi/contributors_taichi-dev_taichi_12.png" width="800px"></a>
+<a href="https://github.com/taichi-dev/taichi/graphs/contributors"><img src="https://raw.githubusercontent.com/taichi-dev/public_files/rex/bugfix/fix-issue-that-blank-avatars-are-generated/taichi/contributors_taichi-dev_taichi_18.png" width="800px"></a>
 
 *Contributor avatars are randomly shuffled.*
 


### PR DESCRIPTION
Issue: #

### Brief Summary

- This PR tried to fix the issue that avatar gallery SVG becomes blank PNG after getting compressed by cairo.

- Note this PR shall be merged only after https://github.com/taichi-dev/public_files/pull/12's getting merged.