### PR TITLE
Debug

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -392,48 +392,42 @@ class TaichiCallableTemplateMapper:
             if isinstance(arg, taichi.lang._ndarray.Ndarray):
                 anno.check_matched(arg.get_type())
                 needs_grad = (arg.grad is not None) if anno.needs_grad is None else anno.needs_grad
-                if isinstance(arg, taichi.lang._ndarray.ScalarNdarray):
-                    return arg.dtype, len(arg.shape), (), Layout.AOS, needs_grad
-                if isinstance(arg, taichi.lang.matrix.VectorNdarray):
-                    return arg.dtype, len(arg.shape) + 1, (arg.n,), Layout.AOS, needs_grad
-                if isinstance(arg, taichi.lang.matrix.MatrixNdarray):
-                    return arg.dtype, len(arg.shape) + 2, (arg.n, arg.m), Layout.AOS, needs_grad
-            else:
-                # external arrays
-                shape = getattr(arg, "shape", None)
-                if shape is None:
-                    raise TaichiRuntimeTypeError(f"Invalid argument into ti.types.ndarray(), got {arg}")
-                shape = tuple(shape)
-                element_shape = ()
-                if isinstance(anno.dtype, MatrixType):
-                    if anno.ndim is not None:
-                        if len(shape) != anno.dtype.ndim + anno.ndim:
-                            raise ValueError(
-                                f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim} element_dim={anno.dtype.ndim}, "
-                                f"but the argument has {len(shape)} dimensions"
-                            )
-                    else:
-                        if len(shape) < anno.dtype.ndim:
-                            raise ValueError(
-                                f"Invalid argument into ti.types.ndarray() - required element_dim={anno.dtype.ndim}, "
-                                f"but the argument has only {len(shape)} dimensions"
-                            )
-                    element_shape = shape[-anno.dtype.ndim :]
-                    anno_element_shape = anno.dtype.get_shape()
-                    if None not in anno_element_shape and element_shape != anno_element_shape:
+                return arg.dtype, len(arg.shape) + len(arg.element_shape), arg.element_shape, Layout.AOS, needs_grad
+            # external arrays
+            shape = getattr(arg, "shape", None)
+            if shape is None:
+                raise TaichiRuntimeTypeError(f"Invalid argument into ti.types.ndarray(), got {arg}")
+            shape = tuple(shape)
+            element_shape = ()
+            if isinstance(anno.dtype, MatrixType):
+                if anno.ndim is not None:
+                    if len(shape) != anno.dtype.ndim + anno.ndim:
                         raise ValueError(
-                            f"Invalid argument into ti.types.ndarray() - required element_shape={anno_element_shape}, "
-                            f"but the argument has element shape of {element_shape}"
-                        )
-                elif anno.dtype is not None:
-                    # User specified scalar dtype
-                    if anno.ndim is not None and len(shape) != anno.ndim:
-                        raise ValueError(
-                            f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim}, "
+                            f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim} element_dim={anno.dtype.ndim}, "
                             f"but the argument has {len(shape)} dimensions"
                         )
-                needs_grad = getattr(arg, "requires_grad", False) if anno.needs_grad is None else anno.needs_grad
-                return to_taichi_type(arg.dtype), len(shape), element_shape, Layout.AOS, needs_grad
+                else:
+                    if len(shape) < anno.dtype.ndim:
+                        raise ValueError(
+                            f"Invalid argument into ti.types.ndarray() - required element_dim={anno.dtype.ndim}, "
+                            f"but the argument has only {len(shape)} dimensions"
+                        )
+                element_shape = shape[-anno.dtype.ndim :]
+                anno_element_shape = anno.dtype.get_shape()
+                if None not in anno_element_shape and element_shape != anno_element_shape:
+                    raise ValueError(
+                        f"Invalid argument into ti.types.ndarray() - required element_shape={anno_element_shape}, "
+                        f"but the argument has element shape of {element_shape}"
+                    )
+            elif anno.dtype is not None:
+                # User specified scalar dtype
+                if anno.ndim is not None and len(shape) != anno.ndim:
+                    raise ValueError(
+                        f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim}, "
+                        f"but the argument has {len(shape)} dimensions"
+                    )
+            needs_grad = getattr(arg, "requires_grad", False) if anno.needs_grad is None else anno.needs_grad
+            return to_taichi_type(arg.dtype), len(shape), element_shape, Layout.AOS, needs_grad
         if isinstance(anno, sparse_matrix_builder):
             return arg.dtype
         # Use '#' as a placeholder because other kinds of arguments are not involved in template instantiation

--- a/taichi/rhi/llvm/allocator.cpp
+++ b/taichi/rhi/llvm/allocator.cpp
@@ -40,6 +40,13 @@ uint64_t *CachingAllocator::allocate(
   if (it_blk != mem_blocks_.end()) {
     size_t remaining_sz = it_blk->first - size_aligned;
     if (remaining_sz > 0) {
+      if (remaining_sz % taichi_page_size != 0) {
+        // Page Alignment Error, print out remaining_sz and taichi_page_size
+        TI_ERROR(
+            "Page Alignment Error: remaining_sz = {}, taichi_page_size = {}, "
+            "it_blk->first = {}, size_aligned = {}",
+            remaining_sz, taichi_page_size, it_blk->first, size_aligned);
+      }
       TI_ASSERT(remaining_sz % taichi_page_size == 0);
       auto remaining_head =
           reinterpret_cast<uint8_t *>(it_blk->second) + size_aligned;

--- a/taichi/rhi/llvm/allocator.cpp
+++ b/taichi/rhi/llvm/allocator.cpp
@@ -68,7 +68,9 @@ void CachingAllocator::release(size_t sz, uint64_t *ptr) {
   if (merge_upon_release_) {
     merge_and_insert(reinterpret_cast<uint8_t *>(ptr), sz);
   } else {
-    mem_blocks_.insert(std::make_pair(sz, reinterpret_cast<uint8_t *>(ptr)));
+    if (sz >= taichi_page_size) {
+      mem_blocks_.insert(std::make_pair(sz, reinterpret_cast<uint8_t *>(ptr)));
+    }
   }
 }
 

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -665,10 +665,13 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
     }
     TI_ASSERT(total_prealloc_size <= total_mem);
 
+    /*
     auto runtime_memory_prealloc_size =
         total_prealloc_size > runtime_objects_prealloc_size
             ? total_prealloc_size - runtime_objects_prealloc_size
             : 0;
+    */
+    auto runtime_memory_prealloc_size = total_prealloc_size;
 
     void *runtime_memory_prealloc_buffer =
         preallocate_memory(runtime_memory_prealloc_size);

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -619,6 +619,8 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
     temp_result_alloc.reset();
     size_t result_buffer_size = sizeof(uint64) * taichi_result_buffer_entries;
 
+    runtime_objects_prealloc_size =
+        taichi::iroundup(runtime_objects_prealloc_size, 10 * (1UL << 20));
     TI_TRACE("Allocating device memory {:.2f} MB",
              1.0 * (runtime_objects_prealloc_size + result_buffer_size) /
                  (1UL << 20));

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -625,8 +625,8 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
              1.0 * (runtime_objects_prealloc_size + result_buffer_size) /
                  (1UL << 20));
 
-    runtime_objects_prealloc_buffer =
-        preallocate_memory(runtime_objects_prealloc_size + result_buffer_size);
+    runtime_objects_prealloc_buffer = preallocate_memory(iroundup(
+        runtime_objects_prealloc_size + result_buffer_size, taichi_page_size));
 
     *result_buffer_ptr =
         (uint64_t *)((uint8_t *)runtime_objects_prealloc_buffer +

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -619,8 +619,6 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
     temp_result_alloc.reset();
     size_t result_buffer_size = sizeof(uint64) * taichi_result_buffer_entries;
 
-    runtime_objects_prealloc_size =
-        taichi::iroundup(runtime_objects_prealloc_size, 10 * (1UL << 20));
     TI_TRACE("Allocating device memory {:.2f} MB",
              1.0 * (runtime_objects_prealloc_size + result_buffer_size) /
                  (1UL << 20));

--- a/taichi/runtime/llvm/llvm_runtime_executor.cpp
+++ b/taichi/runtime/llvm/llvm_runtime_executor.cpp
@@ -623,6 +623,10 @@ void LlvmRuntimeExecutor::materialize_runtime(KernelProfilerBase *profiler,
              1.0 * (runtime_objects_prealloc_size + result_buffer_size) /
                  (1UL << 20));
 
+    TI_WARN("Allocating device memory {} ",
+            iroundup(runtime_objects_prealloc_size + result_buffer_size,
+                     taichi_page_size));
+
     runtime_objects_prealloc_buffer = preallocate_memory(iroundup(
         runtime_objects_prealloc_size + result_buffer_size, taichi_page_size));
 

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -883,7 +883,7 @@ void runtime_memory_allocate_aligned(LLVMRuntime *runtime,
 void runtime_get_memory_requirements(Ptr result_buffer,
                                      i32 num_rand_states,
                                      i32 use_preallocated_buffer) {
-  i64 size = taichi_page_size; // Initial alignment bleeding
+  i64 size = 0;
   
   if (use_preallocated_buffer) {
     size += taichi::iroundup(i64(sizeof(LLVMRuntime)), taichi_page_size);

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -880,6 +880,25 @@ void runtime_memory_allocate_aligned(LLVMRuntime *runtime,
 // External API
 // [ON HOST] CPU backend
 // [ON DEVICE] CUDA/AMDGPU backend
+void runtime_get_memory_requirements(Ptr result_buffer,
+                                     i32 num_rand_states,
+                                     i32 use_preallocated_buffer) {
+  i64 size = taichi_page_size; // Initial alignment bleeding
+  
+  if (use_preallocated_buffer) {
+    size += taichi::iroundup(i64(sizeof(LLVMRuntime)), taichi_page_size);
+  }
+
+  size += taichi::iroundup(i64(taichi_global_tmp_buffer_size), taichi_page_size);
+  size += taichi::iroundup(i64(sizeof(RandState)) * num_rand_states,
+                           taichi_page_size);
+
+  reinterpret_cast<i64 *>(result_buffer)[0] = size;
+}
+
+// External API
+// [ON HOST] CPU backend
+// [ON DEVICE] CUDA/AMDGPU backend
 void runtime_initialize(
     Ptr result_buffer,
     Ptr memory_pool,

--- a/taichi/runtime/llvm/runtime_module/runtime.cpp
+++ b/taichi/runtime/llvm/runtime_module/runtime.cpp
@@ -884,7 +884,7 @@ void runtime_get_memory_requirements(Ptr result_buffer,
                                      i32 num_rand_states,
                                      i32 use_preallocated_buffer) {
   i64 size = 0;
-  
+
   if (use_preallocated_buffer) {
     size += taichi::iroundup(i64(sizeof(LLVMRuntime)), taichi_page_size);
   }


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2b0745</samp>

This pull request enhances the LLVM runtime executor and module with a new function `runtime_get_memory_requirements` that calculates the exact device memory size needed for the runtime objects. It also improves the memory allocation and error handling, and adds a random state initialization based on the seed.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2b0745</samp>

*  Add error handling for device memory allocation failure ([link](https://github.com/taichi-dev/taichi/pull/8006/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L562-R563))
*  Calculate initial random state based on random seed and number of random states needed for each thread ([link](https://github.com/taichi-dev/taichi/pull/8006/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5R574-R593))
*  Implement `runtime_get_memory_requirements` function in `runtime.cpp` to compute the exact size of device memory needed for runtime objects ([link](https://github.com/taichi-dev/taichi/pull/8006/files?diff=unified&w=0#diff-980b2254ce0f4c654a946673ab6cd7a84f78cc6f0d6560bc1361670ec6e678c4R883-R902))
*  Use `runtime_get_memory_requirements` function in `llvm_runtime_executor.cpp` to allocate device memory with the correct size and alignment ([link](https://github.com/taichi-dev/taichi/pull/8006/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L580-R633), [link](https://github.com/taichi-dev/taichi/pull/8006/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L603-R641))
*  Move trace message before device memory allocation in `llvm_runtime_executor.cpp` for consistency ([link](https://github.com/taichi-dev/taichi/pull/8006/files?diff=unified&w=0#diff-b9155792159f392bd8bacd44cb1819be5239b022d707499fc364c0f93dd8c5e5L603-R641))
