### PR TITLE
[Lang] Add cast to field.fill() interface

### DIFF
--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -20,9 +20,9 @@ from taichi.math import vec3
 # A set of helper (meta)functions
 @kernel
 def fill_field(field: template(), val: template()):
-    tmp = ops.cast(val, field.dtype)
+    value = ops.cast(val, field.dtype)
     for I in grouped(field):
-        field[I] = tmp
+        field[I] = value
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -19,9 +19,10 @@ from taichi.math import vec3
 
 # A set of helper (meta)functions
 @kernel
-def fill_tensor(tensor: template(), val: template()):
-    for I in grouped(tensor):
-        tensor[I] = val
+def fill_field(field: template(), val: template()):
+    tmp = ops.cast(val, field.dtype)
+    for I in grouped(field):
+        field[I] = tmp
 
 
 @kernel

--- a/python/taichi/lang/field.py
+++ b/python/taichi/lang/field.py
@@ -282,9 +282,9 @@ class ScalarField(Field):
     def fill(self, val):
         """Fills this scalar field with a specified value."""
         if in_python_scope():
-            from taichi._kernels import fill_tensor  # pylint: disable=C0415
+            from taichi._kernels import fill_field  # pylint: disable=C0415
 
-            fill_tensor(self, val)
+            fill_field(self, val)
         else:
             from taichi._funcs import field_fill_taichi_scope  # pylint: disable=C0415
 


### PR DESCRIPTION
Issue: #https://github.com/taichi-dev/taichi/issues/7678

There's one potential hazard: if the user mistakenly filled a ti.field with out-of-scope values (like filling a ti.field(ti.u8) with > 255), it's just gonna overflow silently.