### PR TITLE
[aot] Fix unused args in cppgen

### DIFF
--- a/python/taichi/aot/conventions/gfxruntime140/dr.py
+++ b/python/taichi/aot/conventions/gfxruntime140/dr.py
@@ -42,6 +42,7 @@ class ArgumentAttributes:
         # Kernels are always launched by indexed arguments and this is for
         # debugging and header generation only.
         name = j["name"] if "name" in j and len(j["name"]) > 0 else None
+        ptype = j["ptype"] if "ptype" in j else None
 
         self.dtype: int = int(dtype)
         self.element_shape: List[int] = [int(x) for x in element_shape]
@@ -52,6 +53,7 @@ class ArgumentAttributes:
         self.offset_in_mem: int = int(offset_in_mem)
         self.stride: int = int(stride)
         self.name: Optional[str] = str(name) if name is not None else None
+        self.ptype: Optional[int] = int(ptype) if ptype is not None else None
 
 
 @json_data_model

--- a/taichi/codegen/spirv/kernel_utils.cpp
+++ b/taichi/codegen/spirv/kernel_utils.cpp
@@ -74,7 +74,7 @@ KernelContextAttributes::KernelContextAttributes(
     }
     aa.element_shape = ka.element_shape;
     aa.field_dim = ka.total_dim - ka.element_shape.size();
-
+    aa.ptype = ka.ptype;
     arg_attribs_vec_.push_back(aa);
   }
   // TODO:

--- a/taichi/codegen/spirv/kernel_utils.h
+++ b/taichi/codegen/spirv/kernel_utils.h
@@ -159,6 +159,7 @@ class KernelContextAttributes {
     // Only used with textures. Sampled textures always have unknown format;
     // while RW textures always have a valid format.
     BufferFormat format{BufferFormat::unknown};
+    ParameterType ptype{ParameterType::kUnknown};
 
     TI_IO_DEF(name,
               stride,
@@ -168,7 +169,8 @@ class KernelContextAttributes {
               is_array,
               element_shape,
               field_dim,
-              format);
+              format,
+              ptype);
   };
 
  public:

--- a/taichi/inc/constants.h
+++ b/taichi/inc/constants.h
@@ -62,6 +62,15 @@ T taichi_union_cast(G g) {
   return taichi_union_cast_with_different_sizes<T>(g);
 }
 
+enum class ParameterType {
+  kScalar,
+  kNdarray,
+  kTexture,
+  kRWTexture,
+  kTensor,
+  kUnknown
+};
+
 enum class ExternalArrayLayout { kAOS, kSOA, kNull };
 
 enum class AutodiffMode { kForward, kReverse, kNone, kCheckAutodiffValid };

--- a/taichi/program/callable.cpp
+++ b/taichi/program/callable.cpp
@@ -11,6 +11,7 @@ Callable::~Callable() = default;
 int Callable::insert_scalar_param(const DataType &dt, const std::string &name) {
   parameter_list.emplace_back(dt->get_compute_type(), /*is_array=*/false);
   parameter_list.back().name = name;
+  parameter_list.back().ptype = ParameterType::kScalar;
   return (int)parameter_list.size() - 1;
 }
 
@@ -48,6 +49,7 @@ int Callable::insert_ndarray_param(const DataType &dt,
                               /*size=*/0, ndim + element_shape.size(),
                               element_shape, BufferFormat::unknown, needs_grad);
   parameter_list.back().name = name;
+  parameter_list.back().ptype = ParameterType::kNdarray;
   return (int)parameter_list.size() - 1;
 }
 
@@ -59,6 +61,7 @@ int Callable::insert_texture_param(int total_dim, const std::string &name) {
   parameter_list.emplace_back(type, /*is_array=*/true, 0, total_dim,
                               std::vector<int>{});
   parameter_list.back().name = name;
+  parameter_list.back().ptype = ParameterType::kTexture;
   return (int)parameter_list.size() - 1;
 }
 
@@ -77,6 +80,7 @@ int Callable::insert_rw_texture_param(int total_dim,
   parameter_list.emplace_back(type, /*is_array=*/true, 0, total_dim,
                               std::vector<int>{}, format);
   parameter_list.back().name = name;
+  parameter_list.back().ptype = ParameterType::kRWTexture;
   return (int)parameter_list.size() - 1;
 }
 

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "taichi/inc/constants.h"
 #include "taichi/rhi/device.h"
 #include "taichi/util/lang_util.h"
 
@@ -19,12 +19,19 @@ class TI_DLL_EXPORT CallableBase {
     BufferFormat format{BufferFormat::unknown};
     bool needs_grad{false};  // TODO: reorder for better alignment
     std::vector<int> element_shape{};
-    TI_IO_DEF(is_array, total_dim, format, dt_, needs_grad, element_shape);
+    ParameterType ptype{ParameterType::kUnknown};
+    TI_IO_DEF(is_array,
+              total_dim,
+              format,
+              dt_,
+              needs_grad,
+              element_shape,
+              ptype);
 
     bool operator==(const Parameter &o) const {
       return is_array == o.is_array && total_dim == o.total_dim &&
              format == o.format && dt_ == o.dt_ && needs_grad == o.needs_grad &&
-             element_shape == o.element_shape;
+             element_shape == o.element_shape && ptype == o.ptype;
     }
 
     /* [arguments with TensorType]

--- a/tests/python/test_aot.py
+++ b/tests/python/test_aot.py
@@ -65,12 +65,14 @@ def test_aot_bind_id():
                     assert args[0]["is_array"] == False
                     assert args[0]["index"] == 0
                     assert args[0]["dtype"] == 1
+                    assert args[0]["ptype"] == 0
 
                     assert args[1]["is_array"] == True
                     assert args[1]["field_dim"] == 2
                     assert args[1]["index"] == 1
                     assert args[1]["dtype"] == 5
                     assert args[1]["element_shape"] == [2]
+                    assert args[1]["ptype"] == 1
 
 
 @test_utils.test(arch=[ti.opengl, ti.vulkan])


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee6aae0</samp>

This pull request adds support for different parameter types for AOT kernels, such as scalar, ndarray, texture, and read-write texture. It introduces a new enum class `ParameterType` and a new field `ptype` in various classes and structs to store and access the parameter type information. It also modifies the code generation and the runtime conventions for AOT kernels to handle different parameter types. It updates the tests to verify the new feature.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee6aae0</samp>

*  Add a new enum class `ParameterType` to define the possible values for the parameter type of an argument, such as scalar, ndarray, texture, etc. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-1ca2451b2f3369712eef917f3b9930f71283db50ac1780e3e34aeb15fed85e37R50-R57), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-ecd477a48a0e074ded288ee4d6f122e40389d6afa29198630550b406c0bfcd19R65-R73))
*  Add a new field `ptype` to the `Parameter` struct and the `AttribsBase` struct, which indicates the parameter type of the parameter or the argument attribute. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-1bd5e24bdf3897dcc8e39382715a141978a19653c4dc99364e9425b3cb5e48abR162), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-e914f7cb94f429034d998974d95d57f6e09de2dadaed4c621e122ec403c9bb22L22-R34))
*  Modify the constructors of the `Parameter` struct and the `AttribsBase` struct to include the `ptype` field and assign it to the corresponding argument. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-1bd5e24bdf3897dcc8e39382715a141978a19653c4dc99364e9425b3cb5e48abL171-R173), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-e914f7cb94f429034d998974d95d57f6e09de2dadaed4c621e122ec403c9bb22L22-R34))
*  Modify the `insert_scalar_param`, `insert_ndarray_param`, `insert_texture_param`, and `insert_rw_texture_param` functions to assign the appropriate `ParameterType` value to the `ptype` field of the `Parameter` object. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-8505840874bba49dcec6e2a71c82e0fea5cfc9ab1f0194836f022fc5a8fa2155R14), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-8505840874bba49dcec6e2a71c82e0fea5cfc9ab1f0194836f022fc5a8fa2155R52), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-8505840874bba49dcec6e2a71c82e0fea5cfc9ab1f0194836f022fc5a8fa2155R64), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-8505840874bba49dcec6e2a71c82e0fea5cfc9ab1f0194836f022fc5a8fa2155R83))
*  Modify the `KernelContextAttributes::add_array` method to assign the `ptype` field of the `Kernel::Arg` object to the `ptype` field of the `AttribsBase` object. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-0933633c5350c8a0e64f59046da02dcafcabe69694bb200d938b8bd415bcbca0L77-R77))
*  Modify the `from_dr_kernel` function to parse the `ptype` attribute of each argument attribute, and create the corresponding `Argument` subclass based on the parameter type, such as `ArgumentScalar`, `ArgumentNdArray`, `ArgumentTexture`, etc. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-1ca2451b2f3369712eef917f3b9930f71283db50ac1780e3e34aeb15fed85e37L266-R297))
*  Add a line to the `__init__` method of the `ArgumentAttributes` class to parse the `ptype` field from the JSON object, and assign it to the `self.ptype` attribute. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-cbaba00c0691d883383ed429835dfde47b0b5c545b5990c3c75d47a8d63c1716R45), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-cbaba00c0691d883383ed429835dfde47b0b5c545b5990c3c75d47a8d63c1716R56))
*  Add a comment to the `from_dr_kernel` function to indicate that the old logic of checking the `is_array` attribute of each argument attribute is kept for backward compatibility, but can be broken if necessary. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-1ca2451b2f3369712eef917f3b9930f71283db50ac1780e3e34aeb15fed85e37L286-R316))
*  Modify the `test_aot_bind_id` function to add assertions to check that the first argument of the kernel has the parameter type scalar, and the second argument of the kernel has the parameter type ndarray. ([link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-a06cb7090d38a637444d3279f6f3df218ef3eb9f97af36c5060b1669c1ad5eceR68), [link](https://github.com/taichi-dev/taichi/pull/8154/files?diff=unified&w=0#diff-a06cb7090d38a637444d3279f6f3df218ef3eb9f97af36c5060b1669c1ad5eceR75))
