### PR TITLE
[bug] Fix mmwrite format.

### DIFF
--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -271,7 +271,7 @@ const std::string EigenSparseMatrix<EigenMatrix>::to_string() const {
 template <class EigenMatrix>
 void EigenSparseMatrix<EigenMatrix>::mmwrite(const std::string &filename) {
   std::ofstream file(filename);
-  file << "%%MatrixMarket matrix coordinate real general\n %" << std::endl;
+  file << "%%MatrixMarket matrix coordinate real general\n%" << std::endl;
   file << matrix_.rows() << " " << matrix_.cols() << " " << matrix_.nonZeros()
        << std::endl;
   for (int k = 0; k < matrix_.outerSize(); ++k) {


### PR DESCRIPTION
Issue: #

### Brief Summary

There is an extra white space in the current `mmwrite()` method, which causes reading error:
![image](https://github.com/taichi-dev/taichi/assets/2747993/1c7423f8-638e-401b-9c7b-4723e3e8fef0)

This PR removes this white space. @chunleili 
