### PR TITLE
[Bug] [spirv] Fix the insertion position of the access chain

### DIFF
--- a/taichi/codegen/spirv/spirv_ir_builder.cpp
+++ b/taichi/codegen/spirv/spirv_ir_builder.cpp
@@ -1672,7 +1672,7 @@ Value IRBuilder::make_access_chain(const SType &out_type,
   for (auto &ind : index_values) {
     ib_.add(ind);
   }
-  ib_.commit(&func_header_);
+  ib_.commit(&function_);
   return ret;
 }
 

--- a/tests/python/test_matrix_arg.py
+++ b/tests/python/test_matrix_arg.py
@@ -70,3 +70,25 @@ def test_matrix_fancy_arg():
     m = mat4x3(m)
 
     k = mat2x6(m)
+
+
+@test_utils.test()
+def test_matrix_arg_insertion_pos():
+    rgba8 = ti.types.vector(4, ti.u8)
+
+    @ti.kernel
+    def _render(
+        color_attm: ti.types.ndarray(rgba8, ndim=2),
+        camera_pos: ti.math.vec3,
+        camera_up: ti.math.vec3,
+    ):
+        up = ti.math.normalize(camera_up)
+
+        for x, y in color_attm:
+            o = camera_pos
+
+    color_attm = ti.Vector.ndarray(4, dtype=ti.u8, shape=(512, 512))
+    camera_pos = ti.math.vec3(0, 0, 0)
+    camera_up = ti.math.vec3(0, 1, 0)
+
+    _render(color_attm, camera_pos, camera_up)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54c493d</samp>

~Renamed a variable and updated a method in the SPIR-V IR builder. This improves the readability and clarity of the code that generates SPIR-V instructions for accessing composite objects.~

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54c493d</samp>

<s>* Rename `func_header_` to `function_` in `SpirvIrBuilder` class to avoid confusion with SPIR-V function header ([link](https://github.com/taichi-dev/taichi/pull/7957/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15L1675-R1675))
</s>* Update `make_access_chain` method to append instruction to `function_` instead of `func_header_` ([link](https://github.com/taichi-dev/taichi/pull/7957/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15L1675-R1675))
