### PR TITLE
[Lang] Move irpass::scalarize() after irpass::auto_diff()

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -730,14 +730,12 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
           /*
             [Static index]
             Fwd:
-            $0 = adstack alloca <4 x i32>
-            $1 = adstack load top
+            $1 = alloca <4 x i32>
             $2 = matrix ptr $1, 2 // offset = 2
             $3 : local store $2, $val
 
             Replaced:
-            $0 = adstack alloca <4 x i32>
-            $1 = adstack load top
+            $1 =  alloca <4 x i32>
             $2 = matrix ptr $1, 2 // --> erase
 
             $3 = matrix ptr $1, 0
@@ -751,7 +749,7 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
 
             $9 = matrix init [$4, $6, $val, $8]
 
-            $10 : adstack push $9
+            $10 : store $1, $9
           */
           int offset =
               matrix_ptr_stmt->offset->as<ConstStmt>()->val.val_int32();
@@ -794,15 +792,13 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
           /*
             [Dynamic index]
             Fwd:
-            $0 = adstack alloca <4 x i32>
-            $1 = adstack load top
+            $1 = alloca <4 x i32>
             $2 = matrix ptr $1, $offset // offset = 2
             $3 : local store $2, $val
 
             Replaced:
-            $0 = adstack alloca <4 x i32>
+            $1 = alloca <4 x i32>
 
-            $1 = adstack load top (return_ptr=false)
             $2 = matrix init [$val, $val, $val, $val]
 
             $3 = matrix init [$offset, $offset, $offset, $offset]
@@ -811,7 +807,7 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
             $5 = bin_eq $3, $4
             $6 = select $5, $2, $1
 
-            $7 : adstack push $6
+            $7 : store $1, $6
           */
           auto tensor_type =
               stack_top_stmt->ret_type.ptr_removed()->as<TensorType>();

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -10,24 +10,6 @@
 
 namespace taichi::lang {
 
-namespace {
-
-std::function<void(const std::string &)>
-make_pass_printer(bool verbose, const std::string &kernel_name, IRNode *ir) {
-  if (!verbose) {
-    return [](const std::string &) {};
-  }
-  return [ir, kernel_name](const std::string &pass) {
-    TI_INFO("[{}] {}:", kernel_name, pass);
-    std::cout << std::flush;
-    irpass::re_id(ir);
-    irpass::print(ir);
-    std::cout << std::flush;
-  };
-}
-
-}  // namespace
-
 template <typename T>
 Stmt *insert_const(const DataType &dtype,
                    Stmt *stmt,
@@ -2198,8 +2180,6 @@ void auto_diff(IRNode *root,
                const CompileConfig &config,
                AutodiffMode autodiff_mode,
                bool use_stack) {
-  auto print = make_pass_printer(true, "asdasdasd", root);
-
   TI_AUTO_PROF;
   if (autodiff_mode == AutodiffMode::kReverse) {
     if (use_stack) {
@@ -2212,11 +2192,7 @@ void auto_diff(IRNode *root,
         ib->accept(&replace);
         type_check(root, config);
 
-        print("After ReplaceLocalVarWithStacks");
-
         MakeAdjoint::run(ib);
-        print("After MakeAdjoint");
-
         type_check(root, config);
         BackupSSA::run(ib);
         irpass::analysis::verify(root);

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -525,6 +525,10 @@ class RegulateTensorTypedStatements : public BasicStmtVisitor {
       auto matrix_ptr_stmt = stmt->dest->template as<MatrixPtrStmt>();
       auto orig_stmt = matrix_ptr_stmt->origin;
 
+      if (!orig_stmt->ret_type.ptr_removed()->template is<TensorType>()) {
+        return;
+      }
+
       auto tensor_type =
           orig_stmt->ret_type.ptr_removed()->template as<TensorType>();
       auto num_elements = tensor_type->get_num_elements();
@@ -721,6 +725,10 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
       if (matrix_ptr_stmt->origin->is<AdStackLoadTopStmt>()) {
         auto stack_top_stmt = matrix_ptr_stmt->origin->as<AdStackLoadTopStmt>();
         TI_ASSERT(stack_top_stmt->return_ptr == true);
+
+        if (!stack_top_stmt->ret_type.ptr_removed()->is<TensorType>()) {
+          return;
+        }
 
         auto tensor_type =
             stack_top_stmt->ret_type.ptr_removed()->as<TensorType>();

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -10,6 +10,24 @@
 
 namespace taichi::lang {
 
+namespace {
+
+std::function<void(const std::string &)>
+make_pass_printer(bool verbose, const std::string &kernel_name, IRNode *ir) {
+  if (!verbose) {
+    return [](const std::string &) {};
+  }
+  return [ir, kernel_name](const std::string &pass) {
+    TI_INFO("[{}] {}:", kernel_name, pass);
+    std::cout << std::flush;
+    irpass::re_id(ir);
+    irpass::print(ir);
+    std::cout << std::flush;
+  };
+}
+
+}  // namespace
+
 template <typename T>
 Stmt *insert_const(const DataType &dtype,
                    Stmt *stmt,
@@ -547,150 +565,185 @@ class ReplaceLocalVarWithStacks : public BasicStmtVisitor {
   void visit(LocalStoreStmt *stmt) override {
     if (stmt->dest->is<MatrixPtrStmt>()) {
       auto matrix_ptr_stmt = stmt->dest->as<MatrixPtrStmt>();
-      if (matrix_ptr_stmt->origin->is<AdStackLoadTopStmt>()) {
-        auto stack_top = matrix_ptr_stmt->origin->as<AdStackLoadTopStmt>();
-        TI_ASSERT(stack_top->return_ptr == true);
+      TI_ASSERT(matrix_ptr_stmt->origin->is<AdStackLoadTopStmt>() ||
+                matrix_ptr_stmt->origin->is<AllocaStmt>());
+      bool is_adstack_load_top =
+          matrix_ptr_stmt->origin->is<AdStackLoadTopStmt>();
+      auto orig_stmt = matrix_ptr_stmt->origin;
 
-        auto tensor_type = stack_top->ret_type.ptr_removed()->as<TensorType>();
-        auto num_elements = tensor_type->get_num_elements();
+      auto tensor_type = orig_stmt->ret_type.ptr_removed()->as<TensorType>();
+      auto num_elements = tensor_type->get_num_elements();
 
-        if (matrix_ptr_stmt->offset->is<ConstStmt>()) {
-          /*
-            [Static index]
-            Fwd:
-            $0 = adstack alloca <4 x i32>
-            $1 = adstack load top
-            $2 = matrix ptr $1, 2 // offset = 2
-            $3 : local store $2, $val
+      if (matrix_ptr_stmt->offset->is<ConstStmt>()) {
+        /*
+          [Static index]
+          Fwd:
+          $0 = adstack alloca <4 x i32>
+          $1 = adstack load top
+          $2 = matrix ptr $1, 2 // offset = 2
+          $3 : local store $2, $val
 
-            Replaced:
-            $0 = adstack alloca <4 x i32>
-            $1 = adstack load top
-            $2 = matrix ptr $1, 2 // --> erase
+          Replaced:
+          $0 = adstack alloca <4 x i32>
+          $1 = adstack load top
+          $2 = matrix ptr $1, 2 // --> erase
 
-            $3 = matrix ptr $1, 0
-            $4 = load $3
+          $3 = matrix ptr $1, 0
+          $4 = load $3
 
-            $5 = matrix ptr $1, 1
-            $6 = load $5
+          $5 = matrix ptr $1, 1
+          $6 = load $5
 
-            $7 = matrix ptr $1, 3
-            $8 = load $7
+          $7 = matrix ptr $1, 3
+          $8 = load $7
 
-            $9 = matrix init [$4, $6, $val, $8]
+          $9 = matrix init [$4, $6, $val, $8]
 
-            $10 : adstack push $9
-          */
-          int offset =
-              matrix_ptr_stmt->offset->as<ConstStmt>()->val.val_int32();
+          $10 : adstack push $9
+        */
+        int offset = matrix_ptr_stmt->offset->as<ConstStmt>()->val.val_int32();
 
-          TI_ASSERT(offset < num_elements);
+        TI_ASSERT(offset < num_elements);
 
-          std::vector<Stmt *> values;
-          for (int i = 0; i < num_elements; i++) {
-            if (i == offset) {
-              values.push_back(stmt->val);
-              continue;
-            }
-
-            auto const_i = insert_const(PrimitiveType::i32, stmt, i, true);
-            auto matrix_ptr_stmt_i =
-                Stmt::make<MatrixPtrStmt>(stack_top, const_i);
-            matrix_ptr_stmt_i->ret_type = tensor_type->get_element_type();
-
-            auto local_load_stmt_i =
-                Stmt::make<LocalLoadStmt>(matrix_ptr_stmt_i.get());
-            local_load_stmt_i->ret_type = tensor_type->get_element_type();
-
-            values.push_back(local_load_stmt_i.get());
-
-            stmt->insert_before_me(std::move(matrix_ptr_stmt_i));
-            stmt->insert_before_me(std::move(local_load_stmt_i));
+        std::vector<Stmt *> values;
+        for (int i = 0; i < num_elements; i++) {
+          if (i == offset) {
+            values.push_back(stmt->val);
+            continue;
           }
 
-          auto matrix_init_stmt = Stmt::make<MatrixInitStmt>(values);
-          matrix_init_stmt->ret_type = tensor_type;
+          auto const_i = insert_const(PrimitiveType::i32, stmt, i, true);
+          auto matrix_ptr_stmt_i =
+              Stmt::make<MatrixPtrStmt>(orig_stmt, const_i);
+          matrix_ptr_stmt_i->ret_type = tensor_type->get_element_type();
 
-          auto stack_push = Stmt::make<AdStackPushStmt>(stack_top->stack,
+          auto local_load_stmt_i =
+              Stmt::make<LocalLoadStmt>(matrix_ptr_stmt_i.get());
+          local_load_stmt_i->ret_type = tensor_type->get_element_type();
+
+          values.push_back(local_load_stmt_i.get());
+
+          stmt->insert_before_me(std::move(matrix_ptr_stmt_i));
+          stmt->insert_before_me(std::move(local_load_stmt_i));
+        }
+
+        auto matrix_init_stmt = Stmt::make<MatrixInitStmt>(values);
+        matrix_init_stmt->ret_type = tensor_type;
+
+        if (is_adstack_load_top) {
+          auto stack_top_stmt =
+              matrix_ptr_stmt->origin->as<AdStackLoadTopStmt>();
+          TI_ASSERT(stack_top_stmt->return_ptr == true);
+
+          auto stack_push = Stmt::make<AdStackPushStmt>(stack_top_stmt->stack,
                                                         matrix_init_stmt.get());
-
           stmt->insert_before_me(std::move(matrix_init_stmt));
           stmt->replace_with(std::move(stack_push));
-          return;
-
         } else {
-          /*
-            [Dynamic index]
-            Fwd:
-            $0 = adstack alloca <4 x i32>
-            $1 = adstack load top
-            $2 = matrix ptr $1, $offset // offset = 2
-            $3 : local store $2, $val
+          auto store_stmt =
+              Stmt::make<LocalStoreStmt>(orig_stmt, matrix_init_stmt.get());
+          stmt->insert_before_me(std::move(matrix_init_stmt));
+          stmt->replace_with(std::move(store_stmt));
+        }
 
-            Replaced:
-            $0 = adstack alloca <4 x i32>
+        return;
 
-            $1 = adstack load top (return_ptr=false)
-            $2 = matrix init [$val, $val, $val, $val]
+      } else {
+        /*
+          [Dynamic index]
+          Fwd:
+          $0 = adstack alloca <4 x i32>
+          $1 = adstack load top
+          $2 = matrix ptr $1, $offset // offset = 2
+          $3 : local store $2, $val
 
-            $3 = matrix init [$offset, $offset, $offset, $offset]
-            $4 = matrix init [0, 1, 2, 3]
+          Replaced:
+          $0 = adstack alloca <4 x i32>
 
-            $5 = bin_eq $3, $4
-            $6 = select $5, $2, $1
+          $1 = adstack load top (return_ptr=false)
+          $2 = matrix init [$val, $val, $val, $val]
 
-            $7 : adstack push $6
-          */
-          auto tensor_type =
-              stack_top->ret_type.ptr_removed()->as<TensorType>();
-          auto num_elements = tensor_type->get_num_elements();
+          $3 = matrix init [$offset, $offset, $offset, $offset]
+          $4 = matrix init [0, 1, 2, 3]
 
-          auto tensor_shape = tensor_type->get_shape();
-          auto index_tensor_type = TypeFactory::get_instance().get_tensor_type(
-              tensor_shape, PrimitiveType::i32);
+          $5 = bin_eq $3, $4
+          $6 = select $5, $2, $1
 
-          std::vector<Stmt *> val_values(num_elements, stmt->val);
-          std::vector<Stmt *> offset_values(num_elements,
-                                            matrix_ptr_stmt->offset);
-          std::vector<Stmt *> index_values(num_elements);
-          for (int i = 0; i < num_elements; i++) {
-            index_values[i] = insert_const(PrimitiveType::i32, stmt, i, true);
-          }
+          $7 : adstack push $6
+        */
+        auto tensor_type = orig_stmt->ret_type.ptr_removed()->as<TensorType>();
+        auto num_elements = tensor_type->get_num_elements();
+
+        auto tensor_shape = tensor_type->get_shape();
+        auto index_tensor_type = TypeFactory::get_instance().get_tensor_type(
+            tensor_shape, PrimitiveType::i32);
+
+        std::vector<Stmt *> val_values(num_elements, stmt->val);
+        std::vector<Stmt *> offset_values(num_elements,
+                                          matrix_ptr_stmt->offset);
+        std::vector<Stmt *> index_values(num_elements);
+        for (int i = 0; i < num_elements; i++) {
+          index_values[i] = insert_const(PrimitiveType::i32, stmt, i, true);
+        }
+
+        auto matrix_val = Stmt::make<MatrixInitStmt>(val_values);
+        matrix_val->ret_type = tensor_type;
+
+        auto matrix_offset = Stmt::make<MatrixInitStmt>(offset_values);
+        matrix_offset->ret_type = index_tensor_type;
+
+        auto matrix_index = Stmt::make<MatrixInitStmt>(index_values);
+        matrix_index->ret_type = index_tensor_type;
+
+        auto matrix_eq = Stmt::make<BinaryOpStmt>(
+            BinaryOpType::cmp_eq, matrix_offset.get(), matrix_index.get());
+        matrix_eq->ret_type = index_tensor_type;
+
+        if (is_adstack_load_top) {
+          auto stack_top_stmt =
+              matrix_ptr_stmt->origin->as<AdStackLoadTopStmt>();
+          TI_ASSERT(stack_top_stmt->return_ptr == true);
 
           auto matrix_alloca_value =
-              Stmt::make<AdStackLoadTopStmt>(stack_top->stack);
+              Stmt::make<AdStackLoadTopStmt>(stack_top_stmt->stack);
           matrix_alloca_value->ret_type = tensor_type;
-
-          auto matrix_val = Stmt::make<MatrixInitStmt>(val_values);
-          matrix_val->ret_type = tensor_type;
-
-          auto matrix_offset = Stmt::make<MatrixInitStmt>(offset_values);
-          matrix_offset->ret_type = index_tensor_type;
-
-          auto matrix_index = Stmt::make<MatrixInitStmt>(index_values);
-          matrix_index->ret_type = index_tensor_type;
-
-          auto matrix_eq = Stmt::make<BinaryOpStmt>(
-              BinaryOpType::cmp_eq, matrix_offset.get(), matrix_index.get());
-          matrix_eq->ret_type = index_tensor_type;
 
           auto matrix_select = Stmt::make<TernaryOpStmt>(
               TernaryOpType::select, matrix_eq.get(), matrix_val.get(),
               matrix_alloca_value.get());
           matrix_select->ret_type = tensor_type;
 
-          auto stack_push = Stmt::make<AdStackPushStmt>(stack_top->stack,
+          auto stack_push = Stmt::make<AdStackPushStmt>(stack_top_stmt->stack,
                                                         matrix_select.get());
 
-          stmt->insert_before_me(std::move(matrix_alloca_value));
           stmt->insert_before_me(std::move(matrix_val));
           stmt->insert_before_me(std::move(matrix_offset));
           stmt->insert_before_me(std::move(matrix_index));
           stmt->insert_before_me(std::move(matrix_eq));
+          stmt->insert_before_me(std::move(matrix_alloca_value));
           stmt->insert_before_me(std::move(matrix_select));
           stmt->replace_with(std::move(stack_push));
-          return;
+        } else {
+          auto orig_value = Stmt::make<LocalLoadStmt>(orig_stmt);
+          orig_value->ret_type = tensor_type;
+
+          auto matrix_select =
+              Stmt::make<TernaryOpStmt>(TernaryOpType::select, matrix_eq.get(),
+                                        matrix_val.get(), orig_value.get());
+          matrix_select->ret_type = tensor_type;
+
+          auto store_stmt =
+              Stmt::make<LocalStoreStmt>(orig_stmt, matrix_select.get());
+
+          stmt->insert_before_me(std::move(matrix_val));
+          stmt->insert_before_me(std::move(matrix_offset));
+          stmt->insert_before_me(std::move(matrix_index));
+          stmt->insert_before_me(std::move(matrix_eq));
+          stmt->insert_before_me(std::move(orig_value));
+          stmt->insert_before_me(std::move(matrix_select));
+          stmt->replace_with(std::move(store_stmt));
         }
+        return;
       }
     }
 
@@ -2145,6 +2198,8 @@ void auto_diff(IRNode *root,
                const CompileConfig &config,
                AutodiffMode autodiff_mode,
                bool use_stack) {
+  auto print = make_pass_printer(true, "asdasdasd", root);
+
   TI_AUTO_PROF;
   if (autodiff_mode == AutodiffMode::kReverse) {
     if (use_stack) {
@@ -2157,7 +2212,10 @@ void auto_diff(IRNode *root,
         ib->accept(&replace);
         type_check(root, config);
 
+        print("After ReplaceLocalVarWithStacks");
+
         MakeAdjoint::run(ib);
+        print("After MakeAdjoint");
 
         type_check(root, config);
         BackupSSA::run(ib);

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -104,14 +104,6 @@ void compile_to_offloads(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
-  if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::die(ir);
-    print("Scalarized");
-  }
-
   if (autodiff_mode == AutodiffMode::kReverse ||
       autodiff_mode == AutodiffMode::kForward) {
     // Remove local atomics here so that we don't have to handle their gradients

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -1079,8 +1079,9 @@ class MergeExternalAndMatrixPtr : public BasicStmtVisitor {
           std::accumulate(begin(origin->element_shape),
                           end(origin->element_shape), 1, std::multiplies<>())};
 
-      auto fused = std::make_unique<ExternalPtrStmt>(
-          origin->base_ptr, indices, element_shape, element_dim);
+      auto fused = std::make_unique<ExternalPtrStmt>(origin->base_ptr, indices,
+                                                     element_shape, element_dim,
+                                                     origin->is_grad);
       fused->ret_type = stmt->ret_type;
       // Note: Update base_ptr's ret_type so that it matches the ExternalPtrStmt
       // with flattened indices. Main goal is to keep all the hacks in a single


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c693990</samp>

This pull request enhances the automatic differentiation feature of Taichi by refactoring and removing some IR passes. It handles global and matrix operations on external tensors more robustly and efficiently, and preserves the gradient information of external pointers. It affects the files `taichi/transforms/auto_diff.cpp`, `taichi/transforms/compile_to_offloads.cpp`, and `taichi/transforms/scalarize.cpp`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c693990</samp>

*  Refactor and simplify the logic of handling external and matrix pointer statements in the automatic differentiation pass ([link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1314-R1324), [link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1329-R1375), [link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1359-R1393), [link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1370-R1416), [link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1447-R1493))
*  Add conditions and statements to handle the cases where the source or destination of a global store or load statement is a matrix element of a global or external tensor in the automatic differentiation pass ([link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1329-R1375), [link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1370-R1416))
*  Add a type check, a backup SSA, and a verification pass to the automatic differentiation pass to ensure the correctness and consistency of the IR after the transformation ([link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583R2163-R2165))
*  Remove the scalarization pass from the compile to offloads pass as it is no longer needed after the automatic differentiation pass handles the external and matrix pointer statements properly ([link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL107-L114))
*  Add a parameter to the constructor of the external pointer statement to indicate whether it is a gradient or not to preserve the information of the origin external pointer statement when merging it with a matrix pointer statement in the scalarization pass ([link](https://github.com/taichi-dev/taichi/pull/7902/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L1082-R1084))
