### PR TITLE
[Lang] Support TensorType for SharedArray

### DIFF
--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -54,6 +54,8 @@ class SharedArray:
             raise ValueError(
                 f"ti.simt.block.shared_array shape must be an integer or a tuple of integers, but got {shape}"
             )
+        if isinstance(dtype, impl.MatrixType):
+            dtype = dtype.tensor_type
         self.dtype = dtype
         self.shared_array_proxy = impl.expr_init_shared_array(self.shape, dtype)
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -726,7 +726,11 @@ Stmt *make_tensor_access(Expression::FlattenContext *ctx,
     ctx->push_back<LocalStoreStmt>(alloca_stmt, var_stmt);
     var_stmt = alloca_stmt;
   }
-  if (ret_type.ptr_removed()->is<TensorType>()) {
+
+  bool is_shared_array =
+      (var_stmt->is<AllocaStmt>() && var_stmt->as<AllocaStmt>()->is_shared);
+
+  if (ret_type.ptr_removed()->is<TensorType>() && !is_shared_array) {
     std::vector<Stmt *> stmts;
     for (auto &indices : indices_group) {
       stmts.push_back(

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -106,7 +106,8 @@ MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
 
   if (origin->is<AllocaStmt>() || origin->is<GlobalTemporaryStmt>() ||
       origin->is<ExternalPtrStmt>() || origin->is<MatrixOfGlobalPtrStmt>() ||
-      origin->is<MatrixOfMatrixPtrStmt>() || origin->is<ThreadLocalPtrStmt>()) {
+      origin->is<MatrixOfMatrixPtrStmt>() || origin->is<ThreadLocalPtrStmt>() ||
+      origin->is<MatrixPtrStmt>()) {
     auto tensor_type = origin->ret_type.ptr_removed()->cast<TensorType>();
     TI_ASSERT(tensor_type != nullptr);
     element_type() = tensor_type->get_element_type();

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -3,6 +3,7 @@
 #include "taichi/util/bit.h"
 #include "taichi/program/kernel.h"
 #include "taichi/program/function.h"
+#include "signal.h"
 
 namespace taichi::lang {
 
@@ -118,6 +119,7 @@ MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
     element_type() = origin->ret_type.get_element_type();
     element_type().set_is_pointer(true);
   } else {
+    raise(SIGSEGV);
     TI_ERROR(
         "MatrixPtrStmt must be used for AllocaStmt / GlobalTemporaryStmt "
         "(locally) or GlobalPtrStmt / MatrixOfGlobalPtrStmt / ExternalPtrStmt "

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -3,7 +3,6 @@
 #include "taichi/util/bit.h"
 #include "taichi/program/kernel.h"
 #include "taichi/program/function.h"
-#include "signal.h"
 
 namespace taichi::lang {
 
@@ -120,7 +119,6 @@ MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
     element_type() = origin->ret_type.get_element_type();
     element_type().set_is_pointer(true);
   } else {
-    raise(SIGSEGV);
     TI_ERROR(
         "MatrixPtrStmt must be used for AllocaStmt / GlobalTemporaryStmt "
         "(locally) or GlobalPtrStmt / MatrixOfGlobalPtrStmt / ExternalPtrStmt "

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -2018,4 +2018,34 @@ class MatrixInitStmt : public Stmt {
   TI_DEFINE_ACCEPT_AND_CLONE
 };
 
+template <typename T>
+std::vector<std::unique_ptr<Stmt>> get_const_stmt_with_value(DataType dt,
+                                                             T value) {
+  if (dt->is<PrimitiveType>()) {
+    TypedConstant constant(dt, value);
+    auto const_stmt = std::make_unique<ConstStmt>(constant);
+
+    std::vector<std::unique_ptr<Stmt>> ret;
+    ret.push_back(std::move(const_stmt));
+    return ret;
+
+  } else if (dt->is<TensorType>()) {
+    DataType element_dt = dt.get_element_type();
+    std::vector<std::unique_ptr<Stmt>> stmts =
+        get_const_stmt_with_value(element_dt, value);
+
+    Stmt *elem_stmt = stmts.back().get();
+    std::vector<Stmt *> elem_stmts(dt->as<TensorType>()->get_num_elements(),
+                                   elem_stmt);
+
+    auto matrix_init_stmt = std::make_unique<MatrixInitStmt>(elem_stmts);
+    matrix_init_stmt->ret_type = dt;
+
+    stmts.push_back(std::move(matrix_init_stmt));
+    return stmts;
+  } else {
+    TI_NOT_IMPLEMENTED
+  }
+}
+
 }  // namespace taichi::lang

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -488,7 +488,7 @@ class MatrixPtrStmt : public Stmt {
   */
   bool offset_used_as_index() const {
     if (origin->is<AllocaStmt>() || origin->is<GlobalTemporaryStmt>() ||
-        origin->is<ExternalPtrStmt>()) {
+        origin->is<ExternalPtrStmt>() || origin->is<MatrixPtrStmt>()) {
       TI_ASSERT_INFO(origin->ret_type.ptr_removed()->is<TensorType>(),
                      "MatrixPtrStmt can only be used for TensorType.");
       return true;

--- a/taichi/ir/type.h
+++ b/taichi/ir/type.h
@@ -740,7 +740,6 @@ Type::jsonserde_ptr_io(const T *&ptr,
     }
   }
 }
-
 }  // namespace taichi::lang
 
 namespace taichi::hashing {

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -294,6 +294,9 @@ void offload_to_executable(IRNode *ir,
        !get_custom_cuda_library_path().empty());
   if (config.real_matrix_scalarize) {
     if (irpass::scalarize(ir, half2_optimization_enabled)) {
+      irpass::die(ir);
+      print("DIE");
+
       // Remove redundant MatrixInitStmt inserted during scalarization
       irpass::full_simplify(
           ir, config,

--- a/taichi/transforms/lower_matrix_ptr.cpp
+++ b/taichi/transforms/lower_matrix_ptr.cpp
@@ -239,6 +239,8 @@ class ScalarizeMatrixPtr : public BasicStmtVisitor {
         auto load_stmt = std::make_unique<LocalLoadStmt>(matrix_ptr_stmt.get());
         load_stmt->ret_type = primitive_type;
 
+        std::cout << (matrix_of_matrix_ptr_stmt->stmts[i] == nullptr)
+                  << std::endl;
         auto store_stmt = std::make_unique<T>(
             matrix_of_matrix_ptr_stmt->stmts[i], load_stmt.get());
 

--- a/taichi/transforms/lower_matrix_ptr.cpp
+++ b/taichi/transforms/lower_matrix_ptr.cpp
@@ -239,8 +239,6 @@ class ScalarizeMatrixPtr : public BasicStmtVisitor {
         auto load_stmt = std::make_unique<LocalLoadStmt>(matrix_ptr_stmt.get());
         load_stmt->ret_type = primitive_type;
 
-        std::cout << (matrix_of_matrix_ptr_stmt->stmts[i] == nullptr)
-                  << std::endl;
         auto store_stmt = std::make_unique<T>(
             matrix_of_matrix_ptr_stmt->stmts[i], load_stmt.get());
 

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -62,8 +62,31 @@ class Scalarize : public BasicStmtVisitor {
         auto const_stmt = std::make_unique<ConstStmt>(
             TypedConstant(get_data_type<int32>(), i));
 
-        auto matrix_ptr_stmt =
-            std::make_unique<MatrixPtrStmt>(stmt->dest, const_stmt.get());
+        // Merge with previous MatrixPtrStmt
+        std::unique_ptr<MatrixPtrStmt> matrix_ptr_stmt = nullptr;
+        if (stmt->dest->template is<MatrixPtrStmt>()) {
+          /*
+            <*[Tensor (16) [Tensor (4) f32]]> $5 = alloca(shared)
+            <*[Tensor (4) f32]> $11 = shift ptr [$5 + $9]
+            <[Tensor (4) f32]> $12 : local store [$11 <- $10]
+          */
+          auto matrix_ptr_stmt_ptr = stmt->dest->template as<MatrixPtrStmt>();
+
+          auto base_offset = matrix_ptr_stmt_ptr->offset;
+          auto merged_offset = std::make_unique<BinaryOpStmt>(
+              BinaryOpType::add, base_offset, const_stmt.get());
+          merged_offset->ret_type = base_offset->ret_type;
+
+          matrix_ptr_stmt = std::make_unique<MatrixPtrStmt>(
+              matrix_ptr_stmt_ptr->origin, merged_offset.get());
+          matrix_ptr_stmt->ret_type = primitive_type;
+          matrix_ptr_stmt->ret_type.set_is_pointer(true);
+
+          delayed_modifier_.insert_before(stmt, std::move(merged_offset));
+        } else {
+          matrix_ptr_stmt =
+              std::make_unique<MatrixPtrStmt>(stmt->dest, const_stmt.get());
+        }
         matrix_ptr_stmt->ret_type = primitive_type;
         matrix_ptr_stmt->ret_type.set_is_pointer(true);
 
@@ -112,8 +135,29 @@ class Scalarize : public BasicStmtVisitor {
         auto const_stmt = std::make_unique<ConstStmt>(
             TypedConstant(get_data_type<int32>(), i));
 
-        auto matrix_ptr_stmt =
-            std::make_unique<MatrixPtrStmt>(stmt->src, const_stmt.get());
+        std::unique_ptr<MatrixPtrStmt> matrix_ptr_stmt = nullptr;
+        if (stmt->src->template is<MatrixPtrStmt>()) {
+          /*
+            <*[Tensor (16) [Tensor (4) f32]]> $5 = alloca(shared)
+            <*[Tensor (4) f32]> $11 = shift ptr [$5 + $9]
+            <[Tensor (4) f32]> $12 : local store [$11 <- $10]
+          */
+          auto matrix_ptr_stmt_ptr = stmt->src->template as<MatrixPtrStmt>();
+
+          auto base_offset = matrix_ptr_stmt_ptr->offset;
+          auto merged_offset = std::make_unique<BinaryOpStmt>(
+              BinaryOpType::add, base_offset, const_stmt.get());
+          merged_offset->ret_type = base_offset->ret_type;
+
+          matrix_ptr_stmt = std::make_unique<MatrixPtrStmt>(
+              matrix_ptr_stmt_ptr->origin, merged_offset.get());
+
+          delayed_modifier_.insert_before(stmt, std::move(merged_offset));
+        } else {
+          matrix_ptr_stmt =
+              std::make_unique<MatrixPtrStmt>(stmt->src, const_stmt.get());
+        }
+
         matrix_ptr_stmt->ret_type = primitive_type;
         matrix_ptr_stmt->ret_type.set_is_pointer(true);
 
@@ -526,8 +570,34 @@ class Scalarize : public BasicStmtVisitor {
         // scalarize to dest_i
         auto const_stmt = std::make_unique<ConstStmt>(
             TypedConstant(get_data_type<int32>(), i));
-        auto matrix_ptr_stmt =
-            std::make_unique<MatrixPtrStmt>(stmt->dest, const_stmt.get());
+
+        // Merge with previous MatrixPtrStmt
+        std::unique_ptr<MatrixPtrStmt> matrix_ptr_stmt = nullptr;
+        if (stmt->dest->is<MatrixPtrStmt>()) {
+          /*
+            <*[Tensor (16) [Tensor (4) f32]]> $5 = alloca(shared)
+            <*[Tensor (4) f32]> $11 = shift ptr [$5 + $9]
+            <[Tensor (4) f32]> $12 : local store [$11 <- $10]
+          */
+          auto matrix_ptr_stmt_ptr = stmt->dest->as<MatrixPtrStmt>();
+
+          auto base_offset = matrix_ptr_stmt_ptr->offset;
+          auto merged_offset = std::make_unique<BinaryOpStmt>(
+              BinaryOpType::add, base_offset, const_stmt.get());
+          merged_offset->ret_type = base_offset->ret_type;
+          matrix_ptr_stmt = std::make_unique<MatrixPtrStmt>(
+              matrix_ptr_stmt_ptr->origin, merged_offset.get());
+          matrix_ptr_stmt->ret_type = primitive_type;
+          matrix_ptr_stmt->ret_type.set_is_pointer(true);
+
+          delayed_modifier_.insert_before(stmt, std::move(merged_offset));
+        } else {
+          matrix_ptr_stmt =
+              std::make_unique<MatrixPtrStmt>(stmt->dest, const_stmt.get());
+        }
+
+        matrix_ptr_stmt->ret_type = primitive_type;
+        matrix_ptr_stmt->ret_type.set_is_pointer(true);
 
         // scalarize to val_i
         auto val_stmt = val_values[i];

--- a/taichi/transforms/scalarize.cpp
+++ b/taichi/transforms/scalarize.cpp
@@ -63,30 +63,8 @@ class Scalarize : public BasicStmtVisitor {
             TypedConstant(get_data_type<int32>(), i));
 
         // Merge with previous MatrixPtrStmt
-        std::unique_ptr<MatrixPtrStmt> matrix_ptr_stmt = nullptr;
-        if (stmt->dest->template is<MatrixPtrStmt>()) {
-          /*
-            <*[Tensor (16) [Tensor (4) f32]]> $5 = alloca(shared)
-            <*[Tensor (4) f32]> $11 = shift ptr [$5 + $9]
-            <[Tensor (4) f32]> $12 : local store [$11 <- $10]
-          */
-          auto matrix_ptr_stmt_ptr = stmt->dest->template as<MatrixPtrStmt>();
-
-          auto base_offset = matrix_ptr_stmt_ptr->offset;
-          auto merged_offset = std::make_unique<BinaryOpStmt>(
-              BinaryOpType::add, base_offset, const_stmt.get());
-          merged_offset->ret_type = base_offset->ret_type;
-
-          matrix_ptr_stmt = std::make_unique<MatrixPtrStmt>(
-              matrix_ptr_stmt_ptr->origin, merged_offset.get());
-          matrix_ptr_stmt->ret_type = primitive_type;
-          matrix_ptr_stmt->ret_type.set_is_pointer(true);
-
-          delayed_modifier_.insert_before(stmt, std::move(merged_offset));
-        } else {
-          matrix_ptr_stmt =
-              std::make_unique<MatrixPtrStmt>(stmt->dest, const_stmt.get());
-        }
+        auto matrix_ptr_stmt =
+            std::make_unique<MatrixPtrStmt>(stmt->dest, const_stmt.get());
         matrix_ptr_stmt->ret_type = primitive_type;
         matrix_ptr_stmt->ret_type.set_is_pointer(true);
 
@@ -135,28 +113,8 @@ class Scalarize : public BasicStmtVisitor {
         auto const_stmt = std::make_unique<ConstStmt>(
             TypedConstant(get_data_type<int32>(), i));
 
-        std::unique_ptr<MatrixPtrStmt> matrix_ptr_stmt = nullptr;
-        if (stmt->src->template is<MatrixPtrStmt>()) {
-          /*
-            <*[Tensor (16) [Tensor (4) f32]]> $5 = alloca(shared)
-            <*[Tensor (4) f32]> $11 = shift ptr [$5 + $9]
-            <[Tensor (4) f32]> $12 : local store [$11 <- $10]
-          */
-          auto matrix_ptr_stmt_ptr = stmt->src->template as<MatrixPtrStmt>();
-
-          auto base_offset = matrix_ptr_stmt_ptr->offset;
-          auto merged_offset = std::make_unique<BinaryOpStmt>(
-              BinaryOpType::add, base_offset, const_stmt.get());
-          merged_offset->ret_type = base_offset->ret_type;
-
-          matrix_ptr_stmt = std::make_unique<MatrixPtrStmt>(
-              matrix_ptr_stmt_ptr->origin, merged_offset.get());
-
-          delayed_modifier_.insert_before(stmt, std::move(merged_offset));
-        } else {
-          matrix_ptr_stmt =
-              std::make_unique<MatrixPtrStmt>(stmt->src, const_stmt.get());
-        }
+        auto matrix_ptr_stmt =
+            std::make_unique<MatrixPtrStmt>(stmt->src, const_stmt.get());
 
         matrix_ptr_stmt->ret_type = primitive_type;
         matrix_ptr_stmt->ret_type.set_is_pointer(true);
@@ -1384,7 +1342,6 @@ bool scalarize(IRNode *root, bool half2_optimization_enabled) {
   modified |= ScalarizePointers::run(root, scalarizable_allocas);
   modified |= ExtractLocalPointers::run(root);
   modified |= FuseMatrixPtr::run(root);
-
   return modified;
 }
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8854acc</samp>

This pull request adds support for shared arrays of matrix types in the Taichi language and IR. It enables nested matrix pointer statements for accessing such arrays, and enhances the scalarize and offload passes to handle them. It also adds a test case and some temporary debugging code.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8854acc</samp>

*  Add support for shared arrays of matrix types ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-aee943d584058490d7717d34c02a3783d3487694dc091653d42b202e45b1e097R57-R58), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L729-R733), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L108-R110), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L491-R491), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L529-R559), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-714976dfca6f0a5c18d59780a3f0be6f007ff8cf8cddafedd2bf07f755519c2bR144-R165))
  - Check and convert the dtype argument of the SharedArray constructor in `python/taichi/lang/simt/block.py` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-aee943d584058490d7717d34c02a3783d3487694dc091653d42b202e45b1e097R57-R58))
  - Avoid treating shared arrays as tensors in the code generation for matrix pointer statements in `taichi/ir/frontend_ir.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L729-R733))
  - Allow nested matrix pointer statements to access shared arrays of matrix types in `taichi/ir/statements.cpp` and `taichi/ir/statements.h` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L108-R110), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L491-R491))
  - Merge with previous matrix pointer statements in the scalarize pass in `taichi/transforms/scalarize.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L529-R559), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528R65))
  - Add a test case that creates and reads a shared array of vec4 type in `tests/python/test_shared_array.py` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-714976dfca6f0a5c18d59780a3f0be6f007ff8cf8cddafedd2bf07f755519c2bR144-R165), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-714976dfca6f0a5c18d59780a3f0be6f007ff8cf8cddafedd2bf07f755519c2bR5))
* Simplify the creation of constant statements for different types in `taichi/ir/statements.h` and `taichi/transforms/offload.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260R2021-R2050), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L541-R550))
  - Add a template function that creates a vector of statements that represent a constant value of a given data type in `taichi/ir/statements.h` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260R2021-R2050))
  - Use the template function to create a constant zero statement and a global store statement for a shared array allocation in `taichi/transforms/offload.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-d47b571f975c1002b8cb93634ac2a3d5f090f3fa9676ec3e0004c2ec4116ee21L541-R550))
* Add debugging code for matrix pointer statements in `taichi/ir/statements.cpp`, `taichi/transforms/compile_to_offloads.cpp`, and `taichi/transforms/lower_matrix_ptr.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5R6), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5R123), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR297-R299), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-9b36b48490841b4018aca81632ae1beac3b2fdf1ee95a5c65eb42b676654b82eR242-R243))
  - Include the signal.h header file and call raise(SIGSEGV) to trigger a segmentation fault when the origin of a matrix pointer statement is invalid in `taichi/ir/statements.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5R6), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5R123))
  - Call the die pass and print the IR after the offload pass in `taichi/transforms/compile_to_offloads.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-8fde186587db97b3bbc8a856e59bc4467b30257335b0fad064b4eebd521a912bR297-R299))
  - Print whether a matrix pointer statement is null or not in `taichi/transforms/lower_matrix_ptr.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-9b36b48490841b4018aca81632ae1beac3b2fdf1ee95a5c65eb42b676654b82eR242-R243))
* Remove or add empty lines in `taichi/ir/type.h` and `taichi/transforms/scalarize.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-87004ca8d67f31ff19e6bc1a62cd6e6d87c09b237197b93533ec6bf617f29149L743), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528R118), [link](https://github.com/taichi-dev/taichi/pull/8258/files?diff=unified&w=0#diff-97b0d9ab204b703802b3b5d04d036d30f66b34b726128216faf0d8a2a8564528L1317))
