### PR TITLE
[bug] Fix imgui_context in destroying multiple GGUI windows

### DIFF
--- a/taichi/ui/backends/vulkan/gui.cpp
+++ b/taichi/ui/backends/vulkan/gui.cpp
@@ -22,7 +22,7 @@ Gui::Gui(AppContext *app_context, SwapChain *swap_chain, TaichiWindow *window) {
   create_descriptor_pool();
 
   IMGUI_CHECKVERSION();
-  ImGui::CreateContext();
+  imgui_context_ = ImGui::CreateContext();
   [[maybe_unused]] ImGuiIO &io = ImGui::GetIO();
 
   ImGui::StyleColorsDark();
@@ -235,7 +235,7 @@ Gui::~Gui() {
 #endif
   }
   cleanup_render_resources();
-  ImGui::DestroyContext();
+  ImGui::DestroyContext(imgui_context_);
 }
 
 bool Gui::is_empty() {

--- a/taichi/ui/backends/vulkan/gui.h
+++ b/taichi/ui/backends/vulkan/gui.h
@@ -62,8 +62,9 @@ class TI_DLL_EXPORT Gui final : public GuiBase {
 
  private:
   bool is_empty_;
-  AppContext *app_context_;
-  SwapChain *swap_chain_;
+  AppContext *app_context_{nullptr};
+  SwapChain *swap_chain_{nullptr};
+  ImGuiContext *imgui_context_{nullptr};
 
   VkRenderPass render_pass_{VK_NULL_HANDLE};
 

--- a/tests/python/test_ggui.py
+++ b/tests/python/test_ggui.py
@@ -1016,3 +1016,10 @@ def test_wireframe_mode():
     render()
     verify_image(window.get_image_buffer_as_numpy(), 'test_wireframe_mode')
     window.destroy()
+
+
+@pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
+@test_utils.test(arch=supported_archs)
+def test_multi_windows():
+    window = ti.ui.Window('x', (128, 128), vsync=True, show_window=False)
+    window2 = ti.ui.Window('x2', (128, 128), vsync=True, show_window=False)


### PR DESCRIPTION
Issue: #7769 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9fa9e7</samp>

Refactored the `GUI` class in the Vulkan backend to use a local ImGui context and added a test case for multiple windows. This improves the modularity and robustness of the `GUI` class and its usage.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a9fa9e7</samp>

*  Add `imgui_context_` member variable to `GUI` class to store and manage its own ImGui context ([link](https://github.com/taichi-dev/taichi/pull/7812/files?diff=unified&w=0#diff-aa837ca266d11faa9968cd0aad76e18080fd5a9d4110ac1a6d6ccd128aee7a4bL25-R25), [link](https://github.com/taichi-dev/taichi/pull/7812/files?diff=unified&w=0#diff-aa837ca266d11faa9968cd0aad76e18080fd5a9d4110ac1a6d6ccd128aee7a4bL238-R238), [link](https://github.com/taichi-dev/taichi/pull/7812/files?diff=unified&w=0#diff-0bd71968053eb6c3a4cbb725ceebe181a7c5b3bef5207e525855ce8980e1bd35L65-R67))
*  Initialize `app_context_` and `swap_chain_` member variables with `nullptr` in `GUI` class header file ([link](https://github.com/taichi-dev/taichi/pull/7812/files?diff=unified&w=0#diff-0bd71968053eb6c3a4cbb725ceebe181a7c5b3bef5207e525855ce8980e1bd35L65-R67))
*  Add test case to check if `GUI` class can support multiple windows in `test_ggui.py` ([link](https://github.com/taichi-dev/taichi/pull/7812/files?diff=unified&w=0#diff-7f78177ffeb214e2e6edde3b288143eb941d514aaf0d1471e4038b5ddf11538eR1019-R1025))
