### PR TITLE
[Doc] Update FAQ to include Python 3.11 support

### DIFF
--- a/docs/lang/articles/faqs/faq.md
+++ b/docs/lang/articles/faqs/faq.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 ### Why does my `pip` complain `package not found` when installing Taichi?
 
-You may have a Python interpreter with an unsupported version. Currently, Taichi only supports Python 3.7/3.8/3.9/3.10 (64-bit) . For more information about installation-specific issues, please check [Installation Troubleshooting](./install.md).
+You may have a Python interpreter with an unsupported version. Currently, Taichi only supports Python 3.7/3.8/3.9/3.10/3.11 (64-bit) . For more information about installation-specific issues, please check [Installation Troubleshooting](./install.md).
 
 ## Parallel programming
 


### PR DESCRIPTION
Issue: N/A (very small change)

### Brief Summary

Update the FAQ page to include python 3.11 support. 

Was checking the FAQ and saw that python 3.11 wasn't listed as supported, even though there is a 3.11 version on PyPI now. So we should update this?

### Walkthrough

N/A