### PR TITLE
[Lang] Let kernel argument support matrix nested in a struct

### DIFF
--- a/c_api/include/taichi/taichi_core.h
+++ b/c_api/include/taichi/taichi_core.h
@@ -463,6 +463,8 @@ typedef enum TiArgumentType {
   TI_ARGUMENT_TYPE_TEXTURE = 3,
   // Typed scalar.
   TI_ARGUMENT_TYPE_SCALAR = 4,
+  // Typed tensor.
+  TI_ARGUMENT_TYPE_TENSOR = 5,
   TI_ARGUMENT_TYPE_MAX_ENUM = 0xffffffff,
 } TiArgumentType;
 
@@ -802,6 +804,12 @@ typedef struct TiScalar {
   TiScalarValue value;
 } TiScalar;
 
+typedef struct TiTensor {
+  uint64_t *data;
+  uint32_t num_elements;
+  uint8_t width;
+} TiTensor;
+
 // Union `TiArgumentValue` (1.4.0)
 //
 // A scalar or structured argument value.
@@ -818,6 +826,8 @@ typedef union TiArgumentValue {
   TiTexture texture;
   // An scalar to be bound.
   TiScalar scalar;
+  // A tensor to be bound.
+  TiTensor tensor;
 } TiArgumentValue;
 
 // Structure `TiArgument` (1.4.0)

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -715,7 +715,6 @@ void ti_launch_kernel(TiRuntime runtime,
   }
 
   auto ti_kernel = (taichi::lang::aot::Kernel *)kernel;
-  TI_INFO("{}", ti_kernel->args_type->to_string());
 
   Runtime &runtime2 = *((Runtime *)runtime);
   taichi::lang::LaunchContextBuilder builder(ti_kernel);

--- a/python/taichi/aot/utils.py
+++ b/python/taichi/aot/utils.py
@@ -97,11 +97,8 @@ def produce_injected_args(kernel, symbolic_args=None):
             texture_shape = (2,) * anno.num_dimensions
             injected_args.append(Texture(Format.rgba8, texture_shape))
         elif isinstance(anno, MatrixType):
-            if not isinstance(symbolic_args[i], list):
-                raise RuntimeError("Expected a symbolic arg with Matrix type.")
-
-            symbolic_mat_n = len(symbolic_args[i])
-            symbolic_mat_m = len(symbolic_args[i][0])
+            symbolic_mat_n = symbolic_args[i].element_shape[0]
+            symbolic_mat_m = symbolic_args[i].element_shape[1]
 
             if symbolic_mat_m != anno.m or symbolic_mat_n != anno.n:
                 raise RuntimeError(

--- a/python/taichi/graph/_graph.py
+++ b/python/taichi/graph/_graph.py
@@ -235,15 +235,7 @@ def _make_arg_matrix(kwargs: Dict[str, Any]):
     dtype = kwargs["dtype"]
     if not isinstance(dtype, MatrixType):
         raise TaichiRuntimeError(f"Tag ArgKind.MATRIX must specify matrix type, but got {dtype}.")
-    arg_list = []
-    i = 0
-    for _ in range(dtype.n):
-        arg_sublist = []
-        for _ in range(dtype.m):
-            arg_sublist.append(_ti_core.Arg(ArgKind.MATRIX, f"{name}_mat_arg_{i}", dtype.dtype, 0, []))
-            i += 1
-        arg_list.append(arg_sublist)
-    return arg_list
+    return _ti_core.Arg(ArgKind.MATRIX, f"{name}_mat_arg", dtype.dtype, 0, [dtype.n, dtype.m])
 
 
 def _make_arg_texture(kwargs: Dict[str, Any]):

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -63,10 +63,10 @@ def decl_scalar_arg(dtype, name):
 def get_type_for_kernel_args(dtype, name):
     if isinstance(dtype, MatrixType):
         if dtype.ndim == 1:
-            structtype = StructType(**{f"{name}_{i}": dtype.dtype for i in range(dtype.n)})
+            elements = [(dtype.dtype, f"{name}_{i}") for i in range(dtype.n)]
         else:
-            structtype = StructType(**{f"{name}_{i}_{j}": dtype.dtype for j in range(dtype.m) for i in range(dtype.n)})
-        return structtype.dtype
+            elements = [(dtype.dtype, f"{name}_{i}_{j}") for j in range(dtype.m) for i in range(dtype.n)]
+        return _ti_core.get_type_factory_instance().get_struct_type(elements)
     if isinstance(dtype, StructType):
         elements = []
         for k, element_type in dtype.members.items():

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -62,6 +62,7 @@ def decl_scalar_arg(dtype, name):
 
 def get_type_for_kernel_args(dtype, name):
     if isinstance(dtype, MatrixType):
+        # Compiling the matrix type to a struct type because the support for the matrix type is not ready yet on SPIR-V based backends.
         if dtype.ndim == 1:
             elements = [(dtype.dtype, f"{name}_{i}") for i in range(dtype.n)]
         else:
@@ -76,6 +77,7 @@ def get_type_for_kernel_args(dtype, name):
             else:
                 elements.append([element_type, k])
         return _ti_core.get_type_factory_instance().get_struct_type(elements)
+    # Assuming dtype is a primitive type
     return dtype
 
 

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -66,7 +66,7 @@ def get_type_for_kernel_args(dtype, name):
         if dtype.ndim == 1:
             elements = [(dtype.dtype, f"{name}_{i}") for i in range(dtype.n)]
         else:
-            elements = [(dtype.dtype, f"{name}_{i}_{j}") for j in range(dtype.m) for i in range(dtype.n)]
+            elements = [(dtype.dtype, f"{name}_{i}_{j}") for i in range(dtype.n) for j in range(dtype.m)]
         return _ti_core.get_type_factory_instance().get_struct_type(elements)
     if isinstance(dtype, StructType):
         elements = []

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -781,7 +781,7 @@ class Kernel:
                         raise ValueError(f"Matrix dtype {needed.dtype} is not integer type or real type.")
 
                     if needed.ndim == 2:
-                        v = [cast_func(v[i, j]) for j in range(needed.m) for i in range(needed.n)]
+                        v = [cast_func(v[i, j]) for i in range(needed.n) for j in range(needed.m)]
                     else:
                         v = [cast_func(v[i]) for i in range(needed.n)]
                     v = needed(*v)

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -764,33 +764,28 @@ class Kernel:
 
                 elif isinstance(needed, MatrixType):
                     if needed.dtype in primitive_types.real_types:
-                        for a in range(needed.n):
-                            for b in range(needed.m):
-                                if actual_argument_slot >= max_arg_num:
-                                    exceed_max_arg_num = True
-                                    break
-                                val = v[a, b] if needed.ndim == 2 else v[a]
-                                if not isinstance(val, (int, float, np.integer, np.floating)):
-                                    raise TaichiRuntimeTypeError.get(i, needed.dtype.to_string(), type(val))
-                                launch_ctx.set_arg_float(actual_argument_slot, float(val))
-                                actual_argument_slot += 1
+
+                        def cast_func(x):
+                            if not isinstance(x, (int, float, np.integer, np.floating)):
+                                raise TaichiRuntimeTypeError.get(i, needed.dtype.to_string(), type(x))
+                            return float(x)
+
                     elif needed.dtype in primitive_types.integer_types:
-                        for a in range(needed.n):
-                            for b in range(needed.m):
-                                if actual_argument_slot >= max_arg_num:
-                                    exceed_max_arg_num = True
-                                    break
-                                val = v[a, b] if needed.ndim == 2 else v[a]
-                                if not isinstance(val, (int, np.integer)):
-                                    raise TaichiRuntimeTypeError.get(i, needed.dtype.to_string(), type(val))
-                                if is_signed(needed.dtype):
-                                    launch_ctx.set_arg_int(actual_argument_slot, int(val))
-                                else:
-                                    launch_ctx.set_arg_uint(actual_argument_slot, int(val))
-                                actual_argument_slot += 1
+
+                        def cast_func(x):
+                            if not isinstance(x, (int, np.integer)):
+                                raise TaichiRuntimeTypeError.get(i, needed.dtype.to_string(), type(x))
+                            return int(x)
+
                     else:
                         raise ValueError(f"Matrix dtype {needed.dtype} is not integer type or real type.")
-                    continue
+
+                    if needed.ndim == 2:
+                        v = [cast_func(v[i, j]) for j in range(needed.m) for i in range(needed.n)]
+                    else:
+                        v = [cast_func(v[i]) for i in range(needed.n)]
+                    v = needed(*v)
+                    needed.set_kernel_struct_args(v, launch_ctx, (actual_argument_slot,))
                 elif isinstance(needed, StructType):
                     needed.set_kernel_struct_args(v, launch_ctx, (actual_argument_slot,))
                 else:

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1664,9 +1664,13 @@ Value IRBuilder::make_access_chain(const SType &out_type,
                                    Value base,
                                    const std::vector<int> &indices) {
   Value ret = new_value(out_type, ValueKind::kVariablePtr);
-  ib_.begin(spv::OpAccessChain).add_seq(out_type, ret, base);
+  std::vector<Value> index_values;
   for (auto &ind : indices) {
-    ib_.add(int_immediate_number(t_int32_, ind));
+    index_values.push_back(int_immediate_number(t_int32_, ind));
+  }
+  ib_.begin(spv::OpAccessChain).add_seq(out_type, ret, base);
+  for (auto &ind : index_values) {
+    ib_.add(ind);
   }
   ib_.commit(&func_header_);
   return ret;

--- a/taichi/program/launch_context_builder.cpp
+++ b/taichi/program/launch_context_builder.cpp
@@ -141,6 +141,8 @@ template <typename T>
 void LaunchContextBuilder::set_struct_arg_impl(std::vector<int> arg_indices,
                                                T v) {
   int offset = args_type->get_element_offset(arg_indices);
+  TI_INFO("offset = {}, size = {}, arg_buffer_size = {}", offset, sizeof(T),
+          arg_buffer_size);
   TI_ASSERT(offset + sizeof(T) <= arg_buffer_size);
   *(T *)(ctx_->arg_buffer + offset) = v;
 }

--- a/taichi/program/launch_context_builder.cpp
+++ b/taichi/program/launch_context_builder.cpp
@@ -141,8 +141,6 @@ template <typename T>
 void LaunchContextBuilder::set_struct_arg_impl(std::vector<int> arg_indices,
                                                T v) {
   int offset = args_type->get_element_offset(arg_indices);
-  TI_INFO("offset = {}, size = {}, arg_buffer_size = {}", offset, sizeof(T),
-          arg_buffer_size);
   TI_ASSERT(offset + sizeof(T) <= arg_buffer_size);
   *(T *)(ctx_->arg_buffer + offset) = v;
 }

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -384,7 +384,8 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     auto top_level_ptr = SquashPtrOffset::run(stmt);
     // We don't support storing a pointer for now.
     if (top_level_ptr->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
-        (stmt->is<ArgLoadStmt>() && stmt->as<ArgLoadStmt>()->is_ptr))
+        (stmt->is<ArgLoadStmt>() && (stmt->as<ArgLoadStmt>()->is_ptr ||
+                                     !stmt->as<ArgLoadStmt>()->create_load)))
       return;
     if ((config_.arch == Arch::opengl || config_.arch == Arch::vulkan ||
          config_.arch == Arch::gles || config_.arch == Arch::metal) &&

--- a/tests/cpp/aot/gfx_utils.cpp
+++ b/tests/cpp/aot/gfx_utils.cpp
@@ -172,7 +172,7 @@ void run_kernel_test1(Arch arch, taichi::lang::Device *device) {
   // Hack to set vector/matrix args
   std::vector<int> vec = {1, 2, 3};
   for (int i = 0; i < vec.size(); ++i) {
-    builder.set_arg(/*arg_id=*/i + 2, vec[i]);
+    builder.set_struct_arg(/*arg_indices=*/{2, i}, vec[i]);
   }
   k_run->launch(builder);
   gfx_runtime->synchronize();

--- a/tests/cpp/aot/llvm/kernel_aot_test.cpp
+++ b/tests/cpp/aot/llvm/kernel_aot_test.cpp
@@ -54,7 +54,7 @@ TEST(LlvmAotTest, CpuKernel) {
   builder.set_arg_ndarray(/*arg_id=*/1, arr);
   std::vector<int> vec = {1, 2, 3};
   for (int i = 0; i < vec.size(); ++i) {
-    builder.set_arg(/*arg_id=*/i + 2, vec[i]);
+    builder.set_struct_arg(/*arg_indices=*/{2, i}, vec[i]);
   }
   k_run->launch(builder);
 
@@ -100,7 +100,7 @@ TEST(LlvmAotTest, CudaKernel) {
     builder.set_arg_ndarray(/*arg_id=*/1, arr);
     std::vector<int> vec = {1, 2, 3};
     for (int i = 0; i < vec.size(); ++i) {
-      builder.set_arg(/*arg_id=*/i + 2, vec[i]);
+      builder.set_struct_arg(/*arg_indices=*/{2, i}, vec[i]);
     }
     k_run->launch(builder);
 

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -4,32 +4,6 @@ import taichi as ti
 from tests import test_utils
 
 
-@test_utils.test(exclude=[ti.opengl, ti.gles])
-def test_exceed_max_64():
-    N = 64
-
-    @ti.kernel
-    def foo1(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-    assert foo1(A) == 64
-
-    N = 65
-
-    @ti.kernel
-    def foo2(a: ti.types.vector(N, ti.i32)) -> ti.i32:
-        return a.sum()
-
-    A = ti.Vector([1] * N)
-
-    with pytest.raises(
-        ti.TaichiRuntimeError,
-        match=f"The number of elements in kernel arguments is too big! Do not exceed 64 on {ti._lib.core.arch_name(ti.lang.impl.current_cfg().arch)} backend.",
-    ):
-        foo2(A)
-
-
 @test_utils.test(debug=True)
 def test_kernel_keyword_args():
     @ti.kernel

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -233,3 +233,26 @@ def test_struct_arg():
 
     ret = foo(s1(a=1, b=s0(a=65537, b=123)))
     assert ret == pytest.approx(125)
+
+
+@test_utils.test()
+def test_struct_arg_with_matrix():
+    mat = ti.types.matrix(3, 2, ti.f32)
+    s0 = ti.types.struct(a=mat, b=ti.f32)
+    s1 = ti.types.struct(a=ti.i32, b=s0)
+
+    @ti.kernel
+    def foo(a: s1) -> ti.i32:
+        ret = a.a + a.b.b
+        for i in range(3):
+            for j in range(2):
+                ret += a.b.a[i, j] * (i + 1) * (j + 2)
+        return ret
+
+    arg = s1(a=1, b=s0(a=mat(1, 2, 3, 4, 5, 6), b=123))
+    ret_std = 1 + 123
+    for i in range(3):
+        for j in range(2):
+            ret_std += (i + 1) * (j + 2) * (i * 2 + j + 1)
+    ret = foo(arg)
+    assert ret == ret_std


### PR DESCRIPTION
Issue: fixes #7821 
A matrix is compiled to a struct with `n * m` elements because the support for matrix arguments is not ready on SPIR-V based backends.

Deleted the test testing the error when the arguments exceed 64 because it doesn't have the limit anymore. I will remove the code that raises the error in another PR.

Refactored the argument passing logic of CGraph and C-API as well.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a2ac2c9</samp>

### Summary
🧮🛠️🚀

<!--
1.  🧮 - This emoji represents the mathematical and tensor-related nature of the changes, as they involve adding support for matrix and struct arguments to kernels, which are common types for linear algebra and tensor computations.
2.  🛠️ - This emoji represents the technical and engineering aspect of the changes, as they involve modifying various parts of the codebase, such as the IR, the C++ and C APIs, the SPIR-V and AOT code generation, and the runtime context initialization, to support the new feature.
3.  🚀 - This emoji represents the performance and optimization potential of the changes, as they enable more efficient and flexible ways of passing data to kernels, which can improve the speed and quality of the computation.
-->
This pull request adds support for matrix and struct arguments in the C++ and C APIs, the AOT graph mode, and the SPIR-V based backends. It does this by introducing new types and functions to represent and handle tensor arguments, modifying the kernel argument processing and launching logic in Python and C++, and updating the code generation and offloading logic for SPIR-V. It also simplifies and fixes some issues with the initialization of the runtime context and the access chain creation for SPIR-V.

> _To pass tensors and matrices to kernels_
> _We need to flatten them to structs or scalars_
> _We use `set_kernel_struct_args` and `get_type_for_kernel_args`_
> _To handle the different cases and casts_
> _And update the codegen for SPIR-V and others_

### Walkthrough
*  Add support for tensor arguments in the C API ([link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-15e4c7e6e43328c5d3d5d3bf87f54fac89fb09ba2158bc9cd34a398f06551cf7R846), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-15e4c7e6e43328c5d3d5d3bf87f54fac89fb09ba2158bc9cd34a398f06551cf7L887-R898), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-4f81eb42782d0a66ae9c536581b6f052c7108a2ddf16579860f8288a5bbbd503R466-R467), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-4f81eb42782d0a66ae9c536581b6f052c7108a2ddf16579860f8288a5bbbd503R807-R812), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-4f81eb42782d0a66ae9c536581b6f052c7108a2ddf16579860f8288a5bbbd503R829-R830), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbR795-R815))
*  Simplify the representation of matrix arguments in the graph data structure and the Python API ([link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-6ce6635d9d3b5a4add63601f3bcbc5fb59d702b4b3b1a6685c22888257e99e3aL100-R102), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL238-R238), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL10-R14), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L767-R788), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L620-R669))
*  Support the compilation of matrix and struct types to struct types in the SPIR-V based backends ([link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL62-R94), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9R1458-R1475), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-39cf507495ad085f8581e2bcd77f65188014888dde181c451ac0962166be548dL92-R127), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L581-R587), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2252-R2255), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2262-R2274), [link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2355-R2356))
*  Avoid allocating a buffer for an argument that is not loaded in the offload pass ([link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L387-R388))
*  Avoid repeating the logic for getting the buffer value for the args struct in the `graph_data.cpp` file ([link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-39cf507495ad085f8581e2bcd77f65188014888dde181c451ac0962166be548dR47-R81))
*  Avoid potential issues with the lifetime of the `Value` objects in the `spirv_ir_builder.cpp` file ([link](https://github.com/taichi-dev/taichi/pull/7873/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15L1667-R1674))


