### PR TITLE
[Lang] Remove the support for 'is'

### DIFF
--- a/tests/python/test_ast_refactor.py
+++ b/tests/python/test_ast_refactor.py
@@ -165,17 +165,6 @@ def test_boolop():
 
 
 @test_utils.test()
-def test_compare_fail():
-    with pytest.raises(ti.TaichiCompilationError, match='"Is" is only supported inside `ti.static`.'):
-
-        @ti.kernel
-        def foo():
-            None is None
-
-        foo()
-
-
-@test_utils.test()
 def test_single_compare():
     @ti.kernel
     def foo(a: ti.template(), b: ti.template(), c: ti.template()):

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -171,33 +171,6 @@ def test_non_static_in():
         foo(ti.i32)
 
 
-@test_utils.test()
-def test_static_is():
-    @ti.kernel
-    def is_f32(tp: ti.template()) -> ti.i32:
-        return ti.static(tp is ti.f32)
-
-    @ti.kernel
-    def is_not_f32(tp: ti.template()) -> ti.i32:
-        return ti.static(tp is not ti.f32)
-
-    assert is_f32(ti.f32) == 1
-    assert is_f32(ti.i32) == 0
-    assert is_not_f32(ti.f32) == 0
-    assert is_not_f32(ti.i32) == 1
-
-
-@test_utils.test()
-def test_non_static_is():
-    with pytest.raises(ti.TaichiCompilationError, match='"Is" is only supported inside `ti.static`.'):
-
-        @ti.kernel
-        def is_f32(tp: ti.template()) -> ti.i32:
-            return tp is ti.f32
-
-        is_f32(ti.f32)
-
-
 @test_utils.test(default_ip=ti.i64, require=ti.extension.data64)
 def test_compare_ret_type():
     # The purpose of this test is to make sure a comparison returns i32

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -99,11 +99,8 @@ def test_deprecate_builtin_min_max():
 
 
 @test_utils.test()
-def test_deprecate_is_is_not():
-    with pytest.warns(
-        DeprecationWarning,
-        match='Operator "is" in Taichi scope is deprecated, ' "and it will be removed in Taichi v1.6.0.",
-    ):
+def test_remove_is_is_not():
+    with pytest.raises(ti.TaichiSyntaxError, match='Operator "is" in Taichi scope is not supported'):
 
         @ti.kernel
         def func():


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 661bbce</samp>

Remove `is` and `is not` operators from Taichi scope and update test case. This change prevents confusion and errors when comparing Taichi tensors and scalars.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 661bbce</samp>

*  Remove support for `is` and `is not` operators in Taichi scope and raise syntax error instead ([link](https://github.com/taichi-dev/taichi/pull/7930/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL1026-L1027), [link](https://github.com/taichi-dev/taichi/pull/7930/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL1034-R1038), [link](https://github.com/taichi-dev/taichi/pull/7930/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L102-R103))
