### PR TITLE
[Lang] Migrate irpass::scalarize() after irpass::demote_atomics()

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -135,14 +135,6 @@ void compile_to_offloads(IRNode *ir,
   print("Offloaded");
   irpass::analysis::verify(ir);
 
-  if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::die(ir);
-    print("Scalarized");
-  }
-
   // TODO: This pass may be redundant as cfg_optimization() is already called
   //  in full_simplify().
   if (config.opt_level > 0 && config.cfg_optimization) {
@@ -158,6 +150,14 @@ void compile_to_offloads(IRNode *ir,
   irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
   print("Simplified III");
   irpass::analysis::verify(ir);
+
+  if (config.real_matrix_scalarize) {
+    irpass::scalarize(ir);
+
+    // Remove redundant MatrixInitStmt inserted during scalarization
+    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
+    print("Scalarized");
+  }
 }
 
 void offload_to_executable(IRNode *ir,

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -135,6 +135,14 @@ void compile_to_offloads(IRNode *ir,
   print("Offloaded");
   irpass::analysis::verify(ir);
 
+  if (config.real_matrix_scalarize) {
+    irpass::scalarize(ir);
+
+    // Remove redundant MatrixInitStmt inserted during scalarization
+    irpass::die(ir);
+    print("Scalarized");
+  }
+
   // TODO: This pass may be redundant as cfg_optimization() is already called
   //  in full_simplify().
   if (config.opt_level > 0 && config.cfg_optimization) {

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -179,6 +179,10 @@ void offload_to_executable(IRNode *ir,
     print("Detect read-only accesses");
   }
 
+  irpass::demote_atomics(ir, config);
+  print("Atomics demoted I");
+  irpass::analysis::verify(ir);
+
   if (config.real_matrix_scalarize) {
     irpass::scalarize(ir);
 
@@ -187,9 +191,6 @@ void offload_to_executable(IRNode *ir,
     print("Scalarized");
   }
 
-  irpass::demote_atomics(ir, config);
-  print("Atomics demoted I");
-  irpass::analysis::verify(ir);
   if (config.cache_loop_invariant_global_vars) {
     irpass::cache_loop_invariant_global_vars(ir, config);
     print("Cache loop-invariant global vars");

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -150,14 +150,6 @@ void compile_to_offloads(IRNode *ir,
   irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
   print("Simplified III");
   irpass::analysis::verify(ir);
-
-  if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
-    print("Scalarized");
-  }
 }
 
 void offload_to_executable(IRNode *ir,


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 027a0bb</samp>

This pull request improves the performance and readability of the IR transforms in `taichi/transforms`. It simplifies the IR generated by `compile_to_offloads`, supports demoting atomics on matrix elements in `demote_atomics`, enhances the scalarization of pointers and offloaded tasks in `scalarize`, and optimizes the initialization of global temporaries in `offload`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 027a0bb</samp>

*  Simplify and optimize the IR passes in `compile_to_offloads` ([link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL130-L137), [link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR185-R193))
* Extend the logic of `DemoteAtomics` to handle `MatrixPtrStmt` ([link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14L42-R56), [link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14L69-R102))
  - Add empty lines to separate the logic for different pointer types ([link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R117), [link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R125))
* Simplify the logic for initializing global temporary variables with zeros in `LowerGlobalPtrStmt` ([link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L536-R548))
* Rename and extend the logic of `ScalarizePointers` ([link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L884-R884), [link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L893-R893), [link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L982-R1010), [link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L1024-R1069), [link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L1121-R1161))
  - Move the comment explaining the transformation to the beginning of the `visit` function ([link](https://github.com/taichi-dev/taichi/pull/7943/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L951-R960))
