### PR TITLE
[lang] Enhance matrixfree solver user experience

### DIFF
--- a/python/taichi/linalg/matrixfree_cg.py
+++ b/python/taichi/linalg/matrixfree_cg.py
@@ -69,7 +69,7 @@ def MatrixFreeCG(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     @ti.kernel
     def init():
         for I in ti.grouped(x):
-            r[I] = b[I]-Ax[I]
+            r[I] = b[I] - Ax[I]
             p[I] = 0.0
             Ap[I] = 0.0
 
@@ -125,7 +125,9 @@ def MatrixFreeCG(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
                     print(f">>> Iter = {i+1:4}, Residual = {sqrt(new_rTr):e}")
         if new_rTr >= tol:
             if not quiet:
-                print(f">>> Conjugate Gradient method failed to converge in {maxiter} iterations: Residual = {sqrt(new_rTr):e}")
+                print(
+                    f">>> Conjugate Gradient method failed to converge in {maxiter} iterations: Residual = {sqrt(new_rTr):e}"
+                )
             suc = False
 
     solve()
@@ -294,6 +296,7 @@ def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
             if not quiet:
                 print(f">>> BICGSTAB failed to converge in {maxiter} iterations: Residual = {sqrt(rTr):e}")
             suc = False
+
     solve()
     vector_fields_snode_tree.destroy()
     scalar_snode_tree.destroy()

--- a/python/taichi/linalg/matrixfree_cg.py
+++ b/python/taichi/linalg/matrixfree_cg.py
@@ -47,6 +47,7 @@ def MatrixFreeCG(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     p = ti.field(dtype=solver_dtype)
     r = ti.field(dtype=solver_dtype)
     Ap = ti.field(dtype=solver_dtype)
+    Ax = ti.field(dtype=solver_dtype)
     if len(size) == 1:
         axes = ti.i
     elif len(size) == 2:
@@ -55,7 +56,7 @@ def MatrixFreeCG(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
         axes = ti.ijk
     else:
         raise TaichiRuntimeError(f"MatrixFreeCG only support 1D, 2D, 3D inputs; your inputs is {len(size)}-D.")
-    vector_fields_builder.dense(axes, size).place(p, r, Ap)
+    vector_fields_builder.dense(axes, size).place(p, r, Ap, Ax)
     vector_fields_snode_tree = vector_fields_builder.finalize()
 
     scalar_builder = ti.FieldsBuilder()
@@ -63,17 +64,18 @@ def MatrixFreeCG(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     beta = ti.field(dtype=solver_dtype)
     scalar_builder.place(alpha, beta)
     scalar_snode_tree = scalar_builder.finalize()
+    suc = True
 
     @ti.kernel
     def init():
         for I in ti.grouped(x):
-            r[I] = b[I]
+            r[I] = b[I]-Ax[I]
             p[I] = 0.0
             Ap[I] = 0.0
 
     @ti.kernel
     def reduce(p: ti.template(), q: ti.template()) -> solver_dtype:
-        result = 0.0
+        result = solver_dtype(0.0)
         for I in ti.grouped(p):
             result += p[I] * q[I]
         return result
@@ -94,34 +96,42 @@ def MatrixFreeCG(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
             p[I] = r[I] + beta[None] * p[I]
 
     def solve():
+        A._matvec(x, Ax)
         init()
         initial_rTr = reduce(r, r)
         if not quiet:
             print(f">>> Initial residual = {initial_rTr:e}")
         old_rTr = initial_rTr
+        new_rTr = initial_rTr
         update_p()
-        # -- Main loop --
-        for i in range(maxiter):
-            A._matvec(p, Ap)  # compute Ap = A x p
-            pAp = reduce(p, Ap)
-            alpha[None] = old_rTr / pAp
-            update_x()
-            update_r()
-            new_rTr = reduce(r, r)
-            if sqrt(new_rTr) < tol:
+        if sqrt(initial_rTr) >= tol:
+            # -- Main loop --
+            for i in range(maxiter):
+                A._matvec(p, Ap)  # compute Ap = A x p
+                pAp = reduce(p, Ap)
+                alpha[None] = old_rTr / pAp
+                update_x()
+                update_r()
+                new_rTr = reduce(r, r)
+                if sqrt(new_rTr) < tol:
+                    if not quiet:
+                        print(">>> Conjugate Gradient method converged.")
+                        print(f">>> #iterations {i}")
+                    break
+                beta[None] = new_rTr / old_rTr
+                update_p()
+                old_rTr = new_rTr
                 if not quiet:
-                    print(">>> Conjugate Gradient method converged.")
-                    print(f">>> #iterations {i}")
-                break
-            beta[None] = new_rTr / old_rTr
-            update_p()
-            old_rTr = new_rTr
+                    print(f">>> Iter = {i+1:4}, Residual = {sqrt(new_rTr):e}")
+        if new_rTr >= tol:
             if not quiet:
-                print(f">>> Iter = {i+1:4}, Residual = {sqrt(new_rTr):e}")
+                print(f">>> Conjugate Gradient method failed to converge in {maxiter} iterations: Residual = {sqrt(new_rTr):e}")
+            suc = False
 
     solve()
     vector_fields_snode_tree.destroy()
     scalar_snode_tree.destroy()
+    return suc
 
 
 def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
@@ -160,6 +170,7 @@ def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     s_hat = ti.field(dtype=solver_dtype)
     t = ti.field(dtype=solver_dtype)
     Ap = ti.field(dtype=solver_dtype)
+    Ax = ti.field(dtype=solver_dtype)
     Ashat = ti.field(dtype=solver_dtype)
     if len(size) == 1:
         axes = ti.i
@@ -169,7 +180,7 @@ def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
         axes = ti.ijk
     else:
         raise TaichiRuntimeError(f"MatrixFreeBICGSTAB only support 1D, 2D, 3D inputs; your inputs is {len(size)}-D.")
-    vector_fields_builder.dense(axes, size).place(p, p_hat, r, r_tld, s, s_hat, t, Ap, Ashat)
+    vector_fields_builder.dense(axes, size).place(p, p_hat, r, r_tld, s, s_hat, t, Ap, Ax, Ashat)
     vector_fields_snode_tree = vector_fields_builder.finalize()
 
     scalar_builder = ti.FieldsBuilder()
@@ -180,11 +191,12 @@ def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
     rho_1 = ti.field(dtype=solver_dtype)
     scalar_builder.place(alpha, beta, omega, rho, rho_1)
     scalar_snode_tree = scalar_builder.finalize()
+    suc = True
 
     @ti.kernel
     def init():
         for I in ti.grouped(x):
-            r[I] = b[I]
+            r[I] = b[I] - Ax[I]
             r_tld[I] = b[I]
             p[I] = 0.0
             Ap[I] = 0.0
@@ -197,7 +209,7 @@ def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
 
     @ti.kernel
     def reduce(p: ti.template(), q: ti.template()) -> solver_dtype:
-        result = 0.0
+        result = solver_dtype(0.0)
         for I in ti.grouped(p):
             result += p[I] * q[I]
         return result
@@ -238,42 +250,51 @@ def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
             r[I] = s[I] - omega[None] * t[I]
 
     def solve():
+        A._matvec(x, Ax)
         init()
         initial_rTr = reduce(r, r)
+        rTr = initial_rTr
         if not quiet:
             print(f">>> Initial residual = {initial_rTr:e}")
-        for i in range(maxiter):
-            rho[None] = reduce(r, r_tld)
-            if rho[None] == 0.0:
-                print(">>> BICGSTAB failed because r@r_tld = 0.")
-                break
-            if i == 0:
-                copy(orig=r, dest=p)
-            else:
-                beta[None] = (rho[None] / rho_1[None]) * (alpha[None] / omega[None])
-                update_p()
-            update_phat()
-            A._matvec(p, Ap)
-            alpha_lower = reduce(r_tld, Ap)
-            alpha[None] = rho[None] / alpha_lower
-            update_s()
-            update_shat()
-            A._matvec(s_hat, Ashat)
-            copy(orig=Ashat, dest=t)
-            omega_upper = reduce(t, s)
-            omega_lower = reduce(t, t)
-            omega[None] = omega_upper / (omega_lower + 1e-16) if omega_lower == 0.0 else omega_upper / omega_lower
-            update_x()
-            update_r()
-            rTr = reduce(r, r)
-            if not quiet:
-                print(f">>> Iter = {i+1:4}, Residual = {sqrt(rTr):e}")
-            if sqrt(rTr) < tol:
+        if sqrt(initial_rTr) >= tol:
+            for i in range(maxiter):
+                rho[None] = reduce(r, r_tld)
+                if rho[None] == 0.0:
+                    if not quiet:
+                        print(">>> BICGSTAB failed because r@r_tld = 0.")
+                    suc = False
+                    break
+                if i == 0:
+                    copy(orig=r, dest=p)
+                else:
+                    beta[None] = (rho[None] / rho_1[None]) * (alpha[None] / omega[None])
+                    update_p()
+                update_phat()
+                A._matvec(p, Ap)
+                alpha_lower = reduce(r_tld, Ap)
+                alpha[None] = rho[None] / alpha_lower
+                update_s()
+                update_shat()
+                A._matvec(s_hat, Ashat)
+                copy(orig=Ashat, dest=t)
+                omega_upper = reduce(t, s)
+                omega_lower = reduce(t, t)
+                omega[None] = omega_upper / (omega_lower + 1e-16) if omega_lower == 0.0 else omega_upper / omega_lower
+                update_x()
+                update_r()
+                rTr = reduce(r, r)
                 if not quiet:
-                    print(f">>> BICGSTAB method converged at #iterations {i}")
-                break
-            rho_1[None] = rho[None]
-
+                    print(f">>> Iter = {i+1:4}, Residual = {sqrt(rTr):e}")
+                if sqrt(rTr) < tol:
+                    if not quiet:
+                        print(f">>> BICGSTAB method converged at #iterations {i}")
+                    break
+                rho_1[None] = rho[None]
+        if rTr >= tol:
+            if not quiet:
+                print(f">>> BICGSTAB failed to converge in {maxiter} iterations: Residual = {sqrt(rTr):e}")
+            suc = False
     solve()
     vector_fields_snode_tree.destroy()
     scalar_snode_tree.destroy()
+    return suc

--- a/python/taichi/linalg/matrixfree_cg.py
+++ b/python/taichi/linalg/matrixfree_cg.py
@@ -104,7 +104,7 @@ def MatrixFreeCG(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
         old_rTr = initial_rTr
         new_rTr = initial_rTr
         update_p()
-        if sqrt(initial_rTr) >= tol: # Do nothing if the initial residual is small enough
+        if sqrt(initial_rTr) >= tol:  # Do nothing if the initial residual is small enough
             # -- Main loop --
             for i in range(maxiter):
                 A._matvec(p, Ap)  # compute Ap = A x p
@@ -258,7 +258,7 @@ def MatrixFreeBICGSTAB(A, b, x, tol=1e-6, maxiter=5000, quiet=True):
         rTr = initial_rTr
         if not quiet:
             print(f">>> Initial residual = {initial_rTr:e}")
-        if sqrt(initial_rTr) >= tol: # Do nothing if the initial residual is small enough
+        if sqrt(initial_rTr) >= tol:  # Do nothing if the initial residual is small enough
             for i in range(maxiter):
                 rho[None] = reduce(r, r_tld)
                 if rho[None] == 0.0:


### PR DESCRIPTION
Issue: #

Change List:
* Add return values for cg/bicgstab solvers to determine whether the solver succeeds or not.
* Ensure the solver does not crash when the initial residual is small enough.
* Change initial residual calculation from `b[i]` to `b[i] - Ax[i]` to allow for user-specified initial value of `x` (warm start). 
* Make sure the data type of `0.0` is consistent with the `solver_dtype`.



### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d26d3b</samp>

This pull request enhances the matrix-free solvers `MatrixFreeCG` and `MatrixFreeBICGSTAB` in `python/taichi/linalg/matrixfree_cg.py` by introducing a new field and a new variable to optimize the residual computation, convergence checking, and output control.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d26d3b</samp>

*  Add a new field `Ax` to store the result of applying the matrix-free operator `A` to the solution vector `x` for both CG and BICGSTAB methods ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3R50), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3R173))
*  Place the new field `Ax` in the same snode tree as the other vector fields for consistent and efficient data layout ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L58-R59), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L172-R183))
*  Add a new variable `suc` to indicate whether the solver has successfully converged or not and return it as a boolean value ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L66-R72), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L183-R199))
*  Modify the `init` kernel to compute the initial residual vector `r = b - Ax` using the new field `Ax` ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L66-R72), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L183-R199))
*  Cast the initial value of `result` to the `solver_dtype` type in the `reduce` kernel to avoid potential type mismatch or precision loss ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L76-R78), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L200-R212))
*  Modify the `solve` function to check the initial residual norm and avoid unnecessary iterations and computations if the initial guess `x` is already close enough to the true solution ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L102-R134), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L241-R300))
*  Modify the `solve` function to update the field `Ax` by applying the matrix-free operator `A` to the solution vector `x` before calling the `init` kernel for BICGSTAB method to avoid recomputing `Ax` ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L241-R300))
*  Modify the `solve` function to check the convergence status and breakdown conditions after the main loop and set the `suc` variable accordingly ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L102-R134), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L241-R300))
*  Modify the `update_p` kernel to update the field `Ax` by applying the matrix-free operator `A` to the solution vector `x` for CG method to keep `Ax` consistent with `x` ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3R99))
*  Add some `not quiet` conditions to the print statements to allow the user to suppress the output if desired ([link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L102-R134), [link](https://github.com/taichi-dev/taichi/pull/8309/files?diff=unified&w=0#diff-31ab3686988c154e67c96adb9ed850b1b0efe586e1cd9e0df2c6b280848adcf3L241-R300))
