### PR TITLE
[ci] Isolate post sm70 tests

### DIFF
--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -127,6 +127,7 @@ function ci-docker-run {
         -e PY \
         -e PROJECT_NAME \
         -e LLVM_VERSION \
+        -e EXTRA_TEST_MARKERS \
         -e TAICHI_CMAKE_ARGS \
         -e IN_DOCKER=true \
         -e TI_CI=1 \

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -33,16 +33,7 @@ echo "wanted archs: $TI_WANTED_ARCHS"
 
 if [ -z "$TI_SKIP_CPP_TESTS" ]; then
     echo "Running cpp tests on platform:" "${PLATFORM}"
-    # Temporary hack before CI Pipeline Overhaul
-    if [[ "$(uname -s)" == "Linux" ]]; then
-        if nvidia-smi -L | grep "Tesla P4"; then
-            python3 tests/run_tests.py --cpp -vr2 -t4 -m "not sm70"
-        else
-            python3 tests/run_tests.py --cpp -vr2 -t4
-        fi
-    else
-        python3 tests/run_tests.py --cpp -vr2 -t4
-    fi
+    python3 tests/run_tests.py --cpp -vr2 -t4 ${EXTRA_TEST_MARKERS:+-m "$EXTRA_TEST_MARKERS"}
 fi
 
 
@@ -77,8 +68,8 @@ function run-it {
     KEYS=${3:-"not torch and not paddle"}
 
     if [[ $TI_WANTED_ARCHS == *"$1"* ]]; then
-        python3 tests/run_tests.py -vr2 -t$PARALLELISM -k "$KEYS" -m "not run_in_serial" -a $ARCH
-        python3 tests/run_tests.py -vr2 -t1 -k "$KEYS" -m "run_in_serial" -a $ARCH
+        python3 tests/run_tests.py -vr2 -t$PARALLELISM -k "$KEYS" -m "not run_in_serial ${EXTRA_TEST_MARKERS:+and $EXTRA_TEST_MARKERS}" -a $ARCH
+        python3 tests/run_tests.py -vr2 -t1 -k "$KEYS" -m "run_in_serial ${EXTRA_TEST_MARKERS:+and $EXTRA_TEST_MARKERS}" -a $ARCH
     fi
 }
 

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -80,7 +80,7 @@ if ("$env:TI_WANTED_ARCHS".Contains("cuda")) {
 RunIt opengl 4
 RunIt vulkan 4
 
-Invoke python tests/run_tests.py -vr2 -t1 -k "torch" -a "$env:TI_WANTED_ARCHS"
+Invoke python tests/run_tests.py -vr2 -t1 -k "torch" -a "$env:TI_WANTED_ARCHS" @EXTRA_TEST_MARKERS_SOLO
 
 if ("$env:TI_RUN_RELEASE_TESTS" -eq "1") {
     Info "Running release tests"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -186,11 +186,20 @@ jobs:
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
     strategy:
       matrix:
-        tags:
-          - [self-hosted, cuda, vulkan, cn, driver470]
-          - [self-hosted, cuda, vulkan, cn, driver510]
+        extra_markers:
+        - sm70
+        - not sm70
+        driver:
+        - driver470
+        - driver510
 
-    runs-on: ${{ matrix.tags }}
+    runs-on:
+    - self-hosted
+    - cn
+    - cuda
+    - vulkan
+    - ${{ matrix.driver }}
+    - ${{ matrix.extra_markers == 'sm70' && 'sm70' || 'Linux' }}
     steps:
       - name: Workaround checkout Needed single revision issue
         run: git submodule foreach 'git rev-parse HEAD > /dev/null 2>&1 || rm -rf $PWD' || true
@@ -239,6 +248,7 @@ jobs:
           TI_WANTED_ARCHS: 'cc,cpu,cuda,vulkan,opengl,gles'
           TI_DEVICE_MEMORY_GB: '1'
           TI_RUN_RELEASE_TESTS: '1'
+          EXTRA_TEST_MARKERS: ${{ matrix.extra_markers }}
 
       - name: Save wheel if test failed
         if: failure() && steps.test.conclusion == 'failure'
@@ -828,6 +838,7 @@ jobs:
     name: AOT Build and Test (GPU)
     needs: check_files
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
+    # TODO(proton): do we need to test both drivers?
     strategy:
       matrix:
         tags:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -384,7 +384,18 @@ jobs:
   build_and_test_windows:
     name: Build and Test Windows
     needs: check_files
-    runs-on: [self-hosted, windows, cuda, OpenGL]
+    strategy:
+      matrix:
+        extra_markers:
+        - sm70
+        - not sm70
+    runs-on:
+    - self-hosted
+    - cn
+    - windows
+    - cuda
+    - OpenGL
+    - ${{ matrix.extra_markers == 'sm70' && 'sm70' || 'windows' }}
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 180 }}
     steps:
       - name: Workaround checkout Needed single revision issue
@@ -430,6 +441,7 @@ jobs:
           TI_SKIP_VERSION_CHECK: ON
           TI_DEVICE_MEMORY_GB: '1'
           TI_RUN_RELEASE_TESTS: '1'
+          EXTRA_TEST_MARKERS: ${{ matrix.extra_markers }}
 
       - name: Save wheel if test failed
         if: failure() && steps.test.conclusion == 'failure'

--- a/tests/python/test_f16.py
+++ b/tests/python/test_f16.py
@@ -10,19 +10,8 @@ from tests import test_utils
 archs_support_f16 = [ti.cpu, ti.cuda, ti.vulkan]
 
 
-def skip_if_not_supported(f):
-    def wrapper(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        except RuntimeError as e:
-            if 'Type f16 not supported' in str(e):
-                pytest.skip('f16 not supported')
-
-    return wrapper
-
-
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_snode_read_write():
     dtype = ti.f16
     x = ti.field(dtype, shape=())
@@ -31,8 +20,8 @@ def test_snode_read_write():
     assert (x[None] == test_utils.approx(0.3, rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_float16():
     dtype = ti.float16
     x = ti.field(dtype, shape=())
@@ -41,8 +30,8 @@ def test_float16():
     assert (x[None] == test_utils.approx(0.3, rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_to_numpy():
     n = 16
     x = ti.field(ti.f16, shape=n)
@@ -58,8 +47,8 @@ def test_to_numpy():
         assert (y[i] == 2 * i)
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_from_numpy():
     n = 16
     y = ti.field(dtype=ti.f16, shape=n)
@@ -77,8 +66,8 @@ def test_from_numpy():
         assert (z[i] == i * 3)
 
 
+@pytest.mark.sm70
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@skip_if_not_supported
 @test_utils.test(arch=archs_support_f16)
 def test_to_torch():
     n = 16
@@ -96,8 +85,8 @@ def test_to_torch():
         assert (y[i] == 2 * i)
 
 
+@pytest.mark.sm70
 @pytest.mark.skipif(not has_pytorch(), reason='Pytorch not installed.')
-@skip_if_not_supported
 @test_utils.test(arch=archs_support_f16)
 def test_from_torch():
     import torch
@@ -118,8 +107,8 @@ def test_from_torch():
         assert (z[i] == i * 3)
 
 
+@pytest.mark.sm70
 @pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
-@skip_if_not_supported
 @test_utils.test(arch=archs_support_f16, exclude=[ti.vulkan, ti.dx11])
 def test_to_paddle():
     import paddle
@@ -140,8 +129,8 @@ def test_to_paddle():
         assert (y[i] == 2 * i)
 
 
+@pytest.mark.sm70
 @pytest.mark.skipif(not has_paddle(), reason='Paddle not installed.')
-@skip_if_not_supported
 @test_utils.test(arch=archs_support_f16, exclude=[ti.vulkan, ti.dx11])
 def test_from_paddle():
     import paddle
@@ -164,8 +153,8 @@ def test_from_paddle():
         assert (z[i] == i * 3)
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_binary_op():
     dtype = ti.f16
     x = ti.field(dtype, shape=())
@@ -184,8 +173,8 @@ def test_binary_op():
     assert (u[None] == test_utils.approx(0.6624, rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_rand_promote():
     dtype = ti.f16
     x = ti.field(dtype, shape=(4, 4))
@@ -199,8 +188,8 @@ def test_rand_promote():
     init()
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_unary_op():
     dtype = ti.f16
     x = ti.field(dtype, shape=())
@@ -218,8 +207,8 @@ def test_unary_op():
     assert (y[None] == test_utils.approx(-1, rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_extra_unary_promote():
     dtype = ti.f16
     x = ti.field(dtype, shape=())
@@ -234,8 +223,8 @@ def test_extra_unary_promote():
     assert (x[None] == test_utils.approx(0.3, rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16, exclude=ti.vulkan)
-@skip_if_not_supported
 def test_binary_extra_promote():
     x = ti.field(dtype=ti.f16, shape=())
     y = ti.field(dtype=ti.f16, shape=())
@@ -251,8 +240,8 @@ def test_binary_extra_promote():
     assert (z[None] == test_utils.approx(math.atan2(0.1**2, 0.3), rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_arg_f16():
     dtype = ti.f16
     x = ti.field(dtype, shape=())
@@ -267,8 +256,8 @@ def test_arg_f16():
     assert (x[None] == test_utils.approx(0.9, rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_fractal_f16():
     n = 320
     pixels = ti.field(dtype=ti.f16, shape=(n * 2, n))
@@ -292,8 +281,8 @@ def test_fractal_f16():
 
 
 # TODO(): Vulkan support
+@pytest.mark.sm70
 @test_utils.test(arch=[ti.cpu, ti.cuda])
-@skip_if_not_supported
 def test_atomic_add_f16():
     f = ti.field(dtype=ti.f16, shape=(2))
 
@@ -313,8 +302,8 @@ def test_atomic_add_f16():
 
 
 # TODO(): Vulkan support
+@pytest.mark.sm70
 @test_utils.test(arch=[ti.cpu, ti.cuda])
-@skip_if_not_supported
 def test_atomic_max_f16():
     f = ti.field(dtype=ti.f16, shape=(2))
 
@@ -334,8 +323,8 @@ def test_atomic_max_f16():
 
 
 # TODO(): Vulkan support
+@pytest.mark.sm70
 @test_utils.test(arch=[ti.cpu, ti.cuda])
-@skip_if_not_supported
 def test_atomic_min_f16():
     f = ti.field(dtype=ti.f16, shape=(2))
 
@@ -354,8 +343,8 @@ def test_atomic_min_f16():
     assert (f[0] == test_utils.approx(f[1], rel=1e-3))
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16)
-@skip_if_not_supported
 def test_cast_f32_to_f16():
     @ti.kernel
     def func() -> ti.f16:
@@ -366,8 +355,8 @@ def test_cast_f32_to_f16():
     assert func() == pytest.approx(23.0 * 4.0, 1e-4)
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=archs_support_f16, require=ti.extension.data64)
-@skip_if_not_supported
 def test_cast_f64_to_f16():
     @ti.kernel
     def func() -> ti.f16:
@@ -378,6 +367,7 @@ def test_cast_f64_to_f16():
     assert func() == pytest.approx(23.0 * 4.0, 1e-4)
 
 
+@pytest.mark.sm70
 @test_utils.test(arch=[ti.cuda], half2_vectorization=True)
 def test_half2_vectorize():
     half2 = ti.types.vector(n=2, dtype=ti.f16)

--- a/tests/python/test_shared_array.py
+++ b/tests/python/test_shared_array.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import taichi as ti
 from tests import test_utils
@@ -8,7 +9,8 @@ from tests import test_utils
 def test_large_shared_array():
     # Skip the GPUs prior to Ampere which doesn't have large dynamical shared memory.
     if ti.lang.impl.get_cuda_compute_capability() < 86:
-        return
+        pytest.skip('Skip the GPUs prior to Ampere')
+
     block_dim = 128
     nBlocks = 64
     N = nBlocks * block_dim


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e785ddc</samp>

This pull request enhances the testing workflow and scripts to support filtering tests based on custom pytest markers, such as `sm70` for testing float16 features on GPUs with high compute capability. It also refactors and improves some existing tests to use the marker mechanism.