### PR TITLE
[Bug] Fix type inference error with LowerMatrixPtr pass

### DIFF
--- a/taichi/transforms/lower_matrix_ptr.cpp
+++ b/taichi/transforms/lower_matrix_ptr.cpp
@@ -446,6 +446,8 @@ class LowerMatrixPtr : public BasicStmtVisitor {
             TypedConstant(origin->dynamic_index_stride));
         auto offset = std::make_unique<BinaryOpStmt>(
             BinaryOpType::mul, stmt->offset, stride.get());
+        offset->ret_type = stmt->offset->ret_type;
+
         auto ptr_base =
             std::make_unique<GlobalPtrStmt>(origin->snodes[0], origin->indices);
         ptr_base->ret_type.set_is_pointer(true);

--- a/tests/python/test_field.py
+++ b/tests/python/test_field.py
@@ -422,3 +422,20 @@ def test_write_u64():
     x = ti.field(ti.u64, shape=())
     x[None] = 2**64 - 1
     assert x[None] == 2**64 - 1
+
+
+@test_utils.test(require=ti.extension.data64)
+def test_field_with_dynamic_index():
+    vel = ti.Vector.field(2, dtype=ti.f64, shape=(100, 100))
+
+    @ti.func
+    def foo(i, j, l):
+        tmp = 1.0 / vel[i, j][l]
+        return tmp
+
+    @ti.kernel
+    def collide():
+        tmp0 = foo(0, 0, 0)
+        print(tmp0)
+
+    collide()


### PR DESCRIPTION
Issue: fix https://github.com/taichi-dev/taichi/issues/8078

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4c1c7c</samp>

Fix a bug in `LowerMatrixPtr` pass and add a test for matrix field access. The bug fix ensures correct type inference for matrix element access, and the test verifies that matrix field access works with dynamic indices and 64-bit data types.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4c1c7c</samp>

* Fix incorrect type inference for matrix element access in `LowerMatrixPtr` pass ([link](https://github.com/taichi-dev/taichi/pull/8105/files?diff=unified&w=0#diff-9b36b48490841b4018aca81632ae1beac3b2fdf1ee95a5c65eb42b676654b82eR449-R450))
* Add test case for accessing matrix fields with dynamic indices and 64-bit data types in `test_field.py` ([link](https://github.com/taichi-dev/taichi/pull/8105/files?diff=unified&w=0#diff-c08dd53cc282976d42e5643ea69e8e30e390e2ebd2f4e73f2789f84ac56f2494R425-R441))
