### PR TITLE
[Gui] [doc] Add subwindow dimension control flags to GGUI interface

### DIFF
--- a/docs/lang/articles/visualization/ggui.md
+++ b/docs/lang/articles/visualization/ggui.md
@@ -437,6 +437,22 @@ with gui.sub_window("Sub Window", x=10, y=10, width=300, height=100):
     color = gui.color_edit_3("name2", color)
 ```
 
+### Locking a subwindow
+
+You can control whether GGUI subwindows dimensions can be manipulated using these flags.
+They all default to `True`:
+
+- `movable`: Allow users to drag the subwindow. If False, position can be updated programmatically.
+- `resizable`: Allow users to resize the subwindow. If `False`, size can be updated programmatically.
+- `collapsible`: Allow users to collapse the subwindow by clicking its title bar.
+
+```python
+# Window that is fully locked
+with gui.sub_window("Locked subwindow", 0.1, 0.1, 0.3, 0.2,
+                    resizable=False, movable=False, collapsible=False):
+    gui.text("Locked!")
+```
+
 ## Show a window
 
 Call `show()` to show a window.

--- a/python/taichi/ui/imgui.py
+++ b/python/taichi/ui/imgui.py
@@ -13,7 +13,7 @@ class Gui:
         self.gui = gui
 
     @contextmanager
-    def sub_window(self, name, x, y, width, height):
+    def sub_window(self, name, x, y, width, height, movable=True, resizable=True, collapsible=True):
         """Creating a context manager for subwindow.
 
         Note:
@@ -26,19 +26,25 @@ class Gui:
                 corner of the subwindow, relative to the full window.
             width (float): The width of the subwindow relative to the full window.
             height (float): The height of the subwindow relative to the full window.
+            movable (bool): Whether the window can be moved by the user. \
+                When False, position can only be changed programmatically.
+            resizable (bool): Whether the window can be resized by the user. \
+                When False, size can only be changed programmatically.
+            collapsible (bool): Whether the window can be collapsed by the user. \
+                When False, the collapse button is disabled.
 
         Example::
 
             >>> with gui.sub_window(name, x, y, width, height) as g:
             >>>     g.text("Hello, World!")
         """
-        self.begin(name, x, y, width, height)
+        self.begin(name, x, y, width, height, movable, resizable, collapsible)
         try:
             yield self
         finally:
             self.end()
 
-    def begin(self, name, x, y, width, height):
+    def begin(self, name, x, y, width, height, movable=True, resizable=True, collapsible=True):
         """Creates a subwindow that holds imgui widgets.
 
         All widget function calls (e.g. `text`, `button`) after the `begin`
@@ -51,8 +57,14 @@ class Gui:
                 corner of the subwindow, relative to the full window.
             width (float): The width of the subwindow relative to the full window.
             height (float): The height of the subwindow relative to the full window.
+            movable (bool): Whether the window can be moved by the user. \
+                When False, position can only be changed programmatically.
+            resizable (bool): Whether the window can be resized by the user. \
+                When False, size can only be changed programmatically.
+            collapsible (bool): Whether the window can be collapsed by the user. \
+                When False, the collapse button is disabled.
         """
-        self.gui.begin(name, x, y, width, height)
+        self.gui.begin(name, x, y, width, height, movable, resizable, collapsible)
 
     def end(self):
         """End the description of the current subwindow."""

--- a/taichi/python/export_ggui.cpp
+++ b/taichi/python/export_ggui.cpp
@@ -60,8 +60,15 @@ py::array_t<float> mat4_to_nparray(glm::mat4 mat) {
 
 struct PyGui {
   GuiBase *gui;  // not owned
-  void begin(std::string name, float x, float y, float width, float height) {
-    gui->begin(name, x, y, width, height);
+  void begin(std::string name,
+             float x,
+             float y,
+             float width,
+             float height,
+             bool movable = true,
+             bool resizable = true,
+             bool collapsible = true) {
+    gui->begin(name, x, y, width, height, movable, resizable, collapsible);
   }
   void end() {
     gui->end();

--- a/taichi/ui/common/gui_base.h
+++ b/taichi/ui/common/gui_base.h
@@ -10,7 +10,10 @@ class GuiBase {
                      float x,
                      float y,
                      float width,
-                     float height) = 0;
+                     float height,
+                     bool movable = true,
+                     bool resizable = true,
+                     bool collapsible = true) = 0;
   virtual void end() = 0;
   virtual void text(const std::string &text) = 0;
   virtual void text(const std::string &text, glm::vec3 color) = 0;

--- a/taichi/ui/ggui/gui.cpp
+++ b/taichi/ui/ggui/gui.cpp
@@ -153,6 +153,20 @@ void Gui::begin(const std::string &name,
     return;
   }
 
+  // Update window dimensions when locked, so programmatic updates use current
+  // window size
+  if ((!movable || !resizable) && app_context_->config.show_window) {
+#ifdef ANDROID
+    widthBeforeDPIScale =
+        (int)ANativeWindow_getWidth(app_context_->taichi_window());
+    heightBeforeDPIScale =
+        (int)ANativeWindow_getHeight(app_context_->taichi_window());
+#else
+    glfwGetWindowSize(app_context_->taichi_window(), &widthBeforeDPIScale,
+                      &heightBeforeDPIScale);
+#endif
+  }
+
   // Set position: Always if locked, Once if unlocked
   ImGuiCond pos_cond = movable ? ImGuiCond_Once : ImGuiCond_Always;
   ImGui::SetNextWindowPos(ImVec2(abs_x(x), abs_y(y)), pos_cond);

--- a/taichi/ui/ggui/gui.cpp
+++ b/taichi/ui/ggui/gui.cpp
@@ -145,13 +145,35 @@ void Gui::begin(const std::string &name,
                 float x,
                 float y,
                 float width,
-                float height) {
+                float height,
+                bool movable,
+                bool resizable,
+                bool collapsible) {
   if (!initialized()) {
     return;
   }
-  ImGui::SetNextWindowPos(ImVec2(abs_x(x), abs_y(y)), ImGuiCond_Once);
-  ImGui::SetNextWindowSize(ImVec2(abs_x(width), abs_y(height)), ImGuiCond_Once);
-  ImGui::Begin(name.c_str());
+
+  // Set position: Always if locked, Once if unlocked
+  ImGuiCond pos_cond = movable ? ImGuiCond_Once : ImGuiCond_Always;
+  ImGui::SetNextWindowPos(ImVec2(abs_x(x), abs_y(y)), pos_cond);
+
+  // Set size: Always if locked, Once if unlocked
+  ImGuiCond size_cond = resizable ? ImGuiCond_Once : ImGuiCond_Always;
+  ImGui::SetNextWindowSize(ImVec2(abs_x(width), abs_y(height)), size_cond);
+
+  // Build window flags
+  ImGuiWindowFlags flags = 0;
+  if (!movable) {
+    flags |= ImGuiWindowFlags_NoMove;
+  }
+  if (!resizable) {
+    flags |= ImGuiWindowFlags_NoResize;
+  }
+  if (!collapsible) {
+    flags |= ImGuiWindowFlags_NoCollapse;
+  }
+
+  ImGui::Begin(name.c_str(), nullptr, flags);
   is_empty_ = false;
 }
 void Gui::end() {

--- a/taichi/ui/ggui/gui.h
+++ b/taichi/ui/ggui/gui.h
@@ -33,7 +33,10 @@ class TI_DLL_EXPORT Gui final : public GuiBase {
              float x,
              float y,
              float width,
-             float height) override;
+             float height,
+             bool movable = true,
+             bool resizable = true,
+             bool collapsible = true) override;
   void end() override;
   void text(const std::string &text) override;
   void text(const std::string &text, glm::vec3 color) override;

--- a/taichi/ui/ggui/gui_metal.h
+++ b/taichi/ui/ggui/gui_metal.h
@@ -27,7 +27,10 @@ class TI_DLL_EXPORT GuiMetal final : public GuiBase {
              float x,
              float y,
              float width,
-             float height) override;
+             float height,
+             bool movable = true,
+             bool resizable = true,
+             bool collapsible = true) override;
   void end() override;
   void text(const std::string &text) override;
   void text(const std::string &text, glm::vec3 color) override;

--- a/taichi/ui/ggui/gui_metal.mm
+++ b/taichi/ui/ggui/gui_metal.mm
@@ -57,6 +57,13 @@ float GuiMetal::abs_y(float y) { return y * heightBeforeDPIScale; }
 void GuiMetal::begin(const std::string &name, float x, float y, float width,
                      float height, bool movable, bool resizable,
                      bool collapsible) {
+  // Update window dimensions when locked, so programmatic updates use current
+  // window size
+  if ((!movable || !resizable) && app_context_->config.show_window) {
+    glfwGetWindowSize(app_context_->taichi_window(), &widthBeforeDPIScale,
+                      &heightBeforeDPIScale);
+  }
+
   // Set position: Always if locked, Once if unlocked
   ImGuiCond pos_cond = movable ? ImGuiCond_Once : ImGuiCond_Always;
   ImGui::SetNextWindowPos(ImVec2(abs_x(x), abs_y(y)), pos_cond);

--- a/taichi/ui/ggui/gui_metal.mm
+++ b/taichi/ui/ggui/gui_metal.mm
@@ -55,10 +55,29 @@ float GuiMetal::abs_x(float x) { return x * widthBeforeDPIScale; }
 float GuiMetal::abs_y(float y) { return y * heightBeforeDPIScale; }
 
 void GuiMetal::begin(const std::string &name, float x, float y, float width,
-                     float height) {
-  ImGui::SetNextWindowPos(ImVec2(abs_x(x), abs_y(y)), ImGuiCond_Once);
-  ImGui::SetNextWindowSize(ImVec2(abs_x(width), abs_y(height)), ImGuiCond_Once);
-  ImGui::Begin(name.c_str());
+                     float height, bool movable, bool resizable,
+                     bool collapsible) {
+  // Set position: Always if locked, Once if unlocked
+  ImGuiCond pos_cond = movable ? ImGuiCond_Once : ImGuiCond_Always;
+  ImGui::SetNextWindowPos(ImVec2(abs_x(x), abs_y(y)), pos_cond);
+
+  // Set size: Always if locked, Once if unlocked
+  ImGuiCond size_cond = resizable ? ImGuiCond_Once : ImGuiCond_Always;
+  ImGui::SetNextWindowSize(ImVec2(abs_x(width), abs_y(height)), size_cond);
+
+  // Build window flags
+  ImGuiWindowFlags flags = 0;
+  if (!movable) {
+    flags |= ImGuiWindowFlags_NoMove;
+  }
+  if (!resizable) {
+    flags |= ImGuiWindowFlags_NoResize;
+  }
+  if (!collapsible) {
+    flags |= ImGuiWindowFlags_NoCollapse;
+  }
+
+  ImGui::Begin(name.c_str(), nullptr, flags);
   is_empty_ = false;
 }
 void GuiMetal::end() { ImGui::End(); }


### PR DESCRIPTION
Adds `movable`, `resizable`, and `collapsible` boolean parameters to GGUI window API, allowing fine-grained control over window behavior. 

## Changes                                                                                                                                

- **New parameters** (all default `True` for backward compatibility):
  - `movable`: When `False`, prevents user dragging (enables programmatic position control)
  - `resizable`: When `False`, prevents user resizing (enables programmatic size control)
  - `collapsible`: When `False`, disables window collapse via double-click

- **Implementation**: Maps to ImGui flags (`NoMove`, `NoResize`, `NoCollapse`) with correct condition logic (`ImGuiCond_Once` for unlocked, `ImGuiCond_Always` for locked)

- **Backends**: Vulkan and Metal implementations

## Use Cases
                                                                                                                                            
- **HUD/status overlays**: Fixed position panels that can't be moved                                                         
- **Animated/Layout-controlled windows**: Programmatically move/resize locked windows each frame                                                            
- **Critical UI**: Prevent accidental hiding with `collapsible=False`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the public GGUI subwindow API and changes ImGui window initialization behavior, which could subtly affect layout or sizing across backends despite defaulting to the previous behavior.
> 
> **Overview**
> Adds optional `movable`, `resizable`, and `collapsible` booleans (default `True`) to `gui.begin()`/`gui.sub_window()` and the underlying pybind/C++ `GuiBase::begin()` API so callers can lock subwindow movement, resizing, and collapsing.
> 
> Updates Vulkan and Metal GGUI backends to apply the corresponding ImGui flags and to use `ImGuiCond_Always` (and refreshed window dimensions) when movement/resizing is locked, enabling reliable programmatic position/size updates. Documentation is updated with a new “Locking a subwindow” section and example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e1dbbfeac0086532a353dac83160559c7382908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->