### PR TITLE
Update euler.py for deprecated get_cmap function in Matplotlib

### DIFF
--- a/python/taichi/examples/simulation/euler.py
+++ b/python/taichi/examples/simulation/euler.py
@@ -1,4 +1,4 @@
-from matplotlib import cm
+from matplotlib import colormaps
 
 import taichi as ti
 
@@ -433,7 +433,7 @@ def paint():
 
 def main():
     gui = ti.GUI("Euler Equations", (res, res))
-    cmap = cm.get_cmap(cmap_name)
+    cmap = colormaps[cmap_name]
     set_ic()
     set_bc()
 


### PR DESCRIPTION
Issue: #
When running ti example 6, there's this warning:
taichi/examples/simulation/euler.py:436: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed in 3.11. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap()`` or ``pyplot.get_cmap()`` instead.
  cmap = cm.get_cmap(cmap_name)

### Brief Summary
macOS 15.2
Python 3.12.7
M1 Pro Macbook Pro

### Walkthrough
ti example
6