### PR TITLE
[aot] Make generated tcm deterministic hash-wise

### DIFF
--- a/python/taichi/aot/module.py
+++ b/python/taichi/aot/module.py
@@ -1,3 +1,5 @@
+import datetime
+import os
 import warnings
 from contextlib import contextmanager
 from glob import glob
@@ -238,9 +240,12 @@ class Module:
         # Save first as usual.
         self.save(temp_dir)
 
+        fixed_time = datetime.datetime(2000, 12, 1).timestamp()
+
         # Package all artifacts into a zip archive and attach contend data.
         with ZipFile(tcm_path, "w") as z:
             for path in glob(f"{temp_dir}/*", recursive=True):
+                os.utime(path, (fixed_time, fixed_time))
                 z.write(path, Path.relative_to(Path(path), temp_dir))
 
         # Remove cached files


### PR DESCRIPTION
Fixes #8087 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae8c29e</samp>

Fix the non-determinism of the `Module.archive` method and add tests for it. Ensure that the method creates zip files with the same content and metadata regardless of the system time or environment.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae8c29e</samp>

*  Ensure zip file created by `Module.archive` is deterministic and reproducible by setting fixed modification time for files in zip archive ([link](https://github.com/taichi-dev/taichi/pull/8088/files?diff=unified&w=0#diff-1f2337b200b22bfe6e17e563cb8b4688f25aabdb8202db1a35461081e0245d95R1-R2), [link](https://github.com/taichi-dev/taichi/pull/8088/files?diff=unified&w=0#diff-1f2337b200b22bfe6e17e563cb8b4688f25aabdb8202db1a35461081e0245d95L241-R248))
*  Test zip file reproducibility by checking SHA-1 hash of zip file created by `Module.archive` in `test_archive` function ([link](https://github.com/taichi-dev/taichi/pull/8088/files?diff=unified&w=0#diff-a06cb7090d38a637444d3279f6f3df218ef3eb9f97af36c5060b1669c1ad5eceR1), [link](https://github.com/taichi-dev/taichi/pull/8088/files?diff=unified&w=0#diff-a06cb7090d38a637444d3279f6f3df218ef3eb9f97af36c5060b1669c1ad5eceR524-R528), [link](https://github.com/taichi-dev/taichi/pull/8088/files?diff=unified&w=0#diff-a06cb7090d38a637444d3279f6f3df218ef3eb9f97af36c5060b1669c1ad5eceL529-R541))
*  Clean up zip file after each call to `Module.archive` in `test_archive` function ([link](https://github.com/taichi-dev/taichi/pull/8088/files?diff=unified&w=0#diff-a06cb7090d38a637444d3279f6f3df218ef3eb9f97af36c5060b1669c1ad5eceL529-R541))
