### PR TITLE
[bug] Remove debug print

### DIFF
--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -415,6 +415,5 @@ def uniform_add(arr_in: template(), in_beg: i32, in_end: i32):
 def blit_from_field_to_field(dst: template(), src: template(), offset: i32, size: i32):
     dst_offset = static(dst.snode.ptr.offset if len(dst.snode.ptr.offset) != 0 else 0)
     src_offset = static(src.snode.ptr.offset if len(src.snode.ptr.offset) != 0 else 0)
-    print("[debug]", dst_offset, src_offset)
     for i in range(size):
         dst[i + dst_offset + offset] = src[i + src_offset]

--- a/taichi/transforms/frontend_type_check.cpp
+++ b/taichi/transforms/frontend_type_check.cpp
@@ -108,8 +108,6 @@ class FrontendTypeCheck : public IRVisitor {
 
   void visit(FrontendIfStmt *stmt) override {
     // TODO: use PrimitiveType::u1 when it's supported
-    std::cerr << fmt::format("[debug] stmt->dbg_info.tb {}\n",
-                             stmt->dbg_info.tb);
     check_cond_type(stmt->condition, "if");
     if (stmt->true_statements)
       stmt->true_statements->accept(this);


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb07647</samp>

Remove unnecessary debug print statements from `blit_from_field_to_field` and `FrontendTypeCheck::visit`. These statements were used for testing or debugging, but are not relevant for the final functionality of the code.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb07647</samp>

* Remove debug print statements from `blit_from_field_to_field` and `FrontendTypeCheck::visit` functions ([link](https://github.com/taichi-dev/taichi/pull/8296/files?diff=unified&w=0#diff-09cd7b8194d05b7454b512d74fc5b442aed2319dcb763e182288b55753ce6feeL418), [link](https://github.com/taichi-dev/taichi/pull/8296/files?diff=unified&w=0#diff-540161ef0e79b2ecf9eabafa3601b58dcd92fcd69583b475dbb80e7d29f84506L111-L112))
