### PR TITLE
[aot] Support multiple AOT runtime devices

### DIFF
--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -250,7 +250,8 @@ TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
   switch (arch) {
 #ifdef TI_WITH_VULKAN
     case TI_ARCH_VULKAN: {
-      taichi::lang::vulkan::set_vulkan_visible_device(std::to_string(device_index));
+      taichi::lang::vulkan::set_vulkan_visible_device(
+          std::to_string(device_index));
       VulkanRuntimeOwned *vulkan_runtime;
       if (is_ci()) {
         auto param = make_vulkan_runtime_creator_params();

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -254,7 +254,6 @@ TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
       VulkanRuntimeOwned *vulkan_runtime;
       if (is_ci()) {
         auto param = make_vulkan_runtime_creator_params();
-        param.device_id = device_index;
         param.enable_validation_layer = true;
         vulkan_runtime = new VulkanRuntimeOwned(std::move(param));
       } else {

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -250,7 +250,7 @@ TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
   switch (arch) {
 #ifdef TI_WITH_VULKAN
     case TI_ARCH_VULKAN: {
-      taichi::lang::vulkan::set_vulkan_visible_device(device_index);
+      taichi::lang::vulkan::set_vulkan_visible_device(std::to_string(device_index));
       VulkanRuntimeOwned *vulkan_runtime;
       if (is_ci()) {
         auto param = make_vulkan_runtime_creator_params();

--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -246,15 +246,15 @@ void ti_set_last_error(TiError error, const char *message) {
 TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
   TiRuntime out = TI_NULL_HANDLE;
   TI_CAPI_TRY_CATCH_BEGIN();
-  // FIXME: (penguinliong) Support device selection.
-  TI_CAPI_NOT_SUPPORTED_IF_RV(device_index != 0);
   TI_INFO("Taichi Runtime C-API version is: {}", TI_C_API_VERSION);
   switch (arch) {
 #ifdef TI_WITH_VULKAN
     case TI_ARCH_VULKAN: {
+      taichi::lang::vulkan::set_vulkan_visible_device(device_index);
       VulkanRuntimeOwned *vulkan_runtime;
       if (is_ci()) {
         auto param = make_vulkan_runtime_creator_params();
+        param.device_id = device_index;
         param.enable_validation_layer = true;
         vulkan_runtime = new VulkanRuntimeOwned(std::move(param));
       } else {
@@ -266,22 +266,26 @@ TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
 #endif  // TI_WITH_VULKAN
 #ifdef TI_WITH_OPENGL
     case TI_ARCH_OPENGL: {
+      TI_CAPI_NOT_SUPPORTED_IF_RV(device_index != 0);
       out = (TiRuntime)(static_cast<Runtime *>(new OpenglRuntime));
       break;
     }
 #endif  // TI_WITH_OPENGL
 #ifdef TI_WITH_LLVM
     case TI_ARCH_X64: {
+      TI_CAPI_NOT_SUPPORTED_IF_RV(device_index != 0);
       out = (TiRuntime)(static_cast<Runtime *>(
           new capi::LlvmRuntime(taichi::Arch::x64)));
       break;
     }
     case TI_ARCH_ARM64: {
+      TI_CAPI_NOT_SUPPORTED_IF_RV(device_index != 0);
       out = (TiRuntime)(static_cast<Runtime *>(
           new capi::LlvmRuntime(taichi::Arch::arm64)));
       break;
     }
     case TI_ARCH_CUDA: {
+      TI_CAPI_NOT_SUPPORTED_IF_RV(device_index != 0);
       out = (TiRuntime)(static_cast<Runtime *>(
           new capi::LlvmRuntime(taichi::Arch::cuda)));
       break;
@@ -289,6 +293,7 @@ TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
 #endif  // TI_WITH_LLVM
 #ifdef TI_WITH_METAL
     case TI_ARCH_METAL: {
+      TI_CAPI_NOT_SUPPORTED_IF_RV(device_index != 0);
       out = (TiRuntime)(static_cast<Runtime *>(new capi::MetalRuntime()));
       break;
     }


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34529d5</samp>

Add Vulkan device selection and error handling to C-API. This allows users to specify a `device_index` for the Vulkan backend in `taichi_core_impl.cpp`, and raises an exception for invalid indices for other backends.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 34529d5</samp>

*  Enable selecting a Vulkan device with the C-API by removing the zero check and calling `set_vulkan_device_index` with the device_index parameter ([link](https://github.com/taichi-dev/taichi/pull/8275/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbL249-R257))
*  Add zero checks and error messages for the other backends that do not support selecting a device with the C-API: CUDA ([link](https://github.com/taichi-dev/taichi/pull/8275/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbR269)), Metal ([link](https://github.com/taichi-dev/taichi/pull/8275/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbR276)), OpenGL ([link](https://github.com/taichi-dev/taichi/pull/8275/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbR282)), CC ([link](https://github.com/taichi-dev/taichi/pull/8275/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbR288)), and LLVM ([link](https://github.com/taichi-dev/taichi/pull/8275/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbR296))
