### PR TITLE
[misc] Remove unnecessary TaskCodeGenLLVM::task_counter

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1954,9 +1954,8 @@ std::string TaskCodeGenLLVM::init_offloaded_task_function(OffloadedStmt *stmt,
       llvm::FunctionType::get(llvm::Type::getVoidTy(*llvm_context),
                               {llvm::PointerType::get(context_ty, 0)}, false);
 
-  auto task_kernel_name =
-      fmt::format("{}_{}_{}_{}{}", kernel_name, task_codegen_id, task_counter++,
-                  stmt->task_name(), suffix);
+  auto task_kernel_name = fmt::format(
+      "{}_{}_{}{}", kernel_name, task_codegen_id, stmt->task_name(), suffix);
   func = llvm::Function::Create(task_function_type,
                                 llvm::Function::ExternalLinkage,
                                 task_kernel_name, module.get());

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -63,11 +63,8 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
   std::unordered_set<int> struct_for_tls_sizes;
   const Callable *current_callable{nullptr};
 
-  // The task_codegen_id and task_counter are used to generate unique task
-  // ids.The task_codegen_id represents the id of the offloaded task, and the
-  // task_counter represents the id of the task within the offloaded task.
+  // The task_codegen_id represents the id of the offloaded task
   int task_codegen_id{0};
-  int task_counter{0};
 
   std::unordered_map<const Stmt *, std::vector<llvm::Value *>> loop_vars_llvm;
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60b3e91</samp>

Simplify task kernel name generation in the LLVM backend by removing the `task_counter` variable from `codegen_llvm.cpp` and `codegen_llvm.h`. This may improve the performance and readability of the code.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60b3e91</samp>

*  Simplify task kernel name generation by removing redundant task_counter variable ([link](https://github.com/taichi-dev/taichi/pull/7777/files?diff=unified&w=0#diff-3c663c78745adcd3f6a7ac81fe99e628decc3040f292ea1e20ecd4b85a7f4313L1957-R1958), [link](https://github.com/taichi-dev/taichi/pull/7777/files?diff=unified&w=0#diff-aebc3d71bb555fba77f1d303d5c29ac7e07d392440b0e54cf556ff5a10a81d0aL66-R67))
*  Delete unused and outdated comment about task_counter variable ([link](https://github.com/taichi-dev/taichi/pull/7777/files?diff=unified&w=0#diff-aebc3d71bb555fba77f1d303d5c29ac7e07d392440b0e54cf556ff5a10a81d0aL66-R67))
