### PR TITLE
[Lang] Fix numerical issue with auto_diff()

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -125,15 +125,17 @@ Stmt::Stmt(const Stmt &stmt) : field_manager(this), fields_registered(false) {
 }
 
 Kernel *Stmt::get_kernel() const {
-  Block *top_level_block = parent;
-  while (top_level_block->parent_block()) {
-    top_level_block = top_level_block->parent_block();
+  Block *parent_block = parent;
+  if (parent_block->parent_kernel()) {
+    return parent_block->parent_kernel();
   }
 
-  Kernel *kernel = top_level_block->parent_kernel();
-  TI_ASSERT(kernel != nullptr);
+  if (parent_block->parent_stmt()) {
+    return parent_block->parent_stmt()->get_kernel();
+  }
 
-  return kernel;
+  TI_ASSERT_INFO(false, "Stmt is not in a kernel.");
+  return nullptr;
 }
 
 Stmt *Stmt::insert_before_me(std::unique_ptr<Stmt> &&new_stmt) {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -453,7 +453,7 @@ class Stmt : public IRNode {
   virtual void replace_operand_with(Stmt *old_stmt, Stmt *new_stmt);
 
   IRNode *get_parent() const override;
-  Kernel *get_kernel() const;
+  virtual Kernel *get_kernel() const;
 
   // returns the inserted stmt
   Stmt *insert_before_me(std::unique_ptr<Stmt> &&new_stmt);

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -122,6 +122,7 @@ MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
 
 bool MatrixPtrStmt::common_statement_eliminable() const {
   Kernel *k = get_kernel();
+  TI_ASSERT(k != nullptr);
   return (k->autodiff_mode == AutodiffMode::kNone);
 }
 
@@ -303,8 +304,8 @@ GetChStmt::GetChStmt(Stmt *input_ptr,
   TI_STMT_REG_FIELDS;
 }
 
-OffloadedStmt::OffloadedStmt(TaskType task_type, Arch arch)
-    : task_type(task_type), device(arch) {
+OffloadedStmt::OffloadedStmt(TaskType task_type, Arch arch, Kernel *kernel)
+    : kernel_(kernel), task_type(task_type), device(arch) {
   if (has_body()) {
     body = std::make_unique<Block>();
     body->set_parent_stmt(this);
@@ -338,7 +339,7 @@ std::string OffloadedStmt::task_type_name(TaskType tt) {
 }
 
 std::unique_ptr<Stmt> OffloadedStmt::clone() const {
-  auto new_stmt = std::make_unique<OffloadedStmt>(task_type, device);
+  auto new_stmt = std::make_unique<OffloadedStmt>(task_type, device, kernel_);
   new_stmt->snode = snode;
   new_stmt->begin_offset = begin_offset;
   new_stmt->end_offset = end_offset;

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -1,6 +1,7 @@
 // TODO: gradually cppize statements.h
 #include "taichi/ir/statements.h"
 #include "taichi/util/bit.h"
+#include "taichi/program/kernel.h"
 
 namespace taichi::lang {
 
@@ -117,6 +118,11 @@ MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
         "(globally).")
   }
   TI_STMT_REG_FIELDS;
+}
+
+bool MatrixPtrStmt::common_statement_eliminable() const {
+  Kernel *k = get_kernel();
+  return (k->autodiff_mode == AutodiffMode::kNone);
 }
 
 SNodeOpStmt::SNodeOpStmt(SNodeOpType op_type,

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1319,6 +1319,7 @@ class OffloadedStmt : public Stmt {
  public:
   using TaskType = OffloadedTaskType;
 
+  Kernel *kernel_;
   TaskType task_type;
   Arch device;
   SNode *snode{nullptr};
@@ -1362,7 +1363,7 @@ class OffloadedStmt : public Stmt {
   std::size_t bls_size{0};
   MemoryAccessOptions mem_access_opt;
 
-  OffloadedStmt(TaskType task_type, Arch arch);
+  OffloadedStmt(TaskType task_type, Arch arch, Kernel *kernel);
 
   std::string task_name() const;
 
@@ -1370,6 +1371,10 @@ class OffloadedStmt : public Stmt {
 
   bool has_body() const {
     return task_type != TaskType::listgen && task_type != TaskType::gc;
+  }
+
+  Kernel *get_kernel() const override {
+    return kernel_;
   }
 
   bool is_container_statement() const override {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -510,6 +510,10 @@ class MatrixPtrStmt : public Stmt {
     return false;
   }
 
+  bool common_statement_eliminable() const override {
+    return false;
+  }
+
   TI_STMT_DEF_FIELDS(ret_type, origin, offset);
   TI_DEFINE_ACCEPT_AND_CLONE
 };

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -510,9 +510,7 @@ class MatrixPtrStmt : public Stmt {
     return false;
   }
 
-  bool common_statement_eliminable() const override {
-    return false;
-  }
+  bool common_statement_eliminable() const override;
 
   TI_STMT_DEF_FIELDS(ret_type, origin, offset);
   TI_DEFINE_ACCEPT_AND_CLONE

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -674,8 +674,7 @@ class RegulateTensorTypedStatements : public BasicStmtVisitor {
     /*
       [Duplicate shared MatrixPtrStmt]
       Fwd:
-      $0 = alloca <4 x i32>
-      $1 = load $0
+      $1 = alloca <4 x i32>
       $2 = matrix ptr $1, 2
 
       $3 = local load $2
@@ -685,8 +684,7 @@ class RegulateTensorTypedStatements : public BasicStmtVisitor {
       ...
 
       Replaced:
-        $0 = alloca <4 x i32>
-        $1 = load $0
+        $1 = alloca <4 x i32>
         $2 = matrix ptr $1, 2
 
         $3 = local load $2
@@ -694,7 +692,7 @@ class RegulateTensorTypedStatements : public BasicStmtVisitor {
         $3 : local store $0, [$val, ...]
 
         $4 = matrix ptr $1, 2
-        $5 = local load $2
+        $5 = local load $4
         ...
     */
     if (stmt->src->template is<MatrixPtrStmt>()) {

--- a/tests/cpp/analysis/bls_analyzer_test.cpp
+++ b/tests/cpp/analysis/bls_analyzer_test.cpp
@@ -29,7 +29,7 @@ class BLSAnalyzerTest : public ::testing::Test {
 
     for_stmt_ = std::make_unique<OffloadedStmt>(
         /*task_type=*/OffloadedTaskType::struct_for,
-        /*arch=*/Arch::x64);
+        /*arch=*/Arch::x64, nullptr);
     for_stmt_->mem_access_opt.add_flag(child_snode_,
                                        SNodeAccessFlag::block_local);
     pads_.insert(child_snode_);

--- a/tests/cpp/analysis/value_diff_test.cpp
+++ b/tests/cpp/analysis/value_diff_test.cpp
@@ -62,7 +62,7 @@ TEST(DiffRangeTest, Add) {
 
   auto for_stmt = std::make_unique<OffloadedStmt>(
       /*task_type=*/OffloadedTaskType::struct_for,
-      /*arch=*/Arch::x64);
+      /*arch=*/Arch::x64, nullptr);
   auto *loop_idx = builder.get_loop_index(for_stmt.get(), /*index=*/0);
   auto *c1 = builder.get_int32(4);
   auto *loop_idx2 = builder.create_add(loop_idx, c1);
@@ -80,7 +80,7 @@ TEST(DiffRangeTest, Sub) {
 
   auto for_stmt = std::make_unique<OffloadedStmt>(
       /*task_type=*/OffloadedTaskType::struct_for,
-      /*arch=*/Arch::x64);
+      /*arch=*/Arch::x64, nullptr);
   auto *loop_idx = builder.get_loop_index(for_stmt.get(), /*index=*/0);
   auto *c1 = builder.get_int32(4);
   auto *loop_idx2 = builder.create_sub(loop_idx, c1);
@@ -98,7 +98,7 @@ TEST(DiffRangeTest, Mul) {
 
   auto for_stmt = std::make_unique<OffloadedStmt>(
       /*task_type=*/OffloadedTaskType::struct_for,
-      /*arch=*/Arch::x64);
+      /*arch=*/Arch::x64, nullptr);
   auto *loop_idx = builder.get_loop_index(for_stmt.get(), /*index=*/0);
   auto *c1 = builder.get_int32(4);
   auto *loop_idx2 = builder.create_mul(loop_idx, c1);
@@ -116,7 +116,7 @@ TEST(DiffRangeTest, Shl) {
 
   auto for_stmt = std::make_unique<OffloadedStmt>(
       /*task_type=*/OffloadedTaskType::struct_for,
-      /*arch=*/Arch::x64);
+      /*arch=*/Arch::x64, nullptr);
   auto *loop_idx = builder.get_loop_index(for_stmt.get(), /*index=*/0);
   auto *c1 = builder.get_int32(2);
   auto *loop_idx2 = builder.create_shl(loop_idx, c1);

--- a/tests/cpp/transforms/make_block_local_test.cpp
+++ b/tests/cpp/transforms/make_block_local_test.cpp
@@ -58,7 +58,7 @@ class MakeBlockLocalTest : public ::testing::Test {
 
     for_stmt_ = std::make_unique<OffloadedStmt>(
         /*task_type=*/OffloadedTaskType::struct_for,
-        /*arch=*/Arch::x64);
+        /*arch=*/Arch::x64, nullptr);
     for_stmt_->mem_access_opt.add_flag(bls_place_snode_,
                                        SNodeAccessFlag::block_local);
     for_stmt_->snode = struct_for_place_snode_;


### PR DESCRIPTION
Issue: #
bug fix
### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 296454f</samp>

This pull request improves the auto-differentiation feature in Taichi by refactoring the internal logic and adding support for ndarray arguments. It also adds a new test case to check the functionality and correctness of the new feature using a hash encoder kernel.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 296454f</samp>

*  Simplify and refactor the auto-differentiation logic for matrix pointer statements by removing the use of adstack and replacing it with normal alloca and load/store statements ([link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L540-R547), [link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L561-R561), [link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L602-R610), [link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L619-R619))
*  Avoid data race issues for shared matrix pointer statements in auto-differentiation by duplicating them for local and global load statements using a new function template `process_load_stmt` ([link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583R672-R721), [link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583R730-R737))
*  Enable auto-differentiation for ndarray arguments in Taichi kernels by adding support for external pointer statements in atomic operation statements and handling the matrix pointer offset and type ([link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1648-R1717), [link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L1668-R1773))
*  Add a new test case in `tests/python/test_ad_ndarray.py` for verifying the functionality and correctness of the new feature using a simple hash encoder kernel ([link](https://github.com/taichi-dev/taichi/pull/8025/files?diff=unified&w=0#diff-015ebf0e792298ff88ac9c4d87efba82414b3a19a4d85d0887d16099dfe2fc09R1466-R1501))
