### PR TITLE
[perf] Fix Taichi CPU backend compile parameter to pair performance with Numba.

### DIFF
--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -317,7 +317,7 @@ void KernelCodeGenCPU::optimize_module(llvm::Module *module) {
   options.HonorSignDependentRoundingFPMathOption = false;
   options.NoZerosInBSS = false;
   options.GuaranteedTailCallOpt = false;
-  
+
   llvm::legacy::FunctionPassManager function_pass_manager(module);
   llvm::legacy::PassManager module_pass_manager;
 

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -303,10 +303,20 @@ void KernelCodeGenCPU::optimize_module(llvm::Module *module) {
   TI_ERROR_UNLESS(target, err_str);
 
   llvm::TargetOptions options;
+  if (compile_config.fast_math) {
+    options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+    options.UnsafeFPMath = 1;
+    options.NoInfsFPMath = 1;
+    options.NoNaNsFPMath = 1;
+  } else {
+    options.AllowFPOpFusion = llvm::FPOpFusion::Strict;
+    options.UnsafeFPMath = 0;
+    options.NoInfsFPMath = 0;
+    options.NoNaNsFPMath = 0;
+  }
   options.HonorSignDependentRoundingFPMathOption = false;
   options.NoZerosInBSS = false;
   options.GuaranteedTailCallOpt = false;
-
   llvm::legacy::FunctionPassManager function_pass_manager(module);
   llvm::legacy::PassManager module_pass_manager;
 

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -317,6 +317,7 @@ void KernelCodeGenCPU::optimize_module(llvm::Module *module) {
   options.HonorSignDependentRoundingFPMathOption = false;
   options.NoZerosInBSS = false;
   options.GuaranteedTailCallOpt = false;
+  
   llvm::legacy::FunctionPassManager function_pass_manager(module);
   llvm::legacy::PassManager module_pass_manager;
 

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -303,17 +303,6 @@ void KernelCodeGenCPU::optimize_module(llvm::Module *module) {
   TI_ERROR_UNLESS(target, err_str);
 
   llvm::TargetOptions options;
-  if (compile_config.fast_math) {
-    options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
-    options.UnsafeFPMath = 1;
-    options.NoInfsFPMath = 1;
-    options.NoNaNsFPMath = 1;
-  } else {
-    options.AllowFPOpFusion = llvm::FPOpFusion::Strict;
-    options.UnsafeFPMath = 0;
-    options.NoInfsFPMath = 0;
-    options.NoNaNsFPMath = 0;
-  }
   options.HonorSignDependentRoundingFPMathOption = false;
   options.NoZerosInBSS = false;
   options.GuaranteedTailCallOpt = false;

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -2543,13 +2543,8 @@ void TaskCodeGenLLVM::initialize_context() {
   builder = std::make_unique<llvm::IRBuilder<>>(*llvm_context);
   if (compile_config.fast_math) {
     llvm::FastMathFlags fast_flags;
-    fast_flags.setNoNaNs();
     fast_flags.setNoInfs();
     fast_flags.setNoSignedZeros();
-    // Don't use approximate reciprocals for division. It's too inaccurate even
-    // for Halide. fast_flags.setAllowReciprocal(); Theoretically,
-    // setAllowReassoc could be setUnsafeAlgebra for earlier versions, but that
-    // turns on all the flags.
     fast_flags.setAllowReassoc();
     builder->setFastMathFlags(fast_flags);
   }

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -2546,9 +2546,9 @@ void TaskCodeGenLLVM::initialize_context() {
     fast_flags.setNoNaNs();
     fast_flags.setNoInfs();
     fast_flags.setNoSignedZeros();
-    // Don't use approximate reciprocals for division. It's too inaccurate even for Halide.
-    // fast_flags.setAllowReciprocal();
-    // Theoretically, setAllowReassoc could be setUnsafeAlgebra for earlier versions, but that
+    // Don't use approximate reciprocals for division. It's too inaccurate even
+    // for Halide. fast_flags.setAllowReciprocal(); Theoretically,
+    // setAllowReassoc could be setUnsafeAlgebra for earlier versions, but that
     // turns on all the flags.
     fast_flags.setAllowReassoc();
     fast_flags.setAllowContract(true);

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -2541,6 +2541,20 @@ void TaskCodeGenLLVM::initialize_context() {
   TI_ASSERT(tlctx != nullptr);
   llvm_context = tlctx->get_this_thread_context();
   builder = std::make_unique<llvm::IRBuilder<>>(*llvm_context);
+  if (compile_config.fast_math) {
+    llvm::FastMathFlags fast_flags;
+    fast_flags.setNoNaNs();
+    fast_flags.setNoInfs();
+    fast_flags.setNoSignedZeros();
+    // Don't use approximate reciprocals for division. It's too inaccurate even for Halide.
+    // fast_flags.setAllowReciprocal();
+    // Theoretically, setAllowReassoc could be setUnsafeAlgebra for earlier versions, but that
+    // turns on all the flags.
+    fast_flags.setAllowReassoc();
+    fast_flags.setAllowContract(true);
+    fast_flags.setApproxFunc();
+    builder->setFastMathFlags(fast_flags);
+  }
 }
 
 llvm::Value *TaskCodeGenLLVM::get_arg(int i) {

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -2551,8 +2551,6 @@ void TaskCodeGenLLVM::initialize_context() {
     // setAllowReassoc could be setUnsafeAlgebra for earlier versions, but that
     // turns on all the flags.
     fast_flags.setAllowReassoc();
-    fast_flags.setAllowContract(true);
-    fast_flags.setApproxFunc();
     builder->setFastMathFlags(fast_flags);
   }
 }


### PR DESCRIPTION
Issue: #7442

### Brief Summary

In this issue, Numba is a magnitude faster than Taichi due to the absence of automatic vectorization. 
The root cause is the incorrect passage of the `fast_flag`.

To solve this problem, `fast_flag` is now added to the initialization of cpu codegen. Numba and Taichi now reveal comparable performance.
Here's perf comparison:
numba:            13052.542478MFlops
taichi(master): 6544.274409MFlops
taichi(this pr):  12778.240179MFlops