### PR TITLE
[lang] Include argument name in error message

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -696,7 +696,7 @@ class ASTTransformer(Builder):
                             raise TaichiSyntaxError(
                                 f"Argument {arg.arg} of type {ctx.func.arguments[i].annotation} is not recognized."
                             )
-                        ctx.func.arguments[i].annotation.check_matched(data.get_type())
+                        ctx.func.arguments[i].annotation.check_matched(data.get_type(), ctx.func.arguments[i].name)
                         ctx.create_variable(ctx.func.arguments[i].name, data)
                         continue
 

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -341,7 +341,7 @@ class TaichiCallableTemplateMapper:
         self.mapping = {}
 
     @staticmethod
-    def extract_arg(arg, anno):
+    def extract_arg(arg, anno, arg_name):
         if isinstance(anno, template):
             if isinstance(arg, taichi.lang.snode.SNode):
                 return arg.ptr
@@ -350,7 +350,7 @@ class TaichiCallableTemplateMapper:
             if isinstance(arg, _ti_core.Expr):
                 return arg.get_underlying_ptr_address()
             if isinstance(arg, tuple):
-                return tuple(TaichiCallableTemplateMapper.extract_arg(item, anno) for item in arg)
+                return tuple(TaichiCallableTemplateMapper.extract_arg(item, anno, arg_name) for item in arg)
             if isinstance(arg, taichi.lang._ndarray.Ndarray):
                 raise TaichiRuntimeTypeError(
                     "Ndarray shouldn't be passed in via `ti.template()`, please annotate your kernel using `ti.types.ndarray(...)` instead"
@@ -371,40 +371,42 @@ class TaichiCallableTemplateMapper:
             return arg
         if isinstance(anno, ArgPackType):
             if not isinstance(arg, ArgPack):
-                raise TaichiRuntimeTypeError(f"Argument must be a argument pack, got {type(arg)}")
+                raise TaichiRuntimeTypeError(f"Argument {arg_name} must be a argument pack, got {type(arg)}")
             return tuple(
-                TaichiCallableTemplateMapper.extract_arg(arg[name], dtype)
+                TaichiCallableTemplateMapper.extract_arg(arg[name], dtype, arg_name)
                 for index, (name, dtype) in enumerate(anno.members.items())
             )
         if isinstance(anno, texture_type.TextureType):
             if not isinstance(arg, taichi.lang._texture.Texture):
-                raise TaichiRuntimeTypeError(f"Argument must be a texture, got {type(arg)}")
+                raise TaichiRuntimeTypeError(f"Argument {arg_name} must be a texture, got {type(arg)}")
             if arg.num_dims != anno.num_dimensions:
                 raise TaichiRuntimeTypeError(
-                    f"TextureType dimension mismatch: expected {anno.num_dimensions}, got {arg.num_dims}"
+                    f"TextureType dimension mismatch for argument {arg_name}: expected {anno.num_dimensions}, got {arg.num_dims}"
                 )
             return (arg.num_dims,)
         if isinstance(anno, texture_type.RWTextureType):
             if not isinstance(arg, taichi.lang._texture.Texture):
-                raise TaichiRuntimeTypeError(f"Argument must be a texture, got {type(arg)}")
+                raise TaichiRuntimeTypeError(f"Argument {arg_name} must be a texture, got {type(arg)}")
             if arg.num_dims != anno.num_dimensions:
                 raise TaichiRuntimeTypeError(
-                    f"RWTextureType dimension mismatch: expected {anno.num_dimensions}, got {arg.num_dims}"
+                    f"RWTextureType dimension mismatch for argument {arg_name}: expected {anno.num_dimensions}, got {arg.num_dims}"
                 )
             if arg.fmt != anno.fmt:
-                raise TaichiRuntimeTypeError(f"RWTextureType format mismatch: expected {anno.fmt}, got {arg.fmt}")
+                raise TaichiRuntimeTypeError(
+                    f"RWTextureType format mismatch for argument {arg_name}: expected {anno.fmt}, got {arg.fmt}"
+                )
             # (penguinliong) '0' is the assumed LOD level. We currently don't
             # support mip-mapping.
             return arg.num_dims, arg.fmt, 0
         if isinstance(anno, ndarray_type.NdarrayType):
             if isinstance(arg, taichi.lang._ndarray.Ndarray):
-                anno.check_matched(arg.get_type())
+                anno.check_matched(arg.get_type(), arg_name)
                 needs_grad = (arg.grad is not None) if anno.needs_grad is None else anno.needs_grad
                 return arg.element_type, len(arg.shape), needs_grad, anno.boundary
             # external arrays
             shape = getattr(arg, "shape", None)
             if shape is None:
-                raise TaichiRuntimeTypeError(f"Invalid argument into ti.types.ndarray(), got {arg}")
+                raise TaichiRuntimeTypeError(f"Invalid type for argument {arg_name}, got {arg}")
             shape = tuple(shape)
             element_shape = ()
             dtype = to_taichi_type(arg.dtype)
@@ -412,34 +414,34 @@ class TaichiCallableTemplateMapper:
                 if anno.ndim is not None:
                     if len(shape) != anno.dtype.ndim + anno.ndim:
                         raise ValueError(
-                            f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim} element_dim={anno.dtype.ndim}, "
-                            f"but the argument has {len(shape)} dimensions"
+                            f"Invalid value for argument {arg_name} - required array has ndim={anno.ndim} element_dim={anno.dtype.ndim}, "
+                            f"array with {len(shape)} dimensions is provided"
                         )
                 else:
                     if len(shape) < anno.dtype.ndim:
                         raise ValueError(
-                            f"Invalid argument into ti.types.ndarray() - required element_dim={anno.dtype.ndim}, "
-                            f"but the argument has only {len(shape)} dimensions"
+                            f"Invalid value for argument {arg_name} - required element_dim={anno.dtype.ndim}, "
+                            f"array with {len(shape)} dimensions is provided"
                         )
                 element_shape = shape[-anno.dtype.ndim :]
                 anno_element_shape = anno.dtype.get_shape()
                 if None not in anno_element_shape and element_shape != anno_element_shape:
                     raise ValueError(
-                        f"Invalid argument into ti.types.ndarray() - required element_shape={anno_element_shape}, "
-                        f"but the argument has element shape of {element_shape}"
+                        f"Invalid value for argument {arg_name} - required element_shape={anno_element_shape}, "
+                        f"array with element shape of {element_shape} is provided"
                     )
             elif anno.dtype is not None:
                 # User specified scalar dtype
                 if anno.dtype != dtype:
                     raise ValueError(
-                        f"Invalid argument into ti.types.ndarray() - required array has dtype={anno.dtype.to_string()}, "
-                        f"but the argument has dtype={dtype.to_string()}"
+                        f"Invalid value for argument {arg_name} - required array has dtype={anno.dtype.to_string()}, "
+                        f"array with dtype={dtype.to_string()} is provided"
                     )
 
                 if anno.ndim is not None and len(shape) != anno.ndim:
                     raise ValueError(
-                        f"Invalid argument into ti.types.ndarray() - required array has ndim={anno.ndim}, "
-                        f"but the argument has {len(shape)} dimensions"
+                        f"Invalid value for argument {arg_name} - required array has ndim={anno.ndim}, "
+                        f"array with {len(shape)} dimensions is provided"
                     )
             needs_grad = getattr(arg, "requires_grad", False) if anno.needs_grad is None else anno.needs_grad
             element_type = (
@@ -456,7 +458,7 @@ class TaichiCallableTemplateMapper:
     def extract(self, args):
         extracted = []
         for arg, kernel_arg in zip(args, self.arguments):
-            extracted.append(self.extract_arg(arg, kernel_arg.annotation))
+            extracted.append(self.extract_arg(arg, kernel_arg.annotation, kernel_arg.name))
         return tuple(extracted)
 
     def lookup(self, args):

--- a/python/taichi/types/ndarray_type.py
+++ b/python/taichi/types/ndarray_type.py
@@ -80,7 +80,7 @@ class NdarrayType:
         self.needs_grad = needs_grad
         self.boundary = to_boundary_enum(boundary)
 
-    def check_matched(self, ndarray_type: NdarrayTypeMetadata):
+    def check_matched(self, ndarray_type: NdarrayTypeMetadata, arg_name: str):
         # FIXME(Haidong) Cannot use Vector/MatrixType due to circular import
         # Use the CompuoundType instead to determine the specific typs.
         # TODO Replace CompoundType with MatrixType and VectorType
@@ -89,27 +89,27 @@ class NdarrayType:
         if isinstance(self.dtype, CompoundType):
             if not self.dtype.check_matched(ndarray_type.element_type):
                 raise ValueError(
-                    f"Invalid argument into ti.types.ndarray() - required element type: {self.dtype.to_string()}, but {ndarray_type.element_type.to_string()} is provided"
+                    f"Invalid value for argument {arg_name} - required element type: {self.dtype.to_string()}, but {ndarray_type.element_type.to_string()} is provided"
                 )
         else:
             if self.dtype is not None:
                 # Check dtype match for scalar.
                 if not self.dtype == ndarray_type.element_type:
                     raise TypeError(
-                        f"Expect element type {self.dtype} for Ndarray, but get {ndarray_type.element_type}"
+                        f"Expect element type {self.dtype} for argument {arg_name}, but get {ndarray_type.element_type}"
                     )
 
         # Check ndim match
         if self.ndim is not None and ndarray_type.shape is not None and self.ndim != len(ndarray_type.shape):
             raise ValueError(
-                f"Invalid argument into ti.types.ndarray() - required ndim={self.ndim}, but {len(ndarray_type.shape)}d ndarray with shape {ndarray_type.shape} is provided"
+                f"Invalid value for argument {arg_name} - required ndim={self.ndim}, but {len(ndarray_type.shape)}d ndarray with shape {ndarray_type.shape} is provided"
             )
 
         # Check needs_grad
         if self.needs_grad is not None and self.needs_grad > ndarray_type.needs_grad:
             # It's okay to pass a needs_grad=True ndarray at runtime to a need_grad=False arg but not vice versa.
             raise ValueError(
-                f"Invalid argument into ti.types.ndarray() - required needs_grad={self.needs_grad}, but {ndarray_type.needs_grad} is provided"
+                f"Invalid value for argument {arg_name} - required needs_grad={self.needs_grad}, but {ndarray_type.needs_grad} is provided"
             )
 
     def __repr__(self):

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -388,7 +388,7 @@ def test_func_ndarray_arg():
 
     assert arr[0] == [20, 20, 20]
 
-    with pytest.raises(ti.TaichiCompilationError, match=r"Invalid argument into ti.types.ndarray()"):
+    with pytest.raises(ti.TaichiCompilationError, match=r"Invalid value for argument a"):
         test_error(arr)
 
 

--- a/tests/python/test_kernel_arg_errors.py
+++ b/tests/python/test_kernel_arg_errors.py
@@ -27,7 +27,7 @@ def test_pass_float_as_ndarray():
 
     with pytest.raises(
         ti.TaichiRuntimeTypeError,
-        match=r"Invalid argument into ti.types.ndarray\(\), got 1.2",
+        match=r"Invalid type for argument a, got 1.2",
     ):
         foo(1.2)
 
@@ -43,7 +43,7 @@ def test_random_python_class_as_ndarray():
 
     with pytest.raises(
         ti.TaichiRuntimeTypeError,
-        match=r"Invalid argument into ti.types.ndarray\(\), got",
+        match=r"Invalid type for argument a, got",
     ):
         b = Bla()
         foo(b)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -508,14 +508,14 @@ def _test_arg_not_match():
     x = ti.Matrix.ndarray(2, 3, ti.i32, shape=(4, 7))
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti\.types\.ndarray\(\) - required element type: VectorType\[2, i32\], but .* is provided",
+        match=r"Invalid value for argument a - required element type: VectorType\[2, i32\], but .* is provided",
     ):
         func1(x)
 
     x = ti.Matrix.ndarray(2, 1, ti.i32, shape=(4, 7))
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti\.types\.ndarray\(\) - required element type: VectorType\[2, i32\], but .* is provided",
+        match=r"Invalid value for argument a - required element type: VectorType\[2, i32\], but .* is provided",
     ):
         func1(x)
 
@@ -526,7 +526,7 @@ def _test_arg_not_match():
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti\.types\.ndarray\(\) - required element type: MatrixType\[2,2, i32\], but .* is provided",
+        match=r"Invalid value for argument a - required element type: MatrixType\[2,2, i32\], but .* is provided",
     ):
         func2(x)
 
@@ -537,7 +537,7 @@ def _test_arg_not_match():
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti\.types\.ndarray\(\) - required element type: MatrixType\[2,1, i32\], but .* is provided",
+        match=r"Invalid value for argument a - required element type: MatrixType\[2,1, i32\], but .* is provided",
     ):
         func3(x)
 
@@ -548,7 +548,7 @@ def _test_arg_not_match():
     x = ti.Vector.ndarray(2, ti.i32, shape=(4, 7))
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti\.types\.ndarray\(\) - required element type",
+        match=r"Invalid value for argument a - required element type",
     ):
         func5(x)
 
@@ -559,7 +559,7 @@ def _test_arg_not_match():
     x = ti.ndarray(ti.i32, shape=(3,))
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti\.types\.ndarray\(\) - required ndim",
+        match=r"Invalid value for argument a - required ndim",
     ):
         func7(x)
 
@@ -568,7 +568,7 @@ def _test_arg_not_match():
         pass
 
     x = ti.ndarray(dtype=ti.i32, shape=(16, 16))
-    with pytest.raises(TypeError, match=r"Expect element type .* for Ndarray, but get .*"):
+    with pytest.raises(TypeError, match=r"Expect element type .* for argument x, but get .*"):
         func8(x)
 
 
@@ -978,7 +978,7 @@ def test_type_hint_matrix():
     assert impl.get_runtime().get_num_compiled_functions() == 2
 
     z = ti.ndarray(ti.math.vec2, (3))
-    with pytest.raises(ValueError, match=r"Invalid argument into ti.types.ndarray\(\)"):
+    with pytest.raises(ValueError, match=r"Invalid value for argument x"):
         test(z)
 
 
@@ -998,7 +998,7 @@ def test_type_hint_vector():
     assert impl.get_runtime().get_num_compiled_functions() == 2
 
     z = ti.ndarray(ti.math.mat2, (3))
-    with pytest.raises(ValueError, match=r"Invalid argument into ti.types.ndarray\(\)"):
+    with pytest.raises(ValueError, match=r"Invalid value for argument x"):
         test(z)
 
 

--- a/tests/python/test_numpy.py
+++ b/tests/python/test_numpy.py
@@ -299,17 +299,17 @@ def test_numpy_ndarray_dim_check():
     np.testing.assert_allclose(d, np.ones(shape=(2, 2), dtype=np.float32))
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti.types.ndarray\(\) - required element_shape=\(.*\), but the argument has element shape of \(.*\)",
+        match=r"Invalid value for argument arr - required element_shape=\(.*\), array with element shape of \(.*\)",
     ):
         add_one_mat(b)
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti.types.ndarray\(\) - required array has ndim=2 element_dim=2, but the argument has 3 dimensions",
+        match=r"Invalid value for argument arr - required array has ndim=2 element_dim=2, array with 3 dimensions is provided",
     ):
         add_one_mat(c)
     with pytest.raises(
         ValueError,
-        match=r"Invalid argument into ti.types.ndarray\(\) - required array has ndim=2, but the argument has 4 dimensions",
+        match=r"Invalid value for argument arr - required array has ndim=2, array with 4 dimensions is provided",
     ):
         add_one_scalar(a)
 
@@ -322,5 +322,5 @@ def test_numpy_dtype_mismatch():
             x[i] = i
 
     xx = np.array([1, 2, 3, 4, 5], dtype=np.int64)  # by default it's int64
-    with pytest.raises(ValueError, match=r"Invalid argument into ti.types.ndarray\(\) - required array has dtype="):
+    with pytest.raises(ValueError, match=r"Invalid value for argument x - required array has dtype="):
         arange(xx)

--- a/tests/python/test_texture.py
+++ b/tests/python/test_texture.py
@@ -195,7 +195,7 @@ def test_rw_texture_2d_struct_for_dim_check():
 
     with pytest.raises(
         ti.TaichiRuntimeError,
-        match="RWTextureType dimension mismatch: expected 2, got 3",
+        match="RWTextureType dimension mismatch for argument tex: expected 2, got 3",
     ) as e:
         write(tex)
 
@@ -211,7 +211,7 @@ def test_rw_texture_wrong_fmt():
 
     with pytest.raises(
         ti.TaichiRuntimeError,
-        match="RWTextureType format mismatch: expected Format.r32f, got Format.rgba8",
+        match="RWTextureType format mismatch for argument tex: expected Format.r32f, got Format.rgba8",
     ) as e:
         write(tex)
 
@@ -227,6 +227,6 @@ def test_rw_texture_wrong_ndim():
 
     with pytest.raises(
         ti.TaichiRuntimeError,
-        match="RWTextureType dimension mismatch: expected 1, got 2",
+        match="RWTextureType dimension mismatch for argument tex: expected 1, got 2",
     ) as e:
         write(tex)


### PR DESCRIPTION
Issue: #

We should unify the error reporting mechanism here in the future. 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a241e7</samp>

This pull request enhances the error messages for various functions and kernels in `taichi` by showing the argument name and more details about the expected and actual types, shapes, and dimensions of the arguments. It also updates the relevant test cases to match the new error messages. The affected files include `kernel_impl.py`, `ndarray_type.py`, `ast_transformer.py`, and several files in the `tests/python` directory.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a241e7</samp>

*  Add argument name parameter to `check_matched` method of argument annotations and modify error messages accordingly ([link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL699-R699), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L401-R403), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L83-R83))
*  Pass argument name to `check_matched` method calls in `extract_arg` method of `TaichiCallableTemplateMapper` class ([link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L344-R344), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L353-R353))
*  Modify error messages for mismatched argument types, dimensions, element shapes, data types, and gradient requirements in `extract_arg` method of `TaichiCallableTemplateMapper` class to include argument name and expected and actual values ([link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L374-R397), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L407-R409), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L415-R424), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L428-R431), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L435-R444), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L92-R92), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L99-R99), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L105-R105), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-06e0109e9fa5071f7d364306981845d410fa17425db48001e3ba69337b47c152L112-R112))
*  Pass argument name to `extract_arg` method calls in `extract` method of `TaichiCallableTemplateMapper` class ([link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L459-R461))
*  Modify test cases for compilation, runtime, value, and type errors in `test_function.py`, `test_kernel_arg_errors.py`, `test_ndarray.py`, `test_numpy.py`, and `test_texture.py` to match the new error messages that include argument name and expected and actual values ([link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-d6f5c74e17462c8ff96d5bba06ebf81d16c015ca667fa945513a80be17bef017L391-R391), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-b63b257f4b2d2f66934692522cbbcaf96a506b4c0271077d31a468491e3685ddL30-R30), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-b63b257f4b2d2f66934692522cbbcaf96a506b4c0271077d31a468491e3685ddL46-R46), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L511-R511), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L518-R518), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L529-R529), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L540-R540), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L551-R551), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L562-R562), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L571-R571), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L981-R981), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L1001-R1001), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-dea0dd59910c752726a992240fe0d79384723802695913b349b26ac26de21583L302-R312), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-dea0dd59910c752726a992240fe0d79384723802695913b349b26ac26de21583L325-R325), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-302584e8de204dcb5e6c4a514ae09be7f4f983963e7b410d3e6684e751cb3a06L198-R198), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-302584e8de204dcb5e6c4a514ae09be7f4f983963e7b410d3e6684e751cb3a06L214-R214), [link](https://github.com/taichi-dev/taichi/pull/8180/files?diff=unified&w=0#diff-302584e8de204dcb5e6c4a514ae09be7f4f983963e7b410d3e6684e751cb3a06L230-R230))
