### PR TITLE
[Lang] Migrate irpass::scalarize() after irpass::cache_loop_invariant_global_vars()

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -135,14 +135,6 @@ void compile_to_offloads(IRNode *ir,
   print("Offloaded");
   irpass::analysis::verify(ir);
 
-  if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::die(ir);
-    print("Scalarized");
-  }
-
   // TODO: This pass may be redundant as cfg_optimization() is already called
   //  in full_simplify().
   if (config.opt_level > 0 && config.cfg_optimization) {
@@ -158,6 +150,14 @@ void compile_to_offloads(IRNode *ir,
   irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
   print("Simplified III");
   irpass::analysis::verify(ir);
+
+  if (config.real_matrix_scalarize) {
+    irpass::scalarize(ir);
+
+    // Remove redundant MatrixInitStmt inserted during scalarization
+    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
+    print("Scalarized");
+  }
 }
 
 void offload_to_executable(IRNode *ir,

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -123,14 +123,6 @@ void compile_to_offloads(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
-  if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::die(ir);
-    print("Scalarized");
-  }
-
   irpass::flag_access(ir);
   print("Access flagged I");
   irpass::analysis::verify(ir);
@@ -142,6 +134,14 @@ void compile_to_offloads(IRNode *ir,
   irpass::offload(ir, config);
   print("Offloaded");
   irpass::analysis::verify(ir);
+
+  if (config.real_matrix_scalarize) {
+    irpass::scalarize(ir);
+
+    // Remove redundant MatrixInitStmt inserted during scalarization
+    irpass::die(ir);
+    print("Scalarized");
+  }
 
   // TODO: This pass may be redundant as cfg_optimization() is already called
   //  in full_simplify().

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -150,14 +150,6 @@ void compile_to_offloads(IRNode *ir,
   irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
   print("Simplified III");
   irpass::analysis::verify(ir);
-
-  if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
-    print("Scalarized");
-  }
 }
 
 void offload_to_executable(IRNode *ir,
@@ -185,6 +177,14 @@ void offload_to_executable(IRNode *ir,
   if (config.detect_read_only) {
     irpass::detect_read_only(ir);
     print("Detect read-only accesses");
+  }
+
+  if (config.real_matrix_scalarize) {
+    irpass::scalarize(ir);
+
+    // Remove redundant MatrixInitStmt inserted during scalarization
+    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
+    print("Scalarized");
   }
 
   irpass::demote_atomics(ir, config);

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -179,6 +179,10 @@ void offload_to_executable(IRNode *ir,
     print("Detect read-only accesses");
   }
 
+  irpass::demote_atomics(ir, config);
+  print("Atomics demoted I");
+  irpass::analysis::verify(ir);
+
   if (config.real_matrix_scalarize) {
     irpass::scalarize(ir);
 
@@ -187,9 +191,6 @@ void offload_to_executable(IRNode *ir,
     print("Scalarized");
   }
 
-  irpass::demote_atomics(ir, config);
-  print("Atomics demoted I");
-  irpass::analysis::verify(ir);
   if (config.cache_loop_invariant_global_vars) {
     irpass::cache_loop_invariant_global_vars(ir, config);
     print("Cache loop-invariant global vars");

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -135,14 +135,6 @@ void compile_to_offloads(IRNode *ir,
   print("Offloaded");
   irpass::analysis::verify(ir);
 
-  if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::die(ir);
-    print("Scalarized");
-  }
-
   // TODO: This pass may be redundant as cfg_optimization() is already called
   //  in full_simplify().
   if (config.opt_level > 0 && config.cfg_optimization) {
@@ -191,17 +183,17 @@ void offload_to_executable(IRNode *ir,
   print("Atomics demoted I");
   irpass::analysis::verify(ir);
 
+  if (config.cache_loop_invariant_global_vars) {
+    irpass::cache_loop_invariant_global_vars(ir, config);
+    print("Cache loop-invariant global vars");
+  }
+
   if (config.real_matrix_scalarize) {
     irpass::scalarize(ir);
 
     // Remove redundant MatrixInitStmt inserted during scalarization
     irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
     print("Scalarized");
-  }
-
-  if (config.cache_loop_invariant_global_vars) {
-    irpass::cache_loop_invariant_global_vars(ir, config);
-    print("Cache loop-invariant global vars");
   }
 
   if (config.demote_dense_struct_fors) {

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -533,24 +533,19 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
         local_to_global_offset_[stmt], ret_type);
     auto offloaded = stmt_to_offloaded_[stmt];
     stmt_to_offloaded_[ptr] = offloaded;
+
+    TypedConstant zero(stmt->ret_type.get_element_type());
+    auto const_zero_stmt = replacement.push_back<ConstStmt>(zero);
     if (auto tensor_type = stmt->ret_type->cast<TensorType>()) {
-      TypedConstant zero(tensor_type->get_element_type());
-      auto const_zero_stmt = replacement.push_back<ConstStmt>(zero);
-      stmt_to_offloaded_[const_zero_stmt] = offloaded;
-      for (int i = 0; i < tensor_type->get_num_elements(); ++i) {
-        auto const_offset_stmt =
-            replacement.push_back<ConstStmt>(TypedConstant(i));
-        auto ptr_offset_stmt =
-            replacement.push_back<MatrixPtrStmt>(ptr, const_offset_stmt);
-        auto global_store_stmt = replacement.push_back<GlobalStoreStmt>(
-            ptr_offset_stmt, const_zero_stmt);
-        stmt_to_offloaded_[const_offset_stmt] = offloaded;
-        stmt_to_offloaded_[ptr_offset_stmt] = offloaded;
-        stmt_to_offloaded_[global_store_stmt] = offloaded;
-      }
+      std::vector<Stmt *> zero_values(tensor_type->get_num_elements(),
+                                      const_zero_stmt);
+      auto zero_matrix_init_stmt =
+          replacement.push_back<MatrixInitStmt>(zero_values);
+      zero_matrix_init_stmt->ret_type = stmt->ret_type.ptr_removed();
+      auto global_store_stmt =
+          replacement.push_back<GlobalStoreStmt>(ptr, zero_matrix_init_stmt);
+      stmt_to_offloaded_[global_store_stmt] = offloaded;
     } else {
-      TypedConstant zero(stmt->ret_type);
-      auto const_zero_stmt = replacement.push_back<ConstStmt>(zero);
       auto global_store_stmt =
           replacement.push_back<GlobalStoreStmt>(ptr, const_zero_stmt);
       stmt_to_offloaded_[global_store_stmt] = offloaded;

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -1049,8 +1049,12 @@ class ExtractLocalPointers : public BasicStmtVisitor {
   Block *top_level_;
 
   explicit ExtractLocalPointers(IRNode *root) : immediate_modifier_(root) {
-    TI_ASSERT(root->is<Block>());
-    top_level_ = root->as<Block>();
+    if (root->is<OffloadedStmt>()) {
+      top_level_ = root->as<OffloadedStmt>()->body.get();
+    } else {
+      TI_ASSERT(root->is<Block>());
+      top_level_ = root->as<Block>();
+    }
     root->accept(this);
     delayed_modifier_.modify_ir();
   }

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -881,7 +881,7 @@ class GatherScalarizableLocalPointers : public BasicStmtVisitor {
   }
 };
 
-class ScalarizeLocalPointers : public BasicStmtVisitor {
+class ScalarizePointers : public BasicStmtVisitor {
  public:
   ImmediateIRModifier immediate_modifier_;
   DelayedIRModifier delayed_modifier_;
@@ -890,7 +890,7 @@ class ScalarizeLocalPointers : public BasicStmtVisitor {
   // { original_alloca_stmt : [scalarized_alloca_stmt0, ...] }
   std::unordered_map<Stmt *, std::vector<Stmt *>> scalarized_local_tensor_map_;
 
-  explicit ScalarizeLocalPointers(
+  explicit ScalarizePointers(
       IRNode *node,
       const std::unordered_set<Stmt *> &scalarizable_allocas)
       : immediate_modifier_(node), scalarizable_allocas_(scalarizable_allocas) {
@@ -948,16 +948,16 @@ class ScalarizeLocalPointers : public BasicStmtVisitor {
     }
   }
 
-  /*
-    Before:
-      MatrixPtrStmt(TensorType<4 x i32>* alloca_stmt, int offset)
-
-    After:
-      scalarized_alloca_stmt =
-    scalarized_local_tensor_map_[alloca_stmt][offset]
-      stmt->replace_all_usages_with(scalarized_alloca_stmt)
-  */
   void visit(MatrixPtrStmt *stmt) override {
+    /*
+      Before:
+        MatrixPtrStmt(TensorType<4 x i32>* alloca_stmt, int offset)
+
+      After:
+        scalarized_alloca_stmt =
+      scalarized_local_tensor_map_[alloca_stmt][offset]
+        stmt->replace_all_usages_with(scalarized_alloca_stmt)
+    */
     if (stmt->origin->is<AllocaStmt>() &&
         scalarizable_allocas_.count(stmt->origin) == 1) {
       auto alloca_stmt = stmt->origin->cast<AllocaStmt>();
@@ -979,6 +979,34 @@ class ScalarizeLocalPointers : public BasicStmtVisitor {
 
       immediate_modifier_.replace_usages_with(stmt, new_stmt);
       delayed_modifier_.erase(stmt);
+      return;
+    }
+
+    /*
+      Before:
+        TensorType<4 x i32>* ptr = GlobalTempStmt(offset_0)
+        i32* ptr_1 = MatrixPtrStmt(ptr, offset_1)
+
+      After:
+        i32* $1 = GlobalTempStmt(offset_0 + offset_1 * sizeof(i32))
+        replace_all_usages_with(ptr_1, $1)
+    */
+    if (stmt->origin->is<GlobalTemporaryStmt>() &&
+        stmt->offset->is<ConstStmt>()) {
+      auto global_temp_stmt = stmt->origin->as<GlobalTemporaryStmt>();
+      auto offset_0 = global_temp_stmt->offset;
+      auto offset_1 = stmt->offset->as<ConstStmt>()->val.val_int32();
+      auto new_offset =
+          offset_0 + offset_1 * data_type_size(stmt->ret_type.ptr_removed());
+
+      auto new_global_temp_stmt = std::make_unique<GlobalTemporaryStmt>(
+          new_offset, stmt->ret_type.ptr_removed().get_element_type());
+      new_global_temp_stmt->ret_type.set_is_pointer(true);
+
+      stmt->replace_usages_with(new_global_temp_stmt.get());
+      delayed_modifier_.insert_before(stmt, std::move(new_global_temp_stmt));
+      delayed_modifier_.erase(stmt);
+      return;
     }
   }
 
@@ -1025,6 +1053,14 @@ class ExtractLocalPointers : public BasicStmtVisitor {
     top_level_ = root->as<Block>();
     root->accept(this);
     delayed_modifier_.modify_ir();
+  }
+
+  void visit(OffloadedStmt *stmt) override {
+    // Extract to OffloadStmt
+    Block *orig_top_level = top_level_;
+    top_level_ = stmt->body.get();
+    stmt->all_blocks_accept(this);
+    top_level_ = orig_top_level;
   }
 
   void visit(MatrixPtrStmt *stmt) override {
@@ -1118,7 +1154,7 @@ void scalarize(IRNode *root) {
   TI_AUTO_PROF;
   Scalarize scalarize_pass(root);
   auto scalarizable_allocas = GatherScalarizableLocalPointers::run(root);
-  ScalarizeLocalPointers scalarize_pointers_pass(root, scalarizable_allocas);
+  ScalarizePointers scalarize_pointers_pass(root, scalarizable_allocas);
   ExtractLocalPointers extract_pointers_pass(root);
   MergeExternalAndMatrixPtr::run(root);
 }


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b2b0e1</samp>

This pull request improves the performance and correctness of the Taichi compiler by extending the caching and demoting of loop-invariant global variables and atomic operations to support matrix expressions, and by moving some passes to a more appropriate stage in the compilation pipeline. The changes affect the files `cache_loop_invariant_global_vars.cpp`, `compile_to_offloads.cpp`, `demote_atomics.cpp`, and `scalarize.cpp`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b2b0e1</samp>

*  Move `scalarize` and `die` passes to a later stage in the compilation pipeline ([link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL138-L145), [link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR191-R198))
* Handle `MatrixPtrStmt` in `is_offload_unique` and `DemoteAtomics` ([link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fL57-R70), [link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fL72-R99), [link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14L42-R56), [link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14L69-R102))
* Handle `OffloadedStmt` in `ExtractLocalPointers` ([link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L1052-R1057))
* Add empty lines for readability ([link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR185), [link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R117), [link](https://github.com/taichi-dev/taichi/pull/7947/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R125))
