### PR TITLE
[gui] Fix for ImGui widget size on HiDPI

### DIFF
--- a/taichi/ui/backends/vulkan/gui.cpp
+++ b/taichi/ui/backends/vulkan/gui.cpp
@@ -18,7 +18,6 @@ PFN_vkVoidFunction load_vk_function_for_gui(const char *name, void *userData) {
 Gui::Gui(AppContext *app_context, SwapChain *swap_chain, TaichiWindow *window) {
   app_context_ = app_context;
   swap_chain_ = swap_chain;
-  glfwGetWindowSize (window, &widthBeforeDPIScale, &heightBeforeDPIScale);
 
   create_descriptor_pool();
 
@@ -31,8 +30,11 @@ Gui::Gui(AppContext *app_context, SwapChain *swap_chain, TaichiWindow *window) {
   if (app_context->config.show_window) {
 #ifdef ANDROID
     ImGui_ImplAndroid_Init(window);
+    widthBeforeDPIScale = (int)ANativeWindow_getWidth(window);
+    heightBeforeDPIScale = (int)ANativeWindow_getHeight(window);
 #else
     ImGui_ImplGlfw_InitForVulkan(window, true);
+    glfwGetWindowSize (window, &widthBeforeDPIScale, &heightBeforeDPIScale);
 #endif
   }
 }

--- a/taichi/ui/backends/vulkan/gui.cpp
+++ b/taichi/ui/backends/vulkan/gui.cpp
@@ -18,6 +18,7 @@ PFN_vkVoidFunction load_vk_function_for_gui(const char *name, void *userData) {
 Gui::Gui(AppContext *app_context, SwapChain *swap_chain, TaichiWindow *window) {
   app_context_ = app_context;
   swap_chain_ = swap_chain;
+  glfwGetWindowSize (window, &widthBeforeDPIScale, &heightBeforeDPIScale);
 
   create_descriptor_pool();
 
@@ -126,10 +127,10 @@ bool Gui::initialized() {
 }
 
 float Gui::abs_x(float x) {
-  return x * app_context_->config.width;
+  return x * widthBeforeDPIScale;
 }
 float Gui::abs_y(float y) {
-  return y * app_context_->config.height;
+  return y * heightBeforeDPIScale;
 }
 
 void Gui::begin(const std::string &name,

--- a/taichi/ui/backends/vulkan/gui.cpp
+++ b/taichi/ui/backends/vulkan/gui.cpp
@@ -36,6 +36,9 @@ Gui::Gui(AppContext *app_context, SwapChain *swap_chain, TaichiWindow *window) {
     ImGui_ImplGlfw_InitForVulkan(window, true);
     glfwGetWindowSize(window, &widthBeforeDPIScale, &heightBeforeDPIScale);
 #endif
+  } else {
+    widthBeforeDPIScale = app_context->config.width;
+    heightBeforeDPIScale = app_context->config.height;
   }
 }
 

--- a/taichi/ui/backends/vulkan/gui.h
+++ b/taichi/ui/backends/vulkan/gui.h
@@ -65,8 +65,8 @@ class TI_DLL_EXPORT Gui final : public GuiBase {
   AppContext *app_context_{nullptr};
   SwapChain *swap_chain_{nullptr};
   ImGuiContext *imgui_context_{nullptr};
-  int widthBeforeDPIScale;
-  int heightBeforeDPIScale;
+  int widthBeforeDPIScale{0};
+  int heightBeforeDPIScale{0};
 
   VkRenderPass render_pass_{VK_NULL_HANDLE};
 

--- a/taichi/ui/backends/vulkan/gui.h
+++ b/taichi/ui/backends/vulkan/gui.h
@@ -65,6 +65,8 @@ class TI_DLL_EXPORT Gui final : public GuiBase {
   AppContext *app_context_{nullptr};
   SwapChain *swap_chain_{nullptr};
   ImGuiContext *imgui_context_{nullptr};
+  int widthBeforeDPIScale;
+  int heightBeforeDPIScale;
 
   VkRenderPass render_pass_{VK_NULL_HANDLE};
 

--- a/tests/python/test_ggui.py
+++ b/tests/python/test_ggui.py
@@ -379,6 +379,7 @@ def test_set_image_with_texture():
     window.destroy()
 
 
+# NOTE: Cannot automate the test for the case of ImGui scaling on HiDPI displays. So that needs to be tested manually.
 @pytest.mark.skipif(not _ti_core.GGUI_AVAILABLE, reason="GGUI Not Available")
 @test_utils.test(arch=supported_archs)
 def test_imgui():


### PR DESCRIPTION
Issue: #7393

### Brief Summary
The ImGui context was inititalized using the GLFW window size. But, the ImGui widget size was being set relative to the framebuffer size, when it should be relative to the GLFW window size. This becomes a problem when DPI scaling != 1.0 since framebuffer size has DPI scaling applied.

Test case added for this in next PR

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5fa7cec</samp>

* Fix GUI rendering on high-DPI screens by using unscaled window dimensions for coordinate conversion ([link](https://github.com/taichi-dev/taichi/pull/8129/files?diff=unified&w=0#diff-aa837ca266d11faa9968cd0aad76e18080fd5a9d4110ac1a6d6ccd128aee7a4bR21), [link](https://github.com/taichi-dev/taichi/pull/8129/files?diff=unified&w=0#diff-aa837ca266d11faa9968cd0aad76e18080fd5a9d4110ac1a6d6ccd128aee7a4bL129-R133), [link](https://github.com/taichi-dev/taichi/pull/8129/files?diff=unified&w=0#diff-0bd71968053eb6c3a4cbb725ceebe181a7c5b3bef5207e525855ce8980e1bd35R68-R69))
