### PR TITLE
[ci] Add games201 in release tests

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -52,6 +52,7 @@ EOF
     pushd repos
     git clone --depth=1 https://github.com/taichi-dev/quantaichi
     git clone --depth=1 https://github.com/taichi-dev/difftaichi
+    git clone --depth=1 https://github.com/taichi-dev/games201
     popd
 
     pushd repos/difftaichi

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -94,6 +94,7 @@ if ("$env:TI_RUN_RELEASE_TESTS" -eq "1") {
     Push-Location repos
     Invoke git clone --depth=1 https://github.com/taichi-dev/quantaichi
     Invoke git clone --depth=1 https://github.com/taichi-dev/difftaichi
+    Invoke git clone --depth=1 https://github.com/taichi-dev/games201
     Pop-Location
     Push-Location repos/difftaichi
     Invoke pip install -r requirements.txt


### PR DESCRIPTION
Issue: #5741

see more, https://github.com/taichi-dev/taichi-release-tests/pull/8

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ebd030</samp>

This pull request updates the test scripts for Linux, macOS, and Windows to clone the `games201` repository, which provides additional examples and tests for the taichi graphics engine.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ebd030</samp>

*  Clone the games201 repository for the taichi graphics engine examples and tests ([link](https://github.com/taichi-dev/taichi/pull/8148/files?diff=unified&w=0#diff-34fa2bad51121dca1ec0d22993a5d102611b68b6466589d40a651b955ea67ca3R55), [link](https://github.com/taichi-dev/taichi/pull/8148/files?diff=unified&w=0#diff-1e56d5e9fca9a2bd938d65c6735714636f8d236462ae1167ca97e3c1a166cf54R97))
