### PR TITLE
[aot] Remove taichi c-api version log

### DIFF
--- a/c_api/src/taichi_core_impl.cpp
+++ b/c_api/src/taichi_core_impl.cpp
@@ -247,7 +247,7 @@ void ti_set_last_error(TiError error, const char *message) {
 TiRuntime ti_create_runtime(TiArch arch, uint32_t device_index) {
   TiRuntime out = TI_NULL_HANDLE;
   TI_CAPI_TRY_CATCH_BEGIN();
-  TI_INFO("Taichi Runtime C-API version is: {}", TI_C_API_VERSION);
+  // TI_INFO("Taichi Runtime C-API version is: {}", TI_C_API_VERSION);
   switch (arch) {
 #ifdef TI_WITH_VULKAN
     case TI_ARCH_VULKAN: {


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b8a6dbe</samp>

Comment out redundant C-API version printing in `taichi_core_impl.cpp`. This reduces the C-API logging output and avoids confusion.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b8a6dbe</samp>

*  Comment out redundant logging of C-API version ([link](https://github.com/taichi-dev/taichi/pull/8415/files?diff=unified&w=0#diff-693e7dacdac48ac69a749431b9e09ec9789a5aa2d4a98a4a3dad596c1fda6abbL250-R250)). This avoids printing the same information twice, since `ti_init` already prints the C-API version. The file `c_api/src/taichi_core_impl.cpp` contains the implementation of the C-API functions, such as `ti_create_runtime`.
