### PR TITLE
Fix TaichiWarning by casting index to int in comet.py

### DIFF
--- a/python/taichi/examples/simulation/comet.py
+++ b/python/taichi/examples/simulation/comet.py
@@ -52,7 +52,7 @@ def substep():
         color[i] *= ti.exp(-dt * color_decay)
 
         if not all(-0.1 <= x[i] <= 1.1):
-            ti.deactivate(x.snode.parent(), [i])
+            ti.deactivate(x.snode.parent(), [int(i)])
 
 
 @ti.kernel


### PR DESCRIPTION
Issue: #
This PR addresses a Taichi warning in `comet.py` by explicitly casting `i` to an integer in the `ti.deactivate` function. The warning appeared as follows:
`TaichiWarning
While compiling substep_c76_0, File “taichi/examples/simulation/comet.py”, line 55, in substep:
ti.deactivate(x.snode.parent(), [i])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Field index 0 not int32, casting into int32 implicitly`

### Changes Made
- Updated `ti.deactivate(x.snode.parent(), [i])` to `ti.deactivate(x.snode.parent(), [int(i)])` in `comet.py`.

### Rationale
Explicitly casting `i` to `int` prevents Taichi from implicitly casting and suppresses the TaichiWarning. This change improves code clarity and ensures compatibility with the expected data type for the function.

### Testing
- Confirmed that the warning is no longer displayed when running `comet.py`.
- Functionality of `comet.py` remains intact after this change.