### PR TITLE
[Bug] Fix error when returning a struct field member when the return …

### DIFF
--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -646,7 +646,11 @@ class StructType(CompoundType):
             return False
         if list(self.members.keys()) != list(instance._Struct__entries.keys()):
             return False
-        if hasattr(instance, '_Struct__dtype') and instance._Struct__dtype != None and instance._Struct__dtype != self.dtype:
+        if (
+            hasattr(instance, "_Struct__dtype")
+            and instance._Struct__dtype != None
+            and instance._Struct__dtype != self.dtype
+        ):
             return False
         for index, (name, dtype) in enumerate(self.members.items()):
             val = instance._members[index]

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -648,7 +648,7 @@ class StructType(CompoundType):
             return False
         if (
             hasattr(instance, "_Struct__dtype")
-            and instance._Struct__dtype != None
+            and instance._Struct__dtype is not None
             and instance._Struct__dtype != self.dtype
         ):
             return False

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -646,7 +646,7 @@ class StructType(CompoundType):
             return False
         if list(self.members.keys()) != list(instance._Struct__entries.keys()):
             return False
-        if instance._Struct__dtype is not None and instance._Struct__dtype != self.dtype:
+        if hasattr(instance, '_Struct__dtype') and instance._Struct__dtype != None and instance._Struct__dtype != self.dtype:
             return False
         for index, (name, dtype) in enumerate(self.members.items()):
             val = instance._members[index]

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -326,3 +326,20 @@ def test_func_scalar_return_cast():
         return bar(a)
 
     assert foo(1.5) == 1.0
+
+
+@test_utils.test()
+def test_return_struct_field():
+    tp = ti.types.struct(a=ti.i32)
+
+    f = tp.field(shape=1)
+
+    @ti.func
+    def bar()->tp:
+        return f[0]
+
+    @ti.kernel
+    def foo()->tp:
+        return bar()
+
+    assert foo().a == 0

--- a/tests/python/test_return.py
+++ b/tests/python/test_return.py
@@ -335,11 +335,11 @@ def test_return_struct_field():
     f = tp.field(shape=1)
 
     @ti.func
-    def bar()->tp:
+    def bar() -> tp:
         return f[0]
 
     @ti.kernel
-    def foo()->tp:
+    def foo() -> tp:
         return bar()
 
     assert foo().a == 0


### PR DESCRIPTION
…type annotation is set

Issue: #8270 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc7a9f2</samp>

Fix a bug in `StructType.__instancecheck__` that caused an AttributeError when the object was not a `Struct` subclass. Update `struct.py` to check for the `_Struct__dtype` attribute before comparing dtypes.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc7a9f2</samp>

*  Fix AttributeError when using isinstance with Struct subclasses ([link](https://github.com/taichi-dev/taichi/pull/8271/files?diff=unified&w=0#diff-3154e0533b9fd63e663c16c2e87c65068c3b002a65cf80529b6577d173bdb5feL649-R649))
