### PR TITLE
[build] Add github ubuntu 22.04 x86 runner

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,6 +183,81 @@ jobs:
   #        path: dist/*
   #        retention-days: 7
 
+  build_and_test_linux_x864_cpu:
+    name: Build and Test Github runner x86 cpu
+    needs: check_files
+    timeout-minutes: ${{ github.event.schedule != '0 18 * * *' && 90 || 120 }}
+
+    runs-on:
+    - ubuntu-22.04
+    env:
+      PY: '3.11'
+      PROJECT_NAME: taichi
+      TAICHI_CMAKE_ARGS: >-
+        -DTI_WITH_OPENGL:BOOL=ON
+        -DTI_WITH_VULKAN:BOOL=ON
+        -DTI_WITH_BACKTRACE:BOOL=ON
+        -DTI_BUILD_TESTS:BOOL=ON
+      TI_WANTED_ARCHS: 'cpu,vulkan,gles'
+      TI_DEVICE_MEMORY_GB: '1'
+      TI_RUN_RELEASE_TESTS: '1'
+
+    steps:
+      - name: Restart X Server
+        run: |
+          sudo systemctl restart xorg
+
+      - name: Workaround checkout Needed single revision issue
+        run: git submodule foreach 'git rev-parse HEAD > /dev/null 2>&1 || rm -rf $PWD' || true
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: '0'
+
+      - name: Prepare Environment
+        run: |
+          . .github/workflows/scripts/common-utils.sh
+          prepare-build-cache
+          echo CI_DOCKER_RUN_EXTRA_ARGS="-v $(pwd):/home/dev/taichi" >> $GITHUB_ENV
+
+      - name: Build & Install
+        run: |
+          [[ ${{needs.check_files.outputs.run_job}} == false ]] && exit 0
+          . .github/workflows/scripts/common-utils.sh
+
+          ci-docker-run-gpu --name taichi-build \
+            registry.botmaster.tgr/taichi-build-cuda:${{ env.CI_IMAGE_VERSION }} \
+            /home/dev/taichi/.github/workflows/scripts/build.py
+
+      - name: Test
+        id: test
+        run: |
+          [[ ${{needs.check_files.outputs.run_job}} == false ]] && exit 0
+          . .github/workflows/scripts/common-utils.sh
+
+          ci-docker-run-gpu --name taichi-test \
+             registry.botmaster.tgr/taichi-test-cuda:${{ env.CI_IMAGE_VERSION }} \
+             /home/dev/taichi/.github/workflows/scripts/unix_test.sh
+        env:
+          EXTRA_TEST_MARKERS: ${{ matrix.extra_markers }}
+
+      - name: Save wheel if test failed
+        if: failure() && steps.test.conclusion == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: broken-wheel
+          path: dist/*
+          retention-days: 7
+
+      - name: Save Bad Captures
+        if: failure() && steps.test.conclusion == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bad-captures
+          path: taichi-release-tests/bad-compare/*
+          retention-days: 7
+
   build_and_test_gpu_linux:
     name: Build and Test (GPU)
     needs: check_files
@@ -286,6 +361,7 @@ jobs:
         -DTI_WITH_VULKAN:BOOL=OFF
         -DTI_WITH_OPENGL:BOOL=OFF
         -DTI_BUILD_TESTS:BOOL=ON
+        -DTI_BUILD_EXAMPLES:BOOL=ON
         -DTI_WITH_AMDGPU:BOOL=ON
 
     steps:


### PR DESCRIPTION
Issue: #

### Brief Summary

Add github ubuntu 22.04 x86 runner

copilot:summary

I am finding it very challenging to build taichi for linux ubuntu 22.04. I've had to make a lot of changes and such. So I suspect that there is a wide disparity between what is being used on the build boxes, and, default ubuntu 22.04.

Therefore, similar to how I'm pushing a Mac OS 15.x build, I'm' adding here a default ubuntu 22.04 build, using github runner.

These runners are free on public repos, see https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners

![Screenshot 2025-05-10 at 2 25 25 PM](https://github.com/user-attachments/assets/3bccfe78-d0cb-416c-87ed-a790f8efc058)

I expect this runner to fail to start with, just as stuff fails on my own builds (but I might be wrong). And then we can gradually merge in changes to fix the issues we see.

### Walkthrough

copilot:walkthrough
