### PR TITLE
[refactor] Remove redundant TensorType class in python scope

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -6,7 +6,6 @@ from taichi.lang.exception import TaichiIndexError
 from taichi.lang.util import cook_dtype, python_scope, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.ndarray_type import NdarrayTypeMetadata
-from taichi.types.compound_types import TensorType
 from taichi.types.utils import is_real, is_signed
 
 
@@ -70,7 +69,7 @@ class Ndarray:
         """
         if impl.current_cfg().arch != _ti_core.Arch.cuda and impl.current_cfg().arch != _ti_core.Arch.x64:
             self._fill_by_kernel(val)
-        elif isinstance(self.element_type, TensorType):
+        elif _ti_core.is_tensor(self.element_type):
             self._fill_by_kernel(val)
         elif self.dtype == primitive_types.f32:
             impl.get_runtime().prog.fill_float(self.arr, val)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -29,8 +29,11 @@ from taichi.lang.util import (
     warning,
 )
 from taichi.types import primitive_types
-from taichi.types.compound_types import CompoundType, TensorType
+from taichi.types.compound_types import CompoundType
 from taichi.types.utils import is_signed
+from taichi._lib.utils import ti_python_core as _ti_python_core
+
+_type_factory = _ti_python_core.get_type_factory_instance()
 
 
 def _generate_swizzle_patterns(key_group: str, required_length=4):
@@ -1366,7 +1369,8 @@ class MatrixType(CompoundType):
         #                 Remove the None dtype when we are ready to break legacy code.
         if dtype is not None:
             self.dtype = cook_dtype(dtype)
-            self.tensor_type = TensorType((n, m) if ndim == 2 else (n,), self.dtype)
+            shape = (n, m) if ndim == 2 else (n,)
+            self.tensor_type = _type_factory.get_tensor_type(shape, self.dtype)
         else:
             self.dtype = None
             self.tensor_type = None
@@ -1607,9 +1611,9 @@ class MatrixNdarray(Ndarray):
 
         self.layout = Layout.AOS
         self.shape = tuple(shape)
-        self.element_type = TensorType((self.n, self.m), dtype)
+        self.element_type = _type_factory.get_tensor_type((self.n, self.m), self.dtype)
         # TODO: we should pass in element_type, shape, layout instead.
-        self.arr = impl.get_runtime().prog.create_ndarray(cook_dtype(self.element_type.ptr), shape, Layout.AOS)
+        self.arr = impl.get_runtime().prog.create_ndarray(cook_dtype(self.element_type), shape, Layout.AOS)
 
     @property
     def element_shape(self):
@@ -1716,8 +1720,8 @@ class VectorNdarray(Ndarray):
 
         self.layout = Layout.AOS
         self.shape = tuple(shape)
-        self.element_type = TensorType((n,), self.dtype)
-        self.arr = impl.get_runtime().prog.create_ndarray(cook_dtype(self.element_type.ptr), shape, Layout.AOS)
+        self.element_type = _type_factory.get_tensor_type((n,), self.dtype)
+        self.arr = impl.get_runtime().prog.create_ndarray(cook_dtype(self.element_type), shape, Layout.AOS)
 
     @property
     def element_shape(self):

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -596,7 +596,7 @@ class StructType(CompoundType):
                 elements.append([dtype.dtype, k])
             elif isinstance(dtype, MatrixType):
                 self.members[k] = dtype
-                elements.append([dtype.tensor_type.ptr, k])
+                elements.append([dtype.tensor_type, k])
             else:
                 dtype = cook_dtype(dtype)
                 self.members[k] = dtype

--- a/python/taichi/types/compound_types.py
+++ b/python/taichi/types/compound_types.py
@@ -9,20 +9,6 @@ class CompoundType:
     pass
 
 
-class TensorType(CompoundType):
-    def __init__(self, shape, dtype):
-        self.ptr = _type_factory.get_tensor_type(shape, dtype)
-
-    def shape(self):
-        return tuple(self.ptr.shape())
-
-    def element_type(self):
-        return self.ptr.element_type()
-
-    def __repr__(self):
-        return f"TensorType(shape={self.shape()}, dtype={self.element_type()})"
-
-
 # TODO: maybe move MatrixType, StructType here to avoid the circular import?
 def matrix(n, m, dtype):
     """Creates a matrix type with given shape and data type.

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -1,6 +1,6 @@
 from taichi._lib import core as _ti_core
 from taichi.lang.enums import Layout
-from taichi.types.compound_types import CompoundType, TensorType, matrix, vector
+from taichi.types.compound_types import CompoundType, matrix, vector
 
 
 class NdarrayTypeMetadata:
@@ -43,16 +43,6 @@ def _make_matrix_dtype_from_element_shape(element_dim, element_shape, primitive_
             else matrix(element_shape[0], element_shape[1], primitive_dtype)
         )
     return mat_dtype
-
-
-# FIXME(zhanlue): Use TensorType exported from pybind and then remove python-scope TensorType
-def is_tensor_type(dtype):
-    if isinstance(dtype, TensorType):
-        return True
-    if isinstance(dtype, _ti_core.DataType):
-        return _ti_core.is_tensor(dtype)
-
-    return False
 
 
 class NdarrayType:
@@ -98,14 +88,14 @@ class NdarrayType:
         if isinstance(self.dtype, CompoundType):
             # Check element shape and dim for MatrixType
             if self.dtype.ndim > 0:
-                if not is_tensor_type(ndarray_type.element_type):
+                if not _ti_core.is_tensor(ndarray_type.element_type):
                     raise TypeError(f"Expect TensorType element for Ndarray with element_dim: {self.dtype.ndim} > 0")
                 if self.dtype.ndim != len(ndarray_type.element_type.shape()):
                     raise ValueError(
                         f"Invalid argument into ti.types.ndarray() - required element_dim={self.dtype.ndim}, but {len(ndarray_type.element_type.shape())} is provided"
                     )
             if self.dtype.get_shape() is not None:
-                if not is_tensor_type(ndarray_type.element_type):
+                if not _ti_core.is_tensor(ndarray_type.element_type):
                     raise TypeError(
                         f"Expect TensorType element for Ndarray with element_shape: {self.dtype.get_shape()}"
                     )

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -177,14 +177,14 @@ def test_ndarray_compound_element():
     assert isinstance(b, ti.VectorNdarray)
     assert b.shape == (n, n)
     assert b.element_type.element_type() == ti.i32
-    assert b.element_type.shape() == (3,)
+    assert b.element_type.shape() == [3]
 
     matrix34 = ti.types.matrix(3, 4, float)
     c = ti.ndarray(matrix34, shape=(n, n + 1))
     assert isinstance(c, ti.MatrixNdarray)
     assert c.shape == (n, n + 1)
     assert c.element_type.element_type() == ti.f32
-    assert c.element_type.shape() == (3, 4)
+    assert c.element_type.shape() == [3, 4]
 
 
 @test_utils.test(arch=supported_archs_taichi_ndarray)
@@ -893,7 +893,7 @@ def test_ndarray_wrong_dtype():
     tp_ivec3 = ti.types.vector(3, ti.i32)
 
     y = ti.ndarray(tp_ivec3, shape=(12, 4))
-    with pytest.raises(TypeError, match=r"get TensorType\(shape=\(3,\), dtype=i32\)"):
+    with pytest.raises(TypeError, match=r"get \[Tensor \(3\) i32\]"):
         test2(y)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8012
* #8010
* __->__ #8009

