### PR TITLE
[Lang] Cherry-pick struct-related PRs to rc-v1.6.0

### DIFF
--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -630,6 +630,7 @@ class StructType(CompoundType):
                 d[name] = dtype.from_taichi_object(func_ret, ret_index + (index,))
             else:
                 d[name] = expr.Expr(_ti_core.make_get_element_expr(func_ret.ptr, ret_index + (index,)))
+        d["__struct_methods"] = self.methods
 
         return Struct(d)
 
@@ -650,6 +651,7 @@ class StructType(CompoundType):
                     d[name] = launch_ctx.get_struct_ret_float(ret_index + (index,))
                 else:
                     raise TaichiRuntimeTypeError(f"Invalid return type on index={ret_index + (index, )}")
+        d["__struct_methods"] = self.methods
 
         return Struct(d)
 

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -60,16 +60,7 @@ KernelContextAttributes::KernelContextAttributes(
   for (const auto &ka : kernel.parameter_list) {
     ArgAttributes aa;
     aa.name = ka.name;
-    aa.dtype = ka.get_element_type()->as<PrimitiveType>()->type;
-    const size_t dt_bytes = ka.get_element_size();
     aa.is_array = ka.is_array;
-    if (aa.is_array) {
-      aa.field_dim = ka.total_dim - ka.get_element_shape().size();
-      aa.element_shape = ka.get_element_shape();
-    }
-    aa.stride = dt_bytes;
-    aa.index = arg_attribs_vec_.size();
-    aa.format = ka.format;
     arg_attribs_vec_.push_back(aa);
   }
   for (const auto &kr : kernel.rets) {
@@ -99,8 +90,8 @@ KernelContextAttributes::KernelContextAttributes(
     for (int i = 0; i < vec->size(); ++i) {
       auto &attribs = (*vec)[i];
       const size_t dt_bytes =
-          (attribs.is_array && !is_ret && has_buffer_ptr)
-              ? sizeof(uint64_t)
+          (attribs.is_array && !is_ret)
+              ? (has_buffer_ptr ? sizeof(uint64_t) : sizeof(uint32_t))
               : data_type_size(PrimitiveType::get(attribs.dtype));
       // Align bytes to the nearest multiple of dt_bytes
       bytes = (bytes + dt_bytes - 1) / dt_bytes * dt_bytes;
@@ -117,21 +108,10 @@ KernelContextAttributes::KernelContextAttributes(
   args_type_ = kernel.args_type;
   rets_type_ = kernel.ret_type;
 
-  TI_TRACE("args:");
-  args_bytes_ = arange_args(
-      &arg_attribs_vec_, 0, false,
-      caps->get(DeviceCapability::spirv_has_physical_storage_buffer));
-  // Align to extra args
-  args_bytes_ = (args_bytes_ + 4 - 1) / 4 * 4;
+  args_bytes_ = kernel.args_size;
 
   TI_TRACE("rets:");
   rets_bytes_ = arange_args(&ret_attribs_vec_, 0, true, false);
-
-  TI_ASSERT(arg_attribs_vec_.size() == kernel.args_type->elements().size());
-  for (int i = 0; i < arg_attribs_vec_.size(); ++i) {
-    TI_ASSERT(arg_attribs_vec_[i].offset_in_mem ==
-              kernel.args_type->get_element_offset({i}));
-  }
 
   TI_ASSERT(ret_attribs_vec_.size() == kernel.ret_type->elements().size());
   for (int i = 0; i < ret_attribs_vec_.size(); ++i) {
@@ -139,7 +119,6 @@ KernelContextAttributes::KernelContextAttributes(
               kernel.ret_type->get_element_offset({i}));
   }
 
-  TI_ASSERT(args_bytes_ == kernel.args_size);
   TI_ASSERT(rets_bytes_ == kernel.ret_size);
 
   TI_TRACE("sizes: args={} rets={}", args_bytes(), rets_bytes());

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -573,14 +573,13 @@ class TaskCodegen : public IRVisitor {
       //    ir_->int_immediate_number(ir_->i32_type(), offset_in_mem);
       // ir_->register_value(stmt->raw_name(), val);
     } else {
-      bool has_buffer_ptr =
-          caps_->get(DeviceCapability::spirv_has_physical_storage_buffer);
-      const auto val_type = ir_->from_taichi_type(arg_type, has_buffer_ptr);
+      auto buffer_value =
+          get_buffer_value(BufferType::Args, PrimitiveType::i32);
+      const auto val_type = args_struct_types_.at(arg_id);
       spirv::Value buffer_val = ir_->make_value(
           spv::OpAccessChain,
           ir_->get_pointer_type(val_type, spv::StorageClassUniform),
-          get_buffer_value(BufferType::Args, PrimitiveType::i32),
-          ir_->int_immediate_number(ir_->i32_type(), arg_id));
+          buffer_value, ir_->int_immediate_number(ir_->i32_type(), arg_id));
       buffer_val.flag = ValueKind::kVariablePtr;
       if (!stmt->create_load) {
         ir_->register_value(stmt->raw_name(), buffer_val);
@@ -2216,11 +2215,28 @@ class TaskCodegen : public IRVisitor {
     auto reduced_blk = ir_reduce_types(&blk, old2new);
     struct_type = old2new[struct_type];
 
+    for (auto &element : element_types) {
+      element = old2new[element];
+    }
+
     // Layout & translate to SPIR-V
     STD140LayoutContext layout_ctx;
     auto ir2spirv_map =
         ir_translate_to_spirv(reduced_blk.get(), layout_ctx, ir_.get());
     args_struct_type_.id = ir2spirv_map[struct_type];
+
+    // Must use the same type in ArgLoadStmt as in the args struct,
+    // otherwise the validation will fail.
+    args_struct_types_.resize(element_types.size());
+    for (int i = 0; i < element_types.size(); i++) {
+      args_struct_types_[i].id = ir2spirv_map.at(element_types[i]);
+      if (i < ctx_attribs_->args_type()->elements().size()) {
+        args_struct_types_[i].dt =
+            ctx_attribs_->args_type()->get_element_type({i});
+      } else {
+        args_struct_types_[i].dt = PrimitiveType::i32;
+      }
+    }
 
     args_buffer_value_ =
         ir_->uniform_struct_argument(args_struct_type_, 0, 0, "args");
@@ -2301,6 +2317,8 @@ class TaskCodegen : public IRVisitor {
 
   spirv::SType args_struct_type_;
   spirv::Value args_buffer_value_;
+
+  std::vector<spirv::SType> args_struct_types_;
 
   spirv::SType ret_struct_type_;
   spirv::Value ret_buffer_value_;

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -586,6 +586,16 @@ class TaskCodegen : public IRVisitor {
     }
   }
 
+  void visit(GetElementStmt *stmt) override {
+    spirv::Value val = ir_->query_value(stmt->src->raw_name());
+    const auto val_type = ir_->get_primitive_type(stmt->element_type());
+    const auto val_type_ptr =
+        ir_->get_pointer_type(val_type, spv::StorageClassUniform);
+    val = ir_->make_access_chain(val_type_ptr, val, stmt->index);
+    val = ir_->load_variable(val, val_type);
+    ir_->register_value(stmt->raw_name(), val);
+  }
+
   void visit(ReturnStmt *stmt) override {
     // Now we only support one ret
     auto dt = stmt->element_types()[0];
@@ -600,17 +610,6 @@ class TaskCodegen : public IRVisitor {
       spirv::Value val = ir_->query_value(stmt->values[i]->raw_name());
       ir_->store_variable(buffer_val, val);
     }
-  }
-
-  void visit(GetElementStmt *stmt) override {
-    auto src_val = ir_->query_value(stmt->src->raw_name());
-    auto ret_type = stmt->src->ret_type.ptr_removed()
-                        ->as<lang::StructType>()
-                        ->get_element_type(stmt->index);
-    auto ret_stype = ir_->get_primitive_type(ret_type);
-    spirv::Value val = ir_->make_value(spv::OpCompositeExtract, ret_stype,
-                                       src_val, stmt->index);
-    ir_->register_value(stmt->raw_name(), val);
   }
 
   void visit(GlobalTemporaryStmt *stmt) override {
@@ -832,7 +831,9 @@ class TaskCodegen : public IRVisitor {
       }
     } else if (stmt->op_type == UnaryOpType::frexp) {
       // FrexpStruct is the same type of the first member.
-      val = ir_->call_glsl450(dst_type, 52, operand_val);
+      val = ir_->alloca_variable(dst_type);
+      auto v = ir_->call_glsl450(dst_type, 52, operand_val);
+      ir_->store_variable(val, v);
     } else if (stmt->op_type == UnaryOpType::popcnt) {
       val = ir_->popcnt(operand_val);
     }

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1628,9 +1628,13 @@ Value IRBuilder::make_access_chain(const SType &out_type,
                                    Value base,
                                    const std::vector<int> &indices) {
   Value ret = new_value(out_type, ValueKind::kVariablePtr);
-  ib_.begin(spv::OpAccessChain).add_seq(out_type, ret, base);
+  std::vector<Value> index_values;
   for (auto &ind : indices) {
-    ib_.add(int_immediate_number(t_int32_, ind));
+    index_values.push_back(int_immediate_number(t_int32_, ind));
+  }
+  ib_.begin(spv::OpAccessChain).add_seq(out_type, ret, base);
+  for (auto &ind : index_values) {
+    ib_.add(ind);
   }
   ib_.commit(&func_header_);
   return ret;

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1603,5 +1603,17 @@ void IRBuilder::init_random_function(Value global_tmp_) {
   init_rand_ = true;
 }
 
+Value IRBuilder::make_access_chain(const SType &out_type,
+                                   Value base,
+                                   const std::vector<int> &indices) {
+  Value ret = new_value(out_type, ValueKind::kVariablePtr);
+  ib_.begin(spv::OpAccessChain).add_seq(out_type, ret, base);
+  for (auto &ind : indices) {
+    ib_.add(int_immediate_number(t_int32_, ind));
+  }
+  ib_.commit(&func_header_);
+  return ret;
+}
+
 }  // namespace spirv
 }  // namespace taichi::lang

--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -328,6 +328,27 @@ SType IRBuilder::get_primitive_type(const DataType &dt) const {
   }
 }
 
+SType IRBuilder::from_taichi_type(const DataType &dt, bool has_buffer_ptr) {
+  if (dt->is<PrimitiveType>()) {
+    return get_primitive_type(dt);
+  } else if (dt->is<PointerType>()) {
+    if (has_buffer_ptr) {
+      return t_uint64_;
+    } else {
+      return t_uint32_;
+    }
+  } else if (auto struct_type = dt->cast<lang::StructType>()) {
+    std::vector<std::tuple<SType, std::string, size_t>> components;
+    for (const auto &[type, name, offset] : struct_type->elements()) {
+      components.push_back(std::make_tuple(
+          from_taichi_type(type, has_buffer_ptr), name, offset));
+    }
+    return create_struct_type(components);
+  } else {
+    TI_ERROR("Type {} not supported.", dt->to_string());
+  }
+}
+
 size_t IRBuilder::get_primitive_type_size(const DataType &dt) const {
   if (dt == PrimitiveType::i64 || dt == PrimitiveType::u64 ||
       dt == PrimitiveType::f64) {

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -297,6 +297,11 @@ class IRBuilder {
     return val;
   }
 
+  // Make an AccessChain
+  Value make_access_chain(const SType &out_type,
+                          Value base,
+                          const std::vector<int> &indices);
+
   // Make a phi value
   PhiValue make_phi(const SType &out_type, uint32_t num_incoming);
 

--- a/taichi/codegen/spirv/spirv_ir_builder.h
+++ b/taichi/codegen/spirv/spirv_ir_builder.h
@@ -337,8 +337,10 @@ class IRBuilder {
 
   // Get null stype
   SType get_null_type();
-  // Get the spirv type for a given Taichi data type
+  // Get the spirv type for a given Taichi primitive data type
   SType get_primitive_type(const DataType &dt) const;
+  // Get the spirv type for a given Taichi data type
+  SType from_taichi_type(const DataType &dt, bool has_buffer_ptr);
   // Get the size in bytes of a given Taichi data type
   size_t get_primitive_type_size(const DataType &dt) const;
   // Get the spirv uint type with the same size of a given Taichi data type

--- a/taichi/codegen/spirv/spirv_types.cpp
+++ b/taichi/codegen/spirv/spirv_types.cpp
@@ -470,6 +470,32 @@ std::unordered_map<const tinyir::Node *, uint32_t> ir_translate_to_spirv(
   translator.visit(blk);
   return std::move(translator.ir_node_2_spv_value);
 }
+const tinyir::Type *translate_ti_type(tinyir::Block &ir_module,
+                                      const DataType t,
+                                      bool has_buffer_ptr) {
+  if (t->is<PrimitiveType>()) {
+    return translate_ti_primitive(ir_module, t);
+  }
+  if (t->is<PointerType>()) {
+    if (has_buffer_ptr) {
+      return ir_module.emplace_back<IntType>(/*num_bits=*/64,
+                                             /*is_signed=*/false);
+    } else {
+      return ir_module.emplace_back<IntType>(/*num_bits=*/32,
+                                             /*is_signed=*/false);
+    }
+  }
+  if (auto struct_type = t->cast<lang::StructType>()) {
+    std::vector<const tinyir::Type *> element_types;
+    auto &elements = struct_type->elements();
+    for (auto &element : elements) {
+      element_types.push_back(
+          translate_ti_type(ir_module, element.type, has_buffer_ptr));
+    }
+    return ir_module.emplace_back<StructType>(element_types);
+  }
+  TI_NOT_IMPLEMENTED
+}
 
 }  // namespace spirv
 }  // namespace taichi::lang

--- a/taichi/codegen/spirv/spirv_types.h
+++ b/taichi/codegen/spirv/spirv_types.h
@@ -226,6 +226,10 @@ class TypeVisitor : public tinyir::Visitor {
 const tinyir::Type *translate_ti_primitive(tinyir::Block &ir_module,
                                            const DataType t);
 
+const tinyir::Type *translate_ti_type(tinyir::Block &ir_module,
+                                      const DataType t,
+                                      bool has_buffer_ptr);
+
 std::string ir_print_types(const tinyir::Block *block);
 
 std::unique_ptr<tinyir::Block> ir_reduce_types(

--- a/taichi/ir/type_utils.h
+++ b/taichi/ir/type_utils.h
@@ -18,6 +18,10 @@ inline int data_type_bits(DataType t) {
   return data_type_size(t) * 8;
 }
 
+inline size_t align_up(size_t x, size_t alignment) {
+  return (x + alignment - 1) / alignment * alignment;
+}
+
 template <typename T>
 inline DataType get_data_type() {
   if (std::is_same<T, float32>()) {

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -789,52 +789,75 @@ GfxRuntime::RegisterParams run_codegen(
 std::pair<const lang::StructType *, size_t>
 GfxRuntime::get_struct_type_with_data_layout(const lang::StructType *old_ty,
                                              const std::string &layout) {
-  // Ported from KernelContextAttributes::KernelContextAttributes as is.
-  // TODO: refactor this.
+  auto [new_ty, size, align] =
+      get_struct_type_with_data_layout_impl(old_ty, layout, true);
+  return {new_ty, size};
+}
+
+std::tuple<const lang::StructType *, size_t, size_t>
+GfxRuntime::get_struct_type_with_data_layout_impl(
+    const lang::StructType *old_ty,
+    const std::string &layout,
+    bool is_outmost) {
   TI_TRACE("get_struct_type_with_data_layout: {}", layout);
-  auto is_ret = layout[0] == '4';
+  TI_ASSERT(layout.size() == 2);
+  auto is_430 = layout[0] == '4';
   auto has_buffer_ptr = layout[1] == 'b';
   auto members = old_ty->elements();
   size_t bytes = 0;
+  size_t align = 0;
   for (int i = 0; i < members.size(); i++) {
     auto &member = members[i];
-    const Type *element_type;
-    size_t stride = 0;
-    bool is_array = false;
-    if (!is_ret) {
-      element_type = DataType(member.type).ptr_removed().get_element_type();
-      is_array = member.type->is<PointerType>();
-    } else if (auto tensor_type = member.type->cast<TensorType>()) {
-      element_type = tensor_type->get_element_type();
-      stride = tensor_type->get_num_elements() * data_type_size(element_type);
-      is_array = true;
+    size_t member_align;
+    size_t member_size;
+    if (auto struct_type = member.type->cast<lang::StructType>()) {
+      auto [new_ty, size, member_align_] =
+          get_struct_type_with_data_layout_impl(struct_type, layout, false);
+      members[i].type = new_ty;
+      member_align = member_align_;
+      member_size = size;
+    } else if (auto tensor_type = member.type->cast<lang::TensorType>()) {
+      size_t element_size = data_type_size(tensor_type->get_element_type());
+      size_t num_elements = tensor_type->get_num_elements();
+      if (num_elements == 2) {
+        member_align = element_size * 2;
+      } else {
+        member_align = element_size * 4;
+      }
+      if (!is_430) {
+        member_size = member_align;
+      } else {
+        member_size = tensor_type->get_num_elements() * element_size;
+      }
+    } else if (auto pointer_type = member.type->cast<PointerType>()) {
+      if (has_buffer_ptr) {
+        member_size = sizeof(uint64_t);
+        member_align = member_size;
+      } else {
+        // Use u32 as placeholder
+        member_size = sizeof(uint32_t);
+        member_align = member_size;
+      }
     } else {
-      auto primitive_type = member.type->as<PrimitiveType>();
-      element_type = primitive_type;
-      stride = data_type_size(primitive_type);
+      TI_ASSERT(member.type->is<PrimitiveType>());
+      member_size = data_type_size(member.type);
+      member_align = member_size;
     }
-
-    const size_t dt_bytes = (member.type->is<PointerType>() && has_buffer_ptr)
-                                ? sizeof(uint64_t)
-                                : data_type_size(element_type);
-    TI_TRACE("dt_bytes={} stride={} is_array={} is_ret={}", dt_bytes, stride,
-             is_array, is_ret);
-    // Align bytes to the nearest multiple of dt_bytes
-    bytes = (bytes + dt_bytes - 1) / dt_bytes * dt_bytes;
-    member.offset = bytes;
-    bytes += is_ret ? stride : dt_bytes;
-    TI_TRACE("  at={} {} offset_in_mem={} stride={}",
-             is_array ? (is_ret ? "array" : "vector ptr") : "scalar", i,
-             member.offset, stride);
+    bytes = align_up(bytes, member_align);
+    members[i].offset = bytes;
+    bytes += member_size;
+    align = std::max(align, member_align);
   }
-  if (!is_ret) {
-    bytes = (bytes + 4 - 1) / 4 * 4;
+
+  if (!is_430) {
+    align = align_up(align, sizeof(float) * 4);
+    bytes = align_up(bytes, is_outmost ? 4 : 4 * sizeof(float));
   }
   TI_TRACE("  total_bytes={}", bytes);
   return {TypeFactory::get_instance()
               .get_struct_type(members, layout)
               ->as<lang::StructType>(),
-          bytes};
+          bytes, align};
 }
 
 }  // namespace gfx

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -133,6 +133,11 @@ class TI_DLL_EXPORT GfxRuntime {
   get_struct_type_with_data_layout(const lang::StructType *old_ty,
                                    const std::string &layout);
 
+  static std::tuple<const lang::StructType *, size_t, size_t>
+  get_struct_type_with_data_layout_impl(const lang::StructType *old_ty,
+                                        const std::string &layout,
+                                        bool is_outmost);
+
  private:
   friend class taichi::lang::gfx::SNodeTreeManager;
 

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -384,7 +384,8 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     auto top_level_ptr = SquashPtrOffset::run(stmt);
     // We don't support storing a pointer for now.
     if (top_level_ptr->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||
-        (stmt->is<ArgLoadStmt>() && stmt->as<ArgLoadStmt>()->is_ptr))
+        (stmt->is<ArgLoadStmt>() && (stmt->as<ArgLoadStmt>()->is_ptr ||
+                                     !stmt->as<ArgLoadStmt>()->create_load)))
       return;
     if ((config_.arch == Arch::opengl || config_.arch == Arch::vulkan ||
          config_.arch == Arch::gles || config_.arch == Arch::metal) &&

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -271,3 +271,28 @@ def test_struct_arg():
 
     ret = foo(s1(a=1, b=s0(a=65537, b=123)))
     assert ret == pytest.approx(125)
+
+
+@test_utils.test()
+def test_struct_arg_with_matrix():
+    mat = ti.types.matrix(3, 2, ti.f32)
+    s0 = ti.types.struct(a=mat, b=ti.f32)
+    s1 = ti.types.struct(a=ti.i32, b=s0)
+
+    @ti.kernel
+    def foo(a: s1) -> ti.i32:
+        ret = a.a + a.b.b
+        for i in range(3):
+            for j in range(2):
+                ret += a.b.a[i, j] * (i + 1) * (j + 2)
+        return ret
+
+    arg = s1(a=1, b=s0(a=mat(1, 2, 3, 4, 5, 6), b=123))
+    ret_std = 1 + 123
+
+    for i in range(3):
+        for j in range(2):
+            ret_std += (i + 1) * (j + 2) * (i * 2 + j + 1)
+
+    ret = foo(arg)
+    assert ret == ret_std

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -260,9 +260,9 @@ def test_args_with_many_ndarrays():
     )
 
 
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test()
 def test_struct_arg():
-    s0 = ti.types.struct(a=ti.i16, b=ti.f64)
+    s0 = ti.types.struct(a=ti.i16, b=ti.f32)
     s1 = ti.types.struct(a=ti.f32, b=s0)
 
     @ti.kernel

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -260,7 +260,7 @@ def test_args_with_many_ndarrays():
     )
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_struct_arg():
     s0 = ti.types.struct(a=ti.i16, b=ti.f32)
     s1 = ti.types.struct(a=ti.f32, b=s0)

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -273,7 +273,7 @@ def test_struct_arg():
     assert ret == pytest.approx(125)
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_struct_arg_with_matrix():
     mat = ti.types.matrix(3, 2, ti.f32)
     s0 = ti.types.struct(a=mat, b=ti.f32)

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -76,3 +76,55 @@ def test_2d_nested():
     for i in range(n * 2):
         for j in range(n):
             assert x[i, j] == i + j * 10
+
+
+@test_utils.test()
+def test_func_of_data_class_as_kernel_arg():
+    @ti.dataclass
+    class Foo:
+        x: ti.f32
+        y: ti.f32
+
+        @ti.func
+        def add(self, other: ti.template()):
+            return Foo(self.x + other.x, self.y + other.y)
+
+    @ti.kernel
+    def foo_x(x: Foo) -> ti.f32:
+        return x.add(x).x
+
+    assert foo_x(Foo(1, 2)) == 2
+
+    @ti.kernel
+    def foo_y(x: Foo) -> ti.f32:
+        return x.add(x).y
+
+    assert foo_y(Foo(1, 2)) == 4
+
+
+@test_utils.test(arch=[ti.cpu, ti.cuda, ti.amdgpu])
+def test_func_of_data_class_as_kernel_return():
+    # TODO: enable this test in SPIR-V based backends after SPIR-V based backends can return structs.
+    @ti.dataclass
+    class Foo:
+        x: ti.f32
+        y: ti.f32
+
+        @ti.func
+        def add(self, other: ti.template()):
+            return Foo(self.x + other.x, self.y + other.y)
+
+        def add_python(self, other):
+            return Foo(self.x + other.x, self.y + other.y)
+
+    @ti.kernel
+    def foo(x: Foo) -> Foo:
+        return x.add(x)
+
+    b = foo(Foo(1, 2))
+    assert b.x == 2
+    assert b.y == 4
+
+    c = b.add_python(b)
+    assert c.x == 4
+    assert c.y == 8

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -78,7 +78,7 @@ def test_2d_nested():
             assert x[i, j] == i + j * 10
 
 
-@test_utils.test()
+@test_utils.test(exclude=[ti.cc])
 def test_func_of_data_class_as_kernel_arg():
     @ti.dataclass
     class Foo:


### PR DESCRIPTION
Issue: #

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b148cc</samp>

### Summary
🧮🛠️🚀

<!--
1.  🧮 for adding a new method to the `MatrixType` class and a new function to the `spirv_types.cpp` file for handling matrix and struct types as kernel arguments and return values.
2. 🛠️ for simplifying and optimizing the `KernelContextAttributes` class and improving the handling of struct and pointer types in the SPIRV codegen.
3. 🚀 for adding new methods to the `IRBuilder` class for generating SPIR-V instructions and simplifying the code generation.
-->
This pull request adds support for matrix and struct types as kernel arguments and return values in Taichi. It also improves the SPIR-V codegen and the gfx runtime to handle these types and optimize the memory layout and access. It modifies several files in `python/taichi/lang`, `taichi/codegen/spirv`, `taichi/runtime/gfx`, and `taichi/transforms` to implement these features and fix some bugs.

> _To make Taichi kernels more flexible_
> _We added support for structs and matrices_
> _We used `get_type_for_kernel_args`_
> _And `IRBuilder` helper methods_
> _To generate SPIR-V code that is sensible_

### Walkthrough
*  Simplify the `KernelContextAttributes` class and remove unnecessary fields and logic from the `ArgAttributes` struct and the constructor ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-0933633c5350c8a0e64f59046da02dcafcabe69694bb200d938b8bd415bcbca0L63-R63), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-0933633c5350c8a0e64f59046da02dcafcabe69694bb200d938b8bd415bcbca0L102-R94), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-0933633c5350c8a0e64f59046da02dcafcabe69694bb200d938b8bd415bcbca0L120-R115), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-0933633c5350c8a0e64f59046da02dcafcabe69694bb200d938b8bd415bcbca0L142))
*  Add a new function `get_type_for_kernel_args` to handle matrix and struct types as kernel arguments and use it in the `decl_struct_arg` function ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeR63-R83), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL74-R98))
*  Add a new method `set_kernel_struct_args` to the `MatrixType` class to set the struct argument for matrices in the launch context ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9R1458-R1475))
*  Add a new attribute `__struct_methods` to the dictionaries returned by the `from_taichi_object` and `from_kernel_struct_ret` methods of the `StructType` class to store the methods of the struct type ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-3154e0533b9fd63e663c16c2e87c65068c3b002a65cf80529b6577d173bdb5feR633), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-3154e0533b9fd63e663c16c2e87c65068c3b002a65cf80529b6577d173bdb5feR654))
*  Modify the `visit` method for the `ArgLoadStmt` in the `TaskCodegen` class to use the args_type and the args_struct_types_ vector to get the correct type and value for each argument ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L569-R570), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L576-R587))
*  Add a new `visit` method for the `GetElementStmt` in the `TaskCodegen` class to handle the case where the src is a struct type and use the make_access_chain and load_variable methods to get the element value ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R593-R602))
*  Remove the old `visit` method for the `GetElementStmt` in the `TaskCodegen` class that only handled the case where the src is a primitive type ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L605-L615))
*  Modify the `visit` method for the `UnaryOpStmt` in the `TaskCodegen` class to handle the frexp unary op by allocating a variable for the val and storing the result of the glsl450 call to the variable ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L835-R840))
*  Modify the `compile_args_struct` function in the `BINARY_OP_TO_SPIRV_FUNC` function to use the translate_ti_type function and the args_type of the ctx_attribs_ to get the corresponding tinyir type for each argument ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L2194-R2203), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2218-R2221), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2228-R2240))
*  Add a new field args_struct_types_ to the `TaskCodegen` class to store the spirv type and the taichi type for each argument ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2321-R2322))
*  Add a new method from_taichi_type to the `IRBuilder` class to get the corresponding spirv type for a taichi data type ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15R331-R351), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-e9e785201af78fa53c937a623f0bd851161ac2064d92383c05384f786cea9cd9L335-R343))
*  Add a new method make_access_chain to the `IRBuilder` class to create an access chain to the element of a base value ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15R1627-R1642), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-e9e785201af78fa53c937a623f0bd851161ac2064d92383c05384f786cea9cd9R300-R304))
*  Add a new function translate_ti_type to the `taichi/codegen/spirv/spirv_types.cpp` file to get the corresponding tinyir type for a taichi data type ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-259a89b8645aab6065eac94864cd4930be7ae91da5cb2e15307ae5fa41015962R473-R498), [link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-b87ff864662b493b7a77265f0abfa44586aab4be0908e951270117f6ba9b7221R229-R232))
*  Add a new function align_up to the `taichi/ir/type_utils.h` file to align the bytes of the struct types ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-1df7532afc2540435b46bd5831a4b6bd11bb1ead5e1fd3607e02fccf9dab112cR21-R24))
*  Modify the `get_struct_type_with_data_layout` method of the `GfxRuntime` class to use the `get_struct_type_with_data_layout_impl` function and simplify the logic to handle different types and layouts ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL792-R860))
*  Add a declaration for the `get_struct_type_with_data_layout_impl` method to the `GfxRuntime` class to handle the recursive case where the type is a struct type ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-a023ad94c9af40b9b4b391fc6ec0d96e9c7f88744d196bf782c51086da96d99aR136-R140))
*  Modify the `test_and_allocate` method of the `IdentifyValuesUsedInOtherOffloads` class to skip the allocation if the create_load field of the `ArgLoadStmt` is false ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L387-R388))
*  Import the `CompoundType` class from `taichi.types.compound_types` module ([link](https://github.com/taichi-dev/taichi/pull/7907/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeR14))

