### PR TITLE
[ci] Add taichiCourse01 & marching_squares release tests

### DIFF
--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -41,7 +41,7 @@ if [ "$TI_RUN_RELEASE_TESTS" == "1" ]; then
     python3 -m pip install PyYAML
     git clone https://github.com/taichi-dev/taichi-release-tests
     pushd taichi-release-tests
-    git checkout 20230608
+    git checkout 20230619
     mkdir -p repos/taichi/python/taichi
     EXAMPLES=$(cat <<EOF | python3 | tail -n 1
 import taichi.examples
@@ -54,38 +54,11 @@ EOF
     git clone --depth=1 https://github.com/taichi-dev/difftaichi
     git clone --depth=1 https://github.com/taichi-dev/games201
     git clone --depth=1 https://github.com/taichiCourse01/--Galaxy
-    git clone --depth=1 https://github.com/taichiCourse01/--Diffuse
     git clone --depth=1 https://github.com/taichiCourse01/--Shadertoys
     git clone --depth=1 https://github.com/taichiCourse01/taichi_ray_tracing
-    git clone --depth=1 https://github.com/taichiCourse01/--Deformables
-    git clone --depth=1 https://github.com/taichiCourse01/taichi_sph
     popd
 
     pushd repos/difftaichi
-    pip install -r requirements.txt
-    popd
-
-    pushd repos/--Galaxy
-    pip install -r requirements.txt
-    popd
-
-    pushd repos/--Diffuse
-    pip install -r requirements.txt
-    popd
-
-    pushd repos/--Shadertoys
-    pip install -r requirements.txt
-    popd
-
-    pushd repos/taichi_ray_tracing
-    pip install -r requirements.txt
-    popd
-
-    pushd repos/--Deformables
-    pip install -r requirements.txt
-    popd
-
-    pushd repos/taichi_sph
     pip install -r requirements.txt
     popd
 

--- a/.github/workflows/scripts/unix_test.sh
+++ b/.github/workflows/scripts/unix_test.sh
@@ -41,7 +41,7 @@ if [ "$TI_RUN_RELEASE_TESTS" == "1" ]; then
     python3 -m pip install PyYAML
     git clone https://github.com/taichi-dev/taichi-release-tests
     pushd taichi-release-tests
-    git checkout 20230607
+    git checkout 20230608
     mkdir -p repos/taichi/python/taichi
     EXAMPLES=$(cat <<EOF | python3 | tail -n 1
 import taichi.examples
@@ -53,9 +53,39 @@ EOF
     git clone --depth=1 https://github.com/taichi-dev/quantaichi
     git clone --depth=1 https://github.com/taichi-dev/difftaichi
     git clone --depth=1 https://github.com/taichi-dev/games201
+    git clone --depth=1 https://github.com/taichiCourse01/--Galaxy
+    git clone --depth=1 https://github.com/taichiCourse01/--Diffuse
+    git clone --depth=1 https://github.com/taichiCourse01/--Shadertoys
+    git clone --depth=1 https://github.com/taichiCourse01/taichi_ray_tracing
+    git clone --depth=1 https://github.com/taichiCourse01/--Deformables
+    git clone --depth=1 https://github.com/taichiCourse01/taichi_sph
     popd
 
     pushd repos/difftaichi
+    pip install -r requirements.txt
+    popd
+
+    pushd repos/--Galaxy
+    pip install -r requirements.txt
+    popd
+
+    pushd repos/--Diffuse
+    pip install -r requirements.txt
+    popd
+
+    pushd repos/--Shadertoys
+    pip install -r requirements.txt
+    popd
+
+    pushd repos/taichi_ray_tracing
+    pip install -r requirements.txt
+    popd
+
+    pushd repos/--Deformables
+    pip install -r requirements.txt
+    popd
+
+    pushd repos/taichi_sph
     pip install -r requirements.txt
     popd
 

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -88,7 +88,7 @@ if ("$env:TI_RUN_RELEASE_TESTS" -eq "1") {
     Invoke pip install PyYAML
     Invoke git clone https://github.com/taichi-dev/taichi-release-tests
     Push-Location taichi-release-tests
-    Invoke git checkout 20230608
+    Invoke git checkout 20230619
     mkdir -p repos/taichi/python/taichi
     $EXAMPLES = & python -c 'import taichi.examples as e; print(e.__path__._path[0])' | Select-Object -Last 1
     Push-Location repos
@@ -96,31 +96,10 @@ if ("$env:TI_RUN_RELEASE_TESTS" -eq "1") {
     Invoke git clone --depth=1 https://github.com/taichi-dev/difftaichi
     Invoke git clone --depth=1 https://github.com/taichi-dev/games201
     Invoke git clone --depth=1 https://github.com/taichiCourse01/--Galaxy
-    Invoke git clone --depth=1 https://github.com/taichiCourse01/--Diffuse
     Invoke git clone --depth=1 https://github.com/taichiCourse01/--Shadertoys
     Invoke git clone --depth=1 https://github.com/taichiCourse01/taichi_ray_tracing
-    Invoke git clone --depth=1 https://github.com/taichiCourse01/--Deformables
-    Invoke git clone --depth=1 https://github.com/taichiCourse01/taichi_sph
     Pop-Location
     Push-Location repos/difftaichi
-    Invoke pip install -r requirements.txt
-    Pop-Location
-    Push-Location repos/--Galaxy
-    Invoke pip install -r requirements.txt
-    Pop-Location
-    Push-Location repos/--Diffuse
-    Invoke pip install -r requirements.txt
-    Pop-Location
-    Push-Location repos/--Shadertoys
-    Invoke pip install -r requirements.txt
-    Pop-Location
-    Push-Location repos/taichi_ray_tracing
-    Invoke pip install -r requirements.txt
-    Pop-Location
-    Push-Location repos/--Deformables
-    Invoke pip install -r requirements.txt
-    Pop-Location
-    Push-Location repos/taichi_sph
     Invoke pip install -r requirements.txt
     Pop-Location
     Invoke python run.py --log=DEBUG --runners 1 timelines

--- a/.github/workflows/scripts/win_test.ps1
+++ b/.github/workflows/scripts/win_test.ps1
@@ -88,15 +88,39 @@ if ("$env:TI_RUN_RELEASE_TESTS" -eq "1") {
     Invoke pip install PyYAML
     Invoke git clone https://github.com/taichi-dev/taichi-release-tests
     Push-Location taichi-release-tests
-    Invoke git checkout 20230607
+    Invoke git checkout 20230608
     mkdir -p repos/taichi/python/taichi
     $EXAMPLES = & python -c 'import taichi.examples as e; print(e.__path__._path[0])' | Select-Object -Last 1
     Push-Location repos
     Invoke git clone --depth=1 https://github.com/taichi-dev/quantaichi
     Invoke git clone --depth=1 https://github.com/taichi-dev/difftaichi
     Invoke git clone --depth=1 https://github.com/taichi-dev/games201
+    Invoke git clone --depth=1 https://github.com/taichiCourse01/--Galaxy
+    Invoke git clone --depth=1 https://github.com/taichiCourse01/--Diffuse
+    Invoke git clone --depth=1 https://github.com/taichiCourse01/--Shadertoys
+    Invoke git clone --depth=1 https://github.com/taichiCourse01/taichi_ray_tracing
+    Invoke git clone --depth=1 https://github.com/taichiCourse01/--Deformables
+    Invoke git clone --depth=1 https://github.com/taichiCourse01/taichi_sph
     Pop-Location
     Push-Location repos/difftaichi
+    Invoke pip install -r requirements.txt
+    Pop-Location
+    Push-Location repos/--Galaxy
+    Invoke pip install -r requirements.txt
+    Pop-Location
+    Push-Location repos/--Diffuse
+    Invoke pip install -r requirements.txt
+    Pop-Location
+    Push-Location repos/--Shadertoys
+    Invoke pip install -r requirements.txt
+    Pop-Location
+    Push-Location repos/taichi_ray_tracing
+    Invoke pip install -r requirements.txt
+    Pop-Location
+    Push-Location repos/--Deformables
+    Invoke pip install -r requirements.txt
+    Pop-Location
+    Push-Location repos/taichi_sph
     Invoke pip install -r requirements.txt
     Pop-Location
     Invoke python run.py --log=DEBUG --runners 1 timelines


### PR DESCRIPTION
Issue: #5741 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc9de83</samp>

This pull request adds tests for more taichi examples and features from external repositories in `taichiCourse01`. It updates the test scripts for both Unix and Windows platforms to clone and install the necessary dependencies and run the tests.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bc9de83</samp>

*  Add six git clone commands to download additional repositories from taichiCourse01 in both `unix_test.sh` and `win_test.ps1` scripts ([link](https://github.com/taichi-dev/taichi/pull/8157/files?diff=unified&w=0#diff-34fa2bad51121dca1ec0d22993a5d102611b68b6466589d40a651b955ea67ca3R56-R61), [link](https://github.com/taichi-dev/taichi/pull/8157/files?diff=unified&w=0#diff-1e56d5e9fca9a2bd938d65c6735714636f8d236462ae1167ca97e3c1a166cf54L98-R125))
*  Add six pairs of pushd and popd commands to install the requirements for each of the cloned repositories using pip in both `unix_test.sh` and `win_test.ps1` scripts ([link](https://github.com/taichi-dev/taichi/pull/8157/files?diff=unified&w=0#diff-34fa2bad51121dca1ec0d22993a5d102611b68b6466589d40a651b955ea67ca3R68-R91), [link](https://github.com/taichi-dev/taichi/pull/8157/files?diff=unified&w=0#diff-1e56d5e9fca9a2bd938d65c6735714636f8d236462ae1167ca97e3c1a166cf54L98-R125))
*  Modify the existing code in `win_test.ps1` to match the changes in `unix_test.sh` for running the tests on different platforms ([link](https://github.com/taichi-dev/taichi/pull/8157/files?diff=unified&w=0#diff-1e56d5e9fca9a2bd938d65c6735714636f8d236462ae1167ca97e3c1a166cf54L98-R125))
