### PR TITLE
[lang] Transform bit_shr to bit_sar for uint

### DIFF
--- a/tests/python/test_bit_operations.py
+++ b/tests/python/test_bit_operations.py
@@ -60,3 +60,12 @@ def test_bit_shr():
     for i in range(n):
         offset = 0x100000000 if i > 0 else 0
         assert shr(neg_test_num, i) == (neg_test_num + offset) >> i
+
+
+@test_utils.test()
+def test_bit_shr_uint():
+    @ti.kernel
+    def func(x: ti.u32, y: ti.i32) -> ti.u32:
+        return ti.bit_shr(x, y)
+
+    assert (func(5, 2) == 1)


### PR DESCRIPTION
Closes #7650

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b81d127</samp>

Fix the demotion transformation for the bit shift right operation with unsigned integers and add a test case for it. This improves the correctness and test coverage for issue `#2840`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b81d127</samp>

*  Relax demotion condition for bit shift right operation to apply to both signed and unsigned integers ([link](https://github.com/taichi-dev/taichi/pull/7757/files?diff=unified&w=0#diff-d217f2b07d4578612dc805b0f01e5dc1883be9acb906b222a8762313cfd0596bL154-R154))
*  Modify demotion transformation for bit shift right operation to cast left operand to unsigned only if originally signed and perform bit shift arithmetic right ([link](https://github.com/taichi-dev/taichi/pull/7757/files?diff=unified&w=0#diff-d217f2b07d4578612dc805b0f01e5dc1883be9acb906b222a8762313cfd0596bL163-R164))
*  Add test case for bit shift right operation with unsigned integers in `test_bit_operations.py` ([link](https://github.com/taichi-dev/taichi/pull/7757/files?diff=unified&w=0#diff-ea8fa4876c4d3e866c5c18e9d9d796364c5debf5eae6447e655326ed44f4257cR63-R71))
