### PR TITLE
[vulkan] Fix shared memory atomic float operations

### DIFF
--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1602,14 +1602,16 @@ class TaskCodegen : public IRVisitor {
     spirv::Value addr_ptr;
     spirv::Value dest_val = ir_->query_value(stmt->dest->raw_name());
     // Shared arrays have already created an accesschain, use it directly.
-    const bool dest_is_matrix_ptr = stmt->dest->is<MatrixPtrStmt>();
+    const bool dest_is_ptr = dest_val.stype.flag == TypeKind::kPtr;
 
     if (dt->is_primitive(PrimitiveTypeID::f64)) {
       if (caps_->get(DeviceCapability::spirv_has_atomic_float64_add) &&
           stmt->op_type == AtomicOpType::add) {
         addr_ptr = at_buffer(stmt->dest, dt);
       } else {
-        addr_ptr = dest_is_matrix_ptr ? dest_val : at_buffer(
+        addr_ptr = dest_is_ptr
+                       ? dest_val
+                       : at_buffer(
             stmt->dest, ir_->get_taichi_uint_type(dt));
       }
     } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
@@ -1617,12 +1619,12 @@ class TaskCodegen : public IRVisitor {
           stmt->op_type == AtomicOpType::add) {
         addr_ptr = at_buffer(stmt->dest, dt);
       } else {
-        addr_ptr = dest_is_matrix_ptr
+        addr_ptr = dest_is_ptr
                        ? dest_val
                        : at_buffer(stmt->dest, ir_->get_taichi_uint_type(dt));
       }
     } else {
-      addr_ptr = dest_is_matrix_ptr ? dest_val : at_buffer(stmt->dest, dt);
+      addr_ptr = dest_is_ptr ? dest_val : at_buffer(stmt->dest, dt);
     }
 
     auto ret_type = ir_->get_primitive_type(dt);

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1600,28 +1600,29 @@ class TaskCodegen : public IRVisitor {
     }
 
     spirv::Value addr_ptr;
+    spirv::Value dest_val = ir_->query_value(stmt->dest->raw_name());
+    // Shared arrays have already created an accesschain, use it directly.
+    const bool dest_is_matrix_ptr = stmt->dest->is<MatrixPtrStmt>();
 
     if (dt->is_primitive(PrimitiveTypeID::f64)) {
       if (caps_->get(DeviceCapability::spirv_has_atomic_float64_add) &&
           stmt->op_type == AtomicOpType::add) {
         addr_ptr = at_buffer(stmt->dest, dt);
       } else {
-        addr_ptr = at_buffer(stmt->dest, ir_->get_taichi_uint_type(dt));
+        addr_ptr = dest_is_matrix_ptr ? dest_val : at_buffer(
+            stmt->dest, ir_->get_taichi_uint_type(dt));
       }
     } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
       if (caps_->get(DeviceCapability::spirv_has_atomic_float_add) &&
           stmt->op_type == AtomicOpType::add) {
         addr_ptr = at_buffer(stmt->dest, dt);
       } else {
-        addr_ptr = at_buffer(stmt->dest, ir_->get_taichi_uint_type(dt));
+        addr_ptr = dest_is_matrix_ptr
+                       ? dest_val
+                       : at_buffer(stmt->dest, ir_->get_taichi_uint_type(dt));
       }
     } else {
-      if (stmt->dest->is<MatrixPtrStmt>()) {
-        // Shared arrays have already created an accesschain, use it directly.
-        addr_ptr = ir_->query_value(stmt->dest->raw_name());
-      } else {
-        addr_ptr = at_buffer(stmt->dest, dt);
-      }
+      addr_ptr = dest_is_matrix_ptr ? dest_val : at_buffer(stmt->dest, dt);
     }
 
     auto ret_type = ir_->get_primitive_type(dt);
@@ -2195,6 +2196,8 @@ class TaskCodegen : public IRVisitor {
       return paddr_ptr;
     }
 
+    TI_ERROR_IF(!is_integral(ptr_val.stype.dt), "at_buffer failed, `ptr_val.stype.dt` is not integeral. Stmt = {} : {}", ptr->name(), ptr->type_hint());
+
     spirv::Value buffer = get_buffer_value(ptr_to_buffers_.at(ptr), dt);
     size_t width = ir_->get_primitive_type_size(dt);
     spirv::Value idx_val = ir_->make_value(
@@ -2303,8 +2306,7 @@ class TaskCodegen : public IRVisitor {
   spirv::Value make_pointer(size_t offset) {
     if (use_64bit_pointers) {
       // This is hacky, should check out how to encode uint64 values in spirv
-      return ir_->cast(ir_->u64_type(), ir_->uint_immediate_number(
-                                            ir_->u32_type(), uint32_t(offset)));
+      return ir_->uint_immediate_number(ir_->u64_type(), offset);
     } else {
       return ir_->uint_immediate_number(ir_->u32_type(), uint32_t(offset));
     }
@@ -2729,7 +2731,7 @@ void KernelCodegen::run(TaichiKernelAttributes &kernel_attribs,
     bool success = true;
     {
       bool result = false;
-      TI_ERROR_IF(
+      TI_WARN_IF(
           (result = !spirv_opt_->Run(optimized_spv.data(), optimized_spv.size(),
                                      &optimized_spv, spirv_opt_options_)),
           "SPIRV optimization failed");

--- a/taichi/codegen/spirv/spirv_codegen.cpp
+++ b/taichi/codegen/spirv/spirv_codegen.cpp
@@ -1611,8 +1611,7 @@ class TaskCodegen : public IRVisitor {
       } else {
         addr_ptr = dest_is_ptr
                        ? dest_val
-                       : at_buffer(
-            stmt->dest, ir_->get_taichi_uint_type(dt));
+                       : at_buffer(stmt->dest, ir_->get_taichi_uint_type(dt));
       }
     } else if (dt->is_primitive(PrimitiveTypeID::f32)) {
       if (caps_->get(DeviceCapability::spirv_has_atomic_float_add) &&


### PR DESCRIPTION
Issue: #

### Brief Summary

With the specific case of shared memory atomic floats, the `at_buffer` command will be called with wrong pointer dtype. Causing the codegen attempting to generate offset arithmetic with actual pointer type, which is invalid

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0eec54b</samp>

*  Simplify and fix the logic of accessing the destination operand of a binary operation in SPIR-V code generation ([link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R1603-R1605), [link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L1609-R1613), [link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L1616-R1625))
* Add error checks and assertions to ensure the validity of data types and inputs in SPIR-V code generation and IR building ([link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000R2199-R2200), [link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15R251), [link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15R258), [link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15R265), [link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15L1497-R1501))
* Fix a bug in the `make_pointer` function in `spirv_codegen.cpp` that caused incorrect pointer arithmetic for 64-bit pointers ([link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L2306-R2309))
* Replace error with warning for the case when the SPIR-V optimizer fails to run in `spirv_codegen.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-1620f2a387fc8acc55e2b2cfced07bb9cba59702609aae6e9489e703cbab5000L2732-R2734))
* Replace explicit type creation with predefined variable in `get_array_type` function in `spirv_ir_builder.cpp` ([link](https://github.com/taichi-dev/taichi/pull/8315/files?diff=unified&w=0#diff-5274ca34a1156d70b415ce034aeea8430182b5b15b95b3cef9efa79661028e15L573-R576))
