### PR TITLE
[lang] Raise TaichiSyntaxError when there are default values in dataclasses

### DIFF
--- a/docs/lang/articles/advanced/dataclass.md
+++ b/docs/lang/articles/advanced/dataclass.md
@@ -72,7 +72,7 @@ get_area() # 201.062...
 ## Notes
 
 - Inheritance of Taichi dataclasses is not supported.
-- Default values in Taichi dataclasses is not supported.
+- Default values in Taichi dataclasses are not supported.
 - While it is convenient and recommended to associate functions with a struct defined via `@ti.dataclass`, `ti.types.struct` can serve the same purpose with the help of the `__struct_methods` argument. As mentioned above, the two methods of defining a struct type produce identical output.
 
 ```python

--- a/docs/lang/articles/advanced/dataclass.md
+++ b/docs/lang/articles/advanced/dataclass.md
@@ -72,6 +72,7 @@ get_area() # 201.062...
 ## Notes
 
 - Inheritance of Taichi dataclasses is not supported.
+- Default values in Taichi dataclasses is not supported.
 - While it is convenient and recommended to associate functions with a struct defined via `@ti.dataclass`, `ti.types.struct` can serve the same purpose with the help of the `__struct_methods` argument. As mentioned above, the two methods of defining a struct type produce identical output.
 
 ```python

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -750,7 +750,7 @@ def dataclass(cls):
     # raise error if there are default values
     for k in fields.keys():
         if hasattr(cls, k):
-            raise TaichiSyntaxError("Default values in @dataclass is not supported.")
+            raise TaichiSyntaxError("Default value in @dataclass is not supported.")
     # get the class methods to be attached to the struct types
     fields["__struct_methods"] = {
         attribute: getattr(cls, attribute)

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -747,6 +747,10 @@ def dataclass(cls):
     """
     # save the annotation fields for the struct
     fields = getattr(cls, "__annotations__", {})
+    # raise error if there are default values
+    for k in fields.keys():
+        if hasattr(cls, k):
+            raise TaichiSyntaxError("Default values in @dataclass is not supported.")
     # get the class methods to be attached to the struct types
     fields["__struct_methods"] = {
         attribute: getattr(cls, attribute)

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -154,3 +154,15 @@ def test_nested_data_class_func():
         return x.testme()
 
     assert k() == 42
+
+
+@test_utils.test()
+def test_nested_data_class_func():
+    with pytest.raises(ti.TaichiSyntaxError, match="Default values in @dataclass is not supported."):
+        @ti.dataclass
+        class Foo:
+            a: int
+            b: float = 3.14
+
+        foo = Foo()
+        print(foo)

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -159,6 +159,7 @@ def test_nested_data_class_func():
 @test_utils.test()
 def test_nested_data_class_func():
     with pytest.raises(ti.TaichiSyntaxError, match="Default values in @dataclass is not supported."):
+
         @ti.dataclass
         class Foo:
             a: int

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -158,7 +158,7 @@ def test_nested_data_class_func():
 
 @test_utils.test()
 def test_nested_data_class_func():
-    with pytest.raises(ti.TaichiSyntaxError, match="Default values in @dataclass is not supported."):
+    with pytest.raises(ti.TaichiSyntaxError, match="Default value in @dataclass is not supported."):
 
         @ti.dataclass
         class Foo:


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7cd7a38</samp>

Prevent dataclasses from having default values. Update the documentation, add a syntax error check, and add a test case for this restriction.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7cd7a38</samp>

* Enforce and document the restriction that Taichi dataclasses cannot have default values ([link](https://github.com/taichi-dev/taichi/pull/8135/files?diff=unified&w=0#diff-7e824916c54f137cbff46e33d70db38d03b30b01ab1b696df632a1b8c1fcc7cbR75), [link](https://github.com/taichi-dev/taichi/pull/8135/files?diff=unified&w=0#diff-3154e0533b9fd63e663c16c2e87c65068c3b002a65cf80529b6577d173bdb5feR750-R753), [link](https://github.com/taichi-dev/taichi/pull/8135/files?diff=unified&w=0#diff-e87bf5cb1cd09e10b5cfa001ab2ef18f31a242db3a7b66ee98a76d60b1615e71R157-R168))
  - Raise a syntax error in `dataclass` function in `struct.py` if any field has a default value ([link](https://github.com/taichi-dev/taichi/pull/8135/files?diff=unified&w=0#diff-3154e0533b9fd63e663c16c2e87c65068c3b002a65cf80529b6577d173bdb5feR750-R753))
  - Add a note in `dataclass.md` to inform users about this limitation and avoid confusion ([link](https://github.com/taichi-dev/taichi/pull/8135/files?diff=unified&w=0#diff-7e824916c54f137cbff46e33d70db38d03b30b01ab1b696df632a1b8c1fcc7cbR75))
  - Add a test case in `test_struct.py` to verify that the syntax error is raised correctly ([link](https://github.com/taichi-dev/taichi/pull/8135/files?diff=unified&w=0#diff-e87bf5cb1cd09e10b5cfa001ab2ef18f31a242db3a7b66ee98a76d60b1615e71R157-R168))
