### PR TITLE
[gui] Fix vec_to_euler that breaks GGUI cameras & handle camera logic better

### DIFF
--- a/python/taichi/ui/camera.py
+++ b/python/taichi/ui/camera.py
@@ -241,9 +241,9 @@ class Camera:
         if window.is_pressed("q"):
             position_change -= up * movement_speed
         self.position(*(self.curr_position + position_change))
-        self.lookat(*(self.curr_lookat + position_change))
 
         curr_mouse_x, curr_mouse_y = window.get_cursor_pos()
+
         if (hold_key is None) or window.is_pressed(hold_key):
             if (self.last_mouse_x is None) or (self.last_mouse_y is None):
                 self.last_mouse_x, self.last_mouse_y = curr_mouse_x, curr_mouse_y
@@ -252,10 +252,8 @@ class Camera:
 
             yaw, pitch = vec_to_euler(front)
 
-            yaw_speed *= time_elapsed * 60.0
-            pitch_speed *= time_elapsed * 60.0
-            yaw -= dx * yaw_speed
-            pitch += dy * pitch_speed
+            yaw -= dx * yaw_speed * time_elapsed * 60.0
+            pitch += dy * pitch_speed * time_elapsed * 60.0
 
             pitch_limit = pi / 2 * 0.99
             if pitch > pitch_limit:
@@ -264,6 +262,6 @@ class Camera:
                 pitch = -pitch_limit
 
             front = euler_to_vec(yaw, pitch)
-            self.lookat(*(self.curr_position + front))
 
+        self.lookat(*(self.curr_position + front))
         self.last_mouse_x, self.last_mouse_y = curr_mouse_x, curr_mouse_y

--- a/python/taichi/ui/utils.py
+++ b/python/taichi/ui/utils.py
@@ -46,17 +46,12 @@ def vec_to_euler(v, eps: float = 1e-6):
     v = v.normalized()
     pitch = asin(v[1])
 
-    sin_yaw = v[0] / cos(pitch)
-    cos_yaw = v[2] / cos(pitch)
+    cos_pitch = np.sqrt(1 - v[1] * v[1])
 
-    if abs(sin_yaw) < eps:
-        yaw = 0
-    else:
-        # fix math domain error due to float precision loss
-        cos_yaw = max(min(cos_yaw, 1.0), -1.0)
-        yaw = acos(cos_yaw)
-        if sin_yaw < 0:
-            yaw = -yaw
+    sin_yaw = v[0] / cos_pitch
+    cos_yaw = v[2] / cos_pitch
+
+    yaw = np.arctan2(sin_yaw, cos_yaw)
 
     return yaw, pitch
 

--- a/python/taichi/ui/utils.py
+++ b/python/taichi/ui/utils.py
@@ -1,5 +1,5 @@
 import platform
-from math import acos, asin, cos, sin
+from math import asin, cos, sin
 
 import numpy as np
 from taichi._lib import core as _ti_core


### PR DESCRIPTION
Issue: #

### Brief Summary

In GGUI with camera when using right click the camera direction can flip, this is caused by a broken `vec_to_eular`:

```python
print(euler_to_vec(*vec_to_euler(Vector([0.0, 0.70710678, -0.70710678]))))
```

prints out `[0.         0.70710678 0.70710678]`. Direction will stay z-positive forever...

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6fc9b3c</samp>

* Fix camera lookat direction when moving by removing redundant line ([link](https://github.com/taichi-dev/taichi/pull/8304/files?diff=unified&w=0#diff-76018fe26d398960a6f43258908d3f4c0c0ddad22f590a54c2b7519363169689L244-R246))
* Simplify yaw and pitch speed calculation by reducing repeated operations ([link](https://github.com/taichi-dev/taichi/pull/8304/files?diff=unified&w=0#diff-76018fe26d398960a6f43258908d3f4c0c0ddad22f590a54c2b7519363169689L255-R256))
* Ensure camera lookat direction always updates based on front vector by moving line outside of if block ([link](https://github.com/taichi-dev/taichi/pull/8304/files?diff=unified&w=0#diff-76018fe26d398960a6f43258908d3f4c0c0ddad22f590a54c2b7519363169689L267-R266))
* Refactor `vec_to_euler` function in `utils.py` to use `np.arctan2` instead of `acos` and `asin` to avoid math domain error and simplify code ([link](https://github.com/taichi-dev/taichi/pull/8304/files?diff=unified&w=0#diff-ee3c66c3874a30d0a080e0249530276145343e52094cad2b1d8249bc83d7f762L49-R55))
