### PR TITLE
[lang] Fix failure with taichi_benchmark

### DIFF
--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -581,7 +581,7 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
   void *runtime_objects_prealloc_buffer = nullptr;
   if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
 #if defined(TI_WITH_CUDA) || defined(TI_WITH_AMDGPU)
-    runtime_objects_prealloc_size = 50 * (1UL << 20);  // 50 MB
+    runtime_objects_prealloc_size = 70 * (1UL << 20);  // 50 MB
     runtime_objects_prealloc_buffer =
         preallocate_memory(runtime_objects_prealloc_size);
 

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -581,7 +581,7 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
   void *runtime_objects_prealloc_buffer = nullptr;
   if (config_.arch == Arch::cuda || config_.arch == Arch::amdgpu) {
 #if defined(TI_WITH_CUDA) || defined(TI_WITH_AMDGPU)
-    runtime_objects_prealloc_size = 70 * (1UL << 20);  // 50 MB
+    runtime_objects_prealloc_size = 60 * (1UL << 20);  // 50 MB
     runtime_objects_prealloc_buffer =
         preallocate_memory(runtime_objects_prealloc_size);
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff32049</samp>

Increased preallocated memory size for runtime objects on GPU backends. This improves memory stability and performance for large-scale simulations on `CUDA` and `AMDGPU`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff32049</samp>

* Increase preallocated memory size for runtime objects on CUDA and AMDGPU devices to avoid allocation failures ([link](https://github.com/taichi-dev/taichi/pull/7975/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L584-R584))
