### PR TITLE
[ci] Ignore dup benchmark data points

### DIFF
--- a/.github/workflows/scripts/post-benchmark-to-github-pr.py
+++ b/.github/workflows/scripts/post-benchmark-to-github-pr.py
@@ -95,7 +95,8 @@ def main():
 
     current = json.loads(Path(options.result).read_text())
     for item in current:
-        db.execute('INSERT INTO current VALUES (?, ?)', flatten_metric(item))
+        db.execute('INSERT OR IGNORE INTO current VALUES (?, ?)',
+                   flatten_metric(item))
 
     ver = requests.get(
         'https://benchmark.taichi-lang.cn/releases?order=vnum.desc&limit=1'
@@ -105,7 +106,8 @@ def main():
     ).json()
 
     for item in release:
-        db.execute('INSERT INTO release VALUES (?, ?)', flatten_metric(item))
+        db.execute('INSERT OR IGNORE INTO release VALUES (?, ?)',
+                   flatten_metric(item))
 
     rs = db.execute('''
         SELECT


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b392d0</samp>

Improve the benchmark database insertion script by avoiding duplicate rows.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b392d0</samp>

*  Add `OR IGNORE` clause to SQL queries to avoid inserting duplicate benchmark results ([link](https://github.com/taichi-dev/taichi/pull/7749/files?diff=unified&w=0#diff-06335d589e11e93714fb6534b8b88f1e251503a92e8f76b9d1c744000de33e63L98-R99), [link](https://github.com/taichi-dev/taichi/pull/7749/files?diff=unified&w=0#diff-06335d589e11e93714fb6534b8b88f1e251503a92e8f76b9d1c744000de33e63L108-R110))
