### PR TITLE
[lang] Check ndarray shape in Python constructor

### DIFF
--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -829,6 +829,8 @@ def ndarray(dtype, shape, needs_grad=False):
 
     if isinstance(shape, numbers.Number):
         shape = (shape,)
+    if not all(isinstance(x, int) and x > 0 and x <= 2**31 - 1 for x in shape):
+        raise TaichiRuntimeError(f"{shape} is not a valid shape for ndarray")
     if dtype in all_types:
         dt = cook_dtype(dtype)
         x = ScalarNdarray(dt, shape)

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -829,7 +829,7 @@ def ndarray(dtype, shape, needs_grad=False):
 
     if isinstance(shape, numbers.Number):
         shape = (shape,)
-    if not all(isinstance(x, int) and x > 0 and x <= 2**31 - 1 for x in shape):
+    if not all((isinstance(x, int) or isinstance(x, np.integer)) and x > 0 and x <= 2**31 - 1 for x in shape):
         raise TaichiRuntimeError(f"{shape} is not a valid shape for ndarray")
     if dtype in all_types:
         dt = cook_dtype(dtype)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -658,9 +658,15 @@ def test_ndarray_as_template():
 
 @pytest.mark.parametrize("shape", [2**31, 1.5, 0, (1, 0), (1, 0.5), (1, 2**31)])
 @test_utils.test(arch=supported_archs_taichi_ndarray)
-def test_ndarray_shape(shape):
+def test_ndarray_shape_invalid(shape):
     with pytest.raises(TaichiRuntimeError, match=r"is not a valid shape for ndarray"):
         x = ti.ndarray(dtype=int, shape=shape)
+
+
+@pytest.mark.parametrize("shape", [1, np.int32(1), (1, np.int32(1), 4096)])
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_shape_valid(shape):
+    x = ti.ndarray(dtype=int, shape=shape)
 
 
 @test_utils.test(arch=supported_archs_taichi_ndarray)

--- a/tests/python/test_ndarray.py
+++ b/tests/python/test_ndarray.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 import pytest
 from taichi.lang import impl
-from taichi.lang.exception import TaichiIndexError, TaichiTypeError
+from taichi.lang.exception import TaichiIndexError, TaichiRuntimeError, TaichiTypeError
 from taichi.lang.misc import get_host_arch_list
 from taichi.lang.util import has_pytorch
 from taichi.math import vec3, ivec3
@@ -654,6 +654,13 @@ def test_ndarray_as_template():
     arr_1 = ti.ndarray(ti.f32, shape=(5, 10))
     with pytest.raises(ti.TaichiRuntimeTypeError, match=r"Ndarray shouldn't be passed in via"):
         func(arr_0, arr_1)
+
+
+@pytest.mark.parametrize("shape", [2**31, 1.5, 0, (1, 0), (1, 0.5), (1, 2**31)])
+@test_utils.test(arch=supported_archs_taichi_ndarray)
+def test_ndarray_shape(shape):
+    with pytest.raises(TaichiRuntimeError, match=r"is not a valid shape for ndarray"):
+        x = ti.ndarray(dtype=int, shape=shape)
 
 
 @test_utils.test(arch=supported_archs_taichi_ndarray)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fc4aa4</samp>

This pull request implements validation and testing for the `ndarray` feature in Taichi, which allows creating and manipulating tensors. It adds a check for the shape argument of the `ndarray` function in `impl.py` and a test case for shape errors in `test_ndarray.py`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fc4aa4</samp>

*  Add validation check for shape argument of `ndarray` function to prevent overflow or type errors ([link](https://github.com/taichi-dev/taichi/pull/8272/files?diff=unified&w=0#diff-99744c5ae5f6a754d6f68408fdc64fb0d6097216518a7f3d1ef43ffe12599577R832-R833))
*  Import `TaichiRuntimeError` exception class from `taichi.lang.exception` module to use in validation check ([link](https://github.com/taichi-dev/taichi/pull/8272/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L6-R6))
*  Add test case for `ndarray` function with various invalid shapes using `pytest.mark.parametrize` decorator and expect `TaichiRuntimeError` with matching message ([link](https://github.com/taichi-dev/taichi/pull/8272/files?diff=unified&w=0#diff-ca3c8d1edb25b6a7f4affbb79b2e3e74f73b3757e5d465258ce42ea9eb09fbc0L659-R666))
