### PR TITLE
[Lang] Remove a.atomic(b)

### DIFF
--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -1,10 +1,16 @@
 from taichi.lang import ops
 from taichi.lang.util import in_python_scope
 from taichi.types import primitive_types
+from typing import TYPE_CHECKING
 
 
 class TaichiOperations:
     """The base class of taichi operations of expressions. Subclasses: :class:`~taichi.lang.expr.Expr`, :class:`~taichi.lang.matrix.Matrix`"""
+
+    if TYPE_CHECKING:
+        # Make pylint happy
+        def __getattr__(self, item):
+            pass
 
     def __neg__(self):
         return ops.neg(self)

--- a/python/taichi/lang/common_ops.py
+++ b/python/taichi/lang/common_ops.py
@@ -1,5 +1,3 @@
-import warnings
-
 from taichi.lang import ops
 from taichi.lang.util import in_python_scope
 from taichi.types import primitive_types
@@ -7,24 +5,6 @@ from taichi.types import primitive_types
 
 class TaichiOperations:
     """The base class of taichi operations of expressions. Subclasses: :class:`~taichi.lang.expr.Expr`, :class:`~taichi.lang.matrix.Matrix`"""
-
-    __deprecated_atomic_ops__ = {
-        "atomic_add": "_atomic_add",
-        "atomic_mul": "_atomic_mul",
-        "atomic_and": "_atomic_and",
-        "atomic_or": "_atomic_or",
-        "atomic_sub": "_atomic_sub",
-        "atomic_xor": "_atomic_xor",
-    }
-
-    def __getattr__(self, item):
-        if item in TaichiOperations.__deprecated_atomic_ops__:
-            warnings.warn(
-                f"a.{item}(b) is deprecated, and it will be removed in Taichi v1.6.0. Please use ti.{item}(a, b) instead.",
-                DeprecationWarning,
-            )
-            return getattr(self, TaichiOperations.__deprecated_atomic_ops__[item])
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
 
     def __neg__(self):
         return ops.neg(self)

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -9,21 +9,6 @@ from tests import test_utils
 
 
 @test_utils.test()
-def test_deprecate_a_atomic_b():
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"a\.atomic_add\(b\) is deprecated, and it will be removed in Taichi v1.6.0.",
-    ):
-
-        @ti.kernel
-        def func():
-            a = 1
-            a.atomic_add(2)
-
-        func()
-
-
-@test_utils.test()
 def test_deprecate_element_shape_scalar():
     with pytest.warns(
         DeprecationWarning,


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf84147</samp>

Removed deprecated and unused code related to atomic operations. Updated tests to use the new `ti.atomic_op` syntax.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf84147</samp>

* Remove deprecated atomic operations from `TaichiOperations` class and simplify code ([link](https://github.com/taichi-dev/taichi/pull/7925/files?diff=unified&w=0#diff-acea46764263e4987a75c9fc436ab4a70c6f1025253a9adc4d70aa1eb030dbebL1-L2), [link](https://github.com/taichi-dev/taichi/pull/7925/files?diff=unified&w=0#diff-acea46764263e4987a75c9fc436ab4a70c6f1025253a9adc4d70aa1eb030dbebL11-L28))
* Remove test function for deprecated atomic operations from `test_deprecation.py` and update test suite ([link](https://github.com/taichi-dev/taichi/pull/7925/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L12-L26))
