### PR TITLE
[gfx] Fix runtime buffer/image copy barrier semantics

### DIFF
--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -576,7 +576,9 @@ void GfxRuntime::launch_kernel(KernelHandle handle,
 
 void GfxRuntime::buffer_copy(DevicePtr dst, DevicePtr src, size_t size) {
   ensure_current_cmdlist();
+  current_cmdlist_->buffer_barrier(src);
   current_cmdlist_->buffer_copy(dst, src, size);
+  current_cmdlist_->buffer_barrier(dst);
 }
 
 void GfxRuntime::copy_image(DeviceAllocation dst,
@@ -587,6 +589,7 @@ void GfxRuntime::copy_image(DeviceAllocation dst,
   transition_image(src, ImageLayout::transfer_src);
   current_cmdlist_->copy_image(dst, src, ImageLayout::transfer_dst,
                                ImageLayout::transfer_src, params);
+  transition_image(dst, ImageLayout::transfer_src);
 }
 
 DeviceAllocation GfxRuntime::create_image(const ImageParams &params) {


### PR DESCRIPTION
Issue: #

### Brief Summary

This pull request enhances the graphics runtime with better memory synchronization for `buffer` and `image` objects. It uses `buffer_barrier` and `transition_image` functions to ensure correct memory ordering.

### Walkthrough

* Add buffer barriers to synchronize memory access for buffer copy ([link](https://github.com/taichi-dev/taichi/pull/7781/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL579-R581))
* Add image barriers (transitions)  to synchronize imageaccess for buffer copy ([link](https://github.com/taichi-dev/taichi/pull/7781/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcR592))


^
Generated from copilot, manually corrected a few things
