### PR TITLE
[aot] Import CPU and CUDA memory for Taichi AOT

### DIFF
--- a/c_api/include/taichi/taichi_cpu.h
+++ b/c_api/include/taichi/taichi_cpu.h
@@ -20,6 +20,10 @@ ti_export_cpu_memory(TiRuntime runtime,
                      TiMemory memory,
                      TiCpuMemoryInteropInfo *interop_info);
 
+TI_DLL_EXPORT TiMemory TI_API_CALL ti_import_cpu_memory(TiRuntime runtime,
+                                                        void *ptr,
+                                                        size_t memory_size);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/c_api/include/taichi/taichi_cuda.h
+++ b/c_api/include/taichi/taichi_cuda.h
@@ -20,6 +20,10 @@ ti_export_cuda_memory(TiRuntime runtime,
                       TiMemory memory,
                       TiCudaMemoryInteropInfo *interop_info);
 
+TI_DLL_EXPORT TiMemory TI_API_CALL ti_import_cuda_memory(TiRuntime runtime,
+                                                         void * ptr,
+                                                         size_t memory_size);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/c_api/src/c_api_test_utils.cpp
+++ b/c_api/src/c_api_test_utils.cpp
@@ -34,9 +34,15 @@ void cudaMalloc(void **ptr, size_t size) {
 #endif
 }
 
-void cudaMemcpy(void *ptr, void *data, size_t size) {
+void cudaMemcpyHostToDevice(void *ptr, void *data, size_t size) {
 #ifdef TI_WITH_CUDA
   taichi::lang::CUDADriver::get_instance().memcpy_host_to_device(ptr, data, size);
+#endif
+}
+
+void cudaMemcpyDeviceToHost(void *ptr, void *data, size_t size) {
+#ifdef TI_WITH_CUDA
+  taichi::lang::CUDADriver::get_instance().memcpy_device_to_host(ptr, data, size);
 #endif
 }
 

--- a/c_api/src/c_api_test_utils.cpp
+++ b/c_api/src/c_api_test_utils.cpp
@@ -43,7 +43,8 @@ void cudaMemcpyHostToDevice(void *ptr, void *data, size_t size) {
 
 void cudaMemcpyDeviceToHost(void *ptr, void *data, size_t size) {
 #ifdef TI_WITH_CUDA
-  taichi::lang::CUDADriver::get_instance().memcpy_device_to_host(ptr, data, size);
+  taichi::lang::CUDADriver::get_instance().memcpy_device_to_host(ptr, data,
+                                                                 size);
 #endif
 }
 

--- a/c_api/src/c_api_test_utils.cpp
+++ b/c_api/src/c_api_test_utils.cpp
@@ -28,20 +28,20 @@ bool check_cuda_value_impl(void *ptr, T value) {
   return false;
 }
 
-void cudaMalloc(void **ptr, size_t size) {
+void cuda_malloc(void **ptr, size_t size) {
 #ifdef TI_WITH_CUDA
   taichi::lang::CUDADriver::get_instance().malloc(ptr, size);
 #endif
 }
 
-void cudaMemcpyHostToDevice(void *ptr, void *data, size_t size) {
+void cuda_memcpy_host_to_device(void *ptr, void *data, size_t size) {
 #ifdef TI_WITH_CUDA
   taichi::lang::CUDADriver::get_instance().memcpy_host_to_device(ptr, data,
                                                                  size);
 #endif
 }
 
-void cudaMemcpyDeviceToHost(void *ptr, void *data, size_t size) {
+void cuda_memcpy_device_to_host(void *ptr, void *data, size_t size) {
 #ifdef TI_WITH_CUDA
   taichi::lang::CUDADriver::get_instance().memcpy_device_to_host(ptr, data,
                                                                  size);

--- a/c_api/src/c_api_test_utils.cpp
+++ b/c_api/src/c_api_test_utils.cpp
@@ -28,6 +28,18 @@ bool check_cuda_value_impl(void *ptr, T value) {
   return false;
 }
 
+void cudaMalloc(void **ptr, size_t size) {
+#ifdef TI_WITH_CUDA
+  taichi::lang::CUDADriver::get_instance().malloc(ptr, size);
+#endif
+}
+
+void cudaMemcpy(void *ptr, void *data, size_t size) {
+#ifdef TI_WITH_CUDA
+  taichi::lang::CUDADriver::get_instance().memcpy_host_to_device(ptr, data, size);
+#endif
+}
+
 bool check_cuda_value(void *ptr, float value) {
   return check_cuda_value_impl(ptr, value);
 }

--- a/c_api/src/c_api_test_utils.h
+++ b/c_api/src/c_api_test_utils.h
@@ -13,7 +13,11 @@ TI_DLL_EXPORT uint16_t to_float16(float in);
 TI_DLL_EXPORT float to_float32(uint16_t in);
 
 TI_DLL_EXPORT void TI_API_CALL cudaMalloc(void **ptr, size_t size);
-TI_DLL_EXPORT void TI_API_CALL cudaMemcpyHostToDevice(void *ptr, void *data, size_t size);
-TI_DLL_EXPORT void TI_API_CALL cudaMemcpyDeviceToHost(void *ptr, void *data, size_t size);
+TI_DLL_EXPORT void TI_API_CALL cudaMemcpyHostToDevice(void *ptr,
+                                                      void *data,
+                                                      size_t size);
+TI_DLL_EXPORT void TI_API_CALL cudaMemcpyDeviceToHost(void *ptr,
+                                                      void *data,
+                                                      size_t size);
 }  // namespace utils
 }  // namespace capi

--- a/c_api/src/c_api_test_utils.h
+++ b/c_api/src/c_api_test_utils.h
@@ -12,5 +12,8 @@ TI_DLL_EXPORT bool TI_API_CALL check_cuda_value(void *ptr, double value);
 TI_DLL_EXPORT uint16_t to_float16(float in);
 TI_DLL_EXPORT float to_float32(uint16_t in);
 
+TI_DLL_EXPORT void TI_API_CALL cudaMalloc(void **ptr, size_t size);
+TI_DLL_EXPORT void TI_API_CALL cudaMemcpy(void *ptr, void *data, size_t size);
+
 }  // namespace utils
 }  // namespace capi

--- a/c_api/src/c_api_test_utils.h
+++ b/c_api/src/c_api_test_utils.h
@@ -13,7 +13,7 @@ TI_DLL_EXPORT uint16_t to_float16(float in);
 TI_DLL_EXPORT float to_float32(uint16_t in);
 
 TI_DLL_EXPORT void TI_API_CALL cudaMalloc(void **ptr, size_t size);
-TI_DLL_EXPORT void TI_API_CALL cudaMemcpy(void *ptr, void *data, size_t size);
-
+TI_DLL_EXPORT void TI_API_CALL cudaMemcpyHostToDevice(void *ptr, void *data, size_t size);
+TI_DLL_EXPORT void TI_API_CALL cudaMemcpyDeviceToHost(void *ptr, void *data, size_t size);
 }  // namespace utils
 }  // namespace capi

--- a/c_api/src/c_api_test_utils.h
+++ b/c_api/src/c_api_test_utils.h
@@ -13,7 +13,11 @@ TI_DLL_EXPORT uint16_t to_float16(float in);
 TI_DLL_EXPORT float to_float32(uint16_t in);
 
 TI_DLL_EXPORT void TI_API_CALL cuda_malloc(void **ptr, size_t size);
-TI_DLL_EXPORT void TI_API_CALL cuda_memcpy_host_to_device(void *ptr, void *data, size_t size);
-TI_DLL_EXPORT void TI_API_CALL cuda_memcpy_device_to_host(void *ptr, void *data, size_t size);
+TI_DLL_EXPORT void TI_API_CALL cuda_memcpy_host_to_device(void *ptr,
+                                                          void *data,
+                                                          size_t size);
+TI_DLL_EXPORT void TI_API_CALL cuda_memcpy_device_to_host(void *ptr,
+                                                          void *data,
+                                                          size_t size);
 }  // namespace utils
 }  // namespace capi

--- a/c_api/src/c_api_test_utils.h
+++ b/c_api/src/c_api_test_utils.h
@@ -12,12 +12,8 @@ TI_DLL_EXPORT bool TI_API_CALL check_cuda_value(void *ptr, double value);
 TI_DLL_EXPORT uint16_t to_float16(float in);
 TI_DLL_EXPORT float to_float32(uint16_t in);
 
-TI_DLL_EXPORT void TI_API_CALL cudaMalloc(void **ptr, size_t size);
-TI_DLL_EXPORT void TI_API_CALL cudaMemcpyHostToDevice(void *ptr,
-                                                      void *data,
-                                                      size_t size);
-TI_DLL_EXPORT void TI_API_CALL cudaMemcpyDeviceToHost(void *ptr,
-                                                      void *data,
-                                                      size_t size);
+TI_DLL_EXPORT void TI_API_CALL cuda_malloc(void **ptr, size_t size);
+TI_DLL_EXPORT void TI_API_CALL cuda_memcpy_host_to_device(void *ptr, void *data, size_t size);
+TI_DLL_EXPORT void TI_API_CALL cuda_memcpy_device_to_host(void *ptr, void *data, size_t size);
 }  // namespace utils
 }  // namespace capi

--- a/c_api/src/taichi_llvm_impl.cpp
+++ b/c_api/src/taichi_llvm_impl.cpp
@@ -167,6 +167,42 @@ void ti_export_cpu_memory(TiRuntime runtime,
 #endif  // TI_WITH_LLVM
 }
 
+TI_DLL_EXPORT TiMemory TI_API_CALL ti_import_cpu_memory(TiRuntime runtime,
+                                                        void *ptr,
+                                                        size_t memory_size) {
+  capi::LlvmRuntime *llvm_runtime =
+      static_cast<capi::LlvmRuntime *>((Runtime *)runtime);
+
+  auto &device = llvm_runtime->get();
+  auto &cpu_device = static_cast<taichi::lang::cpu::CpuDevice &>(device);
+
+  taichi::lang::DeviceAllocation device_alloc =
+      cpu_device.import_memory(ptr, memory_size);
+
+  // prepare memory object
+  TiMemory memory = devalloc2devmem(*llvm_runtime, device_alloc);
+
+  return memory;
+}
+
+TI_DLL_EXPORT TiMemory TI_API_CALL ti_import_cuda_memory(TiRuntime runtime,
+                                                         void *ptr,
+                                                         size_t memory_size) {
+  capi::LlvmRuntime *llvm_runtime = 
+      static_cast<capi::LlvmRuntime *>((Runtime *)runtime);
+  
+  auto &device = llvm_runtime->get();
+  auto &cuda_device = static_cast<taichi::lang::cuda::CudaDevice &>(device);
+
+  taichi::lang::DeviceAllocation device_alloc =
+      cuda_device.import_memory(ptr, memory_size);
+
+  // prepare memory object
+  TiMemory memory = devalloc2devmem(*llvm_runtime, device_alloc);
+
+  return memory;
+}
+
 // function.export_cuda_runtime
 void ti_export_cuda_memory(TiRuntime runtime,
                            TiMemory memory,

--- a/c_api/tests/c_api_behavior_test.cpp
+++ b/c_api/tests/c_api_behavior_test.cpp
@@ -4,8 +4,6 @@
 #include "gtest/gtest.h"
 #include "c_api_test_utils.h"
 #include "taichi/cpp/taichi.hpp"
-#include "taichi/taichi_cpu.h"
-#include "taichi/taichi_cuda.h"
 #include "c_api/tests/gtest_fixture.h"
 
 TEST_F(CapiTest, TestBehaviorCreateRuntime) {

--- a/c_api/tests/c_api_behavior_test.cpp
+++ b/c_api/tests/c_api_behavior_test.cpp
@@ -4,6 +4,8 @@
 #include "gtest/gtest.h"
 #include "c_api_test_utils.h"
 #include "taichi/cpp/taichi.hpp"
+#include "taichi/taichi_cpu.h"
+#include "taichi/taichi_cuda.h"
 #include "c_api/tests/gtest_fixture.h"
 
 TEST_F(CapiTest, TestBehaviorCreateRuntime) {

--- a/c_api/tests/c_api_interop_test.cpp
+++ b/c_api/tests/c_api_interop_test.cpp
@@ -128,7 +128,8 @@ TEST_F(CapiTest, TestCUDAImport) {
   void *device_array;
   size_t device_array_size = sizeof(data_x);
   capi::utils::cuda_malloc(&device_array, device_array_size);
-  capi::utils::cuda_memcpy_host_to_device(device_array, data_x, device_array_size);
+  capi::utils::cuda_memcpy_host_to_device(device_array, data_x,
+                                          device_array_size);
 
   auto memory = ti_import_cuda_memory(runtime, device_array, device_array_size);
 

--- a/c_api/tests/c_api_interop_test.cpp
+++ b/c_api/tests/c_api_interop_test.cpp
@@ -113,10 +113,10 @@ TEST_F(CapiTest, TestCPUImport) {
   std::vector<float> data_out(4);
   ndarray.read(data_out);
 
-  std::cout << data_out[0] << std::endl;
-  std::cout << data_out[1] << std::endl;
-  std::cout << data_out[2] << std::endl;
-  std::cout << data_out[3] << std::endl;
+  EXPECT_TRUE(data_out[0], 1.0);
+  EXPECT_TRUE(data_out[1], 2.0);
+  EXPECT_TRUE(data_out[2], 3.0);
+  EXPECT_TRUE(data_out[3], 4.0);
 }
 
 TEST_F(CapiTest, TestCUDAImport) {
@@ -127,8 +127,8 @@ TEST_F(CapiTest, TestCUDAImport) {
 
   void *device_array;
   size_t device_array_size = sizeof(data_x);
-  capi::utils::cudaMalloc(&device_array, device_array_size);
-  capi::utils::cudaMemcpyHostToDevice(device_array, data_x, device_array_size);
+  capi::utils::cuda_malloc(&device_array, device_array_size);
+  capi::utils::cuda_memcpy_host_to_device(device_array, data_x, device_array_size);
 
   auto memory = ti_import_cuda_memory(runtime, device_array, device_array_size);
 
@@ -151,10 +151,10 @@ TEST_F(CapiTest, TestCUDAImport) {
   std::vector<float> data_out(4);
   ndarray.read(data_out);
 
-  std::cout << data_out[0] << std::endl;
-  std::cout << data_out[1] << std::endl;
-  std::cout << data_out[2] << std::endl;
-  std::cout << data_out[3] << std::endl;
+  EXPECT_TRUE(data_out[0], 1.0);
+  EXPECT_TRUE(data_out[1], 2.0);
+  EXPECT_TRUE(data_out[2], 3.0);
+  EXPECT_TRUE(data_out[3], 4.0);
 }
 
 #endif  // TI_WITH_VULKAN

--- a/c_api/tests/c_api_interop_test.cpp
+++ b/c_api/tests/c_api_interop_test.cpp
@@ -128,7 +128,7 @@ TEST_F(CapiTest, TestCUDAImport) {
   void *device_array;
   size_t device_array_size = sizeof(data_x);
   capi::utils::cudaMalloc(&device_array, device_array_size);
-  capi::utils::cudaMemcpy(device_array, data_x, device_array_size);
+  capi::utils::cudaMemcpyHostToDevice(device_array, data_x, device_array_size);
 
   auto memory = ti_import_cuda_memory(runtime, device_array, device_array_size);
 

--- a/c_api/tests/c_api_interop_test.cpp
+++ b/c_api/tests/c_api_interop_test.cpp
@@ -113,10 +113,10 @@ TEST_F(CapiTest, TestCPUImport) {
   std::vector<float> data_out(4);
   ndarray.read(data_out);
 
-  EXPECT_TRUE(data_out[0], 1.0);
-  EXPECT_TRUE(data_out[1], 2.0);
-  EXPECT_TRUE(data_out[2], 3.0);
-  EXPECT_TRUE(data_out[3], 4.0);
+  EXPECT_EQ(data_out[0], 1.0);
+  EXPECT_EQ(data_out[1], 2.0);
+  EXPECT_EQ(data_out[2], 3.0);
+  EXPECT_EQ(data_out[3], 4.0);
 }
 
 TEST_F(CapiTest, TestCUDAImport) {
@@ -152,10 +152,10 @@ TEST_F(CapiTest, TestCUDAImport) {
   std::vector<float> data_out(4);
   ndarray.read(data_out);
 
-  EXPECT_TRUE(data_out[0], 1.0);
-  EXPECT_TRUE(data_out[1], 2.0);
-  EXPECT_TRUE(data_out[2], 3.0);
-  EXPECT_TRUE(data_out[3], 4.0);
+  EXPECT_EQ(data_out[0], 1.0);
+  EXPECT_EQ(data_out[1], 2.0);
+  EXPECT_EQ(data_out[2], 3.0);
+  EXPECT_EQ(data_out[3], 4.0);
 }
 
 #endif  // TI_WITH_VULKAN

--- a/c_api/tests/c_api_interop_test.cpp
+++ b/c_api/tests/c_api_interop_test.cpp
@@ -86,4 +86,77 @@ TEST_F(CapiTest, AotTestVulkanTextureInterop) {
   }
 }
 
+TEST_F(CapiTest, TestCPUImport) {
+  TiArch arch = TiArch::TI_ARCH_X64;
+  ti::Runtime runtime(arch);
+
+  float data_x[4] = {1.0, 2.0, 3.0, 4.0};
+
+  auto memory = ti_import_cpu_memory(runtime, &data_x[0], sizeof(float) * 4);
+
+  int dim_count = 1;
+  int element_count = 4;
+  auto elem_type = TI_DATA_TYPE_F32;
+
+  // prepare tiNdArray
+  TiNdArray tiNdArray;
+  tiNdArray.memory = memory;
+  tiNdArray.shape.dim_count = dim_count;
+  tiNdArray.shape.dims[0] = element_count;
+  tiNdArray.elem_shape.dim_count = 0;
+  tiNdArray.elem_type = elem_type;
+
+  auto ti_memory = ti::Memory(runtime, memory, sizeof(float) * 4, false);
+  // prepare ndarray
+  auto ndarray = ti::NdArray<float>(std::move(ti_memory), tiNdArray);
+
+  std::vector<float> data_out(4);
+  ndarray.read(data_out);
+
+  std::cout << data_out[0] << std::endl;
+  std::cout << data_out[1] << std::endl;
+  std::cout << data_out[2] << std::endl;
+  std::cout << data_out[3] << std::endl;
+}
+
+TEST_F(CapiTest, TestCUDAImport) {
+  TiArch arch = TiArch::TI_ARCH_CUDA;
+  ti::Runtime runtime(arch);
+  
+  float data_x[4] = {1.0, 2.0, 3.0, 4.0};
+
+  void *device_array;
+  size_t device_array_size = sizeof(data_x);
+  capi::utils::cudaMalloc(&device_array, device_array_size);
+  capi::utils::cudaMemcpy(device_array, data_x, device_array_size);
+
+  auto memory = ti_import_cuda_memory(runtime, device_array, device_array_size);
+
+  int dim_count = 1;
+  int element_count = 4;
+  auto elem_type = TI_DATA_TYPE_F32;
+
+  // prepare tiNdArray
+  TiNdArray tiNdArray;
+  tiNdArray.memory = memory;
+  tiNdArray.shape.dim_count = dim_count;
+  tiNdArray.shape.dims[0] = element_count;
+  tiNdArray.elem_shape.dim_count = 0;
+  tiNdArray.elem_type = elem_type;
+
+  auto ti_memory = ti::Memory(runtime, memory, sizeof(float) * 4, false);
+  // prepare ndarray
+  auto ndarray = ti::NdArray<float>(std::move(ti_memory), tiNdArray);
+
+  std::vector<float> data_out(4);
+  ndarray.read(data_out);
+
+  std::cout << data_out[0] << std::endl;
+  std::cout << data_out[1] << std::endl;
+  std::cout << data_out[2] << std::endl;
+  std::cout << data_out[3] << std::endl;
+}
+
 #endif  // TI_WITH_VULKAN
+
+

--- a/tests/python/test_ipython.ipynb
+++ b/tests/python/test_ipython.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "id": "51b3b00e",

--- a/tests/python/test_ipython.ipynb
+++ b/tests/python/test_ipython.ipynb
@@ -1,5 +1,5 @@
 {
-  "cells": [
+ "cells": [
   {
    "cell_type": "markdown",
    "id": "51b3b00e",


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b3f2f9</samp>

This pull request adds new C API functions to import host or device memory pointers into TiMemory objects, which can be used by the Taichi runtime. It also adds helper functions and test cases for the new functions. The files `taichi_cpu.h`, `taichi_cuda.h`, `taichi_llvm_impl.cpp`, `c_api_test_utils.h`, `c_api_test_utils.cpp`, `c_api_behavior_test.cpp`, and `c_api_interop_test.cpp` are modified or created.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b3f2f9</samp>

*  Add new functions `ti_import_cpu_memory` and `ti_import_cuda_memory` to the C API for importing host or device memory pointers into TiMemory objects ([link](https://github.com/taichi-dev/taichi/pull/8368/files?diff=unified&w=0#diff-967700fcb811673767fc80a62583beccc6063ff4173a466bcc37cf40f73b0567R23-R26), [link](https://github.com/taichi-dev/taichi/pull/8368/files?diff=unified&w=0#diff-1bca6f03207078d06f3d5f80c33e98fe151ba947c762adf79ed61cc36a7eb94bR23-R26), [link](https://github.com/taichi-dev/taichi/pull/8368/files?diff=unified&w=0#diff-10c4f36944f322074d4a7f5e6d1878ada018992f7c965f6944c60d4468f7719dR170-R205))
*  Implement helper functions `cudaMalloc` and `cudaMemcpy` for allocating and copying device memory in the C API test utils ([link](https://github.com/taichi-dev/taichi/pull/8368/files?diff=unified&w=0#diff-3495d342353715c4471db13397e633fa58deaab2699ec692bb2e8af7585090f0R31-R42), [link](https://github.com/taichi-dev/taichi/pull/8368/files?diff=unified&w=0#diff-6f548dde84da13bbc49bc76e4511b60e82c6c473227842b0c31b04a3ea886e62R15-R17))
*  Add test cases for the new import functions in `c_api_interop_test.cpp`, using `cudaMalloc` and `cudaMemcpy` for the CUDA case, and verifying the data values with TiNdArray objects ([link](https://github.com/taichi-dev/taichi/pull/8368/files?diff=unified&w=0#diff-17d6273519c0a4b5bebb35039d02db6f5a7dcd0cbbaec26ebc38e004f234904fL89-R162))
*  Include the CPU and CUDA header files in `c_api_behavior_test.cpp` to enable testing the new functions ([link](https://github.com/taichi-dev/taichi/pull/8368/files?diff=unified&w=0#diff-0b69a55792219a7fa1907350edc56498fa0934bafbaeccca67c5d742c72f6cdaR7-R8))

@jim19930609 
