### PR TITLE
[build] Fix editable build dependency compatibility

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 cmake<4.0.0
+setuptools<82
 colorama
 coverage
 Pillow

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 #     extra cmake args for C++ taichi_python extension.
 
 import glob
+import inspect
 import multiprocessing
 import os
 import platform
@@ -82,7 +83,7 @@ class Clean(clean):
         super().run()
         self.build_temp = os.path.join(root_dir, "_skbuild")
         if os.path.exists(self.build_temp):
-            remove_tree(self.build_temp, dry_run=self.dry_run)
+            self._remove_tree_compat(self.build_temp)
         generated_folders = (
             "bin",
             "dist",
@@ -95,7 +96,7 @@ class Clean(clean):
         )
         for d in generated_folders:
             if os.path.exists(d):
-                remove_tree(d, dry_run=self.dry_run)
+                self._remove_tree_compat(d)
         generated_files = ["taichi/common/commit_hash.h", "taichi/common/version.h"]
         generated_files += glob.glob("taichi/runtime/llvm/runtime_*.bc")
         generated_files += glob.glob("python/taichi/_lib/core/*.so")
@@ -105,6 +106,13 @@ class Clean(clean):
                 print(f"removing generated file {f}")
                 if not self.dry_run:
                     os.remove(f)
+
+    def _remove_tree_compat(self, path):
+        # setuptools/distutils changed remove_tree() signature across versions.
+        if "dry_run" in inspect.signature(remove_tree).parameters:
+            remove_tree(path, dry_run=self.dry_run)
+        elif not self.dry_run:
+            remove_tree(path)
 
 
 def get_cmake_args():


### PR DESCRIPTION
Issue: N/A

### Brief Summary
- Fix build configuration compatibility for editable/develop installs.
- Update development dependency pinning to avoid outdated/incompatible versions.

### Walkthrough
- Updated `setup.py` build/dependency handling for current toolchain behavior.
- Updated `requirements_dev.txt` to consistent compatible versions.
- Verified local editable install/build flow in the Windows dev environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-tooling change that only affects development dependencies and `setup.py clean` behavior; main risk is cleanup not running correctly under unusual setuptools/distutils versions.
> 
> **Overview**
> Improves editable/develop build compatibility by pinning `setuptools<82` in `requirements_dev.txt`.
> 
> Updates `setup.py`’s `Clean` command to remove build artifacts via a new `_remove_tree_compat()` helper that adapts to `remove_tree()` signature differences across setuptools/distutils versions (respecting `dry_run` when supported).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa2a71670b1bd8bbcba4605cd3a22c041006a62e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->