### PR TITLE
[Lang] Fix a bug on PosixPath

### DIFF
--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -113,7 +113,7 @@ class TaichiMain:
     def _exec_python_file(filename: str):
         """Execute a Python file based on filename."""
         # TODO: do we really need this?
-        subprocess.call([sys.executable, str(filename)] + sys.argv[1:])
+        subprocess.call([sys.executable, filename] + sys.argv[1:])
 
     @staticmethod
     def _get_examples_dir() -> Path:
@@ -215,7 +215,7 @@ class TaichiMain:
             content = Syntax.from_path(script, line_numbers=True)
             console = rich.console.Console()
             console.print(content)
-            self._exec_python_file(script)
+            self._exec_python_file(str(script))
 
         index = None
         while not gui.get_event(ti.GUI.ESCAPE, ti.GUI.EXIT):

--- a/python/taichi/_main.py
+++ b/python/taichi/_main.py
@@ -113,7 +113,7 @@ class TaichiMain:
     def _exec_python_file(filename: str):
         """Execute a Python file based on filename."""
         # TODO: do we really need this?
-        subprocess.call([sys.executable, filename] + sys.argv[1:])
+        subprocess.call([sys.executable, str(filename)] + sys.argv[1:])
 
     @staticmethod
     def _get_examples_dir() -> Path:


### PR DESCRIPTION
When calling  `ti gallery,` the `_exec_python_file` function in `_main.py` simply passes a `pathlib.PosixPath` object to the command. This may cause problems on Windows platforms. This PR fixes this issue by forcing using the absolute string path.