### PR TITLE
[doc] Add sparse grid example.

### DIFF
--- a/docs/lang/articles/basic/sparse.md
+++ b/docs/lang/articles/basic/sparse.md
@@ -364,45 +364,33 @@ print(ti.rescale_index(block2, block1, [3, 1]))       # output: [1, 0]
 Regarding line 1, you can also compute the `block1` index given `pixel` index `[7, 3]` as `[7//2//2, 3//2//2]`. However, doing so couples computation code with the internal configuration of data structures (in this case, the size of `block1` containers). By using `ti.rescale_index()`, you can avoid hard-coding internal information of data structures.
 
 
-## Sparse grid example
-We now show a simple example of how to use the sparse data structures to implement a sparse grid.
+## Sparse grid
+We now show an example of how to create a sparse grid with our simplified API(`ti.sparse.grid()`), and how to print the usage with `ti.sparse.usage()`.
 
 ```python
 import taichi as ti
-ti.init()
-grid_size = (10,10)
-@ti.data_oriented
-class SparseGrid():
-    def __init__(self, grid_size):
-        self.mass = ti.field(float)
-        self.pos = ti.Vector.field(3, float)
-        self.snode = ti.root.bitmasked(ti.ij, grid_size)
-        self.snode.place(self.mass)
-        self.snode.place(self.pos)
-    @ti.kernel
-    def usage(self):
-        cnt = 0
-        for I in ti.grouped(self.snode):
-            if ti.is_active(self.snode, I):
-                cnt+=1
-        usage =  cnt/(grid_size[0]*grid_size[1])
-        print("Grid usage: ", usage)
-sp = SparseGrid(grid_size=grid_size)
-pos = sp.pos
-mass = sp.mass
-```
+# create a 2D sparse grid
+grid = ti.sparse.grid(
+    {
+        "pos": ti.math.vec2,
+        "mass": ti.f32,
+        "grid2particles": ti.types.vector(20, ti.i32),
+    },
+    shape=(10, 10),
+)
 
-Use case:
+# access
+grid[0, 0].pos = ti.math.vec2(1, 2)
+grid[0, 0].mass = 1.0
+grid[0, 0].grid2particles[2] = 123
 
-```python cont
-pos[1,2] = ti.Vector([1.5,2,3])
-mass[1,0] = 0.1
-sp.usage()
+# print the usage of the sparse grid, which is in [0,1]
+ti.sparse.usage(grid)
 ```
 
 possible output:
 ```
-Grid usage:  0.020000
+Grid usage:  0.010000
 ```
 
 ## Further reading

--- a/docs/lang/articles/basic/sparse.md
+++ b/docs/lang/articles/basic/sparse.md
@@ -363,6 +363,46 @@ print(ti.rescale_index(block2, block1, [3, 1]))       # output: [1, 0]
 
 Regarding line 1, you can also compute the `block1` index given `pixel` index `[7, 3]` as `[7//2//2, 3//2//2]`. However, doing so couples computation code with the internal configuration of data structures (in this case, the size of `block1` containers). By using `ti.rescale_index()`, you can avoid hard-coding internal information of data structures.
 
+
+## Sparse grid example
+We now show a simple example of how to use the sparse data structures to implement a sparse grid.
+
+```python
+import taichi as ti
+ti.init()
+grid_size = (10,10)
+@ti.data_oriented
+class SparseGrid():
+    def __init__(self, grid_size):
+        self.pos = ti.field(int)
+        self.snode = ti.root.bitmasked(ti.ij, grid_size)
+        self.snode.place(self.pos)
+    @ti.kernel
+    def usage(self):
+        cnt = 0
+        for I in ti.grouped(self.snode):
+            if ti.is_active(self.snode, I):
+                cnt+=1
+        usage =  cnt/(grid_size[0]*grid_size[1])
+        print("Grid usage: ", usage)
+sp = SparseGrid(grid_size=grid_size)
+pos = sp.pos
+```
+
+Use case: 
+```python
+>>> sp.usage()
+Grid usage:  0.000000
+
+>>> pos[1,2] = 1
+
+>>> sp.usage()
+Grid usage:  0.010000
+
+>>> pos[1,3] = 1
+Grid usage:  0.020000
+```
+
 ## Further reading
 
 Please read the SIGGRAPH Asia 2019 [paper](https://yuanming.taichi.graphics/publication/2019-taichi/taichi-lang.pdf) or watch the associated

--- a/docs/lang/articles/basic/sparse.md
+++ b/docs/lang/articles/basic/sparse.md
@@ -374,8 +374,10 @@ grid_size = (10,10)
 @ti.data_oriented
 class SparseGrid():
     def __init__(self, grid_size):
-        self.pos = ti.field(int)
+        self.mass = ti.field(float)
+        self.pos = ti.Vector.field(3, float)
         self.snode = ti.root.bitmasked(ti.ij, grid_size)
+        self.snode.place(self.mass)
         self.snode.place(self.pos)
     @ti.kernel
     def usage(self):
@@ -387,19 +389,19 @@ class SparseGrid():
         print("Grid usage: ", usage)
 sp = SparseGrid(grid_size=grid_size)
 pos = sp.pos
+mass = sp.mass
 ```
 
-Use case:
+Use case: 
+
 ```python
->>> sp.usage()
-Grid usage:  0.000000
+pos[1,2] = ti.Vector([1.5,2,3])
+mass[1,0] = 0.1
+sp.usage()
+```
 
->>> pos[1,2] = 1
-
->>> sp.usage()
-Grid usage:  0.010000
-
->>> pos[1,3] = 1
+possible output:
+```
 Grid usage:  0.020000
 ```
 

--- a/docs/lang/articles/basic/sparse.md
+++ b/docs/lang/articles/basic/sparse.md
@@ -394,7 +394,7 @@ mass = sp.mass
 
 Use case:
 
-```python
+```python cont
 pos[1,2] = ti.Vector([1.5,2,3])
 mass[1,0] = 0.1
 sp.usage()

--- a/docs/lang/articles/basic/sparse.md
+++ b/docs/lang/articles/basic/sparse.md
@@ -389,7 +389,7 @@ sp = SparseGrid(grid_size=grid_size)
 pos = sp.pos
 ```
 
-Use case: 
+Use case:
 ```python
 >>> sp.usage()
 Grid usage:  0.000000

--- a/docs/lang/articles/basic/sparse.md
+++ b/docs/lang/articles/basic/sparse.md
@@ -392,7 +392,7 @@ pos = sp.pos
 mass = sp.mass
 ```
 
-Use case: 
+Use case:
 
 ```python
 pos[1,2] = ti.Vector([1.5,2,3])


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c39432b</samp>

This change updates the documentation with a new section on sparse data structures. It demonstrates how to use the `bitmasked` node to create a sparse grid that saves memory and adapts to the data.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c39432b</samp>

* Add a new section to the documentation on sparse data structures ([link](https://github.com/taichi-dev/taichi/pull/7858/files?diff=unified&w=0#diff-e951f0e114991e0acc29a038e8b18a0ebda9a9b58f035ebd9b75f6216a9f01a8R366-R405))
