### PR TITLE
[Lang] Build subscripted tuple assign

### DIFF
--- a/python/taichi/lang/ast/ast_transformer.py
+++ b/python/taichi/lang/ast/ast_transformer.py
@@ -206,11 +206,18 @@ class ASTTransformer(Builder):
             ctx.create_variable(target.id, var)
         else:
             var = build_stmt(ctx, target)
-            try:
-                var._assign(value)
-            except AttributeError:
-                raise TaichiSyntaxError(
-                    f"Variable '{unparse(target).strip()}' cannot be assigned. Maybe it is not a Taichi object?"
+            if isinstance(var, tuple) and isinstance(value, tuple):
+                if len(var) != len(value):
+                    raise TaichiSyntaxError("Tuple assign with different lengths")
+                vars, values = var, value
+            else:
+                vars, values = (var,), (value,)
+            for i in range(len(var)):
+                try:
+                    vars[i]._assign(values[i])
+                except AttributeError:
+                    raise TaichiSyntaxError(
+                        f"Variable '{unparse(target).strip()}' cannot be assigned. Maybe it is not a Taichi object?"
                 )
         return var
 


### PR DESCRIPTION
Currently assigning to an subscripted list of tuples in taichi scope will results an error. For example:
```
a = [(0, 1)] * 3

a[1] = (0, 2) # results error
```
I modified `build_basic_assign` to support this.

I was motivated from my attempt to create custom iterable from custom data. I have to create a list of tuple like `[(0, 1), (1, 3)]` to fill in the `ndrange`.
