### PR TITLE
[bug] Fix build.py Powershell part.

### DIFF
--- a/.github/workflows/scripts/ti_build/alter.py
+++ b/.github/workflows/scripts/ti_build/alter.py
@@ -117,7 +117,7 @@ def enter_shell():
         if shell.name in ("pwsh.exe", "powershell.exe"):
             pwsh = Command(shell.exe)
             path = _write_ti_pwshrc()
-            pwsh("-Interactive", "-NoExit", "-File", str(path))
+            pwsh("-ExecutionPolicy", "Bypass", "-NoExit", "-File", str(path))
         elif shell.name == "cmd.exe":
             cmd = Command(shell.exe)
             cmd("/k", "set", "PROMPT=TaichiBuild $P$G")


### PR DESCRIPTION
Issue: #

### Brief Summary

"-Interactive" seems not to be a valid argument for the current Powershell. On my Windows 11 machine, invoke `python build.py --shell` gives the following error:

![image](https://github.com/taichi-dev/taichi/assets/2747993/fd58e452-30fd-4d0f-a1fd-145c1fa3f548)

This PR removes the "-Interactive" flag, and add a "ExecutionPolicy" flag which is required for running the remaining part of the `build.py` script.