### PR TITLE
[bug] Fix passing ndarray to a taichi function

### DIFF
--- a/python/taichi/lang/any_array.py
+++ b/python/taichi/lang/any_array.py
@@ -33,7 +33,7 @@ class AnyArray:
 
     def get_type(self):
         return NdarrayTypeMetadata(
-            self.ptr.get_ret_type(), None, _ti_core.get_external_tensor_needs_grad(self.ptr)
+            self.ptr.get_ret_type().ptr_removed(), None, _ti_core.get_external_tensor_needs_grad(self.ptr)
         )  # AnyArray can take any shape
 
     @property

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -111,6 +111,7 @@ void export_lang(py::module &m) {
       .def("__str__", &DataType::to_string)
       .def("shape", &DataType::get_shape)
       .def("element_type", &DataType::get_element_type)
+      .def("ptr_removed", &DataType::ptr_removed)
       .def(
           "get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
           py::return_value_policy::reference)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -1000,3 +1000,17 @@ def test_type_hint_vector():
     z = ti.ndarray(ti.math.mat2, (3))
     with pytest.raises(ValueError, match=r"Invalid argument into ti.types.ndarray\(\)"):
         test(z)
+
+
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_pass_ndarray_to_func():
+    @ti.func
+    def bar(weight: ti.types.ndarray(ti.f32, ndim=3)):
+        pass
+
+    @ti.kernel
+    def foo(weight: ti.types.ndarray(ti.f32, ndim=3)):
+        bar(weight)
+
+    weight = ti.ndarray(dtype=ti.f32, shape=(2, 2, 2))
+    foo(weight)


### PR DESCRIPTION
Issue: fixes #8137 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c0251a</samp>

Fix a bug where passing an ndarray to a taichi function would cause a type mismatch error. Add a `ptr_removed` method to the `DataType` class and use it in `any_array.py`. Add a test case in `test_ndarray.py` to verify the fix.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4c0251a</samp>

* Fix a bug where passing an ndarray to a taichi function causes a type mismatch error ([link](https://github.com/taichi-dev/taichi/pull/8138/files?diff=unified&w=0#diff-2e623ee0b0eec1b200fead36c0627a3c54738f6d83d79757398dc67decc01da8L36-R36), [link](https://github.com/taichi-dev/taichi/pull/8138/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167R114))
* Add a test case to verify that passing an ndarray to a taichi function works as expected ([link](https://github.com/taichi-dev/taichi/pull/8138/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0R1003-R1016))
