### PR TITLE
[cuda] Only set CU_LIMIT_STACK_SIZE when necessary

### DIFF
--- a/taichi/program/compile_config.h
+++ b/taichi/program/compile_config.h
@@ -99,7 +99,7 @@ struct CompileConfig {
   int num_compile_threads{4};
   std::string vk_api_version;
 
-  size_t cuda_stack_limit{8192};
+  size_t cuda_stack_limit{0};
 
   CompileConfig();
 

--- a/taichi/runtime/cuda/kernel_launcher.cpp
+++ b/taichi/runtime/cuda/kernel_launcher.cpp
@@ -134,8 +134,6 @@ void KernelLauncher::launch_llvm_kernel(Handle handle,
         nullptr);
     ctx.get_context().arg_buffer = device_arg_buffer;
   }
-  CUDADriver::get_instance().context_set_limit(
-      CU_LIMIT_STACK_SIZE, executor->get_config().cuda_stack_limit);
 
   for (auto task : offloaded_tasks) {
     TI_TRACE("Launching kernel {}<<<{}, {}>>>", task.name, task.grid_dim,

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -121,6 +121,10 @@ LlvmRuntimeExecutor::LlvmRuntimeExecutor(CompileConfig &config,
       CUDAContext::get_instance().set_profiler(nullptr);
     }
     CUDAContext::get_instance().set_debug(config.debug);
+    if (config.cuda_stack_limit != 0) {
+      CUDADriver::get_instance().context_set_limit(CU_LIMIT_STACK_SIZE,
+                                                   config.cuda_stack_limit);
+    }
     device_ = std::make_shared<cuda::CudaDevice>();
   }
 #endif

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -214,7 +214,7 @@ def test_different_argument_type():
 
 
 @pytest.mark.run_in_serial
-@test_utils.test(arch=[ti.cpu, ti.cuda], cuda_stack_limit=8092)
+@test_utils.test(arch=[ti.cpu, ti.cuda], cuda_stack_limit=8192)
 def test_recursion():
     @ti.experimental.real_func
     def sum(f: ti.template(), l: ti.i32, r: ti.i32) -> ti.i32:

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -214,7 +214,7 @@ def test_different_argument_type():
 
 
 @pytest.mark.run_in_serial
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test(arch=[ti.cpu, ti.cuda], cuda_stack_limit=8092)
 def test_recursion():
     @ti.experimental.real_func
     def sum(f: ti.template(), l: ti.i32, r: ti.i32) -> ti.i32:

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -469,7 +469,7 @@ def test_offline_cache_cleaning(curr_arch, factor, policy):
 @pytest.mark.run_in_serial
 @pytest.mark.parametrize("curr_arch", {ti.cpu, ti.cuda} & supported_archs_offline_cache)
 @_test_offline_cache_dec
-@test_utils.test(cuda_stack_limit=8092)
+@test_utils.test(cuda_stack_limit=8192)
 def test_offline_cache_for_kernels_calling_real_func(curr_arch):
     count_of_cache_file = cache_files_cnt()
 

--- a/tests/python/test_offline_cache.py
+++ b/tests/python/test_offline_cache.py
@@ -469,6 +469,7 @@ def test_offline_cache_cleaning(curr_arch, factor, policy):
 @pytest.mark.run_in_serial
 @pytest.mark.parametrize("curr_arch", {ti.cpu, ti.cuda} & supported_archs_offline_cache)
 @_test_offline_cache_dec
+@test_utils.test(cuda_stack_limit=8092)
 def test_offline_cache_for_kernels_calling_real_func(curr_arch):
     count_of_cache_file = cache_files_cnt()
 


### PR DESCRIPTION
If we set it to 8192 unconditionally it'll increase CUDA memory usage by ~800MB on my 3090. It's not necessary when deep recursively real function call isn't involved so let's default to not set it.

Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 378709f</samp>

Removed redundant and potentially harmful stack size limit settings for CUDA kernels using the LLVM backend. Added a single stack size limit setting based on user preference or default value in the `ti.init` function. These changes aim to improve the performance and compatibility of Taichi on CUDA devices.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 378709f</samp>

*  Remove redundant and potentially harmful stack size limit settings for every kernel launch on CUDA devices using the LLVM backend ([link](https://github.com/taichi-dev/taichi/pull/7906/files?diff=unified&w=0#diff-d8cf951dea16cc738fc36faee3a158f37a605abccd312c4a6f18d73fd2504332L137-L138))
*  Set the stack size limit only once per device, and only if the user specifies a non-zero value in the `ti.init` function, in the function that defines the Taichi runtime functions on CUDA devices using the LLVM backend ([link](https://github.com/taichi-dev/taichi/pull/7906/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5R124-R127))
*  Change the default value of `cuda_stack_limit` in the `CompileConfig` struct from 8192 to 0, to avoid unnecessary stack size limit settings unless the user explicitly requests them ([link](https://github.com/taichi-dev/taichi/pull/7906/files?diff=unified&w=0#diff-604e33db5b7c4f4b819098dee1f2634a36c0974822c1538aec0d57d28ca00dd9L102-R102))
