### PR TITLE
[Opengl] Fix: runtime caught error cannot be displayed in opengl

### DIFF
--- a/taichi/rhi/opengl/opengl_device.cpp
+++ b/taichi/rhi/opengl/opengl_device.cpp
@@ -644,9 +644,18 @@ RhiResult GLDevice::create_pipeline(Pipeline **out_pipeline,
                                     PipelineCache *cache) noexcept {
   try {
     *out_pipeline = new GLPipeline(src, name);
-  } catch (std::bad_alloc &) {
+  } catch (std::bad_alloc &e) {
     *out_pipeline = nullptr;
+    RHI_LOG_ERROR(e.what());
     return RhiResult::out_of_memory;
+  } catch (std::invalid_argument &e) {
+    *out_pipeline = nullptr;
+    RHI_LOG_ERROR(e.what());
+    return RhiResult::invalid_usage;
+  } catch (std::runtime_error &e) {
+    *out_pipeline = nullptr;
+    RHI_LOG_ERROR(e.what());
+    return RhiResult::error;
   }
   return RhiResult::success;
 }


### PR DESCRIPTION
### Brief Summary

This PR fixes the issue that caught errors weren't logged out in opengl device.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9738324</samp>

Refactor and improve error handling of `create_pipeline` function in `opengl_device.cpp`. Catch and log different exceptions and return corresponding error codes.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9738324</samp>

* Improve error handling and reporting in `create_pipeline` function ([link](https://github.com/taichi-dev/taichi/pull/7998/files?diff=unified&w=0#diff-28721a9ee9ac35b296afebd149e19d760c079aac1be524a048e77c5fd8f51069L647-R658)) by catching and logging different types of exceptions and returning different error codes
