### PR TITLE
[build] Python 3.12 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -330,7 +330,7 @@ jobs:
         python: ${{ fromJSON(inputs.python) }}
         _designated: ['']
         exclude:
-        - python: "3.7"
+        - python: "3.12"
         include:
         - _designated: ''
           designated: designated

--- a/.github/workflows/initiator.yaml
+++ b/.github/workflows/initiator.yaml
@@ -57,7 +57,7 @@ jobs:
     with:
       build_id: ${{ needs.preparation.outputs.build_id }}
       nightly: false
-      python: '["3.9", "3.10", "3.11"]'
+      python: '["3.9", "3.10", "3.11", "3.12"]'
     secrets:
       BOT_MINIO_ACCESS_KEY: ${{ secrets.BOT_MINIO_ACCESS_KEY }}
       BOT_MINIO_SECRET_KEY: ${{ secrets.BOT_MINIO_SECRET_KEY }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -43,7 +43,7 @@ jobs:
             /home/dev/taichi/.github/workflows/scripts/build.py
 
         env:
-          PY: '3.8'
+          PY: '3.12'
           PROJECT_NAME: taichi
           TAICHI_CMAKE_ARGS: >-
             -DTI_WITH_OPENGL:BOOL=ON
@@ -82,7 +82,7 @@ jobs:
             /home/dev/taichi/.github/workflows/scripts/unix-perf-mon.sh
 
         env:
-          PY: '3.8'
+          PY: '3.12'
           BENCHMARK_UPLOAD_TOKEN: ${{ secrets.BENCHMARK_UPLOAD_TOKEN }}
           GITHUB_EVENT_ACTION: ${{ github.event.action }}
           GITHUB_TOKEN: ${{ secrets.GARDENER_PAT }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install Dependencies
         run: pip install semver GitPython PyGithub
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,16 +55,16 @@ jobs:
         run: |
           if [ -n "$RELEASE_VERSION" ]; then
             # For production release, we run on five python versions.
-            echo 'matrix={"include":[{"name":"taichi","python":"3.7"},{"name":"taichi","python":"3.8"},{"name":"taichi","python":"3.9"},{"name":"taichi","python":"3.10"},{"name":"taichi","python":"3.11"}]}"' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"name":"taichi","python":"3.7"},{"name":"taichi","python":"3.8"},{"name":"taichi","python":"3.9"},{"name":"taichi","python":"3.10"},{"name":"taichi","python":"3.11"},{"name":"taichi","python":"3.12"}]}"' >> $GITHUB_OUTPUT
 
             # M1 only supports 3.8, 3.9, and 3.10(conda), so change matrix.
-            echo 'matrix_osx={"include":[{"name":"taichi","python":"3.8"},{"name":"taichi","python":"3.9"},{"name":"taichi","python":"3.10"},{"name":"taichi","python":"3.11"}]}"' >> $GITHUB_OUTPUT
+            echo 'matrix_osx={"include":[{"name":"taichi","python":"3.8"},{"name":"taichi","python":"3.9"},{"name":"taichi","python":"3.10"},{"name":"taichi","python":"3.11"},{"name":"taichi","python":"3.12"}]}"' >> $GITHUB_OUTPUT
           else
             # For nightly release, we run on three python versions.
-            echo 'matrix={"include":[{"name":"taichi-nightly","python":"3.7"},{"name":"taichi-nightly","python":"3.8"},{"name":"taichi-nightly","python":"3.9"},{"name":"taichi-nightly","python":"3.10"},{"name":"taichi-nightly","python":"3.11"}]}"' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"name":"taichi-nightly","python":"3.7"},{"name":"taichi-nightly","python":"3.8"},{"name":"taichi-nightly","python":"3.9"},{"name":"taichi-nightly","python":"3.10"},{"name":"taichi-nightly","python":"3.11"},{"name":"taichi","python":"3.12"}]}"' >> $GITHUB_OUTPUT
 
             # M1 only supports 3.8 and 3.10(conda), so change matrix.
-            echo 'matrix_osx={"include":[{"name":"taichi-nightly","python":"3.8"},{"name":"taichi-nightly","python":"3.9"},{"name":"taichi-nightly","python":"3.10"},{"name":"taichi-nightly","python":"3.11"}]}"' >> $GITHUB_OUTPUT
+            echo 'matrix_osx={"include":[{"name":"taichi-nightly","python":"3.8"},{"name":"taichi-nightly","python":"3.9"},{"name":"taichi-nightly","python":"3.10"},{"name":"taichi-nightly","python":"3.11"},{"name":"taichi","python":"3.12"}]}"' >> $GITHUB_OUTPUT
           fi
 
   build_and_test_linux:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -118,7 +118,7 @@ jobs:
       matrix:
         include:
           - os: macos-10.15
-            python: 3.7
+            python: 3.12
             with_cpp_tests: ON
             wanted_archs: 'cpu,vulkan'
     runs-on:
@@ -317,7 +317,7 @@ jobs:
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
     runs-on: [self-hosted, amdgpu]
     env:
-      PY: '3.8'
+      PY: '3.12'
       PROJECT_NAME: taichi
       TI_WANTED_ARCHS: 'cpu,amdgpu'
       TI_DEVICE_MEMORY_GB: '1'
@@ -397,7 +397,7 @@ jobs:
     - ${{ matrix.extra_markers == 'sm70' && 'sm70' || 'windows' }}
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 180 }}
     env:
-      PY: "3.7"
+      PY: "3.12"
       TAICHI_CMAKE_ARGS: >-
         -DTI_WITH_OPENGL:BOOL=ON
         -DTI_WITH_VULKAN:BOOL=ON
@@ -424,7 +424,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.12
 
       - name: Build
         if: ${{ needs.check_files.outputs.run_job != 'false' }}
@@ -465,7 +465,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            python: 3.8
+            python: 3.12
     defaults:
       run:
         # https://github.com/actions/runner/issues/805#issuecomment-844426478
@@ -568,7 +568,7 @@ jobs:
     timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
     runs-on: [self-hosted, Linux, cuda, vulkan, cn]
     env:
-      PY: '3.8'
+      PY: '3.12'
       PROJECT_NAME: taichi
       TI_WANTED_ARCHS: 'cpu,cuda,vulkan,opengl,gles'
       TI_DEVICE_MEMORY_GB: '1'
@@ -643,7 +643,7 @@ jobs:
       contents: read
     env:
       REDIS_HOST: 172.16.5.1
-      PY: '3.9'
+      PY: '3.12'
     steps:
       - name: Workaround checkout Needed single revision issue
         run: git submodule foreach 'git rev-parse HEAD > /dev/null 2>&1 || rm -rf $PWD' || true
@@ -722,7 +722,7 @@ jobs:
       contents: read
     env:
       REDIS_HOST: 172.16.5.1
-      PY: '3.9'
+      PY: '3.12'
     steps:
       - name: Workaround checkout Needed single revision issue
         run: git submodule foreach 'git rev-parse HEAD > /dev/null 2>&1 || rm -rf $PWD' || true
@@ -800,7 +800,7 @@ jobs:
       contents: read
     env:
       REDIS_HOST: 172.16.5.1
-      PY: '3.9'
+      PY: '3.12'
     steps:
       - name: Workaround checkout Needed single revision issue
         run: git submodule foreach 'git rev-parse HEAD > /dev/null 2>&1 || rm -rf $PWD' || true
@@ -891,7 +891,7 @@ jobs:
           - [self-hosted, cuda, vulkan, cn, driver470]
           - [self-hosted, cuda, vulkan, cn, driver510]
     env:
-      PY: '3.8'
+      PY: '3.12'
       PROJECT_NAME: taichi
       TAICHI_CMAKE_ARGS: >-
         -DTI_WITH_OPENGL:BOOL=ON


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38d8294</samp>

This pull request updates the python version to 3.12 for various workflows in `.github/workflows/`. This is to test, build, and release taichi on the latest python version and to ensure compatibility, performance, and quality.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38d8294</samp>

*  Update python version to 3.12 for various workflows to test, measure, and ensure compatibility, performance, and quality of taichi on the latest python version ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L333-R333), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-33678f815917d6f3adc01ad36c9f55974dbae608263bc1d8cf2d71a8c6e5e8dfL60-R60), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-82c5d303a285e8cb2370945e1bb58c7f6c6d57b09ac32ed9b69ac619591b1030L46-R46), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-82c5d303a285e8cb2370945e1bb58c7f6c6d57b09ac32ed9b69ac619591b1030L85-R85), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cL15-R15), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L58-R67), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL121-R121), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL320-R320), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL400-R400), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL427-R427), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL468-R468), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL571-R571), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL646-R646), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL725-R725), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL803-R803), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL894-R894))
*  Test different backends of taichi on linux, such as AMD GPU, OpenGL, CUDA, and Vulkan, using the `testing.yml` workflow ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL320-R320), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL400-R400), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL427-R427), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL571-R571))
*  Test miscellaneous features and modules of taichi, such as driver, on linux using the `testing.yml` workflow ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL646-R646), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL725-R725), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL803-R803), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL894-R894))
*  Test C++ code of taichi on macos using the `testing.yml` workflow ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL121-R121))
*  Test taichi core and python tests on macos using the `testing.yml` workflow ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL468-R468))
*  Build and publish taichi packages for the latest python version using the `release.yml` workflow ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L58-R67))
*  Check code quality and style of taichi on the latest python version using the `pull_request.yml` workflow ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cL15-R15))
*  Measure performance of taichi on the latest python version using the `perf.yml` workflow and upload the results ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-82c5d303a285e8cb2370945e1bb58c7f6c6d57b09ac32ed9b69ac619591b1030L46-R46), [link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-82c5d303a285e8cb2370945e1bb58c7f6c6d57b09ac32ed9b69ac619591b1030L85-R85))
*  Test compatibility of taichi with the latest python version and prepare for future support using the `initiator.yml` workflow ([link](https://github.com/taichi-dev/taichi/pull/8392/files?diff=unified&w=0#diff-33678f815917d6f3adc01ad36c9f55974dbae608263bc1d8cf2d71a8c6e5e8dfL60-R60))
