### PR TITLE
[Misc] Make clang-tidy happy on 'explicit'

### DIFF
--- a/taichi/common/one_or_more.h
+++ b/taichi/common/one_or_more.h
@@ -11,21 +11,27 @@ struct one_or_more {
 
   std::variant<value_type, Container> var;
 
+  // NOLINTNEXTLINE
   one_or_more(value_type const &value) : var(value) {
   }
 
+  // NOLINTNEXTLINE
   one_or_more(value_type &value) : var(value) {
   }
 
+  // NOLINTNEXTLINE
   one_or_more(value_type &&value) : var(std::move(value)) {
   }
 
+  // NOLINTNEXTLINE
   one_or_more(Container const &value) : var(value) {
   }
 
+  // NOLINTNEXTLINE
   one_or_more(Container &value) : var(value) {
   }
 
+  // NOLINTNEXTLINE
   one_or_more(Container &&value) : var(std::move(value)) {
   }
 

--- a/taichi/rhi/amdgpu/amdgpu_context.h
+++ b/taichi/rhi/amdgpu/amdgpu_context.h
@@ -94,7 +94,7 @@ class AMDGPUContext {
     void *new_ctx_;
 
    public:
-    ContextGuard(AMDGPUContext *new_ctx)
+    explicit ContextGuard(AMDGPUContext *new_ctx)
         : old_ctx_(nullptr), new_ctx_(new_ctx) {
       AMDGPUDriver::get_instance().context_get_current(&old_ctx_);
       if (old_ctx_ != new_ctx)

--- a/taichi/rhi/llvm/device_memory_pool.h
+++ b/taichi/rhi/llvm/device_memory_pool.h
@@ -24,7 +24,7 @@ class TI_DLL_EXPORT DeviceMemoryPool {
   void *allocate(std::size_t size, std::size_t alignment, bool managed = false);
   void release(std::size_t size, void *ptr, bool release_raw = false);
   void reset();
-  DeviceMemoryPool(bool merge_upon_release);
+  explicit DeviceMemoryPool(bool merge_upon_release);
   ~DeviceMemoryPool();
 
  protected:

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -29,7 +29,7 @@ extern void *kGetOpenglProcAddr;
 class GLResourceSet : public ShaderResourceSet {
  public:
   GLResourceSet() = default;
-  explicit GLResourceSet(const GLResourceSet &other) = default;
+  GLResourceSet(const GLResourceSet &other) = default;
 
   ~GLResourceSet() override;
 

--- a/taichi/rhi/vulkan/vulkan_device.h
+++ b/taichi/rhi/vulkan/vulkan_device.h
@@ -239,7 +239,7 @@ class VulkanResourceSet : public ShaderResourceSet {
 
 class VulkanRasterResources : public RasterResources {
  public:
-  VulkanRasterResources(VulkanDevice *device) : device_(device) {
+  explicit VulkanRasterResources(VulkanDevice *device) : device_(device) {
   }
 
   struct BufferBinding {

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -48,7 +48,7 @@ using TaskType = OffloadedStmt::TaskType;
 
 class MakeCPUMultithreadedRangeFor : public BasicStmtVisitor {
  public:
-  MakeCPUMultithreadedRangeFor(const CompileConfig &config) : config(config) {
+  explicit MakeCPUMultithreadedRangeFor(const CompileConfig &config) : config(config) {
   }
 
   void visit(Block *block) override {

--- a/taichi/transforms/make_cpu_multithreaded_range_for.cpp
+++ b/taichi/transforms/make_cpu_multithreaded_range_for.cpp
@@ -48,7 +48,8 @@ using TaskType = OffloadedStmt::TaskType;
 
 class MakeCPUMultithreadedRangeFor : public BasicStmtVisitor {
  public:
-  explicit MakeCPUMultithreadedRangeFor(const CompileConfig &config) : config(config) {
+  explicit MakeCPUMultithreadedRangeFor(const CompileConfig &config)
+      : config(config) {
   }
 
   void visit(Block *block) override {


### PR DESCRIPTION
### Brief Summary

This PR tries to resolve the problem during ` Build and Test / Check Static Analyzer (pull_request) `. This check takes too much time and prints out thousands of lines of 'explicit errors' like this:

```
error: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor,-warnings-as-errors]
  one_or_more(Container &&value) : var(std::move(value)) {
  ^
  explicit 
```

This PR also resolves `error: copy constructor should not be declared explicit` on `GLResourceSet`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cbf3891</samp>

*  Suppress clang-tidy warning for single-argument constructors of `one_or_more` class by adding `// NOLINTNEXTLINE` comments ([link](https://github.com/taichi-dev/taichi/pull/7999/files?diff=unified&w=0#diff-6230f8e8c6a8a297f8900dd0f7e212097b07ee7b64fc7fa5a5ffee5af47211a8L14-R34),   ). This class is defined in `taichi/common/one_or_more.h` and allows holding either a single value or a container of values.