### PR TITLE
[Lang] Add constructor to Kernel so we can pass in Block * directly

### DIFF
--- a/taichi/program/kernel.cpp
+++ b/taichi/program/kernel.cpp
@@ -31,6 +31,33 @@ Kernel::Kernel(Program &program,
 }
 
 Kernel::Kernel(Program &program,
+               Block *block,
+               const std::string &primal_name,
+               AutodiffMode autodiff_mode) {
+  this->arch = program.compile_config().arch;
+  this->autodiff_mode = autodiff_mode;
+  this->ir = std::unique_ptr<IRNode>(block);
+  this->program = &program;
+  is_accessor = false;
+  ir_is_ast_ = false;  // CHI IR
+
+  TI_ASSERT(this->ir->is<Block>());
+  this->ir->as<Block>()->set_parent_callable(this);
+
+  if (autodiff_mode == AutodiffMode::kNone) {
+    name = primal_name;
+  } else if (autodiff_mode == AutodiffMode::kForward) {
+    name = primal_name + "_forward_grad";
+  } else if (autodiff_mode == AutodiffMode::kReverse) {
+    name = primal_name + "_reverse_grad";
+  } else if (autodiff_mode == AutodiffMode::kCheckAutodiffValid) {
+    name = primal_name + "_validate_grad";
+  } else {
+    TI_ERROR("Unsupported autodiff mode");
+  }
+}
+
+Kernel::Kernel(Program &program,
                std::unique_ptr<IRNode> &&ir,
                const std::string &primal_name,
                AutodiffMode autodiff_mode) {

--- a/taichi/program/kernel.h
+++ b/taichi/program/kernel.h
@@ -35,6 +35,11 @@ class TI_DLL_EXPORT Kernel : public Callable {
          const std::string &name = "",
          AutodiffMode autodiff_mode = AutodiffMode::kNone);
 
+  Kernel(Program &program,
+         Block *block,
+         const std::string &name = "",
+         AutodiffMode autodiff_mode = AutodiffMode::kNone);
+
   bool ir_is_ast() const {
     return ir_is_ast_;
   }


### PR DESCRIPTION
Issue: #

### Brief Summary

[Lang] Add constructor to Kernel so we can pass in Block * directly

copilot:summary

### Walkthrough

This allows us to build kernels without needing to use the IRBuilder, e.g. here https://github.com/hughperkins/taichi/blob/fb7782c99afc39e419477e512bafd8c74bb7a6df/cpp_examples/scratchpad.cpp#L47

copilot:walkthrough
