### PR TITLE
[lang] Support frexp on spirv-based backends

### DIFF
--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -726,7 +726,6 @@ class TaskCodegen : public IRVisitor {
     spirv::SType src_type = ir_->get_primitive_type(src_dt);
     spirv::SType dst_type;
     if (dst_dt.is_pointer()) {
-      TI_ASSERT(dst_dt.ptr_removed()->is<lang::StructType>());
       auto stype = dst_dt.ptr_removed()->as<lang::StructType>();
       std::vector<std::tuple<SType, std::string, size_t>> components;
       for (int i = 0; i < stype->get_num_elements(); i++) {

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -165,6 +165,13 @@ class InstrBuilder {
     return *this;
   }
 
+  InstrBuilder &add(const std::vector<int> &v) {
+    for (const auto &v0 : v) {
+      add(v0);
+    }
+    return *this;
+  }
+
   InstrBuilder &add(const std::string &v) {
     const uint32_t word_size = sizeof(uint32_t);
     const auto nwords =

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -219,13 +219,13 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
 
   if (type == UnaryOpType::frexp) {
     std::vector<StructMember> elements;
-    elements.push_back(
-        {taichi::lang::TypeFactory::get_instance().get_primitive_real_type(64),
-         "mantissa", 0});
+    TI_ASSERT(operand_primitive_type->is_primitive(PrimitiveTypeID::f32) ||
+              operand_primitive_type->is_primitive(PrimitiveTypeID::f64));
+    elements.push_back({operand_primitive_type, "mantissa", 0});
     elements.push_back(
         {taichi::lang::TypeFactory::get_instance().get_primitive_int_type(
              32, /*is_signed=*/true),
-         "exponent", 8});
+         "exponent", (size_t)data_type_size(operand_primitive_type)});
     ret_type =
         taichi::lang::TypeFactory::get_instance().get_struct_type(elements);
     ret_type.set_is_pointer(true);

--- a/tests/python/test_unary_ops.py
+++ b/tests/python/test_unary_ops.py
@@ -77,7 +77,7 @@ def test_logic_not_invalid():
         test(1.0)
 
 
-@test_utils.test(arch=ti.cuda)
+@test_utils.test(arch=[ti.cuda, ti.vulkan, ti.opengl, ti.metal])
 def test_frexp():
     @ti.kernel
     def get_frac(x: ti.f32) -> ti.f32:


### PR DESCRIPTION
Note we skipped f16 support for now but it should be easily added if necessary.

Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa0c180</samp>

This pull request adds and improves the support for the `frexp` unary operation in the SPIRV and CUDA codegens, and fixes some type issues in the frontend IR and the unit test. It also adds a new helper method for building SPIRV instructions with multiple operands.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa0c180</samp>

*  Fix a bug in the CUDA codegen for the `frexp` operation, which could cause precision loss for float32 inputs. Cast the input and output to double only if necessary. ([link](https://github.com/taichi-dev/taichi/pull/7770/files?diff=unified&w=0#diff-50537ad5ea3b900c0d55a088f3cc285986340ad68c9b96fea481187c4dce49eaL264-R278))
*  Add support for the `GetElementStmt` statement in the SPIRV codegen, which extracts an element from a struct value. Use the `OpCompositeExtract` instruction to create a SPIRV value. ([link](https://github.com/taichi-dev/taichi/pull/7770/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R605-R615), [link](https://github.com/taichi-dev/taichi/pull/7770/files?diff=unified&w=0#diff-e9e785201af78fa53c937a623f0bd851161ac2064d92383c05384f786cea9cd9R168-R174))
*  Add support for struct types as the destination type of unary operations in the SPIRV codegen, by creating a struct type from the components of the source type. This is needed for the `frexp` operation, which returns a struct type containing the mantissa and exponent. ([link](https://github.com/taichi-dev/taichi/pull/7770/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L716-R739))
*  Add a branch for the `frexp` operation in the SPIRV codegen, which calls the GLSL 450 extended instruction set with the opcode 52. Store the result in the `val` variable. ([link](https://github.com/taichi-dev/taichi/pull/7770/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R833-R835))
*  Modify the `type_check` method for the `UnaryOpExpression` class in the frontend IR, which handles unary operations. Use the same type as the input for the mantissa of the `frexp` operation, and adjust the offset of the exponent accordingly. ([link](https://github.com/taichi-dev/taichi/pull/7770/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L218-R224))
