### PR TITLE
[autodiff] Support grad tensor in primal kernel

### DIFF
--- a/python/taichi/lang/any_array.py
+++ b/python/taichi/lang/any_array.py
@@ -38,6 +38,12 @@ class AnyArray:
 
     @property
     @taichi_scope
+    def grad(self):
+        """Returns the gradient of this array."""
+        return AnyArray(_ti_core.make_external_tensor_grad_expr(self.ptr))
+
+    @property
+    @taichi_scope
     def shape(self):
         """A list containing sizes for each dimension. Note that element shape will be excluded.
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -656,7 +656,8 @@ Stmt *make_ndarray_access(Expression::FlattenContext *ctx,
   auto var_stmt = flatten_lvalue(var, ctx);
   auto expr = var.cast<ExternalTensorExpression>();
   auto external_ptr_stmt = std::make_unique<ExternalPtrStmt>(
-      var_stmt, index_stmts, expr->dt.get_shape(), expr->element_dim);
+      var_stmt, index_stmts, expr->dt.get_shape(), expr->element_dim,
+      expr->is_grad);
   if (expr->dim == indices.size()) {
     // Indexing into an scalar element
     external_ptr_stmt->ret_type = expr->dt.ptr_removed().get_element_type();

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -506,7 +506,7 @@ class ExternalTensorExpression : public Expression {
 
   explicit ExternalTensorExpression(Expr *expr) : is_grad(true) {
     auto ptr = expr->cast<ExternalTensorExpression>();
-    init(ptr->dt, ptr->dim, ptr->arg_id, ptr->element_dim, /*needs_grad=*/false);
+    init(ptr->dt, ptr->dim, ptr->arg_id, ptr->element_dim, ptr->needs_grad);
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -506,7 +506,7 @@ class ExternalTensorExpression : public Expression {
 
   explicit ExternalTensorExpression(Expr *expr) : is_grad(true) {
     auto ptr = expr->cast<ExternalTensorExpression>();
-    init(ptr->dt, ptr->dim, ptr->arg_id, ptr->element_dim, ptr->needs_grad);
+    init(ptr->dt, ptr->dim, ptr->arg_id, ptr->element_dim, /*needs_grad=*/false);
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -475,7 +475,8 @@ class ExternalTensorExpression : public Expression {
   int arg_id;
   int element_dim;  // 0: scalar; 1: vector (SOA); 2: matrix (SOA); -1: vector
                     // (AOS); -2: matrix (AOS)
-  bool needs_grad;
+  bool needs_grad{false};
+  bool is_grad{false};
 
   ExternalTensorExpression(const DataType &dt,
                            int dim,
@@ -503,9 +504,9 @@ class ExternalTensorExpression : public Expression {
     }
   }
 
-  explicit ExternalTensorExpression(Expr *expr, bool needs_grad = true) {
+  explicit ExternalTensorExpression(Expr *expr) : is_grad(true) {
     auto ptr = expr->cast<ExternalTensorExpression>();
-    init(ptr->dt, ptr->dim, ptr->arg_id, ptr->element_dim, needs_grad);
+    init(ptr->dt, ptr->dim, ptr->arg_id, ptr->element_dim, ptr->needs_grad);
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -937,6 +937,9 @@ void export_lang(py::module &m) {
         Expr::make<ExternalTensorExpression, const DataType &, int, int, int,
                    const std::vector<int> &, bool>);
 
+  m.def("make_external_tensor_grad_expr",
+        Expr::make<ExternalTensorExpression, Expr *>);
+
   m.def("make_rand_expr", Expr::make<RandExpression, const DataType &>);
 
   m.def("make_const_expr_int",

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1503,10 +1503,13 @@ class MakeAdjoint : public ADTransform {
       } else {
         src = stmt->src->as<ExternalPtrStmt>();
       }
-      TI_ASSERT(!src->is_grad);
       auto arg = src->base_ptr->as<ArgLoadStmt>();
       if (arg->ret_type.ptr_removed()->as<StructType>()->elements().size() >
           TypeFactory::GRAD_PTR_POS_IN_NDARRAY) {
+        TI_ASSERT_INFO(!src->is_grad,
+                       "Cannot automatically differentiate through a grad "
+                       "tensor, if you really want to do that, pass the grad "
+                       "tensor into the kernel directly");
         auto adj_ptr = insert<ExternalPtrStmt>(
             src->base_ptr, src->indices, src->element_shape, src->element_dim,
             /*is_grad=*/true);
@@ -1577,6 +1580,10 @@ class MakeAdjoint : public ADTransform {
           TypeFactory::GRAD_PTR_POS_IN_NDARRAY) {
         return;
       }
+      TI_ASSERT_INFO(!dest->is_grad,
+                     "Cannot automatically differentiate through a grad "
+                     "tensor, if you really want to do that, pass the grad "
+                     "tensor into the kernel directly");
       adjoint_ptr = insert<ExternalPtrStmt>(
           dest->base_ptr, dest->indices, dest->element_shape, dest->element_dim,
           /*is_grad=*/true);
@@ -1639,6 +1646,10 @@ class MakeAdjoint : public ADTransform {
       auto arg = dest->base_ptr->as<ArgLoadStmt>();
       if (arg->ret_type.ptr_removed()->as<StructType>()->elements().size() >
           TypeFactory::GRAD_PTR_POS_IN_NDARRAY) {
+        TI_ASSERT_INFO(!dest->is_grad,
+                       "Cannot automatically differentiate through a grad "
+                       "tensor, if you really want to do that, pass the grad "
+                       "tensor into the kernel directly");
         auto adjoint_ptr =
             insert<ExternalPtrStmt>(dest->base_ptr, dest->indices,
                                     dest->element_shape, dest->element_dim,

--- a/tests/python/test_ad_ndarray.py
+++ b/tests/python/test_ad_ndarray.py
@@ -1343,3 +1343,23 @@ def test_tape_torch_tensor_grad_none():
 
     for i in range(N):
         assert a.grad[i] == 1.0
+
+
+@test_utils.test(arch=archs_support_ndarray_ad)
+def test_grad_tensor_in_kernel():
+    N = 10
+
+    a = ti.ndarray(ti.f32, shape=N, needs_grad=True)
+    b = ti.ndarray(ti.f32, shape=(), needs_grad=True)
+
+    @ti.kernel
+    def test(x: ti.types.ndarray(), b: ti.types.ndarray()):
+        for i in x:
+            b[None] += x.grad[i]
+
+    a.grad.fill(2.0)
+    test(a, b)
+    assert b[None] == N * 2.0
+
+    with pytest.raises(RuntimeError, match=r"Cannot automatically differentiate through a grad tensor"):
+        test.grad(a, b)

--- a/tests/python/test_ad_ndarray.py
+++ b/tests/python/test_ad_ndarray.py
@@ -1364,7 +1364,7 @@ def test_grad_tensor_in_kernel():
     with pytest.raises(RuntimeError, match=r"Cannot automatically differentiate through a grad tensor"):
         test.grad(a, b)
 
-        
+
 @pytest.mark.skipif(not has_pytorch(), reason="Pytorch not installed.")
 @test_utils.test(arch=archs_support_ndarray_ad)
 def test_tensor_shape():


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0091c4f</samp>

This pull request enhances the support and error handling for external tensors and their gradients in Taichi. It adds a `grad` method to `AnyArray` to access the gradient expressions of external tensors, and checks that gradient tensors are not used as external pointers in the auto-differentiation transform. It also updates the `ExternalTensorExpression` and `ExternalPtrStmt` classes to store and use gradient information.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0091c4f</samp>

*  Add a `grad` method to `AnyArray` that returns the gradient expression of the original array ([link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-2e623ee0b0eec1b200fead36c0627a3c54738f6d83d79757398dc67decc01da8R41-R46))
*  Expose `make_external_tensor_grad_expr` to Python, which creates a gradient expression from an `ExternalTensorExpression` ([link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167R940-R942))
*  Add `needs_grad` and `is_grad` fields to `ExternalTensorExpression` to indicate gradient requirements and status ([link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL478-R479), [link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL506-R509))
*  Modify the copy constructor of `ExternalTensorExpression` to set `is_grad` to true ([link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL506-R509))
*  Add `is_grad` argument to `ExternalPtrStmt` constructor to store gradient information of external pointers ([link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L659-R660))
*  Add assertions and error messages to `auto_diff.cpp` to check the validity of gradient computation for external tensors ([link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1506-R1512), [link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583R1583-R1586), [link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583R1649-R1652))
*  Add a test case to `test_ad_ndarray.py` to verify the functionality and error handling of the `grad` method and the auto-differentiation transform ([link](https://github.com/taichi-dev/taichi/pull/7962/files?diff=unified&w=0#diff-015ebf0e792298ff88ac9c4d87efba82414b3a19a4d85d0887d16099dfe2fc09R1346-R1365))
