### PR TITLE
[lang] Pass DebugInfo when lowering statements

### DIFF
--- a/taichi/ir/frontend_ir.h
+++ b/taichi/ir/frontend_ir.h
@@ -49,7 +49,7 @@ class FrontendExternalFuncStmt : public Stmt {
                            const std::string &bc_funcname,
                            const std::vector<Expr> &args,
                            const std::vector<Expr> &outputs,
-                           const DebugInfo &dbg_info)
+                           const DebugInfo &dbg_info = DebugInfo())
       : Stmt(dbg_info),
         so_func(so_func),
         asm_source(asm_source),
@@ -162,7 +162,8 @@ class FrontendIfStmt : public Stmt {
   Expr condition;
   std::unique_ptr<Block> true_statements, false_statements;
 
-  explicit FrontendIfStmt(const Expr &condition, const DebugInfo &dbg_info)
+  explicit FrontendIfStmt(const Expr &condition,
+                          const DebugInfo &dbg_info = DebugInfo())
       : Stmt(dbg_info), condition(condition) {
   }
 
@@ -303,7 +304,8 @@ class FrontendWhileStmt : public Stmt {
   Expr cond;
   std::unique_ptr<Block> body;
 
-  explicit FrontendWhileStmt(const Expr &cond, const DebugInfo &dbg_info)
+  explicit FrontendWhileStmt(const Expr &cond,
+                             const DebugInfo &dbg_info = DebugInfo())
       : Stmt(dbg_info), cond(cond) {
   }
 

--- a/taichi/ir/statements.h
+++ b/taichi/ir/statements.h
@@ -70,7 +70,10 @@ class WhileControlStmt : public Stmt {
  public:
   Stmt *mask;
   Stmt *cond;
-  WhileControlStmt(Stmt *mask, Stmt *cond) : mask(mask), cond(cond) {
+  WhileControlStmt(Stmt *mask,
+                   Stmt *cond,
+                   const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), mask(mask), cond(cond) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -87,7 +90,8 @@ class ContinueStmt : public Stmt {
   // an offloaded task, or a for/while loop inside the kernel.
   Stmt *scope;
 
-  ContinueStmt() : scope(nullptr) {
+  explicit ContinueStmt(const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), scope(nullptr) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -673,8 +677,10 @@ class ExternalFuncCallStmt : public Stmt,
                        std::string bc_filename,
                        std::string bc_funcname,
                        const std::vector<Stmt *> &arg_stmts,
-                       const std::vector<Stmt *> &output_stmts)
-      : type(type),
+                       const std::vector<Stmt *> &output_stmts,
+                       const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info),
+        type(type),
         so_func(so_func),
         asm_source(asm_source),
         bc_filename(bc_filename),
@@ -940,8 +946,9 @@ class PrintStmt : public Stmt {
   const std::vector<FormatType> formats;
 
   PrintStmt(const std::vector<EntryType> &contents_,
-            const std::vector<FormatType> &formats_)
-      : contents(contents_), formats(formats_) {
+            const std::vector<FormatType> &formats_,
+            const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), contents(contents_), formats(formats_) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -1028,7 +1035,8 @@ class RangeForStmt : public Stmt {
                int num_cpu_threads,
                int block_dim,
                bool strictly_serialized,
-               std::string range_hint = "");
+               std::string range_hint = "",
+               const DebugInfo &dbg_info = DebugInfo());
 
   bool is_container_statement() const override {
     return true;
@@ -1070,7 +1078,8 @@ class StructForStmt : public Stmt {
                 std::unique_ptr<Block> &&body,
                 bool is_bit_vectorized,
                 int num_cpu_threads,
-                int block_dim);
+                int block_dim,
+                const DebugInfo &dbg_info = DebugInfo());
 
   bool is_container_statement() const override {
     return true;
@@ -1107,7 +1116,8 @@ class MeshForStmt : public Stmt {
               std::unique_ptr<Block> &&body,
               bool is_bit_vectorized,
               int num_cpu_threads,
-              int block_dim);
+              int block_dim,
+              const DebugInfo &dbg_info = DebugInfo());
 
   bool is_container_statement() const override {
     return true;
@@ -1135,7 +1145,9 @@ class FuncCallStmt : public Stmt, public ir_traits::Store {
   std::vector<Stmt *> args;
   bool global_side_effect{true};
 
-  FuncCallStmt(Function *func, const std::vector<Stmt *> &args);
+  FuncCallStmt(Function *func,
+               const std::vector<Stmt *> &args,
+               const DebugInfo &dbg_info = DebugInfo());
 
   bool has_global_side_effect() const override {
     return global_side_effect;
@@ -1203,7 +1215,9 @@ class ReturnStmt : public Stmt {
  public:
   std::vector<Stmt *> values;
 
-  explicit ReturnStmt(const std::vector<Stmt *> &values) : values(values) {
+  explicit ReturnStmt(const std::vector<Stmt *> &values,
+                      const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), values(values) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -1241,7 +1255,8 @@ class WhileStmt : public Stmt {
   Stmt *mask;
   std::unique_ptr<Block> body;
 
-  explicit WhileStmt(std::unique_ptr<Block> &&body);
+  explicit WhileStmt(std::unique_ptr<Block> &&body,
+                     const DebugInfo &dbg_info = DebugInfo());
 
   bool is_container_statement() const override {
     return true;
@@ -1497,7 +1512,8 @@ class LoopIndexStmt : public Stmt {
   Stmt *loop;
   int index;
 
-  LoopIndexStmt(Stmt *loop, int index) : loop(loop), index(index) {
+  LoopIndexStmt(Stmt *loop, int index, const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), loop(loop), index(index) {
     TI_STMT_REG_FIELDS;
   }
 
@@ -2099,7 +2115,9 @@ class MatrixInitStmt : public Stmt {
  public:
   std::vector<Stmt *> values;
 
-  explicit MatrixInitStmt(const std::vector<Stmt *> &values) : values(values) {
+  explicit MatrixInitStmt(const std::vector<Stmt *> &values,
+                          const DebugInfo &dbg_info = DebugInfo())
+      : Stmt(dbg_info), values(values) {
     TI_STMT_REG_FIELDS;
   }
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fb0dd0</samp>

This pull request adds and propagates debug information to various kinds of statements in the frontend, intermediate, and backend IRs. This enables better debugging features and error reporting for the Taichi compiler. The main changes are adding default `DebugInfo()` arguments to statement constructors, passing `dbg_info` parameters to statement cloning and creation methods, and preserving `dbg_info` during the lowering process from frontend IR to backend IR. The affected files are `taichi/ir/frontend_ir.h`, `taichi/ir/statements.cpp`, `taichi/ir/statements.h`, and `taichi/transforms/lower_ast.cpp`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fb0dd0</samp>

*  Add a default value of `DebugInfo()` to the constructors of various frontend IR statements to make them more convenient to use and to avoid passing an empty `DebugInfo` object explicitly ([link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL52-R52), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL165-R166), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-0bb8e07f3f606e45f4e4284c02b32f986d420388fdd71b115a7475aacb50a42cL306-R308), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L73-R76), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L90-R94), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L943-R951), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1031-R1039), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1073-R1082), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1110-R1120), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1138-R1150), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1206-R1220), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1244-R1259), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L1500-R1516), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L2102-R2120))
*  Add the `dbg_info` member of the base `Stmt` class to the constructors of various backend IR statements to pass the debug information to the base class constructor, and update the `clone` methods of these statements to preserve the debug information when cloning ([link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L213-R213), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L228-R231), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L245-R247), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L254-R259), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L265-R271), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L276-R284), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L290-R297), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L297-R307), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L315-R325), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-05e2a2d0a9c9879a4fb5fde9baf5a43738c7601fc53e234a40ab9bc27d1512a5L322-R331), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-917d9436dcaafa0f1e41ae9bad90273a303f036f00da94e417788a7fa1dc5260L676-R683))
*  Add a local variable `dbg_info` to the `visit` methods of the `LowerAST` class to store the debug information of the frontend IR statements, and use it to pass the debug information to the corresponding backend IR statements in the `taichi/transforms/lower_ast.cpp` file ([link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cR69), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL75-R80), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL93-R95), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL106-R108), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL144-R146), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL151-R161), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL167-R188), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL233-R250), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL258-R266), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL265-R282), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL279-R296), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL291-R303), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL298-R313), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL320-R336), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL330-R376), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL361-R390), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL405-R427), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL423-R446), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL461-R490), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL470-R497), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL527-R553), [link](https://github.com/taichi-dev/taichi/pull/8311/files?diff=unified&w=0#diff-910f401c7490ea6baf336f5e236033494b5305f51af5c30c495a48862c3ca27cL539-R566))
