### PR TITLE
[ci] Add /rerun-failed

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -18,6 +18,7 @@ jobs:
         commands: |
           rebase
           rerun
+          rerun-failed
 
     - name: Slash Command Dispatch - Repo - Triage
       uses: peter-evans/slash-command-dispatch@v3


### PR DESCRIPTION
Issue: Fix #5371

see more, https://github.com/taichi-dev/ci_workflows/pull/8

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 873fa3e</samp>

Added `rerun-failed` keyword to `issue_comment` trigger of GitHub Actions workflow. This allows easy rerunning of failed checks on pull requests by commenting the keyword.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 873fa3e</samp>

* Add `rerun-failed` keyword to trigger workflow by comment ([link](https://github.com/taichi-dev/taichi/pull/8152/files?diff=unified&w=0#diff-97baf80168990eaa9447c249832412086a6bd9da3fa526b7f6cceb8dd3e51c59R21))
