### PR TITLE
[amdgpu] Calculate mcpu_ and compute_capability_ properly and with ROCm 6 compat

### DIFF
--- a/taichi/rhi/amdgpu/amdgpu_context.cpp
+++ b/taichi/rhi/amdgpu/amdgpu_context.cpp
@@ -57,18 +57,27 @@ AMDGPUContext::AMDGPUContext()
   // We can do this safely because hipDeviceProp_t is larger in R0600 then
   // R0000, so using the field offset values in ROCm 5 on a ROCm 6 struct can
   // never cause an out-of-bounds access.
-  compute_capability_ = (*((int *)(hip_device_prop) + int(HIP_DEVICE_MAJOR))) * 100;
-  compute_capability_ += (*((int *)(hip_device_prop) + int(HIP_DEVICE_MINOR))) * 10;
-  mcpu_ = std::string((char*)((int *)hip_device_prop + HIP_DEVICE_GCN_ARCH_NAME));
+  compute_capability_ =
+      (*((int *)(hip_device_prop) + int(HIP_DEVICE_MAJOR))) * 100;
+  compute_capability_ +=
+      (*((int *)(hip_device_prop) + int(HIP_DEVICE_MINOR))) * 10;
+  mcpu_ =
+      std::string((char *)((int *)hip_device_prop + HIP_DEVICE_GCN_ARCH_NAME));
   // Basic sanity check on mcpu_ to ensure we're calling R0000 instead of R0600
   if (mcpu_.empty() || mcpu_.substr(0, 3) != "gfx") {
     // ROCm 6 starts with 60000000
     if (runtime_version < 60000000) {
-      TI_ERROR("hipGetDevicePropertiesR0000 returned an invalid mcpu_ but HIP version {} is not ROCm 6", runtime_version);
+      TI_ERROR(
+          "hipGetDevicePropertiesR0000 returned an invalid mcpu_ but HIP "
+          "version {} is not ROCm 6",
+          runtime_version);
     }
-    compute_capability_ = (*((int *)(hip_device_prop) + int(HIP_DEVICE_MAJOR_6))) * 100;
-    compute_capability_ += (*((int *)(hip_device_prop) + int(HIP_DEVICE_MINOR_6))) * 10;
-    mcpu_ = std::string((char*)((int *)(hip_device_prop) + int(HIP_DEVICE_GCN_ARCH_NAME_6)));
+    compute_capability_ =
+        (*((int *)(hip_device_prop) + int(HIP_DEVICE_MAJOR_6))) * 100;
+    compute_capability_ +=
+        (*((int *)(hip_device_prop) + int(HIP_DEVICE_MINOR_6))) * 10;
+    mcpu_ = std::string(
+        (char *)((int *)(hip_device_prop) + int(HIP_DEVICE_GCN_ARCH_NAME_6)));
   }
   // Strip out xnack/ecc from name
   mcpu_ = mcpu_.substr(0, mcpu_.find(":"));

--- a/taichi/rhi/amdgpu/amdgpu_driver.cpp
+++ b/taichi/rhi/amdgpu/amdgpu_driver.cpp
@@ -51,6 +51,7 @@ AMDGPUDriver::AMDGPUDriver() {
   loader_->load_function("hipGetErrorName", get_error_name);
   loader_->load_function("hipGetErrorString", get_error_string);
   loader_->load_function("hipDriverGetVersion", driver_get_version);
+  loader_->load_function("hipRuntimeGetVersion", runtime_get_version);
 
   int version;
   driver_get_version(&version);

--- a/taichi/rhi/amdgpu/amdgpu_driver.h
+++ b/taichi/rhi/amdgpu/amdgpu_driver.h
@@ -15,8 +15,8 @@ constexpr uint32 HIP_MEM_ADVISE_SET_PREFERRED_LOCATION = 3;
 constexpr uint32 HIP_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 26;
 constexpr uint32 HIP_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 63;
 // sizeof(hipDeviceProperties_t) in ROCm 6.
-// ROCm 5.7.1 is 792 and ROCm 6 is 1472, so to make both work we use whichever is
-// larger.
+// ROCm 5.7.1 is 792 and ROCm 6 is 1472, so to make both work we use whichever
+// is larger.
 constexpr uint32 HIP_DEVICE_PROPERTIES_STRUCT_SIZE = 1472;
 // offsetof(hipDeviceProp_t, gcnArchName) / 4
 constexpr uint32 HIP_DEVICE_GCN_ARCH_NAME = 396 / 4;

--- a/taichi/rhi/amdgpu/amdgpu_driver.h
+++ b/taichi/rhi/amdgpu/amdgpu_driver.h
@@ -14,8 +14,22 @@ constexpr uint32 HIP_MEM_ATTACH_GLOBAL = 0x1;
 constexpr uint32 HIP_MEM_ADVISE_SET_PREFERRED_LOCATION = 3;
 constexpr uint32 HIP_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 26;
 constexpr uint32 HIP_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 63;
-constexpr uint32 HIP_DEVICE_PROPERTIES_STRUCT_SIZE = 792;
-constexpr uint32 HIP_DEVICE_GCN_ARCH = 98;
+// sizeof(hipDeviceProperties_t) in ROCm 6.
+// ROCm 5.7.1 is 792 and ROCm 6 is 1472, so to make both work we use whichever is
+// larger.
+constexpr uint32 HIP_DEVICE_PROPERTIES_STRUCT_SIZE = 1472;
+// offsetof(hipDeviceProp_t, gcnArchName) / 4
+constexpr uint32 HIP_DEVICE_GCN_ARCH_NAME = 396 / 4;
+// offsetof(hipDeviceProp_t, gcnArchName) / 4
+constexpr uint32 HIP_DEVICE_GCN_ARCH_NAME_6 = 1160 / 4;
+// offsetof(hipDeviceProp_t, major) / 4
+constexpr uint32 HIP_DEVICE_MAJOR = 328 / 4;
+// offsetof(hipDeviceProp_t, major) / 4
+constexpr uint32 HIP_DEVICE_MAJOR_6 = 360 / 4;
+// offsetof(hipDeviceProp_t, minor) / 4
+constexpr uint32 HIP_DEVICE_MINOR = 332 / 4;
+// offsetof(hipDeviceProp_t, minor) / 4
+constexpr uint32 HIP_DEVICE_MINOR_6 = 364 / 4;
 constexpr uint32 HIP_ERROR_ASSERT = 710;
 constexpr uint32 HIP_JIT_MAX_REGISTERS = 0;
 constexpr uint32 HIP_POINTER_ATTRIBUTE_MEMORY_TYPE = 2;
@@ -100,6 +114,8 @@ class AMDGPUDriver : protected AMDGPUDriverBase {
   char *(*get_error_string)(uint32);
 
   void (*driver_get_version)(int *);
+
+  void (*runtime_get_version)(int *);
 
   bool detected();
 


### PR DESCRIPTION
Issue: #6434 (part of)

### Brief Summary

In the AMDGPU backend, we calculate `mcpu_` directly based on `compute_capability_` using integer addition. However, this can be problematic as the `mcpu_` name is partially hex-based, e.g. `compute_capability_ = 910` corresponds to `mcpu_ = "gfx90a"`. The proper and [recommended](https://github.com/ROCm/hip/blob/80681169ae20de8f8025b4fad799204c3ae7de50/include/hip/hip_runtime_api.h#L129) way to get `mcpu_` is using field `gcnArchName`. Similarly, `compute_capability_` should be calculated using fields `major` and `minor` instead of `gcnArch`.

Additionally, there are complications in ROCm 6 regarding calling `hipGetDeviceProperties`  by looking up its ABI symbol in `libamdhip64.so`. In ROCm 6, the ABI symbol `hipGetDeviceProperties` (likely) incorrectly maps to the ROCm 5 version of `hipGetDeviceProperties` which is not ABI-compatible. To handle this, we first treat `hipGetDeviceProperties` as ROCm 5 version, and if the values we get don't make sense we then treat it as the ROCm 6 version.

### Walkthrough

copilot:walkthrough
