### PR TITLE
[bug] Fix reduction of atomic max

### DIFF
--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -161,25 +161,25 @@ inline TypedConstant get_max_value(DataType dt) {
 
 inline TypedConstant get_min_value(DataType dt) {
   if (dt->is_primitive(PrimitiveTypeID::i8)) {
-    return {dt, std::numeric_limits<int8>::min()};
+    return {dt, std::numeric_limits<int8>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::i16)) {
-    return {dt, std::numeric_limits<int16>::min()};
+    return {dt, std::numeric_limits<int16>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::i32)) {
-    return {dt, std::numeric_limits<int32>::min()};
+    return {dt, std::numeric_limits<int32>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::i64)) {
-    return {dt, std::numeric_limits<int64>::min()};
+    return {dt, std::numeric_limits<int64>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::u8)) {
-    return {dt, std::numeric_limits<uint8>::min()};
+    return {dt, std::numeric_limits<uint8>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::u16)) {
-    return {dt, std::numeric_limits<uint16>::min()};
+    return {dt, std::numeric_limits<uint16>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::u32)) {
-    return {dt, std::numeric_limits<uint32>::min()};
+    return {dt, std::numeric_limits<uint32>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::u64)) {
-    return {dt, std::numeric_limits<uint64>::min()};
+    return {dt, std::numeric_limits<uint64>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
-    return {dt, std::numeric_limits<float32>::min()};
+    return {dt, std::numeric_limits<float32>::lowest()};
   } else if (dt->is_primitive(PrimitiveTypeID::f64)) {
-    return {dt, std::numeric_limits<float64>::min()};
+    return {dt, std::numeric_limits<float64>::lowest()};
   } else {
     TI_NOT_IMPLEMENTED;
   }

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -393,3 +393,16 @@ def test_atomic_min_rvalue_as_frist_op():
     assert 'atomic_min' in str(e.value)
     assert 'cannot use a non-writable target as the first operand of' in str(
         e.value)
+
+
+@test_utils.test()
+def test_atomic_max_f32():
+    @ti.kernel
+    def max_kernel() -> ti.f32:
+        x = -1000.0
+        for i in range(1, 20):
+            ti.atomic_max(x, -ti.f32(i))
+
+        return x
+
+    assert max_kernel() == -1.0


### PR DESCRIPTION
Issue: fixes #7735 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aab0f5f</samp>

Fix a bug in `get_min_value` for floating-point types and add a test case for `ti.atomic_max` with negative values. These changes improve the correctness and robustness of the type utilities and the atomic operations in Taichi.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aab0f5f</samp>

*  Fix bug in `get_min_value` function that returns incorrect minimum for floating-point types ([link](https://github.com/taichi-dev/taichi/pull/7747/files?diff=unified&w=0#diff-1df7532afc2540435b46bd5831a4b6bd11bb1ead5e1fd3607e02fccf9dab112cL164-R182))
*  Add test case for `ti.atomic_max` function with floating-point variable and negative values ([link](https://github.com/taichi-dev/taichi/pull/7747/files?diff=unified&w=0#diff-4ecaccff18cc51096700d5724aa7e3f71daa90fe82e3c274718bfbdc4e6b319dR396-R408))

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aab0f5f</samp>

> _`get_min_value` fixed_
> _floating-point bug was hidden_
> _autumn tests reveal_