### PR TITLE
[Lang] Let kernel support return type annotated with 'typing.Tuple'

### DIFF
--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -120,6 +120,13 @@ void export_lang(py::module &m) {
       .def(
           "get_ptr", [](DataType *dtype) -> Type * { return *dtype; },
           py::return_value_policy::reference)
+      .def("__call__",
+           [](DataType *dtype, py::args args, const py::kwargs &kwargs) {
+             // Defining __call__ here to make DataType callable in Python,
+             // which enables us to write `typing.Tuple[ti.i32, ti.i32]`.
+             throw TaichiSyntaxError(
+                 "Taichi data types cannot be called outside Taichi kernels.");
+           })
       .def(py::pickle(
           [](const DataType &dt) {
             // Note: this only works for primitive types, which is fine for now.

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+from typing import Tuple
 from pytest import approx
 
 import taichi as ti
@@ -210,7 +211,7 @@ def test_struct_ret_with_matrix():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
-@test_utils.test(arch=[ti.cpu, ti.cuda], debug=True)
+@test_utils.test(arch=[ti.cpu, ti.cuda])
 def test_real_func_tuple_ret_39():
     s0 = ti.types.struct(a=ti.math.vec3, b=ti.i16)
 
@@ -220,6 +221,27 @@ def test_real_func_tuple_ret_39():
 
     @ti.kernel
     def bar() -> tuple[ti.f32, s0]:
+        return foo()
+
+    # bar()
+    ret_a, ret_b = bar()
+    assert ret_a == approx(1)
+    assert ret_b.a[0] == approx(100)
+    assert ret_b.a[1] == approx(0.2)
+    assert ret_b.a[2] == approx(3)
+    assert ret_b.b == 1
+
+
+@test_utils.test(arch=[ti.cpu, ti.cuda])
+def test_real_func_tuple_ret_typing_tuple():
+    s0 = ti.types.struct(a=ti.math.vec3, b=ti.i16)
+
+    @ti.experimental.real_func
+    def foo() -> Tuple[ti.f32, s0]:
+        return 1, s0(a=ti.math.vec3([100, 0.2, 3]), b=65537)
+
+    @ti.kernel
+    def bar() -> Tuple[ti.f32, s0]:
         return foo()
 
     # bar()


### PR DESCRIPTION
Also removed an accidentally added comment in another test.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f7528d3</samp>

### Summary
🚫📝🧹

<!--
1.  🚫 for the syntax error raised by calling a data type outside a kernel.
2.  📝 for the typing annotations for the return type of Taichi functions.
3.  🧹 for the cleanup of the existing test cases.
-->
This pull request adds support for using Python's typing module to annotate the return types of Taichi functions, and tests this feature with a new test case. It also prevents calling data types outside kernels with a syntax error.

> _`DataType` calls_
> _raise syntax error now_
> _typing in autumn_

### Walkthrough
* Add a `__call__` method to the `DataType` class in Python to raise a syntax error if the data type is called outside a Taichi kernel ([link](https://github.com/taichi-dev/taichi/pull/8219/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167R123-R129)). This enables the use of Python's typing module to annotate the return types of Taichi functions, such as `typing.Tuple[ti.i32, ti.i32]`.

 

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8219

