### PR TITLE
[lang] Clean up runtime allocation functions

### DIFF
--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -816,19 +816,11 @@ Ptr LLVMRuntime::allocate_aligned(std::size_t size,
   if (request)
     atomic_add_i64(&total_requested_memory, size);
 
-#if ARCH_cuda || ARCH_amdgpu
-  if (preallocated_memory_chunk.preallocated_size <= 0) {
-    __assertfail(
-        "CUDA and AMDGPU backends must allocate on preallocated memory \n",
-        "Taichi JIT", 0, "allocate_aligned", 1);
+  if (preallocated_memory_chunk.preallocated_size > 0) {
+    return allocate_from_reserved_memory(size, alignment);
   }
 
-  return allocate_from_reserved_memory(size, alignment);
-#else
-  // vm_allocator essentially calls MemoryPool::allocate(), which is a host-only
-  // function.
   return (Ptr)vm_allocator(memory_pool, size, alignment);
-#endif
 }
 
 // [ONLY ON DEVICE] CUDA/AMDGPU backend

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -847,7 +847,7 @@ Ptr LLVMRuntime::allocate_from_reserved_memory(std::size_t size,
     size += alignment_bytes;
     if (preallocated_head + size <= preallocated_tail) {
       ret = (Ptr)(preallocated_head + alignment_bytes);
-      preallocated_head += size;
+      preallocated_memory_chunk.preallocated_head += size;
       success = true;
     } else {
       success = false;

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -541,12 +541,14 @@ void initialize_rand_state(RandState *state, u32 i) {
 
 struct NodeManager;
 
-struct LLVMRuntime {
-  bool preallocated;
-  std::size_t preallocated_size;
+struct PreallocatedMemoryChunk {
+  Ptr preallocated_head = nullptr;
+  Ptr preallocated_tail = nullptr;
+  std::size_t preallocated_size = 0;
+};
 
-  Ptr preallocated_head;
-  Ptr preallocated_tail;
+struct LLVMRuntime {
+  PreallocatedMemoryChunk preallocated_memory_chunk;
 
   vm_allocator_type vm_allocator;
   assert_failed_type assert_failed;
@@ -565,10 +567,10 @@ struct LLVMRuntime {
   Ptr ambient_elements[taichi_max_num_snodes];
   Ptr temporaries;
   RandState *rand_states;
-  Ptr allocate(std::size_t size);
-  Ptr allocate_aligned(std::size_t size, std::size_t alignment);
-  Ptr request_allocate_aligned(std::size_t size, std::size_t alignment);
-  Ptr allocate_from_buffer(std::size_t size, std::size_t alignment);
+  Ptr allocate_aligned(std::size_t size,
+                       std::size_t alignment,
+                       bool request = false);
+  Ptr allocate_from_reserved_memory(std::size_t size, std::size_t alignment);
   Ptr profiler;
   void (*profiler_start)(Ptr, Ptr);
   void (*profiler_stop)(Ptr);
@@ -594,7 +596,7 @@ struct LLVMRuntime {
 
   template <typename T, typename... Args>
   T *create(Args &&...args) {
-    auto ptr = (T *)request_allocate_aligned(sizeof(T), 4096);
+    auto ptr = (T *)allocate_aligned(sizeof(T), 4096, true /*request*/);
     new (ptr) T(std::forward<Args>(args)...);
     return ptr;
   }
@@ -806,23 +808,45 @@ void taichi_assert_runtime(LLVMRuntime *runtime, i32 test, const char *msg) {
   taichi_assert_format(runtime, test, msg, 0, nullptr);
 }
 
-Ptr LLVMRuntime::allocate_aligned(std::size_t size, std::size_t alignment) {
-  if (preallocated) {
-    return allocate_from_buffer(size, alignment);
+// [ON HOST] CPU backend
+// [ON DEVICE] CUDA/AMDGPU backend
+Ptr LLVMRuntime::allocate_aligned(std::size_t size,
+                                  std::size_t alignment,
+                                  bool request) {
+  if (request)
+    atomic_add_i64(&total_requested_memory, size);
+
+#if ARCH_cuda || ARCH_amdgpu
+  if (preallocated_memory_chunk.preallocated_size <= 0) {
+    __assertfail(
+        "CUDA and AMDGPU backends must allocate on preallocated memory \n",
+        "Taichi JIT", 0, "allocate_aligned", 1);
   }
+
+  return allocate_from_reserved_memory(size, alignment);
+#else
+  // vm_allocator essentially calls MemoryPool::allocate(), which is a host-only
+  // function.
   return (Ptr)vm_allocator(memory_pool, size, alignment);
+#endif
 }
 
-Ptr LLVMRuntime::allocate_from_buffer(std::size_t size, std::size_t alignment) {
+// [ONLY ON DEVICE] CUDA/AMDGPU backend
+Ptr LLVMRuntime::allocate_from_reserved_memory(std::size_t size,
+                                               std::size_t alignment) {
   Ptr ret = nullptr;
   bool success = false;
   locked_task(&allocator_lock, [&] {
+    std::size_t preallocated_head =
+        (std::size_t)preallocated_memory_chunk.preallocated_head;
+    std::size_t preallocated_tail =
+        (std::size_t)preallocated_memory_chunk.preallocated_tail;
+
     auto alignment_bytes =
-        alignment - 1 -
-        ((std::size_t)preallocated_head + alignment - 1) % alignment;
+        alignment - 1 - (preallocated_head + alignment - 1) % alignment;
     size += alignment_bytes;
     if (preallocated_head + size <= preallocated_tail) {
-      ret = preallocated_head + alignment_bytes;
+      ret = (Ptr)(preallocated_head + alignment_bytes);
       preallocated_head += size;
       success = true;
     } else {
@@ -839,25 +863,11 @@ Ptr LLVMRuntime::allocate_from_buffer(std::size_t size, std::size_t alignment) {
         "Consider using ti.init(device_memory_fraction=0.9) or "
         "ti.init(device_memory_GB=4) to allocate more"
         " GPU memory",
-        "Taichi JIT", 0, "allocate_from_buffer", 1);
+        "Taichi JIT", 0, "allocate_from_reserved_memory", 1);
 #endif
   }
   taichi_assert_runtime(this, success, "Out of pre-allocated memory");
   return ret;
-}
-
-Ptr LLVMRuntime::allocate(std::size_t size) {
-  return allocate_aligned(size, 1);
-}
-
-Ptr LLVMRuntime::request_allocate_aligned(std::size_t size,
-                                          std::size_t alignment) {
-  atomic_add_i64(&total_requested_memory, size);
-  if (preallocated)
-    return allocate_from_buffer(size, alignment);
-  else {
-    return (Ptr)vm_allocator(memory_pool, size, alignment);
-  }
 }
 
 RuntimeContext *allocate_runtime_context(LLVMRuntime *runtime) {
@@ -869,6 +879,9 @@ void recycle_runtime_context(LLVMRuntime *runtime, RuntimeContext *ptr) {
   runtime->runtime_context_buffer_allocator->recycle((Ptr)ptr);
 }
 
+// External API
+// [ON HOST] CPU backend
+// [ON DEVICE] CUDA/AMDGPU backend
 void runtime_memory_allocate_aligned(LLVMRuntime *runtime,
                                      std::size_t size,
                                      std::size_t alignment,
@@ -877,6 +890,9 @@ void runtime_memory_allocate_aligned(LLVMRuntime *runtime,
       runtime->allocate_aligned(size, alignment));
 }
 
+// External API
+// [ON HOST] CPU backend
+// [ON DEVICE] CUDA/AMDGPU backend
 void runtime_initialize(
     Ptr result_buffer,
     Ptr memory_pool,
@@ -902,9 +918,12 @@ void runtime_initialize(
         (LLVMRuntime *)vm_allocator(memory_pool, sizeof(LLVMRuntime), 128);
   }
 
-  runtime->preallocated = preallocated_size > 0;
-  runtime->preallocated_head = preallocated_buffer;
-  runtime->preallocated_tail = preallocated_tail;
+  PreallocatedMemoryChunk preallocated_memory_chunk;
+  preallocated_memory_chunk.preallocated_size = preallocated_size;
+  preallocated_memory_chunk.preallocated_head = preallocated_buffer;
+  preallocated_memory_chunk.preallocated_tail = preallocated_tail;
+
+  runtime->preallocated_memory_chunk = std::move(preallocated_memory_chunk);
 
   runtime->result_buffer = result_buffer;
   runtime->set_result(taichi_result_buffer_ret_value_id, runtime);
@@ -994,7 +1013,7 @@ void runtime_allocate_ambient(LLVMRuntime *runtime,
   // Do not use NodeManager for the ambient node since it will never be garbage
   // collected.
   runtime->ambient_elements[snode_id] =
-      runtime->request_allocate_aligned(size, 128);
+      runtime->allocate_aligned(size, 128, true /*request*/);
 }
 
 void mutex_lock_i32(Ptr mutex) {
@@ -1615,8 +1634,8 @@ void ListManager::touch_chunk(int chunk_id) {
       // may have been allocated during lock contention
       if (!chunks[chunk_id]) {
         grid_memfence();
-        auto chunk_ptr = runtime->request_allocate_aligned(
-            max_num_elements_per_chunk * element_size, 4096);
+        auto chunk_ptr = runtime->allocate_aligned(
+            max_num_elements_per_chunk * element_size, 4096, true /*request*/);
         atomic_exchange_u64((u64 *)&chunks[chunk_id], (u64)chunk_ptr);
       }
     });


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/7599

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee50a66</samp>

Refactor and optimize memory allocation logic in `runtime.cpp` for different devices. Fix a typo and add comments for external API functions.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee50a66</samp>

*  Refactor the preallocated memory fields in the `LLVMRuntime` struct into a nested struct called `PreallocatedMemoryChunk` for readability and modularity ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L544-R553))
*  Merge the `allocate` and `request_allocate_aligned` functions into one `allocate_aligned` function that takes an additional boolean parameter `request` to simplify the interface and avoid code duplication ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L568-R574), [link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L849-L862))
*  Add device-specific logic for memory allocation in the `allocate_aligned` function that uses the preallocated memory chunk for the device memory and the `vm_allocator` for the host memory ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L809-R850))
*  Update the `create`, `runtime_allocate_ambient`, and `touch_chunk` functions to use the new `allocate_aligned` function with the `request` parameter set to true, consistent with the original behavior ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L597-R600), [link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L997-R1017), [link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L1618-R1639))
*  Fix a typo in the assertion message of the `allocate_from_reserved_memory` function ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L842-R867))
*  Rename the `allocate_from_buffer` function to `allocate_from_reserved_memory` to reflect its usage ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L568-R574), [link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L842-R867))
*  Add comments to indicate that some functions are external API functions that can be called from both the host and the device ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4R883-R885), [link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4R894-R896))
*  Update the `runtime_initialize` function to use the new `PreallocatedMemoryChunk` struct and the `std::move` function to store the preallocated memory fields ([link](https://github.com/taichi-dev/taichi/pull/7773/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L905-R928))
