### PR TITLE
[opengl] Add import of external OpenGL context.

### DIFF
--- a/c_api/include/taichi/taichi_opengl.h
+++ b/c_api/include/taichi/taichi_opengl.h
@@ -32,7 +32,8 @@ typedef struct TiOpenglImageInteropInfo {
 
 // Function `ti_import_opengl_runtime`
 TI_DLL_EXPORT TiRuntime TI_API_CALL
-ti_import_opengl_runtime(TiOpenglRuntimeInteropInfo *interop_info);
+ti_import_opengl_runtime(TiOpenglRuntimeInteropInfo *interop_info,
+                         bool use_gles);
 
 // Function `ti_export_opengl_runtime`
 TI_DLL_EXPORT void TI_API_CALL

--- a/c_api/src/taichi_opengl_impl.cpp
+++ b/c_api/src/taichi_opengl_impl.cpp
@@ -32,7 +32,8 @@ void ti_export_opengl_runtime(TiRuntime runtime,
                               TiOpenglRuntimeInteropInfo *interop_info) {
   TI_CAPI_TRY_CATCH_BEGIN();
   // FIXME: (penguinliogn)
-  interop_info->get_proc_addr = taichi::lang::opengl::kGetOpenglProcAddr.value();
+  interop_info->get_proc_addr =
+      taichi::lang::opengl::kGetOpenglProcAddr.value();
   TI_CAPI_TRY_CATCH_END();
 }
 

--- a/c_api/src/taichi_opengl_impl.cpp
+++ b/c_api/src/taichi_opengl_impl.cpp
@@ -18,11 +18,21 @@ taichi::lang::gfx::GfxRuntime &OpenglRuntime::get_gfx_runtime() {
   return gfx_runtime_;
 }
 
+TiRuntime ti_import_opengl_runtime(TiOpenglRuntimeInteropInfo *interop_info,
+                                   bool use_gles) {
+  TI_CAPI_TRY_CATCH_BEGIN();
+  TI_CAPI_ARGUMENT_NULL_RV(interop_info);
+  taichi::lang::opengl::imported_process_address = interop_info->get_proc_addr;
+  taichi::lang::opengl::set_gles_override(use_gles);
+  TI_CAPI_TRY_CATCH_END();
+  return ti_create_runtime(TI_ARCH_OPENGL, 0);
+}
+
 void ti_export_opengl_runtime(TiRuntime runtime,
                               TiOpenglRuntimeInteropInfo *interop_info) {
   TI_CAPI_TRY_CATCH_BEGIN();
   // FIXME: (penguinliogn)
-  interop_info->get_proc_addr = taichi::lang::opengl::kGetOpenglProcAddr;
+  interop_info->get_proc_addr = taichi::lang::opengl::kGetOpenglProcAddr.value();
   TI_CAPI_TRY_CATCH_END();
 }
 

--- a/taichi/rhi/opengl/opengl_api.cpp
+++ b/taichi/rhi/opengl/opengl_api.cpp
@@ -29,7 +29,7 @@ static bool context_with_glfw = false;
 std::optional<void *> kGetOpenglProcAddr;
 std::optional<void *> imported_process_address;
 namespace {
-  static std::optional<bool> use_gles_override;
+static std::optional<bool> use_gles_override;
 };
 
 void set_gles_override(bool value) {
@@ -64,7 +64,8 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
 
 #ifndef ANDROID
   // If imported_process_address has been set, then use that.
-  if (!imported_process_address.has_value() && window_system::glfw_context_acquire()) {
+  if (!imported_process_address.has_value() &&
+      window_system::glfw_context_acquire()) {
     // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
     if (use_gles) {
       glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);

--- a/taichi/rhi/opengl/opengl_api.cpp
+++ b/taichi/rhi/opengl/opengl_api.cpp
@@ -26,7 +26,19 @@ int opengl_max_grid_dim = 1024;
 static bool kUseGles = false;
 static std::optional<bool> supported;  // std::nullopt
 static bool context_with_glfw = false;
-void *kGetOpenglProcAddr;
+std::optional<void *> kGetOpenglProcAddr;
+std::optional<void *> imported_process_address;
+namespace {
+  static std::optional<bool> use_gles_override;
+};
+
+void set_gles_override(bool value) {
+  use_gles_override = value;
+}
+
+void unset_gles_override() {
+  use_gles_override = std::nullopt;
+}
 
 bool initialize_opengl(bool use_gles, bool error_tolerance) {
   TI_TRACE("initialize_opengl({}, {}) called", use_gles, error_tolerance);
@@ -41,12 +53,18 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
     }
   }
 
+  if (use_gles_override.has_value()) {
+    use_gles = use_gles_override.value();
+    unset_gles_override();
+  }
+
   // Code below is guaranteed to be called at most once.
   int opengl_version = 0;
   void *get_proc_addr = nullptr;
 
 #ifndef ANDROID
-  if (window_system::glfw_context_acquire()) {
+  // If imported_process_address has been set, then use that.
+  if (!imported_process_address.has_value() && window_system::glfw_context_acquire()) {
     // Compute Shader requires OpenGL 4.3+ (or OpenGL ES 3.1+)
     if (use_gles) {
       glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
@@ -63,8 +81,8 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
     glfwWindowHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);
 #endif
     // GL context needs a window (when using GLFW)
-    GLFWwindow *window =
-        glfwCreateWindow(1, 1, "Make OpenGL Context", nullptr, nullptr);
+    GLFWwindow *window = nullptr;
+    window = glfwCreateWindow(1, 1, "Make OpenGL Context", nullptr, nullptr);
     if (!window) {
       const char *desc = nullptr;
       int status = glfwGetError(&desc);
@@ -85,79 +103,98 @@ bool initialize_opengl(bool use_gles, bool error_tolerance) {
     }
   }
 #endif  // ANDROID
+  if (!imported_process_address.has_value()) {
+    if (!opengl_version) {
+      TI_TRACE("Attempting to load with EGL");
 
-  if (!opengl_version) {
-    TI_TRACE("Attempting to load with EGL");
+      // Try EGL instead
+      int egl_version = gladLoaderLoadEGL(nullptr);
 
-    // Try EGL instead
-    int egl_version = gladLoaderLoadEGL(nullptr);
+      if (!egl_version) {
+        TI_DEBUG("Failed to load EGL");
+      } else {
+        static const EGLint configAttribs[] = {EGL_SURFACE_TYPE,
+                                               EGL_PBUFFER_BIT,
+                                               EGL_BLUE_SIZE,
+                                               8,
+                                               EGL_GREEN_SIZE,
+                                               8,
+                                               EGL_RED_SIZE,
+                                               8,
+                                               EGL_DEPTH_SIZE,
+                                               8,
+                                               EGL_RENDERABLE_TYPE,
+                                               EGL_OPENGL_BIT,
+                                               EGL_NONE};
 
-    if (!egl_version) {
-      TI_DEBUG("Failed to load EGL");
+        // Initialize EGL
+        EGLDisplay egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+
+        EGLint major, minor;
+        eglInitialize(egl_display, &major, &minor);
+
+        egl_version = gladLoaderLoadEGL(egl_display);
+
+        TI_DEBUG("Loaded EGL {}.{} on display {}",
+                 GLAD_VERSION_MAJOR(egl_version),
+                 GLAD_VERSION_MINOR(egl_version), egl_display);
+
+        // Select an appropriate configuration
+        EGLint num_configs;
+        EGLConfig egl_config;
+
+        eglChooseConfig(egl_display, configAttribs, &egl_config, 1,
+                        &num_configs);
+
+        // Bind the API (EGL >= 1.2)
+        if (egl_version >= GLAD_MAKE_VERSION(1, 2)) {
+          eglBindAPI(use_gles ? EGL_OPENGL_ES_API : EGL_OPENGL_API);
+        }
+
+        // Create a context and make it current
+        EGLContext egl_context = EGL_NO_CONTEXT;
+        if (use_gles) {
+          static const EGLint gl_attribs[] = {
+              EGL_CONTEXT_MAJOR_VERSION,
+              3,
+              EGL_CONTEXT_MINOR_VERSION,
+              1,
+              EGL_NONE,
+          };
+          egl_context = eglGetCurrentContext();
+          if (egl_context == EGL_NO_CONTEXT) {
+            egl_context = eglCreateContext(egl_display, egl_config,
+                                           EGL_NO_CONTEXT, gl_attribs);
+            eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                           egl_context);
+          }
+
+        } else {
+          egl_context = eglGetCurrentContext();
+          if (egl_context == EGL_NO_CONTEXT) {
+            egl_context = eglCreateContext(egl_display, egl_config,
+                                           EGL_NO_CONTEXT, nullptr);
+            eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                           egl_context);
+          }
+        }
+
+        get_proc_addr = (void *)&glad_eglGetProcAddress;
+        if (use_gles) {
+          opengl_version = gladLoadGLES2(glad_eglGetProcAddress);
+        } else {
+          opengl_version = gladLoadGL(glad_eglGetProcAddress);
+        }
+      }
+    }
+  } else {
+    TI_TRACE("Attempting to load imported context");
+    get_proc_addr = imported_process_address.value();
+    imported_process_address = std::nullopt;
+    if (use_gles) {
+      opengl_version = gladLoadGLES2((GLADloadfunc)get_proc_addr);
     } else {
-      static const EGLint configAttribs[] = {EGL_SURFACE_TYPE,
-                                             EGL_PBUFFER_BIT,
-                                             EGL_BLUE_SIZE,
-                                             8,
-                                             EGL_GREEN_SIZE,
-                                             8,
-                                             EGL_RED_SIZE,
-                                             8,
-                                             EGL_DEPTH_SIZE,
-                                             8,
-                                             EGL_RENDERABLE_TYPE,
-                                             EGL_OPENGL_BIT,
-                                             EGL_NONE};
-
-      // Initialize EGL
-      EGLDisplay egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-
-      EGLint major, minor;
-      eglInitialize(egl_display, &major, &minor);
-
-      egl_version = gladLoaderLoadEGL(egl_display);
-
-      TI_DEBUG("Loaded EGL {}.{} on display {}",
-               GLAD_VERSION_MAJOR(egl_version), GLAD_VERSION_MINOR(egl_version),
-               egl_display);
-
-      // Select an appropriate configuration
-      EGLint num_configs;
-      EGLConfig egl_config;
-
-      eglChooseConfig(egl_display, configAttribs, &egl_config, 1, &num_configs);
-
-      // Bind the API (EGL >= 1.2)
-      if (egl_version >= GLAD_MAKE_VERSION(1, 2)) {
-        eglBindAPI(use_gles ? EGL_OPENGL_ES_API : EGL_OPENGL_API);
-      }
-
-      // Create a context and make it current
-      EGLContext egl_context = EGL_NO_CONTEXT;
-      if (use_gles) {
-        static const EGLint gl_attribs[] = {
-            EGL_CONTEXT_MAJOR_VERSION,
-            3,
-            EGL_CONTEXT_MINOR_VERSION,
-            1,
-            EGL_NONE,
-        };
-
-        egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT,
-                                       gl_attribs);
-      } else {
-        egl_context =
-            eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, nullptr);
-      }
-
-      eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
-
-      get_proc_addr = (void *)&glad_eglGetProcAddress;
-      if (use_gles) {
-        opengl_version = gladLoadGLES2(glad_eglGetProcAddress);
-      } else {
-        opengl_version = gladLoadGL(glad_eglGetProcAddress);
-      }
+      opengl_version = gladLoadGL((GLADloadfunc)get_proc_addr);
     }
   }
 
@@ -214,6 +251,9 @@ bool is_gles() {
 void reset_opengl() {
   supported = std::nullopt;
   kUseGles = false;
+  kGetOpenglProcAddr = std::nullopt;
+  imported_process_address = std::nullopt;
+  unset_gles_override();
 #ifndef ANDROID
   if (context_with_glfw) {
     window_system::glfw_context_release();

--- a/taichi/rhi/opengl/opengl_api.h
+++ b/taichi/rhi/opengl/opengl_api.h
@@ -7,6 +7,8 @@
 namespace taichi::lang {
 namespace opengl {
 
+void set_gles_override(bool value);
+void unset_gles_override();
 bool initialize_opengl(bool use_gles = false, bool error_tolerance = false);
 bool is_opengl_api_available(bool use_gles = false);
 bool is_gles();

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -24,7 +24,8 @@ std::string get_opengl_error_string(GLenum err);
     }                                                                \
   }
 
-extern void *kGetOpenglProcAddr;
+extern std::optional<void *>kGetOpenglProcAddr;
+extern std::optional<void *>imported_process_address;
 
 class GLResourceSet : public ShaderResourceSet {
  public:

--- a/taichi/rhi/opengl/opengl_device.h
+++ b/taichi/rhi/opengl/opengl_device.h
@@ -24,8 +24,8 @@ std::string get_opengl_error_string(GLenum err);
     }                                                                \
   }
 
-extern std::optional<void *>kGetOpenglProcAddr;
-extern std::optional<void *>imported_process_address;
+extern std::optional<void *> kGetOpenglProcAddr;
+extern std::optional<void *> imported_process_address;
 
 class GLResourceSet : public ShaderResourceSet {
  public:


### PR DESCRIPTION
Issue: #8183

### Brief Summary
Adds the ability to import an external OpenGL context as well as specify if using OpenGLES.

### Walkthrough
* Import OpenGL context added with implementation of ti_import_opengl_runtime()
    * ti_import_opengl_runtime sets if using OpenGLES and the process address used to initialize OpenGL with glad.
    * initialize_opengl will now check to see if there is an existing context before it tries to make a new one.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d340716</samp>

*  Add a `use_gles` parameter to the `ti_import_opengl_runtime` function to allow the user to choose between OpenGL ES and OpenGL when importing an existing OpenGL context ([link](https://github.com/taichi-dev/taichi/pull/8185/files?diff=unified&w=0#diff-147f3f663ebf6052b4fefa43ec1fcdfbc84b63cccb10799e53da38bed9649dfeL35-R36), [link](https://github.com/taichi-dev/taichi/pull/8185/files?diff=unified&w=0#diff-49357769896e790fc2a5882464d92c2eb205ec2473db22480ffe5bee895fea58R21-R30))
*  Define a global variable `kSetGles` to store the user's preference for using OpenGL ES or OpenGL and initialize it to `false` by default ([link](https://github.com/taichi-dev/taichi/pull/8185/files?diff=unified&w=0#diff-bd45dc7fa2776d5568cf0085496a6eeb3ff30876de1a1c6e4b7e4e81798679b6L30-R35), [link](https://github.com/taichi-dev/taichi/pull/8185/files?diff=unified&w=0#diff-d152cbed3aa0abc7bff544a62bf4dac327fa2c002f40100a816d73a52b39318aR28))
*  Modify the `initialize_opengl` function in `taichi/rhi/opengl/opengl_api.cpp` to skip creating or loading GLFW, EGL, or OpenGL functions if `kGetOpenglProcAddr` is set, and to use the existing or current contexts instead ([link](https://github.com/taichi-dev/taichi/pull/8185/files?diff=unified&w=0#diff-bd45dc7fa2776d5568cf0085496a6eeb3ff30876de1a1c6e4b7e4e81798679b6L49-R55), [link](https://github.com/taichi-dev/taichi/pull/8185/files?diff=unified&w=0#diff-bd45dc7fa2776d5568cf0085496a6eeb3ff30876de1a1c6e4b7e4e81798679b6L66-R78), [link](https://github.com/taichi-dev/taichi/pull/8185/files?diff=unified&w=0#diff-bd45dc7fa2776d5568cf0085496a6eeb3ff30876de1a1c6e4b7e4e81798679b6L88-R190))