### PR TITLE
[Lang] More evaluative build_for

### DIFF
--- a/python/taichi/lang/_ndrange.py
+++ b/python/taichi/lang/_ndrange.py
@@ -51,7 +51,7 @@ class _Ndrange:
         yield from gen(0, ())
 
     def grouped(self):
-        return GroupedNDRange(self)
+        return Grouped(self)
 
 
 def ndrange(*args) -> Iterable:
@@ -137,7 +137,7 @@ def ndrange(*args) -> Iterable:
     return _Ndrange(*args)
 
 
-class GroupedNDRange:
+class Grouped:
     def __init__(self, r):
         self.r = r
 

--- a/python/taichi/lang/impl.py
+++ b/python/taichi/lang/impl.py
@@ -6,7 +6,7 @@ import numpy as np
 from taichi._lib import core as _ti_core
 from taichi._snode.fields_builder import FieldsBuilder
 from taichi.lang._ndarray import ScalarNdarray
-from taichi.lang._ndrange import GroupedNDRange, _Ndrange
+from taichi.lang._ndrange import Grouped, _Ndrange
 from taichi.lang._texture import RWTextureAccessor
 from taichi.lang.any_array import AnyArray
 from taichi.lang.enums import SNodeGradType
@@ -1109,7 +1109,7 @@ def static(x, *xs) -> Any:
                 list,
                 tuple,
                 enumerate,
-                GroupedNDRange,
+                Grouped,
                 _Ndrange,
                 zip,
                 filter,
@@ -1152,9 +1152,7 @@ def grouped(x):
         >>>     print(I)
         prints [0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2]
     """
-    if isinstance(x, _Ndrange):
-        return x.grouped()
-    return x
+    return Grouped(x)
 
 
 def stop_grad(x):


### PR DESCRIPTION
When build ast for "for loop", decorators like "static", "grouped", exprs like "ndrange" are detected directly from ast. However, "mesh-for" is detected via evaluating the iterable statement's value.
I made some change that  using similar evaluation to detect "grouped" and "ndrange" so that end user can wrap these method into there own iterable.
I'm motivated when developing a type hint rich wrapper for taichi, during which I found no way to wrap "grouped" nor "ndrange" into typed one.
