### PR TITLE
[Lang] Handle MatrixPtrStmt for uniquely_accessed_pointers()

### DIFF
--- a/taichi/ir/analysis.h
+++ b/taichi/ir/analysis.h
@@ -105,9 +105,11 @@ gather_snode_read_writes(IRNode *root);
 std::vector<Stmt *> gather_statements(IRNode *root,
                                       const std::function<bool(Stmt *)> &test);
 void gather_uniquely_accessed_bit_structs(IRNode *root, AnalysisManager *amgr);
-std::pair<std::unordered_map<const SNode *, GlobalPtrStmt *>,
-          std::unordered_map<int, ExternalPtrStmt *>>
+std::tuple<std::unordered_map<const SNode *, GlobalPtrStmt *>,
+           std::unordered_map<int, ExternalPtrStmt *>,
+           std::unordered_set<MatrixPtrStmt *>>
 gather_uniquely_accessed_pointers(IRNode *root);
+
 std::unique_ptr<std::unordered_set<AtomicOpStmt *>> gather_used_atomics(
     IRNode *root);
 stmt_refs get_load_pointers(Stmt *load_stmt, bool get_aliased = false);

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -14,6 +14,7 @@ class DemoteAtomics : public BasicStmtVisitor {
  private:
   std::unordered_map<const SNode *, GlobalPtrStmt *> loop_unique_ptr_;
   std::unordered_map<int, ExternalPtrStmt *> loop_unique_arr_ptr_;
+  std::unordered_set<MatrixPtrStmt *> loop_unique_matrix_ptr_;
 
  public:
   using BasicStmtVisitor::visit;
@@ -48,6 +49,10 @@ class DemoteAtomics : public BasicStmtVisitor {
         } else if (stmt->dest->is<MatrixPtrStmt>() &&
                    stmt->dest->as<MatrixPtrStmt>()
                        ->origin->is<GlobalPtrStmt>()) {
+          if (loop_unique_matrix_ptr_.find(stmt->as<MatrixPtrStmt>()) ==
+              loop_unique_matrix_ptr_.end()) {
+            return;
+          }
           is_global_ptr_stmt = true;
           dest = stmt->dest->as<MatrixPtrStmt>()->origin->as<GlobalPtrStmt>();
         }
@@ -94,6 +99,10 @@ class DemoteAtomics : public BasicStmtVisitor {
         } else if (stmt->dest->is<MatrixPtrStmt>() &&
                    stmt->dest->as<MatrixPtrStmt>()
                        ->origin->is<ExternalPtrStmt>()) {
+          if (loop_unique_matrix_ptr_.find(stmt->as<MatrixPtrStmt>()) ==
+              loop_unique_matrix_ptr_.end()) {
+            return;
+          }
           is_external_ptr_stmt = true;
           dest_ptr =
               stmt->dest->as<MatrixPtrStmt>()->origin->as<ExternalPtrStmt>();
@@ -194,8 +203,10 @@ class DemoteAtomics : public BasicStmtVisitor {
         stmt->task_type == OffloadedTaskType::struct_for) {
       auto uniquely_accessed_pointers =
           irpass::analysis::gather_uniquely_accessed_pointers(stmt);
-      loop_unique_ptr_ = std::move(uniquely_accessed_pointers.first);
-      loop_unique_arr_ptr_ = std::move(uniquely_accessed_pointers.second);
+      loop_unique_ptr_ = std::move(std::get<0>(uniquely_accessed_pointers));
+      loop_unique_arr_ptr_ = std::move(std::get<1>(uniquely_accessed_pointers));
+      loop_unique_matrix_ptr_ =
+          std::move(std::get<2>(uniquely_accessed_pointers));
     }
     // We don't need to visit TLS/BLS prologues/epilogues.
     if (stmt->body) {

--- a/taichi/transforms/demote_atomics.cpp
+++ b/taichi/transforms/demote_atomics.cpp
@@ -49,7 +49,7 @@ class DemoteAtomics : public BasicStmtVisitor {
         } else if (stmt->dest->is<MatrixPtrStmt>() &&
                    stmt->dest->as<MatrixPtrStmt>()
                        ->origin->is<GlobalPtrStmt>()) {
-          if (loop_unique_matrix_ptr_.find(stmt->as<MatrixPtrStmt>()) ==
+          if (loop_unique_matrix_ptr_.find(stmt->dest->as<MatrixPtrStmt>()) ==
               loop_unique_matrix_ptr_.end()) {
             return;
           }
@@ -99,7 +99,7 @@ class DemoteAtomics : public BasicStmtVisitor {
         } else if (stmt->dest->is<MatrixPtrStmt>() &&
                    stmt->dest->as<MatrixPtrStmt>()
                        ->origin->is<ExternalPtrStmt>()) {
-          if (loop_unique_matrix_ptr_.find(stmt->as<MatrixPtrStmt>()) ==
+          if (loop_unique_matrix_ptr_.find(stmt->dest->as<MatrixPtrStmt>()) ==
               loop_unique_matrix_ptr_.end()) {
             return;
           }


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a10e15</samp>

This pull request improves the analysis and optimization of pointers that are uniquely accessed in a loop, especially for `MatrixPtrStmt`s, which are pointers to matrix elements. It modifies the `gather_uniquely_accessed_pointers` function and its return type, and updates the `CacheLoopInvariantGlobalVars` and `DemoteAtomics` transforms to handle `MatrixPtrStmt`s. These changes can enhance the performance of some kernels that use matrix operations.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a10e15</samp>

*  Add support for analyzing and optimizing `MatrixPtrStmt`s that are uniquely accessed in a loop ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eR107-R125), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eR198-R200), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eR209-R231), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eL281-R328), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eL300-R348), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eL375-R424), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-f6bc75768d2e24c782fefa45a7232d0e2b2bae091e697040e7f442a77d80ad45L108-R112))
  * Define a new method `is_matrix_ptr_indices_loop_unique` in `LoopUniqueStmtSearcher` to check the loop-invariance of the origin pointer and offset of a `MatrixPtrStmt` ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eR107-R125))
  * Add a new field `accessed_matrix_pointer_` in `UniquelyAccessedSNodeSearcher` to store the `MatrixPtrStmt`s that are uniquely accessed in the current offloaded task ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eR198-R200))
  * Override the `visit` method of `UniquelyAccessedSNodeSearcher` to handle `MatrixPtrStmt`s and check their origin pointer and indices using `LoopUniqueStmtSearcher` ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eR209-R231))
  * Change the return type of the `run` method of `UniquelyAccessedSNodeSearcher` and the `gather_uniquely_accessed_pointers` function in `irpass::analysis` from a pair of maps to a tuple of a map, a map, and a set, containing the uniquely accessed `GlobalPtrStmt`s, `ExternalPtrStmt`s, and `MatrixPtrStmt`s respectively ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eL281-R328), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eL300-R348), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b0f7fa0caaec4625e20b1a8e166aa5f16ee7b7071a7e3ecbb255e9c1bcc0cb2eL375-R424), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-f6bc75768d2e24c782fefa45a7232d0e2b2bae091e697040e7f442a77d80ad45L108-R112))
* Modify the `CacheLoopInvariantGlobalVars` and `DemoteAtomics` transforms to use the new analysis and optimize `MatrixPtrStmt`s that are loop-unique ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fR24), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fL37-R41), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fR69-R73), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fR103-R107), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R17), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R52-R55), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R102-R105), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14L197-R209))
  * Add a new field `loop_unique_matrix_ptr_` in both transforms to store the loop-unique `MatrixPtrStmt`s in the current offloaded task ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fR24), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R17))
  * Extract the loop-unique `MatrixPtrStmt`s from the third element of the tuple returned by `gather_uniquely_accessed_pointers` and assign them to the new field ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fL37-R41), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14L197-R209))
  * Check the `loop_unique_matrix_ptr_` set in the `is_offload_unique` method of both transforms and return false if the given `Stmt` is a `MatrixPtrStmt` that is not loop-unique ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fR69-R73), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-b811d49ff1b631b511a9e64d42aa77d96c85d8a1d55e2088e7dd5b4a1c3c6a2fR103-R107))
  * Check the `loop_unique_matrix_ptr_` set in the `visit` method of both transforms and skip the optimization if the given `Stmt` is a `MatrixPtrStmt` that is not loop-unique ([link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R52-R55), [link](https://github.com/taichi-dev/taichi/pull/8165/files?diff=unified&w=0#diff-5fe31716eccdda9061aa4d74f5ce21a276137f7e545014ed8d1ff09a1bfdee14R102-R105))
