### PR TITLE
[Misc] explicitly cast indices to int32 in snode_deactivate to preven…

### DIFF
--- a/python/taichi/_kernels.py
+++ b/python/taichi/_kernels.py
@@ -264,13 +264,13 @@ def field_fill_python_scope(F: template(), val: template()):
 @kernel
 def snode_deactivate(b: template()):
     for I in grouped(b):
-        deactivate(b, I)
+        deactivate(b, [int(i) for i in I])
 
 
 @kernel
 def snode_deactivate_dynamic(b: template()):
     for I in grouped(b.parent()):
-        deactivate(b, I)
+        deactivate(b, [int(i) for i in I])
 
 
 @kernel


### PR DESCRIPTION
### Summary
This PR addresses a Taichi warning in `_kernels.py` that occurs during implicit casting in the `snode_deactivate` function. The warning was as follows:
```
TaichiWarning: Field index not int32, casting into int32 implicitly
``` 

### Changes Made
- Updated `snode_deactivate` to explicitly cast each element in `I` to `int32` before calling `deactivate`, which suppresses the implicit casting warning.

### Rationale
Explicitly casting to `int32` prevents the warning and ensures that the code adheres to expected data types.

### Testing
- Verified that the warning no longer appears when running code that triggers `snode_deactivate`.
- Confirmed that `snode_deactivate` still functions as expected post-update.