### PR TITLE
[ir] Add lower_matrix_ptr pass to compile_function and move scalarize to the end

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -354,13 +354,10 @@ void compile_function(IRNode *ir,
       print("Lowered");
     }
 
-    if (config.real_matrix_scalarize) {
-      if (irpass::scalarize(ir)) {
-        // Remove redundant MatrixInitStmt inserted during scalarization
-        irpass::die(ir);
-        print("Scalarized");
-      }
-    }
+    // Removes MatrixOfMatrixPtrStmt & MatrixOfGlobalPtrStmt
+    irpass::lower_matrix_ptr(ir);
+    print("Matrix ptr lowered");
+
     irpass::demote_atomics(ir, config);
     print("Atomics demoted");
     func->set_ir_stage(Function::IRStage::BeforeLowerAccess);
@@ -385,6 +382,14 @@ void compile_function(IRNode *ir,
 
     irpass::demote_operations(ir, config);
     print("Operations demoted");
+
+    if (config.real_matrix_scalarize) {
+      if (irpass::scalarize(ir)) {
+        // Remove redundant MatrixInitStmt inserted during scalarization
+        irpass::die(ir);
+        print("Scalarized");
+      }
+    }
 
     irpass::full_simplify(ir, config,
                           {true, autodiff_mode != AutodiffMode::kNone,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8219
* #8215
* #8208
* #8210
* __->__ #8207

