### PR TITLE
[ci] Polishing build.py, wave 2

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -58,11 +58,10 @@ function prepare-unity-build-env {
 
     export TAICHI_REPO_DIR=$(pwd)
 
-    setup-android-ndk-env
     git clone --reference-if-able /var/lib/git-cache -b "$TAICHI_UNITY2_BRANCH" "$TAICHI_UNITY2_URL"
     mkdir tu2-build
     pushd tu2-build
-    cmake ../taichi-unity2 -DTAICHI_C_API_INSTALL_DIR=$TAICHI_REPO_DIR/_skbuild/linux-x86_64-3.9/cmake-install/c_api $TAICHI_CMAKE_ARGS
+    cmake ../taichi-unity2 $TAICHI_CMAKE_ARGS
     cmake --build .
     popd
     cp tu2-build/bin/libtaichi_unity.so Taichi-UnityExample/Assets/Plugins/Android

--- a/.github/workflows/scripts/ti_build/android.py
+++ b/.github/workflows/scripts/ti_build/android.py
@@ -49,6 +49,7 @@ def build_android(python: Command, pip: Command) -> None:
     cmake_args['TI_WITH_C_API'] = True
     cmake_args['TI_BUILD_TESTS'] = False
     cmake_args.writeback()
+    os.environ['TAICHI_FORCE_PLAT_NAME'] = 'android-arm64'  # affects setup.py
     pip.install('-r', 'requirements_dev.txt')
     python('setup.py', 'clean')
     python('setup.py', 'build_ext')

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -79,8 +79,10 @@ def ensure_dependencies(*deps: str):
             sys.executable, '-m', 'pip', 'install', '--no-user',
             f'--target={bootstrap_root}', '-U'
         ]
+        if run([sys.executable, '-m', 'ensurepip']):
+            raise Exception('Unable to run ensurepip!')
         if run(*pipcmd, 'pip', 'setuptools'):
-            raise Exception('Unable to upgrade pip!')
+            raise Exception('Unable to install pip!')
         if run(*pipcmd, *deps, env={'PYTHONPATH': str(bootstrap_root)}):
             raise Exception('Unable to install dependencies!')
 

--- a/setup.py
+++ b/setup.py
@@ -208,6 +208,12 @@ def sign_development_for_apple_m1():
 
 
 copy_assets()
+
+force_plat_name = os.getenv('TAICHI_FORCE_PLAT_NAME', '').strip()
+if force_plat_name:
+    from skbuild.constants import set_skbuild_plat_name
+    set_skbuild_plat_name(force_plat_name)
+
 setup(name=project_name,
       packages=packages,
       package_dir={"": package_dir},


### PR DESCRIPTION
Issue: #7269 

### Brief Summary

- Setting a skbuild platform name to ensure the Android build can coexist with the Linux build of the C-API shared library.
- Run ensurepip in bootstraping
- Probe mirror before use