### PR TITLE
[Lang] Pass DebugInfo from Python to C++ for ndarray and field

### DIFF
--- a/cpp_examples/aot_save.cpp
+++ b/cpp_examples/aot_save.cpp
@@ -13,7 +13,7 @@ void aot_save(taichi::Arch arch) {
 
   // program.materialize_runtime();
   auto *root = new SNode(0, SNodeType::root);
-  auto *pointer = &root->dense(Axis(0), n, "");
+  auto *pointer = &root->dense(Axis(0), n);
   auto *place = &pointer->insert_children(SNodeType::place);
   place->dt = PrimitiveType::i32;
   program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/true);

--- a/cpp_examples/autograd.cpp
+++ b/cpp_examples/autograd.cpp
@@ -90,11 +90,10 @@ void autograd() {
       }
     };
 
-    auto *snode =
-        &root->dense(Axis(0), n, "").insert_children(SNodeType::place);
+    auto *snode = &root->dense(Axis(0), n).insert_children(SNodeType::place);
     snode->dt = PrimitiveType::f32;
     snode->grad_info = std::make_unique<GradInfoPrimal>(
-        &root->dense(Axis(0), n, "").insert_children(SNodeType::place));
+        &root->dense(Axis(0), n).insert_children(SNodeType::place));
     snode->get_adjoint()->dt = PrimitiveType::f32;
     snode->get_adjoint()->grad_info = std::make_unique<GradInfoAdjoint>();
     return snode;

--- a/cpp_examples/run_snode.cpp
+++ b/cpp_examples/run_snode.cpp
@@ -48,7 +48,7 @@ void run_snode() {
   int n = 10;
   program.materialize_runtime();
   auto *root = new SNode(0, SNodeType::root);
-  auto *pointer = &root->pointer(Axis(0), n, "");
+  auto *pointer = &root->pointer(Axis(0), n);
   auto *place = &pointer->insert_children(SNodeType::place);
   place->dt = PrimitiveType::i32;
   program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/false);

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -3,7 +3,7 @@ from taichi._lib import core as _ti_core
 from taichi.lang import impl
 from taichi.lang.enums import Layout
 from taichi.lang.exception import TaichiIndexError
-from taichi.lang.util import cook_dtype, python_scope, to_numpy_type
+from taichi.lang.util import cook_dtype, get_traceback, python_scope, to_numpy_type
 from taichi.types import primitive_types
 from taichi.types.ndarray_type import NdarrayTypeMetadata
 from taichi.types.utils import is_real, is_signed
@@ -237,7 +237,9 @@ class ScalarNdarray(Ndarray):
     def __init__(self, dtype, arr_shape):
         super().__init__()
         self.dtype = cook_dtype(dtype)
-        self.arr = impl.get_runtime().prog.create_ndarray(self.dtype, arr_shape, layout=Layout.NULL, zero_fill=True)
+        self.arr = impl.get_runtime().prog.create_ndarray(
+            self.dtype, arr_shape, layout=Layout.NULL, zero_fill=True, dbg_info=_ti_core.DebugInfo(get_traceback())
+        )
         self.shape = tuple(self.arr.shape)
         self.element_type = dtype
 

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -15,11 +15,13 @@ class Expr(TaichiOperations):
 
     def __init__(self, *args, tb=None, dtype=None):
         self.tb = tb
+        self.ptr_type_checked = False
         if len(args) == 1:
             if isinstance(args[0], _ti_core.Expr):
                 self.ptr = args[0]
             elif isinstance(args[0], Expr):
                 self.ptr = args[0].ptr
+                self.ptr_type_checked = args[0].ptr_type_checked
                 self.tb = args[0].tb
             elif is_matrix_class(args[0]):
                 self.ptr = make_matrix(args[0].to_list()).ptr
@@ -39,7 +41,9 @@ class Expr(TaichiOperations):
             assert False
         if self.tb:
             self.ptr.set_tb(self.tb)
-        self.ptr.type_check(impl.get_runtime().prog.config())
+        if not self.ptr_type_checked:
+            self.ptr.type_check(impl.get_runtime().prog.config())
+            self.ptr_type_checked = True
 
     def is_tensor(self):
         return self.ptr.is_tensor()

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -20,6 +20,7 @@ from taichi.lang.exception import (
 from taichi.lang.field import Field, ScalarField, SNodeHostAccess
 from taichi.lang.util import (
     cook_dtype,
+    get_traceback,
     in_python_scope,
     python_scope,
     taichi_scope,
@@ -1655,7 +1656,11 @@ class MatrixNdarray(Ndarray):
         self.element_type = _type_factory.get_tensor_type((self.n, self.m), self.dtype)
         # TODO: we should pass in element_type, shape, layout instead.
         self.arr = impl.get_runtime().prog.create_ndarray(
-            cook_dtype(self.element_type), shape, Layout.AOS, zero_fill=True
+            cook_dtype(self.element_type),
+            shape,
+            Layout.AOS,
+            zero_fill=True,
+            dbg_info=ti_python_core.DebugInfo(get_traceback()),
         )
 
     @property
@@ -1765,7 +1770,11 @@ class VectorNdarray(Ndarray):
         self.shape = tuple(shape)
         self.element_type = _type_factory.get_tensor_type((n,), self.dtype)
         self.arr = impl.get_runtime().prog.create_ndarray(
-            cook_dtype(self.element_type), shape, Layout.AOS, zero_fill=True
+            cook_dtype(self.element_type),
+            shape,
+            Layout.AOS,
+            zero_fill=True,
+            dbg_info=ti_python_core.DebugInfo(get_traceback()),
         )
 
     @property

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -35,7 +35,7 @@ class SNode:
         """
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.dense(axes, dimensions, get_traceback()))
+        return SNode(self.ptr.dense(axes, dimensions, _ti_core.DebugInfo(get_traceback())))
 
     def pointer(self, axes, dimensions):
         """Adds a pointer SNode as a child component of `self`.
@@ -51,7 +51,7 @@ class SNode:
             raise TaichiRuntimeError("Pointer SNode is not supported on this backend.")
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.pointer(axes, dimensions, get_traceback()))
+        return SNode(self.ptr.pointer(axes, dimensions, _ti_core.DebugInfo(get_traceback())))
 
     @staticmethod
     def _hash(axes, dimensions):
@@ -78,7 +78,7 @@ class SNode:
         assert len(axis) == 1
         if chunk_size is None:
             chunk_size = dimension
-        return SNode(self.ptr.dynamic(axis[0], dimension, chunk_size, get_traceback()))
+        return SNode(self.ptr.dynamic(axis[0], dimension, chunk_size, _ti_core.DebugInfo(get_traceback())))
 
     def bitmasked(self, axes, dimensions):
         """Adds a bitmasked SNode as a child component of `self`.
@@ -94,7 +94,7 @@ class SNode:
             raise TaichiRuntimeError("Bitmasked SNode is not supported on this backend.")
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.bitmasked(axes, dimensions, get_traceback()))
+        return SNode(self.ptr.bitmasked(axes, dimensions, _ti_core.DebugInfo(get_traceback())))
 
     def quant_array(self, axes, dimensions, max_num_bits):
         """Adds a quant_array SNode as a child component of `self`.
@@ -109,7 +109,7 @@ class SNode:
         """
         if isinstance(dimensions, numbers.Number):
             dimensions = [dimensions] * len(axes)
-        return SNode(self.ptr.quant_array(axes, dimensions, max_num_bits, get_traceback()))
+        return SNode(self.ptr.quant_array(axes, dimensions, max_num_bits, _ti_core.DebugInfo(get_traceback())))
 
     def place(self, *args, offset=None):
         """Places a list of Taichi fields under the `self` container.
@@ -129,7 +129,7 @@ class SNode:
         for arg in args:
             if isinstance(arg, BitpackedFields):
                 bit_struct_type = arg.bit_struct_type_builder.build()
-                bit_struct_snode = self.ptr.bit_struct(bit_struct_type, get_traceback())
+                bit_struct_snode = self.ptr.bit_struct(bit_struct_type, _ti_core.DebugInfo(get_traceback()))
                 for field, id_in_bit_struct in arg.fields:
                     bit_struct_snode.place(field, offset, id_in_bit_struct)
             elif isinstance(arg, Field):

--- a/taichi/ir/snode.cpp
+++ b/taichi/ir/snode.cpp
@@ -37,23 +37,28 @@ SNode &SNode::insert_children(SNodeType t) {
 SNode &SNode::create_node(std::vector<Axis> axes,
                           std::vector<int> sizes,
                           SNodeType type,
-                          const std::string &tb) {
-  TI_ASSERT(axes.size() == sizes.size() || sizes.size() == 1);
+                          const DebugInfo &dbg_info) {
   if (sizes.size() == 1) {
     sizes = std::vector<int>(axes.size(), sizes[0]);
   }
+  ErrorEmitter(
+      axes.size() == sizes.size(), TaichiRuntimeError(), &dbg_info,
+      fmt::format("axes and sizes must have the same size, but got {} and {}.",
+                  axes.size(), sizes.size()));
 
-  if (type == SNodeType::hash)
-    TI_ASSERT_INFO(depth == 0,
-                   "hashed node must be child of root due to initialization "
-                   "memset limitation.");
+  if (type == SNodeType::hash) {
+    ErrorEmitter(depth == 0, TaichiRuntimeError(), &dbg_info,
+                 "hashed node must be child of root due to initialization "
+                 "memset limitation.");
+  }
 
   auto &new_node = insert_children(type);
   for (int i = 0; i < (int)axes.size(); i++) {
-    if (sizes[i] <= 0) {
-      throw TaichiRuntimeError(
-          "Every dimension of a Taichi field should be positive");
-    }
+    ErrorEmitter(sizes[i] > 0, TaichiRuntimeError(), &dbg_info,
+                 fmt::format("Every dimension of a Taichi field should be "
+                             "positive, got {} in demension {}.",
+                             sizes[i], i));
+
     int ind = axes[i].value;
     auto end = new_node.physical_index_position + new_node.num_active_indices;
     bool is_first_division =
@@ -61,11 +66,13 @@ SNode &SNode::create_node(std::vector<Axis> axes,
     if (is_first_division) {
       new_node.physical_index_position[new_node.num_active_indices++] = ind;
     } else {
-      TI_WARN_IF(
-          !bit::is_power_of_two(sizes[i]),
-          "Shape {} is detected on non-first division of axis {}:\n{} For "
-          "best performance, we recommend that you set it to a power of two.",
-          sizes[i], char('i' + ind), tb);
+      ErrorEmitter(
+          bit::is_power_of_two(sizes[i]), TaichiRuntimeWarning(), &dbg_info,
+          fmt::format(
+              "Shape {} is detected on non-first division of axis {}. For "
+              "best performance, we recommend that you set it to a power of "
+              "two.",
+              sizes[i], char('i' + ind)));
     }
     new_node.extractors[ind].active = true;
     new_node.extractors[ind].num_elements_from_root *= sizes[i];
@@ -80,11 +87,11 @@ SNode &SNode::create_node(std::vector<Axis> axes,
     new_node.extractors[i].acc_shape = static_cast<int>(acc_shape);
     acc_shape *= new_node.extractors[i].shape;
   }
-  if (acc_shape > std::numeric_limits<int>::max()) {
-    TI_WARN(
-        "SNode index might be out of int32 boundary but int64 indexing is not "
-        "supported yet. Struct fors might not work either.");
-  }
+  ErrorEmitter(
+      acc_shape <= std::numeric_limits<int>::max(), TaichiIndexWarning(),
+      &dbg_info,
+      "SNode index might be out of int32 boundary but int64 indexing is not "
+      "supported yet. Struct fors might not work either.");
   new_node.num_cells_per_container = acc_shape;
 
   if (new_node.type == SNodeType::dynamic) {
@@ -94,15 +101,15 @@ SNode &SNode::create_node(std::vector<Axis> axes,
         active_extractor_counder += 1;
         SNode *p = new_node.parent;
         while (p) {
-          TI_ASSERT_INFO(
-              !p->extractors[i].active,
-              "Dynamic SNode must have a standalone dimensionality.");
+          ErrorEmitter(!p->extractors[i].active, TaichiRuntimeError(),
+                       &dbg_info,
+                       "Dynamic SNode must have a standalone dimensionality.");
           p = p->parent;
         }
       }
     }
-    TI_ASSERT_INFO(active_extractor_counder == 1,
-                   "Dynamic SNode can have only one index extractor.");
+    ErrorEmitter(active_extractor_counder == 1, TaichiRuntimeError(), &dbg_info,
+                 "Dynamic SNode can have only one index extractor.");
   }
   return new_node;
 }
@@ -110,15 +117,15 @@ SNode &SNode::create_node(std::vector<Axis> axes,
 SNode &SNode::dynamic(const Axis &expr,
                       int n,
                       int chunk_size,
-                      const std::string &tb) {
-  auto &snode = create_node({expr}, {n}, SNodeType::dynamic, tb);
+                      const DebugInfo &dbg_info) {
+  auto &snode = create_node({expr}, {n}, SNodeType::dynamic, dbg_info);
   snode.chunk_size = chunk_size;
   return snode;
 }
 
 SNode &SNode::bit_struct(BitStructType *bit_struct_type,
-                         const std::string &tb) {
-  auto &snode = create_node({}, {}, SNodeType::bit_struct, tb);
+                         const DebugInfo &dbg_info) {
+  auto &snode = create_node({}, {}, SNodeType::bit_struct, dbg_info);
   snode.dt = bit_struct_type;
   snode.physical_type = bit_struct_type->get_physical_type();
   return snode;
@@ -127,8 +134,8 @@ SNode &SNode::bit_struct(BitStructType *bit_struct_type,
 SNode &SNode::quant_array(const std::vector<Axis> &axes,
                           const std::vector<int> &sizes,
                           int bits,
-                          const std::string &tb) {
-  auto &snode = create_node(axes, sizes, SNodeType::quant_array, tb);
+                          const DebugInfo &dbg_info) {
+  auto &snode = create_node(axes, sizes, SNodeType::quant_array, dbg_info);
   snode.physical_type =
       TypeFactory::get_instance().get_primitive_int_type(bits, false);
   return snode;

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -11,7 +11,6 @@
 namespace taichi::lang {
 class Program;
 class SNodeRwAccessorsBank;
-struct DebugInfo;
 
 /**
  * Dimension (or axis) of a tensor.

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -138,74 +138,82 @@ class SNode {
   SNode &create_node(std::vector<Axis> axes,
                      std::vector<int> sizes,
                      SNodeType type,
-                     const DebugInfo &dbg_info);
+                     const DebugInfo &dbg_info = DebugInfo());
 
   // SNodes maintains how flattened index bits are taken from indices
   SNode &dense(const std::vector<Axis> &axes,
                const std::vector<int> &sizes,
-               const DebugInfo &dbg_info) {
+               const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, sizes, SNodeType::dense, dbg_info);
   }
 
   SNode &dense(const std::vector<Axis> &axes,
                int sizes,
-               const DebugInfo &dbg_info) {
+               const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, std::vector<int>{sizes}, SNodeType::dense,
                        dbg_info);
   }
 
-  SNode &dense(const Axis &axis, int size, const DebugInfo &dbg_info) {
+  SNode &dense(const Axis &axis,
+               int size,
+               const DebugInfo &dbg_info = DebugInfo()) {
     return SNode::dense(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &pointer(const std::vector<Axis> &axes,
                  const std::vector<int> &sizes,
-                 const DebugInfo &dbg_info) {
+                 const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, sizes, SNodeType::pointer, dbg_info);
   }
 
   SNode &pointer(const std::vector<Axis> &axes,
                  int sizes,
-                 const DebugInfo &dbg_info) {
+                 const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, std::vector<int>{sizes}, SNodeType::pointer,
                        dbg_info);
   }
 
-  SNode &pointer(const Axis &axis, int size, const DebugInfo &dbg_info) {
+  SNode &pointer(const Axis &axis,
+                 int size,
+                 const DebugInfo &dbg_info = DebugInfo()) {
     return SNode::pointer(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &bitmasked(const std::vector<Axis> &axes,
                    const std::vector<int> &sizes,
-                   const DebugInfo &dbg_info) {
+                   const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, sizes, SNodeType::bitmasked, dbg_info);
   }
 
   SNode &bitmasked(const std::vector<Axis> &axes,
                    int sizes,
-                   const DebugInfo &dbg_info) {
+                   const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, std::vector<int>{sizes}, SNodeType::bitmasked,
                        dbg_info);
   }
 
-  SNode &bitmasked(const Axis &axis, int size, const DebugInfo &dbg_info) {
+  SNode &bitmasked(const Axis &axis,
+                   int size,
+                   const DebugInfo &dbg_info = DebugInfo()) {
     return SNode::bitmasked(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &hash(const std::vector<Axis> &axes,
               const std::vector<int> &sizes,
-              const DebugInfo &dbg_info) {
+              const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, sizes, SNodeType::hash, dbg_info);
   }
 
   SNode &hash(const std::vector<Axis> &axes,
               int sizes,
-              const DebugInfo &dbg_info) {
+              const DebugInfo &dbg_info = DebugInfo()) {
     return create_node(axes, std::vector<int>{sizes}, SNodeType::hash,
                        dbg_info);
   }
 
-  SNode &hash(const Axis &axis, int size, const DebugInfo &dbg_info) {
+  SNode &hash(const Axis &axis,
+              int size,
+              const DebugInfo &dbg_info = DebugInfo()) {
     return hash(std::vector<Axis>{axis}, size, dbg_info);
   }
 
@@ -213,12 +221,13 @@ class SNode {
     return snode_type_name(type);
   }
 
-  SNode &bit_struct(BitStructType *bit_struct_type, const DebugInfo &dbg_info);
+  SNode &bit_struct(BitStructType *bit_struct_type,
+                    const DebugInfo &dbg_info = DebugInfo());
 
   SNode &quant_array(const std::vector<Axis> &axes,
                      const std::vector<int> &sizes,
                      int bits,
-                     const DebugInfo &dbg_info);
+                     const DebugInfo &dbg_info = DebugInfo());
 
   void print();
 
@@ -227,7 +236,7 @@ class SNode {
   SNode &dynamic(const Axis &expr,
                  int n,
                  int chunk_size,
-                 const DebugInfo &dbg_info);
+                 const DebugInfo &dbg_info = DebugInfo());
 
   SNode &morton(bool val = true) {
     _morton = val;

--- a/taichi/ir/snode.h
+++ b/taichi/ir/snode.h
@@ -11,6 +11,7 @@
 namespace taichi::lang {
 class Program;
 class SNodeRwAccessorsBank;
+struct DebugInfo;
 
 /**
  * Dimension (or axis) of a tensor.
@@ -138,81 +139,87 @@ class SNode {
   SNode &create_node(std::vector<Axis> axes,
                      std::vector<int> sizes,
                      SNodeType type,
-                     const std::string &tb);
+                     const DebugInfo &dbg_info);
 
   // SNodes maintains how flattened index bits are taken from indices
   SNode &dense(const std::vector<Axis> &axes,
                const std::vector<int> &sizes,
-               const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::dense, tb);
+               const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::dense, dbg_info);
   }
 
   SNode &dense(const std::vector<Axis> &axes,
                int sizes,
-               const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::dense, tb);
+               const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::dense,
+                       dbg_info);
   }
 
-  SNode &dense(const Axis &axis, int size, const std::string &tb) {
-    return SNode::dense(std::vector<Axis>{axis}, size, tb);
+  SNode &dense(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return SNode::dense(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &pointer(const std::vector<Axis> &axes,
                  const std::vector<int> &sizes,
-                 const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::pointer, tb);
+                 const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::pointer, dbg_info);
   }
 
   SNode &pointer(const std::vector<Axis> &axes,
                  int sizes,
-                 const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::pointer, tb);
+                 const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::pointer,
+                       dbg_info);
   }
 
-  SNode &pointer(const Axis &axis, int size, const std::string &tb) {
-    return SNode::pointer(std::vector<Axis>{axis}, size, tb);
+  SNode &pointer(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return SNode::pointer(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &bitmasked(const std::vector<Axis> &axes,
                    const std::vector<int> &sizes,
-                   const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::bitmasked, tb);
+                   const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::bitmasked, dbg_info);
   }
 
   SNode &bitmasked(const std::vector<Axis> &axes,
                    int sizes,
-                   const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::bitmasked, tb);
+                   const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::bitmasked,
+                       dbg_info);
   }
 
-  SNode &bitmasked(const Axis &axis, int size, const std::string &tb) {
-    return SNode::bitmasked(std::vector<Axis>{axis}, size, tb);
+  SNode &bitmasked(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return SNode::bitmasked(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   SNode &hash(const std::vector<Axis> &axes,
               const std::vector<int> &sizes,
-              const std::string &tb) {
-    return create_node(axes, sizes, SNodeType::hash, tb);
+              const DebugInfo &dbg_info) {
+    return create_node(axes, sizes, SNodeType::hash, dbg_info);
   }
 
-  SNode &hash(const std::vector<Axis> &axes, int sizes, const std::string &tb) {
-    return create_node(axes, std::vector<int>{sizes}, SNodeType::hash, tb);
+  SNode &hash(const std::vector<Axis> &axes,
+              int sizes,
+              const DebugInfo &dbg_info) {
+    return create_node(axes, std::vector<int>{sizes}, SNodeType::hash,
+                       dbg_info);
   }
 
-  SNode &hash(const Axis &axis, int size, const std::string &tb) {
-    return hash(std::vector<Axis>{axis}, size, tb);
+  SNode &hash(const Axis &axis, int size, const DebugInfo &dbg_info) {
+    return hash(std::vector<Axis>{axis}, size, dbg_info);
   }
 
   std::string type_name() {
     return snode_type_name(type);
   }
 
-  SNode &bit_struct(BitStructType *bit_struct_type, const std::string &tb);
+  SNode &bit_struct(BitStructType *bit_struct_type, const DebugInfo &dbg_info);
 
   SNode &quant_array(const std::vector<Axis> &axes,
                      const std::vector<int> &sizes,
                      int bits,
-                     const std::string &tb);
+                     const DebugInfo &dbg_info);
 
   void print();
 
@@ -221,7 +228,7 @@ class SNode {
   SNode &dynamic(const Axis &expr,
                  int n,
                  int chunk_size,
-                 const std::string &tb);
+                 const DebugInfo &dbg_info);
 
   SNode &morton(bool val = true) {
     _morton = val;

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -27,7 +27,7 @@ Ndarray::Ndarray(Program *prog,
                  const DataType type,
                  const std::vector<int> &shape_,
                  ExternalArrayLayout layout_,
-                 DebugInfo dbg_info_)
+                 const DebugInfo& dbg_info_)
     : dtype(type),
       shape(shape_),
       layout(layout_),
@@ -66,7 +66,7 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
                  ExternalArrayLayout layout,
-                 DebugInfo dbg_info)
+                 const DebugInfo& dbg_info)
     : ndarray_alloc_(devalloc),
       dtype(type),
       shape(shape),
@@ -108,7 +108,7 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const std::vector<int> &shape,
                  const std::vector<int> &element_shape,
                  ExternalArrayLayout layout,
-                 DebugInfo dbg_info)
+                 const DebugInfo& dbg_info)
     : Ndarray(devalloc,
               TypeFactory::create_tensor_type(element_shape, type),
               shape,

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -27,7 +27,7 @@ Ndarray::Ndarray(Program *prog,
                  const DataType type,
                  const std::vector<int> &shape_,
                  ExternalArrayLayout layout_,
-                 const DebugInfo& dbg_info_)
+                 const DebugInfo &dbg_info_)
     : dtype(type),
       shape(shape_),
       layout(layout_),
@@ -66,7 +66,7 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
                  ExternalArrayLayout layout,
-                 const DebugInfo& dbg_info)
+                 const DebugInfo &dbg_info)
     : ndarray_alloc_(devalloc),
       dtype(type),
       shape(shape),
@@ -108,7 +108,7 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const std::vector<int> &shape,
                  const std::vector<int> &element_shape,
                  ExternalArrayLayout layout,
-                 const DebugInfo& dbg_info)
+                 const DebugInfo &dbg_info)
     : Ndarray(devalloc,
               TypeFactory::create_tensor_type(element_shape, type),
               shape,

--- a/taichi/program/ndarray.cpp
+++ b/taichi/program/ndarray.cpp
@@ -26,10 +26,12 @@ size_t flatten_index(const std::vector<int> &shapes,
 Ndarray::Ndarray(Program *prog,
                  const DataType type,
                  const std::vector<int> &shape_,
-                 ExternalArrayLayout layout_)
+                 ExternalArrayLayout layout_,
+                 DebugInfo dbg_info_)
     : dtype(type),
       shape(shape_),
       layout(layout_),
+      dbg_info(dbg_info_),
       nelement_(std::accumulate(std::begin(shape_),
                                 std::end(shape_),
                                 1,
@@ -51,7 +53,8 @@ Ndarray::Ndarray(Program *prog,
       std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL,
                       std::multiplies<>());
   if (total_num_scalar > std::numeric_limits<int>::max()) {
-    TI_WARN(
+    ErrorEmitter(
+        TaichiIndexWarning(), &dbg_info,
         "Ndarray index might be out of int32 boundary but int64 indexing is "
         "not supported yet.");
   }
@@ -62,11 +65,13 @@ Ndarray::Ndarray(Program *prog,
 Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
-                 ExternalArrayLayout layout)
+                 ExternalArrayLayout layout,
+                 DebugInfo dbg_info)
     : ndarray_alloc_(devalloc),
       dtype(type),
       shape(shape),
       layout(layout),
+      dbg_info(dbg_info),
       nelement_(std::accumulate(std::begin(shape),
                                 std::end(shape),
                                 1,
@@ -91,7 +96,8 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
       std::accumulate(std::begin(total_shape_), std::end(total_shape_), 1LL,
                       std::multiplies<>());
   if (total_num_scalar > std::numeric_limits<int>::max()) {
-    TI_WARN(
+    ErrorEmitter(
+        TaichiIndexWarning(), &dbg_info,
         "Ndarray index might be out of int32 boundary but int64 indexing is "
         "not supported yet.");
   }
@@ -101,11 +107,13 @@ Ndarray::Ndarray(DeviceAllocation &devalloc,
                  const DataType type,
                  const std::vector<int> &shape,
                  const std::vector<int> &element_shape,
-                 ExternalArrayLayout layout)
+                 ExternalArrayLayout layout,
+                 DebugInfo dbg_info)
     : Ndarray(devalloc,
               TypeFactory::create_tensor_type(element_shape, type),
               shape,
-              layout) {
+              layout,
+              dbg_info) {
   TI_ASSERT(type->is<PrimitiveType>());
 }
 

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -23,7 +23,7 @@ class TI_DLL_EXPORT Ndarray {
                    const DataType type,
                    const std::vector<int> &shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-                   const DebugInfo& dbg_info = DebugInfo());
+                   const DebugInfo &dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * It doesn't handle the allocation and deallocation.
@@ -34,7 +34,7 @@ class TI_DLL_EXPORT Ndarray {
                    const DataType type,
                    const std::vector<int> &shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-                   const DebugInfo& dbg_info = DebugInfo());
+                   const DebugInfo &dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * This is an overloaded constructor for constructing Ndarray with TensorType
@@ -45,7 +45,7 @@ class TI_DLL_EXPORT Ndarray {
                    const std::vector<int> &shape,
                    const std::vector<int> &element_shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-                   const DebugInfo& dbg_info = DebugInfo());
+                   const DebugInfo &dbg_info = DebugInfo());
 
   DeviceAllocation ndarray_alloc_{kDeviceNullAllocation};
   DataType dtype;

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -23,7 +23,7 @@ class TI_DLL_EXPORT Ndarray {
                    const DataType type,
                    const std::vector<int> &shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-                   DebugInfo dbg_info = DebugInfo());
+                   const DebugInfo& dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * It doesn't handle the allocation and deallocation.
@@ -34,7 +34,7 @@ class TI_DLL_EXPORT Ndarray {
                    const DataType type,
                    const std::vector<int> &shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-                   DebugInfo dbg_info = DebugInfo());
+                   const DebugInfo& dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * This is an overloaded constructor for constructing Ndarray with TensorType
@@ -45,7 +45,7 @@ class TI_DLL_EXPORT Ndarray {
                    const std::vector<int> &shape,
                    const std::vector<int> &element_shape,
                    ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-                   DebugInfo dbg_info = DebugInfo());
+                   const DebugInfo& dbg_info = DebugInfo());
 
   DeviceAllocation ndarray_alloc_{kDeviceNullAllocation};
   DataType dtype;

--- a/taichi/program/ndarray.h
+++ b/taichi/program/ndarray.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "taichi/inc/constants.h"
+#include "taichi/ir/ir.h"
 #include "taichi/ir/type_utils.h"
 #include "taichi/rhi/device.h"
 
@@ -21,7 +22,8 @@ class TI_DLL_EXPORT Ndarray {
   explicit Ndarray(Program *prog,
                    const DataType type,
                    const std::vector<int> &shape,
-                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull,
+                   DebugInfo dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * It doesn't handle the allocation and deallocation.
@@ -31,7 +33,8 @@ class TI_DLL_EXPORT Ndarray {
   explicit Ndarray(DeviceAllocation &devalloc,
                    const DataType type,
                    const std::vector<int> &shape,
-                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull,
+                   DebugInfo dbg_info = DebugInfo());
 
   /* Constructs a Ndarray from an existing DeviceAllocation.
    * This is an overloaded constructor for constructing Ndarray with TensorType
@@ -41,7 +44,8 @@ class TI_DLL_EXPORT Ndarray {
                    const DataType type,
                    const std::vector<int> &shape,
                    const std::vector<int> &element_shape,
-                   ExternalArrayLayout layout = ExternalArrayLayout::kNull);
+                   ExternalArrayLayout layout = ExternalArrayLayout::kNull,
+                   DebugInfo dbg_info = DebugInfo());
 
   DeviceAllocation ndarray_alloc_{kDeviceNullAllocation};
   DataType dtype;
@@ -50,6 +54,7 @@ class TI_DLL_EXPORT Ndarray {
   //   num_active_indices = shape.size()
   std::vector<int> shape;
   ExternalArrayLayout layout{ExternalArrayLayout::kNull};
+  DebugInfo dbg_info;
 
   std::vector<int> get_element_shape() const;
   DataType get_element_data_type() const;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -375,8 +375,9 @@ std::size_t Program::get_snode_num_dynamically_allocated(SNode *snode) {
 Ndarray *Program::create_ndarray(const DataType type,
                                  const std::vector<int> &shape,
                                  ExternalArrayLayout layout,
-                                 bool zero_fill) {
-  auto arr = std::make_unique<Ndarray>(this, type, shape, layout);
+                                 bool zero_fill,
+                                 DebugInfo dbg_info) {
+  auto arr = std::make_unique<Ndarray>(this, type, shape, layout, dbg_info);
   if (zero_fill) {
     Arch arch = compile_config().arch;
     if (arch_is_cpu(arch) || arch == Arch::cuda || arch == Arch::amdgpu) {

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -376,7 +376,7 @@ Ndarray *Program::create_ndarray(const DataType type,
                                  const std::vector<int> &shape,
                                  ExternalArrayLayout layout,
                                  bool zero_fill,
-                                 DebugInfo dbg_info) {
+                                 const DebugInfo& dbg_info) {
   auto arr = std::make_unique<Ndarray>(this, type, shape, layout, dbg_info);
   if (zero_fill) {
     Arch arch = compile_config().arch;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -376,7 +376,7 @@ Ndarray *Program::create_ndarray(const DataType type,
                                  const std::vector<int> &shape,
                                  ExternalArrayLayout layout,
                                  bool zero_fill,
-                                 const DebugInfo& dbg_info) {
+                                 const DebugInfo &dbg_info) {
   auto arr = std::make_unique<Ndarray>(this, type, shape, layout, dbg_info);
   if (zero_fill) {
     Arch arch = compile_config().arch;

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -255,7 +255,7 @@ class TI_DLL_EXPORT Program {
       const std::vector<int> &shape,
       ExternalArrayLayout layout = ExternalArrayLayout::kNull,
       bool zero_fill = false,
-      DebugInfo dbg_info = DebugInfo());
+      const DebugInfo& dbg_info = DebugInfo());
 
   ArgPack *create_argpack(const DataType dt);
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -254,7 +254,8 @@ class TI_DLL_EXPORT Program {
       const DataType type,
       const std::vector<int> &shape,
       ExternalArrayLayout layout = ExternalArrayLayout::kNull,
-      bool zero_fill = false);
+      bool zero_fill = false,
+      DebugInfo dbg_info = DebugInfo());
 
   ArgPack *create_argpack(const DataType dt);
 

--- a/taichi/program/program.h
+++ b/taichi/program/program.h
@@ -255,7 +255,7 @@ class TI_DLL_EXPORT Program {
       const std::vector<int> &shape,
       ExternalArrayLayout layout = ExternalArrayLayout::kNull,
       bool zero_fill = false,
-      const DebugInfo& dbg_info = DebugInfo());
+      const DebugInfo &dbg_info = DebugInfo());
 
   ArgPack *create_argpack(const DataType dt);
 

--- a/taichi/program/snode_expr_utils.cpp
+++ b/taichi/program/snode_expr_utils.cpp
@@ -56,7 +56,7 @@ void place_child(Expr *expr_arg,
                  SNodeFieldMap *snode_to_exprs) {
   if (parent->type == SNodeType::root) {
     // never directly place to root
-    auto &ds = parent->dense(std::vector<Axis>(), {}, "");
+    auto &ds = parent->dense(std::vector<Axis>(), {});
     place_child(expr_arg, offset, id_in_bit_struct, &ds, snode_to_exprs);
   } else {
     TI_ASSERT(expr_arg->is<FieldExpression>());

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -443,7 +443,7 @@ void export_lang(py::module &m) {
           },
           py::arg("dt"), py::arg("shape"),
           py::arg("layout") = ExternalArrayLayout::kNull,
-          py::arg("zero_fill") = false, py::arg("dbg_info") = false,
+          py::arg("zero_fill") = false, py::arg("dbg_info") = DebugInfo(),
           py::return_value_policy::reference)
       .def("delete_ndarray", &Program::delete_ndarray)
       .def(

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -147,6 +147,13 @@ void export_lang(py::module &m) {
             return dt;
           }));
 
+  py::class_<DebugInfo>(m, "DebugInfo")
+      .def(py::init<>())
+      .def(py::init<std::string>())
+      .def(py::init<>())
+      .def_readwrite("tb", &DebugInfo::tb)
+      .def_readwrite("src_loc", &DebugInfo::src_loc);
+
   py::class_<CompileConfig>(m, "CompileConfig")
       .def(py::init<>())
       .def_readwrite("arch", &CompileConfig::arch)
@@ -430,12 +437,14 @@ void export_lang(py::module &m) {
           "create_ndarray",
           [&](Program *program, const DataType &dt,
               const std::vector<int> &shape, ExternalArrayLayout layout,
-              bool zero_fill) -> Ndarray * {
-            return program->create_ndarray(dt, shape, layout, zero_fill);
+              bool zero_fill, DebugInfo dbg_info) -> Ndarray * {
+            return program->create_ndarray(dt, shape, layout, zero_fill,
+                                           dbg_info);
           },
           py::arg("dt"), py::arg("shape"),
           py::arg("layout") = ExternalArrayLayout::kNull,
-          py::arg("zero_fill") = false, py::return_value_policy::reference)
+          py::arg("zero_fill") = false, py::arg("dbg_info") = false,
+          py::return_value_policy::reference)
       .def("delete_ndarray", &Program::delete_ndarray)
       .def(
           "create_argpack",
@@ -492,23 +501,23 @@ void export_lang(py::module &m) {
       .def("dense",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::dense),
+                               const DebugInfo &))(&SNode::dense),
            py::return_value_policy::reference)
       .def("pointer",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::pointer),
+                               const DebugInfo &))(&SNode::pointer),
            py::return_value_policy::reference)
       .def("hash",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::hash),
+                               const DebugInfo &))(&SNode::hash),
            py::return_value_policy::reference)
       .def("dynamic", &SNode::dynamic, py::return_value_policy::reference)
       .def("bitmasked",
            (SNode & (SNode::*)(const std::vector<Axis> &,
                                const std::vector<int> &,
-                               const std::string &))(&SNode::bitmasked),
+                               const DebugInfo &))(&SNode::bitmasked),
            py::return_value_policy::reference)
       .def("bit_struct", &SNode::bit_struct, py::return_value_policy::reference)
       .def("quant_array", &SNode::quant_array,

--- a/tests/cpp/analysis/bls_analyzer_test.cpp
+++ b/tests/cpp/analysis/bls_analyzer_test.cpp
@@ -20,7 +20,7 @@ class BLSAnalyzerTest : public ::testing::Test {
   void SetUp() override {
     const std::vector<Axis> axes = {Axis{0}, Axis{1}};
     root_snode_ = std::make_unique<SNode>(/*depth=*/0, /*t=*/SNodeType::root);
-    parent_snode_ = &(root_snode_->dense(axes, /*sizes=*/kBlockSize, ""));
+    parent_snode_ = &(root_snode_->dense(axes, /*sizes=*/kBlockSize));
     child_snode_ = &(parent_snode_->insert_children(SNodeType::place));
     child_snode_->dt = PrimitiveType::i32;
 

--- a/tests/cpp/aot/dx12/aot_save_load_test.cpp
+++ b/tests/cpp/aot/dx12/aot_save_load_test.cpp
@@ -22,7 +22,7 @@ namespace fs = std::filesystem;
   int n = 10;
 
   auto *root = new SNode(0, SNodeType::root);
-  auto *pointer = &root->dense(Axis(0), n, "");
+  auto *pointer = &root->dense(Axis(0), n);
   auto *place = &pointer->insert_children(SNodeType::place);
   place->dt = PrimitiveType::i32;
   program.add_snode_tree(std::unique_ptr<SNode>(root), /*compile_only=*/true);

--- a/tests/cpp/codegen/refine_coordinates_test.cpp
+++ b/tests/cpp/codegen/refine_coordinates_test.cpp
@@ -120,8 +120,8 @@ class RefineCoordinatesTest : public ::testing::Test {
 
     root_snode_ = std::make_unique<SNode>(/*depth=*/0, /*t=*/SNodeType::root);
     const std::vector<Axis> axes = {Axis{0}};
-    ptr_snode_ = &(root_snode_->pointer(axes, kPointerSize, ""));
-    dense_snode_ = &(ptr_snode_->dense(axes, kDenseSize, ""));
+    ptr_snode_ = &(root_snode_->pointer(axes, kPointerSize));
+    dense_snode_ = &(ptr_snode_->dense(axes, kDenseSize));
     // Must end with a `place` SNode.
     auto &leaf_snode = dense_snode_->insert_children(SNodeType::place);
     leaf_snode.dt = PrimitiveType::f32;

--- a/tests/cpp/struct/snode_tree_test.cpp
+++ b/tests/cpp/struct/snode_tree_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "taichi/struct/snode_tree.h"
+#include "taichi/ir/ir.h"
 
 namespace taichi::lang {
 

--- a/tests/cpp/struct/snode_tree_test.cpp
+++ b/tests/cpp/struct/snode_tree_test.cpp
@@ -1,7 +1,6 @@
 #include "gtest/gtest.h"
 
 #include "taichi/struct/snode_tree.h"
-#include "taichi/ir/ir.h"
 
 namespace taichi::lang {
 
@@ -11,8 +10,8 @@ TEST(SNodeTree, GetSNodeToRootMapping) {
   const std::vector<Axis> axes = {Axis{0}};
   std::vector<int> all_snode_ids;
   for (int i = 0; i < 3; ++i) {
-    auto &ptr_snode = root.pointer(axes, kSNodeSize, "");
-    auto &dense_snode = ptr_snode.dense(axes, kSNodeSize, "");
+    auto &ptr_snode = root.pointer(axes, kSNodeSize);
+    auto &dense_snode = ptr_snode.dense(axes, kSNodeSize);
     auto &leaf_snode = dense_snode.insert_children(SNodeType::place);
     all_snode_ids.push_back(ptr_snode.id);
     all_snode_ids.push_back(dense_snode.id);

--- a/tests/cpp/transforms/make_block_local_test.cpp
+++ b/tests/cpp/transforms/make_block_local_test.cpp
@@ -41,14 +41,14 @@ class MakeBlockLocalTest : public ::testing::Test {
     // want to see if the tests can handle the loop index scaling multiplier
     // (block_size) and infer the BLS size correctly.
     const std::vector<Axis> axes = {Axis{0}, Axis{1}};
-    pointer_snode_ = &(root_snode_->pointer(axes, pointer_size, ""));
+    pointer_snode_ = &(root_snode_->pointer(axes, pointer_size));
 
-    bls_snode_ = &(pointer_snode_->dense(axes, /*sizes=*/block_size, ""));
+    bls_snode_ = &(pointer_snode_->dense(axes, /*sizes=*/block_size));
     bls_place_snode_ = &(bls_snode_->insert_children(SNodeType::place));
     bls_place_snode_->dt = PrimitiveType::f32;
 
     struct_for_snode_ = &(pointer_snode_->dynamic({Axis{2}}, /*n=*/1024,
-                                                  /*chunk_size=*/128, ""));
+                                                  /*chunk_size=*/128));
     struct_for_place_snode_ =
         &(struct_for_snode_->insert_children(SNodeType::place));
     struct_for_place_snode_->dt = PrimitiveType::i32;

--- a/tests/cpp/transforms/scalar_pointer_lowerer_test.cpp
+++ b/tests/cpp/transforms/scalar_pointer_lowerer_test.cpp
@@ -35,8 +35,8 @@ class ScalarPointerLowererTest : public ::testing::Test {
   void SetUp() override {
     root_snode_ = std::make_unique<SNode>(/*depth=*/0, /*t=*/SNodeType::root);
     const std::vector<Axis> axes = {Axis{0}};
-    ptr_snode_ = &(root_snode_->pointer(axes, kPointerSize, ""));
-    dense_snode_ = &(ptr_snode_->dense(axes, kDenseSize, ""));
+    ptr_snode_ = &(root_snode_->pointer(axes, kPointerSize));
+    dense_snode_ = &(ptr_snode_->dense(axes, kDenseSize));
     // Must end with a `place` SNode.
     leaf_snode_ = &(dense_snode_->insert_children(SNodeType::place));
     leaf_snode_->dt = PrimitiveType::f32;
@@ -106,9 +106,9 @@ TEST(ScalarPointerLowerer, EliminateModDiv) {
   VecStatement lowered;
   Stmt *index = builder.get_int32(2);
   auto root = std::make_unique<SNode>(/*depth=*/0, SNodeType::root);
-  SNode *dense_1 = &(root->dense({Axis{2}, Axis{1}}, /*size=*/7, ""));
-  SNode *dense_2 = &(root->dense({Axis{1}}, /*size=*/3, ""));
-  SNode *dense_3 = &(dense_2->dense({Axis{0}, Axis{1}}, /*size=*/{5, 8}, ""));
+  SNode *dense_1 = &(root->dense({Axis{2}, Axis{1}}, /*sizes=*/7));
+  SNode *dense_2 = &(root->dense({Axis{1}}, /*size=*/3));
+  SNode *dense_3 = &(dense_2->dense({Axis{0}, Axis{1}}, /*sizes=*/{5, 8}));
   SNode *leaf_1 = &(dense_1->insert_children(SNodeType::place));
   SNode *leaf_2 = &(dense_3->insert_children(SNodeType::place));
   LowererImpl lowerer_1{leaf_1,


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00d994a</samp>

This pull request improves the error reporting and type-checking functionality for `Ndarray` and `SNode` objects in Taichi. It introduces new classes and structs such as `DebugInfo`, `TaichiError`, and `ErrorEmitter` to pass and handle the debug information and exceptions. It also refactors and simplifies the existing code in various files to use these new classes and structs, and to provide more consistent and informative messages to the user.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00d994a</samp>

*  Add new exception and warning classes for different types of errors and warnings (`[link](https://github.com/taichi-dev/taichi/pull/8286/files?diff=unified&w=0#diff-ccaf2900f7c75403d5aecff661ea03785341c847f0f7b1a5c75c6b93e5ede5d9L18-R134)`)
