### PR TITLE
[misc] Optimize import overhead: pytorch and get_clangpp

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -640,10 +640,6 @@ class Kernel:
         self.compiled_kernels[key] = taichi_kernel
 
     def get_function_body(self, t_kernel):
-        if has_pytorch():
-            import torch  # pylint: disable=C0415
-        if has_paddle():
-            import paddle  # pylint: disable=C0415
         # The actual function body
         def func__(*args):
             assert len(args) == len(
@@ -745,61 +741,74 @@ class Kernel:
                             raise ValueError(
                                 "Non contiguous numpy arrays are not supported, please call np.ascontiguousarray(arr) before passing it into taichi kernel."
                             )
-                    elif has_pytorch() and isinstance(v, torch.Tensor):
-                        if not v.is_contiguous():
-                            raise ValueError(
-                                "Non contiguous tensors are not supported, please call tensor.contiguous() before passing it into taichi kernel."
-                            )
-                        taichi_arch = self.runtime.prog.config().arch
+                    elif has_pytorch():
+                        import torch  # pylint: disable=C0415
+                        if isinstance(v, torch.Tensor):
+                            if not v.is_contiguous():
+                                raise ValueError(
+                                    "Non contiguous tensors are not supported, please call tensor.contiguous() before passing it into taichi kernel."
+                                )
+                            taichi_arch = self.runtime.prog.config().arch
 
-                        def get_call_back(u, v):
-                            def call_back():
-                                u.copy_(v)
+                            def get_call_back(u, v):
+                                def call_back():
+                                    u.copy_(v)
 
-                            return call_back
+                                return call_back
 
-                        tmp = v
-                        if str(v.device).startswith(
-                                'cuda') and taichi_arch != _ti_core.Arch.cuda:
-                            # Getting a torch CUDA tensor on Taichi non-cuda arch:
-                            # We just replace it with a CPU tensor and by the end of kernel execution we'll use the callback to copy the values back to the original CUDA tensor.
-                            host_v = v.to(device='cpu', copy=True)
-                            tmp = host_v
-                            callbacks.append(get_call_back(v, host_v))
-
-                        launch_ctx.set_arg_external_array_with_shape(
-                            actual_argument_slot, int(tmp.data_ptr()),
-                            tmp.element_size() * tmp.nelement(), array_shape)
-                    elif has_paddle() and isinstance(v, paddle.Tensor):
-                        # For now, paddle.fluid.core.Tensor._ptr() is only available on develop branch
-                        def get_call_back(u, v):
-                            def call_back():
-                                u.copy_(v, False)
-
-                            return call_back
-
-                        tmp = v.value().get_tensor()
-                        taichi_arch = self.runtime.prog.config().arch
-                        if v.place.is_gpu_place():
-                            if taichi_arch != _ti_core.Arch.cuda:
-                                # Paddle cuda tensor on Taichi non-cuda arch
-                                host_v = v.cpu()
-                                tmp = host_v.value().get_tensor()
+                            tmp = v
+                            if str(v.device).startswith(
+                                    'cuda'
+                            ) and taichi_arch != _ti_core.Arch.cuda:
+                                # Getting a torch CUDA tensor on Taichi non-cuda arch:
+                                # We just replace it with a CPU tensor and by the end of kernel execution we'll use the callback to copy the values back to the original CUDA tensor.
+                                host_v = v.to(device='cpu', copy=True)
+                                tmp = host_v
                                 callbacks.append(get_call_back(v, host_v))
-                        elif v.place.is_cpu_place():
-                            if taichi_arch == _ti_core.Arch.cuda:
-                                # Paddle cpu tensor on Taichi cuda arch
-                                gpu_v = v.cuda()
-                                tmp = gpu_v.value().get_tensor()
-                                callbacks.append(get_call_back(v, gpu_v))
+
+                            launch_ctx.set_arg_external_array_with_shape(
+                                actual_argument_slot, int(tmp.data_ptr()),
+                                tmp.element_size() * tmp.nelement(),
+                                array_shape)
                         else:
-                            # Paddle do support many other backends like XPU, NPU, MLU, IPU
-                            raise TaichiRuntimeTypeError(
-                                f"Taichi do not support backend {v.place} that Paddle support"
-                            )
-                        launch_ctx.set_arg_external_array_with_shape(
-                            actual_argument_slot, int(tmp._ptr()),
-                            v.element_size() * v.size, array_shape)
+                            raise TaichiRuntimeTypeError.get(
+                                i, needed.to_string(), v)
+                    elif has_paddle():
+                        import paddle  # pylint: disable=C0415
+                        if isinstance(v, paddle.Tensor):
+                            # For now, paddle.fluid.core.Tensor._ptr() is only available on develop branch
+                            def get_call_back(u, v):
+                                def call_back():
+                                    u.copy_(v, False)
+
+                                return call_back
+
+                            tmp = v.value().get_tensor()
+                            taichi_arch = self.runtime.prog.config().arch
+                            if v.place.is_gpu_place():
+                                if taichi_arch != _ti_core.Arch.cuda:
+                                    # Paddle cuda tensor on Taichi non-cuda arch
+                                    host_v = v.cpu()
+                                    tmp = host_v.value().get_tensor()
+                                    callbacks.append(get_call_back(v, host_v))
+                            elif v.place.is_cpu_place():
+                                if taichi_arch == _ti_core.Arch.cuda:
+                                    # Paddle cpu tensor on Taichi cuda arch
+                                    gpu_v = v.cuda()
+                                    tmp = gpu_v.value().get_tensor()
+                                    callbacks.append(get_call_back(v, gpu_v))
+                            else:
+                                # Paddle do support many other backends like XPU, NPU, MLU, IPU
+                                raise TaichiRuntimeTypeError(
+                                    f"Taichi do not support backend {v.place} that Paddle support"
+                                )
+                            launch_ctx.set_arg_external_array_with_shape(
+                                actual_argument_slot, int(tmp._ptr()),
+                                v.element_size() * v.size, array_shape)
+                        else:
+                            raise TaichiRuntimeTypeError.get(
+                                i, needed.to_string(), v)
+
                     else:
                         raise TaichiRuntimeTypeError.get(
                             i, needed.to_string(), v)

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -34,12 +34,6 @@ from taichi.types.utils import is_signed
 
 from taichi import _logging
 
-if has_pytorch():
-    import torch
-
-if has_paddle():
-    import paddle
-
 
 def func(fn, is_real_function=False):
     """Marks a function as callable in Taichi-scope.
@@ -646,6 +640,10 @@ class Kernel:
         self.compiled_kernels[key] = taichi_kernel
 
     def get_function_body(self, t_kernel):
+        if has_pytorch():
+            import torch  # pylint: disable=C0415
+        if has_paddle():
+            import paddle  # pylint: disable=C0415
         # The actual function body
         def func__(*args):
             assert len(args) == len(

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -65,7 +65,7 @@ def get_clangpp():
 
 def has_clangpp():
     if _clangpp_presence is False:
-        get_clangpp()
+        return get_clangpp() is not None
     return _clangpp_presence is not None
 
 

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -47,9 +47,6 @@ def has_paddle():
     return _has_paddle
 
 
-_clangpp_presence = False
-
-
 def get_clangpp():
     from distutils.spawn import find_executable  # pylint: disable=C0415
 
@@ -64,9 +61,7 @@ def get_clangpp():
 
 
 def has_clangpp():
-    if _clangpp_presence is False:
-        return get_clangpp() is not None
-    return _clangpp_presence is not None
+    return get_clangpp() is not None
 
 
 def is_matrix_class(rhs):

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -11,25 +11,6 @@ from taichi.lang import impl
 from taichi.types.primitive_types import (f16, f32, f64, i8, i16, i32, i64, u8,
                                           u16, u32, u64)
 
-_has_pytorch = False
-_has_paddle = False
-
-_env_torch = os.environ.get('TI_ENABLE_TORCH', '1')
-if not _env_torch or int(_env_torch):
-    try:
-        import torch
-        _has_pytorch = True
-    except:
-        pass
-
-_env_paddle = os.environ.get('TI_ENABLE_PADDLE', '1')
-if not _env_paddle or int(_env_paddle):
-    try:
-        import paddle
-        _has_paddle = True
-    except:
-        pass
-
 
 def has_pytorch():
     """Whether has pytorch in the current Python environment.
@@ -38,6 +19,14 @@ def has_pytorch():
         bool: True if has pytorch else False.
 
     """
+    _has_pytorch = False
+    _env_torch = os.environ.get('TI_ENABLE_TORCH', '1')
+    if not _env_torch or int(_env_torch):
+        try:
+            import torch  # pylint: disable=C0415
+            _has_pytorch = True
+        except:
+            pass
     return _has_pytorch
 
 
@@ -47,26 +36,37 @@ def has_paddle():
     Returns:
         bool: True if has paddle else False.
     """
+    _has_paddle = False
+    _env_paddle = os.environ.get('TI_ENABLE_PADDLE', '1')
+    if not _env_paddle or int(_env_paddle):
+        try:
+            import paddle  # pylint: disable=C0415
+            _has_paddle = True
+        except:
+            pass
     return _has_paddle
 
 
-from distutils.spawn import find_executable
-
-# Taichi itself uses llvm-10.0.0 to compile.
-# There will be some issues compiling CUDA with other clang++ version.
-_clangpp_candidates = ['clang++-10']
-_clangpp_presence = None
-for c in _clangpp_candidates:
-    if find_executable(c) is not None:
-        _clangpp_presence = find_executable(c)
-
-
-def has_clangpp():
-    return _clangpp_presence is not None
+_clangpp_presence = False
 
 
 def get_clangpp():
-    return _clangpp_presence
+    from distutils.spawn import find_executable  # pylint: disable=C0415
+
+    # Taichi itself uses llvm-10.0.0 to compile.
+    # There will be some issues compiling CUDA with other clang++ version.
+    _clangpp_candidates = ['clang++-10', 'clang++']
+    for c in _clangpp_candidates:
+        if find_executable(c) is not None:
+            _clangpp_presence = find_executable(c)
+            return _clangpp_presence
+    return None
+
+
+def has_clangpp():
+    if _clangpp_presence is False:
+        get_clangpp()
+    return _clangpp_presence is not None
 
 
 def is_matrix_class(rhs):

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -55,7 +55,7 @@ def get_clangpp():
 
     # Taichi itself uses llvm-10.0.0 to compile.
     # There will be some issues compiling CUDA with other clang++ version.
-    _clangpp_candidates = ['clang++-10', 'clang++']
+    _clangpp_candidates = ['clang++-10']
     for c in _clangpp_candidates:
         if find_executable(c) is not None:
             _clangpp_presence = find_executable(c)

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -134,6 +134,8 @@ def to_pytorch_type(dt):
         DataType: The counterpart data type in torch.
 
     """
+    import torch  # pylint: disable=C0415
+
     # pylint: disable=E1101
     if dt == f32:
         return torch.float32
@@ -167,6 +169,7 @@ def to_paddle_type(dt):
         DataType: The counterpart data type in paddle.
 
     """
+    import paddle  # pylint: disable=C0415
     if dt == f32:
         return paddle.float32
     if dt == f64:
@@ -226,6 +229,8 @@ def to_taichi_type(dt):
         return f16
 
     if has_pytorch():
+        import torch  # pylint: disable=C0415
+
         # pylint: disable=E1101
         if dt == torch.float32:
             return f32
@@ -248,6 +253,7 @@ def to_taichi_type(dt):
                 f'PyTorch doesn\'t support {dt.to_string()} data type.')
 
     if has_paddle():
+        import paddle  # pylint: disable=C0415
         if dt == paddle.float32:
             return f32
         if dt == paddle.float64:


### PR DESCRIPTION
Fix #7711 

Reduce import overhead by:
* Don't import pyTorch when importing Taichi. (It will be imported when necessary)
* Don't unconditionally get clangpp executable path.

The former would cutdown Taichi import overhead from ~2s down to 0.7s, while the latter further reduce it from 0.7s to 0.5s.