### PR TITLE
[bug] Fix crashing when a SNode is destroyed after taichi resets

### DIFF
--- a/python/taichi/_snode/snode_tree.py
+++ b/python/taichi/_snode/snode_tree.py
@@ -16,7 +16,7 @@ class SNodeTree:
     def destroy(self):
         if self.destroyed:
             raise TaichiRuntimeError("SNode tree has been destroyed")
-        if not impl.get_runtime().prog or self.prog != impl.get_runtime().prog:
+        if self.prog != impl.get_runtime().prog:
             return
         self.ptr.destroy_snode_tree(impl.get_runtime().prog)
 

--- a/python/taichi/_snode/snode_tree.py
+++ b/python/taichi/_snode/snode_tree.py
@@ -9,12 +9,15 @@ from taichi.lang.exception import TaichiRuntimeError
 
 class SNodeTree:
     def __init__(self, ptr):
+        self.prog = impl.get_runtime().prog
         self.ptr = ptr
         self.destroyed = False
 
     def destroy(self):
         if self.destroyed:
             raise TaichiRuntimeError("SNode tree has been destroyed")
+        if not impl.get_runtime().prog or self.prog != impl.get_runtime().prog:
+            return
         self.ptr.destroy_snode_tree(impl.get_runtime().prog)
 
         # FieldExpression holds a SNode* to the place-SNode associated with a SNodeTree


### PR DESCRIPTION
Issue: fixes #8381 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf37155</samp>

Improve memory management and stability for multiple programs by adding a `prog` attribute and a validity check to `SNodeTree`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf37155</samp>

*  Add `prog` attribute to `SNodeTree` class to store the `Program` object that created the tree ([link](https://github.com/taichi-dev/taichi/pull/8393/files?diff=unified&w=0#diff-849531f8ac85af8c74b97a8c1fd508026fd881ed796ac10adea483142d90ee32R12))
*  Prevent `SNodeTree` from being destroyed by a different or invalid program by checking the `prog` attribute in the `destroy` method ([link](https://github.com/taichi-dev/taichi/pull/8393/files?diff=unified&w=0#diff-849531f8ac85af8c74b97a8c1fd508026fd881ed796ac10adea483142d90ee32R19-R20))
