### PR TITLE
[Lang] Use ErrorEmitter to emit error messages in type check pass

### DIFF
--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -15,11 +15,13 @@ class Expr(TaichiOperations):
 
     def __init__(self, *args, tb=None, dtype=None):
         self.tb = tb
+        self.ptr_type_checked = False
         if len(args) == 1:
             if isinstance(args[0], _ti_core.Expr):
                 self.ptr = args[0]
             elif isinstance(args[0], Expr):
                 self.ptr = args[0].ptr
+                self.ptr_type_checked = args[0].ptr_type_checked
                 self.tb = args[0].tb
             elif is_matrix_class(args[0]):
                 self.ptr = make_matrix(args[0].to_list()).ptr
@@ -39,7 +41,10 @@ class Expr(TaichiOperations):
             assert False
         if self.tb:
             self.ptr.set_tb(self.tb)
-        self.ptr.type_check(impl.get_runtime().prog.config())
+        if not self.ptr_type_checked:
+            self.ptr.type_check(impl.get_runtime().prog.config())
+            self.ptr_type_checked = True
+        
 
     def is_tensor(self):
         return self.ptr.is_tensor()

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -44,7 +44,6 @@ class Expr(TaichiOperations):
         if not self.ptr_type_checked:
             self.ptr.type_check(impl.get_runtime().prog.config())
             self.ptr_type_checked = True
-        
 
     def is_tensor(self):
         return self.ptr.is_tensor()

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -7,6 +7,10 @@ class IRModified {};
 class TaichiExceptionImpl : public std::exception {
   friend struct ErrorEmitter;
 
+ private:
+  virtual void emit() = 0;
+
+ protected:
   std::string msg_;
 
  public:
@@ -22,22 +26,58 @@ class TaichiExceptionImpl : public std::exception {
 
 class TaichiTypeError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiSyntaxError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiIndexError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiRuntimeError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiAssertionError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
+};
+
+class TaichiCastWarning : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  void emit() noexcept override {
+    taichi::Logger::get_instance().warn("TaichiCastWarning\n" + msg_);
+  }
+};
+
+class TaichiTypeWarning : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  void emit() noexcept override {
+    taichi::Logger::get_instance().warn("TaichiTypeWarning\n" + msg_);
+  }
 };
 
 }  // namespace taichi::lang

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -64,6 +64,14 @@ class TaichiAssertionError : public TaichiExceptionImpl {
   }
 };
 
+class TaichiIrError : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
+};
+
 class TaichiCastWarning : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
 
@@ -77,6 +85,14 @@ class TaichiTypeWarning : public TaichiExceptionImpl {
 
   void emit() noexcept override {
     taichi::Logger::get_instance().warn("TaichiTypeWarning\n" + msg_);
+  }
+};
+
+class TaichiIrWarning : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  void emit() noexcept override {
+    taichi::Logger::get_instance().warn("TaichiIrWarning\n" + msg_);
   }
 };
 

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -5,9 +5,14 @@ namespace taichi::lang {
 class IRModified {};
 
 class TaichiExceptionImpl : public std::exception {
+  friend struct ErrorEmitter;
+
   std::string msg_;
 
  public:
+  // Add default constructor to allow passing Exception to ErrorEmitter
+  // TODO: remove this and find a better way
+  explicit TaichiExceptionImpl() = default;
   explicit TaichiExceptionImpl(const std::string msg) : msg_(msg) {
   }
   const char *what() const noexcept override {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -9,10 +9,11 @@
 
 namespace taichi::lang {
 
-#define TI_ASSERT_TYPE_CHECKED(x)                       \
-  TI_ASSERT_INFO(x->ret_type != PrimitiveType::unknown, \
-                 "[{}] was not type-checked",           \
-                 ExpressionHumanFriendlyPrinter::expr_to_string(x))
+#define TI_ASSERT_TYPE_CHECKED(x)                                        \
+  ErrorEmitter(x->ret_type != PrimitiveType::unknown, TaichiTypeError(), \
+               x.expr.get(),                                             \
+               fmt::format("[{}] was not type-checked",                  \
+                           ExpressionHumanFriendlyPrinter::expr_to_string(x)))
 
 static bool is_primitive_or_tensor_type(DataType &type) {
   return type->is<PrimitiveType>() || type->is<TensorType>();
@@ -170,8 +171,10 @@ void TexturePtrExpression::flatten(FlattenContext *ctx) {
 }
 
 void RandExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
-                 "Invalid dt [{}] for RandExpression", dt->to_string());
+  ErrorEmitter(
+      dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
+      TaichiTypeError(), this,
+      fmt::format("Invalid dt [{}] for RandExpression", dt->to_string()));
   ret_type = dt;
 }
 
@@ -196,17 +199,20 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
   auto ret_primitive_type = ret_type;
 
   if (!operand_primitive_type->is<PrimitiveType>()) {
-    throw TaichiTypeError(fmt::format(
-        "unsupported operand type(s) for '{}': '{}'", unary_op_type_name(type),
-        operand_primitive_type->to_string()));
+    ErrorEmitter(TaichiTypeError(), this,
+                 fmt::format("unsupported operand type(s) for '{}': '{}'",
+                             unary_op_type_name(type),
+                             operand_primitive_type->to_string()));
   }
 
   if ((type == UnaryOpType::round || type == UnaryOpType::floor ||
        type == UnaryOpType::ceil || is_trigonometric(type)) &&
       !is_real(operand_primitive_type))
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes real inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes real inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
 
   if ((type == UnaryOpType::sqrt || type == UnaryOpType::exp ||
        type == UnaryOpType::log) &&
@@ -218,9 +224,11 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
 
   if ((type == UnaryOpType::bit_not || type == UnaryOpType::logic_not) &&
       is_real(operand_primitive_type)) {
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes integral inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes integral inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
   }
 
   if (type == UnaryOpType::logic_not) {
@@ -243,9 +251,11 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
   }
 
   if (type == UnaryOpType::popcnt && is_real(operand_primitive_type)) {
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes integral inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes integral inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
   }
 
   if (operand_type->is<TensorType>()) {
@@ -282,7 +292,8 @@ Expr to_broadcast_tensor(const Expr &elt, const DataType &dt) {
     // Only tensor shape will be checked here, since the dtype will
     // be promoted later at irpass::type_check()
     if (elt_type.get_shape() != dt.get_shape()) {
-      TI_ERROR("Cannot broadcast tensor to tensor");
+      ErrorEmitter(TaichiTypeError(), elt.expr.get(),
+                   "Cannot broadcast tensor to tensor");
     } else {
       return elt;
     }
@@ -290,9 +301,10 @@ Expr to_broadcast_tensor(const Expr &elt, const DataType &dt) {
 
   auto tensor_type = dt->as<TensorType>();
   auto tensor_elt_type = tensor_type->get_element_type();
-  TI_ASSERT_INFO(tensor_elt_type->is<PrimitiveType>(),
-                 "Only primitive types are supported in Tensors, got {}",
-                 tensor_elt_type->to_string());
+  ErrorEmitter(
+      tensor_elt_type->is<PrimitiveType>(), TaichiTypeError(), elt.expr.get(),
+      fmt::format("Only primitive types are supported in Tensors, got {}",
+                  tensor_elt_type->to_string()));
   std::vector<Expr> broadcast_values(tensor_type->get_num_elements(), elt);
   auto matrix_expr = Expr::make<MatrixExpression>(
       broadcast_values, tensor_type->get_shape(), elt_type);
@@ -523,7 +535,8 @@ void TernaryOpExpression::type_check(const CompileConfig *config) {
   auto op3_type = op3.get_rvalue_type();
 
   auto error = [&]() {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiTypeError(), this,
         fmt::format("unsupported operand type(s) for '{}': '{}', '{}' and '{}'",
                     ternary_type_name(type), op1_type->to_string(),
                     op2_type->to_string(), op3_type->to_string()));
@@ -821,7 +834,8 @@ static void field_validation(FieldExpression *field_expr, int index_dim) {
   int field_dim = field_expr->snode->num_active_indices;
 
   if (field_dim != index_dim) {
-    throw TaichiIndexError(
+    ErrorEmitter(
+        TaichiIndexError(), field_expr,
         fmt::format("Field with dim {} accessed with indices of dim {}",
                     field_dim, index_dim));
   }
@@ -837,7 +851,8 @@ void IndexExpression::type_check(const CompileConfig *) {
   bool has_slice = !ret_shape.empty();
   auto var_type = var.get_rvalue_type();
   if (has_slice) {
-    TI_ASSERT_INFO(is_tensor(), "Slice or swizzle can only apply on matrices");
+    ErrorEmitter(is_tensor(), TaichiTypeError(), this,
+                 "Slice or swizzle can only apply on matrices");
     auto element_type = var_type->as<TensorType>()->get_element_type();
     ret_type = TypeFactory::create_tensor_type(ret_shape, element_type);
   } else if (is_field()) {  // field
@@ -861,7 +876,8 @@ void IndexExpression::type_check(const CompileConfig *) {
     int element_dim = external_tensor_expr->dt.get_shape().size();
     int total_dim = ndim + element_dim;
     if (total_dim != index_dim + element_dim) {
-      throw TaichiTypeError(
+      ErrorEmitter(
+          TaichiIndexError(), this,
           fmt::format("Array with dim {} accessed with indices of dim {}",
                       total_dim - element_dim, index_dim));
     }
@@ -877,12 +893,14 @@ void IndexExpression::type_check(const CompileConfig *) {
     auto tensor_type = var_type->as<TensorType>();
     auto shape = tensor_type->get_shape();
     if (indices_group[0].size() != shape.size()) {
-      TI_ERROR("Expected {} indices, got {}.", shape.size(),
-               indices_group[0].size());
+      ErrorEmitter(TaichiIndexError(), this,
+                   fmt::format("Expected {} indices, got {}.", shape.size(),
+                               indices_group[0].size()));
     }
     ret_type = tensor_type->get_element_type();
   } else {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiIndexError(), this,
         "Invalid IndexExpression: the source is not among field, ndarray or "
         "local tensor");
   }
@@ -893,10 +911,10 @@ void IndexExpression::type_check(const CompileConfig *) {
       TI_ASSERT_TYPE_CHECKED(expr);
       auto expr_type = expr.get_rvalue_type();
       if (!is_integral(expr_type))
-        throw TaichiTypeError(
-            fmt::format("indices must be integers, however '{}' is "
-                        "provided as index {}",
-                        expr_type->to_string(), i));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("indices must be integers, however '{}' is "
+                                 "provided as index {}",
+                                 expr_type->to_string(), i));
     }
   }
 }
@@ -915,7 +933,8 @@ void IndexExpression::flatten(FlattenContext *ctx) {
         ctx, var, indices_group, ret_type,
         var->ret_type.ptr_removed()->as<TensorType>()->get_shape(), tb);
   } else {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiIndexError(), this,
         "Invalid IndexExpression: the source is not among field, ndarray or "
         "local tensor");
   }
@@ -929,10 +948,10 @@ void RangeAssumptionExpression::type_check(const CompileConfig *) {
   auto base_type = base.get_rvalue_type();
   if (!input_type->is<PrimitiveType>() || !base_type->is<PrimitiveType>() ||
       input_type != base_type)
-    throw TaichiTypeError(
-        fmt::format("unsupported operand type(s) for "
-                    "'range_assumption': '{}' and '{}'",
-                    input_type->to_string(), base_type->to_string()));
+    ErrorEmitter(TaichiTypeError(), this,
+                 fmt::format("unsupported operand type(s) for "
+                             "'range_assumption': '{}' and '{}'",
+                             input_type->to_string(), base_type->to_string()));
   ret_type = input_type;
 }
 
@@ -949,7 +968,8 @@ void LoopUniqueExpression::type_check(const CompileConfig *) {
   auto input_type = input.get_rvalue_type();
 
   if (!input_type->is<PrimitiveType>())
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiTypeError(), this,
         fmt::format("unsupported operand type(s) for 'loop_unique': '{}'",
                     input_type->to_string()));
   ret_type = input_type;
@@ -972,10 +992,12 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
   TI_ASSERT_TYPE_CHECKED(dest);
   TI_ASSERT_TYPE_CHECKED(val);
   auto error = [&]() {
-    throw TaichiTypeError(fmt::format(
-        "unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
-        atomic_op_type_name(op_type), dest->ret_type->to_string(),
-        val->ret_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format(
+            "unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
+            atomic_op_type_name(op_type), dest->ret_type->to_string(),
+            val->ret_type->to_string()));
   };
 
   // Broadcast val to dest if neccessary
@@ -1071,8 +1093,10 @@ void SNodeOpExpression::type_check(const CompileConfig *config) {
       auto value_type = values[i].get_rvalue_type();
       auto promoted = promoted_type(dst_type, value_type);
       if (dst_type != promoted) {
-        TI_WARN("Append may lose precision: {} <- {}\n{}",
-                dst_type->to_string(), value_type->to_string(), tb);
+        ErrorEmitter(
+            TaichiCastWarning(), this,
+            fmt::format("Append may lose precision: {} <- {}\n{}",
+                        dst_type->to_string(), value_type->to_string(), tb));
       }
       values[i] = cast(values[i], dst_type);
       values[i]->type_check(config);
@@ -1091,10 +1115,11 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
       ctx->push_back<GlobalPtrStmt>(snode, indices_stmt, true, is_cell_access);
   ptr->tb = tb;
   if (op_type == SNodeOpType::is_active) {
-    TI_ERROR_IF(snode->type != SNodeType::pointer &&
-                    snode->type != SNodeType::hash &&
-                    snode->type != SNodeType::bitmasked,
-                "ti.is_active only works on pointer, hash or bitmasked nodes.");
+    ErrorEmitter(
+        snode->type == SNodeType::pointer || snode->type == SNodeType::hash ||
+            snode->type == SNodeType::bitmasked,
+        TaichiTypeError(), this,
+        "ti.is_active only works on pointer, hash or bitmasked nodes.");
     ctx->push_back<SNodeOpStmt>(SNodeOpType::is_active, snode, ptr, nullptr);
   } else if (op_type == SNodeOpType::length) {
     ctx->push_back<SNodeOpStmt>(SNodeOpType::length, snode, ptr, nullptr);
@@ -1113,8 +1138,8 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
       ctx->push_back<GlobalStoreStmt>(ch_addr, value_stmt)->set_tb(tb);
     }
     ctx->push_back<LocalLoadStmt>(alloca)->set_tb(tb);
-    TI_ERROR_IF(snode->type != SNodeType::dynamic,
-                "ti.append only works on dynamic nodes.");
+    ErrorEmitter(snode->type == SNodeType::dynamic, TaichiTypeError(), this,
+                 "ti.append only works on dynamic nodes.");
   }
   stmt = ctx->back_stmt();
 }
@@ -1130,15 +1155,16 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
   auto ptr = texture_ptr.cast<TexturePtrExpression>();
   if (op == TextureOpType::kSampleLod) {
     // UV, Lod
-    TI_ASSERT_INFO(args.size() == ptr->num_dims + 1,
-                   "Invalid number of args for sample_lod Texture op with a "
-                   "{}-dimension texture",
-                   ptr->num_dims);
+    ErrorEmitter(args.size() == ptr->num_dims + 1, TaichiTypeError(), this,
+                 fmt::format("Invalid number of args for sample_lod Texture "
+                             "op with a {}-dimension texture",
+                             ptr->num_dims));
     for (int i = 0; i < ptr->num_dims; i++) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::f32) {
-        throw TaichiTypeError(
+        ErrorEmitter(
+            TaichiTypeError(), this,
             fmt::format("Invalid type for texture sample_lod: '{}', all "
                         "arguments must be f32",
                         arg_type->to_string()));
@@ -1154,7 +1180,8 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
+        ErrorEmitter(
+            TaichiTypeError(), this,
             fmt::format("Invalid type for texture fetch_texel: '{}', all "
                         "arguments must be i32",
                         arg_type->to_string()));
@@ -1170,10 +1197,10 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', all "
-                        "arguments must be i32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', all "
+                                 "arguments must be i32",
+                                 arg_type->to_string()));
       }
     }
   } else if (op == TextureOpType::kStore) {
@@ -1186,20 +1213,20 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', index "
-                        "arguments must be i32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', index "
+                                 "arguments must be i32",
+                                 arg_type->to_string()));
       }
     }
     for (int i = ptr->num_dims; i < ptr->num_dims + 4; i++) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::f32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', value "
-                        "arguments must be f32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', value "
+                                 "arguments must be f32",
+                                 arg_type->to_string()));
       }
     }
   } else {
@@ -1221,9 +1248,10 @@ void TextureOpExpression::flatten(FlattenContext *ctx) {
 }
 
 void ConstExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(
+  ErrorEmitter(
       val.dt->is<PrimitiveType>() && val.dt != PrimitiveType::unknown,
-      "Invalid dt [{}] for ConstExpression", val.dt->to_string());
+      TaichiTypeError(), this,
+      fmt::format("Invalid dt [{}] for ConstExpression", val.dt->to_string()));
   ret_type = val.dt;
 }
 
@@ -1233,10 +1261,11 @@ void ConstExpression::flatten(FlattenContext *ctx) {
 }
 
 void ExternalTensorShapeAlongAxisExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(
+  ErrorEmitter(
       ptr.is<ExternalTensorExpression>() || ptr.is<TexturePtrExpression>(),
-      "Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
-      ExpressionHumanFriendlyPrinter::expr_to_string(ptr));
+      TaichiTypeError(), this,
+      fmt::format("Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
+                  ExpressionHumanFriendlyPrinter::expr_to_string(ptr)));
   ret_type = PrimitiveType::i32;
 }
 
@@ -1250,9 +1279,10 @@ void ExternalTensorShapeAlongAxisExpression::flatten(FlattenContext *ctx) {
 void GetElementExpression::type_check(const CompileConfig *config) {
   TI_ASSERT_TYPE_CHECKED(src);
   auto src_type = src->ret_type;
-  TI_ASSERT_INFO(src_type->is<PointerType>(),
-                 "Invalid src [{}] for GetElementExpression",
-                 ExpressionHumanFriendlyPrinter::expr_to_string(src));
+  ErrorEmitter(
+      src_type->is<PointerType>(), TaichiTypeError(), this,
+      fmt::format("Invalid src [{}] for GetElementExpression",
+                  ExpressionHumanFriendlyPrinter::expr_to_string(src)));
 
   ret_type = src_type.ptr_removed()->as<StructType>()->get_element_type(index);
 }
@@ -1352,8 +1382,10 @@ void ASTBuilder::insert_assignment(Expr &lhs,
     this->insert(std::move(stmt));
 
   } else {
-    TI_ERROR("Cannot assign to non-lvalue: {}",
-             ExpressionHumanFriendlyPrinter::expr_to_string(lhs));
+    ErrorEmitter(
+        TaichiRuntimeError(), lhs.expr.get(),
+        fmt::format("Cannot assign to non-lvalue: {}",
+                    ExpressionHumanFriendlyPrinter::expr_to_string(lhs)));
   }
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1007,6 +1007,16 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
   } else {
     error();
   }
+
+  if (ret_type != val_dtype) {
+    auto promoted = promoted_type(ret_type, val_dtype);
+    if (ret_type != promoted) {
+      ErrorEmitter(TaichiCastWarning(), this,
+                   fmt::format("Atomic {} may lose precision: {} <- {}",
+                               atomic_op_type_name(op_type),
+                               ret_type->to_string(), val_dtype->to_string()));
+    }
+  }
 }
 
 void AtomicOpExpression::flatten(FlattenContext *ctx) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1008,13 +1008,15 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
     error();
   }
 
-  if (ret_type != val_dtype) {
-    auto promoted = promoted_type(ret_type, val_dtype);
-    if (ret_type != promoted) {
-      ErrorEmitter(TaichiCastWarning(), this,
-                   fmt::format("Atomic {} may lose precision: {} <- {}",
-                               atomic_op_type_name(op_type),
-                               ret_type->to_string(), val_dtype->to_string()));
+  auto const &ret_element_type = ret_type.get_element_type();
+  if (ret_element_type != val_dtype) {
+    auto promoted = promoted_type(ret_element_type, val_dtype);
+    if (ret_element_type != promoted) {
+      ErrorEmitter(
+          TaichiCastWarning(), this,
+          fmt::format("Atomic {} may lose precision: {} <- {}",
+                      atomic_op_type_name(op_type),
+                      ret_element_type->to_string(), val_dtype->to_string()));
     }
   }
 }

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -538,4 +538,11 @@ void ImmediateIRModifier::replace_usages_with(Stmt *old_stmt, Stmt *new_stmt) {
   }
 }
 
+ErrorEmitter::ErrorEmitter(TaichiExceptionImpl &&error,
+                           const Stmt *stmt,
+                           std::string &&error_msg) {
+  error.msg_ = stmt->tb + error_msg;
+  error.emit();
+}
+
 }  // namespace taichi::lang

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -61,10 +61,8 @@ class StatementTypeNameVisitor : public IRVisitor {
   StatementTypeNameVisitor() {
   }
 
-#define PER_STATEMENT(x)         \
-  void visit(x *stmt) override { \
-    type_name = #x;              \
-  }
+#define PER_STATEMENT(x) \
+  void visit(x *stmt) override { type_name = #x; }
 #include "taichi/inc/statements.inc.h"
 
 #undef PER_STATEMENT

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -61,8 +61,10 @@ class StatementTypeNameVisitor : public IRVisitor {
   StatementTypeNameVisitor() {
   }
 
-#define PER_STATEMENT(x) \
-  void visit(x *stmt) override { type_name = #x; }
+#define PER_STATEMENT(x)         \
+  void visit(x *stmt) override { \
+    type_name = #x;              \
+  }
 #include "taichi/inc/statements.inc.h"
 
 #undef PER_STATEMENT
@@ -543,6 +545,15 @@ ErrorEmitter::ErrorEmitter(TaichiExceptionImpl &&error,
                            std::string &&error_msg) {
   error.msg_ = stmt->tb + error_msg;
   error.emit();
+}
+
+ErrorEmitter::ErrorEmitter(bool expression,
+                           TaichiExceptionImpl &&error,
+                           const Stmt *stmt,
+                           std::string &&error_msg) {
+  if (!expression) {
+    ErrorEmitter(std::move(error), stmt, std::move(error_msg));
+  }
 }
 
 }  // namespace taichi::lang

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -537,21 +537,4 @@ void ImmediateIRModifier::replace_usages_with(Stmt *old_stmt, Stmt *new_stmt) {
     usage->set_operand(i, new_stmt);
   }
 }
-
-ErrorEmitter::ErrorEmitter(TaichiExceptionImpl &&error,
-                           const Stmt *stmt,
-                           std::string &&error_msg) {
-  error.msg_ = stmt->tb + error_msg;
-  error.emit();
-}
-
-ErrorEmitter::ErrorEmitter(bool expression,
-                           TaichiExceptionImpl &&error,
-                           const Stmt *stmt,
-                           std::string &&error_msg) {
-  if (!expression) {
-    ErrorEmitter(std::move(error), stmt, std::move(error_msg));
-  }
-}
-
 }  // namespace taichi::lang

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -508,25 +508,26 @@ class Stmt : public IRNode {
 };
 
 struct ErrorEmitter {
+  ErrorEmitter() = delete;
+
   // Emit an error on stmt with error message
   template <typename T,
             typename = std::enable_if_t<
-                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
-  ErrorEmitter(TaichiExceptionImpl &&error, T *stmt, std::string &&error_msg) {
-    error.msg_ = stmt->tb + error_msg;
+                std::is_same_v<std::decay_t<decltype(std::declval<T>()->tb)>,
+                               std::string>>>
+  ErrorEmitter(TaichiExceptionImpl &&error, T p_stmt, std::string &&error_msg) {
+    error.msg_ = p_stmt->tb + error_msg;
     error.emit();
   }
 
   // Emit an error when expression is false
-  template <typename T,
-            typename = std::enable_if_t<
-                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
+  template <typename T>
   ErrorEmitter(bool expression,
                TaichiExceptionImpl &&error,
-               T *stmt,
+               T p_stmt,
                std::string &&error_msg) {
     if (!expression) {
-      ErrorEmitter(std::move(error), stmt, std::move(error_msg));
+      ErrorEmitter(std::move(error), p_stmt, std::move(error_msg));
     }
   }
 };

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,10 +268,8 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT                     \
-  void accept(IRVisitor *visitor) override { \
-    visitor->visit(this);                    \
-  }
+#define TI_DEFINE_ACCEPT \
+  void accept(IRVisitor *visitor) override { visitor->visit(this); }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,10 +268,8 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT                     \
-  void accept(IRVisitor *visitor) override { \
-    visitor->visit(this);                    \
-  }
+#define TI_DEFINE_ACCEPT \
+  void accept(IRVisitor *visitor) override { visitor->visit(this); }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \
@@ -510,13 +508,9 @@ class Stmt : public IRNode {
 };
 
 struct ErrorEmitter {
-  template <typename T>
-  [[noreturn]] ErrorEmitter(T &&error,
-                            const Stmt *stmt,
-                            std::string &&error_msg) {
-    error.msg_ = stmt->tb + error_msg;
-    throw error;
-  }
+  ErrorEmitter(TaichiExceptionImpl &&error,
+               const Stmt *stmt,
+               std::string &&error_msg);
 };
 
 class Block : public IRNode {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,8 +268,10 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT \
-  void accept(IRVisitor *visitor) override { visitor->visit(this); }
+#define TI_DEFINE_ACCEPT                     \
+  void accept(IRVisitor *visitor) override { \
+    visitor->visit(this);                    \
+  }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \
@@ -508,7 +510,14 @@ class Stmt : public IRNode {
 };
 
 struct ErrorEmitter {
+  // Emit an error on stmt with error message
   ErrorEmitter(TaichiExceptionImpl &&error,
+               const Stmt *stmt,
+               std::string &&error_msg);
+
+  // Emit an error when expression is false
+  ErrorEmitter(bool expression,
+               TaichiExceptionImpl &&error,
                const Stmt *stmt,
                std::string &&error_msg);
 };

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,8 +268,10 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT \
-  void accept(IRVisitor *visitor) override { visitor->visit(this); }
+#define TI_DEFINE_ACCEPT                     \
+  void accept(IRVisitor *visitor) override { \
+    visitor->visit(this);                    \
+  }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \
@@ -387,6 +389,11 @@ class StmtFieldManager {
   mark_fields_registered(); \
   io(field_manager)
 
+struct Location {
+  int line_number;
+  std::string var_name;
+};
+
 class Stmt : public IRNode {
  protected:
   std::vector<Stmt **> operands;
@@ -401,6 +408,7 @@ class Stmt : public IRNode {
   bool fields_registered;
   std::string tb;
   DataType ret_type;
+  Location src_location;
 
   Stmt();
   Stmt(const Stmt &stmt);
@@ -498,6 +506,16 @@ class Stmt : public IRNode {
 
   static void reset_counter() {
     instance_id_counter = 0;
+  }
+};
+
+struct ErrorEmitter {
+  template <typename T>
+  [[noreturn]] ErrorEmitter(T &&error,
+                            const Stmt *stmt,
+                            std::string &&error_msg) {
+    error.msg_ = stmt->tb + error_msg;
+    throw error;
   }
 };
 

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -509,15 +509,26 @@ class Stmt : public IRNode {
 
 struct ErrorEmitter {
   // Emit an error on stmt with error message
-  ErrorEmitter(TaichiExceptionImpl &&error,
-               const Stmt *stmt,
-               std::string &&error_msg);
+  template <typename T,
+            typename = std::enable_if_t<
+                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
+  ErrorEmitter(TaichiExceptionImpl &&error, T *stmt, std::string &&error_msg) {
+    error.msg_ = stmt->tb + error_msg;
+    error.emit();
+  }
 
   // Emit an error when expression is false
+  template <typename T,
+            typename = std::enable_if_t<
+                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
   ErrorEmitter(bool expression,
                TaichiExceptionImpl &&error,
-               const Stmt *stmt,
-               std::string &&error_msg);
+               T *stmt,
+               std::string &&error_msg) {
+    if (!expression) {
+      ErrorEmitter(std::move(error), stmt, std::move(error_msg));
+    }
+  }
 };
 
 class Block : public IRNode {

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -588,7 +588,7 @@ class AssertStmt : public Stmt {
   AssertStmt(Stmt *cond,
              const std::string &text,
              const std::vector<Stmt *> &args)
-      : cond(cond), text(text), args(args) {
+      : cond(cond), text(cond->tb + text), args(args) {
     TI_ASSERT(cond);
     TI_STMT_REG_FIELDS;
   }

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -2455,7 +2455,6 @@ class GloablDataAccessRuleChecker : public BasicStmtVisitor {
         "(kernel={}) Breaks the global data access rule. Snode {} is "
         "overwritten unexpectedly.",
         kernel_name_, dest->snode->get_node_type_name());
-    msg += "\n" + stmt->tb;
 
     stmt->insert_before_me(
         Stmt::make<AssertStmt>(check_equal, msg, std::vector<Stmt *>()));

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -89,7 +89,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
         msg += ", ";
       msg += "%d";
     }
-    msg += "]\n" + stmt->tb;
+    msg += "]";
 
     new_stmts.push_back<AssertStmt>(result, msg, args);
     modifier.insert_before(stmt, std::move(new_stmts));
@@ -152,7 +152,6 @@ class CheckOutOfBound : public BasicStmtVisitor {
       msg += "%d";
     }
     msg += ")";
-    msg += "\n" + stmt->tb;
 
     new_stmts.push_back<AssertStmt>(result, msg, args);
     modifier.insert_before(stmt, std::move(new_stmts));
@@ -197,7 +196,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
         msg += ", ";
       msg += std::to_string(matrix_shape[i]);
     }
-    msg += "] matrix with index [%d]\n" + stmt->tb;
+    msg += "] matrix with index [%d]";
 
     std::vector<Stmt *> args = {index};
     new_stmts.push_back<AssertStmt>(result, msg, args);
@@ -218,7 +217,6 @@ class CheckOutOfBound : public BasicStmtVisitor {
             BinaryOpType::cmp_ge, stmt->rhs, compare_rhs.get());
         compare->ret_type = PrimitiveType::i32;
         std::string msg = "Negative exponent in pow(int, int) is not allowed.";
-        msg += "\n" + stmt->tb;
         auto assert_stmt = std::make_unique<AssertStmt>(compare.get(), msg,
                                                         std::vector<Stmt *>());
         assert_stmt->accept(this);

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -78,6 +78,15 @@ class FrontendTypeCheck : public IRVisitor {
                    fmt::format("cannot assign '{}' to '{}'",
                                rhs_type->to_string(), lhs_type->to_string()));
     }
+
+    if (lhs_type != rhs_type) {
+      auto promoted = promoted_type(lhs_type, rhs_type);
+      if (lhs_type != promoted) {
+        ErrorEmitter(TaichiCastWarning(), stmt,
+                     fmt::format("Assign may lose precision: {} <- {}",
+                                 lhs_type->to_string(), rhs_type->to_string()));
+      }
+    }
   }
 
   void visit(FrontendIfStmt *stmt) override {

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -68,8 +68,8 @@ class FrontendTypeCheck : public IRVisitor {
   }
 
   void visit(FrontendAssignStmt *stmt) override {
-    auto lhs_type = stmt->lhs->ret_type.ptr_removed();
-    auto rhs_type = stmt->rhs->ret_type.ptr_removed();
+    auto const &lhs_type = stmt->lhs->ret_type.ptr_removed();
+    auto const &rhs_type = stmt->rhs->ret_type.ptr_removed();
 
     // No implicit cast at frontend for now
     if (is_tensor(lhs_type) && is_tensor(rhs_type) &&
@@ -79,12 +79,16 @@ class FrontendTypeCheck : public IRVisitor {
                                rhs_type->to_string(), lhs_type->to_string()));
     }
 
-    if (lhs_type != rhs_type) {
-      auto promoted = promoted_type(lhs_type, rhs_type);
-      if (lhs_type != promoted) {
+    auto const &lhs_element_type = lhs_type.get_element_type();
+    auto const &rhs_element_type = rhs_type.get_element_type();
+
+    if (lhs_element_type != rhs_element_type) {
+      auto promoted = promoted_type(lhs_element_type, rhs_element_type);
+      if (lhs_element_type != promoted) {
         ErrorEmitter(TaichiCastWarning(), stmt,
                      fmt::format("Assign may lose precision: {} <- {}",
-                                 lhs_type->to_string(), rhs_type->to_string()));
+                                 lhs_element_type->to_string(),
+                                 rhs_element_type->to_string()));
       }
     }
   }

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -183,9 +183,9 @@ class BasicBlockSimplify : public IRVisitor {
       auto zero = Stmt::make<ConstStmt>(TypedConstant(0));
       auto check_sum =
           Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_ge, sum.get(), zero.get());
-      auto assert = Stmt::make<AssertStmt>(
-          check_sum.get(), "The indices provided are too big!\n" + stmt->tb,
-          std::vector<Stmt *>());
+      auto assert = Stmt::make<AssertStmt>(check_sum.get(),
+                                           "The indices provided are too big!",
+                                           std::vector<Stmt *>());
       // Because Taichi's assertion is checked only after the execution of the
       // kernel, when the linear index overflows and goes negative, we have to
       // replace that with 0 to make sure that the rest of the kernel can still

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -278,7 +278,6 @@ class TypeCheck : public IRVisitor {
     std::string msg =
         "Detected overflow for bit_shift_op with rhs = %d, exceeding limit of "
         "%d.";
-    msg += "\n" + stmt->tb;
     std::vector<Stmt *> args = {rhs, const_stmt.get()};
     auto assert_stmt =
         Stmt::make<AssertStmt>(cond_stmt.get(), msg, std::move(args));


### PR DESCRIPTION
Issue: #

# Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9935113</samp>

This pull request refactors the error reporting and handling system in the Taichi IR codebase. It introduces a new `ErrorEmitter` class that handles the creation and formatting of error messages with statement tracebacks. It also modifies the exception classes, the `IRVisitor` class, and various IR transforms and statements to use the `ErrorEmitter` class and to avoid duplicating the traceback information. These changes improve the consistency, simplicity, and flexibility of the error reporting and debugging for Taichi IR.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9935113</samp>

*  Refactor the error and warning handling in the Taichi IR by introducing the `ErrorEmitter` class, which takes an exception, a statement, and an error message, and throws or logs the exception with the statement's traceback information. ([link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L35-R38), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L48-R59), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L70-R81), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L95-R111), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-50be2dc708119a4c9b53e977807d2f05e4ff6ce98c3f51fa91d1fa9e229962f1R543-R558),  [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L2458), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL35-R38), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL147-R156), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL159-R165), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL301-R308))
*  Add the `emit` method to the `TaichiExceptionImpl` class and its subclasses, which is responsible for throwing or logging the exception, and make the `ErrorEmitter` class a friend of the `TaichiExceptionImpl` class. Add a new subclass `TaichiIrError` for errors related to the Taichi IR, and two new subclasses `TaichiCastWarning` and `TaichiTypeWarning` for warnings related to implicit type casting and type inference. ([link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L8-R19), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L20-R98))
*  Simplify the usage of the `AssertStmt` class by appending the condition's traceback information to the text field of the statement in the constructor, and remove the redundant traceback information from the error messages where the `AssertStmt` class is used. ([link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L591-R591), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL92-R92), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL155), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL200-R199), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL221), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-58b0ebe6a129091d8ae4753ba2bba80c7cc000e7f8eab635a337094582f543edL186-R188), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL278))
*  Simplify the usage of the `check_cond_type` method in the `FrontendTypeCheck` class by passing the statement that contains the condition expression instead of passing the condition and the statement name separately, and use the `ErrorEmitter` class to handle the type errors. ([link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L9-R33), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L49-R67), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L71-R85), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L146-R161))
*  Use the `ErrorEmitter` class to handle the type errors and warnings in the `FrontendTypeCheck` class and the `TypeCheck` class, and remove the redundant statement name and traceback information from the error messages. ([link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L56-R79), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L111-R127), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L121-R138))
*  Add a new struct `Location` to represent the source code location of a statement, and add a new field `src_location` to the `Stmt` class to store the source code location of the statement. This is part of a new feature that aims to provide more accurate and informative source code location information for Taichi IR statements. ([link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR392-R396), [link](https://github.com/taichi-dev/taichi/pull/8243/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR411))
