### PR TITLE
[gui] Remove cached arrays

### DIFF
--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -6,8 +6,6 @@ from .scene import SceneV2
 from .staging_buffer import (
     copy_all_to_vbo,
     copy_all_to_vbo_particle,
-    get_indices_field,
-    get_vbo_field,
     get_indices_fieldV2,
     get_vbo_fieldV2,
     to_rgba8,

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -3,7 +3,15 @@ from taichi.lang import impl
 from taichi.lang._texture import Texture
 from .scene import SceneV2
 
-from .staging_buffer import copy_all_to_vbo, copy_all_to_vbo_particle, get_indices_field, get_vbo_field, get_indices_fieldV2, get_vbo_fieldV2, to_rgba8
+from .staging_buffer import (
+    copy_all_to_vbo,
+    copy_all_to_vbo_particle,
+    get_indices_field,
+    get_vbo_field,
+    get_indices_fieldV2,
+    get_vbo_fieldV2,
+    to_rgba8,
+)
 from .utils import get_field_info
 
 

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -3,7 +3,7 @@ from taichi.lang import impl
 from taichi.lang._texture import Texture
 from .scene import SceneV2
 
-from .staging_buffer import copy_all_to_vbo, copy_all_to_vbo_particle, get_indices_field, get_vbo_field, to_rgba8
+from .staging_buffer import copy_all_to_vbo, copy_all_to_vbo_particle, get_indices_field, get_vbo_field, get_indices_fieldV2, get_vbo_fieldV2, to_rgba8
 from .utils import get_field_info
 
 
@@ -97,13 +97,13 @@ class Canvas:
             per_vertex_color (Tuple[float]): a taichi 3D vector field, \
                 where each element indicate the RGB color of a vertex.
         """
-        vbo = get_vbo_field(vertices)
+        vbo = get_vbo_fieldV2(vertices)
         has_per_vertex_color = per_vertex_color is not None
         copy_all_to_vbo(vbo, vertices, 0, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
         indices_ndarray = None
         if indices:
-            indices_ndarray = get_indices_field(indices)
+            indices_ndarray = get_indices_fieldV2(indices)
         indices_info = get_field_info(indices_ndarray)
         self.canvas.triangles(vbo_info, indices_info, has_per_vertex_color, color)
 
@@ -129,13 +129,13 @@ class Canvas:
             per_vertex_color (tuple[float]): a taichi 3D vector field, where \
                 each element indicate the RGB color of a vertex.
         """
-        vbo = get_vbo_field(vertices)
+        vbo = get_vbo_fieldV2(vertices)
         has_per_vertex_color = per_vertex_color is not None
         copy_all_to_vbo(vbo, vertices, 0, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
         indices_ndarray = None
         if indices:
-            indices_ndarray = get_indices_field(indices)
+            indices_ndarray = get_indices_fieldV2(indices)
         indices_info = get_field_info(indices_ndarray)
         self.canvas.lines(vbo_info, indices_info, has_per_vertex_color, color, width)
 
@@ -153,7 +153,7 @@ class Canvas:
             per_vertex_radius: a taichi float field, where \
                 each element indicates the radius of a circle.
         """
-        vbo = get_vbo_field(centers)
+        vbo = get_vbo_fieldV2(centers)
         has_per_vertex_color = per_vertex_color is not None
         has_per_vertex_radius = per_vertex_radius is not None
         copy_all_to_vbo_particle(

--- a/python/taichi/ui/canvas.py
+++ b/python/taichi/ui/canvas.py
@@ -6,8 +6,8 @@ from .scene import SceneV2
 from .staging_buffer import (
     copy_all_to_vbo,
     copy_all_to_vbo_particle,
-    get_indices_fieldV2,
-    get_vbo_fieldV2,
+    get_indices_field_v2,
+    get_vbo_field_v2,
     to_rgba8,
 )
 from .utils import get_field_info
@@ -103,13 +103,13 @@ class Canvas:
             per_vertex_color (Tuple[float]): a taichi 3D vector field, \
                 where each element indicate the RGB color of a vertex.
         """
-        vbo = get_vbo_fieldV2(vertices)
+        vbo = get_vbo_field_v2(vertices)
         has_per_vertex_color = per_vertex_color is not None
         copy_all_to_vbo(vbo, vertices, 0, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
         indices_ndarray = None
         if indices:
-            indices_ndarray = get_indices_fieldV2(indices)
+            indices_ndarray = get_indices_field_v2(indices)
         indices_info = get_field_info(indices_ndarray)
         self.canvas.triangles(vbo_info, indices_info, has_per_vertex_color, color)
 
@@ -135,13 +135,13 @@ class Canvas:
             per_vertex_color (tuple[float]): a taichi 3D vector field, where \
                 each element indicate the RGB color of a vertex.
         """
-        vbo = get_vbo_fieldV2(vertices)
+        vbo = get_vbo_field_v2(vertices)
         has_per_vertex_color = per_vertex_color is not None
         copy_all_to_vbo(vbo, vertices, 0, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
         indices_ndarray = None
         if indices:
-            indices_ndarray = get_indices_fieldV2(indices)
+            indices_ndarray = get_indices_field_v2(indices)
         indices_info = get_field_info(indices_ndarray)
         self.canvas.lines(vbo_info, indices_info, has_per_vertex_color, color, width)
 
@@ -159,7 +159,7 @@ class Canvas:
             per_vertex_radius: a taichi float field, where \
                 each element indicates the radius of a circle.
         """
-        vbo = get_vbo_fieldV2(centers)
+        vbo = get_vbo_field_v2(centers)
         has_per_vertex_color = per_vertex_color is not None
         has_per_vertex_radius = per_vertex_radius is not None
         copy_all_to_vbo_particle(

--- a/python/taichi/ui/scene.py
+++ b/python/taichi/ui/scene.py
@@ -11,11 +11,11 @@ from .staging_buffer import (
     copy_all_to_vbo,
     copy_all_to_vbo_particle,
     get_indices_field,
-    get_indices_fieldV2,
+    get_indices_field_v2,
     get_transforms_field,
-    get_transforms_fieldV2,
+    get_transforms_field_v2,
     get_vbo_field,
-    get_vbo_fieldV2,
+    get_vbo_field_v2,
 )
 from .utils import check_ggui_availability, get_field_info
 
@@ -160,10 +160,10 @@ class SceneV2:
             vertex_count = vertices.shape[0] - vertex_offset
             vertex_count -= vertex_count % 2
         has_per_vertex_color = per_vertex_color is not None
-        vbo = get_vbo_fieldV2(vertices)
+        vbo = get_vbo_field_v2(vertices)
         copy_all_to_vbo(vbo, vertices, 0, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
-        indices_ndarray = get_indices_fieldV2(indices) if indices is not None else None
+        indices_ndarray = get_indices_field_v2(indices) if indices is not None else None
         indices_info = get_field_info(indices_ndarray)
         self.scene.lines(
             vbo_info,
@@ -238,10 +238,10 @@ class SceneV2:
                 index_count = vertex_count  # FIXME : Need to confirm
             else:
                 index_count = indices.shape[0]
-        vbo = get_vbo_fieldV2(vertices)
+        vbo = get_vbo_field_v2(vertices)
         copy_all_to_vbo(vbo, vertices, normals, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
-        indices_ndarray = get_indices_fieldV2(indices) if indices is not None else None
+        indices_ndarray = get_indices_field_v2(indices) if indices is not None else None
         indices_info = get_field_info(indices_ndarray)
 
         self.scene.mesh(
@@ -339,12 +339,12 @@ class SceneV2:
         else:
             instance_count = 1
 
-        vbo = get_vbo_fieldV2(vertices)
+        vbo = get_vbo_field_v2(vertices)
         copy_all_to_vbo(vbo, vertices, normals, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
-        indices_ndarray = get_indices_fieldV2(indices) if indices else None
+        indices_ndarray = get_indices_field_v2(indices) if indices else None
         indices_info = get_field_info(indices_ndarray)
-        transforms_ndarray = get_transforms_fieldV2(transforms) if transforms else None
+        transforms_ndarray = get_transforms_field_v2(transforms) if transforms else None
         transform_info = get_field_info(transforms_ndarray)
         self.scene.mesh_instance(
             vbo_info,
@@ -395,7 +395,7 @@ class SceneV2:
         if index_count is None:
             index_count = centers.shape[0]
             # per_vertex_radius_vec3[i] = Vector([per_vertex_radius[i], 0., 0.])
-        vbo = get_vbo_fieldV2(centers)
+        vbo = get_vbo_field_v2(centers)
         copy_all_to_vbo_particle(
             vbo,
             centers,

--- a/python/taichi/ui/scene.py
+++ b/python/taichi/ui/scene.py
@@ -11,8 +11,11 @@ from .staging_buffer import (
     copy_all_to_vbo,
     copy_all_to_vbo_particle,
     get_indices_field,
+    get_indices_fieldV2,
     get_transforms_field,
+    get_transforms_fieldV2,
     get_vbo_field,
+    get_vbo_fieldV2,
 )
 from .utils import check_ggui_availability, get_field_info
 
@@ -157,10 +160,10 @@ class SceneV2:
             vertex_count = vertices.shape[0] - vertex_offset
             vertex_count -= vertex_count % 2
         has_per_vertex_color = per_vertex_color is not None
-        vbo = get_vbo_field(vertices)
+        vbo = get_vbo_fieldV2(vertices)
         copy_all_to_vbo(vbo, vertices, 0, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
-        indices_ndarray = get_indices_field(indices) if indices is not None else None
+        indices_ndarray = get_indices_fieldV2(indices) if indices is not None else None
         indices_info = get_field_info(indices_ndarray)
         self.scene.lines(
             vbo_info,
@@ -235,10 +238,10 @@ class SceneV2:
                 index_count = vertex_count  # FIXME : Need to confirm
             else:
                 index_count = indices.shape[0]
-        vbo = get_vbo_field(vertices)
+        vbo = get_vbo_fieldV2(vertices)
         copy_all_to_vbo(vbo, vertices, normals, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
-        indices_ndarray = get_indices_field(indices) if indices is not None else None
+        indices_ndarray = get_indices_fieldV2(indices) if indices is not None else None
         indices_info = get_field_info(indices_ndarray)
 
         self.scene.mesh(
@@ -336,12 +339,12 @@ class SceneV2:
         else:
             instance_count = 1
 
-        vbo = get_vbo_field(vertices)
+        vbo = get_vbo_fieldV2(vertices)
         copy_all_to_vbo(vbo, vertices, normals, 0, per_vertex_color if has_per_vertex_color else 0)
         vbo_info = get_field_info(vbo)
-        indices_ndarray = get_indices_field(indices) if indices else None
+        indices_ndarray = get_indices_fieldV2(indices) if indices else None
         indices_info = get_field_info(indices_ndarray)
-        transforms_ndarray = get_transforms_field(transforms) if transforms else None
+        transforms_ndarray = get_transforms_fieldV2(transforms) if transforms else None
         transform_info = get_field_info(transforms_ndarray)
         self.scene.mesh_instance(
             vbo_info,
@@ -392,7 +395,7 @@ class SceneV2:
         if index_count is None:
             index_count = centers.shape[0]
             # per_vertex_radius_vec3[i] = Vector([per_vertex_radius[i], 0., 0.])
-        vbo = get_vbo_field(centers)
+        vbo = get_vbo_fieldV2(centers)
         copy_all_to_vbo_particle(
             vbo,
             centers,

--- a/python/taichi/ui/staging_buffer.py
+++ b/python/taichi/ui/staging_buffer.py
@@ -9,14 +9,37 @@ from taichi.types.primitive_types import f32, u8, u32
 
 import taichi as ti
 
+vbo_field_cache = {}
+depth_ndarray_cache = {}
+indices_ndarray_cache = {}
+transforms_ndarray_cache = {}
 
 def get_depth_ndarray(window):
+    if window not in depth_ndarray_cache:
+        w, h = window.get_window_shape()
+        depth_arr = ndarray(dtype=ti.f32, shape=w * h)
+        depth_ndarray_cache[window] = depth_arr
+    return depth_ndarray_cache[window]
+
+def get_depth_ndarrayV2(window):
     w, h = window.get_window_shape()
     depth_arr = ndarray(dtype=ti.f32, shape=w * h)
     return depth_arr
 
-
 def get_vbo_field(vertices):
+    if vertices not in vbo_field_cache:
+        N = vertices.shape[0]
+        pos = 3
+        normal = 3
+        tex_coord = 2
+        color = 4
+        vertex_stride = pos + normal + tex_coord + color
+        vbo = np.ndarray((N, vertex_stride), dtype=np.float32)
+        vbo_field_cache[vertices] = vbo
+        return vbo
+    return vbo_field_cache[vertices]
+
+def get_vbo_fieldV2(vertices):
     N = vertices.shape[0]
     pos = 3
     normal = 3
@@ -26,8 +49,14 @@ def get_vbo_field(vertices):
     vbo = np.ndarray((N, vertex_stride), dtype=np.float32)
     return vbo
 
-
 def get_indices_field(indices):
+    if isinstance(indices, np.ndarray):
+        return indices
+    indices_arr = indices.to_numpy()
+    indices_ndarray_cache[indices] = indices_arr
+    return indices_arr
+
+def get_indices_fieldV2(indices):
     if isinstance(indices, np.ndarray):
         return indices
     indices_arr = indices.to_numpy()
@@ -35,6 +64,13 @@ def get_indices_field(indices):
 
 
 def get_transforms_field(transforms):
+    if isinstance(transforms, np.ndarray):
+        return transforms
+    transforms_arr = transforms.to_numpy()
+    transforms_ndarray_cache[transforms] = transforms_arr
+    return transforms_arr
+
+def get_transforms_fieldV2(transforms):
     if isinstance(transforms, np.ndarray):
         return transforms
     transforms_arr = transforms.to_numpy()

--- a/python/taichi/ui/staging_buffer.py
+++ b/python/taichi/ui/staging_buffer.py
@@ -22,13 +22,6 @@ def get_depth_ndarray(window):
         depth_ndarray_cache[window] = depth_arr
     return depth_ndarray_cache[window]
 
-
-def get_depth_ndarrayV2(window):
-    w, h = window.get_window_shape()
-    depth_arr = ndarray(dtype=ti.f32, shape=w * h)
-    return depth_arr
-
-
 def get_vbo_field(vertices):
     if vertices not in vbo_field_cache:
         N = vertices.shape[0]
@@ -43,7 +36,7 @@ def get_vbo_field(vertices):
     return vbo_field_cache[vertices]
 
 
-def get_vbo_fieldV2(vertices):
+def get_vbo_field_v2(vertices):
     N = vertices.shape[0]
     pos = 3
     normal = 3
@@ -62,7 +55,7 @@ def get_indices_field(indices):
     return indices_arr
 
 
-def get_indices_fieldV2(indices):
+def get_indices_field_v2(indices):
     if isinstance(indices, np.ndarray):
         return indices
     indices_arr = indices.to_numpy()
@@ -77,7 +70,7 @@ def get_transforms_field(transforms):
     return transforms_arr
 
 
-def get_transforms_fieldV2(transforms):
+def get_transforms_field_v2(transforms):
     if isinstance(transforms, np.ndarray):
         return transforms
     transforms_arr = transforms.to_numpy()

--- a/python/taichi/ui/staging_buffer.py
+++ b/python/taichi/ui/staging_buffer.py
@@ -22,6 +22,7 @@ def get_depth_ndarray(window):
         depth_ndarray_cache[window] = depth_arr
     return depth_ndarray_cache[window]
 
+
 def get_vbo_field(vertices):
     if vertices not in vbo_field_cache:
         N = vertices.shape[0]

--- a/python/taichi/ui/staging_buffer.py
+++ b/python/taichi/ui/staging_buffer.py
@@ -9,39 +9,28 @@ from taichi.types.primitive_types import f32, u8, u32
 
 import taichi as ti
 
-vbo_field_cache = {}
-depth_ndarray_cache = {}
-indices_ndarray_cache = {}
-transforms_ndarray_cache = {}
-
 
 def get_depth_ndarray(window):
-    if window not in depth_ndarray_cache:
-        w, h = window.get_window_shape()
-        depth_arr = ndarray(dtype=ti.f32, shape=w * h)
-        depth_ndarray_cache[window] = depth_arr
-    return depth_ndarray_cache[window]
+    w, h = window.get_window_shape()
+    depth_arr = ndarray(dtype=ti.f32, shape=w * h)
+    return depth_arr
 
 
 def get_vbo_field(vertices):
-    if vertices not in vbo_field_cache:
-        N = vertices.shape[0]
-        pos = 3
-        normal = 3
-        tex_coord = 2
-        color = 4
-        vertex_stride = pos + normal + tex_coord + color
-        vbo = np.ndarray((N, vertex_stride), dtype=np.float32)
-        vbo_field_cache[vertices] = vbo
-        return vbo
-    return vbo_field_cache[vertices]
+    N = vertices.shape[0]
+    pos = 3
+    normal = 3
+    tex_coord = 2
+    color = 4
+    vertex_stride = pos + normal + tex_coord + color
+    vbo = np.ndarray((N, vertex_stride), dtype=np.float32)
+    return vbo
 
 
 def get_indices_field(indices):
     if isinstance(indices, np.ndarray):
         return indices
     indices_arr = indices.to_numpy()
-    indices_ndarray_cache[indices] = indices_arr
     return indices_arr
 
 
@@ -49,7 +38,6 @@ def get_transforms_field(transforms):
     if isinstance(transforms, np.ndarray):
         return transforms
     transforms_arr = transforms.to_numpy()
-    transforms_ndarray_cache[transforms] = transforms_arr
     return transforms_arr
 
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d18381f</samp>

Refactored `staging_buffer.py` to fix memory leaks and optimize array access. Removed global caches and simplified array functions.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d18381f</samp>

*  Remove global caches for depth, vbo, indices, and transforms arrays to avoid memory leaks and overhead ([link](https://github.com/taichi-dev/taichi/pull/8223/files?diff=unified&w=0#diff-fd7dee80cc57fcef55c9bedc67a63a5aee4f20ac0375921bebec55beeb5bf928L12-R27), [link](https://github.com/taichi-dev/taichi/pull/8223/files?diff=unified&w=0#diff-fd7dee80cc57fcef55c9bedc67a63a5aee4f20ac0375921bebec55beeb5bf928L44), [link](https://github.com/taichi-dev/taichi/pull/8223/files?diff=unified&w=0#diff-fd7dee80cc57fcef55c9bedc67a63a5aee4f20ac0375921bebec55beeb5bf928L52))
*  Return arrays directly from `get_depth_ndarray`, `get_vbo_field`, `get_indices_field`, and `get_transforms_field` functions in `staging_buffer.py` ([link](https://github.com/taichi-dev/taichi/pull/8223/files?diff=unified&w=0#diff-fd7dee80cc57fcef55c9bedc67a63a5aee4f20ac0375921bebec55beeb5bf928L12-R27), [link](https://github.com/taichi-dev/taichi/pull/8223/files?diff=unified&w=0#diff-fd7dee80cc57fcef55c9bedc67a63a5aee4f20ac0375921bebec55beeb5bf928L44), [link](https://github.com/taichi-dev/taichi/pull/8223/files?diff=unified&w=0#diff-fd7dee80cc57fcef55c9bedc67a63a5aee4f20ac0375921bebec55beeb5bf928L52))
