### PR TITLE
[ir] Add 'create_load' to ArgLoadStmt

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1262,7 +1262,7 @@ llvm::Value *TaskCodeGenLLVM::bitcast_to_u64(llvm::Value *val, DataType type) {
 
 void TaskCodeGenLLVM::visit(ArgLoadStmt *stmt) {
   if (!stmt->is_grad) {
-    llvm_val[stmt] = get_struct_arg({stmt->arg_id});
+    llvm_val[stmt] = get_struct_arg({stmt->arg_id}, stmt->create_load);
     return;
   }
 
@@ -2789,7 +2789,8 @@ void TaskCodeGenLLVM::set_struct_to_buffer(
                        current_element, current_index);
 }
 
-llvm::Value *TaskCodeGenLLVM::get_struct_arg(std::vector<int> index) {
+llvm::Value *TaskCodeGenLLVM::get_struct_arg(std::vector<int> index,
+                                             bool create_load) {
   auto *args_ptr = get_args_ptr(current_callable, get_context());
   auto *args_type = current_callable->args_type;
   auto *arg_type = args_type->get_element_type(index);
@@ -2801,6 +2802,9 @@ llvm::Value *TaskCodeGenLLVM::get_struct_arg(std::vector<int> index) {
   }
   auto *gep =
       builder->CreateGEP(tlctx->get_data_type(args_type), args_ptr, gep_index);
+  if (!create_load) {
+    return gep;
+  }
   return builder->CreateLoad(tlctx->get_data_type(arg_type), gep);
 }
 

--- a/taichi/codegen/llvm/codegen_llvm.h
+++ b/taichi/codegen/llvm/codegen_llvm.h
@@ -91,7 +91,7 @@ class TaskCodeGenLLVM : public IRVisitor, public LLVMModuleBuilder {
 
   llvm::Value *get_arg(int i);
 
-  llvm::Value *get_struct_arg(std::vector<int> index);
+  llvm::Value *get_struct_arg(std::vector<int> index, bool create_load);
 
   llvm::Value *get_args_ptr(const Callable *callable, llvm::Value *context);
 

--- a/taichi/ir/expression_printer.h
+++ b/taichi/ir/expression_printer.h
@@ -36,8 +36,8 @@ class ExpressionHumanFriendlyPrinter : public ExpressionPrinter {
   }
 
   void visit(ArgLoadExpression *expr) override {
-    emit(
-        fmt::format("arg[{}] (dt={})", expr->arg_id, data_type_name(expr->dt)));
+    emit(fmt::format("arg{}[{}] (dt={})", expr->create_load ? "load" : "addr",
+                     expr->arg_id, data_type_name(expr->dt)));
   }
 
   void visit(TexturePtrExpression *expr) override {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -139,13 +139,16 @@ FrontendWhileStmt::FrontendWhileStmt(const FrontendWhileStmt &o)
 }
 
 void ArgLoadExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
-                 "Invalid dt [{}] for ArgLoadExpression", dt->to_string());
   ret_type = dt;
+  if (!create_load) {
+    ret_type = TypeFactory::get_instance().get_pointer_type(ret_type, false);
+  }
 }
 
 void ArgLoadExpression::flatten(FlattenContext *ctx) {
-  auto arg_load = std::make_unique<ArgLoadStmt>(arg_id, dt, is_ptr);
+  auto arg_load = std::make_unique<ArgLoadStmt>(arg_id, dt, is_ptr,
+                                                /*is_grad=*/false, create_load);
+  arg_load->ret_type = ret_type;
   ctx->push_back(std::move(arg_load));
   stmt = ctx->back_stmt();
 }
@@ -154,7 +157,8 @@ void TexturePtrExpression::type_check(const CompileConfig *config) {
 }
 
 void TexturePtrExpression::flatten(FlattenContext *ctx) {
-  ctx->push_back<ArgLoadStmt>(arg_id, PrimitiveType::f32, true);
+  ctx->push_back<ArgLoadStmt>(arg_id, PrimitiveType::f32, /*is_ptr=*/true,
+                              /*is_grad=*/false, /*create_load*/ true);
   ctx->push_back<TexturePtrStmt>(ctx->back_stmt(), num_dims, is_storage, format,
                                  lod);
   stmt = ctx->back_stmt();
@@ -587,7 +591,7 @@ void ExternalTensorExpression::flatten(FlattenContext *ctx) {
   //                 irpass::lower_access()
   auto prim_dt = dt;
   auto ptr = Stmt::make<ArgLoadStmt>(arg_id, prim_dt, /*is_ptr=*/true,
-                                     /*is_grad=*/is_grad);
+                                     /*is_grad=*/is_grad, /*create_load=*/true);
 
   ptr->tb = tb;
   ctx->push_back(std::move(ptr));

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -316,8 +316,17 @@ class ArgLoadExpression : public Expression {
   DataType dt;
   bool is_ptr;
 
-  ArgLoadExpression(int arg_id, DataType dt, bool is_ptr = false)
-      : arg_id(arg_id), dt(dt), is_ptr(is_ptr) {
+  /* Creates a load statement if true, otherwise returns the pointer
+   * directly.
+   * TODO: Split ArgLoad into two steps: ArgAddr and GlobalLoad.
+   */
+  bool create_load;
+
+  ArgLoadExpression(int arg_id,
+                    DataType dt,
+                    bool is_ptr = false,
+                    bool create_load = true)
+      : arg_id(arg_id), dt(dt), is_ptr(is_ptr), create_load(create_load) {
   }
 
   void type_check(const CompileConfig *config) override;

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -179,7 +179,8 @@ RandStmt *IRBuilder::create_rand(DataType value_type) {
 }
 
 ArgLoadStmt *IRBuilder::create_arg_load(int arg_id, DataType dt, bool is_ptr) {
-  return insert(Stmt::make_typed<ArgLoadStmt>(arg_id, dt, is_ptr));
+  return insert(Stmt::make_typed<ArgLoadStmt>(
+      arg_id, dt, is_ptr, /*is_grad*/ false, /*create_load*/ true));
 }
 
 ReturnStmt *IRBuilder::create_return(Stmt *value) {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -187,14 +187,18 @@ class ArgLoadStmt : public Stmt {
 
   bool is_grad;
 
+  bool create_load;
+
   ArgLoadStmt(int arg_id,
               const DataType &dt,
-              bool is_ptr = false,
-              bool is_grad = false)
-      : arg_id(arg_id) {
+              bool is_ptr,
+              bool is_grad,
+              bool create_load)
+      : arg_id(arg_id),
+        is_ptr(is_ptr),
+        is_grad(is_grad),
+        create_load(create_load) {
     this->ret_type = dt;
-    this->is_ptr = is_ptr;
-    this->is_grad = is_grad;
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -312,11 +312,10 @@ Kernel &Program::get_snode_writer(SNode *snode) {
     ASTBuilder &builder = kernel->context->builder();
     auto expr =
         builder.expr_subscript(Expr(snode_to_fields_.at(snode)), indices);
-    builder.insert_assignment(
-        expr,
-        Expr::make<ArgLoadExpression>(snode->num_active_indices,
-                                      snode->dt->get_compute_type()),
-        expr->tb);
+    auto argload_expr = Expr::make<ArgLoadExpression>(
+        snode->num_active_indices, snode->dt->get_compute_type());
+    argload_expr->type_check(&this->compile_config());
+    builder.insert_assignment(expr, argload_expr, expr->tb);
   });
   ker.name = kernel_name;
   ker.is_accessor = true;

--- a/taichi/python/export.h
+++ b/taichi/python/export.h
@@ -25,6 +25,8 @@ namespace taichi {
 
 namespace py = pybind11;
 
+using py::literals::operator""_a;
+
 void export_lang(py::module &m);
 
 void export_math(py::module &m);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -929,7 +929,8 @@ void export_lang(py::module &m) {
         Stmt::make<FrontendAssignStmt, const Expr &, const Expr &>);
 
   m.def("make_arg_load_expr",
-        Expr::make<ArgLoadExpression, int, const DataType &, bool>);
+        Expr::make<ArgLoadExpression, int, const DataType &, bool, bool>,
+        "arg_id"_a, "dt"_a, "is_ptr"_a = false, "create_load"_a = true);
 
   m.def("make_reference", Expr::make<ReferenceExpression, const Expr &>);
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -477,7 +477,8 @@ class IRPrinter : public IRVisitor {
 
   void visit(ArgLoadStmt *stmt) override {
     if (!stmt->is_grad) {
-      print("{}{} = arg[{}]", stmt->type_hint(), stmt->name(), stmt->arg_id);
+      print("{}{} = arg{}[{}]", stmt->type_hint(), stmt->name(),
+            stmt->create_load ? "load" : "addr", stmt->arg_id);
     } else {
       print("{}{} = grad_arg[{}]", stmt->type_hint(), stmt->name(),
             stmt->arg_id);

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -574,9 +574,12 @@ class Scalarize : public BasicStmtVisitor {
   }
 
   void visit(ArgLoadStmt *stmt) override {
+    if (stmt->ret_type.ptr_removed()->is<StructType>()) {
+      return;
+    }
     auto ret_type = stmt->ret_type.ptr_removed().get_element_type();
-    auto arg_load = std::make_unique<ArgLoadStmt>(stmt->arg_id, ret_type,
-                                                  stmt->is_ptr, stmt->is_grad);
+    auto arg_load = std::make_unique<ArgLoadStmt>(
+        stmt->arg_id, ret_type, stmt->is_ptr, stmt->is_grad, stmt->create_load);
 
     immediate_modifier_.replace_usages_with(stmt, arg_load.get());
 

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -447,8 +447,7 @@ class TypeCheck : public IRVisitor {
     // defined by the kernel. After that, type_check() pass will purely do
     // verification, without modifying any types.
     if (stmt->is_ptr) {
-      stmt->ret_type =
-          TypeFactory::get_instance().get_pointer_type(stmt->ret_type);
+      stmt->ret_type.set_is_pointer(true);
     }
   }
 

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -446,7 +446,10 @@ class TypeCheck : public IRVisitor {
     // TODO: Maybe have a type_inference() pass, which takes in the args/rets
     // defined by the kernel. After that, type_check() pass will purely do
     // verification, without modifying any types.
-    stmt->ret_type.set_is_pointer(stmt->is_ptr);
+    if (stmt->is_ptr) {
+      stmt->ret_type =
+          TypeFactory::get_instance().get_pointer_type(stmt->ret_type);
+    }
   }
 
   void visit(ReturnStmt *stmt) override {

--- a/tests/cpp/transforms/half2_vectorization_test.cpp
+++ b/tests/cpp/transforms/half2_vectorization_test.cpp
@@ -58,8 +58,9 @@ TEST(Half2Vectorization, Ndarray) {
     alloca_stmt1->replace_all_usages_with(old_val1);
   */
 
-  auto argload_stmt =
-      block->push_back<ArgLoadStmt>(0 /*arg_id*/, PrimitiveType::f16);
+  auto argload_stmt = block->push_back<ArgLoadStmt>(
+      0 /*arg_id*/, PrimitiveType::f16, /*is_ptr*/ false, /*is_grad*/ false,
+      /*create_load*/ true);
   auto const_0_stmt = block->push_back<ConstStmt>(TypedConstant(0));
   auto const_1_stmt = block->push_back<ConstStmt>(TypedConstant(1));
 

--- a/tests/cpp/transforms/scalarize_test.cpp
+++ b/tests/cpp/transforms/scalarize_test.cpp
@@ -28,7 +28,9 @@ TEST(Scalarize, ScalarizeGlobalStore) {
       {2, 2}, type_factory.get_primitive_type(PrimitiveTypeID::i32));
   auto const_1_stmt = block->push_back<ConstStmt>(TypedConstant(1));
   auto const_2_stmt = block->push_back<ConstStmt>(TypedConstant(2));
-  auto argload_stmt = block->push_back<ArgLoadStmt>(0 /*arg_id*/, tensor_type);
+  auto argload_stmt =
+      block->push_back<ArgLoadStmt>(0 /*arg_id*/, tensor_type, /*is_ptr*/ false,
+                                    /*is_grad*/ false, /*create_load*/ true);
 
   std::vector<Stmt *> indices = {};
   Stmt *dest_stmt = block->push_back<ExternalPtrStmt>(
@@ -88,7 +90,9 @@ TEST(Scalarize, ScalarizeGlobalLoad) {
   */
   Type *tensor_type = type_factory.get_tensor_type(
       {2, 2}, type_factory.get_primitive_type(PrimitiveTypeID::i32));
-  auto argload_stmt = block->push_back<ArgLoadStmt>(0 /*arg_id*/, tensor_type);
+  auto argload_stmt =
+      block->push_back<ArgLoadStmt>(0 /*arg_id*/, tensor_type, /*is_ptr*/ false,
+                                    /*is_grad*/ false, /*create_load*/ true);
 
   std::vector<Stmt *> indices = {};
   Stmt *src_stmt = block->push_back<ExternalPtrStmt>(


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 343ecea</samp>

### Summary
🔄🎨🐛

<!--
1.  🔄 - This emoji represents the refactoring of the argument loading mechanism in the LLVM backend, which is the main theme of these changes. It suggests that the code has been reorganized or improved without changing its functionality.
2. 🎨 - This emoji represents the improvement of the readability and debugging of the expression and statement printing, which is a secondary effect of these changes. It suggests that the code has been made more elegant or expressive.
3. 🐛 - This emoji represents the fixing of the potential bugs or incorrect behaviors caused by scalarizing or type checking the pointer to the struct argument, which is another secondary effect of these changes. It suggests that the code has been made more robust or reliable.
-->
Refactor the argument loading mechanism in the LLVM backend to support both value and pointer cases. Add a `create_load` flag to the `ArgLoadStmt` and `ArgLoadExpression` classes to indicate whether the argument should be loaded as a value or returned as a pointer. Update the relevant codegen, transform, and test files to use the new flag and handle the different return types.

> _Oh we're the coders of the LLVM backend_
> _And we're refactoring the `ArgLoadStmt`_
> _We'll use the `create_load` flag to choose_
> _Whether we want a pointer or a value to use_

### Walkthrough
*  Add a `create_load` flag to the `ArgLoadExpression` and `ArgLoadStmt` classes to allow the option of returning the pointer to the argument instead of loading its value ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL319-R329), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L190-R201), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-3c663c78745adcd3f6a7ac81fe99e628decc3040f292ea1e20ecd4b85a7f4313L2792-R2793), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-aebc3d71bb555fba77f1d303d5c29ac7e07d392440b0e54cf556ff5a10a81d0aL94-R94), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L142-R151), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-bdb4f85a29d6478a4482d81ca072237534fb641b52f3c529aca93e872ade6fecL182-R183), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL449-R451))
*  Use the `create_load` flag in the `get_struct_arg` function in `codegen_llvm.cpp` and `codegen_llvm.h` to return the pointer to the struct argument without loading its value if the flag is false ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-3c663c78745adcd3f6a7ac81fe99e628decc3040f292ea1e20ecd4b85a7f4313L1265-R1265), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-3c663c78745adcd3f6a7ac81fe99e628decc3040f292ea1e20ecd4b85a7f4313R2805-R2807))
*  Use the `create_load` flag in the `type_check` and `flatten` methods of the `ArgLoadExpression` class in `frontend_ir.cpp` and `frontend_ir.h` to set the correct return type and generate the corresponding `ArgLoadStmt` ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L142-R151), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL315-R318))
*  Use the `create_load` flag as true in the `flatten` methods of the `TexturePtrExpression` and `ExternalTensorExpression` classes in `frontend_ir.cpp` and `frontend_ir.h` to ensure that the texture and external tensor arguments are always loaded as values ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L157-R161), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L590-R594))
*  Print the `create_load` flag of the `ArgLoadExpression` and `ArgLoadStmt` classes in the `ExpressionHumanFriendlyPrinter` and `IRPrinter` classes in `expression_printer.h` and `ir_printer.cpp` to improve the readability and debugging of the expression and statement printing ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-aa95836220fa5f1bd9eedc9f7535e77c52c3e8ea7489b72408f875bae4adb04dL39-R40), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-77422b8748a46e70519217be594cd28433edadf98ca4960ce116f85da8dbccc3L480-R481))
*  Skip the scalarization of the `ArgLoadStmt` if its return type is a `StructType` in the `Scalarize` class in `scalarize.cpp` to avoid scalarizing the pointer to the struct argument ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L577-R582))
*  Expose the `create_load` flag to the Python users in the `make_arg_load_expr` function in `export_lang.cpp` and `export.h` and accept it as a named argument with a default value of true ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L932-R933), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-4d7c315dcfee49569cbf44fea8ce94dbb5c8e7e0851d74896254642f4490eec1R28-R29))
*  Adapt the test cases in `half2_vectorization_test.cpp` and `scalarize_test.cpp` to use the `create_load` flag as true when creating the `ArgLoadStmt` ([link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-5136d70f7a32456bee3938daca1066aa3d380aecd7d18257fc893b83dfd72a79L61-R63), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-47a444cb69c98c40211b16a69bf8a457f529fcf9c7bcef080ece2bf1c375f230L31-R33), [link](https://github.com/taichi-dev/taichi/pull/7782/files?diff=unified&w=0#diff-47a444cb69c98c40211b16a69bf8a457f529fcf9c7bcef080ece2bf1c375f230L91-R95))


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7756
* __->__ #7782
* #7776

