### PR TITLE
[test] Fix previous discovered flaky test_sparse_linear_solver.py.

### DIFF
--- a/tests/python/test_sparse_linear_solver.py
+++ b/tests/python/test_sparse_linear_solver.py
@@ -18,7 +18,7 @@ Therefore, A_psd is modified from A * A^T to A * A^T + np.eye(n) to improve stab
 @pytest.mark.parametrize("ordering", ["AMD", "COLAMD"])
 @test_utils.test(arch=ti.x64)
 def test_sparse_LLT_solver(dtype, solver_type, ordering):
-    np_dtype = np.float32 if dtype == ti.f32 else np.float64
+    np_dtype = ti.lang.util.to_numpy_type(dtype)
     n = 10
     A = np.random.rand(n, n)
     A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)
@@ -53,7 +53,7 @@ def test_sparse_LLT_solver(dtype, solver_type, ordering):
 @pytest.mark.parametrize("ordering", ["AMD", "COLAMD"])
 @test_utils.test(arch=ti.cpu)
 def test_sparse_solver_ndarray_vector(dtype, solver_type, ordering):
-    np_dtype = np.float32 if dtype == ti.f32 else np.float64
+    np_dtype = ti.lang.util.to_numpy_type(dtype)
     n = 10
     A = np.random.rand(n, n)
     A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)
@@ -146,7 +146,7 @@ def test_gpu_sparse_solver():
 @pytest.mark.parametrize("solver_type", ["LLT", "LU"])
 @test_utils.test(arch=ti.cuda)
 def test_gpu_sparse_solver2(dtype, solver_type):
-    np_dtype = np.float32 if dtype == ti.f32 else np.float64
+    np_dtype = ti.lang.util.to_numpy_type(dtype)
     n = 10
     A = np.random.rand(n, n)
     A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)

--- a/tests/python/test_sparse_linear_solver.py
+++ b/tests/python/test_sparse_linear_solver.py
@@ -4,15 +4,23 @@ import pytest
 import taichi as ti
 from tests import test_utils
 
+"""
+A_psd used in the tests is a random positive definite matrix with a given number of rows and columns:
+A_psd = A * A^T
+Reference: https://stackoverflow.com/questions/619335/a-simple-algorithm-for-generating-positive-semidefinite-matrices
+2023.5.31 qbao: It's observed that the matrix generated above is semi-definite, and it fails about 5% of the tests.
+Therefore, A_psd is modified from A * A^T to A * A^T + np.eye(n) to improve stability.
+"""
 
 @pytest.mark.parametrize("dtype", [ti.f32, ti.f64])
 @pytest.mark.parametrize("solver_type", ["LLT", "LDLT", "LU"])
 @pytest.mark.parametrize("ordering", ["AMD", "COLAMD"])
 @test_utils.test(arch=ti.x64)
 def test_sparse_LLT_solver(dtype, solver_type, ordering):
+    np_dtype = np.float32 if dtype==ti.f32 else np.float64
     n = 10
     A = np.random.rand(n, n)
-    A_psd = np.dot(A, A.transpose())
+    A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)
     Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=100, dtype=dtype)
     b = ti.field(dtype=dtype, shape=n)
 
@@ -44,10 +52,11 @@ def test_sparse_LLT_solver(dtype, solver_type, ordering):
 @pytest.mark.parametrize("ordering", ["AMD", "COLAMD"])
 @test_utils.test(arch=ti.cpu)
 def test_sparse_solver_ndarray_vector(dtype, solver_type, ordering):
+    np_dtype = np.float32 if dtype==ti.f32 else np.float64    
     n = 10
     A = np.random.rand(n, n)
-    A_psd = np.dot(A, A.transpose())
-    Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=300)
+    A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)
+    Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=300, dtype=dtype)
     b = ti.ndarray(ti.f32, shape=n)
 
     @ti.kernel
@@ -73,7 +82,6 @@ def test_sparse_solver_ndarray_vector(dtype, solver_type, ordering):
         assert x[i] == test_utils.approx(res[i], rel=1.0)
 
 
-@pytest.mark.skip(reason="Flaky; Reason to be investigated. 2023.5.18 qbao")
 @test_utils.test(arch=ti.cuda)
 def test_gpu_sparse_solver():
     from scipy.sparse import coo_matrix
@@ -83,13 +91,9 @@ def test_gpu_sparse_solver():
         for i in range(nrows):
             b[i] = 1.0 + i / nrows
 
-    """
-    Generate a positive definite matrix with a given number of rows and columns.
-    Reference: https://stackoverflow.com/questions/619335/a-simple-algorithm-for-generating-positive-semidefinite-matrices
-    """
-    matrixSize = 10
-    A = np.random.rand(matrixSize, matrixSize)
-    A_psd = np.dot(A, A.transpose())
+    n = 10
+    A = np.random.rand(n, n)
+    A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np.float32)
 
     A_raw_coo = coo_matrix(A_psd)
     nrows, ncols = A_raw_coo.shape
@@ -122,7 +126,7 @@ def test_gpu_sparse_solver():
     x_np = np.linalg.solve(A_psd, b_np)
 
     # solve Ax=b using cusolver refectorization
-    solver = ti.linalg.SparseSolver()
+    solver = ti.linalg.SparseSolver(dtype=ti.f32)
     solver.analyze_pattern(A_ti)
     solver.factorize(A_ti)
     x_ti = solver.solve(b)
@@ -130,23 +134,23 @@ def test_gpu_sparse_solver():
     assert np.allclose(x_ti.to_numpy(), x_np, rtol=5.0e-3)
 
     # solve Ax = b using compute function
-    solver = ti.linalg.SparseSolver()
+    solver = ti.linalg.SparseSolver(dtype=ti.f32)
     solver.compute(A_ti)
     x_cti = solver.solve(b)
     ti.sync()
     assert np.allclose(x_cti.to_numpy(), x_np, rtol=5.0e-3)
 
 
-@pytest.mark.skip(reason="Flaky; Reason to be investigated. 2023.5.18 qbao")
 @pytest.mark.parametrize("dtype", [ti.f32])
 @pytest.mark.parametrize("solver_type", ["LLT", "LU"])
 @test_utils.test(arch=ti.cuda)
 def test_gpu_sparse_solver2(dtype, solver_type):
+    np_dtype = np.float32 if dtype==ti.f32 else np.float64    
     n = 10
     A = np.random.rand(n, n)
-    A_psd = np.dot(A, A.transpose())
-    Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=300)
-    b = ti.ndarray(ti.f32, shape=n)
+    A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)
+    Abuilder = ti.linalg.SparseMatrixBuilder(n, n, max_num_triplets=300, dtype=dtype)
+    b = ti.ndarray(dtype, shape=n)
 
     @ti.kernel
     def fill(

--- a/tests/python/test_sparse_linear_solver.py
+++ b/tests/python/test_sparse_linear_solver.py
@@ -12,12 +12,13 @@ Reference: https://stackoverflow.com/questions/619335/a-simple-algorithm-for-gen
 Therefore, A_psd is modified from A * A^T to A * A^T + np.eye(n) to improve stability.
 """
 
+
 @pytest.mark.parametrize("dtype", [ti.f32, ti.f64])
 @pytest.mark.parametrize("solver_type", ["LLT", "LDLT", "LU"])
 @pytest.mark.parametrize("ordering", ["AMD", "COLAMD"])
 @test_utils.test(arch=ti.x64)
 def test_sparse_LLT_solver(dtype, solver_type, ordering):
-    np_dtype = np.float32 if dtype==ti.f32 else np.float64
+    np_dtype = np.float32 if dtype == ti.f32 else np.float64
     n = 10
     A = np.random.rand(n, n)
     A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)
@@ -52,7 +53,7 @@ def test_sparse_LLT_solver(dtype, solver_type, ordering):
 @pytest.mark.parametrize("ordering", ["AMD", "COLAMD"])
 @test_utils.test(arch=ti.cpu)
 def test_sparse_solver_ndarray_vector(dtype, solver_type, ordering):
-    np_dtype = np.float32 if dtype==ti.f32 else np.float64    
+    np_dtype = np.float32 if dtype == ti.f32 else np.float64
     n = 10
     A = np.random.rand(n, n)
     A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)
@@ -145,7 +146,7 @@ def test_gpu_sparse_solver():
 @pytest.mark.parametrize("solver_type", ["LLT", "LU"])
 @test_utils.test(arch=ti.cuda)
 def test_gpu_sparse_solver2(dtype, solver_type):
-    np_dtype = np.float32 if dtype==ti.f32 else np.float64    
+    np_dtype = np.float32 if dtype == ti.f32 else np.float64
     n = 10
     A = np.random.rand(n, n)
     A_psd = (np.dot(A, A.transpose()) + np.eye(n)).astype(np_dtype)


### PR DESCRIPTION
Issue: #8045 

### Brief Summary
`test_sparse_linear_solver.py` failed randomly before as reported in issue #8045. The reason for the failures was two-fold:
1. `dtype` was not aligned between the `SparseMatrixBuilder` and the `SparseSolver`, that caused 95% of the failures.
2. The randomly generated matrix A_psd is not positive-definite and caused about 5% of the failures.

With this PR fixing both of the issues, `test_sparse_linear_solver.py` should pass robustly enough. 

### Additional Comment
Note that with this PR, the two tests that were skipped before (`test_gpu_sparse_solver` and `test_gpu_sparse_solver2`) now come back. @ailzhang 