### PR TITLE
[build] Fix unset proxy

### DIFF
--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -6,6 +6,7 @@ function unset-git-caching-proxy {
     echo "Unsetting git caching proxy"
     # git config --global --list | grep 'url\.' | cut -d'=' -f1 | xargs -L1 git config --global --unset-all || true
     git config --global --unset https.proxy
+    exit 0
 }
 
 function set-git-caching-proxy {

--- a/.github/workflows/scripts/common-utils.sh
+++ b/.github/workflows/scripts/common-utils.sh
@@ -5,6 +5,8 @@ set -x
 function unset-git-caching-proxy {
     echo "Unsetting git caching proxy"
     # git config --global --list | grep 'url\.' | cut -d'=' -f1 | xargs -L1 git config --global --unset-all || true
+    set +e
+    # just leave set +e set, since this always runs at the end of each testing block anyway
     git config --global --unset https.proxy
     exit 0
 }


### PR DESCRIPTION
Issue: #

### Brief Summary

Fix m1 build failing at end of export symbols

copilot:summary

### Walkthrough

See eg https://github.com/hughperkins/taichi/actions/runs/14693755030/job/41232608209

```
+ git config --global --unset https.proxy
Error: Process completed with exit code 5.
```

Hypothesis: the git config --unset is causing exit code 5

Test hypothesis locally:
```
~/git/taichi-m1 (hp/fix-cannot-name-an-alias-template-for-trigger|…1) $ git config --global --unset https.proxy
~/git/taichi-m1 (hp/fix-cannot-name-an-alias-template-for-trigger|…1) $ echo $?
5
```

Make test function and test locally:
```
#!/bin/bash

function foobar {
	echo foobar
	exit 5
}

trap foobar EXIT
```
Test:
```
~/git/taichi-m1 (hp/fix-cannot-name-an-alias-template-for-trigger|…1) $ bash /tmp/test.sh ; echo $?
foobar
5
```

=> can control the exit code of the function using an `exit`

copilot:walkthrough
