### PR TITLE
[bug] Fix extraction of field with None offset to external array

### DIFF
--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -87,7 +87,20 @@ def test_scalr_field_from_numpy(dtype, shape):
 @pytest.mark.parametrize("dtype", data_types)
 @pytest.mark.parametrize(
     "shape, offset",
-    [((), ()), (8, 0), (8, 8), (8, -4), ((6, 12), (-4, -4)), ((6, 12), (-4, 4)), ((6, 12), (4, -4)), ((6, 12), (8, 8))],
+    [
+        ((), None),
+        ((), ()),
+        (8, None),
+        (8, 0),
+        (8, 8),
+        (8, -4),
+        ((6, 12), None),
+        ((6, 12), (0, 0)),
+        ((6, 12), (-4, -4)),
+        ((6, 12), (-4, 4)),
+        ((6, 12), (4, -4)),
+        ((6, 12), (8, 8)),
+    ],
 )
 @test_utils.test(arch=get_host_arch_list())
 def test_scalr_field_from_numpy_with_offset(dtype, shape, offset):

--- a/tests/python/test_ggui.py
+++ b/tests/python/test_ggui.py
@@ -492,7 +492,7 @@ def test_fetching_depth_attachment():
     window.destroy()
 
 
-@pytest.mark.parametrize("offset", [(0, 0), (-256, -256), (256, -256), (-256, 256), (256, 256), (23333, 233333)])
+@pytest.mark.parametrize("offset", [None, (0, 0), (-256, -256), (256, -256), (-256, 256), (256, 256), (23333, 233333)])
 @pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
 @test_utils.test(arch=supported_archs)
 def test_get_depth_buffer_with_offset(offset):

--- a/tests/python/test_gui.py
+++ b/tests/python/test_gui.py
@@ -34,7 +34,7 @@ def test_save_image_without_window(dtype):
 @pytest.mark.parametrize("vector_field", [True, False])
 @pytest.mark.parametrize("dtype", [ti.u8, ti.f32, ti.f64])
 @pytest.mark.parametrize("color", [0, 32, 64, 128, 255])
-@pytest.mark.parametrize("offset", [(-150, -150), (0, 0), (150, 150)])
+@pytest.mark.parametrize("offset", [None, (-150, -150), (0, 0), (150, 150)])
 @test_utils.test(arch=get_host_arch_list())
 def test_set_image_with_offset(vector_field, dtype, color, offset):
     n = 300
@@ -60,7 +60,7 @@ def test_set_image_with_offset(vector_field, dtype, color, offset):
 @pytest.mark.parametrize("channel", [3, 4])
 @pytest.mark.parametrize("dtype", [ti.u8, ti.f32, ti.f64])
 @pytest.mark.parametrize("color", [0, 32, 64, 128, 255])
-@pytest.mark.parametrize("offset", [(-150, -150), (0, 0), (150, 150)])
+@pytest.mark.parametrize("offset", [None, (-150, -150), (0, 0), (150, 150)])
 @test_utils.test(arch=get_host_arch_list())
 def test_set_image_fast_gui_with_offset(channel, dtype, color, offset):
     n = 300

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -1300,13 +1300,15 @@ def test_matrix_oob():
 
 @pytest.mark.parametrize("dtype", [ti.i32, ti.f32, ti.i64, ti.f64])
 @pytest.mark.parametrize("shape", [(8,), (6, 12)])
-@pytest.mark.parametrize("offset", [0, -4, 4])
+@pytest.mark.parametrize("offset", [None, 0, -4, 4])
 @pytest.mark.parametrize("m, n", [(3, 4)])
 @test_utils.test(arch=get_host_arch_list())
 def test_matrix_from_numpy_with_offset(dtype, shape, offset, m, n):
     import numpy as np
 
-    x = ti.Matrix.field(dtype=dtype, m=m, n=n, shape=shape, offset=[offset] * len(shape))
+    x = ti.Matrix.field(
+        dtype=dtype, m=m, n=n, shape=shape, offset=[offset] * len(shape) if offset is not None else None
+    )
     # use the corresponding dtype for the numpy array.
     numpy_dtypes = {
         ti.i32: np.int32,

--- a/tests/python/test_offset.py
+++ b/tests/python/test_offset.py
@@ -147,7 +147,7 @@ def test_offset_must_throw_matrix():
         b = ti.Matrix.field(3, 3, dtype=ti.i32, shape=None, offset=(32, 16))
 
 
-@pytest.mark.parametrize("offset", [(0, 0), (-1, -1), (2, 2), (-23333, -23333), (23333, 23333)])
+@pytest.mark.parametrize("offset", [None, (0, 0), (-1, -1), (2, 2), (-23333, -23333), (23333, 23333)])
 @test_utils.test(arch=get_host_arch_list())
 def test_field_with_offset_print(offset):
     val = ti.field(dtype=ti.f32, shape=(3, 3), offset=offset)
@@ -155,7 +155,7 @@ def test_field_with_offset_print(offset):
     print(val)
 
 
-@pytest.mark.parametrize("offset", [(0, 0), (-1, -1), (2, 2), (-23333, -23333), (23333, 23333)])
+@pytest.mark.parametrize("offset", [None, (0, 0), (-1, -1), (2, 2), (-23333, -23333), (23333, 23333)])
 @test_utils.test(arch=get_host_arch_list())
 def test_field_with_offset_to_numpy(offset):
     shape = (3, 3)


### PR DESCRIPTION
Issue: #

### Brief Summary

This PR fixes an error with `arr.snode.ptr.offset` for empty lists by replacing its usage with zero-filled list.
It also improves code readability and adds additional tests for fields with `None` as their offset.

This PR uses `static_assert(tensor.shape == other.shape)` as a sanity check. However, this triggers a warning complaining about the usage of non-taichi function `len`. Are there any alternative approaches that offer a more elegant solution?

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2ca34fd</samp>

*  Simplify the logic of computing the offset for various functions that convert between tensors, images, vectors, matrices, and external arrays, using a ternary expression to handle the case when the offset is an empty list ([link](https://github.com/taichi-dev/taichi/pull/8093/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL42-R46), [link](https://github.com/taichi-dev/taichi/pull/8093/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL81-R82), [link](https://github.com/taichi-dev/taichi/pull/8093/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL110-R146), [link](https://github.com/taichi-dev/taichi/pull/8093/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL193-R186), [link](https://github.com/taichi-dev/taichi/pull/8093/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL203-R206), [link](https://github.com/taichi-dev/taichi/pull/8093/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL225-R220), [link](https://github.com/taichi-dev/taichi/pull/8093/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL256-R246) in `python/taichi/_kernels.py`)
