### PR TITLE
[Opt] Fix i64 indexes for matrices

### DIFF
--- a/taichi/transforms/type_check.cpp
+++ b/taichi/transforms/type_check.cpp
@@ -158,7 +158,9 @@ class TypeCheck : public IRVisitor {
 
   void visit(MatrixPtrStmt *stmt) override {
     TI_ASSERT(stmt->offset->ret_type.get_element_type()->is_primitive(
-        PrimitiveTypeID::i32));
+                  PrimitiveTypeID::i32) ||
+              stmt->offset->ret_type.get_element_type()->is_primitive(
+                  PrimitiveTypeID::i64));
     stmt->ret_type.set_is_pointer(true);
   }
 


### PR DESCRIPTION
Issue: #8640 

https://github.com/taichi-dev/taichi/issues/8640

### Brief Summary

Using i64 index for matrix fires an assert `is_primitive( PrimitiveTypeID::i32)`

copilot:summary

### Walkthrough

Using i64 index for matrix fires an assert:

```
[E 04/27/25 16:53:32.590 1740211] [type_check.cpp:visit@166] Assertion failure: stmt->offset->ret_type.get_element_type()->is_primitive( PrimitiveTypeID::i32)
```

The assert is because the verifier only allows matrix indices to be i32:
```
    TI_ASSERT(stmt->offset->ret_type.get_element_type()->is_primitive(
                  PrimitiveTypeID::i32));
```

Broadening this to allow i64 fixes the issue:
```
    TI_ASSERT(stmt->offset->ret_type.get_element_type()->is_primitive(
                  PrimitiveTypeID::i32) ||
              stmt->offset->ret_type.get_element_type()->is_primitive(
                  PrimitiveTypeID::i64));
```

copilot:walkthrough
