### PR TITLE
[windows] Workaround C++ mangling special chars

### DIFF
--- a/taichi/runtime/cuda/jit_cuda.cpp
+++ b/taichi/runtime/cuda/jit_cuda.cpp
@@ -53,18 +53,20 @@ std::string convert(std::string new_name) {
   // Evil C++ mangling on Windows will lead to "unsupported characters in
   // symbol" error in LLVM PTX printer. Convert here.
   for (int i = 0; i < (int)new_name.size(); i++) {
-    if (new_name[i] == '@')
+    if (new_name[i] == '@') {
       new_name.replace(i, 1, "_at_");
-    if (new_name[i] == '?')
+    } else if (new_name[i] == '?') {
       new_name.replace(i, 1, "_qm_");
-    if (new_name[i] == '$')
+    } else if (new_name[i] == '$') {
       new_name.replace(i, 1, "_dl_");
-    if (new_name[i] == '<')
+    } else if (new_name[i] == '<') {
       new_name.replace(i, 1, "_lb_");
-    if (new_name[i] == '>')
+    } else if (new_name[i] == '>') {
       new_name.replace(i, 1, "_rb_");
-    TI_ASSERT(std::isalpha(new_name[i]) || std::isdigit(new_name[i]) ||
-              new_name[i] == '_' || new_name[i] == '.');
+    } else if (!std::isalpha(new_name[i]) && !std::isdigit(new_name[i]) &&
+               new_name[i] != '_' && new_name[i] != '.') {
+      new_name.replace(i, 1, "_xx_");
+    }
   }
   if (!new_name.empty())
     TI_ASSERT(isalpha(new_name[0]) || new_name[0] == '_' || new_name[0] == '.');


### PR DESCRIPTION
Issue: https://forum.taichi-lang.cn/t/topic/4292/5

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a215ad4</samp>

Fix name mangling bug for CUDA kernels by replacing invalid characters in `jit_cuda.cpp`

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a215ad4</samp>

* Fix name mangling of CUDA kernels to avoid errors in LLVM PTX printer ([link](https://github.com/taichi-dev/taichi/pull/7964/files?diff=unified&w=0#diff-b7e12be512e7cab600a8ac8de54030fb889df95e3f0424f341b48fac44497fb1L56-R69))
