### PR TITLE
[Error] Update deprecation warning of the graph arguments

### DIFF
--- a/python/taichi/graph/_graph.py
+++ b/python/taichi/graph/_graph.py
@@ -115,7 +115,8 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
     if tag == ArgKind.SCALAR:
         if "element_shape" in kwargs:
             warnings.warn(
-                "The element_shape argument for scalar will be deprecated in v1.6.0. You can remove them safely.",
+                "The element_shape argument for scalar is deprecated in v1.6.0, and will be removed in v1.7.0. "
+                "Please remove them.",
                 DeprecationWarning,
             )
             del kwargs["element_shape"]
@@ -131,7 +132,8 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
                     kwargs["element_shape"] = ()
         else:
             warnings.warn(
-                "The element_shape argument for ndarray will be deprecated in v1.6.0, use vector or matrix data type instead.",
+                "The element_shape argument for ndarray is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+                "Please use vector or matrix data type instead.",
                 DeprecationWarning,
             )
             if "dtype" not in kwargs:
@@ -149,7 +151,8 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
 
         if "shape" in kwargs:
             warnings.warn(
-                "The shape argument for texture will be deprecated in v1.6.0, use ndim instead. (Note that you no longer need the exact texture size.)",
+                "The shape argument for texture is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+                "Please use ndim instead. (Note that you no longer need the exact texture size.)",
                 DeprecationWarning,
             )
             kwargs["ndim"] = len(kwargs["shape"])
@@ -164,12 +167,14 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
                 fmt = TY_CH2FORMAT[(kwargs["channel_format"], kwargs["num_channels"])]
                 kwargs["fmt"] = fmt
                 warnings.warn(
-                    "The channel_format and num_channels arguments for texture will be deprecated in v1.6.0, use fmt instead.",
+                    "The channel_format and num_channels arguments for texture are deprecated in v1.6.0, "
+                    "and they will be removed in v1.7.0. Please use fmt instead.",
                     DeprecationWarning,
                 )
             else:
                 warnings.warn(
-                    "The channel_format and num_channels arguments are no longer required for non-RW textures since v1.6.0, you can remove them safely.",
+                    "The channel_format and num_channels arguments are no longer required for non-RW textures "
+                    "since v1.6.0, and they will be removed in v1.7.0. Please remove them.",
                     DeprecationWarning,
                 )
             if "channel_format" in kwargs:

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -12,7 +12,8 @@ from tests import test_utils
 def test_deprecate_element_shape_scalar():
     with pytest.warns(
         DeprecationWarning,
-        match="The element_shape argument for scalar will be deprecated in v1.6.0. You can remove them safely.",
+        match="The element_shape argument for scalar is deprecated in v1.6.0, and will be removed in v1.7.0. "
+        "Please remove them.",
     ):
         sym_x = ti.graph.Arg(ti.graph.ArgKind.SCALAR, "x", dtype=ti.f32, element_shape=())
 
@@ -21,7 +22,8 @@ def test_deprecate_element_shape_scalar():
 def test_deprecate_element_shape_ndarray_arg():
     with pytest.warns(
         DeprecationWarning,
-        match="The element_shape argument for ndarray will be deprecated in v1.6.0, use vector or matrix data type instead.",
+        match="The element_shape argument for ndarray is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+        "Please use vector or matrix data type instead.",
     ):
         ti.graph.Arg(ti.graph.ArgKind.NDARRAY, "x", ti.f32, ndim=1, element_shape=(1,))
 
@@ -30,7 +32,8 @@ def test_deprecate_element_shape_ndarray_arg():
 def test_deprecate_texture_channel_format_num_channels():
     with pytest.warns(
         DeprecationWarning,
-        match="The channel_format and num_channels arguments are no longer required for non-RW textures since v1.6.0, you can remove them safely.",
+        match="The channel_format and num_channels arguments are no longer required for non-RW textures "
+        "since v1.6.0, and they will be removed in v1.7.0. Please remove them.",
     ):
         ti.graph.Arg(ti.graph.ArgKind.TEXTURE, "x", ndim=2, channel_format=ti.f32, num_channels=1)
 
@@ -39,7 +42,8 @@ def test_deprecate_texture_channel_format_num_channels():
 def test_deprecate_rwtexture_channel_format_num_channels():
     with pytest.warns(
         DeprecationWarning,
-        match="The channel_format and num_channels arguments for texture will be deprecated in v1.6.0, use fmt instead.",
+        match="The channel_format and num_channels arguments for texture are deprecated in v1.6.0, "
+        "and they will be removed in v1.7.0. Please use fmt instead.",
     ):
         ti.graph.Arg(
             ti.graph.ArgKind.RWTEXTURE,
@@ -54,7 +58,8 @@ def test_deprecate_rwtexture_channel_format_num_channels():
 def test_deprecate_texture_ndim():
     with pytest.warns(
         DeprecationWarning,
-        match=r"The shape argument for texture will be deprecated in v1.6.0, use ndim instead. \(Note that you no longer need the exact texture size.\)",
+        match=r"The shape argument for texture is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+        r"Please use ndim instead. \(Note that you no longer need the exact texture size.\)",
     ):
         ti.graph.Arg(ti.graph.ArgKind.TEXTURE, "x", shape=(128, 128), channel_format=ti.f32)
 
@@ -63,7 +68,8 @@ def test_deprecate_texture_ndim():
 def test_deprecate_rwtexture_ndim():
     with pytest.warns(
         DeprecationWarning,
-        match=r"The shape argument for texture will be deprecated in v1.6.0, use ndim instead. \(Note that you no longer need the exact texture size.\)",
+        match=r"The shape argument for texture is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+        r"Please use ndim instead. \(Note that you no longer need the exact texture size.\)",
     ):
         ti.graph.Arg(ti.graph.ArgKind.RWTEXTURE, "x", shape=(128, 128), fmt=ti.Format.r32f)
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0419745</samp>

This pull request improves the deprecation warning messages for some arguments in the `ti.graph` module and updates the corresponding tests. The goal is to inform the users of the upcoming API changes and guide them to use the `ti.graph` module correctly.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0419745</samp>

*  Update the deprecation warning messages for the `element_shape`, `shape`, `channel_format`, and `num_channels` arguments for scalar, ndarray, texture, and RWTexture to reflect the new version number and the removal policy ([link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL118-R119), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL134-R136), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL152-R155), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL167-R177))
*  Update the test cases for the deprecation warning messages in `test_deprecation.py` to match the new messages and verify the expected behavior ([link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L15-R16), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L24-R26), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L33-R36), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L42-R46), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L57-R62), [link](https://github.com/taichi-dev/taichi/pull/7965/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L66-R72))
