### PR TITLE
[misc] Print the IR after every sub-pass of full-simplify

### DIFF
--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -54,6 +54,8 @@ void full_simplify(IRNode *root,
                    const CompileConfig &config,
                    const FullSimplifyPass::Args &args);
 void print(IRNode *root, std::string *output = nullptr);
+std::function<void(const std::string &)>
+make_pass_printer(bool verbose, const std::string &kernel_name, IRNode *ir);
 void frontend_type_check(IRNode *root);
 void lower_ast(IRNode *root);
 void type_check(IRNode *root, const CompileConfig &config);

--- a/taichi/runtime/program_impls/llvm/llvm_program.cpp
+++ b/taichi/runtime/program_impls/llvm/llvm_program.cpp
@@ -36,7 +36,8 @@ namespace taichi::lang {
 LlvmProgramImpl::LlvmProgramImpl(CompileConfig &config_,
                                  KernelProfilerBase *profiler)
     : ProgramImpl(config_),
-      compilation_workers("compile", config_.num_compile_threads) {
+      compilation_workers("compile",
+                          config_.print_ir ? 1 : config_.num_compile_threads) {
   runtime_exec_ = std::make_unique<LlvmRuntimeExecutor>(config_, profiler);
   cache_data_ = std::make_unique<LlvmOfflineCache>();
 }

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -221,7 +221,7 @@ void offload_to_executable(IRNode *ir,
   }
 
   if (make_block_local) {
-    irpass::make_block_local(ir, config, {kernel->get_name()});
+    irpass::make_block_local(ir, config, {kernel->get_name(), verbose});
     print("Make block local");
   }
 

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -883,6 +883,20 @@ void print(IRNode *root, std::string *output) {
   return IRPrinter::run(&expr_printer, root, output);
 }
 
+std::function<void(const std::string &)>
+make_pass_printer(bool verbose, const std::string &kernel_name, IRNode *ir) {
+  if (!verbose) {
+    return [](const std::string &) {};
+  }
+  return [ir, kernel_name](const std::string &pass) {
+    TI_INFO("[{}] {}:", kernel_name, pass);
+    std::cout << std::flush;
+    irpass::re_id(ir);
+    irpass::print(ir);
+    std::cout << std::flush;
+  };
+}
+
 }  // namespace irpass
 
 }  // namespace taichi::lang

--- a/taichi/transforms/make_block_local.h
+++ b/taichi/transforms/make_block_local.h
@@ -10,6 +10,7 @@ class MakeBlockLocalPass : public Pass {
 
   struct Args {
     std::string kernel_name;
+    bool verbose;
   };
 };
 

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -512,6 +512,8 @@ bool simplify(IRNode *root, const CompileConfig &config) {
 void full_simplify(IRNode *root,
                    const CompileConfig &config,
                    const FullSimplifyPass::Args &args) {
+  auto print =
+      make_pass_printer(args.verbose, args.kernel_name + ".simplify", root);
   TI_AUTO_PROF;
   if (config.advanced_optimization) {
     bool first_iteration = true;
@@ -519,24 +521,34 @@ void full_simplify(IRNode *root,
       bool modified = false;
       if (extract_constant(root, config))
         modified = true;
+      print("extract_constant");
       if (unreachable_code_elimination(root))
         modified = true;
+      print("unreachable_code_elimination");
       if (binary_op_simplify(root, config))
         modified = true;
+      print("binary_op_simplify");
       if (config.constant_folding && constant_fold(root))
         modified = true;
+      print("constant_fold");
       if (die(root))
         modified = true;
+      print("die");
       if (alg_simp(root, config))
         modified = true;
+      print("alg_simp");
       if (loop_invariant_code_motion(root, config))
         modified = true;
+      print("loop_invariant_code_motion");
       if (die(root))
         modified = true;
+      print("die");
       if (simplify(root, config))
         modified = true;
+      print("simplify");
       if (die(root))
         modified = true;
+      print("die");
       if (config.opt_level > 0 && whole_kernel_cse(root))
         modified = true;
       // Don't do this time-consuming optimization pass again if the IR is
@@ -545,6 +557,7 @@ void full_simplify(IRNode *root,
           cfg_optimization(root, args.after_lower_access, args.autodiff_enabled,
                            !config.real_matrix_scalarize))
         modified = true;
+      print("cfg_optimization");
       first_iteration = false;
       if (!modified)
         break;
@@ -553,10 +566,14 @@ void full_simplify(IRNode *root,
   }
   if (config.constant_folding) {
     constant_fold(root);
+    print("constant_fold");
     die(root);
+    print("die");
   }
   simplify(root, config);
+  print("simplify");
   die(root);
+  print("die");
 }
 
 }  // namespace irpass

--- a/taichi/transforms/simplify.h
+++ b/taichi/transforms/simplify.h
@@ -13,6 +13,8 @@ class FullSimplifyPass : public Pass {
     // Switch off some optimization in store forwarding if there is an autodiff
     // pass after the full_simplify
     bool autodiff_enabled;
+    std::string kernel_name = "";
+    bool verbose = false;
   };
 };
 


### PR DESCRIPTION
Issue: close #8112 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f170d70</samp>

### Summary
🖨️🔧🐛

<!--
1.  🖨️ - This emoji represents the printing of the IR passes, which is a key feature of this pull request.
2.  🔧 - This emoji represents the refactoring and improvement of the code organization and logic, which is another aspect of this pull request.
3.  🐛 - This emoji represents the debugging and testing of the IR transformations, which is the main motivation and benefit of this pull request.
-->
This pull request adds a new feature to print the IR passes for debugging and testing purposes. It introduces a `print_ir` flag in the config and a verbose flag in the arguments of several IR transformation functions. It also refactors the `make_pass_printer` function and modifies the number of compilation workers to avoid output interference. The affected files are `taichi/transforms/compile_to_offloads.cpp`, `taichi/transforms/make_block_local.cpp`, `taichi/transforms/simplify.cpp`, `taichi/ir/transforms.h`, `taichi/runtime/program_impls/llvm/llvm_program.cpp`, `taichi/transforms/ir_printer.cpp`, `taichi/transforms/make_block_local.h`, and `taichi/transforms/simplify.h`.

> _`print_ir` flag_
> _adds verbose logging for IR_
> _autumn debugging_

### Walkthrough
*  Add a new feature to print the IR passes for debugging and testing purposes ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-448ac6e85e192a27e5ec7c54cd8a91545dc7c83f62d030eafb9c190383cfe934R57-R58), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-77422b8748a46e70519217be594cd28433edadf98ca4960ce116f85da8dbccc3R886-R899))
  * Declare the `make_pass_printer` function in `taichi/ir/transforms.h` that returns a lambda function for printing IR passes ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-448ac6e85e192a27e5ec7c54cd8a91545dc7c83f62d030eafb9c190383cfe934R57-R58))
  * Define the `make_pass_printer` function in `taichi/transforms/ir_printer.cpp` that takes the kernel name and the verbose flag as arguments ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-77422b8748a46e70519217be594cd28433edadf98ca4960ce116f85da8dbccc3R886-R899))
* Modify the `full_simplify` function in `taichi/transforms/simplify.cpp` and `taichi/transforms/simplify.h` to use the `make_pass_printer` function ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edR515-R516), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edL522-R551), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edR560), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edL556-R576), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-10ec6d45529f36e0388647cb0bfbf233de555fcd755707a8bf02c1ac725a37cfR16-R17))
  * Add two new members to the `Args` struct in `taichi/transforms/simplify.h` for the kernel name and the verbose flag ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-10ec6d45529f36e0388647cb0bfbf233de555fcd755707a8bf02c1ac725a37cfR16-R17))
  * Add a local variable `print` in `taichi/transforms/simplify.cpp` that is initialized by calling the `make_pass_printer` function with the arguments from the `Args` struct ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edR515-R516))
  * Add calls to the `print` lambda function after each IR pass in `taichi/transforms/simplify.cpp` to print the IR pass name and content ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edL522-R551), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edR560), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edL556-R576))
* Modify the `make_block_local` function in `taichi/transforms/make_block_local.cpp` and `taichi/transforms/make_block_local.h` to use the `make_pass_printer` function ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-b2368908e6bad68906f40866b6dece421190dfd428d63788f2f5143b14785a45L14-R15), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-b2368908e6bad68906f40866b6dece421190dfd428d63788f2f5143b14785a45L47-R50), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-b2368908e6bad68906f40866b6dece421190dfd428d63788f2f5143b14785a45L382-R389), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-4114601b352d7ab144354fbca7491c709e30265d7fdc665441615ea17191ab92R13))
  * Add a new member to the `Args` struct in `taichi/transforms/make_block_local.h` for the verbose flag ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-4114601b352d7ab144354fbca7491c709e30265d7fdc665441615ea17191ab92R13))
  * Add a new argument to the `make_block_local_offload` function in `taichi/transforms/make_block_local.cpp` for the verbose flag ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-b2368908e6bad68906f40866b6dece421190dfd428d63788f2f5143b14785a45L14-R15), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-b2368908e6bad68906f40866b6dece421190dfd428d63788f2f5143b14785a45L382-R389))
  * Add a new argument to the `full_simplify` function call in `taichi/transforms/make_block_local.cpp` for the kernel name and the verbose flag ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-b2368908e6bad68906f40866b6dece421190dfd428d63788f2f5143b14785a45L47-R50))
* Modify the `LlvmProgramImpl` constructor in `taichi/runtime/program_impls/llvm/llvm_program.cpp` to set the number of compilation workers to 1 if the `print_ir` flag is true ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-f1e8254a73fde569ac328ff8b341e657897bb45916253d5e0af591dac518c363L39-R40))
* Modify the `compile_to_offloads` function in `taichi/transforms/compile_to_offloads.cpp` to use the `make_pass_printer` function ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL15-R15), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL89-R73), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL112-R103), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL130-R120), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL150-R142), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL224-R218), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL230-R224), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL256-R252), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL275-R272), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL295-R293), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL375-R375))
  * Remove the duplicate definition of the `make_pass_printer` function from `taichi/transforms/compile_to_offloads.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL15-R15))
  * Add two new arguments to the `full_simplify` function calls in `taichi/transforms/compile_to_offloads.cpp` for the kernel name and the verbose flag ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL89-R73), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL112-R103), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL130-R120), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL150-R142), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL224-R218), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL256-R252), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL275-R272), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL295-R293), [link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL375-R375))
  * Add a new argument to the `make_block_local` function call in `taichi/transforms/compile_to_offloads.cpp` for the verbose flag ([link](https://github.com/taichi-dev/taichi/pull/8127/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bL230-R224))

