### PR TITLE
[Bug] Fix wrong datatype size when writing to ndarray from Python scope

### DIFF
--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -59,8 +59,7 @@ class TI_DLL_EXPORT Ndarray {
   std::size_t get_element_size() const;
   std::size_t get_nelement() const;
   TypedConstant read(const std::vector<int> &I) const;
-  template <typename T>
-  void write(const std::vector<int> &I, T val) const;
+  void write(const std::vector<int> &I, TypedConstant val) const;
   int64 read_int(const std::vector<int> &i);
   uint64 read_uint(const std::vector<int> &i);
   float64 read_float(const std::vector<int> &i);

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -836,3 +836,15 @@ def test_0dim_ndarray_read_write_taichi_scope():
     y = ti.ndarray(dtype=ti.math.vec2, shape=())
     write(y)
     assert y[None] == [2.0, 2.0]
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray, require=ti.extension.data64)
+def test_read_write_f64_python_scope():
+    x = ti.ndarray(dtype=ti.f64, shape=2)
+
+    x[0] = 1.0
+    assert x[0] == 1.0
+
+    y = ti.ndarray(dtype=ti.math.vec2, shape=2)
+    y[0] = [1.0, 2.0]
+    assert y[0] == [1.0, 2.0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7878
* __->__ #7884

We might be able cleanup the interfaces that `Ndarray` class provides
but will leave that for a separate PR.