### PR TITLE
[lang] Support clamp type hint for ndarrays

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -627,6 +627,7 @@ class ASTTransformer(Builder):
                             ctx.arg_features[i][1],
                             ctx.func.arguments[i].name,
                             ctx.arg_features[i][2],
+                            ctx.arg_features[i][3],
                         ),
                     )
                 elif isinstance(ctx.func.arguments[i].annotation, texture_type.TextureType):

--- a/python/taichi/lang/enums.py
+++ b/python/taichi/lang/enums.py
@@ -4,6 +4,15 @@ Layout = _ti_core.Layout
 AutodiffMode = _ti_core.AutodiffMode
 SNodeGradType = _ti_core.SNodeGradType
 Format = _ti_core.Format
+BoundaryMode = _ti_core.BoundaryMode
+
+
+def to_boundary_enum(boundary):
+    if boundary == "clamp":
+        return BoundaryMode.CLAMP
+    if boundary == "unsafe":
+        return BoundaryMode.UNSAFE
+    raise ValueError(f"Invalid boundary argument: {boundary}")
 
 
 class DeviceCapability:

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -102,9 +102,9 @@ def decl_sparse_matrix(dtype, name):
     return SparseMatrixProxy(_ti_core.make_arg_load_expr(arg_id, ptr_type, False), value_type)
 
 
-def decl_ndarray_arg(element_type, ndim, name, needs_grad):
+def decl_ndarray_arg(element_type, ndim, name, needs_grad, boundary):
     arg_id = impl.get_runtime().compiling_callable.insert_ndarray_param(element_type, ndim, name, needs_grad)
-    return AnyArray(_ti_core.make_external_tensor_expr(element_type, ndim, arg_id, needs_grad))
+    return AnyArray(_ti_core.make_external_tensor_expr(element_type, ndim, arg_id, needs_grad, boundary))
 
 
 def decl_texture_arg(num_dimensions, name):

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -392,7 +392,7 @@ class TaichiCallableTemplateMapper:
             if isinstance(arg, taichi.lang._ndarray.Ndarray):
                 anno.check_matched(arg.get_type())
                 needs_grad = (arg.grad is not None) if anno.needs_grad is None else anno.needs_grad
-                return arg.element_type, len(arg.shape), needs_grad
+                return arg.element_type, len(arg.shape), needs_grad, anno.boundary
             # external arrays
             shape = getattr(arg, "shape", None)
             if shape is None:
@@ -439,7 +439,7 @@ class TaichiCallableTemplateMapper:
                 if len(element_shape) != 0
                 else arg.dtype
             )
-            return element_type, len(shape) - len(element_shape), needs_grad
+            return element_type, len(shape) - len(element_shape), needs_grad, anno.boundary
         if isinstance(anno, sparse_matrix_builder):
             return arg.dtype
         # Use '#' as a placeholder because other kinds of arguments are not involved in template instantiation

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -1,4 +1,4 @@
-from taichi.lang.enums import Layout
+from taichi.lang.enums import Layout, to_boundary_enum
 from taichi.types.compound_types import CompoundType, matrix, vector
 
 
@@ -66,6 +66,7 @@ class NdarrayType:
         element_shape=None,
         field_dim=None,
         needs_grad=None,
+        boundary="unsafe",
     ):
         if field_dim is not None:
             raise ValueError("The field_dim argument for ndarray type is already deprecated. Please use ndim instead.")
@@ -77,6 +78,7 @@ class NdarrayType:
         self.ndim = ndim
         self.layout = Layout.AOS
         self.needs_grad = needs_grad
+        self.boundary = to_boundary_enum(boundary)
 
     def check_matched(self, ndarray_type: NdarrayTypeMetadata):
         # FIXME(Haidong) Cannot use Vector/MatrixType due to circular import

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -67,3 +67,5 @@ enum class ExternalArrayLayout { kAOS, kSOA, kNull };
 enum class AutodiffMode { kForward, kReverse, kNone, kCheckAutodiffValid };
 
 enum class SNodeGradType { kPrimal, kAdjoint, kDual, kAdjointCheckbit };
+
+enum class BoundaryMode { kUnsafe, kClamp };

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -666,9 +666,9 @@ Stmt *make_ndarray_access(Expression::FlattenContext *ctx,
   auto expr = var.cast<ExternalTensorExpression>();
   // FIXME: No need to make it negative since we only support AOS
   auto element_dim = -expr->dt.get_shape().size();
-  auto external_ptr_stmt =
-      std::make_unique<ExternalPtrStmt>(var_stmt, index_stmts, indices.size(),
-                                        expr->dt.get_shape(), expr->is_grad);
+  auto external_ptr_stmt = std::make_unique<ExternalPtrStmt>(
+      var_stmt, index_stmts, indices.size(), expr->dt.get_shape(),
+      expr->is_grad, expr->boundary);
   if (expr->ndim - element_dim == indices.size()) {
     // Indexing into an scalar element
     external_ptr_stmt->ret_type = expr->dt.ptr_removed().get_element_type();

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -477,17 +477,19 @@ class ExternalTensorExpression : public Expression {
   int arg_id;
   bool needs_grad{false};
   bool is_grad{false};
+  BoundaryMode boundary{BoundaryMode::kUnsafe};
 
   ExternalTensorExpression(const DataType &dt,
                            int ndim,
                            int arg_id,
-                           bool needs_grad = false) {
-    init(dt, ndim, arg_id, needs_grad);
+                           bool needs_grad = false,
+                           BoundaryMode boundary = BoundaryMode::kUnsafe) {
+    init(dt, ndim, arg_id, needs_grad, boundary);
   }
 
   explicit ExternalTensorExpression(Expr *expr) : is_grad(true) {
     auto ptr = expr->cast<ExternalTensorExpression>();
-    init(ptr->dt, ptr->ndim, ptr->arg_id, ptr->needs_grad);
+    init(ptr->dt, ptr->ndim, ptr->arg_id, ptr->needs_grad, ptr->boundary);
   }
 
   void flatten(FlattenContext *ctx) override;
@@ -508,11 +510,16 @@ class ExternalTensorExpression : public Expression {
  private:
   const CompileConfig *config_ = nullptr;
 
-  void init(const DataType &dt, int ndim, int arg_id, bool needs_grad) {
+  void init(const DataType &dt,
+            int ndim,
+            int arg_id,
+            bool needs_grad,
+            BoundaryMode boundary) {
     this->dt = dt;
     this->ndim = ndim;
     this->arg_id = arg_id;
     this->needs_grad = needs_grad;
+    this->boundary = boundary;
   }
 };
 

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -35,8 +35,12 @@ bool UnaryOpStmt::same_operation(UnaryOpStmt *o) const {
 
 ExternalPtrStmt::ExternalPtrStmt(Stmt *base_ptr,
                                  const std::vector<Stmt *> &indices,
-                                 bool is_grad)
-    : base_ptr(base_ptr), indices(indices), is_grad(is_grad) {
+                                 bool is_grad,
+                                 BoundaryMode boundary)
+    : base_ptr(base_ptr),
+      indices(indices),
+      is_grad(is_grad),
+      boundary(boundary) {
   ndim = indices.size();
   TI_ASSERT(base_ptr != nullptr);
   TI_ASSERT(base_ptr->is<ArgLoadStmt>());
@@ -47,8 +51,9 @@ ExternalPtrStmt::ExternalPtrStmt(Stmt *base_ptr,
                                  const std::vector<Stmt *> &indices,
                                  int ndim,
                                  const std::vector<int> &element_shape,
-                                 bool is_grad)
-    : ExternalPtrStmt(base_ptr, indices, is_grad) {
+                                 bool is_grad,
+                                 BoundaryMode boundary)
+    : ExternalPtrStmt(base_ptr, indices, is_grad, boundary) {
   this->element_shape = element_shape;
   this->ndim = ndim;
 }

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -353,16 +353,19 @@ class ExternalPtrStmt : public Stmt {
   bool overrided_dtype = false;
 
   bool is_grad = false;
+  BoundaryMode boundary{BoundaryMode::kUnsafe};
 
   ExternalPtrStmt(Stmt *base_ptr,
                   const std::vector<Stmt *> &indices,
-                  bool is_grad = false);
+                  bool is_grad = false,
+                  BoundaryMode boundary = BoundaryMode::kUnsafe);
 
   ExternalPtrStmt(Stmt *base_ptr,
                   const std::vector<Stmt *> &indices,
                   int ndim,
                   const std::vector<int> &element_shape,
-                  bool is_grad = false);
+                  bool is_grad = false,
+                  BoundaryMode boundary = BoundaryMode::kUnsafe);
 
   bool has_global_side_effect() const override {
     return false;

--- a/taichi/ir/transforms.h
+++ b/taichi/ir/transforms.h
@@ -68,6 +68,7 @@ void replace_all_usages_with(IRNode *root, Stmt *old_stmt, Stmt *new_stmt);
 bool check_out_of_bound(IRNode *root,
                         const CompileConfig &config,
                         const CheckOutOfBoundPass::Args &args);
+void handle_external_ptr_boundary(IRNode *root, const CompileConfig &config);
 void make_thread_local(IRNode *root, const CompileConfig &config);
 std::unique_ptr<ScratchPads> initialize_scratch_pad(OffloadedStmt *root);
 void make_block_local(IRNode *root,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -102,6 +102,11 @@ void export_lang(py::module &m) {
       .value("ADJOINT_CHECKBIT", SNodeGradType::kAdjointCheckbit)
       .export_values();
 
+  py::enum_<BoundaryMode>(m, "BoundaryMode", py::arithmetic())
+      .value("UNSAFE", BoundaryMode::kUnsafe)
+      .value("CLAMP", BoundaryMode::kClamp)
+      .export_values();
+
   // TODO(type): This should be removed
   py::class_<DataType>(m, "DataType")
       .def(py::init<Type *>())
@@ -930,7 +935,8 @@ void export_lang(py::module &m) {
   m.def("make_reference", Expr::make<ReferenceExpression, const Expr &>);
 
   m.def("make_external_tensor_expr",
-        Expr::make<ExternalTensorExpression, const DataType &, int, int, bool>);
+        Expr::make<ExternalTensorExpression, const DataType &, int, int, bool,
+                   const BoundaryMode &>);
 
   m.def("make_external_tensor_grad_expr",
         Expr::make<ExternalTensorExpression, Expr *>);

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -74,6 +74,9 @@ void compile_to_offloads(IRNode *ir,
   print("Simplified I");
   irpass::analysis::verify(ir);
 
+  irpass::handle_external_ptr_boundary(ir, config);
+  print("External ptr boundary processed");
+
   if (is_extension_supported(config.arch, Extension::mesh)) {
     irpass::analysis::gather_meshfor_relation_types(ir);
   }

--- a/taichi/transforms/handle_external_ptr_boundary.cpp
+++ b/taichi/transforms/handle_external_ptr_boundary.cpp
@@ -1,0 +1,132 @@
+#include "taichi/ir/ir.h"
+#include "taichi/ir/statements.h"
+#include "taichi/ir/transforms.h"
+#include "taichi/ir/visitors.h"
+#include "taichi/transforms/check_out_of_bound.h"
+#include "taichi/transforms/utils.h"
+#include <set>
+
+namespace taichi::lang {
+
+class HandleExternalPtrBound : public BasicStmtVisitor {
+ public:
+  using BasicStmtVisitor::visit;
+  std::set<int> visited;
+  DelayedIRModifier modifier;
+
+  bool is_done(Stmt *stmt) {
+    return visited.find(stmt->instance_id) != visited.end();
+  }
+
+  void set_done(Stmt *stmt) {
+    visited.insert(stmt->instance_id);
+  }
+
+  void visit(ExternalPtrStmt *stmt) override {
+    if (stmt->boundary == BoundaryMode::kUnsafe || is_done(stmt))
+      return;
+    if (stmt->boundary == BoundaryMode::kClamp) {
+      auto new_stmts = VecStatement();
+      auto zero = new_stmts.push_back<ConstStmt>(TypedConstant(0));
+
+      int flattened_element = 1;
+      for (int i = 0; i < stmt->element_shape.size(); i++) {
+        flattened_element *= stmt->element_shape[i];
+      }
+      for (int i = 0; i < stmt->indices.size(); i++) {
+        auto lower_bound = zero;
+        auto check_lower_bound = new_stmts.push_back<BinaryOpStmt>(
+            BinaryOpType::max, stmt->indices[i], lower_bound);
+
+        Stmt *upper_bound{nullptr};
+
+        auto ndim = stmt->ndim;
+        if (i < ndim) {
+          // Check for External Shape
+          auto axis = i;
+          upper_bound = new_stmts.push_back<ExternalTensorShapeAlongAxisStmt>(
+              /*axis=*/axis,
+              /*arg_id=*/stmt->base_ptr->as<ArgLoadStmt>()->arg_id);
+        } else {
+          // Check for Element Shape
+          upper_bound =
+              new_stmts.push_back<ConstStmt>(TypedConstant(flattened_element));
+        }
+
+        auto one = new_stmts.push_back<ConstStmt>(TypedConstant(1));
+        auto valid_upper = new_stmts.push_back<BinaryOpStmt>(BinaryOpType::sub,
+                                                             upper_bound, one);
+
+        auto check_upper_bound = new_stmts.push_back<BinaryOpStmt>(
+            BinaryOpType::min, check_lower_bound, valid_upper);
+        stmt->indices[i]->replace_usages_with(check_upper_bound);
+        stmt->indices[i] = check_upper_bound;
+      }
+
+      modifier.insert_before(stmt, std::move(new_stmts));
+      set_done(stmt);
+    }
+  }
+
+  // TODO: As offset information per dimension is lacking, only the accumulated
+  // index is checked.
+  void visit(MatrixPtrStmt *stmt) override {
+    if (is_done(stmt) || !stmt->offset_used_as_index())
+      return;
+
+    if (stmt->origin->is<ExternalPtrStmt>() &&
+        stmt->origin->as<ExternalPtrStmt>()->boundary == BoundaryMode::kClamp) {
+      auto const &matrix_shape = stmt->get_origin_shape();
+      int max_valid_index = 1;
+      for (int i = 0; i < matrix_shape.size(); i++) {
+        max_valid_index *= matrix_shape[i];
+      }
+      // index starts from 0, max_valid_index = size(matrix) - 1
+      max_valid_index -= 1;
+
+      auto index = stmt->offset;
+      auto new_stmts = VecStatement();
+      auto zero = new_stmts.push_back<ConstStmt>(TypedConstant(0));
+
+      auto lower_bound = zero;
+
+      auto check_lower_bound = new_stmts.push_back<BinaryOpStmt>(
+          BinaryOpType::max, index, lower_bound);
+      auto upper_bound =
+          new_stmts.push_back<ConstStmt>(TypedConstant(max_valid_index));
+      auto check_upper_bound = new_stmts.push_back<BinaryOpStmt>(
+          BinaryOpType::min, check_lower_bound, upper_bound);
+
+      index->replace_usages_with(check_upper_bound);
+      modifier.insert_before(stmt, std::move(new_stmts));
+      set_done(stmt);
+    }
+  }
+
+  static bool run(IRNode *node, const CompileConfig &config) {
+    HandleExternalPtrBound checker;
+    bool modified = false;
+    while (true) {
+      node->accept(&checker);
+      if (checker.modifier.modify_ir()) {
+        modified = true;
+      } else {
+        break;
+      }
+    }
+    if (modified)
+      irpass::type_check(node, config);
+    return modified;
+  }
+};
+
+namespace irpass {
+
+void handle_external_ptr_boundary(IRNode *root, const CompileConfig &config) {
+  TI_AUTO_PROF;
+  HandleExternalPtrBound::run(root, config);
+}
+
+}  // namespace irpass
+
+}  // namespace taichi::lang

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -1041,3 +1041,16 @@ def test_ndarray_oob_clamp():
             x2[i, j] = [i, j]
     assert test_vec_arr(x2, -1) == 1
     assert test_vec_arr(x2, 2) == 2
+
+    @ti.kernel
+    def test_mat_arr(x: ti.types.ndarray(boundary="clamp"), i: ti.i32, j: ti.i32) -> ti.f32:
+        return x[1, 2][i, j]
+
+    x3 = ti.ndarray(ti.math.mat2, shape=(3, 3))
+    for i in range(3):
+        for j in range(3):
+            x3[i, j] = [[i, j], [i + 1, j + 1]]
+    assert test_mat_arr(x3, -1, 0) == 1
+    assert test_mat_arr(x3, 1, -1) == 2
+    assert test_mat_arr(x3, 2, 0) == 3
+    assert test_mat_arr(x3, 1, 2) == 3

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -1014,3 +1014,30 @@ def test_pass_ndarray_to_func():
 
     weight = ti.ndarray(dtype=ti.f32, shape=(2, 2, 2))
     foo(weight)
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_oob_clamp():
+    @ti.kernel
+    def test(x: ti.types.ndarray(boundary="clamp"), y: ti.i32) -> ti.f32:
+        return x[y]
+
+    x = ti.ndarray(ti.f32, shape=(3))
+    for i in range(3):
+        x[i] = i
+
+    assert test(x, -1) == 0
+    assert test(x, -2) == 0
+    assert test(x, 3) == 2
+    assert test(x, 4) == 2
+
+    @ti.kernel
+    def test_vec_arr(x: ti.types.ndarray(boundary="clamp"), y: ti.i32) -> ti.f32:
+        return x[1, 2][y]
+
+    x2 = ti.ndarray(ti.math.vec2, shape=(3, 3))
+    for i in range(3):
+        for j in range(3):
+            x2[i, j] = [i, j]
+    assert test_vec_arr(x2, -1) == 1
+    assert test_vec_arr(x2, 2) == 2


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e24fecb</samp>

This pull request adds boundary mode support for external arrays passed as kernel arguments, which allows specifying how out-of-bound access is handled. It introduces a new `BoundaryMode` enum class in both Python and C++, and modifies the `NdarrayType`, `ExternalTensorExpression`, and `ExternalPtrStmt` classes to support this option. It also adds a new IR pass `handle_external_ptr_boundary` that inserts boundary checks according to the boundary mode. It updates the Python API and the AST transformer to enable users to specify the boundary mode of ndarrays and external tensor expressions. It also adds a new test case to verify the functionality.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e24fecb</samp>

*  Add a new feature to support boundary mode for ndarrays, which determines how out-of-bound access to the ndarrays is handled, such as clamping or unsafe. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fR630), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-83790ba7fda7b1acb33e660834fce698336bfd50f0f6e779764e59878878f5b2L7-R17), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL105-R107), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L395-R395), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L436-R436), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L1-R1), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152R69), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152R81), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-ecd477a48a0e074ded288ee4d6f122e40389d6afa29198630550b406c0bfcd19R70-R71), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L658-R660), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL479-R491), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL509-R520), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L38-R43), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L50-R56), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L351-R356), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L360-R363), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-448ac6e85e192a27e5ec7c54cd8a91545dc7c83f62d030eafb9c190383cfe934R71), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167R105-R109), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L932-R938), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR77-R79), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-61d2f35cd3ce51fed375f04228f01d7091dc0346a90661a2ba7ab93496d3b51bR1-R132))
  * Define a new enum class `BoundaryMode` in both C++ (`taichi/inc/constants.h`) and Python (`taichi/lang/enums.py`) to represent the possible values for the boundary mode of ndarrays. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-83790ba7fda7b1acb33e660834fce698336bfd50f0f6e779764e59878878f5b2L7-R17), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-ecd477a48a0e074ded288ee4d6f122e40389d6afa29198630550b406c0bfcd19R70-R71), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167R105-R109))
  * Add a new argument `boundary` to the `NdarrayType` constructor and instance attribute, which specifies the boundary mode of the ndarray type. Use the `to_boundary_enum` function to convert the string argument to the enum value. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L1-R1), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152R69), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152R81))
  * Add a new argument `boundary` to the `decl_ndarray_arg` and `make_external_tensor_expr` functions, which passes the boundary mode of the ndarray argument to the `ExternalTensorExpression` constructor. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL105-R107), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L932-R938))
  * Add a new argument `boundary` to the `ExternalTensorExpression` and `ExternalPtrStmt` constructors and instance attributes, which stores the boundary mode of the external tensor expression and statement. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL479-R491), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL509-R520), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L38-R43), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L50-R56), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L351-R356), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L360-R363))
  * Read the `boundary` argument from the annotation of the ndarray argument in the `extract_arg` function, and return it as part of the argument information. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L395-R395), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L436-R436))
  * Pass the `boundary` argument to the `ExternalPtrStmt` constructor call in the `ExternalTensorExpression` constructor and the `ExternalPtrStmt` constructor. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L658-R660), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L50-R56))
  * Implement a new IR pass `handle_external_ptr_boundary` that inserts boundary checks for external pointer statements according to their boundary mode. Use a visitor class `HandleExternalPtrBound` that modifies the IR by inserting binary operations to clamp the indices of external pointer statements to the valid range. Handle the case of matrix pointer statements that originate from external pointer statements. Run the pass until no more modifications are made, and then perform type checking on the modified IR. ([link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-448ac6e85e192a27e5ec7c54cd8a91545dc7c83f62d030eafb9c190383cfe934R71), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR77-R79), [link](https://github.com/taichi-dev/taichi/pull/8136/files?diff=unified&w=0#diff-61d2f35cd3ce51fed375f04228f01d7091dc0346a90661a2ba7ab93496d3b51bR1-R132))
