### PR TITLE
[Bug] Fix macro error with ti_import_cpu_memory

### DIFF
--- a/c_api/tests/c_api_interop_test.cpp
+++ b/c_api/tests/c_api_interop_test.cpp
@@ -60,31 +60,6 @@ TEST_F(CapiTest, AotTestCudaBufferInterop) {
     }
   }
 }
-#endif
-
-#if TI_WITH_VULKAN
-
-static void texture_interop_test(TiArch arch) {
-  ti::Runtime runtime(arch);
-
-  ti::Texture tex_0 =
-      runtime.allocate_texture2d(128, 128, TI_FORMAT_RGBA8, TI_NULL_HANDLE);
-
-  TiVulkanImageInteropInfo viii{};
-  ti_export_vulkan_image(runtime, tex_0.image(), &viii);
-  ti_import_vulkan_image(runtime, &viii, VK_IMAGE_VIEW_TYPE_2D,
-                         VK_IMAGE_LAYOUT_UNDEFINED);
-
-  ti_track_image_ext(runtime, tex_0.image(), TI_IMAGE_LAYOUT_SHADER_READ_WRITE);
-  runtime.wait();
-}
-
-TEST_F(CapiTest, AotTestVulkanTextureInterop) {
-  if (ti::is_arch_available(TI_ARCH_VULKAN)) {
-    TiArch arch = TiArch::TI_ARCH_VULKAN;
-    texture_interop_test(arch);
-  }
-}
 
 TEST_F(CapiTest, TestCPUImport) {
   TiArch arch = TiArch::TI_ARCH_X64;
@@ -117,6 +92,31 @@ TEST_F(CapiTest, TestCPUImport) {
   EXPECT_EQ(data_out[1], 2.0);
   EXPECT_EQ(data_out[2], 3.0);
   EXPECT_EQ(data_out[3], 4.0);
+}
+#endif  // TI_WITH_LLVM
+
+#if TI_WITH_VULKAN
+
+static void texture_interop_test(TiArch arch) {
+  ti::Runtime runtime(arch);
+
+  ti::Texture tex_0 =
+      runtime.allocate_texture2d(128, 128, TI_FORMAT_RGBA8, TI_NULL_HANDLE);
+
+  TiVulkanImageInteropInfo viii{};
+  ti_export_vulkan_image(runtime, tex_0.image(), &viii);
+  ti_import_vulkan_image(runtime, &viii, VK_IMAGE_VIEW_TYPE_2D,
+                         VK_IMAGE_LAYOUT_UNDEFINED);
+
+  ti_track_image_ext(runtime, tex_0.image(), TI_IMAGE_LAYOUT_SHADER_READ_WRITE);
+  runtime.wait();
+}
+
+TEST_F(CapiTest, AotTestVulkanTextureInterop) {
+  if (ti::is_arch_available(TI_ARCH_VULKAN)) {
+    TiArch arch = TiArch::TI_ARCH_VULKAN;
+    texture_interop_test(arch);
+  }
 }
 #endif  // TI_WITH_VULKAN
 

--- a/tests/python/test_ndrange.py
+++ b/tests/python/test_ndrange.py
@@ -63,7 +63,7 @@ def test_3d():
                     assert x[i, j, k] == 0
 
 
-@test_utils.test()
+@test_utils.test(exclude=ti.gles)
 def test_tensor_based_3d():
     x = ti.field(ti.i32, shape=(6, 6, 6))
     y = ti.field(ti.i32, shape=(6, 6, 6))


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2bf9cc6</samp>

Simplify and test Vulkan image interop in C API. Remove redundant preprocessor directives and add a test case for `texture_interop_test` in `c_api_interop_test.cpp`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2bf9cc6</samp>

*  Simplify the code and avoid unnecessary conditional compilation by removing the `#if TI_WITH_VULKAN` and `#endif` preprocessor directives from the `c_api_interop_test.cpp` file ([link](https://github.com/taichi-dev/taichi/pull/8401/files?diff=unified&w=0#diff-17d6273519c0a4b5bebb35039d02db6f5a7dcd0cbbaec26ebc38e004f234904fL63-R63))
*  Test the Vulkan image interop functionality of the C API by adding the `texture_interop_test` function and the `AotTestVulkanTextureInterop` test case to the `c_api_interop_test.cpp` file ([link](https://github.com/taichi-dev/taichi/pull/8401/files?diff=unified&w=0#diff-17d6273519c0a4b5bebb35039d02db6f5a7dcd0cbbaec26ebc38e004f234904fR96-R120))
