### PR TITLE
[opt] Properly handle FuncCallStmt in CFG and simplify passes

### DIFF
--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -217,6 +217,9 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
 
   // Check if store_stmt will ever influence the value of var
   auto may_contain_address = [](Stmt *store_stmt, Stmt *var) {
+    if (store_stmt->is<FuncCallStmt>()) {
+      return true;
+    }
     for (auto store_ptr : irpass::analysis::get_store_destination(store_stmt)) {
       if (var->is<MatrixPtrStmt>() && !store_ptr->is<MatrixPtrStmt>()) {
         // check for aliased address with var
@@ -976,7 +979,8 @@ void ControlFlowGraph::reaching_definition_analysis(bool after_lower_access) {
   for (int i = 0; i < num_nodes; i++) {
     for (int j = nodes[i]->begin_location; j < nodes[i]->end_location; j++) {
       auto stmt = nodes[i]->block->statements[j].get();
-      if ((stmt->is<MatrixPtrStmt>() &&
+      if (stmt->is<FuncCallStmt>() ||
+          (stmt->is<MatrixPtrStmt>() &&
            stmt->as<MatrixPtrStmt>()->origin->is<AllocaStmt>()) ||
           (!after_lower_access &&
            (stmt->is<GlobalPtrStmt>() || stmt->is<ExternalPtrStmt>() ||

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -19,6 +19,7 @@ bool cfg_optimization(
   bool result_modified = false;
   if (!real_matrix_enabled) {
     cfg->simplify_graph();
+
     if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
       result_modified = true;
     }

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -17,15 +17,18 @@ bool cfg_optimization(
   TI_AUTO_PROF;
   auto cfg = analysis::build_cfg(root);
   bool result_modified = false;
+  auto print = make_pass_printer(true, "cfg_optimization", root);
   if (!real_matrix_enabled) {
     cfg->simplify_graph();
-
+    cfg->print_graph_structure();
     if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
       result_modified = true;
     }
+    print("store_to_load_forwarding");
     if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
       result_modified = true;
     }
+    print("dead_store_elimination");
   }
   // TODO: implement cfg->dead_instruction_elimination()
   die(root);  // remove unused allocas

--- a/taichi/transforms/cfg_optimization.cpp
+++ b/taichi/transforms/cfg_optimization.cpp
@@ -17,18 +17,14 @@ bool cfg_optimization(
   TI_AUTO_PROF;
   auto cfg = analysis::build_cfg(root);
   bool result_modified = false;
-  auto print = make_pass_printer(true, "cfg_optimization", root);
   if (!real_matrix_enabled) {
     cfg->simplify_graph();
-    cfg->print_graph_structure();
     if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
       result_modified = true;
     }
-    print("store_to_load_forwarding");
     if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
       result_modified = true;
     }
-    print("dead_store_elimination");
   }
   // TODO: implement cfg->dead_instruction_elimination()
   die(root);  // remove unused allocas

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -95,9 +95,6 @@ class BasicBlockSimplify : public IRVisitor {
                 }
                 continue;
               }
-              if (block->statements[j]->is<FuncCallStmt>()) {
-                has_store = true;
-              }
               if (!irpass::analysis::gather_statements(
                        block->statements[j].get(),
                        [&](Stmt *s) {

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -107,6 +107,8 @@ class BasicBlockSimplify : public IRVisitor {
                          else if (auto atomic = s->cast<AtomicOpStmt>())
                            return irpass::analysis::maybe_same_address(
                                atomic->dest, stmt->src);
+                         else if (auto func_call = s->cast<FuncCallStmt>())
+                           return true;
                          else
                            return false;
                        })

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -155,13 +155,15 @@ def test_experimental_templates():
         x[None] += 1
 
     @ti.kernel
-    def run_func():
+    def run_func(a: ti.u1):
         x[None] = 10
         y[None] = 20
-        inc(x)
+        if a:
+            inc(x)
         answer[0] = x[None]
         answer[1] = y[None]
-        inc(y)
+        if a:
+            inc(y)
         answer[2] = x[None]
         answer[3] = y[None]
 
@@ -172,7 +174,7 @@ def test_experimental_templates():
         assert answer[3] == 21
 
     run_kernel()
-    run_func()
+    run_func(True)
     verify()
 
 
@@ -324,28 +326,22 @@ def test_return_in_if_in_for():
 
 @test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
 def test_ref():
-    # FIXME:
-    #  Failed test if we put assert inside kernel. But test passes with assertion inside kernel if we insert print
-    #  statement after assert.
     @ti.experimental.real_func
     def foo(a: ti.ref(ti.f32)):
         a = 7
 
     @ti.kernel
-    def bar() -> ti.f32:
+    def bar():
         a = 5.0
         foo(a)
-        return a
+        assert a == 7
 
-    assert bar() == 7
+    bar()
 
 
 @test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
 def test_ref_atomic():
-    # FIXME:
-    #  1. Failed test on Pascal (and potentially older) architecture
-    #  2. Failed test if we put assert inside kernel. But test passes with assertion inside kernel if we insert print
-    #     statement after assert.
+    # FIXME: failed test on Pascal (and potentially older) architecture.
     # Please remove this guardiance when you fix this issue
     cur_arch = ti.lang.impl.get_runtime().prog.config().arch
     if cur_arch == ti.cuda and ti.lang.impl.get_cuda_compute_capability() < 70:
@@ -358,12 +354,12 @@ def test_ref_atomic():
         a += a
 
     @ti.kernel
-    def bar() -> ti.f32:
+    def bar():
         a = 5.0
         foo(a)
-        return a
+        assert a == 10.0
 
-    assert bar() == 10.0
+    bar()
 
 
 @test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)


### PR DESCRIPTION
Issue: #602 

Assuming `FuncCallStmt` can load or modify any address. I will write a pass to find out all the addresses loaded and modified in a `FuncCallStmt` later.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cf4766c</samp>

### Summary
📞🔧🧪

<!--
1.  📞 for enhancing the control flow graph analysis and optimization to support function calls.
2.  🔧 for improving the simplification of basic blocks by removing a redundant check and adding a condition for function call statements.
3.  🧪 for testing some experimental features of taichi, such as template arguments and assertions in kernels.
-->
This pull request enhances the control flow graph analysis and optimization to support function calls in taichi kernels. It also improves the simplification of basic blocks and tests some experimental features of taichi. The main files affected are `taichi/ir/control_flow_graph.cpp`, `taichi/transforms/simplify.cpp`, and `tests/python/test_function.py`.

> _We unleash the power of `function calls`_
> _We optimize the `control flow graph`_
> _We test the limits of `taichi`'s core_
> _We simplify the `basic blocks` of wrath_

### Walkthrough
*  Add support for function calls in control flow graph analysis and optimization ([link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-837b90142d1730f6a3ab20c91f1f35c95335ef82a021c74fd4dbdb05ff0e164fR220-R222), [link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-837b90142d1730f6a3ab20c91f1f35c95335ef82a021c74fd4dbdb05ff0e164fL979-R983))
*  Prevent simplifying function call statements that may have side effects or modify global variables ([link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edL98-L100), [link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edR107-R108))
*  Test the experimental template feature that allows passing arguments to functions as template parameters ([link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-d6f5c74e17462c8ff96d5bba06ebf81d16c015ca667fa945513a80be17bef017L158-R166), [link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-d6f5c74e17462c8ff96d5bba06ebf81d16c015ca667fa945513a80be17bef017L175-R177))
*  Test the support for assertions inside kernels ([link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-d6f5c74e17462c8ff96d5bba06ebf81d16c015ca667fa945513a80be17bef017L327-L329), [link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-d6f5c74e17462c8ff96d5bba06ebf81d16c015ca667fa945513a80be17bef017L335-R344), [link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-d6f5c74e17462c8ff96d5bba06ebf81d16c015ca667fa945513a80be17bef017L361-R362))
*  Remove a redundant check for function call statements in `BasicBlockSimplify` ([link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edL98-L100))
*  Remove a comment that is no longer relevant in `test_function.py` ([link](https://github.com/taichi-dev/taichi/pull/8139/files?diff=unified&w=0#diff-d6f5c74e17462c8ff96d5bba06ebf81d16c015ca667fa945513a80be17bef017L327-L329))

