### PR TITLE
[Lang] Use ErrorEmitter to reporting error on ndarray and field (WIP, Don't Merge)

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -3,7 +3,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiIndexError
-from taichi.lang.util import cook_dtype, python_scope, to_numpy_type
+from taichi.lang.util import cook_dtype, get_traceback, python_scope, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.ndarray_type import NdarrayTypeMetadata
 from taichi.types.utils import is_real, is_signed
@@ -237,7 +237,9 @@ class ScalarNdarray(Ndarray):
     def __init__(self, dtype, arr_shape):
         super().__init__()
         self.dtype = cook_dtype(dtype)
-        self.arr = impl.get_runtime().prog.create_ndarray(self.dtype, arr_shape, layout=Layout.NULL, zero_fill=True)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            self.dtype, arr_shape, layout=Layout.NULL, zero_fill=True, dbg_info=_ti_core.DebugInfo(get_traceback())
+        )
         self.shape = tuple(self.arr.shape)
         self.element_type = dtype
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -68,6 +68,9 @@ class ASTTransformer(Builder):
     @staticmethod
     def build_Name(ctx, node):
         node.ptr = ctx.get_var_by_name(node.id)
+        if isinstance(node, (ast.stmt, ast.expr)) and isinstance(node.ptr, Expr):
+            info = ctx.get_pos_info(node)
+            node.ptr.tb = info
         return node.ptr
 
     @staticmethod

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -15,11 +15,13 @@ class Expr(TaichiOperations):
 
     def __init__(self, *args, tb=None, dtype=None):
         self.tb = tb
+        self.ptr_type_checked = False
         if len(args) == 1:
             if isinstance(args[0], _ti_core.Expr):
                 self.ptr = args[0]
             elif isinstance(args[0], Expr):
                 self.ptr = args[0].ptr
+                self.ptr_type_checked = args[0].ptr_type_checked
                 self.tb = args[0].tb
             elif is_matrix_class(args[0]):
                 self.ptr = make_matrix(args[0].to_list()).ptr
@@ -39,7 +41,10 @@ class Expr(TaichiOperations):
             assert False
         if self.tb:
             self.ptr.set_tb(self.tb)
-        self.ptr.type_check(impl.get_runtime().prog.config())
+        if not self.ptr_type_checked:
+            self.ptr.type_check(impl.get_runtime().prog.config())
+            self.ptr_type_checked = True
+        
 
     def is_tensor(self):
         return self.ptr.is_tensor()

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -44,7 +44,6 @@ class Expr(TaichiOperations):
         if not self.ptr_type_checked:
             self.ptr.type_check(impl.get_runtime().prog.config())
             self.ptr_type_checked = True
-        
 
     def is_tensor(self):
         return self.ptr.is_tensor()

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -20,6 +20,7 @@ from taichi.lang.exception import (
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.util import (
     cook_dtype,
+    get_traceback,
     in_python_scope,
     python_scope,
     taichi_scope,
@@ -1637,7 +1638,11 @@ class MatrixNdarray(Ndarray):
         self.element_type = _type_factory.get_tensor_type((self.n, self.m), self.dtype)
         # TODO: we should pass in element_type, shape, layout instead.
         self.arr = impl.get_runtime().prog.create_ndarray(
-            cook_dtype(self.element_type), shape, Layout.AOS, zero_fill=True
+            cook_dtype(self.element_type),
+            shape,
+            Layout.AOS,
+            zero_fill=True,
+            dbg_info=ti_python_core.DebugInfo(get_traceback()),
         )
 
     @property
@@ -1747,7 +1752,11 @@ class VectorNdarray(Ndarray):
         self.shape = tuple(shape)
         self.element_type = _type_factory.get_tensor_type((n,), self.dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
-            cook_dtype(self.element_type), shape, Layout.AOS, zero_fill=True
+            cook_dtype(self.element_type),
+            shape,
+            Layout.AOS,
+            zero_fill=True,
+            dbg_info=ti_python_core.DebugInfo(get_traceback()),
         )
 
     @property

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -35,7 +35,7 @@ class SNode:
         """
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.dense(axes, dimensions, get_traceback()))
+        return SNode(self.ptr.dense(axes, dimensions, _ti_core.DebugInfo(get_traceback())))
 
     def pointer(self, axes, dimensions):
         """Adds a pointer SNode as a child component of `self`.
@@ -51,7 +51,7 @@ class SNode:
             raise TaichiRuntimeError("Pointer SNode is not supported on this backend.")
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.pointer(axes, dimensions, get_traceback()))
+        return SNode(self.ptr.pointer(axes, dimensions, _ti_core.DebugInfo(get_traceback())))
 
     @staticmethod
     def _hash(axes, dimensions):
@@ -78,7 +78,7 @@ class SNode:
         assert len(axis) == 1
         if chunk_size is None:
             chunk_size = dimension
-        return SNode(self.ptr.dynamic(axis[0], dimension, chunk_size, get_traceback()))
+        return SNode(self.ptr.dynamic(axis[0], dimension, chunk_size, _ti_core.DebugInfo(get_traceback())))
 
     def bitmasked(self, axes, dimensions):
         """Adds a bitmasked SNode as a child component of `self`.
@@ -94,7 +94,7 @@ class SNode:
             raise TaichiRuntimeError("Bitmasked SNode is not supported on this backend.")
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.bitmasked(axes, dimensions, get_traceback()))
+        return SNode(self.ptr.bitmasked(axes, dimensions, _ti_core.DebugInfo(get_traceback())))
 
     def quant_array(self, axes, dimensions, max_num_bits):
         """Adds a quant_array SNode as a child component of `self`.
@@ -109,7 +109,7 @@ class SNode:
         """
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.quant_array(axes, dimensions, max_num_bits, get_traceback()))
+        return SNode(self.ptr.quant_array(axes, dimensions, max_num_bits, _ti_core.DebugInfo(get_traceback())))
 
     def place(self, *args, offset=None):
         """Places a list of Taichi fields under the `self` container.
@@ -129,7 +129,7 @@ class SNode:
         for arg in args:
             if isinstance(arg, BitpackedFields):
                 bit_struct_type = arg.bit_struct_type_builder.build()
-                bit_struct_snode = self.ptr.bit_struct(bit_struct_type, get_traceback())
+                bit_struct_snode = self.ptr.bit_struct(bit_struct_type, _ti_core.DebugInfo(get_traceback()))
                 for field, id_in_bit_struct in arg.fields:
                     bit_struct_snode.place(field, offset, id_in_bit_struct)
             elif isinstance(arg, Field):

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -96,4 +96,12 @@ class TaichiIrWarning : public TaichiExceptionImpl {
   }
 };
 
+class TaichiIndexWarning : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  void emit() noexcept override {
+    taichi::Logger::get_instance().warn("TaichiIndexWarning\n" + msg_);
+  }
+};
+
 }  // namespace taichi::lang

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -7,6 +7,10 @@ class IRModified {};
 class TaichiExceptionImpl : public std::exception {
   friend struct ErrorEmitter;
 
+ private:
+  virtual void emit() = 0;
+
+ protected:
   std::string msg_;
 
  public:
@@ -22,22 +26,58 @@ class TaichiExceptionImpl : public std::exception {
 
 class TaichiTypeError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiSyntaxError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiIndexError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiRuntimeError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
 };
 
 class TaichiAssertionError : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
+};
+
+class TaichiCastWarning : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  void emit() noexcept override {
+    taichi::Logger::get_instance().warn("TaichiCastWarning\n" + msg_);
+  }
+};
+
+class TaichiTypeWarning : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  void emit() noexcept override {
+    taichi::Logger::get_instance().warn("TaichiTypeWarning\n" + msg_);
+  }
 };
 
 }  // namespace taichi::lang

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -64,6 +64,14 @@ class TaichiAssertionError : public TaichiExceptionImpl {
   }
 };
 
+class TaichiIrError : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  [[noreturn]] void emit() override {
+    throw *this;
+  }
+};
+
 class TaichiCastWarning : public TaichiExceptionImpl {
   using TaichiExceptionImpl::TaichiExceptionImpl;
 
@@ -77,6 +85,14 @@ class TaichiTypeWarning : public TaichiExceptionImpl {
 
   void emit() noexcept override {
     taichi::Logger::get_instance().warn("TaichiTypeWarning\n" + msg_);
+  }
+};
+
+class TaichiIrWarning : public TaichiExceptionImpl {
+  using TaichiExceptionImpl::TaichiExceptionImpl;
+
+  void emit() noexcept override {
+    taichi::Logger::get_instance().warn("TaichiIrWarning\n" + msg_);
   }
 };
 

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -117,7 +117,7 @@ struct ErrorEmitter {
     if constexpr (std::is_base_of_v<TaichiWarning, std::decay_t<E>>) {
       error.emit();
     } else if constexpr (std::is_base_of_v<TaichiError, std::decay_t<E>>) {
-      throw error;
+      throw std::move(error);
     } else {
       TI_STOP;
     }

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -67,7 +67,6 @@ class TaichiIrError : public TaichiError {
 
 class TaichiCastWarning : public TaichiWarning {
   using TaichiWarning::TaichiWarning;
-
   static constexpr std::string_view name_ = "TaichiCastWarning";
 };
 
@@ -84,6 +83,11 @@ class TaichiIrWarning : public TaichiWarning {
 class TaichiIndexWarning : public TaichiWarning {
   using TaichiWarning::TaichiWarning;
   static constexpr std::string_view name_ = "TaichiIndexWarning";
+};
+
+class TaichiRuntimeWarning : public TaichiWarning {
+  using TaichiWarning::TaichiWarning;
+  static constexpr std::string_view name_ = "TaichiRuntimeWarning";
 };
 
 struct ErrorEmitter {

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -88,6 +88,8 @@ class TaichiIndexWarning : public TaichiWarning {
 
 struct ErrorEmitter {
   ErrorEmitter() = delete;
+  ErrorEmitter(ErrorEmitter &) = delete;
+  ErrorEmitter(ErrorEmitter &&) = delete;
 
   // Emit an error on stmt with error message
   template <typename E,
@@ -98,8 +100,9 @@ struct ErrorEmitter {
                 std::is_same_v<std::decay_t<decltype(std::declval<T>()->tb)>,
                                std::string>>>
   ErrorEmitter(E &&error, T p_stmt, std::string &&error_msg) {
-    if constexpr (std::is_same_v<std::decay_t<T>, DebugInfo> &&
-                  std::is_base_of_v<TaichiError, std::decay_t<E>>) {
+    if constexpr ((std::is_same_v<std::decay_t<T>, DebugInfo *> ||
+                   std::is_same_v<std::decay_t<T>, const DebugInfo *>)&&std::
+                      is_base_of_v<TaichiError, std::decay_t<E>>) {
       // Indicates a failed C++ API call from Python side, we should not print
       // tb here
       error.msg_ = error_msg;

--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -5,9 +5,14 @@ namespace taichi::lang {
 class IRModified {};
 
 class TaichiExceptionImpl : public std::exception {
+  friend struct ErrorEmitter;
+
   std::string msg_;
 
  public:
+  // Add default constructor to allow passing Exception to ErrorEmitter
+  // TODO: remove this and find a better way
+  explicit TaichiExceptionImpl() = default;
   explicit TaichiExceptionImpl(const std::string msg) : msg_(msg) {
   }
   const char *what() const noexcept override {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -9,10 +9,11 @@
 
 namespace taichi::lang {
 
-#define TI_ASSERT_TYPE_CHECKED(x)                       \
-  TI_ASSERT_INFO(x->ret_type != PrimitiveType::unknown, \
-                 "[{}] was not type-checked",           \
-                 ExpressionHumanFriendlyPrinter::expr_to_string(x))
+#define TI_ASSERT_TYPE_CHECKED(x)                                        \
+  ErrorEmitter(x->ret_type != PrimitiveType::unknown, TaichiTypeError(), \
+               x.expr.get(),                                             \
+               fmt::format("[{}] was not type-checked",                  \
+                           ExpressionHumanFriendlyPrinter::expr_to_string(x)))
 
 static bool is_primitive_or_tensor_type(DataType &type) {
   return type->is<PrimitiveType>() || type->is<TensorType>();
@@ -170,8 +171,10 @@ void TexturePtrExpression::flatten(FlattenContext *ctx) {
 }
 
 void RandExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
-                 "Invalid dt [{}] for RandExpression", dt->to_string());
+  ErrorEmitter(
+      dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
+      TaichiTypeError(), this,
+      fmt::format("Invalid dt [{}] for RandExpression", dt->to_string()));
   ret_type = dt;
 }
 
@@ -196,17 +199,20 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
   auto ret_primitive_type = ret_type;
 
   if (!operand_primitive_type->is<PrimitiveType>()) {
-    throw TaichiTypeError(fmt::format(
-        "unsupported operand type(s) for '{}': '{}'", unary_op_type_name(type),
-        operand_primitive_type->to_string()));
+    ErrorEmitter(TaichiTypeError(), this,
+                 fmt::format("unsupported operand type(s) for '{}': '{}'",
+                             unary_op_type_name(type),
+                             operand_primitive_type->to_string()));
   }
 
   if ((type == UnaryOpType::round || type == UnaryOpType::floor ||
        type == UnaryOpType::ceil || is_trigonometric(type)) &&
       !is_real(operand_primitive_type))
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes real inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes real inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
 
   if ((type == UnaryOpType::sqrt || type == UnaryOpType::exp ||
        type == UnaryOpType::log) &&
@@ -218,9 +224,11 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
 
   if ((type == UnaryOpType::bit_not || type == UnaryOpType::logic_not) &&
       is_real(operand_primitive_type)) {
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes integral inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes integral inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
   }
 
   if (type == UnaryOpType::logic_not) {
@@ -243,9 +251,11 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
   }
 
   if (type == UnaryOpType::popcnt && is_real(operand_primitive_type)) {
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes integral inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes integral inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
   }
 
   if (operand_type->is<TensorType>()) {
@@ -282,7 +292,8 @@ Expr to_broadcast_tensor(const Expr &elt, const DataType &dt) {
     // Only tensor shape will be checked here, since the dtype will
     // be promoted later at irpass::type_check()
     if (elt_type.get_shape() != dt.get_shape()) {
-      TI_ERROR("Cannot broadcast tensor to tensor");
+      ErrorEmitter(TaichiTypeError(), elt.expr.get(),
+                   "Cannot broadcast tensor to tensor");
     } else {
       return elt;
     }
@@ -290,9 +301,10 @@ Expr to_broadcast_tensor(const Expr &elt, const DataType &dt) {
 
   auto tensor_type = dt->as<TensorType>();
   auto tensor_elt_type = tensor_type->get_element_type();
-  TI_ASSERT_INFO(tensor_elt_type->is<PrimitiveType>(),
-                 "Only primitive types are supported in Tensors, got {}",
-                 tensor_elt_type->to_string());
+  ErrorEmitter(
+      tensor_elt_type->is<PrimitiveType>(), TaichiTypeError(), elt.expr.get(),
+      fmt::format("Only primitive types are supported in Tensors, got {}",
+                  tensor_elt_type->to_string()));
   std::vector<Expr> broadcast_values(tensor_type->get_num_elements(), elt);
   auto matrix_expr = Expr::make<MatrixExpression>(
       broadcast_values, tensor_type->get_shape(), elt_type);
@@ -523,7 +535,8 @@ void TernaryOpExpression::type_check(const CompileConfig *config) {
   auto op3_type = op3.get_rvalue_type();
 
   auto error = [&]() {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiTypeError(), this,
         fmt::format("unsupported operand type(s) for '{}': '{}', '{}' and '{}'",
                     ternary_type_name(type), op1_type->to_string(),
                     op2_type->to_string(), op3_type->to_string()));
@@ -821,7 +834,8 @@ static void field_validation(FieldExpression *field_expr, int index_dim) {
   int field_dim = field_expr->snode->num_active_indices;
 
   if (field_dim != index_dim) {
-    throw TaichiIndexError(
+    ErrorEmitter(
+        TaichiIndexError(), field_expr,
         fmt::format("Field with dim {} accessed with indices of dim {}",
                     field_dim, index_dim));
   }
@@ -837,7 +851,8 @@ void IndexExpression::type_check(const CompileConfig *) {
   bool has_slice = !ret_shape.empty();
   auto var_type = var.get_rvalue_type();
   if (has_slice) {
-    TI_ASSERT_INFO(is_tensor(), "Slice or swizzle can only apply on matrices");
+    ErrorEmitter(is_tensor(), TaichiTypeError(), this,
+                 "Slice or swizzle can only apply on matrices");
     auto element_type = var_type->as<TensorType>()->get_element_type();
     ret_type = TypeFactory::create_tensor_type(ret_shape, element_type);
   } else if (is_field()) {  // field
@@ -861,7 +876,8 @@ void IndexExpression::type_check(const CompileConfig *) {
     int element_dim = external_tensor_expr->dt.get_shape().size();
     int total_dim = ndim + element_dim;
     if (total_dim != index_dim + element_dim) {
-      throw TaichiTypeError(
+      ErrorEmitter(
+          TaichiIndexError(), this,
           fmt::format("Array with dim {} accessed with indices of dim {}",
                       total_dim - element_dim, index_dim));
     }
@@ -877,12 +893,14 @@ void IndexExpression::type_check(const CompileConfig *) {
     auto tensor_type = var_type->as<TensorType>();
     auto shape = tensor_type->get_shape();
     if (indices_group[0].size() != shape.size()) {
-      TI_ERROR("Expected {} indices, got {}.", shape.size(),
-               indices_group[0].size());
+      ErrorEmitter(TaichiIndexError(), this,
+                   fmt::format("Expected {} indices, got {}.", shape.size(),
+                               indices_group[0].size()));
     }
     ret_type = tensor_type->get_element_type();
   } else {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiIndexError(), this,
         "Invalid IndexExpression: the source is not among field, ndarray or "
         "local tensor");
   }
@@ -893,10 +911,10 @@ void IndexExpression::type_check(const CompileConfig *) {
       TI_ASSERT_TYPE_CHECKED(expr);
       auto expr_type = expr.get_rvalue_type();
       if (!is_integral(expr_type))
-        throw TaichiTypeError(
-            fmt::format("indices must be integers, however '{}' is "
-                        "provided as index {}",
-                        expr_type->to_string(), i));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("indices must be integers, however '{}' is "
+                                 "provided as index {}",
+                                 expr_type->to_string(), i));
     }
   }
 }
@@ -915,7 +933,8 @@ void IndexExpression::flatten(FlattenContext *ctx) {
         ctx, var, indices_group, ret_type,
         var->ret_type.ptr_removed()->as<TensorType>()->get_shape(), tb);
   } else {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiIndexError(), this,
         "Invalid IndexExpression: the source is not among field, ndarray or "
         "local tensor");
   }
@@ -929,10 +948,10 @@ void RangeAssumptionExpression::type_check(const CompileConfig *) {
   auto base_type = base.get_rvalue_type();
   if (!input_type->is<PrimitiveType>() || !base_type->is<PrimitiveType>() ||
       input_type != base_type)
-    throw TaichiTypeError(
-        fmt::format("unsupported operand type(s) for "
-                    "'range_assumption': '{}' and '{}'",
-                    input_type->to_string(), base_type->to_string()));
+    ErrorEmitter(TaichiTypeError(), this,
+                 fmt::format("unsupported operand type(s) for "
+                             "'range_assumption': '{}' and '{}'",
+                             input_type->to_string(), base_type->to_string()));
   ret_type = input_type;
 }
 
@@ -949,7 +968,8 @@ void LoopUniqueExpression::type_check(const CompileConfig *) {
   auto input_type = input.get_rvalue_type();
 
   if (!input_type->is<PrimitiveType>())
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiTypeError(), this,
         fmt::format("unsupported operand type(s) for 'loop_unique': '{}'",
                     input_type->to_string()));
   ret_type = input_type;
@@ -972,10 +992,12 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
   TI_ASSERT_TYPE_CHECKED(dest);
   TI_ASSERT_TYPE_CHECKED(val);
   auto error = [&]() {
-    throw TaichiTypeError(fmt::format(
-        "unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
-        atomic_op_type_name(op_type), dest->ret_type->to_string(),
-        val->ret_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format(
+            "unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
+            atomic_op_type_name(op_type), dest->ret_type->to_string(),
+            val->ret_type->to_string()));
   };
 
   // Broadcast val to dest if neccessary
@@ -1071,8 +1093,10 @@ void SNodeOpExpression::type_check(const CompileConfig *config) {
       auto value_type = values[i].get_rvalue_type();
       auto promoted = promoted_type(dst_type, value_type);
       if (dst_type != promoted) {
-        TI_WARN("Append may lose precision: {} <- {}\n{}",
-                dst_type->to_string(), value_type->to_string(), tb);
+        ErrorEmitter(
+            TaichiCastWarning(), this,
+            fmt::format("Append may lose precision: {} <- {}\n{}",
+                        dst_type->to_string(), value_type->to_string(), tb));
       }
       values[i] = cast(values[i], dst_type);
       values[i]->type_check(config);
@@ -1091,10 +1115,11 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
       ctx->push_back<GlobalPtrStmt>(snode, indices_stmt, true, is_cell_access);
   ptr->tb = tb;
   if (op_type == SNodeOpType::is_active) {
-    TI_ERROR_IF(snode->type != SNodeType::pointer &&
-                    snode->type != SNodeType::hash &&
-                    snode->type != SNodeType::bitmasked,
-                "ti.is_active only works on pointer, hash or bitmasked nodes.");
+    ErrorEmitter(
+        snode->type == SNodeType::pointer || snode->type == SNodeType::hash ||
+            snode->type == SNodeType::bitmasked,
+        TaichiTypeError(), this,
+        "ti.is_active only works on pointer, hash or bitmasked nodes.");
     ctx->push_back<SNodeOpStmt>(SNodeOpType::is_active, snode, ptr, nullptr);
   } else if (op_type == SNodeOpType::length) {
     ctx->push_back<SNodeOpStmt>(SNodeOpType::length, snode, ptr, nullptr);
@@ -1113,8 +1138,8 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
       ctx->push_back<GlobalStoreStmt>(ch_addr, value_stmt)->set_tb(tb);
     }
     ctx->push_back<LocalLoadStmt>(alloca)->set_tb(tb);
-    TI_ERROR_IF(snode->type != SNodeType::dynamic,
-                "ti.append only works on dynamic nodes.");
+    ErrorEmitter(snode->type == SNodeType::dynamic, TaichiTypeError(), this,
+                 "ti.append only works on dynamic nodes.");
   }
   stmt = ctx->back_stmt();
 }
@@ -1130,15 +1155,16 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
   auto ptr = texture_ptr.cast<TexturePtrExpression>();
   if (op == TextureOpType::kSampleLod) {
     // UV, Lod
-    TI_ASSERT_INFO(args.size() == ptr->num_dims + 1,
-                   "Invalid number of args for sample_lod Texture op with a "
-                   "{}-dimension texture",
-                   ptr->num_dims);
+    ErrorEmitter(args.size() == ptr->num_dims + 1, TaichiTypeError(), this,
+                 fmt::format("Invalid number of args for sample_lod Texture "
+                             "op with a {}-dimension texture",
+                             ptr->num_dims));
     for (int i = 0; i < ptr->num_dims; i++) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::f32) {
-        throw TaichiTypeError(
+        ErrorEmitter(
+            TaichiTypeError(), this,
             fmt::format("Invalid type for texture sample_lod: '{}', all "
                         "arguments must be f32",
                         arg_type->to_string()));
@@ -1154,7 +1180,8 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
+        ErrorEmitter(
+            TaichiTypeError(), this,
             fmt::format("Invalid type for texture fetch_texel: '{}', all "
                         "arguments must be i32",
                         arg_type->to_string()));
@@ -1170,10 +1197,10 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', all "
-                        "arguments must be i32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', all "
+                                 "arguments must be i32",
+                                 arg_type->to_string()));
       }
     }
   } else if (op == TextureOpType::kStore) {
@@ -1186,20 +1213,20 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', index "
-                        "arguments must be i32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', index "
+                                 "arguments must be i32",
+                                 arg_type->to_string()));
       }
     }
     for (int i = ptr->num_dims; i < ptr->num_dims + 4; i++) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::f32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', value "
-                        "arguments must be f32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', value "
+                                 "arguments must be f32",
+                                 arg_type->to_string()));
       }
     }
   } else {
@@ -1221,9 +1248,10 @@ void TextureOpExpression::flatten(FlattenContext *ctx) {
 }
 
 void ConstExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(
+  ErrorEmitter(
       val.dt->is<PrimitiveType>() && val.dt != PrimitiveType::unknown,
-      "Invalid dt [{}] for ConstExpression", val.dt->to_string());
+      TaichiTypeError(), this,
+      fmt::format("Invalid dt [{}] for ConstExpression", val.dt->to_string()));
   ret_type = val.dt;
 }
 
@@ -1233,10 +1261,11 @@ void ConstExpression::flatten(FlattenContext *ctx) {
 }
 
 void ExternalTensorShapeAlongAxisExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(
+  ErrorEmitter(
       ptr.is<ExternalTensorExpression>() || ptr.is<TexturePtrExpression>(),
-      "Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
-      ExpressionHumanFriendlyPrinter::expr_to_string(ptr));
+      TaichiTypeError(), this,
+      fmt::format("Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
+                  ExpressionHumanFriendlyPrinter::expr_to_string(ptr)));
   ret_type = PrimitiveType::i32;
 }
 
@@ -1250,9 +1279,10 @@ void ExternalTensorShapeAlongAxisExpression::flatten(FlattenContext *ctx) {
 void GetElementExpression::type_check(const CompileConfig *config) {
   TI_ASSERT_TYPE_CHECKED(src);
   auto src_type = src->ret_type;
-  TI_ASSERT_INFO(src_type->is<PointerType>(),
-                 "Invalid src [{}] for GetElementExpression",
-                 ExpressionHumanFriendlyPrinter::expr_to_string(src));
+  ErrorEmitter(
+      src_type->is<PointerType>(), TaichiTypeError(), this,
+      fmt::format("Invalid src [{}] for GetElementExpression",
+                  ExpressionHumanFriendlyPrinter::expr_to_string(src)));
 
   ret_type = src_type.ptr_removed()->as<StructType>()->get_element_type(index);
 }
@@ -1352,8 +1382,10 @@ void ASTBuilder::insert_assignment(Expr &lhs,
     this->insert(std::move(stmt));
 
   } else {
-    TI_ERROR("Cannot assign to non-lvalue: {}",
-             ExpressionHumanFriendlyPrinter::expr_to_string(lhs));
+    ErrorEmitter(
+        TaichiRuntimeError(), lhs.expr.get(),
+        fmt::format("Cannot assign to non-lvalue: {}",
+                    ExpressionHumanFriendlyPrinter::expr_to_string(lhs)));
   }
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1007,6 +1007,16 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
   } else {
     error();
   }
+
+  if (ret_type != val_dtype) {
+    auto promoted = promoted_type(ret_type, val_dtype);
+    if (ret_type != promoted) {
+      ErrorEmitter(TaichiCastWarning(), this,
+                   fmt::format("Atomic {} may lose precision: {} <- {}",
+                               atomic_op_type_name(op_type),
+                               ret_type->to_string(), val_dtype->to_string()));
+    }
+  }
 }
 
 void AtomicOpExpression::flatten(FlattenContext *ctx) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1008,13 +1008,15 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
     error();
   }
 
-  if (ret_type != val_dtype) {
-    auto promoted = promoted_type(ret_type, val_dtype);
-    if (ret_type != promoted) {
-      ErrorEmitter(TaichiCastWarning(), this,
-                   fmt::format("Atomic {} may lose precision: {} <- {}",
-                               atomic_op_type_name(op_type),
-                               ret_type->to_string(), val_dtype->to_string()));
+  auto const &ret_element_type = ret_type.get_element_type();
+  if (ret_element_type != val_dtype) {
+    auto promoted = promoted_type(ret_element_type, val_dtype);
+    if (ret_element_type != promoted) {
+      ErrorEmitter(
+          TaichiCastWarning(), this,
+          fmt::format("Atomic {} may lose precision: {} <- {}",
+                      atomic_op_type_name(op_type),
+                      ret_element_type->to_string(), val_dtype->to_string()));
     }
   }
 }

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -152,6 +152,7 @@ class FrontendIfStmt : public Stmt {
   std::unique_ptr<Block> true_statements, false_statements;
 
   explicit FrontendIfStmt(const Expr &condition) : condition(condition) {
+    set_tb(condition->tb);
   }
 
   bool is_container_statement() const override {

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -152,7 +152,6 @@ class FrontendIfStmt : public Stmt {
   std::unique_ptr<Block> true_statements, false_statements;
 
   explicit FrontendIfStmt(const Expr &condition) : condition(condition) {
-    set_tb(condition->tb);
   }
 
   bool is_container_statement() const override {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -538,4 +538,11 @@ void ImmediateIRModifier::replace_usages_with(Stmt *old_stmt, Stmt *new_stmt) {
   }
 }
 
+ErrorEmitter::ErrorEmitter(TaichiExceptionImpl &&error,
+                           const Stmt *stmt,
+                           std::string &&error_msg) {
+  error.msg_ = stmt->tb + error_msg;
+  error.emit();
+}
+
 }  // namespace taichi::lang

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -61,10 +61,8 @@ class StatementTypeNameVisitor : public IRVisitor {
   StatementTypeNameVisitor() {
   }
 
-#define PER_STATEMENT(x)         \
-  void visit(x *stmt) override { \
-    type_name = #x;              \
-  }
+#define PER_STATEMENT(x) \
+  void visit(x *stmt) override { type_name = #x; }
 #include "taichi/inc/statements.inc.h"
 
 #undef PER_STATEMENT

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -61,8 +61,10 @@ class StatementTypeNameVisitor : public IRVisitor {
   StatementTypeNameVisitor() {
   }
 
-#define PER_STATEMENT(x) \
-  void visit(x *stmt) override { type_name = #x; }
+#define PER_STATEMENT(x)         \
+  void visit(x *stmt) override { \
+    type_name = #x;              \
+  }
 #include "taichi/inc/statements.inc.h"
 
 #undef PER_STATEMENT
@@ -543,6 +545,15 @@ ErrorEmitter::ErrorEmitter(TaichiExceptionImpl &&error,
                            std::string &&error_msg) {
   error.msg_ = stmt->tb + error_msg;
   error.emit();
+}
+
+ErrorEmitter::ErrorEmitter(bool expression,
+                           TaichiExceptionImpl &&error,
+                           const Stmt *stmt,
+                           std::string &&error_msg) {
+  if (!expression) {
+    ErrorEmitter(std::move(error), stmt, std::move(error_msg));
+  }
 }
 
 }  // namespace taichi::lang

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -537,21 +537,4 @@ void ImmediateIRModifier::replace_usages_with(Stmt *old_stmt, Stmt *new_stmt) {
     usage->set_operand(i, new_stmt);
   }
 }
-
-ErrorEmitter::ErrorEmitter(TaichiExceptionImpl &&error,
-                           const Stmt *stmt,
-                           std::string &&error_msg) {
-  error.msg_ = stmt->tb + error_msg;
-  error.emit();
-}
-
-ErrorEmitter::ErrorEmitter(bool expression,
-                           TaichiExceptionImpl &&error,
-                           const Stmt *stmt,
-                           std::string &&error_msg) {
-  if (!expression) {
-    ErrorEmitter(std::move(error), stmt, std::move(error_msg));
-  }
-}
-
 }  // namespace taichi::lang

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -508,25 +508,26 @@ class Stmt : public IRNode {
 };
 
 struct ErrorEmitter {
+  ErrorEmitter() = delete;
+
   // Emit an error on stmt with error message
   template <typename T,
             typename = std::enable_if_t<
-                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
-  ErrorEmitter(TaichiExceptionImpl &&error, T *stmt, std::string &&error_msg) {
-    error.msg_ = stmt->tb + error_msg;
+                std::is_same_v<std::decay_t<decltype(std::declval<T>()->tb)>,
+                               std::string>>>
+  ErrorEmitter(TaichiExceptionImpl &&error, T p_stmt, std::string &&error_msg) {
+    error.msg_ = p_stmt->tb + error_msg;
     error.emit();
   }
 
   // Emit an error when expression is false
-  template <typename T,
-            typename = std::enable_if_t<
-                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
+  template <typename T>
   ErrorEmitter(bool expression,
                TaichiExceptionImpl &&error,
-               T *stmt,
+               T p_stmt,
                std::string &&error_msg) {
     if (!expression) {
-      ErrorEmitter(std::move(error), stmt, std::move(error_msg));
+      ErrorEmitter(std::move(error), p_stmt, std::move(error_msg));
     }
   }
 };

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -398,7 +398,10 @@ struct DebugInfo {
 
   explicit DebugInfo() = default;
 
-  explicit DebugInfo(std::string tb_) : tb(tb_) {
+  DebugInfo(std::string tb_) : tb(tb_) {
+  }
+
+  DebugInfo(const char *tb_) : tb(tb_) {
   }
 
   explicit DebugInfo(std::string tb_, int line_number, std::string var_name)
@@ -519,31 +522,6 @@ class Stmt : public IRNode {
 
   static void reset_counter() {
     instance_id_counter = 0;
-  }
-};
-
-struct ErrorEmitter {
-  ErrorEmitter() = delete;
-
-  // Emit an error on stmt with error message
-  template <typename T,
-            typename = std::enable_if_t<
-                std::is_same_v<std::decay_t<decltype(std::declval<T>()->tb)>,
-                               std::string>>>
-  ErrorEmitter(TaichiExceptionImpl &&error, T p_stmt, std::string &&error_msg) {
-    error.msg_ = p_stmt->tb + error_msg;
-    error.emit();
-  }
-
-  // Emit an error when expression is false
-  template <typename T>
-  ErrorEmitter(bool expression,
-               TaichiExceptionImpl &&error,
-               T p_stmt,
-               std::string &&error_msg) {
-    if (!expression) {
-      ErrorEmitter(std::move(error), p_stmt, std::move(error_msg));
-    }
   }
 };
 

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -392,6 +392,21 @@ struct Location {
   std::string var_name;
 };
 
+struct DebugInfo {
+  Location src_loc;
+  std::string tb;
+
+  explicit DebugInfo() = default;
+
+  explicit DebugInfo(std::string tb_) : tb(tb_) {
+  }
+
+  explicit DebugInfo(std::string tb_, int line_number, std::string var_name)
+      : src_loc(Location{.line_number = line_number, .var_name = var_name}),
+        tb(tb_) {
+  }
+};
+
 class Stmt : public IRNode {
  protected:
   std::vector<Stmt **> operands;

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,10 +268,8 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT                     \
-  void accept(IRVisitor *visitor) override { \
-    visitor->visit(this);                    \
-  }
+#define TI_DEFINE_ACCEPT \
+  void accept(IRVisitor *visitor) override { visitor->visit(this); }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,10 +268,8 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT                     \
-  void accept(IRVisitor *visitor) override { \
-    visitor->visit(this);                    \
-  }
+#define TI_DEFINE_ACCEPT \
+  void accept(IRVisitor *visitor) override { visitor->visit(this); }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \
@@ -510,13 +508,9 @@ class Stmt : public IRNode {
 };
 
 struct ErrorEmitter {
-  template <typename T>
-  [[noreturn]] ErrorEmitter(T &&error,
-                            const Stmt *stmt,
-                            std::string &&error_msg) {
-    error.msg_ = stmt->tb + error_msg;
-    throw error;
-  }
+  ErrorEmitter(TaichiExceptionImpl &&error,
+               const Stmt *stmt,
+               std::string &&error_msg);
 };
 
 class Block : public IRNode {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,8 +268,10 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT \
-  void accept(IRVisitor *visitor) override { visitor->visit(this); }
+#define TI_DEFINE_ACCEPT                     \
+  void accept(IRVisitor *visitor) override { \
+    visitor->visit(this);                    \
+  }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \
@@ -508,7 +510,14 @@ class Stmt : public IRNode {
 };
 
 struct ErrorEmitter {
+  // Emit an error on stmt with error message
   ErrorEmitter(TaichiExceptionImpl &&error,
+               const Stmt *stmt,
+               std::string &&error_msg);
+
+  // Emit an error when expression is false
+  ErrorEmitter(bool expression,
+               TaichiExceptionImpl &&error,
                const Stmt *stmt,
                std::string &&error_msg);
 };

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -268,8 +268,10 @@ class IRNode {
   std::unique_ptr<IRNode> clone();
 };
 
-#define TI_DEFINE_ACCEPT \
-  void accept(IRVisitor *visitor) override { visitor->visit(this); }
+#define TI_DEFINE_ACCEPT                     \
+  void accept(IRVisitor *visitor) override { \
+    visitor->visit(this);                    \
+  }
 
 #define TI_DEFINE_CLONE                                             \
   std::unique_ptr<Stmt> clone() const override {                    \
@@ -387,6 +389,11 @@ class StmtFieldManager {
   mark_fields_registered(); \
   io(field_manager)
 
+struct Location {
+  int line_number;
+  std::string var_name;
+};
+
 class Stmt : public IRNode {
  protected:
   std::vector<Stmt **> operands;
@@ -401,6 +408,7 @@ class Stmt : public IRNode {
   bool fields_registered;
   std::string tb;
   DataType ret_type;
+  Location src_location;
 
   Stmt();
   Stmt(const Stmt &stmt);
@@ -498,6 +506,16 @@ class Stmt : public IRNode {
 
   static void reset_counter() {
     instance_id_counter = 0;
+  }
+};
+
+struct ErrorEmitter {
+  template <typename T>
+  [[noreturn]] ErrorEmitter(T &&error,
+                            const Stmt *stmt,
+                            std::string &&error_msg) {
+    error.msg_ = stmt->tb + error_msg;
+    throw error;
   }
 };
 

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -403,11 +403,6 @@ struct DebugInfo {
 
   DebugInfo(const char *tb_) : tb(tb_) {
   }
-
-  explicit DebugInfo(std::string tb_, int line_number, std::string var_name)
-      : src_loc(Location{.line_number = line_number, .var_name = var_name}),
-        tb(tb_) {
-  }
 };
 
 class Stmt : public IRNode {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -509,15 +509,26 @@ class Stmt : public IRNode {
 
 struct ErrorEmitter {
   // Emit an error on stmt with error message
-  ErrorEmitter(TaichiExceptionImpl &&error,
-               const Stmt *stmt,
-               std::string &&error_msg);
+  template <typename T,
+            typename = std::enable_if_t<
+                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
+  ErrorEmitter(TaichiExceptionImpl &&error, T *stmt, std::string &&error_msg) {
+    error.msg_ = stmt->tb + error_msg;
+    error.emit();
+  }
 
   // Emit an error when expression is false
+  template <typename T,
+            typename = std::enable_if_t<
+                std::is_same_v<std::string, decltype(std::declval<T>().tb)>>>
   ErrorEmitter(bool expression,
                TaichiExceptionImpl &&error,
-               const Stmt *stmt,
-               std::string &&error_msg);
+               T *stmt,
+               std::string &&error_msg) {
+    if (!expression) {
+      ErrorEmitter(std::move(error), stmt, std::move(error_msg));
+    }
+  }
 };
 
 class Block : public IRNode {

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -11,6 +11,7 @@
 namespace taichi::lang {
 class Program;
 class SNodeRwAccessorsBank;
+struct DebugInfo;
 
 /**
  * Dimension (or axis) of a tensor.
@@ -138,81 +139,87 @@ class SNode {
   SNode &create_node(std::vector<Axis> axes,
                      std::vector<int> sizes,
                      SNodeType type,
-                     const std::string &tb);
+                     const DebugInfo &dbg_info);
 
   // SNodes maintains how flattened index bits are taken from indices
   SNode &dense(const std::vector<Axis> &axes,
                const std::vector<int> &sizes,
-               const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::dense, tb);
+               const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::dense, dbg_info);
   }
 
   SNode &dense(const std::vector<Axis> &axes,
                int sizes,
-               const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::dense, tb);
+               const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::dense,
+                       dbg_info);
   }
 
-  SNode &dense(const Axis &axis, int size, const std::string &tb) {
-    return SNode::dense(std::vector<Axis>{axis}, size, tb);
+  SNode &dense(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return SNode::dense(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &pointer(const std::vector<Axis> &axes,
                  const std::vector<int> &sizes,
-                 const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::pointer, tb);
+                 const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::pointer, dbg_info);
   }
 
   SNode &pointer(const std::vector<Axis> &axes,
                  int sizes,
-                 const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::pointer, tb);
+                 const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::pointer,
+                       dbg_info);
   }
 
-  SNode &pointer(const Axis &axis, int size, const std::string &tb) {
-    return SNode::pointer(std::vector<Axis>{axis}, size, tb);
+  SNode &pointer(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return SNode::pointer(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &bitmasked(const std::vector<Axis> &axes,
                    const std::vector<int> &sizes,
-                   const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::bitmasked, tb);
+                   const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::bitmasked, dbg_info);
   }
 
   SNode &bitmasked(const std::vector<Axis> &axes,
                    int sizes,
-                   const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::bitmasked, tb);
+                   const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::bitmasked,
+                       dbg_info);
   }
 
-  SNode &bitmasked(const Axis &axis, int size, const std::string &tb) {
-    return SNode::bitmasked(std::vector<Axis>{axis}, size, tb);
+  SNode &bitmasked(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return SNode::bitmasked(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &hash(const std::vector<Axis> &axes,
               const std::vector<int> &sizes,
-              const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::hash, tb);
+              const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::hash, dbg_info);
   }
 
-  SNode &hash(const std::vector<Axis> &axes, int sizes, const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::hash, tb);
+  SNode &hash(const std::vector<Axis> &axes,
+              int sizes,
+              const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::hash,
+                       dbg_info);
   }
 
-  SNode &hash(const Axis &axis, int size, const std::string &tb) {
-    return hash(std::vector<Axis>{axis}, size, tb);
+  SNode &hash(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return hash(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   std::string type_name() {
     return snode_type_name(type);
   }
 
-  SNode &bit_struct(BitStructType *bit_struct_type, const std::string &tb);
+  SNode &bit_struct(BitStructType *bit_struct_type, const DebugInfo &dbg_info);
 
   SNode &quant_array(const std::vector<Axis> &axes,
                      const std::vector<int> &sizes,
                      int bits,
-                     const std::string &tb);
+                     const DebugInfo &dbg_info);
 
   void print();
 
@@ -221,7 +228,7 @@ class SNode {
   SNode &dynamic(const Axis &expr,
                  int n,
                  int chunk_size,
-                 const std::string &tb);
+                 const DebugInfo &dbg_info);
 
   SNode &morton(bool val = true) {
     _morton = val;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -588,7 +588,7 @@ class AssertStmt : public Stmt {
   AssertStmt(Stmt *cond,
              const std::string &text,
              const std::vector<Stmt *> &args)
-      : cond(cond), text(text), args(args) {
+      : cond(cond), text(cond->tb + text), args(args) {
     TI_ASSERT(cond);
     TI_STMT_REG_FIELDS;
   }

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -26,10 +26,12 @@ size_t flatten_index(const std::vector<int> &shapes,
 Ndarray::Ndarray(Program *prog,
                  const DataType type,
                  const std::vector<int> &shape_,
-                 ExternalArrayLayout layout_)
+                 ExternalArrayLayout layout_,
+                 DebugInfo dbg_info_)
     : dtype(type),
       shape(shape_),
       layout(layout_),
+      dbg_info(dbg_info_),
       nelement_(std::accumulate(std::begin(shape_),
                                 std::end(shape_),
                                 1,
@@ -51,7 +53,8 @@ Ndarray::Ndarray(Program *prog,
       std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL,
                       std::multiplies<>());
   if (total_num_scalar > std::numeric_limits<int>::max()) {
-    TI_WARN(
+    ErrorEmitter(
+        TaichiIndexWarning(), &dbg_info,
         "Ndarray index might be out of int32 boundary but int64 indexing is "
         "not supported yet.");
   }
@@ -62,11 +65,13 @@ Ndarray::Ndarray(Program *prog,
 Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
-                 ExternalArrayLayout layout)
+                 ExternalArrayLayout layout,
+                 DebugInfo dbg_info)
     : ndarray_alloc_(devalloc),
       dtype(type),
       shape(shape),
       layout(layout),
+      dbg_info(dbg_info),
       nelement_(std::accumulate(std::begin(shape),
                                 std::end(shape),
                                 1,
@@ -91,7 +96,8 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
       std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL,
                       std::multiplies<>());
   if (total_num_scalar > std::numeric_limits<int>::max()) {
-    TI_WARN(
+    ErrorEmitter(
+        TaichiIndexWarning(), &dbg_info,
         "Ndarray index might be out of int32 boundary but int64 indexing is "
         "not supported yet.");
   }
@@ -101,11 +107,13 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
                  const std::vector<int> &element_shape,
-                 ExternalArrayLayout layout)
+                 ExternalArrayLayout layout,
+                 DebugInfo dbg_info)
     : Ndarray(devalloc,
               TypeFactory::create_tensor_type(element_shape, type),
               shape,
-              layout) {
+              layout,
+              dbg_info) {
   TI_ASSERT(type->is<PrimitiveType>());
 }
 

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "taichi/inc/constants.h"
+#include "taichi/ir/ir.h"
 #include "taichi/ir/type_utils.h"
 #include "taichi/rhi/device.h"
 
@@ -21,7 +22,8 @@ class TI_DLL_EXPORT Ndarray {
   explicit Ndarray(Program *prog,
                    const DataType type,
                    const std::vector<int> &shape,
-                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull,
+                   DebugInfo dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * It doesn't handle the allocation and deallocation.
@@ -31,7 +33,8 @@ class TI_DLL_EXPORT Ndarray {
   explicit Ndarray(DeviceAllocation &devalloc,
                    const DataType type,
                    const std::vector<int> &shape,
-                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull,
+                   DebugInfo dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * This is an overloaded constructor for constructing Ndarray with TensorType
@@ -41,7 +44,8 @@ class TI_DLL_EXPORT Ndarray {
                    const DataType type,
                    const std::vector<int> &shape,
                    const std::vector<int> &element_shape,
-                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull,
+                   DebugInfo dbg_info = DebugInfo());
 
   DeviceAllocation ndarray_alloc_{kDeviceNullAllocation};
   DataType dtype;
@@ -50,6 +54,7 @@ class TI_DLL_EXPORT Ndarray {
   //   num_active_indices = shape.size()
   std::vector<int> shape;
   ExternalArrayLayout layout{ExternalArrayLayout::kNull};
+  DebugInfo dbg_info;
 
   std::vector<int> get_element_shape() const;
   DataType get_element_data_type() const;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -372,8 +372,9 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 Ndarray *Program::create_ndarray(const DataType type,
                                  const std::vector<int> &shape,
                                  ExternalArrayLayout layout,
-                                 bool zero_fill) {
-  auto arr = std::make_unique<Ndarray>(this, type, shape, layout);
+                                 bool zero_fill,
+                                 DebugInfo dbg_info) {
+  auto arr = std::make_unique<Ndarray>(this, type, shape, layout, dbg_info);
   if (zero_fill) {
     Arch arch = compile_config().arch;
     if (arch_is_cpu(arch) || arch == Arch::cuda || arch == Arch::amdgpu) {

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -253,7 +253,8 @@ class TI_DLL_EXPORT Program {
       const DataType type,
       const std::vector<int> &shape,
       ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-      bool zero_fill = false);
+      bool zero_fill = false,
+      DebugInfo dbg_info = DebugInfo());
 
   std::string get_kernel_return_data_layout() {
     return program_impl_->get_kernel_return_data_layout();

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -485,23 +485,23 @@ void export_lang(py::module &m) {
       .def("dense",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::dense),
+                               const DebugInfo &))(&SNode::dense),
            py::return_value_policy::reference)
       .def("pointer",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::pointer),
+                               const DebugInfo &))(&SNode::pointer),
            py::return_value_policy::reference)
       .def("hash",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::hash),
+                               const DebugInfo &))(&SNode::hash),
            py::return_value_policy::reference)
       .def("dynamic", &SNode::dynamic, py::return_value_policy::reference)
       .def("bitmasked",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::bitmasked),
+                               const DebugInfo &))(&SNode::bitmasked),
            py::return_value_policy::reference)
       .def("bit_struct", &SNode::bit_struct, py::return_value_policy::reference)
       .def("quant_array", &SNode::quant_array,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -138,6 +138,13 @@ void export_lang(py::module &m) {
             return dt;
           }));
 
+  py::class_<DebugInfo>(m, "DebugInfo")
+      .def(py::init<>())
+      .def(py::init<std::string>())
+      .def(py::init<>())
+      .def_readwrite("tb", &DebugInfo::tb)
+      .def_readwrite("src_loc", &DebugInfo::src_loc);
+
   py::class_<CompileConfig>(m, "CompileConfig")
       .def(py::init<>())
       .def_readwrite("arch", &CompileConfig::arch)
@@ -421,12 +428,14 @@ void export_lang(py::module &m) {
           "create_ndarray",
           [&](Program *program, const DataType &dt,
               const std::vector<int> &shape, ExternalArrayLayout layout,
-              bool zero_fill) -> Ndarray * {
-            return program->create_ndarray(dt, shape, layout, zero_fill);
+              bool zero_fill, DebugInfo dbg_info) -> Ndarray * {
+            return program->create_ndarray(dt, shape, layout, zero_fill,
+                                           dbg_info);
           },
           py::arg("dt"), py::arg("shape"),
           py::arg("layout") = ExternalArrayLayout::kNull,
-          py::arg("zero_fill") = false, py::return_value_policy::reference)
+          py::arg("zero_fill") = false, py::arg("dbg_info") = false,
+          py::return_value_policy::reference)
       .def("delete_ndarray", &Program::delete_ndarray)
       .def(
           "create_texture",

--- a/taichi/transforms/auto_diff.cpp
+++ b/taichi/transforms/auto_diff.cpp
@@ -2455,7 +2455,6 @@ class GloablDataAccessRuleChecker : public BasicStmtVisitor {
         "(kernel={}) Breaks the global data access rule. Snode {} is "
         "overwritten unexpectedly.",
         kernel_name_, dest->snode->get_node_type_name());
-    msg += "\n" + stmt->tb;
 
     stmt->insert_before_me(
         Stmt::make<AssertStmt>(check_equal, msg, std::vector<Stmt *>()));

--- a/taichi/transforms/check_out_of_bound.cpp
+++ b/taichi/transforms/check_out_of_bound.cpp
@@ -89,7 +89,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
         msg += ", ";
       msg += "%d";
     }
-    msg += "]\n" + stmt->tb;
+    msg += "]";
 
     new_stmts.push_back<AssertStmt>(result, msg, args);
     modifier.insert_before(stmt, std::move(new_stmts));
@@ -152,7 +152,6 @@ class CheckOutOfBound : public BasicStmtVisitor {
       msg += "%d";
     }
     msg += ")";
-    msg += "\n" + stmt->tb;
 
     new_stmts.push_back<AssertStmt>(result, msg, args);
     modifier.insert_before(stmt, std::move(new_stmts));
@@ -197,7 +196,7 @@ class CheckOutOfBound : public BasicStmtVisitor {
         msg += ", ";
       msg += std::to_string(matrix_shape[i]);
     }
-    msg += "] matrix with index [%d]\n" + stmt->tb;
+    msg += "] matrix with index [%d]";
 
     std::vector<Stmt *> args = {index};
     new_stmts.push_back<AssertStmt>(result, msg, args);
@@ -218,7 +217,6 @@ class CheckOutOfBound : public BasicStmtVisitor {
             BinaryOpType::cmp_ge, stmt->rhs, compare_rhs.get());
         compare->ret_type = PrimitiveType::i32;
         std::string msg = "Negative exponent in pow(int, int) is not allowed.";
-        msg += "\n" + stmt->tb;
         auto assert_stmt = std::make_unique<AssertStmt>(compare.get(), msg,
                                                         std::vector<Stmt *>());
         assert_stmt->accept(this);

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -6,7 +6,7 @@
 namespace taichi::lang {
 
 class FrontendTypeCheck : public IRVisitor {
-  void check_cond_type(const Expr& cond, const std::string& stmt_name) {
+  void check_cond_type(const Expr &cond, const std::string &stmt_name) {
     DataType cond_type = cond.get_rvalue_type();
     if (!cond_type->is<PrimitiveType>() || !is_integral(cond_type)) {
       ErrorEmitter(

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -78,6 +78,15 @@ class FrontendTypeCheck : public IRVisitor {
                    fmt::format("cannot assign '{}' to '{}'",
                                rhs_type->to_string(), lhs_type->to_string()));
     }
+
+    if (lhs_type != rhs_type) {
+      auto promoted = promoted_type(lhs_type, rhs_type);
+      if (lhs_type != promoted) {
+        ErrorEmitter(TaichiCastWarning(), stmt,
+                     fmt::format("Assign may lose precision: {} <- {}",
+                                 lhs_type->to_string(), rhs_type->to_string()));
+      }
+    }
   }
 
   void visit(FrontendIfStmt *stmt) override {

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -68,8 +68,8 @@ class FrontendTypeCheck : public IRVisitor {
   }
 
   void visit(FrontendAssignStmt *stmt) override {
-    auto lhs_type = stmt->lhs->ret_type.ptr_removed();
-    auto rhs_type = stmt->rhs->ret_type.ptr_removed();
+    auto const &lhs_type = stmt->lhs->ret_type.ptr_removed();
+    auto const &rhs_type = stmt->rhs->ret_type.ptr_removed();
 
     // No implicit cast at frontend for now
     if (is_tensor(lhs_type) && is_tensor(rhs_type) &&
@@ -79,12 +79,16 @@ class FrontendTypeCheck : public IRVisitor {
                                rhs_type->to_string(), lhs_type->to_string()));
     }
 
-    if (lhs_type != rhs_type) {
-      auto promoted = promoted_type(lhs_type, rhs_type);
-      if (lhs_type != promoted) {
+    auto const &lhs_element_type = lhs_type.get_element_type();
+    auto const &rhs_element_type = rhs_type.get_element_type();
+
+    if (lhs_element_type != rhs_element_type) {
+      auto promoted = promoted_type(lhs_element_type, rhs_element_type);
+      if (lhs_element_type != promoted) {
         ErrorEmitter(TaichiCastWarning(), stmt,
                      fmt::format("Assign may lose precision: {} <- {}",
-                                 lhs_type->to_string(), rhs_type->to_string()));
+                                 lhs_element_type->to_string(),
+                                 rhs_element_type->to_string()));
       }
     }
   }

--- a/taichi/transforms/simplify.cpp
+++ b/taichi/transforms/simplify.cpp
@@ -183,9 +183,9 @@ class BasicBlockSimplify : public IRVisitor {
       auto zero = Stmt::make<ConstStmt>(TypedConstant(0));
       auto check_sum =
           Stmt::make<BinaryOpStmt>(BinaryOpType::cmp_ge, sum.get(), zero.get());
-      auto assert = Stmt::make<AssertStmt>(
-          check_sum.get(), "The indices provided are too big!\n" + stmt->tb,
-          std::vector<Stmt *>());
+      auto assert = Stmt::make<AssertStmt>(check_sum.get(),
+                                           "The indices provided are too big!",
+                                           std::vector<Stmt *>());
       // Because Taichi's assertion is checked only after the execution of the
       // kernel, when the linear index overflows and goes negative, we have to
       // replace that with 0 to make sure that the rest of the kernel can still

--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -278,7 +278,6 @@ class TypeCheck : public IRVisitor {
     std::string msg =
         "Detected overflow for bit_shift_op with rhs = %d, exceeding limit of "
         "%d.";
-    msg += "\n" + stmt->tb;
     std::vector<Stmt *> args = {rhs, const_stmt.get()};
     auto assert_stmt =
         Stmt::make<AssertStmt>(cond_stmt.get(), msg, std::move(args));

--- a/tests/cpp/struct/snode_tree_test.cpp
+++ b/tests/cpp/struct/snode_tree_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "taichi/struct/snode_tree.h"
+#include "taichi/ir/ir.h"
 
 namespace taichi::lang {
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 826ac86</samp>

This pull request improves the error reporting and debugging experience for Taichi users by passing and storing the source location and traceback information in `DebugInfo` objects for various IR components, such as `Ndarray`, `SNode`, and `Stmt`. It also refactors the error and warning handling logic in various files by using the `ErrorEmitter` class, which can emit different types of `TaichiExceptionImpl` with informative and consistent messages. Additionally, it removes some redundant and unnecessary code and makes some minor formatting changes.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 826ac86</samp>

*  Add a new `DebugInfo` struct and class to store the traceback and source location information for error reporting (`taichi/ir/ir.h`, `taichi/python/export_lang.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a80a8a9749edd5fd01358e92793b8d52ac098873dc9cec7d1cc9c1f349b202bbL6-R6), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9R23), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L12-R16), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1224-R1268), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-31e26e38faaee1926cea9f76dc2da2efa9b5748334fb7f26a6e56ce402b7ca56R14), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-beef648948caba537e7b600274f753dd65d46021ca105c9e3b063f209f889252R7), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167R141-R147))
*  Add a new `ErrorEmitter` class to emit errors or warnings based on the `TaichiExceptionImpl` subclasses, using the `DebugInfo` object (`taichi/common/exceptions.h`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L35-R38), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L48-R59), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L70-R81), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L95-R111), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L173-R177), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L199-R205), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L207-R215), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L221-R231), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L246-R258), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L285-R296), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L293-R307), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L526-R539), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L824-R838), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L840-R855), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L864-R880), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L880-R903), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L896-R917), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L918-R937), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L932-R954), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L952-R972), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L975-R1000), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35R1032-R1043), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1062-R1099), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1082-R1122), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1104-R1142), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1121-R1167), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1145-R1184), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1161-R1203), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1177-R1219), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1187-R1229), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1212-R1254), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1241-R1285), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1343-R1388), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c88c6764ffa952681c8b0db12b376c473a8422cb7bb0243a10cc643cc245a5a1L54-R57), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c88c6764ffa952681c8b0db12b376c473a8422cb7bb0243a10cc643cc245a5a1L94-R100))
*  Add new subclasses of `TaichiExceptionImpl` for different types of errors and warnings, such as `TaichiError`, `TaichiWarning`, `TaichiTypeError`, `TaichiSyntaxError`, `TaichiIndexError`, `TaichiRuntimeError`, `TaichiAssertionError`, `TaichiIrError`, `TaichiCastWarning`, `TaichiTypeWarning`, `TaichiIrWarning`, `TaichiIndexWarning`, and `TaichiRuntimeWarning` (`taichi/common/exceptions.h`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L18-R134))
*  Add a new parameter `dbg_info` to the `create_ndarray` function and the `Ndarray` constructor, and pass the `DebugInfo` object that contains the traceback information for the `Ndarray` object (`taichi/program/ndarray.h`, `taichi/program/ndarray.cpp`, `taichi/program/program.h`, `taichi/program/program.cpp`, `taichi/python/export_lang.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a80a8a9749edd5fd01358e92793b8d52ac098873dc9cec7d1cc9c1f349b202bbL240-R242), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9L1640-R1645), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9L1750-R1759), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c88c6764ffa952681c8b0db12b376c473a8422cb7bb0243a10cc643cc245a5a1L29-R34), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c88c6764ffa952681c8b0db12b376c473a8422cb7bb0243a10cc643cc245a5a1L65-R74), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c88c6764ffa952681c8b0db12b376c473a8422cb7bb0243a10cc643cc245a5a1L104-R116), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-beef648948caba537e7b600274f753dd65d46021ca105c9e3b063f209f889252L24-R26), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-beef648948caba537e7b600274f753dd65d46021ca105c9e3b063f209f889252L34-R37), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-beef648948caba537e7b600274f753dd65d46021ca105c9e3b063f209f889252L44-R48), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-beef648948caba537e7b600274f753dd65d46021ca105c9e3b063f209f889252R57), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-d2572e3acfa01c9e64a50f4f311338bedac2c1aef1d6ece19a980cda3c3e71abL375-R377), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-57de3017be8b22f694bafeeaa451402a6cff7733c72b80a82af430a7bf817117L256-R257), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L424-R438))
*  Add a new parameter `dbg_info` to the `create_node` function and the `SNode` constructor, and pass the `DebugInfo` object that contains the traceback information for the `SNode` object (`taichi/ir/snode.h`, `taichi/ir/snode.cpp`, `taichi/ir/ir.h`, `taichi/python/export_lang.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L38-R38), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L54-R54), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L81-R81), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L97-R97), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L112-R112), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L132-R132), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR390-R412), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR427), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-fc2fd7d4434687d9b3efc0680e357285c30f4096a5d7c14d03b6fbe32e4017ceL40-R61), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-fc2fd7d4434687d9b3efc0680e357285c30f4096a5d7c14d03b6fbe32e4017ceL64-R75), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-fc2fd7d4434687d9b3efc0680e357285c30f4096a5d7c14d03b6fbe32e4017ceL83-R94), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-fc2fd7d4434687d9b3efc0680e357285c30f4096a5d7c14d03b6fbe32e4017ceL97-R112), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-fc2fd7d4434687d9b3efc0680e357285c30f4096a5d7c14d03b6fbe32e4017ceL113-R121), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-fc2fd7d4434687d9b3efc0680e357285c30f4096a5d7c14d03b6fbe32e4017ceL120-R128), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-fc2fd7d4434687d9b3efc0680e357285c30f4096a5d7c14d03b6fbe32e4017ceL130-R138), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-31e26e38faaee1926cea9f76dc2da2efa9b5748334fb7f26a6e56ce402b7ca56L141-R210), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-31e26e38faaee1926cea9f76dc2da2efa9b5748334fb7f26a6e56ce402b7ca56L210-R222), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-31e26e38faaee1926cea9f76dc2da2efa9b5748334fb7f26a6e56ce402b7ca56L224-R231), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L479-R498), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L495-R504))
*  Add a new member variable `src_location` to the `Stmt` class, and store the source location information for the statement (`taichi/ir/ir.h`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR427))
*  Add a new member variable `ptr_type_checked` to the `Expr` class, and use it to avoid redundant type-checking for the same expression (`taichi/lang/expr.py`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a17f6dbf127b67d009730fd966417bb8d094d2c35504bafa49e450ced2a92258R18), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a17f6dbf127b67d009730fd966417bb8d094d2c35504bafa49e450ced2a92258R24), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a17f6dbf127b67d009730fd966417bb8d094d2c35504bafa49e450ced2a92258L42-R46))
*  Replace the `TI_ASSERT_INFO`, `TI_ERROR`, `TI_ERROR_IF`, `TI_WARN`, and `throw` statements with the `ErrorEmitter` class, and use the `DebugInfo` object to provide the traceback information for the errors or warnings (`taichi/analysis/verify.cpp`, `taichi/ir/frontend_ir.cpp`, `taichi/ir/statements.h`, `taichi/program/ndarray.cpp`, `taichi/transforms/auto_diff.cpp`, `taichi/transforms/check_out_of_bound.cpp`, `taichi/transforms/frontend_type_check.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L35-R38), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L48-R59), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L70-R81), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c44717d8708cfe16c6ec533c5af9e8cb7c1f99056bd0619b2b9d93700ade15b2L95-R111), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L173-R177), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L199-R205), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L207-R215), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L221-R231), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L246-R258), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L285-R296), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L293-R307), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L526-R539), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L824-R838), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L840-R855), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L864-R880), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L880-R903), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L896-R917), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L918-R937), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L932-R954), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L952-R972), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L975-R1000), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35R1032-R1043), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1062-R1099), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1082-R1122), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1104-R1142), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1121-R1167), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1145-R1184), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1161-R1203), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1177-R1219), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1187-R1229), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1212-R1254), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1241-R1285), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1343-R1388), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L591-R591), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c88c6764ffa952681c8b0db12b376c473a8422cb7bb0243a10cc643cc245a5a1L54-R57), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-c88c6764ffa952681c8b0db12b376c473a8422cb7bb0243a10cc643cc245a5a1L94-R100), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L2458), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL92-R92), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL155), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL200-R199), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL221), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L45-R126), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L111-R168), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L121-R179), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L146-R202))
*  Remove the redundant `stmt->tb` prefix from the error messages, since the `ErrorEmitter` already includes the traceback information (`taichi/ir/statements.h`, `taichi/transforms/auto_diff.cpp`, `taichi/transforms/check_out_of_bound.cpp`, `taichi/transforms/frontend_type_check.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L591-R591), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-bd5cf26b80ac9337253eb1e63d32a4e9a5a90f393fc8eca8fc898d8cce037583L2458), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL92-R92), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL155), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL200-R199), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-2d1e902d25643016ff6e05dc05dfdc05d1615face8181014196fe26796c35e0fL221), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L111-R168), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L121-R179))
*  Add a new conditional check for the element type of the atomic operation and the value type, and emit a `TaichiCastWarning` if the element type is not the promoted type of the two types (`taichi/ir/frontend_ir.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35R1032-R1043))
*  Replace the `check_cond_type` function with a new function that takes a `Stmt` pointer as an argument, and use the `ErrorEmitter` class to emit a `TaichiTypeError` if the condition expression is not an integer (`taichi/transforms/frontend_type_check.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L9-R33), [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L146-R202))
*  Add more type checking and error handling logic for the `FrontendSNodeOpStmt`, which represents operations on SNodes (`taichi/transforms/frontend_type_check.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L45-R126))
*  Add a `#pragma once` directive to the `taichi/common/exceptions.h` header file (`taichi/common/exceptions.h`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L3-R20))
*  Remove an empty line from the `taichi/ir/ir.cpp` file (`taichi/ir/ir.cpp`, [link](https://github.com/taichi-dev/taichi/pull/8277/files?diff=unified&w=0#diff-50be2dc708119a4c9b53e977807d2f05e4ff6ce98c3f51fa91d1fa9e229962f1L540))
