### PR TITLE
[test] [cc] Skip tests that cc backend doesn't support

### DIFF
--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -216,6 +216,9 @@ def test_cli_cache():
     archs = {
         ti.cpu, ti.cuda, ti.opengl, ti.vulkan, ti.metal, ti.gles, ti.amdgpu
     }
+    expected_archs = test_utils.expected_archs()
+    if expected_archs == [ti.cc]:
+        return
     archs = {v for v in archs if v in test_utils.expected_archs()}
     exts = ('tic', 'tcb', 'lock')
     tmp_path = tempfile.mkdtemp()

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -904,7 +904,7 @@ def _test_field_and_ndarray(field, ndarray, func, verify):
     verify(ndarray)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_store_scalarize():
     @ti.func
     def func(a: ti.template()):
@@ -923,7 +923,7 @@ def test_store_scalarize():
     _test_field_and_ndarray(field, ndarray, func, verify)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_load_store_scalarize():
     @ti.func
     def func(a: ti.template()):
@@ -942,7 +942,7 @@ def test_load_store_scalarize():
     _test_field_and_ndarray(field, ndarray, func, verify)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_load_broadcast():
     @ti.func
     def func(a: ti.template()):
@@ -958,7 +958,7 @@ def test_load_broadcast():
     _test_field_and_ndarray(field, ndarray, func, verify)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_unary_op_scalarize():
     @ti.func
     def func(a: ti.template()):
@@ -982,7 +982,7 @@ def test_unary_op_scalarize():
     _test_field_and_ndarray(field, ndarray, func, verify)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_binary_op_scalarize():
     @ti.func
     def func(a: ti.template()):
@@ -1076,7 +1076,7 @@ def test_fill_op():
     test_fun()
 
 
-@test_utils.test(debug=True)
+@test_utils.test(exclude=[ti.cc], debug=True)
 def test_atomic_op_scalarize():
     @ti.func
     def func(x: ti.template()):

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -331,7 +331,7 @@ def test_n_loop_var_neq_dimension():
         iter()
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_2d_loop_over_ndarray():
     @ti.kernel
     def foo(arr: ti.types.ndarray(dtype=ti.i32, ndim=1)):

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -269,7 +269,7 @@ def test_numpy_view():
         fill(a)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_numpy_ndarray_dim_check():
     @ti.kernel
     def add_one_mat(arr: ti.types.ndarray(dtype=ti.math.mat3, ndim=2)):


### PR DESCRIPTION
cc backend does not support ndarray and offline cache, so we should skip them.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7719
* __->__ #7718

