### PR TITLE
[Lang] Use ErrorEmitter in type check passes

### DIFF
--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -178,8 +178,8 @@ void RandExpression::type_check(const CompileConfig *) {
     ErrorEmitter(
         TaichiTypeError(), this,
         fmt::format("Invalid dt [{}] for RandExpression", dt->to_string()));
-    ret_type = dt;
   }
+  ret_type = dt;
 }
 
 void RandExpression::flatten(FlattenContext *ctx) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -9,14 +9,15 @@
 
 namespace taichi::lang {
 
-#define TI_ASSERT_TYPE_CHECKED(x)                                        \
-  if (x->ret_type == PrimitiveType::unknown) {                           \
-    ErrorEmitter(                                                        \
-        TaichiTypeError(), x.expr.get(),                                 \
-        fmt::format("[{}] was not type-checked",                         \
-                    ExpressionHumanFriendlyPrinter::expr_to_string(x))); \
-  } else {                                                               \
-  }
+#define TI_ASSERT_TYPE_CHECKED(x)                                          \
+  do {                                                                     \
+    if (x->ret_type == PrimitiveType::unknown) {                           \
+      ErrorEmitter(                                                        \
+          TaichiTypeError(), x.expr.get(),                                 \
+          fmt::format("[{}] was not type-checked",                         \
+                      ExpressionHumanFriendlyPrinter::expr_to_string(x))); \
+    }                                                                      \
+  } while (false)
 
 static bool is_primitive_or_tensor_type(DataType &type) {
   return type->is<PrimitiveType>() || type->is<TensorType>();

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -9,10 +9,14 @@
 
 namespace taichi::lang {
 
-#define TI_ASSERT_TYPE_CHECKED(x)                       \
-  TI_ASSERT_INFO(x->ret_type != PrimitiveType::unknown, \
-                 "[{}] was not type-checked",           \
-                 ExpressionHumanFriendlyPrinter::expr_to_string(x))
+#define TI_ASSERT_TYPE_CHECKED(x)                                        \
+  if (x->ret_type == PrimitiveType::unknown) {                           \
+    ErrorEmitter(                                                        \
+        TaichiTypeError(), x.expr.get(),                                 \
+        fmt::format("[{}] was not type-checked",                         \
+                    ExpressionHumanFriendlyPrinter::expr_to_string(x))); \
+  } else {                                                               \
+  }
 
 static bool is_primitive_or_tensor_type(DataType &type) {
   return type->is<PrimitiveType>() || type->is<TensorType>();
@@ -170,9 +174,12 @@ void TexturePtrExpression::flatten(FlattenContext *ctx) {
 }
 
 void RandExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown,
-                 "Invalid dt [{}] for RandExpression", dt->to_string());
-  ret_type = dt;
+  if (!(dt->is<PrimitiveType>() && dt != PrimitiveType::unknown)) {
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("Invalid dt [{}] for RandExpression", dt->to_string()));
+    ret_type = dt;
+  }
 }
 
 void RandExpression::flatten(FlattenContext *ctx) {
@@ -196,17 +203,20 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
   auto ret_primitive_type = ret_type;
 
   if (!operand_primitive_type->is<PrimitiveType>()) {
-    throw TaichiTypeError(fmt::format(
-        "unsupported operand type(s) for '{}': '{}'", unary_op_type_name(type),
-        operand_primitive_type->to_string()));
+    ErrorEmitter(TaichiTypeError(), this,
+                 fmt::format("unsupported operand type(s) for '{}': '{}'",
+                             unary_op_type_name(type),
+                             operand_primitive_type->to_string()));
   }
 
   if ((type == UnaryOpType::round || type == UnaryOpType::floor ||
        type == UnaryOpType::ceil || is_trigonometric(type)) &&
       !is_real(operand_primitive_type))
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes real inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes real inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
 
   if ((type == UnaryOpType::sqrt || type == UnaryOpType::exp ||
        type == UnaryOpType::log) &&
@@ -218,9 +228,11 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
 
   if ((type == UnaryOpType::bit_not || type == UnaryOpType::logic_not) &&
       is_real(operand_primitive_type)) {
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes integral inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes integral inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
   }
 
   if (type == UnaryOpType::logic_not) {
@@ -243,9 +255,11 @@ void UnaryOpExpression::type_check(const CompileConfig *config) {
   }
 
   if (type == UnaryOpType::popcnt && is_real(operand_primitive_type)) {
-    throw TaichiTypeError(fmt::format(
-        "'{}' takes integral inputs only, however '{}' is provided",
-        unary_op_type_name(type), operand_primitive_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("'{}' takes integral inputs only, however '{}' is provided",
+                    unary_op_type_name(type),
+                    operand_primitive_type->to_string()));
   }
 
   if (operand_type->is<TensorType>()) {
@@ -282,7 +296,8 @@ Expr to_broadcast_tensor(const Expr &elt, const DataType &dt) {
     // Only tensor shape will be checked here, since the dtype will
     // be promoted later at irpass::type_check()
     if (elt_type.get_shape() != dt.get_shape()) {
-      TI_ERROR("Cannot broadcast tensor to tensor");
+      ErrorEmitter(TaichiTypeError(), elt.expr.get(),
+                   "Cannot broadcast tensor to tensor");
     } else {
       return elt;
     }
@@ -290,9 +305,12 @@ Expr to_broadcast_tensor(const Expr &elt, const DataType &dt) {
 
   auto tensor_type = dt->as<TensorType>();
   auto tensor_elt_type = tensor_type->get_element_type();
-  TI_ASSERT_INFO(tensor_elt_type->is<PrimitiveType>(),
-                 "Only primitive types are supported in Tensors, got {}",
-                 tensor_elt_type->to_string());
+  if (!tensor_elt_type->is<PrimitiveType>()) {
+    ErrorEmitter(
+        TaichiTypeError(), elt.expr.get(),
+        fmt::format("Only primitive types are supported in Tensors, got {}",
+                    tensor_elt_type->to_string()));
+  }
   std::vector<Expr> broadcast_values(tensor_type->get_num_elements(), elt);
   auto matrix_expr = Expr::make<MatrixExpression>(
       broadcast_values, tensor_type->get_shape(), elt_type);
@@ -523,7 +541,8 @@ void TernaryOpExpression::type_check(const CompileConfig *config) {
   auto op3_type = op3.get_rvalue_type();
 
   auto error = [&]() {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiTypeError(), this,
         fmt::format("unsupported operand type(s) for '{}': '{}', '{}' and '{}'",
                     ternary_type_name(type), op1_type->to_string(),
                     op2_type->to_string(), op3_type->to_string()));
@@ -822,7 +841,8 @@ static void field_validation(FieldExpression *field_expr, int index_dim) {
   int field_dim = field_expr->snode->num_active_indices;
 
   if (field_dim != index_dim) {
-    throw TaichiIndexError(
+    ErrorEmitter(
+        TaichiIndexError(), field_expr,
         fmt::format("Field with dim {} accessed with indices of dim {}",
                     field_dim, index_dim));
   }
@@ -838,7 +858,10 @@ void IndexExpression::type_check(const CompileConfig *) {
   bool has_slice = !ret_shape.empty();
   auto var_type = var.get_rvalue_type();
   if (has_slice) {
-    TI_ASSERT_INFO(is_tensor(), "Slice or swizzle can only apply on matrices");
+    if (!is_tensor()) {
+      ErrorEmitter(TaichiTypeError(), this,
+                   "Slice or swizzle can only apply on matrices");
+    }
     auto element_type = var_type->as<TensorType>()->get_element_type();
     ret_type = TypeFactory::create_tensor_type(ret_shape, element_type);
   } else if (is_field()) {  // field
@@ -862,7 +885,8 @@ void IndexExpression::type_check(const CompileConfig *) {
     int element_dim = external_tensor_expr->dt.get_shape().size();
     int total_dim = ndim + element_dim;
     if (total_dim != index_dim + element_dim) {
-      throw TaichiTypeError(
+      ErrorEmitter(
+          TaichiIndexError(), this,
           fmt::format("Array with dim {} accessed with indices of dim {}",
                       total_dim - element_dim, index_dim));
     }
@@ -878,12 +902,14 @@ void IndexExpression::type_check(const CompileConfig *) {
     auto tensor_type = var_type->as<TensorType>();
     auto shape = tensor_type->get_shape();
     if (indices_group[0].size() != shape.size()) {
-      TI_ERROR("Expected {} indices, got {}.", shape.size(),
-               indices_group[0].size());
+      ErrorEmitter(TaichiIndexError(), this,
+                   fmt::format("Expected {} indices, got {}.", shape.size(),
+                               indices_group[0].size()));
     }
     ret_type = tensor_type->get_element_type();
   } else {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiIndexError(), this,
         "Invalid IndexExpression: the source is not among field, ndarray or "
         "local tensor");
   }
@@ -894,10 +920,10 @@ void IndexExpression::type_check(const CompileConfig *) {
       TI_ASSERT_TYPE_CHECKED(expr);
       auto expr_type = expr.get_rvalue_type();
       if (!is_integral(expr_type))
-        throw TaichiTypeError(
-            fmt::format("indices must be integers, however '{}' is "
-                        "provided as index {}",
-                        expr_type->to_string(), i));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("indices must be integers, however '{}' is "
+                                 "provided as index {}",
+                                 expr_type->to_string(), i));
     }
   }
 }
@@ -916,7 +942,8 @@ void IndexExpression::flatten(FlattenContext *ctx) {
         ctx, var, indices_group, ret_type,
         var->ret_type.ptr_removed()->as<TensorType>()->get_shape(), get_tb());
   } else {
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiIndexError(), this,
         "Invalid IndexExpression: the source is not among field, ndarray or "
         "local tensor");
   }
@@ -930,10 +957,10 @@ void RangeAssumptionExpression::type_check(const CompileConfig *) {
   auto base_type = base.get_rvalue_type();
   if (!input_type->is<PrimitiveType>() || !base_type->is<PrimitiveType>() ||
       input_type != base_type)
-    throw TaichiTypeError(
-        fmt::format("unsupported operand type(s) for "
-                    "'range_assumption': '{}' and '{}'",
-                    input_type->to_string(), base_type->to_string()));
+    ErrorEmitter(TaichiTypeError(), this,
+                 fmt::format("unsupported operand type(s) for "
+                             "'range_assumption': '{}' and '{}'",
+                             input_type->to_string(), base_type->to_string()));
   ret_type = input_type;
 }
 
@@ -950,7 +977,8 @@ void LoopUniqueExpression::type_check(const CompileConfig *) {
   auto input_type = input.get_rvalue_type();
 
   if (!input_type->is<PrimitiveType>())
-    throw TaichiTypeError(
+    ErrorEmitter(
+        TaichiTypeError(), this,
         fmt::format("unsupported operand type(s) for 'loop_unique': '{}'",
                     input_type->to_string()));
   ret_type = input_type;
@@ -973,10 +1001,12 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
   TI_ASSERT_TYPE_CHECKED(dest);
   TI_ASSERT_TYPE_CHECKED(val);
   auto error = [&]() {
-    throw TaichiTypeError(fmt::format(
-        "unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
-        atomic_op_type_name(op_type), dest->ret_type->to_string(),
-        val->ret_type->to_string()));
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format(
+            "unsupported operand type(s) for 'atomic_{}': '{}' and '{}'",
+            atomic_op_type_name(op_type), dest->ret_type->to_string(),
+            val->ret_type->to_string()));
   };
 
   // Broadcast val to dest if neccessary
@@ -1007,6 +1037,18 @@ void AtomicOpExpression::type_check(const CompileConfig *config) {
     ret_type = dest_dtype;
   } else {
     error();
+  }
+
+  auto const &ret_element_type = ret_type.get_element_type();
+  if (ret_element_type != val_dtype) {
+    auto promoted = promoted_type(ret_element_type, val_dtype);
+    if (ret_element_type != promoted) {
+      ErrorEmitter(
+          TaichiCastWarning(), this,
+          fmt::format("Atomic {} may lose precision: {} <- {}",
+                      atomic_op_type_name(op_type),
+                      ret_element_type->to_string(), val_dtype->to_string()));
+    }
   }
 }
 
@@ -1060,8 +1102,10 @@ void SNodeOpExpression::type_check(const CompileConfig *config) {
       auto value_type = values[i].get_rvalue_type();
       auto promoted = promoted_type(dst_type, value_type);
       if (dst_type != promoted) {
-        TI_WARN("Append may lose precision: {} <- {}\n{}",
-                dst_type->to_string(), value_type->to_string(), get_tb());
+        ErrorEmitter(TaichiCastWarning(), this,
+                     fmt::format("Append may lose precision: {} <- {}\n{}",
+                                 dst_type->to_string(), value_type->to_string(),
+                                 get_tb()));
       }
       values[i] = cast(values[i], dst_type);
       values[i]->type_check(config);
@@ -1080,10 +1124,12 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
       ctx->push_back<GlobalPtrStmt>(snode, indices_stmt, true, is_cell_access);
   ptr->set_tb(get_tb());
   if (op_type == SNodeOpType::is_active) {
-    TI_ERROR_IF(snode->type != SNodeType::pointer &&
-                    snode->type != SNodeType::hash &&
-                    snode->type != SNodeType::bitmasked,
-                "ti.is_active only works on pointer, hash or bitmasked nodes.");
+    if (!(snode->type == SNodeType::pointer || snode->type == SNodeType::hash ||
+          snode->type == SNodeType::bitmasked)) {
+      ErrorEmitter(
+          TaichiTypeError(), this,
+          "ti.is_active only works on pointer, hash or bitmasked nodes.");
+    }
     ctx->push_back<SNodeOpStmt>(SNodeOpType::is_active, snode, ptr, nullptr);
   } else if (op_type == SNodeOpType::length) {
     ctx->push_back<SNodeOpStmt>(SNodeOpType::length, snode, ptr, nullptr);
@@ -1102,8 +1148,10 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
       ctx->push_back<GlobalStoreStmt>(ch_addr, value_stmt)->set_tb(get_tb());
     }
     ctx->push_back<LocalLoadStmt>(alloca)->set_tb(get_tb());
-    TI_ERROR_IF(snode->type != SNodeType::dynamic,
-                "ti.append only works on dynamic nodes.");
+    if (snode->type != SNodeType::dynamic) {
+      ErrorEmitter(TaichiTypeError(), this,
+                   "ti.append only works on dynamic nodes.");
+    }
   }
   stmt = ctx->back_stmt();
 }
@@ -1119,15 +1167,18 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
   auto ptr = texture_ptr.cast<TexturePtrExpression>();
   if (op == TextureOpType::kSampleLod) {
     // UV, Lod
-    TI_ASSERT_INFO(args.size() == ptr->num_dims + 1,
-                   "Invalid number of args for sample_lod Texture op with a "
-                   "{}-dimension texture",
-                   ptr->num_dims);
+    if (args.size() != ptr->num_dims + 1) {
+      ErrorEmitter(TaichiTypeError(), this,
+                   fmt::format("Invalid number of args for sample_lod Texture "
+                               "op with a {}-dimension texture",
+                               ptr->num_dims));
+    }
     for (int i = 0; i < ptr->num_dims; i++) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::f32) {
-        throw TaichiTypeError(
+        ErrorEmitter(
+            TaichiTypeError(), this,
             fmt::format("Invalid type for texture sample_lod: '{}', all "
                         "arguments must be f32",
                         arg_type->to_string()));
@@ -1143,7 +1194,8 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
+        ErrorEmitter(
+            TaichiTypeError(), this,
             fmt::format("Invalid type for texture fetch_texel: '{}', all "
                         "arguments must be i32",
                         arg_type->to_string()));
@@ -1159,10 +1211,10 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', all "
-                        "arguments must be i32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', all "
+                                 "arguments must be i32",
+                                 arg_type->to_string()));
       }
     }
   } else if (op == TextureOpType::kStore) {
@@ -1175,20 +1227,20 @@ void TextureOpExpression::type_check(const CompileConfig *config) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::i32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', index "
-                        "arguments must be i32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', index "
+                                 "arguments must be i32",
+                                 arg_type->to_string()));
       }
     }
     for (int i = ptr->num_dims; i < ptr->num_dims + 4; i++) {
       TI_ASSERT_TYPE_CHECKED(args[i]);
       auto arg_type = args[i].get_rvalue_type();
       if (arg_type != PrimitiveType::f32) {
-        throw TaichiTypeError(
-            fmt::format("Invalid type for texture load: '{}', value "
-                        "arguments must be f32",
-                        arg_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), this,
+                     fmt::format("Invalid type for texture load: '{}', value "
+                                 "arguments must be f32",
+                                 arg_type->to_string()));
       }
     }
   } else {
@@ -1210,9 +1262,11 @@ void TextureOpExpression::flatten(FlattenContext *ctx) {
 }
 
 void ConstExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(
-      val.dt->is<PrimitiveType>() && val.dt != PrimitiveType::unknown,
-      "Invalid dt [{}] for ConstExpression", val.dt->to_string());
+  if (!(val.dt->is<PrimitiveType>() && val.dt != PrimitiveType::unknown)) {
+    ErrorEmitter(TaichiTypeError(), this,
+                 fmt::format("Invalid dt [{}] for ConstExpression",
+                             val.dt->to_string()));
+  }
   ret_type = val.dt;
 }
 
@@ -1222,10 +1276,13 @@ void ConstExpression::flatten(FlattenContext *ctx) {
 }
 
 void ExternalTensorShapeAlongAxisExpression::type_check(const CompileConfig *) {
-  TI_ASSERT_INFO(
-      ptr.is<ExternalTensorExpression>() || ptr.is<TexturePtrExpression>(),
-      "Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
-      ExpressionHumanFriendlyPrinter::expr_to_string(ptr));
+  if (!(ptr.is<ExternalTensorExpression>() || ptr.is<TexturePtrExpression>())) {
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format(
+            "Invalid ptr [{}] for ExternalTensorShapeAlongAxisExpression",
+            ExpressionHumanFriendlyPrinter::expr_to_string(ptr)));
+  }
   ret_type = PrimitiveType::i32;
 }
 
@@ -1254,9 +1311,12 @@ void ExternalTensorBasePtrExpression::flatten(FlattenContext *ctx) {
 void GetElementExpression::type_check(const CompileConfig *config) {
   TI_ASSERT_TYPE_CHECKED(src);
   auto src_type = src->ret_type;
-  TI_ASSERT_INFO(src_type->is<PointerType>(),
-                 "Invalid src [{}] for GetElementExpression",
-                 ExpressionHumanFriendlyPrinter::expr_to_string(src));
+  if (!src_type->is<PointerType>()) {
+    ErrorEmitter(
+        TaichiTypeError(), this,
+        fmt::format("Invalid src [{}] for GetElementExpression",
+                    ExpressionHumanFriendlyPrinter::expr_to_string(src)));
+  }
 
   ret_type = src_type.ptr_removed()->as<StructType>()->get_element_type(index);
 }
@@ -1356,8 +1416,10 @@ void ASTBuilder::insert_assignment(Expr &lhs,
     this->insert(std::move(stmt));
 
   } else {
-    TI_ERROR("Cannot assign to non-lvalue: {}",
-             ExpressionHumanFriendlyPrinter::expr_to_string(lhs));
+    ErrorEmitter(
+        TaichiRuntimeError(), lhs.expr.get(),
+        fmt::format("Cannot assign to non-lvalue: {}",
+                    ExpressionHumanFriendlyPrinter::expr_to_string(lhs)));
   }
 }
 

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -6,13 +6,16 @@
 namespace taichi::lang {
 
 class FrontendTypeCheck : public IRVisitor {
-  void check_cond_type(const Expr &cond, std::string stmt_name) {
-    auto cond_type = cond.get_rvalue_type();
-    if (!cond_type->is<PrimitiveType>() || !is_integral(cond_type))
-      throw TaichiTypeError(fmt::format(
-          "`{0}` conditions must be an integer; found {1}. Consider using "
-          "`{0} x != 0` instead of `{0} x` for float values.",
-          stmt_name, cond_type->to_string()));
+  void check_cond_type(const Expr &cond, const std::string &stmt_name) {
+    DataType cond_type = cond.get_rvalue_type();
+    if (!cond_type->is<PrimitiveType>() || !is_integral(cond_type)) {
+      ErrorEmitter(
+          TaichiTypeError(), cond,
+          fmt::format("`{0}` conditions must be an integer; found {1}. "
+                      "Consider using "
+                      "`{0} x != 0` instead of `{0} x` for float values.",
+                      stmt_name, cond_type->to_string()));
+    }
   }
 
  public:
@@ -42,7 +45,35 @@ class FrontendTypeCheck : public IRVisitor {
   }
 
   void visit(FrontendSNodeOpStmt *stmt) override {
-    // Noop
+    if (!stmt->ret_type.ptr_removed().get_element_type()->is_primitive(
+            PrimitiveTypeID::unknown)) {
+      // pass
+    } else if (stmt->snode) {
+      stmt->ret_type =
+          TypeFactory::get_instance().get_pointer_type(stmt->snode->dt);
+    } else
+      ErrorEmitter(TaichiTypeWarning(), stmt,
+                   "Type inference failed: snode is nullptr.");
+    auto check_indices = [&](SNode *snode) {
+      if (snode->num_active_indices != stmt->indices.size()) {
+        ErrorEmitter(
+            TaichiRuntimeError(), stmt,
+            fmt::format("{} has {} indices. Indexed with {}.",
+                        snode->node_type_name, snode->num_active_indices,
+                        stmt->indices.size()));
+      }
+    };
+    auto is_cell_access = SNodeOpStmt::activation_related(stmt->op_type) &&
+                          stmt->snode->type != SNodeType::dynamic;
+    check_indices(is_cell_access ? stmt->snode : stmt->snode->parent);
+    for (int i = 0; i < stmt->indices.size(); i++) {
+      if (!stmt->indices[i]->ret_type->is_primitive(PrimitiveTypeID::i32)) {
+        ErrorEmitter(
+            TaichiCastWarning(), stmt,
+            fmt::format(
+                "Field index {} not int32, casting into int32 implicitly", i));
+      }
+    }
   }
 
   void visit(FrontendAssertStmt *stmt) override {
@@ -50,19 +81,28 @@ class FrontendTypeCheck : public IRVisitor {
   }
 
   void visit(FrontendAssignStmt *stmt) override {
-    auto lhs_type = stmt->lhs->ret_type.ptr_removed();
-    auto rhs_type = stmt->rhs->ret_type.ptr_removed();
-
-    auto error = [&]() {
-      throw TaichiTypeError(fmt::format("{}cannot assign '{}' to '{}'",
-                                        stmt->get_tb(), rhs_type->to_string(),
-                                        lhs_type->to_string()));
-    };
+    auto const &lhs_type = stmt->lhs->ret_type.ptr_removed();
+    auto const &rhs_type = stmt->rhs->ret_type.ptr_removed();
 
     // No implicit cast at frontend for now
     if (is_tensor(lhs_type) && is_tensor(rhs_type) &&
         lhs_type.get_shape() != rhs_type.get_shape()) {
-      error();
+      ErrorEmitter(TaichiTypeError(), stmt,
+                   fmt::format("cannot assign '{}' to '{}'",
+                               rhs_type->to_string(), lhs_type->to_string()));
+    }
+
+    auto const &lhs_element_type = lhs_type.get_element_type();
+    auto const &rhs_element_type = rhs_type.get_element_type();
+
+    if (lhs_element_type != rhs_element_type) {
+      auto promoted = promoted_type(lhs_element_type, rhs_element_type);
+      if (lhs_element_type != promoted) {
+        ErrorEmitter(TaichiCastWarning(), stmt,
+                     fmt::format("Assign may lose precision: {} <- {}",
+                                 lhs_element_type->to_string(),
+                                 rhs_element_type->to_string()));
+      }
     }
   }
 
@@ -110,8 +150,9 @@ class FrontendTypeCheck : public IRVisitor {
       constexpr std::string_view real_group = "fFeEaAgG";
 
       if (unsupported_group.find(conversion) != std::string::npos) {
-        throw TaichiTypeError(fmt::format("{}conversion '{}' is not supported.",
-                                          stmt->get_tb(), conversion));
+        ErrorEmitter(
+            TaichiTypeError(), stmt,
+            fmt::format("conversion '{}' is not supported.", conversion));
       }
 
       if ((real_group.find(conversion) != std::string::npos &&
@@ -120,9 +161,9 @@ class FrontendTypeCheck : public IRVisitor {
            !(is_integral(data_type) && is_signed(data_type))) ||
           (unsigned_group.find(conversion) != std::string::npos &&
            !(is_integral(data_type) && is_unsigned(data_type)))) {
-        throw TaichiTypeError(fmt::format("{} '{}' doesn't match '{}'.",
-                                          stmt->get_tb(), format_spec,
-                                          data_type->to_string()));
+        ErrorEmitter(TaichiTypeError(), stmt,
+                     fmt::format("'{}' doesn't match '{}'.", format_spec,
+                                 data_type->to_string()));
       }
     }
   }


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79478ec</samp>

This pull request introduces a new exception class `TaichiWarning` and its subclasses to handle warnings during compilation, and refactors the error and warning handling in various files using the `ErrorEmitter` class and `fmt::format`. It also adds source location and traceback information to statements and expressions for better error reporting, and improves the type checking logic for the frontend and backend.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 79478ec</samp>

*  Add new classes and functions for error and warning reporting and handling in `exceptions.h` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L3-R20), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L18-R134))
*  Add new structs for source location and debug information tracking in `ir.h` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR390-R407), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR422))
*  Add new field for source location to the `Stmt` class in `ir.h` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR422))
*  Replace `throw` statements with `ErrorEmitter` calls to emit error messages with expression and traceback information in `frontend_ir.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L199-R205), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L207-R215), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L221-R231), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L246-R258), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L285-R296), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L293-R307), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L824-R838), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L840-R855), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L864-R880), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L880-R903), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L896-R917), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L918-R937), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L932-R954), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L952-R972), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L975-R1000), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1212-R1254), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1224-R1268), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1241-R1285), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1343-R1388))
*  Add type checking and warning logic for implicit casting in `frontend_ir.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35R1032-R1043), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1062-R1099), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1104-R1142))
*  Add type checking and error logic for snode and texture operations in `frontend_ir.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1082-R1122), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1121-R1167), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1145-R1184), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1161-R1203), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1177-R1219), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1187-R1229))
*  Move header files from `frontend_ir.cpp` to `exceptions.h` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L12-R16), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L3-R20))
*  Add an example function for using `ErrorEmitter` in `frontend_ir.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L173-R177))
*  Modify `FrontendTypeCheck` class to use `ErrorEmitter` for error and warning messages in `frontend_type_check.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L9-R18), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L45-R76), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L53-R106), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L111-R153), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L121-R164))
*  Modify `TypeCheck` class to use `ErrorEmitter` for error and warning messages in `type_check.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL147-R143), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL159-R152), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL278), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL301-R295))
*  Remove `stmt_name` parameter and `stmt->tb` from error and warning messages in `type_check.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL21-R21), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL33-L38), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL83-R74), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL108-R97), [link](https://github.com/taichi-dev/taichi/pull/8285/files?diff=unified&w=0#diff-dd572dab7be4dbb5edc1043d6d6339b931ef35198b8657761ebf45a83e76ac2bL176-R166))
