### PR TITLE
[bug] Fix compilation warning in constant fold on bool

### DIFF
--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -87,8 +87,8 @@ class ConstantFold : public BasicStmtVisitor {
       insert_and_erase(stmt, res);                                           \
     } else if (dt->is_primitive(PrimitiveTypeID::u1)) {                      \
       auto res = TypedConstant(                                              \
-          dst_type, PREFIX(int32(lhs->val.val_uint1()) OP_CPP                \
-                               int32(rhs->val.val_uint1())));                \
+          dst_type, PREFIX(int32(lhs->val.val_uint1())                       \
+                               OP_CPP int32(rhs->val.val_uint1())));         \
       insert_and_erase(stmt, res);                                           \
     }                                                                        \
     break;                                                                   \

--- a/taichi/transforms/constant_fold.cpp
+++ b/taichi/transforms/constant_fold.cpp
@@ -67,30 +67,31 @@ class ConstantFold : public BasicStmtVisitor {
     auto dt = lhs->val.dt;
     switch (stmt->op_type) {
 #define COMMA ,
-#define HANDLE_REAL_AND_INTEGRAL_BINARY(OP_TYPE, PREFIX, OP_CPP)               \
-  case BinaryOpType::OP_TYPE: {                                                \
-    if (dt->is_primitive(PrimitiveTypeID::f32) ||                              \
-        dt->is_primitive(PrimitiveTypeID::f64)) {                              \
-      auto res = TypedConstant(                                                \
-          dst_type, PREFIX(lhs->val.val_cast_to_float64()                      \
-                               OP_CPP rhs->val.val_cast_to_float64()));        \
-      insert_and_erase(stmt, res);                                             \
-    } else if (dt->is_primitive(PrimitiveTypeID::i32) ||                       \
-               dt->is_primitive(PrimitiveTypeID::i64)) {                       \
-      auto res = TypedConstant(                                                \
-          dst_type, PREFIX(lhs->val.val_int() OP_CPP rhs->val.val_int()));     \
-      insert_and_erase(stmt, res);                                             \
-    } else if (dt->is_primitive(PrimitiveTypeID::u32) ||                       \
-               dt->is_primitive(PrimitiveTypeID::u64)) {                       \
-      auto res = TypedConstant(                                                \
-          dst_type, PREFIX(lhs->val.val_uint() OP_CPP rhs->val.val_uint()));   \
-      insert_and_erase(stmt, res);                                             \
-    } else if (dt->is_primitive(PrimitiveTypeID::u1)) {                        \
-      auto res = TypedConstant(                                                \
-          dst_type, PREFIX(lhs->val.val_uint1() OP_CPP rhs->val.val_uint1())); \
-      insert_and_erase(stmt, res);                                             \
-    }                                                                          \
-    break;                                                                     \
+#define HANDLE_REAL_AND_INTEGRAL_BINARY(OP_TYPE, PREFIX, OP_CPP)             \
+  case BinaryOpType::OP_TYPE: {                                              \
+    if (dt->is_primitive(PrimitiveTypeID::f32) ||                            \
+        dt->is_primitive(PrimitiveTypeID::f64)) {                            \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_cast_to_float64()                    \
+                               OP_CPP rhs->val.val_cast_to_float64()));      \
+      insert_and_erase(stmt, res);                                           \
+    } else if (dt->is_primitive(PrimitiveTypeID::i32) ||                     \
+               dt->is_primitive(PrimitiveTypeID::i64)) {                     \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_int() OP_CPP rhs->val.val_int()));   \
+      insert_and_erase(stmt, res);                                           \
+    } else if (dt->is_primitive(PrimitiveTypeID::u32) ||                     \
+               dt->is_primitive(PrimitiveTypeID::u64)) {                     \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(lhs->val.val_uint() OP_CPP rhs->val.val_uint())); \
+      insert_and_erase(stmt, res);                                           \
+    } else if (dt->is_primitive(PrimitiveTypeID::u1)) {                      \
+      auto res = TypedConstant(                                              \
+          dst_type, PREFIX(int32(lhs->val.val_uint1()) OP_CPP                \
+                               int32(rhs->val.val_uint1())));                \
+      insert_and_erase(stmt, res);                                           \
+    }                                                                        \
+    break;                                                                   \
   }
 
       HANDLE_REAL_AND_INTEGRAL_BINARY(mul, , *)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13dbe07</samp>

Fix a bug in constant folding for boolean binary operations in `taichi/transforms/constant_fold.cpp`. Cast booleans to `int32` before applying the operation.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13dbe07</samp>

* Fix a bug in constant folding for boolean binary operations by casting to int32 ([link](https://github.com/taichi-dev/taichi/pull/8100/files?diff=unified&w=0#diff-82a8161a7771f3ee974357cda46f5684aead5225049e864e89767b078ad58b30L70-R94))
