### PR TITLE
[Opt] Remove redundant cfg optimization, to fix struct vec crash bug

### DIFF
--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -139,7 +139,7 @@ void compile_to_offloads(IRNode *ir,
   irpass::offload(ir, config);
   print("Offloaded");
   irpass::analysis::verify(ir);
-
+  // NOTE: There was an additional CFG pass here, removed in https://github.com/taichi-dev/taichi/pull/8691
   irpass::flag_access(ir);
   print("Access flagged II");
 

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -140,16 +140,6 @@ void compile_to_offloads(IRNode *ir,
   print("Offloaded");
   irpass::analysis::verify(ir);
 
-  // TODO: This pass may be redundant as cfg_optimization() is already called
-  //  in full_simplify().
-  if (config.opt_level > 0 && config.cfg_optimization) {
-    irpass::cfg_optimization(
-        ir, false, /*autodiff_enabled*/ false,
-        !config.real_matrix_scalarize && !config.force_scalarize_matrix);
-    print("Optimized by CFG");
-    irpass::analysis::verify(ir);
-  }
-
   irpass::flag_access(ir);
   print("Access flagged II");
 

--- a/taichi/transforms/compile_to_offloads.cpp
+++ b/taichi/transforms/compile_to_offloads.cpp
@@ -139,7 +139,8 @@ void compile_to_offloads(IRNode *ir,
   irpass::offload(ir, config);
   print("Offloaded");
   irpass::analysis::verify(ir);
-  // NOTE: There was an additional CFG pass here, removed in https://github.com/taichi-dev/taichi/pull/8691
+  // NOTE: There was an additional CFG pass here, removed in
+  // https://github.com/taichi-dev/taichi/pull/8691
   irpass::flag_access(ir);
   print("Access flagged II");
 


### PR DESCRIPTION
…ev/taichi/issues/8675

Issue: #8675

### Brief Summary

Remove redundant cfg optimization, to fix struct vec crash bug

copilot:summary

### Walkthrough

In https://github.com/taichi-dev/taichi/issues/8675 , the cfg optimization pass causes a crash. Using following script:

```
import taichi as ti
ti.init(arch=ti.cpu, offline_cache=False, advanced_optimization=False,
        cpu_max_num_threads=1, debug=True, log_level=ti.DEBUG)


@ti.dataclass
class DataClassTest:
    v: ti.types.vector(3, dtype=ti.f64)

    @ti.func
    def manipulate_elements(self) -> float:
        self.v = [1.23, 2.34, 3.45]
        idx = 1
        return self.v[idx] # crash
        # return self.v[1]  # work as expected

d = DataClassTest.field(shape=())

@ti.kernel
def my_kernel() -> float:
    val = d[None].manipulate_elements()
    return val

def main():
    print('1')
    ret = my_kernel()
    print('ret', ret)
    print('2')

main()
```

Running on master:
```
[Taichi Build] Hughs-MacBook-Air:taichi hugh$ python ~/git/taichi-play/8675.py
[Taichi] version 1.8.0, llvm 15.0.7, commit 816eed64, osx, python 3.10.17
[Taichi] Starting on arch=arm64
[D 04/27/25 09:21:42.771 1481615] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:42.771 1481616] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:42.771 1481615] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
[D 04/27/25 09:21:42.771 1481616] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
[D 04/27/25 09:21:42.771 1481617] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:42.771 1481617] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
[D 04/27/25 09:21:42.771 1481618] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:42.771 1481618] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
1
[D 04/27/25 09:21:42.832 1481524] [kernel_compilation_manager.cpp:KernelCompilationManager@56] Create KernelCompilationManager with offline_cache_file_path = /Users/hugh/.cache/taichi/ticache

[E 04/27/25 09:21:42.832 1481524] Received signal 11 (Segmentation fault: 11)



                            * Taichi Core - Stack Traceback *
==========================================================================================
|                       Module |  Offset | Function                                      |
|----------------------------------------------------------------------------------------|
* taichi_python.cpython-310-darwin.so |     136 | taichi::Logger::error(std::__1::basic_ |
                                         | string<char, std::__1::char_traits<char>, std |
                                         | ::__1::allocator<char>> const&, bool)         |
* taichi_python.cpython-310-darwin.so |     372 | taichi::(anonymous namespace)::signal_ |
                                         | handler(int)                                  |
```

Running with this branch:
```
[Taichi Build] Hughs-MacBook-Air:taichi hugh$ python ~/git/taichi-play/8675.py
[Taichi] version 1.8.0, llvm 15.0.7, commit 816eed64, osx, python 3.10.17
[Taichi] Starting on arch=arm64
[D 04/27/25 09:21:58.524 1482254] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:58.524 1482256] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:58.524 1482256] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
[D 04/27/25 09:21:58.524 1482253] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:58.525 1482253] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
[D 04/27/25 09:21:58.524 1482255] [parallel_executor.cpp:worker_loop@71] Starting worker thread.
[D 04/27/25 09:21:58.525 1482255] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
[D 04/27/25 09:21:58.524 1482254] [parallel_executor.cpp:worker_loop@86] Worker thread initialized and running.
1
[D 04/27/25 09:21:58.585 1482173] [kernel_compilation_manager.cpp:KernelCompilationManager@56] Create KernelCompilationManager with offline_cache_file_path = /Users/hugh/.cache/taichi/ticache
ret 2.3399999141693115
2
[D 04/27/25 09:21:58.619 1482173] [offline_cache.h:run@199] Start cleaning cache
[D 04/27/25 09:21:58.620 1482173] [offline_cache.h:load_metadata_with_checking@83] Offline cache metadata file /Users/hugh/.cache/taichi/ticache/ticache.tcb not found
[D 04/27/25 09:21:58.620 1482173] [offline_cache.h:operator()@191] Stop cleaning cache
[D 04/27/25 09:21:58.620 1482173] [offline_cache.h:load_metadata_with_checking@83] Offline cache metadata file /Users/hugh/.cache/taichi/ticache/ticache.tcb not found
[Taichi Build] Hughs-MacBook-Air:taichi hugh$
```

Before simply removing this pass, I was originally going to fix it, however I ran the various tests in tests/python/test_optmization.py, printing out the ir before and after the cfg pass, and I saw no effect of this cfg pass, in any of the tests I tried running.

So, I conclude that:
- keeping this cfg pass can cause a crash (see above)
- removing it does not affect any of the optimization test results (presuambly because there is an earlier cfg pass that runs)

copilot:walkthrough
