### PR TITLE
[lang] Support ti.types.vector and matrix as type annotation

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1513,10 +1513,12 @@ class MatrixType(CompoundType):
     def check_matched(self, other):
         if self.ndim != len(other.shape()):
             return False
-        if self.dtype != other.element_type():
+        if self.dtype is not None and self.dtype != other.element_type():
             return False
-        if self.get_shape() != tuple(other.shape()):
-            return False
+        shape = self.get_shape()
+        for i in range(self.ndim):
+            if shape[i] is not None and shape[i] != other.shape()[i]:
+                return False
         return True
 
 

--- a/python/taichi/types/compound_types.py
+++ b/python/taichi/types/compound_types.py
@@ -10,7 +10,7 @@ class CompoundType:
 
 
 # TODO: maybe move MatrixType, StructType here to avoid the circular import?
-def matrix(n, m, dtype):
+def matrix(n=None, m=None, dtype=None):
     """Creates a matrix type with given shape and data type.
 
     Args:
@@ -29,7 +29,7 @@ def matrix(n, m, dtype):
     return taichi.lang.matrix.MatrixType(n, m, 2, dtype)
 
 
-def vector(n, dtype):
+def vector(n=None, dtype=None):
     """Creates a vector type with given shape and data type.
 
     Args:

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -940,3 +940,43 @@ def test_bad_ndim():
 
     with pytest.raises(ValueError, match=r"required ndim=1, but 2d ndarray with shape \(12, 13\) is provided"):
         test5(x)
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_type_hint_matrix():
+    @ti.kernel
+    def test(x: ti.types.ndarray(dtype=ti.types.matrix())):
+        for I in ti.grouped(x):
+            x[I] = 1.0
+
+    x = ti.ndarray(ti.math.mat2, (3))
+    test(x)
+    assert impl.get_runtime().get_num_compiled_functions() == 1
+
+    y = ti.ndarray(ti.math.mat3, (3))
+    test(y)
+    assert impl.get_runtime().get_num_compiled_functions() == 2
+
+    z = ti.ndarray(ti.math.vec2, (3))
+    with pytest.raises(ValueError, match=r"Invalid argument into ti.types.ndarray\(\)"):
+        test(z)
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_type_hint_vector():
+    @ti.kernel
+    def test(x: ti.types.ndarray(dtype=ti.types.vector())):
+        for I in ti.grouped(x):
+            x[I] = 1.0
+
+    x = ti.ndarray(ti.math.vec3, (3))
+    test(x)
+    assert impl.get_runtime().get_num_compiled_functions() == 1
+
+    y = ti.ndarray(ti.math.vec2, (3))
+    test(y)
+    assert impl.get_runtime().get_num_compiled_functions() == 2
+
+    z = ti.ndarray(ti.math.mat2, (3))
+    with pytest.raises(ValueError, match=r"Invalid argument into ti.types.ndarray\(\)"):
+        test(z)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8012
* #8010
* #8009

TODO: deprecate `element_dim` and `element_shape` in ndarray type annotation