### PR TITLE
[refactor] Implement CompiledKernelData::check()

### DIFF
--- a/taichi/codegen/compiled_kernel_data.cpp
+++ b/taichi/codegen/compiled_kernel_data.cpp
@@ -181,6 +181,8 @@ std::string CompiledKernelData::get_err_msg(Err err) {
       return "The taichi is not built with llvm";
     case Err::kTiWithoutSpirv:
       return "The taichi is not built with spirv";
+    case Err::kCompiledKernelDataBroken:
+      return "The CompiledKernelData is broken";
     case Err::kUnknown:
       return "Unkown error";
   }

--- a/taichi/codegen/compiled_kernel_data.h
+++ b/taichi/codegen/compiled_kernel_data.h
@@ -92,6 +92,7 @@ class CompiledKernelData {
     kOutOfMemory,
     kTiWithoutLLVM,
     kTiWithoutSpirv,
+    kCompiledKernelDataBroken,
     kUnknown,
   };
 

--- a/taichi/codegen/llvm/compiled_kernel_data.h
+++ b/taichi/codegen/llvm/compiled_kernel_data.h
@@ -52,6 +52,8 @@ class CompiledKernelData : public lang::CompiledKernelData {
   Arch arch() const override;
   std::unique_ptr<lang::CompiledKernelData> clone() const override;
 
+  Err check() const override;
+
   const InternalData &get_internal_data() const {
     return data_;
   }

--- a/taichi/compilation_manager/kernel_compilation_manager.cpp
+++ b/taichi/compilation_manager/kernel_compilation_manager.cpp
@@ -175,6 +175,7 @@ std::unique_ptr<CompiledKernelData> KernelCompilationManager::compile_kernel(
   auto &compiler = *config_.kernel_compiler;
   auto ir = compiler.compile(compile_config, kernel_def);
   auto ckd = compiler.compile(compile_config, caps, kernel_def, *ir);
+  TI_ASSERT(ckd->check() == CompiledKernelData::Err::kNoError);
   return ckd;
 }
 
@@ -263,7 +264,12 @@ std::unique_ptr<CompiledKernelData> KernelCompilationManager::load_ckd(
     CompiledKernelData::Err err;
     auto ckd = CompiledKernelData::load(ifs, &err);
     if (err != CompiledKernelData::Err::kNoError) {
-      TI_DEBUG("Load cached CompiledKernelData file failed: {}",
+      TI_DEBUG("Load cache file {} failed: {}", filename,
+               CompiledKernelData::get_err_msg(err));
+      return nullptr;
+    }
+    if (auto err = ckd->check(); err != CompiledKernelData::Err::kNoError) {
+      TI_DEBUG("Check CompiledKernelData loaded from {} failed: {}", filename,
                CompiledKernelData::get_err_msg(err));
       return nullptr;
     }


### PR DESCRIPTION
Issue: #7002 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d2c768</samp>

This pull request improves the error handling and debugging of the kernel compilation and caching process using the LLVM backend. It adds a `check` function to the `CompiledKernelData` class that verifies the LLVM module and tasks, and uses it to assert and report the status of the data.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d2c768</samp>

*  Add a new error enum value and message for the case when the CompiledKernelData is broken ([link](https://github.com/taichi-dev/taichi/pull/7743/files?diff=unified&w=0#diff-5e2472488f9620231c8e3d6a2c0413742e2b42424691991f4a85af81832af3f4R95), [link](https://github.com/taichi-dev/taichi/pull/7743/files?diff=unified&w=0#diff-70ec30330946b7543dcf0b458091cfc6128a5cb5460041db64144b84722de4abR184-R185))
*  Implement a check function for the CompiledKernelData class that verifies the LLVM module and the tasks stored in the data using the LLVM verifier ([link](https://github.com/taichi-dev/taichi/pull/7743/files?diff=unified&w=0#diff-3986d4b2137cab0463bb950113c0ddc44cfdf3baff237da6286c42c478309c3bR3), [link](https://github.com/taichi-dev/taichi/pull/7743/files?diff=unified&w=0#diff-3986d4b2137cab0463bb950113c0ddc44cfdf3baff237da6286c42c478309c3bR30-R43), [link](https://github.com/taichi-dev/taichi/pull/7743/files?diff=unified&w=0#diff-e54a1ed2c2d35f9357e4dfbbbc1224e70a95280b43d4a59f0017dc2c6163dca0R55-R56))
*  Add assertions and checks for the result of the check function after compiling or loading a kernel using the LLVM backend, and modify the debug message to include the cache filename ([link](https://github.com/taichi-dev/taichi/pull/7743/files?diff=unified&w=0#diff-b7662dbf5bcf20f4b99048f4f2405316c0ba037c0722273522efaad72d256ef0R178), [link](https://github.com/taichi-dev/taichi/pull/7743/files?diff=unified&w=0#diff-b7662dbf5bcf20f4b99048f4f2405316c0ba037c0722273522efaad72d256ef0L266-R275))
