### PR TITLE
[metal] Support i64 with MSL2.3.0

### DIFF
--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -82,6 +82,11 @@ MetalPipeline *MetalPipeline::create(const MetalDevice &device,
     // Subgroups are only supported in Metal 2.1 and up.
     options.set_msl_version(2, 1, 0);
   }
+  bool feature_64_bit_integer_math =
+      caps.contains(DeviceCapability::spirv_has_int64);
+  if (feature_64_bit_integer_math) {
+    options.set_msl_version(2, 3, 0);
+  }
 
   compiler.set_msl_options(options);
 

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -38,6 +38,17 @@ def test_numpy_f64():
     with_data_type(np.float64)
 
 
+@test_utils.test(arch=ti.metal)
+def test_np_i64_metal():
+    @ti.kernel
+    def arange(x: ti.types.ndarray(ti.i64, ndim=1)):
+        for i in x:
+            x[i] = i
+
+    xx = np.array([1, 2, 3, 4, 5])  # by default it's int64
+    arange(xx)
+
+
 @test_utils.test()
 def test_numpy_i32():
     with_data_type(np.int32)


### PR DESCRIPTION
Fixes #8132 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59bbfd7</samp>

This pull request adds support for 64-bit integers on Metal devices by setting the Metal shading language version to 2.3.0 and adding a test case for using numpy arrays with 64-bit integers.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 59bbfd7</samp>

* Enable 64-bit integer support on Metal devices by setting the shading language version to 2.3.0 if supported ([link](https://github.com/taichi-dev/taichi/pull/8140/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bR85-R89) in `metal_device.mm`)
