### PR TITLE
[Opt] Fix redundant clone of stmts across offloaded tasks

### DIFF
--- a/tests/python/test_offload_cross.py
+++ b/tests/python/test_offload_cross.py
@@ -133,3 +133,24 @@ def test_offload_with_cross_if_inside_for():
                 print("OK")
 
     run(2)
+
+
+@test_utils.test(exclude=ti.amdgpu)
+def test_offload_with_save():
+    a = ti.Vector.field(2, dtype=ti.f32, shape=1)
+    b = ti.Vector.field(2, dtype=ti.f32, shape=1)
+    c = ti.Vector.field(2, dtype=ti.f32, shape=1)
+
+    @ti.kernel
+    def test():
+        a[0] = ti.Vector([1, 1])
+        b[0] = ti.Vector([0, 0])
+        c[0] = ti.Vector([0, 0])
+        b[0] += a[0]  # b[0] = [1, 1]
+        b[0] /= 2  # b[0] = [0.5, 0.5]
+        for i in c:
+            c[i] += b[0]  # c[0] = [0.5, 0.5]
+
+    test()
+    assert c[0][0] == 0.5
+    assert c[0][1] == 0.5


### PR DESCRIPTION
Fixes #7923 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27ee72a</samp>

This pull request enhances the `offload` function to use memory and handle errors more efficiently, and fixes a global load demotion bug. It also adds a new test case to `tests/python/test_offload_cross.py` to verify the offloading logic for global temporaries.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27ee72a</samp>

*  Prevent demoting global loads to local loads in `demotable_axis_load` ([link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21R20-R21))
*  Pass pointers instead of references or copies to the `local_to_global_offset` and `stmt_to_offloaded` maps in the `PromoteIntermediateToGlobalTmp` and `FixCrossOffloadReferences` passes ([link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L445-R448), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L464-R466), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L470-R472), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L480-R486), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L663-R664), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L673-R674), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L786-R788))
*  Use the `at` method instead of the `[]` operator to access the `local_to_global_offset` map and avoid creating default entries ([link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L457-R459), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L502-R505), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L517-R519), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L533-R533), [link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L626-R626))
*  Add a new test case in `test_offload_cross.py` to check the correctness of offloading intermediate values to global temporaries ([link](https://github.com/taichi-dev/taichi/pull/7927/files?diff=unified&w=0#diff-9fe47cc4660760632fda80fff05bd029da4d7e85a75429604feb5d23938b90ecR136-R156))
