### PR TITLE
[bug] Add is_grad to printer of ExternalTensorBasePtrExpression/Stmt

### DIFF
--- a/taichi/ir/expression_printer.h
+++ b/taichi/ir/expression_printer.h
@@ -210,7 +210,7 @@ class ExpressionHumanFriendlyPrinter : public ExpressionPrinter {
   void visit(ExternalTensorBasePtrExpression *expr) override {
     emit("external_tensor_base_ptr(");
     expr->ptr->accept(this);
-    emit(')');
+    emit(", is_grad=", expr->is_grad, ')');
   }
 
   void visit(MeshPatchIndexExpression *expr) override {

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -774,8 +774,8 @@ class IRPrinter : public IRVisitor {
   }
 
   void visit(ExternalTensorBasePtrStmt *stmt) override {
-    print("{}{} = external_tensor_base_ptr (arg_id={})", stmt->type_hint(),
-          stmt->name(), stmt->arg_id);
+    print("{}{} = external_tensor_base_ptr (arg_id={}, is_grad={})",
+          stmt->type_hint(), stmt->name(), stmt->arg_id, stmt->is_grad);
   }
 
   void visit(BitStructStoreStmt *stmt) override {


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f3c4d5</samp>

Add `is_grad` attribute of `ExternalTensorBasePtrStmt` to expression and IR printers. This helps with debugging and testing the integration of external tensors in Taichi programs.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f3c4d5</samp>

*  Add `is_grad` attribute of `ExternalTensorBasePtrStmt` to expression and IR printers ([link](https://github.com/taichi-dev/taichi/pull/8244/files?diff=unified&w=0#diff-aa95836220fa5f1bd9eedc9f7535e77c52c3e8ea7489b72408f875bae4adb04dL213-R213), [link](https://github.com/taichi-dev/taichi/pull/8244/files?diff=unified&w=0#diff-77422b8748a46e70519217be594cd28433edadf98ca4960ce116f85da8dbccc3L777-R778))
