### PR TITLE
[misc] Add FrontendAllocaStmt::is_shared into offline cache key

### DIFF
--- a/taichi/analysis/gen_offline_cache_key.cpp
+++ b/taichi/analysis/gen_offline_cache_key.cpp
@@ -301,6 +301,7 @@ class ASTSerializer : public IRVisitor, public ExpressionVisitor {
   void visit(FrontendAllocaStmt *stmt) override {
     emit(StmtOpCode::FrontendAllocaStmt);
     emit(stmt->ident);
+    emit(stmt->is_shared);
   }
 
   void visit(FrontendAssertStmt *stmt) override {


### PR DESCRIPTION
Issue: #4001

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b155c3</samp>

Emit `is_shared` flag of global pointers to serialized AST in `gen_offline_cache_key.cpp`. This enhances the offline caching key generation for Taichi kernels.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b155c3</samp>

*  Emit `is_shared` flag of `GlobalPtrStmt` to serialized AST ([link](https://github.com/taichi-dev/taichi/pull/8145/files?diff=unified&w=0#diff-8a18339a0c1054e7009398661bce75a53199c889f72320c273da98bdb2014f1cR304))
