### PR TITLE
[lang] Update minimum requirement for CMAKE

### DIFF
--- a/cmake/TaichiCAPI.cmake
+++ b/cmake/TaichiCAPI.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.17)
 
 # This function creates a static target from OBJECT_TARGET, then link TARGET with the static target
 #

--- a/cmake/TaichiCAPITests.cmake
+++ b/cmake/TaichiCAPITests.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(C_API_TESTS_NAME taichi_c_api_tests)
 if (WIN32)

--- a/cmake/TaichiExamples.cmake
+++ b/cmake/TaichiExamples.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(EXAMPLES_NAME taichi_cpp_examples)
 

--- a/cmake/TaichiTests.cmake
+++ b/cmake/TaichiTests.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.17)
 
 set(TESTS_NAME taichi_cpp_tests)
 if (WIN32)


### PR DESCRIPTION
Issue: #8673 

### Brief Summary

copilot:summary
This PR resolves CMake 4.0 compilation failures by standardizing the minimum required version to 3.17 across all submodules (TaichiExamples/TaichiCAPITests/TaichiCAPI/TaichiTests), ensuring compatibility with modern Linux distributions.

### Walkthrough

copilot:walkthrough
#### Context
- CMake 4.0 dropped legacy support (including CMake 3.5) causing build failures on updated distros
- Reference: [CMake Version Policy](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)

#### Changes Made
1. Updated version requirement in:
   - `TaichiExamples.cmake`
   - `TaichiCAPITests.cmake`
   - `TaichiCAPI.cmake` 
   - `TaichiTests.cmake`
2. Unified requirement to CMake 3.17 (already the de facto standard)

#### Impact Analysis
- No breaking changes (3.17 was already the effective minimum)
- Improves forward compatibility
- Affects only build system configuration

#### Verification
- No new tests needed (version requirement change only)
- Confirmed via manual build testing

#### Additional Notes
- Aligns with CMake's modern version policy
- Prevents future issues on rolling-release distros
- Maintains backward compatibility