### PR TITLE
[lang] Pass DebugInfo to frontend expressions

### DIFF
--- a/python/taichi/lang/_texture.py
+++ b/python/taichi/lang/_texture.py
@@ -22,8 +22,9 @@ class TextureSampler:
     @taichi_scope
     def sample_lod(self, uv, lod):
         ast_builder = impl.get_runtime().compiling_callable.ast_builder()
+        dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
         args_group = make_expr_group(*_get_entries(uv), lod)
-        v = ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kSampleLod, self.ptr_expr, args_group)
+        v = ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kSampleLod, self.ptr_expr, args_group, dbg_info)
         r = impl.call_internal("composite_extract_0", v, with_runtime_context=False)
         g = impl.call_internal("composite_extract_1", v, with_runtime_context=False)
         b = impl.call_internal("composite_extract_2", v, with_runtime_context=False)
@@ -33,8 +34,9 @@ class TextureSampler:
     @taichi_scope
     def fetch(self, index, lod):
         ast_builder = impl.get_runtime().compiling_callable.ast_builder()
+        dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
         args_group = make_expr_group(*_get_entries(index), lod)
-        v = ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kFetchTexel, self.ptr_expr, args_group)
+        v = ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kFetchTexel, self.ptr_expr, args_group, dbg_info)
         r = impl.call_internal("composite_extract_0", v, with_runtime_context=False)
         g = impl.call_internal("composite_extract_1", v, with_runtime_context=False)
         b = impl.call_internal("composite_extract_2", v, with_runtime_context=False)
@@ -51,8 +53,9 @@ class RWTextureAccessor:
     @taichi_scope
     def load(self, index):
         ast_builder = impl.get_runtime().compiling_callable.ast_builder()
+        dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
         args_group = make_expr_group(*_get_entries(index))
-        v = ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kLoad, self.ptr_expr, args_group)
+        v = ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kLoad, self.ptr_expr, args_group, dbg_info)
         r = impl.call_internal("composite_extract_0", v, with_runtime_context=False)
         g = impl.call_internal("composite_extract_1", v, with_runtime_context=False)
         b = impl.call_internal("composite_extract_2", v, with_runtime_context=False)
@@ -62,8 +65,11 @@ class RWTextureAccessor:
     @taichi_scope
     def store(self, index, value):
         ast_builder = impl.get_runtime().compiling_callable.ast_builder()
+        dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
         args_group = make_expr_group(*_get_entries(index), *_get_entries(value))
-        impl.expr_init(ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kStore, self.ptr_expr, args_group))
+        impl.expr_init(
+            ast_builder.make_texture_op_expr(_ti_core.TextureOpType.kStore, self.ptr_expr, args_group, dbg_info)
+        )
 
     @property
     @taichi_scope

--- a/python/taichi/lang/_texture.py
+++ b/python/taichi/lang/_texture.py
@@ -80,7 +80,8 @@ class RWTextureAccessor:
             List[Int]: The result list.
         """
         dim = _ti_core.get_external_tensor_dim(self.ptr_expr)
-        ret = [Expr(_ti_core.get_external_tensor_shape_along_axis(self.ptr_expr, i)) for i in range(dim)]
+        dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+        ret = [Expr(_ti_core.get_external_tensor_shape_along_axis(self.ptr_expr, i, dbg_info)) for i in range(dim)]
         return ret
 
     @taichi_scope

--- a/python/taichi/lang/any_array.py
+++ b/python/taichi/lang/any_array.py
@@ -51,7 +51,8 @@ class AnyArray:
             List[Int]: The result list.
         """
         dim = _ti_core.get_external_tensor_dim(self.ptr)
-        return [Expr(_ti_core.get_external_tensor_shape_along_axis(self.ptr, i)) for i in range(dim)]
+        dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+        return [Expr(_ti_core.get_external_tensor_shape_along_axis(self.ptr, i, dbg_info)) for i in range(dim)]
 
     @taichi_scope
     def _loop_range(self):

--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -1409,7 +1409,12 @@ class ASTTransformer(Builder):
             assert isinstance(ctx.mesh, impl.MeshInstance)
             mesh_idx = mesh.MeshElementFieldProxy(ctx.mesh, node.iter.ptr._type, var.ptr)
             ctx.create_variable(target, mesh_idx)
-            ctx.ast_builder.begin_frontend_mesh_for(mesh_idx.ptr, ctx.mesh.mesh_ptr, node.iter.ptr._type)
+            ctx.ast_builder.begin_frontend_mesh_for(
+                mesh_idx.ptr,
+                ctx.mesh.mesh_ptr,
+                node.iter.ptr._type,
+                _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+            )
             build_stmts(ctx, node.body)
             ctx.mesh = None
             ctx.ast_builder.end_frontend_mesh_for()

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -239,10 +239,7 @@ def subscript(ast_builder, value, *_indices, skip_reordered=False):
             [
                 Expr(
                     ast_builder.mesh_index_conversion(
-                        value.mesh_ptr,
-                        value.element_type,
-                        Expr(indices[0]).ptr,
-                        ConvType.g2r,
+                        value.mesh_ptr, value.element_type, Expr(indices[0]).ptr, ConvType.g2r, dbg_info
                     )
                 )
             ]

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -129,10 +129,11 @@ def begin_frontend_struct_for(ast_builder, group, loop_range):
             f"({group.size()} != {len(loop_range.shape)}). Maybe you wanted to "
             'use "for I in ti.grouped(x)" to group all indices into a single vector I?'
         )
+    dbg_info = _ti_core.DebugInfo(get_runtime().get_current_src_info())
     if isinstance(loop_range, (AnyArray, RWTextureAccessor)):
-        ast_builder.begin_frontend_struct_for_on_external_tensor(group, loop_range._loop_range())
+        ast_builder.begin_frontend_struct_for_on_external_tensor(group, loop_range._loop_range(), dbg_info)
     else:
-        ast_builder.begin_frontend_struct_for_on_snode(group, loop_range._loop_range())
+        ast_builder.begin_frontend_struct_for_on_snode(group, loop_range._loop_range(), dbg_info)
 
 
 def begin_frontend_if(ast_builder, cond, stmt_dbg_info):

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -133,7 +133,7 @@ def decl_texture_arg(num_dimensions, name):
     # FIXME: texture_arg doesn't have element_shape so better separate them
     arg_id = impl.get_runtime().compiling_callable.insert_texture_param(num_dimensions, name)
     dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
-    return TextureSampler(_ti_core.make_texture_ptr_expr(arg_id, num_dimensions, 0), num_dimensions, dbg_info)
+    return TextureSampler(_ti_core.make_texture_ptr_expr(arg_id, num_dimensions, 0, dbg_info), num_dimensions)
 
 
 def decl_rw_texture_arg(num_dimensions, buffer_format, lod, name):
@@ -141,7 +141,7 @@ def decl_rw_texture_arg(num_dimensions, buffer_format, lod, name):
     arg_id = impl.get_runtime().compiling_callable.insert_rw_texture_param(num_dimensions, buffer_format, name)
     dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
     return RWTextureAccessor(
-        _ti_core.make_rw_texture_ptr_expr(arg_id, num_dimensions, 0, buffer_format, lod), num_dimensions, dbg_info
+        _ti_core.make_rw_texture_ptr_expr(arg_id, num_dimensions, 0, buffer_format, lod, dbg_info), num_dimensions
     )
 
 

--- a/python/taichi/lang/kernel_arguments.py
+++ b/python/taichi/lang/kernel_arguments.py
@@ -132,15 +132,16 @@ def decl_ndarray_arg(element_type, ndim, name, needs_grad, boundary):
 def decl_texture_arg(num_dimensions, name):
     # FIXME: texture_arg doesn't have element_shape so better separate them
     arg_id = impl.get_runtime().compiling_callable.insert_texture_param(num_dimensions, name)
-    return TextureSampler(_ti_core.make_texture_ptr_expr(arg_id, num_dimensions, 0), num_dimensions)
+    dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    return TextureSampler(_ti_core.make_texture_ptr_expr(arg_id, num_dimensions, 0), num_dimensions, dbg_info)
 
 
 def decl_rw_texture_arg(num_dimensions, buffer_format, lod, name):
     # FIXME: texture_arg doesn't have element_shape so better separate them
     arg_id = impl.get_runtime().compiling_callable.insert_rw_texture_param(num_dimensions, buffer_format, name)
+    dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
     return RWTextureAccessor(
-        _ti_core.make_rw_texture_ptr_expr(arg_id, num_dimensions, 0, buffer_format, lod),
-        num_dimensions,
+        _ti_core.make_rw_texture_ptr_expr(arg_id, num_dimensions, 0, buffer_format, lod), num_dimensions, dbg_info
     )
 
 

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -258,7 +258,9 @@ class Func:
                         raise TaichiTypeError(
                             f"Expected ndarray in the kernel argument for argument {kernel_arg.name}, got {args[i]}"
                         )
-                    non_template_args += _ti_core.get_external_tensor_real_func_args(args[i].ptr)
+                    non_template_args += _ti_core.get_external_tensor_real_func_args(
+                        args[i].ptr, _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+                    )
                 else:
                     non_template_args.append(args[i])
         non_template_args = impl.make_expr_group(non_template_args)
@@ -274,7 +276,13 @@ class Func:
 
         for i, return_type in enumerate(self.return_type):
             if id(return_type) in primitive_types.type_ids:
-                ret.append(Expr(_ti_core.make_get_element_expr(func_call.ptr, (i,))))
+                ret.append(
+                    Expr(
+                        _ti_core.make_get_element_expr(
+                            func_call.ptr, (i,), _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+                        )
+                    )
+                )
             elif isinstance(return_type, (StructType, MatrixType)):
                 ret.append(return_type.from_taichi_object(func_call, (i,)))
             else:

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -266,7 +266,7 @@ class Func:
         func_call = (
             impl.get_runtime()
             .compiling_callable.ast_builder()
-            .insert_func_call(self.taichi_functions[key.instance_id], non_template_args)
+            .insert_func_call(self.taichi_functions[key.instance_id], non_template_args, dbg_info)
         )
         if self.return_type is None:
             return None

--- a/python/taichi/lang/kernel_impl.py
+++ b/python/taichi/lang/kernel_impl.py
@@ -246,21 +246,20 @@ class Func:
         # Skip the template args, e.g., |self|
         assert self.is_real_function
         non_template_args = []
+        dbg_info = _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
         for i, kernel_arg in enumerate(self.arguments):
             anno = kernel_arg.annotation
             if not isinstance(anno, template):
                 if id(anno) in primitive_types.type_ids:
                     non_template_args.append(ops.cast(args[i], anno))
                 elif isinstance(anno, primitive_types.RefType):
-                    non_template_args.append(_ti_core.make_reference(args[i].ptr))
+                    non_template_args.append(_ti_core.make_reference(args[i].ptr, dbg_info))
                 elif isinstance(anno, ndarray_type.NdarrayType):
                     if not isinstance(args[i], AnyArray):
                         raise TaichiTypeError(
                             f"Expected ndarray in the kernel argument for argument {kernel_arg.name}, got {args[i]}"
                         )
-                    non_template_args += _ti_core.get_external_tensor_real_func_args(
-                        args[i].ptr, _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
-                    )
+                    non_template_args += _ti_core.get_external_tensor_real_func_args(args[i].ptr, dbg_info)
                 else:
                     non_template_args.append(args[i])
         non_template_args = impl.make_expr_group(non_template_args)

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -1453,7 +1453,13 @@ class MatrixType(CompoundType):
     def from_taichi_object(self, func_ret, ret_index=()):
         return self(
             [
-                expr.Expr(ti_python_core.make_get_element_expr(func_ret.ptr, ret_index + (i,)))
+                expr.Expr(
+                    ti_python_core.make_get_element_expr(
+                        func_ret.ptr,
+                        ret_index + (i,),
+                        _ti_python_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+                    )
+                )
                 for i in range(self.m * self.n)
             ]
         )

--- a/python/taichi/lang/matrix.py
+++ b/python/taichi/lang/matrix.py
@@ -150,7 +150,12 @@ def make_matrix_with_shape(arr, shape, dt):
     return expr.Expr(
         impl.get_runtime()
         .compiling_callable.ast_builder()
-        .make_matrix_expr(shape, dt, [expr.Expr(elt).ptr for elt in arr])
+        .make_matrix_expr(
+            shape,
+            dt,
+            [expr.Expr(elt).ptr for elt in arr],
+            ti_python_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+        )
     )
 
 
@@ -172,7 +177,12 @@ def make_matrix(arr, dt=None):
     return expr.Expr(
         impl.get_runtime()
         .compiling_callable.ast_builder()
-        .make_matrix_expr(shape, dt, [expr.Expr(elt).ptr for elt in arr])
+        .make_matrix_expr(
+            shape,
+            dt,
+            [expr.Expr(elt).ptr for elt in arr],
+            ti_python_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+        )
     )
 
 

--- a/python/taichi/lang/mesh.py
+++ b/python/taichi/lang/mesh.py
@@ -357,10 +357,21 @@ class MeshInstance:
         _ti_core.add_mesh_attribute(self.mesh_ptr, element_type, snode, reorder_type)
 
     def get_relation_size(self, from_index, to_element_type):
-        return _ti_core.get_relation_size(self.mesh_ptr, from_index.ptr, to_element_type)
+        return _ti_core.get_relation_size(
+            self.mesh_ptr,
+            from_index.ptr,
+            to_element_type,
+            _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+        )
 
     def get_relation_access(self, from_index, to_element_type, neighbor_idx_ptr):
-        return _ti_core.get_relation_access(self.mesh_ptr, from_index.ptr, to_element_type, neighbor_idx_ptr)
+        return _ti_core.get_relation_access(
+            self.mesh_ptr,
+            from_index.ptr,
+            to_element_type,
+            neighbor_idx_ptr,
+            _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+        )
 
 
 class MeshMetadata:
@@ -586,6 +597,7 @@ class MeshElementFieldProxy:
                     element_type,
                     entry_expr,
                     ConvType.l2r if element_field.attr_dict[key].reorder else ConvType.l2g,
+                    _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
                 )
             )  # transform index space
             global_entry_expr_group = impl.make_expr_group(*tuple([global_entry_expr]))
@@ -637,7 +649,13 @@ class MeshElementFieldProxy:
     def id(self):  # return the global non-reordered index
         ast_builder = impl.get_runtime().compiling_callable.ast_builder()
         l2g_expr = impl.Expr(
-            ast_builder.mesh_index_conversion(self.mesh.mesh_ptr, self.element_type, self.entry_expr, ConvType.l2g)
+            ast_builder.mesh_index_conversion(
+                self.mesh.mesh_ptr,
+                self.element_type,
+                self.entry_expr,
+                ConvType.l2g,
+                _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+            )
         )
         return l2g_expr
 

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -574,7 +574,9 @@ def loop_unique(val, covers=None):
     if not isinstance(covers, (list, tuple)):
         covers = [covers]
     covers = [x.snode.ptr if isinstance(x, Expr) else x.ptr for x in covers]
-    return _ti_core.expr_loop_unique(Expr(val).ptr, covers)
+    return _ti_core.expr_loop_unique(
+        Expr(val).ptr, covers, _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    )
 
 
 def _parallelize(v):

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -704,7 +704,11 @@ def mesh_patch_idx():
 
     Related to https://github.com/taichi-dev/taichi/issues/3608
     """
-    return impl.get_runtime().compiling_callable.ast_builder().insert_patch_idx_expr()
+    return (
+        impl.get_runtime()
+        .compiling_callable.ast_builder()
+        .insert_patch_idx_expr(_ti_core.DebugInfo(impl.get_runtime().get_current_src_info()))
+    )
 
 
 def is_arch_supported(arch):

--- a/python/taichi/lang/misc.py
+++ b/python/taichi/lang/misc.py
@@ -563,7 +563,9 @@ def assume_in_range(val, base, low, high):
         >>> x
         10
     """
-    return _ti_core.expr_assume_in_range(Expr(val).ptr, Expr(base).ptr, low, high)
+    return _ti_core.expr_assume_in_range(
+        Expr(val).ptr, Expr(base).ptr, low, high, _ti_core.DebugInfo(impl.get_runtime().get_current_src_info())
+    )
 
 
 def loop_unique(val, covers=None):

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -20,7 +20,11 @@ def is_taichi_expr(a):
 
 
 def wrap_if_not_expr(a):
-    return expr.Expr(a, dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info())) if not is_taichi_expr(a) else a
+    return (
+        expr.Expr(a, dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info()))
+        if not is_taichi_expr(a)
+        else a
+    )
 
 
 def _read_matrix_or_scalar(x):

--- a/python/taichi/lang/ops.py
+++ b/python/taichi/lang/ops.py
@@ -20,7 +20,7 @@ def is_taichi_expr(a):
 
 
 def wrap_if_not_expr(a):
-    return expr.Expr(a) if not is_taichi_expr(a) else a
+    return expr.Expr(a, dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info())) if not is_taichi_expr(a) else a
 
 
 def _read_matrix_or_scalar(x):

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -459,13 +459,11 @@ def get_addr(f, indices):
     Returns:
         ti.u64: The memory address of `f[indices]`.
     """
-    return (
-        expr.Expr(
-            impl.get_runtime()
-            .compiling_callable.ast_builder()
-            .expr_snode_get_addr(f._snode.ptr, expr.make_expr_group(indices)),
-            dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
-        ),
+    return expr.Expr(
+        impl.get_runtime()
+        .compiling_callable.ast_builder()
+        .expr_snode_get_addr(f._snode.ptr, expr.make_expr_group(indices)),
+        dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
     )
 
 

--- a/python/taichi/lang/snode.py
+++ b/python/taichi/lang/snode.py
@@ -397,7 +397,8 @@ def is_active(node, indices):
     return expr.Expr(
         impl.get_runtime()
         .compiling_callable.ast_builder()
-        .expr_snode_is_active(node._snode.ptr, expr.make_expr_group(indices))
+        .expr_snode_is_active(node._snode.ptr, expr.make_expr_group(indices)),
+        dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
     )
 
 
@@ -441,7 +442,8 @@ def length(node, indices):
     return expr.Expr(
         impl.get_runtime()
         .compiling_callable.ast_builder()
-        .expr_snode_length(node._snode.ptr, expr.make_expr_group(indices))
+        .expr_snode_length(node._snode.ptr, expr.make_expr_group(indices)),
+        dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
     )
 
 
@@ -457,10 +459,13 @@ def get_addr(f, indices):
     Returns:
         ti.u64: The memory address of `f[indices]`.
     """
-    return expr.Expr(
-        impl.get_runtime()
-        .compiling_callable.ast_builder()
-        .expr_snode_get_addr(f._snode.ptr, expr.make_expr_group(indices))
+    return (
+        expr.Expr(
+            impl.get_runtime()
+            .compiling_callable.ast_builder()
+            .expr_snode_get_addr(f._snode.ptr, expr.make_expr_group(indices)),
+            dbg_info=_ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+        ),
     )
 
 

--- a/python/taichi/lang/struct.py
+++ b/python/taichi/lang/struct.py
@@ -685,7 +685,13 @@ class StructType(CompoundType):
             if isinstance(dtype, CompoundType):
                 d[name] = dtype.from_taichi_object(func_ret, ret_index + (index,))
             else:
-                d[name] = expr.Expr(_ti_core.make_get_element_expr(func_ret.ptr, ret_index + (index,)))
+                d[name] = expr.Expr(
+                    _ti_core.make_get_element_expr(
+                        func_ret.ptr,
+                        ret_index + (index,),
+                        _ti_core.DebugInfo(impl.get_runtime().get_current_src_info()),
+                    )
+                )
         d["__struct_methods"] = self.methods
 
         struct = Struct(d)

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -113,8 +113,12 @@ Expr expr_rand(DataType dt) {
   return Expr::make<RandExpression>(dt);
 }
 
-Expr assume_range(const Expr &expr, const Expr &base, int low, int high) {
-  return Expr::make<RangeAssumptionExpression>(expr, base, low, high);
+Expr assume_range(const Expr &expr,
+                  const Expr &base,
+                  int low,
+                  int high,
+                  const DebugInfo &dbg_info) {
+  return Expr::make<RangeAssumptionExpression>(expr, base, low, high, dbg_info);
 }
 
 Expr loop_unique(const Expr &input, const std::vector<SNode *> &covers) {

--- a/taichi/ir/expr.cpp
+++ b/taichi/ir/expr.cpp
@@ -121,8 +121,10 @@ Expr assume_range(const Expr &expr,
   return Expr::make<RangeAssumptionExpression>(expr, base, low, high, dbg_info);
 }
 
-Expr loop_unique(const Expr &input, const std::vector<SNode *> &covers) {
-  return Expr::make<LoopUniqueExpression>(input, covers);
+Expr loop_unique(const Expr &input,
+                 const std::vector<SNode *> &covers,
+                 const DebugInfo &dbg_info) {
+  return Expr::make<LoopUniqueExpression>(input, covers, dbg_info);
 }
 
 Expr expr_field(Expr id_expr, DataType dt) {

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -138,7 +138,11 @@ Expr expr_rand() {
   return taichi::lang::expr_rand(get_data_type<T>());
 }
 
-Expr assume_range(const Expr &expr, const Expr &base, int low, int high);
+Expr assume_range(const Expr &expr,
+                  const Expr &base,
+                  int low,
+                  int high,
+                  const DebugInfo &dbg_info = DebugInfo());
 
 Expr loop_unique(const Expr &input, const std::vector<SNode *> &covers);
 

--- a/taichi/ir/expr.h
+++ b/taichi/ir/expr.h
@@ -144,7 +144,9 @@ Expr assume_range(const Expr &expr,
                   int high,
                   const DebugInfo &dbg_info = DebugInfo());
 
-Expr loop_unique(const Expr &input, const std::vector<SNode *> &covers);
+Expr loop_unique(const Expr &input,
+                 const std::vector<SNode *> &covers,
+                 const DebugInfo &dbg_info = DebugInfo());
 
 Expr expr_field(Expr id_expr, DataType dt);
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1148,11 +1148,11 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
           TaichiTypeError(), this,
           "ti.is_active only works on pointer, hash or bitmasked nodes.");
     }
-    ctx->push_back<SNodeOpStmt>(SNodeOpType::is_active, snode, ptr, nullptr);
+    ctx->push_back<SNodeOpStmt>(SNodeOpType::is_active, snode, ptr, nullptr, dbg_info);
   } else if (op_type == SNodeOpType::length) {
-    ctx->push_back<SNodeOpStmt>(SNodeOpType::length, snode, ptr, nullptr);
+    ctx->push_back<SNodeOpStmt>(SNodeOpType::length, snode, ptr, nullptr, dbg_info);
   } else if (op_type == SNodeOpType::get_addr) {
-    ctx->push_back<SNodeOpStmt>(SNodeOpType::get_addr, snode, ptr, nullptr);
+    ctx->push_back<SNodeOpStmt>(SNodeOpType::get_addr, snode, ptr, nullptr, dbg_info);
   } else if (op_type == SNodeOpType::append) {
     auto alloca = ctx->push_back<AllocaStmt>(PrimitiveType::i32, dbg_info);
     auto addr = ctx->push_back<SNodeOpStmt>(SNodeOpType::allocate, snode, ptr,

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1006,7 +1006,7 @@ void LoopUniqueExpression::type_check(const CompileConfig *) {
 
 void LoopUniqueExpression::flatten(FlattenContext *ctx) {
   auto input_stmt = flatten_rvalue(input, ctx);
-  ctx->push_back(Stmt::make<LoopUniqueStmt>(input_stmt, covers));
+  ctx->push_back(Stmt::make<LoopUniqueStmt>(input_stmt, covers, dbg_info));
   stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1586,7 +1586,8 @@ std::optional<Expr> ASTBuilder::insert_func_call(Function *func,
 
 Expr ASTBuilder::make_matrix_expr(const std::vector<int> &shape,
                                   const DataType &dt,
-                                  const std::vector<Expr> &elements) {
+                                  const std::vector<Expr> &elements,
+                                  const DebugInfo &dbg_info) {
   /*
     Since we have both "shape" and "element_type" in MatrixExpression,
     we should flatten all the elements and disallow recursive TensorType in
@@ -1594,8 +1595,8 @@ Expr ASTBuilder::make_matrix_expr(const std::vector<int> &shape,
   */
   TI_ASSERT(dt->is<PrimitiveType>());
   auto expanded_elements = this->expand_exprs(elements);
-  auto mat =
-      Expr(std::make_shared<MatrixExpression>(expanded_elements, shape, dt));
+  auto mat = Expr(std::make_shared<MatrixExpression>(expanded_elements, shape,
+                                                     dt, dbg_info));
   return mat;
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -448,15 +448,15 @@ void BinaryOpExpression::flatten(FlattenContext *ctx) {
   auto rhs_type = rhs.get_rvalue_type();
 
   if (binary_is_logical(type) && !is_tensor(lhs_type) && !is_tensor(rhs_type)) {
-    auto result = ctx->push_back<AllocaStmt>(ret_type);
-    ctx->push_back<LocalStoreStmt>(result, lhs_stmt);
-    auto cond = ctx->push_back<LocalLoadStmt>(result);
-    auto if_stmt = ctx->push_back<IfStmt>(cond);
+    auto result = ctx->push_back<AllocaStmt>(ret_type, dbg_info);
+    ctx->push_back<LocalStoreStmt>(result, lhs_stmt, lhs_stmt->dbg_info);
+    auto cond = ctx->push_back<LocalLoadStmt>(result, dbg_info);
+    auto if_stmt = ctx->push_back<IfStmt>(cond, dbg_info);
 
     FlattenContext rctx;
     rctx.current_block = ctx->current_block;
     auto rhs_stmt = flatten_rvalue(rhs, &rctx);
-    rctx.push_back<LocalStoreStmt>(result, rhs_stmt);
+    rctx.push_back<LocalStoreStmt>(result, rhs_stmt, rhs_stmt->dbg_info);
 
     auto true_block = std::make_unique<Block>();
     if (type == BinaryOpType::logical_and) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -330,7 +330,7 @@ Expr to_broadcast_tensor(const Expr &elt, const DataType &dt) {
   }
   std::vector<Expr> broadcast_values(tensor_type->get_num_elements(), elt);
   auto matrix_expr = Expr::make<MatrixExpression>(
-      broadcast_values, tensor_type->get_shape(), elt_type);
+      broadcast_values, tensor_type->get_shape(), elt_type, elt->dbg_info);
   matrix_expr->type_check(nullptr);
   return matrix_expr;
 }
@@ -1078,10 +1078,10 @@ void AtomicOpExpression::flatten(FlattenContext *ctx) {
   if (op_type == AtomicOpType::sub) {
     if (val->ret_type != ret_type) {
       val.set(Expr::make<UnaryOpExpression>(UnaryOpType::cast_value, val,
-                                            ret_type));
+                                            ret_type, val->dbg_info));
     }
 
-    val.set(Expr::make<UnaryOpExpression>(UnaryOpType::neg, val));
+    val.set(Expr::make<UnaryOpExpression>(UnaryOpType::neg, val, val->dbg_info));
     op_type = AtomicOpType::add;
   }
   // expand rhs

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -183,9 +183,10 @@ void TexturePtrExpression::type_check(const CompileConfig *config) {
 
 void TexturePtrExpression::flatten(FlattenContext *ctx) {
   ctx->push_back<ArgLoadStmt>(arg_id, PrimitiveType::f32, /*is_ptr=*/true,
-                              /*create_load=*/true, /*arg_depth=*/arg_depth);
+                              /*create_load=*/true, /*arg_depth=*/arg_depth,
+                              dbg_info);
   ctx->push_back<TexturePtrStmt>(ctx->back_stmt(), num_dims, is_storage, format,
-                                 lod);
+                                 lod, dbg_info);
   stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -987,8 +987,8 @@ void RangeAssumptionExpression::type_check(const CompileConfig *) {
 void RangeAssumptionExpression::flatten(FlattenContext *ctx) {
   auto input_stmt = flatten_rvalue(input, ctx);
   auto base_stmt = flatten_rvalue(base, ctx);
-  ctx->push_back(
-      Stmt::make<RangeAssumptionStmt>(input_stmt, base_stmt, low, high));
+  ctx->push_back(Stmt::make<RangeAssumptionStmt>(input_stmt, base_stmt, low,
+                                                 high, dbg_info));
   stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1081,7 +1081,8 @@ void AtomicOpExpression::flatten(FlattenContext *ctx) {
                                             ret_type, val->dbg_info));
     }
 
-    val.set(Expr::make<UnaryOpExpression>(UnaryOpType::neg, val, val->dbg_info));
+    val.set(
+        Expr::make<UnaryOpExpression>(UnaryOpType::neg, val, val->dbg_info));
     op_type = AtomicOpType::add;
   }
   // expand rhs
@@ -1148,11 +1149,14 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
           TaichiTypeError(), this,
           "ti.is_active only works on pointer, hash or bitmasked nodes.");
     }
-    ctx->push_back<SNodeOpStmt>(SNodeOpType::is_active, snode, ptr, nullptr, dbg_info);
+    ctx->push_back<SNodeOpStmt>(SNodeOpType::is_active, snode, ptr, nullptr,
+                                dbg_info);
   } else if (op_type == SNodeOpType::length) {
-    ctx->push_back<SNodeOpStmt>(SNodeOpType::length, snode, ptr, nullptr, dbg_info);
+    ctx->push_back<SNodeOpStmt>(SNodeOpType::length, snode, ptr, nullptr,
+                                dbg_info);
   } else if (op_type == SNodeOpType::get_addr) {
-    ctx->push_back<SNodeOpStmt>(SNodeOpType::get_addr, snode, ptr, nullptr, dbg_info);
+    ctx->push_back<SNodeOpStmt>(SNodeOpType::get_addr, snode, ptr, nullptr,
+                                dbg_info);
   } else if (op_type == SNodeOpType::append) {
     auto alloca = ctx->push_back<AllocaStmt>(PrimitiveType::i32, dbg_info);
     auto addr = ctx->push_back<SNodeOpStmt>(SNodeOpType::allocate, snode, ptr,
@@ -1174,8 +1178,9 @@ void SNodeOpExpression::flatten(FlattenContext *ctx) {
 
 TextureOpExpression::TextureOpExpression(TextureOpType op,
                                          Expr texture_ptr,
-                                         const ExprGroup &args)
-    : op(op), texture_ptr(texture_ptr), args(args) {
+                                         const ExprGroup &args,
+                                         const DebugInfo &dbg_info)
+    : Expression(dbg_info), op(op), texture_ptr(texture_ptr), args(args) {
 }
 
 void TextureOpExpression::type_check(const CompileConfig *config) {
@@ -1273,7 +1278,7 @@ void TextureOpExpression::flatten(FlattenContext *ctx) {
   for (Expr &arg : args.exprs) {
     arg_stmts.push_back(flatten_rvalue(arg, ctx));
   }
-  ctx->push_back<TextureOpStmt>(op, texture_ptr_stmt, arg_stmts);
+  ctx->push_back<TextureOpStmt>(op, texture_ptr_stmt, arg_stmts, dbg_info);
   stmt = ctx->back_stmt();
 }
 
@@ -1905,10 +1910,12 @@ void ASTBuilder::pop_scope() {
 
 Expr ASTBuilder::make_texture_op_expr(const TextureOpType &op,
                                       const Expr &texture_ptr,
-                                      const ExprGroup &args) {
+                                      const ExprGroup &args,
+                                      const DebugInfo &dbg_info) {
   ExprGroup expanded_args;
   expanded_args.exprs = this->expand_exprs(args.exprs);
-  return Expr::make<TextureOpExpression>(op, texture_ptr, expanded_args);
+  return Expr::make<TextureOpExpression>(op, texture_ptr, expanded_args,
+                                         dbg_info);
 }
 
 Stmt *flatten_lvalue(Expr expr, Expression::FlattenContext *ctx) {

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -294,7 +294,8 @@ bool UnaryOpExpression::is_cast() const {
 
 void UnaryOpExpression::flatten(FlattenContext *ctx) {
   auto operand_stmt = flatten_rvalue(operand, ctx);
-  auto unary = std::make_unique<UnaryOpStmt>(type, operand_stmt, operand_stmt->dbg_info);
+  auto unary =
+      std::make_unique<UnaryOpStmt>(type, operand_stmt, operand_stmt->dbg_info);
   if (is_cast()) {
     unary->cast_type = cast_type;
   }
@@ -476,8 +477,8 @@ void BinaryOpExpression::flatten(FlattenContext *ctx) {
     return;
   }
   auto rhs_stmt = flatten_rvalue(rhs, ctx);
-  ctx->push_back(
-      std::make_unique<BinaryOpStmt>(type, lhs_stmt, rhs_stmt, dbg_info));
+  ctx->push_back(std::make_unique<BinaryOpStmt>(
+      type, lhs_stmt, rhs_stmt, /*is_bit_vectorized=*/false, dbg_info));
   stmt = ctx->back_stmt();
   stmt->ret_type = ret_type;
 }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1406,7 +1406,7 @@ void ReferenceExpression::type_check(const CompileConfig *) {
 
 void ReferenceExpression::flatten(FlattenContext *ctx) {
   auto var_stmt = flatten_lvalue(var, ctx);
-  ctx->push_back<ReferenceStmt>(var_stmt);
+  ctx->push_back<ReferenceStmt>(var_stmt, dbg_info);
   stmt = ctx->back_stmt();
 }
 

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -294,7 +294,7 @@ bool UnaryOpExpression::is_cast() const {
 
 void UnaryOpExpression::flatten(FlattenContext *ctx) {
   auto operand_stmt = flatten_rvalue(operand, ctx);
-  auto unary = std::make_unique<UnaryOpStmt>(type, operand_stmt, dbg_info);
+  auto unary = std::make_unique<UnaryOpStmt>(type, operand_stmt, operand_stmt->dbg_info);
   if (is_cast()) {
     unary->cast_type = cast_type;
   }

--- a/taichi/ir/frontend_ir.cpp
+++ b/taichi/ir/frontend_ir.cpp
@@ -1292,7 +1292,7 @@ void ConstExpression::type_check(const CompileConfig *) {
 }
 
 void ConstExpression::flatten(FlattenContext *ctx) {
-  ctx->push_back(Stmt::make<ConstStmt>(val));
+  ctx->push_back(Stmt::make<ConstStmt>(val, dbg_info));
   stmt = ctx->back_stmt();
 }
 
@@ -1310,7 +1310,8 @@ void ExternalTensorShapeAlongAxisExpression::type_check(const CompileConfig *) {
 void ExternalTensorShapeAlongAxisExpression::flatten(FlattenContext *ctx) {
   auto temp = ptr.cast<ExternalTensorExpression>();
   TI_ASSERT(0 <= axis && axis < temp->ndim);
-  ctx->push_back<ExternalTensorShapeAlongAxisStmt>(axis, temp->arg_id);
+  ctx->push_back<ExternalTensorShapeAlongAxisStmt>(axis, temp->arg_id,
+                                                   dbg_info);
   stmt = ctx->back_stmt();
 }
 
@@ -1324,7 +1325,7 @@ void ExternalTensorBasePtrExpression::type_check(const CompileConfig *) {
 
 void ExternalTensorBasePtrExpression::flatten(FlattenContext *ctx) {
   auto tensor = ptr.cast<ExternalTensorExpression>();
-  ctx->push_back<ExternalTensorBasePtrStmt>(tensor->arg_id, is_grad);
+  ctx->push_back<ExternalTensorBasePtrStmt>(tensor->arg_id, is_grad, dbg_info);
   stmt = ctx->back_stmt();
   stmt->ret_type = ret_type;
 }
@@ -1343,7 +1344,7 @@ void GetElementExpression::type_check(const CompileConfig *config) {
 }
 
 void GetElementExpression::flatten(FlattenContext *ctx) {
-  ctx->push_back<GetElementStmt>(flatten_rvalue(src, ctx), index);
+  ctx->push_back<GetElementStmt>(flatten_rvalue(src, ctx), index, dbg_info);
   stmt = ctx->back_stmt();
 }
 // Mesh related.

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -927,7 +927,8 @@ class GetElementExpression : public Expression {
 
 class MeshPatchIndexExpression : public Expression {
  public:
-  MeshPatchIndexExpression() {
+  explicit MeshPatchIndexExpression(const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info) {
   }
 
   void type_check(const CompileConfig *config) override;
@@ -948,15 +949,18 @@ class MeshRelationAccessExpression : public Expression {
 
   MeshRelationAccessExpression(mesh::Mesh *mesh,
                                const Expr mesh_idx,
-                               mesh::MeshElementType to_type)
-      : mesh(mesh), mesh_idx(mesh_idx), to_type(to_type) {
+                               mesh::MeshElementType to_type,
+                               const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), mesh(mesh), mesh_idx(mesh_idx), to_type(to_type) {
   }
 
   MeshRelationAccessExpression(mesh::Mesh *mesh,
                                const Expr mesh_idx,
                                mesh::MeshElementType to_type,
-                               const Expr neighbor_idx)
-      : mesh(mesh),
+                               const Expr neighbor_idx,
+                               const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info),
+        mesh(mesh),
         mesh_idx(mesh_idx),
         to_type(to_type),
         neighbor_idx(neighbor_idx) {
@@ -979,7 +983,8 @@ class MeshIndexConversionExpression : public Expression {
   MeshIndexConversionExpression(mesh::Mesh *mesh,
                                 mesh::MeshElementType idx_type,
                                 const Expr idx,
-                                mesh::ConvType conv_type);
+                                mesh::ConvType conv_type,
+                                const DebugInfo &dbg_info = DebugInfo());
 
   void flatten(FlattenContext *ctx) override;
 
@@ -1055,7 +1060,7 @@ class ASTBuilder {
                         const std::vector<Expr> &elements,
                         const DebugInfo &dbg_info = DebugInfo());
   Expr insert_thread_idx_expr();
-  Expr insert_patch_idx_expr();
+  Expr insert_patch_idx_expr(const DebugInfo &dbg_info = DebugInfo());
   void create_kernel_exprgroup_return(const ExprGroup &group,
                                       const DebugInfo &dbg_info = DebugInfo());
   void create_print(std::vector<std::variant<Expr, std::string>> contents,
@@ -1085,7 +1090,8 @@ class ASTBuilder {
   Expr mesh_index_conversion(mesh::MeshPtr mesh_ptr,
                              mesh::MeshElementType idx_type,
                              const Expr &idx,
-                             mesh::ConvType &conv_type);
+                             mesh::ConvType &conv_type,
+                             const DebugInfo &dbg_info = DebugInfo());
 
   void expr_assign(const Expr &lhs,
                    const Expr &rhs,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -1044,7 +1044,8 @@ class ASTBuilder {
   Expr make_id_expr(const std::string &name);
   Expr make_matrix_expr(const std::vector<int> &shape,
                         const DataType &dt,
-                        const std::vector<Expr> &elements);
+                        const std::vector<Expr> &elements,
+                        const DebugInfo &dbg_info = DebugInfo());
   Expr insert_thread_idx_expr();
   Expr insert_patch_idx_expr();
   void create_kernel_exprgroup_return(const ExprGroup &group,

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -442,13 +442,21 @@ class UnaryOpExpression : public Expression {
   Expr operand;
   DataType cast_type;
 
-  UnaryOpExpression(UnaryOpType type, const Expr &operand)
-      : type(type), operand(operand) {
+  UnaryOpExpression(UnaryOpType type,
+                    const Expr &operand,
+                    const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), type(type), operand(operand) {
     cast_type = PrimitiveType::unknown;
   }
 
-  UnaryOpExpression(UnaryOpType type, const Expr &operand, DataType cast_type)
-      : type(type), operand(operand), cast_type(cast_type) {
+  UnaryOpExpression(UnaryOpType type,
+                    const Expr &operand,
+                    DataType cast_type,
+                    const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info),
+        type(type),
+        operand(operand),
+        cast_type(cast_type) {
   }
 
   void type_check(const CompileConfig *config) override;
@@ -643,8 +651,9 @@ class MatrixExpression : public Expression {
 
   MatrixExpression(const std::vector<Expr> &elements,
                    std::vector<int> shape,
-                   DataType element_type)
-      : elements(elements) {
+                   DataType element_type,
+                   const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), elements(elements) {
     dt = TypeFactory::create_tensor_type(shape, element_type);
   }
 

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -815,7 +815,8 @@ class TextureOpExpression : public Expression {
 
   explicit TextureOpExpression(TextureOpType op,
                                Expr texture_ptr,
-                               const ExprGroup &args);
+                               const ExprGroup &args,
+                               const DebugInfo &dbg_info = DebugInfo());
 
   void type_check(const CompileConfig *config) override;
 
@@ -1110,7 +1111,8 @@ class ASTBuilder {
                                const DebugInfo &dbg_info = DebugInfo());
   Expr make_texture_op_expr(const TextureOpType &op,
                             const Expr &texture_ptr,
-                            const ExprGroup &args);
+                            const ExprGroup &args,
+                            const DebugInfo &dbg_info = DebugInfo());
   /*
    * This function allocates the space for a new item (a struct or a scalar)
    * in the Dynamic SNode, and assigns values to the elements inside it.

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -388,8 +388,10 @@ class TexturePtrExpression : public Expression {
 
   explicit TexturePtrExpression(const std::vector<int> &arg_id,
                                 int num_dims,
-                                int arg_depth)
-      : arg_id(arg_id),
+                                int arg_depth,
+                                const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info),
+        arg_id(arg_id),
         num_dims(num_dims),
         is_storage(false),
         arg_depth(arg_depth),
@@ -401,8 +403,10 @@ class TexturePtrExpression : public Expression {
                        int num_dims,
                        int arg_depth,
                        BufferFormat format,
-                       int lod)
-      : arg_id(arg_id),
+                       int lod,
+                       const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info),
+        arg_id(arg_id),
         num_dims(num_dims),
         is_storage(true),
         arg_depth(arg_depth),

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -850,8 +850,11 @@ class ExternalTensorShapeAlongAxisExpression : public Expression {
   Expr ptr;
   int axis;
 
-  ExternalTensorShapeAlongAxisExpression(const Expr &ptr, int axis)
-      : ptr(ptr), axis(axis) {
+  ExternalTensorShapeAlongAxisExpression(
+      const Expr &ptr,
+      int axis,
+      const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), ptr(ptr), axis(axis) {
   }
 
   void type_check(const CompileConfig *config) override;
@@ -866,7 +869,10 @@ class ExternalTensorBasePtrExpression : public Expression {
   Expr ptr;
   bool is_grad;
 
-  explicit ExternalTensorBasePtrExpression(const Expr &ptr, bool is_grad)
+  explicit ExternalTensorBasePtrExpression(
+      const Expr &ptr,
+      bool is_grad,
+      const DebugInfo &dbg_info = DebugInfo())
       : ptr(ptr), is_grad(is_grad) {
   }
 
@@ -906,8 +912,10 @@ class GetElementExpression : public Expression {
 
   void type_check(const CompileConfig *config) override;
 
-  GetElementExpression(const Expr &src, std::vector<int> index)
-      : src(src), index(index) {
+  GetElementExpression(const Expr &src,
+                       std::vector<int> index,
+                       const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), src(src), index(index) {
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -722,8 +722,10 @@ class LoopUniqueExpression : public Expression {
   Expr input;
   std::vector<SNode *> covers;
 
-  LoopUniqueExpression(const Expr &input, const std::vector<SNode *> &covers)
-      : input(input), covers(covers) {
+  LoopUniqueExpression(const Expr &input,
+                       const std::vector<SNode *> &covers,
+                       const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), input(input), covers(covers) {
   }
 
   void type_check(const CompileConfig *config) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -705,8 +705,9 @@ class RangeAssumptionExpression : public Expression {
   RangeAssumptionExpression(const Expr &input,
                             const Expr &base,
                             int low,
-                            int high)
-      : input(input), base(base), low(low), high(high) {
+                            int high,
+                            const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), input(input), base(base), low(low), high(high) {
   }
 
   void type_check(const CompileConfig *config) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -996,7 +996,9 @@ class ReferenceExpression : public Expression {
   Expr var;
   void type_check(const CompileConfig *config) override;
 
-  explicit ReferenceExpression(const Expr &expr) : var(expr) {
+  explicit ReferenceExpression(const Expr &expr,
+                               const DebugInfo &dbg_info = DebugInfo())
+      : Expression(dbg_info), var(expr) {
   }
 
   void flatten(FlattenContext *ctx) override;

--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -892,8 +892,9 @@ class FrontendFuncCallStmt : public Stmt {
   explicit FrontendFuncCallStmt(
       Function *func,
       const ExprGroup &args,
-      const std::optional<Identifier> &id = std::nullopt)
-      : ident(id), func(func), args(args) {
+      const std::optional<Identifier> &id = std::nullopt,
+      const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), ident(id), func(func), args(args) {
     TI_ASSERT(id.has_value() == !func->rets.empty());
   }
 
@@ -1098,7 +1099,9 @@ class ASTBuilder {
   void expr_assign(const Expr &lhs,
                    const Expr &rhs,
                    const DebugInfo &dbg_info = DebugInfo());
-  std::optional<Expr> insert_func_call(Function *func, const ExprGroup &args);
+  std::optional<Expr> insert_func_call(Function *func,
+                                       const ExprGroup &args,
+                                       const DebugInfo &dbg_info = DebugInfo());
   void create_assert_stmt(const Expr &cond,
                           const std::string &msg,
                           const std::vector<Expr> &args,
@@ -1107,14 +1110,18 @@ class ASTBuilder {
                                 const Expr &s,
                                 const Expr &e,
                                 const DebugInfo &dbg_info = DebugInfo());
-  void begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars,
-                                          SNode *snode);
+  void begin_frontend_struct_for_on_snode(
+      const ExprGroup &loop_vars,
+      SNode *snode,
+      const DebugInfo &dbg_info = DebugInfo());
   void begin_frontend_struct_for_on_external_tensor(
       const ExprGroup &loop_vars,
-      const Expr &external_tensor);
+      const Expr &external_tensor,
+      const DebugInfo &dbg_info = DebugInfo());
   void begin_frontend_mesh_for(const Expr &i,
                                const mesh::MeshPtr &mesh_ptr,
-                               const mesh::MeshElementType &element_type);
+                               const mesh::MeshElementType &element_type,
+                               const DebugInfo &dbg_info = DebugInfo());
   void begin_frontend_while(const Expr &cond,
                             const DebugInfo &dbg_info = DebugInfo());
   void insert_break_stmt(const DebugInfo &dbg_info = DebugInfo());

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -187,7 +187,8 @@ LoopUniqueStmt::LoopUniqueStmt(Stmt *input, const std::vector<SNode *> &covers)
   TI_STMT_REG_FIELDS;
 }
 
-IfStmt::IfStmt(Stmt *cond, const DebugInfo& dbg_info) : Stmt(dbg_info), cond(cond) {
+IfStmt::IfStmt(Stmt *cond, const DebugInfo &dbg_info)
+    : Stmt(dbg_info), cond(cond) {
   TI_STMT_REG_FIELDS;
 }
 

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -171,8 +171,10 @@ ExternalTensorBasePtrStmt::ExternalTensorBasePtrStmt(
   TI_STMT_REG_FIELDS;
 }
 
-LoopUniqueStmt::LoopUniqueStmt(Stmt *input, const std::vector<SNode *> &covers)
-    : input(input) {
+LoopUniqueStmt::LoopUniqueStmt(Stmt *input,
+                               const std::vector<SNode *> &covers,
+                               const DebugInfo &dbg_info)
+    : Stmt(dbg_info), input(input) {
   for (const auto &sn : covers) {
     if (sn->is_place()) {
       TI_INFO(

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -187,7 +187,7 @@ LoopUniqueStmt::LoopUniqueStmt(Stmt *input, const std::vector<SNode *> &covers)
   TI_STMT_REG_FIELDS;
 }
 
-IfStmt::IfStmt(Stmt *cond) : cond(cond) {
+IfStmt::IfStmt(Stmt *cond, const DebugInfo& dbg_info) : Stmt(dbg_info), cond(cond) {
   TI_STMT_REG_FIELDS;
 }
 

--- a/taichi/ir/statements.cpp
+++ b/taichi/ir/statements.cpp
@@ -159,15 +159,17 @@ bool SNodeOpStmt::need_activation(SNodeOpType op) {
 
 ExternalTensorShapeAlongAxisStmt::ExternalTensorShapeAlongAxisStmt(
     int axis,
-    const std::vector<int> &arg_id)
-    : axis(axis), arg_id(arg_id) {
+    const std::vector<int> &arg_id,
+    const DebugInfo &dbg_info)
+    : Stmt(dbg_info), axis(axis), arg_id(arg_id) {
   TI_STMT_REG_FIELDS;
 }
 
 ExternalTensorBasePtrStmt::ExternalTensorBasePtrStmt(
     const std::vector<int> &arg_id,
-    bool is_grad)
-    : arg_id(arg_id), is_grad(is_grad) {
+    bool is_grad,
+    const DebugInfo &dbg_info)
+    : Stmt(dbg_info), arg_id(arg_id), is_grad(is_grad) {
   TI_STMT_REG_FIELDS;
 }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -754,7 +754,9 @@ class LoopUniqueStmt : public Stmt {
   // std::unordered_set<> provides operator==, and StmtFieldManager will
   // use that to check if two LoopUniqueStmts are the same.
 
-  LoopUniqueStmt(Stmt *input, const std::vector<SNode *> &covers);
+  LoopUniqueStmt(Stmt *input,
+                 const std::vector<SNode *> &covers,
+                 const DebugInfo &dbg_info = DebugInfo());
 
   bool has_global_side_effect() const override {
     return false;

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -768,7 +768,8 @@ class GlobalLoadStmt : public Stmt, public ir_traits::Load {
  public:
   Stmt *src;
 
-  explicit GlobalLoadStmt(Stmt *src) : src(src) {
+  explicit GlobalLoadStmt(Stmt *src, const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), src(src) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1732,8 +1732,9 @@ class TextureOpStmt : public Stmt {
 
   explicit TextureOpStmt(TextureOpType op,
                          Stmt *texture_ptr,
-                         const std::vector<Stmt *> &args)
-      : op(op), texture_ptr(texture_ptr), args(args) {
+                         const std::vector<Stmt *> &args,
+                         const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), op(op), texture_ptr(texture_ptr), args(args) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -720,8 +720,12 @@ class RangeAssumptionStmt : public Stmt {
   Stmt *base;
   int low, high;
 
-  RangeAssumptionStmt(Stmt *input, Stmt *base, int low, int high)
-      : input(input), base(base), low(low), high(high) {
+  RangeAssumptionStmt(Stmt *input,
+                      Stmt *base,
+                      int low,
+                      int high,
+                      const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), input(input), base(base), low(low), high(high) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1691,8 +1691,10 @@ class TexturePtrStmt : public Stmt {
                           int dimensions,
                           bool is_storage,
                           BufferFormat format,
-                          int lod)
-      : arg_load_stmt(stmt),
+                          int lod,
+                          const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        arg_load_stmt(stmt),
         dimensions(dimensions),
         is_storage(is_storage),
         format(format),
@@ -1700,8 +1702,13 @@ class TexturePtrStmt : public Stmt {
     TI_STMT_REG_FIELDS;
   }
 
-  explicit TexturePtrStmt(Stmt *stmt, int dimensions)
-      : arg_load_stmt(stmt), dimensions(dimensions), is_storage(false) {
+  explicit TexturePtrStmt(Stmt *stmt,
+                          int dimensions,
+                          const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        arg_load_stmt(stmt),
+        dimensions(dimensions),
+        is_storage(false) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1991,8 +1991,10 @@ class MeshRelationAccessStmt : public Stmt {
   MeshRelationAccessStmt(mesh::Mesh *mesh,
                          Stmt *mesh_idx,
                          mesh::MeshElementType to_type,
-                         Stmt *neighbor_idx)
-      : mesh(mesh),
+                         Stmt *neighbor_idx,
+                         const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        mesh(mesh),
         mesh_idx(mesh_idx),
         to_type(to_type),
         neighbor_idx(neighbor_idx) {
@@ -2002,8 +2004,10 @@ class MeshRelationAccessStmt : public Stmt {
 
   MeshRelationAccessStmt(mesh::Mesh *mesh,
                          Stmt *mesh_idx,
-                         mesh::MeshElementType to_type)
-      : mesh(mesh),
+                         mesh::MeshElementType to_type,
+                         const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        mesh(mesh),
         mesh_idx(mesh_idx),
         to_type(to_type),
         neighbor_idx(nullptr) {
@@ -2049,8 +2053,13 @@ class MeshIndexConversionStmt : public Stmt {
   MeshIndexConversionStmt(mesh::Mesh *mesh,
                           mesh::MeshElementType idx_type,
                           Stmt *idx,
-                          mesh::ConvType conv_type)
-      : mesh(mesh), idx_type(idx_type), idx(idx), conv_type(conv_type) {
+                          mesh::ConvType conv_type,
+                          const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        mesh(mesh),
+        idx_type(idx_type),
+        idx(idx),
+        conv_type(conv_type) {
     this->ret_type = PrimitiveType::i32;
     TI_STMT_REG_FIELDS;
   }
@@ -2068,7 +2077,8 @@ class MeshIndexConversionStmt : public Stmt {
  */
 class MeshPatchIndexStmt : public Stmt {
  public:
-  MeshPatchIndexStmt() {
+  explicit MeshPatchIndexStmt(const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info) {
     this->ret_type = PrimitiveType::i32;
     TI_STMT_REG_FIELDS;
   }

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -1160,7 +1160,8 @@ class ReferenceStmt : public Stmt, public ir_traits::Load {
   Stmt *var;
   bool global_side_effect{false};
 
-  explicit ReferenceStmt(Stmt *var) : var(var) {
+  explicit ReferenceStmt(Stmt *var, const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), var(var) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -860,7 +860,7 @@ class LocalStoreStmt : public Stmt, public ir_traits::Store {
   Stmt *dest;
   Stmt *val;
 
-  LocalStoreStmt(Stmt *dest, Stmt *val) : dest(dest), val(val) {
+  LocalStoreStmt(Stmt *dest, Stmt *val, const DebugInfo& dbg_info = DebugInfo()) : dest(dest), val(val) {
     TI_ASSERT(dest->is<AllocaStmt>() || dest->is<MatrixPtrStmt>() ||
               dest->is<MatrixOfMatrixPtrStmt>() || dest->is<GetElementStmt>());
     TI_STMT_REG_FIELDS;
@@ -900,7 +900,7 @@ class IfStmt : public Stmt {
   Stmt *cond;
   std::unique_ptr<Block> true_statements, false_statements;
 
-  explicit IfStmt(Stmt *cond);
+  explicit IfStmt(Stmt *cond, const DebugInfo& dbg_info = DebugInfo());
 
   // Use these setters to set Block::parent_stmt at the same time.
   void set_true_statements(std::unique_ptr<Block> &&new_true_statements);

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -597,7 +597,9 @@ class ExternalTensorShapeAlongAxisStmt : public Stmt {
   int axis;
   std::vector<int> arg_id;
 
-  ExternalTensorShapeAlongAxisStmt(int axis, const std::vector<int> &arg_id);
+  ExternalTensorShapeAlongAxisStmt(int axis,
+                                   const std::vector<int> &arg_id,
+                                   const DebugInfo &dbg_info = DebugInfo());
 
   bool has_global_side_effect() const override {
     return false;
@@ -612,7 +614,9 @@ class ExternalTensorBasePtrStmt : public Stmt {
   std::vector<int> arg_id;
   bool is_grad;
 
-  ExternalTensorBasePtrStmt(const std::vector<int> &arg_id, bool is_grad);
+  ExternalTensorBasePtrStmt(const std::vector<int> &arg_id,
+                            bool is_grad,
+                            const DebugInfo &dbg_info = DebugInfo());
 
   bool has_global_side_effect() const override {
     return false;
@@ -983,7 +987,9 @@ class ConstStmt : public Stmt {
  public:
   TypedConstant val;
 
-  explicit ConstStmt(const TypedConstant &val) : val(val) {
+  explicit ConstStmt(const TypedConstant &val,
+                     const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), val(val) {
     ret_type = val.dt;
     TI_STMT_REG_FIELDS;
   }
@@ -1178,8 +1184,10 @@ class GetElementStmt : public Stmt {
  public:
   Stmt *src;
   std::vector<int> index;
-  GetElementStmt(Stmt *src, const std::vector<int> &index)
-      : src(src), index(index) {
+  GetElementStmt(Stmt *src,
+                 const std::vector<int> &index,
+                 const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), src(src), index(index) {
     TI_STMT_REG_FIELDS;
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -264,8 +264,8 @@ class BinaryOpStmt : public Stmt {
   BinaryOpStmt(BinaryOpType op_type,
                Stmt *lhs,
                Stmt *rhs,
-               const DebugInfo &dbg_info = DebugInfo(),
-               bool is_bit_vectorized = false)
+               bool is_bit_vectorized = false,
+               const DebugInfo &dbg_info = DebugInfo())
       : Stmt(dbg_info),
         op_type(op_type),
         lhs(lhs),
@@ -860,7 +860,8 @@ class LocalStoreStmt : public Stmt, public ir_traits::Store {
   Stmt *dest;
   Stmt *val;
 
-  LocalStoreStmt(Stmt *dest, Stmt *val, const DebugInfo& dbg_info = DebugInfo()) : dest(dest), val(val) {
+  LocalStoreStmt(Stmt *dest, Stmt *val, const DebugInfo &dbg_info = DebugInfo())
+      : dest(dest), val(val) {
     TI_ASSERT(dest->is<AllocaStmt>() || dest->is<MatrixPtrStmt>() ||
               dest->is<MatrixOfMatrixPtrStmt>() || dest->is<GetElementStmt>());
     TI_STMT_REG_FIELDS;
@@ -900,7 +901,7 @@ class IfStmt : public Stmt {
   Stmt *cond;
   std::unique_ptr<Block> true_statements, false_statements;
 
-  explicit IfStmt(Stmt *cond, const DebugInfo& dbg_info = DebugInfo());
+  explicit IfStmt(Stmt *cond, const DebugInfo &dbg_info = DebugInfo());
 
   // Use these setters to set Block::parent_stmt at the same time.
   void set_true_statements(std::unique_ptr<Block> &&new_true_statements);

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1021,7 +1021,8 @@ void export_lang(py::module &m) {
         "arg_id"_a, "dt"_a, "is_ptr"_a = false, "create_load"_a = true,
         "arg_depth"_a = 0, "dbg_info"_a = DebugInfo());
 
-  m.def("make_reference", Expr::make<ReferenceExpression, const Expr &>);
+  m.def("make_reference",
+        Expr::make<ReferenceExpression, const Expr &, const DebugInfo &>);
 
   m.def("make_external_tensor_expr",
         Expr::make<ExternalTensorExpression, const DataType &, int,

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1159,16 +1159,18 @@ void export_lang(py::module &m) {
 
   // Mesh related.
   m.def("get_relation_size", [](mesh::MeshPtr mesh_ptr, const Expr &mesh_idx,
-                                mesh::MeshElementType to_type) {
-    return Expr::make<MeshRelationAccessExpression>(mesh_ptr.ptr.get(),
-                                                    mesh_idx, to_type);
+                                mesh::MeshElementType to_type,
+                                const DebugInfo &dbg_info = DebugInfo()) {
+    return Expr::make<MeshRelationAccessExpression>(
+        mesh_ptr.ptr.get(), mesh_idx, to_type, dbg_info);
   });
 
   m.def("get_relation_access",
         [](mesh::MeshPtr mesh_ptr, const Expr &mesh_idx,
-           mesh::MeshElementType to_type, const Expr &neighbor_idx) {
+           mesh::MeshElementType to_type, const Expr &neighbor_idx,
+           const DebugInfo &dbg_info = DebugInfo()) {
           return Expr::make<MeshRelationAccessExpression>(
-              mesh_ptr.ptr.get(), mesh_idx, to_type, neighbor_idx);
+              mesh_ptr.ptr.get(), mesh_idx, to_type, neighbor_idx, dbg_info);
         });
 
   py::class_<FunctionKey>(m, "FunctionKey")

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -1042,10 +1042,11 @@ void export_lang(py::module &m) {
         Expr::make<ConstExpression, const DataType &, float64>);
 
   m.def("make_texture_ptr_expr",
-        Expr::make<TexturePtrExpression, const std::vector<int> &, int, int>);
+        Expr::make<TexturePtrExpression, const std::vector<int> &, int, int,
+                   const DebugInfo &>);
   m.def("make_rw_texture_ptr_expr",
         Expr::make<TexturePtrExpression, const std::vector<int> &, int, int,
-                   const BufferFormat &, int>);
+                   const BufferFormat &, int, const DebugInfo &>);
 
   auto &&texture =
       py::enum_<TextureOpType>(m, "TextureOpType", py::arithmetic());

--- a/taichi/python/export_lang.cpp
+++ b/taichi/python/export_lang.cpp
@@ -904,7 +904,8 @@ void export_lang(py::module &m) {
   });
 
   m.def("make_get_element_expr",
-        Expr::make<GetElementExpression, const Expr &, std::vector<int>>);
+        Expr::make<GetElementExpression, const Expr &, std::vector<int>,
+                   const DebugInfo &>);
 
   m.def("value_cast", static_cast<Expr (*)(const Expr &expr, DataType)>(cast));
   m.def("bits_cast",
@@ -1128,31 +1129,33 @@ void export_lang(py::module &m) {
   });
 
   m.def("get_external_tensor_shape_along_axis",
-        Expr::make<ExternalTensorShapeAlongAxisExpression, const Expr &, int>);
+        Expr::make<ExternalTensorShapeAlongAxisExpression, const Expr &, int,
+                   const DebugInfo &>);
 
-  m.def("get_external_tensor_real_func_args", [](const Expr &expr) {
-    TI_ASSERT(expr.is<ExternalTensorExpression>());
-    auto external_tensor_expr = expr.cast<ExternalTensorExpression>();
+  m.def("get_external_tensor_real_func_args",
+        [](const Expr &expr, const DebugInfo &dbg_info = DebugInfo()) {
+          TI_ASSERT(expr.is<ExternalTensorExpression>());
+          auto external_tensor_expr = expr.cast<ExternalTensorExpression>();
 
-    std::vector<Expr> args;
-    for (int i = 0; i < external_tensor_expr->ndim; i++) {
-      args.push_back(
-          Expr::make<ExternalTensorShapeAlongAxisExpression>(expr, i));
-      args.back()->type_check(nullptr);
-    }
+          std::vector<Expr> args;
+          for (int i = 0; i < external_tensor_expr->ndim; i++) {
+            args.push_back(Expr::make<ExternalTensorShapeAlongAxisExpression>(
+                expr, i, expr->dbg_info));
+            args.back()->type_check(nullptr);
+          }
 
-    args.push_back(
-        Expr::make<ExternalTensorBasePtrExpression>(expr, /*is_grad=*/false));
-    args.back()->type_check(nullptr);
+          args.push_back(Expr::make<ExternalTensorBasePtrExpression>(
+              expr, /*is_grad=*/false, dbg_info));
+          args.back()->type_check(nullptr);
 
-    if (external_tensor_expr->needs_grad) {
-      args.push_back(
-          Expr::make<ExternalTensorBasePtrExpression>(expr, /*is_grad=*/true));
-      args.back()->type_check(nullptr);
-    }
+          if (external_tensor_expr->needs_grad) {
+            args.push_back(Expr::make<ExternalTensorBasePtrExpression>(
+                expr, /*is_grad=*/true, dbg_info));
+            args.back()->type_check(nullptr);
+          }
 
-    return args;
-  });
+          return args;
+        });
 
   // Mesh related.
   m.def("get_relation_size", [](mesh::MeshPtr mesh_ptr, const Expr &mesh_idx,


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e32e22</samp>

This pull request adds a `dbg_info` argument to various functions and constructors related to expressions, statements, and texture operations in the Taichi frontend and IR. This argument is used to pass and store source code information for debugging purposes, which enables better error reporting and debugging experience for Taichi users and developers.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e32e22</samp>

*  Add `dbg_info` parameters to various expression and statement constructors and function calls, which are used to store and pass the source code location and other debugging information for error reporting and debugging purposes. ([link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c6d83b9e6291bedbadc82d8027e027fe6cdc4785a413467b722b4f55e6e59386L25-R27),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c6d83b9e6291bedbadc82d8027e027fe6cdc4785a413467b722b4f55e6e59386L36-R39),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c6d83b9e6291bedbadc82d8027e027fe6cdc4785a413467b722b4f55e6e59386L54-R58),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c6d83b9e6291bedbadc82d8027e027fe6cdc4785a413467b722b4f55e6e59386L65-R72),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c6d83b9e6291bedbadc82d8027e027fe6cdc4785a413467b722b4f55e6e59386L77-R84),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-2e623ee0b0eec1b200fead36c0627a3c54738f6d83d79757398dc67decc01da8L54-R55),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-3e22417ffade4af0564893b98dc5101d714b8ba6fd4423ab5bc5129e360fee8fL1436-R1441),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-99744c5ae5f6a754d6f68408fdc64fb0d6097216518a7f3d1ef43ffe12599577L132-R136),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-99744c5ae5f6a754d6f68408fdc64fb0d6097216518a7f3d1ef43ffe12599577L242-R243),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL135-R136),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-575efc738df7b1202370c2531ec82232dc7f287b2bec4999af03ef40da4f5deeL141-R144),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1R257),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L263-R264),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L269-R270),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L276-R277),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a157043b38542c8145447ff342fda65fe4d54fb777fe514daa70007e83e20dc1L285-R292),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9L153-R158),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9L175-R185),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-5913c0a6b6a5e279414150955f30b96ea6b9676a1f5b1931ca4bcb39f19c81e9L1446-R1462),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c48bb572255ef55d0c9fd89c9febab88b9668e10dfcfc1fac88feb1be7bd94caL360-R374),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c48bb572255ef55d0c9fd89c9febab88b9668e10dfcfc1fac88feb1be7bd94caR600),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-c48bb572255ef55d0c9fd89c9febab88b9668e10dfcfc1fac88feb1be7bd94caL640-R658),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a028ff808aee30ba7b2c634414a762b6178d6608ae50cf636a2cab5b2af0da62L566-R568),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a028ff808aee30ba7b2c634414a762b6178d6608ae50cf636a2cab5b2af0da62L575-R579),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a028ff808aee30ba7b2c634414a762b6178d6608ae50cf636a2cab5b2af0da62L703-R711),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-059028cb0798284bed05638becbc32d256736846de19746e196fe5f5ee7fd061L23-R27),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L400-R401),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L444-R446),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-62fecfc4627bafe9c85cf060fe4d4531c429a383a263df2efa6cbb28c812efd2L463-R466),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-3154e0533b9fd63e663c16c2e87c65068c3b002a65cf80529b6577d173bdb5feL688-R694),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-624846f1ff7dabb76aa363a9a4b946ad67e2083a2a2521d10f2fc47232dff137L116-R127),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-5a1643cd518f6b50f7019462e057d759dd0c85b13c4e2dacde79ee3a5e2db2ecL141-R149),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L186-R189),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L296-R298),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L331-R333),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L450-R460),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L478-R481),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L488-R504),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L511-R514),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L620-R623),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L987-R991),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1006-R1009),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1078-R1085),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1148-R1159),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1174-R1183),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1273-R1281),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1287-R1295),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1305-R1314),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1319-R1328),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1338-R1347),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1344-R1353),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1362-R1374),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1373-R1389),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1383-R1399),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1393-R1409),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1481-R1497),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1494-R1510),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1562-R1579),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1569-R1592),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1581-R1600),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1589-R1609),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1655-R1681),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1670-R1691),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1676-R1697),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1686-R1715),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1843-R1867),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1865-R1889),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1877-R1902),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1905-R1946),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L1925-R1954),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35R1962),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL391-R394),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL404-R409),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL441-R459),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL642-R656),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL704-R719),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL720-R737),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL802-R819),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL836-R857),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL852-R875),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL872-R897),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL892-R919),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL905-R932),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL926-R955),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL933-R964),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL957-R988),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL969-R1002),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL1030-R1066),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL1062-R1104),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL1076-R1124),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL1097-R1139),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L162-R164),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L169-R179),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L190-R195),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L267-R268),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L600-R602),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L615-R619),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L723-R732),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L753-R763),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L771-R782),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L862-R874),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L902-R914),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L978-R992),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1149-R1164),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1173-R1191),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1694-R1714),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1703-R1728),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1720-R1746),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1970-R1998),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1981-R2011),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L2028-R2063),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L2047-R2082),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L907-R908),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L1023-R1025),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L1045-R1051),[link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-af631a0c71978fe591e17005f01f7c06bc30ae36c65df306bbb3b08ade770167L1130-R1174))
*  Use the `operand_stmt->dbg_info` instead of the `dbg_info` field of the `UnaryOpExpression` class, which is more consistent with the source code information of the operand expression. ([link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-a6e92dd2dd707d705dc44ef91463ddc0423575188e6e8e0555de9e439db88c35L296-R298))
*  Reorder the parameters of the `BinaryOpStmt` constructor, by moving the `dbg_info` parameter to the end of the parameter list, to make it consistent with other statement constructors. ([link](https://github.com/taichi-dev/taichi/pull/8308/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L267-R268))
