### PR TITLE
[Lang] Remove deprecated graph arguments

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -6,13 +6,13 @@ export TI_CI=1
 
 # IF YOU PIN THIS TO A COMMIT/BRANCH, YOU'RE RESPONSIBLE TO REVERT IT BACK TO MASTER ONCE MERGED.
 export TAICHI_AOT_DEMO_URL=https://github.com/taichi-dev/taichi-aot-demo
-export TAICHI_AOT_DEMO_BRANCH=master
+export TAICHI_AOT_DEMO_BRANCH=update_cgraph_api
 
 export TAICHI_UNITY2_URL=https://github.com/taichi-dev/taichi-unity2
 export TAICHI_UNITY2_BRANCH=main
 
 export TAICHI_UNITY_EXAMPLE_URL=https://github.com/taichi-dev/Taichi-UnityExample
-export TAICHI_UNITY_EXAMPLE_BRANCH=main
+export TAICHI_UNITY_EXAMPLE_BRANCH=update_cgraph_api
 
 . $(dirname $0)/common-utils.sh
 

--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -6,13 +6,13 @@ export TI_CI=1
 
 # IF YOU PIN THIS TO A COMMIT/BRANCH, YOU'RE RESPONSIBLE TO REVERT IT BACK TO MASTER ONCE MERGED.
 export TAICHI_AOT_DEMO_URL=https://github.com/taichi-dev/taichi-aot-demo
-export TAICHI_AOT_DEMO_BRANCH=update_cgraph_api
+export TAICHI_AOT_DEMO_BRANCH=master
 
 export TAICHI_UNITY2_URL=https://github.com/taichi-dev/taichi-unity2
 export TAICHI_UNITY2_BRANCH=main
 
 export TAICHI_UNITY_EXAMPLE_URL=https://github.com/taichi-dev/Taichi-UnityExample
-export TAICHI_UNITY_EXAMPLE_BRANCH=update_cgraph_api
+export TAICHI_UNITY_EXAMPLE_BRANCH=main
 
 . $(dirname $0)/common-utils.sh
 

--- a/python/taichi/graph/_graph.py
+++ b/python/taichi/graph/_graph.py
@@ -106,12 +106,10 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
 
     if tag == ArgKind.SCALAR:
         if "element_shape" in kwargs:
-            warnings.warn(
-                "The element_shape argument for scalar is deprecated in v1.6.0, and will be removed in v1.7.0. "
-                "Please remove them.",
-                DeprecationWarning,
+            raise TaichiRuntimeError(
+                "The element_shape argument for scalar is deprecated in v1.6.0, and is removed in v1.7.0. "
+                "Please remove them."
             )
-            del kwargs["element_shape"]
 
     if tag == ArgKind.NDARRAY:
         if "element_shape" not in kwargs:
@@ -123,15 +121,10 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
                 else:
                     kwargs["element_shape"] = ()
         else:
-            warnings.warn(
-                "The element_shape argument for ndarray is deprecated in v1.6.0, and it will be removed in v1.7.0. "
-                "Please use vector or matrix data type instead.",
-                DeprecationWarning,
+            raise TaichiRuntimeError(
+                "The element_shape argument for ndarray is deprecated in v1.6.0, and it is removed in v1.7.0. "
+                "Please use vector or matrix data type instead."
             )
-            if "dtype" not in kwargs:
-                dtype = kwargs["dtype"]
-                if isinstance(dtype, MatrixType):
-                    raise TaichiRuntimeError("Please do not specify element_shape when dtype is a matrix type.")
 
     if tag == ArgKind.RWTEXTURE or tag == ArgKind.TEXTURE:
         if "dtype" in kwargs:
@@ -142,13 +135,10 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
             del kwargs["dtype"]
 
         if "shape" in kwargs:
-            warnings.warn(
-                "The shape argument for texture is deprecated in v1.6.0, and it will be removed in v1.7.0. "
-                "Please use ndim instead. (Note that you no longer need the exact texture size.)",
-                DeprecationWarning,
+            raise TaichiRuntimeError(
+                "The shape argument for texture is deprecated in v1.6.0, and it is removed in v1.7.0. "
+                "Please use ndim instead. (Note that you no longer need the exact texture size.)"
             )
-            kwargs["ndim"] = len(kwargs["shape"])
-            del kwargs["shape"]
 
         if "channel_format" in kwargs or "num_channels" in kwargs:
             if "fmt" in kwargs:
@@ -158,21 +148,15 @@ def _deprecate_arg_args(kwargs: Dict[str, Any]):
             if tag == ArgKind.RWTEXTURE:
                 fmt = TY_CH2FORMAT[(kwargs["channel_format"], kwargs["num_channels"])]
                 kwargs["fmt"] = fmt
-                warnings.warn(
+                raise TaichiRuntimeError(
                     "The channel_format and num_channels arguments for texture are deprecated in v1.6.0, "
-                    "and they will be removed in v1.7.0. Please use fmt instead.",
-                    DeprecationWarning,
+                    "and they are removed in v1.7.0. Please use fmt instead."
                 )
             else:
-                warnings.warn(
+                raise TaichiRuntimeError(
                     "The channel_format and num_channels arguments are no longer required for non-RW textures "
-                    "since v1.6.0, and they will be removed in v1.7.0. Please remove them.",
-                    DeprecationWarning,
+                    "since v1.6.0, and they are removed in v1.7.0. Please remove them."
                 )
-            if "channel_format" in kwargs:
-                del kwargs["channel_format"]
-            if "num_channels" in kwargs:
-                del kwargs["num_channels"]
 
 
 def _check_args(kwargs: Dict[str, Any], allowed_kwargs: List[str]):

--- a/tests/cpp/aot/python_scripts/texture_aot_test_.py
+++ b/tests/cpp/aot/python_scripts/texture_aot_test_.py
@@ -44,30 +44,24 @@ def compile_aot(arch, is_graph):
         _tex0 = ti.graph.Arg(
             ti.graph.ArgKind.TEXTURE,
             "tex0",
-            channel_format=ti.f32,
-            shape=(128, 128),
-            num_channels=1,
+            ndim=2,
         )
         _rw_tex0 = ti.graph.Arg(
             ti.graph.ArgKind.RWTEXTURE,
             "rw_tex0",
-            channel_format=ti.f32,
-            shape=(128, 128),
-            num_channels=1,
+            ndim=2,
+            fmt=ti.Format.r32f,
         )
         _tex1 = ti.graph.Arg(
             ti.graph.ArgKind.TEXTURE,
             "tex1",
-            channel_format=ti.f32,
-            shape=(128, 128),
-            num_channels=1,
+            ndim=2,
         )
         _rw_tex1 = ti.graph.Arg(
             ti.graph.ArgKind.RWTEXTURE,
             "rw_tex1",
-            channel_format=ti.f32,
-            shape=(128, 128),
-            num_channels=1,
+            ndim=2,
+            fmt=ti.Format.r32f,
         )
         _arr = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, "arr", dtype=ti.f32, ndim=2)
 

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -67,7 +67,7 @@ def test_remove_texture_ndim():
 @test_utils.test()
 def test_remove_rwtexture_ndim():
     with pytest.raises(
-            ti.TaichiRuntimeError,
+        ti.TaichiRuntimeError,
         match=r"The shape argument for texture is deprecated in v1.6.0, and it is removed in v1.7.0. "
         r"Please use ndim instead. \(Note that you no longer need the exact texture size.\)",
     ):

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -9,41 +9,41 @@ from tests import test_utils
 
 
 @test_utils.test()
-def test_deprecate_element_shape_scalar():
-    with pytest.warns(
-        DeprecationWarning,
-        match="The element_shape argument for scalar is deprecated in v1.6.0, and will be removed in v1.7.0. "
+def test_remove_element_shape_scalar():
+    with pytest.raises(
+        ti.TaichiRuntimeError,
+        match="The element_shape argument for scalar is deprecated in v1.6.0, and is removed in v1.7.0. "
         "Please remove them.",
     ):
         sym_x = ti.graph.Arg(ti.graph.ArgKind.SCALAR, "x", dtype=ti.f32, element_shape=())
 
 
 @test_utils.test()
-def test_deprecate_element_shape_ndarray_arg():
-    with pytest.warns(
-        DeprecationWarning,
-        match="The element_shape argument for ndarray is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+def test_remove_element_shape_ndarray_arg():
+    with pytest.raises(
+        ti.TaichiRuntimeError,
+        match="The element_shape argument for ndarray is deprecated in v1.6.0, and it is removed in v1.7.0. "
         "Please use vector or matrix data type instead.",
     ):
         ti.graph.Arg(ti.graph.ArgKind.NDARRAY, "x", ti.f32, ndim=1, element_shape=(1,))
 
 
 @test_utils.test()
-def test_deprecate_texture_channel_format_num_channels():
-    with pytest.warns(
-        DeprecationWarning,
+def test_remove_texture_channel_format_num_channels():
+    with pytest.raises(
+        ti.TaichiRuntimeError,
         match="The channel_format and num_channels arguments are no longer required for non-RW textures "
-        "since v1.6.0, and they will be removed in v1.7.0. Please remove them.",
+        "since v1.6.0, and they are removed in v1.7.0. Please remove them.",
     ):
         ti.graph.Arg(ti.graph.ArgKind.TEXTURE, "x", ndim=2, channel_format=ti.f32, num_channels=1)
 
 
 @test_utils.test()
-def test_deprecate_rwtexture_channel_format_num_channels():
-    with pytest.warns(
-        DeprecationWarning,
+def test_remove_rwtexture_channel_format_num_channels():
+    with pytest.raises(
+        ti.TaichiRuntimeError,
         match="The channel_format and num_channels arguments for texture are deprecated in v1.6.0, "
-        "and they will be removed in v1.7.0. Please use fmt instead.",
+        "and they are removed in v1.7.0. Please use fmt instead.",
     ):
         ti.graph.Arg(
             ti.graph.ArgKind.RWTEXTURE,
@@ -55,20 +55,20 @@ def test_deprecate_rwtexture_channel_format_num_channels():
 
 
 @test_utils.test()
-def test_deprecate_texture_ndim():
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"The shape argument for texture is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+def test_remove_texture_ndim():
+    with pytest.raises(
+        ti.TaichiRuntimeError,
+        match=r"The shape argument for texture is deprecated in v1.6.0, and it is removed in v1.7.0. "
         r"Please use ndim instead. \(Note that you no longer need the exact texture size.\)",
     ):
         ti.graph.Arg(ti.graph.ArgKind.TEXTURE, "x", shape=(128, 128), channel_format=ti.f32)
 
 
 @test_utils.test()
-def test_deprecate_rwtexture_ndim():
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"The shape argument for texture is deprecated in v1.6.0, and it will be removed in v1.7.0. "
+def test_remove_rwtexture_ndim():
+    with pytest.raises(
+            ti.TaichiRuntimeError,
+        match=r"The shape argument for texture is deprecated in v1.6.0, and it is removed in v1.7.0. "
         r"Please use ndim instead. \(Note that you no longer need the exact texture size.\)",
     ):
         ti.graph.Arg(ti.graph.ArgKind.RWTEXTURE, "x", shape=(128, 128), fmt=ti.Format.r32f)

--- a/tests/python/test_graph.py
+++ b/tests/python/test_graph.py
@@ -373,16 +373,13 @@ def test_texture():
     _rw_tex = ti.graph.Arg(
         ti.graph.ArgKind.RWTEXTURE,
         "rw_tex",
-        channel_format=ti.f32,
-        shape=(128, 128),
-        num_channels=1,
+        ndim=2,
+        fmt=ti.Format.r32f,
     )
     _tex = ti.graph.Arg(
         ti.graph.ArgKind.TEXTURE,
         "tex",
-        channel_format=ti.f32,
-        shape=(128, 128),
-        num_channels=1,
+        ndim=2,
     )
 
     g_builder = ti.graph.GraphBuilder()
@@ -452,9 +449,8 @@ def test_texture_struct_for():
     sym_tex = ti.graph.Arg(
         ti.graph.ArgKind.RWTEXTURE,
         "tex",
-        channel_format=ti.f32,
-        shape=res,
-        num_channels=1,
+        fmt=ti.Format.r32f,
+        ndim=2,
     )
     sym_arr = ti.graph.Arg(ti.graph.ArgKind.NDARRAY, "arr", ti.f32, ndim=2)
 


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85f2609</samp>

Remove and test deprecated arguments for graph nodes. The pull request removes the `args` and `kwargs` arguments from the `Node` class and its subclasses in `_graph.py`, and raises an error if they are used. It also updates the `test_deprecation.py` file to check for the error instead of a warning.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 85f2609</samp>

*  Enforce the removal of deprecated arguments for graph nodes by raising `TaichiRuntimeError` instead of `DeprecationWarning` ([link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL109-R112), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL126-R127), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL145-R141), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-3b3dff33121c57d33ae7fd0a1288da627f08baed4cdb4039882cc397a2107c0cL161-R159)) in the `_deprecate_arg_args` function of `python/taichi/graph/_graph.py`
* Update the test cases in `tests/python/test_deprecation.py` to expect `TaichiRuntimeError` instead of `DeprecationWarning` for scalar, ndarray, and texture arguments with deprecated arguments ([link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L12-R15), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L22-R25), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L32-R36), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L42-R46), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L58-R61), [link](https://github.com/taichi-dev/taichi/pull/8410/files?diff=unified&w=0#diff-8981be068a363e39524dc2e29d28d4c13a097d0037fc3a1176b249ce5bf35ef8L68-R71))
