### PR TITLE
[refactor] Get rid of unnecessary element_dim in ExternalPtrStmt

### DIFF
--- a/taichi/codegen/llvm/codegen_llvm.cpp
+++ b/taichi/codegen/llvm/codegen_llvm.cpp
@@ -1888,8 +1888,6 @@ void TaskCodeGenLLVM::visit(ExternalPtrStmt *stmt) {
   auto dt = stmt->ret_type.ptr_removed();
   int num_element_indices =
       dt->is<TensorType>() ? 0 : stmt->element_shape.size();
-  const auto layout = stmt->element_dim <= 0 ? ExternalArrayLayout::kAOS
-                                             : ExternalArrayLayout::kSOA;
 
   /*
     ExternalPtrStmt can be divided into "outter" and "inner" parts.
@@ -1905,8 +1903,7 @@ void TaskCodeGenLLVM::visit(ExternalPtrStmt *stmt) {
     "num_indices - num_element_indices" gives how many "extra_args" to read from
   */
   int num_array_args = num_indices - num_element_indices;
-  const size_t element_shape_index_offset =
-      (layout == ExternalArrayLayout::kAOS) ? num_array_args : 0;
+  const size_t element_shape_index_offset = num_array_args;
 
   for (int i = 0; i < num_array_args; i++) {
     auto raw_arg = builder->CreateGEP(

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -712,12 +712,8 @@ class TaskCodegen : public IRVisitor {
       const int num_indices = stmt->indices.size();
       std::vector<std::string> size_var_names;
       const auto &element_shape = stmt->element_shape;
-      const auto layout = stmt->element_dim <= 0 ? ExternalArrayLayout::kAOS
-                                                 : ExternalArrayLayout::kSOA;
       const size_t element_shape_index_offset =
-          (layout == ExternalArrayLayout::kAOS)
-              ? num_indices - element_shape.size()
-              : 0;
+          num_indices - element_shape.size();
       for (int i = 0; i < num_indices - element_shape.size(); i++) {
         std::string var_name = fmt::format("{}_size{}_", stmt->raw_name(), i);
         spirv::Value var_ptr = ir_->make_value(

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -655,9 +655,9 @@ Stmt *make_ndarray_access(Expression::FlattenContext *ctx,
   auto expr = var.cast<ExternalTensorExpression>();
   // FIXME: No need to make it negative since we only support AOS
   auto element_dim = -expr->dt.get_shape().size();
-  auto external_ptr_stmt = std::make_unique<ExternalPtrStmt>(
-      var_stmt, index_stmts, indices.size(), expr->dt.get_shape(), element_dim,
-      expr->is_grad);
+  auto external_ptr_stmt =
+      std::make_unique<ExternalPtrStmt>(var_stmt, index_stmts, indices.size(),
+                                        expr->dt.get_shape(), expr->is_grad);
   if (expr->ndim - element_dim == indices.size()) {
     // Indexing into an scalar element
     external_ptr_stmt->ret_type = expr->dt.ptr_removed().get_element_type();

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -440,8 +440,8 @@ ExternalPtrStmt *IRBuilder::create_external_ptr(
     ArgLoadStmt *ptr,
     const std::vector<Stmt *> &indices,
     bool is_grad) {
-  return insert(Stmt::make_typed<ExternalPtrStmt>(
-      ptr, indices, indices.size(), std::vector<int>(), 0, is_grad));
+  return insert(Stmt::make_typed<ExternalPtrStmt>(ptr, indices, indices.size(),
+                                                  std::vector<int>(), is_grad));
 }
 
 AdStackAllocaStmt *IRBuilder::create_ad_stack(const DataType &dt,

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -47,11 +47,9 @@ ExternalPtrStmt::ExternalPtrStmt(Stmt *base_ptr,
                                  const std::vector<Stmt *> &indices,
                                  int ndim,
                                  const std::vector<int> &element_shape,
-                                 int element_dim,
                                  bool is_grad)
     : ExternalPtrStmt(base_ptr, indices, is_grad) {
   this->element_shape = element_shape;
-  this->element_dim = element_dim;
   this->ndim = ndim;
 }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -341,9 +341,6 @@ class ExternalPtrStmt : public Stmt {
 
   // Shape of element type
   std::vector<int> element_shape;
-  // AOS: element_dim < 0
-  // SOA: element_dim > 0
-  int element_dim;
 
   // irpass::vectorize_half2() will override the ret_type of ExternalPtrStmt.
   // We use "overrided_dtype" to prevent type inference from
@@ -360,7 +357,6 @@ class ExternalPtrStmt : public Stmt {
                   const std::vector<Stmt *> &indices,
                   int ndim,
                   const std::vector<int> &element_shape,
-                  int element_dim,
                   bool is_grad = false);
 
   bool has_global_side_effect() const override {

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -1522,8 +1522,7 @@ class MakeAdjoint : public ADTransform {
                        "tensor into the kernel directly");
         auto adj_ptr =
             insert<ExternalPtrStmt>(src->base_ptr, src->indices, src->ndim,
-                                    src->element_shape, src->element_dim,
-                                    /*is_grad=*/true);
+                                    src->element_shape, /*is_grad=*/true);
         adj_ptr->ret_type = src->ret_type;
 
         if (is_ptr_offset) {
@@ -1595,10 +1594,9 @@ class MakeAdjoint : public ADTransform {
                      "Cannot automatically differentiate through a grad "
                      "tensor, if you really want to do that, pass the grad "
                      "tensor into the kernel directly");
-      adjoint_ptr =
-          insert<ExternalPtrStmt>(dest->base_ptr, dest->indices, dest->ndim,
-                                  dest->element_shape, dest->element_dim,
-                                  /*is_grad=*/true);
+      adjoint_ptr = insert<ExternalPtrStmt>(dest->base_ptr, dest->indices,
+                                            dest->ndim, dest->element_shape,
+                                            /*is_grad=*/true);
       adjoint_ptr->ret_type = dest->ret_type;
 
       if (is_ptr_offset) {
@@ -1668,8 +1666,7 @@ class MakeAdjoint : public ADTransform {
                        "tensor into the kernel directly");
         auto adjoint_ptr =
             insert<ExternalPtrStmt>(dest->base_ptr, dest->indices, dest->ndim,
-                                    dest->element_shape, dest->element_dim,
-                                    /*is_grad=*/true);
+                                    dest->element_shape, /*is_grad=*/true);
         adjoint_ptr->ret_type = dest->ret_type;
 
         if (is_ptr_offset) {

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -60,8 +60,6 @@ class CheckOutOfBound : public BasicStmtVisitor {
           BinaryOpType::cmp_ge, stmt->indices[i], lower_bound);
       Stmt *upper_bound{nullptr};
 
-      // SOA layout for ndarray is deprecated, assert it's AOS layout
-      TI_ASSERT(stmt->element_dim <= 0);
       auto ndim = stmt->ndim;
       if (i < ndim) {
         // Check for External Shape

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -606,8 +606,8 @@ class IRPrinter : public IRVisitor {
       }
       s += ")";
     }
-    s += fmt::format(" element_dim={} layout={} is_grad={}", stmt->element_dim,
-                     (stmt->element_dim <= 0) ? "AOS" : "SOA", stmt->is_grad);
+    s += fmt::format(" element_dim={} layout={} is_grad={}", "AOS",
+                     stmt->is_grad);
 
     print(fmt::format("{}{} = external_ptr {}", stmt->type_hint(), stmt->name(),
                       s));

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -1145,13 +1145,12 @@ class MergeExternalAndMatrixPtr : public BasicStmtVisitor {
       // MatrixPtrStmt has flattened indices, linearization of which is done
       // during IndexExpression::flatten() Here we need to modify the
       // element_dim and element_shape a little bit.
-      int element_dim = -1;  // AOS Vector
       std::vector<int> element_shape = {
           std::accumulate(begin(origin->element_shape),
                           end(origin->element_shape), 1, std::multiplies<>())};
 
       auto fused = std::make_unique<ExternalPtrStmt>(
-          origin->base_ptr, indices, origin->ndim, element_shape, element_dim,
+          origin->base_ptr, indices, origin->ndim, element_shape,
           origin->is_grad);
       fused->ret_type = stmt->ret_type;
       // Note: Update base_ptr's ret_type so that it matches the ExternalPtrStmt


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8084
* #8083
* #8081

