### PR TITLE
[bug] Fix extraction of field with offset to external array

### DIFF
--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -422,5 +422,8 @@ def uniform_add(arr_in: template(), in_beg: i32, in_end: i32):
 
 @kernel
 def blit_from_field_to_field(dst: template(), src: template(), offset: i32, size: i32):
+    dst_offset = static(dst.snode.ptr.offset if len(dst.snode.ptr.offset) != 0 else 0)
+    src_offset = static(src.snode.ptr.offset if len(src.snode.ptr.offset) != 0 else 0)
+    print('[debug]', dst_offset, src_offset)
     for i in range(size):
-        dst[i + offset] = src[i]
+        dst[i + dst_offset + offset] = src[i + src_offset]

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -316,23 +316,23 @@ def sort_stage(
     k: int,
     invocations: int,
 ):
+    keys_offset = static(keys.snode.ptr.offset)
+    values_offset = static(values.snode.ptr.offset)
     for inv in range(invocations):
         j = k % p + inv * 2 * k
         for i in range(0, ops.min(k, N - j - k)):
             a = i + j
             b = i + j + k
             if int(a / (p * 2)) == int(b / (p * 2)):
-                key_a = keys[a]
-                key_b = keys[b]
+                key_a = keys[a + keys_offset]
+                key_b = keys[b + keys_offset]
                 if key_a > key_b:
-                    keys[a] = key_b
-                    keys[b] = key_a
+                    keys[a + keys_offset] = key_b
+                    keys[b + keys_offset] = key_a
                     if use_values != 0:
-                        temp = values[a]
-                        values[a] = values[b]
-                        values[b] = temp
-
-
+                        temp = values[a + values_offset]
+                        values[a + values_offset] = values[b + values_offset]
+                        values[b + values_offset] = temp
 # Parallel Prefix Sum (Scan)
 @func
 def warp_shfl_up_i32(val: template()):

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -214,19 +214,24 @@ def matrix_to_ext_arr(mat: template(), arr: ndarray_type.ndarray(), as_vector: t
 
 @kernel
 def ext_arr_to_matrix(arr: ndarray_type.ndarray(), mat: template(), as_vector: template()):
+    offset = static(mat.snode.ptr.offset)
+    shape = static(mat.shape)
+    # default value of offset is [], replace it with [0] * len
+    offset_new = static([0] * len(shape) if len(offset) == 0 else offset)
+
     for I in grouped(mat):
         for p in static(range(mat.n)):
             for q in static(range(mat.m)):
                 if static(getattr(mat, "ndim", 2) == 1):
                     if static(as_vector):
-                        mat[I][p] = arr[I, p]
+                        mat[I][p] = arr[I - offset_new, p]
                     else:
-                        mat[I][p] = arr[I, p, q]
+                        mat[I][p] = arr[I - offset_new, p, q]
                 else:
                     if static(as_vector):
-                        mat[I][p, q] = arr[I, p]
+                        mat[I][p, q] = arr[I - offset_new, p]
                     else:
-                        mat[I][p, q] = arr[I, p, q]
+                        mat[I][p, q] = arr[I - offset_new, p, q]
 
 
 # extract ndarray of raw vulkan memory layout to normal memory layout.

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -333,6 +333,8 @@ def sort_stage(
                         temp = values[a + values_offset]
                         values[a + values_offset] = values[b + values_offset]
                         values[b + values_offset] = temp
+
+
 # Parallel Prefix Sum (Scan)
 @func
 def warp_shfl_up_i32(val: template()):
@@ -424,6 +426,6 @@ def uniform_add(arr_in: template(), in_beg: i32, in_end: i32):
 def blit_from_field_to_field(dst: template(), src: template(), offset: i32, size: i32):
     dst_offset = static(dst.snode.ptr.offset if len(dst.snode.ptr.offset) != 0 else 0)
     src_offset = static(src.snode.ptr.offset if len(src.snode.ptr.offset) != 0 else 0)
-    print('[debug]', dst_offset, src_offset)
+    print("[debug]", dst_offset, src_offset)
     for i in range(size):
         dst[i + dst_offset + offset] = src[i + src_offset]

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -40,8 +40,12 @@ def fill_ndarray_matrix(ndarray: ndarray_type.ndarray(), val: template()):
 @kernel
 def tensor_to_ext_arr(tensor: template(), arr: ndarray_type.ndarray()):
     offset = static(tensor.snode.ptr.offset)
+    shape = static(tensor.shape)
+    # default value of offset is [], substitute it with [0] * len
+    offset_new = static([0] * len(shape) if len(offset) == 0 else offset)
+
     for I in grouped(tensor):
-        arr[I - offset] = tensor[I]
+        arr[I - offset_new] = tensor[I]
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -133,8 +133,17 @@ def vector_to_image(mat: template(), arr: ndarray_type.ndarray()):
 
 @kernel
 def tensor_to_tensor(tensor: template(), other: template()):
-    for I in grouped(tensor):
-        tensor[I] = other[I]
+    tensor_offset = static(tensor.snode.ptr.offset)
+    tensor_shape = static(tensor.shape)
+    tensor_offset_new = static([0] * len(tensor_shape) if len(tensor_offset) == 0 else tensor_offset)
+
+    other_offset = static(other.snode.ptr.offset)
+    other_shape = static(other.shape)
+    other_offset_new = static([0] * len(other_shape) if len(other_offset) == 0 else other_offset)
+
+    for I in grouped(ndrange(*tensor_shape)):
+        print('index ', I)
+        tensor[I + tensor_offset_new] = other[I + other_offset_new]
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -148,8 +148,12 @@ def tensor_to_tensor(tensor: template(), other: template()):
 
 @kernel
 def ext_arr_to_tensor(arr: ndarray_type.ndarray(), tensor: template()):
+    offset = static(tensor.snode.ptr.offset)
+    shape = static(tensor.shape)
+    # default value of offset is [], replace it with [0] * len
+    offset_new = static([0] * len(shape) if len(offset) == 0 else offset)
     for I in grouped(tensor):
-        tensor[I] = arr[I]
+        tensor[I] = arr[I - offset_new]
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -171,19 +171,24 @@ def ext_arr_to_ndarray_matrix(
 
 @kernel
 def matrix_to_ext_arr(mat: template(), arr: ndarray_type.ndarray(), as_vector: template()):
+    offset = static(mat.snode.ptr.offset)
+    shape = static(mat.shape)
+    # default value of offset is [], replace it with [0] * len
+    offset_new = static([0] * len(shape) if len(offset) == 0 else offset)
+
     for I in grouped(mat):
         for p in static(range(mat.n)):
             for q in static(range(mat.m)):
                 if static(as_vector):
                     if static(getattr(mat, "ndim", 2) == 1):
-                        arr[I, p] = mat[I][p]
+                        arr[I - offset_new, p] = mat[I][p]
                     else:
-                        arr[I, p] = mat[I][p, q]
+                        arr[I - offset_new, p] = mat[I][p, q]
                 else:
                     if static(getattr(mat, "ndim", 2) == 1):
-                        arr[I, p, q] = mat[I][p]
+                        arr[I - offset_new, p, q] = mat[I][p]
                     else:
-                        arr[I, p, q] = mat[I][p, q]
+                        arr[I - offset_new, p, q] = mat[I][p, q]
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -78,10 +78,12 @@ def ndarray_matrix_to_ext_arr(
 
 @kernel
 def vector_to_fast_image(img: template(), out: ndarray_type.ndarray()):
+    i_offset = static(0 if len(img.snode.ptr.offset) == 0 else img.snode.ptr.offset[0])
+    j_offset = static(1 if len(img.snode.ptr.offset) == 0 else img.snode.ptr.offset[1])
     # FIXME: Why is ``for i, j in img:`` slower than:
     for i, j in ndrange(*img.shape):
         r, g, b = 0, 0, 0
-        color = img[i, img.shape[1] - 1 - j]
+        color = img[i + i_offset, (img.shape[1] + j_offset) - 1 - j]
         if static(img.dtype in [f16, f32, f64]):
             r, g, b = ops.min(255, ops.max(0, int(color * 255)))[:3]
         else:

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -107,20 +107,28 @@ def vector_to_fast_image(img: template(), out: ndarray_type.ndarray()):
 
 @kernel
 def tensor_to_image(tensor: template(), arr: ndarray_type.ndarray()):
+    offset = static(tensor.snode.ptr.offset)
+    shape = static(tensor.shape)
+    # default value of offset is [], replace it with [0] * len
+    offset_new = static([0] * len(shape) if len(offset) == 0 else offset)
     for I in grouped(tensor):
         t = ops.cast(tensor[I], f32)
-        arr[I, 0] = t
-        arr[I, 1] = t
-        arr[I, 2] = t
+        arr[I - offset_new, 0] = t
+        arr[I - offset_new, 1] = t
+        arr[I - offset_new, 2] = t
 
 
 @kernel
 def vector_to_image(mat: template(), arr: ndarray_type.ndarray()):
+    offset = static(mat.snode.ptr.offset)
+    shape = static(mat.shape)
+    # default value of offset is [], replace it with [0] * len
+    offset_new = static([0] * len(shape) if len(offset) == 0 else offset)
     for I in grouped(mat):
         for p in static(range(mat.n)):
-            arr[I, p] = ops.cast(mat[I][p], f32)
+            arr[I - offset_new, p] = ops.cast(mat[I][p], f32)
             if static(mat.n <= 2):
-                arr[I, 2] = 0
+                arr[I - offset_new, 2] = 0
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -142,7 +142,7 @@ def tensor_to_tensor(tensor: template(), other: template()):
     other_offset_new = static([0] * len(other_shape) if len(other_offset) == 0 else other_offset)
 
     for I in grouped(ndrange(*tensor_shape)):
-        print('index ', I)
+        print("index ", I)
         tensor[I + tensor_offset_new] = other[I + other_offset_new]
 
 

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -39,8 +39,9 @@ def fill_ndarray_matrix(ndarray: ndarray_type.ndarray(), val: template()):
 
 @kernel
 def tensor_to_ext_arr(tensor: template(), arr: ndarray_type.ndarray()):
+    offset = static(tensor.snode.ptr.offset)
     for I in grouped(tensor):
-        arr[I] = tensor[I]
+        arr[I - offset] = tensor[I]
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -133,16 +133,14 @@ def vector_to_image(mat: template(), arr: ndarray_type.ndarray()):
 
 @kernel
 def tensor_to_tensor(tensor: template(), other: template()):
+    # assumes that tensor and other have the same shape
+    shape = static(tensor.shape)
     tensor_offset = static(tensor.snode.ptr.offset)
-    tensor_shape = static(tensor.shape)
-    tensor_offset_new = static([0] * len(tensor_shape) if len(tensor_offset) == 0 else tensor_offset)
-
+    tensor_offset_new = static([0] * len(shape) if len(tensor_offset) == 0 else tensor_offset)
     other_offset = static(other.snode.ptr.offset)
-    other_shape = static(other.shape)
-    other_offset_new = static([0] * len(other_shape) if len(other_offset) == 0 else other_offset)
+    other_offset_new = static([0] * len(shape) if len(other_offset) == 0 else other_offset)
 
-    for I in grouped(ndrange(*tensor_shape)):
-        print("index ", I)
+    for I in grouped(ndrange(*shape)):
         tensor[I + tensor_offset_new] = other[I + other_offset_new]
 
 

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -251,10 +251,13 @@ def arr_vulkan_layout_to_arr_normal_layout(vk_arr: ndarray_type.ndarray(), norma
 @kernel
 def arr_vulkan_layout_to_field_normal_layout(vk_arr: ndarray_type.ndarray(), normal_field: template()):
     static_assert(len(normal_field.shape) == 2)
-    w = normal_field.shape[0]
-    h = normal_field.shape[1]
+    w = static(normal_field.shape[0])
+    h = static(normal_field.shape[1])
+    i_offset = static(normal_field.snode.ptr.offset[0] if len(normal_field.snode.ptr.offset) != 0 else 0)
+    j_offset = static(normal_field.snode.ptr.offset[1] if len(normal_field.snode.ptr.offset) != 0 else 0)
+
     for i, j in ndrange(w, h):
-        normal_field[i, j] = vk_arr[(h - 1 - j) * w + i]
+        normal_field[i + i_offset, j + j_offset] = vk_arr[(h - 1 - j) * w + i]
 
 
 @kernel

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -41,7 +41,7 @@ def fill_ndarray_matrix(ndarray: ndarray_type.ndarray(), val: template()):
 def tensor_to_ext_arr(tensor: template(), arr: ndarray_type.ndarray()):
     offset = static(tensor.snode.ptr.offset)
     shape = static(tensor.shape)
-    # default value of offset is [], substitute it with [0] * len
+    # default value of offset is [], replace it with [0] * len
     offset_new = static([0] * len(shape) if len(offset) == 0 else offset)
 
     for I in grouped(tensor):

--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -78,8 +78,8 @@ def ndarray_matrix_to_ext_arr(
 
 @kernel
 def vector_to_fast_image(img: template(), out: ndarray_type.ndarray()):
-    i_offset = static(0 if len(img.snode.ptr.offset) == 0 else img.snode.ptr.offset[0])
-    j_offset = static(1 if len(img.snode.ptr.offset) == 0 else img.snode.ptr.offset[1])
+    i_offset = static(img.snode.ptr.offset[0] if len(img.snode.ptr.offset) != 0 else 0)
+    j_offset = static(img.snode.ptr.offset[1] if len(img.snode.ptr.offset) != 0 else 0)
     # FIXME: Why is ``for i, j in img:`` slower than:
     for i, j in ndrange(*img.shape):
         r, g, b = 0, 0, 0
@@ -316,8 +316,8 @@ def sort_stage(
     k: int,
     invocations: int,
 ):
-    keys_offset = static(keys.snode.ptr.offset)
-    values_offset = static(values.snode.ptr.offset)
+    keys_offset = static(keys.snode.ptr.offset if len(keys.snode.ptr.offset) != 0 else 0)
+    values_offset = static(values.snode.ptr.offset if len(values.snode.ptr.offset) != 0 else 0)
     for inv in range(invocations):
         j = k % p + inv * 2 * k
         for i in range(0, ops.min(k, N - j - k)):

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -468,6 +468,7 @@ void export_lang(py::module &m) {
       .def_readwrite("parent", &SNode::parent)
       .def_readonly("type", &SNode::type)
       .def_readonly("id", &SNode::id)
+      .def_readonly("offset", &SNode::index_offsets)
       .def("dense",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -123,6 +123,10 @@ void compile_to_offloads(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
+  irpass::flag_access(ir);
+  print("Access flagged I");
+  irpass::analysis::verify(ir);
+
   if (config.real_matrix_scalarize) {
     irpass::scalarize(ir);
 
@@ -130,10 +134,6 @@ void compile_to_offloads(IRNode *ir,
     irpass::die(ir);
     print("Scalarized");
   }
-
-  irpass::flag_access(ir);
-  print("Access flagged I");
-  irpass::analysis::verify(ir);
 
   irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
   print("Simplified II");

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -85,7 +85,10 @@ def test_scalr_field_from_numpy(dtype, shape):
 
 
 @pytest.mark.parametrize("dtype", data_types)
-@pytest.mark.parametrize("shape, offset", [((), ()), (8, 0), (8, 8), (8, -4), ((6, 12), (-4, -4)), ((6, 12), (-4, 4)), ((6, 12), (4, -4)), ((6, 12), (8, 8))])
+@pytest.mark.parametrize(
+    "shape, offset",
+    [((), ()), (8, 0), (8, 8), (8, -4), ((6, 12), (-4, -4)), ((6, 12), (-4, 4)), ((6, 12), (4, -4)), ((6, 12), (8, 8))],
+)
 @test_utils.test(arch=get_host_arch_list())
 def test_scalr_field_from_numpy_with_offset(dtype, shape, offset):
     import numpy as np
@@ -273,7 +276,19 @@ def test_field_copy_from_with_mismatch_shape():
 
 
 @test_utils.test()
-@pytest.mark.parametrize("shape, x_offset, other_offset", [((), (), ()), (8, 4, 0), (8, 0, -4), (8, -4, -4), (8, 8, -4), ((6, 12), (0, 0), (-6, -6)), ((6, 12), (-6, -6), (0, 0)), ((6, 12), (-6, -6), (-6, -6))])
+@pytest.mark.parametrize(
+    "shape, x_offset, other_offset",
+    [
+        ((), (), ()),
+        (8, 4, 0),
+        (8, 0, -4),
+        (8, -4, -4),
+        (8, 8, -4),
+        ((6, 12), (0, 0), (-6, -6)),
+        ((6, 12), (-6, -6), (0, 0)),
+        ((6, 12), (-6, -6), (-6, -6)),
+    ],
+)
 @pytest.mark.parametrize("dtype", [ti.i32, ti.f32])
 def test_field_copy_from_with_offset(shape, dtype, x_offset, other_offset):
     x = ti.field(dtype=ti.f32, shape=shape, offset=x_offset)

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -85,6 +85,30 @@ def test_scalr_field_from_numpy(dtype, shape):
 
 
 @pytest.mark.parametrize("dtype", data_types)
+@pytest.mark.parametrize("shape, offset", [((), ()), (8, 0), (8, 8), (8, -4), ((6, 12), (-4, -4)), ((6, 12), (-4, 4)), ((6, 12), (4, -4)), ((6, 12), (8, 8))])
+@test_utils.test(arch=get_host_arch_list())
+def test_scalr_field_from_numpy_with_offset(dtype, shape, offset):
+    import numpy as np
+
+    x = ti.field(dtype=dtype, shape=shape, offset=offset)
+    # use the corresponding dtype for the numpy array.
+    numpy_dtypes = {
+        ti.i32: np.int32,
+        ti.f32: np.float32,
+        ti.f64: np.float64,
+        ti.i64: np.int64,
+    }
+    arr = np.ones(shape, dtype=numpy_dtypes[dtype])
+    x.from_numpy(arr)
+
+    def mat_equal(A, B, tol=1e-6):
+        return np.max(np.abs(A - B)) < tol
+
+    tol = 1e-5 if dtype == ti.f32 else 1e-12
+    assert mat_equal(x.to_numpy(), arr, tol=tol)
+
+
+@pytest.mark.parametrize("dtype", data_types)
 @pytest.mark.parametrize("shape", field_shapes)
 @test_utils.test(arch=get_host_arch_list())
 def test_scalr_field_from_numpy_with_mismatch_shape(dtype, shape):

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -249,6 +249,20 @@ def test_field_copy_from_with_mismatch_shape():
 
 
 @test_utils.test()
+@pytest.mark.parametrize("shape, x_offset, other_offset", [((), (), ()), (8, 4, 0), (8, 0, -4), (8, -4, -4), (8, 8, -4), ((6, 12), (0, 0), (-6, -6)), ((6, 12), (-6, -6), (0, 0)), ((6, 12), (-6, -6), (-6, -6))])
+@pytest.mark.parametrize("dtype", [ti.i32, ti.f32])
+def test_field_copy_from_with_offset(shape, dtype, x_offset, other_offset):
+    x = ti.field(dtype=ti.f32, shape=shape, offset=x_offset)
+    other = ti.field(dtype=dtype, shape=shape, offset=other_offset)
+    other.fill(1)
+    x.copy_from(other)
+    convert = lambda arr: arr[0] if len(arr) == 1 else arr
+    assert convert(x.shape) == shape
+    assert x.dtype == ti.f32
+    assert (x.to_numpy() == 1).all()
+
+
+@test_utils.test()
 def test_field_copy_from_with_non_filed_object():
     import numpy as np
 

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -73,7 +73,7 @@ def test_set_image_fast_gui_with_offset(channel, dtype, color, offset):
     gui.set_image(img)
     fast_image = gui.img
 
-    alpha = -16777216
+    alpha = 0xff << 24
     from taichi._lib.utils import get_os_name  # pylint: disable=C0415
 
     rgb_color = (
@@ -81,6 +81,6 @@ def test_set_image_fast_gui_with_offset(channel, dtype, color, offset):
         if ti.static(get_os_name() != "osx")
         else (color << 16) + (color << 8) + color + alpha
     )
-    ground_truth = np.full(n * n, rgb_color, dtype=np.int32)
+    ground_truth = np.full(n * n, rgb_color, dtype=np.uint32)
 
     assert np.allclose(fast_image, ground_truth)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -39,11 +39,11 @@ def test_set_image_with_offset(fast_gui, offset, dtype, color):
     n = 300
     shape = (n, n)
     if fast_gui is True or dtype is ti.f64:
-        img = ti.Vector.field(dtype=dtype, n = 3, shape=shape, offset=offset)
+        img = ti.Vector.field(dtype=dtype, n=3, shape=shape, offset=offset)
     else:
         img = ti.field(dtype=dtype, shape=shape, offset=offset)
-    img.fill(color);
+    img.fill(color)
 
-    gui = ti.GUI(name='test', res=shape, show_gui=False, fast_gui=fast_gui)
+    gui = ti.GUI(name="test", res=shape, show_gui=False, fast_gui=fast_gui)
     gui.set_image(img)
     gui.show()

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -31,19 +31,47 @@ def test_save_image_without_window(dtype):
         assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(delta)
 
 
-@pytest.mark.parametrize("fast_gui", [True, False])
-@pytest.mark.parametrize("dtype, color", [(ti.u8, 128), (ti.f32, 0.5), (ti.f64, 0.5)])
-@pytest.mark.parametrize("offset", [(-299, -299), (-150, -150), (0, 0), (150, 150), (299, 299)])
+@pytest.mark.parametrize("vector_field", [True, False])
+@pytest.mark.parametrize("dtype", [ti.u8,ti.f32,ti.f64])
+@pytest.mark.parametrize("color", [0, 32, 64, 128, 255])
+@pytest.mark.parametrize("offset", [(-150, -150), (0, 0), (150, 150)])
 @test_utils.test(arch=get_host_arch_list())
-def test_set_image_with_offset(fast_gui, offset, dtype, color):
+def test_set_image_with_offset(vector_field, dtype, color, offset):
     n = 300
     shape = (n, n)
-    if fast_gui is True or dtype is ti.f64:
-        img = ti.Vector.field(dtype=dtype, n=3, shape=shape, offset=offset)
-    else:
-        img = ti.field(dtype=dtype, shape=shape, offset=offset)
-    img.fill(color)
 
-    gui = ti.GUI(name="test", res=shape, show_gui=False, fast_gui=fast_gui)
+    img = ti.Vector.field(dtype=dtype, n=3, shape=shape, offset=offset) if vector_field else ti.field(dtype=dtype, shape=shape, offset=offset)
+    img.fill(color if dtype is ti.u8 else color * 1.0 / 255)
+
+    gui = ti.GUI(name="test", res=shape, show_gui=False, fast_gui=False)
     gui.set_image(img)
-    gui.show()
+
+    image_path = test_utils.make_temp_file(suffix=".png")
+    gui.show(image_path)
+    image = ti.tools.imread(image_path)
+    delta = (image - color).sum()
+    assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(delta)
+
+
+@pytest.mark.parametrize("channel", [3, 4])
+@pytest.mark.parametrize("dtype", [ti.u8, ti.f32, ti.f64])
+@pytest.mark.parametrize("color", [0, 32, 64, 128, 255])
+@pytest.mark.parametrize("offset", [(-150, -150), (0, 0), (150, 150)])
+@test_utils.test(arch=get_host_arch_list())
+def test_set_image_fast_gui_with_offset(channel, dtype, color, offset):
+    n = 300
+    shape = (n, n)
+
+    img = ti.Vector.field(dtype=dtype, n=channel, shape=shape, offset=offset)
+    img.fill(color if dtype is ti.u8 else color * 1.0 / 255)
+
+    gui = ti.GUI(name="test", res=shape, show_gui=False, fast_gui=True)
+    gui.set_image(img)
+    fast_image = gui.img
+
+    alpha = -16777216
+    from taichi._lib.utils import get_os_name # pylint: disable=C0415
+    rgb_color= (color << 16) + (color << 8) + color if ti.static(get_os_name() != "osx") else (color << 16) + (color << 8) + color + alpha
+    ground_truth = np.full(n * n, rgb_color, dtype=np.int32)
+
+    assert np.allclose(fast_image, ground_truth)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -31,14 +31,15 @@ def test_save_image_without_window(dtype):
         assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(delta)
 
 
+@pytest.mark.parametrize("fast_gui", [True, False])
 @test_utils.test(arch=get_host_arch_list())
-def test_set_image_with_offset():
+def test_set_image_with_offset(fast_gui):
     n = 300
     shape = (n, n)
     offset = (-(n-1), -(n-1))
     img = ti.Vector.field(dtype=ti.uint8, n = 3, shape=shape, offset=offset)
     img.fill(128);
 
-    gui = ti.GUI(name='test', res=shape, show_gui=False, fast_gui=True)
+    gui = ti.GUI(name='test', res=shape, show_gui=False, fast_gui=fast_gui)
     gui.set_image(img)
     gui.show()

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -29,3 +29,16 @@ def test_save_image_without_window(dtype):
         image = ti.tools.imread(image_path)
         delta = (image - i).sum()
         assert delta == 0, "Expected image difference to be 0 but got {} instead.".format(delta)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_set_image_with_offset():
+    n = 300
+    shape = (n, n)
+    offset = (-(n-1), -(n-1))
+    img = ti.Vector.field(dtype=ti.uint8, n = 3, shape=shape, offset=offset)
+    img.fill(128);
+
+    gui = ti.GUI(name='test', res=shape, show_gui=False, fast_gui=True)
+    gui.set_image(img)
+    gui.show()

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -32,13 +32,17 @@ def test_save_image_without_window(dtype):
 
 
 @pytest.mark.parametrize("fast_gui", [True, False])
+@pytest.mark.parametrize("dtype, color", [(ti.u8, 128), (ti.f32, 0.5), (ti.f64, 0.5)])
+@pytest.mark.parametrize("offset", [(-299, -299), (-150, -150), (0, 0), (150, 150), (299, 299)])
 @test_utils.test(arch=get_host_arch_list())
-def test_set_image_with_offset(fast_gui):
+def test_set_image_with_offset(fast_gui, offset, dtype, color):
     n = 300
     shape = (n, n)
-    offset = (-(n-1), -(n-1))
-    img = ti.Vector.field(dtype=ti.uint8, n = 3, shape=shape, offset=offset)
-    img.fill(128);
+    if fast_gui is True or dtype is ti.f64:
+        img = ti.Vector.field(dtype=dtype, n = 3, shape=shape, offset=offset)
+    else:
+        img = ti.field(dtype=dtype, shape=shape, offset=offset)
+    img.fill(color);
 
     gui = ti.GUI(name='test', res=shape, show_gui=False, fast_gui=fast_gui)
     gui.set_image(img)

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -73,7 +73,7 @@ def test_set_image_fast_gui_with_offset(channel, dtype, color, offset):
     gui.set_image(img)
     fast_image = gui.img
 
-    alpha = 0xff << 24
+    alpha = 0xFF << 24
     from taichi._lib.utils import get_os_name  # pylint: disable=C0415
 
     rgb_color = (

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -32,7 +32,7 @@ def test_save_image_without_window(dtype):
 
 
 @pytest.mark.parametrize("vector_field", [True, False])
-@pytest.mark.parametrize("dtype", [ti.u8,ti.f32,ti.f64])
+@pytest.mark.parametrize("dtype", [ti.u8, ti.f32, ti.f64])
 @pytest.mark.parametrize("color", [0, 32, 64, 128, 255])
 @pytest.mark.parametrize("offset", [(-150, -150), (0, 0), (150, 150)])
 @test_utils.test(arch=get_host_arch_list())
@@ -40,7 +40,11 @@ def test_set_image_with_offset(vector_field, dtype, color, offset):
     n = 300
     shape = (n, n)
 
-    img = ti.Vector.field(dtype=dtype, n=3, shape=shape, offset=offset) if vector_field else ti.field(dtype=dtype, shape=shape, offset=offset)
+    img = (
+        ti.Vector.field(dtype=dtype, n=3, shape=shape, offset=offset)
+        if vector_field
+        else ti.field(dtype=dtype, shape=shape, offset=offset)
+    )
     img.fill(color if dtype is ti.u8 else color * 1.0 / 255)
 
     gui = ti.GUI(name="test", res=shape, show_gui=False, fast_gui=False)
@@ -70,8 +74,13 @@ def test_set_image_fast_gui_with_offset(channel, dtype, color, offset):
     fast_image = gui.img
 
     alpha = -16777216
-    from taichi._lib.utils import get_os_name # pylint: disable=C0415
-    rgb_color= (color << 16) + (color << 8) + color if ti.static(get_os_name() != "osx") else (color << 16) + (color << 8) + color + alpha
+    from taichi._lib.utils import get_os_name  # pylint: disable=C0415
+
+    rgb_color = (
+        (color << 16) + (color << 8) + color
+        if ti.static(get_os_name() != "osx")
+        else (color << 16) + (color << 8) + color + alpha
+    )
     ground_truth = np.full(n * n, rgb_color, dtype=np.int32)
 
     assert np.allclose(fast_image, ground_truth)

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -1312,6 +1312,7 @@ def test_matrix_oob():
 @test_utils.test(arch=get_host_arch_list())
 def test_matrix_from_numpy_with_offset(dtype, shape, offset, m, n):
     import numpy as np
+
     x = ti.Matrix.field(dtype=dtype, m=m, n=n, shape=shape, offset=[offset] * len(shape))
     # use the corresponding dtype for the numpy array.
     numpy_dtypes = {
@@ -1327,7 +1328,7 @@ def test_matrix_from_numpy_with_offset(dtype, shape, offset, m, n):
     @ti.kernel
     def func():
         for I in ti.grouped(x):
-                assert all(abs(I - 1.) < 1e-6)
+            assert all(abs(I - 1.0) < 1e-6)
 
     func()
 
@@ -1339,8 +1340,9 @@ def test_matrix_from_numpy_with_offset(dtype, shape, offset, m, n):
 @test_utils.test(arch=get_host_arch_list())
 def test_matrix_to_numpy_with_offset(dtype, shape, offset, m, n):
     import numpy as np
+
     x = ti.Matrix.field(dtype=dtype, m=m, n=n, shape=shape, offset=[offset] * len(shape))
-    x.fill(1.)
+    x.fill(1.0)
     # use the corresponding dtype for the numpy array.
     numpy_dtypes = {
         ti.i32: np.int32,
@@ -1351,7 +1353,7 @@ def test_matrix_to_numpy_with_offset(dtype, shape, offset, m, n):
     numpy_shape = ((shape,) if isinstance(shape, int) else shape) + (n, m)
     arr = x.to_numpy()
 
-    assert(np.allclose(arr, np.ones(numpy_shape, dtype=numpy_dtypes[dtype])))
+    assert np.allclose(arr, np.ones(numpy_shape, dtype=numpy_dtypes[dtype]))
 
 
 @test_utils.test()

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -1306,13 +1306,17 @@ def test_matrix_oob():
 
 
 @pytest.mark.parametrize("dtype", [ti.i32, ti.f32, ti.i64, ti.f64])
-@pytest.mark.parametrize("shape, offset", [((), ()), (8, 0), (8, 8), (8, -4), ((6, 12), (-4, -4)), ((6, 12), (-4, 4)), ((6, 12), (4, -4)), ((6, 12), (8, 8))])
+@pytest.mark.parametrize(
+    "shape, offset",
+    [((), ()), (8, 0), (8, 8), (8, -4), ((6, 12), (-4, -4)), ((6, 12), (-4, 4)), ((6, 12), (4, -4)), ((6, 12), (8, 8))],
+)
 @test_utils.test(arch=get_host_arch_list())
 def test_matrix_from_numpy_with_offset(dtype, shape, offset):
     import numpy as np
+
     m = 3
     n = 4
-    x = ti.Matrix.field(dtype=dtype,m=m,n=n, shape=shape, offset=offset)
+    x = ti.Matrix.field(dtype=dtype, m=m, n=n, shape=shape, offset=offset)
     # use the corresponding dtype for the numpy array.
     numpy_dtypes = {
         ti.i32: np.int32,

--- a/tests/python/test_offset.py
+++ b/tests/python/test_offset.py
@@ -147,16 +147,18 @@ def test_offset_must_throw_matrix():
         b = ti.Matrix.field(3, 3, dtype=ti.i32, shape=None, offset=(32, 16))
 
 
+@pytest.mark.parametrize("offset", [(0, 0), (-1, -1), (2, 2), (-23333, -23333), (23333, 23333)])
 @test_utils.test(arch=get_host_arch_list())
-def test_field_offset_print():
-    val = ti.field(dtype=ti.f32, shape=(3, 3), offset=(-1, -1))
+def test_field_with_offset_print(offset):
+    val = ti.field(dtype=ti.f32, shape=(3, 3), offset=offset)
     val.fill(1.0)
     print(val)
 
 
+@pytest.mark.parametrize("offset", [(0, 0), (-1, -1), (2, 2), (-23333, -23333), (23333, 23333)])
 @test_utils.test(arch=get_host_arch_list())
-def test_field_offset_to_numpy():
+def test_field_with_offset_to_numpy(offset):
     shape = (3, 3)
-    val = ti.field(dtype=ti.f32, shape=shape, offset=(-1, -1))
+    val = ti.field(dtype=ti.f32, shape=shape, offset=offset)
     val.fill(1.0)
     assert np.allclose(val.to_numpy(), np.ones(shape, dtype=np.float32))

--- a/tests/python/test_offset.py
+++ b/tests/python/test_offset.py
@@ -149,14 +149,14 @@ def test_offset_must_throw_matrix():
 
 @test_utils.test(arch=get_host_arch_list())
 def test_field_offset_print():
-    val = ti.field(dtype=ti.f32, shape=(3,3), offset=(-1, -1))
+    val = ti.field(dtype=ti.f32, shape=(3, 3), offset=(-1, -1))
     val.fill(1.0)
     print(val)
 
 
 @test_utils.test(arch=get_host_arch_list())
 def test_field_offset_to_numpy():
-    shape = (3,3)
-    val =  ti.field(dtype=ti.f32, shape=shape, offset=(-1, -1))
+    shape = (3, 3)
+    val = ti.field(dtype=ti.f32, shape=shape, offset=(-1, -1))
     val.fill(1.0)
     assert np.allclose(val.to_numpy(), np.ones(shape, dtype=np.float32))

--- a/tests/python/test_offset.py
+++ b/tests/python/test_offset.py
@@ -3,6 +3,7 @@ from taichi.lang.misc import get_host_arch_list
 
 import taichi as ti
 from tests import test_utils
+import numpy as np
 
 
 @test_utils.test()
@@ -144,3 +145,18 @@ def test_offset_must_throw_matrix():
         a = ti.Matrix.field(3, 3, dtype=ti.i32, shape=(32, 16, 8), offset=(32, 16))
     with pytest.raises(ti.TaichiCompilationError, match="shape cannot be None when offset is set"):
         b = ti.Matrix.field(3, 3, dtype=ti.i32, shape=None, offset=(32, 16))
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_offset_print():
+    val = ti.field(dtype=ti.f32, shape=(3,3), offset=(-1, -1))
+    val.fill(1.0)
+    print(val)
+
+
+@test_utils.test(arch=get_host_arch_list())
+def test_field_offset_to_numpy():
+    shape = (3,3)
+    val =  ti.field(dtype=ti.f32, shape=shape, offset=(-1, -1))
+    val.fill(1.0)
+    assert np.allclose(val.to_numpy(), np.ones(shape, dtype=np.float32))

--- a/tests/python/test_scan.py
+++ b/tests/python/test_scan.py
@@ -1,3 +1,4 @@
+import pytest
 import taichi as ti
 from tests import test_utils
 
@@ -30,3 +31,31 @@ def test_scan():
     test_scan_for_dtype(ti.i32, 512)
     test_scan_for_dtype(ti.i32, 1024)
     test_scan_for_dtype(ti.i32, 4096)
+
+
+@pytest.mark.parametrize("dtype", [ti.i32])
+@pytest.mark.parametrize("N", [512, 1024, 4096])
+@pytest.mark.parametrize("offset", [0, -1, 1, 256, -256, -23333, 23333])
+@test_utils.test(arch=[ti.cuda, ti.vulkan], exclude=[(ti.vulkan, "Darwin")])
+def test_scan_with_offset(dtype, N, offset):
+    arr = ti.field(dtype, N, offset=offset)
+    arr_aux = ti.field(dtype, N, offset=offset)
+
+    @ti.kernel
+    def fill():
+        for i in arr:
+            arr[i] = ti.random() * N
+            arr_aux[i] = arr[i]
+
+    fill()
+
+    # Performing an inclusive in-place's parallel prefix sum,
+    # only one exectutor is needed for a specified sorting length.
+    executor = ti.algorithms.PrefixSumExecutor(N)
+
+    executor.run(arr)
+
+    cur_sum = 0
+    for i in range(N):
+        cur_sum += arr_aux[i + offset]
+        assert arr[i + offset] == cur_sum


### PR DESCRIPTION
Issue: #7775

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44074b9</samp>

This pull request adds support for offset tensors in Taichi, which are tensors with non-zero lower bounds for their index domains. It updates the `test_offset.py` file to add more tests, the `tensor_to_ext_arr` function to handle offset copying, and the `SNode` class to expose the offset attribute to Python.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 44074b9</samp>

* Add offset attribute to SNode class and expose it to Python interface ([link](https://github.com/taichi-dev/taichi/pull/7945/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167R471))
* Modify tensor_to_ext_arr function to account for offset attribute when copying data to external array ([link](https://github.com/taichi-dev/taichi/pull/7945/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL42-R48))
* Add test cases to check the correctness of offset tensor's data and conversion methods ([link](https://github.com/taichi-dev/taichi/pull/7945/files?diff=unified&w=0#diff-520d9ca52eed08ca617ef520e95d0d1778fb1943b9652f7a388b63abca00ddd1R148-R162), [link](https://github.com/taichi-dev/taichi/pull/7945/files?diff=unified&w=0#diff-520d9ca52eed08ca617ef520e95d0d1778fb1943b9652f7a388b63abca00ddd1R6))
