### PR TITLE
[doc] [test] Update docs for printing with f-strings and formatted strings

### DIFF
--- a/docs/lang/articles/debug/debugging.md
+++ b/docs/lang/articles/debug/debugging.md
@@ -77,25 +77,74 @@ To enable printing on Vulkan, please
 :::
 
 
-### Comma-separated strings only
+### Printing comma-separated strings, f-strings, or formatted strings
 
-Strings passed to `print` in the Taichi scope *must* be comma-separated. Neither f-strings nor formatted strings can be recognized. For example:
+In Taichi scope, you can print both scalar and matrix values using the `print` function. There are multiple ways to format your output, including comma-separated strings, f-strings, and formatted strings via the `str.format()` method.
 
-```python {9-11}
+For instance, suppose you have a scalar field `a` and want to print its value. Here are some examples:
+
+```python
 import taichi as ti
 ti.init(arch=ti.cpu)
+
 a = ti.field(ti.f32, 4)
 
-
 @ti.kernel
-def foo():
+def print_scalar():
     a[0] = 1.0
-    print('a[0] = ', a[0]) # right
-    print(f'a[0] = {a[0]}') # wrong: f-strings are not supported
-    print("a[0] = %f" % a[0]) # wrong: formatted strings are not supported
 
-foo()
+    # comma-separated string
+    print('a[0] =', a[0])
+
+    # f-string
+    print(f'a[0] = {a[0]}')
+    # with format specifier
+    print(f'a[0] = {a[0]:.1f}')
+    # without conversion
+    print(f'a[0] = {a[0]:.1}')
+    # with self-documenting expressions (Python 3.8+)
+    print(f'{a[0] = :.1f}')
+
+    # formatted string via `str.format()` method
+    print('a[0] = {}'.format(a[0]))
+    # with format specifier
+    print('a[0] = {:.1f}'.format(a[0]))
+    # without conversion
+    print('a[0] = {:.1}'.format(a[0]))
+    # with positional arguments
+    print('a[3] = {3:.3f}, a[2] = {2:.2f}, a[1] = {1:.1f}, a[0] = {0:.0f}'.format(a[0], a[1], a[2], a[3]))
 ```
+
+If you have a matrix field m, you can print it as well. Here are some examples:
+
+```python
+@ti.kernel
+def print_matrix():
+    m = ti.Matrix([[2e1, 3e2, 4e3], [5e4, 6e5, 7e6]], ti.f32)
+
+    # comma-separated string
+    print('m =', m)
+
+    # f-string
+    print(f'm = {m}')
+    # with format specifier
+    print(f'm = {m:.1f}')
+    # without conversion
+    print(f'm = {m:.1}')
+    # with self-documenting expressions
+    print(f'{m = :g}')
+
+    # formatted string via `str.format()` method
+    print('m = {}'.format(m))
+    # with format specifier
+    print('m = {:e}'.format(m))
+    # without conversion
+    print('m = {:.1}'.format(m))
+```
+
+:::note
+Building formatted strings using the % operator is currently **not** supported in Taichi.
+:::
 
 ## Compile-time `ti.static_print`
 

--- a/tests/python/py38_only.py
+++ b/tests/python/py38_only.py
@@ -17,3 +17,51 @@ def test_namedexpr():
         return b
 
     assert foo() == 12
+
+
+#TODO: validation layer support on macos vulkan backend is not working.
+vk_on_mac = (ti.vulkan, 'Darwin')
+
+#TODO: capfd doesn't function well on CUDA backend on Windows
+cuda_on_windows = (ti.cuda, 'Windows')
+
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
+                 exclude=[vk_on_mac, cuda_on_windows],
+                 debug=True)
+def test_print_docs_scalar_self_documenting_exp(capfd):
+    a = ti.field(ti.f32, 4)
+
+    @ti.kernel
+    def func():
+        a[0] = 1.0
+
+        # with self-documenting expressions
+        print(f'{a[0] = :.1f}')
+
+    func()
+    ti.sync()
+
+    out, err = capfd.readouterr()
+    expected_out = '''a[0] = 1.0
+'''
+    assert out == expected_out and err == ''
+
+
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
+                 exclude=[vk_on_mac, cuda_on_windows],
+                 debug=True)
+def test_print_docs_matrix_self_documenting_exp(capfd):
+    @ti.kernel
+    def func():
+        m = ti.Matrix([[2e1, 3e2, 4e3], [5e4, 6e5, 7e6]], ti.f32)
+
+        # with self-documenting expressions
+        print(f'{m = :g}')
+
+    func()
+    ti.sync()
+
+    out, err = capfd.readouterr()
+    expected_out = '''m = [[20, 300, 4000], [50000, 600000, 7e+06]]
+'''
+    assert out == expected_out and err == ''

--- a/tests/python/py38_only.py
+++ b/tests/python/py38_only.py
@@ -25,6 +25,7 @@ vk_on_mac = (ti.vulkan, 'Darwin')
 #TODO: capfd doesn't function well on CUDA backend on Windows
 cuda_on_windows = (ti.cuda, 'Windows')
 
+
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
                  exclude=[vk_on_mac, cuda_on_windows],
                  debug=True)

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import taichi as ti
@@ -9,6 +11,10 @@ vk_on_mac = (ti.vulkan, 'Darwin')
 #TODO: capfd doesn't function well on CUDA backend on Windows
 cuda_on_windows = (ti.cuda, 'Windows')
 
+
+if sys.version_info >= (3, 8):
+    # Import the test case only if the Python version is >= 3.8
+    from .py38_only import test_print_docs_matrix_self_documenting_exp, test_print_docs_scalar_self_documenting_exp
 
 # Not really testable..
 # Just making sure it does not crash
@@ -250,8 +256,6 @@ def test_print_docs_scalar(capfd):
         print(f'a[0] = {a[0]:.1f}')
         # without conversion
         print(f'a[0] = {a[0]:.1}')
-        # with self-documenting expressions (Python 3.8+)
-        print(f'{a[0] = :.1f}')
 
         # formatted string via `str.format()` method
         print('a[0] = {}'.format(a[0]))
@@ -268,7 +272,6 @@ def test_print_docs_scalar(capfd):
     out, err = capfd.readouterr()
     expected_out = '''a[0] = 1.000000
 a[0] = 1.000000
-a[0] = 1.0
 a[0] = 1.0
 a[0] = 1.0
 a[0] = 1.000000
@@ -298,8 +301,6 @@ def test_print_docs_matrix(capfd):
         print(f'm = {m:.1f}')
         # can omitting conversion
         print(f'm = {m:.1}')
-        # can with self-documenting expressions
-        print(f'{m = :g}')
 
         # formatted string via `str.format()` method is supported
         print('m = {}'.format(m))
@@ -316,7 +317,6 @@ def test_print_docs_matrix(capfd):
 m = [[20.000000, 300.000000, 4000.000000], [50000.000000, 600000.000000, 7000000.000000]]
 m = [[20.0, 300.0, 4000.0], [50000.0, 600000.0, 7000000.0]]
 m = [[20.0, 300.0, 4000.0], [50000.0, 600000.0, 7000000.0]]
-m = [[20, 300, 4000], [50000, 600000, 7e+06]]
 m = [[20.000000, 300.000000, 4000.000000], [50000.000000, 600000.000000, 7000000.000000]]
 m = [[2.000000e+01, 3.000000e+02, 4.000000e+03], [5.000000e+04, 6.000000e+05, 7.000000e+06]]
 m = [[20.0, 300.0, 4000.0], [50000.0, 600000.0, 7000000.0]]

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -11,10 +11,11 @@ vk_on_mac = (ti.vulkan, 'Darwin')
 #TODO: capfd doesn't function well on CUDA backend on Windows
 cuda_on_windows = (ti.cuda, 'Windows')
 
-
 if sys.version_info >= (3, 8):
     # Import the test case only if the Python version is >= 3.8
-    from .py38_only import test_print_docs_matrix_self_documenting_exp, test_print_docs_scalar_self_documenting_exp
+    from .py38_only import (test_print_docs_matrix_self_documenting_exp,
+                            test_print_docs_scalar_self_documenting_exp)
+
 
 # Not really testable..
 # Just making sure it does not crash
@@ -264,7 +265,8 @@ def test_print_docs_scalar(capfd):
         # without conversion
         print('a[0] = {:.1}'.format(a[0]))
         # with positional arguments
-        print('a[3] = {3:.3f}, a[2] = {2:.2f}, a[1] = {1:.1f}, a[0] = {0:.0f}'.format(a[0], a[1], a[2], a[3]))
+        print('a[3] = {3:.3f}, a[2] = {2:.2f}, a[1] = {1:.1f}, a[0] = {0:.0f}'.
+              format(a[0], a[1], a[2], a[3]))
 
     func()
     ti.sync()

--- a/tests/python/test_print.py
+++ b/tests/python/test_print.py
@@ -232,6 +232,99 @@ def test_print_matrix_fstring_with_spec_mismatch():
 
 
 @test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
+                 exclude=[vk_on_mac, cuda_on_windows],
+                 debug=True)
+def test_print_docs_scalar(capfd):
+    a = ti.field(ti.f32, 4)
+
+    @ti.kernel
+    def func():
+        a[0] = 1.0
+
+        # comma-separated string
+        print('a[0] =', a[0])
+
+        # f-string
+        print(f'a[0] = {a[0]}')
+        # with format specifier
+        print(f'a[0] = {a[0]:.1f}')
+        # without conversion
+        print(f'a[0] = {a[0]:.1}')
+        # with self-documenting expressions (Python 3.8+)
+        print(f'{a[0] = :.1f}')
+
+        # formatted string via `str.format()` method
+        print('a[0] = {}'.format(a[0]))
+        # with format specifier
+        print('a[0] = {:.1f}'.format(a[0]))
+        # without conversion
+        print('a[0] = {:.1}'.format(a[0]))
+        # with positional arguments
+        print('a[3] = {3:.3f}, a[2] = {2:.2f}, a[1] = {1:.1f}, a[0] = {0:.0f}'.format(a[0], a[1], a[2], a[3]))
+
+    func()
+    ti.sync()
+
+    out, err = capfd.readouterr()
+    expected_out = '''a[0] = 1.000000
+a[0] = 1.000000
+a[0] = 1.0
+a[0] = 1.0
+a[0] = 1.0
+a[0] = 1.000000
+a[0] = 1.0
+a[0] = 1.0
+a[3] = 0.000, a[2] = 0.00, a[1] = 0.0, a[0] = 1
+'''
+    assert out == expected_out and err == ''
+
+
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
+                 exclude=[vk_on_mac, cuda_on_windows],
+                 debug=True)
+def test_print_docs_matrix(capfd):
+    a = ti.field(ti.f32, 4)
+
+    @ti.kernel
+    def func():
+        m = ti.Matrix([[2e1, 3e2, 4e3], [5e4, 6e5, 7e6]], ti.f32)
+
+        # comma-seperated string is supported
+        print('m =', m)
+
+        # f-string is supported
+        print(f'm = {m}')
+        # can with format specifier
+        print(f'm = {m:.1f}')
+        # can omitting conversion
+        print(f'm = {m:.1}')
+        # can with self-documenting expressions
+        print(f'{m = :g}')
+
+        # formatted string via `str.format()` method is supported
+        print('m = {}'.format(m))
+        # can with format specifier
+        print('m = {:e}'.format(m))
+        # and can omitting conversion
+        print('m = {:.1}'.format(m))
+
+    func()
+    ti.sync()
+
+    out, err = capfd.readouterr()
+    expected_out = '''m = [[20.000000, 300.000000, 4000.000000], [50000.000000, 600000.000000, 7000000.000000]]
+m = [[20.000000, 300.000000, 4000.000000], [50000.000000, 600000.000000, 7000000.000000]]
+m = [[20.0, 300.0, 4000.0], [50000.0, 600000.0, 7000000.0]]
+m = [[20.0, 300.0, 4000.0], [50000.0, 600000.0, 7000000.0]]
+m = [[20, 300, 4000], [50000, 600000, 7e+06]]
+m = [[20.000000, 300.000000, 4000.000000], [50000.000000, 600000.000000, 7000000.000000]]
+m = [[2.000000e+01, 3.000000e+02, 4.000000e+03], [5.000000e+04, 6.000000e+05, 7.000000e+06]]
+m = [[20.0, 300.0, 4000.0], [50000.0, 600000.0, 7000000.0]]
+'''
+    assert out == expected_out and err == ''
+
+
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.vulkan],
                  exclude=[vk_on_mac],
                  debug=True)
 def test_print_sep_end():


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d4c573</samp>

This pull request improves the `print` function in Taichi scope by adding support for Python 3.8 features and more string formatting options. It also updates the documentation and the tests accordingly. It adds new test cases for f-strings with self-documenting expressions in `tests/python/py38_only.py`, which are only run for Python 3.8 or higher.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d4c573</samp>

*  Update documentation of `print` function in Taichi scope to reflect new support for f-strings and formatted strings ([link](https://github.com/taichi-dev/taichi/pull/7733/files?diff=unified&w=0#diff-f9023fb1bcf09eb9375ba41cff4f5cff78b4024d44e50ae1b1169f84e58c6d5eL80-R148))
*  Add test cases for `print` function with self-documenting expressions in f-strings, which are only available in Python 3.8+ ([link](https://github.com/taichi-dev/taichi/pull/7733/files?diff=unified&w=0#diff-b7d6eb3dbc25e81642a9c0cd54799d7d64d90ff8b5b4aeb4ed2e52ae9a1ca0e8R20-R68), [link](https://github.com/taichi-dev/taichi/pull/7733/files?diff=unified&w=0#diff-05cbd9daaed536ceae369f2ad258217a0be4e523646dce528ef102622491dd24L12-R19))
*  Add test cases for `print` function with f-strings and formatted strings with various format specifiers and conversions ([link](https://github.com/taichi-dev/taichi/pull/7733/files?diff=unified&w=0#diff-05cbd9daaed536ceae369f2ad258217a0be4e523646dce528ef102622491dd24R242-R329))
*  Import `sys` module in `tests/python/test_print.py` to check Python version ([link](https://github.com/taichi-dev/taichi/pull/7733/files?diff=unified&w=0#diff-05cbd9daaed536ceae369f2ad258217a0be4e523646dce528ef102622491dd24R1-R2))