### PR TITLE
[refactor] Migrated kernel result handling to LaunchContextBuilder like llvm on gfx backends

### DIFF
--- a/c_api/src/taichi_metal_impl.mm
+++ b/c_api/src/taichi_metal_impl.mm
@@ -12,8 +12,7 @@ MetalRuntime::MetalRuntime()
 MetalRuntime::MetalRuntime(
     std::unique_ptr<taichi::lang::metal::MetalDevice> &&mtl_device)
     : GfxRuntime(taichi::Arch::metal), mtl_device_(std::move(mtl_device)),
-      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{
-          host_result_buffer_.data(), mtl_device_.get()}) {}
+      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{mtl_device_.get()}) {}
 
 taichi::lang::Device &MetalRuntime::get() {
   return static_cast<taichi::lang::Device &>(*mtl_device_);

--- a/c_api/src/taichi_opengl_impl.cpp
+++ b/c_api/src/taichi_opengl_impl.cpp
@@ -4,8 +4,7 @@
 OpenglRuntime::OpenglRuntime()
     : GfxRuntime(taichi::Arch::opengl),
       device_(),
-      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{
-          host_result_buffer_.data(), &device_}) {
+      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{&device_}) {
   taichi::lang::DeviceCapabilityConfig caps{};
   caps.set(taichi::lang::DeviceCapability::spirv_has_int64, true);
   caps.set(taichi::lang::DeviceCapability::spirv_has_float64, true);

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -104,7 +104,8 @@ VulkanRuntimeOwned::VulkanRuntimeOwned()
 VulkanRuntimeOwned::VulkanRuntimeOwned(
     const taichi::lang::vulkan::VulkanDeviceCreator::Params &params)
     : vk_device_creator_(params),
-      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{vk_device_creator_.device()}) {
+      gfx_runtime_(
+          taichi::lang::gfx::GfxRuntime::Params{vk_device_creator_.device()}) {
 }
 taichi::lang::Device &VulkanRuntimeOwned::get() {
   return *static_cast<taichi::lang::Device *>(vk_device_creator_.device());

--- a/c_api/src/taichi_vulkan_impl.cpp
+++ b/c_api/src/taichi_vulkan_impl.cpp
@@ -58,8 +58,7 @@ VulkanRuntimeImported::VulkanRuntimeImported(
     uint32_t api_version,
     const taichi::lang::vulkan::VulkanDevice::Params &params)
     : inner_(api_version, params),
-      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{
-          host_result_buffer_.data(), &inner_.vk_device}) {
+      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{&inner_.vk_device}) {
 }
 taichi::lang::Device &VulkanRuntimeImported::get() {
   return static_cast<taichi::lang::Device &>(inner_.vk_device);
@@ -105,8 +104,7 @@ VulkanRuntimeOwned::VulkanRuntimeOwned()
 VulkanRuntimeOwned::VulkanRuntimeOwned(
     const taichi::lang::vulkan::VulkanDeviceCreator::Params &params)
     : vk_device_creator_(params),
-      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{
-          host_result_buffer_.data(), vk_device_creator_.device()}) {
+      gfx_runtime_(taichi::lang::gfx::GfxRuntime::Params{vk_device_creator_.device()}) {
 }
 taichi::lang::Device &VulkanRuntimeOwned::get() {
   return *static_cast<taichi::lang::Device *>(vk_device_creator_.device());

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -30,7 +30,7 @@ from taichi.lang.exception import (
 )
 from taichi.lang.expr import Expr
 from taichi.lang.kernel_arguments import KernelArgument
-from taichi.lang.matrix import Matrix, MatrixType, Vector
+from taichi.lang.matrix import MatrixType
 from taichi.lang.shell import _shell_pop_print
 from taichi.lang.struct import StructType
 from taichi.lang.util import cook_dtype, has_paddle, has_pytorch, to_taichi_type

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -808,28 +808,7 @@ class Kernel:
             runtime_ops.sync()
 
         if has_ret:
-            if _ti_core.arch_uses_llvm(impl.current_cfg().arch):
-                ret = self.construct_kernel_ret(launch_ctx, ret_dt, () if isinstance(ret_dt, tuple) else (0,))
-            else:
-                if id(ret_dt) in primitive_types.integer_type_ids:
-                    if is_signed(cook_dtype(ret_dt)):
-                        ret = t_kernel.get_ret_int(0)
-                    else:
-                        ret = t_kernel.get_ret_uint(0)
-                elif id(ret_dt) in primitive_types.real_type_ids:
-                    ret = t_kernel.get_ret_float(0)
-                else:
-                    if id(ret_dt.dtype) in primitive_types.integer_type_ids:
-                        if is_signed(cook_dtype(ret_dt.dtype)):
-                            it = iter(t_kernel.get_ret_int_tensor(0))
-                        else:
-                            it = iter(t_kernel.get_ret_uint_tensor(0))
-                    else:
-                        it = iter(t_kernel.get_ret_float_tensor(0))
-                    if ret_dt.ndim == 1:
-                        ret = Vector([next(it) for _ in range(ret_dt.n)])
-                    else:
-                        ret = Matrix([[next(it) for _ in range(ret_dt.m)] for _ in range(ret_dt.n)])
+            ret = self.construct_kernel_ret(launch_ctx, ret_dt, () if isinstance(ret_dt, tuple) else (0,))
         if callbacks:
             for c in callbacks:
                 c()

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -91,51 +91,6 @@ T Kernel::fetch_ret(DataType dt, int i) {
   }
 }
 
-float64 Kernel::get_ret_float(int i) {
-  auto dt = rets[i].dt->get_compute_type();
-  return fetch_ret<float64>(dt, i);
-}
-
-int64 Kernel::get_ret_int(int i) {
-  auto dt = rets[i].dt->get_compute_type();
-  return fetch_ret<int64>(dt, i);
-}
-
-uint64 Kernel::get_ret_uint(int i) {
-  auto dt = rets[i].dt->get_compute_type();
-  return fetch_ret<uint64>(dt, i);
-}
-
-std::vector<int64> Kernel::get_ret_int_tensor(int i) {
-  DataType dt = rets[i].dt->as<TensorType>()->get_element_type();
-  int size = rets[i].dt->as<TensorType>()->get_num_elements();
-  std::vector<int64> res;
-  for (int j = 0; j < size; j++) {
-    res.emplace_back(fetch_ret<int64>(dt, j));
-  }
-  return res;
-}
-
-std::vector<uint64> Kernel::get_ret_uint_tensor(int i) {
-  DataType dt = rets[i].dt->as<TensorType>()->get_element_type();
-  int size = rets[i].dt->as<TensorType>()->get_num_elements();
-  std::vector<uint64> res;
-  for (int j = 0; j < size; j++) {
-    res.emplace_back(fetch_ret<uint64>(dt, j));
-  }
-  return res;
-}
-
-std::vector<float64> Kernel::get_ret_float_tensor(int i) {
-  DataType dt = rets[i].dt->as<TensorType>()->get_element_type();
-  int size = rets[i].dt->as<TensorType>()->get_num_elements();
-  std::vector<float64> res;
-  for (int j = 0; j < size; j++) {
-    res.emplace_back(fetch_ret<float64>(dt, j));
-  }
-  return res;
-}
-
 std::string Kernel::get_name() const {
   return name;
 }

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -45,13 +45,6 @@ class TI_DLL_EXPORT Kernel : public Callable {
   template <typename T>
   T fetch_ret(DataType dt, int i);
 
-  float64 get_ret_float(int i);
-  int64 get_ret_int(int i);
-  uint64 get_ret_uint(int i);
-  std::vector<int64> get_ret_int_tensor(int i);
-  std::vector<uint64> get_ret_uint_tensor(int i);
-  std::vector<float64> get_ret_float_tensor(int i);
-
   [[nodiscard]] std::string get_name() const override;
 
   void set_kernel_key_for_cache(const std::string &kernel_key) const {

--- a/taichi/program/snode_rw_accessors_bank.cpp
+++ b/taichi/program/snode_rw_accessors_bank.cpp
@@ -54,11 +54,7 @@ float64 SNodeRwAccessorsBank::Accessors::read_float(const std::vector<int> &I) {
       prog_->compile_config(), prog_->get_device_caps(), *reader_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
   prog_->synchronize();
-  if (arch_uses_llvm(prog_->compile_config().arch)) {
-    return launch_ctx.get_struct_ret_float({0});
-  }
-  auto ret = reader_->get_ret_float(0);
-  return ret;
+  return launch_ctx.get_struct_ret_float({0});
 }
 
 // for int32 and int64
@@ -93,11 +89,7 @@ int64 SNodeRwAccessorsBank::Accessors::read_int(const std::vector<int> &I) {
       prog_->compile_config(), prog_->get_device_caps(), *reader_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
   prog_->synchronize();
-  if (arch_uses_llvm(prog_->compile_config().arch)) {
-    return launch_ctx.get_struct_ret_int({0});
-  }
-  auto ret = reader_->get_ret_int(0);
-  return ret;
+  return launch_ctx.get_struct_ret_int({0});
 }
 
 uint64 SNodeRwAccessorsBank::Accessors::read_uint(const std::vector<int> &I) {
@@ -108,11 +100,7 @@ uint64 SNodeRwAccessorsBank::Accessors::read_uint(const std::vector<int> &I) {
       prog_->compile_config(), prog_->get_device_caps(), *reader_);
   prog_->launch_kernel(compiled_kernel_data, launch_ctx);
   prog_->synchronize();
-  if (arch_uses_llvm(prog_->compile_config().arch)) {
-    return launch_ctx.get_struct_ret_uint({0});
-  }
-  auto ret = reader_->get_ret_uint(0);
-  return ret;
+  return launch_ctx.get_struct_ret_uint({0});
 }
 
 }  // namespace taichi::lang

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -681,12 +681,6 @@ void export_lang(py::module &m) {
       .def("insert_ret", &Kernel::insert_ret)
       .def("finalize_rets", &Kernel::finalize_rets)
       .def("finalize_params", &Kernel::finalize_params)
-      .def("get_ret_int", &Kernel::get_ret_int)
-      .def("get_ret_uint", &Kernel::get_ret_uint)
-      .def("get_ret_float", &Kernel::get_ret_float)
-      .def("get_ret_int_tensor", &Kernel::get_ret_int_tensor)
-      .def("get_ret_uint_tensor", &Kernel::get_ret_uint_tensor)
-      .def("get_ret_float_tensor", &Kernel::get_ret_float_tensor)
       .def("make_launch_context", &Kernel::make_launch_context)
       .def(
           "ast_builder",

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -202,8 +202,7 @@ class HostDeviceContextBlitter {
       return nullptr;
     }
     return std::make_unique<HostDeviceContextBlitter>(
-        ctx_attribs, host_ctx, device, device_args_buffer,
-        device_ret_buffer);
+        ctx_attribs, host_ctx, device, device_args_buffer, device_ret_buffer);
   }
 
  private:
@@ -277,8 +276,7 @@ Pipeline *CompiledTaichiKernel::get_pipeline(int i) {
 }
 
 GfxRuntime::GfxRuntime(const Params &params)
-    : device_(params.device),
-      profiler_(params.profiler) {
+    : device_(params.device), profiler_(params.profiler) {
   current_cmdlist_pending_since_ = high_res_clock::now();
   init_nonroot_buffers();
 

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -154,9 +154,7 @@ class HostDeviceContextBlitter {
               RhiResult::success);
 
     void *ctx_result_buffer = host_ctx_.get_context().result_buffer;
-    void *device_ptr = (uint8_t *)device_base;
-    void *host_ptr = (uint8_t *)ctx_result_buffer;
-    std::memcpy(host_ptr, device_ptr, ctx_attribs_->rets_bytes());
+    std::memcpy(ctx_result_buffer, device_base, ctx_attribs_->rets_bytes());
 
     device_->unmap(*device_ret_buffer_);
 

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -31,12 +31,10 @@ class HostDeviceContextBlitter {
   HostDeviceContextBlitter(const KernelContextAttributes *ctx_attribs,
                            LaunchContextBuilder &host_ctx,
                            Device *device,
-                           uint64_t *host_result_buffer,
                            DeviceAllocation *device_args_buffer,
                            DeviceAllocation *device_ret_buffer)
       : ctx_attribs_(ctx_attribs),
         host_ctx_(host_ctx),
-        host_result_buffer_(host_result_buffer),
         device_args_buffer_(device_args_buffer),
         device_ret_buffer_(device_ret_buffer),
         device_(device) {
@@ -155,47 +153,39 @@ class HostDeviceContextBlitter {
     TI_ASSERT(device_->map(*device_ret_buffer_, &device_base) ==
               RhiResult::success);
 
-#define TO_HOST(short_type, type, offset)                            \
-  if (dt->is_primitive(PrimitiveTypeID::short_type)) {               \
-    const type d = *(reinterpret_cast<type *>(device_ptr) + offset); \
-    host_result_buffer_[offset] =                                    \
-        taichi_union_cast_with_different_sizes<uint64>(d);           \
-    continue;                                                        \
-  }
-
+    void *ctx_result_buffer = host_ctx_.get_context().result_buffer;
     for (int i = 0; i < ctx_attribs_->rets().size(); ++i) {
-      // Note that we are copying the i-th return value on Metal to the i-th
-      // *arg* on the host context.
       const auto &ret = ctx_attribs_->rets()[i];
       void *device_ptr = (uint8_t *)device_base + ret.offset_in_mem;
+      void *host_ptr = (uint8_t *)ctx_result_buffer + ret.offset_in_mem;
       const auto dt = PrimitiveType::get(ret.dtype);
       const auto num = ret.stride / data_type_size_gfx(dt);
       for (int j = 0; j < num; ++j) {
         // (penguinliong) Again, it's the module loader's responsibility to
         // check the data type availability.
-        TO_HOST(u1, uint1, j)
-        TO_HOST(i8, int8, j)
-        TO_HOST(u8, uint8, j)
-        TO_HOST(i16, int16, j)
-        TO_HOST(u16, uint16, j)
-        TO_HOST(i32, int32, j)
-        TO_HOST(u32, uint32, j)
-        TO_HOST(f32, float32, j)
-        TO_HOST(i64, int64, j)
-        TO_HOST(u64, uint64, j)
-        TO_HOST(f64, float64, j)
-        if (dt->is_primitive(PrimitiveTypeID::f16)) {
-          const float d = fp16_ieee_to_fp32_value(
-              *reinterpret_cast<uint16 *>(device_ptr) + j);
-          host_result_buffer_[j] =
-              taichi_union_cast_with_different_sizes<uint64>(d);
-          continue;
-        }
+#define COPY_TO_HOST_BUFFER(short_type, type, offset)                \
+  if (dt->is_primitive(PrimitiveTypeID::short_type)) {               \
+    const type d = *(reinterpret_cast<type *>(device_ptr) + offset); \
+    *(reinterpret_cast<type *>(host_ptr) + offset) = d;              \
+    continue;                                                        \
+  }
+        COPY_TO_HOST_BUFFER(u1, uint1, j)
+        COPY_TO_HOST_BUFFER(i8, int8, j)
+        COPY_TO_HOST_BUFFER(u8, uint8, j)
+        COPY_TO_HOST_BUFFER(i16, int16, j)
+        COPY_TO_HOST_BUFFER(u16, uint16, j)
+        COPY_TO_HOST_BUFFER(f16, uint16, j)
+        COPY_TO_HOST_BUFFER(i32, int32, j)
+        COPY_TO_HOST_BUFFER(u32, uint32, j)
+        COPY_TO_HOST_BUFFER(f32, float32, j)
+        COPY_TO_HOST_BUFFER(i64, int64, j)
+        COPY_TO_HOST_BUFFER(u64, uint64, j)
+        COPY_TO_HOST_BUFFER(f64, float64, j)
+#undef TO_HOST
         TI_ERROR("Device does not support return value type={}",
                  data_type_name(PrimitiveType::get(ret.dtype)));
       }
     }
-#undef TO_HOST
 
     device_->unmap(*device_ret_buffer_);
 
@@ -206,21 +196,19 @@ class HostDeviceContextBlitter {
       const KernelContextAttributes *ctx_attribs,
       LaunchContextBuilder &host_ctx,
       Device *device,
-      uint64_t *host_result_buffer,
       DeviceAllocation *device_args_buffer,
       DeviceAllocation *device_ret_buffer) {
     if (ctx_attribs->empty()) {
       return nullptr;
     }
     return std::make_unique<HostDeviceContextBlitter>(
-        ctx_attribs, host_ctx, device, host_result_buffer, device_args_buffer,
+        ctx_attribs, host_ctx, device, device_args_buffer,
         device_ret_buffer);
   }
 
  private:
   const KernelContextAttributes *const ctx_attribs_;
   LaunchContextBuilder &host_ctx_;
-  uint64_t *const host_result_buffer_;
   DeviceAllocation *const device_args_buffer_;
   DeviceAllocation *const device_ret_buffer_;
   Device *const device_;
@@ -290,9 +278,7 @@ Pipeline *CompiledTaichiKernel::get_pipeline(int i) {
 
 GfxRuntime::GfxRuntime(const Params &params)
     : device_(params.device),
-      host_result_buffer_(params.host_result_buffer),
       profiler_(params.profiler) {
-  TI_ASSERT(host_result_buffer_ != nullptr);
   current_cmdlist_pending_since_ = high_res_clock::now();
   init_nonroot_buffers();
 
@@ -412,7 +398,7 @@ void GfxRuntime::launch_kernel(KernelHandle handle,
   // Create context blitter
   auto ctx_blitter = HostDeviceContextBlitter::maybe_make(
       &ti_kernel->ti_kernel_attribs().ctx_attribs, host_ctx, device_,
-      host_result_buffer_, args_buffer.get(), ret_buffer.get());
+      args_buffer.get(), ret_buffer.get());
 
   // `any_arrays` contain both external arrays and NDArrays
   std::unordered_map<int, DeviceAllocation> any_arrays;

--- a/taichi/runtime/gfx/runtime.h
+++ b/taichi/runtime/gfx/runtime.h
@@ -78,7 +78,6 @@ class CompiledTaichiKernel {
 class TI_DLL_EXPORT GfxRuntime {
  public:
   struct Params {
-    uint64_t *host_result_buffer{nullptr};
     Device *device{nullptr};
     KernelProfilerBase *profiler{nullptr};
   };
@@ -146,7 +145,6 @@ class TI_DLL_EXPORT GfxRuntime {
   void init_nonroot_buffers();
 
   Device *device_{nullptr};
-  uint64_t *const host_result_buffer_;
   KernelProfilerBase *profiler_;
 
   std::unique_ptr<PipelineCache> backend_cache_{nullptr};

--- a/taichi/runtime/program_impls/dx/dx_program.cpp
+++ b/taichi/runtime/program_impls/dx/dx_program.cpp
@@ -24,7 +24,6 @@ void Dx11ProgramImpl::materialize_runtime(KernelProfilerBase *profiler,
   device_ = directx11::make_dx11_device();
 
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = *result_buffer_ptr;
   params.device = device_.get();
   runtime_ = std::make_unique<gfx::GfxRuntime>(std::move(params));
   snode_tree_mgr_ = std::make_unique<gfx::SNodeTreeManager>(runtime_.get());

--- a/taichi/runtime/program_impls/metal/metal_program.cpp
+++ b/taichi/runtime/program_impls/metal/metal_program.cpp
@@ -27,7 +27,6 @@ void MetalProgramImpl::materialize_runtime(KernelProfilerBase *profiler,
       std::unique_ptr<metal::MetalDevice>(metal::MetalDevice::create());
 
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = *result_buffer_ptr;
   params.device = embedded_device_.get();
   gfx_runtime_ = std::make_unique<gfx::GfxRuntime>(std::move(params));
   snode_tree_mgr_ = std::make_unique<gfx::SNodeTreeManager>(gfx_runtime_.get());

--- a/taichi/runtime/program_impls/opengl/opengl_program.cpp
+++ b/taichi/runtime/program_impls/opengl/opengl_program.cpp
@@ -23,7 +23,6 @@ void OpenglProgramImpl::materialize_runtime(KernelProfilerBase *profiler,
   device_ = opengl::make_opengl_device();
 
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = *result_buffer_ptr;
   params.device = device_.get();
   runtime_ = std::make_unique<gfx::GfxRuntime>(std::move(params));
   snode_tree_mgr_ = std::make_unique<gfx::SNodeTreeManager>(runtime_.get());

--- a/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
+++ b/taichi/runtime/program_impls/vulkan/vulkan_program.cpp
@@ -138,7 +138,6 @@ void VulkanProgramImpl::materialize_runtime(KernelProfilerBase *profiler,
   embedded_device_ = std::make_unique<VulkanDeviceCreator>(evd_params);
 
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = *result_buffer_ptr;
   params.device = embedded_device_->device();
   params.profiler = profiler;
   vulkan_runtime_ = std::make_unique<gfx::GfxRuntime>(std::move(params));

--- a/tests/cpp/aot/gfx_utils.cpp
+++ b/tests/cpp/aot/gfx_utils.cpp
@@ -59,7 +59,6 @@ void run_dense_field_kernel(Arch arch, taichi::lang::Device *device) {
 
   // Create runtime
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = result_buffer;
   params.device = device;
   auto gfx_runtime =
       std::make_unique<taichi::lang::gfx::GfxRuntime>(std::move(params));
@@ -129,7 +128,6 @@ void run_kernel_test1(Arch arch, taichi::lang::Device *device) {
 
   // Create runtime
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = result_buffer;
   params.device = device;
   auto gfx_runtime =
       std::make_unique<taichi::lang::gfx::GfxRuntime>(std::move(params));
@@ -193,7 +191,6 @@ void run_kernel_test2(Arch arch, taichi::lang::Device *device) {
       sizeof(taichi::uint64) * taichi_result_buffer_entries, 8);
 
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = result_buffer;
   params.device = device;
   auto gfx_runtime =
       std::make_unique<taichi::lang::gfx::GfxRuntime>(std::move(params));
@@ -270,7 +267,6 @@ void run_cgraph1(Arch arch, taichi::lang::Device *device_) {
       sizeof(taichi::uint64) * taichi_result_buffer_entries, 8);
   // Create runtime
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = result_buffer;
   params.device = device_;
   auto gfx_runtime =
       std::make_unique<taichi::lang::gfx::GfxRuntime>(std::move(params));
@@ -346,7 +342,6 @@ void run_cgraph2(Arch arch, taichi::lang::Device *device_) {
       sizeof(taichi::uint64) * taichi_result_buffer_entries, 8);
   // Create runtime
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = result_buffer;
   params.device = device_;
   auto gfx_runtime =
       std::make_unique<taichi::lang::gfx::GfxRuntime>(std::move(params));
@@ -411,7 +406,6 @@ void run_mpm88_graph(Arch arch, taichi::lang::Device *device_) {
       sizeof(taichi::uint64) * taichi_result_buffer_entries, 8);
   // Create runtime
   gfx::GfxRuntime::Params params;
-  params.host_result_buffer = result_buffer;
   params.device = device_;
   auto gfx_runtime =
       std::make_unique<taichi::lang::gfx::GfxRuntime>(std::move(params));


### PR DESCRIPTION
### Summary

Migrated result handling to LaunchContextBuilder on gfx backends.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72a9e33</samp>

*  Simplify the constructors of `MetalRuntime`, `OpenGLRuntime`, `VulkanRuntimeImported`, and `VulkanRuntimeOwned` by removing the `host_result_buffer_` parameter and field, since it is no longer needed for any backend. The `gfx_runtime_` is initialized with only the device parameter. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-030f471f5b44a9e6368ae6e45cd04247849ac02e6a0a26c4d41d1f8a80cd492aL15-R15), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-49357769896e790fc2a5882464d92c2eb205ec2473db22480ffe5bee895fea58L7-R7), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-cc059853ff4263bd3c13e08ac2eb385b877979348f96ca48c9d76125a711e6a8L61-R61), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-cc059853ff4263bd3c13e08ac2eb385b877979348f96ca48c9d76125a711e6a8L108-R108))
* Remove the `get_ret_float`, `get_ret_int`, `get_ret_uint`, `get_ret_int_tensor`, `get_ret_uint_tensor`, and `get_ret_float_tensor` functions in the `Kernel` class, since they are no longer used by any backend. The return values are now handled by the `launch_ctx` and the `construct_kernel_ret` function. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-183534311cce45d4f24cf969ff1836c60a64c8c6050c34f6ee667617cf9d8dddL94-L138), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5831927e99f989a5c80bace0ae3a103f99fb5849cf6e591a22a8bb83d3a14c3fL48-L54), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L684-L689))
* Simplify the `launch_kernel` function in the `Kernel` class by removing the branch for non-LLVM backends, since they are no longer supported. The `construct_kernel_ret` function is used for all backends to construct the return value from the `launch_ctx`. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L811-R811))
* Simplify the `read_float`, `read_int`, and `read_uint` functions in the `Accessors` class by removing the branch for non-LLVM backends, since they are no longer supported. The `launch_ctx.get_struct_ret_float`, `launch_ctx.get_struct_ret_int`, and `launch_ctx.get_struct_ret_uint` functions are used for all backends to read the values from the device memory. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-ec8f98bdcd87ff5dd656ad1abd0d509f68c502ffd1f8eb8df2f064f26b443d6eL57-R57), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-ec8f98bdcd87ff5dd656ad1abd0d509f68c502ffd1f8eb8df2f064f26b443d6eL96-R92), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-ec8f98bdcd87ff5dd656ad1abd0d509f68c502ffd1f8eb8df2f064f26b443d6eL111-R103))
* Simplify the constructor and the `blit_ret` function of `HostDeviceContextBlitter` by removing the `host_result_buffer_` parameter and field, since it is no longer needed for any backend. The `host_ctx_` parameter already contains the result buffer for the host context. The `blit_ret` function is also simplified by removing the special case for `f16` data type, since it is now handled by the `COPY_TO_HOST_BUFFER` macro. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL34-R37), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL158-R160), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL176-R188), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL209), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL216-R205), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL223))
* Simplify the constructor of `GfxRuntime` by removing the `host_result_buffer_` parameter and field, since it is no longer needed for any backend. The `device_` parameter is sufficient to initialize the `GfxRuntime`. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL292-R279), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL415-R399), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-a023ad94c9af40b9b4b391fc6ec0d96e9c7f88744d196bf782c51086da96d99aL81), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-a023ad94c9af40b9b4b391fc6ec0d96e9c7f88744d196bf782c51086da96d99aL149))
* Simplify the `materialize_runtime` functions in the `DXProgram`, `MetalProgram`, `OpenGLProgram`, and `VulkanProgram` classes by removing the `host_result_buffer` argument, since it is no longer needed for any backend. The `device` argument is sufficient to initialize the `GfxRuntime`. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-ae114b8a115f82a4c5822689e6d117731ebe0ef9571f4b707131b06b5e5d4311L27), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-5b7fadec648ccac6ad9a434854c3dd6a3ba367773999a98d89bbfe4c17132606L30), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-247502e21d39ab3eca803992c4ecef4d9929b78d50e7de5151bdd964a5603ed8L26), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-7bb775acbbb066c22871e41bde2bfa92821ed0994da4150e796704e2c7b4e11aL141))
* Simplify the test functions in the `gfx_utils.cpp` file by removing the `host_result_buffer` argument, since it is no longer needed for any backend. The `device` argument is sufficient to initialize the `GfxRuntime`. ([link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-87c49ccfc97d474ac7265446b70631c6498ac144ca53c3258be487c9c083f7b6L62), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-87c49ccfc97d474ac7265446b70631c6498ac144ca53c3258be487c9c083f7b6L132), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-87c49ccfc97d474ac7265446b70631c6498ac144ca53c3258be487c9c083f7b6L196), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-87c49ccfc97d474ac7265446b70631c6498ac144ca53c3258be487c9c083f7b6L273), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-87c49ccfc97d474ac7265446b70631c6498ac144ca53c3258be487c9c083f7b6L349), [link](https://github.com/taichi-dev/taichi/pull/8046/files?diff=unified&w=0#diff-87c49ccfc97d474ac7265446b70631c6498ac144ca53c3258be487c9c083f7b6L414))

### ghstack

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8046

