### PR TITLE
[bug] Fix misbehaviour and assertion error on ti.math.sign

### DIFF
--- a/python/taichi/math/mathimpl.py
+++ b/python/taichi/math/mathimpl.py
@@ -273,7 +273,7 @@ def sign(x):
         >>> ti.math.sign(x)
         [-1.000000, 0.000000, 1.000000]
     """
-    return ops.cast((x >= 0.0) - (x <= 0.0), float)
+    return ops.cast((x >= 0.0), float) - ops.cast((x <= 0.0), float)
 
 
 @func

--- a/tests/python/test_unary_ops.py
+++ b/tests/python/test_unary_ops.py
@@ -142,3 +142,14 @@ def test_popcnt():
     assert test_u32(100) == 3
     assert test_u32(1000) == 6
     assert test_u32(10000) == 5
+
+
+@test_utils.test()
+def test_sign():
+    @ti.kernel
+    def foo(val: ti.f32) -> ti.f32:
+        return ti.math.sign(val)
+
+    assert foo(0.5) == 1.0
+    assert foo(-0.5) == -1.0
+    assert foo(0.0) == 0.0


### PR DESCRIPTION
Issue: #8077 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c77628</samp>

Fix `sign` function bug for negative values and add unit test. The bug caused `sign` to return wrong signs for negative values on LLVM and causes crashes on gfx. The unit test checks `sign` for various inputs in `test_unary_ops.py`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c77628</samp>

* Fix bug in `sign` function that caused incorrect results or crashes for negative values ([link](https://github.com/taichi-dev/taichi/pull/8082/files?diff=unified&w=0#diff-5b3923516b48467202850afb384ef9901ecefae0173f03bcc9055adffe96d738L276-R276))
* Add unit test for `sign` function to verify its behavior for positive, negative, and zero values ([link](https://github.com/taichi-dev/taichi/pull/8082/files?diff=unified&w=0#diff-8ac29975a96f4251587f71dff241aa3724d26d4fcbf7b757901076205924bba5R145-R155))
