### PR TITLE
[lang] Free ndarray memory on the base class

### DIFF
--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -66,7 +66,7 @@ class Ndarray:
 
         rt = impl.get_runtime()
         if rt is not None and rt.prog is not None:
-           rt.prog.delete_ndarray(self.arr)
+            rt.prog.delete_ndarray(self.arr)
 
     @python_scope
     def fill(self, val):
@@ -250,7 +250,6 @@ class ScalarNdarray(Ndarray):
         )
         self.shape = tuple(self.arr.shape)
         self.element_type = dtype
-
 
     @property
     def element_shape(self):

--- a/python/taichi/lang/_ndarray.py
+++ b/python/taichi/lang/_ndarray.py
@@ -60,6 +60,14 @@ class Ndarray:
         """
         raise NotImplementedError()
 
+    def __del__(self):
+        if impl is None or self.arr is None:
+            return
+
+        rt = impl.get_runtime()
+        if rt is not None and rt.prog is not None:
+           rt.prog.delete_ndarray(self.arr)
+
     @python_scope
     def fill(self, val):
         """Fills ndarray with a specific scalar value.
@@ -243,9 +251,6 @@ class ScalarNdarray(Ndarray):
         self.shape = tuple(self.arr.shape)
         self.element_type = dtype
 
-    def __del__(self):
-        if impl is not None and impl.get_runtime() is not None and impl.get_runtime().prog is not None:
-            impl.get_runtime().prog.delete_ndarray(self.arr)
 
     @property
     def element_shape(self):


### PR DESCRIPTION
classes inheriting from Ndarray should have their memory released

Issue: #8763 

### Brief Summary

ScalarNdarray implements __del__() to allow python to get rid of the allocated memory,
but other subclasses of Ndarray (like VectorNdarray() or MatrixNdarray()) don't implement the same behaviour.
Seems to me the __del__() method should be moved to the Ndarray class.
I tested this simple change and indeed it fixes the memory leak.

### Walkthrough
```py
import taichi as ti
import taichi.types as tt

ti.init(ti.gpu)

while True:
    arr = ti.ndarray(tt.vector(3, ti.f32), (1000, 1000))
    arr = arr.to_numpy()
    # whatch gpu memory skyrocket
```

If, instead:

```py
import taichi as ti
import taichi.types as tt

ti.init(ti.gpu)

while True:
    arr = ti.ndarray(ti.f32, (1000, 1000, 3))
    arr = arr.to_numpy()
    # whatch gpu memory basically stay the same
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move deletion logic to `Ndarray.__del__` so all ndarray variants free device memory; remove subclass-specific `__del__` from `ScalarNdarray`.
> 
> - **Memory management**:
>   - Add `Ndarray.__del__` to delete underlying `arr` via `rt.prog.delete_ndarray(...)` when runtime/program exist.
>   - Remove `ScalarNdarray.__del__`; destruction is now handled centrally by base class for all ndarray subclasses.
> - **Files**:
>   - Updated `python/taichi/lang/_ndarray.py` to centralize deletion logic and add safety checks (`impl/arr/runtime/prog` presence).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e581320b5f561f6f1711f0b32853b364cf90a18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->