### PR TITLE
[autodiff] Fix loop index not stored

### DIFF
--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -337,7 +337,7 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
     if (execute_once_)
       return;
     if (!(stmt->is<UnaryOpStmt>() || stmt->is<BinaryOpStmt>() ||
-          stmt->is<TernaryOpStmt>() || stmt->is<GlobalLoadStmt>() ||
+          stmt->is<TernaryOpStmt>() || stmt->is<GlobalLoadStmt>() || stmt->is<LoopIndexStmt>() ||
           stmt->is<AllocaStmt>())) {
       // TODO: this list may be incomplete
       return;

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -337,8 +337,8 @@ class PromoteSSA2LocalVar : public BasicStmtVisitor {
     if (execute_once_)
       return;
     if (!(stmt->is<UnaryOpStmt>() || stmt->is<BinaryOpStmt>() ||
-          stmt->is<TernaryOpStmt>() || stmt->is<GlobalLoadStmt>() || stmt->is<LoopIndexStmt>() ||
-          stmt->is<AllocaStmt>())) {
+          stmt->is<TernaryOpStmt>() || stmt->is<GlobalLoadStmt>() ||
+          stmt->is<LoopIndexStmt>() || stmt->is<AllocaStmt>())) {
       // TODO: this list may be incomplete
       return;
     }

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -993,7 +993,7 @@ def test_ib_global_load():
         assert a.grad[i] == i
 
 
-@test_utils.test()
+@test_utils.test(require=ti.extension.adstack)
 def test_for_loop_index():
     N = 2
     M = 2

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -1036,4 +1036,4 @@ def test_for_loop_index():
 
     for i in range(N):
         for j in range(M):
-            assert test_utils.allclose(x.grad[i, j] - my_x_grad[i, j], 1e-5, 1e-6)
+            assert test_utils.allclose(x.grad[i, j], my_x_grad[i, j])

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -1036,4 +1036,4 @@ def test_for_loop_index():
 
     for i in range(N):
         for j in range(M):
-            assert test_utils.allclose(x.grad[i, j] - my_x_grad[i, j])
+            assert test_utils.allclose(x.grad[i, j] - my_x_grad[i, j], 1e-6)

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -1036,4 +1036,4 @@ def test_for_loop_index():
 
     for i in range(N):
         for j in range(M):
-            assert x.grad[i, j] - my_x_grad[i, j] < 1e-6
+            assert test_utils.allclose(x.grad[i, j] - my_x_grad[i, j])

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -1036,4 +1036,4 @@ def test_for_loop_index():
 
     for i in range(N):
         for j in range(M):
-            assert test_utils.allclose(x.grad[i, j] - my_x_grad[i, j], 1e-6)
+            assert test_utils.allclose(x.grad[i, j] - my_x_grad[i, j], 1e-5, 1e-6)

--- a/tests/python/test_ad_for.py
+++ b/tests/python/test_ad_for.py
@@ -991,3 +991,49 @@ def test_ib_global_load():
     compute.grad()
     for i in range(N):
         assert a.grad[i] == i
+
+
+@test_utils.test()
+def test_for_loop_index():
+    N = 2
+    M = 2
+    x = ti.field(ti.f32, shape=(N, M), needs_grad=True)
+    x[0, 0] = -0.57279384
+    x[0, 1] = 0.7815071
+    x[1, 0] = 0.45064202
+    x[1, 1] = -0.299493
+    my_x_grad = ti.field(ti.f32, shape=(N, M))
+    loss = ti.field(ti.f32, shape=(), needs_grad=True)
+
+    @ti.kernel
+    def compute():
+        for i in range(N):
+            x_sum = 0.0
+            for j in range(M):
+                x_sum += x[i, j]
+            loss[None] += ti.exp(x_sum)
+
+    @ti.kernel
+    def compute_grad():
+        for i in range(N):
+            # forward again
+            x_sum = 0.0
+            for j in range(M):
+                x_sum += x[i, j]
+            # backward
+            x_sum_grad = loss.grad[None] * ti.exp(x_sum)
+            for j in range(M):
+                my_x_grad[i, j] = x_sum_grad
+
+    # Compute gradient using AD
+    loss[None] = 0
+    compute()
+    loss.grad[None] = 1
+    compute.grad()
+
+    # Compute the mannually derived gradient
+    compute_grad()
+
+    for i in range(N):
+        for j in range(M):
+            assert x.grad[i, j] - my_x_grad[i, j] < 1e-6


### PR DESCRIPTION
Issue: #8027 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba812c2</samp>

This pull request implements automatic differentiation for for-loops with loop indices, a feature that allows users to compute gradients of scalar fields that depend on loop variables. It modifies the `PromoteSSA2LocalVar` pass in `taichi/transforms/auto_diff.cpp` to support this feature and adds a test case in `tests/python/test_ad_for.py` to verify its correctness.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba812c2</samp>

* Enable automatic differentiation for for-loops with loop indices by allowing `LoopIndexStmt` to be promoted to local variables ([link](https://github.com/taichi-dev/taichi/pull/8200/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L340-R340))
* Add a test case for the new feature that computes the gradient of a row-sum loss function using both the automatic differentiation mechanism and a manual gradient function, and asserts that they are close enough ([link](https://github.com/taichi-dev/taichi/pull/8200/files?diff=unified&w=0#diff-4bdbef8b06be92bbe99a77155f377dde7acab80d5499bb5231e8fa4d814bf682R994-R1039))
