### PR TITLE
[misc] Remove unused FullSimplifyPass::Args::program

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -93,8 +93,7 @@ void compile_to_offloads(IRNode *ir,
 
   irpass::full_simplify(
       ir, config,
-      {false, /*autodiff_enabled*/ autodiff_mode != AutodiffMode::kNone,
-       kernel->program});
+      {false, /*autodiff_enabled*/ autodiff_mode != AutodiffMode::kNone});
   print("Simplified I");
   irpass::analysis::verify(ir);
 
@@ -117,12 +116,10 @@ void compile_to_offloads(IRNode *ir,
     // Remove local atomics here so that we don't have to handle their gradients
     irpass::demote_atomics(ir, config);
 
-    irpass::full_simplify(ir, config,
-                          {false, /*autodiff_enabled*/ true, kernel->program});
+    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ true});
     irpass::auto_diff(ir, config, autodiff_mode, ad_use_stack);
     // TODO: Be carefull with the full_simplify when do high-order autodiff
-    irpass::full_simplify(ir, config,
-                          {false, /*autodiff_enabled*/ false, kernel->program});
+    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
     print("Gradient");
     irpass::analysis::verify(ir);
   }
@@ -137,8 +134,7 @@ void compile_to_offloads(IRNode *ir,
   print("Access flagged I");
   irpass::analysis::verify(ir);
 
-  irpass::full_simplify(ir, config,
-                        {false, /*autodiff_enabled*/ false, kernel->program});
+  irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
   print("Simplified II");
   irpass::analysis::verify(ir);
 
@@ -158,8 +154,7 @@ void compile_to_offloads(IRNode *ir,
   irpass::flag_access(ir);
   print("Access flagged II");
 
-  irpass::full_simplify(ir, config,
-                        {false, /*autodiff_enabled*/ false, kernel->program});
+  irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
   print("Simplified III");
   irpass::analysis::verify(ir);
 }
@@ -232,8 +227,7 @@ void offload_to_executable(IRNode *ir,
     if (config.make_mesh_block_local && config.arch == Arch::cuda) {
       irpass::make_mesh_block_local(ir, config, {kernel->get_name()});
       print("Make mesh block local");
-      irpass::full_simplify(
-          ir, config, {false, /*autodiff_enabled*/ false, kernel->program});
+      irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
       print("Simplified X");
     }
   }
@@ -265,8 +259,7 @@ void offload_to_executable(IRNode *ir,
   irpass::analysis::verify(ir);
 
   if (lower_global_access) {
-    irpass::full_simplify(ir, config,
-                          {false, /*autodiff_enabled*/ false, kernel->program});
+    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
     print("Simplified before lower access");
     irpass::lower_access(ir, config, {kernel->no_activate, true});
     print("Access lowered");
@@ -284,9 +277,8 @@ void offload_to_executable(IRNode *ir,
   irpass::demote_operations(ir, config);
   print("Operations demoted");
 
-  irpass::full_simplify(
-      ir, config,
-      {lower_global_access, /*autodiff_enabled*/ false, kernel->program});
+  irpass::full_simplify(ir, config,
+                        {lower_global_access, /*autodiff_enabled*/ false});
   print("Simplified IV");
 
   if (determine_ad_stack_size) {
@@ -305,9 +297,8 @@ void offload_to_executable(IRNode *ir,
 
     irpass::type_check(ir, config);
 
-    irpass::full_simplify(
-        ir, config,
-        {lower_global_access, /*autodiff_enabled*/ false, kernel->program});
+    irpass::full_simplify(ir, config,
+                          {lower_global_access, /*autodiff_enabled*/ false});
 
     irpass::flag_access(ir);
     print("Half2 vectorized");
@@ -388,8 +379,8 @@ void compile_function(IRNode *ir,
   irpass::demote_operations(ir, config);
   print("Operations demoted");
 
-  irpass::full_simplify(
-      ir, config, {false, autodiff_mode != AutodiffMode::kNone, func->program});
+  irpass::full_simplify(ir, config,
+                        {false, autodiff_mode != AutodiffMode::kNone});
   print("Simplified");
   irpass::analysis::verify(ir);
 }

--- a/taichi/transforms/simplify.h
+++ b/taichi/transforms/simplify.h
@@ -13,7 +13,6 @@ class FullSimplifyPass : public Pass {
     // Switch off some optimization in store forwarding if there is an autodiff
     // pass after the full_simplify
     bool autodiff_enabled;
-    Program *program;
   };
 };
 

--- a/tests/cpp/transforms/inlining_test.cpp
+++ b/tests/cpp/transforms/inlining_test.cpp
@@ -52,8 +52,7 @@ TEST_F(InliningTest, ArgLoadOfArgLoad) {
   irpass::type_check(kernel_block, CompileConfig());
 
   irpass::inlining(kernel_block, CompileConfig(), {});
-  irpass::full_simplify(kernel_block, CompileConfig(),
-                        {false, false, prog_.get()});
+  irpass::full_simplify(kernel_block, CompileConfig(), {false, false});
 
   EXPECT_EQ(kernel_block->size(), 4);
   EXPECT_TRUE(irpass::analysis::same_statements(func_block, kernel_block));


### PR DESCRIPTION
Issue: #6834

### Brief Summary

The `FullSimplifyPass::Args::program` was used by jit evaluator.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e98bbb5</samp>

Refactored the `full_simplify` pass to remove the unused `program` argument from its interface. Updated the function calls in `compile_to_offloads.cpp`, `simplify.h`, and `inlining_test.cpp` accordingly.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e98bbb5</samp>

*  Remove `program` argument from `full_simplify` function calls and `Args` struct, as it is no longer used by the pass ([link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL96-R96), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL120-R122), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL140-R137), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL161-R157), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL235-R230), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL268-R262), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL287-R281), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL308-R301), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL391-R383), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-10ec6d45529f36e0388647cb0bfbf233de555fcd755707a8bf02c1ac725a37cfL16), [link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-ace6beedf43215762f6710697e896be2a74f96956c24b05a53ca515672108271L55-R55))
* Update test cases in `inlining_test.cpp` to reflect the changes in the `full_simplify` pass interface ([link](https://github.com/taichi-dev/taichi/pull/7750/files?diff=unified&w=0#diff-ace6beedf43215762f6710697e896be2a74f96956c24b05a53ca515672108271L55-R55))
