### PR TITLE
[Bug] Fix issue with passing python-scope Matrix as ti.func argument

### DIFF
--- a/python/taichi/lang/ast/ast_transformer_utils.py
+++ b/python/taichi/lang/ast/ast_transformer_utils.py
@@ -255,7 +255,12 @@ class ASTTransformerContext:
             if name in s:
                 return s[name]
         if name in self.global_vars:
-            return self.global_vars[name]
+            var = self.global_vars[name]
+            from taichi.lang.matrix import Matrix, make_matrix  # pylint: disable-msg=C0415
+
+            if isinstance(var, Matrix):
+                return make_matrix(var.to_list())
+            return var
         try:
             return getattr(builtins, name)
         except AttributeError:

--- a/tests/python/test_matrix.py
+++ b/tests/python/test_matrix.py
@@ -3,6 +3,7 @@ import operator
 
 import numpy as np
 import pytest
+from pytest import approx
 from taichi.lang import impl
 from taichi.lang.exception import TaichiCompilationError, TaichiTypeError
 from taichi.lang.misc import get_host_arch_list
@@ -1358,3 +1359,19 @@ def test_matrix_dtype():
 
     b = ti.types.matrix(2, 2, dtype=ti.i32)([[0, 1], [2, 3]])
     assert b.entries.dtype == np.int32
+
+
+@test_utils.test()
+def test_matrix_and_func():
+    vec4d = ti.types.vector(4, float)
+    v = vec4d(1, 2, 3, 4)
+
+    @ti.func
+    def length(w: vec4d):
+        return w.norm()
+
+    @ti.kernel
+    def test() -> ti.f32:
+        return length(v)
+
+    approx(test(), 5.477226)


### PR DESCRIPTION
Issue: fix #8042 #8114

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da679b9</samp>

Add support for Python matrices and functions in Taichi kernels. Update `get_var_by_name` to handle `Matrix` objects and add a new test case in `test_matrix.py`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da679b9</samp>

*  Enable using Python matrices and functions in Taichi kernels by:
  - Converting `Matrix` objects to `ti.Matrix` objects in `get_var_by_name` ([link](https://github.com/taichi-dev/taichi/pull/8197/files?diff=unified&w=0#diff-3c4fc72604c650382997de2541e648ef88ee8f608a9e3d3ebbe7e6a74cb2eec8L258-R263))
  - Adding a new test case for the matrix and function feature in `test_matrix.py` ([link](https://github.com/taichi-dev/taichi/pull/8197/files?diff=unified&w=0#diff-28226020cc3cc2e223eb43801fa78360d006c26d7140c3b37719faf9e9df34f7R6), [link](https://github.com/taichi-dev/taichi/pull/8197/files?diff=unified&w=0#diff-28226020cc3cc2e223eb43801fa78360d006c26d7140c3b37719faf9e9df34f7R1362-R1377))
