### PR TITLE
[cuda] Update the data layout of CUDA

### DIFF
--- a/taichi/runtime/cuda/jit_cuda.cpp
+++ b/taichi/runtime/cuda/jit_cuda.cpp
@@ -244,8 +244,9 @@ std::unique_ptr<JITSession> create_llvm_jit_session_cuda(
   TI_ASSERT(arch == Arch::cuda);
   // https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#data-layout
   auto data_layout = llvm::DataLayout(
-      "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-"
-      "f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
+      "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-i128:128:128-"
+      "f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:"
+      "64");
   return std::make_unique<JITSessionCUDA>(tlctx, config, data_layout);
 }
 #else


### PR DESCRIPTION
Issue: fixes #7296

### Brief Summary

Updated the deprecated data layout of NVVM IR.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ae6d86</samp>

Added support for i128 type in CUDA JIT data layout to enable atomic operations on 64-bit integers (I don't know if this is true. It's generated by the copilot). Modified `taichi/runtime/cuda/jit_cuda.cpp` accordingly.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ae6d86</samp>

*  Update data layout string for LLVM JIT session for CUDA to support i128 type ([link](https://github.com/taichi-dev/taichi/pull/7748/files?diff=unified&w=0#diff-b7e12be512e7cab600a8ac8de54030fb889df95e3f0424f341b48fac44497fb1L247-R249))

### Poem
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1ae6d86</samp>

> _`i128` type added_
> _To LLVM JIT session_
> _Winter of atomics_