### PR TITLE
[aot] Properly copy import library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ def cmake_install_manifest_filter(manifest_files):
             return True
         if basename in BLACKLISTED_FILES:
             return False
-        return f.endswith((".so", "pyd", ".dll", ".bc", ".h", ".dylib", ".cmake", ".hpp"))
+        return f.endswith((".so", "pyd", ".lib", ".dll", ".bc", ".h", ".dylib", ".cmake", ".hpp"))
 
     return [f for f in manifest_files if should_include(f)]
 


### PR DESCRIPTION
Issue: 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 830a529</samp>

Fix Windows import errors by including `.lib` files in Python package. Modify `setup.py` to copy `.lib` files from CMake output.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 830a529</samp>

*  Include `.lib` files in the Python package to fix Windows import errors ([link](https://github.com/taichi-dev/taichi/pull/8049/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L185-R185))
