### PR TITLE
[bug] Fix missing taichi_common symbol in gfx_runtime

### DIFF
--- a/taichi/runtime/gfx/CMakeLists.txt
+++ b/taichi/runtime/gfx/CMakeLists.txt
@@ -21,3 +21,4 @@ target_include_directories(gfx_runtime
     ${PROJECT_SOURCE_DIR}/external/spdlog/include
         ${LLVM_INCLUDE_DIRS}
   )
+target_link_libraries(gfx_runtime PRIVATE taichi_common)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77d5a50</samp>

Link `gfx_runtime` to `taichi_common` to resolve dependencies. This enables the graphics runtime to use common utilities and error handling from the Taichi project.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77d5a50</samp>

*  Link gfx_runtime target to taichi_common library ([link](https://github.com/taichi-dev/taichi/pull/8362/files?diff=unified&w=0#diff-a3849ebc21f46957843e6fff8fe55678c7284699a3c1dd62c692ddf91e5cb7aeR24))
