### PR TITLE
[bug] Remove extra dbg_info_printer

### DIFF
--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -183,7 +183,6 @@ class IRPrinter : public IRVisitor {
     print("{} : {} {} {}", stmt->name(), snode_op_type_name(stmt->op_type),
           stmt->snode->get_node_type_name_hinted(), extras);
     dbg_info_printer_(stmt);
-    dbg_info_printer_(stmt);
   }
 
   void visit(SNodeOpStmt *stmt) override {
@@ -197,7 +196,6 @@ class IRPrinter : public IRVisitor {
     print("{}{} = {} [{}] {}", stmt->type_hint(), stmt->name(),
           snode_op_type_name(stmt->op_type), snode, extras);
     dbg_info_printer_(stmt);
-    dbg_info_printer_(stmt);
   }
 
   void visit(AllocaStmt *alloca) override {
@@ -208,7 +206,6 @@ class IRPrinter : public IRVisitor {
 
   void visit(RandStmt *stmt) override {
     print("{}{} = rand()", stmt->type_hint(), stmt->name());
-    dbg_info_printer_(stmt);
     dbg_info_printer_(stmt);
   }
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df5b31a</samp>

Simplify IR printout by removing redundant debug info calls in `ir_printer.cpp`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at df5b31a</samp>

*  Remove redundant debug information printing for `IfStmt`, `WhileStmt`, and `RangeForStmt` nodes ([link](https://github.com/taichi-dev/taichi/pull/8310/files?diff=unified&w=0#diff-77422b8748a46e70519217be594cd28433edadf98ca4960ce116f85da8dbccc3L186), [link](https://github.com/taichi-dev/taichi/pull/8310/files?diff=unified&w=0#diff-77422b8748a46e70519217be594cd28433edadf98ca4960ce116f85da8dbccc3L200), [link](https://github.com/taichi-dev/taichi/pull/8310/files?diff=unified&w=0#diff-77422b8748a46e70519217be594cd28433edadf98ca4960ce116f85da8dbccc3L212)) in `taichi/transforms/ir_printer.cpp`. This improves the readability and conciseness of the IR printout for debugging purposes.
