### PR TITLE
[bug] Fixes for numpy 2.0 (unblocking python 3.12 release build on mac)

### DIFF
--- a/python/taichi/examples/simulation/implicit_fem.py
+++ b/python/taichi/examples/simulation/implicit_fem.py
@@ -37,8 +37,8 @@ if args.exp == "implicit":
 use_sparse = args.use_sparse
 
 n_cube = np.array([5] * 3)
-n_verts = np.product(n_cube)
-n_cells = 5 * np.product(n_cube - 1)
+n_verts = np.prod(n_cube)
+n_cells = 5 * np.prod(n_cube - 1)
 dx = 1 / (n_cube.max() - 1)
 
 F_vertices = ti.Vector.field(4, dtype=ti.i32, shape=n_cells)

--- a/tests/python/test_implicit_fem.py
+++ b/tests/python/test_implicit_fem.py
@@ -15,8 +15,8 @@ def test_implicit_fem():
     use_sparse = 0
 
     n_cube = np.array([5] * 3)
-    n_verts = np.product(n_cube)
-    n_cells = 5 * np.product(n_cube - 1)
+    n_verts = np.prod(n_cube)
+    n_cells = 5 * np.prod(n_cube - 1)
     dx = 1 / (n_cube.max() - 1)
 
     F_vertices = ti.Vector.field(4, dtype=ti.i32, shape=n_cells)

--- a/tests/python/test_reduction.py
+++ b/tests/python/test_reduction.py
@@ -89,13 +89,13 @@ def _test_reduction_single(dtype, criterion, op):
 @pytest.mark.parametrize("op", [OP_ADD, OP_MIN, OP_MAX, OP_AND, OP_OR, OP_XOR])
 @test_utils.test()
 def test_reduction_single_i32(op):
-    _test_reduction_single(ti.i32, lambda x, y: x % 2**32 == y % 2**32, op)
+    _test_reduction_single(ti.i32, lambda x, y: int(x) % 2**32 == int(y) % 2**32, op)
 
 
 @pytest.mark.parametrize("op", [OP_ADD])
 @test_utils.test(exclude=[ti.opengl, ti.gles])
 def test_reduction_single_u32(op):
-    _test_reduction_single(ti.u32, lambda x, y: x % 2**32 == y % 2**32, op)
+    _test_reduction_single(ti.u32, lambda x, y: int(x) % 2**32 == int(y) % 2**32, op)
 
 
 @pytest.mark.parametrize("op", [OP_ADD, OP_MIN, OP_MAX])
@@ -107,13 +107,13 @@ def test_reduction_single_f32(op):
 @pytest.mark.parametrize("op", [OP_ADD])
 @test_utils.test(require=ti.extension.data64)
 def test_reduction_single_i64(op):
-    _test_reduction_single(ti.i64, lambda x, y: x % 2**64 == y % 2**64, op)
+    _test_reduction_single(ti.i64, lambda x, y: int(x) % 2**64 == int(y) % 2**64, op)
 
 
 @pytest.mark.parametrize("op", [OP_ADD])
 @test_utils.test(exclude=[ti.opengl, ti.gles], require=ti.extension.data64)
 def test_reduction_single_u64(op):
-    _test_reduction_single(ti.u64, lambda x, y: x % 2**64 == y % 2**64, op)
+    _test_reduction_single(ti.u64, lambda x, y: int(x) % 2**64 == int(y) % 2**64, op)
 
 
 @pytest.mark.parametrize("op", [OP_ADD])


### PR DESCRIPTION
Numpy 2.0 has removed deprecated implicit cast behavior of overflow casting to smaller dtypes. And it has removed .product in favor of .prod