### PR TITLE
[example] Eliminate NANs in mpm examples

### DIFF
--- a/python/taichi/examples/simulation/mpm99.py
+++ b/python/taichi/examples/simulation/mpm99.py
@@ -39,6 +39,9 @@ def substep():
         if material[p] == 0:  # liquid
             mu = 0.0
         U, sig, V = ti.svd(F[p])
+        # Avoid zero eigenvalues because of numerical errors
+        for d in ti.static(range(2)):
+            sig[d, d] = ti.max(sig[d, d], 1e-6)
         J = 1.0
         for d in ti.static(range(2)):
             new_sig = sig[d, d]


### PR DESCRIPTION
Issue: #

### Brief Summary

As a result of numerical errors, in some extreme situations,  the deformation gradient `F[p]` gradually becomes a zero matrix producing zero eigenvalues, which leads to a division-by-zero problem. Visually, it looks like particles "flow out" from the bottom-left corner (because NaN is contagious).

This issue can be reproduced by changing all materials to fluid and setting all particles' initial velocities to (-10, -10).

(Below is a visual comparison: the left is the reproduction of this issue, and the right is the expected behavior)

https://github.com/taichi-dev/taichi/assets/8120108/088e35b0-fb47-4fcd-90af-d191424b7616


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 707f387</samp>

Improve stability and accuracy of MPM simulation by clamping stress tensor diagonals in `mpm99.py`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 707f387</samp>

* Implement a more robust and accurate material point method (MPM) for simulating deformable solids in `mpm99.py` (F0)
  * Add a loop to clamp the diagonal elements of the stress tensor `sig` to a small positive value to avoid zero eigenvalues ([link](https://github.com/taichi-dev/taichi/pull/8260/files?diff=unified&w=0#diff-53a00eefa20c226e8ea5d12549a16dc5f624363458bc479903741fcd6c9da5f8R42-R44))
