### PR TITLE
[lang] Remove useless insertion to global_vars

### DIFF
--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -136,13 +136,6 @@ def _get_tree_and_ctx(
     func_body.decorator_list = []
 
     global_vars = _get_global_vars(self.func)
-    for i, arg in enumerate(func_body.args.args):
-        anno = arg.annotation
-        if isinstance(anno, ast.Name):
-            global_vars[anno.id] = self.arguments[i].annotation
-
-    if isinstance(func_body.returns, ast.Name):
-        global_vars[func_body.returns.id] = self.return_type
 
     if is_kernel or is_real_function:
         # inject template parameters into globals


### PR DESCRIPTION
We don't need to insert the annotations of the arguments and return values to `global_vars` because we always find the annotations in `ctx.func.arguments` and `ctx.func.return_type` in the AST transformer instead of finding them in the `global_vars` dict.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 309040d</samp>

### Summary
🔥🧹🛠️

<!--
1.  🔥 for removing redundant code
2.  🧹 for simplifying the logic
3.  🛠️ for improving the support for template kernels and functions
-->
Refactor template kernel handling by removing redundant annotation code in `kernel_impl.py`. This makes the logic simpler and more consistent.

> _`KernelTemplateMapper`_
> _Simplifies annotations_
> _No more redundancy_

### Walkthrough
*  Simplify the logic for assigning annotations to global variables in template kernels by removing redundant code ([link](https://github.com/taichi-dev/taichi/pull/8210/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L139-R139))



Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #8219
* #8215
* #8208
* __->__ #8210
* #8207

