### PR TITLE
[Lang] Remove deprecated sparse_matrix_builder function

### DIFF
--- a/python/taichi/linalg/sparse_matrix.py
+++ b/python/taichi/linalg/sparse_matrix.py
@@ -1,4 +1,3 @@
-import warnings
 from functools import reduce
 
 import numpy as np
@@ -7,7 +6,7 @@ from taichi.lang._ndarray import Ndarray, ScalarNdarray
 from taichi.lang.exception import TaichiRuntimeError
 from taichi.lang.field import Field
 from taichi.lang.impl import get_runtime
-from taichi.types import annotations, f32
+from taichi.types import f32
 
 
 class SparseMatrix:
@@ -294,14 +293,4 @@ class SparseMatrixBuilder:
         raise TaichiRuntimeError("Sparse matrix only supports CPU and CUDA backends.")
 
 
-# TODO: remove this in 1.0 release
-class sparse_matrix_builder(annotations.sparse_matrix_builder):
-    def __init__(self):
-        warnings.warn(
-            "ti.linalg.sparse_matrix_builder is deprecated, and it will be removed in Taichi v1.6.0. "
-            "Please use ti.types.sparse_matrix_builder instead.",
-            DeprecationWarning,
-        )
-
-
-__all__ = ["SparseMatrix", "SparseMatrixBuilder", "sparse_matrix_builder"]
+__all__ = ["SparseMatrix", "SparseMatrixBuilder"]

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -142,12 +142,3 @@ def test_deprecation_in_taichi_init_py():
         match="ti.SOA is deprecated, and it will be removed in Taichi v1.6.0.",
     ):
         ti.SOA
-
-
-@test_utils.test()
-def test_deprecate_sparse_matrix_builder():
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"ti\.linalg\.sparse_matrix_builder is deprecated, and it will be removed in Taichi v1\.6\.0\.",
-    ):
-        ti.linalg.sparse_matrix_builder()


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6809c08</samp>

Removed deprecated `sparse_matrix_builder` class and related code from `sparse_matrix.py` and `test_deprecation.py`. Simplified the `sparse_matrix` module.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6809c08</samp>

* Remove deprecated `sparse_matrix_builder` class and its alias from `sparse_matrix.py` ([link](https://github.com/taichi-dev/taichi/pull/7942/files?diff=unified&w=0#diff-e788aae97f9ad8507a4eebc224175b2f9ad6f14359999ca0ea99ad4503fc9dcaL297-R296))
* Remove unused `warnings` and `annotations` modules from `sparse_matrix.py` ([link](https://github.com/taichi-dev/taichi/pull/7942/files?diff=unified&w=0#diff-e788aae97f9ad8507a4eebc224175b2f9ad6f14359999ca0ea99ad4503fc9dcaL1), [link](https://github.com/taichi-dev/taichi/pull/7942/files?diff=unified&w=0#diff-e788aae97f9ad8507a4eebc224175b2f9ad6f14359999ca0ea99ad4503fc9dcaL10-R9))
* Remove test case for deprecated `sparse_matrix_builder` class from `test_deprecation.py` ([link](https://github.com/taichi-dev/taichi/pull/7942/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L145-L153))
