### PR TITLE
[bug] Fix vector/matrix ndarray zero fill

### DIFF
--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1628,7 +1628,9 @@ class MatrixNdarray(Ndarray):
         self.shape = tuple(shape)
         self.element_type = _type_factory.get_tensor_type((self.n, self.m), self.dtype)
         # TODO: we should pass in element_type, shape, layout instead.
-        self.arr = impl.get_runtime().prog.create_ndarray(cook_dtype(self.element_type), shape, Layout.AOS)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            cook_dtype(self.element_type), shape, Layout.AOS, zero_fill=True
+        )
 
     @property
     def element_shape(self):
@@ -1736,7 +1738,9 @@ class VectorNdarray(Ndarray):
         self.layout = Layout.AOS
         self.shape = tuple(shape)
         self.element_type = _type_factory.get_tensor_type((n,), self.dtype)
-        self.arr = impl.get_runtime().prog.create_ndarray(cook_dtype(self.element_type), shape, Layout.AOS)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            cook_dtype(self.element_type), shape, Layout.AOS, zero_fill=True
+        )
 
     @property
     def element_shape(self):

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -715,6 +715,26 @@ def test_ndarray_init_as_zero():
     v = np.zeros((6, 10), dtype=np.float32)
     assert test_utils.allclose(a.to_numpy(), v)
 
+    b = ti.ndarray(dtype=ti.math.vec2, shape=(6, 4))
+    k = np.zeros((6, 4, 2), dtype=np.float32)
+    assert test_utils.allclose(b.to_numpy(), k)
+
+    c = ti.ndarray(dtype=ti.math.mat2, shape=(6, 4))
+    m = np.zeros((6, 4, 2, 2), dtype=np.float32)
+    assert test_utils.allclose(c.to_numpy(), m)
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_zero_fill():
+    dt = ti.types.vector(n=2, dtype=ti.f32)
+    arr = ti.ndarray(dtype=dt, shape=(3, 4))
+
+    arr.fill(1.0)
+
+    arr.to_numpy()
+    no = ti.ndarray(dtype=dt, shape=(3, 5))
+    assert no[0, 0][0] == 0.0
+
 
 @test_utils.test(arch=supported_archs_taichi_ndarray)
 def test_ndarray_reset():


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2a553e</samp>

Fixed a bug in `MatrixNdarray` and `VectorNdarray` initialization and added more tests for `zero_fill` argument. This improves the reliability and usability of the ndarray feature.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2a553e</samp>

*  Add `zero_fill` argument to `create_ndarray` method calls in `MatrixNdarray` and `VectorNdarray` constructors to initialize ndarray elements to zero by default ([link](https://github.com/taichi-dev/taichi/pull/8068/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9L1631-R1633), [link](https://github.com/taichi-dev/taichi/pull/8068/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9L1739-R1743))
*  Update `test_ndarray_init_as_zero` function in `test_ndarray.py` to check `zero_fill` argument for different types of ndarrays, such as vectors and matrices ([link](https://github.com/taichi-dev/taichi/pull/8068/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L718-R739))
