### PR TITLE
[Doc] Fix a typo in math/math_module.md

### DIFF
--- a/docs/cover-in-ci.lst
+++ b/docs/cover-in-ci.lst
@@ -36,3 +36,4 @@ docs/rfcs/yyyymmdd-rfc-template.md
 docs/lang/articles/math/linear_solver.md
 docs/lang/articles/math/sparse_matrix.md
 docs/lang/articles/get-started/cloth_simulation.md
+docs/lang/articles/math/math_module.md

--- a/docs/lang/articles/math/math_module.md
+++ b/docs/lang/articles/math/math_module.md
@@ -83,7 +83,7 @@ You can use these types to instantiate vectors/matrices or annotate data types f
 
 ```python
 mat2 = ti.math.mat2
-vec3 = ti.math.mat3
+vec3 = ti.math.vec3
 vec4 = ti.math.vec4
 
 m = mat2(1)  # [[1., 1.], [1., 1.]]

--- a/docs/lang/articles/math/math_module.md
+++ b/docs/lang/articles/math/math_module.md
@@ -114,7 +114,7 @@ u = v.rraa  # vec4(1, 1, 2, 2)
 - `ti.types.vector` is a function that accepts an integer and a primitive type and returns a vector type. For example: `vec5f = ti.types.vector(5, float)`. `vec5f` can then be used to instantiate 5D vectors or annotate data types of function arguments and struct members:
     ```python
     vec5f = ti.types.vector(5, float)
-    
+
     @ti.kernel
     def test(v: vec5f):
         print(v.xyz)

--- a/docs/lang/articles/math/math_module.md
+++ b/docs/lang/articles/math/math_module.md
@@ -114,6 +114,7 @@ u = v.rraa  # vec4(1, 1, 2, 2)
 - `ti.types.vector` is a function that accepts an integer and a primitive type and returns a vector type. For example: `vec5f = ti.types.vector(5, float)`. `vec5f` can then be used to instantiate 5D vectors or annotate data types of function arguments and struct members:
     ```python
     vec5f = ti.types.vector(5, float)
+    
     @ti.kernel
     def test(v: vec5f):
         print(v.xyz)

--- a/docs/lang/articles/math/math_module.md
+++ b/docs/lang/articles/math/math_module.md
@@ -113,6 +113,7 @@ u = v.rraa  # vec4(1, 1, 2, 2)
 - `ti.Vector` is a function that accepts a 1D array and returns a matrix instance that has only one column. For example, `ti.Vector([1, 2, 3, 4, 5])`.
 - `ti.types.vector` is a function that accepts an integer and a primitive type and returns a vector type. For example: `vec5f = ti.types.vector(5, float)`. `vec5f` can then be used to instantiate 5D vectors or annotate data types of function arguments and struct members:
     ```python
+    vec5f = ti.types.vector(5, float)
     @ti.kernel
     def test(v: vec5f):
         print(v.xyz)


### PR DESCRIPTION
Issue: The typo in the documentation is located at https://docs.taichi-lang.org/docs/math_module#small-vector-and-matrix-types

![image](https://github.com/taichi-dev/taichi/assets/68705456/d364aa74-3bc3-493d-9ddb-d6f23090f093)


### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
