### PR TITLE
[Error] [bug] Warn before calling the external function

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -468,11 +468,13 @@ class ASTTransformer(Builder):
             return
         name = unparse(node.func).strip()
         warnings.warn_explicit(
+            f"\x1b[38;5;226m"  # Yellow
             f'Calling non-taichi function "{name}". '
             f"Scope inside the function is not processed by the Taichi AST transformer. "
             f"The function may not work as expected. Proceed with caution! "
-            f"Maybe you can consider turning it into a @ti.func?",
-            UserWarning,
+            f"Maybe you can consider turning it into a @ti.func?"
+            f"\x1b[0m",  # Reset
+            SyntaxWarning,
             ctx.file,
             node.lineno + ctx.lineno_offset,
             module="taichi",
@@ -580,8 +582,8 @@ class ASTTransformer(Builder):
         if hasattr(node.func, "caller"):
             node.ptr = func(node.func.caller, *args, **keywords)
             return node.ptr
-        node.ptr = func(*args, **keywords)
         ASTTransformer.warn_if_is_external_func(ctx, node)
+        node.ptr = func(*args, **keywords)
 
         if getattr(func, "_is_taichi_function", False):
             ctx.func.has_print |= func.func.has_print


### PR DESCRIPTION
Issue: fix #8175 

Also made the warning yellow.

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3453abc</samp>

Improve warning and assignment for non-taichi functions in `ast_transformer.py`. Use `SyntaxWarning` and yellow color for the warning, and preserve `node.ptr` for taichi functions.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3453abc</samp>

*  Modify the warning message for calling non-taichi functions to use yellow color and SyntaxWarning ([link](https://github.com/taichi-dev/taichi/pull/8177/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL471-R477))
*  Avoid assigning `node.ptr` twice for taichi function calls by moving the assignment after the warning check ([link](https://github.com/taichi-dev/taichi/pull/8177/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL583-R586))
