### PR TITLE
Update README.md: experiemental => experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The language has broad applications spanning real-time physical simulation, nume
   - Vulkan
   - OpenGL (4.3+)
   - Apple Metal
-  - WebAssembly (experiemental)
+  - WebAssembly (experimental)
  </details>
 
 Use Python's package installer **pip** to install Taichi Lang:


### PR DESCRIPTION
Just a one word typo: experiemental => experimental, in the README.md