### PR TITLE
[build] Remove unused apt pkg 'libmirclient-dev' to make 'build.py' run properly on ubuntu 22.04

### DIFF
--- a/.github/workflows/scripts/ti_build/ospkg.py
+++ b/.github/workflows/scripts/ti_build/ospkg.py
@@ -22,7 +22,6 @@ UBUNTU_PACKAGES = {
     "libglu1-mesa-dev",
     "libjpeg-dev",
     "liblz4-dev",
-    "libmirclient-dev",
     "libpng-dev",
     "libssl-dev",
     "libtinfo-dev",


### PR DESCRIPTION
Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
