### PR TITLE
[spirv] Fix generating array type in SPIR-V

### DIFF
--- a/taichi/codegen/spirv/spirv_types.cpp
+++ b/taichi/codegen/spirv/spirv_types.cpp
@@ -453,9 +453,10 @@ class Translate2Spirv : public TypeVisitor {
 
   void visit_array_type(const ArrayType *type) override {
     SType vt = spir_builder_->get_null_type();
-    spir_builder_->declare_global(spv::OpTypeArray, vt,
-                                  ir_node_2_spv_value[type->element_type()],
-                                  type->get_constant_shape()[0]);
+    spir_builder_->declare_global(
+        spv::OpTypeArray, vt, ir_node_2_spv_value[type->element_type()],
+        spir_builder_->int_immediate_number(spir_builder_->i32_type(),
+                                            type->get_constant_shape()[0]));
     ir_node_2_spv_value[type] = vt.id;
     spir_builder_->decorate(spv::OpDecorate, vt, spv::DecorationArrayStride,
                             type->memory_alignment_size(layout_context_));


### PR DESCRIPTION
Issue: fixes #7855

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f35995</samp>

Fix array size encoding bug in SPIR-V backend. Use `int_immediate_number` to create SPIR-V constants for array types in `spirv_types.cpp`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8f35995</samp>

* Fix a bug where array size was not encoded as a SPIR-V constant ([link](https://github.com/taichi-dev/taichi/pull/7863/files?diff=unified&w=0#diff-259a89b8645aab6065eac94864cd4930be7ae91da5cb2e15307ae5fa41015962L456-R459))
* Use `int_immediate_number` to create a constant operand for `OpTypeArray` ([link](https://github.com/taichi-dev/taichi/pull/7863/files?diff=unified&w=0#diff-259a89b8645aab6065eac94864cd4930be7ae91da5cb2e15307ae5fa41015962L456-R459))
