### PR TITLE
[bug] Fix dataclass support for struct with matrix

### DIFF
--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -66,7 +66,7 @@ _
 
         for k, v in self.__entries.items():
             if isinstance(v, (list, tuple)):
-                v = Matrix(v, ndim=matrix_ndim.get(k))
+                v = Matrix(v)
             if isinstance(v, dict):
                 v = Struct(v)
             self.__entries[k] = v if in_python_scope() else impl.expr_init(v)

--- a/tests/python/test_struct.py
+++ b/tests/python/test_struct.py
@@ -216,3 +216,37 @@ def test_struct_special_element_name():
         return x.entries + x.keys + x.items + x.methods
 
     assert foo() == 42 + 21 + 23 + 11
+
+
+@test_utils.test()
+def test_struct_with_matrix():
+    @ti.dataclass
+    class TestStruct:
+        p1: ti.math.vec3
+        p2: ti.math.vec3
+
+        @ti.func
+        def get_vec(self, struct2, additional):
+            self.p1 = (self.p1 + average(struct2)) / 2 + additional.p1
+
+    global_struct = TestStruct(p1=[0, 2, 4], p2=[-2, -4, -6])
+
+    @ti.func
+    def average(struct) -> ti.math.vec3:
+        return (struct.p1 + struct.p2) / 2
+
+    @ti.kernel
+    def process_struct(field1: ti.template(), field2: ti.template()):
+        for i in field1:
+            field1[i].get_vec(field2[i], global_struct)
+
+    field1 = TestStruct.field()
+    field2 = TestStruct.field()
+
+    ti.root.dense(ti.i, 64).place(field1, field2)
+
+    for i in range(64):
+        field1[i] = TestStruct(p1=[1, 2, 3], p2=[4, 5, 6])
+        field2[i] = TestStruct(p1=[4, 5, 6], p2=[1, 2, 3])
+
+    process_struct(field1, field2)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c65a65</samp>

Refactor `Matrix` constructor call in `struct.py` and add a new test case for `ti.dataclass` with `ti.math.vec3` fields in `test_struct.py`. These changes aim to simplify the code and enhance the testing of the struct feature.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c65a65</samp>

* Remove unnecessary `ndim` argument from `Matrix` constructor calls ([link](https://github.com/taichi-dev/taichi/pull/8251/files?diff=unified&w=0#diff-3154e0533b9fd63e663c16c2e87c65068c3b002a65cf80529b6577d173bdb5feL69-R69))
* Add new test case for `ti.dataclass` with `ti.math.vec3` fields and `ti.func` methods ([link](https://github.com/taichi-dev/taichi/pull/8251/files?diff=unified&w=0#diff-e87bf5cb1cd09e10b5cfa001ab2ef18f31a242db3a7b66ee98a76d60b1615e71R219-R252))
