### PR TITLE
[Build] Drop manylinux2014 wheel support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -156,49 +156,6 @@ jobs:
           destination_dir: built-wheels/${{ inputs.build_id }}/${{ !matrix.designated && 'matrix/' || '' }}
           endpoint: http://botmaster.tgr:9000
 
-  build_manylinux2014:
-    name: Build manylinux2014
-    timeout-minutes: 30
-    runs-on: [self-hosted, online, Linux, build]
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{ fromJSON(inputs.python) }}
-        _designated: ['']
-        include:
-        - _designated: ''
-          designated: designated
-    env:
-      TAICHI_CMAKE_ARGS: >-
-        -DTI_WITH_OPENGL:BOOL=OFF
-        -DTI_WITH_VULKAN:BOOL=OFF
-        -DTI_BUILD_TESTS:BOOL=ON
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-          fetch-depth: '0'
-
-      - name: Build
-        run: |
-          . .github/workflows/scripts/common-utils.sh
-
-          ci-docker-run-gpu \
-            -v $(pwd):/home/dev/taichi \
-            registry.botmaster.tgr/taichi-build-manylinux2014-cuda:${{ env.CI_IMAGE_VERSION }} \
-            /home/dev/taichi/build.py ${NIGHTLY:+--nightly} --python=${{ matrix.python }} ${SHOULD_TAG_CONFIG:+--tag-config}
-
-      - name: Upload Built Wheel
-        uses: shallwefootball/s3-upload-action@v1.3.3
-        with:
-          aws_key_id: ${{ secrets.BOT_MINIO_ACCESS_KEY }}
-          aws_secret_access_key: ${{ secrets.BOT_MINIO_SECRET_KEY }}
-          aws_bucket: built-wheels
-          source_dir: dist
-          destination_dir: built-wheels/${{ inputs.build_id }}/${{ !matrix.designated && 'matrix/' || '' }}
-          endpoint: http://botmaster.tgr:9000
-
   build_amdgpu_linux:
     name: Build AMDGPU
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,59 +120,6 @@ jobs:
         env:
           PY: ${{ matrix.python }}
 
-  build_and_test_manylinux2014:
-    name: Build and Upload (manylinux2014)
-    needs: matrix_prep
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
-    runs-on: [self-hosted, cuda, cn, release]
-    env:
-      PY: ${{ matrix.python }}
-      PROJECT_NAME: ${{ matrix.name }}
-      TAICHI_CMAKE_ARGS: >-
-        -DTI_WITH_OPENGL:BOOL=OFF
-        -DTI_WITH_VULKAN:BOOL=OFF
-        -DTI_BUILD_TESTS:BOOL=ON
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-          fetch-depth: '0'
-
-      - name: Prepare Environment
-        run: |
-          . .github/workflows/scripts/common-utils.sh
-          prepare-build-cache
-          echo CI_DOCKER_RUN_EXTRA_ARGS="-v $(pwd):/home/dev/taichi" >> $GITHUB_ENV
-
-      - name: Build
-        run: |
-          . .github/workflows/scripts/common-utils.sh
-
-          ci-docker-run-gpu --name taichi-test \
-             registry.botmaster.tgr/taichi-build-manylinux2014-cuda:${{ env.CI_IMAGE_VERSION }} \
-             /home/dev/taichi/.github/workflows/scripts/build.py $NIGHTLY
-
-      - name: Archive Wheel Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: dist/*.whl
-          retention-days: 20
-
-      - name: Test
-        run: |
-          . .github/workflows/scripts/common-utils.sh
-
-          ci-docker-run-gpu --name taichi-test \
-             registry.botmaster.tgr/taichi-test-manylinux2014-cuda:${{ env.CI_IMAGE_VERSION }} \
-             /home/dev/taichi/.github/workflows/scripts/unix_test.sh
-        env:
-          PY: ${{ matrix.python }}
-          TI_WANTED_ARCHS: "cuda,cpu"
-
   build_and_test_mac:
     name: Build and Upload (macOS only)
     needs: matrix_prep
@@ -337,7 +284,7 @@ jobs:
 
   upload_to_pypi:
     name: Upload release to PyPI
-    needs: [build_and_test_linux, build_and_test_manylinux2014, build_and_test_mac, build_and_test_m1, build_and_test_windows]
+    needs: [build_and_test_linux, build_and_test_mac, build_and_test_m1, build_and_test_windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -267,51 +267,6 @@ jobs:
           path: taichi-release-tests/bad-compare/*
           retention-days: 7
 
-  build_and_test_manylinux2014:
-    name: Build and Test (manylinux2014)
-    needs: check_files
-    runs-on: [self-hosted, cuda, cn, release]
-    env:
-      PY: "3.8"
-      PROJECT_NAME: taichi
-      TI_WANTED_ARCHS: "cuda,cpu"
-      TAICHI_CMAKE_ARGS: >-
-        -DTI_WITH_OPENGL:BOOL=OFF
-        -DTI_WITH_VULKAN:BOOL=OFF
-        -DTI_BUILD_TESTS:BOOL=ON
-
-    steps:
-      - name: Restart X Server
-        run: |
-          sudo systemctl restart xorg
-
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-          fetch-depth: '0'
-
-      - name: Prepare Environment
-        run: |
-          . .github/workflows/scripts/common-utils.sh
-          prepare-build-cache
-          echo CI_DOCKER_RUN_EXTRA_ARGS="-v $(pwd):/home/dev/taichi" >> $GITHUB_ENV
-
-      - name: Build
-        run: |
-          . .github/workflows/scripts/common-utils.sh
-
-          ci-docker-run-gpu --name taichi-test \
-             registry.botmaster.tgr/taichi-build-manylinux2014-cuda:${{ env.CI_IMAGE_VERSION }} \
-             /home/dev/taichi/.github/workflows/scripts/build.py
-
-      - name: Test
-        run: |
-          . .github/workflows/scripts/common-utils.sh
-
-          ci-docker-run-gpu --name taichi-test \
-             registry.botmaster.tgr/taichi-test-manylinux2014-cuda:${{ env.CI_IMAGE_VERSION }} \
-             /home/dev/taichi/.github/workflows/scripts/unix_test.sh
-
   build_and_test_amdgpu_linux:
     name: Build and Test (AMDGPU)
     needs: check_files


### PR DESCRIPTION
`manylinux2014`  is ancient and the built wheel is feature incomplete, it doesn't make sense to continue supporting it.