### PR TITLE
[autodiff] Support ExternalTensorShapeAlongAxis in autodiff

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1086,6 +1086,10 @@ class ADTransform : public IRVisitor {
     // do nothing
   }
 
+  void visit(ExternalTensorShapeAlongAxisStmt *stmt) override {
+    // do nothing
+  }
+
   void visit(DecorationStmt *stmt) override {
     // do nothing
   }

--- a/tests/python/test_ad_ndarray.py
+++ b/tests/python/test_ad_ndarray.py
@@ -1343,3 +1343,28 @@ def test_tape_torch_tensor_grad_none():
 
     for i in range(N):
         assert a.grad[i] == 1.0
+
+
+@pytest.mark.skipif(not has_pytorch(), reason="Pytorch not installed.")
+@test_utils.test(arch=archs_support_ndarray_ad)
+def test_tensor_shape():
+    N = 3
+
+    @ti.kernel
+    def test(x: ti.types.ndarray(), y: ti.types.ndarray()):
+        for i in range(N):
+            a = 2.0
+            for j in range(N):
+                a += x[i] / x.shape[0]
+            y[0] += a
+
+    device = "cuda" if ti.lang.impl.current_cfg().arch == ti.cuda else "cpu"
+
+    a = torch.zeros((N,), device=device, requires_grad=True)
+    loss = torch.zeros((1,), device=device, requires_grad=True)
+
+    with ti.ad.Tape(loss=loss):
+        test(a, loss)
+
+    for i in range(N):
+        assert a.grad[i] == 1.0


### PR DESCRIPTION
Issue: #7951

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2598f1</samp>

This pull request adds support for automatic differentiation of external tensors that have shape information. It implements a new visitor method for `ExternalTensorShapeAlongAxisStmt` in `ADTransform` and adds a corresponding test case in `test_ad_ndarray.py`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a2598f1</samp>

*  Add a visitor method for `ExternalTensorShapeAlongAxisStmt` in `ADTransform` to support automatic differentiation for external tensors with shape information ([link](https://github.com/taichi-dev/taichi/pull/7963/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583R1089-R1092))
*  Add a test case for the automatic differentiation of external tensors using shape information in `test_ad_ndarray.py` to verify the correctness of the new visitor method ([link](https://github.com/taichi-dev/taichi/pull/7963/files?diff=unified&w=0#diff-015ebf0e792298ff88ac9c4d87efba82414b3a19a4d85d0887d16099dfe2fc09R1346-R1369))
