### PR TITLE
[cuda] Add fast intrinsics support to sin / cos / log

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -41,7 +41,7 @@ if [ "$TI_RUN_RELEASE_TESTS" == "1" ]; then
     python3 -m pip install PyYAML
     git clone https://github.com/taichi-dev/taichi-release-tests
     pushd taichi-release-tests
-    git checkout 20230130
+    git checkout 20230516
     mkdir -p repos/taichi/python/taichi
     EXAMPLES=$(cat <<EOF | python3 | tail -n 1
 import taichi.examples

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -88,7 +88,7 @@ if ("$env:TI_RUN_RELEASE_TESTS" -eq "1") {
     Invoke pip install PyYAML
     Invoke git clone https://github.com/taichi-dev/taichi-release-tests
     Push-Location taichi-release-tests
-    Invoke git checkout 20230130
+    Invoke git checkout 20230516
     mkdir -p repos/taichi/python/taichi
     $EXAMPLES = & python -c 'import taichi.examples as e; print(e.__path__._path[0])' | Select-Object -Last 1
     Push-Location repos

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -286,16 +286,51 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
       } else {
         TI_NOT_IMPLEMENTED
       }
+    } else if (op == UnaryOpType::log) {
+      if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {
+        // logf has fast-math option
+        llvm_val[stmt] = call(
+            compile_config.fast_math ? "__nv_fast_logf" : "__nv_logf", input);
+      } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) {
+        llvm_val[stmt] = call("__nv_log", input);
+      } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
+        llvm_val[stmt] = call("log", input);
+      } else {
+        TI_ERROR("log() for type {} is not supported",
+                 input_taichi_type.to_string());
+      }
+    } else if (op == UnaryOpType::sin) {
+      if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {
+        // sinf has fast-math option
+        llvm_val[stmt] = call(compile_config.fast_math ? "__nv_fast_sinf" : "__nv_sinf", input);
+      } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) {
+        llvm_val[stmt] = call("__nv_sin", input);
+      } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
+        llvm_val[stmt] = call("sin", input);
+      } else {
+        TI_ERROR("sin() for type {} is not supported",
+                 input_taichi_type.to_string());
+      }
+    } else if (op == UnaryOpType::cos) {
+      if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {
+        // cosf has fast-math option
+        llvm_val[stmt] = call(
+            compile_config.fast_math ? "__nv_fast_cosf" : "__nv_cosf", input);
+      } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) {
+        llvm_val[stmt] = call("__nv_cos", input);
+      } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
+        llvm_val[stmt] = call("cos", input);
+      } else {
+        TI_ERROR("cos() for type {} is not supported",
+                 input_taichi_type.to_string());
+      }
     }
     UNARY_STD(exp)
-    UNARY_STD(log)
     UNARY_STD(tan)
     UNARY_STD(tanh)
     UNARY_STD(sgn)
     UNARY_STD(acos)
     UNARY_STD(asin)
-    UNARY_STD(cos)
-    UNARY_STD(sin)
     else {
       TI_P(unary_op_type_name(op));
       TI_NOT_IMPLEMENTED

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -302,7 +302,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     } else if (op == UnaryOpType::sin) {
       if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {
         // sinf has fast-math option
-        llvm_val[stmt] = call(compile_config.fast_math ? "__nv_fast_sinf" : "__nv_sinf", input);
+        llvm_val[stmt] = call(
+            compile_config.fast_math ? "__nv_fast_sinf" : "__nv_sinf", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f64)) {
         llvm_val[stmt] = call("__nv_sin", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6042a9f</samp>

Enhance CUDA backend with more unary operations and code cleanup. Add `log`, `sin`, and `cos` support for various data types in `taichi/codegen/cuda/codegen_cuda.cpp` and remove duplicate code.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6042a9f</samp>

*  Add support for `log`, `sin`, and `cos` unary operations for different data types on the CUDA backend ([link](https://github.com/taichi-dev/taichi/pull/7991/files?diff=unified&w=0#diff-50537ad5ea3b900c0d55a088f3cc285986340ad68c9b96fea481187c4dce49eaL291-R330))
* Remove redundant calls to `UNARY_STD(cos)` and `UNARY_STD(sin)` that were already handled by the previous change ([link](https://github.com/taichi-dev/taichi/pull/7991/files?diff=unified&w=0#diff-50537ad5ea3b900c0d55a088f3cc285986340ad68c9b96fea481187c4dce49eaL299-L300))
