### PR TITLE
[lang] Pass DebugInfo to frontend statements

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1671,7 +1671,7 @@ class ASTTransformer(Builder):
                 raise TaichiSyntaxError(msg)
             ctx.set_loop_status(LoopStatus.Continue)
         else:
-            ctx.ast_builder.insert_continue_stmt()
+            ctx.ast_builder.insert_continue_stmt(_ti_core.DebugInfo(ctx.get_pos_info(node)))
         return None
 
     @staticmethod

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1518,7 +1518,8 @@ class ASTTransformer(Builder):
             return node
 
         with ctx.non_static_if_guard(node):
-            impl.begin_frontend_if(ctx.ast_builder, node.test.ptr)
+            stmt_dbg_info = ctx.get_pos_info(node)
+            impl.begin_frontend_if(ctx.ast_builder, node.test.ptr, stmt_dbg_info)
             ctx.ast_builder.begin_frontend_if_true()
             build_stmts(ctx, node.body)
             ctx.ast_builder.pop_scope()

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -891,7 +891,9 @@ class ASTTransformer(Builder):
                     return_exprs += expr._get_flattened_ptrs(values)
                 else:
                     raise TaichiSyntaxError("The return type is not supported now!")
-            ctx.ast_builder.create_kernel_exprgroup_return(expr.make_expr_group(return_exprs))
+            ctx.ast_builder.create_kernel_exprgroup_return(
+                expr.make_expr_group(return_exprs), _ti_core.DebugInfo(ctx.get_pos_info(node))
+            )
         else:
             ctx.return_data = node.value.ptr
             if ctx.func.return_type is not None:

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1499,7 +1499,8 @@ class ASTTransformer(Builder):
         with ctx.loop_scope_guard():
             ctx.ast_builder.begin_frontend_while(expr.Expr(1, dtype=primitive_types.i32).ptr)
             while_cond = build_stmt(ctx, node.test)
-            impl.begin_frontend_if(ctx.ast_builder, while_cond)
+            stmt_dbg_info = ctx.get_pos_info(node)
+            impl.begin_frontend_if(ctx.ast_builder, while_cond, stmt_dbg_info)
             ctx.ast_builder.begin_frontend_if_true()
             ctx.ast_builder.pop_scope()
             ctx.ast_builder.begin_frontend_if_false()

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1504,7 +1504,7 @@ class ASTTransformer(Builder):
             ctx.ast_builder.begin_frontend_if_true()
             ctx.ast_builder.pop_scope()
             ctx.ast_builder.begin_frontend_if_false()
-            ctx.ast_builder.insert_break_stmt()
+            ctx.ast_builder.insert_break_stmt(_ti_core.DebugInfo(ctx.get_pos_info(node)))
             ctx.ast_builder.pop_scope()
             build_stmts(ctx, node.body)
             ctx.ast_builder.pop_scope()
@@ -1655,7 +1655,7 @@ class ASTTransformer(Builder):
                 raise TaichiSyntaxError(msg)
             ctx.set_loop_status(LoopStatus.Break)
         else:
-            ctx.ast_builder.insert_break_stmt()
+            ctx.ast_builder.insert_break_stmt(_ti_core.DebugInfo(ctx.get_pos_info(node)))
         return None
 
     @staticmethod

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1638,7 +1638,7 @@ class ASTTransformer(Builder):
         else:
             msg = unparse(node.test)
         test = build_stmt(ctx, node.test)
-        impl.ti_assert(test, msg.strip(), extra_args)
+        impl.ti_assert(test, msg.strip(), extra_args, _ti_core.DebugInfo(ctx.get_pos_info(node)))
         return None
 
     @staticmethod

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1277,7 +1277,8 @@ class ASTTransformer(Builder):
                 begin = ti_ops.cast(expr.Expr(0), primitive_types.i32)
                 end = ti_ops.cast(end_expr, primitive_types.i32)
 
-            ctx.ast_builder.begin_frontend_range_for(loop_var.ptr, begin.ptr, end.ptr)
+            for_di = _ti_core.DebugInfo(ctx.get_pos_info(node))
+            ctx.ast_builder.begin_frontend_range_for(loop_var.ptr, begin.ptr, end.ptr, for_di)
             build_stmts(ctx, node.body)
             ctx.ast_builder.end_frontend_range_for()
         return None
@@ -1292,7 +1293,8 @@ class ASTTransformer(Builder):
                 primitive_types.i32,
             )
             ndrange_loop_var = expr.Expr(ctx.ast_builder.make_id_expr(""))
-            ctx.ast_builder.begin_frontend_range_for(ndrange_loop_var.ptr, ndrange_begin.ptr, ndrange_end.ptr)
+            for_di = _ti_core.DebugInfo(ctx.get_pos_info(node))
+            ctx.ast_builder.begin_frontend_range_for(ndrange_loop_var.ptr, ndrange_begin.ptr, ndrange_end.ptr, for_di)
             I = impl.expr_init(ndrange_loop_var)
             targets = ASTTransformer.get_for_loop_targets(node)
             if len(targets) != len(ndrange_var.dimensions):
@@ -1334,7 +1336,8 @@ class ASTTransformer(Builder):
                 primitive_types.i32,
             )
             ndrange_loop_var = expr.Expr(ctx.ast_builder.make_id_expr(""))
-            ctx.ast_builder.begin_frontend_range_for(ndrange_loop_var.ptr, ndrange_begin.ptr, ndrange_end.ptr)
+            for_di = _ti_core.DebugInfo(ctx.get_pos_info(node))
+            ctx.ast_builder.begin_frontend_range_for(ndrange_loop_var.ptr, ndrange_begin.ptr, ndrange_end.ptr, for_di)
 
             targets = ASTTransformer.get_for_loop_targets(node)
             if len(targets) != 1:
@@ -1425,7 +1428,8 @@ class ASTTransformer(Builder):
             ctx.create_variable(loop_name, loop_var)
             begin = expr.Expr(0)
             end = ti_ops.cast(node.iter.ptr.size, primitive_types.i32)
-            ctx.ast_builder.begin_frontend_range_for(loop_var.ptr, begin.ptr, end.ptr)
+            for_di = _ti_core.DebugInfo(ctx.get_pos_info(node))
+            ctx.ast_builder.begin_frontend_range_for(loop_var.ptr, begin.ptr, end.ptr, for_di)
             entry_expr = _ti_core.get_relation_access(
                 ctx.mesh.mesh_ptr,
                 node.iter.ptr.from_index.ptr,

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -68,6 +68,9 @@ class ASTTransformer(Builder):
     @staticmethod
     def build_Name(ctx, node):
         node.ptr = ctx.get_var_by_name(node.id)
+        if isinstance(node, (ast.stmt, ast.expr)) and isinstance(node.ptr, Expr):
+            info = ctx.get_pos_info(node)
+            node.ptr.tb = info
         return node.ptr
 
     @staticmethod

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1497,14 +1497,14 @@ class ASTTransformer(Builder):
             raise TaichiSyntaxError("'else' clause for 'while' not supported in Taichi kernels")
 
         with ctx.loop_scope_guard():
-            ctx.ast_builder.begin_frontend_while(expr.Expr(1, dtype=primitive_types.i32).ptr)
+            stmt_dbg_info = _ti_core.DebugInfo(ctx.get_pos_info(node))
+            ctx.ast_builder.begin_frontend_while(expr.Expr(1, dtype=primitive_types.i32).ptr, stmt_dbg_info)
             while_cond = build_stmt(ctx, node.test)
-            stmt_dbg_info = ctx.get_pos_info(node)
             impl.begin_frontend_if(ctx.ast_builder, while_cond, stmt_dbg_info)
             ctx.ast_builder.begin_frontend_if_true()
             ctx.ast_builder.pop_scope()
             ctx.ast_builder.begin_frontend_if_false()
-            ctx.ast_builder.insert_break_stmt(_ti_core.DebugInfo(ctx.get_pos_info(node)))
+            ctx.ast_builder.insert_break_stmt(stmt_dbg_info)
             ctx.ast_builder.pop_scope()
             build_stmts(ctx, node.body)
             ctx.ast_builder.pop_scope()

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1525,7 +1525,7 @@ class ASTTransformer(Builder):
             return node
 
         with ctx.non_static_if_guard(node):
-            stmt_dbg_info = ctx.get_pos_info(node)
+            stmt_dbg_info = _ti_core.DebugInfo(ctx.get_pos_info(node))
             impl.begin_frontend_if(ctx.ast_builder, node.test.ptr, stmt_dbg_info)
             ctx.ast_builder.begin_frontend_if_true()
             build_stmts(ctx, node.body)

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -135,7 +135,7 @@ def begin_frontend_struct_for(ast_builder, group, loop_range):
         ast_builder.begin_frontend_struct_for_on_snode(group, loop_range._loop_range())
 
 
-def begin_frontend_if(ast_builder, cond, stmt_tb):
+def begin_frontend_if(ast_builder, cond, stmt_dbg_info):
     assert ast_builder is not None
     if is_taichi_class(cond):
         raise ValueError(
@@ -145,7 +145,7 @@ def begin_frontend_if(ast_builder, cond, stmt_tb):
             "or\n"
             "    if any(x != y):\n"
         )
-    ast_builder.begin_frontend_if(Expr(cond).ptr, _ti_core.DebugInfo(stmt_tb))
+    ast_builder.begin_frontend_if(Expr(cond).ptr, stmt_dbg_info)
 
 
 @taichi_scope

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -127,7 +127,7 @@ def begin_frontend_struct_for(ast_builder, group, loop_range):
         ast_builder.begin_frontend_struct_for_on_snode(group, loop_range._loop_range())
 
 
-def begin_frontend_if(ast_builder, cond):
+def begin_frontend_if(ast_builder, cond, stmt_tb):
     assert ast_builder is not None
     if is_taichi_class(cond):
         raise ValueError(
@@ -137,7 +137,7 @@ def begin_frontend_if(ast_builder, cond):
             "or\n"
             "    if any(x != y):\n"
         )
-    ast_builder.begin_frontend_if(Expr(cond).ptr)
+    ast_builder.begin_frontend_if(Expr(cond).ptr, _ti_core.DebugInfo(stmt_tb))
 
 
 @taichi_scope

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -956,10 +956,10 @@ def ti_format(*args):
 
 
 @taichi_scope
-def ti_assert(cond, msg, extra_args):
+def ti_assert(cond, msg, extra_args, dbg_info):
     # Mostly a wrapper to help us convert from Expr (defined in Python) to
     # _ti_core.Expr (defined in C++)
-    get_runtime().compiling_callable.ast_builder().create_assert_stmt(Expr(cond).ptr, msg, extra_args)
+    get_runtime().compiling_callable.ast_builder().create_assert_stmt(Expr(cond).ptr, msg, extra_args, dbg_info)
 
 
 @taichi_scope

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -253,7 +253,6 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
                     f"Gradient {_var.get_expr_name()} has not been placed, check whether `needs_grad=True`"
                 )
 
-        dbg_info = _ti_core.DebugInfo(get_runtime().get_current_src_info())
         if isinstance(value, MatrixField):
             return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, dbg_info))
         if isinstance(value, StructField):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -63,13 +63,21 @@ from taichi.types.primitive_types import (
 
 @taichi_scope
 def expr_init_shared_array(shape, element_type):
-    return get_runtime().compiling_callable.ast_builder().expr_alloca_shared_array(shape, element_type)
+    return (
+        get_runtime()
+        .compiling_callable.ast_builder()
+        .expr_alloca_shared_array(shape, element_type, _ti_core.DebugInfo(get_runtime().get_current_src_info()))
+    )
 
 
 @taichi_scope
 def expr_init(rhs):
     if rhs is None:
-        return Expr(get_runtime().compiling_callable.ast_builder().expr_alloca())
+        return Expr(
+            get_runtime()
+            .compiling_callable.ast_builder()
+            .expr_alloca(_ti_core.DebugInfo(get_runtime().get_current_src_info()))
+        )
     if isinstance(rhs, Matrix) and (hasattr(rhs, "_DIM")):
         return Matrix(*rhs.to_list(), ndim=rhs.ndim)
     if isinstance(rhs, Matrix):

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -937,7 +937,9 @@ def ti_print(*_vars, sep=" ", end="\n"):
 
     _vars = add_separators(_vars)
     contents, formats = ti_format_list_to_content_entries(_vars)
-    get_runtime().compiling_callable.ast_builder().create_print(contents, formats)
+    get_runtime().compiling_callable.ast_builder().create_print(
+        contents, formats, _ti_core.DebugInfo(get_runtime().get_current_src_info())
+    )
 
 
 @taichi_scope

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -253,6 +253,7 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
                     f"Gradient {_var.get_expr_name()} has not been placed, check whether `needs_grad=True`"
                 )
 
+        dbg_info = _ti_core.DebugInfo(get_runtime().get_current_src_info())
         if isinstance(value, MatrixField):
             return Expr(ast_builder.expr_subscript(value.ptr, indices_expr_group, dbg_info))
         if isinstance(value, StructField):

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -56,7 +56,11 @@ def decl_scalar_arg(dtype, name, arg_depth):
         arg_id = impl.get_runtime().compiling_callable.insert_pointer_param(dtype, name)
     else:
         arg_id = impl.get_runtime().compiling_callable.insert_scalar_param(dtype, name)
-    return Expr(_ti_core.make_arg_load_expr(arg_id, dtype, is_ref, True, arg_depth))
+
+    argload_di = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    return Expr(
+        _ti_core.make_arg_load_expr(arg_id, dtype, is_ref, create_load=True, arg_depth=arg_depth, dbg_info=argload_di)
+    )
 
 
 def get_type_for_kernel_args(dtype, name):
@@ -83,14 +87,20 @@ def get_type_for_kernel_args(dtype, name):
 def decl_matrix_arg(matrixtype, name, arg_depth):
     arg_type = get_type_for_kernel_args(matrixtype, name)
     arg_id = impl.get_runtime().compiling_callable.insert_scalar_param(arg_type, name)
-    arg_load = Expr(_ti_core.make_arg_load_expr(arg_id, arg_type, create_load=False, arg_depth=arg_depth))
+    argload_di = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    arg_load = Expr(
+        _ti_core.make_arg_load_expr(arg_id, arg_type, create_load=False, arg_depth=arg_depth, dbg_info=argload_di)
+    )
     return matrixtype.from_taichi_object(arg_load)
 
 
 def decl_struct_arg(structtype, name, arg_depth):
     arg_type = get_type_for_kernel_args(structtype, name)
     arg_id = impl.get_runtime().compiling_callable.insert_scalar_param(arg_type, name)
-    arg_load = Expr(_ti_core.make_arg_load_expr(arg_id, arg_type, create_load=False, arg_depth=arg_depth))
+    argload_di = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    arg_load = Expr(
+        _ti_core.make_arg_load_expr(arg_id, arg_type, create_load=False, arg_depth=arg_depth, dbg_info=argload_di)
+    )
     return structtype.from_taichi_object(arg_load)
 
 
@@ -108,7 +118,10 @@ def decl_sparse_matrix(dtype, name):
     ptr_type = cook_dtype(u64)
     # Treat the sparse matrix argument as a scalar since we only need to pass in the base pointer
     arg_id = impl.get_runtime().compiling_callable.insert_scalar_param(ptr_type, name)
-    return SparseMatrixProxy(_ti_core.make_arg_load_expr(arg_id, ptr_type, False, True, 0), value_type)
+    argload_di = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    return SparseMatrixProxy(
+        _ti_core.make_arg_load_expr(arg_id, ptr_type, create_load=False, dbg_info=argload_di), value_type
+    )
 
 
 def decl_ndarray_arg(element_type, ndim, name, needs_grad, boundary):

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -120,7 +120,7 @@ def decl_sparse_matrix(dtype, name):
     arg_id = impl.get_runtime().compiling_callable.insert_scalar_param(ptr_type, name)
     argload_di = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
     return SparseMatrixProxy(
-        _ti_core.make_arg_load_expr(arg_id, ptr_type, create_load=False, dbg_info=argload_di), value_type
+        _ti_core.make_arg_load_expr(arg_id, ptr_type, is_ptr=False, dbg_info=argload_di), value_type
     )
 
 

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -587,7 +587,7 @@ def random(dtype=float) -> Union[float, int]:
         >>>     print(j)  # 73412986184350777
     """
     dtype = cook_dtype(dtype)
-    x = expr.Expr(_ti_core.make_rand_expr(dtype))
+    x = expr.Expr(_ti_core.make_rand_expr(dtype, _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())))
     return impl.expr_init(x)
 
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -408,7 +408,9 @@ def activate(node, indices):
         node (:class:`~taichi.SNode`): Must be a pointer, hash or bitmasked node.
         indices (Union[int, :class:`~taichi.Vector`]): the indices to activate.
     """
-    impl.get_runtime().compiling_callable.ast_builder().insert_activate(node._snode.ptr, expr.make_expr_group(indices))
+    impl.get_runtime().compiling_callable.ast_builder().insert_activate(
+        node._snode.ptr, expr.make_expr_group(indices), _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    )
 
 
 def deactivate(node, indices):
@@ -422,7 +424,7 @@ def deactivate(node, indices):
         indices (Union[int, :class:`~taichi.Vector`]): the indices to deactivate.
     """
     impl.get_runtime().compiling_callable.ast_builder().insert_deactivate(
-        node._snode.ptr, expr.make_expr_group(indices)
+        node._snode.ptr, expr.make_expr_group(indices), _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
     )
 
 

--- a/python/taichi/lang/source_builder.py
+++ b/python/taichi/lang/source_builder.py
@@ -115,7 +115,13 @@ class SourceBuilder:
     def __getattr__(self, item):
         def bitcode_func_call_wrapper(*args):
             impl.get_runtime().compiling_callable.ast_builder().insert_external_func_call(
-                0, "", self.bc, item, make_expr_group(args), make_expr_group([])
+                0,
+                "",
+                self.bc,
+                item,
+                make_expr_group(args),
+                make_expr_group([]),
+                _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
             )
 
         if self.mode == "bc":
@@ -124,7 +130,13 @@ class SourceBuilder:
         def external_func_call_wrapper(args=[], outputs=[]):
             func_addr = ctypes.cast(self.so.__getattr__(item), ctypes.c_void_p).value
             impl.get_runtime().compiling_callable.ast_builder().insert_external_func_call(
-                func_addr, "", "", "", make_expr_group(args), make_expr_group(outputs)
+                func_addr,
+                "",
+                "",
+                "",
+                make_expr_group(args),
+                make_expr_group(outputs),
+                _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
             )
 
         if self.mode == "so":

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -66,7 +66,7 @@ def get_clangpp():
 
     # Taichi itself uses llvm-10.0.0 to compile.
     # There will be some issues compiling CUDA with other clang++ version.
-    _clangpp_candidates = ["clang++-10"]
+    _clangpp_candidates = ["clang++"]
     for c in _clangpp_candidates:
         if find_executable(c) is not None:
             _clangpp_presence = find_executable(c)

--- a/python/taichi/lang/util.py
+++ b/python/taichi/lang/util.py
@@ -66,7 +66,7 @@ def get_clangpp():
 
     # Taichi itself uses llvm-10.0.0 to compile.
     # There will be some issues compiling CUDA with other clang++ version.
-    _clangpp_candidates = ["clang++"]
+    _clangpp_candidates = ["clang++-10"]
     for c in _clangpp_candidates:
         if find_executable(c) is not None:
             _clangpp_presence = find_executable(c)

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1505,8 +1505,8 @@ void ASTBuilder::create_print(
   this->insert(std::make_unique<FrontendPrintStmt>(contents, formats));
 }
 
-void ASTBuilder::begin_func(const std::string &funcid, const DebugInfo& dbg_info) {
-  auto stmt_unique = std::make_unique<FrontendFuncDefStmt>(funcid, dbg_info);
+void ASTBuilder::begin_func(const std::string &funcid) {
+  auto stmt_unique = std::make_unique<FrontendFuncDefStmt>(funcid);
   auto stmt = stmt_unique.get();
   this->insert(std::move(stmt_unique));
   this->create_scope(stmt->body);

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -169,8 +169,8 @@ void ArgLoadExpression::type_check(const CompileConfig *) {
 }
 
 void ArgLoadExpression::flatten(FlattenContext *ctx) {
-  auto arg_load =
-      std::make_unique<ArgLoadStmt>(arg_id, dt, is_ptr, create_load, arg_depth);
+  auto arg_load = std::make_unique<ArgLoadStmt>(arg_id, dt, is_ptr, create_load,
+                                                arg_depth, dbg_info);
   arg_load->ret_type = ret_type;
   ctx->push_back(std::move(arg_load));
   stmt = ctx->back_stmt();

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -40,7 +40,9 @@ FrontendSNodeOpStmt::FrontendSNodeOpStmt(SNodeOpType op_type,
   }
 }
 
-FrontendReturnStmt::FrontendReturnStmt(const ExprGroup &group) : values(group) {
+FrontendReturnStmt::FrontendReturnStmt(const ExprGroup &group,
+                                       const DebugInfo &dbg_info)
+    : Stmt(dbg_info), values(group) {
 }
 
 FrontendAssignStmt::FrontendAssignStmt(const Expr &lhs,
@@ -1492,11 +1494,12 @@ Expr ASTBuilder::insert_patch_idx_expr() {
   return Expr::make<MeshPatchIndexExpression>();
 }
 
-void ASTBuilder::create_kernel_exprgroup_return(const ExprGroup &group) {
+void ASTBuilder::create_kernel_exprgroup_return(const ExprGroup &group,
+                                                const DebugInfo &dbg_info) {
   auto expanded_exprs = this->expand_exprs(group.exprs);
   ExprGroup expanded_expr_group;
   expanded_expr_group.exprs = std::move(expanded_exprs);
-  this->insert(Stmt::make<FrontendReturnStmt>(expanded_expr_group));
+  this->insert(Stmt::make<FrontendReturnStmt>(expanded_expr_group, dbg_info));
 }
 
 void ASTBuilder::create_print(

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -50,7 +50,8 @@ FrontendAssignStmt::FrontendAssignStmt(const Expr &lhs,
 }
 
 FrontendIfStmt::FrontendIfStmt(const FrontendIfStmt &o)
-    : condition(o.condition),
+    : Stmt(o.dbg_info),
+      condition(o.condition),
       true_statements(o.true_statements->clone()),
       false_statements(o.false_statements->clone()) {
 }
@@ -1505,8 +1506,8 @@ void ASTBuilder::end_func(const std::string &funcid) {
   this->pop_scope();
 }
 
-void ASTBuilder::begin_frontend_if(const Expr &cond) {
-  auto stmt_tmp = std::make_unique<FrontendIfStmt>(cond);
+void ASTBuilder::begin_frontend_if(const Expr &cond, const DebugInfo &stmt_di) {
+  auto stmt_tmp = std::make_unique<FrontendIfStmt>(cond, stmt_di);
   this->insert(std::move(stmt_tmp));
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -26,8 +26,13 @@ static bool is_primitive_or_tensor_type(DataType &type) {
 FrontendSNodeOpStmt::FrontendSNodeOpStmt(SNodeOpType op_type,
                                          SNode *snode,
                                          const ExprGroup &indices,
-                                         const Expr &val)
-    : op_type(op_type), snode(snode), indices(indices), val(val) {
+                                         const Expr &val,
+                                         const DebugInfo &dbg_info)
+    : Stmt(dbg_info),
+      op_type(op_type),
+      snode(snode),
+      indices(indices),
+      val(val) {
   if (val.expr != nullptr) {
     TI_ASSERT(op_type == SNodeOpType::append);
   } else {
@@ -1703,19 +1708,23 @@ void ASTBuilder::insert_expr_stmt(const Expr &val) {
 }
 
 void ASTBuilder::insert_snode_activate(SNode *snode,
-                                       const ExprGroup &expr_group) {
+                                       const ExprGroup &expr_group,
+                                       const DebugInfo &dbg_info) {
   ExprGroup expanded_group;
   expanded_group.exprs = this->expand_exprs(expr_group.exprs);
-  this->insert(Stmt::make<FrontendSNodeOpStmt>(SNodeOpType::activate, snode,
-                                               expanded_group));
+  this->insert(Stmt::make<FrontendSNodeOpStmt>(
+      SNodeOpType::activate, snode, expanded_group,
+      /*val = */ Expr(std::shared_ptr<Expression>(nullptr)), dbg_info));
 }
 
 void ASTBuilder::insert_snode_deactivate(SNode *snode,
-                                         const ExprGroup &expr_group) {
+                                         const ExprGroup &expr_group,
+                                         const DebugInfo &dbg_info) {
   ExprGroup expanded_group;
   expanded_group.exprs = this->expand_exprs(expr_group.exprs);
-  this->insert(Stmt::make<FrontendSNodeOpStmt>(SNodeOpType::deactivate, snode,
-                                               expanded_group));
+  this->insert(Stmt::make<FrontendSNodeOpStmt>(
+      SNodeOpType::deactivate, snode, expanded_group,
+      /*val = */ Expr(std::shared_ptr<Expression>(nullptr)), dbg_info));
 }
 
 Expr ASTBuilder::snode_append(SNode *snode,

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1505,8 +1505,8 @@ void ASTBuilder::create_print(
   this->insert(std::make_unique<FrontendPrintStmt>(contents, formats));
 }
 
-void ASTBuilder::begin_func(const std::string &funcid) {
-  auto stmt_unique = std::make_unique<FrontendFuncDefStmt>(funcid);
+void ASTBuilder::begin_func(const std::string &funcid, const DebugInfo& dbg_info) {
+  auto stmt_unique = std::make_unique<FrontendFuncDefStmt>(funcid, dbg_info);
   auto stmt = stmt_unique.get();
   this->insert(std::move(stmt_unique));
   this->create_scope(stmt->body);

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1700,11 +1700,11 @@ void ASTBuilder::begin_frontend_while(const Expr &cond) {
   this->create_scope(stmt->body, While);
 }
 
-void ASTBuilder::insert_break_stmt() {
+void ASTBuilder::insert_break_stmt(const DebugInfo &dbg_info) {
   if (loop_state_stack_.back() == Outermost) {
     throw TaichiSyntaxError("Cannot break in the outermost loop");
   }
-  this->insert(Stmt::make<FrontendBreakStmt>());
+  this->insert(Stmt::make<FrontendBreakStmt>(dbg_info));
 }
 
 void ASTBuilder::insert_continue_stmt() {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1434,7 +1434,7 @@ void ASTBuilder::insert_assignment(Expr &lhs,
 }
 
 Expr ASTBuilder::make_var(const Expr &x, const DebugInfo &dbg_info) {
-  auto var = this->expr_alloca();
+  auto var = this->expr_alloca(dbg_info);
   this->insert_assignment(var, x, dbg_info);
   return var;
 }
@@ -1544,11 +1544,11 @@ void ASTBuilder::insert_external_func_call(std::size_t func_addr,
   this->insert(std::move(stmt));
 }
 
-Expr ASTBuilder::expr_alloca() {
+Expr ASTBuilder::expr_alloca(const DebugInfo &dbg_info) {
   auto var = Expr(std::make_shared<IdExpression>(get_next_id()));
   this->insert(std::make_unique<FrontendAllocaStmt>(
       std::static_pointer_cast<IdExpression>(var.expr)->id,
-      PrimitiveType::unknown));
+      PrimitiveType::unknown, dbg_info));
   return var;
 }
 
@@ -1586,11 +1586,12 @@ Expr ASTBuilder::make_matrix_expr(const std::vector<int> &shape,
 }
 
 Expr ASTBuilder::expr_alloca_shared_array(const std::vector<int> &shape,
-                                          const DataType &element_type) {
+                                          const DataType &element_type,
+                                          const DebugInfo &dbg_info) {
   auto var = Expr(std::make_shared<IdExpression>(get_next_id()));
   this->insert(std::make_unique<FrontendAllocaStmt>(
       std::static_pointer_cast<IdExpression>(var.expr)->id, shape, element_type,
-      true));
+      true, dbg_info));
   var->ret_type = this->get_last_stmt()->ret_type;
   return var;
 }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1622,8 +1622,10 @@ Expr ASTBuilder::expr_subscript(const Expr &expr,
 
 void ASTBuilder::create_assert_stmt(const Expr &cond,
                                     const std::string &msg,
-                                    const std::vector<Expr> &args) {
-  auto stmt_unique = std::make_unique<FrontendAssertStmt>(cond, msg, args);
+                                    const std::vector<Expr> &args,
+                                    const DebugInfo &dbg_info) {
+  auto stmt_unique =
+      std::make_unique<FrontendAssertStmt>(cond, msg, args, dbg_info);
   this->insert(std::move(stmt_unique));
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1536,9 +1536,11 @@ void ASTBuilder::insert_external_func_call(std::size_t func_addr,
                                            std::string filename,
                                            std::string funcname,
                                            const ExprGroup &args,
-                                           const ExprGroup &outputs) {
+                                           const ExprGroup &outputs,
+                                           const DebugInfo &dbg_info) {
   auto stmt = Stmt::make<FrontendExternalFuncStmt>(
-      (void *)func_addr, source, filename, funcname, args.exprs, outputs.exprs);
+      (void *)func_addr, source, filename, funcname, args.exprs, outputs.exprs,
+      dbg_info);
   this->insert(std::move(stmt));
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1707,8 +1707,8 @@ void ASTBuilder::insert_break_stmt(const DebugInfo &dbg_info) {
   this->insert(Stmt::make<FrontendBreakStmt>(dbg_info));
 }
 
-void ASTBuilder::insert_continue_stmt() {
-  this->insert(Stmt::make<FrontendContinueStmt>());
+void ASTBuilder::insert_continue_stmt(const DebugInfo &dbg_info) {
+  this->insert(Stmt::make<FrontendContinueStmt>(dbg_info));
 }
 
 void ASTBuilder::insert_expr_stmt(const Expr &val) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1501,8 +1501,10 @@ void ASTBuilder::create_kernel_exprgroup_return(const ExprGroup &group) {
 
 void ASTBuilder::create_print(
     std::vector<std::variant<Expr, std::string>> contents,
-    std::vector<std::optional<std::string>> formats) {
-  this->insert(std::make_unique<FrontendPrintStmt>(contents, formats));
+    std::vector<std::optional<std::string>> formats,
+    const DebugInfo &dbg_info) {
+  this->insert(
+      std::make_unique<FrontendPrintStmt>(contents, formats, dbg_info));
 }
 
 void ASTBuilder::begin_func(const std::string &funcid) {
@@ -1516,7 +1518,8 @@ void ASTBuilder::end_func(const std::string &funcid) {
   this->pop_scope();
 }
 
-void ASTBuilder::begin_frontend_if(const Expr &cond, const DebugInfo &dbg_info) {
+void ASTBuilder::begin_frontend_if(const Expr &cond,
+                                   const DebugInfo &dbg_info) {
   auto stmt_tmp = std::make_unique<FrontendIfStmt>(cond, dbg_info);
   this->insert(std::move(stmt_tmp));
 }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -155,7 +155,7 @@ FrontendFuncDefStmt::FrontendFuncDefStmt(const FrontendFuncDefStmt &o)
 }
 
 FrontendWhileStmt::FrontendWhileStmt(const FrontendWhileStmt &o)
-    : cond(o.cond), body(o.body->clone()) {
+    : Stmt(o.dbg_info), cond(o.cond), body(o.body->clone()) {
 }
 
 void ArgLoadExpression::type_check(const CompileConfig *) {
@@ -1693,8 +1693,9 @@ void ASTBuilder::begin_frontend_mesh_for(
   this->create_scope(stmt->body, For);
 }
 
-void ASTBuilder::begin_frontend_while(const Expr &cond) {
-  auto stmt_unique = std::make_unique<FrontendWhileStmt>(cond);
+void ASTBuilder::begin_frontend_while(const Expr &cond,
+                                      const DebugInfo &dbg_info) {
+  auto stmt_unique = std::make_unique<FrontendWhileStmt>(cond, dbg_info);
   auto stmt = stmt_unique.get();
   this->insert(std::move(stmt_unique));
   this->create_scope(stmt->body, While);

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1516,8 +1516,8 @@ void ASTBuilder::end_func(const std::string &funcid) {
   this->pop_scope();
 }
 
-void ASTBuilder::begin_frontend_if(const Expr &cond, const DebugInfo &stmt_di) {
-  auto stmt_tmp = std::make_unique<FrontendIfStmt>(cond, stmt_di);
+void ASTBuilder::begin_frontend_if(const Expr &cond, const DebugInfo &dbg_info) {
+  auto stmt_tmp = std::make_unique<FrontendIfStmt>(cond, dbg_info);
   this->insert(std::move(stmt_tmp));
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -59,8 +59,9 @@ FrontendIfStmt::FrontendIfStmt(const FrontendIfStmt &o)
 FrontendForStmt::FrontendForStmt(const ExprGroup &loop_vars,
                                  SNode *snode,
                                  Arch arch,
-                                 const ForLoopConfig &config)
-    : snode(snode) {
+                                 const ForLoopConfig &config,
+                                 const DebugInfo &dbg_info)
+    : Stmt(dbg_info), snode(snode) {
   init_config(arch, config);
   init_loop_vars(loop_vars);
 }
@@ -68,8 +69,9 @@ FrontendForStmt::FrontendForStmt(const ExprGroup &loop_vars,
 FrontendForStmt::FrontendForStmt(const ExprGroup &loop_vars,
                                  const Expr &external_tensor,
                                  Arch arch,
-                                 const ForLoopConfig &config)
-    : external_tensor(external_tensor) {
+                                 const ForLoopConfig &config,
+                                 const DebugInfo &dbg_info)
+    : Stmt(dbg_info), external_tensor(external_tensor) {
   init_config(arch, config);
   init_loop_vars(loop_vars);
 }
@@ -78,8 +80,9 @@ FrontendForStmt::FrontendForStmt(const ExprGroup &loop_vars,
                                  const mesh::MeshPtr &mesh,
                                  const mesh::MeshElementType &element_type,
                                  Arch arch,
-                                 const ForLoopConfig &config)
-    : mesh(mesh.ptr.get()), element_type(element_type) {
+                                 const ForLoopConfig &config,
+                                 const DebugInfo &dbg_info)
+    : Stmt(dbg_info), mesh(mesh.ptr.get()), element_type(element_type) {
   init_config(arch, config);
   init_loop_vars(loop_vars);
 }
@@ -88,14 +91,16 @@ FrontendForStmt::FrontendForStmt(const Expr &loop_var,
                                  const Expr &begin,
                                  const Expr &end,
                                  Arch arch,
-                                 const ForLoopConfig &config)
-    : begin(begin), end(end) {
+                                 const ForLoopConfig &config,
+                                 const DebugInfo &dbg_info)
+    : Stmt(dbg_info), begin(begin), end(end) {
   init_config(arch, config);
   add_loop_var(loop_var);
 }
 
 FrontendForStmt::FrontendForStmt(const FrontendForStmt &o)
-    : snode(o.snode),
+    : Stmt(o.dbg_info),
+      snode(o.snode),
       external_tensor(o.external_tensor),
       mesh(o.mesh),
       element_type(o.element_type),
@@ -1619,9 +1624,10 @@ void ASTBuilder::create_assert_stmt(const Expr &cond,
 
 void ASTBuilder::begin_frontend_range_for(const Expr &i,
                                           const Expr &s,
-                                          const Expr &e) {
-  auto stmt_unique =
-      std::make_unique<FrontendForStmt>(i, s, e, arch_, for_loop_dec_.config);
+                                          const Expr &e,
+                                          const DebugInfo &dbg_info) {
+  auto stmt_unique = std::make_unique<FrontendForStmt>(
+      i, s, e, arch_, for_loop_dec_.config, dbg_info);
   auto stmt = stmt_unique.get();
   this->insert(std::move(stmt_unique));
   this->create_scope(stmt->body,

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -197,7 +197,7 @@ void RandExpression::type_check(const CompileConfig *) {
 }
 
 void RandExpression::flatten(FlattenContext *ctx) {
-  auto ran = std::make_unique<RandStmt>(dt);
+  auto ran = std::make_unique<RandStmt>(dt, dbg_info);
   ctx->push_back(std::move(ran));
   stmt = ctx->back_stmt();
 }

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -286,7 +286,9 @@ class FrontendBreakStmt : public Stmt {
 
 class FrontendContinueStmt : public Stmt {
  public:
-  FrontendContinueStmt() = default;
+  explicit FrontendContinueStmt(const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info) {
+  }
 
   bool is_container_statement() const override {
     return false;
@@ -1078,7 +1080,7 @@ class ASTBuilder {
                                const mesh::MeshElementType &element_type);
   void begin_frontend_while(const Expr &cond);
   void insert_break_stmt(const DebugInfo &dbg_info = DebugInfo());
-  void insert_continue_stmt();
+  void insert_continue_stmt(const DebugInfo &dbg_info = DebugInfo());
   void insert_expr_stmt(const Expr &val);
   void insert_snode_activate(SNode *snode,
                              const ExprGroup &expr_group,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -321,7 +321,8 @@ class FrontendReturnStmt : public Stmt {
  public:
   ExprGroup values;
 
-  explicit FrontendReturnStmt(const ExprGroup &group);
+  explicit FrontendReturnStmt(const ExprGroup &group,
+                              const DebugInfo &dbg_info = DebugInfo());
 
   bool is_container_statement() const override {
     return false;
@@ -1029,7 +1030,8 @@ class ASTBuilder {
                         const std::vector<Expr> &elements);
   Expr insert_thread_idx_expr();
   Expr insert_patch_idx_expr();
-  void create_kernel_exprgroup_return(const ExprGroup &group);
+  void create_kernel_exprgroup_return(const ExprGroup &group,
+                                      const DebugInfo &dbg_info = DebugInfo());
   void create_print(std::vector<std::variant<Expr, std::string>> contents,
                     std::vector<std::optional<std::string>> formats,
                     const DebugInfo &dbg_info = DebugInfo());

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -248,9 +248,7 @@ class FrontendFuncDefStmt : public Stmt {
   std::string funcid;
   std::unique_ptr<Block> body;
 
-  explicit FrontendFuncDefStmt(const std::string &funcid,
-                               const DebugInfo &dbg_info)
-      : Stmt(dbg_info), funcid(funcid) {
+  explicit FrontendFuncDefStmt(const std::string &funcid) : funcid(funcid) {
   }
 
   bool is_container_statement() const override {
@@ -1022,8 +1020,7 @@ class ASTBuilder {
   void create_kernel_exprgroup_return(const ExprGroup &group);
   void create_print(std::vector<std::variant<Expr, std::string>> contents,
                     std::vector<std::optional<std::string>> formats);
-  void begin_func(const std::string &funcid,
-                  const DebugInfo &dbg_info = DebugInfo());
+  void begin_func(const std::string &funcid);
   void end_func(const std::string &funcid);
   void begin_frontend_if(const Expr &cond,
                          const DebugInfo &stmt_di = DebugInfo());

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -1077,7 +1077,7 @@ class ASTBuilder {
                                const mesh::MeshPtr &mesh_ptr,
                                const mesh::MeshElementType &element_type);
   void begin_frontend_while(const Expr &cond);
-  void insert_break_stmt(const DebugInfo &dbg_info);
+  void insert_break_stmt(const DebugInfo &dbg_info = DebugInfo());
   void insert_continue_stmt();
   void insert_expr_stmt(const Expr &val);
   void insert_snode_activate(SNode *snode,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -201,24 +201,28 @@ class FrontendForStmt : public Stmt {
   FrontendForStmt(const ExprGroup &loop_vars,
                   SNode *snode,
                   Arch arch,
-                  const ForLoopConfig &config);
+                  const ForLoopConfig &config,
+                  const DebugInfo &dbg_info = DebugInfo());
 
   FrontendForStmt(const ExprGroup &loop_vars,
                   const Expr &external_tensor,
                   Arch arch,
-                  const ForLoopConfig &config);
+                  const ForLoopConfig &config,
+                  const DebugInfo &dbg_info = DebugInfo());
 
   FrontendForStmt(const ExprGroup &loop_vars,
                   const mesh::MeshPtr &mesh,
                   const mesh::MeshElementType &element_type,
                   Arch arch,
-                  const ForLoopConfig &config);
+                  const ForLoopConfig &config,
+                  const DebugInfo &dbg_info = DebugInfo());
 
   FrontendForStmt(const Expr &loop_var,
                   const Expr &begin,
                   const Expr &end,
                   Arch arch,
-                  const ForLoopConfig &config);
+                  const ForLoopConfig &config,
+                  const DebugInfo &dbg_info = DebugInfo());
 
   bool is_container_statement() const override {
     return true;
@@ -1042,7 +1046,10 @@ class ASTBuilder {
   void create_assert_stmt(const Expr &cond,
                           const std::string &msg,
                           const std::vector<Expr> &args);
-  void begin_frontend_range_for(const Expr &i, const Expr &s, const Expr &e);
+  void begin_frontend_range_for(const Expr &i,
+                                const Expr &s,
+                                const Expr &e,
+                                const DebugInfo &dbg_info = DebugInfo());
   void begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars,
                                           SNode *snode);
   void begin_frontend_struct_for_on_external_tensor(

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -162,8 +162,8 @@ class FrontendIfStmt : public Stmt {
   Expr condition;
   std::unique_ptr<Block> true_statements, false_statements;
 
-  explicit FrontendIfStmt(const Expr &condition, const DebugInfo &stmt_di)
-      : Stmt(stmt_di), condition(condition) {
+  explicit FrontendIfStmt(const Expr &condition, const DebugInfo &dbg_info)
+      : Stmt(dbg_info), condition(condition) {
   }
 
   bool is_container_statement() const override {
@@ -1030,7 +1030,7 @@ class ASTBuilder {
   void begin_func(const std::string &funcid);
   void end_func(const std::string &funcid);
   void begin_frontend_if(const Expr &cond,
-                         const DebugInfo &stmt_di = DebugInfo());
+                         const DebugInfo &dbg_info = DebugInfo());
   void begin_frontend_if_true();
   void begin_frontend_if_false();
   void insert_external_func_call(std::size_t func_addr,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -184,8 +184,9 @@ class FrontendPrintStmt : public Stmt {
   const std::vector<FormatType> formats;
 
   FrontendPrintStmt(const std::vector<EntryType> &contents_,
-                    const std::vector<FormatType> &formats_)
-      : contents(contents_), formats(formats_) {
+                    const std::vector<FormatType> &formats_,
+                    const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), contents(contents_), formats(formats_) {
   }
 
   TI_DEFINE_ACCEPT
@@ -1026,7 +1027,8 @@ class ASTBuilder {
   Expr insert_patch_idx_expr();
   void create_kernel_exprgroup_return(const ExprGroup &group);
   void create_print(std::vector<std::variant<Expr, std::string>> contents,
-                    std::vector<std::optional<std::string>> formats);
+                    std::vector<std::optional<std::string>> formats,
+                    const DebugInfo &dbg_info = DebugInfo());
   void begin_func(const std::string &funcid);
   void end_func(const std::string &funcid);
   void begin_frontend_if(const Expr &cond,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -405,7 +405,8 @@ class RandExpression : public Expression {
  public:
   DataType dt;
 
-  explicit RandExpression(DataType dt) : dt(dt) {
+  explicit RandExpression(DataType dt, const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), dt(dt) {
   }
 
   void type_check(const CompileConfig *config) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -153,7 +153,8 @@ class FrontendIfStmt : public Stmt {
   Expr condition;
   std::unique_ptr<Block> true_statements, false_statements;
 
-  explicit FrontendIfStmt(const Expr &condition) : condition(condition) {
+  explicit FrontendIfStmt(const Expr &condition, const DebugInfo &stmt_di)
+      : Stmt(stmt_di), condition(condition) {
   }
 
   bool is_container_statement() const override {
@@ -1012,7 +1013,8 @@ class ASTBuilder {
                     std::vector<std::optional<std::string>> formats);
   void begin_func(const std::string &funcid);
   void end_func(const std::string &funcid);
-  void begin_frontend_if(const Expr &cond);
+  void begin_frontend_if(const Expr &cond,
+                         const DebugInfo &stmt_di = DebugInfo());
   void begin_frontend_if_true();
   void begin_frontend_if_false();
   void insert_external_func_call(std::size_t func_addr,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -248,7 +248,9 @@ class FrontendFuncDefStmt : public Stmt {
   std::string funcid;
   std::unique_ptr<Block> body;
 
-  explicit FrontendFuncDefStmt(const std::string &funcid) : funcid(funcid) {
+  explicit FrontendFuncDefStmt(const std::string &funcid,
+                               const DebugInfo &dbg_info)
+      : Stmt(dbg_info), funcid(funcid) {
   }
 
   bool is_container_statement() const override {
@@ -1020,7 +1022,8 @@ class ASTBuilder {
   void create_kernel_exprgroup_return(const ExprGroup &group);
   void create_print(std::vector<std::variant<Expr, std::string>> contents,
                     std::vector<std::optional<std::string>> formats);
-  void begin_func(const std::string &funcid);
+  void begin_func(const std::string &funcid,
+                  const DebugInfo &dbg_info = DebugInfo());
   void end_func(const std::string &funcid);
   void begin_frontend_if(const Expr &cond,
                          const DebugInfo &stmt_di = DebugInfo());

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -272,7 +272,8 @@ class FrontendFuncDefStmt : public Stmt {
 
 class FrontendBreakStmt : public Stmt {
  public:
-  FrontendBreakStmt() {
+  explicit FrontendBreakStmt(const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info) {
   }
 
   bool is_container_statement() const override {
@@ -1076,7 +1077,7 @@ class ASTBuilder {
                                const mesh::MeshPtr &mesh_ptr,
                                const mesh::MeshElementType &element_type);
   void begin_frontend_while(const Expr &cond);
-  void insert_break_stmt();
+  void insert_break_stmt(const DebugInfo &dbg_info);
   void insert_continue_stmt();
   void insert_expr_stmt(const Expr &val);
   void insert_snode_activate(SNode *snode,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -107,7 +107,8 @@ class FrontendSNodeOpStmt : public Stmt {
       SNodeOpType op_type,
       SNode *snode,
       const ExprGroup &indices,
-      const Expr &val = Expr(std::shared_ptr<Expression>(nullptr)));
+      const Expr &val = Expr(std::shared_ptr<Expression>(nullptr)),
+      const DebugInfo &dbg_info = DebugInfo());
 
   TI_DEFINE_ACCEPT
   TI_DEFINE_CLONE_FOR_FRONTEND_IR
@@ -1062,8 +1063,12 @@ class ASTBuilder {
   void insert_break_stmt();
   void insert_continue_stmt();
   void insert_expr_stmt(const Expr &val);
-  void insert_snode_activate(SNode *snode, const ExprGroup &expr_group);
-  void insert_snode_deactivate(SNode *snode, const ExprGroup &expr_group);
+  void insert_snode_activate(SNode *snode,
+                             const ExprGroup &expr_group,
+                             const DebugInfo &dbg_info = DebugInfo());
+  void insert_snode_deactivate(SNode *snode,
+                               const ExprGroup &expr_group,
+                               const DebugInfo &dbg_info = DebugInfo());
   Expr make_texture_op_expr(const TextureOpType &op,
                             const Expr &texture_ptr,
                             const ExprGroup &args);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -125,14 +125,16 @@ class FrontendAssertStmt : public Stmt {
   Expr cond;
   std::vector<Expr> args;
 
-  FrontendAssertStmt(const Expr &cond, const std::string &text)
-      : text(text), cond(cond) {
+  FrontendAssertStmt(const Expr &cond,
+                     const std::string &text,
+                     const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), text(text), cond(cond) {
   }
 
   FrontendAssertStmt(const Expr &cond,
                      const std::string &text,
                      const std::vector<Expr> &args_,
-                     const DebugInfo &dbg_info)
+                     const DebugInfo &dbg_info = DebugInfo())
       : Stmt(dbg_info), text(text), cond(cond) {
     for (auto &a : args_) {
       args.push_back(a);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -338,8 +338,10 @@ class ArgLoadExpression : public Expression {
                     DataType dt,
                     bool is_ptr = false,
                     bool create_load = true,
-                    int arg_depth = 0)
-      : arg_id(arg_id),
+                    int arg_depth = 0,
+                    const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info),
+        arg_id(arg_id),
         dt(dt),
         is_ptr(is_ptr),
         create_load(create_load),

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -126,8 +126,9 @@ class FrontendAssertStmt : public Stmt {
 
   FrontendAssertStmt(const Expr &cond,
                      const std::string &text,
-                     const std::vector<Expr> &args_)
-      : text(text), cond(cond) {
+                     const std::vector<Expr> &args_,
+                     const DebugInfo &dbg_info)
+      : Stmt(dbg_info), text(text), cond(cond) {
     for (auto &a : args_) {
       args.push_back(a);
     }
@@ -1049,7 +1050,8 @@ class ASTBuilder {
   std::optional<Expr> insert_func_call(Function *func, const ExprGroup &args);
   void create_assert_stmt(const Expr &cond,
                           const std::string &msg,
-                          const std::vector<Expr> &args);
+                          const std::vector<Expr> &args,
+                          const DebugInfo &dbg_info = DebugInfo());
   void begin_frontend_range_for(const Expr &i,
                                 const Expr &s,
                                 const Expr &e,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -78,16 +78,19 @@ class FrontendAllocaStmt : public Stmt {
  public:
   Identifier ident;
 
-  FrontendAllocaStmt(const Identifier &lhs, DataType type)
-      : ident(lhs), is_shared(false) {
+  FrontendAllocaStmt(const Identifier &lhs,
+                     DataType type,
+                     const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), ident(lhs), is_shared(false) {
     ret_type = type;
   }
 
   FrontendAllocaStmt(const Identifier &lhs,
                      std::vector<int> shape,
                      DataType element,
-                     bool is_shared = false)
-      : ident(lhs), is_shared(is_shared) {
+                     bool is_shared = false,
+                     const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), ident(lhs), is_shared(is_shared) {
     ret_type = TypeFactory::get_instance().get_pointer_type(
         DataType(TypeFactory::create_tensor_type(shape, element)));
   }
@@ -1035,9 +1038,10 @@ class ASTBuilder {
                                  const ExprGroup &args,
                                  const ExprGroup &outputs,
                                  const DebugInfo &dbg_info = DebugInfo());
-  Expr expr_alloca();
+  Expr expr_alloca(const DebugInfo &dbg_info = DebugInfo());
   Expr expr_alloca_shared_array(const std::vector<int> &shape,
-                                const DataType &element_type);
+                                const DataType &element_type,
+                                const DebugInfo &dbg_info = DebugInfo());
   Expr expr_subscript(const Expr &expr,
                       const ExprGroup &indices,
                       const DebugInfo &dbg_info = DebugInfo());

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -48,8 +48,10 @@ class FrontendExternalFuncStmt : public Stmt {
                            const std::string &bc_filename,
                            const std::string &bc_funcname,
                            const std::vector<Expr> &args,
-                           const std::vector<Expr> &outputs)
-      : so_func(so_func),
+                           const std::vector<Expr> &outputs,
+                           const DebugInfo &dbg_info)
+      : Stmt(dbg_info),
+        so_func(so_func),
         asm_source(asm_source),
         bc_filename(bc_filename),
         bc_funcname(bc_funcname),
@@ -1031,7 +1033,8 @@ class ASTBuilder {
                                  std::string filename,
                                  std::string funcname,
                                  const ExprGroup &args,
-                                 const ExprGroup &outputs);
+                                 const ExprGroup &outputs,
+                                 const DebugInfo &dbg_info = DebugInfo());
   Expr expr_alloca();
   Expr expr_alloca_shared_array(const std::vector<int> &shape,
                                 const DataType &element_type);

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -303,7 +303,8 @@ class FrontendWhileStmt : public Stmt {
   Expr cond;
   std::unique_ptr<Block> body;
 
-  explicit FrontendWhileStmt(const Expr &cond) : cond(cond) {
+  explicit FrontendWhileStmt(const Expr &cond, const DebugInfo &dbg_info)
+      : Stmt(dbg_info), cond(cond) {
   }
 
   bool is_container_statement() const override {
@@ -1078,7 +1079,8 @@ class ASTBuilder {
   void begin_frontend_mesh_for(const Expr &i,
                                const mesh::MeshPtr &mesh_ptr,
                                const mesh::MeshElementType &element_type);
-  void begin_frontend_while(const Expr &cond);
+  void begin_frontend_while(const Expr &cond,
+                            const DebugInfo &dbg_info = DebugInfo());
   void insert_break_stmt(const DebugInfo &dbg_info = DebugInfo());
   void insert_continue_stmt(const DebugInfo &dbg_info = DebugInfo());
   void insert_expr_stmt(const Expr &val);

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -634,8 +634,9 @@ class AssertStmt : public Stmt {
 
   AssertStmt(Stmt *cond,
              const std::string &text,
-             const std::vector<Stmt *> &args)
-      : cond(cond), text(text), args(args) {
+             const std::vector<Stmt *> &args,
+             const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), cond(cond), text(text), args(args) {
     TI_ASSERT(cond);
     TI_STMT_REG_FIELDS;
   }

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -233,7 +233,8 @@ class ArgLoadStmt : public Stmt {
  */
 class RandStmt : public Stmt {
  public:
-  explicit RandStmt(const DataType &dt) {
+  explicit RandStmt(const DataType &dt, const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info) {
     ret_type = dt;
     TI_STMT_REG_FIELDS;
   }

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -30,8 +30,9 @@ class AllocaStmt : public Stmt, public ir_traits::Store {
 
   AllocaStmt(const std::vector<int> &shape,
              DataType type,
-             bool is_shared = false)
-      : is_shared(is_shared) {
+             bool is_shared = false,
+             const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), is_shared(is_shared) {
     ret_type = TypeFactory::get_instance().get_pointer_type(
         TypeFactory::create_tensor_type(shape, type));
     TI_STMT_REG_FIELDS;

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1026,7 +1026,8 @@ void export_lang(py::module &m) {
   m.def("make_external_tensor_grad_expr",
         Expr::make<ExternalTensorExpression, Expr *>);
 
-  m.def("make_rand_expr", Expr::make<RandExpression, const DataType &>);
+  m.def("make_rand_expr",
+        Expr::make<RandExpression, const DataType &, const DebugInfo &>);
 
   m.def("make_const_expr_bool",
         Expr::make<ConstExpression, const DataType &, uint1>);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1009,7 +1009,7 @@ void export_lang(py::module &m) {
   m.def("make_global_load_stmt", Stmt::make<GlobalLoadStmt, Stmt *>);
   m.def("make_global_store_stmt", Stmt::make<GlobalStoreStmt, Stmt *, Stmt *>);
   m.def("make_frontend_assign_stmt",
-        Stmt::make<FrontendAssignStmt, const Expr &, const Expr &>);
+        Stmt::make<FrontendAssignStmt, const Expr &, const Expr &, const DebugInfo&>);
 
   m.def("make_arg_load_expr",
         Expr::make<ArgLoadExpression, const std::vector<int> &,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1013,9 +1013,9 @@ void export_lang(py::module &m) {
 
   m.def("make_arg_load_expr",
         Expr::make<ArgLoadExpression, const std::vector<int> &,
-                   const DataType &, bool, bool, int>,
+                   const DataType &, bool, bool, int, const DebugInfo &>,
         "arg_id"_a, "dt"_a, "is_ptr"_a = false, "create_load"_a = true,
-        "arg_depth"_a = 0);
+        "arg_depth"_a = 0, "dbg_info"_a = DebugInfo());
 
   m.def("make_reference", Expr::make<ReferenceExpression, const Expr &>);
 

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1009,7 +1009,8 @@ void export_lang(py::module &m) {
   m.def("make_global_load_stmt", Stmt::make<GlobalLoadStmt, Stmt *>);
   m.def("make_global_store_stmt", Stmt::make<GlobalStoreStmt, Stmt *, Stmt *>);
   m.def("make_frontend_assign_stmt",
-        Stmt::make<FrontendAssignStmt, const Expr &, const Expr &, const DebugInfo&>);
+        Stmt::make<FrontendAssignStmt, const Expr &, const Expr &,
+                   const DebugInfo &>);
 
   m.def("make_arg_load_expr",
         Expr::make<ArgLoadExpression, const std::vector<int> &,

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -6,11 +6,13 @@
 namespace taichi::lang {
 
 class FrontendTypeCheck : public IRVisitor {
-  void check_cond_type(const Expr &cond, const std::string &stmt_name) {
+  void check_cond_type(const Expr &cond,
+                       const Stmt *stmt,
+                       const std::string &stmt_name) {
     DataType cond_type = cond.get_rvalue_type();
     if (!cond_type->is<PrimitiveType>() || !is_integral(cond_type)) {
       ErrorEmitter(
-          TaichiTypeError(), cond,
+          TaichiTypeError(), stmt,
           fmt::format("`{0}` conditions must be an integer; found {1}. "
                       "Consider using "
                       "`{0} x != 0` instead of `{0} x` for float values.",
@@ -77,7 +79,7 @@ class FrontendTypeCheck : public IRVisitor {
   }
 
   void visit(FrontendAssertStmt *stmt) override {
-    check_cond_type(stmt->cond, "assert");
+    check_cond_type(stmt->cond, stmt, "assert");
   }
 
   void visit(FrontendAssignStmt *stmt) override {
@@ -108,9 +110,7 @@ class FrontendTypeCheck : public IRVisitor {
 
   void visit(FrontendIfStmt *stmt) override {
     // TODO: use PrimitiveType::u1 when it's supported
-    std::cerr << fmt::format("[debug] stmt->dbg_info.tb {}\n",
-                             stmt->dbg_info.tb);
-    check_cond_type(stmt->condition, "if");
+    check_cond_type(stmt->condition, stmt, "if");
     if (stmt->true_statements)
       stmt->true_statements->accept(this);
     if (stmt->false_statements)
@@ -186,7 +186,7 @@ class FrontendTypeCheck : public IRVisitor {
   }
 
   void visit(FrontendWhileStmt *stmt) override {
-    check_cond_type(stmt->cond, "while");
+    check_cond_type(stmt->cond, stmt, "while");
     stmt->body->accept(this);
   }
 

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -527,9 +527,11 @@ class LowerAST : public IRVisitor {
           output_statements));
     } else {
       for (auto &s : stmt->args) {
-        TI_ASSERT_INFO(
-            s.is<IdExpression>(),
-            "external func call via bitcode must pass in local variables.")
+        if (!s.is<IdExpression>()) {
+          ErrorEmitter(
+              TaichiSyntaxError(), stmt,
+              "external func call via bitcode must pass in local variables.");
+        }
         arg_statements.push_back(flatten_lvalue(s, &ctx));
       }
       ctx.push_back(std::make_unique<ExternalFuncCallStmt>(

--- a/taichi/transforms/lower_ast.cpp
+++ b/taichi/transforms/lower_ast.cpp
@@ -495,7 +495,8 @@ class LowerAST : public IRVisitor {
     for (int i = 0; i < (int)fargs.size(); ++i) {
       args_stmts[i] = flatten_rvalue(fargs[i], &fctx);
     }
-    fctx.push_back<AssertStmt>(val_stmt, stmt->text, args_stmts);
+    fctx.push_back<AssertStmt>(val_stmt, stmt->text, args_stmts,
+                               stmt->dbg_info);
     stmt->parent->replace_with(stmt, std::move(fctx.stmts));
   }
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 734486d</samp>

This pull request adds a new parameter `dbg_info` to various classes and functions in `taichi/ir` and `taichi/ir/frontend_ir` that are related to creating and storing IR statements and expressions. The goal is to pass the debug information from the frontend to the IR, which will enable better error reporting in Taichi.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 734486d</samp>

*  Add a new parameter `dbg_info` to the constructors of various classes that inherit from `Stmt` or `Expression` classes, and pass or assign it to the base constructor or the `dbg_info` field of the class. The purpose of these changes is to pass the debug information from the frontend to the IR for better error reporting. ([link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL154-R166), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL175-R189), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL201-R221), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL212-R228), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL218-R235), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL258-R276), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL271-R291), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL286-R307), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL303-R325), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL333-R358), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL400-R425), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL642-R672), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-50be2dc708119a4c9b53e977807d2f05e4ff6ce98c3f51fa91d1fa9e229962f1R127-R130), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-61484fa2a50e309478017fb2a436198aa4b0afdf72a4039bf574fc4f2aedbe4eR393), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L9-R12), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L65-R70), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L101-R108), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L139-R145), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L317-R329), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L328-R344), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L21-R22), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L32-R35), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L159-R163), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L203-R210), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L231-R238), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L260-R270), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L287-R301), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L314-R335), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L408-R429), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L489-R510), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L547-R569), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L616-R640), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L778-R804), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L806-R833), [link](https://github.com/taichi-dev/taichi/pull/8295/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1333-R1368))
