### PR TITLE
[Lang] Remove deprecated funcs in __init__.py

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -5,7 +5,7 @@ export TI_SKIP_VERSION_CHECK=ON
 export TI_CI=1
 
 # IF YOU PIN THIS TO A COMMIT/BRANCH, YOU'RE RESPONSIBLE TO REVERT IT BACK TO MASTER ONCE MERGED.
-export TAICHI_AOT_DEMO_URL=https://github.com/lin-hitonami/taichi-aot-demo
+export TAICHI_AOT_DEMO_URL=https://github.com/taichi-dev/taichi-aot-demo
 export TAICHI_AOT_DEMO_BRANCH=master
 
 export TAICHI_UNITY2_URL=https://github.com/taichi-dev/taichi-unity2

--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -5,7 +5,7 @@ export TI_SKIP_VERSION_CHECK=ON
 export TI_CI=1
 
 # IF YOU PIN THIS TO A COMMIT/BRANCH, YOU'RE RESPONSIBLE TO REVERT IT BACK TO MASTER ONCE MERGED.
-export TAICHI_AOT_DEMO_URL=https://github.com/taichi-dev/taichi-aot-demo
+export TAICHI_AOT_DEMO_URL=https://github.com/lin-hitonami/taichi-aot-demo
 export TAICHI_AOT_DEMO_BRANCH=master
 
 export TAICHI_UNITY2_URL=https://github.com/taichi-dev/taichi-unity2

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -16,6 +16,13 @@ from taichi.ui import GUI, hex_to_rgb, rgb_to_hex, ui
 # Issue#2223: Do not reorder, or we're busted with partially initialized module
 from taichi import aot  # isort:skip
 
+
+def __getattr__(attr):
+    if attr == "cfg":
+        return None if lang.impl.get_runtime().prog is None else lang.impl.current_cfg()
+    raise AttributeError(f"module '{__name__}' has no attribute '{attr}'")
+
+
 __version__ = (
     _ti_core.get_version_major(),
     _ti_core.get_version_minor(),

--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -1,5 +1,3 @@
-import sys
-
 from taichi._funcs import *
 from taichi._lib import core as _ti_core
 from taichi._lib.utils import warn_restricted_version
@@ -18,87 +16,12 @@ from taichi.ui import GUI, hex_to_rgb, rgb_to_hex, ui
 # Issue#2223: Do not reorder, or we're busted with partially initialized module
 from taichi import aot  # isort:skip
 
-__deprecated_names__ = {
-    "SOA": "Layout.SOA",
-    "AOS": "Layout.AOS",
-    "print_profile_info": "profiler.print_scoped_profiler_info",
-    "clear_profile_info": "profiler.clear_scoped_profiler_info",
-    "print_memory_profile_info": "profiler.print_memory_profiler_info",
-    "CuptiMetric": "profiler.CuptiMetric",
-    "get_predefined_cupti_metrics": "profiler.get_predefined_cupti_metrics",
-    "print_kernel_profile_info": "profiler.print_kernel_profiler_info",
-    "query_kernel_profile_info": "profiler.query_kernel_profiler_info",
-    "clear_kernel_profile_info": "profiler.clear_kernel_profiler_info",
-    "kernel_profiler_total_time": "profiler.get_kernel_profiler_total_time",
-    "set_kernel_profiler_toolkit": "profiler.set_kernel_profiler_toolkit",
-    "set_kernel_profile_metrics": "profiler.set_kernel_profiler_metrics",
-    "collect_kernel_profile_metrics": "profiler.collect_kernel_profiler_metrics",
-    "VideoManager": "tools.VideoManager",
-    "PLYWriter": "tools.PLYWriter",
-    "imread": "tools.imread",
-    "imresize": "tools.imresize",
-    "imshow": "tools.imshow",
-    "imwrite": "tools.imwrite",
-    "ext_arr": "types.ndarray",
-    "any_arr": "types.ndarray",
-    "Tape": "ad.Tape",
-    "clear_all_gradients": "ad.clear_all_gradients",
-}
-
-__customized_deprecations__ = {
-    "parallelize": (
-        "Please use ti.loop_config(parallelize=...) instead.",
-        "lang.misc._parallelize",
-    ),
-    "serialize": (
-        "Please use ti.loop_config(serialize=True) instead.",
-        "lang.misc._serialize",
-    ),
-    "block_dim": (
-        "Please use ti.loop_config(block_dim=...) instead.",
-        "lang.misc._block_dim",
-    ),
-    "TriMesh": (
-        "Please import meshtaichi_patcher as Patcher and use Patcher.load_mesh(...) instead.",
-        "lang.mesh._TriMesh",
-    ),
-    "TetMesh": (
-        "Please import meshtaichi_patcher as Patcher and use Patcher.load_mesh(...) instead.",
-        "lang.mesh._TetMesh",
-    ),
-}
-
-
-def __getattr__(attr):
-    import warnings  # pylint: disable=C0415,W0621
-
-    if attr == "cfg":
-        return None if lang.impl.get_runtime().prog is None else lang.impl.current_cfg()
-    if attr in __deprecated_names__:
-        warnings.warn(
-            f"ti.{attr} is deprecated, and it will be removed in Taichi v1.6.0. Please use ti.{__deprecated_names__[attr]} instead.",
-            DeprecationWarning,
-        )
-        exec(f"{attr} = {__deprecated_names__[attr]}")
-        return locals()[attr]
-    if attr in __customized_deprecations__:
-        msg, fun = __customized_deprecations__[attr]
-        warnings.warn(
-            f"ti.{attr} is deprecated, and it will be removed in Taichi v1.6.0. {msg}",
-            DeprecationWarning,
-        )
-        exec(f"{attr} = {fun}")
-        return locals()[attr]
-    raise AttributeError(f"module '{__name__}' has no attribute '{attr}'")
-
-
 __version__ = (
     _ti_core.get_version_major(),
     _ti_core.get_version_minor(),
     _ti_core.get_version_patch(),
 )
 
-del sys
 del _ti_core
 
 warn_restricted_version()

--- a/python/taichi/examples/autodiff/regression.py
+++ b/python/taichi/examples/autodiff/regression.py
@@ -60,7 +60,7 @@ def regress_raw():
             with ti.ad.Tape(loss=loss):
                 regress()
         else:
-            ti.clear_all_gradients()
+            ti.ad.clear_all_gradients()
             loss[None] = 0
             loss.grad[None] = 1
             regress()

--- a/tests/cpp/aot/python_scripts/mpm88_graph_aot.py
+++ b/tests/cpp/aot/python_scripts/mpm88_graph_aot.py
@@ -27,19 +27,19 @@ def compile_mpm88(arch, save_compute_graph):
     ti.init(arch=arch)
 
     @ti.kernel
-    def substep_reset_grid(grid_v: ti.any_arr(ndim=2), grid_m: ti.any_arr(ndim=2)):
+    def substep_reset_grid(grid_v: ti.types.ndarray(ndim=2), grid_m: ti.types.ndarray(ndim=2)):
         for i, j in grid_m:
             grid_v[i, j] = [0, 0]
             grid_m[i, j] = 0
 
     @ti.kernel
     def substep_p2g(
-        x: ti.any_arr(ndim=1),
-        v: ti.any_arr(ndim=1),
-        C: ti.any_arr(ndim=1),
-        J: ti.any_arr(ndim=1),
-        grid_v: ti.any_arr(ndim=2),
-        grid_m: ti.any_arr(ndim=2),
+        x: ti.types.ndarray(ndim=1),
+        v: ti.types.ndarray(ndim=1),
+        C: ti.types.ndarray(ndim=1),
+        J: ti.types.ndarray(ndim=1),
+        grid_v: ti.types.ndarray(ndim=2),
+        grid_m: ti.types.ndarray(ndim=2),
     ):
         for p in x:
             dx = 1 / grid_v.shape[0]
@@ -59,7 +59,7 @@ def compile_mpm88(arch, save_compute_graph):
                 grid_m[base + offset] += weight * p_mass
 
     @ti.kernel
-    def substep_update_grid_v(grid_v: ti.any_arr(ndim=2), grid_m: ti.any_arr(ndim=2)):
+    def substep_update_grid_v(grid_v: ti.types.ndarray(ndim=2), grid_m: ti.types.ndarray(ndim=2)):
         for i, j in grid_m:
             num_grid = grid_v.shape[0]
             if grid_m[i, j] > 0:
@@ -76,12 +76,12 @@ def compile_mpm88(arch, save_compute_graph):
 
     @ti.kernel
     def substep_g2p(
-        x: ti.any_arr(ndim=1),
-        v: ti.any_arr(ndim=1),
-        C: ti.any_arr(ndim=1),
-        J: ti.any_arr(ndim=1),
-        grid_v: ti.any_arr(ndim=2),
-        pos: ti.any_arr(ndim=1),
+        x: ti.types.ndarray(ndim=1),
+        v: ti.types.ndarray(ndim=1),
+        C: ti.types.ndarray(ndim=1),
+        J: ti.types.ndarray(ndim=1),
+        grid_v: ti.types.ndarray(ndim=2),
+        pos: ti.types.ndarray(ndim=1),
     ):
         for p in x:
             dx = 1 / grid_v.shape[0]
@@ -105,7 +105,7 @@ def compile_mpm88(arch, save_compute_graph):
             C[p] = new_C
 
     @ti.kernel
-    def init_particles(x: ti.any_arr(ndim=1), v: ti.any_arr(ndim=1), J: ti.any_arr(ndim=1)):
+    def init_particles(x: ti.types.ndarray(ndim=1), v: ti.types.ndarray(ndim=1), J: ti.types.ndarray(ndim=1)):
         for i in range(x.shape[0]):
             x[i] = [ti.random() * 0.4 + 0.2, ti.random() * 0.4 + 0.2]
             v[i] = [0, -1]

--- a/tests/cpp/aot/python_scripts/sph_aot.py
+++ b/tests/cpp/aot/python_scripts/sph_aot.py
@@ -67,9 +67,9 @@ W_gradient = W_spiky_gradient
 
 @ti.kernel
 def initialize(
-    boundary_box: ti.any_arr(ndim=1),
-    spawn_box: ti.any_arr(ndim=1),
-    N: ti.any_arr(ndim=1),
+    boundary_box: ti.types.ndarray(ndim=1),
+    spawn_box: ti.types.ndarray(ndim=1),
+    N: ti.types.ndarray(ndim=1),
 ):
     boundary_box[0] = [0.0, 0.0, 0.0]
     boundary_box[1] = [1.0, 1.0, 1.0]
@@ -84,10 +84,10 @@ def initialize(
 
 @ti.kernel
 def initialize_particle(
-    pos: ti.any_arr(ndim=1),
-    spawn_box: ti.any_arr(ndim=1),
-    N: ti.any_arr(ndim=1),
-    gravity: ti.any_arr(ndim=0),
+    pos: ti.types.ndarray(ndim=1),
+    spawn_box: ti.types.ndarray(ndim=1),
+    N: ti.types.ndarray(ndim=1),
+    gravity: ti.types.ndarray(ndim=0),
 ):
     gravity[None] = ti.Vector([0.0, -9.8, 0.0])
     for i in range(particle_num):
@@ -96,7 +96,7 @@ def initialize_particle(
 
 
 @ti.kernel
-def update_density(pos: ti.any_arr(ndim=1), den: ti.any_arr(ndim=1), pre: ti.any_arr(ndim=1)):
+def update_density(pos: ti.types.ndarray(ndim=1), den: ti.types.ndarray(ndim=1), pre: ti.types.ndarray(ndim=1)):
     for i in range(particle_num):
         den[i] = 0.0
         for j in range(particle_num):
@@ -107,12 +107,12 @@ def update_density(pos: ti.any_arr(ndim=1), den: ti.any_arr(ndim=1), pre: ti.any
 
 @ti.kernel
 def update_force(
-    pos: ti.any_arr(ndim=1),
-    vel: ti.any_arr(ndim=1),
-    den: ti.any_arr(ndim=1),
-    pre: ti.any_arr(ndim=1),
-    acc: ti.any_arr(ndim=1),
-    gravity: ti.any_arr(ndim=0),
+    pos: ti.types.ndarray(ndim=1),
+    vel: ti.types.ndarray(ndim=1),
+    den: ti.types.ndarray(ndim=1),
+    pre: ti.types.ndarray(ndim=1),
+    acc: ti.types.ndarray(ndim=1),
+    gravity: ti.types.ndarray(ndim=0),
 ):
     for i in range(particle_num):
         acc[i] = gravity[None]
@@ -139,14 +139,16 @@ def update_force(
 
 
 @ti.kernel
-def advance(pos: ti.any_arr(ndim=1), vel: ti.any_arr(ndim=1), acc: ti.any_arr(ndim=1)):
+def advance(pos: ti.types.ndarray(ndim=1), vel: ti.types.ndarray(ndim=1), acc: ti.types.ndarray(ndim=1)):
     for i in range(particle_num):
         vel[i] += acc[i] * dt
         pos[i] += vel[i] * dt
 
 
 @ti.kernel
-def boundary_handle(pos: ti.any_arr(ndim=1), vel: ti.any_arr(ndim=1), boundary_box: ti.any_arr(ndim=1)):
+def boundary_handle(
+    pos: ti.types.ndarray(ndim=1), vel: ti.types.ndarray(ndim=1), boundary_box: ti.types.ndarray(ndim=1)
+):
     for i in range(particle_num):
         collision_normal = ti.Vector([0.0, 0.0, 0.0])
         for j in ti.static(range(3)):
@@ -164,7 +166,7 @@ def boundary_handle(pos: ti.any_arr(ndim=1), vel: ti.any_arr(ndim=1), boundary_b
 
 
 @ti.kernel
-def copy_data_from_ndarray_to_field(src: ti.template(), dst: ti.any_arr()):
+def copy_data_from_ndarray_to_field(src: ti.template(), dst: ti.types.ndarray()):
     for I in ti.grouped(src):
         src[I] = dst[I]
 

--- a/tests/python/bls_test_template.py
+++ b/tests/python/bls_test_template.py
@@ -54,7 +54,7 @@ def bls_test_template(dim, N, bs, stencil, block_dim=None, scatter=False, benchm
         if ti.static(use_bls and scatter):
             ti.block_local(y)
 
-        ti.block_dim(block_dim)
+        ti.loop_config(block_dim=block_dim)
         for I in ti.grouped(x):
             if ti.static(scatter):
                 for offset in ti.static(stencil):
@@ -167,7 +167,7 @@ def bls_particle_grid(
 
     @ti.kernel
     def insert():
-        ti.block_dim(256)
+        ti.loop_config(block_dim=256)
         for i in x:
             # It is important to ensure insert and p2g uses the exact same way to compute the base
             # coordinates. Otherwise there might be coordinate mismatch due to float-point errors.
@@ -184,7 +184,7 @@ def bls_particle_grid(
 
     @ti.kernel
     def p2g(use_shared: ti.template(), m: ti.template()):
-        ti.block_dim(256)
+        ti.loop_config(block_dim=256)
         if ti.static(use_shared):
             ti.block_local(m)
         for I in ti.grouped(pid):
@@ -202,7 +202,7 @@ def bls_particle_grid(
 
     @ti.kernel
     def p2g_naive():
-        ti.block_dim(256)
+        ti.loop_config(block_dim=256)
         for p in x:
             u = ti.floor(x[p] * N).cast(ti.i32)
 
@@ -216,7 +216,7 @@ def bls_particle_grid(
 
     @ti.kernel
     def g2p(use_shared: ti.template(), s: ti.template()):
-        ti.block_dim(256)
+        ti.loop_config(block_dim=256)
         if ti.static(use_shared):
             ti.block_local(m1)
         for I in ti.grouped(pid):
@@ -239,7 +239,7 @@ def bls_particle_grid(
 
     @ti.kernel
     def g2p_naive(s: ti.template()):
-        ti.block_dim(256)
+        ti.loop_config(block_dim=256)
         for p in x:
             u = ti.floor(x[p] * N).cast(ti.i32)
 

--- a/tests/python/test_bls.py
+++ b/tests/python/test_bls.py
@@ -171,7 +171,7 @@ def test_bls_large_block():
 
     @ti.kernel
     def foo():
-        ti.block_dim(512)
+        ti.loop_config(block_dim=512)
         ti.block_local(a)
         for i, j in a:
             for k in range(stencil_length):

--- a/tests/python/test_clear_all_gradients.py
+++ b/tests/python/test_clear_all_gradients.py
@@ -25,7 +25,7 @@ def test_clear_all_gradients():
             z.grad[i, j] = 5
             w.grad[i, j] = 6
 
-    ti.clear_all_gradients()
+    ti.ad.clear_all_gradients()
     assert impl.get_runtime().get_num_compiled_functions() == 3
 
     assert x.grad[None] == 0
@@ -35,6 +35,6 @@ def test_clear_all_gradients():
             assert z.grad[i, j] == 0
             assert w.grad[i, j] == 0
 
-    ti.clear_all_gradients()
+    ti.ad.clear_all_gradients()
     # No more kernel compilation
     assert impl.get_runtime().get_num_compiled_functions() == 3

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -136,15 +136,6 @@ def test_deprecate_ti_ui_make_camera():
 
 
 @test_utils.test()
-def test_deprecation_in_taichi_init_py():
-    with pytest.warns(
-        DeprecationWarning,
-        match="ti.SOA is deprecated, and it will be removed in Taichi v1.6.0.",
-    ):
-        ti.SOA
-
-
-@test_utils.test()
 def test_deprecate_sparse_matrix_builder():
     with pytest.warns(
         DeprecationWarning,

--- a/tests/python/test_mesh.py
+++ b/tests/python/test_mesh.py
@@ -11,7 +11,7 @@ model_file_path = os.path.join(this_dir, "ell.json")
 
 @test_utils.test(require=ti.extension.mesh)
 def test_mesh_patch_idx():
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.verts.place({"idx": ti.i32})
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
 
@@ -27,7 +27,7 @@ def test_mesh_patch_idx():
 
 
 def _test_mesh_for(cell_reorder=False, vert_reorder=False, extra_tests=True):
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.verts.place({"t": ti.i32}, reorder=vert_reorder)
     mesh_builder.cells.place({"t": ti.i32}, reorder=cell_reorder)
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
@@ -106,7 +106,7 @@ def test_mesh_localize_mapping1():
 @test_utils.test(require=ti.extension.mesh)
 def test_mesh_reorder():
     vec3i = ti.types.vector(3, ti.i32)
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.verts.place({"s": ti.i32, "s3": vec3i}, reorder=True)
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
 
@@ -141,7 +141,7 @@ def test_mesh_reorder():
 
 @test_utils.test(require=ti.extension.mesh)
 def test_mesh_minor_relations():
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.verts.place({"y": ti.i32})
     mesh_builder.edges.place({"x": ti.i32})
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
@@ -163,7 +163,7 @@ def test_mesh_minor_relations():
 
 @test_utils.test(require=ti.extension.mesh, demote_no_access_mesh_fors=True)
 def test_multiple_meshes():
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.verts.place({"y": ti.i32})
     meta = ti.Mesh.load_meta(model_file_path)
     model1 = mesh_builder.build(meta)
@@ -184,7 +184,7 @@ def test_multiple_meshes():
 
 @test_utils.test(require=ti.extension.mesh)
 def test_mesh_local():
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.verts.place({"a": ti.i32})
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
     ext_a = ti.field(ti.i32, shape=len(model.verts))
@@ -219,7 +219,7 @@ def test_mesh_local():
 
 @test_utils.test(require=ti.extension.mesh, experimental_auto_mesh_local=True)
 def test_auto_mesh_local():
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.verts.place({"a": ti.i32, "s": ti.i32})
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
     ext_a = ti.field(ti.i32, shape=len(model.verts))
@@ -255,7 +255,7 @@ def test_auto_mesh_local():
 
 @test_utils.test(require=ti.extension.mesh)
 def test_nested_mesh_for():
-    mesh_builder = ti.TetMesh()
+    mesh_builder = ti.lang.mesh._TetMesh()
     mesh_builder.faces.place({"a": ti.i32, "b": ti.i32})
     model = mesh_builder.build(ti.Mesh.load_meta(model_file_path))
 
@@ -274,7 +274,7 @@ def test_nested_mesh_for():
 
 @test_utils.test(require=ti.extension.mesh)
 def test_multiple_mesh_major_relations():
-    mesh = ti.TetMesh()
+    mesh = ti.lang.mesh._TetMesh()
     mesh.verts.place({"s": ti.i32, "s_": ti.i32, "s1": ti.i32, "a": ti.i32, "b": ti.i32, "c": ti.i32})
     mesh.edges.place({"s2": ti.i32})
     mesh.cells.place({"s3": ti.i32})

--- a/tests/python/test_torch_ad.py
+++ b/tests/python/test_torch_ad.py
@@ -45,7 +45,7 @@ def test_torch_ad():
 
         @staticmethod
         def backward(ctx, outp_grad):
-            ti.clear_all_gradients()
+            ti.ad.clear_all_gradients()
             y.grad.from_torch(outp_grad)
             torch_kernel.grad()
             inp_grad = x.grad.to_torch()
@@ -90,7 +90,7 @@ def test_torch_ad_gpu():
 
         @staticmethod
         def backward(ctx, outp_grad):
-            ti.clear_all_gradients()
+            ti.ad.clear_all_gradients()
             y.grad.from_torch(outp_grad)
             torch_kernel.grad()
             inp_grad = x.grad.to_torch(device=device)


### PR DESCRIPTION
Issue: #
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1f974a4</samp>

### Summary
🔄🗑️🆕

<!--
1.  🔄 - This emoji represents a change that renames or replaces an existing API with a new one, such as the first two changes in the list. It implies that the change is part of a refactoring or an update to the codebase.
2.  🗑️ - This emoji represents a change that removes or deletes unused or deprecated code, such as the third and fourth changes in the list. It implies that the change is part of a cleanup or a simplification of the codebase.
3.  🆕 - This emoji represents a change that adds or introduces new features or functionality, such as the last five changes in the list. It implies that the change is part of a enhancement or a improvement of the codebase.
-->
This pull request removes or updates the usage of several deprecated APIs in Taichi, such as `ti.any_arr`, `ti.block_dim`, `ti.clear_all_gradients`, and `ti.TetMesh`. The goal is to simplify the code, improve the user experience, and prepare for the upcoming release of Taichi v1.6.0. The changes affect various files in `python/taichi`, `tests/python`, and `tests/cpp/aot/python_scripts`.

> _Oh we're the brave Taichi crew, and we've got some work to do_
> _We're clearing out the old code, and bringing in the new_
> _So heave away, me lads and lasses, heave away with me_
> _We'll use `ti.ad` and `ti.loop_config`, and sail the Python sea_

### Walkthrough
*  Remove unused and deprecated imports, names, and statements in `python/taichi/__init__.py` ([link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-e0e39c57bc92c0e1da4c831f8820a4082a3cc26a9b88962bee72964dfa26a74aL1-L2), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-e0e39c57bc92c0e1da4c831f8820a4082a3cc26a9b88962bee72964dfa26a74aL21-R22), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-e0e39c57bc92c0e1da4c831f8820a4082a3cc26a9b88962bee72964dfa26a74aL101))
*  Replace `ti.clear_all_gradients` with `ti.ad.clear_all_gradients` in examples and tests to use the new name for the function that clears all gradients in the autodiff system ([link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-12fc3a7ebde836d97c869694e52b5a407b49988c10e240c8fad33126013012acL63-R63), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-ee690f3a522eafc173aab6fe21fb1c6c4d96eaa8cd6f5aecd441079412e29635L28-R28), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-ee690f3a522eafc173aab6fe21fb1c6c4d96eaa8cd6f5aecd441079412e29635L38-R38), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-bf4b076e3a4f80273a1a730e55a004dcfcea49e3f22378c12636a35c0b707f1eL48-R48), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-bf4b076e3a4f80273a1a730e55a004dcfcea49e3f22378c12636a35c0b707f1eL93-R93))
*  Replace `ti.any_arr` with `ti.types.ndarray` in argument annotations of kernels in `tests/cpp/aot/python_scripts` to use the new name for the type that represents a Taichi ndarray ([link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-4f9548204019161643336c9ebb271a758919885419bd440be93ea851fb62973aL30-R30), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-4f9548204019161643336c9ebb271a758919885419bd440be93ea851fb62973aL37-R42), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-4f9548204019161643336c9ebb271a758919885419bd440be93ea851fb62973aL62-R62), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-4f9548204019161643336c9ebb271a758919885419bd440be93ea851fb62973aL79-R84), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-4f9548204019161643336c9ebb271a758919885419bd440be93ea851fb62973aL108-R108), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-b2b340803f06d4337ecaf4f14abf66755d888946b08939b1f1e88e64d293b40aL70-R72), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-b2b340803f06d4337ecaf4f14abf66755d888946b08939b1f1e88e64d293b40aL87-R90), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-b2b340803f06d4337ecaf4f14abf66755d888946b08939b1f1e88e64d293b40aL99-R99), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-b2b340803f06d4337ecaf4f14abf66755d888946b08939b1f1e88e64d293b40aL110-R115), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-b2b340803f06d4337ecaf4f14abf66755d888946b08939b1f1e88e64d293b40aL142-R142), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-b2b340803f06d4337ecaf4f14abf66755d888946b08939b1f1e88e64d293b40aL149-R151), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-b2b340803f06d4337ecaf4f14abf66755d888946b08939b1f1e88e64d293b40aL167-R169))
*  Replace `ti.block_dim` with `ti.loop_config(block_dim=...)` in kernels in `tests/python` to use the new API for configuring loop parallelization and block dimension ([link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-2ea5f113062438816406fbdb85d44d0b44fde412eed818ea1c06c9584c887277L57-R57), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-2ea5f113062438816406fbdb85d44d0b44fde412eed818ea1c06c9584c887277L170-R170), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-2ea5f113062438816406fbdb85d44d0b44fde412eed818ea1c06c9584c887277L187-R187), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-2ea5f113062438816406fbdb85d44d0b44fde412eed818ea1c06c9584c887277L205-R205), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-2ea5f113062438816406fbdb85d44d0b44fde412eed818ea1c06c9584c887277L219-R219), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-2ea5f113062438816406fbdb85d44d0b44fde412eed818ea1c06c9584c887277L242-R242), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-938cc2e845889f8797de5f5de2d2a6f35fc43679c3c41d8bbbae46810c4ae518L174-R174))
*  Replace `ti.TetMesh` with `ti.lang.mesh._TetMesh` in `tests/python/test_mesh.py` to use the new name for the class that represents a tetrahedral mesh ([link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L14-R14), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L30-R30), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L109-R109), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L144-R144), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L166-R166), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L187-R187), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L222-R222), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L258-R258), [link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-a5d38fced7102d9278d61f209491478ba617cfc016e6dc37840da62cfef36f09L277-R277))
*  Remove the test case for `ti.SOA` in `tests/python/test_deprecation.py` to match the removal of the deprecated name in `python/taichi/__init__.py` ([link](https://github.com/taichi-dev/taichi/pull/7941/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L80-L88))

