### PR TITLE
[refactor] Remove Kernel::task_counter_

### DIFF
--- a/.github/workflows/scripts/post-benchmark-to-github-pr.py
+++ b/.github/workflows/scripts/post-benchmark-to-github-pr.py
@@ -95,7 +95,8 @@ def main():
 
     current = json.loads(Path(options.result).read_text())
     for item in current:
-        db.execute('INSERT INTO current VALUES (?, ?)', flatten_metric(item))
+        db.execute('INSERT OR IGNORE INTO current VALUES (?, ?)',
+                   flatten_metric(item))
 
     ver = requests.get(
         'https://benchmark.taichi-lang.cn/releases?order=vnum.desc&limit=1'
@@ -105,7 +106,8 @@ def main():
     ).json()
 
     for item in release:
-        db.execute('INSERT INTO release VALUES (?, ?)', flatten_metric(item))
+        db.execute('INSERT OR IGNORE INTO release VALUES (?, ?)',
+                   flatten_metric(item))
 
     rs = db.execute('''
         SELECT

--- a/taichi/codegen/amdgpu/codegen_amdgpu.cpp
+++ b/taichi/codegen/amdgpu/codegen_amdgpu.cpp
@@ -27,11 +27,12 @@ using namespace llvm;
 class TaskCodeGenAMDGPU : public TaskCodeGenLLVM {
  public:
   using IRVisitor::visit;
-  TaskCodeGenAMDGPU(const CompileConfig &config,
+  TaskCodeGenAMDGPU(int id,
+                    const CompileConfig &config,
                     TaichiLLVMContext &tlctx,
                     const Kernel *kernel,
                     IRNode *ir = nullptr)
-      : TaskCodeGenLLVM(config, tlctx, kernel, ir) {
+      : TaskCodeGenLLVM(id, config, tlctx, kernel, ir) {
   }
 
   llvm::Value *create_print(std::string tag,
@@ -483,10 +484,12 @@ class TaskCodeGenAMDGPU : public TaskCodeGenLLVM {
 };
 
 LLVMCompiledTask KernelCodeGenAMDGPU::compile_task(
+    int task_codegen_id,
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenAMDGPU gen(config, get_taichi_llvm_context(), kernel, stmt);
+  TaskCodeGenAMDGPU gen(task_codegen_id, config, get_taichi_llvm_context(),
+                        kernel, stmt);
   return gen.run_compilation();
 }
 

--- a/taichi/codegen/amdgpu/codegen_amdgpu.h
+++ b/taichi/codegen/amdgpu/codegen_amdgpu.h
@@ -19,6 +19,7 @@ class KernelCodeGenAMDGPU : public KernelCodeGen {
 // TODO: Stop defining this macro guards in the headers
 #ifdef TI_WITH_LLVM
   LLVMCompiledTask compile_task(
+      int task_codegen_id,
       const CompileConfig &config,
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr) override;

--- a/taichi/codegen/codegen.cpp
+++ b/taichi/codegen/codegen.cpp
@@ -88,7 +88,7 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
       tlctx_.fetch_this_thread_struct_module();
       auto offload = irpass::analysis::clone(offloads[i].get());
       irpass::re_id(offload.get());
-      auto new_data = this->compile_task(compile_config_, nullptr,
+      auto new_data = this->compile_task(i, compile_config_, nullptr,
                                          offload->as<OffloadedStmt>());
       data[i] = std::make_unique<LLVMCompiledTask>(std::move(new_data));
     };

--- a/taichi/codegen/codegen.h
+++ b/taichi/codegen/codegen.h
@@ -60,6 +60,7 @@ class KernelCodeGen {
   virtual LLVMCompiledKernel compile_kernel_to_module();
 
   virtual LLVMCompiledTask compile_task(
+      int task_codegen_id,
       const CompileConfig &config,
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr) {

--- a/taichi/codegen/cpu/codegen_cpu.cpp
+++ b/taichi/codegen/cpu/codegen_cpu.cpp
@@ -27,11 +27,12 @@ class TaskCodeGenCPU : public TaskCodeGenLLVM {
  public:
   using IRVisitor::visit;
 
-  TaskCodeGenCPU(const CompileConfig &config,
+  TaskCodeGenCPU(int id,
+                 const CompileConfig &config,
                  TaichiLLVMContext &tlctx,
                  const Kernel *kernel,
                  IRNode *ir)
-      : TaskCodeGenLLVM(config, tlctx, kernel, ir, nullptr) {
+      : TaskCodeGenLLVM(id, config, tlctx, kernel, ir, nullptr) {
     TI_AUTO_PROF
   }
 
@@ -285,10 +286,11 @@ FunctionType CPUModuleToFunctionConverter::convert(
 }
 
 LLVMCompiledTask KernelCodeGenCPU::compile_task(
+    int task_codegen_id,
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenCPU gen(config, get_taichi_llvm_context(), kernel, stmt);
+  TaskCodeGenCPU gen(task_codegen_id, config, get_taichi_llvm_context(), kernel, stmt);
   return gen.run_compilation();
 }
 

--- a/taichi/codegen/cpu/codegen_cpu.h
+++ b/taichi/codegen/cpu/codegen_cpu.h
@@ -21,6 +21,7 @@ class KernelCodeGenCPU : public KernelCodeGen {
   // TODO: Stop defining this macro guards in the headers
 #ifdef TI_WITH_LLVM
   LLVMCompiledTask compile_task(
+      int task_codegen_id,
       const CompileConfig &config,
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr) override;

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -41,11 +41,12 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
   using IRVisitor::visit;
   size_t dynamic_shared_array_bytes{0};
 
-  explicit TaskCodeGenCUDA(const CompileConfig &config,
+  explicit TaskCodeGenCUDA(int id,
+                           const CompileConfig &config,
                            TaichiLLVMContext &tlctx,
                            const Kernel *kernel,
                            IRNode *ir = nullptr)
-      : TaskCodeGenLLVM(config, tlctx, kernel, ir) {
+      : TaskCodeGenLLVM(id, config, tlctx, kernel, ir) {
   }
 
   llvm::Value *create_print(std::string tag,
@@ -740,10 +741,12 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 };
 
 LLVMCompiledTask KernelCodeGenCUDA::compile_task(
+    int task_codegen_id,
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenCUDA gen(config, get_taichi_llvm_context(), kernel, stmt);
+  TaskCodeGenCUDA gen(task_codegen_id, config, get_taichi_llvm_context(),
+                      kernel, stmt);
   return gen.run_compilation();
 }
 

--- a/taichi/codegen/cuda/codegen_cuda.h
+++ b/taichi/codegen/cuda/codegen_cuda.h
@@ -19,6 +19,7 @@ class KernelCodeGenCUDA : public KernelCodeGen {
 // TODO: Stop defining this macro guards in the headers
 #ifdef TI_WITH_LLVM
   LLVMCompiledTask compile_task(
+      int task_codegen_id,
       const CompileConfig &config,
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr) override;

--- a/taichi/codegen/dx12/codegen_dx12.cpp
+++ b/taichi/codegen/dx12/codegen_dx12.cpp
@@ -21,11 +21,12 @@ class TaskCodeGenLLVMDX12 : public TaskCodeGenLLVM {
  public:
   using IRVisitor::visit;
 
-  TaskCodeGenLLVMDX12(const CompileConfig &config,
+  TaskCodeGenLLVMDX12(int id,
+                      const CompileConfig &config,
                       TaichiLLVMContext &tlctx,
                       const Kernel *kernel,
                       IRNode *ir)
-      : TaskCodeGenLLVM(config, tlctx, kernel, ir, nullptr) {
+      : TaskCodeGenLLVM(id, config, tlctx, kernel, ir, nullptr) {
     TI_AUTO_PROF
   }
 
@@ -243,7 +244,7 @@ KernelCodeGenDX12::CompileResult KernelCodeGenDX12::compile() {
     auto offload = irpass::analysis::clone(offloads[i].get());
     irpass::re_id(offload.get());
     auto *offload_stmt = offload->as<OffloadedStmt>();
-    auto new_data = compile_task(config, nullptr, offload_stmt);
+    auto new_data = compile_task(i, config, nullptr, offload_stmt);
 
     Result.task_dxil_source_codes.emplace_back(
         generate_dxil_from_llvm(new_data, config, kernel));
@@ -260,10 +261,12 @@ KernelCodeGenDX12::CompileResult KernelCodeGenDX12::compile() {
 }
 
 LLVMCompiledTask KernelCodeGenDX12::compile_task(
+    int task_codegen_id,
     const CompileConfig &config,
     std::unique_ptr<llvm::Module> &&module,
     OffloadedStmt *stmt) {
-  TaskCodeGenLLVMDX12 gen(config, get_taichi_llvm_context(), kernel, stmt);
+  TaskCodeGenLLVMDX12 gen(task_codegen_id, config, get_taichi_llvm_context(),
+                          kernel, stmt);
   return gen.run_compilation();
 }
 #endif  // TI_WITH_LLVM

--- a/taichi/codegen/dx12/codegen_dx12.h
+++ b/taichi/codegen/dx12/codegen_dx12.h
@@ -26,6 +26,7 @@ class KernelCodeGenDX12 : public KernelCodeGen {
   CompileResult compile();
 #ifdef TI_WITH_LLVM
   LLVMCompiledTask compile_task(
+      int task_codegen_id,
       const CompileConfig &config,
       std::unique_ptr<llvm::Module> &&module = nullptr,
       OffloadedStmt *stmt = nullptr) override;

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -313,10 +313,10 @@ TaskCodeGenLLVM::TaskCodeGenLLVM(int id,
     : LLVMModuleBuilder(
           module == nullptr ? tlctx.new_module("kernel") : std::move(module),
           &tlctx),
-      task_codegen_id(id),
       compile_config(compile_config),
       kernel(kernel),
       ir(ir),
+      task_codegen_id(id),
       prog(kernel->program) {
   if (ir == nullptr)
     this->ir = kernel->ir.get();

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -316,8 +316,8 @@ TaskCodeGenLLVM::TaskCodeGenLLVM(int id,
       compile_config(compile_config),
       kernel(kernel),
       ir(ir),
-      task_codegen_id(id),
-      prog(kernel->program) {
+      prog(kernel->program),
+      task_codegen_id(id) {
   if (ir == nullptr)
     this->ir = kernel->ir.get();
   initialize_context();

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -303,7 +303,8 @@ void TaskCodeGenLLVM::emit_struct_meta_base(const std::string &name,
                                    snode->get_snode_tree_id()));
 }
 
-TaskCodeGenLLVM::TaskCodeGenLLVM(const CompileConfig &compile_config,
+TaskCodeGenLLVM::TaskCodeGenLLVM(int id,
+                                 const CompileConfig &compile_config,
                                  TaichiLLVMContext &tlctx,
                                  const Kernel *kernel,
                                  IRNode *ir,
@@ -312,6 +313,7 @@ TaskCodeGenLLVM::TaskCodeGenLLVM(const CompileConfig &compile_config,
     : LLVMModuleBuilder(
           module == nullptr ? tlctx.new_module("kernel") : std::move(module),
           &tlctx),
+      task_codegen_id(id),
       compile_config(compile_config),
       kernel(kernel),
       ir(ir),
@@ -1953,7 +1955,7 @@ std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt,
                               {llvm::PointerType::get(context_ty, 0)}, false);
 
   auto task_kernel_name =
-      fmt::format("{}_{}_{}{}", kernel_name, kernel->get_next_task_id(),
+      fmt::format("{}_{}_{}_{}{}", kernel_name, task_codegen_id, task_counter++,
                   stmt->task_name(), suffix);
   func = llvm::Function::Create(task_function_type,
                                 llvm::Function::ExternalLinkage,

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -63,7 +63,9 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   std::unordered_set<int> struct_for_tls_sizes;
   const Callable *current_callable{nullptr};
 
-  // The task_codegen_id and task_counter are used to generate unique task ids
+  // The task_codegen_id and task_counter are used to generate unique task
+  // ids.The task_codegen_id represents the id of the offloaded task, and the
+  // task_counter represents the id of the task within the offloaded task.
   int task_codegen_id{0};
   int task_counter{0};
 

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -63,6 +63,10 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   std::unordered_set<int> struct_for_tls_sizes;
   const Callable *current_callable{nullptr};
 
+  // The task_codegen_id and task_counter are used to generate unique task ids
+  int task_codegen_id{0};
+  int task_counter{0};
+
   std::unordered_map<const Stmt *, std::vector<llvm::Value *>> loop_vars_llvm;
 
   std::unordered_map<Function *, llvm::Function *> func_map;
@@ -70,7 +74,8 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   using IRVisitor::visit;
   using LLVMModuleBuilder::call;
 
-  explicit TaskCodeGenLLVM(const CompileConfig &config,
+  explicit TaskCodeGenLLVM(int id,
+                           const CompileConfig &config,
                            TaichiLLVMContext &tlctx,
                            const Kernel *kernel,
                            IRNode *ir,

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -65,10 +65,6 @@ class TI_DLL_EXPORT Kernel : public Callable {
   std::vector<uint64> get_ret_uint_tensor(int i);
   std::vector<float64> get_ret_float_tensor(int i);
 
-  uint64 get_next_task_id() const {
-    return task_counter_++;
-  }
-
   [[nodiscard]] std::string get_name() const override;
 
   void set_kernel_key_for_cache(const std::string &kernel_key) const {
@@ -92,8 +88,7 @@ class TI_DLL_EXPORT Kernel : public Callable {
   // A flag to record whether |ir| has been fully lowered.
   // lower initial AST all the way down to a bunch of
   // OffloadedStmt for async execution TODO(Lin): Check this comment
-  mutable bool lowered_{false};                  // TODO(PGZXB): Remove it
-  mutable std::atomic<uint64> task_counter_{0};  // TODO(PGZXB): Remove it
+  mutable bool lowered_{false};  // TODO(PGZXB): Remove it
   mutable std::string kernel_key_;
 };
 


### PR DESCRIPTION
Issue: #7002

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 618302d</samp>

This pull request introduces a mechanism to assign unique ids to each offloaded task in different backends, enabling asynchronous execution of kernels on various devices. It modifies the constructors and methods of several codegen classes to accept and pass task ids, and simplifies the task id generation for kernels by using local counters. It mainly affects the files `taichi/codegen/*` and `taichi/program/kernel.h`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 618302d</samp>

*  Add an `id` parameter to the constructors of `TaskCodeGenLLVM` and its subclasses (`TaskCodeGenAMDGPU`, `TaskCodeGenCPU`, `TaskCodeGenCUDA`, `TaskCodeGenLLVMDX12`) to pass a unique identifier for each task codegen instance ([link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-f45ad00d5bebbc900cf84ab5b4f0b634fe8ca7a99770788c2cb5b055612c1e85L30-R35), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-b6e86fbdf536db46b321f67942f66d809c213a4142ceb9f5f81d016684c2d5c8L30-R35), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-50537ad5ea3b900c0d55a088f3cc285986340ad68c9b96fea481187c4dce49eaL44-R49), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-b26bcd66b9334fe882df039d1c619f16f0f91f6c43c3872b6cbb2688b8e7b749L24-R29), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-3c663c78745adcd3f6a7ac81fe99e628decc3040f292ea1e20ecd4b85a7f4313L306-R307), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-aebc3d71bb555fba77f1d303d5c29ac7e07d392440b0e54cf556ff5a10a81d0aL73-R78))
* Add an `task_codegen_id` parameter to the `compile_task` methods of `KernelCodeGen` and its subclasses (`KernelCodeGenAMDGPU`, `KernelCodeGenCPU`, `KernelCodeGenCUDA`, `KernelCodeGenDX12`) to pass the task codegen id to the task codegen constructors ([link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-f45ad00d5bebbc900cf84ab5b4f0b634fe8ca7a99770788c2cb5b055612c1e85L486-R492), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-2dca4a15a3c5e43017b458e9a19d8edabade6e4489c719aea88819e9dc34c285R22), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-54b0d16247300543741692be7cec4b05993efa661e71ad3d69d5da85fcbc7782L91-R91), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-75d426482e598b420f6f3bed213844bbfcca397be6d3a3371c9ff8128275a6fdR63), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-b6e86fbdf536db46b321f67942f66d809c213a4142ceb9f5f81d016684c2d5c8L288-R293), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-9bc17077ecc24636db6f9c92d14d55bdcdb87c18379d72a06a9e84486d20b060R24), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-50537ad5ea3b900c0d55a088f3cc285986340ad68c9b96fea481187c4dce49eaL743-R749), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-15ab2a7729595aeafa4c5a77a6c97e9a7e9d43ffd49210b86d940b6394e58475R22), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-b26bcd66b9334fe882df039d1c619f16f0f91f6c43c3872b6cbb2688b8e7b749L246-R247), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-b26bcd66b9334fe882df039d1c619f16f0f91f6c43c3872b6cbb2688b8e7b749L263-R269), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-d4ff49adc577edb7d11d8e69b2fb1e97162aaf01ef896e588a35cc8a20e061b1R29))
* Use the `task_codegen_id` and a local `task_counter` to generate unique task ids for each offloaded statement in the `init_offloaded_task_function` method of `TaskCodeGenLLVM`, instead of using a shared atomic counter in the `Kernel` class ([link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-3c663c78745adcd3f6a7ac81fe99e628decc3040f292ea1e20ecd4b85a7f4313L1956-R1958), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-3c663c78745adcd3f6a7ac81fe99e628decc3040f292ea1e20ecd4b85a7f4313R316), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-aebc3d71bb555fba77f1d303d5c29ac7e07d392440b0e54cf556ff5a10a81d0aR66-R69), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-5831927e99f989a5c80bace0ae3a103f99fb5849cf6e591a22a8bb83d3a14c3fL68-L71), [link](https://github.com/taichi-dev/taichi/pull/7751/files?diff=unified&w=0#diff-5831927e99f989a5c80bace0ae3a103f99fb5849cf6e591a22a8bb83d3a14c3fL95-R91))
