### PR TITLE
[ui] Fix circular dependency in GGUI CMake linking

### DIFF
--- a/cmake/TaichiCore.cmake
+++ b/cmake/TaichiCore.cmake
@@ -349,7 +349,6 @@ if(TI_WITH_PYTHON)
     # This requires refactoring on the python/export_*.cpp as well as better
     # error message on the Python side.
     add_subdirectory(taichi/ui)
-    target_link_libraries(taichi_ui PUBLIC ${CORE_LIBRARY_NAME})
 
     message("PYTHON_LIBRARIES: " ${PYTHON_LIBRARIES})
     set(CORE_WITH_PYBIND_LIBRARY_NAME taichi_python)
@@ -383,7 +382,6 @@ if(TI_WITH_PYTHON)
 
     if(TI_WITH_GGUI)
         target_compile_definitions(${CORE_WITH_PYBIND_LIBRARY_NAME} PRIVATE -DTI_WITH_GGUI)
-        target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PRIVATE taichi_ui_vulkan)
     endif()
 
     target_link_libraries(${CORE_WITH_PYBIND_LIBRARY_NAME} PRIVATE taichi_ui)

--- a/taichi/ui/CMakeLists.txt
+++ b/taichi/ui/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ./taichi/ui/CMakeLists.txt
 
-add_library(taichi_ui OBJECT
+add_library(taichi_ui
     gui/gui.cpp
     gui/android.cpp
     gui/cocoa.cpp
@@ -24,7 +24,6 @@ target_include_directories(taichi_ui
     ${PROJECT_SOURCE_DIR}/external/glm
   )
 
-target_link_libraries(taichi_ui PRIVATE taichi_core)
 target_link_libraries(taichi_ui PRIVATE taichi_common)
 
 
@@ -53,8 +52,6 @@ if(TI_WITH_GGUI)
 
   target_include_directories(imgui PUBLIC ${IMGUI_DIR} ${IMGUI_DIR}/backends ..)
   target_include_directories(imgui PUBLIC ${PROJECT_SOURCE_DIR}/external/Vulkan-Headers/include)
-
-  target_link_libraries(taichi_ui PRIVATE imgui)
 
   add_subdirectory(backends/vulkan)
   target_link_libraries(taichi_ui PUBLIC taichi_ui_vulkan)

--- a/taichi/ui/backends/vulkan/CMakeLists.txt
+++ b/taichi/ui/backends/vulkan/CMakeLists.txt
@@ -39,7 +39,6 @@ target_include_directories(taichi_ui_vulkan
     ${PROJECT_SOURCE_DIR}/external/glfw/include
   )
 
-target_link_libraries(taichi_ui_vulkan PRIVATE taichi_core)
 target_link_libraries(taichi_ui_vulkan PRIVATE taichi_common)
-target_link_libraries(taichi_ui_vulkan PRIVATE imgui)
-target_link_libraries(taichi_ui_vulkan PRIVATE ti_device_api)
+target_link_libraries(taichi_ui_vulkan PUBLIC imgui)
+target_link_libraries(taichi_ui_vulkan PUBLIC ti_device_api)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18f9b28</samp>

This pull request refactors and simplifies the CMake configuration of `taichi_ui` and `taichi_ui_vulkan` libraries, improving their modularity and usability. It also avoids unnecessary or redundant dependencies on `taichi_core` and other libraries.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18f9b28</samp>

*  Simplify and fix the linking of `taichi_ui` and `taichi_ui_vulkan` libraries ([link](https://github.com/taichi-dev/taichi/pull/8337/files?diff=unified&w=0#diff-ddbed628f91a9ee8bb2f6af3cb6f4b793746b0cc8182bcd4513b6793e816f347L352), [link](https://github.com/taichi-dev/taichi/pull/8337/files?diff=unified&w=0#diff-ddbed628f91a9ee8bb2f6af3cb6f4b793746b0cc8182bcd4513b6793e816f347L386), [link](https://github.com/taichi-dev/taichi/pull/8337/files?diff=unified&w=0#diff-e33fc28fc67040566898b7816ffdf7a8fcd04f0613c7bfb58d4f1ea176d10921L3-R3), [link](https://github.com/taichi-dev/taichi/pull/8337/files?diff=unified&w=0#diff-e33fc28fc67040566898b7816ffdf7a8fcd04f0613c7bfb58d4f1ea176d10921L27), [link](https://github.com/taichi-dev/taichi/pull/8337/files?diff=unified&w=0#diff-e33fc28fc67040566898b7816ffdf7a8fcd04f0613c7bfb58d4f1ea176d10921L57-L58), [link](https://github.com/taichi-dev/taichi/pull/8337/files?diff=unified&w=0#diff-5d0ee39a6fca82325fe07b5491d7ac6b7367ec675730dd76dfc4909e6969321aL42-R44))
