### PR TITLE
[Build] Upgrade vulkan.py to download vulkan 1.4.313.0

### DIFF
--- a/.github/workflows/scripts/ti_build/dep.py
+++ b/.github/workflows/scripts/ti_build/dep.py
@@ -150,9 +150,9 @@ def download_dep(url, outdir, *, strip=0, force=False, args=None, plain=False, e
     if name.endswith(".zip"):
         outdir.mkdir(parents=True, exist_ok=True)
         unzip(local_cached, outdir, strip=strip)
-    elif name.endswith(".tar.gz") or name.endswith(".tgz"):
+    elif name.endswith(".tar.gz") or name.endswith(".tgz") or name.endswith(".xz"):
         outdir.mkdir(parents=True, exist_ok=True)
-        tar("-xzf", local_cached, "-C", outdir, f"--strip-components={strip}")
+        tar("-xf", local_cached, "-C", outdir, f"--strip-components={strip}")
     elif name.endswith(".sh"):
         bash(local_cached, *args)
     elif "." not in name and args is not None:

--- a/.github/workflows/scripts/ti_build/vulkan.py
+++ b/.github/workflows/scripts/ti_build/vulkan.py
@@ -12,12 +12,12 @@ from .python import path_prepend
 
 
 # -- code --
-@banner("Setup Vulkan 1.3.236.0")
+@banner("Setup Vulkan 1.4.313.0")
 def setup_vulkan():
     u = platform.uname()
     if u.system == "Linux":
-        url = "https://sdk.lunarg.com/sdk/download/1.3.236.0/linux/vulkansdk-linux-x86_64-1.3.236.0.tar.gz"
-        prefix = get_cache_home() / "vulkan-1.3.236.0"
+        url = "https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz"
+        prefix = get_cache_home() / "vulkan-1.4.313.0"
         download_dep(url, prefix, strip=1)
         sdk = prefix / "x86_64"
         os.environ["VULKAN_SDK"] = str(sdk)
@@ -27,8 +27,8 @@ def setup_vulkan():
     # elif (u.system, u.machine) == ("Darwin", "arm64"):
     # elif (u.system, u.machine) == ("Darwin", "x86_64"):
     elif (u.system, u.machine) == ("Windows", "AMD64"):
-        url = "https://sdk.lunarg.com/sdk/download/1.3.236.0/windows/VulkanSDK-1.3.236.0-Installer.exe"
-        prefix = get_cache_home() / "vulkan-1.3.236.0"
+        url = "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/vulkansdk-windows-X64-1.4.313.0.exe"
+        prefix = get_cache_home() / "vulkan-1.4.313.0"
         download_dep(
             url,
             prefix,


### PR DESCRIPTION
Issue: #

### Brief Summary

[Build] Upgrade vulkan.py to download vulkan 1.4.313.0, since 1.3.236.0 download no longer exists

copilot:summary

### Walkthrough

- when building on ubuntu 22.04, vulkan 1.3.236.0 download failed
- looking at https://vulkan.lunarg.com/sdk/home, this version is no longer available for download
- updated url to latest version, 1.4.313.0
- note that compression is now .tar.xz instead of .tar.gz
    - therefore changed decompression to use `-xf` instead of `-xzf` (which will select the decompression algorithm automatically, I'm ~80% sure)

copilot:walkthrough
