### PR TITLE
[autodiff] Fix missing grad with using torch tensor with tape

### DIFF
--- a/python/taichi/ad/_ad.py
+++ b/python/taichi/ad/_ad.py
@@ -261,8 +261,11 @@ class Tape:
                 else:
                     import torch  # pylint: disable=C0415
 
-                    with torch.no_grad():
-                        self.loss.grad.fill_(1.0)
+                    if self.loss.grad is None:
+                        self.loss.grad = torch.ones_like(self.loss)
+                    else:
+                        with torch.no_grad():
+                            self.loss.grad.fill_(1.0)
                 func.grad(*args)
 
         self.gradient_evaluated = True


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23ddc9f</samp>

Fix a bug in `taichi.ad._ad.py` that causes an AttributeError when the loss tensor has no gradient. Enhance the autodiff compatibility with PyTorch.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23ddc9f</samp>

* Add a check for the loss tensor having no gradient attribute and assign a tensor of ones as the initial gradient ([link](https://github.com/taichi-dev/taichi/pull/7898/files?diff=unified&w=0#diff-b986921c47e4b8c903d6bfc906398260dfeb17e16f05e5cd5b52e401eddc0bd0L264-R268)). This avoids an AttributeError when calling `self.loss.grad.fill_(1.0)` and improves the compatibility of Taichi's autodiff system with PyTorch.
