### PR TITLE
[Lang] Let kernel argument support matrix nested in a struct

### DIFF
--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1664,9 +1664,13 @@ Value IRBuilder::make_access_chain(const SType &out_type,
                                    Value base,
                                    const std::vector<int> &indices) {
   Value ret = new_value(out_type, ValueKind::kVariablePtr);
-  ib_.begin(spv::OpAccessChain).add_seq(out_type, ret, base);
+  std::vector<Value> index_values;
   for (auto &ind : indices) {
-    ib_.add(int_immediate_number(t_int32_, ind));
+    index_values.push_back(int_immediate_number(t_int32_, ind));
+  }
+  ib_.begin(spv::OpAccessChain).add_seq(out_type, ret, base);
+  for (auto &ind : index_values) {
+    ib_.add(ind);
   }
   ib_.commit(&func_header_);
   return ret;

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -384,7 +384,8 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     auto top_level_ptr = SquashPtrOffset::run(stmt);
     // We don't support storing a pointer for now.
     if (top_level_ptr->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
-        (stmt->is<ArgLoadStmt>() && stmt->as<ArgLoadStmt>()->is_ptr))
+        (stmt->is<ArgLoadStmt>() && (stmt->as<ArgLoadStmt>()->is_ptr ||
+                                     !stmt->as<ArgLoadStmt>()->create_load)))
       return;
     if ((config_.arch == Arch::opengl || config_.arch == Arch::vulkan ||
          config_.arch == Arch::gles || config_.arch == Arch::metal) &&

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -233,3 +233,28 @@ def test_struct_arg():
 
     ret = foo(s1(a=1, b=s0(a=65537, b=123)))
     assert ret == pytest.approx(125)
+
+
+@test_utils.test()
+def test_struct_arg_with_matrix():
+    mat = ti.types.matrix(3, 2, ti.f32)
+    s0 = ti.types.struct(a=mat, b=ti.f32)
+    s1 = ti.types.struct(a=ti.i32, b=s0)
+
+    @ti.kernel
+    def foo(a: s1) -> ti.i32:
+        ret = a.a + a.b.b
+        for i in range(3):
+            for j in range(2):
+                ret += a.b.a[i, j] * (i + 1) * (j + 2)
+        return ret
+
+    arg = s1(a=1, b=s0(a=mat(1, 2, 3, 4, 5, 6), b=123))
+    ret_std = 1 + 123
+
+    for i in range(3):
+        for j in range(2):
+            ret_std += (i + 1) * (j + 2) * (i * 2 + j + 1)
+
+    ret = foo(arg)
+    assert ret == ret_std


### PR DESCRIPTION
Splitted the original PR https://github.com/taichi-dev/taichi/pull/7873 into two PRs.

This PR only compiles the matrix to a struct if it is inside a struct argument, and defines n*m scalar arguments if it is the top-level argument. This PR does not need to change C-API and CGraph because they don't support struct arguments yet.

The next PR compiles a matrix argument to a struct when a matrix is the top-level argument, and it needs to change the argument-passing logic of C-API and CGraph. 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ff7681b</samp>

### Summary
🧮🛠️📦

<!--
1.  🧮 - This emoji represents the matrix type and the new method to set it as a kernel argument.
2.  🛠️ - This emoji represents the improvement of the code performance and readability by using a vector of values for the access chain.
3.  📦 - This emoji represents the support for struct types and the new function to compile them to flattened struct types.
-->
This pull request adds support for matrix and struct types as kernel arguments for SPIR-V based backends. It implements a new function `get_type_for_kernel_args` to compile these types to flattened struct types, and modifies the SPIR-V codegen and the `MatrixType` class to handle them. It also improves the performance and memory efficiency of the SPIR-V codegen and the offload pass.

> _Sing, O Muse, of the valiant code warriors who strove_
> _To enhance the SPIR-V codegen with matrix and struct lore_
> _They crafted new methods and functions with skill and care_
> _`set_kernel_struct_args`, `make_access_chain`, and `get_type_for_kernel_args` among their share_

### Walkthrough
*  Add support for matrix and struct types in kernel arguments for SPIR-V based backends
  * Import `CompoundType` class to represent matrix and struct types in Taichi ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeR14))
  * Add `get_type_for_kernel_args` function to convert Taichi types to kernel argument types ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeR63-R83))
  * Use `get_type_for_kernel_args` function to get the correct type for struct arguments in `decl_struct_arg` function ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL74-R98))
  * Add `set_kernel_struct_args` method to `MatrixType` class to set matrix values as struct arguments ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9R1458-R1475))
  * Modify `visit` method of `TaskCodegen` class to use `args_struct_types_` vector to get the correct type for argument load statements ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L581-R587))
  * Update `element_types` vector with new SPIR-V types generated from Taichi types in `compile_module_to_executable` function ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2252-R2255))
  * Initialize `args_struct_types_` vector with SPIR-V types and Taichi types for kernel arguments in `compile_module_to_executable` function ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2262-R2274))
  * Add `args_struct_types_` member variable to `TaskCodegen` class to store SPIR-V types and Taichi types for kernel arguments ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2355-R2356))
  * Use vector of `Value` objects to store index values for access chain ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15L1667-R1674))
  * Skip allocation of local storage for argument load statements that do not create a load in `test_and_allocate` method ([link](https://github.com/taichi-dev/taichi/pull/7891/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L387-R388))



Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #7892
* __->__ #7891

