### PR TITLE
[autodiff] Support passing vector/matrix args in autodiff kernel

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1046,6 +1046,10 @@ class ADTransform : public IRVisitor {
     // do nothing.
   }
 
+  void visit(GetElementStmt *stmt) override {
+    // do nothing
+  }
+
   void visit(LoopIndexStmt *stmt) override {
     // do nothing.
   }


### PR DESCRIPTION
Fixes #7952 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 758df7d</samp>

This pull request adds support for automatic differentiation with `ti.ndarray` and `ti.types.ndarray` arguments that have vector elements. It implements a `visit` method for `GetElementStmt` in `auto_diff.cpp` and adds a test case in `test_ad_ndarray.py`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 758df7d</samp>

*  Add a `visit` method for `GetElementStmt` to the `ADTransform` class ([link](https://github.com/taichi-dev/taichi/pull/7973/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583R1049-R1052))
* Add a test case for AD with `ti.types.ndarray` arguments that have vector elements ([link](https://github.com/taichi-dev/taichi/pull/7973/files?diff=unified&w=0#diff-015ebf0e792298ff88ac9c4d87efba82414b3a19a4d85d0887d16099dfe2fc09R1438-R1465))
