### PR TITLE
[misc] Relax python_requires to play nice with poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     author="Taichi developers",
     author_email="yuanmhu@gmail.com",
     url="https://github.com/taichi-dev/taichi",
-    python_requires=">=3.6,<3.12",
+    python_requires=">=3.6,<4.0",
     install_requires=[
         "numpy",
         "colorama",


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b446503</samp>

Updated `setup.py` to support Python 3.10 and future versions by changing the `python_requires` argument.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b446503</samp>

* Allow Python versions up to 4.0 (exclusive) in `setup.py` (`python_requires` argument in `setup` function, [link](https://github.com/taichi-dev/taichi/pull/8116/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L225-R225))
