### PR TITLE
[CUDA] Warn driver version if it doesn't support memory pool.

### DIFF
--- a/taichi/rhi/cuda/cuda_context.cpp
+++ b/taichi/rhi/cuda/cuda_context.cpp
@@ -30,10 +30,21 @@ CUDAContext::CUDAContext()
   driver_.device_get_attribute(
       &cc_minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device_);
 
-  int device_supports_mem_pool;
-  driver_.device_get_attribute(&device_supports_mem_pool,
-                               CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
-                               device_);
+  int device_supports_mem_pool = 0;
+  if (driver_.get_version_major() > 11 ||
+      (driver_.get_version_major() == 11 && driver_.get_version_minor() >= 2)) {
+    driver_.device_get_attribute(&device_supports_mem_pool,
+                                 CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
+                                 device_);
+  } else {
+    TI_WARN(
+        "Please consider upgrade your nvidia driver for better device memory pool"
+        "support. Current driver supports CUDA {}.{}, we recommend driver version"
+        "above 470 (CUDA 11.2).",
+        driver_.get_version_major(), driver_.get_version_minor());
+    device_supports_mem_pool = 0;
+  }
+
   if (device_supports_mem_pool) {
     supports_mem_pool_ = true;
     void *default_mem_pool;

--- a/taichi/rhi/cuda/cuda_context.cpp
+++ b/taichi/rhi/cuda/cuda_context.cpp
@@ -38,8 +38,10 @@ CUDAContext::CUDAContext()
                                  device_);
   } else {
     TI_WARN(
-        "Please consider upgrade your nvidia driver for better device memory pool"
-        "support. Current driver supports CUDA {}.{}, we recommend driver version"
+        "Please consider upgrade your nvidia driver for better device memory "
+        "pool"
+        "support. Current driver supports CUDA {}.{}, we recommend driver "
+        "version"
         "above 470 (CUDA 11.2).",
         driver_.get_version_major(), driver_.get_version_minor());
     device_supports_mem_pool = 0;


### PR DESCRIPTION
Fixes #7826 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d158a9</samp>

Check driver version and support for CUDA memory pools in `CUDADriverContext` constructor. Warn users and avoid errors if driver is too old.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d158a9</samp>

*  Add memory pool support for CUDA devices ([link](https://github.com/taichi-dev/taichi/pull/7912/files?diff=unified&w=0#diff-03914c736ef6eca99a9941fae49ef3ee93a9ad1c9a690e31dd1e8862183c154aL33-R47),                              F0
