### PR TITLE
[Runtime] Fix: runtime caught error cannot be displayed in opengl

### DIFF
--- a/taichi/rhi/opengl/opengl_device.cpp
+++ b/taichi/rhi/opengl/opengl_device.cpp
@@ -644,9 +644,18 @@ RhiResult GLDevice::create_pipeline(Pipeline **out_pipeline,
                                     PipelineCache *cache) noexcept {
   try {
     *out_pipeline = new GLPipeline(src, name);
-  } catch (std::bad_alloc &) {
+  } catch (std::bad_alloc &e) {
     *out_pipeline = nullptr;
+    RHI_LOG_ERROR(e.what());
     return RhiResult::out_of_memory;
+  } catch (std::invalid_argument &e) {
+    *out_pipeline = nullptr;
+    RHI_LOG_ERROR(e.what());
+    return RhiResult::invalid_usage;
+  } catch (std::runtime_error &e) {
+    *out_pipeline = nullptr;
+    RHI_LOG_ERROR(e.what());
+    return RhiResult::error;
   }
   return RhiResult::success;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

