### PR TITLE
[llvm] [ir] Fix: type cast for u1 should not truncate

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -376,6 +376,8 @@ void TaskCodeGenLLVM::visit(UnaryOpStmt *stmt) {
 
     if (from == to) {
       llvm_val[stmt] = llvm_val[stmt->operand];
+    } else if (to->is_primitive(PrimitiveTypeID::u1)) {
+      llvm_val[stmt] = builder->CreateIsNotNull(input);
     } else if (is_real(from.get_element_type()) !=
                is_real(to.get_element_type())) {
       if (is_real(from.get_element_type()) &&


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8026
* #8021
* __->__ #8032
* #8029
* #8019
* #8018
* #8008

