### PR TITLE
[Lang] Cast the scalar arguments and return values of ti.func if the type hints exist

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -737,6 +737,11 @@ class ASTTransformer(Builder):
                         ctx.create_variable(arg.arg, impl.expr_init_func(data))
                         continue
 
+                    if id(ctx.func.arguments[i].annotation) in primitive_types.type_ids:
+                        ctx.create_variable(
+                            arg.arg, impl.expr_init_func(ti_ops.cast(data, ctx.func.arguments[i].annotation))
+                        )
+                        continue
                     # Create a copy for non-template arguments,
                     # so that they are passed by value.
                     ctx.create_variable(arg.arg, impl.expr_init_func(data))
@@ -855,6 +860,8 @@ class ASTTransformer(Builder):
             # only need to replace the object part, i.e. args[0].value
         else:
             ctx.return_data = node.value.ptr
+            if id(ctx.func.return_type) in primitive_types.type_ids:
+                ctx.return_data = ti_ops.cast(ctx.return_data, ctx.func.return_type)
         if not ctx.is_real_function:
             ctx.returned = ReturnStatus.ReturnedValue
         return None

--- a/tests/python/test_argument.py
+++ b/tests/python/test_argument.py
@@ -261,3 +261,16 @@ def test_struct_arg_with_matrix_real_func():
 
     ret = bar(arg)
     assert ret == ret_std
+
+
+@test_utils.test()
+def test_func_scalar_arg_cast():
+    @ti.func
+    def bar(a: ti.i32) -> ti.f32:
+        return a
+
+    @ti.kernel
+    def foo(a: ti.f32) -> ti.f32:
+        return bar(a)
+
+    assert foo(1.5) == 1.0

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -248,3 +248,16 @@ def test_return_type_mismatch_3():
 
     with pytest.raises(ti.TaichiCompilationError):
         bar()
+
+
+@test_utils.test()
+def test_func_scalar_return_cast():
+    @ti.func
+    def bar(a: ti.f32) -> ti.i32:
+        return a
+
+    @ti.kernel
+    def foo(a: ti.f32) -> ti.f32:
+        return bar(a)
+
+    assert foo(1.5) == 1.0


### PR DESCRIPTION
Issue: fix #7946

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6275116</samp>

This pull request implements automatic scalar casting for function arguments and return values based on type annotations in Taichi. It also adds two test cases in `test_argument.py` and `test_return.py` to verify the feature.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6275116</samp>

*  Add automatic scalar casting for function arguments and return values ([link](https://github.com/taichi-dev/taichi/pull/8193/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fR740-R744), [link](https://github.com/taichi-dev/taichi/pull/8193/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fR863-R864))
* Add test cases for scalar argument and return value casting ([link](https://github.com/taichi-dev/taichi/pull/8193/files?diff=unified&w=0#diff-f2d9c4a8c504d2073549cde99b31a733a2f39bba4ce9f062cbaa09e1be17aa87R264-R276), [link](https://github.com/taichi-dev/taichi/pull/8193/files?diff=unified&w=0#diff-e206c19691b4678b401a5e2787000e93ab0b0060cbf4ac2625b51f87599d98d8R251-R263))
