### PR TITLE
[lang] Improve misc error report related to passing ndarray to a kernel

### DIFF
--- a/python/taichi/types/compound_types.py
+++ b/python/taichi/types/compound_types.py
@@ -19,6 +19,9 @@ class TensorType(CompoundType):
     def element_type(self):
         return self.ptr.element_type()
 
+    def __repr__(self):
+        return f"TensorType(shape={self.shape()}, dtype={self.element_type()})"
+
 
 # TODO: maybe move MatrixType, StructType here to avoid the circular import?
 def matrix(n, m, dtype):

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -124,7 +124,7 @@ class NdarrayType:
         # Check ndim match
         if self.ndim is not None and ndarray_type.shape is not None and self.ndim != len(ndarray_type.shape):
             raise ValueError(
-                f"Invalid argument into ti.types.ndarray() - required ndim={self.ndim}, but {ndarray_type.element_type} is provided"
+                f"Invalid argument into ti.types.ndarray() - required ndim={self.ndim}, but {len(ndarray_type.shape)}d ndarray with shape {ndarray_type.shape} is provided"
             )
 
         # Check needs_grad


### PR DESCRIPTION
Issue: #6572

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1aa92d</samp>

Add new tests and error handling for ndarray feature. Improve `__repr__` method for `TensorType` and error message for `NdarrayType`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1aa92d</samp>

*  Add a string representation method for tensor types ([link](https://github.com/taichi-dev/taichi/pull/7966/files?diff=unified&w=0#diff-78972e3ce6c462d977b9e713e447e8f3305899c8037a6992c37546aa0c4cb291L22-R25))
*  Improve the error message for ndarray type validation ([link](https://github.com/taichi-dev/taichi/pull/7966/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L127-R127))
*  Add tests for ndarray type mismatch scenarios ([link](https://github.com/taichi-dev/taichi/pull/7966/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L6-R6), [link](https://github.com/taichi-dev/taichi/pull/7966/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0R870-R910))
