### PR TITLE
[refactor] [ir] Change Block::parent_kernel to parent_callable

### DIFF
--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -124,15 +124,16 @@ Stmt::Stmt(const Stmt &stmt) : field_manager(this), fields_registered(false) {
   ret_type = stmt.ret_type;
 }
 
-Kernel *Stmt::get_kernel() const {
+Callable *Stmt::get_callable() const {
   Block *parent_block = parent;
-  if (parent_block->parent_kernel()) {
-    return parent_block->parent_kernel();
+  if (parent_block->parent_callable()) {
+    return parent_block->parent_callable();
   }
 
   if (parent_block->parent_stmt()) {
-    return parent_block->parent_stmt()->get_kernel();
+    return parent_block->parent_stmt()->get_callable();
   }
+  irpass::print((IRNode *)this);
 
   TI_ASSERT_INFO(false, "Stmt is not in a kernel.");
   return nullptr;
@@ -374,13 +375,13 @@ Stmt *Block::parent_stmt() const {
   return ptr == nullptr ? nullptr : *ptr;
 }
 
-Kernel *Block::parent_kernel() const {
-  auto ptr = std::get_if<Kernel *>(&parent_);
+Callable *Block::parent_callable() const {
+  auto ptr = std::get_if<Callable *>(&parent_);
   return ptr == nullptr ? nullptr : *ptr;
 }
 
-void Block::set_parent_kernel(Kernel *kernel) {
-  parent_ = kernel;
+void Block::set_parent_callable(Callable *callable) {
+  parent_ = callable;
 }
 
 void Block::set_parent_stmt(Stmt *stmt) {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -31,6 +31,7 @@ using pStmt = std::unique_ptr<Stmt>;
 class SNode;
 
 class Kernel;
+class Callable;
 struct CompileConfig;
 
 enum class SNodeAccessFlag : int { block_local, read_only, mesh_local };
@@ -453,7 +454,7 @@ class Stmt : public IRNode {
   virtual void replace_operand_with(Stmt *old_stmt, Stmt *new_stmt);
 
   IRNode *get_parent() const override;
-  virtual Kernel *get_kernel() const;
+  virtual Callable *get_callable() const;
 
   // returns the inserted stmt
   Stmt *insert_before_me(std::unique_ptr<Stmt> &&new_stmt);
@@ -502,7 +503,7 @@ class Stmt : public IRNode {
 
 class Block : public IRNode {
  public:
-  std::variant<Stmt *, Kernel *> parent_;
+  std::variant<Stmt *, Callable *> parent_;
   stmt_vector statements;
   stmt_vector trash_bin;
   std::vector<SNode *> stop_gradients;
@@ -511,17 +512,17 @@ class Block : public IRNode {
   // variables, and AllocaStmt for other variables.
   std::map<Identifier, Stmt *> local_var_to_stmt;
 
-  explicit Block(Kernel *kernel = nullptr) {
-    parent_ = kernel;
+  explicit Block(Callable *callable = nullptr) {
+    parent_ = callable;
   }
 
   Stmt *parent_stmt() const;
 
-  void set_parent_kernel(Kernel *kernel);
+  void set_parent_callable(Callable *callable);
 
   void set_parent_stmt(Stmt *stmt);
 
-  Kernel *parent_kernel() const;
+  Callable *parent_callable() const;
 
   Block *parent_block() const;
 

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -126,9 +126,9 @@ MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
 }
 
 bool MatrixPtrStmt::common_statement_eliminable() const {
-  Kernel *k = get_kernel();
-  TI_ASSERT(k != nullptr);
-  return (k->autodiff_mode == AutodiffMode::kNone);
+  Callable *callable = get_callable();
+  TI_ASSERT(callable != nullptr);
+  return (callable->autodiff_mode == AutodiffMode::kNone);
 }
 
 SNodeOpStmt::SNodeOpStmt(SNodeOpType op_type,

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1384,8 +1384,8 @@ class OffloadedStmt : public Stmt {
     return task_type != TaskType::listgen && task_type != TaskType::gc;
   }
 
-  Kernel *get_kernel() const override {
-    return kernel_;
+  Callable *get_callable() const override {
+    return (Callable *)kernel_;
   }
 
   bool is_container_statement() const override {

--- a/taichi/program/callable.h
+++ b/taichi/program/callable.h
@@ -120,6 +120,7 @@ class TI_DLL_EXPORT Callable : public CallableBase {
   Program *program{nullptr};
   std::unique_ptr<IRNode> ir{nullptr};
   std::unique_ptr<FrontendContext> context{nullptr};
+  AutodiffMode autodiff_mode{AutodiffMode::kNone};
 
   Callable();
   virtual ~Callable();

--- a/taichi/program/function.cpp
+++ b/taichi/program/function.cpp
@@ -16,6 +16,9 @@ void Function::set_function_body(const std::function<void()> &func) {
   ir = context->get_root();
   ir_stage_ = IRStage::AST;
 
+  TI_ASSERT(ir->is<Block>());
+  ir->as<Block>()->set_parent_callable(this);
+
   func();
   finalize_params();
   finalize_rets();
@@ -29,6 +32,10 @@ void Function::set_function_body(const std::function<void()> &func) {
 
 void Function::set_function_body(std::unique_ptr<IRNode> func_body) {
   ir = std::move(func_body);
+
+  TI_ASSERT(ir->is<Block>());
+  ir->as<Block>()->set_parent_callable(this);
+
   ir_stage_ = IRStage::InitialIR;
 }
 

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -34,9 +34,9 @@ Kernel::Kernel(Program &program,
 Kernel::Kernel(Program &program,
                std::unique_ptr<IRNode> &&ir,
                const std::string &primal_name,
-               AutodiffMode autodiff_mode)
-    : autodiff_mode(autodiff_mode) {
+               AutodiffMode autodiff_mode) {
   this->arch = program.compile_config().arch;
+  this->autodiff_mode = autodiff_mode;
   this->ir = std::move(ir);
   this->program = &program;
   is_accessor = false;
@@ -107,7 +107,7 @@ void Kernel::init(Program &program,
   ir = context->get_root();
 
   TI_ASSERT(ir->is<Block>());
-  ir->as<Block>()->set_parent_kernel(this);
+  ir->as<Block>()->set_parent_callable(this);
 
   ir_is_ast_ = true;
   arch = program.compile_config().arch;

--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -42,6 +42,9 @@ Kernel::Kernel(Program &program,
   is_accessor = false;
   ir_is_ast_ = false;  // CHI IR
 
+  TI_ASSERT(this->ir->is<Block>());
+  this->ir->as<Block>()->set_parent_callable(this);
+
   if (autodiff_mode == AutodiffMode::kNone) {
     name = primal_name;
   } else if (autodiff_mode == AutodiffMode::kForward) {

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -19,7 +19,6 @@ class TI_DLL_EXPORT Kernel : public Callable {
   std::vector<SNode *> no_activate;
 
   bool is_accessor{false};
-  AutodiffMode autodiff_mode{AutodiffMode::kNone};
 
   Kernel(Program &program,
          const std::function<void()> &func,

--- a/taichi/transforms/offload.cpp
+++ b/taichi/transforms/offload.cpp
@@ -73,8 +73,10 @@ class Offloader {
     auto root_statements = std::move(root_block->statements);
     root_block->statements.clear();
     const auto arch = config.arch;
+    Kernel *kernel = dynamic_cast<Kernel *>(root_block->parent_callable());
+    TI_ASSERT(kernel);
     auto pending_serial_statements = Stmt::make_typed<OffloadedStmt>(
-        OffloadedStmt::TaskType::serial, arch, root_block->parent_kernel());
+        OffloadedStmt::TaskType::serial, arch, kernel);
     pending_serial_statements->grid_dim = 1;
     pending_serial_statements->block_dim = 1;
 
@@ -82,7 +84,7 @@ class Offloader {
       if (!pending_serial_statements->body->statements.empty()) {
         root_block->insert(std::move(pending_serial_statements));
         pending_serial_statements = Stmt::make_typed<OffloadedStmt>(
-            OffloadedStmt::TaskType::serial, arch, root_block->parent_kernel());
+            OffloadedStmt::TaskType::serial, arch, kernel);
         pending_serial_statements->grid_dim = 1;
         pending_serial_statements->block_dim = 1;
       }
@@ -93,9 +95,8 @@ class Offloader {
       // Note that stmt->parent is root_block, which doesn't contain stmt now.
       if (auto s = stmt->cast<RangeForStmt>(); s && !s->strictly_serialized) {
         assemble_serial_statements();
-        auto offloaded =
-            Stmt::make_typed<OffloadedStmt>(OffloadedStmt::TaskType::range_for,
-                                            arch, root_block->parent_kernel());
+        auto offloaded = Stmt::make_typed<OffloadedStmt>(
+            OffloadedStmt::TaskType::range_for, arch, kernel);
         // offloaded->body is an empty block now.
         offloaded->grid_dim = config.saturating_grid_dim;
         if (s->block_dim == 0) {
@@ -141,9 +142,8 @@ class Offloader {
         emit_struct_for(st, root_block, config, st->mem_access_opt);
       } else if (auto st = stmt->cast<MeshForStmt>()) {
         assemble_serial_statements();
-        auto offloaded =
-            Stmt::make_typed<OffloadedStmt>(OffloadedStmt::TaskType::mesh_for,
-                                            arch, root_block->parent_kernel());
+        auto offloaded = Stmt::make_typed<OffloadedStmt>(
+            OffloadedStmt::TaskType::mesh_for, arch, kernel);
         offloaded->grid_dim = config.saturating_grid_dim;
         if (st->block_dim == 0) {
           offloaded->block_dim = Program::default_block_dim(config);
@@ -191,6 +191,8 @@ class Offloader {
     const bool demotable =
         (leaf->is_path_all_dense && config.demote_dense_struct_fors);
     const auto arch = config.arch;
+    Kernel *kernel = dynamic_cast<Kernel *>(root_block->parent_callable());
+    TI_ASSERT(kernel);
     if (!demotable) {
       for (int i = 1; i < path.size(); i++) {
         auto snode_child = path[i];
@@ -200,7 +202,7 @@ class Offloader {
           continue;
         }
         auto offloaded_clear_list = Stmt::make_typed<OffloadedStmt>(
-            OffloadedStmt::TaskType::serial, arch, root_block->parent_kernel());
+            OffloadedStmt::TaskType::serial, arch, kernel);
         offloaded_clear_list->body->insert(
             Stmt::make<ClearListStmt>(snode_child));
         offloaded_clear_list->grid_dim = 1;
@@ -209,9 +211,8 @@ class Offloader {
         // is nothing special about this task, which could otherwise cause
         // problems when fused with other serial tasks.
         root_block->insert(std::move(offloaded_clear_list));
-        auto offloaded_listgen =
-            Stmt::make_typed<OffloadedStmt>(OffloadedStmt::TaskType::listgen,
-                                            arch, root_block->parent_kernel());
+        auto offloaded_listgen = Stmt::make_typed<OffloadedStmt>(
+            OffloadedStmt::TaskType::listgen, arch, kernel);
         offloaded_listgen->snode = snode_child;
         offloaded_listgen->grid_dim = config.saturating_grid_dim;
         offloaded_listgen->block_dim =
@@ -223,7 +224,7 @@ class Offloader {
     }
 
     auto offloaded_struct_for = Stmt::make_typed<OffloadedStmt>(
-        OffloadedStmt::TaskType::struct_for, arch, root_block->parent_kernel());
+        OffloadedStmt::TaskType::struct_for, arch, kernel);
 
     offloaded_struct_for->index_offsets = for_stmt->index_offsets;
 
@@ -677,6 +678,8 @@ class FixCrossOffloadReferences : public BasicStmtVisitor {
 void insert_gc(IRNode *root, const CompileConfig &config) {
   auto *b = dynamic_cast<Block *>(root);
   TI_ASSERT(b);
+  Kernel *kernel = dynamic_cast<Kernel *>(b->parent_callable());
+  TI_ASSERT(kernel);
   std::vector<std::pair<int, std::vector<SNode *>>> gc_statements;
   for (int i = 0; i < (int)b->statements.size(); i++) {
     auto snodes =
@@ -690,7 +693,7 @@ void insert_gc(IRNode *root, const CompileConfig &config) {
     for (auto *snode : snodes) {
       if (is_gc_able(snode->type)) {
         auto gc_task = Stmt::make_typed<OffloadedStmt>(
-            OffloadedStmt::TaskType::gc, config.arch, b->parent_kernel());
+            OffloadedStmt::TaskType::gc, config.arch, kernel);
         gc_task->snode = snode;
         b->insert(std::move(gc_task), i + 1);
       }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e1c5afb</samp>

### Summary
🔄🎁🚀

<!--
1.  🔄 This emoji represents the renaming and refactoring of methods and fields related to `Callable` objects in the IR code. It suggests a change of direction or perspective, as well as an improvement of clarity and consistency.
2. 🎁 This emoji represents the addition of new features and capabilities to the `Callable` and `Block` classes, such as setting the autodiff mode and the parent callable. It suggests a gift or a reward, as well as an enhancement of functionality and flexibility.
3. 🚀 This emoji represents the improvement of performance and efficiency of the `Offloader` class by using a local variable instead of repeated method calls. It suggests a boost or a launch, as well as a speedup and optimization.
-->
This pull request refactors the IR and program classes to use the `Callable` class as a common base for kernels and functions. This simplifies the code, improves the consistency and readability of the IR, and allows more flexibility for autodiff and offloading.

> _To make the IR more extensible_
> _We introduced `Callable` as sensible_
> _It can be a `Kernel` or a `Function`_
> _With its own autodiff junction_
> _And the `Block` class is more comprehensible_

### Walkthrough
*  Rename `get_kernel` and `parent_kernel` methods to `get_callable` and `parent_callable` in `Stmt` and `Block` classes to support both `Kernel` and `Function` objects as callables ([link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-50be2dc708119a4c9b53e977807d2f05e4ff6ce98c3f51fa91d1fa9e229962f1L127-R136), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-50be2dc708119a4c9b53e977807d2f05e4ff6ce98c3f51fa91d1fa9e229962f1L377-R384), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eL456-R457), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eL505-R506), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eL514-R525), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L129-R131), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1387-R1388))
* Add forward declaration of `Callable` class in `ir.h` to avoid circular dependency ([link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR34))
* Move `autodiff_mode` field from `Kernel` to `Callable` class to allow different modes for kernels and functions ([link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-e914f7cb94f429034d998974d95d57f6e09de2dadaed4c621e122ec403c9bb22R123), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-183534311cce45d4f24cf969ff1836c60a64c8c6050c34f6ee667617cf9d8dddL37-R39), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-5831927e99f989a5c80bace0ae3a103f99fb5849cf6e591a22a8bb83d3a14c3fL22))
* Set parent callable of block to itself in constructors and setters of `Kernel` and `Function` classes ([link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-aa860f71a793b08676a24cab247b43f5ed8d105a6493eeb1a035369b916bddc2R19-R21), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-aa860f71a793b08676a24cab247b43f5ed8d105a6493eeb1a035369b916bddc2R35-R38), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-183534311cce45d4f24cf969ff1836c60a64c8c6050c34f6ee667617cf9d8dddR45-R47), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-183534311cce45d4f24cf969ff1836c60a64c8c6050c34f6ee667617cf9d8dddL110-R113))
* Use dynamic cast of parent callable to `Kernel *` and assert validity in `Offloader` class methods that require kernel information ([link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L76-R79), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21R194-R195), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21R681-R682))
* Replace uses of `parent_kernel` method with local `kernel` variable in `Offloader` class methods to create offloaded statements and garbage collection tasks ([link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L85-R87), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L96-R99), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L144-R146), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L203-R205), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L212-R215), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L226-R227), [link](https://github.com/taichi-dev/taichi/pull/8172/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L693-R696))



Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8171
* #8173
* __->__ #8172

