### PR TITLE
[aot] Fix missing .so in manylinux2014 environment

### DIFF
--- a/cmake/TaichiTargets.cmake
+++ b/cmake/TaichiTargets.cmake
@@ -72,12 +72,19 @@ elseif (WIN32)
   )
   list(APPEND _cmake_import_check_files_for_taichi_c_api "${_IMPORT_PREFIX}/bin/taichi_c_api.dll" )
 elseif (UNIX)
+  # Check if the .so file exists in the lib directory
+  if(EXISTS "${_IMPORT_PREFIX}/lib/libtaichi_c_api.so")
+    set(TAICHI_SO_LOCATION "${_IMPORT_PREFIX}/lib/libtaichi_c_api.so")
+  else()
+    set(TAICHI_SO_LOCATION "${_IMPORT_PREFIX}/lib64/libtaichi_c_api.so")
+  endif()
+
   set_target_properties(taichi_c_api PROPERTIES
-    IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/libtaichi_c_api.so"
+    IMPORTED_LOCATION "${TAICHI_SO_LOCATION}"
     IMPORTED_SONAME "libtaichi_c_api.so"
     INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
   )
-  list(APPEND _cmake_import_check_files_for_taichi_c_api "${_IMPORT_PREFIX}/lib/libtaichi_c_api.so" )
+  list(APPEND _cmake_import_check_files_for_taichi_c_api "${TAICHI_SO_LOCATION}" )
 endif()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Issue: # In manylinux2014 environments, cmake can't find `libtaichi_c_api.so`. since the path in manylinux2014 is wrong.

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e75061d</samp>

Improve the portability of the CMake configuration for the taichi C API. Use a variable to handle different library directory names on Linux.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e75061d</samp>

*  Add a conditional check to find the shared library file for the taichi C API in either lib or lib64 directory ([link](https://github.com/taichi-dev/taichi/pull/8404/files?diff=unified&w=0#diff-bfaab7c38c6ea51652cf1c22898de199fe820384908f5758919aacbbb3fd5b7aL75-R87))
*  Use the TAICHI_SO_LOCATION variable to set the imported location and the check file list for the taichi_c_api target ([link](https://github.com/taichi-dev/taichi/pull/8404/files?diff=unified&w=0#diff-bfaab7c38c6ea51652cf1c22898de199fe820384908f5758919aacbbb3fd5b7aL75-R87))
