### PR TITLE
Downgrade clang version 2

### DIFF
--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -36,7 +36,7 @@ def setup_clang(as_compiler=True) -> None:
             return
 
     elif (u.system, u.machine) == ("Windows", "AMD64"):
-        out = get_cache_home() / "clang-14"
+        out = get_cache_home() / "clang-14-v2"
         url = "https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/clang-14.0.6-win-complete.zip"
         download_dep(url, out, force=True)
         clang = str(out / "bin" / "clang++.exe").replace("\\", "\\\\")

--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -37,7 +37,7 @@ def setup_clang(as_compiler=True) -> None:
 
     elif (u.system, u.machine) == ("Windows", "AMD64"):
         out = get_cache_home() / "clang-15-v2"
-        url = "https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/clang-15.0.0-win-complete.zip"
+        url = "https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/clang-14.0.6-win-complete.zip"
         download_dep(url, out, force=True)
         clang = str(out / "bin" / "clang++.exe").replace("\\", "\\\\")
         clangpp = clang

--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -25,7 +25,7 @@ def setup_clang(as_compiler=True) -> None:
     """
     u = platform.uname()
     if u.system in ("Linux", "Darwin"):
-        for v in ("", "-15", "-14", "-13", "-12", "-11", "-10"):
+        for v in ("", "-14", "-13", "-12", "-11", "-10"):
             clang = shutil.which(f"clang{v}")
             if clang is not None:
                 clangpp = shutil.which(f"clang++{v}")

--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -19,7 +19,7 @@ from .tinysh import powershell
 
 # -- code --
 @banner("Setup Clang")
-def setup_clang(as_compiler=True) -> None:
+def setup_clang(as_compiler=True, use_env=True) -> None:
     """
     Setup Clang.
     """
@@ -49,12 +49,12 @@ def setup_clang(as_compiler=True) -> None:
     if as_compiler:
         cc = os.environ.get("CC")
         cxx = os.environ.get("CXX")
-        if cc:
+        if cc and use_env:
             warn(f"Explicitly specified compiler via environment variable CC={cc}, not configuring clang.")
         else:
             cmake_args["CMAKE_C_COMPILER"] = clang
 
-        if cxx:
+        if cxx and use_env:
             warn(f"Explicitly specified compiler via environment variable CXX={cxx}, not configuring clang++.")
         else:
             cmake_args["CMAKE_CXX_COMPILER"] = clangpp

--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -36,7 +36,7 @@ def setup_clang(as_compiler=True) -> None:
             return
 
     elif (u.system, u.machine) == ("Windows", "AMD64"):
-        out = get_cache_home() / "clang-15-v2"
+        out = get_cache_home() / "clang-14"
         url = "https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/clang-14.0.6-win-complete.zip"
         download_dep(url, out, force=True)
         clang = str(out / "bin" / "clang++.exe").replace("\\", "\\\\")

--- a/.github/workflows/scripts/ti_build/entry.py
+++ b/.github/workflows/scripts/ti_build/entry.py
@@ -78,7 +78,7 @@ def setup_basic_build_env():
         setup_msvc()
     else:
         # Use Clang on all other platforms
-        setup_clang()
+        setup_clang(as_compiler=True, use_env=False)
 
     setup_llvm()
     setup_vulkan()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,14 +197,6 @@ if (TI_WITH_LLVM)
 
     check_clang_version()
 
-    if(${CLANG_VERSION_MAJOR} STREQUAL "")
-        # Do nothing
-    else()
-        if (${CLANG_VERSION_MAJOR} VERSION_GREATER ${CLANG_HIGHEST_VERSION})
-          message(FATAL_ERROR "${CLANG_EXECUTABLE} version: ${CLANG_VERSION}, required: <=${CLANG_HIGHEST_VERSION}. Consider passing -DCLANG_EXECUTABLE=/path/to/clang to cmake to use a specific clang.")
-        endif()
-    endif()
-
     add_subdirectory(taichi/runtime/llvm/runtime_module)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,12 @@ if (TI_WITH_LLVM)
 
     check_clang_version()
 
-    if (${CLANG_VERSION_MAJOR} VERSION_GREATER ${CLANG_HIGHEST_VERSION})
-      message(FATAL_ERROR "${CLANG_EXECUTABLE} version: ${CLANG_VERSION}, required: <=${CLANG_HIGHEST_VERSION}. Consider passing -DCLANG_EXECUTABLE=/path/to/clang to cmake to use a specific clang.")
+    if(${CLANG_VERSION_MAJOR} STREQUAL "")
+        # Do nothing
+    else()
+        if (${CLANG_VERSION_MAJOR} VERSION_GREATER ${CLANG_HIGHEST_VERSION})
+          message(FATAL_ERROR "${CLANG_EXECUTABLE} version: ${CLANG_VERSION}, required: <=${CLANG_HIGHEST_VERSION}. Consider passing -DCLANG_EXECUTABLE=/path/to/clang to cmake to use a specific clang.")
+        endif()
     endif()
 
     add_subdirectory(taichi/runtime/llvm/runtime_module)


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4957aaf</samp>

This pull request improves the clang compiler support for Taichi on different platforms. It drops `clang-15` for Linux and Darwin, uses `clang-14` for Windows, and removes the unnecessary clang version check in `CMakeLists.txt`.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4957aaf</samp>

* Remove clang-15 option for Linux and Darwin platforms and update clang-14 URL and output directory for Windows platforms ([link](https://github.com/taichi-dev/taichi/pull/8418/files?diff=unified&w=0#diff-67455722e4753f6e374de9e8113c60adb89c5e011615abe630a5806c87638ca0L28-R28), [link](https://github.com/taichi-dev/taichi/pull/8418/files?diff=unified&w=0#diff-67455722e4753f6e374de9e8113c60adb89c5e011615abe630a5806c87638ca0L39-R40))
* Delete clang version check in `CMakeLists.txt` as it is no longer necessary ([link](https://github.com/taichi-dev/taichi/pull/8418/files?diff=unified&w=0#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL200-L203))
