### PR TITLE
[Lang] Migrate irpass::scalarize() after irpass::make_block_local()

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -30,7 +30,7 @@ namespace irpass {
 void re_id(IRNode *root);
 void flag_access(IRNode *root);
 void eliminate_immutable_local_vars(IRNode *root);
-void scalarize(IRNode *root);
+bool scalarize(IRNode *root);
 void vectorize_half2(IRNode *root);
 void lower_matrix_ptr(IRNode *root);
 bool die(IRNode *root);

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -226,17 +226,17 @@ void offload_to_executable(IRNode *ir,
     }
   }
 
+  if (make_block_local) {
+    irpass::make_block_local(ir, config, {kernel->get_name()});
+    print("Make block local");
+  }
+
   if (config.real_matrix_scalarize) {
     irpass::scalarize(ir);
 
     // Remove redundant MatrixInitStmt inserted during scalarization
     irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
     print("Scalarized");
-  }
-
-  if (make_block_local) {
-    irpass::make_block_local(ir, config, {kernel->get_name()});
-    print("Make block local");
   }
 
   if (is_extension_supported(config.arch, Extension::mesh)) {

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -232,11 +232,11 @@ void offload_to_executable(IRNode *ir,
   }
 
   if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
-    print("Scalarized");
+    if (irpass::scalarize(ir)) {
+      // Remove redundant MatrixInitStmt inserted during scalarization
+      irpass::full_simplify(ir, config, {false, /*autodiff_enabled*/ false});
+      print("Scalarized");
+    }
   }
 
   if (is_extension_supported(config.arch, Extension::mesh)) {
@@ -356,11 +356,11 @@ void compile_function(IRNode *ir,
   }
 
   if (config.real_matrix_scalarize) {
-    irpass::scalarize(ir);
-
-    // Remove redundant MatrixInitStmt inserted during scalarization
-    irpass::die(ir);
-    print("Scalarized");
+    if (irpass::scalarize(ir)) {
+      // Remove redundant MatrixInitStmt inserted during scalarization
+      irpass::die(ir);
+      print("Scalarized");
+    }
   }
 
   irpass::lower_access(ir, config, {{}, true});

--- a/taichi/transforms/make_block_local.cpp
+++ b/taichi/transforms/make_block_local.cpp
@@ -9,24 +9,6 @@ namespace taichi::lang {
 
 namespace {
 
-std::function<void(const std::string &)>
-make_pass_printer(bool verbose, const std::string &kernel_name, IRNode *ir) {
-  if (!verbose) {
-    return [](const std::string &) {};
-  }
-  return [ir, kernel_name](const std::string &pass) {
-    TI_INFO("[{}] {}:", kernel_name, pass);
-    std::cout << std::flush;
-    irpass::re_id(ir);
-    irpass::print(ir);
-    std::cout << std::flush;
-  };
-}
-
-}  // namespace
-
-namespace {
-
 void make_block_local_offload(OffloadedStmt *offload,
                               const CompileConfig &config,
                               const std::string &kernel_name) {
@@ -39,8 +21,6 @@ void make_block_local_offload(OffloadedStmt *offload,
   if (!is_bls_applicable) {
     return;
   }
-
-  auto print = make_pass_printer(true, "asdasdasd", offload);
 
   /*
       [TensorType TODO #2]

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -1196,11 +1196,11 @@ bool scalarize(IRNode *root) {
   TI_AUTO_PROF;
   bool modified = false;
 
-  modified = Scalarize::run(root);
+  modified |= Scalarize::run(root);
   auto scalarizable_allocas = GatherScalarizableLocalPointers::run(root);
-  modified = ScalarizePointers::run(root, scalarizable_allocas);
-  modified = ExtractLocalPointers::run(root);
-  modified = MergeExternalAndMatrixPtr::run(root);
+  modified |= ScalarizePointers::run(root, scalarizable_allocas);
+  modified |= ExtractLocalPointers::run(root);
+  modified |= MergeExternalAndMatrixPtr::run(root);
 
   return modified;
 }

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -18,9 +18,6 @@ class Scalarize : public BasicStmtVisitor {
   DelayedIRModifier delayed_modifier_;
 
   explicit Scalarize(IRNode *node) : immediate_modifier_(node) {
-    node->accept(this);
-
-    delayed_modifier_.modify_ir();
   }
 
   /*
@@ -841,6 +838,12 @@ class Scalarize : public BasicStmtVisitor {
     }
   }
 
+  static bool run(IRNode *node) {
+    Scalarize pass(node);
+    node->accept(&pass);
+    return pass.delayed_modifier_.modify_ir();
+  }
+
  private:
   using BasicStmtVisitor::visit;
   std::unordered_map<Stmt *, std::vector<Stmt *>> scalarized_ad_stack_map_;
@@ -898,9 +901,6 @@ class ScalarizePointers : public BasicStmtVisitor {
       IRNode *node,
       const std::unordered_set<Stmt *> &scalarizable_allocas)
       : immediate_modifier_(node), scalarizable_allocas_(scalarizable_allocas) {
-    node->accept(this);
-
-    delayed_modifier_.modify_ir();
   }
 
   /*
@@ -1041,6 +1041,13 @@ class ScalarizePointers : public BasicStmtVisitor {
     }
   }
 
+  static bool run(IRNode *node,
+                  const std::unordered_set<Stmt *> &scalarizable_allocas) {
+    ScalarizePointers pass(node, scalarizable_allocas);
+    node->accept(&pass);
+    return pass.delayed_modifier_.modify_ir();
+  }
+
  private:
   using BasicStmtVisitor::visit;
 };
@@ -1086,8 +1093,6 @@ class ExtractLocalPointers : public BasicStmtVisitor {
       TI_ASSERT(root->is<Block>());
       top_level_ = root->as<Block>();
     }
-    root->accept(this);
-    delayed_modifier_.modify_ir();
   }
 
   void visit(OffloadedStmt *stmt) override {
@@ -1122,6 +1127,12 @@ class ExtractLocalPointers : public BasicStmtVisitor {
         delayed_modifier_.erase(stmt);
       }
     }
+  }
+
+  static bool run(IRNode *node) {
+    ExtractLocalPointers pass(node);
+    node->accept(&pass);
+    return pass.delayed_modifier_.modify_ir();
   }
 
  private:
@@ -1172,22 +1183,26 @@ class MergeExternalAndMatrixPtr : public BasicStmtVisitor {
     }
   }
 
-  static void run(IRNode *node) {
+  static bool run(IRNode *node) {
     MergeExternalAndMatrixPtr pass;
     node->accept(&pass);
-    pass.modifier_.modify_ir();
+    return pass.modifier_.modify_ir();
   }
 };
 
 namespace irpass {
 
-void scalarize(IRNode *root) {
+bool scalarize(IRNode *root) {
   TI_AUTO_PROF;
-  Scalarize scalarize_pass(root);
+  bool modified = false;
+
+  modified = Scalarize::run(root);
   auto scalarizable_allocas = GatherScalarizableLocalPointers::run(root);
-  ScalarizePointers scalarize_pointers_pass(root, scalarizable_allocas);
-  ExtractLocalPointers extract_pointers_pass(root);
-  MergeExternalAndMatrixPtr::run(root);
+  modified = ScalarizePointers::run(root, scalarizable_allocas);
+  modified = ExtractLocalPointers::run(root);
+  modified = MergeExternalAndMatrixPtr::run(root);
+
+  return modified;
 }
 
 }  // namespace irpass


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 810c17d</samp>

Implement block-local storage optimization for dense and bitmasked SNodes and refactor `compile_to_offloads.cpp`. Fix a bug in `make_block_local.cpp` to handle tensor indices for global pointers.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 810c17d</samp>

*  Enable BLS optimization for dense and bitmasked SNodes by calling `irpass::make_block_local` before `irpass::offload` ([link](https://github.com/taichi-dev/taichi/pull/8090/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR229-R233))
*  Simplify code by removing redundant call to `irpass::make_block_local` after `irpass::offload` ([link](https://github.com/taichi-dev/taichi/pull/8090/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL237-L241))
*  Handle tensor index for global pointer statements in BLS analysis by applying scalarization and simplification passes in `make_block_local_offload` ([link](https://github.com/taichi-dev/taichi/pull/8090/files?diff=unified&w=0#diff-b2368908e6bad68906f40866b6dece421190dfd428d63788f2f5143b14785a45R18-R48))
