### PR TITLE
[Lang] Migrate irpass::scalarize() after irpass::make_thread_local()

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -210,17 +210,17 @@ void offload_to_executable(IRNode *ir,
     irpass::analysis::verify(ir);
   }
 
+  if (make_thread_local) {
+    irpass::make_thread_local(ir, config);
+    print("Make thread local");
+  }
+
   if (config.real_matrix_scalarize) {
     irpass::scalarize(ir);
 
     // Remove redundant MatrixInitStmt inserted during scalarization
     irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
     print("Scalarized");
-  }
-
-  if (make_thread_local) {
-    irpass::make_thread_local(ir, config);
-    print("Make thread local");
   }
 
   if (is_extension_supported(config.arch, Extension::mesh)) {


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d709fb5</samp>

This pull request improves the performance of Taichi programs by applying the `make_thread_local` pass to each task, and enabling it to handle atomic operations on matrix elements. It also simplifies the IR by scalarizing matrix pointer expressions with thread-local origins.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d709fb5</samp>

*  Move and apply `make_thread_local` pass to each offload task for better performance ([link](https://github.com/taichi-dev/taichi/pull/8028/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR213-R217), [link](https://github.com/taichi-dev/taichi/pull/8028/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL221-L225), [link](https://github.com/taichi-dev/taichi/pull/8028/files?diff=unified&w=0#diff-41f2b7e0141e8b6ab3d206580124b9d5726813d9bd84cbdeeae4932803065e7dL117-R128))
  * Use `find_global_reduction_destinations` helper function to collect them ([link](https://github.com/taichi-dev/taichi/pull/8028/files?diff=unified&w=0#diff-41f2b7e0141e8b6ab3d206580124b9d5726813d9bd84cbdeeae4932803065e7dL24-R25))
* Add a new case to `Scalarize` pass to simplify `MatrixPtrStmt` with `ThreadLocalPtrStmt` origin and constant offset ([link](https://github.com/taichi-dev/taichi/pull/8028/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528R1015-R1041))
