### PR TITLE
[rhi] Add MetalPipeline raster support and MetalRasterResources

### DIFF
--- a/taichi/rhi/metal/metal_device.h
+++ b/taichi/rhi/metal/metal_device.h
@@ -28,6 +28,7 @@ DEFINE_METAL_ID_TYPE(MTLSamplerState);
 DEFINE_METAL_ID_TYPE(MTLLibrary);
 DEFINE_METAL_ID_TYPE(MTLFunction);
 DEFINE_METAL_ID_TYPE(MTLComputePipelineState);
+DEFINE_METAL_ID_TYPE(MTLRenderPipelineState);
 DEFINE_METAL_ID_TYPE(MTLCommandQueue);
 DEFINE_METAL_ID_TYPE(MTLCommandBuffer);
 DEFINE_METAL_ID_TYPE(MTLBlitCommandEncoder);
@@ -113,15 +114,15 @@ class MetalPipeline final : public Pipeline {
                          MTLLibrary_id mtl_library,
                          const std::vector<MTLFunction_id>
                              &mtl_functions,  // Should be vertex and fragment
-                         const RasterParams &raster_params,
-                         const std::vector<VertexInputBinding> &vertex_inputs,
-                         const std::vector<VertexInputAttribute> &vertex_attrs);
+                         MTLRenderPipelineState_id mtl_render_pipeline_state,
+                         const RasterParams raster_params);
   ~MetalPipeline() final;
 
-  static MetalPipeline *create(const MetalDevice &device,
-                               const uint32_t *spv_data,
-                               size_t spv_size,
-                               const std::string &name);
+  static MetalPipeline *create_compute_pipeline(const MetalDevice &device,
+                                                const uint32_t *spv_data,
+                                                size_t spv_size,
+                                                const std::string &name);
+
   void destroy();
 
   inline MTLComputePipelineState_id mtl_compute_pipeline_state() const {
@@ -129,6 +130,14 @@ class MetalPipeline final : public Pipeline {
   }
   inline const MetalWorkgroupSize &workgroup_size() const {
     return workgroup_size_;
+  }
+
+  inline MTLRenderPipelineState_id mtl_render_pipeline_state() const {
+    return mtl_render_pipeline_state_;
+  }
+
+  inline const RasterParams raster_params() const {
+    return raster_params_;
   }
 
  private:
@@ -145,6 +154,8 @@ class MetalPipeline final : public Pipeline {
 
   // Raster variables
   std::vector<MTLFunction_id> mtl_functions_;
+  MTLRenderPipelineState_id mtl_render_pipeline_state_;
+  const RasterParams raster_params_;
 };
 
 enum class MetalShaderResourceType {
@@ -393,11 +404,17 @@ class MetalDevice final : public GraphicsDevice {
     return *default_sampler_;
   }
 
+  const BufferFormat get_swap_image_format() {
+    return swap_chain_image_format_;
+  }
+
   MTLFunction_id get_mtl_function(MTLLibrary_id mtl_lib,
                                   const std::string &func_name) const;
   MTLLibrary_id get_mtl_library(const std::string &source) const;
 
  private:
+  const BufferFormat swap_chain_image_format_{BufferFormat::bgra8};
+
   const std::string frag_function_name = "frag_function";
   const std::string vert_function_name = "vert_function";
 

--- a/taichi/rhi/metal/metal_device.h
+++ b/taichi/rhi/metal/metal_device.h
@@ -100,6 +100,10 @@ struct MetalWorkgroupSize {
   uint32_t y{0};
   uint32_t z{0};
 };
+struct MetalRasterFunctions {
+  MTLFunction_id vertex;
+  MTLFunction_id fragment;
+};
 class MetalPipeline final : public Pipeline {
  public:
   // `mtl_library`, `mtl_function`, `mtl_compute_pipeline_state` should be
@@ -112,8 +116,7 @@ class MetalPipeline final : public Pipeline {
 
   explicit MetalPipeline(const MetalDevice &device,
                          MTLLibrary_id mtl_library,
-                         const std::vector<MTLFunction_id>
-                             &mtl_functions,  // Should be vertex and fragment
+                         const MetalRasterFunctions &mtl_functions,
                          MTLRenderPipelineState_id mtl_render_pipeline_state,
                          const RasterParams raster_params);
   ~MetalPipeline() final;
@@ -153,7 +156,7 @@ class MetalPipeline final : public Pipeline {
   MetalWorkgroupSize workgroup_size_;
 
   // Raster variables
-  std::vector<MTLFunction_id> mtl_functions_;
+  MetalRasterFunctions mtl_functions_;
   MTLRenderPipelineState_id mtl_render_pipeline_state_;
   const RasterParams raster_params_;
 };
@@ -341,6 +344,11 @@ class MetalSurface final : public Surface {
   CAMetalLayer *layer_;
 };
 
+constexpr BufferFormat kSwapChainImageFormat{BufferFormat::bgra8};
+
+constexpr auto kMetalFragFunctionName = "frag_function";
+constexpr auto kMetalVertFunctionName = "vert_function";
+
 class MetalDevice final : public GraphicsDevice {
  public:
   // `mtl_device` should be already retained.
@@ -404,20 +412,11 @@ class MetalDevice final : public GraphicsDevice {
     return *default_sampler_;
   }
 
-  const BufferFormat get_swap_image_format() {
-    return swap_chain_image_format_;
-  }
-
   MTLFunction_id get_mtl_function(MTLLibrary_id mtl_lib,
                                   const std::string &func_name) const;
   MTLLibrary_id get_mtl_library(const std::string &source) const;
 
  private:
-  const BufferFormat swap_chain_image_format_{BufferFormat::bgra8};
-
-  const std::string frag_function_name = "frag_function";
-  const std::string vert_function_name = "vert_function";
-
   MTLDevice_id mtl_device_;
   rhi_impl::SyncedPtrStableObjectList<MetalMemory> memory_allocs_;
   rhi_impl::SyncedPtrStableObjectList<MetalImage> image_allocs_;

--- a/taichi/rhi/metal/metal_device.mm
+++ b/taichi/rhi/metal/metal_device.mm
@@ -102,7 +102,7 @@ MTLPixelFormat format2mtl(BufferFormat format) {
       {BufferFormat::rgb32f, MTLPixelFormatInvalid},
       {BufferFormat::rgba32f, MTLPixelFormatRGBA32Float},
       {BufferFormat::depth16, MTLPixelFormatDepth16Unorm},
-      {BufferFormat::depth24stencil8, MTLPixelFormatX24_Stencil8},
+      {BufferFormat::depth24stencil8, MTLPixelFormatInvalid},
       {BufferFormat::depth32f, MTLPixelFormatDepth32Float},
   };
   auto it = map.find(format);


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f3c134</samp>

This pull request adds rasterization capabilities to the Metal backend, allowing it to render 2D and 3D graphics using the Taichi compiler. It introduces new classes and methods for creating and executing raster pipelines, and managing the required resources. It also improves the code quality and debuggability of the Metal device implementation.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f3c134</samp>

*  Add support for rasterization in Metal backend by creating and managing raster pipelines and resources ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614R7), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614R31), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L110-R125), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L125-R158), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614R212-R233), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L344-R396), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L361-R420), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bR10-R60), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL137-R202), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL179-R245), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bR276), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bR385-R409), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL614-R674), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL833-R894), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL840-R1083))
  * Define a macro for declaring Metal object ID types and release functions, such as `MTLRenderPipelineState` ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614R31))
  * Add a new constructor and fields for the `MetalPipeline` class to store raster pipeline variables, such as functions, render pipeline state, and raster parameters ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L110-R125), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L125-R158))
  * Add a new class `MetalRasterResources` that inherits from the `RasterResources` interface and implements the methods for setting vertex and index buffers ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614R212-R233))
  * Implement the `create_raster_pipeline` method of the `MetalDevice` class, which takes SPIR-V binaries and raster parameters and returns a `MetalPipeline` object ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L344-R396))
    * Use the `spirv_cross` library to compile SPIR-V binaries to MSL source code and rename the entry point functions ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L361-R420))
    * Use the `get_mtl_library` and `get_mtl_function` methods of the `MetalDevice` class to create and cache Metal library and function objects from the MSL source code ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L361-R420), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL179-R245))
    * Use the Metal API to create a render pipeline state from the library and functions, and set up the vertex descriptor and input primitive topology ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L344-R396), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL179-R245))
  * Implement the `create_raster_resources` method of the `MetalDevice` class, which returns a new `MetalRasterResources` object ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L344-R396), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL840-R1083))
  * Implement the `vertex_buffer` and `index_buffer` methods of the `MetalRasterResources` class, which set the Metal buffer ID and offset for each binding ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bR385-R409))
  * Add a field for the swap chain image format to the `MetalDevice` class, and use it to set the pixel format of the render pipeline descriptor ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-5b304e188996abd217fad85fd8b2434e729ad9c089eb9ef48a848c0fcc74d614L361-R420), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL614-R674))
  * Add a function `vertexformat2mtl` to convert `BufferFormat` enum values to `MTLVertexFormat` enum values, and use it to set the vertex attribute format in the vertex descriptor ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bR10-R60))
* Rename the `MetalPipeline::create` method to `MetalPipeline::create_compute_pipeline` and add a name parameter, to reflect the fact that it is only used for compute pipelines and to improve logging and debugging ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL137-R202), [link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL833-R894))
* Fix a typo in the `format2mtl` function, which converts `BufferFormat` enum values to `MTLPixelFormat` enum values, and use the correct pixel format for the `BufferFormat::depth24stencil8` case ([link](https://github.com/taichi-dev/taichi/pull/8299/files?diff=unified&w=0#diff-c350a27659df1ebcf2c854e2c21a80f82de87d3b325a80e00f6a6dd6ca53303bL54-R105))
