### PR TITLE
[lang] Refactor allocation logic for SNodeTreeBufferManager

### DIFF
--- a/taichi/math/arithmetic.h
+++ b/taichi/math/arithmetic.h
@@ -13,7 +13,7 @@ template <typename T,
 T iroundup(T a, U b) {
   static_assert(std::is_integral_v<T>, "LHS must be integral type");
   static_assert(std::is_integral_v<U>, "RHS must be integral type");
-  return ((a + b + 1) / b) * b;
+  return ((a + b - 1) / b) * b;
 }
 
 template <typename T>

--- a/taichi/math/arithmetic.h
+++ b/taichi/math/arithmetic.h
@@ -13,7 +13,7 @@ template <typename T,
 T iroundup(T a, U b) {
   static_assert(std::is_integral_v<T>, "LHS must be integral type");
   static_assert(std::is_integral_v<U>, "RHS must be integral type");
-  return ((a + b - 1) / b) * b;
+  return ((a + b + 1) / b) * b;
 }
 
 template <typename T>

--- a/taichi/rhi/cuda/cuda_device.cpp
+++ b/taichi/rhi/cuda/cuda_device.cpp
@@ -47,7 +47,9 @@ DeviceAllocation CudaDevice::allocate_memory_runtime(
     const LlvmRuntimeAllocParams &params) {
   AllocInfo info;
   info.size = taichi::iroundup(params.size, taichi_page_size);
-  if (params.use_cached) {
+  if (info.size == 0) {
+    info.ptr = nullptr;
+  } else if (params.use_cached) {
     info.ptr =
         DeviceMemoryPool::get_instance().allocate_with_cache(this, params);
 
@@ -76,6 +78,9 @@ void CudaDevice::dealloc_memory(DeviceAllocation handle) {
 
   validate_device_alloc(handle);
   AllocInfo &info = allocations_[handle.alloc_id];
+  if (info.size == 0) {
+    return;
+  }
   if (info.ptr == nullptr) {
     TI_ERROR("the DeviceAllocation is already deallocated");
   }

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -394,8 +394,6 @@ void LlvmRuntimeExecutor::initialize_llvm_runtime_snodes(
   const int tree_id = field_cache_data.tree_id;
   const int root_id = field_cache_data.root_id;
 
-  root_size =
-      std::max(root_size, (size_t)taichi_page_size);  // minimal allocation size
   TI_TRACE("Allocating data structure of size {} bytes", root_size);
   std::size_t rounded_size = taichi::iroundup(root_size, taichi_page_size);
 

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -394,12 +394,13 @@ void LlvmRuntimeExecutor::initialize_llvm_runtime_snodes(
   const int tree_id = field_cache_data.tree_id;
   const int root_id = field_cache_data.root_id;
 
+  root_size =
+      std::max(root_size, (size_t)taichi_page_size);  // minimal allocation size
   TI_TRACE("Allocating data structure of size {} bytes", root_size);
   std::size_t rounded_size = taichi::iroundup(root_size, taichi_page_size);
 
-  Ptr root_buffer = snode_tree_buffer_manager_->allocate(
-      runtime_jit, llvm_runtime_, rounded_size, taichi_page_size, tree_id,
-      result_buffer);
+  Ptr root_buffer = snode_tree_buffer_manager_->allocate(rounded_size, tree_id,
+                                                         result_buffer);
   if (config_.arch == Arch::cuda) {
 #if defined(TI_WITH_CUDA)
     CUDADriver::get_instance().memset(root_buffer, 0, rounded_size);

--- a/taichi/runtime/llvm/snode_tree_buffer_manager.h
+++ b/taichi/runtime/llvm/snode_tree_buffer_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "taichi/inc/constants.h"
 #include "taichi/struct/snode_tree.h"
+#include "taichi/rhi/public_device.h"
 #define TI_RUNTIME_HOST
 
 #include <set>
@@ -16,23 +17,15 @@ class SNodeTreeBufferManager {
  public:
   explicit SNodeTreeBufferManager(LlvmRuntimeExecutor *runtime_exec);
 
-  void merge_and_insert(Ptr ptr, std::size_t size);
-
-  Ptr allocate(JITModule *runtime_jit,
-               void *runtime,
-               std::size_t size,
-               std::size_t alignment,
+  Ptr allocate(std::size_t size,
                const int snode_tree_id,
                uint64 *result_buffer);
 
   void destroy(SNodeTree *snode_tree);
 
  private:
-  std::set<std::pair<std::size_t, Ptr>> size_set_;
-  std::map<Ptr, std::size_t> ptr_map_;
   LlvmRuntimeExecutor *runtime_exec_;
-  Ptr roots_[kMaxNumSnodeTreesLlvm];
-  std::size_t sizes_[kMaxNumSnodeTreesLlvm];
+  std::map<int, DeviceAllocation> snode_tree_id_to_device_alloc_;
 };
 
 }  // namespace taichi::lang


### PR DESCRIPTION
Issue: https://github.com/taichi-dev/taichi/issues/7599

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b192299</samp>

This pull request refactors and simplifies the memory management classes and interfaces in the RHI module, by introducing `HostMemoryPool` and `DeviceMemoryPool` classes that use the unified allocator and the caching allocator respectively. It also adapts the CC, CPU, CUDA, and AMDGPU backends to use the new memory pool classes, and updates the relevant header files, source files, and CMakeLists files.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b192299</samp>

*  Rename `MemoryPool` class to `HostMemoryPool` and move its implementation from `memory_pool.cpp` to `host_memory_pool.cpp` ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-3b567f822ae335185b4ee459dbe761b0f385b8502caea7e51e9d4a12c064c7e5L12), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-4a2f42ebf872b21247efc079652e216f1b006b8f5564744813a5436f9db10befL7-R7), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-c7f11648081cc60e309965f3b13b2644536f2da81d1eb9d45eeeafc87346cb07R1-R135), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-77849776a4e61703fdf4a076fd01bb3d70b0edf16d96879fc7a6bb051b1c00e1))
*  Update the include paths of `memory_pool.h` to `host_memory_pool.h` in `cc_program.cpp`, `program.cpp`, `unified_allocator.cpp`, and `cpu_device.cpp` ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-0a875d6f7e430ca9b888f9203cb94c9862c2c08cd3153b6ceba055fabec3a47eL2-R2), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL18-R18), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L3-R4), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L3-R3))
*  Remove the `arch` argument and field from `HostMemoryPool` and `UnifiedAllocator` classes, and update their constructors and calls accordingly ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-0092a6dc164cbb577e2900a6ac31599e7583362a892ddb36347f0ba9a58fc275L40-R37), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L34-R32), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-9a3937a6437de08c0a5c79e202d18bcd154cbce83265d171f07ba50996a8947cL28-R37), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L82-R75), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL338), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL357-R356), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L15), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L22-R22), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e49f3cb85e1e9d5e83043e56f4d5d69c371bf8f40b4b653e31fc24eaea7e30c7L56-R55))
*  Add `DeviceMemoryPool` class in `device_memory_pool.h` and `device_memory_pool.cpp`, which uses `CachingAllocator` to allocate and release memory on the device ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-aa21493a95ff3932837037225cd6f333d54c7ddcd3e9a8774fd65a0a096c21a1R9), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-cd7ce2b821966dececd4c4d49390a1c3e750be38c980d6448787b4dbf50f329dR1-R151), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-dbd6bdc1bd636021e4226b81e8ebdaccca472d22f9e54b90013b84260710d048R1-R43))
*  Add constructors for `CudaDevice` and `AmdgpuDevice` classes, which initialize the device memory pool instance with different `merge_upon_release` flags ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654R8-R12), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-01cbaa214a08d98caa33977f217853d54c85d51c03e2dab610909f530b63ee7fR84), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9R9-R13), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-a7b85199b3c0a668f23bf0b723c126009e774437499d555de255883c1d1f4648R70))
*  Update `CudaDevice` and `AmdgpuDevice` classes to use `DeviceMemoryPool` instead of directly calling the CUDA or AMDGPU driver to allocate and release memory, and remove the unused caching allocator instances and comments ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L17-R31), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L31-L34), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L49-R52), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654L76-R79), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-01cbaa214a08d98caa33977f217853d54c85d51c03e2dab610909f530b63ee7fL7), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-01cbaa214a08d98caa33977f217853d54c85d51c03e2dab610909f530b63ee7fL139), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9L17-L24), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9R28-R38), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9L49-R59), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9L77-R86), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-a7b85199b3c0a668f23bf0b723c126009e774437499d555de255883c1d1f4648L9), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-a7b85199b3c0a668f23bf0b723c126009e774437499d555de255883c1d1f4648L113))
*  Update `CachingAllocator` class to remove the `device` field and argument, and pass the `device` argument to the `merge_and_insert` and `allocate_llvm_runtime_memory_jit` functions instead ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-2db035897bca403c2ce8a2b5ce2ff1de0ecc77b6fa97f9dae0bb7fd6416de2adL6-R7), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-2db035897bca403c2ce8a2b5ce2ff1de0ecc77b6fa97f9dae0bb7fd6416de2adR34), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-2db035897bca403c2ce8a2b5ce2ff1de0ecc77b6fa97f9dae0bb7fd6416de2adL54-R55), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-06b92f3a1b8326081cb6b99afd424e2c0be4d4f3df97ca913a8978c9c9b5d2d2L15-R18), [link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-06b92f3a1b8326081cb6b99afd424e2c0be4d4f3df97ca913a8978c9c9b5d2d2L25))
*  Update the assertion in `unified_allocator.cpp` to use `HostMemoryPool::page_size` instead of `MemoryPool::page_size` ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-6cdadd09403135efbb53bd51e0c282e0ac6d50fd8784f31a65044771aa7627c0L90-R82))
*  Update the comment for `HostMemoryPool` class in `host_memory_pool.h` ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-0092a6dc164cbb577e2900a6ac31599e7583362a892ddb36347f0ba9a58fc275L12-R30))
*  Remove the unused local variable `arch` in `finalize` function in `program.cpp` ([link](https://github.com/taichi-dev/taichi/pull/7795/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL338))
