### PR TITLE
[build] Include Windows import lib in built wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ def cmake_install_manifest_filter(manifest_files):
             return True
         if basename in BLACKLISTED_FILES:
             return False
-        return f.endswith((".so", "pyd", ".dll", ".bc", ".h", ".dylib", ".cmake", ".hpp"))
+        return f.endswith((".so", "pyd", ".dll", ".bc", ".h", ".dylib", ".cmake", ".hpp", ".lib"))
 
     return [f for f in manifest_files if should_include(f)]
 


### PR DESCRIPTION
Issue: #7977

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6118623</samp>

Fixed a Windows build issue by including `.lib` files in the Python package. Modified `setup.py` to use a more robust file filter function.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6118623</samp>

*  Include `.lib` files in the `cmake_install_manifest_filter` function to fix Windows build issue ([link](https://github.com/taichi-dev/taichi/pull/8067/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L185-R185))
