### PR TITLE
[lang] Enforce dtype check for numpy arrays

### DIFF
--- a/docs/lang/articles/basic/ndarray.md
+++ b/docs/lang/articles/basic/ndarray.md
@@ -142,7 +142,7 @@ add_one(arr_np) # arr_np is updated by taichi kernel
 To feed a PyTorch tensor:
 
 ```python cont
-arr_torch = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], device='cuda:0')
+arr_torch = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.float, device='cuda:0')
 add_one(arr_torch) # arr_torch is updated by taichi kernel
 ```
 

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -399,6 +399,7 @@ class TaichiCallableTemplateMapper:
                 raise TaichiRuntimeTypeError(f"Invalid argument into ti.types.ndarray(), got {arg}")
             shape = tuple(shape)
             element_shape = ()
+            dtype = to_taichi_type(arg.dtype)
             if isinstance(anno.dtype, MatrixType):
                 if anno.ndim is not None:
                     if len(shape) != anno.dtype.ndim + anno.ndim:
@@ -421,13 +422,18 @@ class TaichiCallableTemplateMapper:
                     )
             elif anno.dtype is not None:
                 # User specified scalar dtype
+                if anno.dtype != dtype:
+                    raise ValueError(
+                        f"Invalid argument into ti.types.ndarray() - required array has dtype={anno.dtype.to_string()}, "
+                        f"but the argument has dtype={dtype.to_string()}"
+                    )
+
                 if anno.ndim is not None and len(shape) != anno.ndim:
                     raise ValueError(
                         f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim}, "
                         f"but the argument has {len(shape)} dimensions"
                     )
             needs_grad = getattr(arg, "requires_grad", False) if anno.needs_grad is None else anno.needs_grad
-            dtype = to_taichi_type(arg.dtype)
             element_type = (
                 _ti_core.get_type_factory_instance().get_tensor_type(element_shape, dtype)
                 if len(element_shape) != 0

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -301,3 +301,15 @@ def test_numpy_ndarray_dim_check():
         match=r"Invalid argument into ti.types.ndarray\(\) - required array has ndim=2, but the argument has 4 dimensions",
     ):
         add_one_scalar(a)
+
+
+@test_utils.test()
+def test_numpy_dtype_mismatch():
+    @ti.kernel
+    def arange(x: ti.types.ndarray(ti.i32, ndim=1)):
+        for i in x:
+            x[i] = i
+
+    xx = np.array([1, 2, 3, 4, 5], dtype=np.int64)  # by default it's int64
+    with pytest.raises(ValueError, match=r"Invalid argument into ti.types.ndarray\(\) - required array has dtype="):
+        arange(xx)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2640c91</samp>

Improve type checking of numpy array arguments to Taichi kernels. Add a test case to `test_numpy.py` to verify the error handling.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2640c91</samp>

*  Add dtype checking for numpy arrays passed to Taichi kernels ([link](https://github.com/taichi-dev/taichi/pull/8141/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R402), [link](https://github.com/taichi-dev/taichi/pull/8141/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R425-R430), [link](https://github.com/taichi-dev/taichi/pull/8141/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L430), [link](https://github.com/taichi-dev/taichi/pull/8141/files?diff=unified&w=0#diff-dea0dd59910c752726a992240fe0d79384723802695913b349b26ac26de21583R304-R315))
