### PR TITLE
[misc] SparseCG now respecting verbose value

### DIFF
--- a/python/taichi/linalg/sparse_cg.py
+++ b/python/taichi/linalg/sparse_cg.py
@@ -22,15 +22,16 @@ class SparseCG:
     def __init__(self, A, b, x0=None, max_iter=50, atol=1e-6):
         self.dtype = A.dtype
         self.ti_arch = get_runtime().prog.config().arch
+        self.verbose = get_runtime().prog.config().verbose
         self.matrix = A
         self.b = b
         if self.ti_arch == _ti_core.Arch.cuda:
-            self.cg_solver = _ti_core.make_cucg_solver(A.matrix, max_iter, atol, True)
+            self.cg_solver = _ti_core.make_cucg_solver(A.matrix, max_iter, atol, self.verbose)
         elif self.ti_arch == _ti_core.Arch.x64 or self.ti_arch == _ti_core.Arch.arm64:
             if self.dtype == f32:
-                self.cg_solver = _ti_core.make_float_cg_solver(A.matrix, max_iter, atol, True)
+                self.cg_solver = _ti_core.make_float_cg_solver(A.matrix, max_iter, atol, self.verbose)
             elif self.dtype == f64:
-                self.cg_solver = _ti_core.make_double_cg_solver(A.matrix, max_iter, atol, True)
+                self.cg_solver = _ti_core.make_double_cg_solver(A.matrix, max_iter, atol, self.verbose)
             else:
                 raise TaichiRuntimeError(f"Unsupported CG dtype: {self.dtype}")
             if isinstance(b, Ndarray):

--- a/python/taichi/linalg/sparse_cg.py
+++ b/python/taichi/linalg/sparse_cg.py
@@ -22,16 +22,16 @@ class SparseCG:
     def __init__(self, A, b, x0=None, max_iter=50, atol=1e-6):
         self.dtype = A.dtype
         self.ti_arch = get_runtime().prog.config().arch
-        self.verbose = get_runtime().prog.config().verbose
         self.matrix = A
         self.b = b
+        verbose = get_runtime().prog.config().verbose
         if self.ti_arch == _ti_core.Arch.cuda:
-            self.cg_solver = _ti_core.make_cucg_solver(A.matrix, max_iter, atol, self.verbose)
+            self.cg_solver = _ti_core.make_cucg_solver(A.matrix, max_iter, atol, verbose)
         elif self.ti_arch == _ti_core.Arch.x64 or self.ti_arch == _ti_core.Arch.arm64:
             if self.dtype == f32:
-                self.cg_solver = _ti_core.make_float_cg_solver(A.matrix, max_iter, atol, self.verbose)
+                self.cg_solver = _ti_core.make_float_cg_solver(A.matrix, max_iter, atol, verbose)
             elif self.dtype == f64:
-                self.cg_solver = _ti_core.make_double_cg_solver(A.matrix, max_iter, atol, self.verbose)
+                self.cg_solver = _ti_core.make_double_cg_solver(A.matrix, max_iter, atol, verbose)
             else:
                 raise TaichiRuntimeError(f"Unsupported CG dtype: {self.dtype}")
             if isinstance(b, Ndarray):


### PR DESCRIPTION
Before this we always passed `True` to `make_float_cg_solver(...)`
instead of the `verbose` value.

Issue: #8707 

### Brief Summary

SparseCG was always printing information about convergence without a way to 
turn off, this now respects the value of `verbose` that is passed in via `ti.init(...)`, as it should be.

### Walkthrough

We now pass the value of `verbose` to `make_float_cg_solver(...)`

Closes #8707 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures CG solver logging adheres to `ti.init(verbose=...)`.
> 
> - `SparseCG.__init__` now uses `get_runtime().prog.config().verbose` when creating `_ti_core.make_cucg_solver`, `_ti_core.make_float_cg_solver`, and `_ti_core.make_double_cg_solver` instead of always passing `True`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b6e2d1ddbb423e607d9f2c38d567fcae489a959. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->