### PR TITLE
[ci] Ghstack bot treats neutral checks as success and ignore copilot for PRs

### DIFF
--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -92,8 +92,10 @@ def main():
         for cr in checkruns["check_runs"]:
             status = cr.get("conclusion", cr["status"])
             name = cr["name"]
+            if name == "Copilot for PRs":
+                continue
             must(
-                status == "success",
+                status in ("success", "neutral"),
                 f"PR #{n} check-run `{name}`'s status `{status}` is not success!",
             )
         print("SUCCESS!")


### PR DESCRIPTION
Issue: NA

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5053a2</samp>

Skip 'Copilot for PRs' check-run in permission check script. This allows PRs that use GitHub Copilot to pass the permission check even if some code suggestions do not pass other check-runs.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5053a2</samp>

* Skip the 'Copilot for PRs' check-run in the permission check script ([link](https://github.com/taichi-dev/taichi/pull/8174/files?diff=unified&w=0#diff-c6fef5298947d51a312cfe23449004b5bddf4c6d7374dd55d012f6346edefc69L95-R98)). This allows PRs that use GitHub Copilot to pass the check even if the code suggestions are not valid. The script is located in `.github/workflows/scripts/ghstack-perm-check.py`.
