### PR TITLE
[build] [mac] Fix mac build symbol export failure

### DIFF
--- a/.github/workflows/scripts/aot-demo.sh
+++ b/.github/workflows/scripts/aot-demo.sh
@@ -173,7 +173,11 @@ function check-c-api-export-symbols {
     python3 .github/workflows/scripts/build.py wheel --permissive --write-env=/tmp/ti-aot-env.sh
     . /tmp/ti-aot-env.sh
 
-    LIBTAICHI_C_API=$TAICHI_C_API_INSTALL_DIR/lib/libtaichi_c_api.so
+    SO_EXT=.so
+    if [ $(uname) == Darwin ]; then {
+        SO_EXT=.dylib
+    } fi
+    LIBTAICHI_C_API=$TAICHI_C_API_INSTALL_DIR/lib/libtaichi_c_api${SO_EXT}
 
     # T: global functions
     # B: global variables (uninitialized)


### PR DESCRIPTION
Issue: #

### Brief Summary

Fixes exported name check on mac build, by looking for .dylib instead of .so

copilot:summary

### Walkthrough

Currently, Mac builds fail on the check exported symbols check, e.g. https://github.com/hughperkins/taichi/actions/runs/14691553460/job/41227531475?pr=2 :  
```
/Library/Developer/CommandLineTools/usr/bin/nm: error: /Users/runner/work/taichi/taichi/_skbuild/macosx-15.0-arm64-3.9/cmake-install/python/taichi/_lib/c_api/lib/libtaichi_c_api.so: No such file or directory
```
The reason is that, on Mac, this file has '.dylib' extension. E.g. on my own Mac:
```
~/git/taichi-m1 (hp/fix-cannot-name-an-alias-template-for-trigger|…1△2) $ find . -name '*_c_api*'
./misc/generate_c_api.py
./misc/generate_c_api_docs.py
./tests/run_c_api_compat_test.py
./_skbuild/macosx-15.0-arm64-3.9/cmake-build/CMakeFiles/taichi_c_api.dir
./_skbuild/macosx-15.0-arm64-3.9/cmake-build/CMakeFiles/taichi_static_c_api_tests.dir
./_skbuild/macosx-15.0-arm64-3.9/cmake-build/CMakeFiles/taichi_c_api_tests.dir
./_skbuild/macosx-15.0-arm64-3.9/cmake-build/CMakeFiles/taichi_static_c_api.dir
./_skbuild/macosx-15.0-arm64-3.9/cmake-build/libtaichi_c_api.dylib
./_skbuild/macosx-15.0-arm64-3.9/cmake-install/python/taichi/_lib/c_api/lib/libtaichi_c_api.dylib
./_skbuild/macosx-15.0-arm64-3.9/setuptools/lib.macosx-15.0-arm64-cpython-39/taichi/_lib/c_api/lib/libtaichi_c_api.dylib
./build/taichi_static_c_api
./build/taichi_static_c_api_tests
./build/taichi_c_api_tests
```

This PR updates the exported name check script to look for a .dylib, when building on mac (uname == "Darwin"), which addresses this issue, and should hopefully fix the build.

copilot:walkthrough
