### PR TITLE
[Lang] Cancel deprecating native min/max

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -434,17 +434,6 @@ class ASTTransformer(Builder):
 
         if id(func) in replace_func:
             node.ptr = replace_func[id(func)](*args, **keywords)
-            if func is min or func is max:
-                name = "min" if func is min else "max"
-                warnings.warn_explicit(
-                    f'Calling builtin function "{name}" in Taichi scope is deprecated, '
-                    f"and it will be removed in Taichi v1.6.0."
-                    f'Please use "ti.{name}" instead.',
-                    DeprecationWarning,
-                    ctx.file,
-                    node.lineno + ctx.lineno_offset,
-                    module="taichi",
-                )
             return True
         return False
 

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -84,21 +84,6 @@ def test_deprecate_rwtexture_ndim():
 
 
 @test_utils.test()
-def test_deprecate_builtin_min_max():
-    with pytest.warns(
-        DeprecationWarning,
-        match='Calling builtin function "max" in Taichi scope is deprecated, '
-        "and it will be removed in Taichi v1.6.0.",
-    ):
-
-        @ti.kernel
-        def func():
-            max(1, 2)
-
-        func()
-
-
-@test_utils.test()
 def test_deprecate_is_is_not():
     with pytest.warns(
         DeprecationWarning,

--- a/tests/python/test_native_functions.py
+++ b/tests/python/test_native_functions.py
@@ -72,9 +72,7 @@ def test_minmax():
         y[i] = N - i
         z[i] = i - 2 if i % 2 else i + 2
 
-    with pytest.warns(DeprecationWarning, match="Calling builtin function") as records:
-        func()
-    assert len(records) > 0
+    func()
 
     assert np.allclose(
         minimum.to_numpy(),


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fcf8184</samp>

Remove the deprecation warning for using the builtin `min` and `max` functions in Taichi scope. Update the related test cases to match the new behavior.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fcf8184</samp>

*  Remove the deprecation warning for using the builtin `min` and `max` functions in Taichi scope ([link](https://github.com/taichi-dev/taichi/pull/7928/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL437-L447))
*  Update the test cases to reflect the new behavior of the AST transformer ([link](https://github.com/taichi-dev/taichi/pull/7928/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L87-L101), [link](https://github.com/taichi-dev/taichi/pull/7928/files?diff=unified&w=0#diff-cc8e7da3222177c1a6a058d133c0b6ea736f6a1fc34a958bc4bc6fe7ea9462d0L75-R75))
