### PR TITLE
[autodiff] Enfore strict check for ndarrays when used in ti.ad.Tape

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -205,10 +205,22 @@ class Tape:
 
             clear_loss(self.loss)
         elif isinstance(self.loss, Ndarray):
+            if self.loss._get_nelement() != 1:
+                raise RuntimeError("The loss of `Tape` must be an ndarray with only one element")
+            if self.loss.grad is None:
+                raise RuntimeError(
+                    "Gradients of loss are not allocated, please set needs_grad=True for all ndarrays that are required by autodiff."
+                )
             self.loss.fill(0.0)
         else:
             import torch  # pylint: disable=C0415
 
+            if self.loss.numel() != 1:
+                raise RuntimeError("The loss of `Tape` must be a tensor only contains one element")
+            if not self.loss.requires_grad:
+                raise RuntimeError(
+                    "Gradients of loss are not allocated, please set requires_grad=True for all tensors that are required by autodiff."
+                )
             with torch.no_grad():
                 self.loss.fill_(0.0)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #7889
* #7888
* #7887
* #7878

Also added a test to show that how ndarray ad can work with PyTorch.