### PR TITLE
[test] [llvm] Add assert to builder

### DIFF
--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -138,6 +138,12 @@ LoopIndexStmt *IRBuilder::get_loop_index(Stmt *loop, int index) {
   return insert(Stmt::make_typed<LoopIndexStmt>(loop, index));
 }
 
+ConstStmt *IRBuilder::get_bool(bool value) {
+  return insert(Stmt::make_typed<ConstStmt>(TypedConstant(
+      TypeFactory::get_instance().get_primitive_type(PrimitiveTypeID::u1),
+      value)));
+}
+
 ConstStmt *IRBuilder::get_int32(int32 value) {
   return insert(Stmt::make_typed<ConstStmt>(TypedConstant(
       TypeFactory::get_instance().get_primitive_type(PrimitiveTypeID::i32),

--- a/taichi/ir/ir_builder.cpp
+++ b/taichi/ir/ir_builder.cpp
@@ -129,6 +129,12 @@ ContinueStmt *IRBuilder::create_continue() {
   return insert(Stmt::make_typed<ContinueStmt>());
 }
 
+void IRBuilder::create_assert(Stmt *cond, const std::string &msg) {
+  std::vector<Stmt *> empty_args;
+  auto assert_stmt = Stmt::make_typed<AssertStmt>(cond, msg, empty_args);
+  insert(std::move(assert_stmt));
+}
+
 FuncCallStmt *IRBuilder::create_func_call(Function *func,
                                           const std::vector<Stmt *> &args) {
   return insert(Stmt::make_typed<FuncCallStmt>(func, args));

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -130,6 +130,7 @@ class IRBuilder {
   LoopIndexStmt *get_loop_index(Stmt *loop, int index = 0);
 
   // Constants. TODO: add more types
+  ConstStmt *get_bool(bool value);
   ConstStmt *get_int32(int32 value);
   ConstStmt *get_int64(int64 value);
   ConstStmt *get_uint32(uint32 value);

--- a/taichi/ir/ir_builder.h
+++ b/taichi/ir/ir_builder.h
@@ -121,6 +121,7 @@ class IRBuilder {
   IfStmt *create_if(Stmt *cond);
   WhileControlStmt *create_break();
   ContinueStmt *create_continue();
+  void create_assert(Stmt *cond, const std::string &msg);
 
   // Function.
   FuncCallStmt *create_func_call(Function *func,

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -29,6 +29,22 @@ TEST(IRBuilder, Bool) {
 )");
 }
 
+TEST(IRBuilder, Assert) {
+  IRBuilder builder;
+  auto *bool_true = builder.get_bool(true);
+  builder.create_assert(bool_true, "assertion failed");
+  auto block = builder.extract_ir();
+
+  auto print = irpass::make_pass_printer(true, true, "", bool_true);
+  std::string ir_string;
+  irpass::print(block->get_ir_root(), &ir_string);
+  EXPECT_STREQ(ir_string.c_str(),
+               "kernel {\n"
+               "  <u1> $0 = const true\n"
+               "  1 : assert $0, \"assertion failed\"\n"
+               "}\n");
+}
+
 TEST(IRBuilder, Basic) {
   IRBuilder builder;
   auto *lhs = builder.get_int32(40);

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -15,17 +15,18 @@ TEST(IRBuilder, Bool) {
   IRBuilder builder;
   auto *bool_true = builder.get_bool(true);
   auto *bool_false = builder.get_bool(false);
-  auto ir = builder.extract_ir();
-  // auto *result = builder.create_print(bool_true, "", "");
-  // auto *print = result->cast<PrintStmt>();
+  builder.create_and(bool_true, bool_false);
+  auto block = builder.extract_ir();
+
   auto print = irpass::make_pass_printer(true, true, "", bool_true);
-  // irpass::re_id(ir);
-  std::cout << std::flush;
-  irpass::print(bool_true);
-  std::cout << std::flush;
-  std::cout << std::flush;
-  irpass::print(bool_false);
-  std::cout << std::flush;
+  std::string ir_string;
+  irpass::print(block->get_ir_root(), &ir_string);
+  EXPECT_STREQ(ir_string.c_str(), R"(kernel {
+  <u1> $0 = const true
+  <u1> $1 = const false
+  $2 = bit_and $0 $1
+}
+)");
 }
 
 TEST(IRBuilder, Basic) {

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -35,7 +35,6 @@ TEST(IRBuilder, Assert) {
   builder.create_assert(bool_true, "assertion failed");
   auto block = builder.extract_ir();
 
-  auto print = irpass::make_pass_printer(true, true, "", bool_true);
   std::string ir_string;
   irpass::print(block->get_ir_root(), &ir_string);
   EXPECT_STREQ(ir_string.c_str(),

--- a/tests/cpp/ir/ir_builder_test.cpp
+++ b/tests/cpp/ir/ir_builder_test.cpp
@@ -4,11 +4,29 @@
 #include "taichi/ir/statements.h"
 #include "tests/cpp/program/test_program.h"
 #include "tests/cpp/ir/ndarray_kernel.h"
+#include "taichi/ir/transforms.h"
 #ifdef TI_WITH_VULKAN
 #include "taichi/rhi/vulkan/vulkan_loader.h"
 #endif
 
 namespace taichi::lang {
+
+TEST(IRBuilder, Bool) {
+  IRBuilder builder;
+  auto *bool_true = builder.get_bool(true);
+  auto *bool_false = builder.get_bool(false);
+  auto ir = builder.extract_ir();
+  // auto *result = builder.create_print(bool_true, "", "");
+  // auto *print = result->cast<PrintStmt>();
+  auto print = irpass::make_pass_printer(true, true, "", bool_true);
+  // irpass::re_id(ir);
+  std::cout << std::flush;
+  irpass::print(bool_true);
+  std::cout << std::flush;
+  std::cout << std::flush;
+  irpass::print(bool_false);
+  std::cout << std::flush;
+}
 
 TEST(IRBuilder, Basic) {
   IRBuilder builder;


### PR DESCRIPTION
Issue: #

### Brief Summary

Add assert to IR builder. Use like:

```
builder.create_assert(bool_true, "assertion failed");
```

Example IR:

```
               kernel {
                 <u1> $0 = const true
                 1 : assert $0, "assertion failed"
               }
```

Will facilitate creating unit test for CFG issue.

Note: this depends on the PR that adds a boolean constant to ir builder.

copilot:summary

### Walkthrough

copilot:walkthrough
