### PR TITLE
[Doc] Update field.md

### DIFF
--- a/docs/lang/articles/basic/field.md
+++ b/docs/lang/articles/basic/field.md
@@ -265,7 +265,7 @@ The layout of `f`:
             └  └──────┴──────┴──────┘  ┘
 ```
 
-The following code snippet declares a `300x300x300` vector field `volumetric_field`, whose vector dimension is 3:
+The following code snippet declares a `300x300x300` vector field `volumetric_field`, whose vector dimension is 4:
 
 ```python
 box_size = (300, 300, 300)  # A 300x300x300 grid in a 3D space


### PR DESCRIPTION
Fixed a documentation error in vector fields declaration, which is declared as a 4-dimension but say that vector dimension is 4

Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e09e1fe</samp>

Fix a typo and improve consistency in `docs/lang/articles/basic/field.md`. Update the vector dimension of `volumetric_field` to match the code example.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e09e1fe</samp>

* Fix a typo and update the vector dimension of `volumetric_field` from 3 to 4, to match the code example ([link](https://github.com/taichi-dev/taichi/pull/7819/files?diff=unified&w=0#diff-5b7c8b1d0dee84f0dd4bf9a9aff720460c0eeb510d7372b8db9065ae63aa2089L268-R268))
