### PR TITLE
[Bugfix] Use correct num_triplets

### DIFF
--- a/taichi/program/sparse_matrix.cpp
+++ b/taichi/program/sparse_matrix.cpp
@@ -380,7 +380,7 @@ void make_sparse_matrix_from_ndarray(Program *prog,
                                      const Ndarray &ndarray) {
   std::string sdtype = taichi::lang::data_type_name(sm.get_data_type());
   auto data_ptr = prog->get_ndarray_data_ptr_as_int(&ndarray);
-  auto num_triplets = ndarray.get_nelement() * ndarray.get_element_size() / 3;
+  auto num_triplets = ndarray.get_nelement();
   if (sdtype == "f32") {
     build_ndarray_template<float32>(sm, data_ptr, num_triplets);
   } else if (sdtype == "f64") {


### PR DESCRIPTION
Issue: fixes #8501

Use `ndarray.get_nelement()` as `num_triplets`.