### PR TITLE
[autodiff] Remove redundant autodiff mode in kernel name

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -562,15 +562,8 @@ class Kernel:
         if key in self.runtime.compiled_functions:
             return
 
-        grad_suffix = ""
-        if self.autodiff_mode == AutodiffMode.FORWARD:
-            grad_suffix = "_forward_grad"
-        elif self.autodiff_mode == AutodiffMode.REVERSE:
-            grad_suffix = "_reverse_grad"
-        elif self.autodiff_mode == AutodiffMode.VALIDATION:
-            grad_suffix = "_validate_grad"
-        kernel_name = f"{self.func.__name__}_c{self.kernel_counter}_{key[1]}{grad_suffix}"
-        _logging.trace(f"Compiling kernel {kernel_name}...")
+        kernel_name = f"{self.func.__name__}_c{self.kernel_counter}_{key[1]}"
+        _logging.trace(f"Compiling kernel {kernel_name} in {self.autodiff_mode}...")
 
         tree, ctx = _get_tree_and_ctx(
             self,

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -50,6 +50,10 @@ Kernel::Kernel(Program &program,
     name = primal_name + "_forward_grad";
   } else if (autodiff_mode == AutodiffMode::kReverse) {
     name = primal_name + "_reverse_grad";
+  } else if (autodiff_mode == AutodiffMode::kCheckAutodiffValid) {
+    name = primal_name + "_validate_grad";
+  } else {
+    TI_ERROR("Unsupported autodiff mode");
   }
 }
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 939d7a4</samp>

Simplify kernel name generation and add a new autodiff mode for validation. The new mode `kCheckAutodiffValid` compares the forward and reverse gradients and requires a separate kernel name in `kernel.cpp`. The kernel name generation in `kernel_impl.py` is simplified by removing the grad_suffix and appending the autodiff mode.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 939d7a4</samp>

*  Simplify kernel name generation by removing grad_suffix and appending autodiff mode ([link](https://github.com/taichi-dev/taichi/pull/7829/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L565-R566))
*  Add branch to handle kCheckAutodiffValid mode for autodiff validation ([link](https://github.com/taichi-dev/taichi/pull/7829/files?diff=unified&w=0#diff-183534311cce45d4f24cf969ff1836c60a64c8c6050c34f6ee667617cf9d8dddR53-R56))
