### PR TITLE
[ir] Let expand_exprs support expanding nested structs

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1672,7 +1672,7 @@ std::vector<Expr> ASTBuilder::expand_exprs(const std::vector<Expr> &exprs) {
   for (auto expr : exprs) {
     TI_ASSERT_TYPE_CHECKED(expr);
 
-    auto expand_tensor_or_scalar = [&](Expr expr) {
+    auto expand_tensor_or_scalar = [&](const Expr &expr) {
       if (!expr->ret_type.ptr_removed()->is<TensorType>()) {
         expanded_exprs.push_back(expr);
       } else {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1677,20 +1677,22 @@ std::vector<Expr> ASTBuilder::expand_exprs(const std::vector<Expr> &exprs) {
         expanded_exprs.push_back(expr);
       } else {
         // Expand TensorType expr
+        // clang-format off
         /*
           Before:
             TensorType<4 x i32> index = Expr;
 
-      After:
-        TensorType<4 x i32>* id_expr = FrontendAllocaStmt(TensorType<4 x i32>)
+          After:
+            TensorType<4 x i32>* id_expr = FrontendAllocaStmt(TensorType<4 x i32>)
             i32 ind0 = IndexExpression(id_expr, 0)
-                i32 ind1 = IndexExpression(id_expr, 1)
-                    i32 ind2 = IndexExpression(id_expr, 2)
-                        i32 ind3 = IndexExpression(id_expr, 3)
+            i32 ind1 = IndexExpression(id_expr, 1)
+            i32 ind2 = IndexExpression(id_expr, 2)
+            i32 ind3 = IndexExpression(id_expr, 3)
 
-                                       return {ind0, ind1, ind2, ind3}
+            return {ind0, ind1, ind2, ind3}
 
-                                           */
+         */
+        // clang-format on
         auto tensor_type = expr->ret_type.ptr_removed()->cast<TensorType>();
 
         Expr id_expr;

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1671,62 +1671,82 @@ std::vector<Expr> ASTBuilder::expand_exprs(const std::vector<Expr> &exprs) {
   std::vector<Expr> expanded_exprs;
   for (auto expr : exprs) {
     TI_ASSERT_TYPE_CHECKED(expr);
-    if (auto struct_type = expr->ret_type.ptr_removed()->cast<StructType>()) {
-      auto num_elem = struct_type->elements().size();
-      for (int i = 0; i < num_elem; i++) {
-        std::vector<int> indices = {i};
-        auto elem = Expr(std::make_shared<GetElementExpression>(expr, indices));
-        elem.expr->ret_type = struct_type->get_element_type(indices);
-        expanded_exprs.push_back(elem);
-      }
-    } else if (!expr->ret_type.ptr_removed()->is<TensorType>()) {
-      expanded_exprs.push_back(expr);
-    } else {
-      // Expand TensorType expr
-      /*
-        Before:
-          TensorType<4 x i32> index = Expr;
 
-        After:
-          TensorType<4 x i32>* id_expr = FrontendAllocaStmt(TensorType<4 x i32>)
-          i32 ind0 = IndexExpression(id_expr, 0)
-          i32 ind1 = IndexExpression(id_expr, 1)
-          i32 ind2 = IndexExpression(id_expr, 2)
-          i32 ind3 = IndexExpression(id_expr, 3)
-
-          return {ind0, ind1, ind2, ind3}
-
-      */
-      auto tensor_type = expr->ret_type.ptr_removed()->cast<TensorType>();
-
-      Expr id_expr;
-      if (expr.is<IdExpression>()) {
-        id_expr = expr;
+    auto expand_tensor_or_scalar = [&](Expr expr) {
+      if (!expr->ret_type.ptr_removed()->is<TensorType>()) {
+        expanded_exprs.push_back(expr);
       } else {
-        id_expr = make_var(expr, expr->tb);
-      }
-      auto shape = tensor_type->get_shape();
-      if (shape.size() == 1) {
-        for (int i = 0; i < shape[0]; i++) {
-          auto ind = Expr(std::make_shared<IndexExpression>(
-              id_expr, ExprGroup(Expr(i)), expr->tb));
-          ind->type_check(nullptr);
-          expanded_exprs.push_back(ind);
+        // Expand TensorType expr
+        /*
+          Before:
+            TensorType<4 x i32> index = Expr;
+
+      After:
+        TensorType<4 x i32>* id_expr = FrontendAllocaStmt(TensorType<4 x i32>)
+            i32 ind0 = IndexExpression(id_expr, 0)
+                i32 ind1 = IndexExpression(id_expr, 1)
+                    i32 ind2 = IndexExpression(id_expr, 2)
+                        i32 ind3 = IndexExpression(id_expr, 3)
+
+                                       return {ind0, ind1, ind2, ind3}
+
+                                           */
+        auto tensor_type = expr->ret_type.ptr_removed()->cast<TensorType>();
+
+        Expr id_expr;
+        if (expr.is<IdExpression>()) {
+          id_expr = expr;
+        } else {
+          id_expr = make_var(expr, expr->tb);
         }
-      } else {
-        TI_ASSERT(shape.size() == 2);
-        for (int i = 0; i < shape[0]; i++) {
-          for (int j = 0; j < shape[1]; j++) {
+        auto shape = tensor_type->get_shape();
+        if (shape.size() == 1) {
+          for (int i = 0; i < shape[0]; i++) {
             auto ind = Expr(std::make_shared<IndexExpression>(
-                id_expr, ExprGroup(Expr(i), Expr(j)), expr->tb));
+                id_expr, ExprGroup(Expr(i)), expr->tb));
             ind->type_check(nullptr);
             expanded_exprs.push_back(ind);
           }
+        } else {
+          TI_ASSERT(shape.size() == 2);
+          for (int i = 0; i < shape[0]; i++) {
+            for (int j = 0; j < shape[1]; j++) {
+              auto ind = Expr(std::make_shared<IndexExpression>(
+                  id_expr, ExprGroup(Expr(i), Expr(j)), expr->tb));
+              ind->type_check(nullptr);
+              expanded_exprs.push_back(ind);
+            }
+          }
         }
       }
+    };
+
+    std::function<void(const Expr &, const StructType *, std::vector<int> &)>
+        expand_struct = [&](const Expr &expr, const StructType *struct_type,
+                            std::vector<int> &indices) {
+          auto num_elem = struct_type->elements().size();
+          for (int i = 0; i < num_elem; i++) {
+            indices.push_back(i);
+            auto element_type = struct_type->get_element_type({i});
+            if (auto element_struct_type = element_type->cast<StructType>()) {
+              expand_struct(expr, element_struct_type, indices);
+            } else {
+              auto elem =
+                  Expr(std::make_shared<GetElementExpression>(expr, indices));
+              elem.expr->ret_type = element_type;
+              expand_tensor_or_scalar(elem);
+            }
+            indices.pop_back();
+          }
+        };
+    auto type = expr->ret_type.ptr_removed();
+    if (auto struct_type = type->cast<StructType>()) {
+      std::vector<int> indices;
+      expand_struct(expr, struct_type, indices);
+    } else {
+      expand_tensor_or_scalar(expr);
     }
   }
-
   return expanded_exprs;
 }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8776794</samp>

### Summary
🛠️🔄🧠

<!--
1.  🛠️ This emoji represents a tool or a fix, and it can be used to indicate that the change refactors or improves the existing code.
2.  🔄 This emoji represents a cycle or a loop, and it can be used to indicate that the change introduces a recursive function or a traversal algorithm.
3.  🧠 This emoji represents a brain or intelligence, and it can be used to indicate that the change adds some comments or explanations to the code.
-->
Refactor `expand_exprs` function in `taichi/ir/frontend_ir.cpp` to handle nested structs and tensors. Use recursive lambda functions to extract and expand scalar and tensor elements from structs. Add comments to explain the expansion logic.

> _`expand_exprs` grows_
> _nested structs and tensors_
> _autumn leaves unfold_

### Walkthrough
*  Refactor `expand_exprs` function to handle nested structs and tensors using recursive lambda functions ([link](https://github.com/taichi-dev/taichi/pull/8190/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1674-R1749))
*  Add comments to explain the logic of struct and tensor expansion ([link](https://github.com/taichi-dev/taichi/pull/8190/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1674-R1749))



Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8188
* #8191
* #8192
* __->__ #8190

