### PR TITLE
[build] Temporarily switch to clang-14

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -10,7 +10,7 @@ on:
 env:
   TI_CI: "1"
   TI_SKIP_VERSION_CHECK: "ON"
-  CI_IMAGE_VERSION: '202305261112'
+  CI_IMAGE_VERSION: '202311231829'
 
 jobs:
   gpu_backends:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   METADATA_URL: ${{ secrets.METADATA_URL }}
   RELEASE_VERSION: ${{ github.event.inputs.version }}
   NIGHTLY: ${{ !github.event.inputs.version && '--nightly' || '' }}
-  CI_IMAGE_VERSION: '202305261112'
+  CI_IMAGE_VERSION: '202311231829'
   TI_CI: "1"
   TI_SKIP_VERSION_CHECK: 'ON'
   TI_USE_GIT_CACHE: ${{ vars.TI_USE_GIT_CACHE }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ env:
   TI_SKIP_VERSION_CHECK: 'ON'
   TI_LITE_TEST: ${{ github.event_name == 'pull_request' && ! contains(github.event.pull_request.labels.*.name, 'full-ci') && ! startsWith(github.base_ref, 'rc-') && '1' || '' }}
   TI_TEST_OFFLINE_CACHE: ${{ github.event.schedule == '0 18 * * *' && '1' || '' }}
-  CI_IMAGE_VERSION: '202305261112'
+  CI_IMAGE_VERSION: '202311231829'
   TI_USE_GIT_CACHE: ${{ vars.TI_USE_GIT_CACHE }}
 
 jobs:

--- a/ci/Dockerfile.tpl
+++ b/ci/Dockerfile.tpl
@@ -61,9 +61,9 @@ RUN set -x && \
     add-apt-repository -y ppa:git-core/ppa && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
     . /etc/lsb-release && \
-    echo "deb http://apt.llvm.org/$DISTRIB_CODENAME/ llvm-toolchain-$DISTRIB_CODENAME-15 main" > /etc/apt/sources.list.d/llvm-15.list && \
+    echo "deb http://apt.llvm.org/$DISTRIB_CODENAME/ llvm-toolchain-$DISTRIB_CODENAME-14 main" > /etc/apt/sources.list.d/llvm-14.list && \
     apt update && \
-    apt install -y build-essential clang-15 clang-tidy-15 llvm-15 lld-15 gcc-11 g++-11 curl wget sudo python3-pip git unzip && \
+    apt install -y build-essential clang-14 clang-tidy-14 llvm-14 lld-14 gcc-11 g++-11 curl wget sudo python3-pip git unzip && \
     python3 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --upgrade pip && \
     pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple && \
     pip install -U cmake && \
@@ -72,17 +72,14 @@ RUN set -x && \
     rm /usr/bin/ld && ln -sf /usr/bin/mold /usr/bin/ld && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
-    ln -sf /usr/bin/clang-15 /usr/bin/clang && \
-    ln -sf /usr/bin/clang++-15 /usr/bin/clang++ && \
-    ln -sf /usr/bin/lld-15 /usr/bin/lld && \
-    ln -sf /usr/bin/ld.lld-15 /usr/bin/ld.lld && \
+    ln -sf /usr/bin/clang-14 /usr/bin/clang && \
+    ln -sf /usr/bin/clang++-14 /usr/bin/clang++ && \
+    ln -sf /usr/bin/lld-14 /usr/bin/lld && \
+    ln -sf /usr/bin/ld.lld-14 /usr/bin/ld.lld && \
     true
 
 # mold version is not special, just the latest one at the time of writing
 # lld is for AMDGPU backend, C++ code runs it.
-
-ENV CC="/usr/bin/clang" \
-    CXX="/usr/bin/clang++"
 
 # -------
 SNIPPET debian-addons-test
@@ -196,7 +193,6 @@ RUN set -x && \
         'platforms;android-30' \
         'platforms;android-33' \
         'platform-tools' \
-        'patcher;v4' \
         emulator \
         && \
     chown -R 1000:1000 /android-sdk && \
@@ -271,7 +267,6 @@ RUN set -x && \
         && \
     clang++ -v && \
     true
-ENV CC="clang" CXX="clang++"
 
 FROM centos:7 AS manylinux2014
 USE manylinux2014-addons


### PR DESCRIPTION
Issue: #

### Brief Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ba889a6</samp>

Updated the docker image and workflows to use LLVM 14 for taichi. This improves the compatibility, simplicity, and efficiency of the development and testing environment.

### Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ba889a6</samp>

*  Update the docker image version for the performance, release, and testing workflows to use LLVM 14 instead of LLVM 15 ([link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-82c5d303a285e8cb2370945e1bb58c7f6c6d57b09ac32ed9b69ac619591b1030L13-R13), [link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R22), [link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL21-R21))
  - Install clang, clang-tidy, llvm, and lld packages from the LLVM 14 apt repository instead of LLVM 15 ([link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-1004f67c8648eea37bd279ea6e4adaa464a84e65ef4e23ab50980a173b7d84f8L64-R66))
  - Create symbolic links for clang, clang++, lld, and ld.lld binaries using the LLVM 14 version instead of LLVM 15 ([link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-1004f67c8648eea37bd279ea6e4adaa464a84e65ef4e23ab50980a173b7d84f8L75-R78))
  - Remove the redundant environment variables `CC` and `CXX` that were already set by the symbolic links ([link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-1004f67c8648eea37bd279ea6e4adaa464a84e65ef4e23ab50980a173b7d84f8L84-L86), [link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-1004f67c8648eea37bd279ea6e4adaa464a84e65ef4e23ab50980a173b7d84f8L274))
  - Remove the installation of the `patcher;v4` component from the Android SDK, as it is not needed by taichi ([link](https://github.com/taichi-dev/taichi/pull/8419/files?diff=unified&w=0#diff-1004f67c8648eea37bd279ea6e4adaa464a84e65ef4e23ab50980a173b7d84f8L199))
