### PR TITLE
[Bug] Fix bug to disable taichi header print

### DIFF
--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -82,9 +82,7 @@ def is_ci():
     return os.environ.get("TI_CI", "") == "1"
 
 
-package_root = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-)
+package_root = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 
 def get_core_shared_object():
@@ -106,9 +104,7 @@ def print_yellow_bold(*args, **kwargs):
 
 def check_exists(src):
     if not os.path.exists(src):
-        raise FileNotFoundError(
-            f'File "{src}" not exist. Installation corrupted or build incomplete?'
-        )
+        raise FileNotFoundError(f'File "{src}" not exist. Installation corrupted or build incomplete?')
 
 
 ti_python_core = import_ti_python_core()
@@ -241,9 +237,7 @@ def warn_restricted_version():
                     )
                     print()
                     print_yellow_bold("    $ python3 -m pip install --upgrade pip")
-                    print_yellow_bold(
-                        "    $ python3 -m pip install --force-reinstall taichi"
-                    )
+                    print_yellow_bold("    $ python3 -m pip install --force-reinstall taichi")
                     print()
 
                 print_yellow_bold(

--- a/python/taichi/_lib/utils.py
+++ b/python/taichi/_lib/utils.py
@@ -82,7 +82,9 @@ def is_ci():
     return os.environ.get("TI_CI", "") == "1"
 
 
-package_root = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+package_root = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+)
 
 
 def get_core_shared_object():
@@ -104,7 +106,9 @@ def print_yellow_bold(*args, **kwargs):
 
 def check_exists(src):
     if not os.path.exists(src):
-        raise FileNotFoundError(f'File "{src}" not exist. Installation corrupted or build incomplete?')
+        raise FileNotFoundError(
+            f'File "{src}" not exist. Installation corrupted or build incomplete?'
+        )
 
 
 ti_python_core = import_ti_python_core()
@@ -169,7 +173,7 @@ def _print_taichi_header():
     print(header)
 
 
-if os.environ.get("ENABLE_TAICHI_HEADER_PRINT", True):
+if os.getenv("ENABLE_TAICHI_HEADER_PRINT", "True").lower() not in ("false", "0", "f"):
     _print_taichi_header()
 
 
@@ -237,7 +241,9 @@ def warn_restricted_version():
                     )
                     print()
                     print_yellow_bold("    $ python3 -m pip install --upgrade pip")
-                    print_yellow_bold("    $ python3 -m pip install --force-reinstall taichi")
+                    print_yellow_bold(
+                        "    $ python3 -m pip install --force-reinstall taichi"
+                    )
                     print()
 
                 print_yellow_bold(


### PR DESCRIPTION
Issue: #8334 

### Brief Summary

The previous code #8413 had no effect because the value in os.environ can only be a string. This pull request will enable users to disable the Taichi header print by setting one of the following ways:

- os.environ['ENABLE_TAICHI_HEADER_PRINT'] = 'False'
- os.environ['ENABLE_TAICHI_HEADER_PRINT'] = 'FALSE'
- os.environ['ENABLE_TAICHI_HEADER_PRINT'] = 'F'
- os.environ['ENABLE_TAICHI_HEADER_PRINT'] = '0'

### Walkthrough

copilot:walkthrough
