### PR TITLE
[bug] Fix incorrect error message in checking matrix shape

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -786,9 +786,9 @@ class ASTTransformer(Builder):
             elif isinstance(ctx.func.return_type, MatrixType):
                 values = node.value.ptr
                 if isinstance(values, Matrix):
-                    if len(values.get_shape()) != ctx.func.return_type.ndim:
+                    if values.ndim != ctx.func.return_type.ndim:
                         raise TaichiRuntimeTypeError(
-                            f"Return matrix ndim mismatch, expecting={ctx.func.return_type.ndim}, got={len(values.get_shape())}."
+                            f"Return matrix ndim mismatch, expecting={ctx.func.return_type.ndim}, got={values.ndim}."
                         )
                     elif ctx.func.return_type.get_shape() != values.get_shape():
                         raise TaichiRuntimeTypeError(
@@ -820,7 +820,7 @@ class ASTTransformer(Builder):
                         )
                     elif ctx.func.return_type.get_shape() != values.get_shape():
                         raise TaichiRuntimeTypeError(
-                            f"Return matrix ndim mismatch, expecting={ctx.func.return_type.ndim}, got={len(values.get_shape())}."
+                            f"Return matrix shape mismatch, expecting={ctx.func.return_type.get_shape()}, got={values.get_shape()}."
                         )
                     values = [values]
                 else:


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2f6993</samp>

Simplify matrix shape handling and fix typo in `ast_transformer.py`. Use a more consistent and concise way to access matrix dimensions and improve error message clarity.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a2f6993</samp>

*  Simplify code by using `ndim` property of `Matrix` class instead of calling `get_shape` method ([link](https://github.com/taichi-dev/taichi/pull/8201/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL789-R791))
*  Fix typo in error message for return matrix shape mismatch ([link](https://github.com/taichi-dev/taichi/pull/8201/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL823-R823))
