### PR TITLE
[Lang] Fix error with irpass::check_out_of_bound() for TensorTyped ExternalPtrStmt

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -656,7 +656,7 @@ Stmt *make_ndarray_access(Expression::FlattenContext *ctx,
   auto var_stmt = flatten_lvalue(var, ctx);
   auto expr = var.cast<ExternalTensorExpression>();
   auto external_ptr_stmt = std::make_unique<ExternalPtrStmt>(
-      var_stmt, index_stmts, expr->dt.get_shape(), expr->element_dim,
+      var_stmt, index_stmts, expr->dim, expr->dt.get_shape(), expr->element_dim,
       expr->is_grad);
   if (expr->dim == indices.size()) {
     // Indexing into an scalar element

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -441,7 +441,7 @@ ExternalPtrStmt *IRBuilder::create_external_ptr(
     const std::vector<Stmt *> &indices,
     bool is_grad) {
   return insert(Stmt::make_typed<ExternalPtrStmt>(
-      ptr, indices, std::vector<int>(), 0, is_grad));
+      ptr, indices, indices.size(), std::vector<int>(), 0, is_grad));
 }
 
 AdStackAllocaStmt *IRBuilder::create_ad_stack(const DataType &dt,

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -36,6 +36,7 @@ ExternalPtrStmt::ExternalPtrStmt(Stmt *base_ptr,
                                  const std::vector<Stmt *> &indices,
                                  bool is_grad)
     : base_ptr(base_ptr), indices(indices), is_grad(is_grad) {
+  ndim = indices.size();
   TI_ASSERT(base_ptr != nullptr);
   TI_ASSERT(base_ptr->is<ArgLoadStmt>());
   TI_STMT_REG_FIELDS;
@@ -43,12 +44,14 @@ ExternalPtrStmt::ExternalPtrStmt(Stmt *base_ptr,
 
 ExternalPtrStmt::ExternalPtrStmt(Stmt *base_ptr,
                                  const std::vector<Stmt *> &indices,
+                                 int ndim,
                                  const std::vector<int> &element_shape,
                                  int element_dim,
                                  bool is_grad)
     : ExternalPtrStmt(base_ptr, indices, is_grad) {
   this->element_shape = element_shape;
   this->element_dim = element_dim;
+  this->ndim = ndim;
 }
 
 GlobalPtrStmt::GlobalPtrStmt(SNode *snode,

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -333,7 +333,13 @@ class AtomicOpStmt : public Stmt,
 class ExternalPtrStmt : public Stmt {
  public:
   Stmt *base_ptr;
+
   std::vector<Stmt *> indices;
+
+  // Number of dimensions of external shape
+  int ndim;
+
+  // Shape of element type
   std::vector<int> element_shape;
   // AOS: element_dim < 0
   // SOA: element_dim > 0
@@ -352,6 +358,7 @@ class ExternalPtrStmt : public Stmt {
 
   ExternalPtrStmt(Stmt *base_ptr,
                   const std::vector<Stmt *> &indices,
+                  int ndim,
                   const std::vector<int> &element_shape,
                   int element_dim,
                   bool is_grad = false);

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1518,9 +1518,10 @@ class MakeAdjoint : public ADTransform {
                        "Cannot automatically differentiate through a grad "
                        "tensor, if you really want to do that, pass the grad "
                        "tensor into the kernel directly");
-        auto adj_ptr = insert<ExternalPtrStmt>(
-            src->base_ptr, src->indices, src->element_shape, src->element_dim,
-            /*is_grad=*/true);
+        auto adj_ptr =
+            insert<ExternalPtrStmt>(src->base_ptr, src->indices, src->ndim,
+                                    src->element_shape, src->element_dim,
+                                    /*is_grad=*/true);
         adj_ptr->ret_type = src->ret_type;
 
         if (is_ptr_offset) {
@@ -1592,9 +1593,10 @@ class MakeAdjoint : public ADTransform {
                      "Cannot automatically differentiate through a grad "
                      "tensor, if you really want to do that, pass the grad "
                      "tensor into the kernel directly");
-      adjoint_ptr = insert<ExternalPtrStmt>(
-          dest->base_ptr, dest->indices, dest->element_shape, dest->element_dim,
-          /*is_grad=*/true);
+      adjoint_ptr =
+          insert<ExternalPtrStmt>(dest->base_ptr, dest->indices, dest->ndim,
+                                  dest->element_shape, dest->element_dim,
+                                  /*is_grad=*/true);
       adjoint_ptr->ret_type = dest->ret_type;
 
       if (is_ptr_offset) {
@@ -1659,7 +1661,7 @@ class MakeAdjoint : public ADTransform {
                        "tensor, if you really want to do that, pass the grad "
                        "tensor into the kernel directly");
         auto adjoint_ptr =
-            insert<ExternalPtrStmt>(dest->base_ptr, dest->indices,
+            insert<ExternalPtrStmt>(dest->base_ptr, dest->indices, dest->ndim,
                                     dest->element_shape, dest->element_dim,
                                     /*is_grad=*/true);
         adjoint_ptr->ret_type = dest->ret_type;

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -62,7 +62,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
 
       // SOA layout for ndarray is deprecated, assert it's AOS layout
       TI_ASSERT(stmt->element_dim <= 0);
-      auto ndim = std::abs(stmt->element_dim);
+      auto ndim = stmt->ndim;
       if (i < ndim) {
         // Check for External Shape
         auto axis = i;

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -1119,9 +1119,9 @@ class MergeExternalAndMatrixPtr : public BasicStmtVisitor {
           std::accumulate(begin(origin->element_shape),
                           end(origin->element_shape), 1, std::multiplies<>())};
 
-      auto fused = std::make_unique<ExternalPtrStmt>(origin->base_ptr, indices,
-                                                     element_shape, element_dim,
-                                                     origin->is_grad);
+      auto fused = std::make_unique<ExternalPtrStmt>(
+          origin->base_ptr, indices, origin->ndim, element_shape, element_dim,
+          origin->is_grad);
       fused->ret_type = stmt->ret_type;
       // Note: Update base_ptr's ret_type so that it matches the ExternalPtrStmt
       // with flattened indices. Main goal is to keep all the hacks in a single

--- a/taichi/transforms/vectorize_half2.cpp
+++ b/taichi/transforms/vectorize_half2.cpp
@@ -355,7 +355,8 @@ class Half2Vectorize : public BasicStmtVisitor {
       std::vector<int> element_shape = {2};
       int element_dim = -1;
       auto new_extern_stmt = std::make_unique<ExternalPtrStmt>(
-          self_ptr, new_indices, element_shape, element_dim);
+          self_ptr, new_indices, self_extern_stmt->ndim, element_shape,
+          element_dim);
       new_extern_stmt->overrided_dtype = true;
       new_extern_stmt->ret_type = tensor_type;
       new_extern_stmt->ret_type.set_is_pointer(true);

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -779,10 +779,23 @@ def test_matrix_ndarray_oob():
     def access_arr(input: ti.types.ndarray(), p: ti.i32, q: ti.i32, x: ti.i32, y: ti.i32) -> ti.f32:
         return input[p, q][x, y]
 
+    @ti.kernel
+    def valid_access(indicies: ti.types.ndarray(dtype=ivec3, ndim=1), dummy: ti.types.ndarray(dtype=ivec3, ndim=1)):
+        for i in indicies:
+            index_vec = ti.Vector([0, 0, 0])
+            for j in ti.static(range(3)):
+                index = indicies[i][j]
+                index_vec[j] = index
+            dummy[i] = index_vec
+
     input = ti.ndarray(dtype=ti.math.mat2, shape=(4, 5))
+
+    indices = ti.ndarray(dtype=ivec3, shape=(10))
+    dummy = ti.ndarray(dtype=ivec3, shape=(10))
 
     # Works
     access_arr(input, 2, 3, 0, 1)
+    valid_access(indices, dummy)
 
     # element_shape
     with pytest.raises(AssertionError, match=r"Out of bound access"):

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -781,11 +781,11 @@ def test_matrix_ndarray_oob():
         return input[p, q][x, y]
 
     @ti.kernel
-    def valid_access(indicies: ti.types.ndarray(dtype=ivec3, ndim=1), dummy: ti.types.ndarray(dtype=ivec3, ndim=1)):
-        for i in indicies:
+    def valid_access(indices: ti.types.ndarray(dtype=ivec3, ndim=1), dummy: ti.types.ndarray(dtype=ivec3, ndim=1)):
+        for i in indices:
             index_vec = ti.Vector([0, 0, 0])
             for j in ti.static(range(3)):
-                index = indicies[i][j]
+                index = indices[i][j]
                 index_vec[j] = index
             dummy[i] = index_vec
 

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -6,6 +6,7 @@ from taichi.lang import impl
 from taichi.lang.exception import TaichiIndexError, TaichiTypeError
 from taichi.lang.misc import get_host_arch_list
 from taichi.lang.util import has_pytorch
+from taichi.math import vec3, ivec3
 
 import taichi as ti
 from tests import test_utils


### PR DESCRIPTION

Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fde5c3c</samp>

Simplify and clean up the code for out-of-bound check for external tensors in `taichi/transforms/check_out_of_bound.cpp`. Remove the deprecated SOA layout branch and use consistent naming for dimensions and shapes.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fde5c3c</samp>

*  Simplify code and remove deprecated SOA layout branch for ndarray in `check_out_of_bound` transform ([link](https://github.com/taichi-dev/taichi/pull/7997/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL62-R77))
