### PR TITLE
[Lang] Support tuple return value for kernel and real function

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -583,6 +583,7 @@ class ASTTransformer(Builder):
             node.ptr = func(node.func.caller, *args, **keywords)
             return node.ptr
         ASTTransformer.warn_if_is_external_func(ctx, node)
+        print(func)
         node.ptr = func(*args, **keywords)
 
         if getattr(func, "_is_taichi_function", False):
@@ -645,7 +646,8 @@ class ASTTransformer(Builder):
         def transform_as_kernel():
             # Treat return type
             if node.returns is not None:
-                kernel_arguments.decl_ret(ctx.func.return_type)
+                for return_type in ctx.func.return_type:
+                    kernel_arguments.decl_ret(return_type)
             impl.get_runtime().compiling_callable.finalize_rets()
 
             for i, arg in enumerate(args.args):
@@ -770,98 +772,97 @@ class ASTTransformer(Builder):
                     "with a return value must be annotated "
                     "with a return type, e.g. def func() -> ti.f32"
                 )
-            if id(ctx.func.return_type) in primitive_types.type_ids:
-                if isinstance(node.value.ptr, Expr):
-                    if (
-                        node.value.ptr.is_tensor()
-                        or node.value.ptr.is_struct()
-                        or node.value.ptr.element_type() not in primitive_types.all_types
-                    ):
-                        raise TaichiRuntimeTypeError.get_ret(str(ctx.func.return_type), node.value.ptr)
-                elif not isinstance(node.value.ptr, (float, int, np.floating, np.integer)):
-                    raise TaichiRuntimeTypeError.get_ret(str(ctx.func.return_type), node.value.ptr)
-                ctx.ast_builder.create_kernel_exprgroup_return(
-                    expr.make_expr_group(ti_ops.cast(expr.Expr(node.value.ptr), ctx.func.return_type).ptr)
-                )
-            elif isinstance(ctx.func.return_type, MatrixType):
-                values = node.value.ptr
-                if isinstance(values, Matrix):
-                    if len(values.get_shape()) != ctx.func.return_type.ndim:
-                        raise TaichiRuntimeTypeError(
-                            f"Return matrix ndim mismatch, expecting={ctx.func.return_type.ndim}, got={len(values.get_shape())}."
+            return_exprs = []
+            if len(ctx.func.return_type) == 1:
+                node.value.ptr = [node.value.ptr]
+            assert len(ctx.func.return_type) == len(node.value.ptr)
+            for return_type, ptr in zip(ctx.func.return_type, node.value.ptr):
+                if id(return_type) in primitive_types.type_ids:
+                    if isinstance(ptr, Expr):
+                        if ptr.is_tensor() or ptr.is_struct() or ptr.element_type() not in primitive_types.all_types:
+                            raise TaichiRuntimeTypeError.get_ret(str(return_type), ptr)
+                    elif not isinstance(ptr, (float, int, np.floating, np.integer)):
+                        raise TaichiRuntimeTypeError.get_ret(str(return_type), ptr)
+                    return_exprs += [ti_ops.cast(expr.Expr(ptr), return_type).ptr]
+                elif isinstance(return_type, MatrixType):
+                    values = ptr
+                    if isinstance(values, Matrix):
+                        if len(values.get_shape()) != return_type.ndim:
+                            raise TaichiRuntimeTypeError(
+                                f"Return matrix ndim mismatch, expecting={return_type.ndim}, got={len(values.get_shape())}."
+                            )
+                        elif return_type.get_shape() != values.get_shape():
+                            raise TaichiRuntimeTypeError(
+                                f"Return matrix shape mismatch, expecting={return_type.get_shape()}, got={values.get_shape()}."
+                            )
+                        values = (
+                            itertools.chain.from_iterable(values.to_list())
+                            if values.ndim == 1
+                            else iter(values.to_list())
                         )
-                    elif ctx.func.return_type.get_shape() != values.get_shape():
-                        raise TaichiRuntimeTypeError(
-                            f"Return matrix shape mismatch, expecting={ctx.func.return_type.get_shape()}, got={values.get_shape()}."
-                        )
-                    values = (
-                        itertools.chain.from_iterable(values.to_list()) if values.ndim == 1 else iter(values.to_list())
-                    )
-                elif isinstance(values, Expr):
-                    if not values.is_tensor():
-                        raise TaichiRuntimeTypeError.get_ret(ctx.func.return_type.to_string(), node.value.ptr)
-                    elif (
-                        ctx.func.return_type.dtype in primitive_types.real_types
-                        and not values.element_type() in primitive_types.all_types
-                    ):
-                        raise TaichiRuntimeTypeError.get_ret(
-                            ctx.func.return_type.dtype.to_string(), values.element_type()
-                        )
-                    elif (
-                        ctx.func.return_type.dtype in primitive_types.integer_types
-                        and not values.element_type() in primitive_types.integer_types
-                    ):
-                        raise TaichiRuntimeTypeError.get_ret(
-                            ctx.func.return_type.dtype.to_string(), values.element_type()
-                        )
-                    elif len(values.get_shape()) != ctx.func.return_type.ndim:
-                        raise TaichiRuntimeTypeError(
-                            f"Return matrix ndim mismatch, expecting={ctx.func.return_type.ndim}, got={len(values.get_shape())}."
-                        )
-                    elif ctx.func.return_type.get_shape() != values.get_shape():
-                        raise TaichiRuntimeTypeError(
-                            f"Return matrix ndim mismatch, expecting={ctx.func.return_type.ndim}, got={len(values.get_shape())}."
-                        )
-                    values = [values]
+                    elif isinstance(values, Expr):
+                        if not values.is_tensor():
+                            raise TaichiRuntimeTypeError.get_ret(return_type.to_string(), ptr)
+                        elif (
+                            return_type.dtype in primitive_types.real_types
+                            and not values.element_type() in primitive_types.all_types
+                        ):
+                            raise TaichiRuntimeTypeError.get_ret(return_type.dtype.to_string(), values.element_type())
+                        elif (
+                            return_type.dtype in primitive_types.integer_types
+                            and not values.element_type() in primitive_types.integer_types
+                        ):
+                            raise TaichiRuntimeTypeError.get_ret(return_type.dtype.to_string(), values.element_type())
+                        elif len(values.get_shape()) != return_type.ndim:
+                            raise TaichiRuntimeTypeError(
+                                f"Return matrix ndim mismatch, expecting={return_type.ndim}, got={len(values.get_shape())}."
+                            )
+                        elif return_type.get_shape() != values.get_shape():
+                            raise TaichiRuntimeTypeError(
+                                f"Return matrix ndim mismatch, expecting={return_type.ndim}, got={len(values.get_shape())}."
+                            )
+                        values = [values]
+                    else:
+                        np_array = np.array(values)
+                        dt, shape, ndim = np_array.dtype, np_array.shape, np_array.ndim
+                        if return_type.dtype in primitive_types.real_types and dt not in (
+                            float,
+                            int,
+                            np.floating,
+                            np.integer,
+                        ):
+                            raise TaichiRuntimeTypeError.get_ret(return_type.dtype.to_string(), dt)
+                        elif return_type.dtype in primitive_types.integer_types and dt not in (int, np.integer):
+                            raise TaichiRuntimeTypeError.get_ret(return_type.dtype.to_string(), dt)
+                        elif ndim != return_type.ndim:
+                            raise TaichiRuntimeTypeError(
+                                f"Return matrix ndim mismatch, expecting={return_type.ndim}, got={ndim}."
+                            )
+                        elif return_type.get_shape() != shape:
+                            raise TaichiRuntimeTypeError(
+                                f"Return matrix shape mismatch, expecting={return_type.get_shape()}, got={shape}."
+                            )
+                        values = [values]
+                    return_exprs += [ti_ops.cast(exp, return_type.dtype) for exp in values]
+                elif isinstance(return_type, StructType):
+                    if not isinstance(ptr, Struct) or not isinstance(ptr, return_type):
+                        raise TaichiRuntimeTypeError.get_ret(str(return_type), ptr)
+                    values = ptr
+                    assert isinstance(values, Struct)
+                    return_exprs += expr._get_flattened_ptrs(values)
                 else:
-                    np_array = np.array(values)
-                    dt, shape, ndim = np_array.dtype, np_array.shape, np_array.ndim
-                    if ctx.func.return_type.dtype in primitive_types.real_types and dt not in (
-                        float,
-                        int,
-                        np.floating,
-                        np.integer,
-                    ):
-                        raise TaichiRuntimeTypeError.get_ret(ctx.func.return_type.dtype.to_string(), dt)
-                    elif ctx.func.return_type.dtype in primitive_types.integer_types and dt not in (int, np.integer):
-                        raise TaichiRuntimeTypeError.get_ret(ctx.func.return_type.dtype.to_string(), dt)
-                    elif ndim != ctx.func.return_type.ndim:
-                        raise TaichiRuntimeTypeError(
-                            f"Return matrix ndim mismatch, expecting={ctx.func.return_type.ndim}, got={ndim}."
-                        )
-                    elif ctx.func.return_type.get_shape() != shape:
-                        raise TaichiRuntimeTypeError(
-                            f"Return matrix shape mismatch, expecting={ctx.func.return_type.get_shape()}, got={shape}."
-                        )
-                    values = [values]
-                ctx.ast_builder.create_kernel_exprgroup_return(
-                    expr.make_expr_group([ti_ops.cast(exp, ctx.func.return_type.dtype) for exp in values])
-                )
-            elif isinstance(ctx.func.return_type, StructType):
-                if not isinstance(node.value.ptr, Struct) or not isinstance(node.value.ptr, ctx.func.return_type):
-                    raise TaichiRuntimeTypeError.get_ret(str(ctx.func.return_type), node.value.ptr)
-                values = node.value.ptr
-                assert isinstance(values, Struct)
-                ctx.ast_builder.create_kernel_exprgroup_return(expr.make_expr_group(expr._get_flattened_ptrs(values)))
-            else:
-                raise TaichiSyntaxError("The return type is not supported now!")
-            # For args[0], it is an ast.Attribute, because it loads the
-            # attribute, |ptr|, of the expression |ret_expr|. Therefore we
-            # only need to replace the object part, i.e. args[0].value
+                    raise TaichiSyntaxError("The return type is not supported now!")
+            ctx.ast_builder.create_kernel_exprgroup_return(expr.make_expr_group(return_exprs))
         else:
             ctx.return_data = node.value.ptr
-            if id(ctx.func.return_type) in primitive_types.type_ids:
-                ctx.return_data = ti_ops.cast(ctx.return_data, ctx.func.return_type)
+            if ctx.func.return_type is not None:
+                if len(ctx.func.return_type) == 1:
+                    ctx.return_data = [ctx.return_data]
+                for i, return_type in enumerate(ctx.func.return_type):
+                    if id(return_type) in primitive_types.type_ids:
+                        ctx.return_data[i] = ti_ops.cast(ctx.return_data[i], return_type)
+                if len(ctx.func.return_type) == 1:
+                    ctx.return_data = ctx.return_data[0]
         if not ctx.is_real_function:
             ctx.returned = ReturnStatus.ReturnedValue
         return None

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -136,7 +136,7 @@ def make_var_list(size, ast_builder=None):
     return exprs
 
 
-def make_expr_group(*exprs, real_func_arg=False):
+def make_expr_group(*exprs):
     from taichi.lang.matrix import Matrix  # pylint: disable=C0415
 
     if len(exprs) == 1:

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -5,6 +5,8 @@ import operator
 import re
 import sys
 import textwrap
+import typing
+import types
 import warnings
 import weakref
 
@@ -266,7 +268,7 @@ class Func:
                     non_template_args.append(args[i].ptr)
                 else:
                     non_template_args.append(args[i])
-        non_template_args = impl.make_expr_group(non_template_args, real_func_arg=True)
+        non_template_args = impl.make_expr_group(non_template_args)
         func_call = (
             impl.get_runtime()
             .compiling_callable.ast_builder()
@@ -275,13 +277,18 @@ class Func:
         if self.return_type is None:
             return None
         func_call = Expr(func_call)
-        if id(self.return_type) in primitive_types.type_ids:
-            return Expr(_ti_core.make_get_element_expr(func_call.ptr, (0,)))
-        if isinstance(self.return_type, StructType):
-            return self.return_type.from_taichi_object(func_call, (0,))
-        if isinstance(self.return_type, MatrixType):
-            return self.return_type.from_taichi_object(func_call, (0,))
-        raise TaichiTypeError(f"Unsupported return type: {self.return_type}")
+        ret = []
+
+        for i, return_type in enumerate(self.return_type):
+            if id(return_type) in primitive_types.type_ids:
+                ret.append(Expr(_ti_core.make_get_element_expr(func_call.ptr, (i,))))
+            elif isinstance(return_type, (StructType, MatrixType)):
+                ret.append(return_type.from_taichi_object(func_call, (i,)))
+            else:
+                raise TaichiTypeError(f"Unsupported return type for return value {i}: {return_type}")
+        if len(ret) == 1:
+            return ret[0]
+        return tuple(ret)
 
     def do_compile(self, key, args, arg_features):
         tree, ctx = _get_tree_and_ctx(
@@ -304,6 +311,20 @@ class Func:
         sig = inspect.signature(self.func)
         if sig.return_annotation not in (inspect.Signature.empty, None):
             self.return_type = sig.return_annotation
+            if sys.version_info >= (3, 9):
+                if (
+                    isinstance(self.return_type, (types.GenericAlias, typing._GenericAlias))
+                    and self.return_type.__origin__ is tuple
+                ):
+                    self.return_type = self.return_type.__args__
+            else:
+                if isinstance(self.return_type, typing._GenericAlias) and self.return_type.__origin__ is tuple:
+                    self.return_type = self.return_type.__args__
+            if not isinstance(self.return_type, (list, tuple)):
+                self.return_type = (self.return_type,)
+            for i, return_type in enumerate(self.return_type):
+                if return_type is Ellipsis:
+                    raise TaichiSyntaxError("Ellipsis is not supported in return type annotations")
         params = sig.parameters
         arg_names = params.keys()
         for i, arg_name in enumerate(arg_names):
@@ -543,6 +564,20 @@ class Kernel:
         sig = inspect.signature(self.func)
         if sig.return_annotation not in (inspect._empty, None):
             self.return_type = sig.return_annotation
+            if sys.version_info >= (3, 9):
+                if (
+                    isinstance(self.return_type, (types.GenericAlias, typing._GenericAlias))
+                    and self.return_type.__origin__ is tuple
+                ):
+                    self.return_type = self.return_type.__args__
+            else:
+                if isinstance(self.return_type, typing._GenericAlias) and self.return_type.__origin__ is tuple:
+                    self.return_type = self.return_type.__args__
+            if not isinstance(self.return_type, (list, tuple)):
+                self.return_type = (self.return_type,)
+            for i, return_type in enumerate(self.return_type):
+                if return_type is Ellipsis:
+                    raise TaichiSyntaxError("Ellipsis is not supported in return type annotations")
         params = sig.parameters
         arg_names = params.keys()
         for i, arg_name in enumerate(arg_names):
@@ -872,7 +907,12 @@ class Kernel:
             runtime_ops.sync()
 
         if has_ret:
-            ret = self.construct_kernel_ret(launch_ctx, ret_dt, () if isinstance(ret_dt, tuple) else (0,))
+            ret = []
+            for i, ret_type in enumerate(ret_dt):
+                ret.append(self.construct_kernel_ret(launch_ctx, ret_type, (i,)))
+            if len(ret_dt) == 1:
+                ret = ret[0]
+            # ret = self.construct_kernel_ret(launch_ctx, ret_dt, () if isinstance(ret_dt, tuple) else (0,))
         if callbacks:
             for c in callbacks:
                 c()
@@ -880,8 +920,8 @@ class Kernel:
         return ret
 
     def construct_kernel_ret(self, launch_ctx, ret_type, index=()):
-        if isinstance(ret_type, tuple):
-            return [self.construct_kernel_ret(launch_ctx, ret_type[i], index + (i,)) for i in range(len(ret_type))]
+        # if isinstance(ret_type, tuple):
+        #     return tuple([self.construct_kernel_ret(launch_ctx, ret_type[i], index + (i,)) for i in range(len(ret_type))])
         if isinstance(ret_type, CompoundType):
             return ret_type.from_kernel_struct_ret(launch_ctx, index)
         if ret_type in primitive_types.integer_types:

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -493,7 +493,7 @@ def test_real_func_struct_ret():
     assert foo() == pytest.approx(123 * 1.2345e300)
 
 
-@test_utils.test(arch=[ti.cpu, ti.cuda])
+@test_utils.test(arch=[ti.cpu, ti.cuda], print_full_traceback=True)
 def test_real_func_struct_ret_with_matrix():
     s0 = ti.types.struct(a=ti.math.vec3, b=ti.i16)
     s1 = ti.types.struct(a=ti.f32, b=s0)

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -207,6 +207,37 @@ def test_struct_ret_with_matrix():
     assert ret.b.b == 1
 
 
+@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+def test_real_func_multiple_ret():
+    s0 = ti.types.struct(a=ti.math.vec3, b=ti.i16)
+    s1 = ti.types.struct(a=ti.f32, b=s0)
+
+    @ti.experimental.real_func
+    def foo() -> tuple[ti.f32, s0]:
+        return 1, s0(a=ti.math.vec3([100, 0.2, 3]), b=65537)
+
+    @ti.kernel
+    def bar():
+        ret_a, ret_b = foo()
+        assert ret_a == 1
+        assert ret_b.a[0] == 100
+        assert ret_b.a[1] == 0.2
+        assert ret_b.a[2] == 3
+        assert ret_b.b == 1
+
+    bar()
+    # ret = foo()
+    # assert ret.a == approx(1)
+    # assert ret.b.a[0] == approx(100)
+    # assert ret.b.a[1] == approx(0.2)
+    # assert ret.b.a[2] == approx(3)
+    # assert ret.b.b == 1
+
+
+# ti.init(print_ir=True)
+# test_real_func_multiple_ret()
+
+
 @test_utils.test()
 def test_return_type_mismatch_1():
     with pytest.raises(ti.TaichiCompilationError):


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fac3e0e</samp>

### Summary
🚫🔄🎁

<!--
1.  🚫 - This emoji means "no" or "stop", and it can represent the removal of the `real_func_arg` parameter from the `make_expr_group` function, since it is no longer needed.
2.  🔄 - This emoji means "repeat" or "refresh", and it can represent the support for multiple return types for real functions in the AST transformer, since it allows the return types to be declared and constructed in different ways.
3.  🎁 - This emoji means "gift" or "present", and it can represent the feature of enabling real functions and kernels to have multiple return types, using tuple type annotations, since it gives more flexibility and functionality to the users.
-->
This pull request adds support for multiple return types of real functions and kernels in Taichi, using tuple type annotations. It modifies the AST transformer, the `Func` and `Kernel` classes, and the `make_expr_group` function to handle the new syntax and semantics. It also adds tests for the new feature in `test_return.py`.

> _`Func` and `Kernel`_
> _return tuples of values_
> _autumn of `real_func_arg`_

### Walkthrough
*  Support multiple return types for real functions and kernels ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL648-R649), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL773-R864), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L271-R285), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R307-R320), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R560-R573), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L868-R907), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L876-L877))
  * Modify `transform_as_kernel` and `build_Return` in `ASTTransformer` to handle multiple return types in real functions ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL648-R649), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL773-R864))
  * Modify `func_call_rvalue` and `extract_arguments` in `Func` and `Kernel` to handle multiple return types in real functions and kernels ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L271-R285), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R307-R320), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R560-R573))
  * Modify `launch_kernel` in `Kernel` to return a single value or a tuple of values depending on the return types ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L868-R907))
  * Remove redundant code for tuple return types in `launch_kernel` ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L876-L877))
* Remove `real_func_arg` parameter from `make_expr_group` in `expr.py` and `func_call_rvalue` in `Func`, since it is no longer needed ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a17f6dbf127b67d009730fd966417bb8d094d2c35504bafa49e450ced2a92258L139-R139), [link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L262-R264))
* Add `typing` and `types` modules to the imports in `kernel_impl.py`, since they are used for checking the return type annotations ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R8-R9))
* Add two tests to `test_return.py` to check the functionality of multiple return types for real functions, using Python 3.9 and older syntax ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-e206c19691b4678b401a5e2787000e93ab0b0060cbf4ac2625b51f87599d98d8R212-R254))
* Add `sys` module to the imports in `test_return.py`, since it is used for checking the Python version in the tests ([link](https://github.com/taichi-dev/taichi/pull/8208/files?diff=unified&w=0#diff-e206c19691b4678b401a5e2787000e93ab0b0060cbf4ac2625b51f87599d98d8R1-R2))




Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8219
* #8215
* __->__ #8208
* #8210
* #8207

