### PR TITLE
[bug] Fix assign may lose precision warning & improve related logging

### DIFF
--- a/taichi/common/exceptions.h
+++ b/taichi/common/exceptions.h
@@ -26,6 +26,10 @@ struct DebugInfo {
   explicit DebugInfo(const char *tb_) : tb(tb_) {
   }
 
+  std::string get_last_tb() const {
+    return tb;
+  }
+
   std::string const &get_tb() const {
     return tb;
   }
@@ -141,7 +145,7 @@ struct ErrorEmitter {
       // tb here
       error.msg_ = error_msg;
     } else {
-      error.msg_ = p_dbg_info->get_tb() + error_msg;
+      error.msg_ = p_dbg_info->get_last_tb() + error_msg;
     }
 
     if constexpr (std::is_base_of_v<TaichiWarning, std::decay_t<E>>) {

--- a/taichi/ir/control_flow_graph.cpp
+++ b/taichi/ir/control_flow_graph.cpp
@@ -3,6 +3,7 @@
 #include <queue>
 #include <unordered_set>
 
+#include "taichi/common/exceptions.h"
 #include "taichi/ir/analysis.h"
 #include "taichi/ir/statements.h"
 #include "taichi/system/profiler.h"
@@ -337,8 +338,8 @@ Stmt *CFGNode::get_store_forwarding_data(Stmt *var, int position) const {
   }
   if (!result) {
     // The UD-chain is empty.
-    TI_WARN("stmt {} loaded in stmt {} before storing.", var->id,
-            block->statements[position]->id);
+    auto offending_load = block->statements[position].get();
+    ErrorEmitter(TaichiIrWarning(), offending_load, fmt::format("Loading variable {} before anything is stored to it.", var->id));
     return nullptr;
   }
   if (!result_visible) {

--- a/taichi/ir/expression.h
+++ b/taichi/ir/expression.h
@@ -64,6 +64,10 @@ class Expression {
     return stmt;
   }
 
+  std::string get_last_tb() const {
+    return dbg_info.get_last_tb();
+  }
+
   std::string const &get_tb() const {
     return dbg_info.tb;
   }

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -147,7 +147,7 @@ Callable *Stmt::get_callable() const {
   }
   irpass::print((IRNode *)this);
 
-  TI_ASSERT_INFO(false, "Stmt is not in a kernel.");
+  TI_WARN("Stmt is not in a kernel.");
   return nullptr;
 }
 
@@ -222,7 +222,8 @@ std::string Stmt::get_last_tb() const {
     }
 
     const auto stmt_type_name = typeid(*this).name();
-    const auto callable_name = get_callable()->get_name();
+    const auto *callable = get_callable();
+    const auto callable_name = callable ? callable->get_name() : "";
 
     return fmt::format("{}::{} of type {}\n", callable_name, name(),
                        cpp_demangle(stmt_type_name));

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -43,6 +43,14 @@ IRNode *IRNode::get_ir_root() {
   return node;
 }
 
+const IRNode *IRNode::get_ir_root() const {
+  auto node = this;
+  while (node->get_parent()) {
+    node = node->get_parent();
+  }
+  return node;
+}
+
 std::unique_ptr<IRNode> IRNode::clone() {
   std::unique_ptr<IRNode> new_irnode;
   if (is<Block>())
@@ -193,6 +201,32 @@ std::string Stmt::type() {
 
 IRNode *Stmt::get_parent() const {
   return parent;
+}
+
+std::string Stmt::get_last_tb() const {
+  const auto& tb = dbg_info.tb;
+  if (tb.empty()) {
+    // If has no tb, try to find tb from the immediate previous statement
+    if (parent) {
+      auto it_this = std::find_if(parent->statements.rbegin(), parent->statements.rend(),
+                                         [this](const pStmt &stmt) { return stmt.get() == this; });
+
+      while (it_this != parent->statements.rend()) {
+        const auto &stmt = *it_this;
+        if (!stmt->get_tb().empty()) {
+          return stmt->get_tb();
+        }
+        ++it_this;
+      }
+    }
+
+    const auto stmt_type_name = typeid(*this).name();
+    const auto callable_name = get_callable()->get_name();
+
+    return fmt::format("{}::{} of type {}\n", callable_name, name(), cpp_demangle(stmt_type_name));
+  }
+  
+  return tb;
 }
 
 std::vector<Stmt *> Stmt::get_operands() const {

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -204,12 +204,13 @@ IRNode *Stmt::get_parent() const {
 }
 
 std::string Stmt::get_last_tb() const {
-  const auto& tb = dbg_info.tb;
+  const auto &tb = dbg_info.tb;
   if (tb.empty()) {
     // If has no tb, try to find tb from the immediate previous statement
     if (parent) {
-      auto it_this = std::find_if(parent->statements.rbegin(), parent->statements.rend(),
-                                         [this](const pStmt &stmt) { return stmt.get() == this; });
+      auto it_this = std::find_if(
+          parent->statements.rbegin(), parent->statements.rend(),
+          [this](const pStmt &stmt) { return stmt.get() == this; });
 
       while (it_this != parent->statements.rend()) {
         const auto &stmt = *it_this;
@@ -223,9 +224,10 @@ std::string Stmt::get_last_tb() const {
     const auto stmt_type_name = typeid(*this).name();
     const auto callable_name = get_callable()->get_name();
 
-    return fmt::format("{}::{} of type {}\n", callable_name, name(), cpp_demangle(stmt_type_name));
+    return fmt::format("{}::{} of type {}\n", callable_name, name(),
+                       cpp_demangle(stmt_type_name));
   }
-  
+
   return tb;
 }
 

--- a/taichi/ir/ir.cpp
+++ b/taichi/ir/ir.cpp
@@ -204,6 +204,12 @@ IRNode *Stmt::get_parent() const {
 }
 
 std::string Stmt::get_last_tb() const {
+  const auto *callable = get_callable();
+  const auto callable_name = callable ? callable->get_name() : "";
+
+  std::string prefix =
+      !callable_name.empty() ? "While compiling `" + callable_name + "`, " : "";
+
   const auto &tb = dbg_info.tb;
   if (tb.empty()) {
     // If has no tb, try to find tb from the immediate previous statement
@@ -215,21 +221,19 @@ std::string Stmt::get_last_tb() const {
       while (it_this != parent->statements.rend()) {
         const auto &stmt = *it_this;
         if (!stmt->get_tb().empty()) {
-          return stmt->get_tb();
+          return prefix + stmt->get_tb();
         }
         ++it_this;
       }
     }
 
     const auto stmt_type_name = typeid(*this).name();
-    const auto *callable = get_callable();
-    const auto callable_name = callable ? callable->get_name() : "";
 
-    return fmt::format("{}::{} of type {}\n", callable_name, name(),
+    return fmt::format("{}Statement {} (type={});\n", prefix, name(),
                        cpp_demangle(stmt_type_name));
   }
 
-  return tb;
+  return prefix + tb;
 }
 
 std::vector<Stmt *> Stmt::get_operands() const {

--- a/taichi/ir/ir.h
+++ b/taichi/ir/ir.h
@@ -235,6 +235,7 @@ class IRNode {
   virtual IRNode *get_parent() const = 0;
 
   IRNode *get_ir_root();
+  const IRNode *get_ir_root() const;
 
   virtual ~IRNode() = default;
 
@@ -440,6 +441,8 @@ class Stmt : public IRNode {
     // TI_ASSERT(0 <= i && i < (int)operands.size());
     return *operands[i];
   }
+
+  std::string get_last_tb() const;
 
   TI_FORCE_INLINE std::string const &get_tb() const {
     return dbg_info.tb;

--- a/taichi/program/program.cpp
+++ b/taichi/program/program.cpp
@@ -310,6 +310,7 @@ Kernel &Program::get_snode_writer(SNode *snode) {
     ASTBuilder &builder = kernel->context->builder();
     auto expr =
         builder.expr_subscript(Expr(snode_to_fields_.at(snode)), indices);
+    expr.type_check(&this->compile_config());
     auto argload_expr = Expr::make<ArgLoadExpression>(
         std::vector<int>{snode->num_active_indices},
         snode->dt->get_compute_type());

--- a/taichi/system/demangling.cpp
+++ b/taichi/system/demangling.cpp
@@ -43,11 +43,7 @@ class Demangling : public Task {
       printf("There should be at least one parameter for demangling.\n");
     }
     for (auto p : parameters) {
-#if !defined(_WIN64)
       printf("Demangled C++ Identifier: %s\n", cpp_demangle(p).c_str());
-#else
-      TI_NOT_IMPLEMENTED
-#endif
     }
     return "";
   }

--- a/taichi/system/demangling.cpp
+++ b/taichi/system/demangling.cpp
@@ -9,6 +9,10 @@
 #include <cxxabi.h>
 #endif
 
+#if defined(TI_PLATFORM_WINDOWS)
+#include <DbgHelp.h>
+#endif
+
 namespace taichi {
 
 // From https://en.wikipedia.org/wiki/Name_mangling
@@ -22,6 +26,12 @@ std::string cpp_demangle(const std::string &mangled_name) {
   std::string ret(demangled_name);
   free(demangled_name);
   return ret;
+#elif defined(TI_PLATFORM_WINDOWS)
+  PCSTR mangled = mangled_name.c_str();
+  char demangled[1024];
+  DWORD length =
+      UnDecorateSymbolName(mangled, demangled, 1024, UNDNAME_NAME_ONLY);
+  return std::string(demangled, size_t(length));
 #else
   TI_NOT_IMPLEMENTED
 #endif

--- a/taichi/transforms/ir_printer.cpp
+++ b/taichi/transforms/ir_printer.cpp
@@ -53,9 +53,9 @@ class IRPrinter : public IRVisitor {
     if (print_ir_dbg_info) {
       dbg_info_printer_ = [this](const Stmt *stmt) {
         auto tb = stmt->get_tb();
-        print_raw(tb.empty() ? "No DebugInfo avaliable.\n"
-                             : tb.substr(0, tb.length()),
-                  "");
+        if (!tb.empty()) {
+          this->print_raw(tb.substr(0, tb.length()), "");
+        }
       };
     }
   }


### PR DESCRIPTION
Does these few things:
1. Removed printing of "No DebugInfo Available". This is simply a lot of spam when printing IR. Don't print when there's nothing to print
2. Improve debug info handling for things that doesn't have source correlation, by first searching the immediate preceding statements for debug info (so the user at least know the ballpark), and when that fails prints the callable name & statement id
3. Fixed the issue within snode_writer that emits `Assign may lose precision: unknown <- f32` like crazy. (The unknown type is caused by a missing `type_check` on the indexing expression)
4. Use our exception system to emit more helpful warnings for load-to-store forwarding, e.g.:

```
[W 06/23/24 19:08:39.945 11791278] TaichiWarning
File "/Users/bobcao3/taichi/python/taichi/lang/matrix_ops.py", line 281, in _matmul_helper:
                mat_z[i, j] = mat_z[i, j] + mat_x[i, k] * mat_y[k, j]
                                            ^^^^^^^^^^^
Loading variable 937 before anything is stored to it.
```