### PR TITLE
[misc] Update git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,8 @@
 # Reformat everything (#617)
 02a4048b547e0c00c65856f47351c4ecf0163268
+
+# [misc] Relax Black formatter line length limit to 120 (#7824)
+4fe7f150790012e6d9298614a040bb0053acd0fb
+
+# [misc]  Switch code formatter from `yapf` to `black` (#7785)
+e0aa905991a01dfd68b7bcf1ad20f5132408febc


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d78e88</samp>

Add commits that applied Black code formatter to `.git-blame-ignore-revs` file. This helps preserve the original authorship information when using `git blame`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2d78e88</samp>

* Add two commit hashes to `.git-blame-ignore-revs` to exclude Black formatting changes ([link](https://github.com/taichi-dev/taichi/pull/7825/files?diff=unified&w=0#diff-f247fbfbe928b907db42554d0b3006b28dd11c25a59be031abda73b11a2c934aR3-R8))
