### PR TITLE
[build] Fix build of RHI examples (temporarily)

### DIFF
--- a/cpp_examples/rhi_examples/CMakeLists.txt
+++ b/cpp_examples/rhi_examples/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(${executable_name} SYSTEM
   PUBLIC
     ${PROJECT_SOURCE_DIR}/external/VulkanMemoryAllocator/include
   )
-target_link_libraries(${executable_name} taichi_c_api ti_device_api glfw)
+target_link_libraries(${executable_name} taichi_core glfw)
 endmacro()
 
 make_sample(sample_1_window sample_1_window.cpp)

--- a/cpp_examples/rhi_examples/common.h
+++ b/cpp_examples/rhi_examples/common.h
@@ -45,6 +45,7 @@ class App {
     TI_INFO("Creating App '{}' of {}x{}", title, width, height);
 
     TI_ASSERT(taichi::lang::vulkan::is_vulkan_api_available());
+    glfwInitVulkanLoader(vkGetInstanceProcAddr);
 
     if (glfwInit()) {
       TI_INFO("Initialized GLFW");

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -2805,7 +2805,7 @@ StreamSemaphore VulkanSurface::acquire_next_image() {
         device_->vk_device(), swapchain_, uint64_t(4 * 1e9),
         image_available_->semaphore, VK_NULL_HANDLE, &image_index_);
     if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR) {
-      BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "vkAcquireNextImageKHR failed");      
+      BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "vkAcquireNextImageKHR failed");
     }
     return std::make_shared<VulkanStreamSemaphoreObject>(image_available_);
   }

--- a/taichi/rhi/vulkan/vulkan_device.cpp
+++ b/taichi/rhi/vulkan/vulkan_device.cpp
@@ -2804,7 +2804,9 @@ StreamSemaphore VulkanSurface::acquire_next_image() {
     VkResult res = vkAcquireNextImageKHR(
         device_->vk_device(), swapchain_, uint64_t(4 * 1e9),
         image_available_->semaphore, VK_NULL_HANDLE, &image_index_);
-    BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "vkAcquireNextImageKHR failed");
+    if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR) {
+      BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "vkAcquireNextImageKHR failed");      
+    }
     return std::make_shared<VulkanStreamSemaphoreObject>(image_available_);
   }
 }


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5bc5eb1</samp>

This pull request fixes some bugs and improves the compatibility of the `rhi_examples` that demonstrate the use of the Vulkan backend for the Taichi programming language. It fixes the linking error in `CMakeLists.txt`, the Vulkan loader initialization in `common.h`, and the swapchain recreation in `vulkan_device.cpp`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5bc5eb1</samp>

* Fix linking error for rhi_examples by using `taichi_core` library ([link](https://github.com/taichi-dev/taichi/pull/8213/files?diff=unified&w=0#diff-ce18c0b2ae4fee335806357f23ceb248ed7b32ab121fdd4f750e5856bfc65328L27-R27))
* Initialize Vulkan loader for GLFW to create Vulkan window and surface ([link](https://github.com/taichi-dev/taichi/pull/8213/files?diff=unified&w=0#diff-675d40050ebb39182902d37dca8b430ff301ef0a6834221993580761300c850eR48))
* Handle `VK_SUBOPTIMAL_KHR` result from `vkAcquireNextImageKHR` to avoid aborting program and allow swapchain recreation ([link](https://github.com/taichi-dev/taichi/pull/8213/files?diff=unified&w=0#diff-4479f242ce99cd434c015531997155aa7faa38fb3ead6b0997caf097b05cecb8L2807-R2809))
