### PR TITLE
[Lang] Optimize alias checking conditions for store-to-load forwarding

### DIFF
--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -157,16 +157,25 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
 
   // Check if store_stmt will ever influence the value of var
   auto may_contain_address = [](Stmt *store_stmt, Stmt *var) {
-    std::vector<Stmt *> aliased_vars = {var};
-    if (var->is<MatrixPtrStmt>()) {
-      aliased_vars.push_back(var->as<MatrixPtrStmt>()->origin);
-    }
-    for (auto aliased_var : aliased_vars) {
-      for (auto store_ptr : irpass::analysis::get_store_destination(
-               store_stmt, true /*get_aliased*/)) {
-        if (irpass::analysis::maybe_same_address(aliased_var, store_ptr)) {
+    for (auto store_ptr : irpass::analysis::get_store_destination(store_stmt)) {
+      if (var->is<MatrixPtrStmt>() && !store_ptr->is<MatrixPtrStmt>()) {
+        // check for aliased address with var
+        if (irpass::analysis::maybe_same_address(
+                var->as<MatrixPtrStmt>()->origin, store_ptr)) {
           return true;
         }
+      }
+
+      if (!var->is<MatrixPtrStmt>() && store_ptr->is<MatrixPtrStmt>()) {
+        // check for aliased address with store_ptr
+        if (irpass::analysis::maybe_same_address(
+                store_ptr->as<MatrixPtrStmt>()->origin, var)) {
+          return true;
+        }
+      }
+
+      if (irpass::analysis::maybe_same_address(var, store_ptr)) {
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9196c1</samp>

Simplify and optimize the `may_contain_address` function in `taichi/ir/control_flow_graph.cpp` to fix a bug and improve alias analysis.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9196c1</samp>

*  Simplify and optimize the `may_contain_address` function by removing unnecessary loop and flag ([link](https://github.com/taichi-dev/taichi/pull/8079/files?diff=unified&w=0#diff-837b90142d1730f6a3ab20c91f1f35c95335ef82a021c74fd4dbdb05ff0e164fL160-R179))
*  Fix incorrect alias analysis for some cases involving `MatrixPtrStmt` ([link](https://github.com/taichi-dev/taichi/pull/8079/files?diff=unified&w=0#diff-837b90142d1730f6a3ab20c91f1f35c95335ef82a021c74fd4dbdb05ff0e164fL160-R179))
