### PR TITLE
[misc] Wrap path with std::filesystem::path

### DIFF
--- a/taichi/ui/utils/utils.h
+++ b/taichi/ui/utils/utils.h
@@ -34,6 +34,7 @@
 
 #include "taichi/rhi/vulkan/vulkan_common.h"
 #include "taichi/rhi/window_system.h"
+#include "taichi/common/filesystem.hpp"
 
 #include <stdarg.h>
 
@@ -184,7 +185,8 @@ inline std::string button_id_to_name(int id) {
 #endif
 
 inline std::vector<char> read_file(const std::string &filename) {
-  std::ifstream file(filename, std::ios::ate | std::ios::binary);
+  std::ifstream file(std::filesystem::path{filename},
+                     std::ios::ate | std::ios::binary);
 
   if (!file.is_open()) {
     throw std::runtime_error(filename + " failed to open file!");


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6bd587</samp>

Improved file path handling in `taichi/ui/utils/utils.h` by using `std::filesystem::path` in `read_file`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6bd587</samp>

*  Include `taichi/common/filesystem.hpp` to use `std::filesystem::path` class for cross-platform file path abstraction ([link](https://github.com/taichi-dev/taichi/pull/7754/files?diff=unified&w=0#diff-ea1bec4314f7736959c0ea32a753cad9c496c0aa6ec8b7208cebb7cbe6ba6eb2R37))
*  Wrap `filename` argument of `read_file` function with `std::filesystem::path` to normalize and ensure compatibility of file paths ([link](https://github.com/taichi-dev/taichi/pull/7754/files?diff=unified&w=0#diff-ea1bec4314f7736959c0ea32a753cad9c496c0aa6ec8b7208cebb7cbe6ba6eb2L187-R189))
