### PR TITLE
[lang] Improve error message for mismatched index for ndarrays in python scope

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -2,6 +2,7 @@ import numpy as np
 from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.enums import Layout
+from taichi.lang.exception import TaichiIndexError
 from taichi.lang.util import cook_dtype, python_scope, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.ndarray_type import NdarrayTypeMetadata
@@ -212,7 +213,10 @@ class Ndarray:
             key = ()
         if not isinstance(key, (tuple, list)):
             key = (key, )
-        assert len(key) == len(self.arr.total_shape())
+        if len(key) != len(self.arr.total_shape()):
+            raise TaichiIndexError(
+                f'{len(self.arr.total_shape())}d ndarray indexed with {len(key)}-d indices: {key}'
+            )
         return key
 
     @python_scope

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -215,7 +215,7 @@ class Ndarray:
             key = (key, )
         if len(key) != len(self.arr.total_shape()):
             raise TaichiIndexError(
-                f'{len(self.arr.total_shape())}d ndarray indexed with {len(key)}-d indices: {key}'
+                f'{len(self.arr.total_shape())}d ndarray indexed with {len(key)}d indices: {key}'
             )
         return key
 

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -3,6 +3,7 @@ import copy
 import numpy as np
 import pytest
 from taichi.lang import impl
+from taichi.lang.exception import TaichiIndexError
 from taichi.lang.misc import get_host_arch_list
 from taichi.lang.util import has_pytorch
 
@@ -796,3 +797,15 @@ def test_matrix_ndarray_oob():
         access_arr(input, 3, 5, 0, 1)
     with pytest.raises(AssertionError, match=r'Out of bound access'):
         access_arr(input, 2, -10, 1, 1)
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_mismatched_index_python_scope():
+    x = ti.ndarray(dtype=ti.f32, shape=(4, 4))
+    with pytest.raises(TaichiIndexError,
+                       match=r'2d ndarray indexed with 1-d indices'):
+        x[0]
+
+    with pytest.raises(TaichiIndexError,
+                       match=r'2d ndarray indexed with 3-d indices'):
+        x[0, 0, 0]

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -803,9 +803,9 @@ def test_matrix_ndarray_oob():
 def test_mismatched_index_python_scope():
     x = ti.ndarray(dtype=ti.f32, shape=(4, 4))
     with pytest.raises(TaichiIndexError,
-                       match=r'2d ndarray indexed with 1-d indices'):
+                       match=r'2d ndarray indexed with 1d indices'):
         x[0]
 
     with pytest.raises(TaichiIndexError,
-                       match=r'2d ndarray indexed with 3-d indices'):
+                       match=r'2d ndarray indexed with 3d indices'):
         x[0, 0, 0]


### PR DESCRIPTION

Issue: #

### Brief Summary
We used to throw AssertionError without much context for this case. 
```
Traceback (most recent call last):
  File "/home/ailing/github/taichi/repro.py", line 19, in <module>
    test_ad_ndarray()
  File "/home/ailing/github/taichi/repro.py", line 14, in test_ad_ndarray
    x[0] = 0.2
  File "/home/ailing/github/taichi/python/taichi/lang/util.py", line 311, in wrapped
    return func(*args, **kwargs)
  File "/home/ailing/github/taichi/python/taichi/lang/_ndarray.py", line 255, in __setitem__
    self.host_accessor.setter(value, *self._pad_key(key))
  File "/home/ailing/github/taichi/python/taichi/lang/util.py", line 311, in wrapped
    return func(*args, **kwargs)
  File "/home/ailing/github/taichi/python/taichi/lang/_ndarray.py", line 215, in _pad_key
    assert len(key) == len(self.arr.total_shape())
AssertionError
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b71bf79</samp>

This pull request improves the error handling and testing of `Ndarray` objects in Python scope. It uses `TaichiIndexError` to raise informative exceptions for invalid indexing, and adds new test cases to `test_ndarray.py` to cover this scenario.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b71bf79</samp>

*  Import and use `TaichiIndexError` class to handle mismatched indexing of ndarrays in Python scope ([link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-a80a8a9749edd5fd01358e92793b8d52ac098873dc9cec7d1cc9c1f349b202bbR5), [link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-a80a8a9749edd5fd01358e92793b8d52ac098873dc9cec7d1cc9c1f349b202bbL215-R219), [link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0R6), [link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0R800-R811))
  - Add `from taichi.lang.exception import TaichiIndexError` to `python/taichi/lang/_ndarray.py` and `tests/python/test_ndarray.py` ([link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-a80a8a9749edd5fd01358e92793b8d52ac098873dc9cec7d1cc9c1f349b202bbR5), [link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0R6))
  - Modify `_pad_key` method of `Ndarray` class to check key length and raise `TaichiIndexError` with message if it does not match ndarray shape ([link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-a80a8a9749edd5fd01358e92793b8d52ac098873dc9cec7d1cc9c1f349b202bbL215-R219))
  - Add two test cases to `test_mismatched_index_python_scope` function in `tests/python/test_ndarray.py` to assert that `TaichiIndexError` is raised and message is correct when 2d ndarray is indexed with 1d or 3d indices in Python scope ([link](https://github.com/taichi-dev/taichi/pull/7737/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0R800-R811))