### PR TITLE
[bug] Avoid redundant cache loading

### DIFF
--- a/taichi/compilation_manager/kernel_compilation_manager.cpp
+++ b/taichi/compilation_manager/kernel_compilation_manager.cpp
@@ -217,6 +217,8 @@ const CompiledKernelData *KernelCompilationManager::try_load_cached_kernel(
     if (iter != kernels.end()) {
       auto &k = iter->second;
       if (k.compiled_kernel_data) {
+        TI_DEBUG("Create kernel '{}' from cache (key='{}')",
+                 kernel_def.get_name(), kernel_key);
         return k.compiled_kernel_data.get();
       } else if (auto loaded = load_ckd(kernel_key, arch)) {
         TI_DEBUG("Create kernel '{}' from cache (key='{}')",

--- a/taichi/compilation_manager/kernel_compilation_manager.cpp
+++ b/taichi/compilation_manager/kernel_compilation_manager.cpp
@@ -216,16 +216,16 @@ const CompiledKernelData *KernelCompilationManager::try_load_cached_kernel(
     auto iter = kernels.find(kernel_key);
     if (iter != kernels.end()) {
       auto &k = iter->second;
-      if (!k.compiled_kernel_data) {
-        if (auto loaded = load_ckd(kernel_key, arch)) {
-          TI_DEBUG("Create kernel '{}' from cache (key='{}')",
-                   kernel_def.get_name(), kernel_key);
-          TI_ASSERT(loaded->arch() == arch);
-          k.last_used_at = std::time(nullptr);
-          k.compiled_kernel_data = std::move(loaded);
-          updated_data_.push_back(&k);
-          return k.compiled_kernel_data.get();
-        }
+      if (k.compiled_kernel_data) {
+        return k.compiled_kernel_data.get();
+      } else if (auto loaded = load_ckd(kernel_key, arch)) {
+        TI_DEBUG("Create kernel '{}' from cache (key='{}')",
+                 kernel_def.get_name(), kernel_key);
+        TI_ASSERT(loaded->arch() == arch);
+        k.last_used_at = std::time(nullptr);
+        k.compiled_kernel_data = std::move(loaded);
+        updated_data_.push_back(&k);
+        return k.compiled_kernel_data.get();
       }
     }
   }

--- a/taichi/compilation_manager/kernel_compilation_manager.cpp
+++ b/taichi/compilation_manager/kernel_compilation_manager.cpp
@@ -216,14 +216,16 @@ const CompiledKernelData *KernelCompilationManager::try_load_cached_kernel(
     auto iter = kernels.find(kernel_key);
     if (iter != kernels.end()) {
       auto &k = iter->second;
-      if (auto loaded = load_ckd(kernel_key, arch)) {
-        TI_DEBUG("Create kernel '{}' from cache (key='{}')",
-                 kernel_def.get_name(), kernel_key);
-        TI_ASSERT(loaded->arch() == arch);
-        k.last_used_at = std::time(nullptr);
-        k.compiled_kernel_data = std::move(loaded);
-        updated_data_.push_back(&k);
-        return k.compiled_kernel_data.get();
+      if (!k.compiled_kernel_data) {
+        if (auto loaded = load_ckd(kernel_key, arch)) {
+          TI_DEBUG("Create kernel '{}' from cache (key='{}')",
+                   kernel_def.get_name(), kernel_key);
+          TI_ASSERT(loaded->arch() == arch);
+          k.last_used_at = std::time(nullptr);
+          k.compiled_kernel_data = std::move(loaded);
+          updated_data_.push_back(&k);
+          return k.compiled_kernel_data.get();
+        }
       }
     }
   }


### PR DESCRIPTION
Issue: #7002 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2ee059</samp>

Improve kernel compilation manager efficiency by avoiding redundant cache loading.
### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2ee059</samp>

* Add a check for existing kernel data to avoid redundant loading ([link](https://github.com/taichi-dev/taichi/pull/7741/files?diff=unified&w=0#diff-b7662dbf5bcf20f4b99048f4f2405316c0ba037c0722273522efaad72d256ef0L219-R228))
