### PR TITLE
[bug] Fix optimization of exp with negative exponent

### DIFF
--- a/taichi/transforms/alg_simp.cpp
+++ b/taichi/transforms/alg_simp.cpp
@@ -279,11 +279,13 @@ class AlgSimp : public BasicStmtVisitor {
 
     cast_to_result_type(one, stmt);
     auto new_exponent = Stmt::make<UnaryOpStmt>(UnaryOpType::neg, stmt->rhs);
+    new_exponent->ret_type = stmt->rhs->ret_type;
     auto a_to_n = Stmt::make<BinaryOpStmt>(BinaryOpType::pow, stmt->lhs,
                                            new_exponent.get());
     a_to_n->ret_type = stmt->ret_type;
     auto result =
         Stmt::make<BinaryOpStmt>(BinaryOpType::div, one, a_to_n.get());
+    result->ret_type = stmt->ret_type;
     stmt->replace_usages_with(result.get());
     modifier.insert_before(stmt, std::move(new_exponent));
     modifier.insert_before(stmt, std::move(a_to_n));

--- a/tests/python/test_optimization.py
+++ b/tests/python/test_optimization.py
@@ -158,10 +158,10 @@ def test_casts_int_uint():
 def test_negative_exp():
     @ti.dataclass
     class Particle:
-        epsilon: ti.f64
+        epsilon: ti.f32
 
     @ti.kernel
-    def test()->ti.f64:
+    def test()->ti.f32:
         p1 = Particle()
         p1.epsilon = 1.
         e = p1.epsilon

--- a/tests/python/test_optimization.py
+++ b/tests/python/test_optimization.py
@@ -153,3 +153,18 @@ def test_casts_int_uint():
         return ti.cast(y, ti.u32)
 
     assert my_cast(-1) == 4294967295
+
+@test_utils.test()
+def test_negative_exp():
+    @ti.dataclass
+    class Particle:
+        epsilon: ti.f64
+
+    @ti.kernel
+    def test()->ti.f64:
+        p1 = Particle()
+        p1.epsilon = 1.
+        e = p1.epsilon
+        return e ** -1
+
+    assert test() == 1.


### PR DESCRIPTION
Issue: fixes #8269 

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a8b410</samp>

Fix the return type of exponent statements that are simplified by `alg_simp` and add a test case for this optimization. This improves the correctness and performance of code generation for exponent operations.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a8b410</samp>

*  Simplify negative exponents by using reciprocal function ([link](https://github.com/taichi-dev/taichi/pull/8398/files?diff=unified&w=0#diff-77d8ca8e4dc6081988bd6dddb74bb9a5485af28ce3e0b43bc06d123256695513R282), [link](https://github.com/taichi-dev/taichi/pull/8398/files?diff=unified&w=0#diff-77d8ca8e4dc6081988bd6dddb74bb9a5485af28ce3e0b43bc06d123256695513R288))
  - Set return type of new exponent statement to match original right-hand side ([link](https://github.com/taichi-dev/taichi/pull/8398/files?diff=unified&w=0#diff-77d8ca8e4dc6081988bd6dddb74bb9a5485af28ce3e0b43bc06d123256695513R282))
  - Set return type of result statement to match original exponent statement ([link](https://github.com/taichi-dev/taichi/pull/8398/files?diff=unified&w=0#diff-77d8ca8e4dc6081988bd6dddb74bb9a5485af28ce3e0b43bc06d123256695513R288))
* Add test case for negative exponent simplification in `test_optimization.py` ([link](https://github.com/taichi-dev/taichi/pull/8398/files?diff=unified&w=0#diff-b8b031f0789413acece482512df4af5b8419a2a2dea3624b26114bbb9b57d334L156-R169))
