### PR TITLE
[aot] Remove redundant copy of libtaichi_c_api.so to build

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -54,7 +54,8 @@ function prepare-unity-build-env {
 
     python3 misc/generate_unity_language_binding.py
     cp c_api/unity/*.cs Taichi-UnityExample/Assets/Taichi/Generated
-    cp build/libtaichi_c_api.so Taichi-UnityExample/Assets/Plugins/Android
+    CAPI_SO_LOC=$(find . -wholename "**/cmake-build/libtaichi_c_api.so")
+    cp $CAPI_SO_LOC Taichi-UnityExample/Assets/Plugins/Android
 
     export TAICHI_REPO_DIR=$(pwd)
 

--- a/.github/workflows/scripts/ti_build/android.py
+++ b/.github/workflows/scripts/ti_build/android.py
@@ -48,4 +48,5 @@ def build_android(python: Command, pip: Command) -> None:
     pip.install("-r", "requirements_dev.txt")
     python("setup.py", "clean")
     python("setup.py", "build_ext")
-    sh("aarch64-linux-android-strip", "build/libtaichi_c_api.so")
+    for p in Path(os.getcwd()).glob("**/libtaichi_c_api.so"):
+        sh("aarch64-linux-android-strip", p)

--- a/cmake/TaichiCAPI.cmake
+++ b/cmake/TaichiCAPI.cmake
@@ -90,27 +90,6 @@ elseif(APPLE)
     target_link_options(${TAICHI_C_API_NAME} PRIVATE -Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/c_api/version_scripts/export_symbols_mac.lds)
 endif()
 
-set(C_API_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
-set_target_properties(${TAICHI_C_API_NAME} PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${C_API_OUTPUT_DIRECTORY}
-    ARCHIVE_OUTPUT_DIRECTORY ${C_API_OUTPUT_DIRECTORY})
-
-if (${CMAKE_GENERATOR} MATCHES "^Visual Studio")
-  # Visual Studio is a multi-config generator, which appends ${CMAKE_BUILD_TYPE} to the output folder
-  add_custom_command(
-        TARGET ${TAICHI_C_API_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${C_API_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/${TAICHI_C_API_NAME}.dll
-                ${C_API_OUTPUT_DIRECTORY}/${TAICHI_C_API_NAME}.dll)
-elseif (${CMAKE_GENERATOR} STREQUAL "XCode")
-  # XCode is also a multi-config generator
-  add_custom_command(
-        TARGET ${TAICHI_C_API_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy
-                ${C_API_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/lib${TAICHI_C_API_NAME}.dylib
-                ${C_API_OUTPUT_DIRECTORY}/lib${TAICHI_C_API_NAME}.dylib)
-endif()
-
 target_include_directories(${TAICHI_C_API_NAME}
     PUBLIC
         # Used when building the library:


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96d400f</samp>

Comment out redundant code that copies C API library in `cmake/TaichiCAPI.cmake`. This fixes the Windows issue of finding the library by the Python wrapper.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96d400f</samp>

*  Remove unnecessary copy command for C API library ([link](https://github.com/taichi-dev/taichi/pull/8014/files?diff=unified&w=0#diff-10352bff7efe48325ce87e625e5f5a62bb33011655bbf87c25c7fafb7e9077deL98-R112)). This fixes the issue #2879 where the C API library was not found by the Python wrapper on Windows. The `install` command already copies the library to the output directory, so the extra copy command was redundant and caused conflicts.
