### PR TITLE
[Build] Use brew clang compiler on mac

### DIFF
--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -3,11 +3,13 @@
 # -- stdlib --
 from pathlib import Path
 import os
+from os.path import join
 import json
 import platform
 import shutil
 import tempfile
 import sys
+import subprocess
 
 # -- third party --
 # -- own --
@@ -17,6 +19,12 @@ from .misc import banner, error, get_cache_home, warn
 from .tinysh import powershell
 
 
+def grep(value, target):
+    for line in target.split("\n"):
+        if value in line:
+           return line
+
+
 # -- code --
 @banner("Setup Clang")
 def setup_clang(as_compiler=True) -> None:
@@ -24,7 +32,7 @@ def setup_clang(as_compiler=True) -> None:
     Setup Clang.
     """
     u = platform.uname()
-    if u.system in ("Linux", "Darwin"):
+    if u.system == "Linux":
         for v in ("", "-14", "-13", "-12", "-11", "-10"):
             clang = shutil.which(f"clang{v}")
             if clang is not None:
@@ -34,7 +42,13 @@ def setup_clang(as_compiler=True) -> None:
         else:
             error("Could not find clang of any version")
             return
-
+    elif u.system == 'Darwin':
+        brew_config = subprocess.check_output(["brew", "config"]).decode("utf-8")
+        print("brew_config", brew_config)
+        brew_prefix = grep("HOMEBREW_PREFIX", brew_config).split()[1]
+        print("brew_prefix", brew_prefix)
+        clang = join(brew_prefix, "opt", "llvm@15", "bin", "clang")
+        clangpp = join(brew_prefix, "opt", "llvm@15", "bin", "clang++")
     elif (u.system, u.machine) == ("Windows", "AMD64"):
         out = get_cache_home() / "clang-14-v2"
         url = "https://github.com/taichi-dev/taichi_assets/releases/download/llvm15/clang-14.0.6-win-complete.zip"

--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -22,7 +22,7 @@ from .tinysh import powershell
 def grep(value, target):
     for line in target.split("\n"):
         if value in line:
-           return line
+            return line
 
 
 # -- code --
@@ -42,7 +42,7 @@ def setup_clang(as_compiler=True) -> None:
         else:
             error("Could not find clang of any version")
             return
-    elif u.system == 'Darwin':
+    elif u.system == "Darwin":
         brew_config = subprocess.check_output(["brew", "config"]).decode("utf-8")
         print("brew_config", brew_config)
         brew_prefix = grep("HOMEBREW_PREFIX", brew_config).split()[1]


### PR DESCRIPTION
Issue: #

### Brief Summary

Use brew clang compiler on mac

copilot:summary

### Walkthrough

When building on latest Macs, e.g. Sequoia, the system clang is 16.0.0, or 17.0.0, depending on whether using XCode (16.0.0), or command line tools (17.0.0). Either way, the bytecode generated at python/taichi/_lib/runtime/runtime_arm64.bc is not loadable by llvm 15. Trying to load the clang-15/16 compiled runtime_arm64.bc with llvm 15 gives an error about unknown attribute (86). llvm 15 is the version of llvm used by taichi currently. therefore, building using system clang on macos sequoia prevents taichi from loading/running.

Example failure: 

https://github.com/taichi-dev/taichi/actions/runs/14742813933/job/41384420135?pr=8688

![Screenshot 2025-04-30 at 7 28 39 AM](https://github.com/user-attachments/assets/9fe577b6-1879-4bc8-b99c-cf9909565083)


To fix this, we use the clang from the brew installed llvm@15 instead. This then runs ok.

We assume in compile.py that brew has already been used earlier in the script to install llvm@15. We use brew config to locate brew, and then assume the clang path as `{HOMEBREW_PREFIX}/opt/llvm@15/bin/clang`, and similarly for clang++.

copilot:walkthrough
