### PR TITLE
[Bug] Set initial value for Cuda device allocation

### DIFF
--- a/taichi/rhi/cuda/cuda_device.cpp
+++ b/taichi/rhi/cuda/cuda_device.cpp
@@ -60,6 +60,10 @@ DeviceAllocation CudaDevice::allocate_memory_runtime(
     info.ptr =
         DeviceMemoryPool::get_instance().allocate_with_cache(this, params);
   }
+
+  if (info.ptr)
+    CUDADriver::get_instance().memset((void *)info.ptr, 0, info.size);
+
   info.is_imported = false;
   info.use_cached = true;
   info.use_preallocated = true;


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a5aefc</samp>

Zero-initialize memory allocated by `CUDADriver` in the CUDA backend. This improves consistency and avoids bugs.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a5aefc</samp>

*  Zero-initialize memory allocated by `malloc_managed` in `CUDADevice::allocate_memory` to match other backends and avoid bugs ([link](https://github.com/taichi-dev/taichi/pull/8063/files?diff=unified&w=0#diff-7919f5d7e33aafc72f27ed93febc58a0ac77c220ae718bf78ef134dad3790654R63-R66))
