### PR TITLE
[misc] Add flag to disable taichi header print

### DIFF
--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -169,7 +169,7 @@ def _print_taichi_header():
     print(header)
 
 
-if os.environ.get('ENABLE_TAICHI_HEADER_PRINT', True):
+if os.environ.get("ENABLE_TAICHI_HEADER_PRINT", True):
     _print_taichi_header()
 
 

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -169,7 +169,8 @@ def _print_taichi_header():
     print(header)
 
 
-_print_taichi_header()
+if os.environ.get('ENABLE_TAICHI_HEADER_PRINT', True):
+    _print_taichi_header()
 
 
 def try_get_wheel_tag(module):


### PR DESCRIPTION
Issue: #8334 

### Brief Summary

Add a flag to disable Taichi header print. One can set ``os.environ['ENABLE_TAICHI_HEADER_PRINT'] = False`` to disable the header print.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 65548e0</samp>

Add an option to disable Taichi header printing using an environment variable. Modify `python/taichi/_lib/utils.py` to implement the option.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 65548e0</samp>

* Add a conditional check to enable or disable the Taichi header printing ([link](https://github.com/taichi-dev/taichi/pull/8413/files?diff=unified&w=0#diff-46daba8967b07b778d2090c80d91720ba234f327d62bc475b2fb956c9f04223dL172-R173))
* Use an environment variable `ENABLE_TAICI_HEADER_PRINT` to control the check ([link](https://github.com/taichi-dev/taichi/pull/8413/files?diff=unified&w=0#diff-46daba8967b07b778d2090c80d91720ba234f327d62bc475b2fb956c9f04223dL172-R173))
