### PR TITLE
[autodiff] Support passing requires_grad=True tensor to an arg with needs_grad=False

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -389,50 +389,51 @@ class TaichiCallableTemplateMapper:
             # support mip-mapping.
             return arg.num_dims, arg.fmt, 0
         if isinstance(anno, ndarray_type.NdarrayType):
-            if isinstance(arg, taichi.lang._ndarray.ScalarNdarray):
+            if isinstance(arg, taichi.lang._ndarray.Ndarray):
                 anno.check_matched(arg.get_type())
-                return arg.dtype, len(arg.shape), (), Layout.AOS, arg.grad is not None
-            if isinstance(arg, taichi.lang.matrix.VectorNdarray):
-                anno.check_matched(arg.get_type())
-                return arg.dtype, len(arg.shape) + 1, (arg.n,), Layout.AOS, arg.grad is not None
-            if isinstance(arg, taichi.lang.matrix.MatrixNdarray):
-                anno.check_matched(arg.get_type())
-                return arg.dtype, len(arg.shape) + 2, (arg.n, arg.m), Layout.AOS, arg.grad is not None
-            # external arrays
-            shape = getattr(arg, "shape", None)
-            if shape is None:
-                raise TaichiRuntimeTypeError(f"Invalid argument into ti.types.ndarray(), got {arg}")
-            shape = tuple(shape)
-            element_shape = ()
-            if isinstance(anno.dtype, MatrixType):
-                if anno.ndim is not None:
-                    if len(shape) != anno.dtype.ndim + anno.ndim:
+                needs_grad = (arg.grad is not None) if anno.needs_grad is None else anno.needs_grad
+                if isinstance(arg, taichi.lang._ndarray.ScalarNdarray):
+                    return arg.dtype, len(arg.shape), (), Layout.AOS, needs_grad
+                if isinstance(arg, taichi.lang.matrix.VectorNdarray):
+                    return arg.dtype, len(arg.shape) + 1, (arg.n,), Layout.AOS, needs_grad
+                if isinstance(arg, taichi.lang.matrix.MatrixNdarray):
+                    return arg.dtype, len(arg.shape) + 2, (arg.n, arg.m), Layout.AOS, needs_grad
+            else:
+                # external arrays
+                shape = getattr(arg, "shape", None)
+                if shape is None:
+                    raise TaichiRuntimeTypeError(f"Invalid argument into ti.types.ndarray(), got {arg}")
+                shape = tuple(shape)
+                element_shape = ()
+                if isinstance(anno.dtype, MatrixType):
+                    if anno.ndim is not None:
+                        if len(shape) != anno.dtype.ndim + anno.ndim:
+                            raise ValueError(
+                                f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim} element_dim={anno.dtype.ndim}, "
+                                f"but the argument has {len(shape)} dimensions"
+                            )
+                    else:
+                        if len(shape) < anno.dtype.ndim:
+                            raise ValueError(
+                                f"Invalid argument into ti.types.ndarray() - required element_dim={anno.dtype.ndim}, "
+                                f"but the argument has only {len(shape)} dimensions"
+                            )
+                    element_shape = shape[-anno.dtype.ndim :]
+                    anno_element_shape = anno.dtype.get_shape()
+                    if None not in anno_element_shape and element_shape != anno_element_shape:
                         raise ValueError(
-                            f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim} element_dim={anno.dtype.ndim}, "
+                            f"Invalid argument into ti.types.ndarray() - required element_shape={anno_element_shape}, "
+                            f"but the argument has element shape of {element_shape}"
+                        )
+                elif anno.dtype is not None:
+                    # User specified scalar dtype
+                    if anno.ndim is not None and len(shape) != anno.ndim:
+                        raise ValueError(
+                            f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim}, "
                             f"but the argument has {len(shape)} dimensions"
                         )
-                else:
-                    if len(shape) < anno.dtype.ndim:
-                        raise ValueError(
-                            f"Invalid argument into ti.types.ndarray() - required element_dim={anno.dtype.ndim}, "
-                            f"but the argument has only {len(shape)} dimensions"
-                        )
-                element_shape = shape[-anno.dtype.ndim :]
-                anno_element_shape = anno.dtype.get_shape()
-                if None not in anno_element_shape and element_shape != anno_element_shape:
-                    raise ValueError(
-                        f"Invalid argument into ti.types.ndarray() - required element_shape={anno_element_shape}, "
-                        f"but the argument has element shape of {element_shape}"
-                    )
-            elif anno.dtype is not None:
-                # User specified scalar dtype
-                if anno.ndim is not None and len(shape) != anno.ndim:
-                    raise ValueError(
-                        f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim}, "
-                        f"but the argument has {len(shape)} dimensions"
-                    )
-            needs_grad = getattr(arg, "requires_grad", False)
-            return to_taichi_type(arg.dtype), len(shape), element_shape, Layout.AOS, needs_grad
+                needs_grad = getattr(arg, "requires_grad", False) if anno.needs_grad is None else anno.needs_grad
+                return to_taichi_type(arg.dtype), len(shape), element_shape, Layout.AOS, needs_grad
         if isinstance(anno, sparse_matrix_builder):
             return arg.dtype
         # Use '#' as a placeholder because other kinds of arguments are not involved in template instantiation

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -128,7 +128,8 @@ class NdarrayType:
             )
 
         # Check needs_grad
-        if self.needs_grad is not None and self.needs_grad != ndarray_type.needs_grad:
+        if self.needs_grad is not None and self.needs_grad > ndarray_type.needs_grad:
+            # It's okay to pass a needs_grad=True ndarray at runtime to a need_grad=False arg but not vice versa.
             raise ValueError(
                 f"Invalid argument into ti.types.ndarray() - required needs_grad={self.needs_grad}, but {ndarray_type.needs_grad} is provided"
             )


### PR DESCRIPTION


Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a3e51bb</samp>

This pull request adds support for the `needs_grad` attribute of the `NdarrayType` annotation, which allows specifying whether an ndarray argument requires gradient computation or not. It modifies the `extract_arg` and `check_matched` functions in `kernel_impl.py` and `ndarray_type.py` to handle the attribute, and adds two test cases in `test_ad_ndarray.py` to verify the behavior.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a3e51bb</samp>

*  Add logic to handle `needs_grad` attribute of `NdarrayType` annotation in `extract_arg` function ([link](https://github.com/taichi-dev/taichi/pull/7970/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L392-R436))
*  Relax condition for matching `needs_grad` attribute of `NdarrayType` annotation and actual ndarray type in `check_matched` function ([link](https://github.com/taichi-dev/taichi/pull/7970/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L131-R132))
*  Add test cases to verify `needs_grad` attribute of `NdarrayType` annotation in `test_ad_ndarray.py` ([link](https://github.com/taichi-dev/taichi/pull/7970/files?diff=unified&w=0#diff-015ebf0e792298ff88ac9c4d87efba82414b3a19a4d85d0887d16099dfe2fc09R1371-R1417))
