### PR TITLE
[Lang] Explicit new variable and hide variable

### DIFF
--- a/python/taichi/__init__.py
+++ b/python/taichi/__init__.py
@@ -16,6 +16,8 @@ from taichi.ui import GUI, hex_to_rgb, rgb_to_hex, ui
 # Issue#2223: Do not reorder, or we're busted with partially initialized module
 from taichi import aot  # isort:skip
 
+from taichi.lang.ast.hint import new, hide
+
 
 def __getattr__(attr):
     if attr == "cfg":

--- a/python/taichi/lang/ast/ast_transformer_utils.py
+++ b/python/taichi/lang/ast/ast_transformer_utils.py
@@ -240,9 +240,14 @@ class ASTTransformerContext:
         return False
 
     def create_variable(self, name, var):
-        if name in self.current_scope():
-            raise TaichiSyntaxError("Recreating variables is not allowed")
+        # if name in self.current_scope():
+        #     raise TaichiSyntaxError("Recreating variables is not allowed")
         self.current_scope()[name] = var
+
+    def hide_variable(self, name, var):
+        for s in reversed(self.local_scopes):
+            if name in s:
+                s[name] = var
 
     def check_loop_var(self, loop_var):
         if self.is_var_declared(loop_var):

--- a/python/taichi/lang/ast/hint.py
+++ b/python/taichi/lang/ast/hint.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+type new = Any
+type hide = Any


### PR DESCRIPTION
In many language e.g. rust, we can use `let a = 1` to create a new variable. However, in taichi set the value of a variable and create a new variable writes in the same way.
I made two hint `taichi.new` and `taichi.hide` that used in annoted assign to specify if we want to create a new variable in current scope or hide a variable with a new variable in previous scope.