### PR TITLE
[Lang] Separate out preallocation logics for runtime objects

### DIFF
--- a/taichi/rhi/amdgpu/amdgpu_device.cpp
+++ b/taichi/rhi/amdgpu/amdgpu_device.cpp
@@ -42,6 +42,8 @@ RhiResult AmdgpuDevice::allocate_memory(const AllocParams &params,
     return RhiResult::out_of_memory;
   }
 
+  AMDGPUDriver::get_instance().memset((void *)info.ptr, 0, info.size);
+
   *out_devalloc = DeviceAllocation{};
   out_devalloc->alloc_id = allocations_.size();
   out_devalloc->device = this;

--- a/taichi/rhi/amdgpu/amdgpu_device.h
+++ b/taichi/rhi/amdgpu/amdgpu_device.h
@@ -101,6 +101,14 @@ class AmdgpuDevice : public LlvmDevice {
 
   DeviceAllocation import_memory(void *ptr, size_t size) override;
 
+  void *get_memory_addr(DeviceAllocation devalloc) override {
+    return get_alloc_info(devalloc).ptr;
+  }
+
+  std::size_t get_total_memory() override {
+    return AMDGPUContext::get_instance().get_total_memory();
+  }
+
   Stream *get_compute_stream() override{TI_NOT_IMPLEMENTED};
 
   void wait_idle() override{TI_NOT_IMPLEMENTED};

--- a/taichi/rhi/cuda/cuda_device.cpp
+++ b/taichi/rhi/cuda/cuda_device.cpp
@@ -37,6 +37,8 @@ RhiResult CudaDevice::allocate_memory(const AllocParams &params,
   info.use_cached = false;
   info.use_preallocated = false;
 
+  CUDADriver::get_instance().memset((void *)info.ptr, 0, info.size);
+
   *out_devalloc = DeviceAllocation{};
   out_devalloc->alloc_id = allocations_.size();
   out_devalloc->device = this;

--- a/taichi/rhi/cuda/cuda_device.h
+++ b/taichi/rhi/cuda/cuda_device.h
@@ -127,6 +127,14 @@ class CudaDevice : public LlvmDevice {
 
   DeviceAllocation import_memory(void *ptr, size_t size) override;
 
+  void *get_memory_addr(DeviceAllocation devalloc) override {
+    return get_alloc_info(devalloc).ptr;
+  }
+
+  std::size_t get_total_memory() override {
+    return CUDAContext::get_instance().get_total_memory();
+  }
+
   Stream *get_compute_stream() override{TI_NOT_IMPLEMENTED};
 
   void wait_idle() override{TI_NOT_IMPLEMENTED};

--- a/taichi/rhi/llvm/llvm_device.h
+++ b/taichi/rhi/llvm/llvm_device.h
@@ -26,6 +26,14 @@ class LlvmDevice : public Device {
     return device;
   }
 
+  virtual void *get_memory_addr(DeviceAllocation devalloc) {
+    TI_NOT_IMPLEMENTED
+  }
+
+  virtual std::size_t get_total_memory() {
+    TI_NOT_IMPLEMENTED
+  }
+
   virtual DeviceAllocation import_memory(void *ptr, size_t size) {
     TI_NOT_IMPLEMENTED
   }

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -78,7 +78,6 @@ LlvmRuntimeExecutor::LlvmRuntimeExecutor(CompileConfig &config,
 
   snode_tree_buffer_manager_ = std::make_unique<SNodeTreeBufferManager>(this);
   thread_pool_ = std::make_unique<ThreadPool>(config.cpu_max_num_threads);
-  preallocated_device_buffer_ = nullptr;
 
   llvm_runtime_ = nullptr;
 
@@ -535,9 +534,10 @@ uint64_t *LlvmRuntimeExecutor::get_ndarray_alloc_info_ptr(
 
 void LlvmRuntimeExecutor::finalize() {
   profiler_ = nullptr;
-  if (preallocated_device_buffer_ != nullptr) {
+  for (auto &preallocated_device_buffer_alloc :
+       preallocated_device_buffer_allocs_) {
     if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
-      llvm_device()->dealloc_memory(preallocated_device_buffer_alloc_);
+      llvm_device()->dealloc_memory(preallocated_device_buffer_alloc);
       llvm_device()->clear();
       DeviceMemoryPool::get_instance().reset();
     }
@@ -551,6 +551,23 @@ LlvmRuntimeExecutor::~LlvmRuntimeExecutor() {
   }
 }
 
+void *LlvmRuntimeExecutor::preallocate_memory(std::size_t prealloc_size) {
+  DeviceAllocation preallocated_device_buffer_alloc;
+
+  Device::AllocParams preallocated_device_buffer_alloc_params;
+  preallocated_device_buffer_alloc_params.size = prealloc_size;
+  RhiResult res =
+      llvm_device()->allocate_memory(preallocated_device_buffer_alloc_params,
+                                     &preallocated_device_buffer_alloc);
+  TI_ASSERT(res == RhiResult::success);
+
+  void *preallocated_device_buffer =
+      llvm_device()->get_memory_addr(preallocated_device_buffer_alloc);
+  preallocated_device_buffer_allocs_.emplace_back(
+      std::move(preallocated_device_buffer_alloc));
+  return preallocated_device_buffer;
+}
+
 void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
                                               uint64 **result_buffer_ptr) {
   // The result buffer allocated here is only used for the launches of
@@ -560,74 +577,22 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
   // | ==================preallocated device buffer ========================== |
   // |<- reserved for return ->|<---- usable for allocators on the device ---->|
 
-  std::size_t prealloc_size = 0;
-  if (config_.arch == Arch::cuda) {
-#if defined(TI_WITH_CUDA)
-    const auto total_mem = CUDAContext::get_instance().get_total_memory();
-    if (config_.device_memory_fraction == 0) {
-      TI_ASSERT(config_.device_memory_GB > 0);
-      prealloc_size = std::size_t(config_.device_memory_GB * (1UL << 30));
-    } else {
-      prealloc_size = std::size_t(config_.device_memory_fraction * total_mem);
-    }
-    TI_ASSERT(prealloc_size <= total_mem);
+  std::size_t runtime_objects_prealloc_size = 0;
+  void *runtime_objects_prealloc_buffer = nullptr;
+  if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
+#if defined(TI_WITH_CUDA) || defined(TI_WITH_AMDGPU)
+    runtime_objects_prealloc_size = 50 * (1UL << 20);  // 50 MB
+    runtime_objects_prealloc_buffer =
+        preallocate_memory(runtime_objects_prealloc_size);
 
-    TI_TRACE("Allocating device memory {:.2f} GB",
-             1.0 * prealloc_size / (1UL << 30));
+    TI_TRACE("Allocating device memory {:.2f} MB",
+             1.0 * runtime_objects_prealloc_size / (1UL << 20));
 
-    Device::AllocParams preallocated_device_buffer_alloc_params;
-    preallocated_device_buffer_alloc_params.size = prealloc_size;
-    RhiResult res =
-        llvm_device()->allocate_memory(preallocated_device_buffer_alloc_params,
-                                       &preallocated_device_buffer_alloc_);
-    TI_ASSERT(res == RhiResult::success);
-    cuda::CudaDevice::AllocInfo preallocated_device_buffer_alloc_info =
-        llvm_device()->as<cuda::CudaDevice>()->get_alloc_info(
-            preallocated_device_buffer_alloc_);
-    preallocated_device_buffer_ = preallocated_device_buffer_alloc_info.ptr;
-
-    CUDADriver::get_instance().memset(preallocated_device_buffer_, 0,
-                                      prealloc_size);
-    *result_buffer_ptr = (uint64 *)preallocated_device_buffer_;
+    *result_buffer_ptr = (uint64 *)runtime_objects_prealloc_buffer;
     size_t result_buffer_size = sizeof(uint64) * taichi_result_buffer_entries;
-    preallocated_device_buffer_ =
-        (char *)preallocated_device_buffer_ + result_buffer_size;
-    prealloc_size -= result_buffer_size;
-#else
-    TI_NOT_IMPLEMENTED
-#endif
-  } else if (config_.arch == Arch::amdgpu) {
-#if defined(TI_WITH_AMDGPU)
-    const auto total_mem = AMDGPUContext::get_instance().get_total_memory();
-    if (config_.device_memory_fraction == 0) {
-      TI_ASSERT(config_.device_memory_GB > 0);
-      prealloc_size = std::size_t(config_.device_memory_GB * (1UL << 30));
-    } else {
-      prealloc_size = std::size_t(config_.device_memory_fraction * total_mem);
-    }
-    TI_ASSERT(prealloc_size <= total_mem);
-
-    TI_TRACE("Allocating device memory {:.2f} GB",
-             1.0 * prealloc_size / (1UL << 30));
-
-    Device::AllocParams preallocated_device_buffer_alloc_params;
-    preallocated_device_buffer_alloc_params.size = prealloc_size;
-    RhiResult res =
-        llvm_device()->allocate_memory(preallocated_device_buffer_alloc_params,
-                                       &preallocated_device_buffer_alloc_);
-    TI_ASSERT(res == RhiResult::success);
-    amdgpu::AmdgpuDevice::AllocInfo preallocated_device_buffer_alloc_info =
-        llvm_device()->as<amdgpu::AmdgpuDevice>()->get_alloc_info(
-            preallocated_device_buffer_alloc_);
-    preallocated_device_buffer_ = preallocated_device_buffer_alloc_info.ptr;
-
-    AMDGPUDriver::get_instance().memset(preallocated_device_buffer_, 0,
-                                        prealloc_size);
-    *result_buffer_ptr = (uint64 *)preallocated_device_buffer_;
-    size_t result_buffer_size = sizeof(uint64) * taichi_result_buffer_entries;
-    preallocated_device_buffer_ =
-        (char *)preallocated_device_buffer_ + result_buffer_size;
-    prealloc_size -= result_buffer_size;
+    runtime_objects_prealloc_buffer =
+        (char *)runtime_objects_prealloc_buffer + result_buffer_size;
+    runtime_objects_prealloc_size -= result_buffer_size;
 #else
     TI_NOT_IMPLEMENTED
 #endif
@@ -663,14 +628,43 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
   runtime_jit
       ->call<void *, void *, std::size_t, void *, int, void *, void *, void *>(
           "runtime_initialize", *result_buffer_ptr, host_memory_pool,
-          prealloc_size, preallocated_device_buffer_, num_rand_states,
-          (void *)&host_allocate_aligned, (void *)std::printf,
+          runtime_objects_prealloc_size, runtime_objects_prealloc_buffer,
+          num_rand_states, (void *)&host_allocate_aligned, (void *)std::printf,
           (void *)std::vsnprintf);
 
   TI_TRACE("LLVMRuntime initialized (excluding `root`)");
   llvm_runtime_ = fetch_result<void *>(taichi_result_buffer_ret_value_id,
                                        *result_buffer_ptr);
   TI_TRACE("LLVMRuntime pointer fetched");
+
+  // Preallocate for runtime memory and update to LLVMRuntime
+  if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
+    std::size_t total_prealloc_size = 0;
+    const auto total_mem = llvm_device()->get_total_memory();
+    if (config_.device_memory_fraction == 0) {
+      TI_ASSERT(config_.device_memory_GB > 0);
+      total_prealloc_size = std::size_t(config_.device_memory_GB * (1UL << 30));
+    } else {
+      total_prealloc_size =
+          std::size_t(config_.device_memory_fraction * total_mem);
+    }
+    TI_ASSERT(total_prealloc_size <= total_mem);
+
+    auto runtime_memory_prealloc_size =
+        total_prealloc_size > runtime_objects_prealloc_size
+            ? total_prealloc_size - runtime_objects_prealloc_size
+            : 0;
+
+    void *runtime_memory_prealloc_buffer =
+        preallocate_memory(runtime_memory_prealloc_size);
+
+    TI_TRACE("Allocating device memory {:.2f} MB",
+             1.0 * runtime_memory_prealloc_size / (1UL << 20));
+
+    runtime_jit->call<void *, std::size_t, void *>(
+        "runtime_initialize_memory", llvm_runtime_,
+        runtime_memory_prealloc_size, runtime_memory_prealloc_buffer);
+  }
 
   if (config_.arch == Arch::cuda) {
     TI_TRACE("Initializing {} random states using CUDA", num_rand_states);

--- a/taichi/runtime/llvm/llvm_runtime_executor.h
+++ b/taichi/runtime/llvm/llvm_runtime_executor.h
@@ -96,6 +96,8 @@ class LlvmRuntimeExecutor {
                     std::size_t size,
                     uint32_t data);
 
+  void *preallocate_memory(std::size_t prealloc_size);
+
   /* ------------------------- */
   /* ---- Runtime Helpers ---- */
   /* ------------------------- */
@@ -142,8 +144,7 @@ class LlvmRuntimeExecutor {
 
   std::unique_ptr<SNodeTreeBufferManager> snode_tree_buffer_manager_{nullptr};
   std::unordered_map<int, DeviceAllocation> snode_tree_allocs_;
-  void *preallocated_device_buffer_{nullptr};  // TODO: move to memory allocator
-  DeviceAllocation preallocated_device_buffer_alloc_{kDeviceNullAllocation};
+  std::vector<DeviceAllocation> preallocated_device_buffer_allocs_;
 
   // good buddy
   friend LlvmProgramImpl;

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -562,10 +562,14 @@ struct LLVMRuntime {
   Ptr ambient_elements[taichi_max_num_snodes];
   Ptr temporaries;
   RandState *rand_states;
+  
+  // Cross backend (CPU, CUDA, AMDGPU) runtime memory allocation
   Ptr allocate_aligned(PreallocatedMemoryChunk &memory_chunk,
                        std::size_t size,
                        std::size_t alignment,
                        bool request = false);
+ 
+  // Allocate from preallocated memory (CUDA, AMDGPU)
   Ptr allocate_from_reserved_memory(PreallocatedMemoryChunk &memory_chunk,
                                     std::size_t size,
                                     std::size_t alignment);

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -562,13 +562,13 @@ struct LLVMRuntime {
   Ptr ambient_elements[taichi_max_num_snodes];
   Ptr temporaries;
   RandState *rand_states;
-  
+
   // Cross backend (CPU, CUDA, AMDGPU) runtime memory allocation
   Ptr allocate_aligned(PreallocatedMemoryChunk &memory_chunk,
                        std::size_t size,
                        std::size_t alignment,
                        bool request = false);
- 
+
   // Allocate from preallocated memory (CUDA, AMDGPU)
   Ptr allocate_from_reserved_memory(PreallocatedMemoryChunk &memory_chunk,
                                     std::size_t size,

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -542,7 +542,8 @@ struct PreallocatedMemoryChunk {
 };
 
 struct LLVMRuntime {
-  PreallocatedMemoryChunk preallocated_memory_chunk;
+  PreallocatedMemoryChunk runtime_objects_chunk;
+  PreallocatedMemoryChunk runtime_memory_chunk;
 
   host_allocator_type host_allocator;
   assert_failed_type assert_failed;
@@ -561,10 +562,13 @@ struct LLVMRuntime {
   Ptr ambient_elements[taichi_max_num_snodes];
   Ptr temporaries;
   RandState *rand_states;
-  Ptr allocate_aligned(std::size_t size,
+  Ptr allocate_aligned(PreallocatedMemoryChunk &memory_chunk,
+                       std::size_t size,
                        std::size_t alignment,
                        bool request = false);
-  Ptr allocate_from_reserved_memory(std::size_t size, std::size_t alignment);
+  Ptr allocate_from_reserved_memory(PreallocatedMemoryChunk &memory_chunk,
+                                    std::size_t size,
+                                    std::size_t alignment);
   Ptr profiler;
   void (*profiler_start)(Ptr, Ptr);
   void (*profiler_stop)(Ptr);
@@ -590,7 +594,8 @@ struct LLVMRuntime {
 
   template <typename T, typename... Args>
   T *create(Args &&...args) {
-    auto ptr = (T *)allocate_aligned(sizeof(T), 4096, true /*request*/);
+    auto ptr = (T *)allocate_aligned(runtime_memory_chunk, sizeof(T), 4096,
+                                     true /*request*/);
     new (ptr) T(std::forward<Args>(args)...);
     return ptr;
   }
@@ -804,36 +809,37 @@ void taichi_assert_runtime(LLVMRuntime *runtime, i32 test, const char *msg) {
 
 // [ON HOST] CPU backend
 // [ON DEVICE] CUDA/AMDGPU backend
-Ptr LLVMRuntime::allocate_aligned(std::size_t size,
+Ptr LLVMRuntime::allocate_aligned(PreallocatedMemoryChunk &memory_chunk,
+                                  std::size_t size,
                                   std::size_t alignment,
                                   bool request) {
   if (request)
     atomic_add_i64(&total_requested_memory, size);
 
-  if (preallocated_memory_chunk.preallocated_size > 0) {
-    return allocate_from_reserved_memory(size, alignment);
+  if (memory_chunk.preallocated_size > 0) {
+    return allocate_from_reserved_memory(memory_chunk, size, alignment);
   }
 
   return (Ptr)host_allocator(memory_pool, size, alignment);
 }
 
 // [ONLY ON DEVICE] CUDA/AMDGPU backend
-Ptr LLVMRuntime::allocate_from_reserved_memory(std::size_t size,
-                                               std::size_t alignment) {
+Ptr LLVMRuntime::allocate_from_reserved_memory(
+    PreallocatedMemoryChunk &memory_chunk,
+    std::size_t size,
+    std::size_t alignment) {
   Ptr ret = nullptr;
   bool success = false;
   locked_task(&allocator_lock, [&] {
-    std::size_t preallocated_head =
-        (std::size_t)preallocated_memory_chunk.preallocated_head;
-    std::size_t preallocated_tail =
-        (std::size_t)preallocated_memory_chunk.preallocated_tail;
+    std::size_t preallocated_head = (std::size_t)memory_chunk.preallocated_head;
+    std::size_t preallocated_tail = (std::size_t)memory_chunk.preallocated_tail;
 
     auto alignment_bytes =
         alignment - 1 - (preallocated_head + alignment - 1) % alignment;
     size += alignment_bytes;
     if (preallocated_head + size <= preallocated_tail) {
       ret = (Ptr)(preallocated_head + alignment_bytes);
-      preallocated_memory_chunk.preallocated_head += size;
+      memory_chunk.preallocated_head += size;
       success = true;
     } else {
       success = false;
@@ -872,8 +878,9 @@ void runtime_memory_allocate_aligned(LLVMRuntime *runtime,
                                      std::size_t size,
                                      std::size_t alignment,
                                      uint64 *result) {
-  *result = taichi_union_cast_with_different_sizes<uint64>(
-      runtime->allocate_aligned(size, alignment));
+  *result =
+      taichi_union_cast_with_different_sizes<uint64>(runtime->allocate_aligned(
+          runtime->runtime_memory_chunk, size, alignment));
 }
 
 // External API
@@ -904,12 +911,12 @@ void runtime_initialize(
         (LLVMRuntime *)host_allocator(memory_pool, sizeof(LLVMRuntime), 128);
   }
 
-  PreallocatedMemoryChunk preallocated_memory_chunk;
-  preallocated_memory_chunk.preallocated_size = preallocated_size;
-  preallocated_memory_chunk.preallocated_head = preallocated_buffer;
-  preallocated_memory_chunk.preallocated_tail = preallocated_tail;
+  PreallocatedMemoryChunk runtime_objects_chunk;
+  runtime_objects_chunk.preallocated_size = preallocated_size;
+  runtime_objects_chunk.preallocated_head = preallocated_buffer;
+  runtime_objects_chunk.preallocated_tail = preallocated_tail;
 
-  runtime->preallocated_memory_chunk = std::move(preallocated_memory_chunk);
+  runtime->runtime_objects_chunk = std::move(runtime_objects_chunk);
 
   runtime->result_buffer = result_buffer;
   runtime->set_result(taichi_result_buffer_ret_value_id, runtime);
@@ -921,11 +928,24 @@ void runtime_initialize(
   runtime->total_requested_memory = 0;
 
   runtime->temporaries = (Ptr)runtime->allocate_aligned(
-      taichi_global_tmp_buffer_size, taichi_page_size);
+      runtime->runtime_objects_chunk, taichi_global_tmp_buffer_size,
+      taichi_page_size);
 
   runtime->num_rand_states = num_rand_states;
   runtime->rand_states = (RandState *)runtime->allocate_aligned(
+      runtime->runtime_objects_chunk,
       sizeof(RandState) * runtime->num_rand_states, taichi_page_size);
+}
+
+void runtime_initialize_memory(LLVMRuntime *runtime,
+                               std::size_t preallocated_size,
+                               Ptr preallocated_buffer) {
+  if (preallocated_size) {
+    runtime->runtime_memory_chunk.preallocated_size = preallocated_size;
+    runtime->runtime_memory_chunk.preallocated_head = preallocated_buffer;
+    runtime->runtime_memory_chunk.preallocated_tail =
+        preallocated_buffer + preallocated_size;
+  }
 }
 
 void runtime_initialize_runtime_context_buffer(LLVMRuntime *runtime) {
@@ -998,8 +1018,8 @@ void runtime_allocate_ambient(LLVMRuntime *runtime,
                               std::size_t size) {
   // Do not use NodeManager for the ambient node since it will never be garbage
   // collected.
-  runtime->ambient_elements[snode_id] =
-      runtime->allocate_aligned(size, 128, true /*request*/);
+  runtime->ambient_elements[snode_id] = runtime->allocate_aligned(
+      runtime->runtime_memory_chunk, size, 128, true /*request*/);
 }
 
 void mutex_lock_i32(Ptr mutex) {
@@ -1621,6 +1641,7 @@ void ListManager::touch_chunk(int chunk_id) {
       if (!chunks[chunk_id]) {
         grid_memfence();
         auto chunk_ptr = runtime->allocate_aligned(
+            runtime->runtime_memory_chunk,
             max_num_elements_per_chunk * element_size, 4096, true /*request*/);
         atomic_exchange_u64((u64 *)&chunks[chunk_id], (u64)chunk_ptr);
       }


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99e0581</samp>

This pull request refactors the preallocation logic for the LLVM runtime on the CUDA and AMDGPU backends, using a vector of `DeviceAllocation` objects and a new function `preallocate_memory`. It also adds methods to the device classes to get the memory address and the total memory of the preallocated buffers, and initializes the memory to zero. These changes aim to simplify the memory management and improve the performance and stability of the runtime module.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99e0581</samp>

*  Add methods `get_memory_addr` and `get_total_memory` to `AmdgpuDevice` and `CudaDevice` classes to support preallocation logic for LLVM runtime on AMDGPU and CUDA backends ([link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-a7b85199b3c0a668f23bf0b723c126009e774437499d555de255883c1d1f4648R104-R111), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-01cbaa214a08d98caa33977f217853d54c85d51c03e2dab610909f530b63ee7fR130-R137))
*  Initialize allocated memory to zero in `allocate_memory` function of `AmdgpuDevice` and `CudaDevice` classes to avoid potential errors or undefined behavior ([link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-e0843d34a17298595cd26f5b47b1933a0d18c5c795b0c91b73ec8541a2cdd3f9R45-R46), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654R40-R41))
*  Declare virtual methods `get_memory_addr` and `get_total_memory` in `LlvmDevice` class to match the interface of `Device` class and allow polymorphism ([link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-96f2f848955ca34e50c83bdaa4b970cd7d60ac595e924f626c4568a03a43658eR30-R37))
*  Refactor preallocation logic in `LlvmRuntimeExecutor` class to use multiple buffers for different purposes, such as runtime objects and runtime memory, and store them in a vector of `DeviceAllocation` objects ([link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L81), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L539-R541), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5R555-R571), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L564-R599), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L667-R633), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5R641-R669), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-adcaa7ccf61abaaedec76fa32fca2339069974a6cb912ce1db304087a083d0b6R99-R100), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-adcaa7ccf61abaaedec76fa32fca2339069974a6cb912ce1db304087a083d0b6L145-R147))
*  Refactor preallocation logic in `LLVMRuntime` struct and related functions in `runtime.cpp` file to use separate memory chunks for runtime objects and runtime memory, and pass them as arguments to allocation functions ([link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L545-R546), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L564-R571), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L593-R598), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L807-R813), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L813-R820), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L821-R835), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L836-R842), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L875-R883), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L907-R919), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L924-R950), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L1001-R1022), [link](https://github.com/taichi-dev/taichi/pull/7938/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4R1644))
