### PR TITLE
Replace deprecated locale.getdefaultlocale() in diagnose.py

### DIFF
--- a/python/taichi/tools/diagnose.py
+++ b/python/taichi/tools/diagnose.py
@@ -16,8 +16,9 @@ def main():
     print(f"platform: {platform.platform()}")
     print(f'architecture: {" ".join(platform.architecture())}')
     print(f"uname: {platform.uname()}")
-
-    print(f'locale: {".".join(locale.getdefaultlocale())}')
+    locale.setlocale(locale.LC_ALL, '')
+    loc, enc = locale.getlocale(), locale.getpreferredencoding()
+    print(f'locale: {loc[0]}.{enc if enc else loc[1]}')
     print(f'PATH: {os.environ.get("PATH")}')
     print(f"PYTHONPATH: {sys.path}")
     print("")


### PR DESCRIPTION
### Brief Summary
This PR addresses a `DeprecationWarning` in `diagnose.py` related to the use of `locale.getdefaultlocale()`, which is deprecated as of Python 3.15. The warning was as follows:
```
DeprecationWarning: ‘locale.getdefaultlocale’ is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
``` 
### Changes Made
- Replaced `locale.getdefaultlocale()` with a combination of `locale.setlocale(locale.LC_ALL, '')`, `locale.getlocale()`, and `locale.getpreferredencoding()` to fetch locale and encoding information without triggering the deprecation warning.
- Updated the code to format the output similarly to the original function.

### Rationale
This change future-proofs the code by using recommended functions (`getlocale()` and `getpreferredencoding()`), ensuring compatibility with Python 3.15 and beyond.

### Testing
- Verified that the `DeprecationWarning` no longer appears when running `diagnose.py`.
- Confirmed that the output format remains consistent with the original implementation.


