### PR TITLE
[ci] Build.py polishing, wave 5

### DIFF
--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -4,7 +4,6 @@
 from pathlib import Path
 from types import ModuleType
 from typing import Optional
-import ctypes
 import importlib
 import os
 import platform
@@ -233,7 +232,7 @@ def windows_enable_long_paths():
                     "1",
                     "/f",
                 )
-        except ctypes.WinError as e:
+        except OSError as e:
             if e.errno == 1223:  # ERROR_CANCELLED
                 warn("Enabling long paths cancelled, you may encounter compile errors later")
             else:

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -232,7 +232,8 @@ def windows_enable_long_paths():
                     "1",
                     "/f",
                 )
-        except OSError as e:
+        except Exception as e:
+            print(e, type(e), e.errno)
             if e.errno == 1223:  # ERROR_CANCELLED
                 warn("Enabling long paths cancelled, you may encounter compile errors later")
             else:

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from types import ModuleType
 from typing import Optional
+import ctypes
 import importlib
 import os
 import platform
@@ -232,7 +233,7 @@ def windows_enable_long_paths():
                     "1",
                     "/f",
                 )
-        except OSError as e:
+        except ctypes.WinError as e:
             if e.errno == 1223:  # ERROR_CANCELLED
                 warn("Enabling long paths cancelled, you may encounter compile errors later")
             else:

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -7,6 +7,7 @@ from typing import Optional
 import importlib
 import os
 import platform
+import re
 import subprocess
 import sys
 import sysconfig
@@ -90,7 +91,7 @@ def ensure_dependencies(*deps: str):
 
     try:
         for dep in deps:
-            dep = dep.split("==")[0]
+            dep = re.split(r"[><=]=?", dep)[0]
             importlib.import_module(dep)
         return
     except ModuleNotFoundError:
@@ -210,6 +211,6 @@ def early_init():
     This must be called before any other non-stdlib imports.
     """
     detect_crippled_python()
-    ensure_dependencies("tqdm", "requests", "mslex", "psutil")
+    ensure_dependencies("tqdm", "requests", "mslex", "psutil>=5.9.5")
     chdir_to_root()
     monkey_patch_environ()

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -219,11 +219,17 @@ def windows_enable_long_paths():
         from .tinysh import Command, sudo
 
         info("Enabling long paths on Windows")
-        python = Command(sys.executable)
+        reg = Command("reg.exe")
         with sudo():
-            python(
-                "-c",
-                "import winreg; winreg.SetValueEx(winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r'SYSTEM\CurrentControlSet\Control\FileSystem'), 'LongPathsEnabled', None, winreg.REG_DWORD, 1)",
+            reg.add(
+                r"HKLM\SYSTEM\CurrentControlSet\Control\FileSystem",
+                "/v",
+                "LongPathsEnabled",
+                "/t",
+                "REG_DWORD",
+                "/d",
+                "1",
+                "/f",
             )
 
 

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -215,22 +215,28 @@ def windows_enable_long_paths():
         enabled = False
 
     if not enabled:
-        from .misc import info
+        from .misc import info, warn
         from .tinysh import Command, sudo
 
         info("Enabling long paths on Windows")
         reg = Command("reg.exe")
-        with sudo():
-            reg.add(
-                r"HKLM\SYSTEM\CurrentControlSet\Control\FileSystem",
-                "/v",
-                "LongPathsEnabled",
-                "/t",
-                "REG_DWORD",
-                "/d",
-                "1",
-                "/f",
-            )
+        try:
+            with sudo():
+                reg.add(
+                    r"HKLM\SYSTEM\CurrentControlSet\Control\FileSystem",
+                    "/v",
+                    "LongPathsEnabled",
+                    "/t",
+                    "REG_DWORD",
+                    "/d",
+                    "1",
+                    "/f",
+                )
+        except OSError as e:
+            if e.errno == 1223:  # ERROR_CANCELLED
+                warn("Enabling long paths cancelled, you may encounter compile errors later")
+            else:
+                raise
 
 
 def early_init():

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -9,6 +9,7 @@ import os
 import platform
 import subprocess
 import sys
+import sysconfig
 
 # -- third party --
 # -- own --
@@ -100,7 +101,10 @@ def ensure_dependencies(*deps: str):
     pip_install = ["-m", "pip", "install", "--no-user", f"--target={bootstrap_root}", "-U"]
 
     if ensurepip:
-        wheels = Path(ensurepip.__path__[0]).glob("**/*.whl")
+        search_path = sysconfig.get_config_var("WHEEL_PKG_DIR")
+        if search_path is None:
+            search_path = ensurepip.__path__[0]
+        wheels = Path(search_path).glob("**/*.whl")
         wheels = os.pathsep.join(map(str, wheels))
         if run(py, "-S", *pip_install, "pip", env={"PYTHONPATH": wheels}):
             raise Exception("Unable to install pip! (ensurepip method)")

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -232,9 +232,8 @@ def windows_enable_long_paths():
                     "1",
                     "/f",
                 )
-        except Exception as e:
-            print(e, type(e), e.errno)
-            if e.errno == 1223:  # ERROR_CANCELLED
+        except OSError as e:
+            if e.winerror == 1223:
                 warn("Enabling long paths cancelled, you may encounter compile errors later")
             else:
                 raise

--- a/.github/workflows/scripts/ti_build/bootstrap.py
+++ b/.github/workflows/scripts/ti_build/bootstrap.py
@@ -210,7 +210,7 @@ def windows_enable_long_paths():
 
     key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Control\FileSystem")
     try:
-        enabled = winreg.QueryKeyEx(key, "LongPathsEnabled") == (1, 4)
+        enabled = winreg.QueryValueEx(key, "LongPathsEnabled") == (1, 4)
     except FileNotFoundError:
         enabled = False
 

--- a/.github/workflows/scripts/ti_build/misc.py
+++ b/.github/workflows/scripts/ti_build/misc.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 
 # -- stdlib --
+from pathlib import Path
+from typing import Any, Callable
 import inspect
 import os
 import platform
 import sys
-from pathlib import Path
-from typing import Any, Callable
 
 # -- third party --
 # -- own --
 from .bootstrap import get_cache_home  # noqa, this is a re-export
 from .escapes import escape_codes
+
 
 # -- code --
 options = None

--- a/.github/workflows/scripts/ti_build/tinysh.py
+++ b/.github/workflows/scripts/ti_build/tinysh.py
@@ -216,6 +216,8 @@ def sudo():
         return with_options({"runas": True})
     elif os.geteuid() != 0:
         return prefix("sudo")
+    else:
+        return with_options({})
 
 
 def nice():

--- a/.github/workflows/scripts/ti_build/tinysh.py
+++ b/.github/workflows/scripts/ti_build/tinysh.py
@@ -214,7 +214,7 @@ def sudo():
     """
     if IS_WINDOWS:
         return with_options({"runas": True})
-    else:
+    elif os.geteuid() != 0:
         return prefix("sudo")
 
 


### PR DESCRIPTION
- More robust bootstrapping on Debian/Ubuntu
- Do not call `sudo` (may be absent) when running with EUID=0
- Pin `psutil` version
- Try enabling long paths on Windows