### PR TITLE
[bug] Fix: clang-tidy complaining explicit

### DIFF
--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -511,7 +511,7 @@ class Block : public IRNode {
   // variables, and AllocaStmt for other variables.
   std::map<Identifier, Stmt *> local_var_to_stmt;
 
-  Block(Kernel *kernel = nullptr) {
+  explicit Block(Kernel *kernel = nullptr) {
     parent_ = kernel;
   }
 


### PR DESCRIPTION
### Brief Summary

I found that the CI process `Build and Test / Check Static Analyzer (pull_request)` takes too much time. In its output, many lines of explicit warnings were generated who made that CI process slow. This PR added `explicit` to `Block` constructor in `ir.h`. This makes clang-tidy happy with `explicit`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a657bb</samp>

* Mark `Block` constructor as `explicit` to avoid implicit conversions from `Kernel *` ([link](https://github.com/taichi-dev/taichi/pull/8109/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eL514-R514))
