### PR TITLE
[Error] Add option to print full traceback in Python

### DIFF
--- a/python/taichi/lang/ast/ast_transformer_utils.py
+++ b/python/taichi/lang/ast/ast_transformer_utils.py
@@ -26,6 +26,8 @@ class Builder:
             with impl.get_runtime().src_info_guard(info):
                 return method(ctx, node)
         except Exception as e:
+            if impl.get_runtime().print_full_traceback:
+                raise e
             if ctx.raised or not isinstance(node, (ast.stmt, ast.expr)):
                 raise e.with_traceback(None)
             ctx.raised = True

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -810,6 +810,8 @@ class Kernel:
             prog.launch_kernel(compiled_kernel_data, launch_ctx)
         except Exception as e:
             e = handle_exception_from_cpp(e)
+            if impl.get_runtime().print_full_traceback:
+                raise e
             raise e from None
 
         ret = None
@@ -947,6 +949,8 @@ def _kernel_impl(_func, level_of_class_stackframe, verbose=False):
             try:
                 return primal(*args, **kwargs)
             except (TaichiCompilationError, TaichiRuntimeError) as e:
+                if impl.get_runtime().print_full_traceback:
+                    raise e
                 raise type(e)("\n" + str(e)) from None
 
         wrapped.grad = adjoint
@@ -1006,6 +1010,8 @@ class _BoundedDifferentiableMethod:
                 return self._primal(*args, **kwargs)
             return self._primal(self._kernel_owner, *args, **kwargs)
         except (TaichiCompilationError, TaichiRuntimeError) as e:
+            if impl.get_runtime().print_full_traceback:
+                raise e
             raise type(e)("\n" + str(e)) from None
 
     def grad(self, *args, **kwargs):

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -263,6 +263,7 @@ class _SpecialConfig:
         self.log_level = "info"
         self.gdb_trigger = False
         self.short_circuit_operators = True
+        self.print_full_traceback = False
 
 
 def prepare_sandbox():
@@ -414,6 +415,7 @@ def init(
     env_spec.add("log_level", str)
     env_spec.add("gdb_trigger")
     env_spec.add("short_circuit_operators")
+    env_spec.add("print_full_traceback")
 
     # compiler configurations (ti.cfg):
     for key in dir(cfg):
@@ -433,6 +435,7 @@ def init(
     if not _test_mode:
         _ti_core.set_core_trigger_gdb_when_crash(spec_cfg.gdb_trigger)
         impl.get_runtime().short_circuit_operators = spec_cfg.short_circuit_operators
+        impl.get_runtime().print_full_traceback = spec_cfg.print_full_traceback
         _logging.set_logging_level(spec_cfg.log_level.lower())
 
     # select arch (backend):


### PR DESCRIPTION
Issue: #8158 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 118930b</samp>

Add a feature to show full Python tracebacks for Taichi kernel errors. Use the `print_full_traceback` flag in the `_SpecialConfig` class and the `TI_PRINT_FULL_TRACEBACK` environment variable to enable it. Modify `kernel_impl.py`, `misc.py`, and `ast_transformer_utils.py` to re-raise the exceptions with the full traceback.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 118930b</samp>

*  Add a new feature to print the full Python traceback when an error occurs in the Taichi runtime, controlled by a flag `print_full_traceback` ([link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-a028ff808aee30ba7b2c634414a762b6178d6608ae50cf636a2cab5b2af0da62R266), [link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-a028ff808aee30ba7b2c634414a762b6178d6608ae50cf636a2cab5b2af0da62R418), [link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-a028ff808aee30ba7b2c634414a762b6178d6608ae50cf636a2cab5b2af0da62R438))
*  Check the flag `print_full_traceback` in the `ast_transformer_utils.py`, `kernel_impl.py` and re-raise the exception if it is True, instead of suppressing the Python traceback and only showing the Taichi traceback ([link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-3c4fc72604c650382997de2541e648ef88ee8f608a9e3d3ebbe7e6a74cb2eec8R29-R30), [link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R813-R814), [link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R952-R953), [link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R1013-R1014))
*  Allow the user to set the flag `print_full_traceback` by using the environment variable `TI_PRINT_FULL_TRACEBACK` ([link](https://github.com/taichi-dev/taichi/pull/8160/files?diff=unified&w=0#diff-a028ff808aee30ba7b2c634414a762b6178d6608ae50cf636a2cab5b2af0da62R418))
