### PR TITLE
[aot] Export aot kernels with decorator properly

### DIFF
--- a/python/taichi/aot/_export.py
+++ b/python/taichi/aot/_export.py
@@ -23,4 +23,4 @@ def export_as(name: str, *, template_types: Optional[Dict[str, Any]] = None):
 
 
 def export(f):
-    export_as(f.__name__)(f)
+    return export_as(f.__name__)(f)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a6a469</samp>

Improved the `export` decorator for AOT compilation to preserve the original function. This enables testing and debugging the decorated functions in `python/taichi/aot/_export.py`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a6a469</samp>

* Return the decorated function from the `export` decorator ([link](https://github.com/taichi-dev/taichi/pull/8016/files?diff=unified&w=0#diff-692796189e46a99de2d76c2bb011e1b11e685372591bca868db0c8b0aa267f82L26-R26)). This enables the user to access the original function for testing and debugging, as suggested by a reviewer.
