### PR TITLE
[lang] Passing DebugInfo instead of std::string traceback

### DIFF
--- a/python/taichi/lang/any_array.py
+++ b/python/taichi/lang/any_array.py
@@ -88,7 +88,7 @@ class AnyArrayAccess:
             ast_builder.expr_subscript(
                 self.arr.ptr,
                 make_expr_group(*indices),
-                impl.get_runtime().get_current_src_info(),
+                _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
             )
         )
 

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -988,7 +988,7 @@ class ASTTransformer(Builder):
                         .expr_subscript(
                             node.value.ptr.ptr,
                             make_expr_group(keygroup.index(node.attr)),
-                            impl.get_runtime().get_current_src_info(),
+                            _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
                         )
                     )
                 else:
@@ -997,7 +997,7 @@ class ASTTransformer(Builder):
                             node.value.ptr.ptr,
                             [make_expr_group(keygroup.index(ch)) for ch in node.attr],
                             (attr_len,),
-                            impl.get_runtime().get_current_src_info(),
+                            _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
                         )
                     )
             else:

--- a/python/taichi/lang/expr.py
+++ b/python/taichi/lang/expr.py
@@ -40,7 +40,7 @@ class Expr(TaichiOperations):
         else:
             assert False
         if self.tb:
-            self.ptr.set_tb(self.tb)
+            self.ptr.set_dbg_info(_ti_core.DebugInfo(self.tb))
         if not self.ptr_type_checked:
             self.ptr.type_check(impl.get_runtime().prog.config())
             self.ptr_type_checked = True

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -177,6 +177,7 @@ def validate_subscript_index(value, index):
 
 @taichi_scope
 def subscript(ast_builder, value, *_indices, skip_reordered=False):
+    dbg_info = _ti_core.DebugInfo(get_runtime().get_current_src_info())
     ast_builder = get_runtime().compiling_callable.ast_builder()
     # Directly evaluate in Python for non-Taichi types
     if not isinstance(
@@ -252,7 +253,6 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
                     f"Gradient {_var.get_expr_name()} has not been placed, check whether `needs_grad=True`"
                 )
 
-        dbg_info = _ti_core.DebugInfo(get_runtime().get_current_src_info())
         if isinstance(value, MatrixField):
             return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, dbg_info))
         if isinstance(value, StructField):
@@ -294,14 +294,10 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
                 value.ptr,
                 multiple_indices,
                 return_shape,
-                _ti_core.DebugInfo(get_runtime().get_current_src_info()),
+                dbg_info,
             )
         )
-    return Expr(
-        ast_builder.expr_subscript(
-            value.ptr, indices_expr_group, _ti_core.DebugInfo(get_runtime().get_current_src_info())
-        )
-    )
+    return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, dbg_info))
 
 
 class SrcInfoGuard:

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -97,7 +97,9 @@ def expr_init(rhs):
     if hasattr(rhs, "_data_oriented"):
         return rhs
     return Expr(
-        get_runtime().compiling_callable.ast_builder().expr_var(Expr(rhs).ptr, get_runtime().get_current_src_info())
+        get_runtime()
+        .compiling_callable.ast_builder()
+        .expr_var(Expr(rhs).ptr, _ti_core.DebugInfo(get_runtime().get_current_src_info()))
     )
 
 
@@ -292,10 +294,14 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
                 value.ptr,
                 multiple_indices,
                 return_shape,
-                get_runtime().get_current_src_info(),
+                _ti_core.DebugInfo(get_runtime().get_current_src_info()),
             )
         )
-    return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, get_runtime().get_current_src_info()))
+    return Expr(
+        ast_builder.expr_subscript(
+            value.ptr, indices_expr_group, _ti_core.DebugInfo(get_runtime().get_current_src_info())
+        )
+    )
 
 
 class SrcInfoGuard:

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -250,15 +250,16 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
                     f"Gradient {_var.get_expr_name()} has not been placed, check whether `needs_grad=True`"
                 )
 
+        dbg_info = _ti_core.DebugInfo(get_runtime().get_current_src_info())
         if isinstance(value, MatrixField):
-            return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, get_runtime().get_current_src_info()))
+            return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, dbg_info))
         if isinstance(value, StructField):
             entries = {k: subscript(ast_builder, v, *indices) for k, v in value._items}
             entries["__struct_methods"] = value.struct_methods
             return _IntermediateStruct(entries)
-        return Expr(ast_builder.expr_subscript(_var, indices_expr_group, get_runtime().get_current_src_info()))
+        return Expr(ast_builder.expr_subscript(_var, indices_expr_group, dbg_info))
     if isinstance(value, AnyArray):
-        return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, get_runtime().get_current_src_info()))
+        return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, dbg_info))
     assert isinstance(value, Expr)
     # Index into TensorType
     # value: IndexExpression with ret_type = TensorType

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -597,7 +597,7 @@ class MeshElementFieldProxy:
                         ast_builder.expr_subscript(
                             attr.ptr,
                             global_entry_expr_group,
-                            impl.get_runtime().get_current_src_info(),
+                            _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
                         )
                     ),
                 )
@@ -612,7 +612,7 @@ class MeshElementFieldProxy:
                         ast_builder.expr_subscript(
                             var,
                             global_entry_expr_group,
-                            impl.get_runtime().get_current_src_info(),
+                            _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
                         )
                     ),
                 )

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -1358,7 +1358,7 @@ def atomic_xor(x, y):
 
 @writeback_binary
 def assign(a, b):
-    impl.get_runtime().compiling_callable.ast_builder().expr_assign(a.ptr, b.ptr, stack_info())
+    impl.get_runtime().compiling_callable.ast_builder().expr_assign(a.ptr, b.ptr, _ti_core.DebugInfo(stack_info()))
     return a
 
 

--- a/python/taichi/lang/simt/block.py
+++ b/python/taichi/lang/simt/block.py
@@ -66,6 +66,6 @@ class SharedArray:
             ast_builder.expr_subscript(
                 self.shared_array_proxy,
                 make_expr_group(*indices),
-                impl.get_runtime().get_current_src_info(),
+                _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
             )
         )

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -6,8 +6,8 @@
 
 namespace taichi::lang {
 
-void Expr::set_tb(const std::string &tb) {
-  expr->set_tb(tb);
+void Expr::set_dbg_info(const DebugInfo &dbg_info) {
+  expr->dbg_info = dbg_info;
 }
 
 const std::string &Expr::get_tb() const {

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -92,8 +92,8 @@ class Expr {
 
   SNode *snode() const;
 
-  // traceback for type checking error message
-  void set_tb(const std::string &tb);
+  // debug info, contains traceback for type checking error message
+  void set_dbg_info(const DebugInfo &dbg_info);
 
   const std::string &get_tb() const;
 

--- a/taichi/ir/expression.h
+++ b/taichi/ir/expression.h
@@ -41,6 +41,10 @@ class Expression {
     stmt = nullptr;
   }
 
+  explicit Expression(const DebugInfo &dbg_info) : Expression() {
+    this->dbg_info = dbg_info;
+  }
+
   virtual void type_check(const CompileConfig *config) = 0;
 
   virtual void accept(ExpressionVisitor *visitor) = 0;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -140,7 +140,9 @@ class FrontendAssignStmt : public Stmt {
  public:
   Expr lhs, rhs;
 
-  FrontendAssignStmt(const Expr &lhs, const Expr &rhs);
+  FrontendAssignStmt(const Expr &lhs,
+                     const Expr &rhs,
+                     const DebugInfo &dbg_info = DebugInfo());
 
   TI_DEFINE_ACCEPT
   TI_DEFINE_CLONE_FOR_FRONTEND_IR
@@ -639,12 +641,12 @@ class IndexExpression : public Expression {
 
   IndexExpression(const Expr &var,
                   const ExprGroup &indices,
-                  std::string tb = "");
+                  const DebugInfo &dbg_info = DebugInfo());
 
   IndexExpression(const Expr &var,
                   const std::vector<ExprGroup> &indices_group,
                   const std::vector<int> &ret_shape,
-                  std::string tb = "");
+                  const DebugInfo &dbg_info = DebugInfo());
 
   void type_check(const CompileConfig *config) override;
 
@@ -993,8 +995,8 @@ class ASTBuilder {
   void stop_gradient(SNode *);
   void insert_assignment(Expr &lhs,
                          const Expr &rhs,
-                         const std::string &tb = "");
-  Expr make_var(const Expr &x, std::string tb);
+                         const DebugInfo &dbg_info = DebugInfo());
+  Expr make_var(const Expr &x, const DebugInfo &dbg_info = DebugInfo());
   void insert_for(const Expr &s,
                   const Expr &e,
                   const std::function<void(Expr)> &func);
@@ -1024,14 +1026,16 @@ class ASTBuilder {
                                 const DataType &element_type);
   Expr expr_subscript(const Expr &expr,
                       const ExprGroup &indices,
-                      std::string tb = "");
+                      const DebugInfo &dbg_info = DebugInfo());
 
   Expr mesh_index_conversion(mesh::MeshPtr mesh_ptr,
                              mesh::MeshElementType idx_type,
                              const Expr &idx,
                              mesh::ConvType &conv_type);
 
-  void expr_assign(const Expr &lhs, const Expr &rhs, std::string tb);
+  void expr_assign(const Expr &lhs,
+                   const Expr &rhs,
+                   const DebugInfo &dbg_info = DebugInfo());
   std::optional<Expr> insert_func_call(Function *func, const ExprGroup &args);
   void create_assert_stmt(const Expr &cond,
                           const std::string &msg,

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -124,6 +124,10 @@ Stmt::Stmt(const Stmt &stmt) : field_manager(this), fields_registered(false) {
   ret_type = stmt.ret_type;
 }
 
+Stmt::Stmt(const DebugInfo &dbg_info) : Stmt() {
+  this->dbg_info = dbg_info;
+}
+
 Callable *Stmt::get_callable() const {
   Block *parent_block = parent;
   if (parent_block->parent_callable()) {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -390,6 +390,7 @@ class StmtFieldManager {
 class Stmt : public IRNode {
  protected:
   std::vector<Stmt **> operands;
+  explicit Stmt(const DebugInfo &dbg_info);
 
  public:
   StmtFieldManager field_manager;

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -6,8 +6,10 @@
 
 namespace taichi::lang {
 
-UnaryOpStmt::UnaryOpStmt(UnaryOpType op_type, Stmt *operand)
-    : op_type(op_type), operand(operand) {
+UnaryOpStmt::UnaryOpStmt(UnaryOpType op_type,
+                         Stmt *operand,
+                         const DebugInfo &dbg_info)
+    : Stmt(dbg_info), op_type(op_type), operand(operand) {
   TI_ASSERT(!operand->is<AllocaStmt>());
   cast_type = PrimitiveType::unknown;
   TI_STMT_REG_FIELDS;
@@ -62,8 +64,10 @@ ExternalPtrStmt::ExternalPtrStmt(Stmt *base_ptr,
 GlobalPtrStmt::GlobalPtrStmt(SNode *snode,
                              const std::vector<Stmt *> &indices,
                              bool activate,
-                             bool is_cell_access)
-    : snode(snode),
+                             bool is_cell_access,
+                             const DebugInfo &dbg_info)
+    : Stmt(dbg_info),
+      snode(snode),
       indices(indices),
       activate(activate),
       is_cell_access(is_cell_access),
@@ -98,10 +102,10 @@ MatrixOfMatrixPtrStmt::MatrixOfMatrixPtrStmt(const std::vector<Stmt *> &stmts,
 
 MatrixPtrStmt::MatrixPtrStmt(Stmt *origin_input,
                              Stmt *offset_input,
-                             const std::string &tb) {
+                             const DebugInfo &dbg_info) {
   origin = origin_input;
   offset = offset_input;
-  this->set_tb(tb);
+  this->dbg_info = dbg_info;
 
   if (origin->is<AllocaStmt>() || origin->is<GlobalTemporaryStmt>() ||
       origin->is<ExternalPtrStmt>() || origin->is<MatrixOfGlobalPtrStmt>() ||
@@ -136,8 +140,9 @@ bool MatrixPtrStmt::common_statement_eliminable() const {
 SNodeOpStmt::SNodeOpStmt(SNodeOpType op_type,
                          SNode *snode,
                          Stmt *ptr,
-                         Stmt *val)
-    : op_type(op_type), snode(snode), ptr(ptr), val(val) {
+                         Stmt *val,
+                         const DebugInfo &dbg_info)
+    : Stmt(dbg_info), op_type(op_type), snode(snode), ptr(ptr), val(val) {
   element_type() = PrimitiveType::i32;
   TI_STMT_REG_FIELDS;
 }
@@ -314,8 +319,14 @@ std::unique_ptr<Stmt> WhileStmt::clone() const {
   return new_stmt;
 }
 
-GetChStmt::GetChStmt(Stmt *input_ptr, int chid, bool is_bit_vectorized)
-    : input_ptr(input_ptr), chid(chid), is_bit_vectorized(is_bit_vectorized) {
+GetChStmt::GetChStmt(Stmt *input_ptr,
+                     int chid,
+                     bool is_bit_vectorized,
+                     const DebugInfo &dbg_info)
+    : Stmt(dbg_info),
+      input_ptr(input_ptr),
+      chid(chid),
+      is_bit_vectorized(is_bit_vectorized) {
   TI_ASSERT(input_ptr->is<SNodeLookupStmt>());
   input_snode = input_ptr->as<SNodeLookupStmt>()->snode;
   output_snode = input_snode->ch[chid].get();
@@ -325,8 +336,12 @@ GetChStmt::GetChStmt(Stmt *input_ptr, int chid, bool is_bit_vectorized)
 GetChStmt::GetChStmt(Stmt *input_ptr,
                      SNode *snode,
                      int chid,
-                     bool is_bit_vectorized)
-    : input_ptr(input_ptr), chid(chid), is_bit_vectorized(is_bit_vectorized) {
+                     bool is_bit_vectorized,
+                     const DebugInfo &dbg_info)
+    : Stmt(dbg_info),
+      input_ptr(input_ptr),
+      chid(chid),
+      is_bit_vectorized(is_bit_vectorized) {
   input_snode = snode;
   output_snode = input_snode->ch[chid].get();
   TI_STMT_REG_FIELDS;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -18,7 +18,8 @@ class Function;
  */
 class AllocaStmt : public Stmt, public ir_traits::Store {
  public:
-  explicit AllocaStmt(DataType type) : is_shared(false) {
+  explicit AllocaStmt(DataType type, const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), is_shared(false) {
     if (type->is_primitive(PrimitiveTypeID::unknown)) {
       ret_type = type;
     } else {
@@ -156,7 +157,9 @@ class UnaryOpStmt : public Stmt {
   Stmt *operand;
   DataType cast_type;
 
-  UnaryOpStmt(UnaryOpType op_type, Stmt *operand);
+  UnaryOpStmt(UnaryOpType op_type,
+              Stmt *operand,
+              const DebugInfo &dbg_info = DebugInfo());
 
   bool same_operation(UnaryOpStmt *o) const;
   bool is_cast() const;
@@ -200,8 +203,10 @@ class ArgLoadStmt : public Stmt {
               const DataType &dt,
               bool is_ptr,
               bool create_load,
-              int arg_depth)
-      : arg_id(arg_id),
+              int arg_depth,
+              const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        arg_id(arg_id),
         is_ptr(is_ptr),
         create_load(create_load),
         arg_depth(arg_depth) {
@@ -257,8 +262,10 @@ class BinaryOpStmt : public Stmt {
   BinaryOpStmt(BinaryOpType op_type,
                Stmt *lhs,
                Stmt *rhs,
+               const DebugInfo &dbg_info = DebugInfo(),
                bool is_bit_vectorized = false)
-      : op_type(op_type),
+      : Stmt(dbg_info),
+        op_type(op_type),
         lhs(lhs),
         rhs(rhs),
         is_bit_vectorized(is_bit_vectorized) {
@@ -284,8 +291,12 @@ class TernaryOpStmt : public Stmt {
   TernaryOpType op_type;
   Stmt *op1, *op2, *op3;
 
-  TernaryOpStmt(TernaryOpType op_type, Stmt *op1, Stmt *op2, Stmt *op3)
-      : op_type(op_type), op1(op1), op2(op2), op3(op3) {
+  TernaryOpStmt(TernaryOpType op_type,
+                Stmt *op1,
+                Stmt *op2,
+                Stmt *op3,
+                const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), op_type(op_type), op1(op1), op2(op2), op3(op3) {
     TI_ASSERT(!op1->is<AllocaStmt>());
     TI_ASSERT(!op2->is<AllocaStmt>());
     TI_ASSERT(!op3->is<AllocaStmt>());
@@ -311,8 +322,15 @@ class AtomicOpStmt : public Stmt,
   Stmt *dest, *val;
   bool is_reduction;
 
-  AtomicOpStmt(AtomicOpType op_type, Stmt *dest, Stmt *val)
-      : op_type(op_type), dest(dest), val(val), is_reduction(false) {
+  AtomicOpStmt(AtomicOpType op_type,
+               Stmt *dest,
+               Stmt *val,
+               const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        op_type(op_type),
+        dest(dest),
+        val(val),
+        is_reduction(false) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -405,7 +423,8 @@ class GlobalPtrStmt : public Stmt {
   GlobalPtrStmt(SNode *snode,
                 const std::vector<Stmt *> &indices,
                 bool activate = true,
-                bool is_cell_access = false);
+                bool is_cell_access = false,
+                const DebugInfo &dbg_info = DebugInfo());
 
   bool has_global_side_effect() const override {
     return activate;
@@ -486,7 +505,7 @@ class MatrixPtrStmt : public Stmt {
   Stmt *origin{nullptr};
   Stmt *offset{nullptr};
 
-  MatrixPtrStmt(Stmt *, Stmt *, const std::string & = "");
+  MatrixPtrStmt(Stmt *, Stmt *, const DebugInfo & = DebugInfo());
 
   /* TODO(zhanlue/yi): Unify semantics of offset in MatrixPtrStmt
 
@@ -544,7 +563,8 @@ class SNodeOpStmt : public Stmt, public ir_traits::Store {
   SNodeOpStmt(SNodeOpType op_type,
               SNode *snode,
               Stmt *ptr,
-              Stmt *val = nullptr);
+              Stmt *val = nullptr,
+              const DebugInfo &dbg_info = DebugInfo());
 
   static bool activation_related(SNodeOpType op);
 
@@ -775,7 +795,10 @@ class GlobalStoreStmt : public Stmt, public ir_traits::Store {
   Stmt *dest;
   Stmt *val;
 
-  GlobalStoreStmt(Stmt *dest, Stmt *val) : dest(dest), val(val) {
+  GlobalStoreStmt(Stmt *dest,
+                  Stmt *val,
+                  const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), dest(dest), val(val) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -803,7 +826,8 @@ class LocalLoadStmt : public Stmt, public ir_traits::Load {
  public:
   Stmt *src;
 
-  explicit LocalLoadStmt(Stmt *src) : src(src) {
+  explicit LocalLoadStmt(Stmt *src, const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), src(src) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -1330,11 +1354,15 @@ class GetChStmt : public Stmt {
   // irpass::type_check()
   bool overrided_dtype = false;
 
-  GetChStmt(Stmt *input_ptr, int chid, bool is_bit_vectorized = false);
+  GetChStmt(Stmt *input_ptr,
+            int chid,
+            bool is_bit_vectorized = false,
+            const DebugInfo &dbg_info = DebugInfo());
   GetChStmt(Stmt *input_ptr,
             SNode *snode,
             int chid,
-            bool is_bit_vectorized = false);
+            bool is_bit_vectorized = false,
+            const DebugInfo &dbg_info = DebugInfo());
 
   bool has_global_side_effect() const override {
     return false;

--- a/taichi/math/svd.h
+++ b/taichi/math/svd.h
@@ -61,9 +61,8 @@ sifakis_svd_export(ASTBuilder *ast_builder, const Expr &mat, int num_iters) {
   constexpr Tf Sine_Pi_Over_Eight = 0.3826834323650897f;
   constexpr Tf Cosine_Pi_Over_Eight = 0.9238795325112867f;
 
-  std::string tb = "";
-  auto Var = [ast_builder, tb](const taichi::lang::Expr &x) {
-    return ast_builder->make_var(x, tb);
+  auto Var = [ast_builder](const taichi::lang::Expr &x) {
+    return ast_builder->make_var(x);
   };
 
   auto Sfour_gamma_squared = Var(Expr(Tf(0.0)));

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -314,7 +314,7 @@ Kernel &Program::get_snode_writer(SNode *snode) {
         std::vector<int>{snode->num_active_indices},
         snode->dt->get_compute_type());
     argload_expr->type_check(&this->compile_config());
-    builder.insert_assignment(expr, argload_expr, expr->get_tb());
+    builder.insert_assignment(expr, argload_expr, expr->dbg_info);
   });
   ker.name = kernel_name;
   ker.is_accessor = true;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1083,7 +1083,7 @@ void export_lang(py::module &m) {
   m.def(
       "subscript_with_multiple_indices",
       Expr::make<IndexExpression, const Expr &, const std::vector<ExprGroup> &,
-                 const std::vector<int> &, std::string>);
+                 const std::vector<int> &, const DebugInfo &>);
 
   m.def("get_external_tensor_element_dim", [](const Expr &expr) {
     TI_ASSERT(expr.is<ExternalTensorExpression>());

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -828,7 +828,7 @@ void export_lang(py::module &m) {
                     SNodeGradType::kPrimal;
            })
       .def("is_lvalue", [](Expr *expr) { return expr->expr->is_lvalue(); })
-      .def("set_tb", &Expr::set_tb)
+      .def("set_dbg_info", &Expr::set_dbg_info)
       .def("set_name",
            [&](Expr *expr, std::string na) {
              expr->cast<FieldExpression>()->name = na;

--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -382,7 +382,7 @@ class AlgSimp : public BasicStmtVisitor {
           Stmt::make<BinaryOpStmt>(BinaryOpType::bit_shl, stmt->lhs, new_rhs);
       result->ret_type = stmt->ret_type;
 
-      result->set_tb(stmt->get_tb());
+      result->dbg_info = stmt->dbg_info;
       stmt->replace_usages_with(result.get());
       modifier.insert_before(stmt, std::move(result));
       modifier.erase(stmt);

--- a/tests/cpp/ir/frontend_type_inference_test.cpp
+++ b/tests/cpp/ir/frontend_type_inference_test.cpp
@@ -33,7 +33,7 @@ TEST(FrontendTypeInference, Id) {
   auto const_i32 = value<int32>(-(1 << 20));
   const_i32->type_check(nullptr);
   auto id_i32 =
-      kernel->context->builder().make_var(const_i32, const_i32->get_tb());
+      kernel->context->builder().make_var(const_i32, const_i32->dbg_info);
   EXPECT_EQ(id_i32->ret_type,
             DataType(TypeFactory::get_instance().get_pointer_type(
                 PrimitiveType::i32)));


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3304bee</samp>

Refactor the IR code to use `DebugInfo` objects to store and pass source info. This simplifies the IR construction and debugging, and avoids duplication of the `tb` argument. Modify various files in `python/taichi/lang` and `taichi/ir` to use the new `DebugInfo` constructor and argument.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3304bee</samp>

*  Unify the way source info is stored and passed in the IR by using `DebugInfo` objects instead of `Traceback` objects or raw strings. ([link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-2e623ee0b0eec1b200fead36c0627a3c54738f6d83d79757398dc67decc01da8L91-R91), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL991-R991), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL1000-R1000), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-99744c5ae5f6a754d6f68408fdc64fb0d6097216518a7f3d1ef43ffe12599577L253-R262), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-c48bb572255ef55d0c9fd89c9febab88b9668e10dfcfc1fac88feb1be7bd94caL600-R600), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-c48bb572255ef55d0c9fd89c9febab88b9668e10dfcfc1fac88feb1be7bd94caL615-R615), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-059028cb0798284bed05638becbc32d256736846de19746e196fe5f5ee7fd061L1361-R1361), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-aee943d584058490d7717d34c02a3783d3487694dc091653d42b202e45b1e097L69-R69), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-9d4212518d49c780c1b10ace5a5d873aed525373a2751e7d888f164ea51edd7fR44-R47), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L41-R44), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L281-R287), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L458-R459), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L465-R466), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L604-R609), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L625-R624), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L633-R635), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L709-R707), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L735-R733), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L743-R741), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L757-R761), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L792-R791), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L800-R801), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L807), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L948-R947), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L955-R954), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1075-R1075), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1110-R1111), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1128-R1127), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1144-R1150), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1413-R1408), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1419-R1414), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1431-R1427), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1591-R1589), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1600-R1595), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1614-R1609), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1786-R1781), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1792-R1787), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1801-R1796), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL143-R145), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL642-R649), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL996-R999), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL1027-R1029), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL1034-R1038), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-50be2dc708119a4c9b53e977807d2f05e4ff6ce98c3f51fa91d1fa9e229962f1R127-R130), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR393), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L9-R12), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L65-R70), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L101-R108), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L139-R145), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L317-R329), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L328-R344), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L21-R22), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L159-R162), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L203-R209), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L260-R268), [link](https://github.com/taichi-dev/taichi/pull/8293/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L287-R299))
