### PR TITLE
[Lang] [bug] Let static assert be in static scope

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -535,7 +535,7 @@ class ASTTransformer(Builder):
 
     @staticmethod
     def build_Call(ctx, node):
-        if ASTTransformer.get_decorator(ctx, node) == "static":
+        if ASTTransformer.get_decorator(ctx, node) in ["static", "static_assert"]:
             with ctx.static_scope_guard():
                 build_stmt(ctx, node.func)
                 build_stmts(ctx, node.args)
@@ -1116,6 +1116,7 @@ class ASTTransformer(Builder):
             return ""
         for wanted, name in [
             (impl.static, "static"),
+            (impl.static_assert, "static_assert"),
             (impl.grouped, "grouped"),
             (ndrange, "ndrange"),
         ]:


### PR DESCRIPTION
Issue: fix #8218 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec8cb2c</samp>

Add `static_assert` feature for compile-time assertions in Taichi. Modify `ast_transformer.py` to handle the `static_assert` decorator.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec8cb2c</samp>

*  Add support for `static_assert` decorator to enable compile-time assertions ([link](https://github.com/taichi-dev/taichi/pull/8217/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL538-R538), [link](https://github.com/taichi-dev/taichi/pull/8217/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fR1119))
