### PR TITLE
[spirv] [ir] [lang] Support struct object as return value in spir-v

### DIFF
--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -62,10 +62,10 @@ KernelContextAttributes::KernelContextAttributes(
     arg_attribs_vec_.push_back(aa);
   }
   // TODO:
-  //  ret_attribs_vec_ and this for loop is redundant now. Remove it in a follow
+  //  ret_attribs_vec_ and this if loop is redundant now. Remove it in a follow
   //  up PR. We keep this loop and use i32 as a placeholder to ensure that
   //  GfxRuntime::device_to_host::require_sync works properly.
-  for (const auto &kr : kernel.rets) {
+  if (!kernel.rets.empty()) {
     RetAttributes ra;
     ra.dtype = PrimitiveTypeID::i32;
     ret_attribs_vec_.push_back(ra);

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -62,8 +62,8 @@ KernelContextAttributes::KernelContextAttributes(
     arg_attribs_vec_.push_back(aa);
   }
   // TODO:
-  //  ret_attribs_vec_ and this for loop is redundant now. Remove it in a follow up PR.
-  //  We keep this loop and use i32 as a placeholder to ensure that
+  //  ret_attribs_vec_ and this for loop is redundant now. Remove it in a follow
+  //  up PR. We keep this loop and use i32 as a placeholder to ensure that
   //  GfxRuntime::device_to_host::require_sync works properly.
   for (const auto &kr : kernel.rets) {
     RetAttributes ra;

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -615,24 +615,54 @@ class TaskCodegen : public IRVisitor {
   }
 
   void visit(ReturnStmt *stmt) override {
-    // Now we only support one ret
-    auto dt = stmt->element_types()[0];
-    for (int i = 0; i < stmt->values.size(); i++) {
+    TI_ASSERT(ctx_attribs_->has_rets());
+    // The `PrimitiveType::i32` in this function call is a placeholder.
+    auto buffer_value = get_buffer_value(BufferType::Rets, PrimitiveType::i32);
+    // Function to store variable using indices provided by `calc_indices_and_store`.
+    auto store_variable = [&](int index, const std::vector<int>& indices) {
+      auto dt = stmt->element_types()[index];
       auto val_type = ir_->get_primitive_type(dt);
-      if (dt->is_primitive(PrimitiveTypeID::u1)) {
+      // Extend u1 values to i32 to be passed to the host.
+      if (dt->is_primitive(PrimitiveTypeID::u1))
         val_type = ir_->i32_type();
-      }
-      spirv::Value buffer_val = ir_->make_value(
-          spv::OpAccessChain, ir_->get_storage_pointer_type(val_type),
-          get_buffer_value(BufferType::Rets, dt),
-          ir_->int_immediate_number(ir_->i32_type(), 0),
-          ir_->int_immediate_number(ir_->i32_type(), i));
+      spirv::Value buffer_val;
+      // Accessing based on `indices` using OpAccessChain.
+      buffer_val = ir_->make_access_chain(
+          ir_->get_storage_pointer_type(val_type), buffer_value, indices);
       buffer_val.flag = ValueKind::kVariablePtr;
-      spirv::Value val = ir_->query_value(stmt->values[i]->raw_name());
-      if (dt->is_primitive(PrimitiveTypeID::u1)) {
+      spirv::Value val = ir_->query_value(stmt->values[index]->raw_name());
+      // Extend u1 values to i32 to be passed to the host.
+      if (dt->is_primitive(PrimitiveTypeID::u1))
         val = ir_->select(val, ir_->const_i32_one_, ir_->const_i32_zero_);
-      }
       ir_->store_variable(buffer_val, val);
+    };
+    // Function to traverse struct tree in depth-first order recursively to calculate AccessChain indices.
+    std::function<void(const taichi::lang::Type*, int&, std::vector<int>&)>
+        calc_indices_and_store = [&](const taichi::lang::Type* type, int& index, std::vector<int>& indices) {
+        if (auto struct_type = type->cast<taichi::lang::StructType>()) {
+          for (int i = 0; i < struct_type->elements().size(); ++i) {
+            indices.push_back(i);
+            calc_indices_and_store(struct_type->elements()[i].type, index, indices);
+            indices.pop_back();
+          }
+        } else if (auto tensor_type = type->cast<taichi::lang::TensorType>()) {
+          int num = tensor_type->get_num_elements();
+          for (int i = 0; i < num; ++i) {
+            indices.push_back(i);
+            store_variable(index++, indices);
+            indices.pop_back();
+          }
+        } else {
+          store_variable(index++, indices);
+        }
+    };
+    // Launch depth-first traversal using `calc_indices_and_store` on return struct.
+    std::vector<int> indices;
+    int index = 0;
+    for (int i = 0; i < ctx_attribs_->rets_type()->elements().size(); ++i) {
+      indices.push_back(i);
+      calc_indices_and_store(ctx_attribs_->rets_type()->elements()[i].type, index, indices);
+      indices.pop_back();
     }
   }
 
@@ -2290,26 +2320,45 @@ class TaskCodegen : public IRVisitor {
     if (!ctx_attribs_->has_rets())
       return;
 
-    std::vector<std::tuple<spirv::SType, std::string, size_t>>
-        struct_components_;
-    // Now we only have one ret
-    TI_ASSERT(ctx_attribs_->rets().size() == 1);
-    for (auto &ret : ctx_attribs_->rets()) {
-      // Use array size = 0 to generate a RuntimeArray
-      if (auto tensor_type =
-              PrimitiveType::get(ret.dtype)->cast<TensorType>()) {
-        struct_components_.emplace_back(
-            ir_->get_array_type(
-                ir_->get_primitive_type(tensor_type->get_element_type()), 0),
-            "ret" + std::to_string(ret.index), ret.offset_in_mem);
+    // Generate struct IR
+    tinyir::Block blk;
+    std::vector<const tinyir::Type *> element_types;
+    bool has_buffer_ptr =
+        caps_->get(DeviceCapability::spirv_has_physical_storage_buffer);
+    for (auto &element : ctx_attribs_->rets_type()->elements()) {
+      element_types.push_back(
+          translate_ti_type(blk, element.type, has_buffer_ptr));
+    }
+    const tinyir::Type *struct_type =
+        blk.emplace_back<StructType>(element_types);
+
+    // Reduce struct IR
+    std::unordered_map<const tinyir::Type *, const tinyir::Type *> old2new;
+    auto reduced_blk = ir_reduce_types(&blk, old2new);
+    struct_type = old2new[struct_type];
+
+    for (auto &element : element_types) {
+      element = old2new[element];
+    }
+
+    // Layout & translate to SPIR-V
+    STD430LayoutContext layout_ctx;
+    auto ir2spirv_map =
+        ir_translate_to_spirv(reduced_blk.get(), layout_ctx, ir_.get());
+    ret_struct_type_.id = ir2spirv_map[struct_type];
+
+    // Must use the same type in ArgLoadStmt as in the args struct,
+    // otherwise the validation will fail.
+    rets_struct_types_.resize(element_types.size());
+    for (int i = 0; i < element_types.size(); i++) {
+      rets_struct_types_[i].id = ir2spirv_map.at(element_types[i]);
+      if (i < ctx_attribs_->rets_type()->elements().size()) {
+        rets_struct_types_[i].dt =
+            ctx_attribs_->rets_type()->get_element_type({i});
       } else {
-        struct_components_.emplace_back(
-            ir_->get_array_type(
-                ir_->get_primitive_type(PrimitiveType::get(ret.dtype)), 0),
-            "ret" + std::to_string(ret.index), ret.offset_in_mem);
+        rets_struct_types_[i].dt = PrimitiveType::i32;
       }
     }
-    ret_struct_type_ = ir_->create_struct_type(struct_components_);
 
     ret_buffer_value_ =
         ir_->buffer_struct_argument(ret_struct_type_, 0, 1, "rets");
@@ -2363,6 +2412,7 @@ class TaskCodegen : public IRVisitor {
   spirv::Value args_buffer_value_;
 
   std::vector<spirv::SType> args_struct_types_;
+  std::vector<spirv::SType> rets_struct_types_;
 
   spirv::SType ret_struct_type_;
   spirv::Value ret_buffer_value_;

--- a/taichi/codegen/spirv/spirv_types.cpp
+++ b/taichi/codegen/spirv/spirv_types.cpp
@@ -186,7 +186,7 @@ const tinyir::Type *translate_ti_primitive(tinyir::Block &ir_module,
       // boolean types has the same width with int32 in GLSL, we use int32
       // instead.
       return ir_module.emplace_back<IntType>(/*num_bits=*/32,
-                                             /*is_signed=*/false);
+                                             /*is_signed=*/true);
     } else if (t == PrimitiveType::u8) {
       return ir_module.emplace_back<IntType>(/*num_bits=*/8,
                                              /*is_signed=*/false);

--- a/taichi/codegen/spirv/spirv_types.cpp
+++ b/taichi/codegen/spirv/spirv_types.cpp
@@ -497,8 +497,9 @@ const tinyir::Type *translate_ti_type(tinyir::Block &ir_module,
     }
   }
   if (t->is<TensorType>()) {
-    return ir_module.emplace_back<ArrayType>(translate_ti_primitive(ir_module, t.get_element_type()),
-                                             t->as<TensorType>()->get_num_elements());
+    return ir_module.emplace_back<ArrayType>(
+        translate_ti_primitive(ir_module, t.get_element_type()),
+        t->as<TensorType>()->get_num_elements());
   }
   if (auto struct_type = t->cast<lang::StructType>()) {
     std::vector<const tinyir::Type *> element_types;

--- a/taichi/codegen/spirv/spirv_types.cpp
+++ b/taichi/codegen/spirv/spirv_types.cpp
@@ -496,6 +496,10 @@ const tinyir::Type *translate_ti_type(tinyir::Block &ir_module,
                                              /*is_signed=*/false);
     }
   }
+  if (t->is<TensorType>()) {
+    return ir_module.emplace_back<ArrayType>(translate_ti_primitive(ir_module, t.get_element_type()),
+                                             t->as<TensorType>()->get_num_elements());
+  }
   if (auto struct_type = t->cast<lang::StructType>()) {
     std::vector<const tinyir::Type *> element_types;
     auto &elements = struct_type->elements();

--- a/taichi/runtime/gfx/runtime.cpp
+++ b/taichi/runtime/gfx/runtime.cpp
@@ -775,14 +775,15 @@ GfxRuntime::get_struct_type_with_data_layout_impl(
     } else if (auto tensor_type = member.type->cast<lang::TensorType>()) {
       size_t element_size = data_type_size_gfx(tensor_type->get_element_type());
       size_t num_elements = tensor_type->get_num_elements();
-      if (num_elements == 2) {
-        member_align = element_size * 2;
-      } else {
-        member_align = element_size * 4;
-      }
       if (!is_430) {
+        if (num_elements == 2) {
+          member_align = element_size * 2;
+        } else {
+          member_align = element_size * 4;
+        }
         member_size = member_align;
       } else {
+        member_align = element_size;
         member_size = tensor_type->get_num_elements() * element_size;
       }
     } else if (auto pointer_type = member.type->cast<PointerType>()) {

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -190,7 +190,7 @@ def test_return_uint64_vec():
     assert foo()[0] == 2**64 - 1
 
 
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test()
 def test_struct_ret_with_matrix():
     s0 = ti.types.struct(a=ti.math.vec3, b=ti.i16)
     s1 = ti.types.struct(a=ti.f32, b=s0)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3582ab4</samp>

This pull request adds a new struct type for return values in the spirv codegen, which enables more efficient and flexible handling of complex data types. It updates the relevant classes and functions in the `taichi/codegen/spirv` directory to use the new struct type, and fixes a bug in the `GfxRuntime` constructor. It also modifies a test function in `tests/python/test_return.py` to only run on the spirv backend.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3582ab4</samp>

*  Simplify the constructor of `KernelContextAttributes` and remove the array or vector logic for return values ([link](https://github.com/taichi-dev/taichi/pull/8061/files?diff=unified&w=0#diff-0933633c5350c8a0e64f59046da02dcafcabe69694bb200d938b8bd415bcbca0L64-R79))
*  Modify the `visit` method of `ReturnStmt` in `TaskCodegen` to use a recursive function and a helper function to store the return values in the buffer based on the new struct type ([link](https://github.com/taichi-dev/taichi/pull/8061/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L618-R665))
*  Modify the `compile_ret_struct` method of `TaskCodegen` to use a helper function and two existing functions to generate and optimize the spirv type for the return struct ([link](https://github.com/taichi-dev/taichi/pull/8061/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L2293-R2361))
*  Add a new member `rets_struct_types_` to `TaskCodegen` to store the spirv types of the struct elements for return values ([link](https://github.com/taichi-dev/taichi/pull/8061/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2415))
*  Add a new case to `translate_ti_primitive` to handle the `TensorType` in the tinyir representation ([link](https://github.com/taichi-dev/taichi/pull/8061/files?diff=unified&w=0#diff-259a89b8645aab6065eac94864cd4930be7ae91da5cb2e15307ae5fa41015962R499-R502))
*  Modify the constructor of `GfxRuntime` to update the logic for calculating the member alignment and size for the `STD430LayoutContext` and fix a bug for non-430 layouts ([link](https://github.com/taichi-dev/taichi/pull/8061/files?diff=unified&w=0#diff-5de6a93ab8620f5ececa55c3e762efa567d428c85058593ab49bb641f0c4c2fcL778-R786))
*  Modify the `test_struct_ret_with_matrix` function in `test_return.py` to remove the arch argument from the `test_utils.test` decorator ([link](https://github.com/taichi-dev/taichi/pull/8061/files?diff=unified&w=0#diff-e206c19691b4678b401a5e2787000e93ab0b0060cbf4ac2625b51f87599d98d8L193-R193))
