### PR TITLE
[llvm] Simplified and add support for type u1 in logical not operation

### DIFF
--- a/taichi/codegen/amdgpu/codegen_amdgpu.cpp
+++ b/taichi/codegen/amdgpu/codegen_amdgpu.cpp
@@ -65,13 +65,7 @@ class TaskCodeGenAMDGPU : public TaskCodeGenLLVM {
       TI_NOT_IMPLEMENTED                                                \
     }                                                                   \
   }
-    if (op == UnaryOpType::logic_not) {
-      if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
-        llvm_val[stmt] = call("logic_not_i32", input);
-      } else {
-        TI_NOT_IMPLEMENTED
-      }
-    } else if (op == UnaryOpType::abs) {
+    if (op == UnaryOpType::abs) {
       if (input_taichi_type->is_primitive(PrimitiveTypeID::f16)) {
         llvm_val[stmt] = call("__ocml_fasb_f16", input);
       } else if (input_taichi_type->is_primitive(PrimitiveTypeID::f32)) {

--- a/taichi/codegen/cuda/codegen_cuda.cpp
+++ b/taichi/codegen/cuda/codegen_cuda.cpp
@@ -257,12 +257,6 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
       } else {
         TI_NOT_IMPLEMENTED
       }
-    } else if (op == UnaryOpType::logic_not) {
-      if (input_taichi_type->is_primitive(PrimitiveTypeID::i32)) {
-        llvm_val[stmt] = call("logic_not_i32", input);
-      } else {
-        TI_NOT_IMPLEMENTED
-      }
     } else if (op == UnaryOpType::frexp) {
       auto stype = tlctx->get_data_type(stmt->ret_type.ptr_removed());
       auto res = builder->CreateAlloca(stype);

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -524,7 +524,7 @@ void TaskCodeGenLLVM::visit(UnaryOpStmt *stmt) {
       llvm_val[stmt] = builder->CreateNeg(input, "neg");
     }
   } else if (op == UnaryOpType::logic_not) {
-    llvm_val[stmt] = builder->CreateNot(builder->CreateIsNull(input));
+    llvm_val[stmt] = builder->CreateIsNull(input);
     // TODO: (zhantong) remove this zero ext
     llvm_val[stmt] = builder->CreateZExt(
         llvm_val[stmt], tlctx->get_data_type(PrimitiveType::i32));

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -524,9 +524,11 @@ void TaskCodeGenLLVM::visit(UnaryOpStmt *stmt) {
       llvm_val[stmt] = builder->CreateNeg(input, "neg");
     }
   } else if (op == UnaryOpType::logic_not) {
-    llvm_val[stmt] = builder->CreateSelect(builder->CreateIsNull(input),
-                                           tlctx->get_constant(true),
-                                           tlctx->get_constant(false));
+    llvm_val[stmt] = builder->CreateNot(builder->CreateIsNull(input));
+    // TODO: (zhantong) remove this zero ext
+    llvm_val[stmt] =
+        builder->CreateZExt(llvm_val[stmt],
+                            tlctx->get_data_type(PrimitiveType::i32));
   }
   UNARY_INTRINSIC(round)
   UNARY_INTRINSIC(floor)

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -526,9 +526,8 @@ void TaskCodeGenLLVM::visit(UnaryOpStmt *stmt) {
   } else if (op == UnaryOpType::logic_not) {
     llvm_val[stmt] = builder->CreateNot(builder->CreateIsNull(input));
     // TODO: (zhantong) remove this zero ext
-    llvm_val[stmt] =
-        builder->CreateZExt(llvm_val[stmt],
-                            tlctx->get_data_type(PrimitiveType::i32));
+    llvm_val[stmt] = builder->CreateZExt(
+        llvm_val[stmt], tlctx->get_data_type(PrimitiveType::i32));
   }
   UNARY_INTRINSIC(round)
   UNARY_INTRINSIC(floor)

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -861,9 +861,9 @@ void TaskCodeGenLLVM::visit(BinaryOpStmt *stmt) {
 
 void TaskCodeGenLLVM::visit(TernaryOpStmt *stmt) {
   TI_ASSERT(stmt->op_type == TernaryOpType::select);
-  llvm_val[stmt] = builder->CreateSelect(
-      builder->CreateIsNotNull(llvm_val[stmt->op1]),
-      llvm_val[stmt->op2], llvm_val[stmt->op3]);
+  llvm_val[stmt] =
+      builder->CreateSelect(builder->CreateIsNotNull(llvm_val[stmt->op1]),
+                            llvm_val[stmt->op2], llvm_val[stmt->op3]);
 }
 
 void TaskCodeGenLLVM::visit(IfStmt *if_stmt) {

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -209,11 +209,6 @@ void TaskCodeGenLLVM::emit_extra_unary(UnaryOpStmt *stmt) {
     llvm_val[stmt] =
         builder->CreateIntrinsic(llvm::Intrinsic::ctpop, {input_type}, {input});
   }
-  else if (op == UnaryOpType::logic_not) {
-    llvm_val[stmt] = builder->CreateSelect(builder->CreateIsNull(input),
-                                           tlctx->get_constant(true),
-                                           tlctx->get_constant(false));
-  }
   else {
     TI_P(unary_op_type_name(op));
     TI_NOT_IMPLEMENTED
@@ -528,6 +523,10 @@ void TaskCodeGenLLVM::visit(UnaryOpStmt *stmt) {
     } else {
       llvm_val[stmt] = builder->CreateNeg(input, "neg");
     }
+  } else if (op == UnaryOpType::logic_not) {
+    llvm_val[stmt] = builder->CreateSelect(builder->CreateIsNull(input),
+                                           tlctx->get_constant(true),
+                                           tlctx->get_constant(false));
   }
   UNARY_INTRINSIC(round)
   UNARY_INTRINSIC(floor)

--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -197,7 +197,6 @@ void TaskCodeGenLLVM::emit_extra_unary(UnaryOpStmt *stmt) {
   UNARY_STD(tan)
   UNARY_STD(tanh)
   UNARY_STD(sgn)
-  UNARY_STD(logic_not)
   UNARY_STD(acos)
   UNARY_STD(asin)
   UNARY_STD(cos)
@@ -209,6 +208,11 @@ void TaskCodeGenLLVM::emit_extra_unary(UnaryOpStmt *stmt) {
   else if (op == UnaryOpType::popcnt) {
     llvm_val[stmt] =
         builder->CreateIntrinsic(llvm::Intrinsic::ctpop, {input_type}, {input});
+  }
+  else if (op == UnaryOpType::logic_not) {
+    llvm_val[stmt] = builder->CreateSelect(builder->CreateIsNull(input),
+                                           tlctx->get_constant(true),
+                                           tlctx->get_constant(false));
   }
   else {
     TI_P(unary_op_type_name(op));

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -229,10 +229,6 @@ i64 max_i64(i64 a, i64 b) {
   return a > b ? a : b;
 }
 
-int32 logic_not_i32(int32 a) {
-  return !a;
-}
-
 float32 sgn_f32(float32 a) {
   float32 b;
   if (a > 0)


### PR DESCRIPTION
### Summary

This PR removed logic_not as a runtime function and provides support for logic_not using ir.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad869c3</samp>

*  Remove logic_not operation for i32 type from AMDGPU and CUDA codegens, since it is handled by LLVM IR builder ([link](https://github.com/taichi-dev/taichi/pull/8005/files?diff=unified&w=0#diff-f45ad00d5bebbc900cf84ab5b4f0b634fe8ca7a99770788c2cb5b055612c1e85L68-R68), [link](https://github.com/taichi-dev/taichi/pull/8005/files?diff=unified&w=0#diff-50537ad5ea3b900c0d55a088f3cc285986340ad68c9b96fea481187c4dce49eaL257-L262))
*  Delete logic_not_i32 function from runtime module, as it is not used by any backend ([link](https://github.com/taichi-dev/taichi/pull/8005/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4L232-L235))

### ghstack
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8013
* #8008
* __->__ #8005
* #8003
* #7995

