### PR TITLE
[Lang] Raise error when the dimension of the ndrange does not equal to the number of the loop variable

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1165,16 +1165,11 @@ class ASTTransformer(Builder):
             I = impl.expr_init(ndrange_loop_var)
             targets = ASTTransformer.get_for_loop_targets(node)
             if len(targets) != len(ndrange_var.dimensions):
-                warnings.warn_explicit(
+                raise TaichiSyntaxError(
                     "Ndrange for loop with number of the loop variables not equal to "
-                    "the dimension of the ndrange is deprecated, "
-                    "and it will be removed in Taichi 1.6.0. "
+                    "the dimension of the ndrange is not supported. "
                     "Please check if the number of arguments of ti.ndrange() is equal to "
-                    "the number of the loop variables.",
-                    DeprecationWarning,
-                    ctx.file,
-                    node.lineno + ctx.lineno_offset,
-                    module="taichi",
+                    "the number of the loop variables."
                 )
             for i, target in enumerate(targets):
                 if i + 1 < len(targets):

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -112,23 +112,6 @@ def test_deprecate_is_is_not():
         func()
 
 
-@test_utils.test()
-def test_deprecate_ndrange():
-    with pytest.warns(
-        DeprecationWarning,
-        match="Ndrange for loop with number of the loop variables not equal to "
-        "the dimension of the ndrange is deprecated, "
-        "and it will be removed in Taichi 1.6.0. ",
-    ):
-
-        @ti.kernel
-        def func():
-            for i in ti.ndrange(4, 4):
-                pass
-
-        func()
-
-
 @pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
 @test_utils.test(arch=ti.cpu)
 def test_deprecate_ti_ui_window():

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -336,3 +336,19 @@ def test_2d_loop_over_ndarray():
 
     array = ti.ndarray(ti.i32, shape=(16,))
     foo(array)
+
+
+@test_utils.test()
+def test_dimension_error():
+    with pytest.raises(
+        ti.TaichiSyntaxError,
+        match="Ndrange for loop with number of the loop variables not equal to "
+        "the dimension of the ndrange is not supported",
+    ):
+
+        @ti.kernel
+        def func():
+            for i in ti.ndrange(4, 4):
+                pass
+
+        func()

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -312,20 +312,6 @@ def test_static_ndrange_should_accept_numpy_integer():
     example()
 
 
-@test_utils.test(exclude=[ti.amdgpu])
-def test_n_loop_var_neq_dimension():
-    @ti.kernel
-    def iter():
-        for i in ti.ndrange(1, 4):
-            print(i)
-
-    with pytest.warns(
-        DeprecationWarning,
-        match="Ndrange for loop with number of the loop variables not equal to",
-    ):
-        iter()
-
-
 @test_utils.test()
 def test_2d_loop_over_ndarray():
     @ti.kernel


### PR DESCRIPTION

Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e85b25b</samp>

Remove the deprecated feature of allowing mismatched loop variables and ndrange dimensions in for loops. Raise a syntax error instead and update the tests accordingly.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e85b25b</samp>

*  Raise a syntax error when the number of loop variables does not match the dimension of the ndrange in a for loop ([link](https://github.com/taichi-dev/taichi/pull/7933/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL1168-R1172))
*  Remove the test case for the deprecated warning of using ndrange incorrectly from `test_deprecation.py` ([link](https://github.com/taichi-dev/taichi/pull/7933/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L115-L131))
*  Add a test case for the syntax error of using ndrange incorrectly to `test_ndrange.py` ([link](https://github.com/taichi-dev/taichi/pull/7933/files?diff=unified&w=0#diff-a9b0dba640148aa2d28264b8b5c2ecaebab68a09ea0ea0c2fae5aaf303e69ed7R339-R354))
