### PR TITLE
[lang] Migrate Caching Allocation logics from CudaDevice/AmdgpuDevice to DeviceMemoryPool

### DIFF
--- a/taichi/rhi/amdgpu/amdgpu_device.cpp
+++ b/taichi/rhi/amdgpu/amdgpu_device.cpp
@@ -76,6 +76,11 @@ DeviceAllocation AmdgpuDevice::allocate_memory_runtime(
 }
 
 void AmdgpuDevice::dealloc_memory(DeviceAllocation handle) {
+  // After reset, all allocations are invalid
+  if (allocations_.empty()) {
+    return;
+  }
+
   validate_device_alloc(handle);
   AllocInfo &info = allocations_[handle.alloc_id];
   if (info.ptr == nullptr) {

--- a/taichi/rhi/amdgpu/amdgpu_device.cpp
+++ b/taichi/rhi/amdgpu/amdgpu_device.cpp
@@ -6,6 +6,11 @@ namespace lang {
 
 namespace amdgpu {
 
+AmdgpuDevice::AmdgpuDevice() {
+  // Initialize the device memory pool
+  DeviceMemoryPool::get_instance(false /*merge_upon_release*/);
+}
+
 AmdgpuDevice::AllocInfo AmdgpuDevice::get_alloc_info(
     const DeviceAllocation handle) {
   validate_device_alloc(handle);
@@ -50,11 +55,10 @@ DeviceAllocation AmdgpuDevice::allocate_memory_runtime(
   if (params.host_read || params.host_write) {
     TI_NOT_IMPLEMENTED
   } else if (params.use_cached) {
-    if (caching_allocator_ == nullptr) {
-      caching_allocator_ = std::make_unique<CachingAllocator>(
-          this, false /*merge_upon_release*/);
-    }
-    info.ptr = caching_allocator_->allocate(params);
+    info.ptr =
+        DeviceMemoryPool::get_instance().allocate_with_cache(this, params);
+    TI_ASSERT(info.ptr != nullptr);
+
     AMDGPUDriver::get_instance().memset((void *)info.ptr, 0, info.size);
   } else {
     info.ptr = allocate_llvm_runtime_memory_jit(params);
@@ -79,10 +83,8 @@ void AmdgpuDevice::dealloc_memory(DeviceAllocation handle) {
   }
   TI_ASSERT(!info.is_imported);
   if (info.use_cached) {
-    if (caching_allocator_ == nullptr) {
-      TI_ERROR("the CachingAllocator is not initialized");
-    }
-    caching_allocator_->release(info.size, (uint64_t *)info.ptr);
+    DeviceMemoryPool::get_instance().release(info.size, (uint64_t *)info.ptr,
+                                             false);
   } else if (!info.use_preallocated) {
     DeviceMemoryPool::get_instance().release(info.size, info.ptr);
     info.ptr = nullptr;

--- a/taichi/rhi/amdgpu/amdgpu_device.h
+++ b/taichi/rhi/amdgpu/amdgpu_device.h
@@ -68,6 +68,7 @@ class AmdgpuDevice : public LlvmDevice {
 
   AllocInfo get_alloc_info(const DeviceAllocation handle);
 
+  AmdgpuDevice();
   ~AmdgpuDevice() override{};
 
   RhiResult allocate_memory(const AllocParams &params,
@@ -110,7 +111,6 @@ class AmdgpuDevice : public LlvmDevice {
       TI_ERROR("invalid DeviceAllocation");
     }
   }
-  std::unique_ptr<CachingAllocator> caching_allocator_{nullptr};
 };
 
 }  // namespace amdgpu

--- a/taichi/rhi/amdgpu/amdgpu_device.h
+++ b/taichi/rhi/amdgpu/amdgpu_device.h
@@ -104,6 +104,10 @@ class AmdgpuDevice : public LlvmDevice {
 
   void wait_idle() override{TI_NOT_IMPLEMENTED};
 
+  void clear() override {
+    allocations_.clear();
+  }
+
  private:
   std::vector<AllocInfo> allocations_;
   void validate_device_alloc(const DeviceAllocation alloc) {

--- a/taichi/rhi/cuda/cuda_device.cpp
+++ b/taichi/rhi/cuda/cuda_device.cpp
@@ -5,6 +5,11 @@ namespace taichi::lang {
 
 namespace cuda {
 
+CudaDevice::CudaDevice() {
+  // Initialize the device memory pool
+  DeviceMemoryPool::get_instance(true /*merge_upon_release*/);
+}
+
 CudaDevice::AllocInfo CudaDevice::get_alloc_info(
     const DeviceAllocation handle) {
   validate_device_alloc(handle);
@@ -43,10 +48,11 @@ DeviceAllocation CudaDevice::allocate_memory_runtime(
   AllocInfo info;
   info.size = taichi::iroundup(params.size, taichi_page_size);
   if (params.use_cached) {
-    if (caching_allocator_ == nullptr) {
-      caching_allocator_ = std::make_unique<CachingAllocator>(this);
-    }
-    info.ptr = caching_allocator_->allocate(params);
+    info.ptr =
+        DeviceMemoryPool::get_instance().allocate_with_cache(this, params);
+
+    TI_ASSERT(info.ptr != nullptr);
+
     CUDADriver::get_instance().memset((void *)info.ptr, 0, info.size);
   } else {
     info.ptr = allocate_llvm_runtime_memory_jit(params);
@@ -64,6 +70,10 @@ DeviceAllocation CudaDevice::allocate_memory_runtime(
 }
 
 void CudaDevice::dealloc_memory(DeviceAllocation handle) {
+  // After reset, all allocations are invalid
+  if (allocations_.empty())
+    return;
+
   validate_device_alloc(handle);
   AllocInfo &info = allocations_[handle.alloc_id];
   if (info.ptr == nullptr) {
@@ -71,10 +81,8 @@ void CudaDevice::dealloc_memory(DeviceAllocation handle) {
   }
   TI_ASSERT(!info.is_imported);
   if (info.use_cached) {
-    if (caching_allocator_ == nullptr) {
-      TI_ERROR("the CachingAllocator is not initialized");
-    }
-    caching_allocator_->release(info.size, (uint64_t *)info.ptr);
+    DeviceMemoryPool::get_instance().release(info.size, (uint64_t *)info.ptr,
+                                             false);
   } else if (!info.use_preallocated) {
     auto &mem_pool = DeviceMemoryPool::get_instance();
     mem_pool.release(info.size, info.ptr, true /*release_raw*/);

--- a/taichi/rhi/cuda/cuda_device.h
+++ b/taichi/rhi/cuda/cuda_device.h
@@ -82,6 +82,7 @@ class CudaDevice : public LlvmDevice {
 
   AllocInfo get_alloc_info(const DeviceAllocation handle);
 
+  CudaDevice();
   ~CudaDevice() override{};
 
   RhiResult allocate_memory(const AllocParams &params,
@@ -129,6 +130,10 @@ class CudaDevice : public LlvmDevice {
 
   void wait_idle() override{TI_NOT_IMPLEMENTED};
 
+  void clear() override {
+    allocations_.clear();
+  }
+
  private:
   std::vector<AllocInfo> allocations_;
   void validate_device_alloc(const DeviceAllocation alloc) {
@@ -136,7 +141,6 @@ class CudaDevice : public LlvmDevice {
       TI_ERROR("invalid DeviceAllocation");
     }
   }
-  std::unique_ptr<CachingAllocator> caching_allocator_{nullptr};
 };
 
 }  // namespace cuda

--- a/taichi/rhi/llvm/allocator.cpp
+++ b/taichi/rhi/llvm/allocator.cpp
@@ -3,8 +3,8 @@
 
 namespace taichi::lang {
 
-CachingAllocator::CachingAllocator(LlvmDevice *device, bool merge_upon_release)
-    : device_(device), merge_upon_release_(merge_upon_release) {
+CachingAllocator::CachingAllocator(bool merge_upon_release)
+    : merge_upon_release_(merge_upon_release) {
 }
 
 void CachingAllocator::merge_and_insert(uint8_t *ptr, std::size_t size) {
@@ -31,6 +31,7 @@ void CachingAllocator::merge_and_insert(uint8_t *ptr, std::size_t size) {
 }
 
 uint64_t *CachingAllocator::allocate(
+    LlvmDevice *device,
     const LlvmDevice::LlvmRuntimeAllocParams &params) {
   uint64_t *ret{nullptr};
   auto size_aligned = taichi::iroundup(params.size, taichi_page_size);
@@ -51,7 +52,7 @@ uint64_t *CachingAllocator::allocate(
 
   } else {
     ret = reinterpret_cast<uint64_t *>(
-        device_->allocate_llvm_runtime_memory_jit(params));
+        device->allocate_llvm_runtime_memory_jit(params));
   }
   return ret;
 }

--- a/taichi/rhi/llvm/allocator.h
+++ b/taichi/rhi/llvm/allocator.h
@@ -12,9 +12,10 @@ namespace taichi::lang {
 
 class CachingAllocator {
  public:
-  explicit CachingAllocator(LlvmDevice *device, bool merge_upon_release = true);
+  explicit CachingAllocator(bool merge_upon_release = true);
 
-  uint64_t *allocate(const LlvmDevice::LlvmRuntimeAllocParams &params);
+  uint64_t *allocate(LlvmDevice *device,
+                     const LlvmDevice::LlvmRuntimeAllocParams &params);
   void release(size_t sz, uint64_t *ptr);
 
  private:
@@ -22,7 +23,6 @@ class CachingAllocator {
 
   std::set<std::pair<std::size_t, uint8_t *>> mem_blocks_;
   std::map<uint8_t *, std::size_t> ptr_map_;
-  LlvmDevice *device_{nullptr};
 
   // Allocator options
   bool merge_upon_release_ = true;

--- a/taichi/rhi/llvm/device_memory_pool.h
+++ b/taichi/rhi/llvm/device_memory_pool.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "taichi/common/core.h"
-#include "taichi/rhi/common/unified_allocator.h"
 #include "taichi/rhi/device.h"
+#include "taichi/rhi/llvm/llvm_device.h"
+#include "taichi/rhi/llvm/allocator.h"
 #include <mutex>
 #include <vector>
 #include <memory>
@@ -13,14 +14,17 @@ namespace taichi::lang {
 
 class TI_DLL_EXPORT DeviceMemoryPool {
  public:
+  std::unique_ptr<CachingAllocator> allocator_{nullptr};
   static const size_t page_size;
 
-  static DeviceMemoryPool &get_instance();
+  static DeviceMemoryPool &get_instance(bool merge_upon_release = true);
 
+  void *allocate_with_cache(LlvmDevice *device,
+                            const LlvmDevice::LlvmRuntimeAllocParams &params);
   void *allocate(std::size_t size, std::size_t alignment, bool managed = false);
   void release(std::size_t size, void *ptr, bool release_raw = false);
   void reset();
-  DeviceMemoryPool();
+  DeviceMemoryPool(bool merge_upon_release);
   ~DeviceMemoryPool();
 
  protected:
@@ -32,6 +36,7 @@ class TI_DLL_EXPORT DeviceMemoryPool {
   std::map<void *, std::size_t> raw_memory_chunks_;
 
   std::mutex mut_allocation_;
+  bool merge_upon_release_ = true;
 };
 
 }  // namespace taichi::lang

--- a/taichi/rhi/llvm/llvm_device.h
+++ b/taichi/rhi/llvm/llvm_device.h
@@ -36,6 +36,10 @@ class LlvmDevice : public Device {
     TI_NOT_IMPLEMENTED;
   }
 
+  virtual void clear() {
+    TI_NOT_IMPLEMENTED;
+  }
+
   uint64_t *allocate_llvm_runtime_memory_jit(
       const LlvmRuntimeAllocParams &params);
 };

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -535,6 +535,7 @@ void LlvmRuntimeExecutor::finalize() {
   if (preallocated_device_buffer_ != nullptr) {
     if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
       llvm_device()->dealloc_memory(preallocated_device_buffer_alloc_);
+      llvm_device()->clear();
       DeviceMemoryPool::get_instance().reset();
     }
   }


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/7599

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5a5fcf</samp>

This pull request refactors the memory allocation and management logic in Taichi to support device memory allocation and caching. It introduces a new `DeviceMemoryPool` class that wraps the CUDA or AMDGPU drivers and a `HostMemoryPool` class that replaces the old `MemoryPool` class. It also updates the references and dependencies of these classes in various files and modules.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d5a5fcf</samp>

*  Rename `MemoryPool` to `HostMemoryPool` and update its interface to only handle host memory allocation and deallocation using OS APIs ([link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-3b567f822ae335185b4ee459dbe761b0f385b8502caea7e51e9d4a12c064c7e5L12), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-0a875d6f7e430ca9b888f9203cb94c9862c2c08cd3153b6ceba055fabec3a47eL2-R2), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-0a875d6f7e430ca9b888f9203cb94c9862c2c08cd3153b6ceba055fabec3a47eL36-R37), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL18-R18), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL338), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL357-R356), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L3-R4), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L34-R32), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L82-R75), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L90-R82), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-9a3937a6437de08c0a5c79e202d18bcd154cbce83265d171f07ba50996a8947cL28-R37), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L3-R3), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L15), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L22-R22), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L56-R55), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-36789bee03bd10430f6b60242918f8518e49eec53a9024c7ef6043de304712b4L118), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L3-R3), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L27-R30), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L629-R632), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L657-R663), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L42-R42), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L552-R552), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L822-R822), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L894-R898), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L909-R909), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L921-R921), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-77849776a4e61703fdf4a076fd01bb3d70b0edf16d96879fc7a6bb051b1c00e1))
* Add `HostMemoryPool` implementation in `host_memory_pool.cpp` and update its comment in `host_memory_pool.h` ([link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-c7f11648081cc60e309965f3b13b2644536f2da81d1eb9d45eeeafc87346cb07R1-R135), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-0092a6dc164cbb577e2900a6ac31599e7583362a892ddb36347f0ba9a58fc275L12-R30), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-0092a6dc164cbb577e2900a6ac31599e7583362a892ddb36347f0ba9a58fc275L40-R37))
* Add `DeviceMemoryPool` class as a new abstraction that handles device memory allocation and deallocation using CUDA or AMDGPU drivers, and also provides caching functionality using the `CachingAllocator` class ([link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9R2), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L2-R2), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-aa21493a95ff3932837037225cd6f333d54c7ddcd3e9a8774fd65a0a096c21a1R9), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-cd7ce2b821966dececd4c4d49390a1c3e750be38c980d6448787b4dbf50f329dR1-R143), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-dbd6bdc1bd636021e4226b81e8ebdaccca472d22f9e54b90013b84260710d048R1-R41), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5R9))
* Add constructors to `CudaDevice` and `AmdgpuDevice` that initialize the `DeviceMemoryPool` instance and update their memory allocation and deallocation methods to use the `DeviceMemoryPool` interface ([link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9R9-R13), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9L17-L24), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9R28-R38), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9L49-R58), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9L77-R85), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-a7b85199b3c0a668f23bf0b723c126009e774437499d555de255883c1d1f4648R68), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-a7b85199b3c0a668f23bf0b723c126009e774437499d555de255883c1d1f4648L113), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654R8-R12), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L17-R31), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L31-L34), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L49-R51), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L76-R78), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-01cbaa214a08d98caa33977f217853d54c85d51c03e2dab610909f530b63ee7fR84), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-01cbaa214a08d98caa33977f217853d54c85d51c03e2dab610909f530b63ee7fL139))
* Add the call to `DeviceMemoryPool::reset` in the `finalize` method of the `LlvmRuntimeExecutor` class to release the device memory pool when the program is finalized ([link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5R538))
* Update the source file names in `CMakeLists.txt` files to reflect the renaming of `memory_pool.cpp` to `host_memory_pool.cpp` and the addition of `device_memory_pool.cpp` ([link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-4a2f42ebf872b21247efc079652e216f1b006b8f5564744813a5436f9db10befL7-R7), [link](https://github.com/taichi-dev/taichi/pull/7793/files?diff=unified&w=0#diff-aa21493a95ff3932837037225cd6f333d54c7ddcd3e9a8774fd65a0a096c21a1R9))
