### PR TITLE
[ci] Temporarily force Windows release builds to run on sm70 nodes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
-    runs-on: [self-hosted, windows, cuda, OpenGL]
+    # FIXME: force running on sm70 for now. Should be refactored out
+    runs-on: [self-hosted, windows, cuda, OpenGL, sm70]
     steps:
       - name: Workaround checkout Needed single revision issue
         run: |


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 659276d</samp>

Modified the CI workflow to use self-hosted runners with `sm70` GPUs for testing. This is a temporary fix to avoid GPU compatibility issues.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 659276d</samp>

*  Add `sm70` label to `runs-on` key for self-hosted runners to ensure compatible GPU architecture ([link](https://github.com/taichi-dev/taichi/pull/7767/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L279-R280)). This is a temporary workaround and should be refactored later. This affects the `.github/workflows/release.yml` file, which defines the workflow for releasing new versions of taichi-dev/taichi.
